### PR TITLE
Fix I2CPullups test API mismatches

### DIFF
--- a/tests/test_schematic_blocks.py
+++ b/tests/test_schematic_blocks.py
@@ -2288,8 +2288,8 @@ class TestI2CPullupsMocked:
 
     def test_i2c_pullups_with_filter_caps(self, mock_schematic):
         """Create I2C pull-ups with filter capacitors."""
-        pullups = I2CPullups(mock_schematic, x=100, y=100, filter_cap="100pF")
-        assert pullups.filter_cap == "100pF"
+        pullups = I2CPullups(mock_schematic, x=100, y=100, filter_caps="100pF")
+        assert pullups.filter_caps_value == "100pF"
 
     def test_i2c_pullups_ports(self, mock_schematic):
         """Verify I2C pull-ups port definitions."""
@@ -2314,12 +2314,14 @@ class TestI2CPullupsFactoryFunctions:
 
     def test_create_i2c_pullups_default(self, mock_schematic):
         """Create I2C pull-ups with default values."""
-        pullups = create_i2c_pullups(mock_schematic, x=100, y=100, ref="R1")
+        pullups = create_i2c_pullups(mock_schematic, x=100, y=100)
         assert isinstance(pullups, I2CPullups)
 
     def test_create_i2c_pullups_custom_value(self, mock_schematic):
-        """Create I2C pull-ups with custom resistor value."""
-        pullups = create_i2c_pullups(mock_schematic, x=100, y=100, ref="R1", resistor_value="10k")
+        """Create I2C pull-ups with custom resistor value using class directly."""
+        # Use I2CPullups directly for custom resistor values
+        # Factory function uses speed presets, not custom values
+        pullups = I2CPullups(mock_schematic, x=100, y=100, resistor_value="10k")
         assert pullups.resistor_value == "10k"
 
 


### PR DESCRIPTION
## Summary

Fixes 3 failing tests in `test_schematic_blocks.py` caused by API mismatches between tests and the `I2CPullups` implementation.

## Changes

- **test_i2c_pullups_with_filter_caps**: Changed `filter_cap` to `filter_caps` (matching implementation parameter name) and `filter_cap` attribute access to `filter_caps_value`
- **test_create_i2c_pullups_default**: Removed invalid `ref` parameter (factory function doesn't accept this)
- **test_create_i2c_pullups_custom_value**: Changed to use `I2CPullups` class directly instead of factory function, since the factory uses speed presets rather than accepting custom resistor values

## Test Plan

- All 5 I2CPullups tests pass:
  - `test_i2c_pullups_basic` ✓
  - `test_i2c_pullups_with_filter_caps` ✓
  - `test_i2c_pullups_ports` ✓
  - `test_create_i2c_pullups_default` ✓
  - `test_create_i2c_pullups_custom_value` ✓
- Test file passes linting and formatting checks

Closes #218