### PR TITLE
Refactor: Move requires_requests decorator to base module

### DIFF
--- a/src/kicad_tools/datasheet/sources/lcsc.py
+++ b/src/kicad_tools/datasheet/sources/lcsc.py
@@ -12,28 +12,12 @@ from typing import TYPE_CHECKING
 
 from ..models import DatasheetResult
 from ..utils import calculate_part_confidence
-from .base import DatasheetSource
+from .base import DatasheetSource, requires_requests
 
 if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
-
-
-def _requires_requests(func):
-    """Decorator to check if requests is available."""
-
-    def wrapper(*args, **kwargs):
-        try:
-            import requests  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "The 'requests' library is required for datasheet downloads. "
-                "Install with: pip install kicad-tools[parts]"
-            )
-        return func(*args, **kwargs)
-
-    return wrapper
 
 
 class LCSCDatasheetSource(DatasheetSource):
@@ -86,7 +70,7 @@ class LCSCDatasheetSource(DatasheetSource):
             )
         return self._session
 
-    @_requires_requests
+    @requires_requests
     def search(self, part_number: str) -> list[DatasheetResult]:
         """
         Search LCSC for datasheets matching the part number.
@@ -123,9 +107,7 @@ class LCSCDatasheetSource(DatasheetSource):
             search_result = client.search(part_number, page_size=10)
             for part in search_result.parts:
                 if part.datasheet_url:
-                    confidence = calculate_part_confidence(
-                        part_number, part.mfr_part or ""
-                    )
+                    confidence = calculate_part_confidence(part_number, part.mfr_part or "")
 
                     results.append(
                         DatasheetResult(
@@ -143,7 +125,7 @@ class LCSCDatasheetSource(DatasheetSource):
 
         return results
 
-    @_requires_requests
+    @requires_requests
     def download(self, result: DatasheetResult, output_path: Path) -> Path:
         """
         Download a datasheet from LCSC.

--- a/src/kicad_tools/datasheet/sources/octopart.py
+++ b/src/kicad_tools/datasheet/sources/octopart.py
@@ -12,25 +12,9 @@ from pathlib import Path
 
 from ..models import DatasheetResult
 from ..utils import calculate_part_confidence
-from .base import DatasheetSource
+from .base import DatasheetSource, requires_requests
 
 logger = logging.getLogger(__name__)
-
-
-def _requires_requests(func):
-    """Decorator to check if requests is available."""
-
-    def wrapper(*args, **kwargs):
-        try:
-            import requests  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "The 'requests' library is required for Octopart API access. "
-                "Install with: pip install kicad-tools[parts]"
-            )
-        return func(*args, **kwargs)
-
-    return wrapper
 
 
 # Octopart API endpoint
@@ -101,7 +85,7 @@ class OctopartDatasheetSource(DatasheetSource):
             time.sleep(sleep_time)
         self._last_request_time = time.time()
 
-    @_requires_requests
+    @requires_requests
     def search(self, part_number: str) -> list[DatasheetResult]:
         """
         Search Octopart for datasheets matching the part number.
@@ -173,7 +157,7 @@ class OctopartDatasheetSource(DatasheetSource):
 
         return results
 
-    @_requires_requests
+    @requires_requests
     def download(self, result: DatasheetResult, output_path: Path) -> Path:
         """
         Download a datasheet found via Octopart.


### PR DESCRIPTION
## Summary

Move the `_requires_requests` decorator from `lcsc.py` and `octopart.py` to `base.py` to eliminate code duplication. This reduces maintenance burden and ensures consistent behavior across datasheet sources.

## Changes

- Add `requires_requests` decorator to `base.py` with `functools.wraps` for proper metadata preservation
- Update `lcsc.py` to import from base and remove local duplicate
- Update `octopart.py` to import from base and remove local duplicate
- Rename from `_requires_requests` to `requires_requests` (public API)

## Test Plan

- All 158 datasheet tests pass
- Both sources import correctly
- Decorator functions as expected

Closes #224