### PR TITLE
Refactor: Consolidate query filter method boilerplate with mixin

### DIFF
--- a/src/kicad_tools/query/footprints.py
+++ b/src/kicad_tools/query/footprints.py
@@ -7,16 +7,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from .base import BaseQuery
+from .base import BaseQuery, ComponentQueryMixin
 
 if TYPE_CHECKING:
     from ..schema.pcb import Footprint
 
 
-class FootprintQuery(BaseQuery["Footprint"]):
+class FootprintQuery(ComponentQueryMixin["Footprint"], BaseQuery["Footprint"]):
     """Query interface for PCB footprints.
 
     Extends BaseQuery with footprint-specific convenience methods.
+    Inherits common component methods from ComponentQueryMixin.
 
     Example:
         query = FootprintQuery(footprints)
@@ -24,20 +25,6 @@ class FootprintQuery(BaseQuery["Footprint"]):
         smd = query.smd().all()
         top = query.on_layer("F.Cu").all()
     """
-
-    def by_reference(self, reference: str) -> Footprint | None:
-        """Get footprint by reference designator.
-
-        Args:
-            reference: Reference designator (e.g., "U1", "R1", "C1")
-
-        Returns:
-            Footprint with matching reference, or None
-
-        Example:
-            u1 = query.by_reference("U1")
-        """
-        return self.filter(reference=reference).first()
 
     def by_name(self, name: str) -> FootprintQuery:
         """Filter by footprint name.
@@ -52,20 +39,6 @@ class FootprintQuery(BaseQuery["Footprint"]):
             r0402 = query.by_name("Resistor_SMD:R_0402_1005Metric").all()
         """
         return cast("FootprintQuery", self.filter(name=name))
-
-    def by_value(self, value: str) -> FootprintQuery:
-        """Filter by value.
-
-        Args:
-            value: Component value (e.g., "10k", "100nF")
-
-        Returns:
-            Query filtered to matching value
-
-        Example:
-            caps_100nf = query.by_value("100nF").all()
-        """
-        return cast("FootprintQuery", self.filter(value=value))
 
     def on_layer(self, layer: str) -> FootprintQuery:
         """Filter by layer.
@@ -112,38 +85,6 @@ class FootprintQuery(BaseQuery["Footprint"]):
             Query filtered to through-hole footprints
         """
         return cast("FootprintQuery", self.filter(attr="through_hole"))
-
-    def capacitors(self) -> FootprintQuery:
-        """Filter to capacitors (C* references).
-
-        Returns:
-            Query filtered to capacitors
-        """
-        return cast("FootprintQuery", self.filter(reference__startswith="C"))
-
-    def resistors(self) -> FootprintQuery:
-        """Filter to resistors (R* references).
-
-        Returns:
-            Query filtered to resistors
-        """
-        return cast("FootprintQuery", self.filter(reference__startswith="R"))
-
-    def ics(self) -> FootprintQuery:
-        """Filter to ICs (U* references).
-
-        Returns:
-            Query filtered to ICs
-        """
-        return cast("FootprintQuery", self.filter(reference__startswith="U"))
-
-    def connectors(self) -> FootprintQuery:
-        """Filter to connectors (J* references).
-
-        Returns:
-            Query filtered to connectors
-        """
-        return cast("FootprintQuery", self.filter(reference__startswith="J"))
 
     def with_prefix(self, prefix: str) -> FootprintQuery:
         """Filter by reference prefix.

--- a/src/kicad_tools/query/symbols.py
+++ b/src/kicad_tools/query/symbols.py
@@ -7,16 +7,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from .base import BaseQuery
+from .base import BaseQuery, ComponentQueryMixin
 
 if TYPE_CHECKING:
     from ..schema.symbol import SymbolInstance
 
 
-class SymbolQuery(BaseQuery["SymbolInstance"]):
+class SymbolQuery(ComponentQueryMixin["SymbolInstance"], BaseQuery["SymbolInstance"]):
     """Query interface for symbol instances.
 
     Extends BaseQuery with symbol-specific convenience methods.
