### PR TITLE
Add physics module with PCB stackup analysis

### DIFF
--- a/src/kicad_tools/physics/__init__.py
+++ b/src/kicad_tools/physics/__init__.py
@@ -1,0 +1,84 @@
+"""Physics-based calculations for PCB signal integrity.
+
+This module provides analytical electromagnetic calculations for
+transmission line impedance, crosstalk estimation, and timing analysis.
+
+Stackup Analysis:
+    >>> from kicad_tools.physics import Stackup
+    >>> from kicad_tools.schema.pcb import PCB
+    >>>
+    >>> # Parse stackup from KiCad board
+    >>> pcb = PCB.load("board.kicad_pcb")
+    >>> stackup = Stackup.from_pcb(pcb)
+    >>>
+    >>> # Or use manufacturer preset
+    >>> stackup = Stackup.jlcpcb_4layer()
+    >>>
+    >>> # Query layer properties
+    >>> h = stackup.get_dielectric_height("F.Cu")
+    >>> er = stackup.get_dielectric_constant("F.Cu")
+    >>> print(f"Height to reference: {h}mm, epsilon_r: {er}")
+
+Material Properties:
+    >>> from kicad_tools.physics import FR4_STANDARD, ROGERS_4350B
+    >>>
+    >>> print(f"FR4 epsilon_r: {FR4_STANDARD.epsilon_r}")
+    >>> print(f"Rogers loss tangent: {ROGERS_4350B.loss_tangent}")
+
+Note:
+    This module focuses on analytical calculations that are fast enough
+    for agent iteration (microseconds per calculation). For full-wave
+    electromagnetic simulation, use dedicated tools like openEMS or HFSS.
+"""
+
+from .constants import (
+    COPPER_1OZ,
+    COPPER_2OZ,
+    COPPER_CONDUCTIVITY,
+    # Copper weights
+    COPPER_HALF_OZ,
+    FR4_HIGH_TG,
+    FR4_STANDARD,
+    ISOLA_370HR,
+    ROGERS_4003C,
+    ROGERS_4350B,
+    # Physical constants
+    SPEED_OF_LIGHT,
+    CopperWeight,
+    # Dielectric materials
+    DielectricMaterial,
+    copper_thickness_from_oz,
+    # Lookup functions
+    get_material,
+    get_material_or_default,
+)
+from .stackup import (
+    LayerType,
+    Stackup,
+    StackupLayer,
+)
+
+__all__ = [
+    # Constants
+    "SPEED_OF_LIGHT",
+    "COPPER_CONDUCTIVITY",
+    # Copper
+    "CopperWeight",
+    "COPPER_HALF_OZ",
+    "COPPER_1OZ",
+    "COPPER_2OZ",
+    "copper_thickness_from_oz",
+    # Materials
+    "DielectricMaterial",
+    "FR4_STANDARD",
+    "FR4_HIGH_TG",
+    "ROGERS_4350B",
+    "ROGERS_4003C",
+    "ISOLA_370HR",
+    "get_material",
+    "get_material_or_default",
+    # Stackup
+    "LayerType",
+    "StackupLayer",
+    "Stackup",
+]

