### PR TITLE
Add support for .kicad_mod and .kicad_dru file formats

### DIFF
--- a/src/kicad_tools/cli/lib_footprints.py
+++ b/src/kicad_tools/cli/lib_footprints.py
@@ -1,0 +1,282 @@
+"""
+CLI commands for footprint library operations.
+
+Provides commands to list footprints in a .pretty directory
+and show details of individual .kicad_mod files.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from kicad_tools.core.sexp_file import load_footprint
+from kicad_tools.sexp import SExp
+
+
+def list_footprints(directory: Path, output_format: str = "table") -> int:
+    """
+    List all footprints in a .pretty directory.
+
+    Args:
+        directory: Path to .pretty directory
+        output_format: "table" or "json"
+
+    Returns:
+        Exit code (0 for success)
+    """
+    if not directory.is_dir():
+        print(f"Error: Not a directory: {directory}")
+        return 1
+
+    # Find all .kicad_mod files
+    mod_files = sorted(directory.glob("*.kicad_mod"))
+
+    if not mod_files:
+        print(f"No footprint files found in {directory}")
+        return 0
+
+    footprints = []
+    for mod_file in mod_files:
+        try:
+            sexp = load_footprint(mod_file)
+            name = _get_footprint_name(sexp)
+            pad_count = _count_pads(sexp)
+            layer = _get_layer(sexp)
+            footprints.append({
+                "file": mod_file.name,
+                "name": name,
+                "pads": pad_count,
+                "layer": layer,
+            })
+        except Exception as e:
+            footprints.append({
+                "file": mod_file.name,
+                "name": "(error)",
+                "pads": 0,
+                "layer": "",
+                "error": str(e),
+            })
+
+    if output_format == "json":
+        print(json.dumps(footprints, indent=2))
+    else:
+        _print_footprint_table(directory, footprints)
+
+    return 0
+
+
+def show_footprint(file_path: Path, output_format: str = "text", show_pads: bool = False) -> int:
+    """
+    Show details of a single footprint file.
+
+    Args:
+        file_path: Path to .kicad_mod file
+        output_format: "text" or "json"
+        show_pads: Whether to show pad details
+
+    Returns:
+        Exit code (0 for success)
+    """
+    try:
+        sexp = load_footprint(file_path)
+    except Exception as e:
+        print(f"Error loading footprint: {e}")
+        return 1
+
+    info = _extract_footprint_info(sexp, show_pads)
+
+    if output_format == "json":
+        print(json.dumps(info, indent=2))
+    else:
+        _print_footprint_info(file_path, info)
+
+    return 0
+
+
+def _get_footprint_name(sexp: SExp) -> str:
+    """Extract footprint name from S-expression."""
+    # The first value after the tag is the footprint name
+    if sexp.values and isinstance(sexp.values[0], str):
+        return sexp.values[0]
+    return "(unknown)"
+
+
+def _count_pads(sexp: SExp) -> int:
+    """Count pads in a footprint."""
+    return len(sexp.find_children("pad"))
+
+
+def _get_layer(sexp: SExp) -> str:
+    """Get the primary layer of the footprint."""
+    layer = sexp.find_child("layer")
+    if layer and layer.values:
+        return str(layer.values[0])
+    return "F.Cu"
+
+
+def _extract_footprint_info(sexp: SExp, include_pads: bool = False) -> Dict[str, Any]:
+    """Extract detailed footprint information."""
+    info: Dict[str, Any] = {
+        "name": _get_footprint_name(sexp),
+        "format": "KiCad 6+" if sexp.tag == "footprint" else "KiCad 5",
+        "layer": _get_layer(sexp),
+    }
+
+    # Get version if present
+    version = sexp.find_child("version")
+    if version and version.values:
+        info["version"] = int(version.values[0]) if isinstance(version.values[0], (int, float)) else str(version.values[0])
+
+    # Get description
+    descr = sexp.find_child("descr")
+    if descr and descr.values:
+        info["description"] = str(descr.values[0])
+
+    # Get tags
+    tags = sexp.find_child("tags")
+    if tags and tags.values:
+        info["tags"] = str(tags.values[0])
+
+    # Count elements
+    pads = sexp.find_children("pad")
+    info["pad_count"] = len(pads)
+
+    fp_lines = sexp.find_children("fp_line")
+    info["line_count"] = len(fp_lines)
+
+    fp_arcs = sexp.find_children("fp_arc")
+    info["arc_count"] = len(fp_arcs)
+
+    fp_circles = sexp.find_children("fp_circle")
+    info["circle_count"] = len(fp_circles)
+
+    fp_text_elements = sexp.find_children("fp_text")
+    info["text_count"] = len(fp_text_elements)
+
+    # 3D model info
+    models = sexp.find_children("model")
+    if models:
+        info["3d_models"] = [_extract_model_info(m) for m in models]
+
+    # Extract pad details if requested
+    if include_pads:
+        info["pads"] = [_extract_pad_info(pad) for pad in pads]
+
+    return info
+
+
+def _extract_pad_info(pad: SExp) -> Dict[str, Any]:
+    """Extract information about a single pad."""
+    pad_info: Dict[str, Any] = {}
+
+    # Pad number/name is first value
+    if pad.values and isinstance(pad.values[0], str):
+        pad_info["name"] = pad.values[0]
+
+    # Pad type is second value (smd, thru_hole, np_thru_hole, connect)
+    if len(pad.values) > 1 and isinstance(pad.values[1], str):
+        pad_info["type"] = pad.values[1]
+
+    # Pad shape is third value
+    if len(pad.values) > 2 and isinstance(pad.values[2], str):
+        pad_info["shape"] = pad.values[2]
+
+    # Position
+    at = pad.find_child("at")
+    if at and at.values:
+        pad_info["x"] = float(at.values[0]) if at.values else 0.0
+        pad_info["y"] = float(at.values[1]) if len(at.values) > 1 else 0.0
+        if len(at.values) > 2:
+            pad_info["rotation"] = float(at.values[2])
+
+    # Size
+    size = pad.find_child("size")
+    if size and size.values:
+        pad_info["width"] = float(size.values[0]) if size.values else 0.0
+        pad_info["height"] = float(size.values[1]) if len(size.values) > 1 else pad_info.get("width", 0.0)
+
+    # Drill
+    drill = pad.find_child("drill")
+    if drill and drill.values:
+        pad_info["drill"] = float(drill.values[0]) if drill.values else None
+
+    # Layers
+    layers = pad.find_child("layers")
+    if layers and layers.values:
+        pad_info["layers"] = [str(v) for v in layers.values]
+
+    return pad_info
+
+
+def _extract_model_info(model: SExp) -> Dict[str, Any]:
+    """Extract 3D model information."""
+    model_info: Dict[str, Any] = {}
+
+    # Model path is first value
+    if model.values and isinstance(model.values[0], str):
+        model_info["path"] = model.values[0]
+
+    return model_info
+
+
+def _print_footprint_table(directory: Path, footprints: List[Dict[str, Any]]) -> None:
+    """Print footprints in table format."""
+    print(f"\nFootprints in {directory.name}:")
+    print("=" * 70)
+    print(f"{'Name':<40} {'Pads':>6} {'Layer':<12}")
+    print("-" * 70)
+
+    for fp in footprints:
+        if "error" in fp:
+            print(f"{fp['file']:<40} {'ERROR':>6} {fp.get('error', ''):<12}")
+        else:
+            print(f"{fp['name']:<40} {fp['pads']:>6} {fp['layer']:<12}")
+
+    print("-" * 70)
+    print(f"Total: {len(footprints)} footprints")
+
+
+def _print_footprint_info(file_path: Path, info: Dict[str, Any]) -> None:
+    """Print footprint information in text format."""
+    print(f"\nFootprint: {info['name']}")
+    print("=" * 60)
+
+    print(f"\nFile: {file_path}")
+    print(f"Format: {info['format']}")
+    print(f"Layer: {info['layer']}")
+
+    if "version" in info:
+        print(f"Version: {info['version']}")
+
+    if "description" in info:
+        print(f"\nDescription: {info['description']}")
+
+    if "tags" in info:
+        print(f"Tags: {info['tags']}")
+
+    print("\nElements:")
+    print(f"  Pads: {info['pad_count']}")
+    print(f"  Lines: {info['line_count']}")
+    print(f"  Arcs: {info['arc_count']}")
+    print(f"  Circles: {info['circle_count']}")
+    print(f"  Text: {info['text_count']}")
+
+    if "3d_models" in info:
+        print("\n3D Models:")
+        for model in info["3d_models"]:
+            print(f"  - {model.get('path', '(unknown)')}")
+
+    if "pads" in info:
+        print("\nPad Details:")
+        print("-" * 60)
+        for pad in info["pads"]:
+            name = pad.get("name", "?")
+            pad_type = pad.get("type", "?")
+            shape = pad.get("shape", "?")
+            x = pad.get("x", 0)
+            y = pad.get("y", 0)
+            w = pad.get("width", 0)
+            h = pad.get("height", 0)
+            print(f"  {name:>4}: {pad_type:<10} {shape:<10} at ({x:>7.3f}, {y:>7.3f}) size {w:.3f}x{h:.3f}")
+
+    print("")

--- a/src/kicad_tools/cli/mfr_dru.py
+++ b/src/kicad_tools/cli/mfr_dru.py
@@ -1,0 +1,184 @@
+"""
+CLI commands for KiCad design rules file (.kicad_dru) operations.
+
+Provides the import-dru command to parse and display design rules files.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from kicad_tools.core.sexp_file import load_design_rules
+from kicad_tools.sexp import SExp
+
+
+def import_dru(file_path: Path, output_format: str = "text") -> int:
+    """
+    Parse and display a KiCad design rules file.
+
+    Args:
+        file_path: Path to .kicad_dru file
+        output_format: "text" or "json"
+
+    Returns:
+        Exit code (0 for success)
+    """
+    try:
+        sexp = load_design_rules(file_path)
+    except Exception as e:
+        print(f"Error loading design rules: {e}")
+        return 1
+
+    rules = _extract_design_rules(sexp)
+
+    if output_format == "json":
+        print(json.dumps(rules, indent=2))
+    else:
+        _print_design_rules(file_path, rules)
+
+    return 0
+
+
+def _extract_design_rules(sexp: SExp) -> Dict[str, Any]:
+    """Extract design rules from S-expression tree."""
+    rules: Dict[str, Any] = {
+        "version": None,
+        "rules": [],
+    }
+
+    for child in sexp.values:
+        if not isinstance(child, SExp):
+            continue
+
+        if child.tag == "version":
+            if child.values:
+                rules["version"] = int(child.values[0]) if isinstance(child.values[0], (int, float)) else str(child.values[0])
+
+        elif child.tag == "rule":
+            rule = _extract_rule(child)
+            if rule:
+                rules["rules"].append(rule)
+
+    return rules
+
+
+def _extract_rule(rule_sexp: SExp) -> Dict[str, Any]:
+    """Extract a single rule definition."""
+    rule: Dict[str, Any] = {}
+
+    # Rule name is first value
+    if rule_sexp.values and isinstance(rule_sexp.values[0], str):
+        rule["name"] = rule_sexp.values[0]
+
+    # Find constraint
+    constraint = rule_sexp.find_child("constraint")
+    if constraint:
+        rule["constraint"] = _extract_constraint(constraint)
+
+    # Find condition (optional)
+    condition = rule_sexp.find_child("condition")
+    if condition and condition.values:
+        rule["condition"] = str(condition.values[0])
+
+    # Find layer (optional)
+    layer = rule_sexp.find_child("layer")
+    if layer and layer.values:
+        rule["layer"] = str(layer.values[0])
+
+    return rule
+
+
+def _extract_constraint(constraint_sexp: SExp) -> Dict[str, Any]:
+    """Extract constraint details."""
+    constraint: Dict[str, Any] = {}
+
+    # Constraint type is first value
+    if constraint_sexp.values and isinstance(constraint_sexp.values[0], str):
+        constraint["type"] = constraint_sexp.values[0]
+
+    # Find min/max/opt values
+    for child in constraint_sexp.values:
+        if isinstance(child, SExp):
+            if child.tag == "min" and child.values:
+                constraint["min"] = _parse_value_with_unit(child.values[0])
+            elif child.tag == "max" and child.values:
+                constraint["max"] = _parse_value_with_unit(child.values[0])
+            elif child.tag == "opt" and child.values:
+                constraint["opt"] = _parse_value_with_unit(child.values[0])
+
+    return constraint
+
+
+def _parse_value_with_unit(value: Any) -> Dict[str, Any]:
+    """Parse a value that may have a unit suffix."""
+    if isinstance(value, (int, float)):
+        return {"value": float(value), "unit": None}
+
+    value_str = str(value)
+
+    # Check for common units
+    if value_str.endswith("mm"):
+        try:
+            return {"value": float(value_str[:-2]), "unit": "mm"}
+        except ValueError:
+            pass
+    elif value_str.endswith("mil"):
+        try:
+            return {"value": float(value_str[:-3]), "unit": "mil"}
+        except ValueError:
+            pass
+    elif value_str.endswith("in"):
+        try:
+            return {"value": float(value_str[:-2]), "unit": "in"}
+        except ValueError:
+            pass
+
+    # Try to parse as plain number
+    try:
+        return {"value": float(value_str), "unit": None}
+    except ValueError:
+        return {"value": value_str, "unit": None}
+
+
+def _print_design_rules(file_path: Path, rules: Dict[str, Any]) -> None:
+    """Print design rules in text format."""
+    print(f"\nDesign Rules: {file_path.name}")
+    print("=" * 60)
+
+    if rules["version"]:
+        print(f"Version: {rules['version']}")
+
+    print(f"\nRules ({len(rules['rules'])} total):")
+    print("-" * 60)
+
+    for rule in rules["rules"]:
+        name = rule.get("name", "(unnamed)")
+        print(f"\n  {name}:")
+
+        if "constraint" in rule:
+            c = rule["constraint"]
+            constraint_type = c.get("type", "unknown")
+            print(f"    Type: {constraint_type}")
+
+            if "min" in c:
+                min_val = c["min"]
+                unit = min_val.get("unit", "")
+                print(f"    Min: {min_val['value']}{unit}")
+
+            if "max" in c:
+                max_val = c["max"]
+                unit = max_val.get("unit", "")
+                print(f"    Max: {max_val['value']}{unit}")
+
+            if "opt" in c:
+                opt_val = c["opt"]
+                unit = opt_val.get("unit", "")
+                print(f"    Opt: {opt_val['value']}{unit}")
+
+        if "condition" in rule:
+            print(f"    Condition: {rule['condition']}")
+
+        if "layer" in rule:
+            print(f"    Layer: {rule['layer']}")
+
+    print("\n" + "=" * 60)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,3 +323,93 @@ def zone_test_pcb(tmp_path: Path) -> Path:
     pcb_file = tmp_path / "zone_test.kicad_pcb"
     pcb_file.write_text(ZONE_TEST_PCB)
     return pcb_file
