### PR TITLE
Refactor: Extract shared HTTP download logic from datasheet sources

### DIFF
--- a/src/kicad_tools/datasheet/sources/base.py
+++ b/src/kicad_tools/datasheet/sources/base.py
@@ -4,12 +4,15 @@ Base interface for datasheet sources.
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..models import DatasheetResult
+
+logger = logging.getLogger(__name__)
 
 
 class DatasheetSource(ABC):
@@ -55,6 +58,60 @@ class DatasheetSource(ABC):
             DatasheetDownloadError: If download fails
         """
         ...
+
+    def _download_file(
+        self,
+        session: Any,
+        url: str,
+        output_path: Path,
+        timeout: float,
+    ) -> Path:
+        """
+        Download a file from a URL using the provided session.
+
+        This is a shared helper method that handles the common HTTP download
+        logic used by multiple datasheet sources.
+
+        Args:
+            session: A requests.Session object to use for the download
+            url: The URL to download from
+            output_path: Where to save the file
+            timeout: Request timeout in seconds
+
+        Returns:
+            Path to the downloaded file
+
+        Raises:
+            DatasheetDownloadError: If download fails
+        """
+        import requests
+
+        from ..exceptions import DatasheetDownloadError
+
+        try:
+            response = session.get(
+                url,
+                timeout=timeout,
+                stream=True,
+                allow_redirects=True,
+            )
+            response.raise_for_status()
+
+            # Ensure parent directory exists
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Write to file in chunks
+            with open(output_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+
+            logger.info(f"Downloaded datasheet to {output_path}")
+            return output_path
+
+        except requests.RequestException as e:
+            raise DatasheetDownloadError(
+                f"Failed to download datasheet from {url}: {e}"
+            ) from e
 
     def __str__(self) -> str:
         return self.name

--- a/src/kicad_tools/datasheet/sources/lcsc.py
+++ b/src/kicad_tools/datasheet/sources/lcsc.py
@@ -165,36 +165,13 @@ class LCSCDatasheetSource(DatasheetSource):
         Raises:
             DatasheetDownloadError: If download fails
         """
-        import requests
-
-        from ..exceptions import DatasheetDownloadError
-
         session = self._get_session()
-
-        try:
-            response = session.get(
-                result.datasheet_url,
-                timeout=self.timeout,
-                stream=True,
-                allow_redirects=True,
-            )
-            response.raise_for_status()
-
-            # Ensure parent directory exists
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Write to file
-            with open(output_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
-
-            logger.info(f"Downloaded datasheet to {output_path}")
-            return output_path
-
-        except requests.RequestException as e:
-            raise DatasheetDownloadError(
-                f"Failed to download datasheet from {result.datasheet_url}: {e}"
-            ) from e
+        return self._download_file(
+            session=session,
+            url=result.datasheet_url,
+            output_path=output_path,
+            timeout=self.timeout,
+        )
 
     def close(self) -> None:
         """Close the HTTP session."""

--- a/src/kicad_tools/datasheet/sources/octopart.py
+++ b/src/kicad_tools/datasheet/sources/octopart.py
@@ -197,37 +197,14 @@ class OctopartDatasheetSource(DatasheetSource):
         Raises:
             DatasheetDownloadError: If download fails
         """
-        import requests
-
-        from ..exceptions import DatasheetDownloadError
-
         session = self._get_session()
         self._rate_limit()
-
-        try:
-            response = session.get(
-                result.datasheet_url,
-                timeout=self.timeout,
-                stream=True,
-                allow_redirects=True,
-            )
-            response.raise_for_status()
-
-            # Ensure parent directory exists
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Write to file
-            with open(output_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
-
-            logger.info(f"Downloaded datasheet to {output_path}")
-            return output_path
-
-        except requests.RequestException as e:
-            raise DatasheetDownloadError(
-                f"Failed to download datasheet from {result.datasheet_url}: {e}"
-            ) from e
+        return self._download_file(
+            session=session,
+            url=result.datasheet_url,
+            output_path=output_path,
+            timeout=self.timeout,
+        )
 
     def close(self) -> None:
         """Close the HTTP session."""


### PR DESCRIPTION
## Summary

Extracts common HTTP download logic from LCSC and Octopart datasheet sources into a shared `_download_file()` helper method in the `DatasheetSource` base class. This reduces code duplication while preserving source-specific behavior.

## Changes

- Added `_download_file()` method to `DatasheetSource` base class (`sources/base.py`)
  - Handles streaming HTTP download with chunked writes
  - Creates parent directories if needed
  - Proper error handling with `DatasheetDownloadError`
  - Consistent logging
- Updated `LCSCDatasheetSource.download()` to use shared helper
- Updated `OctopartDatasheetSource.download()` to use shared helper (preserving rate limiting)

## Test Plan

- All 3341 tests pass (1 pre-existing failure unrelated to this change)
- Linting passes with `ruff check`
- No new type errors introduced

Closes #222