--- a/src/kicad_tools/physics/constants.py
+++ b/src/kicad_tools/physics/constants.py
@@ -1,0 +1,150 @@
+"""Physical constants and material properties for electromagnetic calculations.
+
+This module provides:
+- Physical constants (speed of light, etc.)
+- Dielectric material properties (FR4, Rogers, etc.)
+- Copper properties at various weights
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Physical constants
+SPEED_OF_LIGHT = 299792458  # m/s
+VACUUM_PERMITTIVITY = 8.854187817e-12  # F/m
+VACUUM_PERMEABILITY = 1.2566370614e-6  # H/m
+
+# Copper conductivity
+COPPER_CONDUCTIVITY = 5.8e7  # S/m at 20C
+
+
+@dataclass(frozen=True)
+class CopperWeight:
+    """Copper foil specification by weight."""
+
+    oz: float  # Weight in oz/ft^2
+    thickness_um: float  # Thickness in micrometers
+    thickness_mm: float  # Thickness in millimeters
+
+    @classmethod
+    def from_oz(cls, oz: float) -> CopperWeight:
+        """Create from weight in oz/ft^2."""
+        # 1 oz/ft^2 = 35 um (approximately)
+        thickness_um = oz * 35.0
+        return cls(oz=oz, thickness_um=thickness_um, thickness_mm=thickness_um / 1000)
+
+
+# Standard copper weights
+COPPER_HALF_OZ = CopperWeight.from_oz(0.5)  # 17.5 um
+COPPER_1OZ = CopperWeight.from_oz(1.0)  # 35 um
+COPPER_2OZ = CopperWeight.from_oz(2.0)  # 70 um
+
+
+@dataclass(frozen=True)
+class DielectricMaterial:
+    """Dielectric material properties."""
+
+    name: str
+    epsilon_r: float  # Relative permittivity (dielectric constant)
+    loss_tangent: float  # tan(delta) at 1 GHz
+    description: str = ""
+
+    @property
+    def epsilon_eff_approx(self) -> float:
+        """Approximate effective epsilon for microstrip (rough estimate)."""
+        # For microstrip, epsilon_eff is typically between 1 and epsilon_r
+        # This is a very rough approximation; actual value depends on geometry
+        return (self.epsilon_r + 1) / 2
+
+
+# Common PCB dielectric materials
+FR4_STANDARD = DielectricMaterial(
+    name="FR4",
+    epsilon_r=4.5,
+    loss_tangent=0.02,
+    description="Standard FR4 glass-reinforced epoxy laminate",
+)
+
+FR4_HIGH_TG = DielectricMaterial(
+    name="FR4 High-Tg",
+    epsilon_r=4.4,
+    loss_tangent=0.018,
+    description="High glass transition temperature FR4",
+)
+
+ROGERS_4350B = DielectricMaterial(
+    name="Rogers RO4350B",
+    epsilon_r=3.48,
+    loss_tangent=0.0037,
+    description="High-frequency laminate with low loss",
+)
+
+ROGERS_4003C = DielectricMaterial(
+    name="Rogers RO4003C",
+    epsilon_r=3.55,
+    loss_tangent=0.0027,
+    description="Woven glass reinforced hydrocarbon/ceramic",
+)
+
+ISOLA_370HR = DielectricMaterial(
+    name="Isola 370HR",
+    epsilon_r=4.0,
+    loss_tangent=0.015,
+    description="High-performance FR4 alternative",
+)
+
+# Material database by name (case-insensitive lookup)
+MATERIALS: dict[str, DielectricMaterial] = {
+    "fr4": FR4_STANDARD,
+    "fr-4": FR4_STANDARD,
+    "fr4 high-tg": FR4_HIGH_TG,
+    "fr4_high_tg": FR4_HIGH_TG,
+    "rogers 4350b": ROGERS_4350B,
+    "ro4350b": ROGERS_4350B,
+    "rogers 4003c": ROGERS_4003C,
+    "ro4003c": ROGERS_4003C,
+    "isola 370hr": ISOLA_370HR,
+    "370hr": ISOLA_370HR,
+}
+
+
+def get_material(name: str) -> DielectricMaterial | None:
+    """Look up material by name (case-insensitive).
+
+    Args:
+        name: Material name (e.g., "FR4", "Rogers 4350B")
+
+    Returns:
+        DielectricMaterial if found, None otherwise
+    """
+    return MATERIALS.get(name.lower())
+
+
+def get_material_or_default(
+    name: str | None, default: DielectricMaterial = FR4_STANDARD
+) -> DielectricMaterial:
+    """Look up material by name, returning default if not found.
+
+    Args:
+        name: Material name (e.g., "FR4", "Rogers 4350B")
+        default: Default material if not found
+
+    Returns:
+        DielectricMaterial
+    """
+    if not name:
+        return default
+    return MATERIALS.get(name.lower(), default)
+
+
+def copper_thickness_from_oz(oz: float) -> float:
+    """Convert copper weight (oz/ft^2) to thickness (mm).
+
+    Args:
+        oz: Copper weight in oz/ft^2
+
+    Returns:
+        Thickness in mm
+    """
+    return oz * 0.035  # 1 oz = 35 um = 0.035 mm

--- a/src/kicad_tools/physics/stackup.py
+++ b/src/kicad_tools/physics/stackup.py
@@ -1,0 +1,822 @@
+"""PCB stackup representation for electromagnetic calculations.
+
+Provides the Stackup class for parsing and representing PCB layer stackups,
+including copper thicknesses, dielectric properties, and manufacturer presets.
+
+Example::
+
+    from kicad_tools.physics import Stackup
+    from kicad_tools.schema.pcb import PCB
+
+    # Parse from KiCad board file
+    pcb = PCB.load("board.kicad_pcb")
+    stackup = Stackup.from_pcb(pcb)
+
+    # Or use manufacturer preset
+    stackup = Stackup.jlcpcb_4layer()
+
+    # Get layer properties
+    h = stackup.get_dielectric_height("F.Cu")  # Height to reference plane
+    er = stackup.get_dielectric_constant("F.Cu")  # Dielectric constant
+    t = stackup.get_copper_thickness("F.Cu")  # Copper thickness
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from .constants import (
+    COPPER_1OZ,
+    COPPER_HALF_OZ,
+    FR4_STANDARD,
+    copper_thickness_from_oz,
+)
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import PCB
+
+
+class LayerType(Enum):
+    """Type of layer in the stackup."""
+
+    COPPER = "copper"
+    DIELECTRIC = "dielectric"  # Prepreg or core
+    SOLDER_MASK = "solder mask"
+    SILK_SCREEN = "silk screen"
+
+
+@dataclass
+class StackupLayer:
+    """Single layer in a PCB stackup.
+
+    Attributes:
+        name: Layer name (e.g., "F.Cu", "prepreg 1", "core")
+        layer_type: Type of layer (copper, dielectric, etc.)
+        thickness_mm: Layer thickness in millimeters
+        material: Material name (e.g., "FR4", "copper")
+        epsilon_r: Relative permittivity (for dielectrics)
+        loss_tangent: Loss tangent tan(delta) (for dielectrics)
+        copper_weight_oz: Copper weight in oz/ft^2 (for copper layers)
+    """
+
+    name: str
+    layer_type: LayerType
+    thickness_mm: float = 0.0
+    material: str = ""
+    epsilon_r: float = 0.0
+    loss_tangent: float = 0.0
+    copper_weight_oz: float | None = None
+
+    @property
+    def is_copper(self) -> bool:
+        """Check if this is a copper layer."""
+        return self.layer_type == LayerType.COPPER
+
+    @property
+    def is_dielectric(self) -> bool:
+        """Check if this is a dielectric layer."""
+        return self.layer_type == LayerType.DIELECTRIC
+
+    @property
+    def is_signal_layer(self) -> bool:
+        """Check if this is a signal copper layer (F.Cu, B.Cu, In*.Cu)."""
+        if not self.is_copper:
+            return False
+        name = self.name.lower()
+        return name.endswith(".cu")
+
+
+@dataclass
+class Stackup:
+    """Complete PCB layer stackup for electromagnetic calculations.
+
+    The stackup is ordered from top to bottom:
+    - layers[0] is the top layer (typically F.Cu or solder mask)
+    - layers[-1] is the bottom layer (typically B.Cu or solder mask)
+
+    Attributes:
+        layers: Ordered list of layers from top to bottom
+        board_thickness_mm: Total board thickness in mm
+        copper_finish: Surface finish (e.g., "ENIG", "HASL")
+    """
+
+    layers: list[StackupLayer] = field(default_factory=list)
+    board_thickness_mm: float = 1.6
+    copper_finish: str = ""
+
+    @classmethod
+    def from_pcb(cls, pcb: PCB) -> Stackup:
+        """Parse stackup from a KiCad PCB file.
+
+        KiCad 7+ stores stackup information in the (setup (stackup ...)) section.
+        For older files or files without explicit stackup, this creates a
+        default 2-layer stackup based on the board's copper layers.
+
+        Args:
+            pcb: Loaded PCB object
+
+        Returns:
+            Stackup object with parsed or default layer information
+        """
+        setup = pcb.setup
+        if not setup or not setup.stackup:
+            # No stackup defined, create default based on copper layer count
+            return cls._create_default_stackup(pcb)
+
+        # Parse explicit stackup from KiCad file
+        layers = []
+        for layer_data in setup.stackup:
+            layer_type = cls._parse_layer_type(layer_data.type)
+
+            layer = StackupLayer(
+                name=layer_data.name,
+                layer_type=layer_type,
+                thickness_mm=layer_data.thickness,
+                material=layer_data.material,
+                epsilon_r=layer_data.epsilon_r,
+            )
+
+            # Infer copper weight from thickness
+            if layer_type == LayerType.COPPER and layer.thickness_mm > 0:
+                # Approximate oz from thickness (35um = 1oz)
+                layer.copper_weight_oz = layer.thickness_mm / 0.035
+
+            layers.append(layer)
+
+        # Calculate total board thickness
+        total_thickness = sum(layer.thickness_mm for layer in layers)
+
+        return cls(
+            layers=layers,
+            board_thickness_mm=total_thickness if total_thickness > 0 else 1.6,
+            copper_finish=setup.copper_finish if hasattr(setup, "copper_finish") else "",
+        )
+
+    @classmethod
+    def _create_default_stackup(cls, pcb: PCB) -> Stackup:
+        """Create a default stackup for boards without explicit stackup data.
+
+        Args:
+            pcb: Loaded PCB object
+
+        Returns:
+            Default stackup based on copper layer count
+        """
+        copper_layers = pcb.copper_layers
+        num_copper = len(copper_layers)
+
+        if num_copper <= 2:
+            return cls.default_2layer()
+        elif num_copper == 4:
+            return cls.jlcpcb_4layer()
+        elif num_copper == 6:
+            return cls.default_6layer()
+        else:
+            # Generic multi-layer
+            return cls._create_generic_stackup(num_copper)
+
+    @classmethod
+    def _create_generic_stackup(cls, num_copper_layers: int) -> Stackup:
+        """Create a generic stackup for N copper layers.
+
+        Args:
+            num_copper_layers: Number of copper layers
+
+        Returns:
+            Generic stackup with sensible defaults
+        """
+        layers = []
+
+        # Outer layer copper (1oz)
+        layers.append(
+            StackupLayer(
+                name="F.Cu",
+                layer_type=LayerType.COPPER,
+                thickness_mm=COPPER_1OZ.thickness_mm,
+                material="copper",
+                copper_weight_oz=1.0,
+            )
+        )
+
+        # Inner layers with prepreg/core sandwich
+        for i in range(1, num_copper_layers - 1):
+            # Dielectric before inner layer
+            dielectric_name = "core" if i % 2 == 0 else "prepreg"
+            layers.append(
+                StackupLayer(
+                    name=f"{dielectric_name} {i}",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=0.2,
+                    material="FR4",
+                    epsilon_r=FR4_STANDARD.epsilon_r,
+                    loss_tangent=FR4_STANDARD.loss_tangent,
+                )
+            )
+
+            # Inner copper layer (0.5oz typical)
+            layers.append(
+                StackupLayer(
+                    name=f"In{i}.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=COPPER_HALF_OZ.thickness_mm,
+                    material="copper",
+                    copper_weight_oz=0.5,
+                )
+            )
+
+        # Final dielectric before bottom
+        layers.append(
+            StackupLayer(
+                name="prepreg bottom",
+                layer_type=LayerType.DIELECTRIC,
+                thickness_mm=0.2,
+                material="FR4",
+                epsilon_r=FR4_STANDARD.epsilon_r,
+                loss_tangent=FR4_STANDARD.loss_tangent,
+            )
+        )
+
+        # Bottom copper (1oz)
+        layers.append(
+            StackupLayer(
+                name="B.Cu",
+                layer_type=LayerType.COPPER,
+                thickness_mm=COPPER_1OZ.thickness_mm,
+                material="copper",
+                copper_weight_oz=1.0,
+            )
+        )
+
+        total_thickness = sum(layer.thickness_mm for layer in layers)
+        return cls(layers=layers, board_thickness_mm=total_thickness)
+
+    @staticmethod
+    def _parse_layer_type(type_str: str) -> LayerType:
+        """Parse layer type from KiCad string.
+
+        Args:
+            type_str: Type string from KiCad (e.g., "copper", "prepreg", "core")
+
+        Returns:
+            LayerType enum value
+        """
+        type_lower = type_str.lower()
+        if type_lower == "copper":
+            return LayerType.COPPER
+        elif type_lower in ("prepreg", "core", "dielectric"):
+            return LayerType.DIELECTRIC
+        elif "mask" in type_lower:
+            return LayerType.SOLDER_MASK
+        elif "silk" in type_lower:
+            return LayerType.SILK_SCREEN
+        else:
+            return LayerType.DIELECTRIC  # Default to dielectric
+
+    # Manufacturer presets
+
+    @classmethod
+    def default_2layer(cls, thickness_mm: float = 1.6) -> Stackup:
+        """Create a generic 2-layer FR4 stackup.
+
+        Standard 2-layer board with 1oz copper on both sides.
+
+        Args:
+            thickness_mm: Total board thickness (default 1.6mm)
+
+        Returns:
+            2-layer Stackup
+        """
+        dielectric_thickness = thickness_mm - 2 * COPPER_1OZ.thickness_mm
+
+        return cls(
+            layers=[
+                StackupLayer(
+                    name="F.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=COPPER_1OZ.thickness_mm,
+                    material="copper",
+                    copper_weight_oz=1.0,
+                ),
+                StackupLayer(
+                    name="core",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=dielectric_thickness,
+                    material="FR4",
+                    epsilon_r=FR4_STANDARD.epsilon_r,
+                    loss_tangent=FR4_STANDARD.loss_tangent,
+                ),
+                StackupLayer(
+                    name="B.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=COPPER_1OZ.thickness_mm,
+                    material="copper",
+                    copper_weight_oz=1.0,
+                ),
+            ],
+            board_thickness_mm=thickness_mm,
+        )
+
+    @classmethod
+    def jlcpcb_4layer(cls) -> Stackup:
+        """JLCPCB JLC04161H-3313 4-layer stackup.
+
+        Standard 1.6mm 4-layer:
+        - F.Cu: 35um (1oz)
+        - Prepreg: 0.2104mm (7075), er=4.05
+        - In1.Cu: 17.5um (0.5oz)
+        - Core: 1.065mm, er=4.6
+        - In2.Cu: 17.5um (0.5oz)
+        - Prepreg: 0.2104mm (7075), er=4.05
+        - B.Cu: 35um (1oz)
+
+        Total: ~1.6mm
+
+        Returns:
+            JLCPCB 4-layer Stackup
+        """
+        return cls(
+            layers=[
+                StackupLayer(
+                    name="F.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.035,
+                    material="copper",
+                    copper_weight_oz=1.0,
+                ),
+                StackupLayer(
+                    name="prepreg 1",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=0.2104,
+                    material="FR4 7628",
+                    epsilon_r=4.05,
+                    loss_tangent=0.02,
+                ),
+                StackupLayer(
+                    name="In1.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.0175,
+                    material="copper",
+                    copper_weight_oz=0.5,
+                ),
+                StackupLayer(
+                    name="core",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=1.065,
+                    material="FR4",
+                    epsilon_r=4.6,
+                    loss_tangent=0.02,
+                ),
+                StackupLayer(
+                    name="In2.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.0175,
+                    material="copper",
+                    copper_weight_oz=0.5,
+                ),
+                StackupLayer(
+                    name="prepreg 2",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=0.2104,
+                    material="FR4 7628",
+                    epsilon_r=4.05,
+                    loss_tangent=0.02,
+                ),
+                StackupLayer(
+                    name="B.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.035,
+                    material="copper",
+                    copper_weight_oz=1.0,
+                ),
+            ],
+            board_thickness_mm=1.6,
+            copper_finish="HASL",
+        )
+
+    @classmethod
+    def oshpark_4layer(cls) -> Stackup:
+        """OSH Park 4-layer stackup.
+
+        OSH Park 4-layer:
+        - F.Cu: 35um (1oz)
+        - Prepreg: 0.17mm, er=4.5
+        - In1.Cu: 17.5um (0.5oz)
+        - Core: 1.2mm, er=4.5
+        - In2.Cu: 17.5um (0.5oz)
+        - Prepreg: 0.17mm, er=4.5
+        - B.Cu: 35um (1oz)
+
+        Total: ~1.6mm
+
+        Returns:
+            OSH Park 4-layer Stackup
+        """
+        return cls(
+            layers=[
+                StackupLayer(
+                    name="F.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.035,
+                    material="copper",
+                    copper_weight_oz=1.0,
+                ),
+                StackupLayer(
+                    name="prepreg 1",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=0.17,
+                    material="FR408",
+                    epsilon_r=4.5,
+                    loss_tangent=0.012,
+                ),
+                StackupLayer(
+                    name="In1.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.0175,
+                    material="copper",
+                    copper_weight_oz=0.5,
+                ),
+                StackupLayer(
+                    name="core",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=1.2,
+                    material="FR408",
+                    epsilon_r=4.5,
+                    loss_tangent=0.012,
+                ),
+                StackupLayer(
+                    name="In2.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.0175,
+                    material="copper",
+                    copper_weight_oz=0.5,
+                ),
+                StackupLayer(
+                    name="prepreg 2",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=0.17,
+                    material="FR408",
+                    epsilon_r=4.5,
+                    loss_tangent=0.012,
+                ),
+                StackupLayer(
+                    name="B.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.035,
+                    material="copper",
+                    copper_weight_oz=1.0,
+                ),
+            ],
+            board_thickness_mm=1.6,
+            copper_finish="ENIG",
+        )
+
+    @classmethod
+    def default_6layer(cls) -> Stackup:
+        """Create a generic 6-layer FR4 stackup.
+
+        Standard 6-layer with 1oz outer and 0.5oz inner copper.
+
+        Returns:
+            6-layer Stackup
+        """
+        return cls(
+            layers=[
+                StackupLayer(
+                    name="F.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.035,
+                    material="copper",
+                    copper_weight_oz=1.0,
+                ),
+                StackupLayer(
+                    name="prepreg 1",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=0.18,
+                    material="FR4",
+                    epsilon_r=4.5,
+                    loss_tangent=0.02,
+                ),
+                StackupLayer(
+                    name="In1.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.0175,
+                    material="copper",
+                    copper_weight_oz=0.5,
+                ),
+                StackupLayer(
+                    name="core 1",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=0.36,
+                    material="FR4",
+                    epsilon_r=4.5,
+                    loss_tangent=0.02,
+                ),
+                StackupLayer(
+                    name="In2.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.0175,
+                    material="copper",
+                    copper_weight_oz=0.5,
+                ),
+                StackupLayer(
+                    name="prepreg 2",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=0.18,
+                    material="FR4",
+                    epsilon_r=4.5,
+                    loss_tangent=0.02,
+                ),
+                StackupLayer(
+                    name="In3.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.0175,
+                    material="copper",
+                    copper_weight_oz=0.5,
+                ),
+                StackupLayer(
+                    name="core 2",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=0.36,
+                    material="FR4",
+                    epsilon_r=4.5,
+                    loss_tangent=0.02,
+                ),
+                StackupLayer(
+                    name="In4.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.0175,
+                    material="copper",
+                    copper_weight_oz=0.5,
+                ),
+                StackupLayer(
+                    name="prepreg 3",
+                    layer_type=LayerType.DIELECTRIC,
+                    thickness_mm=0.18,
+                    material="FR4",
+                    epsilon_r=4.5,
+                    loss_tangent=0.02,
+                ),
+                StackupLayer(
+                    name="B.Cu",
+                    layer_type=LayerType.COPPER,
+                    thickness_mm=0.035,
+                    material="copper",
+                    copper_weight_oz=1.0,
+                ),
+            ],
+            board_thickness_mm=1.6,
+        )
+
+    # Query methods
+
+    @property
+    def copper_layers(self) -> list[StackupLayer]:
+        """Get all copper layers in order from top to bottom."""
+        return [layer for layer in self.layers if layer.is_copper]
+
+    @property
+    def dielectric_layers(self) -> list[StackupLayer]:
+        """Get all dielectric layers in order."""
+        return [layer for layer in self.layers if layer.is_dielectric]
+
+    @property
+    def num_copper_layers(self) -> int:
+        """Get number of copper layers."""
+        return len(self.copper_layers)
+
+    def get_layer(self, name: str) -> StackupLayer | None:
+        """Get a layer by name.
+
+        Args:
+            name: Layer name (e.g., "F.Cu", "In1.Cu", "core")
+
+        Returns:
+            StackupLayer if found, None otherwise
+        """
+        for layer in self.layers:
+            if layer.name == name:
+                return layer
+        return None
+
+    def get_layer_index(self, name: str) -> int:
+        """Get the index of a layer in the stackup.
+
+        Args:
+            name: Layer name
+
+        Returns:
+            Index (0 = top), or -1 if not found
+        """
+        for i, layer in enumerate(self.layers):
+            if layer.name == name:
+                return i
+        return -1
+
+    def is_outer_layer(self, layer_name: str) -> bool:
+        """Check if a layer is on the outside of the board (microstrip geometry).
+
+        Outer layers have dielectric on only one side.
+
+        Args:
+            layer_name: Layer name (e.g., "F.Cu", "B.Cu")
+
+        Returns:
+            True if layer is on top or bottom of stackup
+        """
+        copper_layers = self.copper_layers
+        if not copper_layers:
+            return False
+
+        # Check if this is the first or last copper layer
+        return layer_name in (copper_layers[0].name, copper_layers[-1].name)
+
+    def get_copper_thickness(self, layer_name: str) -> float:
+        """Get copper thickness for a layer in mm.
+
+        Args:
+            layer_name: Layer name (e.g., "F.Cu")
+
+        Returns:
+            Thickness in mm, or 0.035 (1oz) as default
+        """
+        layer = self.get_layer(layer_name)
+        if layer and layer.is_copper:
+            if layer.thickness_mm > 0:
+                return layer.thickness_mm
+            if layer.copper_weight_oz:
+                return copper_thickness_from_oz(layer.copper_weight_oz)
+        return 0.035  # Default 1oz
+
+    def get_dielectric_above(self, layer_name: str) -> StackupLayer | None:
+        """Get the dielectric layer above a copper layer.
+
+        For outer layers (F.Cu), this is the dielectric between the
+        copper and the first reference plane.
+
+        Args:
+            layer_name: Copper layer name (e.g., "F.Cu")
+
+        Returns:
+            Dielectric layer above, or None if not found
+        """
+        layer_idx = self.get_layer_index(layer_name)
+        if layer_idx < 0:
+            return None
+
+        # Search downward (higher index) for next dielectric
+        for i in range(layer_idx + 1, len(self.layers)):
+            if self.layers[i].is_dielectric:
+                return self.layers[i]
+
+        return None
+
+    def get_dielectric_below(self, layer_name: str) -> StackupLayer | None:
+        """Get the dielectric layer below a copper layer.
+
+        Args:
+            layer_name: Copper layer name
+
+        Returns:
+            Dielectric layer below, or None if not found
+        """
+        layer_idx = self.get_layer_index(layer_name)
+        if layer_idx < 0:
+            return None
+
+        # Search upward (lower index) for dielectric
+        for i in range(layer_idx - 1, -1, -1):
+            if self.layers[i].is_dielectric:
+                return self.layers[i]
+
+        return None
+
+    def get_dielectric_height(self, layer_name: str) -> float:
+        """Get height from copper layer to nearest reference plane.
+
+        For microstrip (outer layers), this is the dielectric thickness
+        to the ground plane below.
+
+        For stripline (inner layers), this returns the distance to the
+        nearest reference plane (smaller of above/below distances).
+
+        Args:
+            layer_name: Copper layer name (e.g., "F.Cu", "In1.Cu")
+
+        Returns:
+            Height in mm to reference plane
+        """
+        if self.is_outer_layer(layer_name):
+            # Microstrip: height to plane below
+            dielectric = self.get_dielectric_above(layer_name)
+            if dielectric:
+                return dielectric.thickness_mm
+        else:
+            # Stripline: distance to nearest plane
+            above = self.get_dielectric_above(layer_name)
+            below = self.get_dielectric_below(layer_name)
+
+            heights = []
+            if above:
+                heights.append(above.thickness_mm)
+            if below:
+                heights.append(below.thickness_mm)
+
+            if heights:
+                return min(heights)
+
+        # Default fallback
+        return 0.2
+
+    def get_dielectric_constant(self, layer_name: str) -> float:
+        """Get effective dielectric constant for a copper layer.
+
+        For microstrip, uses the dielectric above (between trace and ground).
+        For stripline, uses average of surrounding dielectrics.
+
+        Args:
+            layer_name: Copper layer name
+
+        Returns:
+            Dielectric constant (epsilon_r)
+        """
+        if self.is_outer_layer(layer_name):
+            # Microstrip: use dielectric above
+            dielectric = self.get_dielectric_above(layer_name)
+            if dielectric and dielectric.epsilon_r > 0:
+                return dielectric.epsilon_r
+        else:
+            # Stripline: average surrounding dielectrics
+            above = self.get_dielectric_above(layer_name)
+            below = self.get_dielectric_below(layer_name)
+
+            eps_values = []
+            if above and above.epsilon_r > 0:
+                eps_values.append(above.epsilon_r)
+            if below and below.epsilon_r > 0:
+                eps_values.append(below.epsilon_r)
+
+            if eps_values:
+                return sum(eps_values) / len(eps_values)
+
+        # Default FR4
+        return FR4_STANDARD.epsilon_r
+
+    def get_loss_tangent(self, layer_name: str) -> float:
+        """Get dielectric loss tangent for a copper layer.
+
+        Args:
+            layer_name: Copper layer name
+
+        Returns:
+            Loss tangent (tan delta)
+        """
+        dielectric = self.get_dielectric_above(layer_name)
+        if dielectric and dielectric.loss_tangent > 0:
+            return dielectric.loss_tangent
+        return FR4_STANDARD.loss_tangent
+
+    def get_reference_plane_distance(self, layer_name: str) -> float:
+        """Get distance from a signal layer to the nearest reference plane.
+
+        This is equivalent to get_dielectric_height for most cases,
+        but explicitly named for clarity in impedance calculations.
+
+        Args:
+            layer_name: Signal layer name (e.g., "F.Cu")
+
+        Returns:
+            Distance in mm to nearest reference plane (ground/power)
+        """
+        return self.get_dielectric_height(layer_name)
+
+    def summary(self) -> dict:
+        """Get a summary of the stackup.
+
+        Returns:
+            Dictionary with stackup information
+        """
+        return {
+            "board_thickness_mm": self.board_thickness_mm,
+            "num_copper_layers": self.num_copper_layers,
+            "copper_finish": self.copper_finish,
+            "layers": [
+                {
+                    "name": layer.name,
+                    "type": layer.layer_type.value,
+                    "thickness_mm": layer.thickness_mm,
+                    "material": layer.material,
+                    "epsilon_r": layer.epsilon_r if layer.is_dielectric else None,
+                    "copper_oz": layer.copper_weight_oz if layer.is_copper else None,
+                }
+                for layer in self.layers
+            ],
+        }
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return (
+            f"Stackup(layers={self.num_copper_layers}L, "
+            f"thickness={self.board_thickness_mm}mm)"
+        )

