### PR TITLE
Add parametric footprint generators for common package types

### DIFF
--- a/src/kicad_tools/library/__init__.py
+++ b/src/kicad_tools/library/__init__.py
@@ -1,0 +1,46 @@
+"""
+Library module for KiCad footprint and symbol generation.
+
+This module provides tools for programmatically creating KiCad footprints
+and symbols, including parametric generators for common package types.
+
+Usage:
+    from kicad_tools.library import Footprint, create_soic, create_chip
+
+    # Create a SOIC-8 footprint
+    fp = create_soic(pins=8)
+    fp.save("MyFootprints.pretty/SOIC-8_Custom.kicad_mod")
+
+    # Create a chip resistor footprint
+    fp = create_chip("0603", prefix="R")
+    fp.save("MyFootprints.pretty/R_0603_Custom.kicad_mod")
+"""
+
+from .footprint import Footprint, Pad, GraphicLine, GraphicRect, GraphicCircle, GraphicArc
+from .generators import (
+    create_soic,
+    create_qfp,
+    create_qfn,
+    create_sot,
+    create_chip,
+    create_dip,
+    create_pin_header,
+)
+
+__all__ = [
+    # Core classes
+    "Footprint",
+    "Pad",
+    "GraphicLine",
+    "GraphicRect",
+    "GraphicCircle",
+    "GraphicArc",
+    # Generators
+    "create_soic",
+    "create_qfp",
+    "create_qfn",
+    "create_sot",
+    "create_chip",
+    "create_dip",
+    "create_pin_header",
+]

