### PR TITLE
Add footprint creation and save support

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "kicad-tools"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary

- Implements `FootprintLibrary` class for managing .pretty directories
- Adds programmatic footprint creation with pads and graphics
- Generates valid KiCad 8.x .kicad_mod files
- Comprehensive test suite with 42 passing tests

## Features

- `FootprintLibrary.create()` creates .pretty directory
- `lib.create_footprint()` creates new footprints
- `fp.add_pad()` supports SMD and through-hole pads with various shapes
- `fp.add_line/rect/circle()` adds graphic elements
- `fp.add_text()` adds reference/value text
- `lib.save()` writes valid .kicad_mod files

## Example Usage

```python
from kicad_tools.library import FootprintLibrary

# Create new library
lib = FootprintLibrary.create("MyProject.pretty")

# Create footprint
fp = lib.create_footprint("MySensor_4x4mm")
fp.add_pad("1", pad_type="smd", shape="rect", position=(0, -1.5), size=(0.8, 1.2))
fp.add_pad("2", pad_type="smd", shape="rect", position=(0, 1.5), size=(0.8, 1.2))
fp.add_line(layer="F.SilkS", start=(-2, -2), end=(2, -2), width=0.12)
fp.add_rect(layer="F.CrtYd", start=(-2.5, -2.5), end=(2.5, 2.5), width=0.05)
fp.set_description("Custom sensor footprint")
fp.add_tags(["sensor", "custom"])

# Save library
lib.save()
```

## Test plan

- [x] `FootprintLibrary.create()` creates .pretty directory
- [x] `lib.create_footprint()` creates new footprint
- [x] `fp.add_pad()` supports SMD and through-hole pads
- [x] `fp.add_line/rect/circle()` adds graphic elements
- [x] `lib.save()` writes valid .kicad_mod files
- [x] All 42 tests pass

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)