### PR TITLE
Refactor: Reduce CircuitBlock initialization boilerplate

### DIFF
--- a/src/kicad_tools/schematic/blocks/base.py
+++ b/src/kicad_tools/schematic/blocks/base.py
@@ -32,14 +32,27 @@ class CircuitBlock:
     - Exposes ports for external connections
 
     Subclasses should implement their setup logic in __init__, calling
-    super().__init__() first and then setting up components, wiring, and ports.
+    super().__init__(sch, x, y) first and then setting up components,
+    wiring, and ports.
     """
 
-    def __init__(self):
-        """Initialize base attributes."""
-        self.schematic: Schematic = None
-        self.x: float = 0
-        self.y: float = 0
+    def __init__(
+        self,
+        sch: "Schematic" = None,
+        x: float = 0,
+        y: float = 0,
+    ):
+        """
+        Initialize base attributes.
+
+        Args:
+            sch: Schematic to add components to
+            x: X coordinate of block origin
+            y: Y coordinate of block origin
+        """
+        self.schematic: Schematic = sch
+        self.x: float = x
+        self.y: float = y
         self.ports: dict[str, tuple[float, float]] = {}
         self.components: dict[str, SymbolInstance] = {}
 

--- a/src/kicad_tools/schematic/blocks/indicators.py
+++ b/src/kicad_tools/schematic/blocks/indicators.py
@@ -48,10 +48,7 @@ class LEDIndicator(CircuitBlock):
             resistor_symbol: KiCad symbol for resistor
             vertical: If True, LED is vertical (rotated 90°)
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
 
         # Parse reference prefix
         d_ref = ref_prefix if ref_prefix[-1].isdigit() else ref_prefix

--- a/src/kicad_tools/schematic/blocks/interface.py
+++ b/src/kicad_tools/schematic/blocks/interface.py
@@ -132,10 +132,7 @@ class DebugHeader(CircuitBlock):
             header_symbol: KiCad symbol for header (auto-selected if None)
             resistor_symbol: KiCad symbol for resistors
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.interface = interface.lower()
         self.pins = pins
         self.series_resistors = series_resistors
@@ -415,10 +412,7 @@ class USBConnector(CircuitBlock):
             esd_tvs_value: Part value for ESD TVS (e.g., "USBLC6-2SC6")
             vbus_tvs_value: Part value for VBUS TVS (e.g., "SMBJ5.0A")
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.connector_type = connector_type.lower()
         self.esd_protection = esd_protection
         self.vbus_protection = vbus_protection
@@ -853,10 +847,7 @@ class I2CPullups(CircuitBlock):
             resistor_symbol: KiCad symbol for resistors
             cap_symbol: KiCad symbol for capacitors
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.resistor_value = resistor_value
         self.filter_caps_value = filter_caps
 
@@ -1215,10 +1206,7 @@ class CANTransceiver(CircuitBlock):
             tvs_symbol: KiCad symbol for TVS diodes
             tvs_value: Part value for CAN TVS diode (e.g., "PESD1CAN")
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.transceiver_type = transceiver
         self.termination = termination
         self.esd_protection = esd_protection

--- a/src/kicad_tools/schematic/blocks/mcu.py
+++ b/src/kicad_tools/schematic/blocks/mcu.py
@@ -97,10 +97,7 @@ class MCUBlock(CircuitBlock):
             cap_symbol: KiCad symbol for bypass capacitors
             unit: Symbol unit number (for multi-unit symbols)
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
 
         # Default bypass caps if not specified
         if bypass_caps is None:
@@ -396,10 +393,7 @@ class ResetButton(CircuitBlock):
             tvs_symbol: KiCad symbol for TVS diode
             tvs_value: Part value for TVS diode (e.g., "PESD5V0S1BL")
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.active_low = active_low
         self.esd_protection = esd_protection
 
@@ -773,10 +767,7 @@ class BootModeSelector(CircuitBlock):
             resistor_symbol: KiCad symbol for resistor
             button_symbol: KiCad symbol for push button
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.mode = mode.lower()
         self.include_button = include_button
         self.resistor_value = resistor_value

--- a/src/kicad_tools/schematic/blocks/power.py
+++ b/src/kicad_tools/schematic/blocks/power.py
@@ -48,10 +48,7 @@ class DecouplingCaps(CircuitBlock):
             spacing: Horizontal spacing between caps
             cap_symbol: KiCad symbol for capacitors
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.caps = []
 
         # Place capacitors
@@ -145,14 +142,10 @@ class LDOBlock(CircuitBlock):
             cap_ref_start: Starting reference number for caps
             en_tied_to_vin: If True, tie EN pin to VIN
         """
