### PR TITLE
Add constraint conflict detection

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -37,6 +37,7 @@ from kicad_tools.exceptions import KiCadToolsError
 from .commands import (
     run_check_command,
     run_config_command,
+    run_constraints_command,
     run_datasheet_command,
     run_fix_footprints_command,
     run_footprint_command,
@@ -260,6 +261,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "validate":
         return run_validate_command(args)
+
+    elif args.command == "constraints":
+        return run_constraints_command(args)
 
     return 0
 

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -5,7 +5,7 @@ This package contains command handler modules organized by domain:
 - pcb: pcb subcommand handlers
 - library: lib subcommand handlers
 - routing: route, zones, optimize-traces handlers
-- validation: validate, check handlers
+- validation: validate, check, constraints handlers
 - footprint: footprint generation handlers
 - parts: LCSC parts lookup handlers
 - datasheet: datasheet command handlers
@@ -27,6 +27,7 @@ from .routing import run_optimize_command, run_route_command, run_zones_command
 from .schematic import run_sch_command
 from .validation import (
     run_check_command,
+    run_constraints_command,
     run_fix_footprints_command,
     run_validate_command,
     run_validate_footprints_command,
@@ -48,6 +49,7 @@ __all__ = [
     "run_validate_command",
     "run_validate_footprints_command",
     "run_fix_footprints_command",
+    "run_constraints_command",
     # Footprint
     "run_footprint_command",
     # Parts

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -1,4 +1,4 @@
-"""Validation command handlers (check, validate, validate-footprints, fix-footprints)."""
+"""Validation command handlers (check, validate, validate-footprints, fix-footprints, constraints)."""
 
 __all__ = [
     "run_check_command",
@@ -6,6 +6,7 @@ __all__ = [
     "run_validate_connectivity_command",
     "run_validate_footprints_command",
     "run_fix_footprints_command",
+    "run_constraints_command",
 ]
 
 
@@ -137,3 +138,31 @@ def run_validate_connectivity_command(args) -> int:
         sub_argv.append("--verbose")
 
     return validate_connectivity_main(sub_argv)
+
+
+def run_constraints_command(args) -> int:
+    """Handle constraints command with its subcommands."""
+    if not getattr(args, "constraints_command", None):
+        print("Usage: kicad-tools constraints <command> [options]")
+        print("\nCommands:")
+        print("  check    Detect conflicts between constraints")
+        print("\nUse 'kicad-tools constraints <command> --help' for more info.")
+        return 1
+
+    if args.constraints_command == "check":
+        from ..constraints_cmd import main as constraints_main
+
+        sub_argv = [args.pcb]
+        if args.format != "table":
+            sub_argv.extend(["--format", args.format])
+        if args.keepout:
+            sub_argv.extend(["--keepout", args.keepout])
+        if getattr(args, "constraints_file", None):
+            sub_argv.extend(["--constraints", args.constraints_file])
+        if getattr(args, "auto_keepout", False):
+            sub_argv.append("--auto-keepout")
+        if args.verbose:
+            sub_argv.append("--verbose")
+        return constraints_main(sub_argv)
+
+    return 0

--- a/src/kicad_tools/cli/constraints_cmd.py
+++ b/src/kicad_tools/cli/constraints_cmd.py
@@ -1,0 +1,294 @@
+"""
+CLI command for constraint conflict detection.
+
+Usage:
+    kct constraints check board.kicad_pcb              # Check all constraints
+    kct constraints check board.kicad_pcb --format json   # JSON output
+    kct constraints check board.kicad_pcb --keepout config.yaml  # With keepout config
+
+Exit Codes:
+    0 - No conflicts found
+    1 - Conflicts found or command failure
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from kicad_tools.constraints import (
+    ConstraintConflict,
+    ConstraintConflictDetector,
+)
+from kicad_tools.constraints.locks import RegionConstraint
+from kicad_tools.optim.constraints import GroupingConstraint
+from kicad_tools.optim.keepout import (
+    KeepoutZone,
+    detect_keepout_zones,
+    load_keepout_zones_from_yaml,
+)
+from kicad_tools.schema.pcb import PCB
+
+if TYPE_CHECKING:
+    pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for kct constraints command."""
+    parser = argparse.ArgumentParser(
+        prog="kct constraints check",
+        description="Detect conflicts between placement/routing constraints",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "pcb",
+        help="Path to .kicad_pcb file to check",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "summary"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.add_argument(
+        "--keepout",
+        metavar="FILE",
+        help="YAML file defining keepout zones",
+    )
+    parser.add_argument(
+        "--constraints",
+        metavar="FILE",
+        help="YAML file with grouping constraints",
+    )
+    parser.add_argument(
+        "--auto-keepout",
+        action="store_true",
+        help="Auto-detect keepout zones from mounting holes and connectors",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show detailed conflict information",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Load PCB
+    pcb_path = Path(args.pcb)
+    if not pcb_path.exists():
+        print(f"Error: PCB file not found: {pcb_path}", file=sys.stderr)
+        return 1
+
+    if pcb_path.suffix != ".kicad_pcb":
+        print(f"Error: Expected .kicad_pcb file, got: {pcb_path.suffix}", file=sys.stderr)
+        return 1
+
+    try:
+        pcb = PCB.load(str(pcb_path))
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    # Collect constraints
+    keepout_zones: list[KeepoutZone] = []
+    grouping_constraints: list[GroupingConstraint] = []
+    region_constraints: list[RegionConstraint] = []
+
+    # Load keepout zones
+    if args.keepout:
+        keepout_path = Path(args.keepout)
+        if not keepout_path.exists():
+            print(f"Error: Keepout file not found: {keepout_path}", file=sys.stderr)
+            return 1
+        try:
+            keepout_zones.extend(load_keepout_zones_from_yaml(str(keepout_path)))
+        except Exception as e:
+            print(f"Error loading keepout zones: {e}", file=sys.stderr)
+            return 1
+
+    # Auto-detect keepout zones
+    if args.auto_keepout:
+        detected = detect_keepout_zones(pcb)
+        keepout_zones.extend(detected)
+
+    # Load grouping constraints
+    if args.constraints:
+        constraints_path = Path(args.constraints)
+        if not constraints_path.exists():
+            print(f"Error: Constraints file not found: {constraints_path}", file=sys.stderr)
+            return 1
+        try:
+            grouping_constraints.extend(_load_grouping_constraints(constraints_path))
+        except Exception as e:
+            print(f"Error loading constraints: {e}", file=sys.stderr)
+            return 1
+
+    # Detect conflicts
+    detector = ConstraintConflictDetector()
+    conflicts = detector.detect(
+        keepout_zones=keepout_zones,
+        grouping_constraints=grouping_constraints,
+        region_constraints=region_constraints,
+        pcb=pcb,
+    )
+
+    # Output results
+    if args.format == "json":
+        output_json(conflicts, pcb_path)
+    elif args.format == "summary":
+        output_summary(conflicts, pcb_path)
+    else:
+        output_table(conflicts, pcb_path, args.verbose)
+
+    return 1 if conflicts else 0
+
+
+def _load_grouping_constraints(path: Path) -> list[GroupingConstraint]:
+    """Load grouping constraints from YAML file."""
+    import yaml
+
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    constraints = []
+    for group_data in data.get("groups", []):
+        from kicad_tools.optim.constraints import SpatialConstraint
+
+        spatial_constraints = []
+        for c in group_data.get("constraints", []):
+            ctype = c.get("type")
+            if ctype == "max_distance":
+                spatial_constraints.append(
+                    SpatialConstraint.max_distance(
+                        anchor=c.get("anchor", ""),
+                        radius_mm=c.get("radius_mm", 10.0),
+                    )
+                )
+            elif ctype == "alignment":
+                spatial_constraints.append(
+                    SpatialConstraint.alignment(
+                        axis=c.get("axis", "horizontal"),
+                        tolerance_mm=c.get("tolerance_mm", 0.5),
+                    )
+                )
+
+        constraints.append(
+            GroupingConstraint(
+                name=group_data.get("name", ""),
+                members=group_data.get("members", []),
+                constraints=spatial_constraints,
+            )
+        )
+
+    return constraints
+
+
+def output_table(
+    conflicts: list[ConstraintConflict],
+    pcb_path: Path,
+    verbose: bool = False,
+) -> None:
+    """Output conflicts as a formatted table."""
+    print(f"\n{'=' * 60}")
+    print("CONSTRAINT CONFLICT CHECK")
+    print(f"{'=' * 60}")
+    print(f"File: {pcb_path.name}")
+    print(f"Conflicts: {len(conflicts)}")
+
+    if not conflicts:
+        print(f"\n{'=' * 60}")
+        print("NO CONFLICTS FOUND")
+        return
+
+    # Group by conflict type
+    by_type: dict[str, list[ConstraintConflict]] = {}
+    for c in conflicts:
+        key = c.conflict_type.value
+        if key not in by_type:
+            by_type[key] = []
+        by_type[key].append(c)
+
+    print(f"\n{'-' * 60}")
+    print("BY TYPE:")
+    for ctype, clist in sorted(by_type.items()):
+        print(f"  {ctype}: {len(clist)}")
+
+    print(f"\n{'-' * 60}")
+    print("CONFLICTS:")
+
+    for i, conflict in enumerate(conflicts, 1):
+        _print_conflict(i, conflict, verbose)
+
+    print(f"\n{'=' * 60}")
+    print(f"FOUND {len(conflicts)} CONFLICT(S) - Review and resolve")
+
+
+def _print_conflict(index: int, conflict: ConstraintConflict, verbose: bool) -> None:
+    """Print a single conflict."""
+    symbol = "!" if conflict.conflict_type.value == "overlap" else "X"
+    print(f"\n  [{symbol}] Conflict #{index}: {conflict.conflict_type.value.upper()}")
+    print(f"      {conflict.constraint1_type}:{conflict.constraint1_name} vs "
+          f"{conflict.constraint2_type}:{conflict.constraint2_name}")
+    print(f"      {conflict.description}")
+
+    if conflict.location:
+        print(f"      Location: ({conflict.location[0]:.2f}, {conflict.location[1]:.2f}) mm")
+
+    if conflict.priority_winner:
+        print(f"      Priority winner: {conflict.priority_winner}")
+
+    if verbose and conflict.resolutions:
+        print("      Possible resolutions:")
+        for res in conflict.resolutions:
+            priority_str = "+" * max(0, res.priority) if res.priority > 0 else ""
+            print(f"        {priority_str} {res.action}: {res.description}")
+            print(f"          Trade-off: {res.trade_off}")
+
+
+def output_json(
+    conflicts: list[ConstraintConflict],
+    pcb_path: Path,
+) -> None:
+    """Output conflicts as JSON."""
+    data = {
+        "file": str(pcb_path),
+        "summary": {
+            "conflicts": len(conflicts),
+            "passed": len(conflicts) == 0,
+        },
+        "conflicts": [c.to_dict() for c in conflicts],
+    }
+    print(json.dumps(data, indent=2))
+
+
+def output_summary(
+    conflicts: list[ConstraintConflict],
+    pcb_path: Path,
+) -> None:
+    """Output conflict summary."""
+    if not conflicts:
+        print(f"PASSED: {pcb_path.name} - No constraint conflicts")
+        return
+
+    print(f"Constraint Conflicts: {pcb_path.name}")
+    print("=" * 50)
+
+    # Group by type
+    by_type: dict[str, int] = {}
+    for c in conflicts:
+        key = c.conflict_type.value
+        by_type[key] = by_type.get(key, 0) + 1
+
+    print(f"{'Type':<20} {'Count':<10}")
+    print("-" * 30)
+    for ctype, count in sorted(by_type.items()):
+        print(f"{ctype:<20} {count:<10}")
+    print("-" * 30)
+    print(f"{'TOTAL':<20} {len(conflicts):<10}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -132,6 +132,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_config_parser(subparsers)
     _add_interactive_parser(subparsers)
     _add_validate_parser(subparsers)
+    _add_constraints_parser(subparsers)
 
     return parser
 
@@ -1247,4 +1248,49 @@ def _add_validate_parser(subparsers) -> None:
         dest="validate_verbose",
         action="store_true",
         help="Show detailed issue information",
+    )
+
+
+def _add_constraints_parser(subparsers) -> None:
+    """Add constraints subcommand parser with its subcommands."""
+    constraints_parser = subparsers.add_parser(
+        "constraints", help="Constraint conflict detection and management"
+    )
+    constraints_subparsers = constraints_parser.add_subparsers(
+        dest="constraints_command", help="Constraints commands"
+    )
+
+    # constraints check
+    constraints_check = constraints_subparsers.add_parser(
+        "check", help="Detect conflicts between constraints"
+    )
+    constraints_check.add_argument("pcb", help="Path to .kicad_pcb file")
+    constraints_check.add_argument(
+        "--format",
+        choices=["table", "json", "summary"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    constraints_check.add_argument(
+        "--keepout",
+        metavar="FILE",
+        help="YAML file defining keepout zones",
+    )
+    constraints_check.add_argument(
+        "--constraints",
+        metavar="FILE",
+        dest="constraints_file",
+        help="YAML file with grouping constraints",
+    )
+    constraints_check.add_argument(
+        "--auto-keepout",
+        action="store_true",
+        dest="auto_keepout",
+        help="Auto-detect keepout zones from mounting holes and connectors",
+    )
+    constraints_check.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show detailed conflict information",
     )

--- a/src/kicad_tools/constraints/__init__.py
+++ b/src/kicad_tools/constraints/__init__.py
@@ -41,6 +41,12 @@ Classes:
     ConstraintManifest: Container for all constraints with serialization
 """
 
+from .conflict import (
+    ConflictResolution,
+    ConflictType,
+    ConstraintConflict,
+    ConstraintConflictDetector,
+)
 from .locks import (
     ComponentLock,
     LockType,
@@ -61,6 +67,11 @@ __all__ = [
     "NetRouteLock",
     "RegionConstraint",
     "RelativeConstraint",
+    # Conflict detection
+    "ConflictType",
+    "ConflictResolution",
+    "ConstraintConflict",
+    "ConstraintConflictDetector",
     # Serialization
     "ConstraintManifest",
 ]

--- a/src/kicad_tools/constraints/conflict.py
+++ b/src/kicad_tools/constraints/conflict.py
@@ -1,0 +1,637 @@
+"""
+Constraint conflict detection for PCB design.
+
+Detects conflicts between placement/routing constraints like "keepout overlaps
+required via" and provides resolution guidance. Enables agents to understand
+and resolve constraint conflicts during optimization.
+
+Example usage::
+
+    from kicad_tools.constraints.conflict import (
+        ConstraintConflictDetector,
+        ConflictType,
+    )
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.optim.keepout import detect_keepout_zones
+
+    pcb = PCB.load("board.kicad_pcb")
+    detector = ConstraintConflictDetector()
+
+    # Load constraints
+    keepouts = detect_keepout_zones(pcb)
+    groupings = load_grouping_constraints("constraints.yaml")
+
+    # Detect conflicts
+    conflicts = detector.detect(
+        keepout_zones=keepouts,
+        grouping_constraints=groupings,
+        pcb=pcb,
+    )
+
+    for conflict in conflicts:
+        print(f"Conflict: {conflict.description}")
+        for resolution in conflict.resolutions:
+            print(f"  Option: {resolution.action} - {resolution.trade_off}")
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from itertools import combinations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.constraints.locks import RegionConstraint
+    from kicad_tools.optim.constraints import GroupingConstraint
+    from kicad_tools.optim.keepout import KeepoutZone
+    from kicad_tools.schema.pcb import PCB
+
+
+__all__ = [
+    "ConflictType",
+    "ConflictResolution",
+    "ConstraintConflict",
+    "ConstraintConflictDetector",
+]
+
+
+class ConflictType(Enum):
+    """Types of constraint conflicts."""
+
+    OVERLAP = "overlap"  # Two constraints have overlapping regions
+    CONTRADICTION = "contradiction"  # Constraints require mutually exclusive states
+    IMPOSSIBLE = "impossible"  # No valid solution exists
+
+
+@dataclass
+class ConflictResolution:
+    """
+    A possible resolution for a constraint conflict.
+
+    Provides guidance on how to resolve a conflict, including what action
+    to take and what trade-offs are involved.
+    """
+
+    action: str  # What to do (e.g., "shrink_keepout", "reroute_signal")
+    description: str  # Human-readable explanation
+    trade_off: str  # What you lose by choosing this resolution
+    priority: int = 0  # Higher = more preferred (0 = neutral)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "action": self.action,
+            "description": self.description,
+            "trade_off": self.trade_off,
+            "priority": self.priority,
+        }
+
+
+@dataclass
+class ConstraintConflict:
+    """
+    A conflict between two or more constraints.
+
+    Records the conflicting constraints, the type of conflict, and
+    possible resolutions with their trade-offs.
+    """
+
+    constraint1_type: str  # "keepout", "grouping", "region", "routing"
+    constraint1_name: str
+    constraint2_type: str
+    constraint2_name: str
+    conflict_type: ConflictType
+    description: str
+    location: tuple[float, float] | None = None  # Conflict location (x, y) in mm
+    priority_winner: str | None = None  # Which constraint should win, if determinable
+    resolutions: list[ConflictResolution] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "constraint1": {
+                "type": self.constraint1_type,
+                "name": self.constraint1_name,
+            },
+            "constraint2": {
+                "type": self.constraint2_type,
+                "name": self.constraint2_name,
+            },
+            "conflict_type": self.conflict_type.value,
+            "description": self.description,
+            "location": self.location,
+            "priority_winner": self.priority_winner,
+            "resolutions": [r.to_dict() for r in self.resolutions],
+        }
+
+
+class ConstraintConflictDetector:
+    """
+    Detects conflicts between constraints.
+
+    Analyzes different types of constraints (keepout zones, grouping rules,
+    region constraints, routing requirements) and identifies where they
+    conflict with each other.
+
+    Example::
+
+        detector = ConstraintConflictDetector()
+        conflicts = detector.detect(
+            keepout_zones=keepouts,
+            grouping_constraints=groups,
+            region_constraints=regions,
+            pcb=pcb,
+        )
+    """
+
+    def detect(
+        self,
+        keepout_zones: list[KeepoutZone] | None = None,
+        grouping_constraints: list[GroupingConstraint] | None = None,
+        region_constraints: list[RegionConstraint] | None = None,
+        pcb: PCB | None = None,
+    ) -> list[ConstraintConflict]:
+        """
+        Detect all constraint conflicts.
+
+        Args:
+            keepout_zones: List of keepout zones from optim.keepout
+            grouping_constraints: List of grouping constraints from optim.constraints
+            region_constraints: List of region constraints from constraints.locks
+            pcb: PCB object for context (component positions, board outline)
+
+        Returns:
+            List of detected ConstraintConflict objects
+        """
+        conflicts: list[ConstraintConflict] = []
+        keepout_zones = keepout_zones or []
+        grouping_constraints = grouping_constraints or []
+        region_constraints = region_constraints or []
+
+        # Check keepout vs keepout conflicts
+        for k1, k2 in combinations(keepout_zones, 2):
+            conflict = self._check_keepout_vs_keepout(k1, k2)
+            if conflict:
+                conflict.resolutions = self._find_keepout_keepout_resolutions(k1, k2)
+                conflicts.append(conflict)
+
+        # Check keepout vs grouping conflicts
+        for keepout in keepout_zones:
+            for grouping in grouping_constraints:
+                conflict = self._check_keepout_vs_grouping(keepout, grouping, pcb)
+                if conflict:
+                    conflict.resolutions = self._find_keepout_grouping_resolutions(
+                        keepout, grouping
+                    )
+                    conflicts.append(conflict)
+
+        # Check keepout vs region conflicts
+        for keepout in keepout_zones:
+            for region in region_constraints:
+                conflict = self._check_keepout_vs_region(keepout, region)
+                if conflict:
+                    conflict.resolutions = self._find_keepout_region_resolutions(
+                        keepout, region
+                    )
+                    conflicts.append(conflict)
+
+        # Check grouping vs region conflicts (edge placement)
+        for grouping in grouping_constraints:
+            for region in region_constraints:
+                conflict = self._check_grouping_vs_region(grouping, region, pcb)
+                if conflict:
+                    conflict.resolutions = self._find_grouping_region_resolutions(
+                        grouping, region
+                    )
+                    conflicts.append(conflict)
+
+        # Check grouping vs grouping conflicts
+        for g1, g2 in combinations(grouping_constraints, 2):
+            conflict = self._check_grouping_vs_grouping(g1, g2, pcb)
+            if conflict:
+                conflict.resolutions = self._find_grouping_grouping_resolutions(g1, g2)
+                conflicts.append(conflict)
+
+        return conflicts
+
+    def _check_keepout_vs_keepout(
+        self,
+        k1: KeepoutZone,
+        k2: KeepoutZone,
+    ) -> ConstraintConflict | None:
+        """Check if two keepout zones overlap."""
+        # Get polygons
+        poly1 = k1.get_expanded_polygon()
+        poly2 = k2.get_expanded_polygon()
+
+        # Check for overlap by testing if any vertex of one is inside the other
+        overlap_point = None
+        for v in poly1.vertices:
+            if poly2.contains_point(v):
+                overlap_point = (v.x, v.y)
+                break
+        if not overlap_point:
+            for v in poly2.vertices:
+                if poly1.contains_point(v):
+                    overlap_point = (v.x, v.y)
+                    break
+
+        if overlap_point:
+            return ConstraintConflict(
+                constraint1_type="keepout",
+                constraint1_name=k1.name,
+                constraint2_type="keepout",
+                constraint2_name=k2.name,
+                conflict_type=ConflictType.OVERLAP,
+                description=f"Keepout zones '{k1.name}' and '{k2.name}' overlap",
+                location=overlap_point,
+            )
+        return None
+
+    def _check_keepout_vs_grouping(
+        self,
+        keepout: KeepoutZone,
+        grouping: GroupingConstraint,
+        pcb: PCB | None,
+    ) -> ConstraintConflict | None:
+        """Check if a keepout zone conflicts with a grouping constraint."""
+        if pcb is None:
+            return None
+
+        # Get component positions for grouping members
+        member_positions: dict[str, tuple[float, float]] = {}
+        for fp in pcb.footprints:
+            if fp.reference in grouping.members:
+                member_positions[fp.reference] = fp.position
+
+        if not member_positions:
+            return None
+
+        # Check if the keepout overlaps with the bounding box of the group
+        # or if any member must be placed in the keepout
+        keepout_poly = keepout.get_expanded_polygon()
+
+        # Check for components that are currently in the keepout
+        components_in_keepout = []
+        for ref, (x, y) in member_positions.items():
+            from kicad_tools.optim.geometry import Vector2D
+
+            if keepout_poly.contains_point(Vector2D(x, y)):
+                components_in_keepout.append(ref)
+
+        if components_in_keepout:
+            # Check if there's a max_distance constraint that would require
+            # staying near the keepout
+            for constraint in grouping.constraints:
+                if constraint.constraint_type.value == "max_distance":
+                    anchor = constraint.parameters.get("anchor")
+                    if anchor in member_positions:
+                        anchor_x, anchor_y = member_positions[anchor]
+                        from kicad_tools.optim.geometry import Vector2D
+
+                        if keepout_poly.contains_point(Vector2D(anchor_x, anchor_y)):
+                            return ConstraintConflict(
+                                constraint1_type="keepout",
+                                constraint1_name=keepout.name,
+                                constraint2_type="grouping",
+                                constraint2_name=grouping.name,
+                                conflict_type=ConflictType.CONTRADICTION,
+                                description=(
+                                    f"Group '{grouping.name}' anchor '{anchor}' is inside "
+                                    f"keepout '{keepout.name}', but group members must stay nearby"
+                                ),
+                                location=member_positions[anchor],
+                            )
+
+        return None
+
+    def _check_keepout_vs_region(
+        self,
+        keepout: KeepoutZone,
+        region: RegionConstraint,
+    ) -> ConstraintConflict | None:
+        """Check if a keepout zone conflicts with a region constraint."""
+        # Get region bounds
+        bounds = region.bounds
+        region_min_x = bounds.get("x_min", float("-inf"))
+        region_max_x = bounds.get("x_max", float("inf"))
+        region_min_y = bounds.get("y_min", float("-inf"))
+        region_max_y = bounds.get("y_max", float("inf"))
+
+        # Get keepout polygon
+        keepout_poly = keepout.get_expanded_polygon()
+        keepout_vertices = [(v.x, v.y) for v in keepout_poly.vertices]
+
+        if not keepout_vertices:
+            return None
+
+        # Check if keepout overlaps with region bounds
+        keepout_min_x = min(v[0] for v in keepout_vertices)
+        keepout_max_x = max(v[0] for v in keepout_vertices)
+        keepout_min_y = min(v[1] for v in keepout_vertices)
+        keepout_max_y = max(v[1] for v in keepout_vertices)
+
+        # Check for bounding box overlap
+        x_overlap = keepout_min_x <= region_max_x and keepout_max_x >= region_min_x
+        y_overlap = keepout_min_y <= region_max_y and keepout_max_y >= region_min_y
+
+        if x_overlap and y_overlap:
+            # Calculate overlap center
+            overlap_x = (max(keepout_min_x, region_min_x) + min(keepout_max_x, region_max_x)) / 2
+            overlap_y = (max(keepout_min_y, region_min_y) + min(keepout_max_y, region_max_y)) / 2
+
+            return ConstraintConflict(
+                constraint1_type="keepout",
+                constraint1_name=keepout.name,
+                constraint2_type="region",
+                constraint2_name=region.name,
+                conflict_type=ConflictType.OVERLAP,
+                description=(
+                    f"Keepout '{keepout.name}' overlaps with region '{region.name}' "
+                    f"({region.reason})"
+                ),
+                location=(overlap_x, overlap_y),
+            )
+
+        return None
+
+    def _check_grouping_vs_region(
+        self,
+        grouping: GroupingConstraint,
+        region: RegionConstraint,
+        pcb: PCB | None,
+    ) -> ConstraintConflict | None:
+        """Check if a grouping constraint conflicts with a region constraint."""
+        if pcb is None:
+            return None
+
+        # Get member positions
+        member_positions: dict[str, tuple[float, float]] = {}
+        for fp in pcb.footprints:
+            if fp.reference in grouping.members:
+                member_positions[fp.reference] = fp.position
+
+        if not member_positions:
+            return None
+
+        # Check for conflicts where:
+        # 1. A component is in the disallowed list but is inside the region
+        # 2. A component needs to be in a specific position (grouping) but region forbids it
+
+        for ref, (x, y) in member_positions.items():
+            in_region = region.contains_point(x, y)
+            is_disallowed = ref in region.disallowed_components
+
+            if in_region and is_disallowed:
+                return ConstraintConflict(
+                    constraint1_type="grouping",
+                    constraint1_name=grouping.name,
+                    constraint2_type="region",
+                    constraint2_name=region.name,
+                    conflict_type=ConflictType.CONTRADICTION,
+                    description=(
+                        f"Component '{ref}' in group '{grouping.name}' is inside "
+                        f"region '{region.name}' but is in the disallowed list"
+                    ),
+                    location=(x, y),
+                )
+
+        return None
+
+    def _check_grouping_vs_grouping(
+        self,
+        g1: GroupingConstraint,
+        g2: GroupingConstraint,
+        pcb: PCB | None,
+    ) -> ConstraintConflict | None:
+        """Check if two grouping constraints conflict."""
+        # Check for shared members with conflicting requirements
+        shared_members = set(g1.members) & set(g2.members)
+        if not shared_members:
+            return None
+
+        # Check for conflicting constraints on shared members
+        for member in shared_members:
+            # Check for conflicting max_distance constraints
+            g1_anchors = []
+            g2_anchors = []
+
+            for c in g1.constraints:
+                if c.constraint_type.value == "max_distance":
+                    g1_anchors.append(
+                        (c.parameters.get("anchor"), c.parameters.get("radius_mm", 0))
+                    )
+
+            for c in g2.constraints:
+                if c.constraint_type.value == "max_distance":
+                    g2_anchors.append(
+                        (c.parameters.get("anchor"), c.parameters.get("radius_mm", 0))
+                    )
+
+            # If both groups have different anchors and the anchors are far apart,
+            # the shared member can't satisfy both constraints
+            if g1_anchors and g2_anchors and pcb:
+                for anchor1, radius1 in g1_anchors:
+                    for anchor2, radius2 in g2_anchors:
+                        if anchor1 and anchor2 and anchor1 != anchor2:
+                            # Find positions of anchors
+                            pos1 = pos2 = None
+                            for fp in pcb.footprints:
+                                if fp.reference == anchor1:
+                                    pos1 = fp.position
+                                if fp.reference == anchor2:
+                                    pos2 = fp.position
+
+                            if pos1 and pos2:
+                                dist = math.sqrt(
+                                    (pos1[0] - pos2[0]) ** 2 + (pos1[1] - pos2[1]) ** 2
+                                )
+                                if dist > radius1 + radius2:
+                                    return ConstraintConflict(
+                                        constraint1_type="grouping",
+                                        constraint1_name=g1.name,
+                                        constraint2_type="grouping",
+                                        constraint2_name=g2.name,
+                                        conflict_type=ConflictType.IMPOSSIBLE,
+                                        description=(
+                                            f"Component '{member}' cannot satisfy both groups: "
+                                            f"must be within {radius1}mm of '{anchor1}' ({g1.name}) "
+                                            f"and within {radius2}mm of '{anchor2}' ({g2.name}), "
+                                            f"but anchors are {dist:.1f}mm apart"
+                                        ),
+                                        location=pos1,
+                                    )
+
+        return None
+
+    def _find_keepout_keepout_resolutions(
+        self,
+        k1: KeepoutZone,
+        k2: KeepoutZone,
+    ) -> list[ConflictResolution]:
+        """Find resolutions for keepout vs keepout conflict."""
+        resolutions = []
+
+        # Option 1: Shrink one keepout
+        resolutions.append(
+            ConflictResolution(
+                action="shrink_keepout",
+                description=f"Reduce the size of '{k1.name}' to eliminate overlap",
+                trade_off="Less protected area around the original keepout zone",
+                priority=1,
+            )
+        )
+
+        # Option 2: Shrink the other keepout
+        resolutions.append(
+            ConflictResolution(
+                action="shrink_keepout",
+                description=f"Reduce the size of '{k2.name}' to eliminate overlap",
+                trade_off="Less protected area around the original keepout zone",
+                priority=1,
+            )
+        )
+
+        # Option 3: Merge into single keepout
+        resolutions.append(
+            ConflictResolution(
+                action="merge_keepouts",
+                description="Combine both keepouts into a single larger zone",
+                trade_off="Increased restricted area, may limit placement options",
+                priority=0,
+            )
+        )
+
+        # Option 4: Remove one keepout
+        resolutions.append(
+            ConflictResolution(
+                action="remove_keepout",
+                description=f"Remove '{k2.name}' if it's less critical",
+                trade_off="Complete loss of protection from the removed zone",
+                priority=-1,
+            )
+        )
+
+        return resolutions
+
+    def _find_keepout_grouping_resolutions(
+        self,
+        keepout: KeepoutZone,
+        grouping: GroupingConstraint,
+    ) -> list[ConflictResolution]:
+        """Find resolutions for keepout vs grouping conflict."""
+        return [
+            ConflictResolution(
+                action="shrink_keepout",
+                description=f"Reduce '{keepout.name}' to allow group members",
+                trade_off="Less protection in the keepout area",
+                priority=1,
+            ),
+            ConflictResolution(
+                action="relax_grouping",
+                description=f"Increase max_distance for '{grouping.name}'",
+                trade_off="Group members may be placed further from anchor",
+                priority=0,
+            ),
+            ConflictResolution(
+                action="move_group",
+                description=f"Move entire group '{grouping.name}' away from keepout",
+                trade_off="Group may end up in less optimal location",
+                priority=0,
+            ),
+            ConflictResolution(
+                action="redesign_grouping",
+                description="Split group into multiple smaller groups",
+                trade_off="More complex constraint management",
+                priority=-1,
+            ),
+        ]
+
+    def _find_keepout_region_resolutions(
+        self,
+        keepout: KeepoutZone,
+        region: RegionConstraint,
+    ) -> list[ConflictResolution]:
+        """Find resolutions for keepout vs region conflict."""
+        return [
+            ConflictResolution(
+                action="shrink_keepout",
+                description=f"Reduce '{keepout.name}' to fit within region boundaries",
+                trade_off="Less protected area",
+                priority=1,
+            ),
+            ConflictResolution(
+                action="adjust_region",
+                description=f"Modify '{region.name}' bounds to avoid keepout",
+                trade_off="Region may not cover intended area",
+                priority=0,
+            ),
+            ConflictResolution(
+                action="allow_exception",
+                description=f"Add exception in '{region.name}' for keepout area",
+                trade_off="More complex region definition",
+                priority=0,
+            ),
+        ]
+
+    def _find_grouping_region_resolutions(
+        self,
+        grouping: GroupingConstraint,
+        region: RegionConstraint,
+    ) -> list[ConflictResolution]:
+        """Find resolutions for grouping vs region conflict."""
+        return [
+            ConflictResolution(
+                action="update_region_allowlist",
+                description=f"Add group members to '{region.name}' allowed list",
+                trade_off="Region constraint becomes less strict",
+                priority=1,
+            ),
+            ConflictResolution(
+                action="move_group_to_edge",
+                description=f"Relocate '{grouping.name}' to board edge/allowed area",
+                trade_off="May affect signal routing or thermal performance",
+                priority=0,
+            ),
+            ConflictResolution(
+                action="relax_grouping",
+                description="Remove conflicting component from group",
+                trade_off="Group may not achieve intended purpose",
+                priority=-1,
+            ),
+        ]
+
+    def _find_grouping_grouping_resolutions(
+        self,
+        g1: GroupingConstraint,
+        g2: GroupingConstraint,
+    ) -> list[ConflictResolution]:
+        """Find resolutions for grouping vs grouping conflict."""
+        return [
+            ConflictResolution(
+                action="increase_radii",
+                description="Increase max_distance for both groups",
+                trade_off="Groups become less tightly coupled",
+                priority=1,
+            ),
+            ConflictResolution(
+                action="move_anchor",
+                description=f"Move anchor of '{g1.name}' closer to '{g2.name}'",
+                trade_off="May affect component positioning strategy",
+                priority=0,
+            ),
+            ConflictResolution(
+                action="remove_from_group",
+                description="Remove shared component from one of the groups",
+                trade_off="One group loses intended member",
+                priority=-1,
+            ),
+            ConflictResolution(
+                action="merge_groups",
+                description="Combine both groups into a single larger group",
+                trade_off="More complex constraint, may be harder to satisfy",
+                priority=-1,
+            ),
+        ]

--- a/tests/test_constraint_conflict.py
+++ b/tests/test_constraint_conflict.py
@@ -1,0 +1,238 @@
+"""Tests for constraint conflict detection."""
+
+
+from kicad_tools.constraints.conflict import (
+    ConflictResolution,
+    ConflictType,
+    ConstraintConflict,
+    ConstraintConflictDetector,
+)
+from kicad_tools.constraints.locks import RegionConstraint
+from kicad_tools.optim.constraints import GroupingConstraint, SpatialConstraint
+from kicad_tools.optim.keepout import KeepoutType, KeepoutZone
+
+
+class TestConflictResolution:
+    """Tests for ConflictResolution dataclass."""
+
+    def test_create_resolution(self):
+        """Test creating a conflict resolution."""
+        resolution = ConflictResolution(
+            action="shrink_keepout",
+            description="Reduce the size of the keepout zone",
+            trade_off="Less protected area",
+            priority=1,
+        )
+        assert resolution.action == "shrink_keepout"
+        assert resolution.priority == 1
+
+    def test_to_dict(self):
+        """Test serialization to dictionary."""
+        resolution = ConflictResolution(
+            action="merge_keepouts",
+            description="Combine zones",
+            trade_off="Larger restricted area",
+            priority=0,
+        )
+        d = resolution.to_dict()
+        assert d["action"] == "merge_keepouts"
+        assert d["description"] == "Combine zones"
+        assert d["trade_off"] == "Larger restricted area"
+        assert d["priority"] == 0
+
+
+class TestConstraintConflict:
+    """Tests for ConstraintConflict dataclass."""
+
+    def test_create_conflict(self):
+        """Test creating a constraint conflict."""
+        conflict = ConstraintConflict(
+            constraint1_type="keepout",
+            constraint1_name="usb_zone",
+            constraint2_type="keepout",
+            constraint2_name="antenna_zone",
+            conflict_type=ConflictType.OVERLAP,
+            description="Zones overlap at corner",
+            location=(10.0, 20.0),
+        )
+        assert conflict.constraint1_type == "keepout"
+        assert conflict.conflict_type == ConflictType.OVERLAP
+        assert conflict.location == (10.0, 20.0)
+
+    def test_to_dict(self):
+        """Test serialization to dictionary."""
+        conflict = ConstraintConflict(
+            constraint1_type="grouping",
+            constraint1_name="decoupling_caps",
+            constraint2_type="region",
+            constraint2_name="analog_domain",
+            conflict_type=ConflictType.CONTRADICTION,
+            description="Group member in disallowed region",
+            location=(5.0, 5.0),
+            priority_winner="region",
+            resolutions=[
+                ConflictResolution(
+                    action="move_group",
+                    description="Move group to allowed area",
+                    trade_off="Longer traces",
+                )
+            ],
+        )
+        d = conflict.to_dict()
+        assert d["constraint1"]["type"] == "grouping"
+        assert d["constraint1"]["name"] == "decoupling_caps"
+        assert d["conflict_type"] == "contradiction"
+        assert d["priority_winner"] == "region"
+        assert len(d["resolutions"]) == 1
+
+
+class TestConstraintConflictDetector:
+    """Tests for ConstraintConflictDetector class."""
+
+    def test_no_conflicts_empty_inputs(self):
+        """Test with no constraints returns no conflicts."""
+        detector = ConstraintConflictDetector()
+        conflicts = detector.detect()
+        assert conflicts == []
+
+    def test_keepout_vs_keepout_overlap(self):
+        """Test detection of overlapping keepout zones."""
+        # Create two overlapping keepout zones
+        zone1 = KeepoutZone(
+            name="zone1",
+            zone_type=KeepoutType.MECHANICAL,
+            polygon=[(0, 0), (10, 0), (10, 10), (0, 10)],
+        )
+        zone2 = KeepoutZone(
+            name="zone2",
+            zone_type=KeepoutType.THERMAL,
+            polygon=[(5, 5), (15, 5), (15, 15), (5, 15)],
+        )
+
+        detector = ConstraintConflictDetector()
+        conflicts = detector.detect(keepout_zones=[zone1, zone2])
+
+        assert len(conflicts) == 1
+        assert conflicts[0].conflict_type == ConflictType.OVERLAP
+        assert "zone1" in conflicts[0].constraint1_name or "zone1" in conflicts[0].constraint2_name
+        assert "zone2" in conflicts[0].constraint1_name or "zone2" in conflicts[0].constraint2_name
+        assert len(conflicts[0].resolutions) > 0
+
+    def test_keepout_vs_keepout_no_overlap(self):
+        """Test non-overlapping keepout zones produce no conflict."""
+        zone1 = KeepoutZone(
+            name="zone1",
+            zone_type=KeepoutType.MECHANICAL,
+            polygon=[(0, 0), (10, 0), (10, 10), (0, 10)],
+        )
+        zone2 = KeepoutZone(
+            name="zone2",
+            zone_type=KeepoutType.THERMAL,
+            polygon=[(20, 20), (30, 20), (30, 30), (20, 30)],
+        )
+
+        detector = ConstraintConflictDetector()
+        conflicts = detector.detect(keepout_zones=[zone1, zone2])
+
+        assert len(conflicts) == 0
+
+    def test_keepout_vs_region_overlap(self):
+        """Test detection of keepout vs region overlap."""
+        keepout = KeepoutZone(
+            name="mounting_hole",
+            zone_type=KeepoutType.MECHANICAL,
+            polygon=[(5, 5), (15, 5), (15, 15), (5, 15)],
+        )
+        region = RegionConstraint(
+            name="analog_domain",
+            bounds={"x_min": 0, "x_max": 20, "y_min": 0, "y_max": 20},
+            reason="Analog signal isolation",
+        )
+
+        detector = ConstraintConflictDetector()
+        conflicts = detector.detect(
+            keepout_zones=[keepout],
+            region_constraints=[region],
+        )
+
+        assert len(conflicts) == 1
+        assert conflicts[0].conflict_type == ConflictType.OVERLAP
+
+    def test_grouping_vs_grouping_shared_member(self):
+        """Test detection of conflicting grouping constraints with shared members."""
+        # Create two groups with a shared member but different anchors
+        group1 = GroupingConstraint(
+            name="power_section",
+            members=["U1", "C1", "C2"],
+            constraints=[SpatialConstraint.max_distance(anchor="U1", radius_mm=5.0)],
+        )
+        group2 = GroupingConstraint(
+            name="analog_section",
+            members=["U2", "C1", "C3"],  # C1 is shared
+            constraints=[SpatialConstraint.max_distance(anchor="U2", radius_mm=5.0)],
+        )
+
+        # Without PCB context, we can't determine if anchors are too far apart
+        detector = ConstraintConflictDetector()
+        conflicts = detector.detect(grouping_constraints=[group1, group2])
+
+        # Should not have conflicts without PCB to check distances
+        assert len(conflicts) == 0
+
+    def test_resolution_suggestions(self):
+        """Test that resolutions are generated for conflicts."""
+        zone1 = KeepoutZone(
+            name="zone1",
+            zone_type=KeepoutType.MECHANICAL,
+            polygon=[(0, 0), (10, 0), (10, 10), (0, 10)],
+        )
+        zone2 = KeepoutZone(
+            name="zone2",
+            zone_type=KeepoutType.THERMAL,
+            polygon=[(5, 5), (15, 5), (15, 15), (5, 15)],
+        )
+
+        detector = ConstraintConflictDetector()
+        conflicts = detector.detect(keepout_zones=[zone1, zone2])
+
+        assert len(conflicts) == 1
+        resolutions = conflicts[0].resolutions
+        assert len(resolutions) >= 2  # Should have multiple resolution options
+
+        # Check resolution actions
+        actions = [r.action for r in resolutions]
+        assert "shrink_keepout" in actions
+        assert any("merge" in a or "remove" in a for a in actions)
+
+    def test_conflict_location(self):
+        """Test that conflict location is captured."""
+        zone1 = KeepoutZone(
+            name="zone1",
+            zone_type=KeepoutType.MECHANICAL,
+            polygon=[(0, 0), (10, 0), (10, 10), (0, 10)],
+        )
+        zone2 = KeepoutZone(
+            name="zone2",
+            zone_type=KeepoutType.THERMAL,
+            polygon=[(5, 5), (15, 5), (15, 15), (5, 15)],
+        )
+
+        detector = ConstraintConflictDetector()
+        conflicts = detector.detect(keepout_zones=[zone1, zone2])
+
+        assert len(conflicts) == 1
+        assert conflicts[0].location is not None
+        # Location should be in the overlap region
+        x, y = conflicts[0].location
+        assert 5 <= x <= 10
+        assert 5 <= y <= 10
+
+
+class TestConflictType:
+    """Tests for ConflictType enum."""
+
+    def test_conflict_types(self):
+        """Test all conflict types are available."""
+        assert ConflictType.OVERLAP.value == "overlap"
+        assert ConflictType.CONTRADICTION.value == "contradiction"
+        assert ConflictType.IMPOSSIBLE.value == "impossible"


### PR DESCRIPTION
## Summary
- Adds `ConstraintConflictDetector` class to detect conflicts between placement/routing constraints
- Creates `ConstraintConflict` and `ConflictResolution` dataclasses for conflict description
- Adds `kct constraints check` CLI command with table/json/summary output formats

## Implementation
- Detects keepout vs keepout zone overlaps
- Detects keepout vs region constraint overlaps  
- Detects grouping vs grouping conflicts (shared members with incompatible anchors)
- Provides resolution suggestions with trade-offs and priorities

## Test plan
- [x] Unit tests for conflict detection (12 tests passing)
- [x] Type checks passing (pyright)
- [x] Linting checks passing (ruff)
- [ ] Manual testing with a real PCB file

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)