--- a/tests/test_physics_stackup.py
+++ b/tests/test_physics_stackup.py
@@ -1,0 +1,333 @@
+"""Tests for physics stackup module."""
+
+import pytest
+
+from kicad_tools.physics import (
+    COPPER_1OZ,
+    COPPER_2OZ,
+    COPPER_CONDUCTIVITY,
+    COPPER_HALF_OZ,
+    FR4_HIGH_TG,
+    FR4_STANDARD,
+    ROGERS_4350B,
+    # Constants
+    SPEED_OF_LIGHT,
+    CopperWeight,
+    # Materials
+    LayerType,
+    Stackup,
+    StackupLayer,
+    copper_thickness_from_oz,
+    get_material,
+    get_material_or_default,
+)
+
+
+class TestPhysicalConstants:
+    """Tests for physical constants."""
+
+    def test_speed_of_light(self):
+        """Test speed of light constant."""
+        assert SPEED_OF_LIGHT == 299792458  # m/s
+
+    def test_copper_conductivity(self):
+        """Test copper conductivity constant."""
+        assert COPPER_CONDUCTIVITY == 5.8e7  # S/m
+
+
+class TestCopperWeight:
+    """Tests for copper weight calculations."""
+
+    def test_half_oz_copper(self):
+        """Test 0.5oz copper thickness."""
+        assert COPPER_HALF_OZ.oz == 0.5
+        assert COPPER_HALF_OZ.thickness_um == pytest.approx(17.5, rel=0.01)
+        assert COPPER_HALF_OZ.thickness_mm == pytest.approx(0.0175, rel=0.01)
+
+    def test_1oz_copper(self):
+        """Test 1oz copper thickness."""
+        assert COPPER_1OZ.oz == 1.0
+        assert COPPER_1OZ.thickness_um == pytest.approx(35, rel=0.01)
+        assert COPPER_1OZ.thickness_mm == pytest.approx(0.035, rel=0.01)
+
+    def test_2oz_copper(self):
+        """Test 2oz copper thickness."""
+        assert COPPER_2OZ.oz == 2.0
+        assert COPPER_2OZ.thickness_um == pytest.approx(70, rel=0.01)
+        assert COPPER_2OZ.thickness_mm == pytest.approx(0.070, rel=0.01)
+
+    def test_copper_thickness_from_oz(self):
+        """Test copper thickness conversion function."""
+        assert copper_thickness_from_oz(1.0) == pytest.approx(0.035, rel=0.01)
+        assert copper_thickness_from_oz(0.5) == pytest.approx(0.0175, rel=0.01)
+        assert copper_thickness_from_oz(2.0) == pytest.approx(0.070, rel=0.01)
+
+    def test_custom_copper_weight(self):
+        """Test creating custom copper weight."""
+        custom = CopperWeight.from_oz(1.5)
+        assert custom.oz == 1.5
+        assert custom.thickness_um == pytest.approx(52.5, rel=0.01)
+
+
+class TestDielectricMaterials:
+    """Tests for dielectric material properties."""
+
+    def test_fr4_standard(self):
+        """Test standard FR4 properties."""
+        assert FR4_STANDARD.name == "FR4"
+        assert FR4_STANDARD.epsilon_r == pytest.approx(4.5, rel=0.1)
+        assert FR4_STANDARD.loss_tangent == pytest.approx(0.02, rel=0.1)
+
+    def test_fr4_high_tg(self):
+        """Test high-Tg FR4 properties."""
+        assert FR4_HIGH_TG.epsilon_r == pytest.approx(4.4, rel=0.1)
+        assert FR4_HIGH_TG.loss_tangent < FR4_STANDARD.loss_tangent
+
+    def test_rogers_4350b(self):
+        """Test Rogers RO4350B properties."""
+        assert ROGERS_4350B.epsilon_r == pytest.approx(3.48, rel=0.05)
+        assert ROGERS_4350B.loss_tangent == pytest.approx(0.0037, rel=0.1)
+        # Rogers should have lower loss than FR4
+        assert ROGERS_4350B.loss_tangent < FR4_STANDARD.loss_tangent
+
+    def test_get_material_case_insensitive(self):
+        """Test material lookup is case-insensitive."""
+        assert get_material("fr4") == FR4_STANDARD
+        assert get_material("FR4") == FR4_STANDARD
+        assert get_material("Fr4") == FR4_STANDARD
+
+    def test_get_material_not_found(self):
+        """Test material lookup returns None for unknown materials."""
+        assert get_material("unknown_material") is None
+
+    def test_get_material_or_default(self):
+        """Test material lookup with default."""
+        result = get_material_or_default("unknown")
+        assert result == FR4_STANDARD
+
+        result = get_material_or_default(None)
+        assert result == FR4_STANDARD
+
+
+class TestStackupLayer:
+    """Tests for StackupLayer dataclass."""
+
+    def test_copper_layer(self):
+        """Test creating a copper layer."""
+        layer = StackupLayer(
+            name="F.Cu",
+            layer_type=LayerType.COPPER,
+            thickness_mm=0.035,
+            material="copper",
+            copper_weight_oz=1.0,
+        )
+        assert layer.is_copper is True
+        assert layer.is_dielectric is False
+        assert layer.is_signal_layer is True
+
+    def test_dielectric_layer(self):
+        """Test creating a dielectric layer."""
+        layer = StackupLayer(
+            name="prepreg 1",
+            layer_type=LayerType.DIELECTRIC,
+            thickness_mm=0.2,
+            material="FR4",
+            epsilon_r=4.5,
+            loss_tangent=0.02,
+        )
+        assert layer.is_copper is False
+        assert layer.is_dielectric is True
+        assert layer.is_signal_layer is False
+
+    def test_inner_layer_is_signal(self):
+        """Test that inner copper layers are identified as signal layers."""
+        layer = StackupLayer(
+            name="In1.Cu",
+            layer_type=LayerType.COPPER,
+            thickness_mm=0.0175,
+        )
+        assert layer.is_signal_layer is True
+
+
+class TestStackupPresets:
+    """Tests for manufacturer stackup presets."""
+
+    def test_default_2layer(self):
+        """Test default 2-layer stackup."""
+        stackup = Stackup.default_2layer()
+
+        assert stackup.num_copper_layers == 2
+        assert stackup.board_thickness_mm == pytest.approx(1.6, rel=0.1)
+        assert len(stackup.layers) == 3  # F.Cu, core, B.Cu
+
+        # Check layer order
+        assert stackup.layers[0].name == "F.Cu"
+        assert stackup.layers[1].name == "core"
+        assert stackup.layers[2].name == "B.Cu"
+
+        # Check copper thickness
+        assert stackup.get_copper_thickness("F.Cu") == pytest.approx(0.035, rel=0.1)
+        assert stackup.get_copper_thickness("B.Cu") == pytest.approx(0.035, rel=0.1)
+
+    def test_default_2layer_custom_thickness(self):
+        """Test 2-layer stackup with custom thickness."""
+        stackup = Stackup.default_2layer(thickness_mm=1.0)
+        assert stackup.board_thickness_mm == pytest.approx(1.0, rel=0.1)
+
+    def test_jlcpcb_4layer(self):
+        """Test JLCPCB 4-layer stackup."""
+        stackup = Stackup.jlcpcb_4layer()
+
+        assert stackup.num_copper_layers == 4
+        assert stackup.board_thickness_mm == pytest.approx(1.6, rel=0.1)
+        assert len(stackup.layers) == 7  # 4 copper + 3 dielectric
+
+        # Check copper layer names
+        copper_names = [l.name for l in stackup.copper_layers]
+        assert copper_names == ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+
+        # Check outer layer copper weight (1oz)
+        f_cu = stackup.get_layer("F.Cu")
+        assert f_cu is not None
+        assert f_cu.copper_weight_oz == 1.0
+
+        # Check inner layer copper weight (0.5oz)
+        in1_cu = stackup.get_layer("In1.Cu")
+        assert in1_cu is not None
+        assert in1_cu.copper_weight_oz == 0.5
+
+        # Check dielectric constants
+        prepreg1 = stackup.get_layer("prepreg 1")
+        assert prepreg1 is not None
+        assert prepreg1.epsilon_r == pytest.approx(4.05, rel=0.1)
+
+    def test_oshpark_4layer(self):
+        """Test OSH Park 4-layer stackup."""
+        stackup = Stackup.oshpark_4layer()
+
+        assert stackup.num_copper_layers == 4
+        assert stackup.board_thickness_mm == pytest.approx(1.6, rel=0.1)
+        assert stackup.copper_finish == "ENIG"
+
+        # OSH Park uses FR408 which has lower loss
+        prepreg1 = stackup.get_layer("prepreg 1")
+        assert prepreg1 is not None
+        assert prepreg1.loss_tangent < FR4_STANDARD.loss_tangent
+
+    def test_default_6layer(self):
+        """Test default 6-layer stackup."""
+        stackup = Stackup.default_6layer()
+
+        assert stackup.num_copper_layers == 6
+        assert stackup.board_thickness_mm == pytest.approx(1.6, rel=0.1)
+
+        # Check all copper layers exist
+        copper_names = [l.name for l in stackup.copper_layers]
+        assert "F.Cu" in copper_names
+        assert "In1.Cu" in copper_names
+        assert "In2.Cu" in copper_names
+        assert "In3.Cu" in copper_names
+        assert "In4.Cu" in copper_names
+        assert "B.Cu" in copper_names
+
+
+class TestStackupQueries:
+    """Tests for stackup query methods."""
+
+    def test_is_outer_layer(self):
+        """Test identifying outer layers."""
+        stackup = Stackup.jlcpcb_4layer()
+
+        assert stackup.is_outer_layer("F.Cu") is True
+        assert stackup.is_outer_layer("B.Cu") is True
+        assert stackup.is_outer_layer("In1.Cu") is False
+        assert stackup.is_outer_layer("In2.Cu") is False
+
+    def test_get_dielectric_height_outer(self):
+        """Test getting dielectric height for outer layer (microstrip)."""
+        stackup = Stackup.jlcpcb_4layer()
+
+        # F.Cu should have prepreg thickness to In1.Cu
+        h = stackup.get_dielectric_height("F.Cu")
+        assert h == pytest.approx(0.2104, rel=0.1)
+
+    def test_get_dielectric_height_inner(self):
+        """Test getting dielectric height for inner layer (stripline)."""
+        stackup = Stackup.jlcpcb_4layer()
+
+        # In1.Cu should return smaller of prepreg (0.21) or core (1.065)
+        h = stackup.get_dielectric_height("In1.Cu")
+        assert h == pytest.approx(0.2104, rel=0.1)  # prepreg is smaller
+
+    def test_get_dielectric_constant_outer(self):
+        """Test getting dielectric constant for outer layer."""
+        stackup = Stackup.jlcpcb_4layer()
+
+        er = stackup.get_dielectric_constant("F.Cu")
+        assert er == pytest.approx(4.05, rel=0.1)  # prepreg er
+
+    def test_get_dielectric_constant_inner(self):
+        """Test getting dielectric constant for inner layer."""
+        stackup = Stackup.jlcpcb_4layer()
+
+        # In1.Cu is between prepreg (er=4.05) and core (er=4.6)
+        er = stackup.get_dielectric_constant("In1.Cu")
+        # Should be average
+        expected = (4.05 + 4.6) / 2
+        assert er == pytest.approx(expected, rel=0.1)
+
+    def test_get_copper_thickness(self):
+        """Test getting copper thickness."""
+        stackup = Stackup.jlcpcb_4layer()
+
+        # Outer layers are 1oz
+        assert stackup.get_copper_thickness("F.Cu") == pytest.approx(0.035, rel=0.1)
+
+        # Inner layers are 0.5oz
+        assert stackup.get_copper_thickness("In1.Cu") == pytest.approx(0.0175, rel=0.1)
+
+    def test_get_reference_plane_distance(self):
+        """Test getting reference plane distance (alias for dielectric height)."""
+        stackup = Stackup.jlcpcb_4layer()
+
+        h = stackup.get_reference_plane_distance("F.Cu")
+        assert h == stackup.get_dielectric_height("F.Cu")
+
+    def test_get_loss_tangent(self):
+        """Test getting loss tangent."""
+        stackup = Stackup.jlcpcb_4layer()
+
+        tan_d = stackup.get_loss_tangent("F.Cu")
+        assert tan_d == pytest.approx(0.02, rel=0.1)
+
+    def test_summary(self):
+        """Test stackup summary."""
+        stackup = Stackup.jlcpcb_4layer()
+
+        summary = stackup.summary()
+        assert summary["num_copper_layers"] == 4
+        assert summary["board_thickness_mm"] == pytest.approx(1.6, rel=0.1)
+        assert len(summary["layers"]) == 7
+
+
+class TestStackupFromPCB:
+    """Tests for parsing stackup from PCB files."""
+
+    def test_from_pcb_no_stackup(self):
+        """Test that PCB without explicit stackup gets default."""
+        from kicad_tools.schema.pcb import PCB
+
+        # Load a simple 2-layer board without stackup
+        pcb = PCB.load("tests/fixtures/routing-diagnostic.kicad_pcb")
+        stackup = Stackup.from_pcb(pcb)
+
+        # Should get a 2-layer default
+        assert stackup.num_copper_layers == 2
+        assert stackup.board_thickness_mm == pytest.approx(1.6, rel=0.1)
+
+    def test_repr(self):
+        """Test string representation."""
+        stackup = Stackup.jlcpcb_4layer()
+        repr_str = repr(stackup)
+        assert "4L" in repr_str
+        assert "1.6mm" in repr_str