+    Inherits common component methods from ComponentQueryMixin.
 
     Example:
         query = SymbolQuery(symbols)
@@ -24,20 +25,6 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         caps = query.capacitors().all()
         power = query.filter(lib_id__startswith="power:").all()
     """
-
-    def by_reference(self, reference: str) -> SymbolInstance | None:
-        """Get symbol by reference designator.
-
-        Args:
-            reference: Reference designator (e.g., "U1", "R1", "C1")
-
-        Returns:
-            Symbol with matching reference, or None
-
-        Example:
-            u1 = query.by_reference("U1")
-        """
-        return self.filter(reference=reference).first()
 
     def by_lib_id(self, lib_id: str) -> SymbolQuery:
         """Filter by library ID.
@@ -53,20 +40,6 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         """
         return cast("SymbolQuery", self.filter(lib_id=lib_id))
 
-    def by_value(self, value: str) -> SymbolQuery:
-        """Filter by value.
-
-        Args:
-            value: Component value (e.g., "10k", "100nF")
-
-        Returns:
-            Query filtered to matching value
-
-        Example:
-            caps_100nf = query.by_value("100nF").all()
-        """
-        return cast("SymbolQuery", self.filter(value=value))
-
     def by_footprint(self, footprint: str) -> SymbolQuery:
         """Filter by footprint.
 
@@ -81,22 +54,6 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
         """
         return cast("SymbolQuery", self.filter(footprint=footprint))
 
-    def capacitors(self) -> SymbolQuery:
-        """Filter to capacitors (C* references).
-
-        Returns:
-            Query filtered to capacitors
-        """
-        return cast("SymbolQuery", self.filter(reference__startswith="C"))
-
-    def resistors(self) -> SymbolQuery:
-        """Filter to resistors (R* references).
-
-        Returns:
-            Query filtered to resistors
-        """
-        return cast("SymbolQuery", self.filter(reference__startswith="R"))
-
     def inductors(self) -> SymbolQuery:
         """Filter to inductors (L* references).
 
@@ -104,22 +61,6 @@ class SymbolQuery(BaseQuery["SymbolInstance"]):
             Query filtered to inductors
         """
         return cast("SymbolQuery", self.filter(reference__startswith="L"))
-
-    def ics(self) -> SymbolQuery:
-        """Filter to ICs (U* references).
-
-        Returns:
-            Query filtered to ICs
-        """
-        return cast("SymbolQuery", self.filter(reference__startswith="U"))
-
-    def connectors(self) -> SymbolQuery:
-        """Filter to connectors (J* references).
-
-        Returns:
-            Query filtered to connectors
-        """
-        return cast("SymbolQuery", self.filter(reference__startswith="J"))
 
     def transistors(self) -> SymbolQuery:
         """Filter to transistors (Q* references).


### PR DESCRIPTION
## Summary

Consolidates duplicated query filter methods between `SymbolQuery` and `FootprintQuery` by introducing a `ComponentQueryMixin` class in the base module.

## Changes

### New: `ComponentQueryMixin` in `base.py`
A mixin class providing common query methods for component-like items:
- `by_reference(reference)` - Get item by reference designator
- `by_value(value)` - Filter by component value  
- `capacitors()` - Filter to C* references
- `resistors()` - Filter to R* references
- `ics()` - Filter to U* references
- `connectors()` - Filter to J* references

### Updated: `SymbolQuery` and `FootprintQuery`
Both classes now inherit from `ComponentQueryMixin`, removing duplicated implementations while maintaining the same public API.

## Impact

- **Lines changed**: 81 additions, 125 deletions (net -44 lines)
- **Files affected**: 3 (`base.py`, `symbols.py`, `footprints.py`)
- **API changes**: None (fully backward compatible)

## Test Plan

- [x] All 53 query-related tests pass
- [x] Ruff linting passes on all modified files
- [x] Public API remains unchanged

Closes #229