### PR TITLE
Add type hints for mypy --strict compliance

### DIFF
--- a/src/kicad_tools/query/footprints.py
+++ b/src/kicad_tools/query/footprints.py
@@ -5,7 +5,7 @@ Provides query interface for PCB footprints.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, cast
 
 from .base import BaseQuery
 
@@ -51,7 +51,7 @@ class FootprintQuery(BaseQuery["Footprint"]):
         Example:
             r0402 = query.by_name("Resistor_SMD:R_0402_1005Metric").all()
         """
-        return self.filter(name=name)
+        return cast("FootprintQuery", self.filter(name=name))
 
     def by_value(self, value: str) -> "FootprintQuery":
         """Filter by value.
@@ -65,7 +65,7 @@ class FootprintQuery(BaseQuery["Footprint"]):
         Example:
             caps_100nf = query.by_value("100nF").all()
         """
-        return self.filter(value=value)
+        return cast("FootprintQuery", self.filter(value=value))
 
     def on_layer(self, layer: str) -> "FootprintQuery":
         """Filter by layer.
@@ -79,7 +79,7 @@ class FootprintQuery(BaseQuery["Footprint"]):
         Example:
             top_side = query.on_layer("F.Cu").all()
         """
-        return self.filter(layer=layer)
+        return cast("FootprintQuery", self.filter(layer=layer))
 
     def on_top(self) -> "FootprintQuery":
         """Filter to footprints on top layer (F.Cu).
@@ -103,7 +103,7 @@ class FootprintQuery(BaseQuery["Footprint"]):
         Returns:
             Query filtered to SMD footprints
         """
-        return self.filter(attr="smd")
+        return cast("FootprintQuery", self.filter(attr="smd"))
 
     def through_hole(self) -> "FootprintQuery":
         """Filter to through-hole footprints.
@@ -111,7 +111,7 @@ class FootprintQuery(BaseQuery["Footprint"]):
         Returns:
             Query filtered to through-hole footprints
         """
-        return self.filter(attr="through_hole")
+        return cast("FootprintQuery", self.filter(attr="through_hole"))
 
     def capacitors(self) -> "FootprintQuery":
         """Filter to capacitors (C* references).
@@ -119,7 +119,7 @@ class FootprintQuery(BaseQuery["Footprint"]):
         Returns:
             Query filtered to capacitors
         """
-        return self.filter(reference__startswith="C")
+        return cast("FootprintQuery", self.filter(reference__startswith="C"))
 
     def resistors(self) -> "FootprintQuery":
         """Filter to resistors (R* references).
@@ -127,7 +127,7 @@ class FootprintQuery(BaseQuery["Footprint"]):
         Returns:
             Query filtered to resistors
         """
-        return self.filter(reference__startswith="R")
+        return cast("FootprintQuery", self.filter(reference__startswith="R"))
 
     def ics(self) -> "FootprintQuery":
         """Filter to ICs (U* references).
@@ -135,7 +135,7 @@ class FootprintQuery(BaseQuery["Footprint"]):
         Returns:
             Query filtered to ICs
         """
-        return self.filter(reference__startswith="U")
+        return cast("FootprintQuery", self.filter(reference__startswith="U"))
 
     def connectors(self) -> "FootprintQuery":
         """Filter to connectors (J* references).
@@ -143,7 +143,7 @@ class FootprintQuery(BaseQuery["Footprint"]):
         Returns:
             Query filtered to connectors
         """
-        return self.filter(reference__startswith="J")
+        return cast("FootprintQuery", self.filter(reference__startswith="J"))
 
     def with_prefix(self, prefix: str) -> "FootprintQuery":
         """Filter by reference prefix.
@@ -157,10 +157,10 @@ class FootprintQuery(BaseQuery["Footprint"]):
         Example:
             transistors = query.with_prefix("Q").all()
         """
-        return self.filter(reference__startswith=prefix)
+        return cast("FootprintQuery", self.filter(reference__startswith=prefix))
 
 
-class FootprintList(list):
+class FootprintList(List["Footprint"]):
     """List subclass with query methods for footprints.
 
     Extends list to provide backward compatibility while adding
@@ -234,7 +234,7 @@ class FootprintList(list):
         """
         return self.query().by_value(value).all()
 
-    def filter(self, **kwargs) -> List["Footprint"]:
+    def filter(self, **kwargs: Any) -> List["Footprint"]:
         """Filter footprints (shortcut, returns list).
 
         For chained filtering, use .query().filter(...).filter(...)
@@ -247,7 +247,7 @@ class FootprintList(list):
         """
         return self.query().filter(**kwargs).all()
 
-    def exclude(self, **kwargs) -> List["Footprint"]:
+    def exclude(self, **kwargs: Any) -> List["Footprint"]:
         """Exclude footprints (shortcut, returns list).
 
         Args:

--- a/src/kicad_tools/query/symbols.py
+++ b/src/kicad_tools/query/symbols.py
@@ -5,7 +5,7 @@ Provides query interface for schematic symbol instances.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, cast
 
 from .base import BaseQuery
 
@@ -51,7 +51,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Example:
             resistors = query.by_lib_id("Device:R").all()
         """
-        return self.filter(lib_id=lib_id)
+        return cast("SymbolQuery", self.filter(lib_id=lib_id))
 
     def by_value(self, value: str) -> "SymbolQuery":
         """Filter by value.
@@ -65,7 +65,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Example:
             caps_100nf = query.by_value("100nF").all()
         """
-        return self.filter(value=value)
+        return cast("SymbolQuery", self.filter(value=value))
 
     def by_footprint(self, footprint: str) -> "SymbolQuery":
         """Filter by footprint.
