### PR TITLE
Remove invalid S-expression comments from route output

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -670,14 +670,13 @@ def main(argv: list[str] | None = None) -> int:
             route_sexp = router.to_sexp()
 
             # Insert routes and zones before final closing parenthesis
+            # Note: KiCad's S-expression format doesn't support ; comments
             if route_sexp or zone_sexp:
                 output_content = original_content.rstrip().rstrip(")")
                 if zone_sexp:
-                    output_content += "\n  ; === COPPER ZONES ===\n"
-                    output_content += f"  {zone_sexp}\n"
+                    output_content += f"\n  {zone_sexp}\n"
                 if route_sexp:
-                    output_content += "\n  ; === AUTOROUTED TRACES ===\n"
-                    output_content += f"  {route_sexp}\n"
+                    output_content += f"\n  {route_sexp}\n"
                 output_content += ")\n"
             else:
                 output_content = original_content

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "kicad-tools"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary

- Removes `; === AUTOROUTED TRACES ===` and `; === COPPER ZONES ===` comments from routed PCB output
- KiCad's S-expression format does not support semicolon comments at the top level
- This was causing KiCad 9 to fail with "Failed to load board" error

## Problem

When running `kicad-tools route`, the output PCB file contained:

```
  )

  ; === AUTOROUTED TRACES ===
  (segment
    ...
```

KiCad's S-expression parser doesn't recognize `;` as a comment delimiter, causing the entire file to fail to load.

## Test plan

- [x] Verified autorouted output now loads in KiCad 9
- [x] DRC runs successfully on routed file (332 violations, 41 unconnected - expected for partial routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)