### PR TITLE
Add actionable error messages with error codes and JSON serialization

### DIFF
--- a/src/kicad_tools/exceptions.py
+++ b/src/kicad_tools/exceptions.py
@@ -5,7 +5,8 @@ Provides consistent error handling with context, suggestions, and actionable gui
 All exceptions include:
 - Context information (file paths, line numbers, etc.)
 - Suggestions for how to fix the issue
-- Clear, formatted error messages
+- Error codes for programmatic handling
+- JSON serialization for CLI output
 
 Example::
 
@@ -21,34 +22,83 @@ Example::
     # Validation with multiple errors
     errors = ["Field 'name' is required", "Invalid email format"]
     raise ValidationError(errors, context={"file": "config.json"})
+
+    # JSON serialization for CLI
+    try:
+        load_schematic("missing.kicad_sch")
+    except KiCadToolsError as e:
+        print(json.dumps(e.to_dict()))
+        # {"error_code": "FILE_NOT_FOUND", "message": "...", ...}
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
+
+
+def _class_name_to_error_code(class_name: str) -> str:
+    """Convert CamelCase class name to SCREAMING_SNAKE_CASE error code.
+
+    Example: FileNotFoundError -> FILE_NOT_FOUND
+    """
+    # Remove 'Error' suffix if present
+    name = class_name
+    if name.endswith("Error"):
+        name = name[:-5]
+
+    # Convert CamelCase to SCREAMING_SNAKE_CASE
+    # Insert underscore before uppercase letters (except at start)
+    result = re.sub(r"(?<!^)(?=[A-Z])", "_", name)
+    return result.upper()
 
 
 class KiCadToolsError(Exception):
     """
     Base exception for all kicad-tools errors.
 
-    Provides consistent formatting with context and suggestions.
+    Provides consistent formatting with context, suggestions, and error codes.
 
     Attributes:
+        message: Human-readable error message
+        error_code: Machine-readable error code for programmatic handling
         context: Dictionary of contextual information (file, line, etc.)
         suggestions: List of actionable suggestions for fixing the error
+
+    Example::
+
+        try:
+            do_something()
+        except KiCadToolsError as e:
+            if e.error_code == "FILE_NOT_FOUND":
+                # Handle specifically
+                pass
+            print(e.to_dict())  # JSON-serializable format
     """
+
+    # Default error code (subclasses can override)
+    _default_error_code: str | None = None
 
     def __init__(
         self,
         message: str,
         context: dict[str, Any] | None = None,
         suggestions: list[str] | None = None,
+        error_code: str | None = None,
     ):
         self.message = message
         self.context = context or {}
         self.suggestions = suggestions or []
+
+        # Use provided error_code, or class default, or auto-generate from class name
+        if error_code is not None:
+            self.error_code = error_code
+        elif self._default_error_code is not None:
+            self.error_code = self._default_error_code
+        else:
+            self.error_code = _class_name_to_error_code(self.__class__.__name__)
+
         super().__init__(self._format_message())
 
     def _format_message(self) -> str:
@@ -69,6 +119,32 @@ class KiCadToolsError(Exception):
 
     def __str__(self) -> str:
         return self._format_message()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert exception to a JSON-serializable dictionary.
+
+        Useful for CLI --json output and programmatic error handling.
+
+        Returns:
+            Dictionary with error_code, message, context, and suggestions.
+
+        Example::
+
+            >>> err = FileNotFoundError("File not found", context={"file": "x.txt"})
+            >>> err.to_dict()
+            {
+                "error_code": "FILE_NOT_FOUND",
+                "message": "File not found",
+                "context": {"file": "x.txt"},
+                "suggestions": []
+            }
+        """
+        return {
+            "error_code": self.error_code,
+            "message": self.message,
+            "context": self.context,
+            "suggestions": self.suggestions,
+        }
 
 
 class ParseError(KiCadToolsError):
@@ -95,6 +171,7 @@ class ParseError(KiCadToolsError):
         line: int | None = None,
         column: int | None = None,
         file_path: str | Path | None = None,
+        error_code: str | None = None,
     ):
         # Build context from convenience parameters
         ctx = context or {}
@@ -105,7 +182,7 @@ class ParseError(KiCadToolsError):
         if column is not None and "column" not in ctx:
             ctx["column"] = column
 
-        super().__init__(message, ctx, suggestions)
+        super().__init__(message, ctx, suggestions, error_code)
 
 
 class ValidationError(KiCadToolsError):
@@ -133,11 +210,18 @@ class ValidationError(KiCadToolsError):
         errors: list[str],
         context: dict[str, Any] | None = None,
         suggestions: list[str] | None = None,
+        error_code: str | None = None,
     ):
         self.errors = errors
         message = f"Validation failed with {len(errors)} error(s):\n"
         message += "\n".join(f"  {i + 1}. {e}" for i, e in enumerate(errors))
-        super().__init__(message, context, suggestions)
+        super().__init__(message, context, suggestions, error_code)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary, including individual validation errors."""
+        result = super().to_dict()
+        result["errors"] = self.errors
+        return result
 
 
 class FileFormatError(KiCadToolsError):


### PR DESCRIPTION
## Summary

Enhance the exception hierarchy with programmatic error codes and JSON serialization for better agent error recovery.

## Changes

- Add `error_code` field to all `KiCadToolsError` subclasses
  - Auto-generated from class name (e.g., `FileNotFoundError` → `FILE_NOT_FOUND`)
  - Can be overridden via constructor parameter
- Add `to_dict()` method for JSON-serializable error output
  - Returns `{error_code, message, context, suggestions}`
  - `ValidationError.to_dict()` also includes individual `errors` list
- Add comprehensive tests for error codes and JSON serialization

## Example Usage

```python
try:
    load_schematic("missing.kicad_sch")
except KiCadToolsError as e:
    # Programmatic handling
    if e.error_code == "FILE_NOT_FOUND":
        print(f"File missing: {e.context.get('file')}")
    
    # JSON output for CLI
    print(json.dumps(e.to_dict()))
    # {"error_code": "FILE_NOT_FOUND", "message": "...", ...}
```

## Test Plan

- [x] All exception tests pass (35 tests)
- [x] Error codes are unique across all exception types
- [x] `to_dict()` output is JSON-serializable
- [x] Ruff linting passes
- [x] Mypy type checking passes

Closes #164