### PR TITLE
Consolidate duplicate confidence scoring logic

### DIFF
--- a/src/kicad_tools/datasheet/sources/lcsc.py
+++ b/src/kicad_tools/datasheet/sources/lcsc.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..models import DatasheetResult
+from ..utils import calculate_part_confidence
 from .base import DatasheetSource
 
 if TYPE_CHECKING:
@@ -122,17 +123,9 @@ class LCSCDatasheetSource(DatasheetSource):
             search_result = client.search(part_number, page_size=10)
             for part in search_result.parts:
                 if part.datasheet_url:
-                    # Calculate confidence based on match quality
-                    confidence = 1.0
-                    query_lower = part_number.lower()
-                    mfr_lower = (part.mfr_part or "").lower()
-
-                    if query_lower == mfr_lower:
-                        confidence = 1.0
-                    elif query_lower in mfr_lower or mfr_lower in query_lower:
-                        confidence = 0.9
-                    else:
-                        confidence = 0.7
+                    confidence = calculate_part_confidence(
+                        part_number, part.mfr_part or ""
+                    )
 
                     results.append(
                         DatasheetResult(

--- a/src/kicad_tools/datasheet/sources/octopart.py
+++ b/src/kicad_tools/datasheet/sources/octopart.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 
 from ..models import DatasheetResult
+from ..utils import calculate_part_confidence
 from .base import DatasheetSource
 
 logger = logging.getLogger(__name__)
@@ -154,17 +155,7 @@ class OctopartDatasheetSource(DatasheetSource):
                 for ds in datasheets:
                     url = ds.get("url", "")
                     if url:
-                        # Calculate confidence
-                        confidence = 1.0
-                        query_lower = part_number.lower()
-                        mpn_lower = mpn.lower()
-
-                        if query_lower == mpn_lower:
-                            confidence = 1.0
-                        elif query_lower in mpn_lower or mpn_lower in query_lower:
-                            confidence = 0.9
-                        else:
-                            confidence = 0.7
+                        confidence = calculate_part_confidence(part_number, mpn)
 
                         results.append(
                             DatasheetResult(

--- a/src/kicad_tools/datasheet/utils.py
+++ b/src/kicad_tools/datasheet/utils.py
@@ -1,0 +1,32 @@
+"""
+Utility functions for datasheet processing.
+"""
+
+from __future__ import annotations
+
+
+def calculate_part_confidence(query: str, part_number: str) -> float:
+    """
+    Calculate confidence score for part number matching.
+
+    The confidence score indicates how closely the query matches the part number:
+    - 1.0: Exact match (case-insensitive)
+    - 0.9: Substring match (query in part_number or vice versa)
+    - 0.7: No direct match (result from search relevance)
+
+    Args:
+        query: The search query (e.g., user-provided part number)
+        part_number: The manufacturer part number from the result
+
+    Returns:
+        Confidence score between 0.0 and 1.0
+    """
+    query_lower = query.lower()
+    part_lower = (part_number or "").lower()
+
+    if query_lower == part_lower:
+        return 1.0
+    elif query_lower in part_lower or part_lower in query_lower:
+        return 0.9
+    else:
+        return 0.7

--- a/tests/test_datasheet.py
+++ b/tests/test_datasheet.py
@@ -18,6 +18,42 @@ from kicad_tools.datasheet.models import (
     DatasheetSearchResult,
 )
 from kicad_tools.datasheet.tables import ExtractedTable
+from kicad_tools.datasheet.utils import calculate_part_confidence
+
+
+class TestCalculatePartConfidence:
+    """Tests for calculate_part_confidence utility function."""
+
+    def test_exact_match(self):
+        """Test exact match returns 1.0 confidence."""
+        assert calculate_part_confidence("STM32F103C8T6", "STM32F103C8T6") == 1.0
+
+    def test_exact_match_case_insensitive(self):
+        """Test exact match is case-insensitive."""
+        assert calculate_part_confidence("stm32f103c8t6", "STM32F103C8T6") == 1.0
+        assert calculate_part_confidence("STM32F103C8T6", "stm32f103c8t6") == 1.0
+
+    def test_query_in_part_number(self):
+        """Test partial match when query is substring of part number."""
+        assert calculate_part_confidence("STM32", "STM32F103C8T6") == 0.9
+
+    def test_part_number_in_query(self):
+        """Test partial match when part number is substring of query."""
+        assert calculate_part_confidence("STM32F103C8T6-FULL", "STM32F103C8T6") == 0.9
+
+    def test_no_match(self):
+        """Test no match returns 0.7 confidence."""
+        assert calculate_part_confidence("LM7805", "STM32F103C8T6") == 0.7
+
+    def test_empty_part_number(self):
+        """Test empty part number is treated as substring (empty is in everything)."""
+        # Empty string is a substring of any string, so returns 0.9
+        assert calculate_part_confidence("STM32", "") == 0.9
+
+    def test_none_part_number(self):
+        """Test None part number is handled gracefully as empty string."""
+        # None is converted to empty string, which is a substring of any string
+        assert calculate_part_confidence("STM32", None) == 0.9
 
 
 class TestDatasheetResult:


### PR DESCRIPTION
## Summary

Extract the duplicate confidence scoring logic from LCSC and Octopart datasheet sources into a shared utility function.

## Changes

- Created `src/kicad_tools/datasheet/utils.py` with `calculate_part_confidence()` function
- Updated `lcsc.py` to use the shared utility (removed ~10 lines of duplicate code)
- Updated `octopart.py` to use the shared utility (removed ~10 lines of duplicate code)
- Added comprehensive tests for the utility function in `test_datasheet.py`

## Test Plan

- [x] All 134 existing datasheet tests pass
- [x] New tests cover exact match, case-insensitive match, substring match, and no-match scenarios
- [x] Ruff linting passes

Closes #223