### PR TITLE
Add 6-layer PCB design rule presets for supported manufacturers

### DIFF
--- a/docs/tutorials/drc-manufacturer-rules.md
+++ b/docs/tutorials/drc-manufacturer-rules.md
@@ -24,12 +24,12 @@ For full DRC functionality, you'll also need KiCad 8+ installed (for `kicad-cli`
 
 kicad-tools includes profiles for these PCB fabs:
 
-| Manufacturer | ID | Features |
-|--------------|-----|----------|
-| JLCPCB | `jlcpcb` | Low cost, LCSC parts, assembly service |
-| PCBWay | `pcbway` | Flexible options, global shipping |
-| OSHPark | `oshpark` | US-based, purple boards, per-sq-inch pricing |
-| Seeed Fusion | `seeed` | OPL parts library, assembly service |
+| Manufacturer | ID | Layers | Features |
+|--------------|-----|--------|----------|
+| JLCPCB | `jlcpcb` | 2, 4, 6 | Low cost, LCSC parts, assembly service |
+| PCBWay | `pcbway` | 2, 4, 6 | Flexible options, global shipping |
+| OSHPark | `oshpark` | 2, 4 | US-based, purple boards, per-sq-inch pricing |
+| Seeed Fusion | `seeed` | 2, 4, 6 | OPL parts library, assembly service |
 
 ## CLI: Basic DRC
 

--- a/src/kicad_tools/manufacturers/rules/jlcpcb-6layer-1oz.kicad_dru
+++ b/src/kicad_tools/manufacturers/rules/jlcpcb-6layer-1oz.kicad_dru
@@ -1,0 +1,17 @@
+(version 1)
+(rule "Trace Width"
+  (constraint track_width (min 0.0889mm)))
+(rule "Clearance"
+  (constraint clearance (min 0.0889mm)))
+(rule "Via Drill"
+  (constraint hole_size (min 0.2mm)))
+(rule "Via Diameter"
+  (constraint via_diameter (min 0.45mm)))
+(rule "Annular Ring"
+  (constraint annular_width (min 0.125mm)))
+(rule "Copper to Edge"
+  (constraint edge_clearance (min 0.3mm)))
+(rule "Hole to Edge"
+  (constraint hole_to_hole (min 0.4mm)))
+(rule "Silkscreen Width"
+  (constraint silk_clearance (min 0.15mm)))

--- a/src/kicad_tools/manufacturers/rules/pcbway-6layer-1oz.kicad_dru
+++ b/src/kicad_tools/manufacturers/rules/pcbway-6layer-1oz.kicad_dru
@@ -1,0 +1,17 @@
+(version 1)
+(rule "Trace Width"
+  (constraint track_width (min 0.0889mm)))
+(rule "Clearance"
+  (constraint clearance (min 0.0889mm)))
+(rule "Via Drill"
+  (constraint hole_size (min 0.15mm)))
+(rule "Via Diameter"
+  (constraint via_diameter (min 0.35mm)))
+(rule "Annular Ring"
+  (constraint annular_width (min 0.1mm)))
+(rule "Copper to Edge"
+  (constraint edge_clearance (min 0.25mm)))
+(rule "Hole to Edge"
+  (constraint hole_to_hole (min 0.4mm)))
+(rule "Silkscreen Width"
+  (constraint silk_clearance (min 0.15mm)))

--- a/src/kicad_tools/manufacturers/rules/seeed-6layer-1oz.kicad_dru
+++ b/src/kicad_tools/manufacturers/rules/seeed-6layer-1oz.kicad_dru
@@ -1,0 +1,17 @@
+(version 1)
+(rule "Trace Width"
+  (constraint track_width (min 0.127mm)))
+(rule "Clearance"
+  (constraint clearance (min 0.127mm)))
+(rule "Via Drill"
+  (constraint hole_size (min 0.25mm)))
+(rule "Via Diameter"
+  (constraint via_diameter (min 0.5mm)))
+(rule "Annular Ring"
+  (constraint annular_width (min 0.125mm)))
+(rule "Copper to Edge"
+  (constraint edge_clearance (min 0.5mm)))
+(rule "Hole to Edge"
+  (constraint hole_to_hole (min 0.5mm)))
+(rule "Silkscreen Width"
+  (constraint silk_clearance (min 0.15mm)))

--- a/src/kicad_tools/manufacturers/seeed.py
+++ b/src/kicad_tools/manufacturers/seeed.py
@@ -88,6 +88,24 @@ SEEED_4LAYER_2OZ = DesignRules(
     inner_copper_oz=1.0,
 )
 
+SEEED_6LAYER_1OZ = DesignRules(
+    min_trace_width_mm=0.127,  # 5 mil
+    min_clearance_mm=0.127,  # 5 mil
+    min_via_drill_mm=0.25,
+    min_via_diameter_mm=0.5,
+    min_annular_ring_mm=0.125,
+    min_hole_diameter_mm=0.25,
+    max_hole_diameter_mm=6.3,
+    min_copper_to_edge_mm=0.5,
+    min_hole_to_edge_mm=0.5,
+    min_silkscreen_width_mm=0.15,
+    min_silkscreen_height_mm=0.8,
+    min_solder_mask_dam_mm=0.1,
+    board_thickness_mm=1.6,
+    outer_copper_oz=1.0,
+    inner_copper_oz=0.5,
+)
+
 # Seeed Fusion Assembly Capabilities
 SEEED_ASSEMBLY = AssemblyCapabilities(
     min_component_pitch_mm=0.4,
@@ -173,6 +191,7 @@ SEEED_PROFILE = ManufacturerProfile(
         "2layer_2oz": SEEED_2LAYER_2OZ,
         "4layer_1oz": SEEED_4LAYER_1OZ,
         "4layer_2oz": SEEED_4LAYER_2OZ,
+        "6layer_1oz": SEEED_6LAYER_1OZ,
     },
     assembly=SEEED_ASSEMBLY,
     parts_library=SEEED_OPL,


### PR DESCRIPTION
## Summary

Add 6-layer PCB design rule presets (.kicad_dru files) for manufacturers that support them:

- **JLCPCB**: 3.5 mil trace/clearance, 0.2mm via drill
- **PCBWay**: 3.5 mil trace/clearance, 0.15mm via drill  
- **Seeed**: 5 mil trace/clearance, 0.25mm via drill

## Changes

- Add `SEEED_6LAYER_1OZ` Python profile to `seeed.py` (was missing)
- Create `jlcpcb-6layer-1oz.kicad_dru` file
- Create `pcbway-6layer-1oz.kicad_dru` file
- Create `seeed-6layer-1oz.kicad_dru` file
- Add tests verifying 6-layer rules and DRU file validity
- Update documentation to show 6-layer support per manufacturer

## Test Plan

- [x] All 6-layer Python profiles accessible via `get_design_rules(layers=6)`
- [x] All 3 DRU files created in `manufacturers/rules/`
- [x] DRU files follow KiCad format (version 1, 8 standard rules)
- [x] Values in DRU files match Python profiles
- [x] `pnpm check:ci` passes (format, lint, tests)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)