### PR TITLE
Fix incorrect import paths in sexp module docstrings

### DIFF
--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -6,7 +6,7 @@ Convenience functions for building KiCad schematic S-expressions.
 These builders produce SExp nodes that serialize to valid KiCad format.
 
 Usage:
-    from kicad_sexp_builders import xy, at, stroke, effects, uuid_node
+    from kicad_tools.sexp.builders import xy, at, stroke, effects, uuid_node
 
     wire_node = SExp.list("wire",
         SExp.list("pts", xy(10, 20), xy(30, 40)),

--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -13,7 +13,7 @@ Performance optimizations in this module:
 - Pre-compiled character sets for fast whitespace/delimiter detection
 
 Usage:
-    from kicad_sexp import SExp, parse_file, parse_string
+    from kicad_tools.sexp import SExp, parse_file, parse_string
 
     # Parse a schematic
     doc = parse_file("project.kicad_sch")


### PR DESCRIPTION
## Summary

Fix incorrect import path examples in docstrings for the sexp module. Users copying these examples would get ImportError.

## Changes

- **builders.py:9**: Changed `from kicad_sexp_builders import ...` to `from kicad_tools.sexp.builders import ...`
- **parser.py:16**: Changed `from kicad_sexp import ...` to `from kicad_tools.sexp import ...`

## Test Plan

- [x] Verified files pass ruff format and lint checks
- [x] All 164 sexp-related tests pass

Closes #201