--- a/src/kicad_tools/library/footprint.py
+++ b/src/kicad_tools/library/footprint.py
@@ -1,0 +1,393 @@
+"""
+Footprint data structures and KiCad .kicad_mod export.
+
+This module provides data classes representing KiCad footprint elements
+and the ability to serialize them to valid .kicad_mod files.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+
+@dataclass
+class Pad:
+    """A footprint pad (SMD or through-hole)."""
+
+    name: str
+    pad_type: Literal["smd", "thru_hole", "np_thru_hole", "connect"] = "smd"
+    shape: Literal["circle", "rect", "oval", "roundrect", "trapezoid", "custom"] = (
+        "roundrect"
+    )
+    x: float = 0.0
+    y: float = 0.0
+    width: float = 1.0
+    height: float = 1.0
+    drill: float | None = None  # For through-hole pads
+    layers: tuple[str, ...] = ("F.Cu", "F.Paste", "F.Mask")
+    roundrect_ratio: float = 0.25  # For roundrect pads
+
+    def to_sexp(self) -> str:
+        """Convert to KiCad S-expression format."""
+        lines = [f'\t(pad "{self.name}" {self.pad_type} {self.shape}']
+        lines.append(f"\t\t(at {_fmt(self.x)} {_fmt(self.y)})")
+        lines.append(f"\t\t(size {_fmt(self.width)} {_fmt(self.height)})")
+
+        if self.drill is not None:
+            lines.append(f"\t\t(drill {_fmt(self.drill)})")
+
+        layers_str = " ".join(f'"{layer}"' for layer in self.layers)
+        lines.append(f"\t\t(layers {layers_str})")
+
+        if self.shape == "roundrect":
+            lines.append(f"\t\t(roundrect_rratio {self.roundrect_ratio})")
+
+        lines.append("\t)")
+        return "\n".join(lines)
+
+
+@dataclass
+class GraphicLine:
+    """A graphic line on a footprint layer."""
+
+    start_x: float
+    start_y: float
+    end_x: float
+    end_y: float
+    layer: str = "F.SilkS"
+    width: float = 0.12
+
+    def to_sexp(self) -> str:
+        """Convert to KiCad S-expression format."""
+        return f"""\t(fp_line
+\t\t(start {_fmt(self.start_x)} {_fmt(self.start_y)})
+\t\t(end {_fmt(self.end_x)} {_fmt(self.end_y)})
+\t\t(stroke
+\t\t\t(width {self.width})
+\t\t\t(type solid)
+\t\t)
+\t\t(layer "{self.layer}")
+\t)"""
+
+
+@dataclass
+class GraphicRect:
+    """A graphic rectangle on a footprint layer."""
+
+    start_x: float
+    start_y: float
+    end_x: float
+    end_y: float
+    layer: str = "F.SilkS"
+    width: float = 0.12
+    fill: bool = False
+
+    def to_sexp(self) -> str:
+        """Convert to KiCad S-expression format."""
+        fill_str = "solid" if self.fill else "none"
+        return f"""\t(fp_rect
+\t\t(start {_fmt(self.start_x)} {_fmt(self.start_y)})
+\t\t(end {_fmt(self.end_x)} {_fmt(self.end_y)})
+\t\t(stroke
+\t\t\t(width {self.width})
+\t\t\t(type solid)
+\t\t)
+\t\t(fill {fill_str})
+\t\t(layer "{self.layer}")
+\t)"""
+
+
+@dataclass
+class GraphicCircle:
+    """A graphic circle on a footprint layer."""
+
+    center_x: float
+    center_y: float
+    radius: float
+    layer: str = "F.SilkS"
+    width: float = 0.12
+    fill: bool = False
+
+    def to_sexp(self) -> str:
+        """Convert to KiCad S-expression format."""
+        # KiCad uses center + end point on circumference
+        fill_str = "solid" if self.fill else "none"
+        return f"""\t(fp_circle
+\t\t(center {_fmt(self.center_x)} {_fmt(self.center_y)})
+\t\t(end {_fmt(self.center_x + self.radius)} {_fmt(self.center_y)})
+\t\t(stroke
+\t\t\t(width {self.width})
+\t\t\t(type solid)
+\t\t)
+\t\t(fill {fill_str})
+\t\t(layer "{self.layer}")
+\t)"""
+
+
+@dataclass
+class GraphicArc:
+    """A graphic arc on a footprint layer."""
+
+    start_x: float
+    start_y: float
+    mid_x: float
+    mid_y: float
+    end_x: float
+    end_y: float
+    layer: str = "F.SilkS"
+    width: float = 0.12
+
+    def to_sexp(self) -> str:
+        """Convert to KiCad S-expression format."""
+        return f"""\t(fp_arc
+\t\t(start {_fmt(self.start_x)} {_fmt(self.start_y)})
+\t\t(mid {_fmt(self.mid_x)} {_fmt(self.mid_y)})
+\t\t(end {_fmt(self.end_x)} {_fmt(self.end_y)})
+\t\t(stroke
+\t\t\t(width {self.width})
+\t\t\t(type solid)
+\t\t)
+\t\t(layer "{self.layer}")
+\t)"""
+
+
+@dataclass
+class GraphicText:
+    """A text element on a footprint layer."""
+
+    text_type: Literal["reference", "value", "user"]
+    text: str
+    x: float
+    y: float
+    layer: str = "F.SilkS"
+    font_size: float = 1.0
+    font_thickness: float = 0.15
+    hide: bool = False
+
+    def to_sexp(self) -> str:
+        """Convert to KiCad S-expression format."""
+        hide_str = " hide" if self.hide else ""
+        return f"""\t(fp_text {self.text_type} "{self.text}"
+\t\t(at {_fmt(self.x)} {_fmt(self.y)})
+\t\t(layer "{self.layer}"{hide_str})
+\t\t(effects
+\t\t\t(font
+\t\t\t\t(size {self.font_size} {self.font_size})
+\t\t\t\t(thickness {self.font_thickness})
+\t\t\t)
+\t\t)
+\t)"""
+
+
+@dataclass
+class Footprint:
+    """
+    A KiCad footprint with pads, graphics, and metadata.
+
+    This class represents a complete footprint that can be exported
+    to a .kicad_mod file.
+    """
+
+    name: str
+    description: str = ""
+    tags: list[str] = field(default_factory=list)
+    attr: Literal["smd", "through_hole"] = "smd"
+    pads: list[Pad] = field(default_factory=list)
+    graphics: list = field(default_factory=list)  # Lines, rects, circles, arcs, text
+
+    def add_pad(
+        self,
+        name: str,
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+        pad_type: str = "smd",
+        shape: str = "roundrect",
+        drill: float | None = None,
+        layers: tuple[str, ...] | None = None,
+    ) -> "Footprint":
+        """Add a pad to the footprint."""
+        if layers is None:
+            if pad_type == "smd":
+                layers = ("F.Cu", "F.Paste", "F.Mask")
+            else:
+                layers = ("*.Cu", "*.Mask")
+
+        self.pads.append(
+            Pad(
+                name=name,
+                pad_type=pad_type,
+                shape=shape,
+                x=x,
+                y=y,
+                width=width,
+                height=height,
+                drill=drill,
+                layers=layers,
+            )
+        )
+        return self
+
+    def add_line(
+        self,
+        start: tuple[float, float],
+        end: tuple[float, float],
+        layer: str = "F.SilkS",
+        width: float = 0.12,
+    ) -> "Footprint":
+        """Add a line to the footprint."""
+        self.graphics.append(
+            GraphicLine(
+                start_x=start[0],
+                start_y=start[1],
+                end_x=end[0],
+                end_y=end[1],
+                layer=layer,
+                width=width,
+            )
+        )
+        return self
+
+    def add_rect(
+        self,
+        start: tuple[float, float],
+        end: tuple[float, float],
+        layer: str = "F.SilkS",
+        width: float = 0.12,
+        fill: bool = False,
+    ) -> "Footprint":
+        """Add a rectangle to the footprint."""
+        self.graphics.append(
+            GraphicRect(
+                start_x=start[0],
+                start_y=start[1],
+                end_x=end[0],
+                end_y=end[1],
+                layer=layer,
+                width=width,
+                fill=fill,
+            )
+        )
+        return self
+
+    def add_circle(
+        self,
+        center: tuple[float, float],
+        radius: float,
+        layer: str = "F.SilkS",
+        width: float = 0.12,
+        fill: bool = False,
+    ) -> "Footprint":
+        """Add a circle to the footprint."""
+        self.graphics.append(
+            GraphicCircle(
+                center_x=center[0],
+                center_y=center[1],
+                radius=radius,
+                layer=layer,
+                width=width,
+                fill=fill,
+            )
+        )
+        return self
+
+    def add_text(
+        self,
+        text_type: str,
+        text: str,
+        position: tuple[float, float],
+        layer: str = "F.SilkS",
+        font_size: float = 1.0,
+        hide: bool = False,
+    ) -> "Footprint":
+        """Add text to the footprint."""
+        self.graphics.append(
+            GraphicText(
+                text_type=text_type,
+                text=text,
+                x=position[0],
+                y=position[1],
+                layer=layer,
+                font_size=font_size,
+                hide=hide,
+            )
+        )
+        return self
+
+    def to_sexp(self) -> str:
+        """Convert footprint to KiCad S-expression format."""
+        lines = [f'(footprint "{self.name}"']
+        lines.append('\t(version 20241229)')
+        lines.append('\t(generator "kicad_tools")')
+        lines.append('\t(layer "F.Cu")')
+
+        if self.description:
+            lines.append(f'\t(descr "{self.description}")')
+
+        if self.tags:
+            tags_str = " ".join(self.tags)
+            lines.append(f'\t(tags "{tags_str}")')
+
+        # Reference and Value properties (always present)
+        ref_y = self._get_ref_position()
+        lines.append(f'\t(property "Reference" "REF**"')
+        lines.append(f'\t\t(at 0 {_fmt(ref_y)} 0)')
+        lines.append('\t\t(layer "F.SilkS")')
+        lines.append("\t\t(effects")
+        lines.append("\t\t\t(font")
+        lines.append("\t\t\t\t(size 1 1)")
+        lines.append("\t\t\t\t(thickness 0.15)")
+        lines.append("\t\t\t)")
+        lines.append("\t\t)")
+        lines.append("\t)")
+
+        lines.append(f'\t(property "Value" "{self.name}"')
+        lines.append(f'\t\t(at 0 {_fmt(-ref_y)} 0)')
+        lines.append('\t\t(layer "F.Fab")')
+        lines.append("\t\t(effects")
+        lines.append("\t\t\t(font")
+        lines.append("\t\t\t\t(size 1 1)")
+        lines.append("\t\t\t\t(thickness 0.15)")
+        lines.append("\t\t\t)")
+        lines.append("\t\t)")
+        lines.append("\t)")
+
+        # Attribute
+        lines.append(f"\t(attr {self.attr})")
+
+        # Graphics
+        for graphic in self.graphics:
+            lines.append(graphic.to_sexp())
+
+        # Pads
+        for pad in self.pads:
+            lines.append(pad.to_sexp())
+
+        lines.append(")")
+        return "\n".join(lines)
+
+    def _get_ref_position(self) -> float:
+        """Calculate reference text position based on footprint size."""
+        if not self.pads:
+            return -2.0
+
+        min_y = min(p.y - p.height / 2 for p in self.pads)
+        return min_y - 1.5
+
+    def save(self, filepath: str | Path) -> None:
+        """Save footprint to a .kicad_mod file."""
+        filepath = Path(filepath)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        filepath.write_text(self.to_sexp())
+
+
+def _fmt(val: float) -> str:
+    """Format a float value, removing trailing zeros."""
+    if val == int(val):
+        return str(int(val))
+    # Round to 3 decimal places
+    rounded = round(val, 3)
+    if rounded == int(rounded):
+        return str(int(rounded))
+    return str(rounded)

--- a/src/kicad_tools/library/generators/__init__.py
+++ b/src/kicad_tools/library/generators/__init__.py
@@ -1,0 +1,22 @@
+"""
+Parametric footprint generators for common package types.
+
+These generators create KiCad footprints following IPC-7351 naming conventions.
+"""
+
+from .soic import create_soic
+from .qfp import create_qfp
+from .qfn import create_qfn
+from .sot import create_sot
+from .chip import create_chip
+from .through_hole import create_dip, create_pin_header
+
+__all__ = [
+    "create_soic",
+    "create_qfp",
+    "create_qfn",
+    "create_sot",
+    "create_chip",
+    "create_dip",
+    "create_pin_header",
+]

--- a/src/kicad_tools/library/generators/chip.py
+++ b/src/kicad_tools/library/generators/chip.py
@@ -1,0 +1,101 @@
+"""
+Chip component footprint generator.
+
+Generates footprints for chip resistors, capacitors, and other 2-terminal
+passive components following IPC-7351 naming conventions.
+"""
+
+from ..footprint import Footprint
+from .standards import CHIP_SIZES
+
+
+def create_chip(
+    size: str,
+    prefix: str = "",
+    metric: bool = False,
+    name: str | None = None,
+) -> Footprint:
+    """
+    Create a chip component footprint (resistor, capacitor, etc.).
+
+    Args:
+        size: Imperial size code ("0201", "0402", "0603", "0805", "1206", etc.)
+        prefix: Component prefix for naming ("R", "C", "L", etc.)
+        metric: Use metric naming convention (e.g., "1005" instead of "0402")
+        name: Custom footprint name (auto-generated if not specified)
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_chip("0603", prefix="R")
+        >>> fp.name
+        'R_0603_1608Metric'
+
+        >>> fp = create_chip("0402", prefix="C", metric=True)
+        >>> fp.name
+        'C_1005Metric'
+    """
+    if size not in CHIP_SIZES:
+        valid_sizes = ", ".join(sorted(CHIP_SIZES.keys()))
+        raise ValueError(f"Unknown chip size: {size}. Valid sizes: {valid_sizes}")
+
+    std = CHIP_SIZES[size]
+    length = std["length"]
+    width = std["width"]
+    pad_width = std["pad_width"]
+    pad_height = std["pad_height"]
+    pad_gap = std["pad_gap"]
+    metric_size = std["metric"]
+
+    # Generate IPC-7351 compliant name
+    if name is None:
+        if metric:
+            name = f"{prefix}_{metric_size}Metric" if prefix else f"{metric_size}Metric"
+        else:
+            name = f"{prefix}_{size}_{metric_size}Metric" if prefix else f"{size}_{metric_size}Metric"
+
+    # Determine component type for description
+    if prefix == "R":
+        comp_type = "Resistor"
+    elif prefix == "C":
+        comp_type = "Capacitor"
+    elif prefix == "L":
+        comp_type = "Inductor"
+    else:
+        comp_type = "Chip"
+
+    fp = Footprint(
+        name=name,
+        description=f"{comp_type} SMD {size} ({length}x{width}mm)",
+        tags=[size, metric_size, "SMD", comp_type.lower()],
+        attr="smd",
+    )
+
+    # Calculate pad positions
+    # Pads are centered on the component, gap between them
+    pad_x = (pad_gap + pad_width) / 2
+
+    # Pad 1 on left (cathode for diodes/LEDs, negative for caps)
+    fp.add_pad("1", -pad_x, 0, pad_width, pad_height)
+    # Pad 2 on right
+    fp.add_pad("2", pad_x, 0, pad_width, pad_height)
+
+    # Silkscreen - just small marks at ends to avoid pad overlap
+    silk_y = width / 2 + 0.15
+    if pad_height < width * 0.9:  # Only if there's room
+        fp.add_line((-length / 2 - 0.1, -silk_y), (-length / 2 - 0.1, silk_y), "F.SilkS", 0.12)
+        fp.add_line((length / 2 + 0.1, -silk_y), (length / 2 + 0.1, silk_y), "F.SilkS", 0.12)
+
+    # Courtyard
+    crt_margin = 0.15
+    crt_x = pad_x + pad_width / 2 + crt_margin
+    crt_y = max(width / 2, pad_height / 2) + crt_margin
+    fp.add_rect((-crt_x, -crt_y), (crt_x, crt_y), "F.CrtYd", 0.05)
+
+    # Fab layer - component body outline
+    fab_x = length / 2
+    fab_y = width / 2
+    fp.add_rect((-fab_x, -fab_y), (fab_x, fab_y), "F.Fab", 0.1)
+
+    return fp

--- a/src/kicad_tools/library/generators/qfn.py
+++ b/src/kicad_tools/library/generators/qfn.py
@@ -1,0 +1,149 @@
+"""
+QFN (Quad Flat No-lead) footprint generator.
+
+Generates QFN and DFN footprints with optional exposed thermal pads.
+"""
+
+from ..footprint import Footprint
+from .standards import QFN_STANDARDS
+
+
+def create_qfn(
+    pins: int,
+    pitch: float | None = None,
+    body_size: float | None = None,
+    pad_width: float | None = None,
+    pad_height: float | None = None,
+    exposed_pad: float | None = None,
+    name: str | None = None,
+) -> Footprint:
+    """
+    Create a QFN footprint with optional exposed thermal pad.
+
+    Args:
+        pins: Number of pins (not including exposed pad)
+        pitch: Pin pitch in mm (default: 0.5mm)
+        body_size: Package body size in mm (square packages)
+        pad_width: Pad width (length of pad) in mm
+        pad_height: Pad height (perpendicular to pad length) in mm
+        exposed_pad: Size of center exposed thermal pad in mm (optional)
+        name: Custom footprint name (auto-generated if not specified)
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_qfn(pins=16, pitch=0.5, body_size=3.0, exposed_pad=1.7)
+        >>> fp.save("MyLib.pretty/QFN-16_3x3mm.kicad_mod")
+    """
+    if pins < 4:
+        raise ValueError(f"QFN must have at least 4 pins, got {pins}")
+
+    if pins % 4 != 0:
+        raise ValueError(f"QFN must have pins divisible by 4, got {pins}")
+
+    # Get defaults from standards table
+    key = (pins, body_size) if body_size else None
+    std = QFN_STANDARDS.get(key, {})
+
+    pitch = pitch or std.get("pitch", 0.5)
+    body_size = body_size or 4.0  # Default 4x4mm
+    pad_width = pad_width or std.get("pad_width", 0.8)
+    pad_height = pad_height or std.get("pad_height", 0.3)
+    exposed_pad = exposed_pad if exposed_pad is not None else std.get("exposed_pad")
+
+    pins_per_side = pins // 4
+
+    # Generate IPC-7351 compliant name
+    if name is None:
+        ep_suffix = "_EP" if exposed_pad else ""
+        name = f"QFN-{pins}_{body_size}x{body_size}mm_P{pitch}mm{ep_suffix}"
+
+    desc = f"QFN, {pins} Pin, pitch {pitch}mm, {body_size}x{body_size}mm"
+    if exposed_pad:
+        desc += f", exposed pad {exposed_pad}x{exposed_pad}mm"
+
+    fp = Footprint(
+        name=name,
+        description=desc,
+        tags=["QFN", f"P{pitch}mm", "DFN"],
+        attr="smd",
+    )
+
+    # Calculate pad positions
+    span = (pins_per_side - 1) * pitch
+    pad_center = body_size / 2 - pad_width / 2 + 0.1  # Slight extension
+
+    pin_num = 1
+
+    # Bottom side (left to right)
+    for i in range(pins_per_side):
+        x = -span / 2 + i * pitch
+        y = pad_center
+        fp.add_pad(str(pin_num), x, y, pad_height, pad_width)
+        pin_num += 1
+
+    # Right side (bottom to top)
+    for i in range(pins_per_side):
+        x = pad_center
+        y = span / 2 - i * pitch
+        fp.add_pad(str(pin_num), x, y, pad_width, pad_height)
+        pin_num += 1
+
+    # Top side (right to left)
+    for i in range(pins_per_side):
+        x = span / 2 - i * pitch
+        y = -pad_center
+        fp.add_pad(str(pin_num), x, y, pad_height, pad_width)
+        pin_num += 1
+
+    # Left side (top to bottom)
+    for i in range(pins_per_side):
+        x = -pad_center
+        y = -span / 2 + i * pitch
+        fp.add_pad(str(pin_num), x, y, pad_width, pad_height)
+        pin_num += 1
+
+    # Exposed thermal pad
+    if exposed_pad:
+        fp.add_pad(
+            name=str(pins + 1),
+            x=0,
+            y=0,
+            width=exposed_pad,
+            height=exposed_pad,
+            shape="rect",
+            layers=("F.Cu", "F.Paste", "F.Mask"),
+        )
+
+    # Silkscreen - just corners to avoid pad overlap
+    silk_x = body_size / 2 + 0.1
+    silk_y = body_size / 2 + 0.1
+    corner_len = min(0.6, span / 3)
+
+    # Draw corner marks
+    for sx, sy in [(-1, -1), (1, -1), (1, 1), (-1, 1)]:
+        cx, cy = sx * silk_x, sy * silk_y
+        fp.add_line((cx, cy - sy * corner_len), (cx, cy), "F.SilkS", 0.12)
+        fp.add_line((cx, cy), (cx - sx * corner_len, cy), "F.SilkS", 0.12)
+
+    # Pin 1 marker
+    marker_x = -span / 2 - 0.3
+    marker_y = silk_y + 0.4
+    fp.add_circle((marker_x, marker_y), 0.15, "F.SilkS", 0.12, fill=True)
+
+    # Courtyard
+    crt_margin = 0.25
+    crt = body_size / 2 + crt_margin
+    fp.add_rect((-crt, -crt), (crt, crt), "F.CrtYd", 0.05)
+
+    # Fab layer with pin 1 chamfer
+    fab = body_size / 2
+    chamfer = min(0.5, body_size / 8)
+    fp.add_line((-fab + chamfer, fab), (fab, fab), "F.Fab", 0.1)
+    fp.add_line((fab, fab), (fab, -fab), "F.Fab", 0.1)
+    fp.add_line((fab, -fab), (-fab, -fab), "F.Fab", 0.1)
+    fp.add_line((-fab, -fab), (-fab, fab - chamfer), "F.Fab", 0.1)
+    fp.add_line((-fab, fab - chamfer), (-fab + chamfer, fab), "F.Fab", 0.1)
+
+    return fp

--- a/src/kicad_tools/library/generators/qfp.py
+++ b/src/kicad_tools/library/generators/qfp.py
@@ -1,0 +1,187 @@
+"""
+QFP (Quad Flat Package) footprint generator.
+
+Generates LQFP and TQFP footprints following IPC-7351 naming conventions.
+"""
+
+from ..footprint import Footprint
+from .standards import LQFP_STANDARDS
+
+
+def create_qfp(
+    pins: int,
+    pitch: float | None = None,
+    body_size: float | None = None,
+    body_width: float | None = None,
+    body_length: float | None = None,
+    pad_width: float | None = None,
+    pad_height: float | None = None,
+    pins_x: int | None = None,
+    pins_y: int | None = None,
+    name: str | None = None,
+) -> Footprint:
+    """
+    Create a QFP/LQFP footprint.
+
+    Args:
+        pins: Total number of pins (must be divisible by 4 for square QFP)
+        pitch: Pin pitch in mm (default: 0.5mm)
+        body_size: Package body size in mm (for square packages)
+        body_width: Package body width in mm (for rectangular packages)
+        body_length: Package body length in mm (for rectangular packages)
+        pad_width: Pad width (length of pad) in mm
+        pad_height: Pad height (perpendicular to pad length) in mm
+        pins_x: Pins per horizontal side (for rectangular packages)
+        pins_y: Pins per vertical side (for rectangular packages)
+        name: Custom footprint name (auto-generated if not specified)
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_qfp(pins=48, pitch=0.5, body_size=7.0)
+        >>> fp.save("MyLib.pretty/LQFP-48_7x7mm.kicad_mod")
+    """
+    if pins < 8:
+        raise ValueError(f"QFP must have at least 8 pins, got {pins}")
+
+    # Get defaults from standards table
+    std = LQFP_STANDARDS.get(pins, {})
+    pitch = pitch or std.get("pitch", 0.5)
+    pad_width = pad_width or std.get("pad_width", 1.2)
+    pad_height = pad_height or std.get("pad_height", 0.3)
+
+    # Handle square vs rectangular packages
+    if body_size is not None:
+        body_width = body_size
+        body_length = body_size
+    else:
+        body_width = body_width or std.get("body_size", 10.0)
+        body_length = body_length or body_width
+
+    # Calculate pins per side
+    if pins_x is None and pins_y is None:
+        if body_width == body_length:
+            # Square package - equal pins per side
+            if pins % 4 != 0:
+                raise ValueError(f"Square QFP must have pins divisible by 4, got {pins}")
+            pins_per_side = pins // 4
+            pins_x = pins_per_side
+            pins_y = pins_per_side
+        else:
+            # Rectangular - need explicit pins_x and pins_y
+            raise ValueError("Rectangular QFP requires pins_x and pins_y parameters")
+    elif pins_x is None or pins_y is None:
+        raise ValueError("Both pins_x and pins_y must be specified for rectangular QFP")
+
+    # Verify pin count
+    total_expected = 2 * pins_x + 2 * pins_y
+    if total_expected != pins:
+        raise ValueError(
+            f"pins_x={pins_x} and pins_y={pins_y} give {total_expected} pins, expected {pins}"
+        )
+
+    # Generate IPC-7351 compliant name
+    if name is None:
+        if body_width == body_length:
+            name = f"LQFP-{pins}_{body_width}x{body_length}mm_P{pitch}mm"
+        else:
+            name = f"LQFP-{pins}_{body_width}x{body_length}mm_P{pitch}mm"
+
+    fp = Footprint(
+        name=name,
+        description=f"LQFP, {pins} Pin, pitch {pitch}mm, {body_width}x{body_length}mm",
+        tags=["LQFP", "QFP", f"P{pitch}mm"],
+        attr="smd",
+    )
+
+    # Calculate pad positions
+    # Pin numbering: starts at bottom-left corner of pin 1 indicator, goes CCW
+    # Bottom side: 1 to pins_x (left to right)
+    # Right side: pins_x+1 to pins_x+pins_y (bottom to top)
+    # Top side: pins_x+pins_y+1 to 2*pins_x+pins_y (right to left)
+    # Left side: 2*pins_x+pins_y+1 to pins (top to bottom)
+
+    span_x = (pins_x - 1) * pitch
+    span_y = (pins_y - 1) * pitch
+
+    pad_center_x = body_width / 2 + pad_width / 2 - 0.3
+    pad_center_y = body_length / 2 + pad_width / 2 - 0.3
+
+    pin_num = 1
+
+    # Bottom side (pins go left to right)
+    for i in range(pins_x):
+        x = -span_x / 2 + i * pitch
+        y = pad_center_y
+        fp.add_pad(str(pin_num), x, y, pad_height, pad_width)  # Note: rotated
+        pin_num += 1
+
+    # Right side (pins go bottom to top)
+    for i in range(pins_y):
+        x = pad_center_x
+        y = span_y / 2 - i * pitch
+        fp.add_pad(str(pin_num), x, y, pad_width, pad_height)
+        pin_num += 1
+
+    # Top side (pins go right to left)
+    for i in range(pins_x):
+        x = span_x / 2 - i * pitch
+        y = -pad_center_y
+        fp.add_pad(str(pin_num), x, y, pad_height, pad_width)  # Note: rotated
+        pin_num += 1
+
+    # Left side (pins go top to bottom)
+    for i in range(pins_y):
+        x = -pad_center_x
+        y = -span_y / 2 + i * pitch
+        fp.add_pad(str(pin_num), x, y, pad_width, pad_height)
+        pin_num += 1
+
+    # Silkscreen outline
+    silk_margin = 0.2
+    silk_x = body_width / 2 + silk_margin
+    silk_y = body_length / 2 + silk_margin
+
+    # Draw corners only (to avoid pad overlap)
+    corner_len = min(1.0, span_x / 4, span_y / 4)
+
+    # Top-left corner
+    fp.add_line((-silk_x, -silk_y + corner_len), (-silk_x, -silk_y), "F.SilkS", 0.12)
+    fp.add_line((-silk_x, -silk_y), (-silk_x + corner_len, -silk_y), "F.SilkS", 0.12)
+
+    # Top-right corner
+    fp.add_line((silk_x - corner_len, -silk_y), (silk_x, -silk_y), "F.SilkS", 0.12)
+    fp.add_line((silk_x, -silk_y), (silk_x, -silk_y + corner_len), "F.SilkS", 0.12)
+
+    # Bottom-right corner
+    fp.add_line((silk_x, silk_y - corner_len), (silk_x, silk_y), "F.SilkS", 0.12)
+    fp.add_line((silk_x, silk_y), (silk_x - corner_len, silk_y), "F.SilkS", 0.12)
+
+    # Bottom-left corner (with pin 1 marker)
+    fp.add_line((-silk_x + corner_len, silk_y), (-silk_x, silk_y), "F.SilkS", 0.12)
+    fp.add_line((-silk_x, silk_y), (-silk_x, silk_y - corner_len), "F.SilkS", 0.12)
+
+    # Pin 1 marker
+    marker_x = -span_x / 2 - 0.5
+    marker_y = silk_y + 0.5
+    fp.add_circle((marker_x, marker_y), 0.15, "F.SilkS", 0.12, fill=True)
+
+    # Courtyard
+    courtyard_margin = 0.25
+    crt_x = pad_center_x + pad_width / 2 + courtyard_margin
+    crt_y = pad_center_y + pad_width / 2 + courtyard_margin
+    fp.add_rect((-crt_x, -crt_y), (crt_x, crt_y), "F.CrtYd", 0.05)
+
+    # Fab layer with pin 1 chamfer
+    fab_x = body_width / 2
+    fab_y = body_length / 2
+    chamfer = min(0.8, body_width / 8)
+
+    fp.add_line((-fab_x + chamfer, fab_y), (fab_x, fab_y), "F.Fab", 0.1)
+    fp.add_line((fab_x, fab_y), (fab_x, -fab_y), "F.Fab", 0.1)
+    fp.add_line((fab_x, -fab_y), (-fab_x, -fab_y), "F.Fab", 0.1)
+    fp.add_line((-fab_x, -fab_y), (-fab_x, fab_y - chamfer), "F.Fab", 0.1)
+    fp.add_line((-fab_x, fab_y - chamfer), (-fab_x + chamfer, fab_y), "F.Fab", 0.1)
+
+    return fp

--- a/src/kicad_tools/library/generators/soic.py
+++ b/src/kicad_tools/library/generators/soic.py
@@ -1,0 +1,142 @@
+"""
+SOIC (Small Outline Integrated Circuit) footprint generator.
+
+Generates SOIC footprints following IPC-7351 naming conventions.
+"""
+
+from ..footprint import Footprint
+from .standards import SOIC_STANDARDS
+
+
+def create_soic(
+    pins: int,
+    pitch: float | None = None,
+    body_width: float | None = None,
+    body_length: float | None = None,
+    pad_width: float | None = None,
+    pad_height: float | None = None,
+    name: str | None = None,
+) -> Footprint:
+    """
+    Create a SOIC footprint.
+
+    Args:
+        pins: Number of pins (must be even, 8-28)
+        pitch: Pin pitch in mm (default: 1.27mm)
+        body_width: Package body width in mm
+        body_length: Package body length in mm
+        pad_width: Pad width (length of pad) in mm
+        pad_height: Pad height (perpendicular to pad length) in mm
+        name: Custom footprint name (auto-generated if not specified)
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_soic(pins=8)
+        >>> fp.save("MyLib.pretty/SOIC-8_Custom.kicad_mod")
+
+        >>> fp = create_soic(pins=16, pitch=1.27)
+        >>> print(fp.name)
+        'SOIC-16_3.9x9.9mm_P1.27mm'
+    """
+    if pins % 2 != 0:
+        raise ValueError(f"SOIC must have even number of pins, got {pins}")
+
+    if pins < 4 or pins > 32:
+        raise ValueError(f"SOIC pin count must be 4-32, got {pins}")
+
+    # Get defaults from standards table
+    std = SOIC_STANDARDS.get(pins, {})
+    pitch = pitch or std.get("pitch", 1.27)
+    body_width = body_width or std.get("body_width", 3.9)
+    pad_width = pad_width or std.get("pad_width", 1.95)
+    pad_height = pad_height or std.get("pad_height", 0.6)
+
+    # Calculate body length if not specified
+    if body_length is None:
+        pins_per_side = pins // 2
+        body_length = std.get("body_length", (pins_per_side - 1) * pitch + 2.0)
+
+    # Generate IPC-7351 compliant name
+    if name is None:
+        name = f"SOIC-{pins}_{body_width}x{body_length}mm_P{pitch}mm"
+
+    # Calculate pad positions
+    # Pads are centered around origin, pins on left and right sides
+    pins_per_side = pins // 2
+    total_pin_span = (pins_per_side - 1) * pitch
+
+    # Pad center X position (from body edge + pad width/2)
+    pad_x = body_width / 2 + pad_width / 2 - 0.5  # Slight inset
+
+    fp = Footprint(
+        name=name,
+        description=f"SOIC, {pins} Pin, pitch {pitch}mm, {body_width}x{body_length}mm",
+        tags=["SOIC", "SO", f"P{pitch}mm"],
+        attr="smd",
+    )
+
+    # Add pads - left side (pins 1 to pins_per_side, bottom to top)
+    for i in range(pins_per_side):
+        pin_num = i + 1
+        y = -total_pin_span / 2 + i * pitch
+        fp.add_pad(
+            name=str(pin_num),
+            x=-pad_x,
+            y=y,
+            width=pad_width,
+            height=pad_height,
+        )
+
+    # Right side (pins pins_per_side+1 to pins, top to bottom)
+    for i in range(pins_per_side):
+        pin_num = pins_per_side + i + 1
+        y = total_pin_span / 2 - i * pitch
+        fp.add_pad(
+            name=str(pin_num),
+            x=pad_x,
+            y=y,
+            width=pad_width,
+            height=pad_height,
+        )
+
+    # Add silkscreen outline
+    silk_margin = 0.2
+    silk_x = body_width / 2 + silk_margin
+    silk_y = body_length / 2 + silk_margin
+
+    # Top and bottom lines
+    fp.add_line((-silk_x, -silk_y), (silk_x, -silk_y), "F.SilkS", 0.12)
+    fp.add_line((-silk_x, silk_y), (silk_x, silk_y), "F.SilkS", 0.12)
+
+    # Side lines (only where they don't overlap pads)
+    pad_extent = total_pin_span / 2 + pad_height / 2 + 0.15
+    if pad_extent < silk_y:
+        fp.add_line((-silk_x, -silk_y), (-silk_x, -pad_extent), "F.SilkS", 0.12)
+        fp.add_line((-silk_x, pad_extent), (-silk_x, silk_y), "F.SilkS", 0.12)
+        fp.add_line((silk_x, -silk_y), (silk_x, -pad_extent), "F.SilkS", 0.12)
+        fp.add_line((silk_x, pad_extent), (silk_x, silk_y), "F.SilkS", 0.12)
+
+    # Pin 1 marker (triangle on silkscreen)
+    marker_x = -pad_x - pad_width / 2 - 0.3
+    marker_y = -total_pin_span / 2
+    fp.add_circle((marker_x, marker_y), 0.15, "F.SilkS", 0.12, fill=True)
+
+    # Courtyard (0.25mm outside pads)
+    courtyard_margin = 0.25
+    crt_x = pad_x + pad_width / 2 + courtyard_margin
+    crt_y = max(body_length / 2, total_pin_span / 2 + pad_height / 2) + courtyard_margin
+    fp.add_rect((-crt_x, -crt_y), (crt_x, crt_y), "F.CrtYd", 0.05)
+
+    # Fab layer (body outline with pin 1 chamfer)
+    fab_x = body_width / 2
+    fab_y = body_length / 2
+    chamfer = 0.8
+    fp.add_line((-fab_x + chamfer, -fab_y), (fab_x, -fab_y), "F.Fab", 0.1)
+    fp.add_line((fab_x, -fab_y), (fab_x, fab_y), "F.Fab", 0.1)
+    fp.add_line((fab_x, fab_y), (-fab_x, fab_y), "F.Fab", 0.1)
+    fp.add_line((-fab_x, fab_y), (-fab_x, -fab_y + chamfer), "F.Fab", 0.1)
+    fp.add_line((-fab_x, -fab_y + chamfer), (-fab_x + chamfer, -fab_y), "F.Fab", 0.1)
+
+    return fp

--- a/src/kicad_tools/library/generators/sot.py
+++ b/src/kicad_tools/library/generators/sot.py
@@ -1,0 +1,160 @@
+"""
+SOT (Small Outline Transistor) footprint generator.
+
+Generates SOT-23, SOT-223, SOT-89, and variant footprints.
+"""
+
+from ..footprint import Footprint
+from .standards import SOT_STANDARDS
+
+
+def create_sot(
+    variant: str | None = None,
+    pins: int | None = None,
+    pitch: float | None = None,
+    body_width: float | None = None,
+    body_length: float | None = None,
+    name: str | None = None,
+) -> Footprint:
+    """
+    Create a SOT footprint.
+
+    Args:
+        variant: Standard variant name ("SOT-23", "SOT-23-5", "SOT-23-6",
+                 "SOT-223", "SOT-89")
+        pins: Number of pins (used with custom dimensions)
+        pitch: Pin pitch in mm (used with custom dimensions)
+        body_width: Package body width in mm (used with custom dimensions)
+        body_length: Package body length in mm (used with custom dimensions)
+        name: Custom footprint name (auto-generated if not specified)
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_sot("SOT-23")
+        >>> fp = create_sot("SOT-23-5")
+        >>> fp = create_sot("SOT-223")
+    """
+    if variant is not None:
+        if variant not in SOT_STANDARDS:
+            raise ValueError(
+                f"Unknown SOT variant: {variant}. "
+                f"Valid variants: {list(SOT_STANDARDS.keys())}"
+            )
+        std = SOT_STANDARDS[variant]
+        pins = std["pins"]
+        pitch = std["pitch"]
+        body_width = std["body_width"]
+        body_length = std["body_length"]
+        pad_width = std["pad_width"]
+        pad_height = std["pad_height"]
+        pad_positions = std["pad_positions"]
+        tab_width = std.get("tab_width")
+        tab_height = std.get("tab_height")
+    else:
+        if pins is None or pitch is None or body_width is None or body_length is None:
+            raise ValueError(
+                "Either specify a variant or provide pins, pitch, body_width, body_length"
+            )
+        # Use SOT-23 style layout for custom
+        pad_width = 1.0
+        pad_height = 0.6
+        pad_positions = None
+        tab_width = None
+        tab_height = None
+
+    if name is None:
+        if variant:
+            name = variant
+        else:
+            name = f"SOT-{pins}_{body_width}x{body_length}mm"
+
+    fp = Footprint(
+        name=name,
+        description=f"{name}, {pins} Pin, {body_width}x{body_length}mm",
+        tags=["SOT", name.replace("-", "")],
+        attr="smd",
+    )
+
+    # Add pads
+    if pad_positions is not None:
+        for i, (x, y) in enumerate(pad_positions):
+            pin_num = i + 1
+            # SOT-223 has a larger tab for the last pin
+            if variant == "SOT-223" and pin_num == pins:
+                fp.add_pad(
+                    str(pin_num), x, y, tab_width, tab_height, shape="rect"
+                )
+            elif variant == "SOT-89" and pin_num == 2:
+                # SOT-89 has an extended center tab
+                fp.add_pad(
+                    str(pin_num), x, y - 0.7, tab_width, tab_height + 1.4, shape="rect"
+                )
+            else:
+                fp.add_pad(str(pin_num), x, y, pad_width, pad_height)
+    else:
+        # Generic SOT-23 style layout
+        if pins == 3:
+            positions = [(-pitch / 2, body_length / 2), (pitch / 2, body_length / 2), (0, -body_length / 2)]
+        else:
+            raise ValueError(f"Custom SOT layout not implemented for {pins} pins")
+
+        for i, (x, y) in enumerate(positions):
+            fp.add_pad(str(i + 1), x, y, pad_width, pad_height)
+
+    # Silkscreen outline
+    silk_margin = 0.15
+    silk_x = body_width / 2 + silk_margin
+    silk_y = body_length / 2 + silk_margin
+
+    # For SOT-23 variants, draw lines that avoid pads
+    if variant and variant.startswith("SOT-23"):
+        # Left and right edges
+        fp.add_line((-silk_x, -silk_y), (-silk_x, silk_y), "F.SilkS", 0.12)
+        fp.add_line((silk_x, -silk_y), (silk_x, silk_y), "F.SilkS", 0.12)
+
+        # Pin 1 marker
+        fp.add_circle((-body_width / 2 - 0.5, body_length / 2), 0.15, "F.SilkS", 0.12, fill=True)
+
+    elif variant == "SOT-223":
+        # Draw corner marks to avoid the large tab
+        corner = 0.8
+        # Top corners
+        fp.add_line((-silk_x, -silk_y + corner), (-silk_x, -silk_y), "F.SilkS", 0.12)
+        fp.add_line((-silk_x, -silk_y), (-silk_x + corner, -silk_y), "F.SilkS", 0.12)
+        fp.add_line((silk_x - corner, -silk_y), (silk_x, -silk_y), "F.SilkS", 0.12)
+        fp.add_line((silk_x, -silk_y), (silk_x, -silk_y + corner), "F.SilkS", 0.12)
+
+        # Bottom corners (near pins)
+        fp.add_line((-silk_x, silk_y), (-silk_x, silk_y - corner), "F.SilkS", 0.12)
+        fp.add_line((silk_x, silk_y), (silk_x, silk_y - corner), "F.SilkS", 0.12)
+
+        # Pin 1 marker
+        fp.add_circle((-pitch - 0.5, silk_y + 0.3), 0.15, "F.SilkS", 0.12, fill=True)
+
+    elif variant == "SOT-89":
+        # Similar to SOT-223
+        corner = 0.6
+        fp.add_line((-silk_x, -silk_y + corner), (-silk_x, -silk_y), "F.SilkS", 0.12)
+        fp.add_line((-silk_x, -silk_y), (-silk_x + corner, -silk_y), "F.SilkS", 0.12)
+        fp.add_line((silk_x - corner, -silk_y), (silk_x, -silk_y), "F.SilkS", 0.12)
+        fp.add_line((silk_x, -silk_y), (silk_x, -silk_y + corner), "F.SilkS", 0.12)
+
+        fp.add_circle((-pitch - 0.4, silk_y + 0.3), 0.15, "F.SilkS", 0.12, fill=True)
+
+    # Courtyard
+    crt_margin = 0.25
+    # Account for pad extensions
+    max_y = max(abs(p.y) + p.height / 2 for p in fp.pads)
+    max_x = max(abs(p.x) + p.width / 2 for p in fp.pads)
+    crt_x = max(body_width / 2, max_x) + crt_margin
+    crt_y = max(body_length / 2, max_y) + crt_margin
+    fp.add_rect((-crt_x, -crt_y), (crt_x, crt_y), "F.CrtYd", 0.05)
+
+    # Fab layer
+    fab_x = body_width / 2
+    fab_y = body_length / 2
+    fp.add_rect((-fab_x, -fab_y), (fab_x, fab_y), "F.Fab", 0.1)
+
+    return fp

--- a/src/kicad_tools/library/generators/standards.py
+++ b/src/kicad_tools/library/generators/standards.py
@@ -1,0 +1,152 @@
+"""
+Standard dimensions for common IC packages.
+
+These dimensions are based on JEDEC and IPC-7351 standards.
+"""
+
+# SOIC (Small Outline Integrated Circuit) - JEDEC MS-012
+# Narrow body (3.9mm) packages
+SOIC_STANDARDS = {
+    8: {"pitch": 1.27, "body_width": 3.9, "body_length": 4.9, "pad_width": 1.95, "pad_height": 0.6},
+    14: {"pitch": 1.27, "body_width": 3.9, "body_length": 8.65, "pad_width": 1.95, "pad_height": 0.6},
+    16: {"pitch": 1.27, "body_width": 3.9, "body_length": 9.9, "pad_width": 1.95, "pad_height": 0.6},
+    18: {"pitch": 1.27, "body_width": 7.5, "body_length": 11.55, "pad_width": 1.95, "pad_height": 0.6},
+    20: {"pitch": 1.27, "body_width": 7.5, "body_length": 12.8, "pad_width": 1.95, "pad_height": 0.6},
+    24: {"pitch": 1.27, "body_width": 7.5, "body_length": 15.4, "pad_width": 1.95, "pad_height": 0.6},
+    28: {"pitch": 1.27, "body_width": 7.5, "body_length": 17.9, "pad_width": 1.95, "pad_height": 0.6},
+}
+
+# TSSOP (Thin Shrink Small Outline Package) - JEDEC MO-153
+TSSOP_STANDARDS = {
+    8: {"pitch": 0.65, "body_width": 3.0, "body_length": 3.0, "pad_width": 1.5, "pad_height": 0.4},
+    14: {"pitch": 0.65, "body_width": 4.4, "body_length": 5.0, "pad_width": 1.5, "pad_height": 0.4},
+    16: {"pitch": 0.65, "body_width": 4.4, "body_length": 5.0, "pad_width": 1.5, "pad_height": 0.4},
+    20: {"pitch": 0.65, "body_width": 4.4, "body_length": 6.5, "pad_width": 1.5, "pad_height": 0.4},
+    24: {"pitch": 0.65, "body_width": 4.4, "body_length": 7.8, "pad_width": 1.5, "pad_height": 0.4},
+    28: {"pitch": 0.65, "body_width": 4.4, "body_length": 9.7, "pad_width": 1.5, "pad_height": 0.4},
+}
+
+# LQFP (Low-profile Quad Flat Package) - JEDEC MS-026
+LQFP_STANDARDS = {
+    32: {"pitch": 0.8, "body_size": 7.0, "pad_width": 1.5, "pad_height": 0.55},
+    44: {"pitch": 0.8, "body_size": 10.0, "pad_width": 1.5, "pad_height": 0.55},
+    48: {"pitch": 0.5, "body_size": 7.0, "pad_width": 1.2, "pad_height": 0.3},
+    64: {"pitch": 0.5, "body_size": 10.0, "pad_width": 1.2, "pad_height": 0.3},
+    80: {"pitch": 0.5, "body_size": 12.0, "pad_width": 1.2, "pad_height": 0.3},
+    100: {"pitch": 0.5, "body_size": 14.0, "pad_width": 1.2, "pad_height": 0.3},
+    144: {"pitch": 0.5, "body_size": 20.0, "pad_width": 1.2, "pad_height": 0.3},
+}
+
+# QFN (Quad Flat No-lead) - common sizes
+QFN_STANDARDS = {
+    # (pins, body_size): specs
+    (8, 2.0): {"pitch": 0.5, "pad_width": 0.8, "pad_height": 0.3, "exposed_pad": 0.9},
+    (16, 3.0): {"pitch": 0.5, "pad_width": 0.8, "pad_height": 0.3, "exposed_pad": 1.7},
+    (20, 4.0): {"pitch": 0.5, "pad_width": 0.8, "pad_height": 0.3, "exposed_pad": 2.4},
+    (24, 4.0): {"pitch": 0.5, "pad_width": 0.8, "pad_height": 0.3, "exposed_pad": 2.4},
+    (32, 5.0): {"pitch": 0.5, "pad_width": 0.8, "pad_height": 0.3, "exposed_pad": 3.4},
+    (48, 7.0): {"pitch": 0.5, "pad_width": 0.8, "pad_height": 0.3, "exposed_pad": 5.2},
+}
+
+# SOT (Small Outline Transistor) packages
+SOT_STANDARDS = {
+    "SOT-23": {
+        "pins": 3,
+        "pitch": 0.95,
+        "body_width": 1.3,
+        "body_length": 2.9,
+        "pad_width": 1.0,
+        "pad_height": 0.6,
+        "pad_positions": [(-0.95, -1.0), (0.95, -1.0), (0, 1.0)],  # Pin 1, 2, 3
+    },
+    "SOT-23-5": {
+        "pins": 5,
+        "pitch": 0.95,
+        "body_width": 1.6,
+        "body_length": 2.9,
+        "pad_width": 1.06,
+        "pad_height": 0.6,
+        "pad_positions": [
+            (-0.95, -1.3),
+            (0, -1.3),
+            (0.95, -1.3),  # Pins 1, 2, 3
+            (0.95, 1.3),
+            (-0.95, 1.3),  # Pins 4, 5
+        ],
+    },
+    "SOT-23-6": {
+        "pins": 6,
+        "pitch": 0.95,
+        "body_width": 1.6,
+        "body_length": 2.9,
+        "pad_width": 1.06,
+        "pad_height": 0.6,
+        "pad_positions": [
+            (-0.95, -1.3),
+            (0, -1.3),
+            (0.95, -1.3),  # Pins 1, 2, 3
+            (0.95, 1.3),
+            (0, 1.3),
+            (-0.95, 1.3),  # Pins 4, 5, 6
+        ],
+    },
+    "SOT-223": {
+        "pins": 4,  # 3 small + 1 large tab
+        "pitch": 2.3,
+        "body_width": 3.5,
+        "body_length": 6.5,
+        "pad_width": 1.6,
+        "pad_height": 0.9,
+        "tab_width": 3.0,
+        "tab_height": 1.6,
+        "pad_positions": [
+            (-2.3, 3.15),
+            (0, 3.15),
+            (2.3, 3.15),  # Pins 1, 2, 3
+            (0, -3.15),  # Tab (pin 4)
+        ],
+    },
+    "SOT-89": {
+        "pins": 3,
+        "pitch": 1.5,
+        "body_width": 2.5,
+        "body_length": 4.5,
+        "pad_width": 1.5,
+        "pad_height": 0.6,
+        "tab_width": 1.5,
+        "tab_height": 2.0,
+        "pad_positions": [
+            (-1.5, 2.05),
+            (0, 2.05),
+            (1.5, 2.05),  # Pins 1, 2, 3
+        ],
+    },
+}
+
+# Chip components (resistors, capacitors, etc.)
+# Imperial size -> metric size (mm)
+CHIP_SIZES = {
+    "0201": {"length": 0.6, "width": 0.3, "pad_width": 0.4, "pad_height": 0.35, "pad_gap": 0.3, "metric": "0603"},
+    "0402": {"length": 1.0, "width": 0.5, "pad_width": 0.6, "pad_height": 0.55, "pad_gap": 0.5, "metric": "1005"},
+    "0603": {"length": 1.6, "width": 0.8, "pad_width": 0.9, "pad_height": 0.95, "pad_gap": 0.8, "metric": "1608"},
+    "0805": {"length": 2.0, "width": 1.25, "pad_width": 1.0, "pad_height": 1.35, "pad_gap": 1.0, "metric": "2012"},
+    "1206": {"length": 3.2, "width": 1.6, "pad_width": 1.15, "pad_height": 1.8, "pad_gap": 1.8, "metric": "3216"},
+    "1210": {"length": 3.2, "width": 2.5, "pad_width": 1.15, "pad_height": 2.7, "pad_gap": 1.8, "metric": "3225"},
+    "1812": {"length": 4.5, "width": 3.2, "pad_width": 1.3, "pad_height": 3.4, "pad_gap": 2.6, "metric": "4532"},
+    "2010": {"length": 5.0, "width": 2.5, "pad_width": 1.3, "pad_height": 2.7, "pad_gap": 3.0, "metric": "5025"},
+    "2512": {"length": 6.3, "width": 3.2, "pad_width": 1.5, "pad_height": 3.4, "pad_gap": 4.0, "metric": "6332"},
+}
+
+# DIP (Dual In-line Package) standards
+DIP_STANDARDS = {
+    # Narrow DIP (0.3" = 7.62mm row spacing)
+    8: {"pitch": 2.54, "row_spacing": 7.62, "pad_diameter": 1.6, "drill": 0.8},
+    14: {"pitch": 2.54, "row_spacing": 7.62, "pad_diameter": 1.6, "drill": 0.8},
+    16: {"pitch": 2.54, "row_spacing": 7.62, "pad_diameter": 1.6, "drill": 0.8},
+    18: {"pitch": 2.54, "row_spacing": 7.62, "pad_diameter": 1.6, "drill": 0.8},
+    20: {"pitch": 2.54, "row_spacing": 7.62, "pad_diameter": 1.6, "drill": 0.8},
+    # Wide DIP (0.6" = 15.24mm row spacing)
+    24: {"pitch": 2.54, "row_spacing": 15.24, "pad_diameter": 1.6, "drill": 0.8},
+    28: {"pitch": 2.54, "row_spacing": 15.24, "pad_diameter": 1.6, "drill": 0.8},
+    40: {"pitch": 2.54, "row_spacing": 15.24, "pad_diameter": 1.6, "drill": 0.8},
+}

--- a/src/kicad_tools/library/generators/through_hole.py
+++ b/src/kicad_tools/library/generators/through_hole.py
@@ -1,0 +1,224 @@
+"""
+Through-hole footprint generators.
+
+Generates DIP packages and pin headers.
+"""
+
+from ..footprint import Footprint
+from .standards import DIP_STANDARDS
+
+
+def create_dip(
+    pins: int,
+    pitch: float | None = None,
+    row_spacing: float | None = None,
+    pad_diameter: float | None = None,
+    drill: float | None = None,
+    name: str | None = None,
+) -> Footprint:
+    """
+    Create a DIP (Dual In-line Package) footprint.
+
+    Args:
+        pins: Number of pins (must be even)
+        pitch: Pin pitch in mm (default: 2.54mm)
+        row_spacing: Distance between rows in mm (default: 7.62mm for narrow,
+                     15.24mm for wide)
+        pad_diameter: Pad diameter in mm
+        drill: Drill hole diameter in mm
+        name: Custom footprint name (auto-generated if not specified)
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_dip(pins=8)
+        >>> fp.name
+        'DIP-8_W7.62mm_P2.54mm'
+
+        >>> fp = create_dip(pins=28, row_spacing=15.24)
+        >>> fp.name
+        'DIP-28_W15.24mm_P2.54mm'
+    """
+    if pins % 2 != 0:
+        raise ValueError(f"DIP must have even number of pins, got {pins}")
+
+    if pins < 4:
+        raise ValueError(f"DIP must have at least 4 pins, got {pins}")
+
+    # Get defaults from standards
+    std = DIP_STANDARDS.get(pins, {})
+    pitch = pitch or std.get("pitch", 2.54)
+    row_spacing = row_spacing or std.get("row_spacing", 7.62 if pins <= 22 else 15.24)
+    pad_diameter = pad_diameter or std.get("pad_diameter", 1.6)
+    drill = drill or std.get("drill", 0.8)
+
+    if name is None:
+        name = f"DIP-{pins}_W{row_spacing}mm_P{pitch}mm"
+
+    fp = Footprint(
+        name=name,
+        description=f"DIP, {pins} Pin, pitch {pitch}mm, row spacing {row_spacing}mm",
+        tags=["DIP", "THT", f"P{pitch}mm"],
+        attr="through_hole",
+    )
+
+    pins_per_side = pins // 2
+    span = (pins_per_side - 1) * pitch
+
+    # Left column (pins 1 to pins_per_side)
+    for i in range(pins_per_side):
+        pin_num = i + 1
+        y = -span / 2 + i * pitch
+        fp.add_pad(
+            str(pin_num),
+            x=-row_spacing / 2,
+            y=y,
+            width=pad_diameter,
+            height=pad_diameter,
+            pad_type="thru_hole",
+            shape="circle" if pin_num > 1 else "rect",  # Pin 1 is square
+            drill=drill,
+            layers=("*.Cu", "*.Mask"),
+        )
+
+    # Right column (pins pins_per_side+1 to pins, bottom to top)
+    for i in range(pins_per_side):
+        pin_num = pins_per_side + i + 1
+        y = span / 2 - i * pitch
+        fp.add_pad(
+            str(pin_num),
+            x=row_spacing / 2,
+            y=y,
+            width=pad_diameter,
+            height=pad_diameter,
+            pad_type="thru_hole",
+            shape="circle",
+            drill=drill,
+            layers=("*.Cu", "*.Mask"),
+        )
+
+    # Silkscreen outline
+    body_width = row_spacing - 2.0  # Body is narrower than row spacing
+    body_length = span + pitch
+    silk_x = body_width / 2
+    silk_y = body_length / 2
+
+    # Body outline with notch at pin 1 end
+    notch_radius = 0.8
+    fp.add_line((-silk_x, -silk_y), (silk_x, -silk_y), "F.SilkS", 0.12)
+    fp.add_line((silk_x, -silk_y), (silk_x, silk_y), "F.SilkS", 0.12)
+    fp.add_line((silk_x, silk_y), (-silk_x, silk_y), "F.SilkS", 0.12)
+    fp.add_line((-silk_x, silk_y), (-silk_x, -silk_y + notch_radius), "F.SilkS", 0.12)
+    fp.add_line((-silk_x, -silk_y + notch_radius), (-silk_x + notch_radius, -silk_y), "F.SilkS", 0.12)
+
+    # Pin 1 marker
+    fp.add_circle((-row_spacing / 2, -span / 2 - 0.8), 0.2, "F.SilkS", 0.12, fill=True)
+
+    # Courtyard
+    crt_margin = 0.25
+    crt_x = row_spacing / 2 + pad_diameter / 2 + crt_margin
+    crt_y = span / 2 + pad_diameter / 2 + crt_margin
+    fp.add_rect((-crt_x, -crt_y), (crt_x, crt_y), "F.CrtYd", 0.05)
+
+    # Fab layer
+    fp.add_rect((-silk_x, -silk_y), (silk_x, silk_y), "F.Fab", 0.1)
+
+    return fp
+
+
+def create_pin_header(
+    pins: int,
+    rows: int = 1,
+    pitch: float = 2.54,
+    pad_diameter: float = 1.7,
+    drill: float = 1.0,
+    name: str | None = None,
+) -> Footprint:
+    """
+    Create a pin header footprint.
+
+    Args:
+        pins: Total number of pins
+        rows: Number of rows (1 or 2)
+        pitch: Pin pitch in mm (default: 2.54mm)
+        pad_diameter: Pad diameter in mm
+        drill: Drill hole diameter in mm
+        name: Custom footprint name (auto-generated if not specified)
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_pin_header(pins=10, rows=1)
+        >>> fp.name
+        'PinHeader_1x10_P2.54mm_Vertical'
+
+        >>> fp = create_pin_header(pins=20, rows=2)
+        >>> fp.name
+        'PinHeader_2x10_P2.54mm_Vertical'
+    """
+    if rows not in (1, 2):
+        raise ValueError(f"Rows must be 1 or 2, got {rows}")
+
+    if rows == 2 and pins % 2 != 0:
+        raise ValueError(f"2-row header must have even number of pins, got {pins}")
+
+    pins_per_row = pins if rows == 1 else pins // 2
+
+    if name is None:
+        name = f"PinHeader_{rows}x{pins_per_row}_P{pitch}mm_Vertical"
+
+    fp = Footprint(
+        name=name,
+        description=f"Pin Header, {rows}x{pins_per_row}, pitch {pitch}mm",
+        tags=["PinHeader", "THT", f"P{pitch}mm"],
+        attr="through_hole",
+    )
+
+    span = (pins_per_row - 1) * pitch
+    row_offset = pitch / 2 if rows == 2 else 0
+
+    pin_num = 1
+    for row in range(rows):
+        x = -row_offset + row * pitch if rows == 2 else 0
+        for i in range(pins_per_row):
+            y = -span / 2 + i * pitch
+            fp.add_pad(
+                str(pin_num),
+                x=x,
+                y=y,
+                width=pad_diameter,
+                height=pad_diameter,
+                pad_type="thru_hole",
+                shape="rect" if pin_num == 1 else "circle",
+                drill=drill,
+                layers=("*.Cu", "*.Mask"),
+            )
+            pin_num += 1
+
+    # Silkscreen outline
+    silk_margin = 0.3
+    if rows == 1:
+        silk_x = pitch / 2 - 0.1
+    else:
+        silk_x = pitch + 0.1
+    silk_y = span / 2 + pitch / 2
+
+    fp.add_rect((-silk_x - silk_margin, -silk_y - silk_margin),
+                (silk_x + silk_margin, silk_y + silk_margin), "F.SilkS", 0.12)
+
+    # Pin 1 marker
+    marker_x = -silk_x - silk_margin - 0.3 if rows == 1 else -row_offset - 0.5
+    fp.add_circle((marker_x, -span / 2), 0.15, "F.SilkS", 0.12, fill=True)
+
+    # Courtyard
+    crt_margin = 0.25
+    crt_x = silk_x + silk_margin + crt_margin
+    crt_y = silk_y + silk_margin + crt_margin
+    fp.add_rect((-crt_x, -crt_y), (crt_x, crt_y), "F.CrtYd", 0.05)
+
+    # Fab layer
+    fp.add_rect((-silk_x, -silk_y), (silk_x, silk_y), "F.Fab", 0.1)
+
+    return fp

--- a/tests/test_footprint_generators.py
+++ b/tests/test_footprint_generators.py
@@ -1,0 +1,545 @@
+"""
+Tests for parametric footprint generators.
+
+Tests cover:
+- SOIC, QFP, QFN, SOT, chip, DIP, and pin header generators
+- IPC-7351 naming conventions
+- Correct pad positions and dimensions
+- .kicad_mod export format
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.library import (
+    Footprint,
+    Pad,
+    create_soic,
+    create_qfp,
+    create_qfn,
+    create_sot,
+    create_chip,
+    create_dip,
+    create_pin_header,
+)
+
+
+# =============================================================================
+# Footprint Data Class Tests
+# =============================================================================
+
+
+class TestFootprint:
+    """Tests for the Footprint data class."""
+
+    def test_create_empty_footprint(self):
+        """Test creating an empty footprint."""
+        fp = Footprint(name="Test")
+        assert fp.name == "Test"
+        assert fp.pads == []
+        assert fp.graphics == []
+
+    def test_add_pad(self):
+        """Test adding pads to a footprint."""
+        fp = Footprint(name="Test")
+        fp.add_pad("1", x=0, y=0, width=1.0, height=0.5)
+
+        assert len(fp.pads) == 1
+        assert fp.pads[0].name == "1"
+        assert fp.pads[0].x == 0
+        assert fp.pads[0].y == 0
+
+    def test_add_line(self):
+        """Test adding a line to a footprint."""
+        fp = Footprint(name="Test")
+        fp.add_line((0, 0), (1, 1), "F.SilkS", 0.12)
+
+        assert len(fp.graphics) == 1
+        assert fp.graphics[0].start_x == 0
+        assert fp.graphics[0].end_x == 1
+
+    def test_add_rect(self):
+        """Test adding a rectangle to a footprint."""
+        fp = Footprint(name="Test")
+        fp.add_rect((-1, -1), (1, 1), "F.CrtYd", 0.05)
+
+        assert len(fp.graphics) == 1
+        assert fp.graphics[0].start_x == -1
+        assert fp.graphics[0].end_x == 1
+
+    def test_to_sexp(self):
+        """Test S-expression export."""
+        fp = Footprint(name="Test", description="Test footprint", tags=["test"])
+        fp.add_pad("1", x=-0.5, y=0, width=0.6, height=0.4)
+        fp.add_pad("2", x=0.5, y=0, width=0.6, height=0.4)
+
+        sexp = fp.to_sexp()
+
+        assert '(footprint "Test"' in sexp
+        assert '(descr "Test footprint")' in sexp
+        assert '(tags "test")' in sexp
+        assert '(pad "1" smd roundrect' in sexp
+        assert '(pad "2" smd roundrect' in sexp
+
+    def test_save_footprint(self):
+        """Test saving footprint to file."""
+        fp = Footprint(name="Test")
+        fp.add_pad("1", x=0, y=0, width=1.0, height=0.5)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.kicad_mod"
+            fp.save(path)
+
+            assert path.exists()
+            content = path.read_text()
+            assert '(footprint "Test"' in content
+
+
+# =============================================================================
+# SOIC Generator Tests
+# =============================================================================
+
+
+class TestSOICGenerator:
+    """Tests for SOIC footprint generator."""
+
+    def test_create_soic_8(self):
+        """Test creating SOIC-8 with default dimensions."""
+        fp = create_soic(pins=8)
+
+        assert fp.name == "SOIC-8_3.9x4.9mm_P1.27mm"
+        assert len(fp.pads) == 8
+        assert fp.attr == "smd"
+
+    def test_create_soic_16(self):
+        """Test creating SOIC-16."""
+        fp = create_soic(pins=16)
+
+        assert "SOIC-16" in fp.name
+        assert len(fp.pads) == 16
+
+    def test_soic_pin_positions(self):
+        """Test SOIC pad positions are correct."""
+        fp = create_soic(pins=8, pitch=1.27)
+
+        # Pins 1-4 on left, 5-8 on right
+        left_pads = [p for p in fp.pads if p.x < 0]
+        right_pads = [p for p in fp.pads if p.x > 0]
+
+        assert len(left_pads) == 4
+        assert len(right_pads) == 4
+
+        # Check pitch between pins
+        left_sorted = sorted(left_pads, key=lambda p: p.y)
+        for i in range(len(left_sorted) - 1):
+            pitch = left_sorted[i + 1].y - left_sorted[i].y
+            assert abs(pitch - 1.27) < 0.01
+
+    def test_soic_custom_dimensions(self):
+        """Test SOIC with custom dimensions."""
+        fp = create_soic(
+            pins=8,
+            pitch=1.27,
+            body_width=4.0,
+            body_length=5.0,
+            pad_width=2.0,
+            pad_height=0.65,
+        )
+
+        assert fp.pads[0].width == 2.0
+        assert fp.pads[0].height == 0.65
+
+    def test_soic_custom_name(self):
+        """Test SOIC with custom name."""
+        fp = create_soic(pins=8, name="MyCustomSOIC")
+
+        assert fp.name == "MyCustomSOIC"
+
+    def test_soic_invalid_pins(self):
+        """Test SOIC with invalid pin count."""
+        with pytest.raises(ValueError, match="even number"):
+            create_soic(pins=7)
+
+        with pytest.raises(ValueError, match="4-32"):
+            create_soic(pins=64)
+
+
+# =============================================================================
+# QFP Generator Tests
+# =============================================================================
+
+
+class TestQFPGenerator:
+    """Tests for QFP/LQFP footprint generator."""
+
+    def test_create_lqfp_48(self):
+        """Test creating LQFP-48."""
+        fp = create_qfp(pins=48, pitch=0.5, body_size=7.0)
+
+        assert "LQFP-48" in fp.name
+        assert len(fp.pads) == 48
+
+    def test_qfp_square_pin_count(self):
+        """Test QFP with pins divisible by 4."""
+        fp = create_qfp(pins=64, body_size=10.0)
+
+        assert len(fp.pads) == 64
+        # 16 pins per side
+        bottom = [p for p in fp.pads if p.y > 4]
+        assert len(bottom) == 16
+
+    def test_qfp_rectangular(self):
+        """Test rectangular QFP."""
+        fp = create_qfp(
+            pins=64,
+            pitch=0.5,
+            body_width=10.0,
+            body_length=14.0,
+            pins_x=16,
+            pins_y=16,
+        )
+
+        assert len(fp.pads) == 64
+
+    def test_qfp_invalid_square_pins(self):
+        """Test QFP with pins not divisible by 4."""
+        with pytest.raises(ValueError, match="divisible by 4"):
+            create_qfp(pins=50, body_size=10.0)
+
+
+# =============================================================================
+# QFN Generator Tests
+# =============================================================================
+
+
+class TestQFNGenerator:
+    """Tests for QFN footprint generator."""
+
+    def test_create_qfn_16(self):
+        """Test creating QFN-16."""
+        fp = create_qfn(pins=16, pitch=0.5, body_size=3.0)
+
+        assert "QFN-16" in fp.name
+        # 16 signal pins, no EP by default if not in standards
+        assert len(fp.pads) >= 16
+
+    def test_qfn_with_exposed_pad(self):
+        """Test QFN with exposed thermal pad."""
+        fp = create_qfn(pins=16, body_size=3.0, exposed_pad=1.7)
+
+        assert "_EP" in fp.name
+        assert len(fp.pads) == 17  # 16 + exposed pad
+
+        # Find the exposed pad (should be center, larger)
+        ep = [p for p in fp.pads if p.name == "17"][0]
+        assert ep.x == 0
+        assert ep.y == 0
+        assert ep.width == 1.7
+
+    def test_qfn_pad_positions(self):
+        """Test QFN pad positions around perimeter."""
+        fp = create_qfn(pins=16, body_size=4.0)
+
+        # 4 pins per side
+        for i in range(1, 17):
+            pad = [p for p in fp.pads if p.name == str(i)][0]
+            # All pads should be near edges (not center)
+            assert abs(pad.x) > 1.0 or abs(pad.y) > 1.0
+
+
+# =============================================================================
+# SOT Generator Tests
+# =============================================================================
+
+
+class TestSOTGenerator:
+    """Tests for SOT footprint generator."""
+
+    def test_create_sot23(self):
+        """Test creating SOT-23."""
+        fp = create_sot("SOT-23")
+
+        assert fp.name == "SOT-23"
+        assert len(fp.pads) == 3
+
+    def test_create_sot23_5(self):
+        """Test creating SOT-23-5."""
+        fp = create_sot("SOT-23-5")
+
+        assert fp.name == "SOT-23-5"
+        assert len(fp.pads) == 5
+
+    def test_create_sot23_6(self):
+        """Test creating SOT-23-6."""
+        fp = create_sot("SOT-23-6")
+
+        assert fp.name == "SOT-23-6"
+        assert len(fp.pads) == 6
+
+    def test_create_sot223(self):
+        """Test creating SOT-223."""
+        fp = create_sot("SOT-223")
+
+        assert fp.name == "SOT-223"
+        assert len(fp.pads) == 4
+
+        # Tab pad should be larger
+        tab = [p for p in fp.pads if p.name == "4"][0]
+        assert tab.width > 2.0  # Tab is larger
+
+    def test_create_sot89(self):
+        """Test creating SOT-89."""
+        fp = create_sot("SOT-89")
+
+        assert fp.name == "SOT-89"
+        assert len(fp.pads) == 3
+
+    def test_sot_invalid_variant(self):
+        """Test SOT with invalid variant."""
+        with pytest.raises(ValueError, match="Unknown SOT variant"):
+            create_sot("SOT-999")
+
+
+# =============================================================================
+# Chip Component Generator Tests
+# =============================================================================
+
+
+class TestChipGenerator:
+    """Tests for chip component footprint generator."""
+
+    def test_create_chip_0603(self):
+        """Test creating 0603 chip."""
+        fp = create_chip("0603")
+
+        assert "0603" in fp.name
+        assert "1608" in fp.name  # Metric size
+        assert len(fp.pads) == 2
+
+    def test_create_chip_with_prefix(self):
+        """Test creating chip with prefix."""
+        fp = create_chip("0402", prefix="R")
+
+        assert fp.name.startswith("R_")
+        assert "0402" in fp.name
+
+    def test_create_chip_metric_naming(self):
+        """Test chip with metric naming."""
+        fp = create_chip("0402", prefix="C", metric=True)
+
+        assert "1005" in fp.name
+        assert "0402" not in fp.name
+
+    def test_chip_sizes(self):
+        """Test various chip sizes."""
+        sizes = ["0201", "0402", "0603", "0805", "1206"]
+
+        for size in sizes:
+            fp = create_chip(size)
+            assert len(fp.pads) == 2
+            # Larger sizes should have larger pads
+            if size == "0201":
+                assert fp.pads[0].height < 0.5
+            elif size == "1206":
+                assert fp.pads[0].height > 1.5
+
+    def test_chip_invalid_size(self):
+        """Test chip with invalid size."""
+        with pytest.raises(ValueError, match="Unknown chip size"):
+            create_chip("9999")
+
+
+# =============================================================================
+# DIP Generator Tests
+# =============================================================================
+
+
+class TestDIPGenerator:
+    """Tests for DIP footprint generator."""
+
+    def test_create_dip_8(self):
+        """Test creating DIP-8."""
+        fp = create_dip(pins=8)
+
+        assert "DIP-8" in fp.name
+        assert len(fp.pads) == 8
+        assert fp.attr == "through_hole"
+
+    def test_dip_wide(self):
+        """Test creating wide DIP."""
+        fp = create_dip(pins=28, row_spacing=15.24)
+
+        assert "W15.24mm" in fp.name
+        # Check row spacing
+        left_pads = [p for p in fp.pads if p.x < 0]
+        right_pads = [p for p in fp.pads if p.x > 0]
+        spacing = right_pads[0].x - left_pads[0].x
+        assert abs(spacing - 15.24) < 0.01
+
+    def test_dip_pin_layout(self):
+        """Test DIP pin layout."""
+        fp = create_dip(pins=8)
+
+        # Pins 1-4 on left, 5-8 on right
+        pin1 = [p for p in fp.pads if p.name == "1"][0]
+        pin8 = [p for p in fp.pads if p.name == "8"][0]
+
+        assert pin1.x < 0  # Left side
+        assert pin8.x > 0  # Right side
+
+        # Pin 1 should be square
+        assert pin1.shape == "rect"
+
+    def test_dip_invalid_pins(self):
+        """Test DIP with invalid pin count."""
+        with pytest.raises(ValueError, match="even number"):
+            create_dip(pins=7)
+
+
+# =============================================================================
+# Pin Header Generator Tests
+# =============================================================================
+
+
+class TestPinHeaderGenerator:
+    """Tests for pin header footprint generator."""
+
+    def test_create_single_row(self):
+        """Test creating single row header."""
+        fp = create_pin_header(pins=10, rows=1)
+
+        assert "1x10" in fp.name
+        assert len(fp.pads) == 10
+
+    def test_create_dual_row(self):
+        """Test creating dual row header."""
+        fp = create_pin_header(pins=20, rows=2)
+
+        assert "2x10" in fp.name
+        assert len(fp.pads) == 20
+
+    def test_header_pin1_square(self):
+        """Test that pin 1 is square."""
+        fp = create_pin_header(pins=4, rows=1)
+
+        pin1 = [p for p in fp.pads if p.name == "1"][0]
+        assert pin1.shape == "rect"
+
+        # Other pins should be round
+        pin2 = [p for p in fp.pads if p.name == "2"][0]
+        assert pin2.shape == "circle"
+
+    def test_header_invalid_rows(self):
+        """Test header with invalid row count."""
+        with pytest.raises(ValueError, match="Rows must be 1 or 2"):
+            create_pin_header(pins=10, rows=3)
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+class TestIntegration:
+    """Integration tests for footprint generators."""
+
+    def test_save_and_reload(self):
+        """Test saving and verifying .kicad_mod content."""
+        fp = create_soic(pins=8)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "SOIC-8.kicad_mod"
+            fp.save(path)
+
+            content = path.read_text()
+
+            # Verify key elements
+            assert "(footprint" in content
+            assert "(version" in content
+            assert "(generator" in content
+            assert "(layer" in content
+            assert "(property" in content
+            assert "(pad" in content
+            assert "(fp_line" in content or "(fp_rect" in content
+
+    def test_all_generators_produce_valid_output(self):
+        """Test that all generators produce valid footprints."""
+        footprints = [
+            create_soic(pins=8),
+            create_qfp(pins=48, body_size=7.0),
+            create_qfn(pins=16, body_size=3.0),
+            create_sot("SOT-23"),
+            create_chip("0603"),
+            create_dip(pins=8),
+            create_pin_header(pins=6, rows=1),
+        ]
+
+        for fp in footprints:
+            sexp = fp.to_sexp()
+
+            # Basic structure checks
+            assert sexp.startswith("(footprint")
+            assert sexp.endswith(")")
+            assert "(version" in sexp
+            assert "(pad" in sexp
+
+    def test_ipc7351_naming(self):
+        """Test IPC-7351 naming convention compliance."""
+        # SOIC
+        soic = create_soic(pins=8, pitch=1.27, body_width=3.9, body_length=4.9)
+        assert "SOIC-8" in soic.name
+        assert "P1.27mm" in soic.name
+
+        # Chip
+        chip = create_chip("0603", prefix="R")
+        assert "R_0603" in chip.name
+        assert "Metric" in chip.name
+
+        # QFN
+        qfn = create_qfn(pins=16, body_size=3.0, exposed_pad=1.5)
+        assert "QFN-16" in qfn.name
+        assert "EP" in qfn.name
+
+
+# =============================================================================
+# Edge Case Tests
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_minimum_pin_counts(self):
+        """Test minimum valid pin counts."""
+        # These should work
+        create_soic(pins=4)
+        create_qfp(pins=8, body_size=5.0, pins_x=2, pins_y=2)
+        create_qfn(pins=4, body_size=2.0)
+        create_dip(pins=4)
+        create_pin_header(pins=1, rows=1)
+
+    def test_large_pin_counts(self):
+        """Test large pin counts."""
+        fp = create_qfp(pins=144, body_size=20.0)
+        assert len(fp.pads) == 144
+
+    def test_custom_names_preserved(self):
+        """Test that custom names are preserved."""
+        name = "MyCustomFootprint_v2"
+
+        fp = create_soic(pins=8, name=name)
+        assert fp.name == name
+
+        fp = create_qfn(pins=16, body_size=3.0, name=name)
+        assert fp.name == name
+
+    def test_fluent_api(self):
+        """Test fluent API for adding elements."""
+        fp = Footprint(name="Test")
+        result = fp.add_pad("1", 0, 0, 1, 1).add_line((0, 0), (1, 1)).add_rect((-1, -1), (1, 1))
+
+        assert result is fp
+        assert len(fp.pads) == 1
+        assert len(fp.graphics) == 2


