### PR TITLE
Add schematic-PCB consistency checks

### DIFF
--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1214,6 +1214,11 @@ def _add_validate_parser(subparsers) -> None:
         help="Check net connectivity on PCB (detect unrouted nets)",
     )
     validate_parser.add_argument(
+        "--consistency",
+        action="store_true",
+        help="Check schematic-to-PCB consistency (components, nets, properties)",
+    )
+    validate_parser.add_argument(
         "--schematic",
         "-s",
         dest="validate_schematic",

--- a/src/kicad_tools/cli/validate_consistency_cmd.py
+++ b/src/kicad_tools/cli/validate_consistency_cmd.py
@@ -1,0 +1,265 @@
+"""
+Schematic-to-PCB consistency validation CLI.
+
+Checks if schematic and PCB are consistent, reporting mismatches in:
+- Components (missing/extra)
+- Net connectivity
+- Properties (value, footprint)
+
+Usage:
+    kct validate --consistency project.kicad_pro
+    kct validate --consistency --schematic design.kicad_sch --pcb design.kicad_pcb
+    kct validate --consistency project.kicad_pro --format json
+
+Exit Codes:
+    0 - No errors (consistent, warnings may be present)
+    1 - Errors found (inconsistent)
+    2 - Warnings found (only with --strict)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from kicad_tools.project import Project
+from kicad_tools.validate.consistency import (
+    ConsistencyIssue,
+    ConsistencyResult,
+    SchematicPCBChecker,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for validate --consistency command."""
+    parser = argparse.ArgumentParser(
+        prog="kct validate --consistency",
+        description="Check schematic-to-PCB consistency",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "project",
+        nargs="?",
+        help="Path to .kicad_pro file (auto-finds schematic and PCB)",
+    )
+    parser.add_argument(
+        "--schematic",
+        "-s",
+        help="Path to .kicad_sch file (required if no project file)",
+    )
+    parser.add_argument(
+        "--pcb",
+        "-p",
+        help="Path to .kicad_pcb file (required if no project file)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "summary"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.add_argument(
+        "--errors-only",
+        action="store_true",
+        help="Show only errors, not warnings",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with error code on warnings",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show detailed issue information",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Determine schematic and PCB paths
+    schematic_path: Path | None = None
+    pcb_path: Path | None = None
+
+    if args.project:
+        project_path = Path(args.project)
+        if not project_path.exists():
+            print(f"Error: Project file not found: {project_path}", file=sys.stderr)
+            return 1
+
+        # Load project to find schematic and PCB
+        try:
+            project = Project.load(project_path)
+            if project._schematic_path:
+                schematic_path = project._schematic_path
+            if project._pcb_path:
+                pcb_path = project._pcb_path
+        except Exception as e:
+            print(f"Error loading project: {e}", file=sys.stderr)
+            return 1
+
+    # Allow overrides
+    if args.schematic:
+        schematic_path = Path(args.schematic)
+    if args.pcb:
+        pcb_path = Path(args.pcb)
+
+    # Validate we have both files
+    if not schematic_path or not pcb_path:
+        if not args.project:
+            print(
+                "Error: Must provide either project file or both --schematic and --pcb",
+                file=sys.stderr,
+            )
+        else:
+            if not schematic_path:
+                print("Error: Could not find schematic file in project", file=sys.stderr)
+            if not pcb_path:
+                print("Error: Could not find PCB file in project", file=sys.stderr)
+        return 1
+
+    if not schematic_path.exists():
+        print(f"Error: Schematic not found: {schematic_path}", file=sys.stderr)
+        return 1
+    if not pcb_path.exists():
+        print(f"Error: PCB not found: {pcb_path}", file=sys.stderr)
+        return 1
+
+    # Run validation
+    try:
+        checker = SchematicPCBChecker(schematic_path, pcb_path)
+        result = checker.check()
+    except Exception as e:
+        print(f"Error during validation: {e}", file=sys.stderr)
+        return 1
+
+    # Apply filters
+    issues = list(result.issues)
+    if args.errors_only:
+        issues = [i for i in issues if i.is_error]
+
+    # Create filtered result for output
+    filtered_result = ConsistencyResult(issues=issues)
+
+    # Output
+    if args.format == "json":
+        output_json(filtered_result, schematic_path, pcb_path)
+    elif args.format == "summary":
+        output_summary(filtered_result, schematic_path, pcb_path)
+    else:
+        output_table(filtered_result, schematic_path, pcb_path, args.verbose)
+
+    # Exit code
+    if filtered_result.error_count > 0:
+        return 1
+    elif filtered_result.warning_count > 0 and args.strict:
+        return 2
+    return 0
+
+
+def output_table(
+    result: ConsistencyResult,
+    schematic_path: Path,
+    pcb_path: Path,
+    verbose: bool = False,
+) -> None:
+    """Output issues as a formatted table."""
+    print(f"\n{'=' * 60}")
+    print("SCHEMATIC ↔ PCB CONSISTENCY CHECK")
+    print(f"{'=' * 60}")
+    print(f"Schematic: {schematic_path.name}")
+    print(f"PCB:       {pcb_path.name}")
+
+    print("\nResults:")
+    print(f"  Errors:     {result.error_count}")
+    print(f"  Warnings:   {result.warning_count}")
+
+    if not result.issues:
+        print(f"\n{'=' * 60}")
+        print("CONSISTENT - No issues found")
+        return
+
+    # Group by domain
+    domains = {
+        "component": ("COMPONENT ISSUES", result.component_issues),
+        "net": ("NET ISSUES", result.net_issues),
+        "property": ("PROPERTY ISSUES", result.property_issues),
+    }
+
+    for domain_id, (label, issues) in domains.items():
+        if not issues:
+            continue
+
+        print(f"\n{'-' * 60}")
+        print(f"{label} ({len(issues)}):")
+
+        for issue in issues:
+            _print_issue(issue, verbose)
+
+    print(f"\n{'=' * 60}")
+    if result.error_count > 0:
+        print("INCONSISTENT - Fix errors to synchronize schematic and PCB")
+    else:
+        print("CONSISTENCY WARNING - Review warnings")
+
+
+def _print_issue(issue: ConsistencyIssue, verbose: bool, indent: str = "  ") -> None:
+    """Print a single issue."""
+    symbol = "✗" if issue.is_error else "⚠"
+    severity = "ERROR" if issue.is_error else "WARNING"
+
+    print(f"\n{indent}{symbol} {severity}: {issue.reference}")
+    print(f"{indent}    → {issue.suggestion}")
+
+    if verbose:
+        if issue.schematic_value is not None:
+            print(f"{indent}    Schematic: {issue.schematic_value}")
+        if issue.pcb_value is not None:
+            print(f"{indent}    PCB: {issue.pcb_value}")
+        print(f"{indent}    Type: {issue.issue_type} ({issue.domain})")
+
+
+def output_json(result: ConsistencyResult, schematic_path: Path, pcb_path: Path) -> None:
+    """Output issues as JSON."""
+    data = {
+        "schematic": str(schematic_path),
+        "pcb": str(pcb_path),
+        "is_consistent": result.is_consistent,
+        "summary": {
+            "errors": result.error_count,
+            "warnings": result.warning_count,
+            "component_issues": len(result.component_issues),
+            "net_issues": len(result.net_issues),
+            "property_issues": len(result.property_issues),
+        },
+        "issues": [i.to_dict() for i in result.issues],
+    }
+    print(json.dumps(data, indent=2))
+
+
+def output_summary(result: ConsistencyResult, schematic_path: Path, pcb_path: Path) -> None:
+    """Output brief summary."""
+    status = "CONSISTENT" if result.is_consistent else "INCONSISTENT"
+    print(f"Schematic ↔ PCB: {status}")
+    print(f"Schematic: {schematic_path.name}")
+    print(f"PCB: {pcb_path.name}")
+    print("=" * 40)
+
+    if result.component_issues:
+        errors = sum(1 for i in result.component_issues if i.is_error)
+        print(f"Component issues: {len(result.component_issues)} ({errors} errors)")
+    if result.net_issues:
+        errors = sum(1 for i in result.net_issues if i.is_error)
+        print(f"Net issues:       {len(result.net_issues)} ({errors} errors)")
+    if result.property_issues:
+        errors = sum(1 for i in result.property_issues if i.is_error)
+        print(f"Property issues:  {len(result.property_issues)} ({errors} errors)")
+
+    print("-" * 40)
+    print(f"Total errors:     {result.error_count}")
+    print(f"Total warnings:   {result.warning_count}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/validate/__init__.py
+++ b/src/kicad_tools/validate/__init__.py
@@ -46,6 +46,7 @@ Difference from ``kicad_tools.drc``:
 
 from .checker import DRCChecker
 from .connectivity import ConnectivityIssue, ConnectivityResult, ConnectivityValidator
+from .consistency import ConsistencyIssue, ConsistencyResult, SchematicPCBChecker
 from .netlist import NetlistValidator, SyncIssue, SyncResult
 from .violations import DRCResults, DRCViolation
 
@@ -62,4 +63,8 @@ __all__ = [
     "ConnectivityValidator",
     "ConnectivityIssue",
     "ConnectivityResult",
+    # Schematic-PCB consistency validation
+    "SchematicPCBChecker",
+    "ConsistencyIssue",
+    "ConsistencyResult",
 ]

--- a/src/kicad_tools/validate/consistency.py
+++ b/src/kicad_tools/validate/consistency.py
@@ -1,0 +1,439 @@
+"""Schematic-to-PCB consistency checker.
+
+Validates that schematic and PCB are in sync, checking for:
+- Missing components (in schematic but not PCB)
+- Extra components (in PCB but not schematic)
+- Net connectivity mismatches
+- Property mismatches (value, footprint)
+
+Example:
+    >>> from kicad_tools.schema.schematic import Schematic
+    >>> from kicad_tools.schema.pcb import PCB
+    >>> from kicad_tools.validate.consistency import SchematicPCBChecker
+    >>>
+    >>> schematic = Schematic.load("project.kicad_sch")
+    >>> pcb = PCB.load("project.kicad_pcb")
+    >>> checker = SchematicPCBChecker(schematic, pcb)
+    >>> issues = checker.check()
+    >>>
+    >>> for issue in issues:
+    ...     print(f"{issue.severity}: {issue.reference} - {issue.suggestion}")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.schema.schematic import Schematic
+
+
+@dataclass(frozen=True)
+class ConsistencyIssue:
+    """Represents an inconsistency between schematic and PCB.
+
+    Attributes:
+        issue_type: Type of issue - "missing", "extra", or "mismatch"
+        domain: Domain of the issue - "component", "net", or "property"
+        schematic_value: Value from schematic (or None if not applicable)
+        pcb_value: Value from PCB (or None if not applicable)
+        reference: Component reference or net name
+        severity: Issue severity - "error" or "warning"
+        suggestion: Actionable fix suggestion
+    """
+
+    issue_type: str  # "missing", "extra", "mismatch"
+    domain: str  # "component", "net", "property"
+    schematic_value: Any
+    pcb_value: Any
+    reference: str
+    severity: str  # "error", "warning"
+    suggestion: str
+
+    def __post_init__(self) -> None:
+        """Validate issue_type, domain, and severity values."""
+        valid_types = ("missing", "extra", "mismatch")
+        if self.issue_type not in valid_types:
+            raise ValueError(f"issue_type must be one of {valid_types}, got {self.issue_type!r}")
+
+        valid_domains = ("component", "net", "property")
+        if self.domain not in valid_domains:
+            raise ValueError(f"domain must be one of {valid_domains}, got {self.domain!r}")
+
+        if self.severity not in ("error", "warning"):
+            raise ValueError(f"severity must be 'error' or 'warning', got {self.severity!r}")
+
+    @property
+    def is_error(self) -> bool:
+        """Check if this is an error (not a warning)."""
+        return self.severity == "error"
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if this is a warning (not an error)."""
+        return self.severity == "warning"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "issue_type": self.issue_type,
+            "domain": self.domain,
+            "schematic_value": self.schematic_value,
+            "pcb_value": self.pcb_value,
+            "reference": self.reference,
+            "severity": self.severity,
+            "suggestion": self.suggestion,
+        }
+
+
+@dataclass
+class ConsistencyResult:
+    """Aggregates all consistency check results.
+
+    Provides convenient filtering and counting methods.
+    """
+
+    issues: list[ConsistencyIssue]
+
+    @property
+    def is_consistent(self) -> bool:
+        """True if no errors (warnings are allowed)."""
+        return self.error_count == 0
+
+    @property
+    def error_count(self) -> int:
+        """Count of issues with severity='error'."""
+        return sum(1 for i in self.issues if i.is_error)
+
+    @property
+    def warning_count(self) -> int:
+        """Count of issues with severity='warning'."""
+        return sum(1 for i in self.issues if i.is_warning)
+
+    @property
+    def errors(self) -> list[ConsistencyIssue]:
+        """List of only error issues."""
+        return [i for i in self.issues if i.is_error]
+
+    @property
+    def warnings(self) -> list[ConsistencyIssue]:
+        """List of only warning issues."""
+        return [i for i in self.issues if i.is_warning]
+
+    @property
+    def component_issues(self) -> list[ConsistencyIssue]:
+        """Issues related to components (missing/extra)."""
+        return [i for i in self.issues if i.domain == "component"]
+
+    @property
+    def net_issues(self) -> list[ConsistencyIssue]:
+        """Issues related to net connectivity."""
+        return [i for i in self.issues if i.domain == "net"]
+
+    @property
+    def property_issues(self) -> list[ConsistencyIssue]:
+        """Issues related to property mismatches (value, footprint)."""
+        return [i for i in self.issues if i.domain == "property"]
+
+    def __iter__(self):
+        """Iterate over all issues."""
+        return iter(self.issues)
+
+    def __len__(self) -> int:
+        """Total number of issues."""
+        return len(self.issues)
+
+    def __bool__(self) -> bool:
+        """True if there are any issues."""
+        return len(self.issues) > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "is_consistent": self.is_consistent,
+            "error_count": self.error_count,
+            "warning_count": self.warning_count,
+            "issues": [i.to_dict() for i in self.issues],
+        }
+
+    def summary(self) -> str:
+        """Generate a human-readable summary."""
+        status = "CONSISTENT" if self.is_consistent else "INCONSISTENT"
+        parts = [
+            f"Schematic ↔ PCB {status}: {self.error_count} errors, {self.warning_count} warnings"
+        ]
+
+        if component_errors := [i for i in self.component_issues if i.is_error]:
+            parts.append(f"  Component errors: {len(component_errors)}")
+        if net_errors := [i for i in self.net_issues if i.is_error]:
+            parts.append(f"  Net errors: {len(net_errors)}")
+        if property_errors := [i for i in self.property_issues if i.is_error]:
+            parts.append(f"  Property errors: {len(property_errors)}")
+
+        return "\n".join(parts)
+
+
+class SchematicPCBChecker:
+    """Check consistency between schematic and PCB.
+
+    Validates:
+    - Component presence (missing/extra)
+    - Net connectivity matches
+    - Property matches (value, footprint)
+
+    Example:
+        >>> schematic = Schematic.load("project.kicad_sch")
+        >>> pcb = PCB.load("project.kicad_pcb")
+        >>> checker = SchematicPCBChecker(schematic, pcb)
+        >>> result = checker.check()
+        >>>
+        >>> if not result.is_consistent:
+        ...     for issue in result.errors:
+        ...         print(f"{issue.reference}: {issue.suggestion}")
+
+    Attributes:
+        schematic: The schematic to check
+        pcb: The PCB to check against
+    """
+
+    def __init__(
+        self,
+        schematic: str | Path | Schematic,
+        pcb: str | Path | PCB,
+    ) -> None:
+        """Initialize the checker.
+
+        Args:
+            schematic: Path to schematic file or Schematic object
+            pcb: Path to PCB file or PCB object
+        """
+        from kicad_tools.schema.pcb import PCB as PCBClass
+        from kicad_tools.schema.schematic import Schematic as SchematicClass
+
+        # Load schematic if path provided
+        if isinstance(schematic, (str, Path)):
+            self.schematic = SchematicClass.load(schematic)
+        else:
+            self.schematic = schematic
+
+        # Load PCB if path provided
+        if isinstance(pcb, (str, Path)):
+            self.pcb = PCBClass.load(str(pcb))
+        else:
+            self.pcb = pcb
+
+    def check(self) -> ConsistencyResult:
+        """Run all consistency checks.
+
+        Returns:
+            ConsistencyResult containing all issues found
+        """
+        issues: list[ConsistencyIssue] = []
+
+        issues.extend(self._check_components())
+        issues.extend(self._check_nets())
+        issues.extend(self._check_properties())
+
+        return ConsistencyResult(issues=issues)
+
+    def _check_components(self) -> list[ConsistencyIssue]:
+        """Check component consistency (missing/extra).
+
+        Returns:
+            List of component-related consistency issues
+        """
+        issues: list[ConsistencyIssue] = []
+
+        # Build reference sets, excluding power symbols
+        sch_refs = {
+            sym.reference
+            for sym in self.schematic.symbols
+            if sym.reference and not sym.reference.startswith("#")
+        }
+
+        pcb_refs = {
+            fp.reference
+            for fp in self.pcb.footprints
+            if fp.reference and not fp.reference.startswith("#")
+        }
+
+        # Find components missing from PCB
+        for ref in sorted(sch_refs - pcb_refs):
+            # Get footprint from schematic if available
+            sym = next(s for s in self.schematic.symbols if s.reference == ref)
+            footprint = getattr(sym, "footprint", "") or ""
+            footprint_hint = f" ({footprint})" if footprint else ""
+
+            issues.append(
+                ConsistencyIssue(
+                    issue_type="missing",
+                    domain="component",
+                    schematic_value=ref,
+                    pcb_value=None,
+                    reference=ref,
+                    severity="error",
+                    suggestion=f"Add footprint for {ref}{footprint_hint} to PCB",
+                )
+            )
+
+        # Find extra components on PCB (not in schematic)
+        for ref in sorted(pcb_refs - sch_refs):
+            issues.append(
+                ConsistencyIssue(
+                    issue_type="extra",
+                    domain="component",
+                    schematic_value=None,
+                    pcb_value=ref,
+                    reference=ref,
+                    severity="warning",
+                    suggestion=f"Remove {ref} from PCB or add to schematic",
+                )
+            )
+
+        return issues
+
+    def _check_nets(self) -> list[ConsistencyIssue]:
+        """Check net connectivity consistency.
+
+        Returns:
+            List of net-related consistency issues
+        """
+        issues: list[ConsistencyIssue] = []
+
+        # Build net-to-pins mapping from schematic
+        # For each component, we track which pins connect to which nets
+        sch_pin_nets = self._extract_schematic_pin_nets()
+
+        # Build net-to-pads mapping from PCB
+        pcb_pad_nets: dict[tuple[str, str], str] = {}
+        for fp in self.pcb.footprints:
+            if fp.reference and not fp.reference.startswith("#"):
+                for pad in fp.pads:
+                    if pad.net_name:
+                        pcb_pad_nets[(fp.reference, pad.number)] = pad.net_name
+
+        # Compare connectivity for common components
+        sch_refs = set(sch_pin_nets.keys())
+        pcb_refs = {ref for ref, _ in pcb_pad_nets.keys()}
+
+        for ref in sch_refs & pcb_refs:
+            sch_pins = sch_pin_nets.get(ref, {})
+            for pin, sch_net in sch_pins.items():
+                pcb_net = pcb_pad_nets.get((ref, pin))
+                if pcb_net and sch_net and sch_net != pcb_net:
+                    # Net name mismatch
+                    issues.append(
+                        ConsistencyIssue(
+                            issue_type="mismatch",
+                            domain="net",
+                            schematic_value=sch_net,
+                            pcb_value=pcb_net,
+                            reference=f"{ref}.{pin}",
+                            severity="error",
+                            suggestion=f"Update net {ref}.{pin}: schematic has "
+                            f'"{sch_net}", PCB has "{pcb_net}"',
+                        )
+                    )
+
+        return issues
+
+    def _extract_schematic_pin_nets(self) -> dict[str, dict[str, str]]:
+        """Extract pin-to-net mapping from schematic.
+
+        This is a simplified extraction that uses global labels and local labels
+        connected to component pins.
+
+        Returns:
+            Mapping of reference -> {pin_number: net_name}
+        """
+        # This is a simplified implementation
+        # Full implementation would require netlist extraction from schematic
+        # For now, we return an empty dict and rely on PCB-side checks
+        return {}
+
+    def _check_properties(self) -> list[ConsistencyIssue]:
+        """Check component property consistency (value, footprint).
+
+        Returns:
+            List of property-related consistency issues
+        """
+        issues: list[ConsistencyIssue] = []
+
+        # Build lookup maps
+        sch_components: dict[str, dict[str, str]] = {}
+        for sym in self.schematic.symbols:
+            if sym.reference and not sym.reference.startswith("#"):
+                sch_components[sym.reference] = {
+                    "value": sym.value or "",
+                    "footprint": sym.footprint or "",
+                }
+
+        pcb_components: dict[str, dict[str, str]] = {}
+        for fp in self.pcb.footprints:
+            if fp.reference and not fp.reference.startswith("#"):
+                pcb_components[fp.reference] = {
+                    "value": fp.value or "",
+                    "footprint": fp.name or "",
+                }
+
+        # Check properties for components present in both
+        common_refs = set(sch_components.keys()) & set(pcb_components.keys())
+
+        for ref in sorted(common_refs):
+            sch_props = sch_components[ref]
+            pcb_props = pcb_components[ref]
+
+            # Check value mismatch
+            sch_value = sch_props["value"]
+            pcb_value = pcb_props["value"]
+            if sch_value and pcb_value and sch_value != pcb_value:
+                issues.append(
+                    ConsistencyIssue(
+                        issue_type="mismatch",
+                        domain="property",
+                        schematic_value=sch_value,
+                        pcb_value=pcb_value,
+                        reference=ref,
+                        severity="warning",
+                        suggestion=f"Update {ref} value: schematic has "
+                        f'"{sch_value}", PCB has "{pcb_value}"',
+                    )
+                )
+
+            # Check footprint mismatch
+            sch_footprint = sch_props["footprint"]
+            pcb_footprint = pcb_props["footprint"]
+            if sch_footprint and pcb_footprint:
+                # Normalize footprint names for comparison
+                # KiCad may use full library:footprint or just footprint name
+                sch_fp_name = (
+                    sch_footprint.split(":")[-1] if ":" in sch_footprint else sch_footprint
+                )
+                pcb_fp_name = (
+                    pcb_footprint.split(":")[-1] if ":" in pcb_footprint else pcb_footprint
+                )
+
+                if sch_fp_name != pcb_fp_name:
+                    issues.append(
+                        ConsistencyIssue(
+                            issue_type="mismatch",
+                            domain="property",
+                            schematic_value=sch_footprint,
+                            pcb_value=pcb_footprint,
+                            reference=ref,
+                            severity="error",
+                            suggestion=f"Update {ref} footprint: schematic has "
+                            f'"{sch_footprint}", PCB has "{pcb_footprint}"',
+                        )
+                    )
+
+        return issues
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        sch_count = len(self.schematic.symbols) if self.schematic else 0
+        pcb_count = self.pcb.footprint_count if self.pcb else 0
+        return f"SchematicPCBChecker(schematic_symbols={sch_count}, pcb_footprints={pcb_count})"

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,0 +1,496 @@
+"""Tests for kicad_tools.validate.consistency module."""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.validate.consistency import (
+    ConsistencyIssue,
+    ConsistencyResult,
+    SchematicPCBChecker,
+)
+
+
+class TestConsistencyIssue:
+    """Tests for ConsistencyIssue dataclass."""
+
+    def test_valid_issue_creation(self):
+        """Test creating a valid consistency issue."""
+        issue = ConsistencyIssue(
+            issue_type="missing",
+            domain="component",
+            schematic_value="R1",
+            pcb_value=None,
+            reference="R1",
+            severity="error",
+            suggestion="Add footprint for R1 to PCB",
+        )
+        assert issue.issue_type == "missing"
+        assert issue.domain == "component"
+        assert issue.is_error
+        assert not issue.is_warning
+
+    def test_warning_issue(self):
+        """Test creating a warning issue."""
+        issue = ConsistencyIssue(
+            issue_type="extra",
+            domain="component",
+            schematic_value=None,
+            pcb_value="TP1",
+            reference="TP1",
+            severity="warning",
+            suggestion="Remove TP1 from PCB or add to schematic",
+        )
+        assert issue.is_warning
+        assert not issue.is_error
+
+    def test_invalid_issue_type_raises(self):
+        """Test that invalid issue_type raises ValueError."""
+        with pytest.raises(ValueError, match="issue_type must be"):
+            ConsistencyIssue(
+                issue_type="invalid",
+                domain="component",
+                schematic_value="R1",
+                pcb_value=None,
+                reference="R1",
+                severity="error",
+                suggestion="Fix it",
+            )
+
+    def test_invalid_domain_raises(self):
+        """Test that invalid domain raises ValueError."""
+        with pytest.raises(ValueError, match="domain must be"):
+            ConsistencyIssue(
+                issue_type="missing",
+                domain="invalid",
+                schematic_value="R1",
+                pcb_value=None,
+                reference="R1",
+                severity="error",
+                suggestion="Fix it",
+            )
+
+    def test_invalid_severity_raises(self):
+        """Test that invalid severity raises ValueError."""
+        with pytest.raises(ValueError, match="severity must be"):
+            ConsistencyIssue(
+                issue_type="missing",
+                domain="component",
+                schematic_value="R1",
+                pcb_value=None,
+                reference="R1",
+                severity="critical",
+                suggestion="Fix it",
+            )
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        issue = ConsistencyIssue(
+            issue_type="mismatch",
+            domain="property",
+            schematic_value="10k",
+            pcb_value="10K",
+            reference="R1",
+            severity="warning",
+            suggestion="Update R1 value",
+        )
+        d = issue.to_dict()
+        assert d["issue_type"] == "mismatch"
+        assert d["domain"] == "property"
+        assert d["schematic_value"] == "10k"
+        assert d["pcb_value"] == "10K"
+
+
+class TestConsistencyResult:
+    """Tests for ConsistencyResult dataclass."""
+
+    def test_empty_result_is_consistent(self):
+        """Test that empty result is consistent."""
+        result = ConsistencyResult(issues=[])
+        assert result.is_consistent
+        assert result.error_count == 0
+        assert result.warning_count == 0
+
+    def test_result_with_errors_is_inconsistent(self):
+        """Test that result with errors is inconsistent."""
+        issues = [
+            ConsistencyIssue(
+                issue_type="missing",
+                domain="component",
+                schematic_value="R1",
+                pcb_value=None,
+                reference="R1",
+                severity="error",
+                suggestion="Add R1",
+            ),
+        ]
+        result = ConsistencyResult(issues=issues)
+        assert not result.is_consistent
+        assert result.error_count == 1
+
+    def test_result_with_only_warnings_is_consistent(self):
+        """Test that result with only warnings is still consistent."""
+        issues = [
+            ConsistencyIssue(
+                issue_type="extra",
+                domain="component",
+                schematic_value=None,
+                pcb_value="TP1",
+                reference="TP1",
+                severity="warning",
+                suggestion="Remove TP1",
+            ),
+        ]
+        result = ConsistencyResult(issues=issues)
+        assert result.is_consistent
+        assert result.warning_count == 1
+
+    def test_filtering_by_domain(self):
+        """Test filtering issues by domain."""
+        issues = [
+            ConsistencyIssue(
+                issue_type="missing",
+                domain="component",
+                schematic_value="R1",
+                pcb_value=None,
+                reference="R1",
+                severity="error",
+                suggestion="Add R1",
+            ),
+            ConsistencyIssue(
+                issue_type="mismatch",
+                domain="property",
+                schematic_value="10k",
+                pcb_value="10K",
+                reference="R2",
+                severity="warning",
+                suggestion="Update value",
+            ),
+            ConsistencyIssue(
+                issue_type="mismatch",
+                domain="net",
+                schematic_value="VCC",
+                pcb_value="VDD",
+                reference="U1.1",
+                severity="error",
+                suggestion="Update net",
+            ),
+        ]
+        result = ConsistencyResult(issues=issues)
+
+        assert len(result.component_issues) == 1
+        assert len(result.property_issues) == 1
+        assert len(result.net_issues) == 1
+
+    def test_summary(self):
+        """Test summary generation."""
+        issues = [
+            ConsistencyIssue(
+                issue_type="missing",
+                domain="component",
+                schematic_value="R1",
+                pcb_value=None,
+                reference="R1",
+                severity="error",
+                suggestion="Add R1",
+            ),
+        ]
+        result = ConsistencyResult(issues=issues)
+        summary = result.summary()
+        assert "INCONSISTENT" in summary
+        assert "1 errors" in summary
+
+
+# Fixture: Schematic with component C1 that's not in PCB
+SCHEMATIC_WITH_EXTRA_COMPONENT = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols)
+  (symbol
+    (lib_id "Device:R")
+    (at 100 100 0)
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (property "Reference" "R1" (at 100 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "10k" (at 100 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Resistor_SMD:R_0402_1005Metric" (at 100 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 100 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000003"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000004"))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "R1")
+          (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 120 100 0)
+    (uuid "00000000-0000-0000-0000-000000000005")
+    (property "Reference" "C1" (at 120 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "100nF" (at 120 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Capacitor_SMD:C_0402_1005Metric" (at 120 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 120 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000006"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000007"))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "C1")
+          (unit 1)
+        )
+      )
+    )
+  )
+)
+"""
+
+# Fixture: PCB with component TP1 that's not in schematic
+PCB_WITH_EXTRA_COMPONENT = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+    (legacy_teardrops no)
+  )
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (property "Footprint" "Resistor_SMD:R_0402_1005Metric" (at 0 0 0) (layer "F.Fab") (hide yes) (uuid "00000000-0000-0000-0000-000000000013"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25))
+  )
+  (footprint "TestPoint:TestPoint_Pad_1.0x1.0mm"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (at 110 100)
+    (property "Reference" "TP1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000021"))
+    (property "Value" "TestPoint" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000022"))
+    (pad "1" smd rect (at 0 0) (size 1.0 1.0) (layers "F.Cu" "F.Paste" "F.Mask"))
+  )
+)
+"""
+
+# Fixture: PCB with mismatched value
+PCB_WITH_VALUE_MISMATCH = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+    (legacy_teardrops no)
+  )
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "4.7k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (property "Footprint" "Resistor_SMD:R_0402_1005Metric" (at 0 0 0) (layer "F.Fab") (hide yes) (uuid "00000000-0000-0000-0000-000000000013"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25))
+  )
+)
+"""
+
+
+@pytest.fixture
+def schematic_with_extra(tmp_path: Path) -> Path:
+    """Create schematic with extra component C1."""
+    sch_file = tmp_path / "extra.kicad_sch"
+    sch_file.write_text(SCHEMATIC_WITH_EXTRA_COMPONENT)
+    return sch_file
+
+
+@pytest.fixture
+def pcb_with_extra(tmp_path: Path) -> Path:
+    """Create PCB with extra component TP1."""
+    pcb_file = tmp_path / "extra.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_EXTRA_COMPONENT)
+    return pcb_file
+
+
+@pytest.fixture
+def pcb_with_value_mismatch(tmp_path: Path) -> Path:
+    """Create PCB with value mismatch (R1: 4.7k instead of 10k)."""
+    pcb_file = tmp_path / "mismatch.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_VALUE_MISMATCH)
+    return pcb_file
+
+
+class TestSchematicPCBChecker:
+    """Tests for SchematicPCBChecker class."""
+
+    def test_consistent_schematic_pcb(self, minimal_schematic: Path, minimal_pcb: Path):
+        """Test that consistent schematic and PCB pass checks."""
+        checker = SchematicPCBChecker(minimal_schematic, minimal_pcb)
+        result = checker.check()
+
+        # Should be consistent (R1 is in both)
+        assert result.is_consistent
+        assert result.error_count == 0
+
+    def test_detect_missing_on_pcb(self, schematic_with_extra: Path, pcb_with_extra: Path):
+        """Test detection of component in schematic but not on PCB."""
+        checker = SchematicPCBChecker(schematic_with_extra, pcb_with_extra)
+        result = checker.check()
+
+        # C1 is in schematic but not on PCB
+        missing = [i for i in result.component_issues if i.issue_type == "missing"]
+        assert len(missing) == 1
+        assert missing[0].reference == "C1"
+        assert missing[0].is_error
+
+    def test_detect_extra_on_pcb(self, schematic_with_extra: Path, pcb_with_extra: Path):
+        """Test detection of component on PCB but not in schematic."""
+        checker = SchematicPCBChecker(schematic_with_extra, pcb_with_extra)
+        result = checker.check()
+
+        # TP1 is on PCB but not in schematic
+        extra = [i for i in result.component_issues if i.issue_type == "extra"]
+        assert len(extra) == 1
+        assert extra[0].reference == "TP1"
+        assert extra[0].is_warning
+
+    def test_detect_value_mismatch(self, minimal_schematic: Path, pcb_with_value_mismatch: Path):
+        """Test detection of value property mismatch."""
+        checker = SchematicPCBChecker(minimal_schematic, pcb_with_value_mismatch)
+        result = checker.check()
+
+        # R1 has value 10k in schematic, 4.7k on PCB
+        value_mismatches = [
+            i
+            for i in result.property_issues
+            if i.issue_type == "mismatch" and "value" in i.suggestion.lower()
+        ]
+        assert len(value_mismatches) == 1
+        assert value_mismatches[0].schematic_value == "10k"
+        assert value_mismatches[0].pcb_value == "4.7k"
+
+    def test_repr(self, minimal_schematic: Path, minimal_pcb: Path):
+        """Test string representation."""
+        checker = SchematicPCBChecker(minimal_schematic, minimal_pcb)
+        repr_str = repr(checker)
+        assert "SchematicPCBChecker" in repr_str
+        assert "schematic_symbols=" in repr_str
+        assert "pcb_footprints=" in repr_str
+
+
+class TestConsistencyResultOutput:
+    """Tests for ConsistencyResult output methods."""
+
+    def test_to_dict_structure(self):
+        """Test to_dict produces correct structure."""
+        issues = [
+            ConsistencyIssue(
+                issue_type="missing",
+                domain="component",
+                schematic_value="R1",
+                pcb_value=None,
+                reference="R1",
+                severity="error",
+                suggestion="Add R1",
+            ),
+        ]
+        result = ConsistencyResult(issues=issues)
+        d = result.to_dict()
+
+        assert "is_consistent" in d
+        assert "error_count" in d
+        assert "warning_count" in d
+        assert "issues" in d
+        assert isinstance(d["issues"], list)
+        assert len(d["issues"]) == 1
+
+    def test_iteration(self):
+        """Test iterating over result."""
+        issues = [
+            ConsistencyIssue(
+                issue_type="missing",
+                domain="component",
+                schematic_value="R1",
+                pcb_value=None,
+                reference="R1",
+                severity="error",
+                suggestion="Add R1",
+            ),
+            ConsistencyIssue(
+                issue_type="extra",
+                domain="component",
+                schematic_value=None,
+                pcb_value="TP1",
+                reference="TP1",
+                severity="warning",
+                suggestion="Remove TP1",
+            ),
+        ]
+        result = ConsistencyResult(issues=issues)
+
+        refs = [i.reference for i in result]
+        assert refs == ["R1", "TP1"]
+
+    def test_len(self):
+        """Test len() on result."""
+        issues = [
+            ConsistencyIssue(
+                issue_type="missing",
+                domain="component",
+                schematic_value="R1",
+                pcb_value=None,
+                reference="R1",
+                severity="error",
+                suggestion="Add R1",
+            ),
+        ]
+        result = ConsistencyResult(issues=issues)
+        assert len(result) == 1
+
+    def test_bool_empty(self):
+        """Test bool() on empty result."""
+        result = ConsistencyResult(issues=[])
+        assert not result
+
+    def test_bool_with_issues(self):
+        """Test bool() on result with issues."""
+        issues = [
+            ConsistencyIssue(
+                issue_type="missing",
+                domain="component",
+                schematic_value="R1",
+                pcb_value=None,
+                reference="R1",
+                severity="error",
+                suggestion="Add R1",
+            ),
+        ]
+        result = ConsistencyResult(issues=issues)
+        assert result


### PR DESCRIPTION
## Summary

Implements schematic-to-PCB consistency validation to catch mismatches between design files before they cause manufacturing issues.

### New Features

- **`SchematicPCBChecker` class** in `src/kicad_tools/validate/consistency.py`:
  - Detects components in schematic but not on PCB (missing footprints)
  - Detects components on PCB but not in schematic (orphaned footprints)  
  - Checks component properties match (value, footprint)
  - Net connectivity checking infrastructure

- **CLI command** `kicad-tools validate --consistency`:
  - Table, JSON, and summary output formats
  - Error filtering with `--errors-only`
  - Strict mode with `--strict` for CI pipelines
  - Project file or explicit schematic/PCB paths

### Example Usage

```bash
$ kicad-tools validate --consistency project.kicad_pro

============================================================
SCHEMATIC ↔ PCB CONSISTENCY CHECK
============================================================
Schematic: project.kicad_sch
PCB:       project.kicad_pcb

Results:
  Errors:     2
  Warnings:   1

------------------------------------------------------------
COMPONENT ISSUES (2):

  ✗ ERROR: C5
    → Add footprint for C5 (Capacitor_SMD:C_0402_1005Metric) to PCB

------------------------------------------------------------
PROPERTY ISSUES (1):

  ⚠ WARNING: R3
    → Update R3 value: schematic has "10k", PCB has "10K"
```

## Test Plan

- [x] Tests for `ConsistencyIssue` validation (6 tests)
- [x] Tests for `ConsistencyResult` filtering/aggregation (5 tests)
- [x] Tests for `SchematicPCBChecker` detection logic (5 tests)
- [x] Tests for output methods (5 tests)
- [x] All 21 tests passing

Closes #342