### PR TITLE
Remove unused numpy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = [
-    "numpy>=1.20",
-]
+dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/rjwalters/kicad-tools"


### PR DESCRIPTION
## Summary

Remove the unused `numpy>=1.20` dependency from `pyproject.toml`. This dependency was declared but never imported or used anywhere in the codebase.

## Changes

- Removed `"numpy>=1.20"` from the `dependencies` array in `pyproject.toml`

## Benefits

- **Reduced install size**: ~20-50MB smaller package installation
- **Faster installs**: No numpy compilation or wheel downloads required
- **Simpler CI**: Eliminates platform-specific numpy wheel considerations
- **Accurate dependencies**: `pyproject.toml` now reflects actual requirements

## Test Plan

- [x] Verified numpy is not imported anywhere: `rg "import numpy|from numpy" src/`
- [x] Verified numpy alias not used: `rg "np\." src/`
- [x] All 1561 tests pass after removal

Closes #37