### PR TITLE
Add routing congestion analysis

### DIFF
--- a/src/kicad_tools/analysis/__init__.py
+++ b/src/kicad_tools/analysis/__init__.py
@@ -1,0 +1,15 @@
+"""PCB analysis tools.
+
+This module provides analysis tools for PCB designs:
+- Routing congestion analysis
+- Density calculations
+- Problem area identification
+"""
+
+from .congestion import CongestionAnalyzer, CongestionReport, Severity
+
+__all__ = [
+    "CongestionAnalyzer",
+    "CongestionReport",
+    "Severity",
+]

--- a/src/kicad_tools/analysis/congestion.py
+++ b/src/kicad_tools/analysis/congestion.py
@@ -1,0 +1,444 @@
+"""Routing congestion analysis for PCB designs.
+
+Analyzes routing congestion to identify problem areas and suggest solutions.
+Uses grid-based density analysis to find hotspots where tracks, vias,
+and components are concentrated.
+
+Example:
+    >>> from kicad_tools.schema.pcb import PCB
+    >>> from kicad_tools.analysis import CongestionAnalyzer
+    >>> pcb = PCB.load("board.kicad_pcb")
+    >>> analyzer = CongestionAnalyzer()
+    >>> reports = analyzer.analyze(pcb)
+    >>> for report in reports:
+    ...     print(f"{report.severity}: Area around {report.center}")
+    ...     for suggestion in report.suggestions:
+    ...         print(f"  - {suggestion}")
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import PCB
+
+
+class Severity(Enum):
+    """Congestion severity level."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+@dataclass
+class CongestionReport:
+    """Report on routing congestion in an area.
+
+    Attributes:
+        center: Center point (x, y) of the congested area in mm.
+        radius: Radius of the analyzed area in mm.
+        track_density: Track length per unit area (mm/mm²).
+        via_count: Number of vias in the area.
+        unrouted_connections: Number of pads without connections.
+        components: Reference designators of components in the area.
+        nets: Net names involved in the congestion.
+        severity: Severity level of the congestion.
+        suggestions: List of actionable suggestions to relieve congestion.
+    """
+
+    center: tuple[float, float]
+    radius: float
+
+    # Metrics
+    track_density: float  # mm of track per mm²
+    via_count: int
+    unrouted_connections: int
+
+    # Elements contributing to congestion
+    components: list[str] = field(default_factory=list)
+    nets: list[str] = field(default_factory=list)
+
+    # Severity
+    severity: Severity = Severity.LOW
+
+    # Suggestions
+    suggestions: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "center": {"x": self.center[0], "y": self.center[1]},
+            "radius": self.radius,
+            "track_density": round(self.track_density, 3),
+            "via_count": self.via_count,
+            "unrouted_connections": self.unrouted_connections,
+            "components": self.components,
+            "nets": self.nets,
+            "severity": self.severity.value,
+            "suggestions": self.suggestions,
+        }
+
+
+@dataclass
+class _GridCell:
+    """Internal grid cell for density analysis."""
+
+    x: int  # Grid cell x index
+    y: int  # Grid cell y index
+    center_x: float  # Center x in mm
+    center_y: float  # Center y in mm
+    track_length: float = 0.0  # Total track length in mm
+    via_count: int = 0
+    pad_count: int = 0
+    connected_pads: int = 0
+    components: set[str] = field(default_factory=set)
+    nets: set[int] = field(default_factory=set)
+
+
+class CongestionAnalyzer:
+    """Analyze routing congestion on a PCB.
+
+    Uses a grid-based approach to identify areas of high track density,
+    excessive vias, and unrouted connections. Generates actionable
+    suggestions for relieving congestion.
+
+    Args:
+        grid_size: Size of each grid cell in mm. Default 2.0mm.
+        merge_radius: Radius for merging adjacent hotspots in mm. Default 5.0mm.
+    """
+
+    # Density thresholds for severity classification (mm track per mm² area)
+    DENSITY_LOW = 0.5
+    DENSITY_MEDIUM = 1.0
+    DENSITY_HIGH = 1.5
+    DENSITY_CRITICAL = 2.0
+
+    # Via count thresholds per grid cell
+    VIA_LOW = 2
+    VIA_MEDIUM = 5
+    VIA_HIGH = 8
+    VIA_CRITICAL = 12
+
+    def __init__(self, grid_size: float = 2.0, merge_radius: float = 5.0):
+        """Initialize the analyzer.
+
+        Args:
+            grid_size: Size of each grid cell in mm.
+            merge_radius: Radius for merging adjacent hotspots in mm.
+        """
+        self.grid_size = grid_size
+        self.merge_radius = merge_radius
+
+    def analyze(self, board: PCB) -> list[CongestionReport]:
+        """Find congested areas on the board.
+
+        Args:
+            board: PCB object to analyze.
+
+        Returns:
+            List of CongestionReport objects for each congested area,
+            sorted by severity (most severe first).
+        """
+        # Build the net name lookup
+        net_names = {net.number: net.name for net in board.nets.values()}
+
+        # Create density grid
+        grid = self._create_density_grid(board)
+
+        # Find hotspot cells
+        hotspots = self._find_hotspots(grid)
+
+        # Merge adjacent hotspots and create reports
+        reports = []
+        for hotspot in self._merge_hotspots(hotspots):
+            report = self._create_report(hotspot, net_names)
+            report.suggestions = self._suggest_fixes(report, board)
+            reports.append(report)
+
+        # Sort by severity (critical first)
+        severity_order = {
+            Severity.CRITICAL: 0,
+            Severity.HIGH: 1,
+            Severity.MEDIUM: 2,
+            Severity.LOW: 3,
+        }
+        reports.sort(key=lambda r: severity_order[r.severity])
+
+        return reports
+
+    def _create_density_grid(self, board: PCB) -> dict[tuple[int, int], _GridCell]:
+        """Create a grid of cells with density metrics.
+
+        Args:
+            board: PCB to analyze.
+
+        Returns:
+            Dictionary mapping (x, y) grid indices to GridCell objects.
+        """
+        grid: dict[tuple[int, int], _GridCell] = {}
+
+        def get_cell(x: float, y: float) -> _GridCell:
+            """Get or create the grid cell for a point."""
+            gx = int(x // self.grid_size)
+            gy = int(y // self.grid_size)
+            key = (gx, gy)
+            if key not in grid:
+                grid[key] = _GridCell(
+                    x=gx,
+                    y=gy,
+                    center_x=(gx + 0.5) * self.grid_size,
+                    center_y=(gy + 0.5) * self.grid_size,
+                )
+            return grid[key]
+
+        # Process segments (tracks)
+        for segment in board.segments:
+            # Calculate segment length
+            dx = segment.end[0] - segment.start[0]
+            dy = segment.end[1] - segment.start[1]
+            length = math.sqrt(dx * dx + dy * dy)
+
+            if length < 0.01:
+                continue  # Skip zero-length segments
+
+            # Distribute track length across all cells the segment passes through
+            # Sample at regular intervals (every grid_size/2 for good coverage)
+            num_samples = max(2, int(length / (self.grid_size / 2)) + 1)
+            length_per_sample = length / num_samples
+
+            for i in range(num_samples):
+                t = i / (num_samples - 1) if num_samples > 1 else 0.5
+                px = segment.start[0] + t * dx
+                py = segment.start[1] + t * dy
+                cell = get_cell(px, py)
+                cell.track_length += length_per_sample
+                cell.nets.add(segment.net_number)
+
+        # Process vias
+        for via in board.vias:
+            cell = get_cell(via.position[0], via.position[1])
+            cell.via_count += 1
+            cell.nets.add(via.net_number)
+
+        # Process footprints and pads
+        for footprint in board.footprints:
+            fx, fy = footprint.position
+            cell = get_cell(fx, fy)
+            cell.components.add(footprint.reference)
+
+            for pad in footprint.pads:
+                # Transform pad position to board coordinates
+                # (simplified - assumes no rotation for now)
+                pad_x = fx + pad.position[0]
+                pad_y = fy + pad.position[1]
+                pad_cell = get_cell(pad_x, pad_y)
+                pad_cell.pad_count += 1
+                if pad.net_number != 0:
+                    pad_cell.connected_pads += 1
+                    pad_cell.nets.add(pad.net_number)
+
+        return grid
+
+    def _find_hotspots(self, grid: dict[tuple[int, int], _GridCell]) -> list[_GridCell]:
+        """Find cells with significant congestion.
+
+        Args:
+            grid: Grid of density cells.
+
+        Returns:
+            List of cells that exceed congestion thresholds.
+        """
+        hotspots = []
+        cell_area = self.grid_size * self.grid_size
+
+        for cell in grid.values():
+            density = cell.track_length / cell_area
+
+            # Check if this cell is a hotspot
+            is_hotspot = (
+                density >= self.DENSITY_LOW
+                or cell.via_count >= self.VIA_LOW
+                or (cell.pad_count > 0 and cell.connected_pads < cell.pad_count)
+            )
+
+            if is_hotspot:
+                hotspots.append(cell)
+
+        return hotspots
+
+    def _merge_hotspots(self, cells: list[_GridCell]) -> list[_GridCell]:
+        """Merge adjacent hotspot cells into larger regions.
+
+        For now, returns cells as-is. Future enhancement could
+        cluster adjacent cells into unified regions.
+
+        Args:
+            cells: List of hotspot cells.
+
+        Returns:
+            List of representative cells (potentially merged).
+        """
+        # Simple implementation: return top N hotspots by density
+        # Sort by combined score
+        cell_area = self.grid_size * self.grid_size
+
+        def score(cell: _GridCell) -> float:
+            density = cell.track_length / cell_area
+            return density + (cell.via_count * 0.1)
+
+        cells_sorted = sorted(cells, key=score, reverse=True)
+
+        # Return top 10 hotspots, filtering out nearby duplicates
+        result = []
+        for cell in cells_sorted:
+            # Check if too close to an existing result
+            too_close = False
+            for existing in result:
+                dist = math.sqrt(
+                    (cell.center_x - existing.center_x) ** 2
+                    + (cell.center_y - existing.center_y) ** 2
+                )
+                if dist < self.merge_radius:
+                    # Merge into existing
+                    existing.track_length += cell.track_length
+                    existing.via_count += cell.via_count
+                    existing.components.update(cell.components)
+                    existing.nets.update(cell.nets)
+                    too_close = True
+                    break
+
+            if not too_close:
+                result.append(cell)
+
+            if len(result) >= 10:
+                break
+
+        return result
+
+    def _create_report(
+        self, cell: _GridCell, net_names: dict[int, str]
+    ) -> CongestionReport:
+        """Create a CongestionReport from a grid cell.
+
+        Args:
+            cell: Grid cell with congestion metrics.
+            net_names: Mapping of net numbers to names.
+
+        Returns:
+            CongestionReport for the cell.
+        """
+        cell_area = self.grid_size * self.grid_size
+        density = cell.track_length / cell_area
+
+        # Determine severity
+        if density >= self.DENSITY_CRITICAL or cell.via_count >= self.VIA_CRITICAL:
+            severity = Severity.CRITICAL
+        elif density >= self.DENSITY_HIGH or cell.via_count >= self.VIA_HIGH:
+            severity = Severity.HIGH
+        elif density >= self.DENSITY_MEDIUM or cell.via_count >= self.VIA_MEDIUM:
+            severity = Severity.MEDIUM
+        else:
+            severity = Severity.LOW
+
+        # Get net names
+        nets = [
+            net_names.get(n, f"net_{n}")
+            for n in sorted(cell.nets)
+            if n != 0  # Skip unconnected net
+        ]
+
+        # Calculate unrouted connections
+        unrouted = cell.pad_count - cell.connected_pads
+
+        return CongestionReport(
+            center=(round(cell.center_x, 2), round(cell.center_y, 2)),
+            radius=self.grid_size,
+            track_density=round(density, 3),
+            via_count=cell.via_count,
+            unrouted_connections=max(0, unrouted),
+            components=sorted(cell.components),
+            nets=nets[:10],  # Limit to 10 nets
+            severity=severity,
+        )
+
+    def _suggest_fixes(
+        self, report: CongestionReport, board: PCB
+    ) -> list[str]:
+        """Generate suggestions to relieve congestion.
+
+        Args:
+            report: Congestion report to generate suggestions for.
+            board: PCB for context.
+
+        Returns:
+            List of actionable suggestion strings.
+        """
+        suggestions = []
+
+        # Suggest moving components if there are many in the area
+        if len(report.components) >= 2:
+            comp_list = ", ".join(report.components[:3])
+            if len(report.components) > 3:
+                comp_list += f" (and {len(report.components) - 3} more)"
+            suggestions.append(
+                f"Consider moving {comp_list} to reduce component density"
+            )
+
+        # Suggest layer changes for high density
+        if report.severity in (Severity.HIGH, Severity.CRITICAL):
+            suggestions.append(
+                "Route some nets on inner layers to reduce top/bottom congestion"
+            )
+
+        # Suggest via reduction
+        if report.via_count >= 10:
+            suggestions.append(
+                f"Area has {report.via_count} vias; consider optimizing routing "
+                "to reduce layer changes"
+            )
+        elif report.via_count >= 5:
+            suggestions.append(
+                f"Consider reducing vias ({report.via_count}) by routing on "
+                "fewer layers"
+            )
+
+        # Suggest addressing unrouted connections
+        if report.unrouted_connections > 0:
+            suggestions.append(
+                f"{report.unrouted_connections} unrouted connection(s) in this area; "
+                "may need manual routing or component repositioning"
+            )
+
+        # Suggest specific net routing if there are many nets
+        if len(report.nets) >= 5:
+            # Find power/ground nets
+            power_nets = [
+                n for n in report.nets if any(p in n.upper() for p in ["VCC", "VDD", "GND", "VSS", "PWR"])
+            ]
+            if power_nets:
+                suggestions.append(
+                    f"Power nets ({', '.join(power_nets[:3])}) could use wider "
+                    "traces or dedicated planes"
+                )
+
+        # Suggest via-in-pad for bypass caps
+        bypass_refs = [r for r in report.components if r.startswith("C")]
+        if bypass_refs and report.severity in (Severity.HIGH, Severity.CRITICAL):
+            suggestions.append(
+                f"Consider via-in-pad for bypass capacitors ({', '.join(bypass_refs[:3])})"
+            )
+
+        # Generic suggestion for critical areas
+        if report.severity == Severity.CRITICAL and not suggestions:
+            suggestions.append(
+                "Critical congestion: consider redesigning component placement "
+                "or adding board layers"
+            )
+
+        return suggestions

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -24,6 +24,7 @@ Provides CLI commands for common KiCad operations via the `kicad-tools` or `kct`
     kicad-tools optimize-traces <pcb>  - Optimize PCB traces
     kicad-tools validate-footprints    - Validate footprint pad spacing
     kicad-tools fix-footprints <pcb>   - Fix footprint pad spacing issues
+    kicad-tools analyze <command>      - PCB analysis tools (congestion, etc.)
     kicad-tools config                 - View/manage configuration
     kicad-tools interactive            - Launch interactive REPL mode
 
@@ -35,6 +36,7 @@ import sys
 from kicad_tools.exceptions import KiCadToolsError
 
 from .commands import (
+    run_analyze_command,
     run_check_command,
     run_config_command,
     run_datasheet_command,
@@ -260,6 +262,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "validate":
         return run_validate_command(args)
+
+    elif args.command == "analyze":
+        return run_analyze_command(args)
 
     return 0
 

--- a/src/kicad_tools/cli/analyze_cmd.py
+++ b/src/kicad_tools/cli/analyze_cmd.py
@@ -1,0 +1,240 @@
+"""Analyze command for PCB analysis tools.
+
+Provides the `analyze congestion` subcommand for routing congestion analysis.
+
+Usage:
+    kicad-tools analyze congestion board.kicad_pcb
+    kicad-tools analyze congestion board.kicad_pcb --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from rich.console import Console
+from rich.table import Table
+
+from kicad_tools.analysis import CongestionAnalyzer, Severity
+from kicad_tools.schema.pcb import PCB
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for analyze command."""
+    parser = argparse.ArgumentParser(
+        prog="kicad-tools analyze",
+        description="PCB analysis tools",
+    )
+
+    subparsers = parser.add_subparsers(dest="subcommand", help="Analysis type")
+
+    # Congestion subcommand
+    congestion_parser = subparsers.add_parser(
+        "congestion",
+        help="Analyze routing congestion",
+        description="Identify congested areas and suggest solutions",
+    )
+    congestion_parser.add_argument(
+        "pcb",
+        help="PCB file to analyze (.kicad_pcb)",
+    )
+    congestion_parser.add_argument(
+        "--format",
+        "-f",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    congestion_parser.add_argument(
+        "--grid-size",
+        type=float,
+        default=2.0,
+        help="Grid cell size in mm (default: 2.0)",
+    )
+    congestion_parser.add_argument(
+        "--min-severity",
+        choices=["low", "medium", "high", "critical"],
+        default="low",
+        help="Minimum severity to report (default: low)",
+    )
+    congestion_parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Suppress informational output",
+    )
+
+    if argv is None:
+        argv = sys.argv[1:]
+
+    args = parser.parse_args(argv)
+
+    if not args.subcommand:
+        parser.print_help()
+        return 1
+
+    if args.subcommand == "congestion":
+        return _run_congestion_analysis(args)
+
+    return 0
+
+
+def _run_congestion_analysis(args: argparse.Namespace) -> int:
+    """Run congestion analysis on a PCB."""
+    pcb_path = Path(args.pcb)
+
+    if not pcb_path.exists():
+        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
+        return 1
+
+    if not pcb_path.suffix == ".kicad_pcb":
+        print(f"Error: Expected .kicad_pcb file, got: {pcb_path.suffix}", file=sys.stderr)
+        return 1
+
+    # Load PCB
+    try:
+        pcb = PCB.load(str(pcb_path))
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    # Run analysis
+    analyzer = CongestionAnalyzer(grid_size=args.grid_size)
+    reports = analyzer.analyze(pcb)
+
+    # Filter by minimum severity
+    severity_order = {
+        "low": 0,
+        "medium": 1,
+        "high": 2,
+        "critical": 3,
+    }
+    min_severity = severity_order[args.min_severity]
+    reports = [
+        r for r in reports
+        if severity_order[r.severity.value] >= min_severity
+    ]
+
+    # Output results
+    if args.format == "json":
+        _output_json(reports)
+    else:
+        _output_text(reports, pcb_path.name, quiet=args.quiet)
+
+    # Return non-zero if critical issues found
+    has_critical = any(r.severity == Severity.CRITICAL for r in reports)
+    has_high = any(r.severity == Severity.HIGH for r in reports)
+
+    if has_critical:
+        return 2
+    elif has_high:
+        return 1
+    return 0
+
+
+def _output_json(reports: list) -> None:
+    """Output reports as JSON."""
+    output = {
+        "reports": [r.to_dict() for r in reports],
+        "summary": {
+            "total": len(reports),
+            "critical": sum(1 for r in reports if r.severity == Severity.CRITICAL),
+            "high": sum(1 for r in reports if r.severity == Severity.HIGH),
+            "medium": sum(1 for r in reports if r.severity == Severity.MEDIUM),
+            "low": sum(1 for r in reports if r.severity == Severity.LOW),
+        },
+    }
+    print(json.dumps(output, indent=2))
+
+
+def _output_text(reports: list, filename: str, quiet: bool = False) -> None:
+    """Output reports as formatted text."""
+    console = Console()
+
+    if not reports:
+        if not quiet:
+            console.print(f"[green]No congestion issues found in {filename}[/green]")
+        return
+
+    if not quiet:
+        console.print(f"\n[bold]Congestion Analysis: {filename}[/bold]\n")
+
+    # Summary table
+    summary_table = Table(title="Summary", show_header=False)
+    summary_table.add_column("Metric", style="dim")
+    summary_table.add_column("Value")
+
+    critical = sum(1 for r in reports if r.severity == Severity.CRITICAL)
+    high = sum(1 for r in reports if r.severity == Severity.HIGH)
+    medium = sum(1 for r in reports if r.severity == Severity.MEDIUM)
+    low = sum(1 for r in reports if r.severity == Severity.LOW)
+
+    summary_table.add_row("Total areas", str(len(reports)))
+    if critical > 0:
+        summary_table.add_row("Critical", f"[red]{critical}[/red]")
+    if high > 0:
+        summary_table.add_row("High", f"[yellow]{high}[/yellow]")
+    if medium > 0:
+        summary_table.add_row("Medium", f"[blue]{medium}[/blue]")
+    if low > 0:
+        summary_table.add_row("Low", str(low))
+
+    console.print(summary_table)
+    console.print()
+
+    # Detail for each report
+    for i, report in enumerate(reports, 1):
+        _print_report(console, report, i)
+
+
+def _print_report(console: Console, report, index: int) -> None:
+    """Print a single congestion report."""
+    # Severity color
+    severity_colors = {
+        Severity.CRITICAL: "red",
+        Severity.HIGH: "yellow",
+        Severity.MEDIUM: "blue",
+        Severity.LOW: "dim",
+    }
+    color = severity_colors[report.severity]
+
+    # Header
+    x, y = report.center
+    console.print(
+        f"[{color}][bold]{report.severity.value.upper()}[/bold][/{color}]: "
+        f"Area around ({x:.1f}, {y:.1f})"
+    )
+
+    # Metrics
+    console.print(f"  Track density: {report.track_density:.2f} mm/mm²")
+    console.print(f"  Vias: {report.via_count}")
+    if report.unrouted_connections > 0:
+        console.print(f"  Unrouted: {report.unrouted_connections} connection(s)")
+
+    # Components
+    if report.components:
+        comp_str = ", ".join(report.components[:5])
+        if len(report.components) > 5:
+            comp_str += f" (+{len(report.components) - 5} more)"
+        console.print(f"  Components: {comp_str}")
+
+    # Nets
+    if report.nets:
+        net_str = ", ".join(report.nets[:5])
+        if len(report.nets) > 5:
+            net_str += f" (+{len(report.nets) - 5} more)"
+        console.print(f"  Nets: {net_str}")
+
+    # Suggestions
+    if report.suggestions:
+        console.print("  [dim]Suggestions:[/dim]")
+        for suggestion in report.suggestions:
+            console.print(f"    • {suggestion}")
+
+    console.print()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -12,8 +12,10 @@ This package contains command handler modules organized by domain:
 - reasoning: reason command handler
 - config: config and interactive command handlers
 - manufacturer: mfr subcommand handlers
+- analyze: PCB analysis tools (congestion, etc.)
 """
 
+from .analyze import run_analyze_command
 from .config import run_config_command, run_interactive_command
 from .datasheet import run_datasheet_command
 from .footprint import run_footprint_command
@@ -63,4 +65,6 @@ __all__ = [
     "run_interactive_command",
     # Manufacturer
     "run_mfr_command",
+    # Analysis
+    "run_analyze_command",
 ]

--- a/src/kicad_tools/cli/commands/analyze.py
+++ b/src/kicad_tools/cli/commands/analyze.py
@@ -1,0 +1,34 @@
+"""Analyze command handlers (congestion analysis, etc.)."""
+
+__all__ = ["run_analyze_command"]
+
+
+def run_analyze_command(args) -> int:
+    """Handle analyze command and its subcommands."""
+    if not args.analyze_command:
+        print("Usage: kicad-tools analyze <command> [options] <file>")
+        print("Commands: congestion")
+        return 1
+
+    if args.analyze_command == "congestion":
+        return _run_congestion_command(args)
+
+    return 1
+
+
+def _run_congestion_command(args) -> int:
+    """Handle analyze congestion command."""
+    from ..analyze_cmd import main as analyze_main
+
+    sub_argv = ["congestion", args.pcb]
+
+    if getattr(args, "analyze_format", "text") != "text":
+        sub_argv.extend(["--format", args.analyze_format])
+    if getattr(args, "analyze_grid_size", 2.0) != 2.0:
+        sub_argv.extend(["--grid-size", str(args.analyze_grid_size)])
+    if getattr(args, "analyze_min_severity", "low") != "low":
+        sub_argv.extend(["--min-severity", args.analyze_min_severity])
+    if getattr(args, "global_quiet", False):
+        sub_argv.append("--quiet")
+
+    return analyze_main(sub_argv)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -36,6 +36,7 @@ Provides CLI commands for common KiCad operations via the `kicad-tools` or `kct`
     kicad-tools optimize-traces <pcb>  - Optimize PCB traces
     kicad-tools validate-footprints    - Validate footprint pad spacing
     kicad-tools fix-footprints <pcb>   - Fix footprint pad spacing issues
+    kicad-tools analyze <command>      - PCB analysis tools
     kicad-tools config                 - View/manage configuration
     kicad-tools interactive            - Launch interactive REPL mode
 
@@ -132,6 +133,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_config_parser(subparsers)
     _add_interactive_parser(subparsers)
     _add_validate_parser(subparsers)
+    _add_analyze_parser(subparsers)
 
     return parser
 
@@ -1247,4 +1249,42 @@ def _add_validate_parser(subparsers) -> None:
         dest="validate_verbose",
         action="store_true",
         help="Show detailed issue information",
+    )
+
+
+def _add_analyze_parser(subparsers) -> None:
+    """Add analyze subcommand parser with its subcommands."""
+    analyze_parser = subparsers.add_parser("analyze", help="PCB analysis tools")
+    analyze_subparsers = analyze_parser.add_subparsers(
+        dest="analyze_command", help="Analysis commands"
+    )
+
+    # analyze congestion
+    congestion_parser = analyze_subparsers.add_parser(
+        "congestion",
+        help="Analyze routing congestion",
+        description="Identify congested areas and suggest solutions",
+    )
+    congestion_parser.add_argument("pcb", help="PCB file to analyze (.kicad_pcb)")
+    congestion_parser.add_argument(
+        "--format",
+        "-f",
+        dest="analyze_format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    congestion_parser.add_argument(
+        "--grid-size",
+        dest="analyze_grid_size",
+        type=float,
+        default=2.0,
+        help="Grid cell size in mm (default: 2.0)",
+    )
+    congestion_parser.add_argument(
+        "--min-severity",
+        dest="analyze_min_severity",
+        choices=["low", "medium", "high", "critical"],
+        default="low",
+        help="Minimum severity to report (default: low)",
     )

--- a/tests/test_congestion.py
+++ b/tests/test_congestion.py
@@ -1,0 +1,456 @@
+"""Tests for routing congestion analysis."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.analysis import CongestionAnalyzer, CongestionReport, Severity
+from kicad_tools.schema.pcb import PCB
+
+
+# PCB with multiple traces and vias in a small area (congested)
+CONGESTED_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+  (net 3 "SDA")
+  (net 4 "SCL")
+  (net 5 "GPIO1")
+  (net 6 "GPIO2")
+
+  (gr_rect
+    (start 0 0)
+    (end 20 20)
+    (stroke (width 0.1))
+    (layer "Edge.Cuts")
+  )
+
+  (footprint "Package_QFP:LQFP-48_7x7mm_P0.5mm"
+    (layer "F.Cu")
+    (at 10 10)
+    (property "Reference" "U1")
+    (pad "1" smd rect (at -3.5 0) (size 0.5 0.5) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at -3.0 0) (size 0.5 0.5) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+    (pad "3" smd rect (at -2.5 0) (size 0.5 0.5) (layers "F.Cu" "F.Mask") (net 3 "SDA"))
+    (pad "4" smd rect (at -2.0 0) (size 0.5 0.5) (layers "F.Cu" "F.Mask") (net 4 "SCL"))
+    (pad "5" smd rect (at -1.5 0) (size 0.5 0.5) (layers "F.Cu" "F.Mask") (net 5 "GPIO1"))
+    (pad "6" smd rect (at -1.0 0) (size 0.5 0.5) (layers "F.Cu" "F.Mask") (net 6 "GPIO2"))
+    (pad "7" smd rect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+  )
+
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (at 8 10)
+    (property "Reference" "C1")
+    (pad "1" smd rect (at 0 -0.25) (size 0.4 0.4) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 0 0.25) (size 0.4 0.4) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (at 12 10)
+    (property "Reference" "C2")
+    (pad "1" smd rect (at 0 -0.25) (size 0.4 0.4) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 0 0.25) (size 0.4 0.4) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+
+  (segment (start 6.5 10) (end 7.5 10) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 7.5 10) (end 8 10) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 8 10) (end 9 10) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 9 10) (end 10 10) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 10 10) (end 11 10) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 11 10) (end 12 10) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 12 10) (end 13 10) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 13 10) (end 14 10) (width 0.25) (layer "F.Cu") (net 1))
+
+  (segment (start 6.5 10.5) (end 14 10.5) (width 0.25) (layer "F.Cu") (net 2))
+  (segment (start 6.5 9.5) (end 14 9.5) (width 0.25) (layer "F.Cu") (net 3))
+  (segment (start 6.5 9) (end 14 9) (width 0.25) (layer "F.Cu") (net 4))
+  (segment (start 6.5 11) (end 14 11) (width 0.25) (layer "F.Cu") (net 5))
+  (segment (start 6.5 11.5) (end 14 11.5) (width 0.25) (layer "F.Cu") (net 6))
+
+  (via (at 8 9) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1))
+  (via (at 9 9) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 2))
+  (via (at 10 9) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 3))
+  (via (at 11 9) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 4))
+  (via (at 12 9) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 5))
+  (via (at 8 11) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1))
+  (via (at 9 11) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 2))
+  (via (at 10 11) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 3))
+  (via (at 11 11) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 4))
+  (via (at 12 11) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 5))
+)
+"""
+
+
+# Simple PCB with minimal routing (not congested)
+SIMPLE_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+
+  (gr_rect
+    (start 0 0)
+    (end 50 50)
+    (stroke (width 0.1))
+    (layer "Edge.Cuts")
+  )
+
+  (footprint "Resistor_SMD:R_0805"
+    (layer "F.Cu")
+    (at 10 10)
+    (property "Reference" "R1")
+    (pad "1" smd rect (at -1 0) (size 0.8 0.8) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 1 0) (size 0.8 0.8) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+
+  (footprint "Resistor_SMD:R_0805"
+    (layer "F.Cu")
+    (at 40 40)
+    (property "Reference" "R2")
+    (pad "1" smd rect (at -1 0) (size 0.8 0.8) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 1 0) (size 0.8 0.8) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+
+  (segment (start 11 10) (end 39 10) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 39 10) (end 39 40) (width 0.25) (layer "F.Cu") (net 1))
+)
+"""
+
+
+@pytest.fixture
+def congested_pcb(tmp_path: Path) -> Path:
+    """Create a congested PCB file."""
+    pcb_file = tmp_path / "congested.kicad_pcb"
+    pcb_file.write_text(CONGESTED_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def simple_pcb(tmp_path: Path) -> Path:
+    """Create a simple non-congested PCB file."""
+    pcb_file = tmp_path / "simple.kicad_pcb"
+    pcb_file.write_text(SIMPLE_PCB)
+    return pcb_file
+
+
+class TestCongestionReport:
+    """Tests for CongestionReport dataclass."""
+
+    def test_to_dict_basic(self):
+        """Test basic to_dict conversion."""
+        report = CongestionReport(
+            center=(10.5, 20.5),
+            radius=2.0,
+            track_density=1.5,
+            via_count=5,
+            unrouted_connections=2,
+            components=["U1", "C1"],
+            nets=["VCC", "GND"],
+            severity=Severity.HIGH,
+            suggestions=["Move components", "Use inner layers"],
+        )
+
+        d = report.to_dict()
+
+        assert d["center"] == {"x": 10.5, "y": 20.5}
+        assert d["radius"] == 2.0
+        assert d["track_density"] == 1.5
+        assert d["via_count"] == 5
+        assert d["unrouted_connections"] == 2
+        assert d["components"] == ["U1", "C1"]
+        assert d["nets"] == ["VCC", "GND"]
+        assert d["severity"] == "high"
+        assert len(d["suggestions"]) == 2
+
+    def test_to_dict_serializable(self):
+        """Test that to_dict output is JSON serializable."""
+        report = CongestionReport(
+            center=(10.0, 20.0),
+            radius=2.0,
+            track_density=1.5,
+            via_count=5,
+            unrouted_connections=0,
+            severity=Severity.MEDIUM,
+        )
+
+        # Should not raise
+        json_str = json.dumps(report.to_dict())
+        assert isinstance(json_str, str)
+
+
+class TestCongestionAnalyzer:
+    """Tests for CongestionAnalyzer class."""
+
+    def test_analyzer_init_defaults(self):
+        """Test analyzer initialization with defaults."""
+        analyzer = CongestionAnalyzer()
+        assert analyzer.grid_size == 2.0
+        assert analyzer.merge_radius == 5.0
+
+    def test_analyzer_init_custom(self):
+        """Test analyzer initialization with custom values."""
+        analyzer = CongestionAnalyzer(grid_size=1.0, merge_radius=3.0)
+        assert analyzer.grid_size == 1.0
+        assert analyzer.merge_radius == 3.0
+
+    def test_analyze_congested_pcb(self, congested_pcb: Path):
+        """Test analyzing a congested PCB."""
+        pcb = PCB.load(str(congested_pcb))
+        analyzer = CongestionAnalyzer(grid_size=2.0)
+
+        reports = analyzer.analyze(pcb)
+
+        # Should find at least one congested area
+        assert len(reports) > 0
+
+        # Reports should be sorted by severity
+        if len(reports) > 1:
+            severities = [r.severity for r in reports]
+            severity_order = {
+                Severity.CRITICAL: 0,
+                Severity.HIGH: 1,
+                Severity.MEDIUM: 2,
+                Severity.LOW: 3,
+            }
+            orders = [severity_order[s] for s in severities]
+            assert orders == sorted(orders)
+
+    def test_analyze_simple_pcb(self, simple_pcb: Path):
+        """Test analyzing a simple non-congested PCB."""
+        pcb = PCB.load(str(simple_pcb))
+        analyzer = CongestionAnalyzer(grid_size=2.0)
+
+        reports = analyzer.analyze(pcb)
+
+        # May find some low-severity areas but should not find critical/high
+        critical_high = [
+            r for r in reports if r.severity in (Severity.CRITICAL, Severity.HIGH)
+        ]
+        assert len(critical_high) == 0
+
+    def test_analyze_reports_have_required_fields(self, congested_pcb: Path):
+        """Test that reports have all required fields."""
+        pcb = PCB.load(str(congested_pcb))
+        analyzer = CongestionAnalyzer()
+
+        reports = analyzer.analyze(pcb)
+
+        for report in reports:
+            assert isinstance(report.center, tuple)
+            assert len(report.center) == 2
+            assert isinstance(report.radius, float)
+            assert isinstance(report.track_density, float)
+            assert isinstance(report.via_count, int)
+            assert isinstance(report.unrouted_connections, int)
+            assert isinstance(report.components, list)
+            assert isinstance(report.nets, list)
+            assert isinstance(report.severity, Severity)
+            assert isinstance(report.suggestions, list)
+
+    def test_analyze_suggestions_generated(self, congested_pcb: Path):
+        """Test that suggestions are generated for congested areas."""
+        pcb = PCB.load(str(congested_pcb))
+        analyzer = CongestionAnalyzer()
+
+        reports = analyzer.analyze(pcb)
+
+        # At least some reports should have suggestions
+        reports_with_suggestions = [r for r in reports if r.suggestions]
+        assert len(reports_with_suggestions) > 0
+
+    def test_analyze_with_small_grid(self, congested_pcb: Path):
+        """Test analysis with smaller grid size."""
+        pcb = PCB.load(str(congested_pcb))
+        analyzer = CongestionAnalyzer(grid_size=1.0)
+
+        reports = analyzer.analyze(pcb)
+
+        # Smaller grid should still work
+        assert isinstance(reports, list)
+
+    def test_analyze_components_identified(self, congested_pcb: Path):
+        """Test that components are identified in reports."""
+        pcb = PCB.load(str(congested_pcb))
+        analyzer = CongestionAnalyzer()
+
+        reports = analyzer.analyze(pcb)
+
+        # Some reports should identify components
+        all_components = set()
+        for report in reports:
+            all_components.update(report.components)
+
+        # Should identify at least U1 from the congested area
+        assert len(all_components) > 0
+
+    def test_analyze_nets_identified(self, congested_pcb: Path):
+        """Test that nets are identified in reports."""
+        pcb = PCB.load(str(congested_pcb))
+        analyzer = CongestionAnalyzer()
+
+        reports = analyzer.analyze(pcb)
+
+        # Some reports should identify nets
+        all_nets = set()
+        for report in reports:
+            all_nets.update(report.nets)
+
+        # Should identify some nets
+        assert len(all_nets) > 0
+
+
+class TestCongestionCLI:
+    """Tests for the analyze congestion CLI command."""
+
+    def test_cli_file_not_found(self, capsys):
+        """Test CLI with missing file."""
+        from kicad_tools.cli.analyze_cmd import main
+
+        result = main(["congestion", "nonexistent.kicad_pcb"])
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "not found" in captured.err.lower() or "Error" in captured.err
+
+    def test_cli_wrong_extension(self, capsys, tmp_path: Path):
+        """Test CLI with wrong file extension."""
+        from kicad_tools.cli.analyze_cmd import main
+
+        wrong_file = tmp_path / "test.txt"
+        wrong_file.write_text("not a pcb")
+
+        result = main(["congestion", str(wrong_file)])
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert ".kicad_pcb" in captured.err
+
+    def test_cli_text_output(self, congested_pcb: Path, capsys):
+        """Test CLI with text output format."""
+        from kicad_tools.cli.analyze_cmd import main
+
+        result = main(["congestion", str(congested_pcb)])
+
+        # Return code depends on severity found
+        assert result in (0, 1, 2)
+
+        captured = capsys.readouterr()
+        # Should have some output
+        assert len(captured.out) > 0
+
+    def test_cli_json_output(self, congested_pcb: Path, capsys):
+        """Test CLI with JSON output format."""
+        from kicad_tools.cli.analyze_cmd import main
+
+        result = main(["congestion", str(congested_pcb), "--format", "json"])
+        assert result in (0, 1, 2)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        assert "reports" in data
+        assert "summary" in data
+        assert isinstance(data["reports"], list)
+        assert "total" in data["summary"]
+
+    def test_cli_min_severity_filter(self, congested_pcb: Path, capsys):
+        """Test CLI with minimum severity filter."""
+        from kicad_tools.cli.analyze_cmd import main
+
+        # Run with critical filter - should filter out lower severity
+        result = main([
+            "congestion",
+            str(congested_pcb),
+            "--format", "json",
+            "--min-severity", "critical",
+        ])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        # All remaining reports should be critical
+        for report in data["reports"]:
+            assert report["severity"] == "critical"
+
+    def test_cli_grid_size_option(self, congested_pcb: Path, capsys):
+        """Test CLI with custom grid size."""
+        from kicad_tools.cli.analyze_cmd import main
+
+        result = main([
+            "congestion",
+            str(congested_pcb),
+            "--format", "json",
+            "--grid-size", "1.0",
+        ])
+        assert result in (0, 1, 2)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "reports" in data
+
+    def test_cli_quiet_mode(self, simple_pcb: Path, capsys):
+        """Test CLI quiet mode suppresses informational output."""
+        from kicad_tools.cli.analyze_cmd import main
+
+        result = main(["congestion", str(simple_pcb), "--quiet"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        # In quiet mode with no issues, output should be minimal
+        # (no header, no "No congestion issues found" message)
+
+
+class TestSeverityClassification:
+    """Tests for severity classification logic."""
+
+    def test_severity_low_threshold(self, tmp_path: Path):
+        """Test that low density gets LOW severity."""
+        # PCB with minimal routing
+        pcb_content = SIMPLE_PCB
+        pcb_file = tmp_path / "low.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        pcb = PCB.load(str(pcb_file))
+        analyzer = CongestionAnalyzer()
+
+        reports = analyzer.analyze(pcb)
+
+        # All should be LOW severity (if any)
+        for report in reports:
+            assert report.severity == Severity.LOW
+
+    def test_severity_high_with_many_vias(self, congested_pcb: Path):
+        """Test that areas with many vias get higher severity."""
+        pcb = PCB.load(str(congested_pcb))
+        analyzer = CongestionAnalyzer()
+
+        reports = analyzer.analyze(pcb)
+
+        # The congested PCB has many vias in a small area
+        # Should find at least one area with elevated severity
+        elevated = [
+            r for r in reports
+            if r.severity in (Severity.MEDIUM, Severity.HIGH, Severity.CRITICAL)
+        ]
+        assert len(elevated) > 0


### PR DESCRIPTION
## Summary
- Implement `CongestionAnalyzer` to identify high-density areas on PCB designs
- Add CLI command `kicad-tools analyze congestion <pcb>` with JSON/text output
- Use grid-based density analysis to find hotspots where tracks, vias, and components are concentrated
- Generate actionable suggestions for relieving congestion

## Changes
- New `src/kicad_tools/analysis/` module with `CongestionAnalyzer` class
- CLI command with `--format`, `--grid-size`, and `--min-severity` options
- 20 test cases covering analyzer logic and CLI

## Test plan
- [x] Run `uv run pytest tests/test_congestion.py` - all 20 tests pass
- [x] Test CLI: `kicad-tools analyze congestion board.kicad_pcb`
- [x] Test JSON output: `kicad-tools analyze congestion board.kicad_pcb --format json`

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)