### PR TITLE
Fix autorouter creating traces through pads in negotiated mode

### DIFF
--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -138,7 +138,13 @@ class Router:
                     if allow_sharing and not cell.is_obstacle:
                         # Allow routing through used cells (will get cost penalty)
                         if cell.net != 0 and cell.net != net:
-                            continue  # Allow with cost penalty later
+                            # Only allow sharing if this cell has been used by routes
+                            # (usage_count > 0). Cells with usage_count == 0 are static
+                            # obstacles like pads that should never be shared.
+                            # See issue #174: pad clearance zones must block other nets.
+                            if cell.usage_count == 0:
+                                return True  # Static obstacle (pad) - block
+                            continue  # Allow with cost penalty (routed cell)
                     else:
                         # Standard mode: block if:
                         # - Cell is an obstacle (is_obstacle=True) - always block
@@ -193,7 +199,13 @@ class Router:
                 if allow_sharing and not cell.is_obstacle:
                     # In negotiated mode, non-obstacle cells can be shared
                     if cell.net != 0 and cell.net != net:
-                        continue  # Allow with cost penalty
+                        # Only allow sharing if this cell has been used by routes
+                        # (usage_count > 0). Cells with usage_count == 0 are static
+                        # obstacles like pads that should never be shared.
+                        # See issue #174: pad clearance zones must block other nets.
+                        if cell.usage_count == 0:
+                            return True  # Static obstacle (pad) - block
+                        continue  # Allow with cost penalty (routed cell)
                 else:
                     # Standard mode: block if obstacle or different net
                     if cell.is_obstacle or cell.net != net:
@@ -227,7 +239,13 @@ class Router:
                     if allow_sharing and not cell.is_obstacle:
                         # Allow routing through used cells (will get cost penalty)
                         if cell.net != 0 and cell.net != net:
-                            continue  # Allow with cost penalty later
+                            # Only allow sharing if this cell has been used by routes
+                            # (usage_count > 0). Cells with usage_count == 0 are static
+                            # obstacles like pads that should never be shared.
+                            # See issue #174: pad clearance zones must block other nets.
+                            if cell.usage_count == 0:
+                                return True  # Static obstacle (pad) - block
+                            continue  # Allow with cost penalty (routed cell)
                     else:
                         # Standard mode: block if obstacle or different net
                         if cell.is_obstacle or cell.net != net:


### PR DESCRIPTION
## Summary
- Fixed bug where autorouter created traces through pad clearance zones in negotiated congestion mode
- Root cause: pad cells were incorrectly treated as "shareable" cells instead of static obstacles
- Fix uses `usage_count` field to distinguish between pads (usage_count=0) and routed traces (usage_count>0)
- Added 4 tests covering pad obstacle behavior in negotiated mode

## Technical Details
The negotiated routing mode allows routing through previously-routed cells with a cost penalty, enabling congestion resolution through rip-up and reroute. However, the blocking check methods (`_is_trace_blocked`, `_is_via_blocked`, `_is_diagonal_corner_blocked`) were incorrectly treating pad clearance zone cells as shareable because:

1. Pad cells have `is_obstacle=False` (only set to True when nets conflict during pad placement)
2. The check `if allow_sharing and not cell.is_obstacle` allowed sharing these cells

The fix checks `usage_count == 0` to identify static obstacles (pads, keepouts) that should never be shared, distinguishing them from routed cells that can be shared.

## Test plan
- [x] `test_pad_blocks_other_net_in_negotiated_mode` - verifies pads block other nets
- [x] `test_grid_cell_usage_count_distinguishes_pads_from_routes` - verifies pad cells have usage_count=0
- [x] `test_routed_cell_has_usage_count_after_marking` - verifies routed cells get usage_count>0
- [x] `test_same_net_can_reach_own_pad` - verifies same-net routing still works
- [x] All 301 router tests pass

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)