-        super().__init__()
+        super().__init__(sch, x, y)
 
         if output_caps is None:
             output_caps = ["10uF", "100nF"]
-
-        self.schematic = sch
-        self.x = x
-        self.y = y
 
         # Spacing constants
         cap_spacing = 15
@@ -293,10 +286,7 @@ class BarrelJackInput(CircuitBlock):
             diode_symbol: KiCad symbol for Schottky diode
             cap_symbol: KiCad symbol for polarized capacitor
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.protection = protection
 
         # Component spacing
@@ -444,10 +434,7 @@ class USBPowerInput(CircuitBlock):
             fuse_symbol: KiCad symbol for fuse/polyfuse
             cap_symbol: KiCad symbol for capacitor
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.protection = protection
 
         # Component spacing
@@ -568,10 +555,7 @@ class BatteryInput(CircuitBlock):
             diode_symbol: KiCad symbol for Schottky diode
             cap_symbol: KiCad symbol for capacitor
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.protection = protection
         self.voltage = voltage
         self.connector_type = connector
@@ -845,10 +829,7 @@ class VoltageDivider(CircuitBlock):
             resistor_symbol: KiCad symbol for resistors
             cap_symbol: KiCad symbol for capacitor
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
         self.r_top_value = r_top
         self.r_bottom_value = r_bottom
         self.has_filter_cap = filter_cap is not None

--- a/src/kicad_tools/schematic/blocks/timing.py
+++ b/src/kicad_tools/schematic/blocks/timing.py
@@ -52,10 +52,7 @@ class OscillatorBlock(CircuitBlock):
             cap_ref: Capacitor reference designator
             en_tied_to_vcc: If True, tie EN pin to VCC
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
 
         # Place oscillator
         self.osc = sch.add_symbol(osc_symbol, x, y, ref, value)
@@ -192,10 +189,7 @@ class CrystalOscillator(CircuitBlock):
             crystal_symbol: KiCad symbol for crystal
             cap_symbol: KiCad symbol for capacitors
         """
-        super().__init__()
-        self.schematic = sch
-        self.x = x
-        self.y = y
+        super().__init__(sch, x, y)
 
         # Parse reference prefix
         if ref_prefix[-1].isdigit():


### PR DESCRIPTION
## Summary

Reduces boilerplate in CircuitBlock subclasses by updating the base class `__init__` to accept `sch`, `x`, and `y` parameters directly.

**Before** (4 lines per subclass):
```python
super().__init__()
self.schematic = sch
self.x = x
self.y = y
```

**After** (1 line per subclass):
```python
super().__init__(sch, x, y)
```

## Changes

- Updated `CircuitBlock.__init__` in `base.py` to accept optional `sch`, `x`, `y` parameters with defaults for backward compatibility
- Refactored 16 subclasses across 5 files:
  - `power.py`: DecouplingCaps, LDOBlock, BarrelJackInput, USBPowerInput, BatteryInput, VoltageDivider
  - `mcu.py`: MCUBlock, ResetButton, BootModeSelector
  - `timing.py`: OscillatorBlock, CrystalOscillator
  - `interface.py`: DebugHeader, USBConnector, I2CPullups, CANTransceiver
  - `indicators.py`: LEDIndicator

## Test Plan

- [x] All existing tests pass (3341 passed, 1 unrelated pre-existing failure in test_parts.py)
- [x] Ruff linting passes on all modified files
- [x] Base class maintains backward compatibility with default parameters

Closes #227