### PR TITLE
Add component grouping constraints for placement optimization

### DIFF
--- a/src/kicad_tools/cli/commands/placement.py
+++ b/src/kicad_tools/cli/commands/placement.py
@@ -62,6 +62,8 @@ def run_placement_command(args) -> int:
             sub_argv.extend(["--grid", str(args.grid)])
         if args.fixed:
             sub_argv.extend(["--fixed", args.fixed])
+        if getattr(args, "constraints", None):
+            sub_argv.extend(["--constraints", args.constraints])
         if args.dry_run:
             sub_argv.append("--dry-run")
         if args.verbose:

--- a/src/kicad_tools/optim/__init__.py
+++ b/src/kicad_tools/optim/__init__.py
@@ -56,6 +56,18 @@ from kicad_tools.optim.components import (
     Spring,
 )
 from kicad_tools.optim.config import PlacementConfig
+from kicad_tools.optim.constraint_loader import (
+    load_constraints_from_yaml,
+    save_constraints_to_yaml,
+)
+from kicad_tools.optim.constraints import (
+    ConstraintType,
+    ConstraintViolation,
+    GroupingConstraint,
+    SpatialConstraint,
+    expand_member_patterns,
+    validate_grouping_constraints,
+)
 from kicad_tools.optim.evolutionary import (
     EvolutionaryConfig,
     EvolutionaryPlacementOptimizer,
@@ -79,8 +91,18 @@ __all__ = [
     "EvolutionaryConfig",
     "Individual",
     "Pin",
+    # Functional clustering
     "FunctionalCluster",
     "ClusterType",
     "ClusterDetector",
     "detect_functional_clusters",
+    # Constraints
+    "GroupingConstraint",
+    "SpatialConstraint",
+    "ConstraintType",
+    "ConstraintViolation",
+    "validate_grouping_constraints",
+    "expand_member_patterns",
+    "load_constraints_from_yaml",
+    "save_constraints_to_yaml",
 ]

--- a/src/kicad_tools/optim/constraint_loader.py
+++ b/src/kicad_tools/optim/constraint_loader.py
@@ -1,0 +1,207 @@
+"""
+YAML loader for grouping constraints.
+
+Provides functionality to load grouping constraints from YAML configuration files,
+enabling users to define component grouping rules in a human-readable format.
+
+Example YAML format:
+    groups:
+      - name: status_leds
+        members: ["LED1", "LED2", "LED3", "LED4"]
+        constraints:
+          - type: alignment
+            axis: horizontal
+            tolerance_mm: 0.5
+          - type: ordering
+            axis: horizontal
+            order: ["LED1", "LED2", "LED3", "LED4"]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from kicad_tools.optim.constraints import (
+    ConstraintType,
+    GroupingConstraint,
+    SpatialConstraint,
+)
+
+__all__ = ["load_constraints_from_yaml", "save_constraints_to_yaml"]
+
+
+def load_constraints_from_yaml(path: str | Path) -> list[GroupingConstraint]:
+    """
+    Load grouping constraints from a YAML file.
+
+    Args:
+        path: Path to YAML constraint file
+
+    Returns:
+        List of GroupingConstraint objects
+
+    Raises:
+        FileNotFoundError: If file doesn't exist
+        ValueError: If YAML format is invalid
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Constraint file not found: {path}")
+
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    if not data:
+        return []
+
+    return _parse_constraints(data)
+
+
+def save_constraints_to_yaml(
+    constraints: list[GroupingConstraint],
+    path: str | Path,
+) -> None:
+    """
+    Save grouping constraints to a YAML file.
+
+    Args:
+        constraints: List of GroupingConstraint objects to save
+        path: Output file path
+    """
+    path = Path(path)
+    data = _serialize_constraints(constraints)
+
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+def _parse_constraints(data: dict[str, Any]) -> list[GroupingConstraint]:
+    """Parse constraint data from YAML dict."""
+    groups = data.get("groups", [])
+    if not isinstance(groups, list):
+        raise ValueError("'groups' must be a list")
+
+    result = []
+    for group_data in groups:
+        result.append(_parse_group(group_data))
+
+    return result
+
+
+def _parse_group(data: dict[str, Any]) -> GroupingConstraint:
+    """Parse a single grouping constraint from dict."""
+    if not isinstance(data, dict):
+        raise ValueError(f"Group must be a dict, got {type(data)}")
+
+    name = data.get("name")
+    if not name:
+        raise ValueError("Group must have a 'name' field")
+
+    members = data.get("members", [])
+    if not isinstance(members, list):
+        raise ValueError(f"'members' must be a list, got {type(members)}")
+
+    constraints_data = data.get("constraints", [])
+    constraints = [_parse_spatial_constraint(c) for c in constraints_data]
+
+    return GroupingConstraint(
+        name=name,
+        members=members,
+        constraints=constraints,
+    )
+
+
+def _parse_spatial_constraint(data: dict[str, Any]) -> SpatialConstraint:
+    """Parse a single spatial constraint from dict."""
+    if not isinstance(data, dict):
+        raise ValueError(f"Constraint must be a dict, got {type(data)}")
+
+    type_str = data.get("type")
+    if not type_str:
+        raise ValueError("Constraint must have a 'type' field")
+
+    # Map type string to enum
+    try:
+        constraint_type = ConstraintType(type_str)
+    except ValueError:
+        valid_types = [t.value for t in ConstraintType]
+        raise ValueError(f"Unknown constraint type '{type_str}', must be one of: {valid_types}")
+
+    # Extract parameters (all fields except 'type')
+    parameters = {k: v for k, v in data.items() if k != "type"}
+
+    # Validate required parameters for each type
+    _validate_constraint_params(constraint_type, parameters)
+
+    return SpatialConstraint(
+        constraint_type=constraint_type,
+        parameters=parameters,
+    )
+
+
+def _validate_constraint_params(
+    constraint_type: ConstraintType,
+    params: dict[str, Any],
+) -> None:
+    """Validate constraint parameters based on type."""
+    if constraint_type == ConstraintType.MAX_DISTANCE:
+        if "anchor" not in params:
+            raise ValueError("max_distance constraint requires 'anchor' parameter")
+        if "radius_mm" not in params:
+            raise ValueError("max_distance constraint requires 'radius_mm' parameter")
+        if not isinstance(params["radius_mm"], (int, float)):
+            raise ValueError("'radius_mm' must be a number")
+
+    elif constraint_type == ConstraintType.ALIGNMENT:
+        if "axis" not in params:
+            raise ValueError("alignment constraint requires 'axis' parameter")
+        if params["axis"] not in ("horizontal", "vertical"):
+            raise ValueError("'axis' must be 'horizontal' or 'vertical'")
+
+    elif constraint_type == ConstraintType.ORDERING:
+        if "axis" not in params:
+            raise ValueError("ordering constraint requires 'axis' parameter")
+        if "order" not in params:
+            raise ValueError("ordering constraint requires 'order' parameter")
+        if params["axis"] not in ("horizontal", "vertical"):
+            raise ValueError("'axis' must be 'horizontal' or 'vertical'")
+        if not isinstance(params["order"], list):
+            raise ValueError("'order' must be a list")
+
+    elif constraint_type == ConstraintType.WITHIN_BOX:
+        required = ["x", "y", "width", "height"]
+        for field in required:
+            if field not in params:
+                raise ValueError(f"within_box constraint requires '{field}' parameter")
+            if not isinstance(params[field], (int, float)):
+                raise ValueError(f"'{field}' must be a number")
+
+    elif constraint_type == ConstraintType.RELATIVE_POSITION:
+        if "reference" not in params:
+            raise ValueError("relative_position constraint requires 'reference' parameter")
+        if "dx" not in params or "dy" not in params:
+            raise ValueError("relative_position constraint requires 'dx' and 'dy' parameters")
+
+
+def _serialize_constraints(constraints: list[GroupingConstraint]) -> dict[str, Any]:
+    """Serialize constraints to YAML-compatible dict."""
+    groups = []
+    for constraint in constraints:
+        group_data = {
+            "name": constraint.name,
+            "members": constraint.members,
+            "constraints": [_serialize_spatial_constraint(c) for c in constraint.constraints],
+        }
+        groups.append(group_data)
+
+    return {"groups": groups}
+
+
+def _serialize_spatial_constraint(constraint: SpatialConstraint) -> dict[str, Any]:
+    """Serialize a spatial constraint to dict."""
+    data = {"type": constraint.constraint_type.value}
+    data.update(constraint.parameters)
+    return data

--- a/src/kicad_tools/optim/constraints.py
+++ b/src/kicad_tools/optim/constraints.py
@@ -1,0 +1,453 @@
+"""
+Grouping constraints for component placement optimization.
+
+Provides constraint definitions that control spatial relationships between
+components during placement optimization. Constraints can specify:
+- Maximum distance from an anchor component
+- Alignment along an axis
+- Ordering along an axis
+- Containment within a bounding box
+- Relative position to a reference component
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.optim.components import Component
+
+
+__all__ = [
+    "ConstraintType",
+    "SpatialConstraint",
+    "GroupingConstraint",
+    "ConstraintViolation",
+    "validate_grouping_constraints",
+    "expand_member_patterns",
+]
+
+
+class ConstraintType(Enum):
+    """Types of spatial constraints."""
+
+    MAX_DISTANCE = "max_distance"
+    ALIGNMENT = "alignment"
+    ORDERING = "ordering"
+    WITHIN_BOX = "within_box"
+    RELATIVE_POSITION = "relative_position"
+
+
+@dataclass
+class SpatialConstraint:
+    """
+    Individual spatial constraint within a group.
+
+    Defines a specific spatial relationship that components must satisfy.
+    """
+
+    constraint_type: ConstraintType
+    parameters: dict = field(default_factory=dict)
+
+    @classmethod
+    def max_distance(cls, anchor: str, radius_mm: float) -> SpatialConstraint:
+        """Create a max distance constraint: all members within radius of anchor."""
+        return cls(
+            constraint_type=ConstraintType.MAX_DISTANCE,
+            parameters={"anchor": anchor, "radius_mm": radius_mm},
+        )
+
+    @classmethod
+    def alignment(cls, axis: str, tolerance_mm: float = 0.5) -> SpatialConstraint:
+        """Create an alignment constraint: members aligned on axis (horizontal/vertical)."""
+        return cls(
+            constraint_type=ConstraintType.ALIGNMENT,
+            parameters={"axis": axis, "tolerance_mm": tolerance_mm},
+        )
+
+    @classmethod
+    def ordering(cls, axis: str, order: list[str]) -> SpatialConstraint:
+        """Create an ordering constraint: members in specific order along axis."""
+        return cls(
+            constraint_type=ConstraintType.ORDERING,
+            parameters={"axis": axis, "order": order},
+        )
+
+    @classmethod
+    def within_box(cls, x: float, y: float, width: float, height: float) -> SpatialConstraint:
+        """Create a bounding box constraint: members contained in box."""
+        return cls(
+            constraint_type=ConstraintType.WITHIN_BOX,
+            parameters={"x": x, "y": y, "width": width, "height": height},
+        )
+
+    @classmethod
+    def relative_position(
+        cls, reference: str, dx: float, dy: float, tolerance_mm: float = 0.5
+    ) -> SpatialConstraint:
+        """Create a relative position constraint: specific offset from reference."""
+        return cls(
+            constraint_type=ConstraintType.RELATIVE_POSITION,
+            parameters={
+                "reference": reference,
+                "dx": dx,
+                "dy": dy,
+                "tolerance_mm": tolerance_mm,
+            },
+        )
+
+
+@dataclass
+class GroupingConstraint:
+    """
+    Defines a component group with spatial constraints.
+
+    Members can be specified as exact reference designators or glob patterns
+    (e.g., "LED*" for all LEDs, "C1?" for C10-C19).
+    """
+
+    name: str
+    members: list[str]  # Reference designators or patterns
+    constraints: list[SpatialConstraint] = field(default_factory=list)
+
+    def get_resolved_members(self, all_refs: list[str]) -> list[str]:
+        """
+        Resolve member patterns to actual component references.
+
+        Args:
+            all_refs: List of all component reference designators
+
+        Returns:
+            List of resolved reference designators
+        """
+        return expand_member_patterns(self.members, all_refs)
+
+
+@dataclass
+class ConstraintViolation:
+    """
+    A violation of a grouping constraint.
+
+    Records details about what constraint was violated and by how much.
+    """
+
+    group_name: str
+    constraint_type: ConstraintType
+    message: str
+    components: list[str]
+    severity: float = 0.0  # How far from satisfying (0 = satisfied)
+
+    def __str__(self) -> str:
+        return f"[{self.group_name}] {self.constraint_type.value}: {self.message}"
+
+
+def expand_member_patterns(patterns: list[str], all_refs: list[str]) -> list[str]:
+    """
+    Expand glob patterns to actual reference designators.
+
+    Supports:
+    - Exact matches: "LED1" -> ["LED1"]
+    - Glob patterns: "LED*" -> ["LED1", "LED2", ...]
+    - Character classes: "C1?" -> ["C10", "C11", ...]
+    - Ranges: "R[1-5]" -> ["R1", "R2", "R3", "R4", "R5"]
+
+    Args:
+        patterns: List of patterns or exact references
+        all_refs: List of all available reference designators
+
+    Returns:
+        List of matched reference designators (deduplicated, order preserved)
+    """
+    result = []
+    seen = set()
+
+    for pattern in patterns:
+        # Check if pattern contains glob characters
+        if any(c in pattern for c in "*?["):
+            # Use fnmatch for glob matching
+            for ref in all_refs:
+                if fnmatch.fnmatch(ref, pattern):
+                    if ref not in seen:
+                        result.append(ref)
+                        seen.add(ref)
+        else:
+            # Exact match
+            if pattern in all_refs and pattern not in seen:
+                result.append(pattern)
+                seen.add(pattern)
+
+    return result
+
+
+def validate_grouping_constraints(
+    components: list[Component],
+    constraints: list[GroupingConstraint],
+) -> list[ConstraintViolation]:
+    """
+    Check if current placement satisfies constraints.
+
+    Args:
+        components: List of all components with current positions
+        constraints: List of grouping constraints to validate
+
+    Returns:
+        List of constraint violations (empty if all satisfied)
+    """
+    violations = []
+    comp_map = {comp.ref: comp for comp in components}
+    all_refs = list(comp_map.keys())
+
+    for group in constraints:
+        members = group.get_resolved_members(all_refs)
+        member_comps = [comp_map[ref] for ref in members if ref in comp_map]
+
+        if not member_comps:
+            continue
+
+        for constraint in group.constraints:
+            violation = _validate_single_constraint(group.name, constraint, member_comps, comp_map)
+            if violation:
+                violations.append(violation)
+
+    return violations
+
+
+def _validate_single_constraint(
+    group_name: str,
+    constraint: SpatialConstraint,
+    members: list[Component],
+    comp_map: dict[str, Component],
+) -> ConstraintViolation | None:
+    """Validate a single constraint against member components."""
+    if constraint.constraint_type == ConstraintType.MAX_DISTANCE:
+        return _validate_max_distance(group_name, constraint, members, comp_map)
+    elif constraint.constraint_type == ConstraintType.ALIGNMENT:
+        return _validate_alignment(group_name, constraint, members)
+    elif constraint.constraint_type == ConstraintType.ORDERING:
+        return _validate_ordering(group_name, constraint, members)
+    elif constraint.constraint_type == ConstraintType.WITHIN_BOX:
+        return _validate_within_box(group_name, constraint, members)
+    elif constraint.constraint_type == ConstraintType.RELATIVE_POSITION:
+        return _validate_relative_position(group_name, constraint, members, comp_map)
+    return None
+
+
+def _validate_max_distance(
+    group_name: str,
+    constraint: SpatialConstraint,
+    members: list[Component],
+    comp_map: dict[str, Component],
+) -> ConstraintViolation | None:
+    """Validate max_distance constraint."""
+    params = constraint.parameters
+    anchor_ref = params["anchor"]
+    radius = params["radius_mm"]
+
+    anchor = comp_map.get(anchor_ref)
+    if not anchor:
+        return ConstraintViolation(
+            group_name=group_name,
+            constraint_type=constraint.constraint_type,
+            message=f"Anchor component {anchor_ref} not found",
+            components=[anchor_ref],
+            severity=float("inf"),
+        )
+
+    violators = []
+    max_violation = 0.0
+
+    for comp in members:
+        if comp.ref == anchor_ref:
+            continue
+        dist = math.sqrt((comp.x - anchor.x) ** 2 + (comp.y - anchor.y) ** 2)
+        if dist > radius:
+            violators.append(comp.ref)
+            max_violation = max(max_violation, dist - radius)
+
+    if violators:
+        return ConstraintViolation(
+            group_name=group_name,
+            constraint_type=constraint.constraint_type,
+            message=f"Components {violators} exceed max distance {radius}mm from {anchor_ref}",
+            components=violators,
+            severity=max_violation,
+        )
+    return None
+
+
+def _validate_alignment(
+    group_name: str,
+    constraint: SpatialConstraint,
+    members: list[Component],
+) -> ConstraintViolation | None:
+    """Validate alignment constraint."""
+    params = constraint.parameters
+    axis = params["axis"]
+    tolerance = params.get("tolerance_mm", 0.5)
+
+    if len(members) < 2:
+        return None
+
+    # Get positions along the alignment axis
+    if axis == "horizontal":
+        positions = [comp.y for comp in members]
+    else:  # vertical
+        positions = [comp.x for comp in members]
+
+    # Check if all positions are within tolerance of each other
+    min_pos = min(positions)
+    max_pos = max(positions)
+    spread = max_pos - min_pos
+
+    if spread > tolerance:
+        return ConstraintViolation(
+            group_name=group_name,
+            constraint_type=constraint.constraint_type,
+            message=f"Components spread {spread:.2f}mm along {axis} axis (tolerance: {tolerance}mm)",
+            components=[comp.ref for comp in members],
+            severity=spread - tolerance,
+        )
+    return None
+
+
+def _validate_ordering(
+    group_name: str,
+    constraint: SpatialConstraint,
+    members: list[Component],
+) -> ConstraintViolation | None:
+    """Validate ordering constraint."""
+    params = constraint.parameters
+    axis = params["axis"]
+    expected_order = params["order"]
+
+    # Build map of ref -> component
+    comp_by_ref = {comp.ref: comp for comp in members}
+
+    # Get positions in expected order
+    if axis == "horizontal":
+        # For horizontal ordering, check x positions (left to right)
+        ordered_comps = [(ref, comp_by_ref[ref].x) for ref in expected_order if ref in comp_by_ref]
+    else:  # vertical
+        # For vertical ordering, check y positions (top to bottom or bottom to top)
+        ordered_comps = [(ref, comp_by_ref[ref].y) for ref in expected_order if ref in comp_by_ref]
+
+    if len(ordered_comps) < 2:
+        return None
+
+    # Check if positions follow expected order
+    violations = []
+    for i in range(len(ordered_comps) - 1):
+        ref1, pos1 = ordered_comps[i]
+        ref2, pos2 = ordered_comps[i + 1]
+        if pos1 >= pos2:
+            violations.append((ref1, ref2))
+
+    if violations:
+        return ConstraintViolation(
+            group_name=group_name,
+            constraint_type=constraint.constraint_type,
+            message=f"Ordering violated: {violations}",
+            components=[ref for v in violations for ref in v],
+            severity=float(len(violations)),
+        )
+    return None
+
+
+def _validate_within_box(
+    group_name: str,
+    constraint: SpatialConstraint,
+    members: list[Component],
+) -> ConstraintViolation | None:
+    """Validate within_box constraint."""
+    params = constraint.parameters
+    box_x = params["x"]
+    box_y = params["y"]
+    box_width = params["width"]
+    box_height = params["height"]
+
+    # Box boundaries
+    x_min = box_x
+    x_max = box_x + box_width
+    y_min = box_y
+    y_max = box_y + box_height
+
+    violators = []
+    max_violation = 0.0
+
+    for comp in members:
+        # Check if component center is within box
+        in_x = x_min <= comp.x <= x_max
+        in_y = y_min <= comp.y <= y_max
+
+        if not (in_x and in_y):
+            violators.append(comp.ref)
+            # Calculate how far outside
+            dx = max(0, x_min - comp.x, comp.x - x_max)
+            dy = max(0, y_min - comp.y, comp.y - y_max)
+            max_violation = max(max_violation, math.sqrt(dx * dx + dy * dy))
+
+    if violators:
+        return ConstraintViolation(
+            group_name=group_name,
+            constraint_type=constraint.constraint_type,
+            message=f"Components {violators} are outside bounding box",
+            components=violators,
+            severity=max_violation,
+        )
+    return None
+
+
+def _validate_relative_position(
+    group_name: str,
+    constraint: SpatialConstraint,
+    members: list[Component],
+    comp_map: dict[str, Component],
+) -> ConstraintViolation | None:
+    """Validate relative_position constraint."""
+    params = constraint.parameters
+    reference_ref = params["reference"]
+    dx = params["dx"]
+    dy = params["dy"]
+    tolerance = params.get("tolerance_mm", 0.5)
+
+    reference = comp_map.get(reference_ref)
+    if not reference:
+        return ConstraintViolation(
+            group_name=group_name,
+            constraint_type=constraint.constraint_type,
+            message=f"Reference component {reference_ref} not found",
+            components=[reference_ref],
+            severity=float("inf"),
+        )
+
+    # Expected position
+    expected_x = reference.x + dx
+    expected_y = reference.y + dy
+
+    violators = []
+    max_violation = 0.0
+
+    for comp in members:
+        if comp.ref == reference_ref:
+            continue
+        actual_dx = comp.x - expected_x
+        actual_dy = comp.y - expected_y
+        error = math.sqrt(actual_dx * actual_dx + actual_dy * actual_dy)
+
+        if error > tolerance:
+            violators.append(comp.ref)
+            max_violation = max(max_violation, error - tolerance)
+
+    if violators:
+        return ConstraintViolation(
+            group_name=group_name,
+            constraint_type=constraint.constraint_type,
+            message=f"Components {violators} not at expected offset ({dx}, {dy}) from {reference_ref}",
+            components=violators,
+            severity=max_violation,
+        )
+    return None

--- a/tests/test_grouping_constraints.py
+++ b/tests/test_grouping_constraints.py
@@ -1,0 +1,557 @@
+"""Tests for the grouping constraints module."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.optim import (
+    Component,
+    ConstraintType,
+    ConstraintViolation,
+    GroupingConstraint,
+    PlacementOptimizer,
+    Polygon,
+    SpatialConstraint,
+    expand_member_patterns,
+    load_constraints_from_yaml,
+    save_constraints_to_yaml,
+    validate_grouping_constraints,
+)
+
+
+class TestSpatialConstraint:
+    """Tests for SpatialConstraint dataclass."""
+
+    def test_max_distance_factory(self):
+        constraint = SpatialConstraint.max_distance(anchor="U1", radius_mm=10.0)
+        assert constraint.constraint_type == ConstraintType.MAX_DISTANCE
+        assert constraint.parameters["anchor"] == "U1"
+        assert constraint.parameters["radius_mm"] == 10.0
+
+    def test_alignment_factory(self):
+        constraint = SpatialConstraint.alignment(axis="horizontal", tolerance_mm=0.25)
+        assert constraint.constraint_type == ConstraintType.ALIGNMENT
+        assert constraint.parameters["axis"] == "horizontal"
+        assert constraint.parameters["tolerance_mm"] == 0.25
+
+    def test_ordering_factory(self):
+        constraint = SpatialConstraint.ordering(axis="horizontal", order=["LED1", "LED2", "LED3"])
+        assert constraint.constraint_type == ConstraintType.ORDERING
+        assert constraint.parameters["axis"] == "horizontal"
+        assert constraint.parameters["order"] == ["LED1", "LED2", "LED3"]
+
+    def test_within_box_factory(self):
+        constraint = SpatialConstraint.within_box(x=10, y=20, width=30, height=40)
+        assert constraint.constraint_type == ConstraintType.WITHIN_BOX
+        assert constraint.parameters["x"] == 10
+        assert constraint.parameters["y"] == 20
+        assert constraint.parameters["width"] == 30
+        assert constraint.parameters["height"] == 40
+
+    def test_relative_position_factory(self):
+        constraint = SpatialConstraint.relative_position(
+            reference="U1", dx=5.0, dy=10.0, tolerance_mm=0.5
+        )
+        assert constraint.constraint_type == ConstraintType.RELATIVE_POSITION
+        assert constraint.parameters["reference"] == "U1"
+        assert constraint.parameters["dx"] == 5.0
+        assert constraint.parameters["dy"] == 10.0
+        assert constraint.parameters["tolerance_mm"] == 0.5
+
+
+class TestGroupingConstraint:
+    """Tests for GroupingConstraint dataclass."""
+
+    def test_basic_creation(self):
+        constraint = GroupingConstraint(
+            name="status_leds",
+            members=["LED1", "LED2", "LED3"],
+            constraints=[SpatialConstraint.alignment(axis="horizontal")],
+        )
+        assert constraint.name == "status_leds"
+        assert constraint.members == ["LED1", "LED2", "LED3"]
+        assert len(constraint.constraints) == 1
+
+    def test_get_resolved_members_exact(self):
+        constraint = GroupingConstraint(
+            name="test",
+            members=["LED1", "LED2", "LED3"],
+        )
+        all_refs = ["LED1", "LED2", "LED3", "LED4", "R1", "R2"]
+        resolved = constraint.get_resolved_members(all_refs)
+        assert resolved == ["LED1", "LED2", "LED3"]
+
+    def test_get_resolved_members_pattern(self):
+        constraint = GroupingConstraint(
+            name="test",
+            members=["LED*"],
+        )
+        all_refs = ["LED1", "LED2", "LED3", "LED4", "R1", "R2"]
+        resolved = constraint.get_resolved_members(all_refs)
+        assert set(resolved) == {"LED1", "LED2", "LED3", "LED4"}
+
+    def test_get_resolved_members_mixed(self):
+        constraint = GroupingConstraint(
+            name="test",
+            members=["R1", "LED*"],
+        )
+        all_refs = ["LED1", "LED2", "R1", "R2"]
+        resolved = constraint.get_resolved_members(all_refs)
+        assert "R1" in resolved
+        assert "LED1" in resolved
+        assert "LED2" in resolved
+
+
+class TestExpandMemberPatterns:
+    """Tests for expand_member_patterns function."""
+
+    def test_exact_match(self):
+        result = expand_member_patterns(["LED1"], ["LED1", "LED2", "R1"])
+        assert result == ["LED1"]
+
+    def test_no_match(self):
+        result = expand_member_patterns(["LED5"], ["LED1", "LED2", "R1"])
+        assert result == []
+
+    def test_glob_star(self):
+        result = expand_member_patterns(["LED*"], ["LED1", "LED2", "LED10", "R1"])
+        assert set(result) == {"LED1", "LED2", "LED10"}
+
+    def test_glob_question(self):
+        result = expand_member_patterns(["C1?"], ["C10", "C11", "C12", "C1", "C100"])
+        assert set(result) == {"C10", "C11", "C12"}
+
+    def test_glob_range(self):
+        result = expand_member_patterns(["R[1-3]"], ["R1", "R2", "R3", "R4", "R5"])
+        assert set(result) == {"R1", "R2", "R3"}
+
+    def test_deduplication(self):
+        result = expand_member_patterns(["LED1", "LED*"], ["LED1", "LED2"])
+        # LED1 should appear only once
+        assert result.count("LED1") == 1
+
+
+class TestConstraintViolationDataclass:
+    """Tests for ConstraintViolation dataclass."""
+
+    def test_basic_creation(self):
+        from kicad_tools.optim.constraints import ConstraintViolation as CV
+
+        violation = CV(
+            group_name="test_group",
+            constraint_type=ConstraintType.ALIGNMENT,
+            message="Components not aligned",
+            components=["LED1", "LED2"],
+            severity=0.5,
+        )
+        assert violation.group_name == "test_group"
+        assert violation.constraint_type == ConstraintType.ALIGNMENT
+        assert "LED1" in violation.components
+        assert violation.severity == 0.5
+
+    def test_str_representation(self):
+        from kicad_tools.optim.constraints import ConstraintViolation as CV
+
+        violation = CV(
+            group_name="test_group",
+            constraint_type=ConstraintType.ALIGNMENT,
+            message="Components not aligned",
+            components=["LED1", "LED2"],
+        )
+        s = str(violation)
+        assert "test_group" in s
+        assert "alignment" in s
+
+
+class TestValidateMaxDistance:
+    """Tests for max_distance constraint validation."""
+
+    @pytest.fixture
+    def components(self):
+        return [
+            Component(ref="U1", x=50.0, y=50.0),
+            Component(ref="C1", x=55.0, y=50.0),  # 5mm from U1
+            Component(ref="C2", x=60.0, y=50.0),  # 10mm from U1
+            Component(ref="C3", x=70.0, y=50.0),  # 20mm from U1
+        ]
+
+    def test_all_within_radius(self, components):
+        constraints = [
+            GroupingConstraint(
+                name="power_section",
+                members=["U1", "C1", "C2"],
+                constraints=[SpatialConstraint.max_distance(anchor="U1", radius_mm=15.0)],
+            )
+        ]
+        violations = validate_grouping_constraints(components, constraints)
+        assert len(violations) == 0
+
+    def test_some_outside_radius(self, components):
+        constraints = [
+            GroupingConstraint(
+                name="power_section",
+                members=["U1", "C1", "C2", "C3"],
+                constraints=[SpatialConstraint.max_distance(anchor="U1", radius_mm=15.0)],
+            )
+        ]
+        violations = validate_grouping_constraints(components, constraints)
+        assert len(violations) == 1
+        assert "C3" in violations[0].components
+
+
+class TestValidateAlignment:
+    """Tests for alignment constraint validation."""
+
+    @pytest.fixture
+    def aligned_components(self):
+        return [
+            Component(ref="LED1", x=10.0, y=50.0),
+            Component(ref="LED2", x=20.0, y=50.0),
+            Component(ref="LED3", x=30.0, y=50.0),
+        ]
+
+    @pytest.fixture
+    def misaligned_components(self):
+        return [
+            Component(ref="LED1", x=10.0, y=50.0),
+            Component(ref="LED2", x=20.0, y=52.0),  # 2mm off
+            Component(ref="LED3", x=30.0, y=50.0),
+        ]
+
+    def test_horizontal_alignment_satisfied(self, aligned_components):
+        constraints = [
+            GroupingConstraint(
+                name="status_leds",
+                members=["LED1", "LED2", "LED3"],
+                constraints=[SpatialConstraint.alignment(axis="horizontal", tolerance_mm=0.5)],
+            )
+        ]
+        violations = validate_grouping_constraints(aligned_components, constraints)
+        assert len(violations) == 0
+
+    def test_horizontal_alignment_violated(self, misaligned_components):
+        constraints = [
+            GroupingConstraint(
+                name="status_leds",
+                members=["LED1", "LED2", "LED3"],
+                constraints=[SpatialConstraint.alignment(axis="horizontal", tolerance_mm=0.5)],
+            )
+        ]
+        violations = validate_grouping_constraints(misaligned_components, constraints)
+        assert len(violations) == 1
+        assert violations[0].constraint_type == ConstraintType.ALIGNMENT
+
+
+class TestValidateOrdering:
+    """Tests for ordering constraint validation."""
+
+    @pytest.fixture
+    def ordered_components(self):
+        return [
+            Component(ref="LED1", x=10.0, y=50.0),
+            Component(ref="LED2", x=20.0, y=50.0),
+            Component(ref="LED3", x=30.0, y=50.0),
+        ]
+
+    @pytest.fixture
+    def unordered_components(self):
+        return [
+            Component(ref="LED1", x=30.0, y=50.0),  # Wrong position
+            Component(ref="LED2", x=20.0, y=50.0),
+            Component(ref="LED3", x=10.0, y=50.0),  # Wrong position
+        ]
+
+    def test_ordering_satisfied(self, ordered_components):
+        constraints = [
+            GroupingConstraint(
+                name="status_leds",
+                members=["LED1", "LED2", "LED3"],
+                constraints=[
+                    SpatialConstraint.ordering(axis="horizontal", order=["LED1", "LED2", "LED3"])
+                ],
+            )
+        ]
+        violations = validate_grouping_constraints(ordered_components, constraints)
+        assert len(violations) == 0
+
+    def test_ordering_violated(self, unordered_components):
+        constraints = [
+            GroupingConstraint(
+                name="status_leds",
+                members=["LED1", "LED2", "LED3"],
+                constraints=[
+                    SpatialConstraint.ordering(axis="horizontal", order=["LED1", "LED2", "LED3"])
+                ],
+            )
+        ]
+        violations = validate_grouping_constraints(unordered_components, constraints)
+        assert len(violations) == 1
+        assert violations[0].constraint_type == ConstraintType.ORDERING
+
+
+class TestValidateWithinBox:
+    """Tests for within_box constraint validation."""
+
+    @pytest.fixture
+    def components_in_box(self):
+        return [
+            Component(ref="C1", x=15.0, y=15.0),
+            Component(ref="C2", x=20.0, y=20.0),
+        ]
+
+    @pytest.fixture
+    def components_outside_box(self):
+        return [
+            Component(ref="C1", x=15.0, y=15.0),  # Inside
+            Component(ref="C2", x=50.0, y=50.0),  # Outside
+        ]
+
+    def test_all_within_box(self, components_in_box):
+        constraints = [
+            GroupingConstraint(
+                name="power_section",
+                members=["C1", "C2"],
+                constraints=[SpatialConstraint.within_box(x=10, y=10, width=20, height=20)],
+            )
+        ]
+        violations = validate_grouping_constraints(components_in_box, constraints)
+        assert len(violations) == 0
+
+    def test_some_outside_box(self, components_outside_box):
+        constraints = [
+            GroupingConstraint(
+                name="power_section",
+                members=["C1", "C2"],
+                constraints=[SpatialConstraint.within_box(x=10, y=10, width=20, height=20)],
+            )
+        ]
+        violations = validate_grouping_constraints(components_outside_box, constraints)
+        assert len(violations) == 1
+        assert "C2" in violations[0].components
+
+
+class TestValidateRelativePosition:
+    """Tests for relative_position constraint validation."""
+
+    @pytest.fixture
+    def components(self):
+        return [
+            Component(ref="U1", x=50.0, y=50.0),
+            Component(ref="C1", x=55.0, y=50.0),  # 5mm to the right
+        ]
+
+    def test_relative_position_satisfied(self, components):
+        constraints = [
+            GroupingConstraint(
+                name="decoupling",
+                members=["U1", "C1"],
+                constraints=[
+                    SpatialConstraint.relative_position(
+                        reference="U1", dx=5.0, dy=0.0, tolerance_mm=0.5
+                    )
+                ],
+            )
+        ]
+        violations = validate_grouping_constraints(components, constraints)
+        assert len(violations) == 0
+
+    def test_relative_position_violated(self, components):
+        constraints = [
+            GroupingConstraint(
+                name="decoupling",
+                members=["U1", "C1"],
+                constraints=[
+                    SpatialConstraint.relative_position(
+                        reference="U1", dx=10.0, dy=0.0, tolerance_mm=0.5
+                    )
+                ],
+            )
+        ]
+        violations = validate_grouping_constraints(components, constraints)
+        assert len(violations) == 1
+        assert "C1" in violations[0].components
+
+
+class TestConstraintLoader:
+    """Tests for YAML constraint loading and saving."""
+
+    def test_load_basic_yaml(self):
+        yaml_content = """
+groups:
+  - name: status_leds
+    members: ["LED1", "LED2", "LED3"]
+    constraints:
+      - type: alignment
+        axis: horizontal
+        tolerance_mm: 0.5
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            constraints = load_constraints_from_yaml(f.name)
+
+        assert len(constraints) == 1
+        assert constraints[0].name == "status_leds"
+        assert constraints[0].members == ["LED1", "LED2", "LED3"]
+        assert len(constraints[0].constraints) == 1
+        assert constraints[0].constraints[0].constraint_type == ConstraintType.ALIGNMENT
+
+        Path(f.name).unlink()
+
+    def test_load_multiple_constraints(self):
+        yaml_content = """
+groups:
+  - name: status_leds
+    members: ["LED1", "LED2", "LED3", "LED4"]
+    constraints:
+      - type: alignment
+        axis: horizontal
+        tolerance_mm: 0.5
+      - type: ordering
+        axis: horizontal
+        order: ["LED1", "LED2", "LED3", "LED4"]
+
+  - name: power_section
+    members: ["U2", "C10", "C11", "L1", "D1"]
+    constraints:
+      - type: within_box
+        x: 0
+        y: 0
+        width: 25
+        height: 20
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            constraints = load_constraints_from_yaml(f.name)
+
+        assert len(constraints) == 2
+        assert constraints[0].name == "status_leds"
+        assert len(constraints[0].constraints) == 2
+        assert constraints[1].name == "power_section"
+
+        Path(f.name).unlink()
+
+    def test_save_and_reload(self):
+        original = [
+            GroupingConstraint(
+                name="test_group",
+                members=["LED1", "LED2"],
+                constraints=[
+                    SpatialConstraint.alignment(axis="horizontal", tolerance_mm=0.5),
+                    SpatialConstraint.max_distance(anchor="LED1", radius_mm=10.0),
+                ],
+            )
+        ]
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            save_constraints_to_yaml(original, f.name)
+            loaded = load_constraints_from_yaml(f.name)
+
+        assert len(loaded) == 1
+        assert loaded[0].name == "test_group"
+        assert len(loaded[0].constraints) == 2
+
+        Path(f.name).unlink()
+
+    def test_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_constraints_from_yaml("/nonexistent/path/to/file.yaml")
+
+    def test_invalid_constraint_type(self):
+        yaml_content = """
+groups:
+  - name: test
+    members: ["LED1"]
+    constraints:
+      - type: invalid_type
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            with pytest.raises(ValueError, match="Unknown constraint type"):
+                load_constraints_from_yaml(f.name)
+
+        Path(f.name).unlink()
+
+
+class TestPlacementOptimizerConstraints:
+    """Tests for constraint integration in PlacementOptimizer."""
+
+    @pytest.fixture
+    def optimizer_with_components(self):
+        board = Polygon.rectangle(50, 50, 100, 80)
+        optimizer = PlacementOptimizer(board)
+
+        # Add some components
+        optimizer.add_component(Component(ref="LED1", x=10.0, y=50.0))
+        optimizer.add_component(Component(ref="LED2", x=20.0, y=50.0))
+        optimizer.add_component(Component(ref="LED3", x=30.0, y=50.0))
+        optimizer.add_component(Component(ref="U1", x=50.0, y=50.0))
+
+        return optimizer
+
+    def test_add_grouping_constraint(self, optimizer_with_components):
+        constraint = GroupingConstraint(
+            name="test",
+            members=["LED1", "LED2"],
+            constraints=[SpatialConstraint.alignment(axis="horizontal")],
+        )
+        optimizer_with_components.add_grouping_constraint(constraint)
+        assert len(optimizer_with_components.grouping_constraints) == 1
+
+    def test_add_multiple_constraints(self, optimizer_with_components):
+        constraints = [
+            GroupingConstraint(name="group1", members=["LED1", "LED2"]),
+            GroupingConstraint(name="group2", members=["LED3", "U1"]),
+        ]
+        optimizer_with_components.add_grouping_constraints(constraints)
+        assert len(optimizer_with_components.grouping_constraints) == 2
+
+    def test_validate_constraints(self, optimizer_with_components):
+        constraint = GroupingConstraint(
+            name="leds",
+            members=["LED1", "LED2", "LED3"],
+            constraints=[SpatialConstraint.alignment(axis="horizontal", tolerance_mm=0.5)],
+        )
+        optimizer_with_components.add_grouping_constraint(constraint)
+        violations = optimizer_with_components.validate_constraints()
+        # All LEDs are at y=50, so should be aligned
+        assert len(violations) == 0
+
+    def test_constraint_forces_computed(self, optimizer_with_components):
+        # Add a constraint that should create forces
+        constraint = GroupingConstraint(
+            name="leds",
+            members=["LED1", "LED2", "LED3"],
+            constraints=[SpatialConstraint.max_distance(anchor="LED1", radius_mm=5.0)],
+        )
+        optimizer_with_components.add_grouping_constraint(constraint)
+
+        # LED3 is 20mm from LED1, constraint says max 5mm
+        # So forces should be non-zero
+        forces = optimizer_with_components.compute_constraint_forces()
+        assert forces["LED3"].magnitude() > 0
+
+    def test_optimization_respects_constraints(self, optimizer_with_components):
+        # Put LED3 far from LED1
+        optimizer_with_components.get_component("LED3").x = 60.0
+
+        constraint = GroupingConstraint(
+            name="leds",
+            members=["LED1", "LED2", "LED3"],
+            constraints=[SpatialConstraint.max_distance(anchor="LED1", radius_mm=15.0)],
+        )
+        optimizer_with_components.add_grouping_constraint(constraint)
+
+        # Run optimization
+        optimizer_with_components.run(iterations=100, dt=0.01)
+
+        # LED3 should have moved closer to LED1
+        led1 = optimizer_with_components.get_component("LED1")
+        led3 = optimizer_with_components.get_component("LED3")
+        final_dist = ((led3.x - led1.x) ** 2 + (led3.y - led1.y) ** 2) ** 0.5
+
+        # Should be closer than initial 50mm
+        assert final_dist < 50.0


### PR DESCRIPTION
## Summary

- Implements a constraint system for defining component groups and their spatial relationships
- Adds 5 constraint types: max_distance, alignment, ordering, within_box, relative_position
- Supports glob patterns for member selection (e.g., "LED*", "C1?")
- Integrates constraints as soft penalty forces during optimization
- Adds `--constraints` CLI option with YAML configuration file support

## Test plan

- [x] Run `pytest tests/test_grouping_constraints.py` - 37 tests pass
- [ ] Verify constraint loading from YAML files
- [ ] Test each constraint type with real PCB optimization

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)