### PR TITLE
Fix zone hatch type 'edge' being incorrectly quoted

### DIFF
--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -575,6 +575,8 @@ class SExp:
             # Zone fill modes
             "hatch",
             "hatched",
+            # Zone hatch types
+            "edge",
             # Via types
             "blind",
             "micro",

--- a/tests/test_sexp_parser.py
+++ b/tests/test_sexp_parser.py
@@ -565,6 +565,27 @@ class TestRoundTrip:
         assert "none" in serialized
         assert '"none"' not in serialized
 
+    def test_roundtrip_zone_hatch_type_unquoted(self):
+        """Zone hatch type 'edge' should not be quoted (fixes issue #114)."""
+        sexp = """(hatch edge 0.5)"""
+        parsed = parse_string(sexp)
+        serialized = parsed.to_string()
+
+        # 'edge' is a keyword that should not be quoted
+        assert "edge" in serialized
+        assert '"edge"' not in serialized
+        assert serialized.strip() == "(hatch edge 0.5)"
+
+    def test_roundtrip_zone_hatch_all_types_unquoted(self):
+        """All zone hatch types (none, edge, full) should not be quoted."""
+        for hatch_type in ["none", "edge", "full"]:
+            sexp = f"(hatch {hatch_type} 0.5)"
+            parsed = parse_string(sexp)
+            serialized = parsed.to_string()
+
+            assert hatch_type in serialized
+            assert f'"{hatch_type}"' not in serialized
+
     def test_roundtrip_boolean_values_unquoted(self):
         """Boolean values like yes, no are not quoted."""
         sexp = """(legacy_teardrops no)"""


### PR DESCRIPTION
## Summary

Fix zone hatch type serialization by adding `edge` to the `unquoted_keywords` set in the S-expression parser.

## Problem

When loading and saving a PCB file with zones, the hatch type value (`edge`, `none`, `full`) was being quoted:

```
(hatch "edge" 0.5)  ← Incorrect - KiCad rejects this
```

KiCad expects:

```
(hatch edge 0.5)    ← Correct - unquoted keyword
```

## Changes

- Added `edge` to `unquoted_keywords` in `src/kicad_tools/sexp/parser.py`
- Added tests for zone hatch type serialization

## Test Plan

- [x] New tests verify `edge`, `none`, and `full` are not quoted
- [x] All existing sexp and zone tests pass (100 tests)
- [x] Verified fix with manual test command

Closes #114