### PR TITLE
Add Rich terminal rendering for error output

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -55,7 +55,7 @@ from .commands import (
     run_zones_command,
 )
 from .parser import create_parser
-from .utils import format_error
+from .utils import format_error, print_error
 
 __all__ = [
     "main",
@@ -65,6 +65,7 @@ __all__ = [
     "drc_main",
     "bom_main",
     "format_error",
+    "print_error",
 ]
 
 
@@ -95,10 +96,10 @@ def main(argv: list[str] | None = None) -> int:
         print("\nInterrupted", file=sys.stderr)
         return 130
     except KiCadToolsError as e:
-        print(format_error(e, verbose), file=sys.stderr)
+        print_error(e, verbose)
         return 1
     except Exception as e:
-        print(format_error(e, verbose), file=sys.stderr)
+        print_error(e, verbose)
         return 1
 
 

--- a/src/kicad_tools/cli/utils.py
+++ b/src/kicad_tools/cli/utils.py
@@ -1,15 +1,77 @@
 """Shared utilities for CLI commands."""
 
+from __future__ import annotations
+
+import sys
 import traceback
+from typing import TYPE_CHECKING
 
 from kicad_tools.exceptions import KiCadToolsError
 
-__all__ = ["format_error"]
+if TYPE_CHECKING:
+    from rich.console import Console
+
+__all__ = ["format_error", "print_error", "get_error_console"]
+
+# Module-level console for error output, created lazily
+_error_console: Console | None = None
+
+
+def get_error_console() -> Console:
+    """Get or create the Rich console for error output.
+
+    Returns a console configured for stderr with appropriate settings.
+    The console is created lazily and cached for reuse.
+    """
+    global _error_console
+    if _error_console is None:
+        from rich.console import Console
+
+        _error_console = Console(stderr=True, force_terminal=None)
+    return _error_console
+
+
+def print_error(
+    e: Exception,
+    verbose: bool = False,
+    use_rich: bool | None = None,
+) -> None:
+    """
+    Print an exception with Rich formatting when available.
+
+    Uses Rich console for beautiful error output on TTY terminals,
+    falls back to plain text for non-TTY (pipes, JSON mode, etc.).
+
+    Args:
+        e: The exception to print
+        verbose: If True, include full stack trace
+        use_rich: Override automatic TTY detection (None = auto-detect)
+    """
+    console = get_error_console()
+
+    # Determine whether to use Rich formatting
+    if use_rich is None:
+        use_rich = console.is_terminal
+
+    if verbose:
+        # Always use plain text for stack traces
+        print(traceback.format_exc(), file=sys.stderr)
+        return
+
+    if use_rich and isinstance(e, KiCadToolsError):
+        # Use Rich rendering via __rich_console__
+        console.print(e)
+    else:
+        # Plain text fallback
+        print(format_error(e, verbose=False), file=sys.stderr)
 
 
 def format_error(e: Exception, verbose: bool = False) -> str:
     """
-    Format an exception for user-friendly display.
+    Format an exception for user-friendly display (plain text).
+
+    This is the plain-text fallback for non-TTY environments.
+    For Rich formatted output, use print_error() instead.
 
     Args:
         e: The exception to format


### PR DESCRIPTION
## Summary

Add Rich library integration for beautiful, syntax-highlighted error output in the terminal. This improves the debugging experience by making errors more scannable with colors, panels, and proper formatting.

## Changes

- Add `__rich_console__` method to `KiCadToolsError` for Rich rendering
- Add specialized rendering for `ValidationError` with numbered error list  
- Create `print_error()` utility that auto-detects TTY for Rich vs plain text
- Update CLI main entry point to use Rich console for errors
- Add comprehensive tests for Rich rendering functionality

## Features

- Bold red error headers with error codes (e.g., `[PARSE] ...`)
- Context information displayed in styled panels
- Source snippets with syntax highlighting for S-expressions (when available)
- Yellow-highlighted suggestions as bullet points
- Graceful fallback to plain text for non-TTY environments (pipes, JSON mode)

## Test Plan

- [x] Existing exception tests pass
- [x] New Rich rendering tests pass
- [x] CLI tests pass
- [x] Ruff linting passes on modified files
- [x] Verified Rich fallback behavior for non-TTY

Closes #332