### PR TITLE
feat: Complete LLM-driven PCB reasoning module integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,45 @@ result = router.route_all()
 print(f"Routed {result.routed_nets}/{result.total_nets} nets")
 ```
 
+### LLM-Driven PCB Layout
+
+The reasoning module enables LLMs to make strategic PCB layout decisions while tools handle geometric execution:
+
+```python
+from kicad_tools import PCBReasoningAgent
+
+# Load board
+agent = PCBReasoningAgent.from_pcb("board.kicad_pcb")
+
+# Reasoning loop
+while not agent.is_complete():
+    # Get state as prompt for LLM
+    prompt = agent.get_prompt()
+
+    # Call your LLM (OpenAI, Anthropic, local, etc.)
+    command = call_llm(prompt)
+
+    # Execute and get feedback
+    result, diagnosis = agent.execute(command)
+
+# Save result
+agent.save("board_routed.kicad_pcb")
+```
+
+CLI usage:
+```bash
+# Export state for external LLM
+kct reason board.kicad_pcb --export-state
+
+# Interactive mode
+kct reason board.kicad_pcb --interactive
+
+# Auto-route priority nets
+kct reason board.kicad_pcb --auto-route
+```
+
+See `examples/llm-routing/` for complete examples.
+
 ## CLI Commands
 
 ### Unified CLI (`kct` or `kicad-tools`)
@@ -91,6 +130,8 @@ print(f"Routed {result.routed_nets}/{result.total_nets} nets")
 | `kct bom <schematic>` | Generate bill of materials |
 | `kct erc <schematic>` | Run electrical rules check |
 | `kct drc <pcb>` | Run design rules check |
+| `kct route <pcb>` | Autoroute a PCB |
+| `kct reason <pcb>` | LLM-driven PCB layout reasoning |
 
 All commands support `--format json` for machine-readable output.
 
@@ -122,6 +163,7 @@ All commands support `--format json` for machine-readable output.
 | `manufacturers` | PCB fab profiles (JLCPCB, OSHPark, PCBWay, Seeed) |
 | `operations` | Schematic operations (net tracing, symbol replacement) |
 | `router` | A* PCB autorouter with pluggable heuristics |
+| `reasoning` | LLM-driven PCB layout with chain-of-thought reasoning |
 
 ## Features
 

--- a/examples/llm-routing/README.md
+++ b/examples/llm-routing/README.md
@@ -1,0 +1,153 @@
+# LLM-Driven PCB Routing
+
+This directory contains examples demonstrating how to integrate LLMs (Large Language Models) with kicad-tools for semantic PCB layout decisions.
+
+## The Concept
+
+Traditional autorouters are **semantically blind** - they connect pads mechanically without understanding design intent. An LLM can reason about **WHY** decisions matter:
+
+- "Route clock signals on the shortest path"
+- "Keep analog section isolated from digital"
+- "Use wider traces for power nets"
+- "Minimize crosstalk between differential pairs"
+
+The kicad-tools reasoning module provides:
+1. **PCB state representation** suitable for LLM prompts
+2. **Command vocabulary** for routing actions
+3. **Feedback/diagnosis** for failed operations
+
+## Quick Start
+
+### CLI Usage
+
+```bash
+# Export current state as JSON for external LLM processing
+kct reason board.kicad_pcb --export-state
+
+# Get detailed analysis of current board state
+kct reason board.kicad_pcb --analyze
+
+# Auto-route priority nets (without LLM)
+kct reason board.kicad_pcb --auto-route --max-nets 5
+
+# Interactive mode (for LLM integration)
+kct reason board.kicad_pcb --interactive
+```
+
+### Python API
+
+```python
+from kicad_tools import PCBReasoningAgent
+
+# Load board
+agent = PCBReasoningAgent.from_pcb("board.kicad_pcb")
+
+# Reasoning loop
+while not agent.is_complete():
+    # Get state as prompt for LLM
+    prompt = agent.get_prompt()
+
+    # Call your LLM (OpenAI, Anthropic, local, etc.)
+    command = call_your_llm(prompt)
+
+    # Execute and get feedback
+    result, diagnosis = agent.execute_dict(command)
+
+    if not result.success:
+        # Feed diagnosis back to LLM
+        print(diagnosis)
+
+# Save result
+agent.save("board_routed.kicad_pcb")
+```
+
+## Available Commands
+
+The LLM should return JSON commands:
+
+### Route a Net
+
+```json
+{
+    "command": "route_net",
+    "net": "SCL",
+    "minimize_vias": true,
+    "avoid_regions": ["analog_corner"]
+}
+```
+
+### Delete Traces
+
+```json
+{
+    "command": "delete_trace",
+    "net": "GND",
+    "near": [50.0, 30.0],
+    "radius": 2.0,
+    "reason": "fixing short circuit"
+}
+```
+
+### Place Component
+
+```json
+{
+    "command": "place_component",
+    "ref": "U2",
+    "at": [50.0, 30.0],
+    "rotation": 90
+}
+```
+
+## Example Script
+
+See `route_with_llm.py` for a complete example that:
+1. Loads a PCB
+2. Runs a reasoning loop with LLM calls
+3. Handles failures with diagnosis feedback
+4. Saves the result and routing history
+
+```bash
+# Set your LLM API key
+export OPENAI_API_KEY="your-key-here"
+
+# Run the example
+python route_with_llm.py board.kicad_pcb
+```
+
+## State Format
+
+The `--export-state` option exports:
+
+```json
+{
+    "pcb_file": "board.kicad_pcb",
+    "outline": {"width": 100.0, "height": 80.0},
+    "components": {
+        "U1": {
+            "x": 50.0, "y": 40.0,
+            "rotation": 0,
+            "footprint": "QFP-48",
+            "pads": [
+                {"name": "1", "x": 45.0, "y": 35.0, "net": "VCC"},
+                ...
+            ]
+        },
+        ...
+    },
+    "nets": {
+        "routed": [{"name": "GND", "pad_count": 12}],
+        "unrouted": [{"name": "SCL", "pad_count": 2, "priority": 1}]
+    },
+    "violations": [...],
+    "prompt": "## Progress\nNets routed: 5/20..."
+}
+```
+
+## Tips for LLM Integration
+
+1. **Use the prompt**: The `prompt` field is pre-formatted for LLM consumption
+2. **Handle failures**: Always process the diagnosis on failure
+3. **Iterate**: Complex boards may need multiple routing attempts
+4. **Prioritize**: Route critical nets (clocks, power) first
+5. **Check violations**: Monitor for shorts and clearance issues

--- a/examples/llm-routing/route_with_llm.py
+++ b/examples/llm-routing/route_with_llm.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Example: LLM-Driven PCB Routing with kicad-tools
+
+This example demonstrates how to integrate an LLM (like GPT-4 or Claude) with
+kicad-tools to perform semantic PCB routing decisions.
+
+The key insight: Traditional autorouters are semantically blind - they connect
+pads without understanding design intent. An LLM can reason about WHY decisions
+matter ("keep clocks short", "isolate analog section").
+
+Usage:
+    # Set your LLM API key
+    export OPENAI_API_KEY="your-key-here"
+
+    # Run the example
+    python route_with_llm.py board.kicad_pcb
+
+This script demonstrates the integration pattern. For production use, you'd
+adapt the call_llm() function to your preferred LLM provider.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def call_llm(prompt: str) -> dict:
+    """Call your LLM to get routing decisions.
+
+    This is a placeholder that demonstrates the integration pattern.
+    Replace with your actual LLM API call (OpenAI, Anthropic, local, etc.)
+
+    The LLM should return a JSON command like:
+    {
+        "command": "route_net",
+        "net": "SCL",
+        "minimize_vias": true,
+        "avoid_regions": ["analog_corner"]
+    }
+
+    Or:
+    {
+        "command": "place_component",
+        "ref": "U2",
+        "at": [50.0, 30.0],
+        "rotation": 90
+    }
+    """
+    # Check for OpenAI
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if api_key:
+        try:
+            import openai
+
+            client = openai.OpenAI(api_key=api_key)
+            response = client.chat.completions.create(
+                model="gpt-4",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": """You are a PCB layout assistant. Analyze the board state
+and suggest the next routing action as JSON. Available commands:
+
+- route_net: Route a net
+  {"command": "route_net", "net": "NET_NAME", "minimize_vias": true}
+
+- delete_trace: Remove traces (e.g., to fix shorts)
+  {"command": "delete_trace", "net": "NET_NAME", "reason": "fixing short"}
+
+- place_component: Move a component
+  {"command": "place_component", "ref": "U1", "at": [x, y], "rotation": 0}
+
+Respond with ONLY valid JSON, no explanation.""",
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+                max_tokens=200,
+            )
+            result_text = response.choices[0].message.content.strip()
+            return json.loads(result_text)
+        except ImportError:
+            print("OpenAI library not installed. Install with: pip install openai")
+        except Exception as e:
+            print(f"LLM call failed: {e}")
+
+    # Fallback: Simple heuristic-based routing
+    # This demonstrates the command format without requiring an actual LLM
+    print("  (Using fallback heuristic - no LLM API configured)")
+    return {"command": "route_net", "net": "auto", "minimize_vias": True}
+
+
+def main():
+    """Main example demonstrating LLM-driven PCB routing."""
+    if len(sys.argv) < 2:
+        print("Usage: python route_with_llm.py <board.kicad_pcb>")
+        print("\nThis example demonstrates LLM integration for PCB layout.")
+        print("Set OPENAI_API_KEY environment variable for actual LLM calls.")
+        sys.exit(1)
+
+    pcb_path = Path(sys.argv[1])
+    if not pcb_path.exists():
+        print(f"Error: File not found: {pcb_path}")
+        sys.exit(1)
+
+    # Import reasoning module
+    from kicad_tools.reasoning import PCBReasoningAgent
+
+    print("=" * 60)
+    print("LLM-Driven PCB Routing Example")
+    print("=" * 60)
+
+    # Create reasoning agent
+    print(f"\nLoading: {pcb_path}")
+    agent = PCBReasoningAgent.from_pcb(str(pcb_path))
+
+    # Show initial state
+    state = agent.get_state()
+    print(f"Board: {state.outline.width:.1f}mm x {state.outline.height:.1f}mm")
+    print(f"Components: {len(state.components)}")
+    print(f"Unrouted nets: {len(state.unrouted_nets)}")
+    print(f"Violations: {len(state.violations)}")
+
+    # Reasoning loop
+    print("\n--- Starting LLM Reasoning Loop ---")
+    max_iterations = 20
+    iteration = 0
+
+    while not agent.is_complete() and iteration < max_iterations:
+        iteration += 1
+        print(f"\n[Iteration {iteration}]")
+
+        # Get current state as prompt for LLM
+        prompt = agent.get_prompt()
+
+        # Show condensed state
+        progress = agent.get_progress()
+        print(f"  Progress: {progress.nets_routed}/{progress.nets_total} nets")
+        print(f"  Violations: {progress.violations_current}")
+
+        # Get LLM decision
+        print("  Calling LLM...")
+        try:
+            command_dict = call_llm(prompt)
+            print(f"  LLM suggests: {command_dict}")
+        except Exception as e:
+            print(f"  LLM error: {e}")
+            break
+
+        # Handle special "auto" net - route next priority net
+        if command_dict.get("net") == "auto" and state.unrouted_nets:
+            command_dict["net"] = sorted(
+                state.unrouted_nets, key=lambda n: n.priority
+            )[0].name
+            print(f"  Auto-selected net: {command_dict['net']}")
+
+        # Execute command
+        result, diagnosis = agent.execute_dict(command_dict)
+
+        if result.success:
+            print(f"  Result: SUCCESS - {result.message}")
+        else:
+            print(f"  Result: FAILED - {result.message}")
+            if diagnosis:
+                # Show first 200 chars of diagnosis
+                print(f"  Diagnosis: {diagnosis[:200]}...")
+
+    # Final status
+    print("\n" + "=" * 60)
+    if agent.is_complete():
+        print("SUCCESS: All nets routed!")
+    else:
+        progress = agent.get_progress()
+        print(f"INCOMPLETE: {progress.nets_routed}/{progress.nets_total} nets routed")
+        print(f"Violations remaining: {progress.violations_current}")
+
+    # Save result
+    output_path = pcb_path.with_stem(pcb_path.stem + "_llm_routed")
+    print(f"\nSaving to: {output_path}")
+    agent.save(str(output_path))
+
+    # Export history for analysis
+    history_path = pcb_path.with_stem(pcb_path.stem + "_routing_history").with_suffix(
+        ".json"
+    )
+    agent.export_history(str(history_path))
+    print(f"History exported to: {history_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kicad_tools/__init__.py
+++ b/src/kicad_tools/__init__.py
@@ -59,6 +59,13 @@ from kicad_tools.query import (
     FootprintList,
 )
 
+# Reasoning - LLM-driven PCB layout
+from kicad_tools.reasoning import (
+    PCBReasoningAgent,
+    PCBState,
+    CommandInterpreter,
+)
+
 __all__ = [
     # Version
     "__version__",
@@ -83,4 +90,8 @@ __all__ = [
     "SymbolList",
     "FootprintQuery",
     "FootprintList",
+    # Reasoning - LLM-driven PCB layout
+    "PCBReasoningAgent",
+    "PCBState",
+    "CommandInterpreter",
 ]

--- a/src/kicad_tools/cli/reason_cmd.py
+++ b/src/kicad_tools/cli/reason_cmd.py
@@ -1,0 +1,299 @@
+"""
+LLM-driven PCB reasoning CLI command.
+
+Provides command-line access to the reasoning module for LLM-assisted layout:
+
+    kct reason board.kicad_pcb --export-state
+    kct reason board.kicad_pcb --interactive
+    kct reason board.kicad_pcb --analyze
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Main entry point for reason command."""
+    parser = argparse.ArgumentParser(
+        prog="kicad-tools reason",
+        description="LLM-driven PCB layout reasoning",
+    )
+    parser.add_argument("pcb", help="Path to .kicad_pcb file")
+    parser.add_argument(
+        "-o", "--output",
+        help="Output file path (default: <input>_reasoned.kicad_pcb)",
+    )
+    parser.add_argument(
+        "--export-state",
+        action="store_true",
+        help="Export current state as JSON for external LLM processing",
+    )
+    parser.add_argument(
+        "--state-output",
+        help="Output path for state JSON (default: stdout)",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Run interactive reasoning loop (stdin/stdout for LLM)",
+    )
+    parser.add_argument(
+        "--analyze",
+        action="store_true",
+        help="Print detailed analysis of current PCB state",
+    )
+    parser.add_argument(
+        "--auto-route",
+        action="store_true",
+        help="Auto-route priority nets without LLM (convenience mode)",
+    )
+    parser.add_argument(
+        "--max-nets",
+        type=int,
+        default=10,
+        help="Maximum nets to auto-route (default: 10)",
+    )
+    parser.add_argument(
+        "--drc",
+        help="Path to DRC report file for violation awareness",
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Verbose output",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without writing output",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Validate input
+    pcb_path = Path(args.pcb)
+    if not pcb_path.exists():
+        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
+        return 1
+
+    if not pcb_path.suffix == ".kicad_pcb":
+        print(f"Warning: Expected .kicad_pcb file, got {pcb_path.suffix}")
+
+    # Determine output path
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        output_path = pcb_path.with_stem(pcb_path.stem + "_reasoned")
+
+    # Import reasoning module
+    from kicad_tools.reasoning import PCBReasoningAgent
+
+    # Print header
+    print("=" * 60)
+    print("KiCad LLM-Driven PCB Reasoning")
+    print("=" * 60)
+    print(f"Input: {pcb_path}")
+
+    # Create agent
+    print("\n--- Loading PCB ---")
+    try:
+        agent = PCBReasoningAgent.from_pcb(
+            str(pcb_path),
+            drc_path=args.drc,
+        )
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    state = agent.get_state()
+    print(f"  Board size: {state.outline.width:.1f}mm x {state.outline.height:.1f}mm")
+    print(f"  Components: {len(state.components)}")
+    print(f"  Nets total: {len(state.routed_nets) + len(state.unrouted_nets)}")
+    print(f"  Nets routed: {len(state.routed_nets)}")
+    print(f"  Nets unrouted: {len(state.unrouted_nets)}")
+    print(f"  Violations: {len(state.violations)}")
+
+    # Handle different modes
+    if args.export_state:
+        return _export_state(agent, args)
+
+    if args.analyze:
+        return _analyze(agent, args)
+
+    if args.interactive:
+        return _interactive_loop(agent, output_path, args)
+
+    if args.auto_route:
+        return _auto_route(agent, output_path, args)
+
+    # Default: show prompt and exit
+    print("\n--- Current State Prompt ---")
+    print(agent.get_prompt())
+    print("\n" + "=" * 60)
+    print("Use --export-state, --interactive, --analyze, or --auto-route")
+    return 0
+
+
+def _export_state(agent, args) -> int:
+    """Export state as JSON for external LLM processing."""
+    state = agent.get_state()
+
+    # Build state dictionary
+    state_dict = {
+        "pcb_file": str(agent.pcb_path),
+        "outline": {
+            "width": state.outline.width,
+            "height": state.outline.height,
+        },
+        "components": {
+            ref: {
+                "x": comp.x,
+                "y": comp.y,
+                "rotation": comp.rotation,
+                "layer": comp.layer,
+                "footprint": comp.footprint,
+                "pads": [
+                    {"name": p.name, "x": p.x, "y": p.y, "net": p.net}
+                    for p in comp.pads
+                ],
+            }
+            for ref, comp in state.components.items()
+        },
+        "nets": {
+            "routed": [
+                {"name": n.name, "pad_count": n.pad_count}
+                for n in state.routed_nets
+            ],
+            "unrouted": [
+                {"name": n.name, "pad_count": n.pad_count, "priority": n.priority}
+                for n in state.unrouted_nets
+            ],
+        },
+        "violations": [
+            {
+                "type": v.type,
+                "severity": v.severity,
+                "message": v.message,
+                "x": v.x,
+                "y": v.y,
+                "nets": v.nets,
+            }
+            for v in state.violations
+        ],
+        "prompt": agent.get_prompt(),
+    }
+
+    # Output
+    json_str = json.dumps(state_dict, indent=2)
+
+    if args.state_output:
+        Path(args.state_output).write_text(json_str)
+        print(f"\n--- State exported to {args.state_output} ---")
+    else:
+        print("\n--- State JSON ---")
+        print(json_str)
+
+    return 0
+
+
+def _analyze(agent, args) -> int:
+    """Print detailed analysis of PCB state."""
+    print("\n" + agent.analyze_current_state())
+    return 0
+
+
+def _interactive_loop(agent, output_path: Path, args) -> int:
+    """Run interactive reasoning loop."""
+    print("\n--- Interactive Mode ---")
+    print("Enter commands as JSON. Type 'quit' to exit, 'save' to save.")
+    print("Example: {\"command\": \"route_net\", \"net\": \"SCL\"}")
+    print()
+
+    while not agent.is_complete():
+        # Show current state
+        print(agent.get_prompt())
+        print("\nCommand> ", end="", flush=True)
+
+        try:
+            line = input().strip()
+        except EOFError:
+            break
+
+        if not line:
+            continue
+
+        if line.lower() == "quit":
+            break
+
+        if line.lower() == "save":
+            if not args.dry_run:
+                agent.save(str(output_path))
+                print(f"Saved to {output_path}")
+            else:
+                print("Dry run - not saving")
+            continue
+
+        if line.lower() == "status":
+            progress = agent.get_progress()
+            print(progress.to_prompt())
+            continue
+
+        # Parse and execute command
+        try:
+            command_dict = json.loads(line)
+            result, diagnosis = agent.execute_dict(command_dict)
+
+            if result.success:
+                print(f"✓ {result.message}")
+            else:
+                print(f"✗ {result.message}")
+                if diagnosis:
+                    print(f"  Diagnosis: {diagnosis[:200]}...")
+
+        except json.JSONDecodeError as e:
+            print(f"Invalid JSON: {e}")
+        except Exception as e:
+            print(f"Error: {e}")
+
+        print()
+
+    # Final save
+    if not args.dry_run and not agent.is_complete():
+        print("\n--- Session ended ---")
+        save = input("Save current state? (y/n) ").strip().lower()
+        if save == "y":
+            agent.save(str(output_path))
+            print(f"Saved to {output_path}")
+
+    return 0
+
+
+def _auto_route(agent, output_path: Path, args) -> int:
+    """Auto-route priority nets without LLM."""
+    print(f"\n--- Auto-routing up to {args.max_nets} priority nets ---")
+
+    results = agent.route_priority_nets(max_nets=args.max_nets)
+
+    successful = sum(1 for r in results if r.success)
+    print(f"\nRouted {successful}/{len(results)} nets")
+
+    # Show final progress
+    progress = agent.get_progress()
+    print(progress.to_prompt())
+
+    # Save
+    if args.dry_run:
+        print("\n--- Dry run - not saving ---")
+    else:
+        print(f"\n--- Saving to {output_path} ---")
+        agent.save(str(output_path))
+        print(f"Saved to {output_path}")
+
+    return 0 if successful == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `kct reason` CLI command for LLM-assisted PCB layout
- Export key reasoning classes in `kicad_tools/__init__.py`
- Add example script and documentation for LLM integration

This enables LLMs to make strategic PCB layout decisions (semantic understanding like "keep clocks short", "isolate analog section") while kicad-tools handles geometric execution.

## Changes

- **CLI command** (`kct reason`): Export state for external LLM, interactive mode, analyze current state, auto-route priority nets
- **Public API**: `PCBReasoningAgent`, `PCBState`, `CommandInterpreter` now exported from main package
- **Examples**: `examples/llm-routing/route_with_llm.py` demonstrates full integration pattern
- **Documentation**: README updated with usage examples and module description

## Test Plan

- [x] Verify imports work: `from kicad_tools import PCBReasoningAgent`
- [x] Verify CLI help works: `kct reason --help`
- [ ] Manual testing with a sample PCB file (use `--export-state` and `--analyze`)

Closes #40