### PR TITLE
Add pin↔label match status to sch hierarchy labels command

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -503,3 +503,9 @@ def minimal_symbol_library(tmp_path: Path) -> Path:
     lib_file = tmp_path / "test.kicad_sym"
     lib_file.write_text(MINIMAL_SYMBOL_LIBRARY)
     return lib_file
+
+
+@pytest.fixture
+def hierarchical_schematic(fixtures_dir: Path) -> Path:
+    """Return the path to the hierarchical test schematic."""
+    return fixtures_dir / "projects" / "hierarchical_main.kicad_sch"

--- a/tests/fixtures/projects/logic_subsheet.kicad_sch
+++ b/tests/fixtures/projects/logic_subsheet.kicad_sch
@@ -1,0 +1,31 @@
+(kicad_sch
+	(version 20231120)
+	(generator "kicadtools_test")
+	(generator_version "8.0")
+	(uuid "00000000-0000-0000-0000-000000000002")
+	(paper "A4")
+	(title_block
+		(title "Logic Subsheet")
+		(date "2024-12-30")
+		(rev "1.0")
+	)
+	(lib_symbols)
+	(hierarchical_label "VCC"
+		(shape input)
+		(at 50 40 180)
+		(effects (font (size 1.27 1.27)) (justify right))
+		(uuid "hlabel-vcc")
+	)
+	(hierarchical_label "GND"
+		(shape input)
+		(at 50 60 180)
+		(effects (font (size 1.27 1.27)) (justify right))
+		(uuid "hlabel-gnd")
+	)
+	(hierarchical_label "OUT"
+		(shape output)
+		(at 100 50 0)
+		(effects (font (size 1.27 1.27)) (justify left))
+		(uuid "hlabel-out")
+	)
+)

--- a/tests/fixtures/projects/output_subsheet.kicad_sch
+++ b/tests/fixtures/projects/output_subsheet.kicad_sch
@@ -1,0 +1,19 @@
+(kicad_sch
+	(version 20231120)
+	(generator "kicadtools_test")
+	(generator_version "8.0")
+	(uuid "00000000-0000-0000-0000-000000000003")
+	(paper "A4")
+	(title_block
+		(title "Output Subsheet")
+		(date "2024-12-30")
+		(rev "1.0")
+	)
+	(lib_symbols)
+	(hierarchical_label "IN"
+		(shape input)
+		(at 50 50 180)
+		(effects (font (size 1.27 1.27)) (justify right))
+		(uuid "hlabel-in")
+	)
+)


### PR DESCRIPTION
## Summary

The `kct sch hierarchy labels` command now shows match status between sheet pins and hierarchical labels in hierarchical schematics:

- Groups output by sheet for clearer organization  
- Shows ✓ for matches and ✗ for mismatches
- Indicates MISSING when a pin lacks its corresponding label (or vice versa)
- Adds summary line showing total signals and mismatch count

## Changes

- `src/kicad_tools/cli/sch_hierarchy.py`: Enhanced `cmd_labels` function to analyze pin↔label matching
- `tests/conftest.py`: Added `hierarchical_schematic` fixture
- `tests/fixtures/projects/logic_subsheet.kicad_sch`: New test fixture with matching labels
- `tests/fixtures/projects/output_subsheet.kicad_sch`: New test fixture with intentionally missing label
- `tests/test_cli_sch.py`: Added tests for match status functionality

## Example Output

**Text output:**
```
Hierarchical Label Connections
======================================================================

⚡ GND ✓
   Sheet: Logic
     Pin:   GND (input) ← ✓
     Label: GND ✓

⚡ LED ✗
   Sheet: Output
     Pin:   LED (output) → ✓
     Label: LED ✗ MISSING

Summary: 5 signals, 1 mismatch
```

**JSON output now includes:**
- `matched` field for each signal and sheet
- `has_pin` and `has_label` fields for each sheet entry
- Summary statistics: `total_signals`, `matched_signals`, `mismatched_signals`

## Test Plan

- [x] Added tests for text output with match status
- [x] Added tests for JSON output with matched fields
- [x] Added test for mismatch detection
- [x] Verified existing tests still pass
- [x] Ran ruff lint checks

Closes #379