### PR TITLE
Fix floating point precision in world_to_grid

### DIFF
--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -146,9 +146,14 @@ class RoutingGrid:
         return stats
 
     def world_to_grid(self, x: float, y: float) -> tuple[int, int]:
-        """Convert world coordinates to grid indices."""
-        gx = int((x - self.origin_x) / self.resolution)
-        gy = int((y - self.origin_y) / self.resolution)
+        """Convert world coordinates to grid indices.
+
+        Uses round() instead of int() to avoid floating point precision errors.
+        For example, (112.6 - 75.0) / 0.1 = 375.9999999999999 should map to 376,
+        but int() would truncate to 375, causing off-by-one grid cell errors.
+        """
+        gx = round((x - self.origin_x) / self.resolution)
+        gy = round((y - self.origin_y) / self.resolution)
         return (max(0, min(gx, self.cols - 1)), max(0, min(gy, self.rows - 1)))
 
     def grid_to_world(self, gx: int, gy: int) -> tuple[float, float]:


### PR DESCRIPTION
## Summary

- Changes `int()` to `round()` in `world_to_grid()` to fix off-by-one grid cell errors
- Adds regression test for the floating point precision edge case
- This fixes a root cause of DRC shorting violations in autorouted PCBs

## Problem

When converting world coordinates to grid indices, floating point precision errors cause incorrect cell selection:

```python
# Example: (112.6 - 75.0) / 0.1 = 375.9999999999999
gx = int(375.9999999999999)  # Returns 375, should be 376!
```

This causes:
- Pads to block wrong grid cells
- Routes to pass through "unblocked" areas that actually contain pads
- DRC shorts in the resulting PCB

## Fix

Use `round()` instead of `int()` for proper rounding:

```python
gx = round((x - self.origin_x) / self.resolution)
gy = round((y - self.origin_y) / self.resolution)
```

## Test plan

- [x] Added `test_world_to_grid_floating_point_precision` test case
- [x] All 50 tests in `test_router_grid.py` pass
- [ ] Test on timing test HAT PCB to verify reduced DRC violations

Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)