### PR TITLE
fix: Add KiCad 7+ compatible net class handling

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -34,7 +34,12 @@ from .heuristics import (
     ManhattanHeuristic,
     WeightedCongestionHeuristic,
 )
-from .io import load_pcb_for_routing, route_pcb
+from .io import (
+    generate_netclass_setup,
+    load_pcb_for_routing,
+    merge_routes_into_pcb,
+    route_pcb,
+)
 from .layers import Layer, LayerDefinition, LayerStack, LayerType, ViaDefinition, ViaRules, ViaType
 from .pathfinder import AStarNode, Router
 from .primitives import GridCell, Obstacle, Pad, Point, Route, Segment, Via
@@ -102,6 +107,8 @@ __all__ = [
     # I/O
     "route_pcb",
     "load_pcb_for_routing",
+    "generate_netclass_setup",
+    "merge_routes_into_pcb",
     # Optimizer
     "TraceOptimizer",
     "OptimizationConfig",


### PR DESCRIPTION
## Summary
- Documents that the old KiCad 6 `(net_settings (net_class ...))` format is incompatible with KiCad 7+ and should NOT be used
- Adds `generate_netclass_setup()` function for KiCad 7+ compatible net class definitions (optional since routes are self-contained)
- Adds `merge_routes_into_pcb()` helper to safely insert routes without adding incompatible `net_settings` blocks
- Adds comprehensive tests verifying KiCad 7+ compatibility and self-contained route generation

## Test plan
- [x] All 178 router tests pass
- [x] New tests verify `generate_netclass_setup()` produces KiCad 7+ compatible output
- [x] New tests verify `merge_routes_into_pcb()` doesn't add `net_settings` blocks
- [x] New tests verify routes (segments/vias) embed trace/via sizes directly

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)