### PR TITLE
Add progress callbacks for long operations

### DIFF
--- a/src/kicad_tools/__init__.py
+++ b/src/kicad_tools/__init__.py
@@ -16,6 +16,7 @@ Modules:
     operations: Schematic and PCB operations
     router: PCB autorouter with A* pathfinding
     constraints: Constraint locking for multi-stage optimization
+    progress: Progress callback infrastructure for long-running operations
 
 Quick Start::
 
@@ -34,6 +35,13 @@ Quick Start::
     project = Project.load("project.kicad_pro")
     result = project.cross_reference()
     project.export_assembly("output/", manufacturer="jlcpcb")
+
+    # Use progress callbacks for long operations
+    from kicad_tools.progress import ProgressCallback, ProgressContext
+    def on_progress(progress, message, cancelable):
+        print(f"{progress*100:.0f}%: {message}")
+        return True  # Continue
+    # ... use with router, DRC, export functions
 """
 
 __version__ = "0.2.0"
@@ -46,6 +54,19 @@ from kicad_tools.constraints import (
     LockType,
 )
 from kicad_tools.core.sexp_file import load_pcb, load_schematic, save_pcb, save_schematic
+
+# Progress callback infrastructure
+from kicad_tools.progress import (
+    ProgressCallback,
+    ProgressContext,
+    ProgressEvent,
+    SubProgressCallback,
+    create_json_callback,
+    create_print_callback,
+    get_current_callback,
+    null_progress,
+    report_progress,
+)
 
 # Project
 from kicad_tools.project import Project
@@ -105,4 +126,14 @@ __all__ = [
     "ConstraintManager",
     "ConstraintViolation",
     "LockType",
+    # Progress - callback infrastructure for long operations
+    "ProgressCallback",
+    "ProgressContext",
+    "ProgressEvent",
+    "SubProgressCallback",
+    "create_json_callback",
+    "create_print_callback",
+    "get_current_callback",
+    "null_progress",
+    "report_progress",
 ]

--- a/src/kicad_tools/progress.py
+++ b/src/kicad_tools/progress.py
@@ -1,0 +1,354 @@
+"""
+Progress callback infrastructure for long-running operations.
+
+Provides a callback-based progress reporting API for routing, DRC, and export operations.
+This enables progress reporting in agents and UIs.
+
+Example::
+
+    from kicad_tools.progress import ProgressCallback, ProgressContext
+
+    # Callback function signature
+    def on_progress(progress: float, message: str, cancelable: bool) -> bool:
+        '''
+        Args:
+            progress: 0.0 to 1.0 (or -1 for indeterminate)
+            message: Current operation description
+            cancelable: Whether cancel is supported
+
+        Returns:
+            False to cancel operation, True to continue
+        '''
+        print(f"{progress*100:.0f}%: {message}")
+        return True  # Continue
+
+    # Usage with routing
+    from kicad_tools.router import route_pcb
+    route_pcb(
+        "board.kicad_pcb",
+        progress_callback=on_progress,
+    )
+
+    # Context manager for scoped progress
+    with ProgressContext(callback=on_progress) as ctx:
+        # Operations automatically use ctx callback
+        ...
+
+For CLI usage, see kicad_tools.cli.progress for Rich-based progress bars.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Protocol, TypeAlias
+
+# Type alias for progress callbacks
+# Returns False to cancel, True to continue
+ProgressCallback: TypeAlias = Callable[[float, str, bool], bool]
+
+
+class ProgressReporter(Protocol):
+    """Protocol for progress reporters."""
+
+    def report(self, progress: float, message: str, cancelable: bool = True) -> bool:
+        """Report progress.
+
+        Args:
+            progress: 0.0 to 1.0, or -1 for indeterminate
+            message: Current operation description
+            cancelable: Whether operation can be cancelled
+
+        Returns:
+            False to cancel, True to continue
+        """
+        ...
+
+
+# Context variable for the current progress callback
+_current_progress: ContextVar[ProgressCallback | None] = ContextVar(
+    "current_progress", default=None
+)
+
+
+def get_current_callback() -> ProgressCallback | None:
+    """Get the current progress callback from context.
+
+    Returns:
+        The current progress callback, or None if not in a progress context.
+    """
+    return _current_progress.get()
+
+
+def report_progress(progress: float, message: str, cancelable: bool = True) -> bool:
+    """Report progress using the current context callback.
+
+    This is a convenience function for use within operations that support
+    progress callbacks. It checks for a context callback and calls it if present.
+
+    Args:
+        progress: 0.0 to 1.0, or -1 for indeterminate
+        message: Current operation description
+        cancelable: Whether operation can be cancelled
+
+    Returns:
+        False if cancelled, True to continue (always True if no callback)
+    """
+    callback = get_current_callback()
+    if callback is not None:
+        return callback(progress, message, cancelable)
+    return True
+
+
+@dataclass
+class ProgressEvent:
+    """A progress event for JSON output mode."""
+
+    progress: float
+    message: str
+    cancelable: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "progress": self.progress,
+            "message": self.message,
+            "cancelable": self.cancelable,
+        }
+
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict())
+
+
+class ProgressContext:
+    """Context manager for scoped progress reporting.
+
+    Allows setting a progress callback that applies to all operations
+    within the context scope.
+
+    Example::
+
+        def on_progress(progress, message, cancelable):
+            print(f"{progress*100:.0f}%: {message}")
+            return True
+
+        with ProgressContext(callback=on_progress) as ctx:
+            # Operations within this context will use the callback
+            router.route_all()  # Will report progress
+            exporter.export()   # Will also report progress
+
+        # Or access the context for manual reporting
+        with ProgressContext(callback=on_progress) as ctx:
+            ctx.report(0.5, "Halfway done")
+    """
+
+    def __init__(self, callback: ProgressCallback | None = None):
+        """Initialize progress context.
+
+        Args:
+            callback: Progress callback function. If None, progress is not reported.
+        """
+        self._callback = callback
+        self._token = None
+        self._cancelled = False
+
+    def __enter__(self) -> ProgressContext:
+        """Enter the context, setting the callback as current."""
+        self._token = _current_progress.set(self._callback)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Exit the context, restoring the previous callback."""
+        if self._token is not None:
+            _current_progress.reset(self._token)
+
+    def report(self, progress: float, message: str, cancelable: bool = True) -> bool:
+        """Report progress through the callback.
+
+        Args:
+            progress: 0.0 to 1.0, or -1 for indeterminate
+            message: Current operation description
+            cancelable: Whether operation can be cancelled
+
+        Returns:
+            False if cancelled, True to continue
+        """
+        if self._cancelled:
+            return False
+        if self._callback is not None:
+            result = self._callback(progress, message, cancelable)
+            if not result:
+                self._cancelled = True
+            return result
+        return True
+
+    @property
+    def cancelled(self) -> bool:
+        """Check if operation has been cancelled."""
+        return self._cancelled
+
+
+def create_json_callback(file=None) -> ProgressCallback:
+    """Create a callback that outputs JSON progress events.
+
+    Useful for agent consumption where structured output is needed.
+
+    Args:
+        file: File to write to (default: sys.stderr)
+
+    Returns:
+        A progress callback that outputs JSON events.
+
+    Example::
+
+        callback = create_json_callback()
+        route_pcb("board.kicad_pcb", progress_callback=callback)
+        # Outputs: {"progress": 0.5, "message": "Routing net GND", "cancelable": true}
+    """
+    output = file or sys.stderr
+
+    def json_callback(progress: float, message: str, cancelable: bool) -> bool:
+        event = ProgressEvent(progress=progress, message=message, cancelable=cancelable)
+        print(event.to_json(), file=output, flush=True)
+        return True  # Never cancel from JSON callback
+
+    return json_callback
+
+
+def create_print_callback(file=None, show_percent: bool = True) -> ProgressCallback:
+    """Create a simple callback that prints progress to a file.
+
+    Args:
+        file: File to write to (default: sys.stderr)
+        show_percent: Whether to show percentage
+
+    Returns:
+        A progress callback that prints progress.
+    """
+    output = file or sys.stderr
+
+    def print_callback(progress: float, message: str, cancelable: bool) -> bool:
+        if show_percent and progress >= 0:
+            print(f"{progress * 100:.0f}%: {message}", file=output, flush=True)
+        else:
+            print(message, file=output, flush=True)
+        return True
+
+    return print_callback
+
+
+@contextmanager
+def null_progress():
+    """Context manager that provides no-op progress reporting.
+
+    Useful for testing or when progress is not needed.
+    """
+    yield ProgressContext(callback=None)
+
+
+class SubProgressCallback:
+    """Wrapper that scales progress for sub-operations.
+
+    When an operation has multiple phases, this allows each phase
+    to report 0-100% while the parent sees the scaled range.
+
+    Example::
+
+        def on_progress(progress, message, cancelable):
+            print(f"Overall: {progress*100:.0f}%")
+            return True
+
+        # Phase 1: 0-50%
+        phase1 = SubProgressCallback(on_progress, start=0.0, end=0.5)
+        phase1(0.5, "Phase 1 halfway")  # Reports 25% to parent
+
+        # Phase 2: 50-100%
+        phase2 = SubProgressCallback(on_progress, start=0.5, end=1.0)
+        phase2(0.5, "Phase 2 halfway")  # Reports 75% to parent
+    """
+
+    def __init__(
+        self,
+        parent: ProgressCallback,
+        start: float = 0.0,
+        end: float = 1.0,
+        prefix: str = "",
+    ):
+        """Initialize sub-progress wrapper.
+
+        Args:
+            parent: Parent callback to forward to
+            start: Start of this phase in parent's progress (0.0-1.0)
+            end: End of this phase in parent's progress (0.0-1.0)
+            prefix: Optional prefix for messages
+        """
+        self._parent = parent
+        self._start = start
+        self._end = end
+        self._prefix = prefix
+
+    def __call__(self, progress: float, message: str, cancelable: bool = True) -> bool:
+        """Report progress, scaling to parent range.
+
+        Args:
+            progress: 0.0 to 1.0 within this phase, or -1 for indeterminate
+            message: Current operation description
+            cancelable: Whether operation can be cancelled
+
+        Returns:
+            False to cancel, True to continue
+        """
+        if progress < 0:
+            # Indeterminate - pass through
+            scaled = -1
+        else:
+            # Scale to parent range
+            scaled = self._start + (progress * (self._end - self._start))
+
+        full_message = f"{self._prefix}{message}" if self._prefix else message
+        return self._parent(scaled, full_message, cancelable)
+
+
+def create_cli_adapter(quiet: bool = False):
+    """Create an adapter that bridges progress callbacks to CLI progress bars.
+
+    This integrates with the Rich-based progress bars in kicad_tools.cli.progress.
+
+    Args:
+        quiet: If True, creates a no-op adapter
+
+    Returns:
+        A context manager that provides both CLI progress and callback progress.
+
+    Example::
+
+        with create_cli_adapter(quiet=args.quiet) as (progress, callback):
+            # progress is a Rich Progress instance
+            # callback is a ProgressCallback for the operation
+            route_pcb("board.kicad_pcb", progress_callback=callback)
+    """
+    from .cli.progress import create_progress
+
+    @contextmanager
+    def adapter():
+        with create_progress(quiet=quiet) as progress:
+            task_id = None
+
+            def callback(prog: float, message: str, cancelable: bool) -> bool:
+                nonlocal task_id
+                if task_id is None:
+                    task_id = progress.add_task(message, total=100)
+                if prog >= 0:
+                    progress.update(task_id, completed=int(prog * 100), description=message)
+                else:
+                    progress.update(task_id, description=message)
+                return True
+
+            yield progress, callback
+
+    return adapter()

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -21,9 +21,15 @@ Note on net class metadata:
     as this is incompatible with KiCad 7+.
 """
 