### PR DESCRIPTION
## Summary

Implements parametric footprint generators following IPC-7351 naming conventions for common package types. This implementation provides the core generator functionality that can later be integrated with FootprintLibrary (issues #87, #88).

**Key features:**
- New `kicad_tools.library` module with `Footprint` data class
- Seven parametric generators: SOIC, QFP, QFN, SOT, chip, DIP, pin header
- Direct `.kicad_mod` file export capability
- Standards database with JEDEC/IPC dimensions

## Generators Implemented

| Generator | Description | Example Output |
|-----------|-------------|----------------|
| `create_soic()` | SOIC 8-28 pins | `SOIC-8_3.9x4.9mm_P1.27mm` |
| `create_qfp()` | LQFP square/rectangular | `LQFP-48_7x7mm_P0.5mm` |
| `create_qfn()` | QFN with optional exposed pad | `QFN-16_3x3mm_P0.5mm_EP` |
| `create_sot()` | SOT-23, SOT-223, SOT-89 | `SOT-23-5` |
| `create_chip()` | 0201-2512 passives | `R_0603_1608Metric` |
| `create_dip()` | DIP through-hole | `DIP-8_W7.62mm_P2.54mm` |
| `create_pin_header()` | 1x/2x pin headers | `PinHeader_1x10_P2.54mm_Vertical` |

## Usage Example

```python
from kicad_tools.library import create_soic, create_chip

# Create SOIC-8 with default dimensions
fp = create_soic(pins=8)
fp.save("MyLib.pretty/SOIC-8_Custom.kicad_mod")

# Create chip resistor 0603
fp = create_chip("0603", prefix="R")
print(fp.name)  # R_0603_1608Metric
```

## Test Plan

- [x] 45 unit tests covering all generators (all passing)
- [x] Edge case tests (minimum/maximum pin counts, invalid inputs)
- [x] Integration tests (save and verify .kicad_mod format)
- [x] IPC-7351 naming compliance verification

## Files Added

- `src/kicad_tools/library/__init__.py` - Module exports
- `src/kicad_tools/library/footprint.py` - Footprint data class with export
- `src/kicad_tools/library/generators/` - All generator implementations
- `tests/test_footprint_generators.py` - Comprehensive test suite

Closes #89