### PR TITLE
Fix incorrect module references in docstrings

### DIFF
--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -6,7 +6,7 @@ Convenience functions for building KiCad schematic S-expressions.
 These builders produce SExp nodes that serialize to valid KiCad format.
 
 Usage:
-    from kicad_sexp_builders import xy, at, stroke, effects, uuid_node
+    from kicad_tools.sexp.builders import xy, at, stroke, effects, uuid_node
 
     wire_node = SExp.list("wire",
         SExp.list("pts", xy(10, 20), xy(30, 40)),

--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -13,7 +13,7 @@ Performance optimizations in this module:
 - Pre-compiled character sets for fast whitespace/delimiter detection
 
 Usage:
-    from kicad_sexp import SExp, parse_file, parse_string
+    from kicad_tools.sexp import SExp, parse_file, parse_string
 
     # Parse a schematic
     doc = parse_file("project.kicad_sch")


### PR DESCRIPTION
## Summary

Update docstring examples to use correct internal module imports:
- `parser.py`: Changed `from kicad_sexp import ...` to `from kicad_tools.sexp import ...`
- `builders.py`: Changed `from kicad_sexp_builders import ...` to `from kicad_tools.sexp.builders import ...`

## Changes

- Fixed docstring example import in `src/kicad_tools/sexp/parser.py:16`
- Fixed docstring example import in `src/kicad_tools/sexp/builders.py:9`

## Test Plan

- [x] Verified files pass ruff format check
- [x] Verified files pass ruff lint check
- [x] All sexp tests pass (54/54)

Closes #193