### PR TITLE
Skip benchmark tests gracefully when pytest-benchmark not installed

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -15,6 +15,20 @@ from pathlib import Path
 
 import pytest
 
+# Check if pytest-benchmark is available
+try:
+    import pytest_benchmark  # noqa: F401
+
+    HAS_BENCHMARK = True
+except ImportError:
+    HAS_BENCHMARK = False
+
+# Marker to skip tests when pytest-benchmark is not installed
+requires_benchmark = pytest.mark.skipif(
+    not HAS_BENCHMARK,
+    reason="pytest-benchmark not installed (install with: pip install pytest-benchmark)",
+)
+
 from kicad_tools.schema.pcb import PCB
 from kicad_tools.schema.schematic import Schematic
 from kicad_tools.sexp import SExp, parse_sexp, serialize_sexp
@@ -232,6 +246,7 @@ def xlarge_pcb_content() -> str:
 # --- S-Expression Parsing Benchmarks ---
 
 
+@requires_benchmark
 class TestSexpParseBenchmarks:
     """Benchmarks for S-expression parsing."""
 
@@ -279,6 +294,7 @@ class TestSexpParseBenchmarks:
 # --- Schematic Loading Benchmarks ---
 
 
+@requires_benchmark
 class TestSchematicLoadBenchmarks:
     """Benchmarks for schematic loading (file to schema objects)."""
 
@@ -322,6 +338,7 @@ class TestSchematicLoadBenchmarks:
 # --- PCB Loading Benchmarks ---
 
 
+@requires_benchmark
 class TestPCBLoadBenchmarks:
     """Benchmarks for PCB loading (file to schema objects)."""
 
@@ -365,6 +382,7 @@ class TestPCBLoadBenchmarks:
 # --- Query Benchmarks ---
 
 
+@requires_benchmark
 class TestQueryBenchmarks:
     """Benchmarks for query operations."""
 
@@ -436,6 +454,7 @@ class TestQueryBenchmarks:
 # --- Serialization Benchmarks ---
 
 
+@requires_benchmark
 class TestSerializationBenchmarks:
     """Benchmarks for S-expression serialization."""
 


### PR DESCRIPTION
## Summary

Skip benchmark tests gracefully when pytest-benchmark is not installed, instead of failing with fixture errors.

## Changes

- Add `HAS_BENCHMARK` flag to detect pytest-benchmark availability at import time
- Create `requires_benchmark` marker that skips tests with a helpful message
- Apply `@requires_benchmark` decorator to all 5 benchmark test classes (21 tests total)
- Preserve `TestMemoryUsage` tests which don't require the benchmark fixture

## Test Plan

- [x] Without pytest-benchmark: All 21 benchmark tests are SKIPPED gracefully
- [x] With pytest-benchmark: All benchmark tests PASS as expected
- [x] Memory tests run regardless of pytest-benchmark availability
- [x] No fixture errors in test output

## Before/After

**Before** (without pytest-benchmark):
```
E       fixture 'benchmark' not found
```

**After** (without pytest-benchmark):
```
tests/test_benchmarks.py::TestSexpParseBenchmarks::test_parse_small_schematic SKIPPED
...
tests/test_benchmarks.py::TestMemoryUsage::test_xlarge_schematic_memory PASSED
```

Closes #219