+from __future__ import annotations
+
 import math
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.progress import ProgressCallback
 
 from .core import Autorouter
 from .layers import Layer
@@ -39,6 +45,7 @@ def route_pcb(
     origin_x: float = 0,
     origin_y: float = 0,
     skip_nets: list[str] | None = None,
+    progress_callback: ProgressCallback | None = None,
 ) -> tuple[str, dict]:
     """
     Route a PCB given component placements and net assignments.
@@ -59,6 +66,9 @@ def route_pcb(
         rules: DesignRules (optional)
         origin_x, origin_y: Board origin
         skip_nets: Net names to skip (e.g., ["GND", "+3.3V"] for plane nets)
+        progress_callback: Optional callback for progress reporting.
+            Signature: (progress: float, message: str, cancelable: bool) -> bool
+            Returns False to cancel, True to continue.
 
     Returns:
         Tuple of (sexp_string, statistics_dict)
@@ -129,7 +139,7 @@ def route_pcb(
 
     # Route nets
     print(f"Autorouting {len(nets_to_route)} nets...")
-    router.route_all(nets_to_route)
+    router.route_all(nets_to_route, progress_callback=progress_callback)
 
     stats = router.get_statistics()
     print(

--- a/tests/test_progress_callback.py
+++ b/tests/test_progress_callback.py
@@ -1,0 +1,317 @@
+"""Tests for progress callback infrastructure."""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from kicad_tools.progress import (
+    ProgressContext,
+    ProgressEvent,
+    SubProgressCallback,
+    create_json_callback,
+    create_print_callback,
+    get_current_callback,
+    null_progress,
+    report_progress,
+)
+
+
+class TestProgressCallback:
+    """Tests for the basic progress callback type."""
+
+    def test_callback_receives_progress_values(self):
+        """Test that callbacks receive correct progress, message, and cancelable values."""
+        received = []
+
+        def callback(progress: float, message: str, cancelable: bool) -> bool:
+            received.append((progress, message, cancelable))
+            return True
+
+        # Simulate calling the callback
+        callback(0.0, "Starting", True)
+        callback(0.5, "Halfway", True)
+        callback(1.0, "Complete", False)
+
+        assert len(received) == 3
+        assert received[0] == (0.0, "Starting", True)
+        assert received[1] == (0.5, "Halfway", True)
+        assert received[2] == (1.0, "Complete", False)
+
+    def test_callback_can_cancel_operation(self):
+        """Test that returning False from callback signals cancellation."""
+        call_count = 0
+
+        def cancel_callback(progress: float, message: str, cancelable: bool) -> bool:
+            nonlocal call_count
+            call_count += 1
+            # Cancel after first call
+            return call_count < 2
+
+        # Simulate an operation that respects cancellation
+        for i in range(10):
+            progress = i / 10
+            if not cancel_callback(progress, f"Step {i}", True):
+                break
+
+        # Should have stopped after 2 calls
+        assert call_count == 2
+
+
+class TestProgressContext:
+    """Tests for the ProgressContext context manager."""
+
+    def test_context_sets_current_callback(self):
+        """Test that entering context sets the current callback."""
+        received = []
+
+        def callback(progress: float, message: str, cancelable: bool) -> bool:
+            received.append((progress, message))
+            return True
+
+        # Before context, no callback
+        assert get_current_callback() is None
+
+        with ProgressContext(callback=callback) as ctx:
+            # Inside context, callback is set
+            current = get_current_callback()
+            assert current is not None
+            ctx.report(0.5, "Test message")
+
+        # After context, callback is cleared
+        assert get_current_callback() is None
+
+        # Check callback was invoked
+        assert len(received) == 1
+        assert received[0] == (0.5, "Test message")
+
+    def test_context_tracks_cancellation(self):
+        """Test that context tracks when operation is cancelled."""
+
+        def cancel_callback(progress: float, message: str, cancelable: bool) -> bool:
+            return progress < 0.5  # Cancel at 50%
+
+        with ProgressContext(callback=cancel_callback) as ctx:
+            assert not ctx.cancelled
+
+            # Report progress up to cancellation point
+            ctx.report(0.25, "Quarter done")
+            assert not ctx.cancelled
+
+            ctx.report(0.5, "Half done")  # This should trigger cancel
+            assert ctx.cancelled
+
+            # Further reports should return False immediately
+            result = ctx.report(0.75, "Should not process")
+            assert result is False
+
+    def test_null_context(self):
+        """Test that null context provides no-op progress."""
+        with ProgressContext(callback=None) as ctx:
+            # Should not raise, just return True
+            result = ctx.report(0.5, "Test")
+            assert result is True
+
+    def test_report_progress_uses_current_context(self):
+        """Test that report_progress uses the current context callback."""
+        received = []
+
+        def callback(progress: float, message: str, cancelable: bool) -> bool:
+            received.append((progress, message))
+            return True
+
+        # Without context, report_progress returns True (no-op)
+        result = report_progress(0.5, "No context")
+        assert result is True
+        assert len(received) == 0
+
+        # With context, report_progress uses the callback
+        with ProgressContext(callback=callback):
+            result = report_progress(0.5, "With context")
+            assert result is True
+            assert len(received) == 1
+            assert received[0] == (0.5, "With context")
+
+
+class TestProgressEvent:
+    """Tests for ProgressEvent dataclass."""
+
+    def test_event_to_dict(self):
+        """Test conversion to dictionary."""
+        event = ProgressEvent(progress=0.5, message="Halfway", cancelable=True)
+        d = event.to_dict()
+
+        assert d == {"progress": 0.5, "message": "Halfway", "cancelable": True}
+
+    def test_event_to_json(self):
+        """Test conversion to JSON string."""
+        event = ProgressEvent(progress=0.75, message="Almost done", cancelable=False)
+        j = event.to_json()
+
+        parsed = json.loads(j)
+        assert parsed["progress"] == 0.75
+        assert parsed["message"] == "Almost done"
+        assert parsed["cancelable"] is False
+
+
+class TestSubProgressCallback:
+    """Tests for SubProgressCallback scaling wrapper."""
+
+    def test_sub_progress_scales_values(self):
+        """Test that sub-progress correctly scales progress values."""
+        received = []
+
+        def parent(progress: float, message: str, cancelable: bool) -> bool:
+            received.append(progress)
+            return True
+
+        # Phase 1: 0-50%
+        phase1 = SubProgressCallback(parent, start=0.0, end=0.5)
+        phase1(0.0, "Start phase 1", True)  # 0.0 -> 0.0
+        phase1(0.5, "Mid phase 1", True)  # 0.5 -> 0.25
+        phase1(1.0, "End phase 1", True)  # 1.0 -> 0.5
+
+        # Phase 2: 50-100%
+        phase2 = SubProgressCallback(parent, start=0.5, end=1.0)
+        phase2(0.0, "Start phase 2", True)  # 0.0 -> 0.5
+        phase2(0.5, "Mid phase 2", True)  # 0.5 -> 0.75
+        phase2(1.0, "End phase 2", True)  # 1.0 -> 1.0
+
+        assert len(received) == 6
+        assert received[0] == pytest.approx(0.0)
+        assert received[1] == pytest.approx(0.25)
+        assert received[2] == pytest.approx(0.5)
+        assert received[3] == pytest.approx(0.5)
+        assert received[4] == pytest.approx(0.75)
+        assert received[5] == pytest.approx(1.0)
+
+    def test_sub_progress_with_prefix(self):
+        """Test that sub-progress can add message prefix."""
+        received = []
+
+        def parent(progress: float, message: str, cancelable: bool) -> bool:
+            received.append(message)
+            return True
+
+        sub = SubProgressCallback(parent, start=0.0, end=1.0, prefix="Phase 1: ")
+        sub(0.5, "Working", True)
+
+        assert received[0] == "Phase 1: Working"
+
+    def test_sub_progress_passes_through_indeterminate(self):
+        """Test that indeterminate progress (-1) is passed through."""
+        received = []
+
+        def parent(progress: float, message: str, cancelable: bool) -> bool:
+            received.append(progress)
+            return True
+
+        sub = SubProgressCallback(parent, start=0.0, end=0.5)
+        sub(-1, "Indeterminate", True)
+
+        assert received[0] == -1
+
+    def test_sub_progress_propagates_cancel(self):
+        """Test that cancellation from parent is propagated."""
+
+        def cancel_parent(progress: float, message: str, cancelable: bool) -> bool:
+            return False  # Always cancel
+
+        sub = SubProgressCallback(cancel_parent, start=0.0, end=1.0)
+        result = sub(0.5, "Test", True)
+
+        assert result is False
+
+
+class TestFactoryFunctions:
+    """Tests for callback factory functions."""
+
+    def test_create_json_callback(self):
+        """Test JSON callback outputs properly formatted events."""
+        output = io.StringIO()
+        callback = create_json_callback(file=output)
+
+        callback(0.5, "Test message", True)
+
+        output.seek(0)
+        line = output.readline().strip()
+        parsed = json.loads(line)
+
+        assert parsed["progress"] == 0.5
+        assert parsed["message"] == "Test message"
+        assert parsed["cancelable"] is True
+
+    def test_json_callback_never_cancels(self):
+        """Test that JSON callback always returns True (never cancels)."""
+        output = io.StringIO()
+        callback = create_json_callback(file=output)
+
+        # Should always return True
+        assert callback(0.0, "Start", True) is True
+        assert callback(0.5, "Mid", True) is True
+        assert callback(1.0, "End", False) is True
+
+    def test_create_print_callback(self):
+        """Test print callback outputs progress messages."""
+        output = io.StringIO()
+        callback = create_print_callback(file=output, show_percent=True)
+
+        callback(0.5, "Halfway", True)
+
+        output.seek(0)
+        line = output.readline().strip()
+        assert "50%" in line
+        assert "Halfway" in line
+
+    def test_print_callback_without_percent(self):
+        """Test print callback can hide percentage."""
+        output = io.StringIO()
+        callback = create_print_callback(file=output, show_percent=False)
+
+        callback(0.5, "Halfway", True)
+
+        output.seek(0)
+        line = output.readline().strip()
+        assert "%" not in line
+        assert "Halfway" in line
+
+    def test_null_progress_context(self):
+        """Test null_progress provides no-op context."""
+        with null_progress() as ctx:
+            # Should not have a callback
+            assert ctx._callback is None
+
+            # Report should succeed without error
+            result = ctx.report(0.5, "Test")
+            assert result is True
+
+
+class TestNestedContexts:
+    """Tests for nested progress contexts."""
+
+    def test_nested_contexts_restore_correctly(self):
+        """Test that nested contexts properly restore previous callback."""
+        outer_received = []
+        inner_received = []
+
+        def outer_callback(progress: float, message: str, cancelable: bool) -> bool:
+            outer_received.append(message)
+            return True
+
+        def inner_callback(progress: float, message: str, cancelable: bool) -> bool:
+            inner_received.append(message)
+            return True
+
+        with ProgressContext(callback=outer_callback):
+            report_progress(0.5, "Outer 1")
+
+            with ProgressContext(callback=inner_callback):
+                report_progress(0.5, "Inner")
+
+            # After inner context, outer should be restored
+            report_progress(0.5, "Outer 2")
+
+        assert outer_received == ["Outer 1", "Outer 2"]
+        assert inner_received == ["Inner"]


### PR DESCRIPTION
## Summary

- Adds a new `kicad_tools/progress.py` module with callback-based progress reporting API
- Enables progress reporting in agents and UIs for routing, DRC, and export operations
- Includes `ProgressContext` for scoped progress and `SubProgressCallback` for phase scaling
- Provides `create_json_callback()` for agent-friendly JSON output

## Changes

- **New module** `kicad_tools/progress.py`:
  - `ProgressCallback` type alias for `(progress, message, cancelable) -> bool`
  - `ProgressContext` context manager with context variable support
  - `ProgressEvent` dataclass for JSON serialization
  - `SubProgressCallback` wrapper for scaling progress in phases
  - Factory functions for JSON and text output

- **Router** (`router/core.py`, `router/io.py`):
  - Added `progress_callback` to `route_pcb()`, `route_all()`, `route_all_negotiated()`, `route_all_monte_carlo()`, `route_all_advanced()`

- **DRC** (`drc/checker.py`):
  - Added `progress_callback` to `check_manufacturer_rules()`

- **Export** (`export/gerber.py`):
  - Added `progress_callback` to `GerberExporter.export()`, `export_for_manufacturer()`, `export_gerbers()`

- **Tests**: 18 new tests in `tests/test_progress_callback.py`

## Test plan

- [x] All 18 new progress callback tests pass
- [x] All 2877 existing tests pass (excluding pre-existing benchmark fixture issue)
- [x] Ruff lint and format checks pass

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)