### PR TITLE
Add bus routing support to autorouter

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -23,6 +23,15 @@ Example::
     print(f"Routed {result.routed_nets}/{result.total_nets} nets")
 """
 
+from .bus import (
+    BusGroup,
+    BusRoutingConfig,
+    BusRoutingMode,
+    BusSignal,
+    analyze_buses,
+    detect_bus_signals,
+    group_buses,
+)
 from .core import AdaptiveAutorouter, Autorouter, RoutingResult
 from .grid import RoutingGrid
 from .heuristics import (
@@ -58,6 +67,14 @@ __all__ = [
     "Autorouter",
     "AdaptiveAutorouter",
     "RoutingResult",
+    # Bus routing
+    "BusGroup",
+    "BusRoutingConfig",
+    "BusRoutingMode",
+    "BusSignal",
+    "analyze_buses",
+    "detect_bus_signals",
+    "group_buses",
     # Grid
     "RoutingGrid",
     # Pathfinding

--- a/src/kicad_tools/router/bus.py
+++ b/src/kicad_tools/router/bus.py
@@ -1,0 +1,318 @@
+"""
+Bus routing support for the autorouter.
+
+This module provides:
+- BusSignal: Represents a signal that is part of a bus
+- BusGroup: A group of related bus signals (e.g., DATA[7:0])
+- detect_bus_signals: Parse net names to identify bus signals
+- group_buses: Group related signals into bus groups
+- BusRoutingMode: Routing modes for bus signals
+
+Bus signals are detected from common naming conventions:
+- Array notation: DATA[0], DATA[1], ADDR[15]
+- Underscore suffix: DATA_0, DATA_1, ADDR_15
+- Numeric suffix: DATA0, DATA1, ADDR15
+"""
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+
+class BusRoutingMode(Enum):
+    """Routing modes for bus signals."""
+
+    PARALLEL = "parallel"  # All traces run side-by-side
+    STACKED = "stacked"  # Traces on alternating layers
+    BUNDLED = "bundled"  # Closest packing for dense routing
+
+
+@dataclass
+class BusSignal:
+    """A signal that is part of a bus.
+
+    Attributes:
+        net_name: Original net name (e.g., "DATA[7]")
+        net_id: Net ID in the router
+        bus_name: Base name of the bus (e.g., "DATA")
+        index: Bit index in the bus (e.g., 7)
+        notation: How the signal was named ("bracket", "underscore", "numeric")
+    """
+
+    net_name: str
+    net_id: int
+    bus_name: str
+    index: int
+    notation: str  # "bracket", "underscore", "numeric"
+
+    def __hash__(self) -> int:
+        return hash((self.net_id, self.bus_name, self.index))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BusSignal):
+            return NotImplemented
+        return (
+            self.net_id == other.net_id
+            and self.bus_name == other.bus_name
+            and self.index == other.index
+        )
+
+
+@dataclass
+class BusGroup:
+    """A group of related bus signals.
+
+    Attributes:
+        name: Base name of the bus (e.g., "DATA")
+        signals: List of signals in the bus, sorted by index
+        width: Number of bits in the bus
+        min_index: Lowest bit index
+        max_index: Highest bit index
+    """
+
+    name: str
+    signals: List[BusSignal] = field(default_factory=list)
+
+    @property
+    def width(self) -> int:
+        """Number of signals in the bus."""
+        return len(self.signals)
+
+    @property
+    def min_index(self) -> int:
+        """Lowest bit index."""
+        if not self.signals:
+            return 0
+        return min(s.index for s in self.signals)
+
+    @property
+    def max_index(self) -> int:
+        """Highest bit index."""
+        if not self.signals:
+            return 0
+        return max(s.index for s in self.signals)
+
+    def is_complete(self) -> bool:
+        """Check if all indices from min to max are present."""
+        if not self.signals:
+            return False
+        indices = {s.index for s in self.signals}
+        expected = set(range(self.min_index, self.max_index + 1))
+        return indices == expected
+
+    def get_net_ids(self) -> List[int]:
+        """Get net IDs in bit order (LSB to MSB)."""
+        return [s.net_id for s in sorted(self.signals, key=lambda s: s.index)]
+
+    def __str__(self) -> str:
+        return f"{self.name}[{self.max_index}:{self.min_index}]"
+
+
+# Regex patterns for bus signal detection
+# Pattern 1: Bracket notation - DATA[7], ADDR[15], etc.
+_BRACKET_PATTERN = re.compile(r"^(.+)\[(\d+)\]$")
+
+# Pattern 2: Underscore suffix - DATA_7, ADDR_15, etc.
+_UNDERSCORE_PATTERN = re.compile(r"^(.+)_(\d+)$")
+
+# Pattern 3: Numeric suffix - DATA7, ADDR15, etc.
+# Must have at least one non-digit before the number
+_NUMERIC_PATTERN = re.compile(r"^([A-Za-z][A-Za-z0-9_]*[A-Za-z_])(\d+)$")
+
+
+def parse_bus_signal(net_name: str) -> Optional[Tuple[str, int, str]]:
+    """Parse a net name to extract bus information.
+
+    Args:
+        net_name: The net name to parse
+
+    Returns:
+        Tuple of (bus_name, index, notation) if this is a bus signal, None otherwise.
+        notation is one of: "bracket", "underscore", "numeric"
+    """
+    # Try bracket notation first (most explicit)
+    match = _BRACKET_PATTERN.match(net_name)
+    if match:
+        return (match.group(1), int(match.group(2)), "bracket")
+
+    # Try underscore notation
+    match = _UNDERSCORE_PATTERN.match(net_name)
+    if match:
+        return (match.group(1), int(match.group(2)), "underscore")
+
+    # Try numeric suffix (least specific, may have false positives)
+    match = _NUMERIC_PATTERN.match(net_name)
+    if match:
+        return (match.group(1), int(match.group(2)), "numeric")
+
+    return None
+
+
+def detect_bus_signals(
+    net_names: Dict[int, str],
+    min_bus_width: int = 2,
+) -> List[BusSignal]:
+    """Detect bus signals from net names.
+
+    Args:
+        net_names: Mapping of net ID to net name
+        min_bus_width: Minimum number of signals to consider a bus (default: 2)
+
+    Returns:
+        List of detected BusSignal objects
+    """
+    signals: List[BusSignal] = []
+    bus_counts: Dict[str, int] = {}  # Count signals per bus name
+
+    # First pass: parse all potential bus signals and count
+    potential_signals: List[BusSignal] = []
+    for net_id, net_name in net_names.items():
+        parsed = parse_bus_signal(net_name)
+        if parsed:
+            bus_name, index, notation = parsed
+            potential_signals.append(
+                BusSignal(
+                    net_name=net_name,
+                    net_id=net_id,
+                    bus_name=bus_name,
+                    index=index,
+                    notation=notation,
+                )
+            )
+            bus_counts[bus_name] = bus_counts.get(bus_name, 0) + 1
+
+    # Second pass: only include signals from buses with enough members
+    for signal in potential_signals:
+        if bus_counts[signal.bus_name] >= min_bus_width:
+            signals.append(signal)
+
+    return signals
+
+
+def group_buses(
+    signals: List[BusSignal],
+    min_bus_width: int = 2,
+) -> List[BusGroup]:
+    """Group bus signals into bus groups.
+
+    Args:
+        signals: List of BusSignal objects
+        min_bus_width: Minimum width to form a bus group
+
+    Returns:
+        List of BusGroup objects, sorted by bus name
+    """
+    # Group signals by bus name
+    groups_dict: Dict[str, List[BusSignal]] = {}
+    for signal in signals:
+        if signal.bus_name not in groups_dict:
+            groups_dict[signal.bus_name] = []
+        groups_dict[signal.bus_name].append(signal)
+
+    # Create BusGroup objects
+    groups: List[BusGroup] = []
+    for bus_name, bus_signals in sorted(groups_dict.items()):
+        if len(bus_signals) >= min_bus_width:
+            # Sort signals by index
+            sorted_signals = sorted(bus_signals, key=lambda s: s.index)
+            groups.append(BusGroup(name=bus_name, signals=sorted_signals))
+
+    return groups
+
+
+def get_bus_routing_order(
+    groups: List[BusGroup],
+    mode: BusRoutingMode = BusRoutingMode.PARALLEL,
+) -> List[List[int]]:
+    """Get the routing order for bus signals.
+
+    Returns a list of routing batches. In PARALLEL mode, each batch contains
+    one signal from each bus to route simultaneously. In other modes, signals
+    are routed sequentially within each bus.
+
+    Args:
+        groups: List of BusGroup objects
+        mode: Routing mode
+
+    Returns:
+        List of batches, where each batch is a list of net IDs to route together
+    """
+    if mode == BusRoutingMode.PARALLEL:
+        # Route signals at the same bit position together across buses
+        # This promotes parallel trace alignment
+        max_width = max((g.width for g in groups), default=0)
+        batches: List[List[int]] = []
+
+        for i in range(max_width):
+            batch: List[int] = []
+            for group in groups:
+                if i < len(group.signals):
+                    batch.append(group.signals[i].net_id)
+            if batch:
+                batches.append(batch)
+
+        return batches
+
+    else:
+        # STACKED or BUNDLED: route each bus as a unit
+        batches = []
+        for group in groups:
+            batches.append(group.get_net_ids())
+        return batches
+
+
+@dataclass
+class BusRoutingConfig:
+    """Configuration for bus routing.
+
+    Attributes:
+        enabled: Whether bus routing is enabled
+        mode: Routing mode (parallel, stacked, bundled)
+        spacing: Spacing between bus signals in mm (default: trace_width + clearance)
+        min_bus_width: Minimum signals to consider a bus
+        maintain_order: Keep signals in bit order during routing
+    """
+
+    enabled: bool = False
+    mode: BusRoutingMode = BusRoutingMode.PARALLEL
+    spacing: Optional[float] = None  # None = auto (trace_width + clearance)
+    min_bus_width: int = 2
+    maintain_order: bool = True
+
+    def get_spacing(self, trace_width: float, clearance: float) -> float:
+        """Get the actual spacing value."""
+        if self.spacing is not None:
+            return self.spacing
+        return trace_width + clearance
+
+
+def analyze_buses(net_names: Dict[int, str]) -> Dict[str, any]:
+    """Analyze net names to provide a bus detection summary.
+
+    Args:
+        net_names: Mapping of net ID to net name
+
+    Returns:
+        Dictionary with analysis results
+    """
+    signals = detect_bus_signals(net_names)
+    groups = group_buses(signals)
+
+    return {
+        "total_signals": len(signals),
+        "total_groups": len(groups),
+        "groups": [
+            {
+                "name": str(g),
+                "width": g.width,
+                "complete": g.is_complete(),
+                "signals": [s.net_name for s in g.signals],
+            }
+            for g in groups
+        ],
+        "non_bus_nets": [
+            name for net_id, name in net_names.items()
+            if not any(s.net_id == net_id for s in signals)
+        ],
+    }

--- a/tests/test_bus_routing.py
+++ b/tests/test_bus_routing.py
@@ -1,0 +1,373 @@
+"""Tests for bus routing module."""
+
+from kicad_tools.router.bus import (
+    BusGroup,
+    BusRoutingConfig,
+    BusRoutingMode,
+    BusSignal,
+    analyze_buses,
+    detect_bus_signals,
+    group_buses,
+    parse_bus_signal,
+)
+
+
+class TestParseBusSignal:
+    """Tests for bus signal name parsing."""
+
+    def test_bracket_notation(self):
+        """Test parsing bracket notation like DATA[7]."""
+        result = parse_bus_signal("DATA[7]")
+        assert result is not None
+        bus_name, index, notation = result
+        assert bus_name == "DATA"
+        assert index == 7
+        assert notation == "bracket"
+
+    def test_bracket_notation_multi_digit(self):
+        """Test parsing bracket notation with multi-digit index."""
+        result = parse_bus_signal("ADDR[15]")
+        assert result is not None
+        bus_name, index, notation = result
+        assert bus_name == "ADDR"
+        assert index == 15
+        assert notation == "bracket"
+
+    def test_bracket_notation_with_underscore(self):
+        """Test parsing bracket notation with underscore in name."""
+        result = parse_bus_signal("DATA_BUS[3]")
+        assert result is not None
+        bus_name, index, notation = result
+        assert bus_name == "DATA_BUS"
+        assert index == 3
+        assert notation == "bracket"
+
+    def test_underscore_notation(self):
+        """Test parsing underscore notation like DATA_7."""
+        result = parse_bus_signal("DATA_7")
+        assert result is not None
+        bus_name, index, notation = result
+        assert bus_name == "DATA"
+        assert index == 7
+        assert notation == "underscore"
+
+    def test_underscore_notation_multi_digit(self):
+        """Test parsing underscore notation with multi-digit index."""
+        result = parse_bus_signal("ADDR_15")
+        assert result is not None
+        bus_name, index, notation = result
+        assert bus_name == "ADDR"
+        assert index == 15
+        assert notation == "underscore"
+
+    def test_numeric_suffix_notation(self):
+        """Test parsing numeric suffix like DATA7."""
+        result = parse_bus_signal("DATA7")
+        assert result is not None
+        bus_name, index, notation = result
+        assert bus_name == "DATA"
+        assert index == 7
+        assert notation == "numeric"
+
+    def test_numeric_suffix_multi_digit(self):
+        """Test parsing numeric suffix with multi-digit index."""
+        result = parse_bus_signal("ADDR15")
+        assert result is not None
+        bus_name, index, notation = result
+        assert bus_name == "ADDR"
+        assert index == 15
+        assert notation == "numeric"
+
+    def test_non_bus_signal(self):
+        """Test that non-bus signals return None."""
+        assert parse_bus_signal("VCC") is None
+        assert parse_bus_signal("GND") is None
+        assert parse_bus_signal("CLK") is None
+        assert parse_bus_signal("RESET") is None
+
+    def test_single_digit_number(self):
+        """Test single character names don't match numeric pattern."""
+        # Single letter followed by number shouldn't match (needs at least 2 chars before)
+        result = parse_bus_signal("D7")
+        # This should match underscore pattern: D_7 would be "D" with index 7
+        # But D7 doesn't have underscore, and numeric pattern needs 2+ letters
+        assert result is None  # "D7" doesn't match: needs at least 2 chars before digit
+
+    def test_complex_bus_names(self):
+        """Test complex bus names with mixed characters."""
+        result = parse_bus_signal("I2C_SDA_0")
+        assert result is not None
+        assert result[0] == "I2C_SDA"
+        assert result[1] == 0
+
+        result = parse_bus_signal("SPI_MOSI[0]")
+        assert result is not None
+        assert result[0] == "SPI_MOSI"
+        assert result[1] == 0
+
+
+class TestBusSignal:
+    """Tests for BusSignal dataclass."""
+
+    def test_bus_signal_creation(self):
+        """Test creating a BusSignal."""
+        signal = BusSignal(
+            net_name="DATA[0]",
+            net_id=1,
+            bus_name="DATA",
+            index=0,
+            notation="bracket",
+        )
+        assert signal.net_name == "DATA[0]"
+        assert signal.net_id == 1
+        assert signal.bus_name == "DATA"
+        assert signal.index == 0
+        assert signal.notation == "bracket"
+
+    def test_bus_signal_hash(self):
+        """Test BusSignal hashing."""
+        signal1 = BusSignal("DATA[0]", 1, "DATA", 0, "bracket")
+        signal2 = BusSignal("DATA[0]", 1, "DATA", 0, "bracket")
+        assert hash(signal1) == hash(signal2)
+
+    def test_bus_signal_equality(self):
+        """Test BusSignal equality."""
+        signal1 = BusSignal("DATA[0]", 1, "DATA", 0, "bracket")
+        signal2 = BusSignal("DATA[0]", 1, "DATA", 0, "bracket")
+        signal3 = BusSignal("DATA[1]", 2, "DATA", 1, "bracket")
+        assert signal1 == signal2
+        assert signal1 != signal3
+
+
+class TestBusGroup:
+    """Tests for BusGroup dataclass."""
+
+    def test_bus_group_creation(self):
+        """Test creating a BusGroup."""
+        group = BusGroup(name="DATA")
+        assert group.name == "DATA"
+        assert group.signals == []
+        assert group.width == 0
+
+    def test_bus_group_with_signals(self):
+        """Test BusGroup with signals."""
+        signals = [
+            BusSignal("DATA[0]", 1, "DATA", 0, "bracket"),
+            BusSignal("DATA[1]", 2, "DATA", 1, "bracket"),
+            BusSignal("DATA[2]", 3, "DATA", 2, "bracket"),
+        ]
+        group = BusGroup(name="DATA", signals=signals)
+        assert group.width == 3
+        assert group.min_index == 0
+        assert group.max_index == 2
+
+    def test_bus_group_is_complete(self):
+        """Test is_complete for contiguous indices."""
+        signals = [
+            BusSignal("DATA[0]", 1, "DATA", 0, "bracket"),
+            BusSignal("DATA[1]", 2, "DATA", 1, "bracket"),
+            BusSignal("DATA[2]", 3, "DATA", 2, "bracket"),
+        ]
+        group = BusGroup(name="DATA", signals=signals)
+        assert group.is_complete() is True
+
+    def test_bus_group_is_incomplete(self):
+        """Test is_complete for non-contiguous indices."""
+        signals = [
+            BusSignal("DATA[0]", 1, "DATA", 0, "bracket"),
+            BusSignal("DATA[2]", 3, "DATA", 2, "bracket"),  # Missing [1]
+        ]
+        group = BusGroup(name="DATA", signals=signals)
+        assert group.is_complete() is False
+
+    def test_bus_group_get_net_ids(self):
+        """Test get_net_ids returns IDs in bit order."""
+        signals = [
+            BusSignal("DATA[2]", 3, "DATA", 2, "bracket"),
+            BusSignal("DATA[0]", 1, "DATA", 0, "bracket"),
+            BusSignal("DATA[1]", 2, "DATA", 1, "bracket"),
+        ]
+        group = BusGroup(name="DATA", signals=signals)
+        assert group.get_net_ids() == [1, 2, 3]  # Sorted by index
+
+    def test_bus_group_str(self):
+        """Test BusGroup string representation."""
+        signals = [
+            BusSignal("DATA[0]", 1, "DATA", 0, "bracket"),
+            BusSignal("DATA[7]", 8, "DATA", 7, "bracket"),
+        ]
+        group = BusGroup(name="DATA", signals=signals)
+        assert str(group) == "DATA[7:0]"
+
+
+class TestDetectBusSignals:
+    """Tests for bus signal detection."""
+
+    def test_detect_single_bus(self):
+        """Test detecting a single bus."""
+        net_names = {
+            1: "DATA[0]",
+            2: "DATA[1]",
+            3: "DATA[2]",
+            4: "DATA[3]",
+        }
+        signals = detect_bus_signals(net_names)
+        assert len(signals) == 4
+        assert all(s.bus_name == "DATA" for s in signals)
+
+    def test_detect_multiple_buses(self):
+        """Test detecting multiple buses."""
+        net_names = {
+            1: "DATA[0]",
+            2: "DATA[1]",
+            3: "ADDR[0]",
+            4: "ADDR[1]",
+        }
+        signals = detect_bus_signals(net_names)
+        assert len(signals) == 4
+        data_signals = [s for s in signals if s.bus_name == "DATA"]
+        addr_signals = [s for s in signals if s.bus_name == "ADDR"]
+        assert len(data_signals) == 2
+        assert len(addr_signals) == 2
+
+    def test_detect_mixed_notation(self):
+        """Test detecting buses with different notation styles."""
+        net_names = {
+            1: "DATA[0]",  # bracket
+            2: "DATA[1]",
+            3: "CTRL_0",  # underscore
+            4: "CTRL_1",
+        }
+        signals = detect_bus_signals(net_names)
+        assert len(signals) == 4
+
+    def test_min_bus_width_filter(self):
+        """Test that signals below min_bus_width are excluded."""
+        net_names = {
+            1: "DATA[0]",  # Only 1 signal - below threshold
+            2: "ADDR[0]",
+            3: "ADDR[1]",
+            4: "ADDR[2]",
+        }
+        signals = detect_bus_signals(net_names, min_bus_width=2)
+        # DATA should be excluded (only 1 signal)
+        assert len(signals) == 3
+        assert all(s.bus_name == "ADDR" for s in signals)
+
+    def test_detect_with_non_bus_signals(self):
+        """Test detection with mixed bus and non-bus signals."""
+        net_names = {
+            1: "DATA[0]",
+            2: "DATA[1]",
+            3: "VCC",
+            4: "GND",
+            5: "CLK",
+        }
+        signals = detect_bus_signals(net_names)
+        assert len(signals) == 2
+        assert all(s.bus_name == "DATA" for s in signals)
+
+
+class TestGroupBuses:
+    """Tests for bus grouping."""
+
+    def test_group_single_bus(self):
+        """Test grouping signals into a single bus."""
+        signals = [
+            BusSignal("DATA[0]", 1, "DATA", 0, "bracket"),
+            BusSignal("DATA[1]", 2, "DATA", 1, "bracket"),
+            BusSignal("DATA[2]", 3, "DATA", 2, "bracket"),
+        ]
+        groups = group_buses(signals)
+        assert len(groups) == 1
+        assert groups[0].name == "DATA"
+        assert groups[0].width == 3
+
+    def test_group_multiple_buses(self):
+        """Test grouping signals into multiple buses."""
+        signals = [
+            BusSignal("DATA[0]", 1, "DATA", 0, "bracket"),
+            BusSignal("DATA[1]", 2, "DATA", 1, "bracket"),
+            BusSignal("ADDR[0]", 3, "ADDR", 0, "bracket"),
+            BusSignal("ADDR[1]", 4, "ADDR", 1, "bracket"),
+        ]
+        groups = group_buses(signals)
+        assert len(groups) == 2
+        group_names = {g.name for g in groups}
+        assert group_names == {"DATA", "ADDR"}
+
+    def test_group_sorted_by_index(self):
+        """Test that signals in groups are sorted by index."""
+        signals = [
+            BusSignal("DATA[3]", 4, "DATA", 3, "bracket"),
+            BusSignal("DATA[1]", 2, "DATA", 1, "bracket"),
+            BusSignal("DATA[0]", 1, "DATA", 0, "bracket"),
+            BusSignal("DATA[2]", 3, "DATA", 2, "bracket"),
+        ]
+        groups = group_buses(signals)
+        assert len(groups) == 1
+        indices = [s.index for s in groups[0].signals]
+        assert indices == [0, 1, 2, 3]
+
+
+class TestBusRoutingConfig:
+    """Tests for BusRoutingConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = BusRoutingConfig()
+        assert config.enabled is False
+        assert config.mode == BusRoutingMode.PARALLEL
+        assert config.spacing is None
+        assert config.min_bus_width == 2
+        assert config.maintain_order is True
+
+    def test_enabled_config(self):
+        """Test enabled configuration."""
+        config = BusRoutingConfig(enabled=True, mode=BusRoutingMode.STACKED)
+        assert config.enabled is True
+        assert config.mode == BusRoutingMode.STACKED
+
+    def test_get_spacing_auto(self):
+        """Test auto spacing calculation."""
+        config = BusRoutingConfig()
+        spacing = config.get_spacing(trace_width=0.2, clearance=0.15)
+        assert spacing == 0.35  # 0.2 + 0.15
+
+    def test_get_spacing_custom(self):
+        """Test custom spacing."""
+        config = BusRoutingConfig(spacing=0.5)
+        spacing = config.get_spacing(trace_width=0.2, clearance=0.15)
+        assert spacing == 0.5
+
+
+class TestAnalyzeBuses:
+    """Tests for bus analysis function."""
+
+    def test_analyze_buses(self):
+        """Test bus analysis output."""
+        net_names = {
+            1: "DATA[0]",
+            2: "DATA[1]",
+            3: "DATA[2]",
+            4: "VCC",
+            5: "GND",
+        }
+        analysis = analyze_buses(net_names)
+
+        assert analysis["total_signals"] == 3
+        assert analysis["total_groups"] == 1
+        assert len(analysis["groups"]) == 1
+        assert analysis["groups"][0]["name"] == "DATA[2:0]"
+        assert analysis["groups"][0]["width"] == 3
+        assert analysis["groups"][0]["complete"] is True
+        assert set(analysis["non_bus_nets"]) == {"VCC", "GND"}
+
+    def test_analyze_empty(self):
+        """Test bus analysis with no buses."""
+        net_names = {1: "VCC", 2: "GND"}
+        analysis = analyze_buses(net_names)
+
+        assert analysis["total_signals"] == 0
+        assert analysis["total_groups"] == 0
+        assert len(analysis["groups"]) == 0


### PR DESCRIPTION
## Summary

Adds bus-aware routing capability that detects and routes bus signals (e.g., DATA[0:7], ADDR[0:15]) as groups with consistent spacing.

## Features

- **Bus signal detection** from common naming conventions:
  - Bracket notation: `DATA[7]`, `ADDR[15]`
  - Underscore suffix: `DATA_7`, `ADDR_15`
  - Numeric suffix: `DATA7`, `ADDR15`
- **Bus grouping** into `BusGroup` objects with automatic bit ordering
- **Three routing modes**:
  - `parallel`: All traces run side-by-side (default)
  - `stacked`: Traces on alternating layers
  - `bundled`: Closest packing for dense routing
- **Configurable signal spacing** (defaults to trace_width + clearance)
- **CLI support**: `--bus-routing`, `--bus-mode`, `--bus-spacing`, `--bus-min-width`
- **Visual grouping** in routing output showing detected buses

## Changes

- `src/kicad_tools/router/bus.py` (new): Bus detection, grouping, and routing config
- `src/kicad_tools/router/core.py`: Added `route_all_with_buses()`, `detect_buses()`, `route_bus_group()`
- `src/kicad_tools/router/__init__.py`: Export bus-related classes
- `src/kicad_tools/cli/route_cmd.py`: Added CLI flags for bus routing
- `tests/test_bus_routing.py` (new): 33 comprehensive tests

## CLI Usage

```bash
# Enable bus routing with parallel mode (default)
kct route board.kicad_pcb --bus-routing --strategy basic

# Use stacked mode for dense routing
kct route board.kicad_pcb --bus-routing --bus-mode stacked

# Custom spacing between bus signals
kct route board.kicad_pcb --bus-routing --bus-spacing 0.5

# Verbose output shows detected buses
kct route board.kicad_pcb --bus-routing -v
```

## Test Plan

- [x] All 33 new bus routing tests pass
- [x] All 1574 existing tests still pass
- [x] Linting passes (except pre-existing issue)
- [ ] Manual test with a bus-heavy PCB design

Closes #35