### PR TITLE
fix: SExp serialization to match KiCad format

### DIFF
--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -215,7 +215,8 @@ class SExp:
         if not self.name and not self.children:
             return "()"
 
-        tab = "\t"
+        # KiCad uses 2 spaces for indentation
+        tab = "  "
         tabs = tab * indent
 
         # Check if should render inline
@@ -282,7 +283,7 @@ class SExp:
             if child.is_atom:
                 if indent == 0 or started_new_lines:
                     # Already on new lines, continue that way
-                    lines.append(f"{tabs}\t{child.to_string(compact=True)}")
+                    lines.append(f"{tabs}{tab}{child.to_string(compact=True)}")
                     started_new_lines = True
                 else:
                     # Atoms go on same line as parent opener
@@ -290,11 +291,11 @@ class SExp:
             elif child._should_inline():
                 if indent == 0:
                     # Root level: each child on own line
-                    lines.append(f"{tabs}\t{child.to_string(compact=True)}")
+                    lines.append(f"{tabs}{tab}{child.to_string(compact=True)}")
                     started_new_lines = True
                 elif force_structured_on_lines or started_new_lines:
                     # Structured nodes get their own lines
-                    lines.append(f"{tabs}\t{child.to_string(compact=True)}")
+                    lines.append(f"{tabs}{tab}{child.to_string(compact=True)}")
                     started_new_lines = True
                 else:
                     # Inline children on same line
@@ -533,6 +534,59 @@ class SExp:
             "signal",
             "power",
             "user",
+            "mixed",
+            "jumper",
+            # Pad types
+            "thru_hole",
+            "smd",
+            "connect",
+            "np_thru_hole",
+            # Pad shapes
+            "rect",
+            "oval",
+            "circle",
+            "roundrect",
+            "trapezoid",
+            "custom",
+            # fp_text types
+            "reference",
+            "value",
+            "user",
+            # Zone connection types
+            "thermal_reliefs",
+            "full",
+            # Zone fill modes
+            "hatch",
+            "hatched",
+            # Via types
+            "blind",
+            "micro",
+            "through",
+            # Arc/curve modes
+            "arc",
+            "start",
+            "mid",
+            "end",
+            # Text effects
+            "italic",
+            "bold",
+            # Module/footprint attributes
+            "smd",
+            "through_hole",
+            "virtual",
+            "exclude_from_pos_files",
+            "exclude_from_bom",
+            "board_only",
+            "dnp",
+            # Net class
+            "clearance",
+            "trace_width",
+            "via_dia",
+            "via_drill",
+            "uvia_dia",
+            "uvia_drill",
+            "diff_pair_width",
+            "diff_pair_gap",
         }
 
         if s in unquoted_keywords:

