### PR TITLE
Add rectilinear staircase compression for A* router output

### DIFF
--- a/src/kicad_tools/router/optimizer.py
+++ b/src/kicad_tools/router/optimizer.py
@@ -516,8 +516,12 @@ class TraceOptimizer:
         """
         Find the end index of a staircase pattern starting at start_idx.
 
-        A staircase is a run of segments alternating between two directions
-        that are approximately 45° apart (e.g., 0° and 45°, or 180° and 135°).
+        A staircase is a run of segments alternating between two directions:
+        - Orthogonal+diagonal patterns: ~45° apart (e.g., 0° and 45°, or 180° and 135°)
+        - Rectilinear patterns: ~90° apart (e.g., 0° and 90°, horizontal/vertical)
+
+        The rectilinear pattern detection enables compression of H/V staircases
+        produced by A* routers on rectilinear grids.
 
         Args:
             segments: List of all segments.
@@ -533,14 +537,18 @@ class TraceOptimizer:
         dir1 = self._segment_direction(segments[start_idx])
         dir2 = self._segment_direction(segments[start_idx + 1])
 
-        # Check if they form a valid staircase pair (approximately 45° apart)
+        # Check if they form a valid staircase pair
         angle_diff = abs(dir1 - dir2)
         # Handle wraparound (e.g., 350° and 10° are 20° apart, not 340°)
         if angle_diff > 180:
             angle_diff = 360 - angle_diff
 
-        # Valid staircase: directions should be ~45° apart (allow ±15° tolerance)
-        if not (30 <= angle_diff <= 60):
+        # Valid staircase patterns:
+        # - Orthogonal+diagonal: ~45° apart (30-60° range)
+        # - Rectilinear H/V: ~90° apart (75-105° range)
+        is_diagonal_staircase = 30 <= angle_diff <= 60
+        is_rectilinear_staircase = 75 <= angle_diff <= 105
+        if not (is_diagonal_staircase or is_rectilinear_staircase):
             return start_idx + 1
 
         # Find how far the alternating pattern continues
@@ -661,16 +669,18 @@ class TraceOptimizer:
 
         # If we couldn't create any segments, create a direct connection
         if not result:
-            result.append(Segment(
-                x1=start[0],
-                y1=start[1],
-                x2=end[0],
-                y2=end[1],
-                width=template.width,
-                layer=template.layer,
-                net=template.net,
-                net_name=template.net_name,
-            ))
+            result.append(
+                Segment(
+                    x1=start[0],
+                    y1=start[1],
+                    x2=end[0],
+                    y2=end[1],
+                    width=template.width,
+                    layer=template.layer,
+                    net=template.net,
+                    net_name=template.net_name,
+                )
+            )
 
         return result
 
@@ -988,12 +998,14 @@ class TraceOptimizer:
                     if i == j:
                         continue
                     # Check if start of seg matches any endpoint of other
-                    if (abs(seg.x1 - other.x1) < tol and abs(seg.y1 - other.y1) < tol) or \
-                       (abs(seg.x1 - other.x2) < tol and abs(seg.y1 - other.y2) < tol):
+                    if (abs(seg.x1 - other.x1) < tol and abs(seg.y1 - other.y1) < tol) or (
+                        abs(seg.x1 - other.x2) < tol and abs(seg.y1 - other.y2) < tol
+                    ):
                         start_shared = True
                     # Check if end of seg matches any endpoint of other
-                    if (abs(seg.x2 - other.x1) < tol and abs(seg.y2 - other.y1) < tol) or \
-                       (abs(seg.x2 - other.x2) < tol and abs(seg.y2 - other.y2) < tol):
+                    if (abs(seg.x2 - other.x1) < tol and abs(seg.y2 - other.y1) < tol) or (
+                        abs(seg.x2 - other.x2) < tol and abs(seg.y2 - other.y2) < tol
+                    ):
                         end_shared = True
 
                 # If start is not shared, this is a good starting point
@@ -1013,8 +1025,8 @@ class TraceOptimizer:
         # Ensure segment is oriented so we're starting from an unshared endpoint
         # Check if current.start is shared with remaining segments
         start_shared = any(
-            (abs(current.x1 - other.x1) < tol and abs(current.y1 - other.y1) < tol) or
-            (abs(current.x1 - other.x2) < tol and abs(current.y1 - other.y2) < tol)
+            (abs(current.x1 - other.x1) < tol and abs(current.y1 - other.y1) < tol)
+            or (abs(current.x1 - other.x2) < tol and abs(current.y1 - other.y2) < tol)
             for other in remaining
         )
         if start_shared:


### PR DESCRIPTION
## Summary

Adds support for detecting and compressing rectilinear (H/V alternating) staircase patterns in the TraceOptimizer. This enables efficient compression of traces produced by A* routers on rectilinear grids.

## Changes

- Extended `_find_staircase_end()` to detect 90° H/V patterns in addition to existing 45° diagonal patterns
- Added 6 new unit tests for rectilinear staircase compression
- Updated existing test that expected 90° patterns to NOT be staircases (now they ARE valid)
- Updated docstrings to document the new behavior

## Test Plan

- [x] All existing trace optimizer tests pass (52 tests)
- [x] New rectilinear staircase tests pass (6 tests)
- [x] H/V staircase detection works for 90° angle differences
- [x] Compression of 10 H/V segments to ≤4 segments verified
- [x] Segment properties (width, layer, net, net_name) preserved
- [x] Both diagonal and H/V staircases work in same route
- [x] ruff format and ruff check pass for modified files

## Impact

This affects all PCBs routed with the A* router on a rectilinear grid:
- Debug signals (SWCLK, SWDIO) - currently 50-80 segments each, reduced to ~5-10
- Power distribution traces
- Any net that routes around obstacles

Closes #124