### PR TITLE
Refactor: Use configuration-driven approach for design rules

### DIFF
--- a/src/kicad_tools/manufacturers/__init__.py
+++ b/src/kicad_tools/manufacturers/__init__.py
@@ -27,6 +27,7 @@ from .base import (
     DesignRules,
     ManufacturerProfile,
     PartsLibrary,
+    load_design_rules_from_yaml,
 )
 from .jlcpcb import JLCPCB_PROFILE
 from .oshpark import OSHPARK_PROFILE
@@ -43,6 +44,7 @@ __all__ = [
     "get_profile",
     "list_manufacturers",
     "get_manufacturer_ids",
+    "load_design_rules_from_yaml",
     # Profiles (for direct access)
     "JLCPCB_PROFILE",
     "SEEED_PROFILE",

--- a/src/kicad_tools/manufacturers/data/jlcpcb.yaml
+++ b/src/kicad_tools/manufacturers/data/jlcpcb.yaml
@@ -1,0 +1,91 @@
+# JLCPCB Design Rules Configuration
+# Source: https://jlcpcb.com/capabilities/pcb-capabilities
+#         https://github.com/ayberkozgur/jlcpcb-design-rules-stackups
+#
+# All measurements in millimeters unless otherwise noted.
+
+design_rules:
+  2layer_1oz:
+    min_trace_width_mm: 0.127       # 5 mil
+    min_clearance_mm: 0.127         # 5 mil
+    min_via_drill_mm: 0.3
+    min_via_diameter_mm: 0.6
+    min_annular_ring_mm: 0.15
+    min_hole_diameter_mm: 0.3
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.3
+    min_hole_to_edge_mm: 0.5
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.1
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.0            # No inner layers
+
+  2layer_2oz:
+    min_trace_width_mm: 0.2032      # 8 mil (wider for 2oz)
+    min_clearance_mm: 0.2032        # 8 mil
+    min_via_drill_mm: 0.3
+    min_via_diameter_mm: 0.6
+    min_annular_ring_mm: 0.15
+    min_hole_diameter_mm: 0.3
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.3
+    min_hole_to_edge_mm: 0.5
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.1
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0
+    inner_copper_oz: 0.0
+
+  4layer_1oz:
+    min_trace_width_mm: 0.1016      # 4 mil
+    min_clearance_mm: 0.1016        # 4 mil
+    min_via_drill_mm: 0.2
+    min_via_diameter_mm: 0.45
+    min_annular_ring_mm: 0.125
+    min_hole_diameter_mm: 0.2
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.3
+    min_hole_to_edge_mm: 0.4
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.1
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.5
+
+  4layer_2oz:
+    min_trace_width_mm: 0.2032      # 8 mil outer, 4 mil inner
+    min_clearance_mm: 0.1016        # 4 mil
+    min_via_drill_mm: 0.2
+    min_via_diameter_mm: 0.45
+    min_annular_ring_mm: 0.125
+    min_hole_diameter_mm: 0.2
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.3
+    min_hole_to_edge_mm: 0.4
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.1
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0
+    inner_copper_oz: 0.5
+
+  6layer_1oz:
+    min_trace_width_mm: 0.0889      # 3.5 mil
+    min_clearance_mm: 0.0889        # 3.5 mil
+    min_via_drill_mm: 0.2
+    min_via_diameter_mm: 0.45
+    min_annular_ring_mm: 0.125
+    min_hole_diameter_mm: 0.2
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.3
+    min_hole_to_edge_mm: 0.4
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.1
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.5

--- a/src/kicad_tools/manufacturers/data/oshpark.yaml
+++ b/src/kicad_tools/manufacturers/data/oshpark.yaml
@@ -1,0 +1,114 @@
+# OSHPark Design Rules Configuration
+# Source: https://docs.oshpark.com/design-tools/
+#
+# All measurements in millimeters unless otherwise noted.
+# Note: OSHPark is PCB-only, no assembly services.
+
+design_rules:
+  # Standard 2-layer service (purple boards)
+  2layer_1oz:
+    min_trace_width_mm: 0.1524      # 6 mil
+    min_clearance_mm: 0.1524        # 6 mil
+    min_via_drill_mm: 0.254         # 10 mil
+    min_via_diameter_mm: 0.508      # 20 mil (10 mil annular)
+    min_annular_ring_mm: 0.127      # 5 mil
+    min_hole_diameter_mm: 0.254     # 10 mil
+    max_hole_diameter_mm: 6.35      # 250 mil
+    min_copper_to_edge_mm: 0.381    # 15 mil
+    min_hole_to_edge_mm: 0.381      # 15 mil
+    min_silkscreen_width_mm: 0.127  # 5 mil
+    min_silkscreen_height_mm: 0.762 # 30 mil
+    min_solder_mask_dam_mm: 0.102   # 4 mil
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.0
+
+  # Alias for standard 2-layer
+  2layer_standard:
+    min_trace_width_mm: 0.1524
+    min_clearance_mm: 0.1524
+    min_via_drill_mm: 0.254
+    min_via_diameter_mm: 0.508
+    min_annular_ring_mm: 0.127
+    min_hole_diameter_mm: 0.254
+    max_hole_diameter_mm: 6.35
+    min_copper_to_edge_mm: 0.381
+    min_hole_to_edge_mm: 0.381
+    min_silkscreen_width_mm: 0.127
+    min_silkscreen_height_mm: 0.762
+    min_solder_mask_dam_mm: 0.102
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.0
+
+  # 4-layer service
+  4layer_1oz:
+    min_trace_width_mm: 0.127       # 5 mil
+    min_clearance_mm: 0.127         # 5 mil
+    min_via_drill_mm: 0.254         # 10 mil
+    min_via_diameter_mm: 0.508      # 20 mil
+    min_annular_ring_mm: 0.127      # 5 mil
+    min_hole_diameter_mm: 0.254
+    max_hole_diameter_mm: 6.35
+    min_copper_to_edge_mm: 0.381
+    min_hole_to_edge_mm: 0.381
+    min_silkscreen_width_mm: 0.127
+    min_silkscreen_height_mm: 0.762
+    min_solder_mask_dam_mm: 0.102
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.5
+
+  # Swift service (2-layer, faster turnaround)
+  swift:
+    min_trace_width_mm: 0.127       # 5 mil
+    min_clearance_mm: 0.127         # 5 mil
+    min_via_drill_mm: 0.254
+    min_via_diameter_mm: 0.508
+    min_annular_ring_mm: 0.127
+    min_hole_diameter_mm: 0.254
+    max_hole_diameter_mm: 6.35
+    min_copper_to_edge_mm: 0.254    # Tighter for Swift
+    min_hole_to_edge_mm: 0.254
+    min_silkscreen_width_mm: 0.127
+    min_silkscreen_height_mm: 0.762
+    min_solder_mask_dam_mm: 0.102
+    board_thickness_mm: 0.8         # 0.8mm for Swift
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.0
+
+  # After Dark (black solder mask, 2oz copper)
+  afterdark:
+    min_trace_width_mm: 0.1524      # 6 mil
+    min_clearance_mm: 0.1524        # 6 mil
+    min_via_drill_mm: 0.254
+    min_via_diameter_mm: 0.508
+    min_annular_ring_mm: 0.127
+    min_hole_diameter_mm: 0.254
+    max_hole_diameter_mm: 6.35
+    min_copper_to_edge_mm: 0.381
+    min_hole_to_edge_mm: 0.381
+    min_silkscreen_width_mm: 0.127
+    min_silkscreen_height_mm: 0.762
+    min_solder_mask_dam_mm: 0.102
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0            # 2oz copper
+    inner_copper_oz: 0.0
+
+  # Alias - After Dark is the 2oz option
+  2layer_2oz:
+    min_trace_width_mm: 0.1524
+    min_clearance_mm: 0.1524
+    min_via_drill_mm: 0.254
+    min_via_diameter_mm: 0.508
+    min_annular_ring_mm: 0.127
+    min_hole_diameter_mm: 0.254
+    max_hole_diameter_mm: 6.35
+    min_copper_to_edge_mm: 0.381
+    min_hole_to_edge_mm: 0.381
+    min_silkscreen_width_mm: 0.127
+    min_silkscreen_height_mm: 0.762
+    min_solder_mask_dam_mm: 0.102
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0
+    inner_copper_oz: 0.0

--- a/src/kicad_tools/manufacturers/data/pcbway.yaml
+++ b/src/kicad_tools/manufacturers/data/pcbway.yaml
@@ -1,0 +1,73 @@
+# PCBWay Design Rules Configuration
+# Source: https://www.pcbway.com/capabilities.html
+#
+# All measurements in millimeters unless otherwise noted.
+
+design_rules:
+  2layer_1oz:
+    min_trace_width_mm: 0.127       # 5 mil
+    min_clearance_mm: 0.127         # 5 mil
+    min_via_drill_mm: 0.2
+    min_via_diameter_mm: 0.4
+    min_annular_ring_mm: 0.1
+    min_hole_diameter_mm: 0.2
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.25
+    min_hole_to_edge_mm: 0.4
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.08
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.0
+
+  2layer_2oz:
+    min_trace_width_mm: 0.2         # 8 mil for 2oz
+    min_clearance_mm: 0.2           # 8 mil
+    min_via_drill_mm: 0.2
+    min_via_diameter_mm: 0.4
+    min_annular_ring_mm: 0.1
+    min_hole_diameter_mm: 0.2
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.25
+    min_hole_to_edge_mm: 0.4
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.08
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0
+    inner_copper_oz: 0.0
+
+  4layer_1oz:
+    min_trace_width_mm: 0.1016      # 4 mil
+    min_clearance_mm: 0.1016        # 4 mil
+    min_via_drill_mm: 0.2
+    min_via_diameter_mm: 0.4
+    min_annular_ring_mm: 0.1
+    min_hole_diameter_mm: 0.2
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.25
+    min_hole_to_edge_mm: 0.4
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.08
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.5
+
+  6layer_1oz:
+    min_trace_width_mm: 0.0889      # 3.5 mil
+    min_clearance_mm: 0.0889        # 3.5 mil
+    min_via_drill_mm: 0.15
+    min_via_diameter_mm: 0.35
+    min_annular_ring_mm: 0.1
+    min_hole_diameter_mm: 0.15
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.25
+    min_hole_to_edge_mm: 0.4
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.08
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.5

--- a/src/kicad_tools/manufacturers/data/seeed.yaml
+++ b/src/kicad_tools/manufacturers/data/seeed.yaml
@@ -1,0 +1,92 @@
+# Seeed Fusion Design Rules Configuration
+# Source: https://www.seeedstudio.com/fusion_pcb.html
+#         https://support.seeedstudio.com/knowledgebase/articles/447362-fusion-pcb-specification
+#
+# All measurements in millimeters unless otherwise noted.
+# Note: Seeed values are slightly more conservative than JLCPCB.
+
+design_rules:
+  2layer_1oz:
+    min_trace_width_mm: 0.1524      # 6 mil
+    min_clearance_mm: 0.1524        # 6 mil
+    min_via_drill_mm: 0.3
+    min_via_diameter_mm: 0.6
+    min_annular_ring_mm: 0.15
+    min_hole_diameter_mm: 0.3
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.5
+    min_hole_to_edge_mm: 0.5
+    min_silkscreen_width_mm: 0.15   # 6 mil
+    min_silkscreen_height_mm: 0.8   # 32 mil
+    min_solder_mask_dam_mm: 0.1
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.0
+
+  2layer_2oz:
+    min_trace_width_mm: 0.2         # 8 mil for 2oz
+    min_clearance_mm: 0.2           # 8 mil
+    min_via_drill_mm: 0.3
+    min_via_diameter_mm: 0.6
+    min_annular_ring_mm: 0.15
+    min_hole_diameter_mm: 0.3
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.5
+    min_hole_to_edge_mm: 0.5
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.1
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0
+    inner_copper_oz: 0.0
+
+  4layer_1oz:
+    min_trace_width_mm: 0.1524      # 6 mil (conservative)
+    min_clearance_mm: 0.1524        # 6 mil
+    min_via_drill_mm: 0.3
+    min_via_diameter_mm: 0.6
+    min_annular_ring_mm: 0.15
+    min_hole_diameter_mm: 0.3
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.5
+    min_hole_to_edge_mm: 0.5
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.1
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.5
+
+  4layer_2oz:
+    min_trace_width_mm: 0.2         # 8 mil for 2oz outer
+    min_clearance_mm: 0.2           # 8 mil
+    min_via_drill_mm: 0.3
+    min_via_diameter_mm: 0.6
+    min_annular_ring_mm: 0.15
+    min_hole_diameter_mm: 0.3
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.5
+    min_hole_to_edge_mm: 0.5
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.1
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0
+    inner_copper_oz: 1.0
+
+  6layer_1oz:
+    min_trace_width_mm: 0.127       # 5 mil
+    min_clearance_mm: 0.127         # 5 mil
+    min_via_drill_mm: 0.25
+    min_via_diameter_mm: 0.5
+    min_annular_ring_mm: 0.125
+    min_hole_diameter_mm: 0.25
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.5
+    min_hole_to_edge_mm: 0.5
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 0.8
+    min_solder_mask_dam_mm: 0.1
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.5

--- a/src/kicad_tools/manufacturers/jlcpcb.py
+++ b/src/kicad_tools/manufacturers/jlcpcb.py
@@ -8,103 +8,13 @@ Source: https://jlcpcb.com/capabilities/pcb-capabilities
 
 from .base import (
     AssemblyCapabilities,
-    DesignRules,
     ManufacturerProfile,
     PartsLibrary,
+    load_design_rules_from_yaml,
 )
 
-# JLCPCB Design Rules by layer count and copper weight
-# Source: Official JLCPCB capabilities + community-verified rules
-
-JLCPCB_2LAYER_1OZ = DesignRules(
-    min_trace_width_mm=0.127,  # 5 mil
-    min_clearance_mm=0.127,  # 5 mil
-    min_via_drill_mm=0.3,
-    min_via_diameter_mm=0.6,
-    min_annular_ring_mm=0.15,
-    min_hole_diameter_mm=0.3,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.3,
-    min_hole_to_edge_mm=0.5,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.1,
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.0,  # No inner layers
-)
-
-JLCPCB_2LAYER_2OZ = DesignRules(
-    min_trace_width_mm=0.2032,  # 8 mil (wider for 2oz)
-    min_clearance_mm=0.2032,  # 8 mil
-    min_via_drill_mm=0.3,
-    min_via_diameter_mm=0.6,
-    min_annular_ring_mm=0.15,
-    min_hole_diameter_mm=0.3,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.3,
-    min_hole_to_edge_mm=0.5,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.1,
-    board_thickness_mm=1.6,
-    outer_copper_oz=2.0,
-    inner_copper_oz=0.0,
-)
-
-JLCPCB_4LAYER_1OZ = DesignRules(
-    min_trace_width_mm=0.1016,  # 4 mil
-    min_clearance_mm=0.1016,  # 4 mil
-    min_via_drill_mm=0.2,
-    min_via_diameter_mm=0.45,
-    min_annular_ring_mm=0.125,
-    min_hole_diameter_mm=0.2,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.3,
-    min_hole_to_edge_mm=0.4,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.1,
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.5,
-)
-
-JLCPCB_4LAYER_2OZ = DesignRules(
-    min_trace_width_mm=0.2032,  # 8 mil outer, 4 mil inner
-    min_clearance_mm=0.1016,  # 4 mil
-    min_via_drill_mm=0.2,
-    min_via_diameter_mm=0.45,
-    min_annular_ring_mm=0.125,
-    min_hole_diameter_mm=0.2,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.3,
-    min_hole_to_edge_mm=0.4,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.1,
-    board_thickness_mm=1.6,
-    outer_copper_oz=2.0,
-    inner_copper_oz=0.5,
-)
-
-JLCPCB_6LAYER_1OZ = DesignRules(
-    min_trace_width_mm=0.0889,  # 3.5 mil
-    min_clearance_mm=0.0889,  # 3.5 mil
-    min_via_drill_mm=0.2,
-    min_via_diameter_mm=0.45,
-    min_annular_ring_mm=0.125,
-    min_hole_diameter_mm=0.2,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.3,
-    min_hole_to_edge_mm=0.4,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.1,
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.5,
-)
+# Load design rules from YAML configuration
+_DESIGN_RULES = load_design_rules_from_yaml("jlcpcb")
 
 # JLCPCB Assembly Capabilities
 JLCPCB_ASSEMBLY = AssemblyCapabilities(
@@ -197,13 +107,7 @@ JLCPCB_PROFILE = ManufacturerProfile(
     id="jlcpcb",
     name="JLCPCB",
     website="https://jlcpcb.com",
-    design_rules={
-        "2layer_1oz": JLCPCB_2LAYER_1OZ,
-        "2layer_2oz": JLCPCB_2LAYER_2OZ,
-        "4layer_1oz": JLCPCB_4LAYER_1OZ,
-        "4layer_2oz": JLCPCB_4LAYER_2OZ,
-        "6layer_1oz": JLCPCB_6LAYER_1OZ,
-    },
+    design_rules=_DESIGN_RULES,
     assembly=JLCPCB_ASSEMBLY,
     parts_library=LCSC_LIBRARY,
     lead_times={

--- a/src/kicad_tools/manufacturers/oshpark.py
+++ b/src/kicad_tools/manufacturers/oshpark.py
@@ -7,87 +7,12 @@ Source: https://docs.oshpark.com/design-tools/
 """
 
 from .base import (
-    DesignRules,
     ManufacturerProfile,
+    load_design_rules_from_yaml,
 )
 
-# OSHPark Design Rules
-# Standard 2-layer service (purple boards)
-
-OSHPARK_2LAYER_STANDARD = DesignRules(
-    min_trace_width_mm=0.1524,  # 6 mil
-    min_clearance_mm=0.1524,  # 6 mil
-    min_via_drill_mm=0.254,  # 10 mil
-    min_via_diameter_mm=0.508,  # 20 mil (10 mil annular)
-    min_annular_ring_mm=0.127,  # 5 mil
-    min_hole_diameter_mm=0.254,  # 10 mil
-    max_hole_diameter_mm=6.35,  # 250 mil
-    min_copper_to_edge_mm=0.381,  # 15 mil
-    min_hole_to_edge_mm=0.381,  # 15 mil
-    min_silkscreen_width_mm=0.127,  # 5 mil
-    min_silkscreen_height_mm=0.762,  # 30 mil
-    min_solder_mask_dam_mm=0.102,  # 4 mil
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.0,
-)
-
-# OSHPark 4-layer service
-OSHPARK_4LAYER = DesignRules(
-    min_trace_width_mm=0.127,  # 5 mil
-    min_clearance_mm=0.127,  # 5 mil
-    min_via_drill_mm=0.254,  # 10 mil
-    min_via_diameter_mm=0.508,  # 20 mil
-    min_annular_ring_mm=0.127,  # 5 mil
-    min_hole_diameter_mm=0.254,
-    max_hole_diameter_mm=6.35,
-    min_copper_to_edge_mm=0.381,
-    min_hole_to_edge_mm=0.381,
-    min_silkscreen_width_mm=0.127,
-    min_silkscreen_height_mm=0.762,
-    min_solder_mask_dam_mm=0.102,
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.5,
-)
-
-# OSHPark Swift service (2-layer, faster turnaround)
-OSHPARK_SWIFT = DesignRules(
-    min_trace_width_mm=0.127,  # 5 mil
-    min_clearance_mm=0.127,  # 5 mil
-    min_via_drill_mm=0.254,
-    min_via_diameter_mm=0.508,
-    min_annular_ring_mm=0.127,
-    min_hole_diameter_mm=0.254,
-    max_hole_diameter_mm=6.35,
-    min_copper_to_edge_mm=0.254,  # Tighter for Swift
-    min_hole_to_edge_mm=0.254,
-    min_silkscreen_width_mm=0.127,
-    min_silkscreen_height_mm=0.762,
-    min_solder_mask_dam_mm=0.102,
-    board_thickness_mm=0.8,  # 0.8mm for Swift
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.0,
-)
-
-# OSHPark After Dark (black solder mask)
-OSHPARK_AFTERDARK = DesignRules(
-    min_trace_width_mm=0.1524,  # 6 mil
-    min_clearance_mm=0.1524,  # 6 mil
-    min_via_drill_mm=0.254,
-    min_via_diameter_mm=0.508,
-    min_annular_ring_mm=0.127,
-    min_hole_diameter_mm=0.254,
-    max_hole_diameter_mm=6.35,
-    min_copper_to_edge_mm=0.381,
-    min_hole_to_edge_mm=0.381,
-    min_silkscreen_width_mm=0.127,
-    min_silkscreen_height_mm=0.762,
-    min_solder_mask_dam_mm=0.102,
-    board_thickness_mm=1.6,
-    outer_copper_oz=2.0,  # 2oz copper
-    inner_copper_oz=0.0,
-)
+# Load design rules from YAML configuration
+_DESIGN_RULES = load_design_rules_from_yaml("oshpark")
 
 # Complete OSHPark Profile
 # Note: No assembly, no parts library
@@ -95,14 +20,7 @@ OSHPARK_PROFILE = ManufacturerProfile(
     id="oshpark",
     name="OSHPark",
     website="https://oshpark.com",
-    design_rules={
-        "2layer_1oz": OSHPARK_2LAYER_STANDARD,
-        "2layer_standard": OSHPARK_2LAYER_STANDARD,
-        "4layer_1oz": OSHPARK_4LAYER,
-        "swift": OSHPARK_SWIFT,
-        "afterdark": OSHPARK_AFTERDARK,
-        "2layer_2oz": OSHPARK_AFTERDARK,  # After Dark is 2oz
-    },
+    design_rules=_DESIGN_RULES,
     assembly=None,  # PCB only - no assembly
     parts_library=None,  # No parts library
     lead_times={

--- a/src/kicad_tools/manufacturers/pcbway.py
+++ b/src/kicad_tools/manufacturers/pcbway.py
@@ -7,85 +7,13 @@ Source: https://www.pcbway.com/capabilities.html
 
 from .base import (
     AssemblyCapabilities,
-    DesignRules,
     ManufacturerProfile,
     PartsLibrary,
+    load_design_rules_from_yaml,
 )
 
-# PCBWay Design Rules
-# Similar to JLCPCB with some variations
-
-PCBWAY_2LAYER_1OZ = DesignRules(
-    min_trace_width_mm=0.127,  # 5 mil
-    min_clearance_mm=0.127,  # 5 mil
-    min_via_drill_mm=0.2,
-    min_via_diameter_mm=0.4,
-    min_annular_ring_mm=0.1,
-    min_hole_diameter_mm=0.2,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.25,
-    min_hole_to_edge_mm=0.4,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.08,
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.0,
-)
-
-PCBWAY_2LAYER_2OZ = DesignRules(
-    min_trace_width_mm=0.2,  # 8 mil for 2oz
-    min_clearance_mm=0.2,  # 8 mil
-    min_via_drill_mm=0.2,
-    min_via_diameter_mm=0.4,
-    min_annular_ring_mm=0.1,
-    min_hole_diameter_mm=0.2,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.25,
-    min_hole_to_edge_mm=0.4,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.08,
-    board_thickness_mm=1.6,
-    outer_copper_oz=2.0,
-    inner_copper_oz=0.0,
-)
-
-PCBWAY_4LAYER_1OZ = DesignRules(
-    min_trace_width_mm=0.1016,  # 4 mil
-    min_clearance_mm=0.1016,  # 4 mil
-    min_via_drill_mm=0.2,
-    min_via_diameter_mm=0.4,
-    min_annular_ring_mm=0.1,
-    min_hole_diameter_mm=0.2,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.25,
-    min_hole_to_edge_mm=0.4,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.08,
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.5,
-)
-
-PCBWAY_6LAYER_1OZ = DesignRules(
-    min_trace_width_mm=0.0889,  # 3.5 mil
-    min_clearance_mm=0.0889,  # 3.5 mil
-    min_via_drill_mm=0.15,
-    min_via_diameter_mm=0.35,
-    min_annular_ring_mm=0.1,
-    min_hole_diameter_mm=0.15,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.25,
-    min_hole_to_edge_mm=0.4,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.08,
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.5,
-)
+# Load design rules from YAML configuration
+_DESIGN_RULES = load_design_rules_from_yaml("pcbway")
 
 # PCBWay Assembly Capabilities
 PCBWAY_ASSEMBLY = AssemblyCapabilities(
@@ -173,12 +101,7 @@ PCBWAY_PROFILE = ManufacturerProfile(
     id="pcbway",
     name="PCBWay",
     website="https://www.pcbway.com",
-    design_rules={
-        "2layer_1oz": PCBWAY_2LAYER_1OZ,
-        "2layer_2oz": PCBWAY_2LAYER_2OZ,
-        "4layer_1oz": PCBWAY_4LAYER_1OZ,
-        "6layer_1oz": PCBWAY_6LAYER_1OZ,
-    },
+    design_rules=_DESIGN_RULES,
     assembly=PCBWAY_ASSEMBLY,
     parts_library=PCBWAY_PARTS,
     lead_times={

--- a/src/kicad_tools/manufacturers/seeed.py
+++ b/src/kicad_tools/manufacturers/seeed.py
@@ -8,103 +8,13 @@ Source: https://www.seeedstudio.com/fusion_pcb.html
 
 from .base import (
     AssemblyCapabilities,
-    DesignRules,
     ManufacturerProfile,
     PartsLibrary,
+    load_design_rules_from_yaml,
 )
 
-# Seeed Fusion Design Rules (conservative values for reliable manufacturing)
-# These are slightly more conservative than JLCPCB to ensure compatibility
-
-SEEED_2LAYER_1OZ = DesignRules(
-    min_trace_width_mm=0.1524,  # 6 mil
-    min_clearance_mm=0.1524,  # 6 mil
-    min_via_drill_mm=0.3,
-    min_via_diameter_mm=0.6,
-    min_annular_ring_mm=0.15,
-    min_hole_diameter_mm=0.3,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.5,
-    min_hole_to_edge_mm=0.5,
-    min_silkscreen_width_mm=0.15,  # 6 mil
-    min_silkscreen_height_mm=0.8,  # 32 mil
-    min_solder_mask_dam_mm=0.1,
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.0,
-)
-
-SEEED_2LAYER_2OZ = DesignRules(
-    min_trace_width_mm=0.2,  # 8 mil for 2oz
-    min_clearance_mm=0.2,  # 8 mil
-    min_via_drill_mm=0.3,
-    min_via_diameter_mm=0.6,
-    min_annular_ring_mm=0.15,
-    min_hole_diameter_mm=0.3,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.5,
-    min_hole_to_edge_mm=0.5,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.1,
-    board_thickness_mm=1.6,
-    outer_copper_oz=2.0,
-    inner_copper_oz=0.0,
-)
-
-SEEED_4LAYER_1OZ = DesignRules(
-    min_trace_width_mm=0.1524,  # 6 mil (conservative)
-    min_clearance_mm=0.1524,  # 6 mil
-    min_via_drill_mm=0.3,
-    min_via_diameter_mm=0.6,
-    min_annular_ring_mm=0.15,
-    min_hole_diameter_mm=0.3,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.5,
-    min_hole_to_edge_mm=0.5,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.1,
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.5,
-)
-
-SEEED_4LAYER_2OZ = DesignRules(
-    min_trace_width_mm=0.2,  # 8 mil for 2oz outer
-    min_clearance_mm=0.2,  # 8 mil
-    min_via_drill_mm=0.3,
-    min_via_diameter_mm=0.6,
-    min_annular_ring_mm=0.15,
-    min_hole_diameter_mm=0.3,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.5,
-    min_hole_to_edge_mm=0.5,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.1,
-    board_thickness_mm=1.6,
-    outer_copper_oz=2.0,
-    inner_copper_oz=1.0,
-)
-
-SEEED_6LAYER_1OZ = DesignRules(
-    min_trace_width_mm=0.127,  # 5 mil
-    min_clearance_mm=0.127,  # 5 mil
-    min_via_drill_mm=0.25,
-    min_via_diameter_mm=0.5,
-    min_annular_ring_mm=0.125,
-    min_hole_diameter_mm=0.25,
-    max_hole_diameter_mm=6.3,
-    min_copper_to_edge_mm=0.5,
-    min_hole_to_edge_mm=0.5,
-    min_silkscreen_width_mm=0.15,
-    min_silkscreen_height_mm=0.8,
-    min_solder_mask_dam_mm=0.1,
-    board_thickness_mm=1.6,
-    outer_copper_oz=1.0,
-    inner_copper_oz=0.5,
-)
+# Load design rules from YAML configuration
+_DESIGN_RULES = load_design_rules_from_yaml("seeed")
 
 # Seeed Fusion Assembly Capabilities
 SEEED_ASSEMBLY = AssemblyCapabilities(
@@ -186,13 +96,7 @@ SEEED_PROFILE = ManufacturerProfile(
     id="seeed",
     name="Seeed Fusion",
     website="https://www.seeedstudio.com/fusion.html",
-    design_rules={
-        "2layer_1oz": SEEED_2LAYER_1OZ,
-        "2layer_2oz": SEEED_2LAYER_2OZ,
-        "4layer_1oz": SEEED_4LAYER_1OZ,
-        "4layer_2oz": SEEED_4LAYER_2OZ,
-        "6layer_1oz": SEEED_6LAYER_1OZ,
-    },
+    design_rules=_DESIGN_RULES,
     assembly=SEEED_ASSEMBLY,
     parts_library=SEEED_OPL,
     lead_times={


### PR DESCRIPTION
## Summary

Refactor manufacturer design rules from repetitive Python code to YAML configuration files. This addresses the code duplication identified in the issue by:

- Moving ~300 lines of repetitive `DesignRules` definitions to 4 YAML files
- Adding a configuration loader function that reads design rules from YAML
- Updating all 4 manufacturer modules to use the new loader

## Changes

- **New files**:
  - `src/kicad_tools/manufacturers/data/jlcpcb.yaml`
  - `src/kicad_tools/manufacturers/data/pcbway.yaml`
  - `src/kicad_tools/manufacturers/data/seeed.yaml`
  - `src/kicad_tools/manufacturers/data/oshpark.yaml`

- **Modified files**:
  - `base.py`: Added `load_design_rules_from_yaml()` function
  - `__init__.py`: Export the new loader function
  - `jlcpcb.py`, `pcbway.py`, `seeed.py`, `oshpark.py`: Use config loader instead of inline definitions

## Benefits

- **Easier to add new manufacturers**: Just add a YAML file
- **Simpler to update values**: Edit YAML instead of Python code
- **Better separation of data and code**: Configuration is now human-readable
- **Consistent patterns**: All manufacturers now load design rules the same way

## Test Plan

- All 42 existing manufacturer tests pass (40 passed, 2 skipped for missing demo files)
- Design rule values are identical before and after the refactor
- Linting and formatting checks pass

Closes #231