--- a/tests/test_sexp_roundtrip.py
+++ b/tests/test_sexp_roundtrip.py
@@ -1,0 +1,147 @@
+"""
+Integration tests for S-expression round-trip with KiCad.
+
+These tests verify that files saved by the SExp serializer can be loaded by KiCad CLI.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.sexp import parse_file
+
+# Check if kicad-cli is available
+KICAD_CLI = shutil.which("kicad-cli")
+
+
+@pytest.fixture
+def demo_pcb_path():
+    """Path to a demo PCB file."""
+    path = Path(__file__).parent.parent / "demo" / "charlieplex_led_grid" / "charlieplex_3x3.kicad_pcb"
+    if not path.exists():
+        pytest.skip(f"Demo PCB file not found: {path}")
+    return path
+
+
+@pytest.fixture
+def demo_routed_pcb_path():
+    """Path to a demo routed PCB file."""
+    path = Path(__file__).parent.parent / "demo" / "charlieplex_led_grid" / "charlieplex_3x3_routed.kicad_pcb"
+    if not path.exists():
+        pytest.skip(f"Demo PCB file not found: {path}")
+    return path
+
+
+class TestSExpRoundTripWithKiCad:
+    """Tests that verify round-trip compatibility with KiCad CLI."""
+
+    @pytest.mark.skipif(KICAD_CLI is None, reason="kicad-cli not installed")
+    def test_roundtrip_demo_pcb_loads_in_kicad(self, demo_pcb_path, tmp_path):
+        """Verify that serialized PCB can be loaded by kicad-cli."""
+        # Parse the original file
+        doc = parse_file(demo_pcb_path)
+
+        # Serialize to temp file
+        output_path = tmp_path / "roundtrip_test.kicad_pcb"
+        output_path.write_text(doc.to_string())
+
+        # Try to load with kicad-cli (DRC command will fail if file can't be loaded)
+        result = subprocess.run(
+            [KICAD_CLI, "pcb", "drc", str(output_path), "-o", str(tmp_path / "drc.json")],
+            capture_output=True,
+            text=True,
+        )
+
+        # kicad-cli returns 0 on success or if violations found, non-zero only on load failure
+        assert "Failed to load board" not in result.stderr, (
+            f"KiCad failed to load serialized file.\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+    @pytest.mark.skipif(KICAD_CLI is None, reason="kicad-cli not installed")
+    def test_roundtrip_routed_pcb_loads_in_kicad(self, demo_routed_pcb_path, tmp_path):
+        """Verify that serialized routed PCB can be loaded by kicad-cli."""
+        # Parse the original file
+        doc = parse_file(demo_routed_pcb_path)
+
+        # Serialize to temp file
+        output_path = tmp_path / "roundtrip_routed_test.kicad_pcb"
+        output_path.write_text(doc.to_string())
+
+        # Try to load with kicad-cli
+        result = subprocess.run(
+            [KICAD_CLI, "pcb", "drc", str(output_path), "-o", str(tmp_path / "drc.json")],
+            capture_output=True,
+            text=True,
+        )
+
+        assert "Failed to load board" not in result.stderr, (
+            f"KiCad failed to load serialized file.\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+    def test_serialized_output_format(self, demo_pcb_path):
+        """Verify that serialized output uses correct KiCad formatting."""
+        doc = parse_file(demo_pcb_path)
+        output = doc.to_string()
+
+        # Check indentation uses spaces, not tabs
+        assert '\t' not in output, "Output should use spaces, not tabs"
+
+        # Check that known keywords are not quoted
+        # These keywords appear in the demo file
+        assert " signal)" in output or " signal\n" in output, "signal keyword should not be quoted"
+        assert " user)" in output or " user " in output, "user keyword should not be quoted"
+        assert " no)" in output or " no\n" in output, "no keyword should not be quoted"
+        assert " none)" in output or " none\n" in output, "none keyword should not be quoted"
+        assert " default)" in output or " default\n" in output, "default keyword should not be quoted"
+
+        # Check that layer names are quoted
+        assert '"F.Cu"' in output, "Layer names should be quoted"
+        assert '"B.Cu"' in output, "Layer names should be quoted"
+
+    def test_serialized_output_reparseable(self, demo_pcb_path):
+        """Verify that serialized output can be parsed again."""
+        doc = parse_file(demo_pcb_path)
+        output = doc.to_string()
+
+        # Should be able to parse the output
+        reparsed = parse_file.__wrapped__(output) if hasattr(parse_file, '__wrapped__') else None
+        if reparsed is None:
+            # parse_file expects a path, use parse_string equivalent
+            from kicad_tools.sexp.parser import parse_string
+            reparsed = parse_string(output)
+
+        assert reparsed.name == "kicad_pcb"
+        assert reparsed["version"] is not None
+        assert reparsed["generator"] is not None
+
+    def test_footprint_keywords_unquoted(self, demo_pcb_path):
+        """Verify that footprint keywords are not quoted."""
+        doc = parse_file(demo_pcb_path)
+        output = doc.to_string()
+
+        # Check pad type keywords
+        if "thru_hole" in output:
+            assert '"thru_hole"' not in output, "thru_hole should not be quoted"
+        if "smd" in output:
+            assert '"smd"' not in output, "smd should not be quoted"
+
+        # Check pad shape keywords
+        if "rect " in output or "rect)" in output:
+            assert '"rect"' not in output, "rect should not be quoted"
+        if "oval " in output or "oval)" in output:
+            assert '"oval"' not in output, "oval should not be quoted"
+        if "roundrect" in output:
+            assert '"roundrect"' not in output, "roundrect should not be quoted"
+
+        # Check fp_text types
+        if "reference" in output:
+            assert '"reference"' not in output, "reference should not be quoted"
+        if " value " in output or "(fp_text value" in output:
+            # Note: 'value' as keyword, not as a component value like "100R"
+            pass  # This is trickier to test, skip for now


### PR DESCRIPTION
## Summary

This PR fixes the S-expression serialization to produce output that is loadable by KiCad CLI and GUI.

### Changes

- **Indentation**: Changed from tabs to 2-space indentation (KiCad standard)
- **Keyword handling**: Added comprehensive list of KiCad keywords that should NOT be quoted:
  - Pad types: `thru_hole`, `smd`, `np_thru_hole`, `connect`
  - Pad shapes: `rect`, `oval`, `circle`, `roundrect`, `trapezoid`, `custom`
  - Layer types: `signal`, `power`, `user`, `mixed`
  - Boolean values: `yes`, `no`, `true`, `false`
  - Fill types: `none`, `solid`, `outline`, `background`
  - fp_text types: `reference`, `value`
  - And many more...
- **Layer names**: Strings with dots (like `F.Cu`, `B.Cu`) are correctly quoted

### Before

```
(pad "1" "thru_hole" "rect"
	(at -3.810 -3.810)
```

KiCad output: `Failed to load board`

### After

```
(pad "1" thru_hole rect
  (at -3.810 -3.810)
```

KiCad output: Successfully loads and runs DRC

### Test Plan

- [x] All existing SExp parser tests pass
- [x] New round-trip tests verify keyword quoting
- [x] New round-trip tests verify 2-space indentation
- [x] KiCad CLI integration tests pass (validates with `kicad-cli pcb drc`)
- [x] Full test suite passes (1466 passed, 20 skipped)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)