### PR TITLE
Add BGA and DFN parametric footprint generators

### DIFF
--- a/src/kicad_tools/library/__init__.py
+++ b/src/kicad_tools/library/__init__.py
@@ -18,7 +18,11 @@ Usage:
 
 from .footprint import Footprint, GraphicArc, GraphicCircle, GraphicLine, GraphicRect, Pad
 from .generators import (
+    create_bga,
+    create_bga_standard,
     create_chip,
+    create_dfn,
+    create_dfn_standard,
     create_dip,
     create_pin_header,
     create_qfn,
@@ -43,4 +47,8 @@ __all__ = [
     "create_chip",
     "create_dip",
     "create_pin_header",
+    "create_bga",
+    "create_bga_standard",
+    "create_dfn",
+    "create_dfn_standard",
 ]

--- a/src/kicad_tools/library/generators/__init__.py
+++ b/src/kicad_tools/library/generators/__init__.py
@@ -4,7 +4,9 @@ Parametric footprint generators for common package types.
 These generators create KiCad footprints following IPC-7351 naming conventions.
 """
 
+from .bga import create_bga, create_bga_standard
 from .chip import create_chip
+from .dfn import create_dfn, create_dfn_standard
 from .qfn import create_qfn
 from .qfp import create_qfp
 from .soic import create_soic
@@ -19,4 +21,8 @@ __all__ = [
     "create_chip",
     "create_dip",
     "create_pin_header",
+    "create_bga",
+    "create_bga_standard",
+    "create_dfn",
+    "create_dfn_standard",
 ]

--- a/src/kicad_tools/library/generators/bga.py
+++ b/src/kicad_tools/library/generators/bga.py
@@ -1,0 +1,208 @@
+"""
+BGA (Ball Grid Array) footprint generator.
+
+Generates BGA footprints with configurable grid layout, ball naming,
+and support for depopulated balls and thermal pads.
+"""
+
+import string
+
+from ..footprint import Footprint
+from .standards import BGA_STANDARDS
+
+
+def _get_row_letter(row: int) -> str:
+    """
+    Get the row letter for a BGA ball, skipping I and O per standard convention.
+
+    Args:
+        row: 0-indexed row number
+
+    Returns:
+        Row letter (A, B, C, D, E, F, G, H, J, K, ...)
+    """
+    # Standard BGA letters skip I and O to avoid confusion with 1 and 0
+    letters = [c for c in string.ascii_uppercase if c not in ("I", "O")]
+    if row < len(letters):
+        return letters[row]
+    # For rows beyond Z, use AA, AB, etc.
+    first = row // len(letters) - 1
+    second = row % len(letters)
+    return letters[first] + letters[second]
+
+
+def _get_ball_name(row: int, col: int) -> str:
+    """
+    Get the ball name for a BGA position.
+
+    Args:
+        row: 0-indexed row number
+        col: 0-indexed column number
+
+    Returns:
+        Ball name (e.g., "A1", "B2", "J10")
+    """
+    return f"{_get_row_letter(row)}{col + 1}"
+
+
+def create_bga(
+    rows: int,
+    cols: int,
+    pitch: float = 0.8,
+    ball_diameter: float | None = None,
+    body_size: float | None = None,
+    depopulated: list[str] | None = None,
+    thermal_pad: float | None = None,
+    name: str | None = None,
+) -> Footprint:
+    """
+    Create a BGA footprint with configurable grid layout.
+
+    Args:
+        rows: Number of rows in the ball grid
+        cols: Number of columns in the ball grid
+        pitch: Ball pitch in mm (default: 0.8mm)
+        ball_diameter: Pad diameter in mm (default: pitch * 0.5)
+        body_size: Package body size in mm (default: calculated from grid)
+        depopulated: List of ball names to skip (e.g., ["A1", "J10"])
+        thermal_pad: Size of center thermal pad in mm (optional)
+        name: Custom footprint name (auto-generated if not specified)
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_bga(rows=10, cols=10, pitch=0.8)
+        >>> fp.save("MyLib.pretty/BGA-100_10x10_0.8mm.kicad_mod")
+    """
+    if rows < 1:
+        raise ValueError(f"BGA must have at least 1 row, got {rows}")
+    if cols < 1:
+        raise ValueError(f"BGA must have at least 1 column, got {cols}")
+    if pitch <= 0:
+        raise ValueError(f"Pitch must be positive, got {pitch}")
+
+    # Calculate defaults
+    ball_diameter = ball_diameter or pitch * 0.5
+    grid_width = (cols - 1) * pitch
+    grid_height = (rows - 1) * pitch
+    body_size = body_size or max(grid_width, grid_height) + pitch * 2
+
+    # Normalize depopulated list
+    depopulated_set = set(depopulated or [])
+
+    # Count actual pins (excluding depopulated)
+    total_balls = rows * cols - len(depopulated_set)
+
+    # Generate IPC-7351 compliant name
+    if name is None:
+        ep_suffix = "_EP" if thermal_pad else ""
+        name = f"BGA-{total_balls}_{body_size}x{body_size}mm_P{pitch}mm{ep_suffix}"
+
+    desc = f"BGA, {rows}x{cols} grid, pitch {pitch}mm, {body_size}x{body_size}mm"
+    if thermal_pad:
+        desc += f", thermal pad {thermal_pad}x{thermal_pad}mm"
+    if depopulated_set:
+        desc += f", {len(depopulated_set)} depopulated"
+
+    fp = Footprint(
+        name=name,
+        description=desc,
+        tags=["BGA", f"P{pitch}mm", f"{rows}x{cols}"],
+        attr="smd",
+    )
+
+    # Calculate grid origin (center of grid at 0,0)
+    origin_x = -grid_width / 2
+    origin_y = -grid_height / 2
+
+    # Add pads for each ball
+    for row in range(rows):
+        for col in range(cols):
+            ball_name = _get_ball_name(row, col)
+            if ball_name in depopulated_set:
+                continue
+
+            x = origin_x + col * pitch
+            y = origin_y + row * pitch
+
+            fp.add_pad(
+                name=ball_name,
+                x=x,
+                y=y,
+                width=ball_diameter,
+                height=ball_diameter,
+                shape="circle",
+            )
+
+    # Add thermal pad if specified
+    if thermal_pad:
+        fp.add_pad(
+            name=str(total_balls + 1),
+            x=0,
+            y=0,
+            width=thermal_pad,
+            height=thermal_pad,
+            shape="rect",
+            layers=("F.Cu", "F.Paste", "F.Mask"),
+        )
+
+    # Silkscreen - corners to avoid ball overlap
+    silk = body_size / 2 + 0.1
+    corner_len = min(1.0, body_size / 6)
+
+    # Draw corner marks
+    for sx, sy in [(-1, -1), (1, -1), (1, 1), (-1, 1)]:
+        cx, cy = sx * silk, sy * silk
+        fp.add_line((cx, cy - sy * corner_len), (cx, cy), "F.SilkS", 0.12)
+        fp.add_line((cx, cy), (cx - sx * corner_len, cy), "F.SilkS", 0.12)
+
+    # Pin A1 marker (top-left corner indicator)
+    marker_x = origin_x - ball_diameter
+    marker_y = origin_y - ball_diameter
+    fp.add_circle((marker_x, marker_y), 0.2, "F.SilkS", 0.12, fill=True)
+
+    # Courtyard
+    crt_margin = 0.25
+    crt = body_size / 2 + crt_margin
+    fp.add_rect((-crt, -crt), (crt, crt), "F.CrtYd", 0.05)
+
+    # Fab layer with pin A1 chamfer
+    fab = body_size / 2
+    chamfer = min(1.0, body_size / 8)
+    fp.add_line((-fab + chamfer, -fab), (fab, -fab), "F.Fab", 0.1)
+    fp.add_line((fab, -fab), (fab, fab), "F.Fab", 0.1)
+    fp.add_line((fab, fab), (-fab, fab), "F.Fab", 0.1)
+    fp.add_line((-fab, fab), (-fab, -fab + chamfer), "F.Fab", 0.1)
+    fp.add_line((-fab, -fab + chamfer), (-fab + chamfer, -fab), "F.Fab", 0.1)
+
+    return fp
+
+
+def create_bga_standard(package: str) -> Footprint:
+    """
+    Create a BGA footprint from a standard package name.
+
+    Args:
+        package: Standard package name (e.g., "BGA-256_17x17_0.8mm")
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_bga_standard("BGA-256_17x17_0.8mm")
+    """
+    if package not in BGA_STANDARDS:
+        available = ", ".join(sorted(BGA_STANDARDS.keys()))
+        raise ValueError(f"Unknown BGA package '{package}'. Available: {available}")
+
+    spec = BGA_STANDARDS[package]
+    return create_bga(
+        rows=spec["rows"],
+        cols=spec["cols"],
+        pitch=spec["pitch"],
+        ball_diameter=spec.get("ball_diameter"),
+        body_size=spec.get("body_size"),
+        thermal_pad=spec.get("thermal_pad"),
+        name=package,
+    )

--- a/src/kicad_tools/library/generators/dfn.py
+++ b/src/kicad_tools/library/generators/dfn.py
@@ -1,0 +1,205 @@
+"""
+DFN (Dual Flat No-lead) footprint generator.
+
+Generates DFN footprints with optional exposed thermal pads and wettable flanks.
+DFN packages have leads on two sides (unlike QFN which has leads on all four sides).
+"""
+
+from ..footprint import Footprint
+from .standards import DFN_STANDARDS
+
+
+def create_dfn(
+    pins: int,
+    pitch: float = 0.5,
+    body_width: float | None = None,
+    body_length: float | None = None,
+    pad_width: float | None = None,
+    pad_height: float | None = None,
+    exposed_pad: tuple[float, float] | float | bool | None = None,
+    wettable_flanks: bool = False,
+    name: str | None = None,
+) -> Footprint:
+    """
+    Create a DFN footprint with optional exposed thermal pad.
+
+    DFN packages have leads on two opposing sides (top and bottom), unlike
+    QFN which has leads on all four sides.
+
+    Args:
+        pins: Number of pins (not including exposed pad, must be even)
+        pitch: Pin pitch in mm (default: 0.5mm)
+        body_width: Package body width in mm (perpendicular to leads)
+        body_length: Package body length in mm (parallel to leads)
+        pad_width: Pad width (length extending from body) in mm
+        pad_height: Pad height (perpendicular to pad length) in mm
+        exposed_pad: Exposed thermal pad specification:
+            - tuple (width, height): Custom pad dimensions
+            - float: Square pad with given size
+            - True: Auto-calculate based on body size
+            - None/False: No exposed pad
+        wettable_flanks: If True, increase pad size for wettable flank packages
+        name: Custom footprint name (auto-generated if not specified)
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_dfn(pins=8, pitch=0.5, body_width=3.0, body_length=3.0)
+        >>> fp.save("MyLib.pretty/DFN-8_3x3mm.kicad_mod")
+    """
+    if pins < 2:
+        raise ValueError(f"DFN must have at least 2 pins, got {pins}")
+    if pins % 2 != 0:
+        raise ValueError(f"DFN must have even number of pins, got {pins}")
+    if pitch <= 0:
+        raise ValueError(f"Pitch must be positive, got {pitch}")
+
+    pins_per_side = pins // 2
+
+    # Get defaults from standards table if available
+    key = (pins, body_width, body_length) if body_width and body_length else None
+    std = DFN_STANDARDS.get(key, {})
+
+    # Apply defaults
+    body_width = body_width or std.get("body_width", 3.0)
+    body_length = body_length or std.get("body_length", 3.0)
+    pad_width = pad_width or std.get("pad_width", 0.8)
+    pad_height = pad_height or std.get("pad_height", 0.3)
+
+    # Wettable flanks increase pad size for better solder wetting
+    if wettable_flanks:
+        pad_width = pad_width * 1.2
+        pad_height = pad_height * 1.1
+
+    # Process exposed pad specification
+    ep_width = None
+    ep_height = None
+    if exposed_pad is True:
+        # Auto-calculate: roughly 60% of body area
+        ep_width = body_width * 0.6
+        ep_height = body_length * 0.5
+    elif isinstance(exposed_pad, (int, float)):
+        ep_width = ep_height = float(exposed_pad)
+    elif isinstance(exposed_pad, tuple) and len(exposed_pad) == 2:
+        ep_width, ep_height = exposed_pad
+
+    has_exposed_pad = ep_width is not None and ep_height is not None
+
+    # Generate IPC-7351 compliant name
+    if name is None:
+        ep_suffix = "_EP" if has_exposed_pad else ""
+        wf_suffix = "_WF" if wettable_flanks else ""
+        name = f"DFN-{pins}_{body_width}x{body_length}mm_P{pitch}mm{ep_suffix}{wf_suffix}"
+
+    desc = f"DFN, {pins} Pin, pitch {pitch}mm, {body_width}x{body_length}mm"
+    if has_exposed_pad:
+        desc += f", exposed pad {ep_width}x{ep_height}mm"
+    if wettable_flanks:
+        desc += ", wettable flanks"
+
+    tags = ["DFN", f"P{pitch}mm"]
+    if wettable_flanks:
+        tags.append("wettable-flanks")
+
+    fp = Footprint(
+        name=name,
+        description=desc,
+        tags=tags,
+        attr="smd",
+    )
+
+    # Calculate pad positions
+    span = (pins_per_side - 1) * pitch
+    pad_center_y = body_length / 2 - pad_width / 2 + 0.1  # Slight extension
+
+    pin_num = 1
+
+    # Bottom side (left to right) - pins 1 to pins_per_side
+    for i in range(pins_per_side):
+        x = -span / 2 + i * pitch
+        y = pad_center_y
+        fp.add_pad(str(pin_num), x, y, pad_height, pad_width)
+        pin_num += 1
+
+    # Top side (right to left) - pins pins_per_side+1 to pins
+    for i in range(pins_per_side):
+        x = span / 2 - i * pitch
+        y = -pad_center_y
+        fp.add_pad(str(pin_num), x, y, pad_height, pad_width)
+        pin_num += 1
+
+    # Exposed thermal pad
+    if has_exposed_pad:
+        fp.add_pad(
+            name=str(pins + 1),
+            x=0,
+            y=0,
+            width=ep_width,
+            height=ep_height,
+            shape="rect",
+            layers=("F.Cu", "F.Paste", "F.Mask"),
+        )
+
+    # Silkscreen - lines on left and right sides (avoiding pads on top/bottom)
+    silk_x = body_width / 2 + 0.1
+    silk_y = body_length / 2 + 0.1
+
+    # Left and right edge lines
+    fp.add_line((-silk_x, -silk_y), (-silk_x, silk_y), "F.SilkS", 0.12)
+    fp.add_line((silk_x, -silk_y), (silk_x, silk_y), "F.SilkS", 0.12)
+
+    # Pin 1 marker
+    marker_x = -span / 2 - 0.3
+    marker_y = silk_y + 0.4
+    fp.add_circle((marker_x, marker_y), 0.15, "F.SilkS", 0.12, fill=True)
+
+    # Courtyard
+    crt_margin = 0.25
+    crt_x = body_width / 2 + crt_margin
+    crt_y = body_length / 2 + crt_margin
+    fp.add_rect((-crt_x, -crt_y), (crt_x, crt_y), "F.CrtYd", 0.05)
+
+    # Fab layer with pin 1 chamfer
+    fab_x = body_width / 2
+    fab_y = body_length / 2
+    chamfer = min(0.5, min(body_width, body_length) / 8)
+    fp.add_line((-fab_x + chamfer, fab_y), (fab_x, fab_y), "F.Fab", 0.1)
+    fp.add_line((fab_x, fab_y), (fab_x, -fab_y), "F.Fab", 0.1)
+    fp.add_line((fab_x, -fab_y), (-fab_x, -fab_y), "F.Fab", 0.1)
+    fp.add_line((-fab_x, -fab_y), (-fab_x, fab_y - chamfer), "F.Fab", 0.1)
+    fp.add_line((-fab_x, fab_y - chamfer), (-fab_x + chamfer, fab_y), "F.Fab", 0.1)
+
+    return fp
+
+
+def create_dfn_standard(package: str) -> Footprint:
+    """
+    Create a DFN footprint from a standard package name.
+
+    Args:
+        package: Standard package name (e.g., "DFN-8_3x3_0.5mm")
+
+    Returns:
+        Footprint object ready for export
+
+    Example:
+        >>> fp = create_dfn_standard("DFN-8_3x3_0.5mm")
+    """
+    if package not in DFN_STANDARDS:
+        # Only list string keys (package names), not tuple keys (for internal lookup)
+        available = ", ".join(sorted(k for k in DFN_STANDARDS.keys() if isinstance(k, str)))
+        raise ValueError(f"Unknown DFN package '{package}'. Available: {available}")
+
+    spec = DFN_STANDARDS[package]
+    return create_dfn(
+        pins=spec["pins"],
+        pitch=spec["pitch"],
+        body_width=spec["body_width"],
+        body_length=spec["body_length"],
+        pad_width=spec.get("pad_width"),
+        pad_height=spec.get("pad_height"),
+        exposed_pad=spec.get("exposed_pad"),
+        wettable_flanks=spec.get("wettable_flanks", False),
+        name=package,
+    )

--- a/src/kicad_tools/library/generators/standards.py
+++ b/src/kicad_tools/library/generators/standards.py
@@ -236,6 +236,126 @@ CHIP_SIZES = {
     },
 }
 
+# BGA (Ball Grid Array) - common sizes
+BGA_STANDARDS = {
+    # Package name: specs
+    "BGA-256_17x17_0.8mm": {
+        "rows": 16,
+        "cols": 16,
+        "pitch": 0.8,
+        "ball_diameter": 0.4,
+        "body_size": 17.0,
+    },
+    "BGA-324_18x18_0.8mm": {
+        "rows": 18,
+        "cols": 18,
+        "pitch": 0.8,
+        "ball_diameter": 0.4,
+        "body_size": 19.0,
+    },
+    "BGA-484_22x22_1.0mm": {
+        "rows": 22,
+        "cols": 22,
+        "pitch": 1.0,
+        "ball_diameter": 0.5,
+        "body_size": 23.0,
+    },
+    "BGA-100_10x10_0.8mm": {
+        "rows": 10,
+        "cols": 10,
+        "pitch": 0.8,
+        "ball_diameter": 0.4,
+        "body_size": 12.0,
+    },
+    "BGA-144_12x12_0.8mm": {
+        "rows": 12,
+        "cols": 12,
+        "pitch": 0.8,
+        "ball_diameter": 0.4,
+        "body_size": 14.0,
+    },
+    # Fine-pitch BGA (FBGA)
+    "FBGA-256_17x17_0.5mm": {
+        "rows": 16,
+        "cols": 16,
+        "pitch": 0.5,
+        "ball_diameter": 0.25,
+        "body_size": 14.0,
+    },
+}
+
+# DFN (Dual Flat No-lead) - common sizes
+DFN_STANDARDS = {
+    # Package name: specs (for create_dfn_standard)
+    "DFN-8_3x3_0.5mm": {
+        "pins": 8,
+        "pitch": 0.5,
+        "body_width": 3.0,
+        "body_length": 3.0,
+        "pad_width": 0.8,
+        "pad_height": 0.3,
+        "exposed_pad": (1.5, 2.0),
+    },
+    "DFN-6_2x2_0.65mm": {
+        "pins": 6,
+        "pitch": 0.65,
+        "body_width": 2.0,
+        "body_length": 2.0,
+        "pad_width": 0.7,
+        "pad_height": 0.35,
+        "exposed_pad": (0.9, 1.2),
+    },
+    "DFN-8_2x3_0.5mm": {
+        "pins": 8,
+        "pitch": 0.5,
+        "body_width": 2.0,
+        "body_length": 3.0,
+        "pad_width": 0.7,
+        "pad_height": 0.3,
+        "exposed_pad": (0.9, 1.7),
+    },
+    "DFN-10_3x3_0.5mm": {
+        "pins": 10,
+        "pitch": 0.5,
+        "body_width": 3.0,
+        "body_length": 3.0,
+        "pad_width": 0.8,
+        "pad_height": 0.25,
+        "exposed_pad": (1.5, 2.0),
+    },
+    "DFN-12_4x4_0.5mm": {
+        "pins": 12,
+        "pitch": 0.5,
+        "body_width": 4.0,
+        "body_length": 4.0,
+        "pad_width": 0.8,
+        "pad_height": 0.25,
+        "exposed_pad": (2.4, 2.8),
+    },
+    "DFN-16_5x5_0.5mm": {
+        "pins": 16,
+        "pitch": 0.5,
+        "body_width": 5.0,
+        "body_length": 5.0,
+        "pad_width": 0.8,
+        "pad_height": 0.25,
+        "exposed_pad": (3.2, 3.6),
+    },
+    # Keyed by tuple for lookup in create_dfn
+    (8, 3.0, 3.0): {
+        "pitch": 0.5,
+        "pad_width": 0.8,
+        "pad_height": 0.3,
+        "exposed_pad": (1.5, 2.0),
+    },
+    (6, 2.0, 2.0): {
+        "pitch": 0.65,
+        "pad_width": 0.7,
+        "pad_height": 0.35,
+        "exposed_pad": (0.9, 1.2),
+    },
+}
+
 # DIP (Dual In-line Package) standards
 DIP_STANDARDS = {
     # Narrow DIP (0.3" = 7.62mm row spacing)


### PR DESCRIPTION
## Summary

Add parametric footprint generators for BGA (Ball Grid Array) and DFN (Dual Flat No-Lead) packages to complement the existing generator set.

## Changes

### BGA Generator (`bga.py`)
- Configurable rows, columns, pitch, and ball diameter
- Standard ball naming convention (A1, A2, B1, B2...) skipping I and O to avoid confusion with 1 and 0
- Support for depopulated balls (thermal/mechanical voids in the ball grid)
- Optional center thermal pad
- IPC-7351 compliant naming
- `create_bga()` for custom configurations
- `create_bga_standard()` for common package presets

### DFN Generator (`dfn.py`)
- Configurable pin count, pitch, and body dimensions
- Optional exposed thermal pad (supports tuple, float, or auto-calculated sizes)
- Wettable flanks option for improved solder wetting
- Leads on two sides (unlike QFN which has 4 sides)
- IPC-7351 compliant naming
- `create_dfn()` for custom configurations
- `create_dfn_standard()` for common package presets

### Standards
- Added common BGA presets: BGA-100, BGA-144, BGA-256, BGA-324, BGA-484, FBGA-256
- Added common DFN presets: DFN-6, DFN-8, DFN-10, DFN-12, DFN-16

### Tests
- 12 new tests for BGA generator
- 12 new tests for DFN generator
- Updated integration tests to include BGA and DFN
- All 70 tests passing

## Test Plan

- [x] `test_create_bga_basic` - Create BGA with specified rows/cols/pitch
- [x] `test_bga_pin_naming` - Verify A1, A2, B1, B2... naming convention
- [x] `test_bga_skips_i_and_o` - Verify I and O are skipped in row naming
- [x] `test_bga_depopulated_balls` - Verify missing balls don't create pads
- [x] `test_bga_thermal_pad` - Verify center thermal/ground pad
- [x] `test_bga_pad_positions` - Verify ball positions match pitch/count
- [x] `test_create_dfn_basic` - Create DFN with pins/pitch/body size
- [x] `test_dfn_exposed_pad_*` - Verify thermal pad generation (tuple, float, auto)
- [x] `test_dfn_wettable_flanks` - Verify wettable flank option affects pad size
- [x] `test_dfn_pad_positions` - Verify pads on correct sides
- [x] Integration tests updated to include BGA and DFN

Closes #144