+
+
+# Minimal KiCad footprint (KiCad 6+ format)
+MINIMAL_FOOTPRINT = """(footprint "R_0402_1005Metric"
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (layer "F.Cu")
+  (descr "Resistor SMD 0402 (1005 Metric)")
+  (tags "resistor 0402")
+  (property "Reference" "REF**" (at 0 -1.1 0) (layer "F.SilkS") (uuid "ref-uuid"))
+  (property "Value" "R_0402_1005Metric" (at 0 1.1 0) (layer "F.Fab") (uuid "val-uuid"))
+  (fp_line (start -0.153641 -0.38) (end 0.153641 -0.38) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+  (fp_line (start -0.153641 0.38) (end 0.153641 0.38) (stroke (width 0.12) (type solid)) (layer "F.SilkS"))
+  (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25))
+  (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25))
+  (model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+    (offset (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0))
+  )
+)
+"""
+
+# Minimal KiCad footprint (KiCad 5 format with "module" tag)
+MINIMAL_FOOTPRINT_KICAD5 = """(module "R_0402_1005Metric"
+  (layer "F.Cu")
+  (descr "Resistor SMD 0402 (1005 Metric)")
+  (tags "resistor 0402")
+  (fp_text reference "REF**" (at 0 -1.1) (layer "F.SilkS"))
+  (fp_text value "R_0402_1005Metric" (at 0 1.1) (layer "F.Fab"))
+  (pad 1 smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25))
+  (pad 2 smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25))
+)
+"""
+
+# Minimal KiCad design rules file
+MINIMAL_DESIGN_RULES = """(version 1)
+(rule "Trace Width"
+  (constraint track_width (min 0.127mm)))
+(rule "Clearance"
+  (constraint clearance (min 0.127mm)))
+(rule "Via Drill"
+  (constraint hole_size (min 0.3mm)))
+(rule "Via Diameter"
+  (constraint via_diameter (min 0.6mm)))
+(rule "Annular Ring"
+  (constraint annular_width (min 0.15mm)))
+(rule "Copper to Edge"
+  (constraint edge_clearance (min 0.3mm)))
+"""
+
+
+@pytest.fixture
+def minimal_footprint(tmp_path: Path) -> Path:
+    """Create a minimal footprint file for testing (KiCad 6+ format)."""
+    mod_file = tmp_path / "R_0402_1005Metric.kicad_mod"
+    mod_file.write_text(MINIMAL_FOOTPRINT)
+    return mod_file
+
+
+@pytest.fixture
+def minimal_footprint_kicad5(tmp_path: Path) -> Path:
+    """Create a minimal footprint file for testing (KiCad 5 format)."""
+    mod_file = tmp_path / "R_0402_1005Metric_v5.kicad_mod"
+    mod_file.write_text(MINIMAL_FOOTPRINT_KICAD5)
+    return mod_file
+
+
+@pytest.fixture
+def footprint_library_dir(tmp_path: Path) -> Path:
+    """Create a .pretty directory with multiple footprints for testing."""
+    pretty_dir = tmp_path / "TestLib.pretty"
+    pretty_dir.mkdir()
+
+    # Add a couple of footprints
+    (pretty_dir / "R_0402_1005Metric.kicad_mod").write_text(MINIMAL_FOOTPRINT)
+    (pretty_dir / "C_0402_1005Metric.kicad_mod").write_text(
+        MINIMAL_FOOTPRINT.replace("R_0402", "C_0402").replace("Resistor", "Capacitor")
+    )
+
+    return pretty_dir
+
+
+@pytest.fixture
+def minimal_design_rules(tmp_path: Path) -> Path:
+    """Create a minimal design rules file for testing."""
+    dru_file = tmp_path / "test.kicad_dru"
+    dru_file.write_text(MINIMAL_DESIGN_RULES)
+    return dru_file

