### PR TITLE
Add symbol library creation and save support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -415,3 +415,37 @@ def minimal_design_rules(tmp_path: Path) -> Path:
     dru_file = tmp_path / "test.kicad_dru"
     dru_file.write_text(MINIMAL_DESIGN_RULES)
     return dru_file
+
+
+# Minimal KiCad symbol library for testing
+MINIMAL_SYMBOL_LIBRARY = """(kicad_symbol_lib
+  (version "20231120")
+  (generator "test")
+  (symbol "Device:R"
+    (property "Reference" "R" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "R" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "" (at 0 0 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 0 0 0) (effects (hide yes)))
+    (symbol "Device:R_0_1"
+      (pin passive line (at -2.54 0 0) (length 2.54) (name "1") (number "1"))
+      (pin passive line (at 2.54 0 180) (length 2.54) (name "2") (number "2"))
+    )
+  )
+  (symbol "Device:C"
+    (property "Reference" "C" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "C" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+    (symbol "Device:C_0_1"
+      (pin passive line (at -2.54 0 0) (length 2.54) (name "1") (number "1"))
+      (pin passive line (at 2.54 0 180) (length 2.54) (name "2") (number "2"))
+    )
+  )
+)
+"""
+
+
+@pytest.fixture
+def minimal_symbol_library(tmp_path: Path) -> Path:
+    """Create a minimal symbol library file for testing."""
+    lib_file = tmp_path / "test.kicad_sym"
+    lib_file.write_text(MINIMAL_SYMBOL_LIBRARY)
+    return lib_file


### PR DESCRIPTION
## Summary

Extend `SymbolLibrary` to support creating new libraries and saving them to `.kicad_sym` files with round-trip fidelity.

### Changes

- Add `SymbolLibrary.create()` class method for creating empty libraries
- Add `SymbolLibrary.save()` method for writing libraries to files
- Store original S-expression for round-trip support (preserves file structure when loading and saving)
- Add `version` and `generator` attributes extracted from files
- Add comprehensive tests for create, save, and round-trip scenarios

### Usage Examples

```python
from kicad_tools.schema.library import SymbolLibrary

# Create empty library
lib = SymbolLibrary.create("my-symbols.kicad_sym")

# Or with version info
lib = SymbolLibrary.create("my-symbols.kicad_sym", version="20231120")

# Save to original path
lib.save()

# Save to new path
lib.save("output/my-symbols.kicad_sym")

# Round-trip fidelity
lib = SymbolLibrary.load("existing.kicad_sym")
lib.save()  # Preserves original structure
```

## Test Plan

- [x] `SymbolLibrary.create()` creates valid empty library with correct defaults
- [x] `SymbolLibrary.create()` accepts custom version strings
- [x] `SymbolLibrary.save()` writes valid .kicad_sym files
- [x] Saved files can be reloaded successfully
- [x] Round-trip: load → save preserves file structure and symbols
- [x] Error handling: raises ValueError when no path is specified
- [x] All existing tests continue to pass

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)