### PR TITLE
Fix test_cli_check.py tests by adding DRC-clean fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,60 @@ def minimal_pcb(tmp_path: Path) -> Path:
     return pcb_file
 
 
+# PCB that passes all DRC checks - for testing kct check command
+# This fixture is specifically designed to have no DRC violations:
+# - Board outline with adequate edge clearance
+# - Traces with proper clearance from pads
+# - Silkscreen text with adequate height (1.0mm >= JLCPCB 0.8mm minimum)
+DRC_CLEAN_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 125 125)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (segment (start 122 125) (end 115 125) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000020"))
+)
+"""
+
+
+@pytest.fixture
+def drc_clean_pcb(tmp_path: Path) -> Path:
+    """Create a PCB file that passes all DRC checks."""
+    pcb_file = tmp_path / "drc_clean.kicad_pcb"
+    pcb_file.write_text(DRC_CLEAN_PCB)
+    return pcb_file
+
+
 # PCB with edge cuts and multiple components for routing tests
 ROUTING_TEST_PCB = """(kicad_pcb
   (version 20240108)

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -32,23 +32,22 @@ class TestCheckCommand:
         captured = capsys.readouterr()
         assert ".kicad_pcb" in captured.err
 
-    def test_check_basic_table_output(self, minimal_pcb: Path, capsys):
+    def test_check_basic_table_output(self, drc_clean_pcb: Path, capsys):
         """Test check command with table output format."""
         from kicad_tools.cli.check_cmd import main
 
-        result = main([str(minimal_pcb)])
-        # With stub implementations returning no violations, should pass
+        result = main([str(drc_clean_pcb)])
         assert result == 0
 
         captured = capsys.readouterr()
         assert "PURE PYTHON DRC CHECK" in captured.out
         assert "DRC PASSED" in captured.out or "Results:" in captured.out
 
-    def test_check_json_output(self, minimal_pcb: Path, capsys):
+    def test_check_json_output(self, drc_clean_pcb: Path, capsys):
         """Test check command with JSON output format."""
         from kicad_tools.cli.check_cmd import main
 
-        result = main([str(minimal_pcb), "--format", "json"])
+        result = main([str(drc_clean_pcb), "--format", "json"])
         assert result == 0
 
         captured = capsys.readouterr()
@@ -61,59 +60,59 @@ class TestCheckCommand:
         assert "summary" in data
         assert "violations" in data
         assert "passed" in data["summary"]
-        assert data["summary"]["passed"] is True  # No violations with stubs
+        assert data["summary"]["passed"] is True  # No violations with clean PCB
 
-    def test_check_summary_output(self, minimal_pcb: Path, capsys):
+    def test_check_summary_output(self, drc_clean_pcb: Path, capsys):
         """Test check command with summary output format."""
         from kicad_tools.cli.check_cmd import main
 
-        result = main([str(minimal_pcb), "--format", "summary"])
+        result = main([str(drc_clean_pcb), "--format", "summary"])
         assert result == 0
 
         captured = capsys.readouterr()
         assert "DRC" in captured.out
 
-    def test_check_manufacturer_option(self, minimal_pcb: Path, capsys):
+    def test_check_manufacturer_option(self, drc_clean_pcb: Path, capsys):
         """Test check command with manufacturer option."""
         from kicad_tools.cli.check_cmd import main
 
         # Test with different manufacturers
         for mfr in ["jlcpcb", "seeed", "pcbway", "oshpark"]:
-            result = main([str(minimal_pcb), "--mfr", mfr])
+            result = main([str(drc_clean_pcb), "--mfr", mfr])
             assert result == 0, f"Failed for manufacturer {mfr}"
 
-    def test_check_layers_option(self, minimal_pcb: Path, capsys):
+    def test_check_layers_option(self, drc_clean_pcb: Path, capsys):
         """Test check command with layers option."""
         from kicad_tools.cli.check_cmd import main
 
-        result = main([str(minimal_pcb), "--layers", "4"])
+        result = main([str(drc_clean_pcb), "--layers", "4"])
         assert result == 0
 
         captured = capsys.readouterr()
         assert "4" in captured.out  # Layer count should appear in output
 
-    def test_check_only_filter(self, minimal_pcb: Path, capsys):
+    def test_check_only_filter(self, drc_clean_pcb: Path, capsys):
         """Test check command with --only filter."""
         from kicad_tools.cli.check_cmd import main
 
         # Run only clearance checks
-        result = main([str(minimal_pcb), "--only", "clearance"])
+        result = main([str(drc_clean_pcb), "--only", "clearance"])
         assert result == 0
 
         # Run multiple categories
-        result = main([str(minimal_pcb), "--only", "clearance,dimensions"])
+        result = main([str(drc_clean_pcb), "--only", "clearance,dimensions"])
         assert result == 0
 
-    def test_check_skip_filter(self, minimal_pcb: Path, capsys):
+    def test_check_skip_filter(self, drc_clean_pcb: Path, capsys):
         """Test check command with --skip filter."""
         from kicad_tools.cli.check_cmd import main
 
         # Skip silkscreen checks
-        result = main([str(minimal_pcb), "--skip", "silkscreen"])
+        result = main([str(drc_clean_pcb), "--skip", "silkscreen"])
         assert result == 0
 
         # Skip multiple categories
-        result = main([str(minimal_pcb), "--skip", "silkscreen,edge"])
+        result = main([str(drc_clean_pcb), "--skip", "silkscreen,edge"])
         assert result == 0
 
     def test_check_invalid_filter_category(self, minimal_pcb: Path, capsys):
@@ -126,25 +125,25 @@ class TestCheckCommand:
         captured = capsys.readouterr()
         assert "Unknown check category" in captured.err
 
-    def test_check_errors_only_flag(self, minimal_pcb: Path, capsys):
+    def test_check_errors_only_flag(self, drc_clean_pcb: Path, capsys):
         """Test check command with --errors-only flag."""
         from kicad_tools.cli.check_cmd import main
 
-        result = main([str(minimal_pcb), "--errors-only"])
-        assert result == 0  # No errors with stub implementation
+        result = main([str(drc_clean_pcb), "--errors-only"])
+        assert result == 0  # No errors with clean PCB
 
-    def test_check_verbose_flag(self, minimal_pcb: Path, capsys):
+    def test_check_verbose_flag(self, drc_clean_pcb: Path, capsys):
         """Test check command with --verbose flag."""
         from kicad_tools.cli.check_cmd import main
 
-        result = main([str(minimal_pcb), "--verbose"])
+        result = main([str(drc_clean_pcb), "--verbose"])
         assert result == 0
 
-    def test_check_copper_weight_option(self, minimal_pcb: Path, capsys):
+    def test_check_copper_weight_option(self, drc_clean_pcb: Path, capsys):
         """Test check command with copper weight option."""
         from kicad_tools.cli.check_cmd import main
 
-        result = main([str(minimal_pcb), "--copper", "2.0"])
+        result = main([str(drc_clean_pcb), "--copper", "2.0"])
         assert result == 0
 
     def test_check_help_text(self, capsys):
@@ -162,24 +161,24 @@ class TestCheckCommand:
 class TestCheckCommandIntegration:
     """Integration tests for check command via main CLI."""
 
-    def test_check_via_main_cli(self, minimal_pcb: Path, capsys):
+    def test_check_via_main_cli(self, drc_clean_pcb: Path, capsys):
         """Test check command through the main CLI dispatcher."""
         from kicad_tools.cli import main
 
-        result = main(["check", str(minimal_pcb)])
+        result = main(["check", str(drc_clean_pcb)])
         assert result == 0
 
         captured = capsys.readouterr()
         assert "DRC" in captured.out
 
-    def test_check_via_main_cli_with_options(self, minimal_pcb: Path, capsys):
+    def test_check_via_main_cli_with_options(self, drc_clean_pcb: Path, capsys):
         """Test check command through main CLI with options."""
         from kicad_tools.cli import main
 
         result = main(
             [
                 "check",
-                str(minimal_pcb),
+                str(drc_clean_pcb),
                 "--mfr",
                 "seeed",
                 "--layers",
@@ -199,39 +198,47 @@ class TestCheckCommandIntegration:
 class TestCheckExitCodes:
     """Tests for check command exit codes."""
 
-    def test_exit_code_0_no_violations(self, minimal_pcb: Path):
+    def test_exit_code_0_no_violations(self, drc_clean_pcb: Path):
         """Test exit code 0 when no violations found."""
         from kicad_tools.cli.check_cmd import main
 
-        result = main([str(minimal_pcb)])
+        result = main([str(drc_clean_pcb)])
         assert result == 0
 
-    def test_exit_code_0_warnings_only_no_strict(self, minimal_pcb: Path):
+    def test_exit_code_0_warnings_only_no_strict(self, drc_clean_pcb: Path):
         """Test exit code 0 with warnings when not in strict mode."""
         from kicad_tools.cli.check_cmd import main
 
-        # With stub implementation, no warnings to test
+        # With clean PCB, no warnings to test
         # But this confirms the code path works
-        result = main([str(minimal_pcb)])
+        result = main([str(drc_clean_pcb)])
         assert result == 0
 
-    def test_exit_code_with_strict_flag(self, minimal_pcb: Path):
+    def test_exit_code_with_strict_flag(self, drc_clean_pcb: Path):
         """Test that --strict flag works (would return 2 on warnings)."""
         from kicad_tools.cli.check_cmd import main
 
-        # With stub implementation returning no violations, still returns 0
-        result = main([str(minimal_pcb), "--strict"])
+        # With clean PCB returning no violations, still returns 0
+        result = main([str(drc_clean_pcb), "--strict"])
         assert result == 0
+
+    def test_exit_code_1_with_violations(self, minimal_pcb: Path):
+        """Test exit code 1 when DRC violations are found."""
+        from kicad_tools.cli.check_cmd import main
+
+        # minimal_pcb has a trace overlapping a pad, causing a clearance violation
+        result = main([str(minimal_pcb)])
+        assert result == 1  # Errors found
 
 
 class TestCheckJsonSchema:
     """Tests for check command JSON output schema."""
 
-    def test_json_schema_complete(self, minimal_pcb: Path, capsys):
+    def test_json_schema_complete(self, drc_clean_pcb: Path, capsys):
         """Test that JSON output contains all required fields."""
         from kicad_tools.cli.check_cmd import main
 
-        main([str(minimal_pcb), "--format", "json"])
+        main([str(drc_clean_pcb), "--format", "json"])
         captured = capsys.readouterr()
         data = json.loads(captured.out)
 
@@ -251,11 +258,11 @@ class TestCheckJsonSchema:
         # violations should be a list
         assert isinstance(data["violations"], list)
 
-    def test_json_output_is_ci_friendly(self, minimal_pcb: Path, capsys):
+    def test_json_output_is_ci_friendly(self, drc_clean_pcb: Path, capsys):
         """Test that JSON output can be parsed by CI tools."""
         from kicad_tools.cli.check_cmd import main
 
-        main([str(minimal_pcb), "--format", "json"])
+        main([str(drc_clean_pcb), "--format", "json"])
         captured = capsys.readouterr()
 
         # Should be parseable without errors


### PR DESCRIPTION
## Summary

Add a new `drc_clean_pcb` test fixture that passes all DRC checks, and update tests in `test_cli_check.py` to use it instead of `minimal_pcb` which has intentional DRC violations.

## Changes

- Add `DRC_CLEAN_PCB` constant and `drc_clean_pcb` fixture to `tests/conftest.py`
  - Board outline with adequate edge clearance (25mm from edges)
  - Trace with proper clearance from pads (starts 2mm away from footprint)
  - Trace width 0.25mm (passes all copper weight checks including 2oz)
  - Silkscreen text with adequate height (1.0mm >= JLCPCB 0.8mm minimum)
- Update 15 tests in `test_cli_check.py` to use `drc_clean_pcb` fixture
- Add new test `test_exit_code_1_with_violations` to verify DRC correctly detects violations

## Test Plan

- [x] Run `pnpm test tests/test_cli_check.py` - all 22 tests pass
- [x] Run lint checks on changed files - pass
- [x] Verify existing tests using `minimal_pcb` still work

Closes #137