--- a/tests/test_file_formats.py
+++ b/tests/test_file_formats.py
@@ -1,0 +1,267 @@
+"""Tests for additional KiCad file format support.
+
+Tests for:
+- .kicad_mod (footprint) loading and saving
+- .kicad_dru (design rules) loading and saving
+- CLI commands for footprint and design rules files
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.core.sexp_file import (
+    load_design_rules,
+    load_footprint,
+    save_design_rules,
+    save_footprint,
+)
+from kicad_tools.exceptions import FileFormatError
+from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
+
+
+class TestLoadFootprint:
+    """Tests for load_footprint function."""
+
+    def test_load_kicad6_footprint(self, minimal_footprint: Path):
+        """Test loading a KiCad 6+ format footprint."""
+        sexp = load_footprint(minimal_footprint)
+
+        assert sexp.tag == "footprint"
+        assert sexp.values[0] == "R_0402_1005Metric"
+
+        # Check for pads
+        pads = sexp.find_children("pad")
+        assert len(pads) == 2
+
+    def test_load_kicad5_footprint(self, minimal_footprint_kicad5: Path):
+        """Test loading a KiCad 5 format footprint (module tag)."""
+        sexp = load_footprint(minimal_footprint_kicad5)
+
+        assert sexp.tag == "module"
+        assert sexp.values[0] == "R_0402_1005Metric"
+
+    def test_load_footprint_not_found(self, tmp_path: Path):
+        """Test that loading a non-existent file raises appropriate error."""
+        with pytest.raises(KiCadFileNotFoundError):
+            load_footprint(tmp_path / "nonexistent.kicad_mod")
+
+    def test_load_footprint_wrong_format(self, tmp_path: Path):
+        """Test that loading a non-footprint file raises appropriate error."""
+        wrong_file = tmp_path / "wrong.kicad_mod"
+        wrong_file.write_text("(kicad_sch (version 1))")
+
+        with pytest.raises(FileFormatError) as exc_info:
+            load_footprint(wrong_file)
+
+        assert "Not a KiCad footprint" in str(exc_info.value)
+
+
+class TestSaveFootprint:
+    """Tests for save_footprint function."""
+
+    def test_save_footprint_roundtrip(self, minimal_footprint: Path, tmp_path: Path):
+        """Test that saving and reloading a footprint preserves content."""
+        # Load
+        sexp = load_footprint(minimal_footprint)
+
+        # Save to new location
+        output_path = tmp_path / "output.kicad_mod"
+        save_footprint(sexp, output_path)
+
+        # Reload and verify
+        reloaded = load_footprint(output_path)
+        assert reloaded.tag == sexp.tag
+        assert reloaded.values[0] == sexp.values[0]
+
+        # Compare pad count
+        assert len(reloaded.find_children("pad")) == len(sexp.find_children("pad"))
+
+    def test_save_footprint_wrong_type(self, tmp_path: Path):
+        """Test that saving non-footprint S-expression raises error."""
+        from kicad_tools.sexp import SExp
+
+        wrong_sexp = SExp.list("kicad_sch")
+
+        with pytest.raises(FileFormatError):
+            save_footprint(wrong_sexp, tmp_path / "wrong.kicad_mod")
+
+
+class TestLoadDesignRules:
+    """Tests for load_design_rules function."""
+
+    def test_load_design_rules(self, minimal_design_rules: Path):
+        """Test loading a design rules file."""
+        sexp = load_design_rules(minimal_design_rules)
+
+        assert sexp.tag == "design_rules"
+
+        # Check for version
+        version = sexp.find_child("version")
+        assert version is not None
+        assert version.values[0] == 1
+
+        # Check for rules
+        rules = sexp.find_children("rule")
+        assert len(rules) == 6
+
+    def test_load_design_rules_not_found(self, tmp_path: Path):
+        """Test that loading a non-existent file raises appropriate error."""
+        with pytest.raises(KiCadFileNotFoundError):
+            load_design_rules(tmp_path / "nonexistent.kicad_dru")
+
+    def test_load_design_rules_empty(self, tmp_path: Path):
+        """Test that loading an empty file raises appropriate error."""
+        empty_file = tmp_path / "empty.kicad_dru"
+        empty_file.write_text("")
+
+        with pytest.raises(FileFormatError) as exc_info:
+            load_design_rules(empty_file)
+
+        assert "Empty design rules" in str(exc_info.value)
+
+    def test_load_design_rules_no_version(self, tmp_path: Path):
+        """Test that loading a file without version raises appropriate error."""
+        no_version = tmp_path / "no_version.kicad_dru"
+        no_version.write_text('(rule "Test" (constraint clearance))')
+
+        with pytest.raises(FileFormatError) as exc_info:
+            load_design_rules(no_version)
+
+        assert "Invalid design rules" in str(exc_info.value)
+
+
+class TestSaveDesignRules:
+    """Tests for save_design_rules function."""
+
+    def test_save_design_rules_roundtrip(self, minimal_design_rules: Path, tmp_path: Path):
+        """Test that saving and reloading design rules preserves content."""
+        # Load
+        sexp = load_design_rules(minimal_design_rules)
+
+        # Save to new location
+        output_path = tmp_path / "output.kicad_dru"
+        save_design_rules(sexp, output_path)
+
+        # Reload and verify
+        reloaded = load_design_rules(output_path)
+        assert len(reloaded.find_children("rule")) == len(sexp.find_children("rule"))
+
+    def test_save_design_rules_wrong_type(self, tmp_path: Path):
+        """Test that saving non-design-rules S-expression raises error."""
+        from kicad_tools.sexp import SExp
+
+        wrong_sexp = SExp.list("footprint", "test")
+
+        with pytest.raises(FileFormatError):
+            save_design_rules(wrong_sexp, tmp_path / "wrong.kicad_dru")
+
+
+class TestLibFootprintsCLI:
+    """Tests for lib footprints CLI commands."""
+
+    def test_list_footprints(self, footprint_library_dir: Path, capsys):
+        """Test listing footprints in a directory."""
+        from kicad_tools.cli.lib_footprints import list_footprints
+
+        result = list_footprints(footprint_library_dir, "table")
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "R_0402_1005Metric" in captured.out
+        assert "C_0402_1005Metric" in captured.out
+        assert "2 footprints" in captured.out
+
+    def test_list_footprints_json(self, footprint_library_dir: Path, capsys):
+        """Test listing footprints in JSON format."""
+        from kicad_tools.cli.lib_footprints import list_footprints
+
+        result = list_footprints(footprint_library_dir, "json")
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data) == 2
+        assert any(fp["name"] == "R_0402_1005Metric" for fp in data)
+
+    def test_show_footprint(self, minimal_footprint: Path, capsys):
+        """Test showing footprint details."""
+        from kicad_tools.cli.lib_footprints import show_footprint
+
+        result = show_footprint(minimal_footprint, "text", show_pads=False)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "R_0402_1005Metric" in captured.out
+        assert "Pads: 2" in captured.out
+
+    def test_show_footprint_with_pads(self, minimal_footprint: Path, capsys):
+        """Test showing footprint details with pad information."""
+        from kicad_tools.cli.lib_footprints import show_footprint
+
+        result = show_footprint(minimal_footprint, "text", show_pads=True)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Pad Details" in captured.out
+        assert "smd" in captured.out
+
+    def test_show_footprint_json(self, minimal_footprint: Path, capsys):
+        """Test showing footprint details in JSON format."""
+        from kicad_tools.cli.lib_footprints import show_footprint
+
+        result = show_footprint(minimal_footprint, "json", show_pads=True)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["name"] == "R_0402_1005Metric"
+        assert data["pad_count"] == 2
+        assert "pads" in data
+
+
+class TestMfrDruCLI:
+    """Tests for mfr import-dru CLI command."""
+
+    def test_import_dru(self, minimal_design_rules: Path, capsys):
+        """Test importing a design rules file."""
+        from kicad_tools.cli.mfr_dru import import_dru
+
+        result = import_dru(minimal_design_rules, "text")
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Version: 1" in captured.out
+        assert "Trace Width" in captured.out
+        assert "Clearance" in captured.out
+        assert "6 total" in captured.out
+
+    def test_import_dru_json(self, minimal_design_rules: Path, capsys):
+        """Test importing a design rules file in JSON format."""
+        from kicad_tools.cli.mfr_dru import import_dru
+
+        result = import_dru(minimal_design_rules, "json")
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["version"] == 1
+        assert len(data["rules"]) == 6
+        assert any(r["name"] == "Trace Width" for r in data["rules"])
+
+    def test_import_dru_constraint_values(self, minimal_design_rules: Path, capsys):
+        """Test that constraint values are properly parsed."""
+        from kicad_tools.cli.mfr_dru import import_dru
+
+        result = import_dru(minimal_design_rules, "json")
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        # Find the trace width rule
+        trace_rule = next(r for r in data["rules"] if r["name"] == "Trace Width")
+        assert trace_rule["constraint"]["type"] == "track_width"
+        assert trace_rule["constraint"]["min"]["value"] == 0.127
+        assert trace_rule["constraint"]["min"]["unit"] == "mm"


### PR DESCRIPTION
## Summary

- Add `load_footprint()` and `save_footprint()` functions to `core/sexp_file.py` for .kicad_mod files
- Add `load_design_rules()` and `save_design_rules()` functions for .kicad_dru files
- Add new CLI commands: `kct lib footprints`, `kct lib footprint`, `kct mfr import-dru`, `kct mfr export-dru`
- Support both KiCad 5 ("module") and KiCad 6+ ("footprint") formats for footprints

## Test plan

- [x] All 20 new tests pass in `test_file_formats.py`
- [x] Tests cover load/save roundtrips for both formats
- [x] Tests cover CLI commands in text and JSON output formats
- [x] Tests cover error cases (file not found, wrong format)
- [x] Ruff lint passes

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)