### PR TITLE
Fix pad parsing regex to handle unquoted numeric pad numbers

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -222,11 +222,13 @@ def load_pcb_for_routing(
                 continue
 
             # Extract pad number and type
-            pad_start = re.match(r'\(pad\s+"([^"]+)"\s+(\w+)', line)
+            # Handle both quoted ("A1") and unquoted (1) pad numbers
+            # KiCad uses unquoted numbers for numeric pads, quoted for alphanumeric (BGA)
+            pad_start = re.match(r'\(pad\s+(?:"([^"]+)"|(\S+))\s+(\w+)', line)
             if not pad_start:
                 continue
-            pad_num = pad_start.group(1)
-            pad_type = pad_start.group(2)  # smd or thru_hole
+            pad_num = pad_start.group(1) or pad_start.group(2)
+            pad_type = pad_start.group(3)  # smd or thru_hole
 
             # Extract at position
             at_match = re.search(r"\(at\s+([-\d.]+)\s+([-\d.]+)", line)


### PR DESCRIPTION
## Summary

- Fixed regex in `router/io.py` to handle both quoted and unquoted pad numbers
- Added tests for unquoted and mixed pad number formats

## Root Cause

The pad parsing regex at line 225 required quoted pad numbers:
```python
pad_start = re.match(r'\(pad\s+"([^"]+)"\s+(\w+)', line)
```

But KiCad uses unquoted numeric pad numbers for most components:
```
(pad 1 smd rect ...)  # Unquoted - common in real PCBs
(pad "A1" smd ...)    # Quoted - only for BGA/alphanumeric pads
```

## Fix

Changed the regex to use an alternation that handles both formats:
```python
pad_start = re.match(r'\(pad\s+(?:"([^"]+)"|(\S+))\s+(\w+)', line)
pad_num = pad_start.group(1) or pad_start.group(2)
```

## Test plan

- [x] Added `test_load_pcb_unquoted_pad_numbers` - verifies parsing of unquoted numeric pads
- [x] Added `test_load_pcb_mixed_pad_formats` - verifies parsing of mixed quoted/unquoted pads
- [x] All existing `TestLoadPcbForRouting` tests pass

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)