### PR TITLE
Implement edge clearance DRC checks

### DIFF
--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from kicad_tools.manufacturers import DesignRules, get_profile
 
 from .rules.clearance import ClearanceRule
+from .rules.edge import EdgeClearanceRule
 from .violations import DRCResults
 
 if TYPE_CHECKING:
@@ -120,13 +121,15 @@ class DRCChecker:
     def check_edge_clearances(self) -> DRCResults:
         """Check edge clearance rules (copper-to-board-edge).
 
+        Validates that all copper elements (traces, pads, zones) and holes
+        (vias, through-hole pads) maintain minimum clearance from the board
+        edge as specified by manufacturer design rules.
+
         Returns:
             DRCResults containing edge clearance violations
-
-        Note:
-            This is a stub method. Actual implementation is in issue #95.
         """
-        return DRCResults(rules_checked=0)
+        rule = EdgeClearanceRule()
+        return rule.check(self.pcb, self.design_rules)
 
     def check_silkscreen(self) -> DRCResults:
         """Check silkscreen rules (line width, text height, over-pad).

--- a/src/kicad_tools/validate/rules/__init__.py
+++ b/src/kicad_tools/validate/rules/__init__.py
@@ -7,5 +7,6 @@ implementations for the pure Python DRC checker.
 from .base import DRCRule
 from .clearance import ClearanceRule
 from .dimensions import DimensionRules
+from .edge import EdgeClearanceRule
 
-__all__ = ["DRCRule", "ClearanceRule", "DimensionRules"]
+__all__ = ["DRCRule", "ClearanceRule", "DimensionRules", "EdgeClearanceRule"]

--- a/src/kicad_tools/validate/rules/edge.py
+++ b/src/kicad_tools/validate/rules/edge.py
@@ -1,0 +1,306 @@
+"""Edge clearance DRC rules.
+
+This module implements board edge validation rules that check minimum
+copper-to-edge and hole-to-edge clearances.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from ..violations import DRCResults, DRCViolation
+from .base import DRCRule
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers import DesignRules
+    from kicad_tools.schema.pcb import PCB
+
+
+class EdgeClearanceRule(DRCRule):
+    """Check copper and hole clearances to board edge.
+
+    Validates that all copper elements (traces, pads, zones) and holes (vias)
+    maintain minimum clearance from the board edge as specified by
+    manufacturer design rules.
+
+    Rule IDs generated:
+        - edge_clearance_trace: Trace too close to board edge
+        - edge_clearance_pad: Pad too close to board edge
+        - edge_clearance_via: Via too close to board edge
+        - edge_clearance_zone: Zone copper too close to board edge
+    """
+
+    rule_id = "edge_clearance"
+    name = "Edge Clearance"
+    description = "Check copper-to-edge and hole-to-edge clearances"
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Check all edge clearance rules.
+
+        Args:
+            pcb: The PCB to check
+            design_rules: Design rules from the manufacturer profile
+
+        Returns:
+            DRCResults containing edge clearance violations
+        """
+        results = DRCResults()
+
+        # Get board outline segments for distance calculations
+        outline_segments = pcb.get_board_outline_segments()
+        if not outline_segments:
+            # No board outline defined, can't check edge clearances
+            return results
+
+        # Check each type of copper element
+        self._check_segments(pcb, outline_segments, design_rules, results)
+        self._check_vias(pcb, outline_segments, design_rules, results)
+        self._check_pads(pcb, outline_segments, design_rules, results)
+        self._check_zones(pcb, outline_segments, design_rules, results)
+
+        return results
+
+    def _check_segments(
+        self,
+        pcb: PCB,
+        outline_segments: list[tuple[tuple[float, float], tuple[float, float]]],
+        design_rules: DesignRules,
+        results: DRCResults,
+    ) -> None:
+        """Check trace segment clearances to board edge."""
+        min_clearance = design_rules.min_copper_to_edge_mm
+
+        for segment in pcb.segments:
+            # Check both endpoints and consider trace width
+            half_width = segment.width / 2
+
+            for point in [segment.start, segment.end]:
+                distance = self._min_distance_to_outline(point, outline_segments)
+                # Actual clearance from trace edge (not centerline)
+                actual_clearance = distance - half_width
+
+                if actual_clearance < min_clearance:
+                    results.add(
+                        DRCViolation(
+                            rule_id="edge_clearance_trace",
+                            severity="error",
+                            message=(
+                                f"Trace to board edge {actual_clearance:.3f}mm "
+                                f"< minimum {min_clearance:.2f}mm"
+                            ),
+                            location=point,
+                            layer=segment.layer,
+                            actual_value=actual_clearance,
+                            required_value=min_clearance,
+                            items=(f"Net {segment.net_number}",),
+                        )
+                    )
+
+        results.rules_checked += 1
+
+    def _check_vias(
+        self,
+        pcb: PCB,
+        outline_segments: list[tuple[tuple[float, float], tuple[float, float]]],
+        design_rules: DesignRules,
+        results: DRCResults,
+    ) -> None:
+        """Check via clearances to board edge.
+
+        Vias use min_hole_to_edge_mm which is typically stricter than copper clearance.
+        """
+        min_clearance = design_rules.min_hole_to_edge_mm
+
+        for via in pcb.vias:
+            distance = self._min_distance_to_outline(via.position, outline_segments)
+            # Via edge is at position - size/2
+            half_size = via.size / 2
+            actual_clearance = distance - half_size
+
+            if actual_clearance < min_clearance:
+                results.add(
+                    DRCViolation(
+                        rule_id="edge_clearance_via",
+                        severity="error",
+                        message=(
+                            f"Via to board edge {actual_clearance:.3f}mm "
+                            f"< minimum {min_clearance:.2f}mm"
+                        ),
+                        location=via.position,
+                        layer=via.layers[0] if via.layers else None,
+                        actual_value=actual_clearance,
+                        required_value=min_clearance,
+                        items=(f"Net {via.net_number}",),
+                    )
+                )
+
+        results.rules_checked += 1
+
+    def _check_pads(
+        self,
+        pcb: PCB,
+        outline_segments: list[tuple[tuple[float, float], tuple[float, float]]],
+        design_rules: DesignRules,
+        results: DRCResults,
+    ) -> None:
+        """Check pad clearances to board edge.
+
+        Through-hole pads use min_hole_to_edge_mm.
+        SMD pads use min_copper_to_edge_mm.
+        """
+        min_copper_clearance = design_rules.min_copper_to_edge_mm
+        min_hole_clearance = design_rules.min_hole_to_edge_mm
+
+        for footprint in pcb.footprints:
+            fp_x, fp_y = footprint.position
+            fp_rotation = math.radians(footprint.rotation)
+            cos_rot = math.cos(fp_rotation)
+            sin_rot = math.sin(fp_rotation)
+
+            for pad in footprint.pads:
+                # Transform pad position to board coordinates
+                pad_local_x, pad_local_y = pad.position
+                pad_x = fp_x + (pad_local_x * cos_rot - pad_local_y * sin_rot)
+                pad_y = fp_y + (pad_local_x * sin_rot + pad_local_y * cos_rot)
+                pad_pos = (pad_x, pad_y)
+
+                distance = self._min_distance_to_outline(pad_pos, outline_segments)
+
+                # Calculate pad edge offset (use larger dimension for safety)
+                half_size = max(pad.size[0], pad.size[1]) / 2
+                actual_clearance = distance - half_size
+
+                # Select clearance rule based on pad type
+                if pad.type == "thru_hole":
+                    min_clearance = min_hole_clearance
+                    rule_id = "edge_clearance_pad_hole"
+                else:
+                    min_clearance = min_copper_clearance
+                    rule_id = "edge_clearance_pad"
+
+                if actual_clearance < min_clearance:
+                    results.add(
+                        DRCViolation(
+                            rule_id=rule_id,
+                            severity="error",
+                            message=(
+                                f"Pad {pad.number} to board edge {actual_clearance:.3f}mm "
+                                f"< minimum {min_clearance:.2f}mm"
+                            ),
+                            location=pad_pos,
+                            layer=footprint.layer,
+                            actual_value=actual_clearance,
+                            required_value=min_clearance,
+                            items=(footprint.reference, f"Pad {pad.number}"),
+                        )
+                    )
+
+        results.rules_checked += 1
+
+    def _check_zones(
+        self,
+        pcb: PCB,
+        outline_segments: list[tuple[tuple[float, float], tuple[float, float]]],
+        design_rules: DesignRules,
+        results: DRCResults,
+    ) -> None:
+        """Check zone copper clearances to board edge.
+
+        Checks the filled polygon vertices of each zone.
+        """
+        min_clearance = design_rules.min_copper_to_edge_mm
+
+        for zone in pcb.zones:
+            # Check filled polygons (actual copper) rather than boundary
+            polygons_to_check = zone.filled_polygons if zone.filled_polygons else [zone.polygon]
+
+            for polygon in polygons_to_check:
+                for point in polygon:
+                    distance = self._min_distance_to_outline(point, outline_segments)
+
+                    if distance < min_clearance:
+                        results.add(
+                            DRCViolation(
+                                rule_id="edge_clearance_zone",
+                                severity="error",
+                                message=(
+                                    f"Zone copper to board edge {distance:.3f}mm "
+                                    f"< minimum {min_clearance:.2f}mm"
+                                ),
+                                location=point,
+                                layer=zone.layer,
+                                actual_value=distance,
+                                required_value=min_clearance,
+                                items=(zone.net_name or f"Net {zone.net_number}",),
+                            )
+                        )
+
+        results.rules_checked += 1
+
+    def _min_distance_to_outline(
+        self,
+        point: tuple[float, float],
+        outline_segments: list[tuple[tuple[float, float], tuple[float, float]]],
+    ) -> float:
+        """Calculate minimum distance from a point to the board outline.
+
+        Args:
+            point: (x, y) coordinate in mm
+            outline_segments: List of line segments forming the board outline
+
+        Returns:
+            Minimum distance in mm from point to any outline segment
+        """
+        min_dist = float("inf")
+
+        for seg_start, seg_end in outline_segments:
+            dist = self._point_to_segment_distance(point, seg_start, seg_end)
+            min_dist = min(min_dist, dist)
+
+        return min_dist
+
+    @staticmethod
+    def _point_to_segment_distance(
+        point: tuple[float, float],
+        seg_start: tuple[float, float],
+        seg_end: tuple[float, float],
+    ) -> float:
+        """Calculate distance from a point to a line segment.
+
+        Args:
+            point: (x, y) coordinate
+            seg_start: Start of line segment (x, y)
+            seg_end: End of line segment (x, y)
+
+        Returns:
+            Distance from point to the closest point on the segment
+        """
+        px, py = point
+        x1, y1 = seg_start
+        x2, y2 = seg_end
+
+        # Vector from seg_start to seg_end
+        dx = x2 - x1
+        dy = y2 - y1
+
+        # Length squared of segment
+        length_sq = dx * dx + dy * dy
+
+        if length_sq == 0:
+            # Segment is a point
+            return math.sqrt((px - x1) ** 2 + (py - y1) ** 2)
+
+        # Project point onto segment line, clamped to [0, 1]
+        t = max(0, min(1, ((px - x1) * dx + (py - y1) * dy) / length_sq))
+
+        # Find closest point on segment
+        closest_x = x1 + t * dx
+        closest_y = y1 + t * dy
+
+        # Return distance to closest point
+        return math.sqrt((px - closest_x) ** 2 + (py - closest_y) ** 2)


### PR DESCRIPTION
## Summary

- Implement edge clearance DRC checks for PCB designs (issue #95)
- Add GraphicLine and GraphicArc classes to parse board outline from Edge.Cuts layer
- Create EdgeClearanceRule that validates copper-to-edge and hole-to-edge clearances
- Check traces, vias, pads, and zones against manufacturer design rules

## Changes

**PCB Schema (`schema/pcb.py`)**:
- Add `GraphicLine` and `GraphicArc` dataclasses for parsing `gr_line`/`gr_arc` elements
- Add `PCB.graphic_lines` and `PCB.graphic_arcs` properties
- Add `PCB.get_board_outline()` to extract ordered polygon from Edge.Cuts
- Add `PCB.get_board_outline_segments()` for distance calculations

**Validation (`validate/rules/edge.py`)**:
- Create `EdgeClearanceRule` class implementing `DRCRule`
- Check trace endpoints accounting for trace width
- Check via positions accounting for via size
- Check pad positions accounting for pad size and type (SMD vs through-hole)
- Check zone filled polygon vertices
- Use manufacturer's `min_copper_to_edge_mm` and `min_hole_to_edge_mm` rules

**Tests (`tests/test_validate.py`)**:
- Add tests for GraphicLine parsing
- Add tests for board outline extraction
- Add tests for edge clearance violations (traces, vias, pads)
- Add tests for point-to-segment distance calculation

## Test plan

- [x] Unit tests pass for graphic line parsing
- [x] Unit tests pass for board outline extraction
- [x] Unit tests detect traces too close to edge
- [x] Unit tests detect vias too close to edge
- [x] Unit tests detect pads too close to edge
- [x] Centered elements don't trigger false positives
- [x] No violations reported when no board outline exists

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)