### PR TITLE
Add interactive REPL mode for multi-step CLI workflows

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -20,6 +20,7 @@ Provides CLI commands for common KiCad operations via the `kicad-tools` or `kct`
     kicad-tools validate-footprints    - Validate footprint pad spacing
     kicad-tools fix-footprints <pcb>   - Fix footprint pad spacing issues
     kicad-tools config                 - View/manage configuration
+    kicad-tools interactive            - Launch interactive REPL mode
 
 Examples:
     kct symbols design.kicad_sch --filter "U*"
@@ -37,6 +38,8 @@ Examples:
     kct reason board.kicad_pcb --analyze
     kct validate-footprints board.kicad_pcb --min-pad-gap 0.15
     kct fix-footprints board.kicad_pcb --min-pad-gap 0.2 --dry-run
+    kct interactive
+    kct interactive --project myboard.kicad_pro
 """
 
 import argparse
@@ -549,6 +552,15 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="Value to set",
     )
 
+    # INTERACTIVE subcommand - REPL mode
+    interactive_parser = subparsers.add_parser(
+        "interactive", help="Launch interactive REPL mode"
+    )
+    interactive_parser.add_argument(
+        "--project",
+        help="Auto-load a project on startup",
+    )
+
     args = parser.parse_args(argv)
 
     if not args.command:
@@ -683,6 +695,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "config":
         return _run_config_command(args)
+
+    elif args.command == "interactive":
+        return _run_interactive_command(args)
 
     return 0
 
@@ -1142,6 +1157,16 @@ def _run_config_command(args) -> int:
     if args.config_value:
         sub_argv.append(args.config_value)
     return config_main(sub_argv) or 0
+
+
+def _run_interactive_command(args) -> int:
+    """Handle interactive command."""
+    from .interactive import main as interactive_main
+
+    sub_argv = []
+    if args.project:
+        sub_argv.extend(["--project", args.project])
+    return interactive_main(sub_argv)
 
 
 def symbols_main() -> int:

--- a/src/kicad_tools/cli/interactive.py
+++ b/src/kicad_tools/cli/interactive.py
@@ -1,0 +1,419 @@
+"""
+Interactive REPL mode for kicad-tools.
+
+Provides a command-line shell for multi-step workflows with session state,
+file path completion, and command history.
+"""
+
+import cmd
+import os
+import readline
+import shlex
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass
+class InteractiveSession:
+    """Holds state for an interactive session."""
+
+    schematic: Optional[Path] = None
+    pcb: Optional[Path] = None
+    project: Optional[Path] = None
+    output_dir: Path = field(default_factory=lambda: Path("./output"))
+
+    def status_summary(self) -> str:
+        """Return a brief status summary."""
+        parts = []
+        if self.schematic:
+            parts.append(f"sch: {self.schematic.name}")
+        if self.pcb:
+            parts.append(f"pcb: {self.pcb.name}")
+        if self.project:
+            parts.append(f"project: {self.project.name}")
+        return ", ".join(parts) if parts else "no files loaded"
+
+
+class InteractiveShell(cmd.Cmd):
+    """Interactive REPL shell for kicad-tools."""
+
+    intro = """
+kicad-tools interactive mode
+Type 'help' for available commands, 'quit' to exit.
+"""
+    prompt = "kicad-tools> "
+
+    def __init__(self, project: Optional[str] = None):
+        super().__init__()
+        self.session = InteractiveSession()
+
+        # Set up readline history
+        self.histfile = Path.home() / ".kicad_tools_history"
+        try:
+            readline.read_history_file(self.histfile)
+        except (FileNotFoundError, PermissionError, OSError):
+            pass
+
+        # Configure readline for file path completion
+        readline.set_completer_delims(" \t\n;")
+
+        # Auto-load project if specified
+        if project:
+            self._load_file(project)
+
+    def _save_history(self) -> None:
+        """Save command history."""
+        try:
+            readline.write_history_file(self.histfile)
+        except OSError:
+            pass
+
+    def _load_file(self, filepath: str) -> bool:
+        """Load a file based on its extension."""
+        path = Path(filepath).expanduser().resolve()
+
+        if not path.exists():
+            print(f"Error: File not found: {path}")
+            return False
+
+        suffix = path.suffix.lower()
+
+        if suffix == ".kicad_sch":
+            self.session.schematic = path
+            print(f"Loaded schematic: {path.name}")
+            return True
+        elif suffix == ".kicad_pcb":
+            self.session.pcb = path
+            print(f"Loaded PCB: {path.name}")
+            return True
+        elif suffix == ".kicad_pro":
+            self.session.project = path
+            # Auto-detect schematic and PCB from project directory
+            proj_dir = path.parent
+            stem = path.stem
+            sch_path = proj_dir / f"{stem}.kicad_sch"
+            pcb_path = proj_dir / f"{stem}.kicad_pcb"
+            if sch_path.exists():
+                self.session.schematic = sch_path
+            if pcb_path.exists():
+                self.session.pcb = pcb_path
+            print(f"Loaded project: {path.name}")
+            if self.session.schematic:
+                print(f"  Schematic: {self.session.schematic.name}")
+            if self.session.pcb:
+                print(f"  PCB: {self.session.pcb.name}")
+            return True
+        else:
+            print(f"Error: Unknown file type: {suffix}")
+            print("Supported: .kicad_sch, .kicad_pcb, .kicad_pro")
+            return False
+
+    def _complete_path(self, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+        """Complete file paths."""
+        if not text:
+            text = "./"
+
+        # Expand user home directory
+        if text.startswith("~"):
+            text = os.path.expanduser(text)
+
+        # Get directory and prefix
+        if os.path.isdir(text):
+            directory = text
+            prefix = ""
+        else:
+            directory = os.path.dirname(text) or "."
+            prefix = os.path.basename(text)
+
+        try:
+            entries = os.listdir(directory)
+        except OSError:
+            return []
+
+        completions = []
+        for entry in entries:
+            if entry.startswith(prefix):
+                full_path = os.path.join(directory, entry)
+                if os.path.isdir(full_path):
+                    completions.append(entry + "/")
+                else:
+                    completions.append(entry)
+
+        return completions
+
+    # -------------------------------------------------------------------------
+    # Commands
+    # -------------------------------------------------------------------------
+
+    def do_load(self, arg: str) -> None:
+        """Load a KiCad file (schematic, PCB, or project).
+
+        Usage: load <file>
+
+        Examples:
+            load design.kicad_sch
+            load board.kicad_pcb
+            load project.kicad_pro
+        """
+        if not arg:
+            print("Usage: load <file>")
+            return
+        self._load_file(arg.strip())
+
+    def complete_load(self, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+        """Tab completion for load command."""
+        return self._complete_path(text, line, begidx, endidx)
+
+    def do_status(self, arg: str) -> None:
+        """Show current session status.
+
+        Usage: status
+        """
+        print("Session Status:")
+        print(f"  Schematic: {self.session.schematic or 'not loaded'}")
+        print(f"  PCB: {self.session.pcb or 'not loaded'}")
+        print(f"  Project: {self.session.project or 'not loaded'}")
+        print(f"  Output dir: {self.session.output_dir}")
+
+    def do_symbols(self, arg: str) -> None:
+        """List symbols from the loaded schematic.
+
+        Usage: symbols [--filter <pattern>] [--format table|json|csv]
+
+        Requires a schematic to be loaded first.
+        """
+        if not self.session.schematic:
+            print("Error: No schematic loaded. Use 'load <file>' first.")
+            return
+
+        from kicad_tools.cli.symbols import main as symbols_cmd
+
+        argv = [str(self.session.schematic)]
+        if arg:
+            argv.extend(shlex.split(arg))
+
+        try:
+            symbols_cmd(argv)
+        except SystemExit:
+            pass
+
+    def do_bom(self, arg: str) -> None:
+        """Generate bill of materials from loaded schematic.
+
+        Usage: bom [--format table|csv|json] [--group]
+
+        Requires a schematic to be loaded first.
+        """
+        if not self.session.schematic:
+            print("Error: No schematic loaded. Use 'load <file>' first.")
+            return
+
+        from kicad_tools.cli.bom_cmd import main as bom_cmd
+
+        argv = [str(self.session.schematic)]
+        if arg:
+            argv.extend(shlex.split(arg))
+
+        try:
+            bom_cmd(argv)
+        except SystemExit:
+            pass
+
+    def do_nets(self, arg: str) -> None:
+        """Trace and analyze nets in loaded schematic.
+
+        Usage: nets [--net <name>] [--stats] [--format table|json]
+
+        Requires a schematic to be loaded first.
+        """
+        if not self.session.schematic:
+            print("Error: No schematic loaded. Use 'load <file>' first.")
+            return
+
+        from kicad_tools.cli.nets import main as nets_cmd
+
+        argv = [str(self.session.schematic)]
+        if arg:
+            argv.extend(shlex.split(arg))
+
+        try:
+            nets_cmd(argv)
+        except SystemExit:
+            pass
+
+    def do_summary(self, arg: str) -> None:
+        """Show summary of loaded schematic or PCB.
+
+        Usage: summary [sch|pcb]
+
+        With no argument, shows schematic summary if loaded.
+        """
+        target = arg.strip().lower() if arg else "sch"
+
+        if target in ("sch", "schematic"):
+            if not self.session.schematic:
+                print("Error: No schematic loaded. Use 'load <file>' first.")
+                return
+            from kicad_tools.cli.sch_summary import run_summary
+
+            try:
+                run_summary(self.session.schematic, "text", False)
+            except SystemExit:
+                pass
+
+        elif target in ("pcb", "board"):
+            if not self.session.pcb:
+                print("Error: No PCB loaded. Use 'load <file>' first.")
+                return
+            from kicad_tools.cli.pcb_query import main as pcb_main
+
+            try:
+                pcb_main([str(self.session.pcb), "summary"])
+            except SystemExit:
+                pass
+
+        else:
+            print(f"Unknown target: {target}")
+            print("Usage: summary [sch|pcb]")
+
+    def do_erc(self, arg: str) -> None:
+        """Parse an ERC report file.
+
+        Usage: erc <report> [--format table|json|summary] [--errors-only]
+        """
+        if not arg:
+            print("Usage: erc <report>")
+            return
+
+        from kicad_tools.cli.erc_cmd import main as erc_cmd
+
+        try:
+            erc_cmd(shlex.split(arg))
+        except SystemExit:
+            pass
+
+    def complete_erc(self, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+        """Tab completion for erc command."""
+        return self._complete_path(text, line, begidx, endidx)
+
+    def do_drc(self, arg: str) -> None:
+        """Parse a DRC report file.
+
+        Usage: drc <report> [--format table|json|summary] [--errors-only]
+        """
+        if not arg:
+            print("Usage: drc <report>")
+            return
+
+        from kicad_tools.cli.drc_cmd import main as drc_cmd
+
+        try:
+            drc_cmd(shlex.split(arg))
+        except SystemExit:
+            pass
+
+    def complete_drc(self, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+        """Tab completion for drc command."""
+        return self._complete_path(text, line, begidx, endidx)
+
+    def do_output(self, arg: str) -> None:
+        """Set or show the output directory.
+
+        Usage: output [<directory>]
+
+        With no argument, shows current output directory.
+        """
+        if arg:
+            path = Path(arg.strip()).expanduser().resolve()
+            self.session.output_dir = path
+            print(f"Output directory set to: {path}")
+        else:
+            print(f"Output directory: {self.session.output_dir}")
+
+    def complete_output(self, text: str, line: str, begidx: int, endidx: int) -> List[str]:
+        """Tab completion for output command."""
+        return self._complete_path(text, line, begidx, endidx)
+
+    def do_clear(self, arg: str) -> None:
+        """Clear the session (unload all files).
+
+        Usage: clear
+        """
+        self.session = InteractiveSession()
+        print("Session cleared.")
+
+    def do_quit(self, arg: str) -> bool:
+        """Exit interactive mode.
+
+        Usage: quit
+        """
+        self._save_history()
+        print("Goodbye!")
+        return True
+
+    def do_exit(self, arg: str) -> bool:
+        """Exit interactive mode (alias for quit).
+
+        Usage: exit
+        """
+        return self.do_quit(arg)
+
+    def do_EOF(self, arg: str) -> bool:
+        """Handle Ctrl+D."""
+        print()  # Print newline for clean exit
+        return self.do_quit(arg)
+
+    def emptyline(self) -> bool:
+        """Do nothing on empty line (don't repeat last command)."""
+        return False
+
+    def default(self, line: str) -> None:
+        """Handle unknown commands."""
+        print(f"Unknown command: {line.split()[0]}")
+        print("Type 'help' for available commands.")
+
+    def postcmd(self, stop: bool, line: str) -> bool:
+        """Update prompt after each command."""
+        status = self.session.status_summary()
+        if status != "no files loaded":
+            self.prompt = f"kicad-tools ({status})> "
+        else:
+            self.prompt = "kicad-tools> "
+        return stop
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point for interactive mode."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="kicad-tools interactive",
+        description="Launch interactive REPL mode",
+    )
+    parser.add_argument(
+        "--project",
+        help="Auto-load a project on startup",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Check if running in a TTY
+    if not sys.stdin.isatty():
+        print("Warning: Running in non-TTY mode (limited features)", file=sys.stderr)
+
+    shell = InteractiveShell(project=args.project)
+
+    try:
+        shell.cmdloop()
+    except KeyboardInterrupt:
+        print("\nInterrupted")
+        shell._save_history()
+        return 130
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -1,0 +1,285 @@
+"""Tests for interactive CLI mode."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli.interactive import InteractiveSession, InteractiveShell, main
+
+
+class TestInteractiveSession:
+    """Tests for InteractiveSession dataclass."""
+
+    def test_default_session(self):
+        """Test default session state."""
+        session = InteractiveSession()
+        assert session.schematic is None
+        assert session.pcb is None
+        assert session.project is None
+        assert session.output_dir == Path("./output")
+
+    def test_status_summary_empty(self):
+        """Test status summary with no files loaded."""
+        session = InteractiveSession()
+        assert session.status_summary() == "no files loaded"
+
+    def test_status_summary_with_schematic(self):
+        """Test status summary with schematic loaded."""
+        session = InteractiveSession(schematic=Path("/path/to/design.kicad_sch"))
+        assert "sch: design.kicad_sch" in session.status_summary()
+
+    def test_status_summary_with_pcb(self):
+        """Test status summary with PCB loaded."""
+        session = InteractiveSession(pcb=Path("/path/to/board.kicad_pcb"))
+        assert "pcb: board.kicad_pcb" in session.status_summary()
+
+    def test_status_summary_with_all_files(self):
+        """Test status summary with all files loaded."""
+        session = InteractiveSession(
+            schematic=Path("/path/to/design.kicad_sch"),
+            pcb=Path("/path/to/board.kicad_pcb"),
+            project=Path("/path/to/project.kicad_pro"),
+        )
+        summary = session.status_summary()
+        assert "sch: design.kicad_sch" in summary
+        assert "pcb: board.kicad_pcb" in summary
+        assert "project: project.kicad_pro" in summary
+
+
+class TestInteractiveShell:
+    """Tests for InteractiveShell class."""
+
+    def test_shell_creation(self):
+        """Test shell can be created."""
+        shell = InteractiveShell()
+        assert shell.session is not None
+        assert shell.prompt == "kicad-tools> "
+
+    def test_load_nonexistent_file(self, capsys):
+        """Test loading a file that doesn't exist."""
+        shell = InteractiveShell()
+        shell.do_load("/nonexistent/file.kicad_sch")
+        captured = capsys.readouterr()
+        assert "Error: File not found" in captured.out
+
+    def test_load_unknown_extension(self, tmp_path, capsys):
+        """Test loading a file with unknown extension."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("test")
+        shell = InteractiveShell()
+        shell.do_load(str(test_file))
+        captured = capsys.readouterr()
+        assert "Unknown file type" in captured.out
+
+    def test_load_schematic(self, tmp_path, capsys):
+        """Test loading a schematic file."""
+        sch_file = tmp_path / "design.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+        shell = InteractiveShell()
+        shell.do_load(str(sch_file))
+        captured = capsys.readouterr()
+        assert "Loaded schematic" in captured.out
+        # Use resolve() to handle macOS /tmp -> /private/tmp symlink
+        assert shell.session.schematic.resolve() == sch_file.resolve()
+
+    def test_load_pcb(self, tmp_path, capsys):
+        """Test loading a PCB file."""
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+        shell = InteractiveShell()
+        shell.do_load(str(pcb_file))
+        captured = capsys.readouterr()
+        assert "Loaded PCB" in captured.out
+        assert shell.session.pcb.resolve() == pcb_file.resolve()
+
+    def test_load_project(self, tmp_path, capsys):
+        """Test loading a project file with associated schematic and PCB."""
+        pro_file = tmp_path / "project.kicad_pro"
+        sch_file = tmp_path / "project.kicad_sch"
+        pcb_file = tmp_path / "project.kicad_pcb"
+        pro_file.write_text("{}")
+        sch_file.write_text("(kicad_sch)")
+        pcb_file.write_text("(kicad_pcb)")
+
+        shell = InteractiveShell()
+        shell.do_load(str(pro_file))
+        captured = capsys.readouterr()
+        assert "Loaded project" in captured.out
+        assert shell.session.project.resolve() == pro_file.resolve()
+        assert shell.session.schematic.resolve() == sch_file.resolve()
+        assert shell.session.pcb.resolve() == pcb_file.resolve()
+
+    def test_status_command(self, capsys):
+        """Test status command output."""
+        shell = InteractiveShell()
+        shell.do_status("")
+        captured = capsys.readouterr()
+        assert "Session Status:" in captured.out
+        assert "Schematic:" in captured.out
+        assert "PCB:" in captured.out
+
+    def test_clear_command(self, tmp_path, capsys):
+        """Test clear command resets session."""
+        sch_file = tmp_path / "design.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+        shell = InteractiveShell()
+        shell.do_load(str(sch_file))
+        shell.do_clear("")
+        captured = capsys.readouterr()
+        assert "Session cleared" in captured.out
+        assert shell.session.schematic is None
+
+    def test_output_command_show(self, capsys):
+        """Test output command shows current directory."""
+        shell = InteractiveShell()
+        shell.do_output("")
+        captured = capsys.readouterr()
+        assert "Output directory:" in captured.out
+
+    def test_output_command_set(self, tmp_path, capsys):
+        """Test output command sets directory."""
+        shell = InteractiveShell()
+        shell.do_output(str(tmp_path / "output"))
+        captured = capsys.readouterr()
+        assert "Output directory set to" in captured.out
+        # The path gets resolved, so just check the name
+        assert shell.session.output_dir.name == "output"
+
+    def test_quit_returns_true(self):
+        """Test quit command returns True to stop loop."""
+        shell = InteractiveShell()
+        result = shell.do_quit("")
+        assert result is True
+
+    def test_exit_calls_quit(self, capsys):
+        """Test exit command calls quit."""
+        shell = InteractiveShell()
+        result = shell.do_exit("")
+        assert result is True
+        captured = capsys.readouterr()
+        assert "Goodbye" in captured.out
+
+    def test_eof_exits(self, capsys):
+        """Test EOF (Ctrl+D) exits with goodbye."""
+        shell = InteractiveShell()
+        result = shell.do_EOF("")
+        assert result is True
+        captured = capsys.readouterr()
+        assert "Goodbye" in captured.out
+
+    def test_emptyline_returns_false(self):
+        """Test emptyline returns False (don't exit)."""
+        shell = InteractiveShell()
+        result = shell.emptyline()
+        assert result is False
+
+    def test_unknown_command(self, capsys):
+        """Test unknown command shows error."""
+        shell = InteractiveShell()
+        shell.default("unknowncmd arg1 arg2")
+        captured = capsys.readouterr()
+        assert "Unknown command: unknowncmd" in captured.out
+
+    def test_prompt_updates_after_load(self, tmp_path):
+        """Test prompt includes file info after loading."""
+        sch_file = tmp_path / "design.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+        shell = InteractiveShell()
+        shell.do_load(str(sch_file))
+        shell.postcmd(False, "load")
+        assert "design.kicad_sch" in shell.prompt
+
+    def test_symbols_without_schematic(self, capsys):
+        """Test symbols command without schematic loaded."""
+        shell = InteractiveShell()
+        shell.do_symbols("")
+        captured = capsys.readouterr()
+        assert "No schematic loaded" in captured.out
+
+    def test_bom_without_schematic(self, capsys):
+        """Test bom command without schematic loaded."""
+        shell = InteractiveShell()
+        shell.do_bom("")
+        captured = capsys.readouterr()
+        assert "No schematic loaded" in captured.out
+
+    def test_nets_without_schematic(self, capsys):
+        """Test nets command without schematic loaded."""
+        shell = InteractiveShell()
+        shell.do_nets("")
+        captured = capsys.readouterr()
+        assert "No schematic loaded" in captured.out
+
+    def test_summary_without_file(self, capsys):
+        """Test summary command without file loaded."""
+        shell = InteractiveShell()
+        shell.do_summary("")  # defaults to sch
+        captured = capsys.readouterr()
+        assert "No schematic loaded" in captured.out
+
+    def test_summary_pcb_without_file(self, capsys):
+        """Test summary pcb command without file loaded."""
+        shell = InteractiveShell()
+        shell.do_summary("pcb")
+        captured = capsys.readouterr()
+        assert "No PCB loaded" in captured.out
+
+    def test_erc_without_args(self, capsys):
+        """Test erc command without arguments."""
+        shell = InteractiveShell()
+        shell.do_erc("")
+        captured = capsys.readouterr()
+        assert "Usage: erc" in captured.out
+
+    def test_drc_without_args(self, capsys):
+        """Test drc command without arguments."""
+        shell = InteractiveShell()
+        shell.do_drc("")
+        captured = capsys.readouterr()
+        assert "Usage: drc" in captured.out
+
+    def test_load_without_args(self, capsys):
+        """Test load command without arguments."""
+        shell = InteractiveShell()
+        shell.do_load("")
+        captured = capsys.readouterr()
+        assert "Usage: load" in captured.out
+
+
+class TestInteractiveMain:
+    """Tests for main entry point."""
+
+    def test_main_help(self):
+        """Test main with --help exits cleanly."""
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--help"])
+        assert excinfo.value.code == 0
+
+    @patch("sys.stdin.isatty", return_value=False)
+    @patch.object(InteractiveShell, "cmdloop")
+    def test_main_non_tty_warning(self, mock_cmdloop, mock_isatty, capsys):
+        """Test warning when running in non-TTY mode."""
+        mock_cmdloop.return_value = None
+        main([])
+        captured = capsys.readouterr()
+        assert "non-TTY mode" in captured.err
+
+    @patch("sys.stdin.isatty", return_value=True)
+    @patch.object(InteractiveShell, "cmdloop")
+    def test_main_with_project(self, mock_cmdloop, mock_isatty, tmp_path):
+        """Test main with --project argument."""
+        pro_file = tmp_path / "test.kicad_pro"
+        pro_file.write_text("{}")
+        mock_cmdloop.return_value = None
+        result = main(["--project", str(pro_file)])
+        assert result == 0
+
+    @patch("sys.stdin.isatty", return_value=True)
+    @patch.object(InteractiveShell, "cmdloop", side_effect=KeyboardInterrupt)
+    def test_main_keyboard_interrupt(self, mock_cmdloop, mock_isatty, capsys):
+        """Test Ctrl+C handling in main."""
+        result = main([])
+        assert result == 130
+        captured = capsys.readouterr()
+        assert "Interrupted" in captured.out


### PR DESCRIPTION
## Summary

Adds an interactive REPL mode for multi-step CLI workflows, addressing issue #29.

**Key Features:**
- `kct interactive` launches an interactive shell for KiCad tools
- Session state management for loaded schematic/PCB/project files
- Commands: `load`, `symbols`, `bom`, `nets`, `summary`, `erc`, `drc`, `status`, `output`, `clear`, `quit`
- Tab completion for file paths
- Command history persisted in `~/.kicad_tools_history`
- Graceful handling of Ctrl+C and EOF (Ctrl+D)

**Implementation:**
- Uses Python's stdlib `cmd.Cmd` module (Option B from issue - zero dependencies)
- Follows existing CLI patterns from `cli/__init__.py`
- Integrates with existing command handlers

## Changes
- New file: `src/kicad_tools/cli/interactive.py` - Interactive shell implementation
- Modified: `src/kicad_tools/cli/__init__.py` - Added `interactive` subcommand
- New file: `tests/test_cli_interactive.py` - Comprehensive test coverage (33 tests)

## Test Plan

- [x] All 33 new tests pass
- [x] Full test suite passes (1874 tests)
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Interactive mode launches without error
- [x] Ctrl+C exits gracefully

Closes #29