@@ -79,7 +79,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Example:
             smd_0402 = query.by_footprint("Resistor_SMD:R_0402_1005Metric").all()
         """
-        return self.filter(footprint=footprint)
+        return cast("SymbolQuery", self.filter(footprint=footprint))
 
     def capacitors(self) -> "SymbolQuery":
         """Filter to capacitors (C* references).
@@ -87,7 +87,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to capacitors
         """
-        return self.filter(reference__startswith="C")
+        return cast("SymbolQuery", self.filter(reference__startswith="C"))
 
     def resistors(self) -> "SymbolQuery":
         """Filter to resistors (R* references).
@@ -95,7 +95,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to resistors
         """
-        return self.filter(reference__startswith="R")
+        return cast("SymbolQuery", self.filter(reference__startswith="R"))
 
     def inductors(self) -> "SymbolQuery":
         """Filter to inductors (L* references).
@@ -103,7 +103,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to inductors
         """
-        return self.filter(reference__startswith="L")
+        return cast("SymbolQuery", self.filter(reference__startswith="L"))
 
     def ics(self) -> "SymbolQuery":
         """Filter to ICs (U* references).
@@ -111,7 +111,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to ICs
         """
-        return self.filter(reference__startswith="U")
+        return cast("SymbolQuery", self.filter(reference__startswith="U"))
 
     def connectors(self) -> "SymbolQuery":
         """Filter to connectors (J* references).
@@ -119,7 +119,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to connectors
         """
-        return self.filter(reference__startswith="J")
+        return cast("SymbolQuery", self.filter(reference__startswith="J"))
 
     def transistors(self) -> "SymbolQuery":
         """Filter to transistors (Q* references).
@@ -127,7 +127,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to transistors
         """
-        return self.filter(reference__startswith="Q")
+        return cast("SymbolQuery", self.filter(reference__startswith="Q"))
 
     def diodes(self) -> "SymbolQuery":
         """Filter to diodes (D* references).
@@ -135,7 +135,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to diodes
         """
-        return self.filter(reference__startswith="D")
+        return cast("SymbolQuery", self.filter(reference__startswith="D"))
 
     def power_symbols(self) -> "SymbolQuery":
         """Filter to power symbols.
@@ -143,7 +143,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to power symbols (lib_id starts with "power:")
         """
-        return self.filter(lib_id__startswith="power:")
+        return cast("SymbolQuery", self.filter(lib_id__startswith="power:"))
 
     def non_power(self) -> "SymbolQuery":
         """Filter out power symbols.
@@ -151,7 +151,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query excluding power symbols
         """
-        return self.exclude(lib_id__startswith="power:")
+        return cast("SymbolQuery", self.exclude(lib_id__startswith="power:"))
 
     def in_bom(self) -> "SymbolQuery":
         """Filter to components included in BOM.
@@ -159,7 +159,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to in_bom=True and not DNP
         """
-        return self.filter(in_bom=True, dnp=False)
+        return cast("SymbolQuery", self.filter(in_bom=True, dnp=False))
 
     def dnp(self) -> "SymbolQuery":
         """Filter to Do Not Place components.
@@ -167,7 +167,7 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to DNP symbols
         """
-        return self.filter(dnp=True)
+        return cast("SymbolQuery", self.filter(dnp=True))
 
     def on_board(self) -> "SymbolQuery":
         """Filter to components that should be on the PCB.
@@ -175,10 +175,10 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         Returns:
             Query filtered to on_board=True
         """
-        return self.filter(on_board=True)
+        return cast("SymbolQuery", self.filter(on_board=True))
 
 
-class SymbolList(list):
+class SymbolList(List["SymbolInstance"]):
     """List subclass with query methods for symbols.
 
     Extends list to provide backward compatibility while adding
@@ -248,7 +248,7 @@ class SymbolList(list):
         """
         return self.query().by_value(value).all()
 
-    def filter(self, **kwargs) -> List["SymbolInstance"]:
+    def filter(self, **kwargs: Any) -> List["SymbolInstance"]:
         """Filter symbols (shortcut, returns list).
 
         For chained filtering, use .query().filter(...).filter(...)
@@ -261,7 +261,7 @@ class SymbolList(list):
         """
         return self.query().filter(**kwargs).all()
 
-    def exclude(self, **kwargs) -> List["SymbolInstance"]:
+    def exclude(self, **kwargs: Any) -> List["SymbolInstance"]:
         """Exclude symbols (shortcut, returns list).
 
         Args:


### PR DESCRIPTION
## Summary

- Fix type hint issues in `query` module to pass `mypy --strict` validation
- Fix type hints in `project.py` for strict compliance
- All 1676 tests continue to pass
- Modules now fully type-annotated for better IDE support and static analysis

## Changes

### query/base.py
- Add explicit `bool()` casts for comparison operations returning `Any`
- Add proper generic type parameters to `Dict`, `Tuple`, `List` annotations
- Fix lambda type inference in `exclude()` method

### query/footprints.py and query/symbols.py
- Add `cast()` for method chaining to preserve subclass types
- Use generic `List["Footprint"]` instead of bare `list` for class inheritance
- Add `Any` type annotation to `**kwargs` parameters

### project.py
- Convert `Path` to `str` for `extract_bom()` call
- Add `TYPE_CHECKING` import for `AssemblyPackageResult`
- Add proper `Dict[str, Any]` type parameters

## Test Plan

- [x] `uv run mypy --strict src/kicad_tools/query/` - passes
- [x] `uv run mypy --strict src/kicad_tools/project.py` - passes
- [x] `uv run pytest tests/` - all 1676 tests pass
- [x] `uv run ruff check` - no linting issues

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)