### PR DESCRIPTION
## Summary

- Introduces a new `physics` module for signal integrity calculations
- Implements stackup parsing from KiCad PCB files via `Stackup.from_pcb()`
- Provides manufacturer stackup presets (JLCPCB 4-layer, OSH Park 4-layer, generic 2/6-layer)
- Includes physical constants, copper weight specs, and dielectric material database

## Changes

### New Files
- `src/kicad_tools/physics/__init__.py` - Module exports
- `src/kicad_tools/physics/constants.py` - Physical constants, CopperWeight, DielectricMaterial
- `src/kicad_tools/physics/stackup.py` - Stackup class with parsing and presets
- `tests/test_physics_stackup.py` - 32 comprehensive test cases

### Key Features
- **Stackup.from_pcb()**: Parse stackup from KiCad PCB files
- **Manufacturer presets**: `jlcpcb_4layer()`, `oshpark_4layer()`, `default_2layer()`, `default_6layer()`
- **Query methods**: `get_dielectric_height()`, `get_dielectric_constant()`, `get_copper_thickness()`, `is_outer_layer()`
- **Material database**: FR4, FR4 High-Tg, Rogers 4350B/4003C, Isola 370HR

## Test plan

- [x] All 32 unit tests pass
- [x] Linting passes (ruff check)
- [ ] Review stackup parsing from real KiCad files
- [ ] Verify manufacturer preset values against datasheets

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)