### PR TITLE
Add BOM-placement verification feature

### DIFF
--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -5,6 +5,7 @@ __all__ = [
     "run_validate_command",
     "run_validate_connectivity_command",
     "run_validate_consistency_command",
+    "run_validate_placement_command",
     "run_validate_footprints_command",
     "run_fix_footprints_command",
     "run_constraints_command",
@@ -90,17 +91,23 @@ def run_validate_command(args) -> int:
     if getattr(args, "consistency", False):
         return run_validate_consistency_command(args)
 
+    # Route to placement validation if --placement flag is set
+    if getattr(args, "placement", False):
+        return run_validate_placement_command(args)
+
     # Default to sync validation
     if not args.sync:
         print("Usage: kicad-tools validate --sync [options] <project>")
         print("       kicad-tools validate --connectivity [options] <pcb>")
         print("       kicad-tools validate --consistency [options] <project>")
+        print("       kicad-tools validate --placement [options] <project>")
         print("\nOptions:")
         print("  --sync           Check schematic-to-PCB netlist synchronization")
         print("  --connectivity   Check net connectivity on PCB (detect unrouted nets)")
         print(
             "  --consistency    Check schematic-to-PCB consistency (components, nets, properties)"
         )
+        print("  --placement      Check BOM components are placed on PCB")
         return 1
 
     from ..validate_sync_cmd import main as validate_sync_main
@@ -171,6 +178,30 @@ def run_validate_consistency_command(args) -> int:
         sub_argv.append("--verbose")
 
     return validate_consistency_main(sub_argv)
+
+
+def run_validate_placement_command(args) -> int:
+    """Handle validate --placement command."""
+    from ..validate_placement_cmd import main as validate_placement_main
+
+    sub_argv = []
+
+    if getattr(args, "validate_project", None):
+        sub_argv.append(args.validate_project)
+    if getattr(args, "validate_schematic", None):
+        sub_argv.extend(["--schematic", args.validate_schematic])
+    if getattr(args, "validate_pcb", None):
+        sub_argv.extend(["--pcb", args.validate_pcb])
+    if getattr(args, "validate_format", "table") != "table":
+        sub_argv.extend(["--format", args.validate_format])
+    if getattr(args, "validate_errors_only", False):
+        sub_argv.append("--errors-only")
+    if getattr(args, "validate_strict", False):
+        sub_argv.append("--strict")
+    if getattr(args, "validate_verbose", False):
+        sub_argv.append("--verbose")
+
+    return validate_placement_main(sub_argv)
 
 
 def run_constraints_command(args) -> int:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1220,6 +1220,11 @@ def _add_validate_parser(subparsers) -> None:
         help="Check schematic-to-PCB consistency (components, nets, properties)",
     )
     validate_parser.add_argument(
+        "--placement",
+        action="store_true",
+        help="Check BOM components are placed on PCB",
+    )
+    validate_parser.add_argument(
         "--schematic",
         "-s",
         dest="validate_schematic",

--- a/src/kicad_tools/cli/validate_placement_cmd.py
+++ b/src/kicad_tools/cli/validate_placement_cmd.py
@@ -1,0 +1,257 @@
+"""
+BOM-to-PCB placement validation CLI.
+
+Verifies that all BOM components are placed on the PCB, identifying:
+- Components in BOM but missing from PCB
+- Components in PCB but at origin (unplaced)
+
+Usage:
+    kct validate --placement project.kicad_pro
+    kct validate --placement --schematic design.kicad_sch --pcb design.kicad_pcb
+    kct validate --placement project.kicad_pro --format json
+
+Exit Codes:
+    0 - All components placed
+    1 - Some components not placed or missing
+    2 - Warnings only (with --strict)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from kicad_tools.project import Project
+from kicad_tools.validate.placement import (
+    BOMPlacementVerifier,
+    PlacementResult,
+    PlacementStatus,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for validate --placement command."""
+    parser = argparse.ArgumentParser(
+        prog="kct validate --placement",
+        description="Verify BOM components are placed on PCB",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "project",
+        nargs="?",
+        help="Path to .kicad_pro file (auto-finds schematic and PCB)",
+    )
+    parser.add_argument(
+        "--schematic",
+        "-s",
+        help="Path to .kicad_sch file (required if no project file)",
+    )
+    parser.add_argument(
+        "--pcb",
+        "-p",
+        help="Path to .kicad_pcb file (required if no project file)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "summary"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    parser.add_argument(
+        "--errors-only",
+        action="store_true",
+        help="Show only unplaced/missing components",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with error code on any issues",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show detailed placement information",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Determine schematic and PCB paths
+    schematic_path: Path | None = None
+    pcb_path: Path | None = None
+
+    if args.project:
+        project_path = Path(args.project)
+        if not project_path.exists():
+            print(f"Error: Project file not found: {project_path}", file=sys.stderr)
+            return 1
+
+        # Load project to find schematic and PCB
+        try:
+            project = Project.load(project_path)
+            if project._schematic_path:
+                schematic_path = project._schematic_path
+            if project._pcb_path:
+                pcb_path = project._pcb_path
+        except Exception as e:
+            print(f"Error loading project: {e}", file=sys.stderr)
+            return 1
+
+    # Allow overrides
+    if args.schematic:
+        schematic_path = Path(args.schematic)
+    if args.pcb:
+        pcb_path = Path(args.pcb)
+
+    # Validate we have both files
+    if not schematic_path or not pcb_path:
+        if not args.project:
+            print(
+                "Error: Must provide either project file or both --schematic and --pcb",
+                file=sys.stderr,
+            )
+        else:
+            if not schematic_path:
+                print("Error: Could not find schematic file in project", file=sys.stderr)
+            if not pcb_path:
+                print("Error: Could not find PCB file in project", file=sys.stderr)
+        return 1
+
+    if not schematic_path.exists():
+        print(f"Error: Schematic not found: {schematic_path}", file=sys.stderr)
+        return 1
+    if not pcb_path.exists():
+        print(f"Error: PCB not found: {pcb_path}", file=sys.stderr)
+        return 1
+
+    # Run verification
+    try:
+        verifier = BOMPlacementVerifier(schematic_path, pcb_path)
+        result = verifier.verify()
+    except Exception as e:
+        print(f"Error during verification: {e}", file=sys.stderr)
+        return 1
+
+    # Output
+    if args.format == "json":
+        output_json(result, schematic_path, pcb_path)
+    elif args.format == "summary":
+        output_summary(result, schematic_path, pcb_path)
+    else:
+        output_table(result, schematic_path, pcb_path, args.verbose, args.errors_only)
+
+    # Exit code
+    if result.unplaced_count > 0:
+        return 1
+    elif args.strict and not result.all_placed:
+        return 2
+    return 0
+
+
+def output_table(
+    result: PlacementResult,
+    schematic_path: Path,
+    pcb_path: Path,
+    verbose: bool = False,
+    errors_only: bool = False,
+) -> None:
+    """Output results as a formatted table."""
+    print(f"\n{'=' * 60}")
+    print("BOM ↔ PLACEMENT VERIFICATION")
+    print(f"{'=' * 60}")
+    print(f"Schematic: {schematic_path.name}")
+    print(f"PCB:       {pcb_path.name}")
+
+    print(f"\nPlaced: {result.placed_count}/{result.total_count} components")
+
+    if result.all_placed:
+        print(f"\n{'=' * 60}")
+        print("ALL PLACED - All BOM components are on the board")
+        return
+
+    # Show unplaced components
+    if result.unplaced:
+        print(f"\n{'-' * 60}")
+        print(f"UNPLACED ({len(result.unplaced)}):")
+
+        for status in result.unplaced:
+            _print_status(status, verbose)
+
+    # Optionally show placed components
+    if verbose and not errors_only and result.placed:
+        print(f"\n{'-' * 60}")
+        print(f"PLACED ({len(result.placed)}):")
+
+        for status in result.placed:
+            _print_status(status, verbose)
+
+    # Summary
+    print(f"\n{'=' * 60}")
+    print("Summary:")
+    if result.missing_count > 0:
+        print(f"  - {result.missing_count} component(s) in BOM but not in PCB")
+    at_origin_count = len(result.at_origin)
+    if at_origin_count > 0:
+        print(f"  - {at_origin_count} component(s) in PCB but not placed (at origin)")
+
+
+def _print_status(status: PlacementStatus, verbose: bool, indent: str = "  ") -> None:
+    """Print a single placement status."""
+    if status.is_placed:
+        symbol = "✓"
+    else:
+        symbol = "✗"
+
+    print(f"\n{indent}{symbol} {status.reference} ({status.value}, {status.footprint})")
+
+    for issue in status.issues:
+        print(f"{indent}    → {issue}")
+
+    if verbose and status.position:
+        x, y = status.position
+        print(f"{indent}    Position: ({x:.2f}, {y:.2f}) on {status.layer}")
+
+
+def output_json(result: PlacementResult, schematic_path: Path, pcb_path: Path) -> None:
+    """Output results as JSON."""
+    data = {
+        "schematic": str(schematic_path),
+        "pcb": str(pcb_path),
+        "all_placed": result.all_placed,
+        "summary": {
+            "total": result.total_count,
+            "placed": result.placed_count,
+            "unplaced": result.unplaced_count,
+            "missing_from_pcb": result.missing_count,
+            "at_origin": len(result.at_origin),
+        },
+        "components": [s.to_dict() for s in result.statuses],
+    }
+    print(json.dumps(data, indent=2))
+
+
+def output_summary(result: PlacementResult, schematic_path: Path, pcb_path: Path) -> None:
+    """Output brief summary."""
+    status = "ALL PLACED" if result.all_placed else "INCOMPLETE"
+    print(f"BOM ↔ Placement: {status}")
+    print(f"Schematic: {schematic_path.name}")
+    print(f"PCB: {pcb_path.name}")
+    print("=" * 40)
+
+    print(f"Placed:           {result.placed_count}/{result.total_count}")
+
+    if result.missing_count > 0:
+        print(f"Missing from PCB: {result.missing_count}")
+    if len(result.at_origin) > 0:
+        print(f"At origin:        {len(result.at_origin)}")
+
+    print("-" * 40)
+    if result.all_placed:
+        print("Status: OK")
+    else:
+        print(f"Status: {result.unplaced_count} component(s) need attention")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/validate/__init__.py
+++ b/src/kicad_tools/validate/__init__.py
@@ -48,6 +48,7 @@ from .checker import DRCChecker
 from .connectivity import ConnectivityIssue, ConnectivityResult, ConnectivityValidator
 from .consistency import ConsistencyIssue, ConsistencyResult, SchematicPCBChecker
 from .netlist import NetlistValidator, SyncIssue, SyncResult
+from .placement import BOMPlacementVerifier, PlacementResult, PlacementStatus
 from .violations import DRCResults, DRCViolation
 
 __all__ = [
@@ -67,4 +68,8 @@ __all__ = [
     "SchematicPCBChecker",
     "ConsistencyIssue",
     "ConsistencyResult",
+    # BOM placement validation
+    "BOMPlacementVerifier",
+    "PlacementStatus",
+    "PlacementResult",
 ]

--- a/src/kicad_tools/validate/placement.py
+++ b/src/kicad_tools/validate/placement.py
@@ -1,0 +1,347 @@
+"""BOM-to-PCB placement verification.
+
+Verifies that all BOM components are placed on the PCB and identifies
+unplaced or missing parts.
+
+Example:
+    >>> from kicad_tools.schema.bom import extract_bom
+    >>> from kicad_tools.schema.pcb import PCB
+    >>> from kicad_tools.validate.placement import BOMPlacementVerifier
+    >>>
+    >>> bom = extract_bom("project.kicad_sch")
+    >>> pcb = PCB.load("project.kicad_pcb")
+    >>> verifier = BOMPlacementVerifier(bom, pcb)
+    >>> result = verifier.verify()
+    >>>
+    >>> for status in result.unplaced:
+    ...     print(f"{status.reference}: {status.issues}")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.bom import BOM
+    from kicad_tools.schema.pcb import PCB
+
+
+# Default threshold for considering a component at origin as "unplaced"
+# Components within this distance from (0,0) are flagged as potentially unplaced
+ORIGIN_THRESHOLD = 0.1  # mm
+
+
+@dataclass(frozen=True)
+class PlacementStatus:
+    """Placement status for a BOM item.
+
+    Attributes:
+        reference: Component reference designator (e.g., "R1", "U3")
+        value: Component value (e.g., "10k", "STM32F103")
+        footprint: Footprint name (e.g., "0402", "TSSOP-20")
+        in_bom: Whether component is in the BOM
+        in_pcb: Whether component exists in the PCB file
+        is_placed: Whether component has a valid position on the board
+        position: Component position as (x, y) tuple, or None if not in PCB
+        layer: Layer the component is on, or None if not in PCB
+        issues: List of issues found with this component
+    """
+
+    reference: str
+    value: str
+    footprint: str
+    in_bom: bool
+    in_pcb: bool
+    is_placed: bool
+    position: tuple[float, float] | None
+    layer: str | None
+    issues: tuple[str, ...]  # Use tuple for hashability (frozen dataclass)
+
+    @property
+    def has_issues(self) -> bool:
+        """Check if this component has any issues."""
+        return len(self.issues) > 0
+
+    @property
+    def is_error(self) -> bool:
+        """Check if this is an error (missing or not placed)."""
+        return not self.in_pcb or not self.is_placed
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if this is a warning (has issues but is placed)."""
+        return self.has_issues and self.is_placed
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "reference": self.reference,
+            "value": self.value,
+            "footprint": self.footprint,
+            "in_bom": self.in_bom,
+            "in_pcb": self.in_pcb,
+            "is_placed": self.is_placed,
+            "position": list(self.position) if self.position else None,
+            "layer": self.layer,
+            "issues": list(self.issues),
+        }
+
+
+@dataclass
+class PlacementResult:
+    """Aggregates all placement verification results.
+
+    Provides convenient filtering and counting methods.
+    """
+
+    statuses: list[PlacementStatus] = field(default_factory=list)
+
+    @property
+    def total_count(self) -> int:
+        """Total number of components checked."""
+        return len(self.statuses)
+
+    @property
+    def placed_count(self) -> int:
+        """Number of components that are placed."""
+        return sum(1 for s in self.statuses if s.is_placed)
+
+    @property
+    def unplaced_count(self) -> int:
+        """Number of components that are not placed or missing."""
+        return sum(1 for s in self.statuses if not s.is_placed)
+
+    @property
+    def missing_count(self) -> int:
+        """Number of components in BOM but not in PCB."""
+        return sum(1 for s in self.statuses if s.in_bom and not s.in_pcb)
+
+    @property
+    def all_placed(self) -> bool:
+        """True if all components are placed."""
+        return self.unplaced_count == 0
+
+    @property
+    def placed(self) -> list[PlacementStatus]:
+        """List of placed components."""
+        return [s for s in self.statuses if s.is_placed]
+
+    @property
+    def unplaced(self) -> list[PlacementStatus]:
+        """List of unplaced or missing components."""
+        return [s for s in self.statuses if not s.is_placed]
+
+    @property
+    def missing(self) -> list[PlacementStatus]:
+        """List of components in BOM but not in PCB."""
+        return [s for s in self.statuses if s.in_bom and not s.in_pcb]
+
+    @property
+    def at_origin(self) -> list[PlacementStatus]:
+        """List of components at or near origin (possibly unplaced)."""
+        return [s for s in self.statuses if not s.is_placed and s.in_pcb]
+
+    def __iter__(self):
+        """Iterate over all statuses."""
+        return iter(self.statuses)
+
+    def __len__(self) -> int:
+        """Total number of statuses."""
+        return len(self.statuses)
+
+    def __bool__(self) -> bool:
+        """True if there are any statuses."""
+        return len(self.statuses) > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "all_placed": self.all_placed,
+            "total": self.total_count,
+            "placed": self.placed_count,
+            "unplaced": self.unplaced_count,
+            "missing": self.missing_count,
+            "statuses": [s.to_dict() for s in self.statuses],
+        }
+
+    def summary(self) -> str:
+        """Generate a human-readable summary."""
+        status = "ALL PLACED" if self.all_placed else "INCOMPLETE"
+        parts = [f"BOM ↔ Placement {status}: {self.placed_count}/{self.total_count} placed"]
+
+        if self.missing_count > 0:
+            parts.append(f"  Missing from PCB: {self.missing_count}")
+        if at_origin := len(self.at_origin):
+            parts.append(f"  At origin (unplaced): {at_origin}")
+
+        return "\n".join(parts)
+
+
+class BOMPlacementVerifier:
+    """Verify BOM items are placed on PCB.
+
+    Checks that:
+    - All BOM components exist in the PCB file
+    - Components have valid positions (not at origin)
+    - Reports placement status for each component
+
+    Example:
+        >>> bom = extract_bom("project.kicad_sch")
+        >>> pcb = PCB.load("project.kicad_pcb")
+        >>> verifier = BOMPlacementVerifier(bom, pcb)
+        >>> result = verifier.verify()
+        >>>
+        >>> if not result.all_placed:
+        ...     for status in result.unplaced:
+        ...         print(f"{status.reference}: {status.issues}")
+
+    Attributes:
+        bom: The BOM to verify
+        pcb: The PCB to check against
+        origin_threshold: Distance from origin to consider as "unplaced"
+    """
+
+    def __init__(
+        self,
+        bom: str | Path | BOM,
+        pcb: str | Path | PCB,
+        origin_threshold: float = ORIGIN_THRESHOLD,
+    ) -> None:
+        """Initialize the verifier.
+
+        Args:
+            bom: Path to schematic file or BOM object
+            pcb: Path to PCB file or PCB object
+            origin_threshold: Distance from origin to consider as "unplaced"
+        """
+        from kicad_tools.schema.bom import extract_bom
+        from kicad_tools.schema.pcb import PCB as PCBClass
+
+        # Load BOM if path provided
+        if isinstance(bom, (str, Path)):
+            self.bom = extract_bom(str(bom))
+        else:
+            self.bom = bom
+
+        # Load PCB if path provided
+        if isinstance(pcb, (str, Path)):
+            self.pcb = PCBClass.load(str(pcb))
+        else:
+            self.pcb = pcb
+
+        self.origin_threshold = origin_threshold
+
+    def verify(self) -> PlacementResult:
+        """Check placement status of all BOM items.
+
+        Returns:
+            PlacementResult containing status for each component
+        """
+        statuses: list[PlacementStatus] = []
+
+        # Build lookup of PCB footprints by reference
+        pcb_footprints = {fp.reference: fp for fp in self.pcb.footprints}
+
+        # Check each BOM item
+        for item in self.bom.items:
+            # Skip virtual/power components
+            if item.is_virtual:
+                continue
+
+            # Skip DNP components
+            if item.dnp:
+                continue
+
+            footprint = pcb_footprints.get(item.reference)
+
+            issues: list[str] = []
+            position: tuple[float, float] | None = None
+            layer: str | None = None
+            is_placed = False
+
+            if footprint:
+                position = footprint.position
+                layer = footprint.layer
+
+                if self._is_at_origin(footprint.position):
+                    issues.append("Component at origin (not placed on board)")
+                    is_placed = False
+                else:
+                    is_placed = True
+            else:
+                issues.append("Component missing from PCB")
+
+            status = PlacementStatus(
+                reference=item.reference,
+                value=item.value,
+                footprint=item.footprint,
+                in_bom=True,
+                in_pcb=footprint is not None,
+                is_placed=is_placed,
+                position=position,
+                layer=layer,
+                issues=tuple(issues),
+            )
+            statuses.append(status)
+
+        # Sort by reference for consistent output
+        statuses.sort(key=lambda s: self._sort_key(s.reference))
+
+        return PlacementResult(statuses=statuses)
+
+    def get_unplaced(self) -> list[PlacementStatus]:
+        """Get only unplaced components.
+
+        Convenience method that returns just the unplaced components.
+
+        Returns:
+            List of PlacementStatus for unplaced components
+        """
+        return self.verify().unplaced
+
+    def _is_at_origin(self, position: tuple[float, float]) -> bool:
+        """Check if position is at or near origin (unplaced).
+
+        Components at (0, 0) or very close to it are typically unplaced.
+
+        Args:
+            position: (x, y) position in mm
+
+        Returns:
+            True if position is at or near origin
+        """
+        if position is None:
+            return True
+
+        x, y = position
+        return abs(x) < self.origin_threshold and abs(y) < self.origin_threshold
+
+    @staticmethod
+    def _sort_key(reference: str) -> tuple[str, int]:
+        """Generate sort key for reference designators.
+
+        Sorts by prefix (letter) first, then by number.
+        E.g., C1, C2, C10, R1, R2, U1
+
+        Args:
+            reference: Reference designator (e.g., "R1", "U23")
+
+        Returns:
+            Tuple of (prefix, number) for sorting
+        """
+        import re
+
+        match = re.match(r"([A-Za-z_#]+)(\d*)", reference)
+        if match:
+            prefix = match.group(1)
+            number = int(match.group(2)) if match.group(2) else 0
+            return (prefix, number)
+        return (reference, 0)
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        bom_count = len(self.bom.items) if self.bom else 0
+        pcb_count = self.pcb.footprint_count if self.pcb else 0
+        return f"BOMPlacementVerifier(bom_items={bom_count}, pcb_footprints={pcb_count})"

--- a/tests/test_placement_validation.py
+++ b/tests/test_placement_validation.py
@@ -1,0 +1,433 @@
+"""Tests for kicad_tools.validate.placement module."""
+
+from pathlib import Path
+
+import pytest  # noqa: F401 - used for fixtures
+
+from kicad_tools.validate.placement import (
+    BOMPlacementVerifier,
+    PlacementResult,
+    PlacementStatus,
+)
+
+
+class TestPlacementStatus:
+    """Tests for PlacementStatus dataclass."""
+
+    def test_placed_component(self):
+        """Test creating a status for a placed component."""
+        status = PlacementStatus(
+            reference="R1",
+            value="10k",
+            footprint="Resistor_SMD:R_0402",
+            in_bom=True,
+            in_pcb=True,
+            is_placed=True,
+            position=(50.0, 50.0),
+            layer="F.Cu",
+            issues=(),
+        )
+        assert status.reference == "R1"
+        assert status.is_placed
+        assert not status.has_issues
+        assert not status.is_error
+
+    def test_missing_component(self):
+        """Test creating a status for a missing component."""
+        status = PlacementStatus(
+            reference="C5",
+            value="100nF",
+            footprint="Capacitor_SMD:C_0402",
+            in_bom=True,
+            in_pcb=False,
+            is_placed=False,
+            position=None,
+            layer=None,
+            issues=("Component missing from PCB",),
+        )
+        assert not status.in_pcb
+        assert not status.is_placed
+        assert status.has_issues
+        assert status.is_error
+
+    def test_unplaced_at_origin(self):
+        """Test creating a status for component at origin."""
+        status = PlacementStatus(
+            reference="U1",
+            value="STM32",
+            footprint="TSSOP-20",
+            in_bom=True,
+            in_pcb=True,
+            is_placed=False,
+            position=(0.0, 0.0),
+            layer="F.Cu",
+            issues=("Component at origin (not placed on board)",),
+        )
+        assert status.in_pcb
+        assert not status.is_placed
+        assert status.has_issues
+        assert status.is_error
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        status = PlacementStatus(
+            reference="R1",
+            value="10k",
+            footprint="R_0402",
+            in_bom=True,
+            in_pcb=True,
+            is_placed=True,
+            position=(100.0, 200.0),
+            layer="F.Cu",
+            issues=(),
+        )
+        d = status.to_dict()
+        assert d["reference"] == "R1"
+        assert d["value"] == "10k"
+        assert d["position"] == [100.0, 200.0]
+        assert d["is_placed"] is True
+        assert d["issues"] == []
+
+
+class TestPlacementResult:
+    """Tests for PlacementResult class."""
+
+    def test_empty_result(self):
+        """Test empty result."""
+        result = PlacementResult()
+        assert result.total_count == 0
+        assert result.placed_count == 0
+        assert result.unplaced_count == 0
+        assert result.all_placed
+        assert len(result) == 0
+
+    def test_all_placed(self):
+        """Test result with all components placed."""
+        statuses = [
+            PlacementStatus(
+                reference="R1",
+                value="10k",
+                footprint="R_0402",
+                in_bom=True,
+                in_pcb=True,
+                is_placed=True,
+                position=(50.0, 50.0),
+                layer="F.Cu",
+                issues=(),
+            ),
+            PlacementStatus(
+                reference="C1",
+                value="100nF",
+                footprint="C_0402",
+                in_bom=True,
+                in_pcb=True,
+                is_placed=True,
+                position=(60.0, 60.0),
+                layer="F.Cu",
+                issues=(),
+            ),
+        ]
+        result = PlacementResult(statuses=statuses)
+        assert result.total_count == 2
+        assert result.placed_count == 2
+        assert result.unplaced_count == 0
+        assert result.all_placed
+        assert len(result.placed) == 2
+        assert len(result.unplaced) == 0
+
+    def test_mixed_placement(self):
+        """Test result with some components not placed."""
+        statuses = [
+            PlacementStatus(
+                reference="R1",
+                value="10k",
+                footprint="R_0402",
+                in_bom=True,
+                in_pcb=True,
+                is_placed=True,
+                position=(50.0, 50.0),
+                layer="F.Cu",
+                issues=(),
+            ),
+            PlacementStatus(
+                reference="C1",
+                value="100nF",
+                footprint="C_0402",
+                in_bom=True,
+                in_pcb=False,
+                is_placed=False,
+                position=None,
+                layer=None,
+                issues=("Component missing from PCB",),
+            ),
+            PlacementStatus(
+                reference="U1",
+                value="STM32",
+                footprint="TSSOP-20",
+                in_bom=True,
+                in_pcb=True,
+                is_placed=False,
+                position=(0.0, 0.0),
+                layer="F.Cu",
+                issues=("Component at origin (not placed on board)",),
+            ),
+        ]
+        result = PlacementResult(statuses=statuses)
+        assert result.total_count == 3
+        assert result.placed_count == 1
+        assert result.unplaced_count == 2
+        assert result.missing_count == 1
+        assert not result.all_placed
+        assert len(result.placed) == 1
+        assert len(result.unplaced) == 2
+        assert len(result.missing) == 1
+        assert len(result.at_origin) == 1
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        statuses = [
+            PlacementStatus(
+                reference="R1",
+                value="10k",
+                footprint="R_0402",
+                in_bom=True,
+                in_pcb=True,
+                is_placed=True,
+                position=(50.0, 50.0),
+                layer="F.Cu",
+                issues=(),
+            ),
+        ]
+        result = PlacementResult(statuses=statuses)
+        d = result.to_dict()
+        assert d["all_placed"] is True
+        assert d["total"] == 1
+        assert d["placed"] == 1
+        assert d["unplaced"] == 0
+        assert d["missing"] == 0
+        assert len(d["statuses"]) == 1
+
+    def test_summary(self):
+        """Test summary generation."""
+        statuses = [
+            PlacementStatus(
+                reference="R1",
+                value="10k",
+                footprint="R_0402",
+                in_bom=True,
+                in_pcb=True,
+                is_placed=True,
+                position=(50.0, 50.0),
+                layer="F.Cu",
+                issues=(),
+            ),
+        ]
+        result = PlacementResult(statuses=statuses)
+        summary = result.summary()
+        assert "ALL PLACED" in summary
+        assert "1/1" in summary
+
+
+class TestBOMPlacementVerifier:
+    """Tests for BOMPlacementVerifier class."""
+
+    def test_verifier_with_all_placed(self, minimal_schematic: Path, minimal_pcb: Path):
+        """Test verifier when all components are placed."""
+        verifier = BOMPlacementVerifier(minimal_schematic, minimal_pcb)
+        result = verifier.verify()
+
+        # The minimal fixtures have R1 in both schematic and PCB at position 100,100
+        assert result.total_count >= 1
+        assert result.all_placed or result.placed_count >= 1
+
+    def test_verifier_detects_missing(self, tmp_path: Path):
+        """Test verifier detects components missing from PCB."""
+        # Create schematic with R1 and C1
+        schematic_content = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols)
+  (symbol
+    (lib_id "Device:R")
+    (at 100 100 0)
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (property "Reference" "R1" (at 100 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "10k" (at 100 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Resistor_SMD:R_0402_1005Metric" (at 100 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 100 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000003"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000004"))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "R1")
+          (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 150 100 0)
+    (uuid "00000000-0000-0000-0000-000000000005")
+    (property "Reference" "C1" (at 150 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "100nF" (at 150 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Capacitor_SMD:C_0402_1005Metric" (at 150 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 150 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000006"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000007"))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "C1")
+          (unit 1)
+        )
+      )
+    )
+  )
+)
+"""
+        # Create PCB with only R1 (C1 is missing)
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 50 50)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu"))
+  )
+)
+"""
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(schematic_content)
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        verifier = BOMPlacementVerifier(sch_file, pcb_file)
+        result = verifier.verify()
+
+        assert result.missing_count == 1
+        assert not result.all_placed
+
+        # Find the missing component
+        missing = [s for s in result.statuses if s.reference == "C1"]
+        assert len(missing) == 1
+        assert not missing[0].in_pcb
+        assert "missing" in missing[0].issues[0].lower()
+
+    def test_verifier_detects_at_origin(self, tmp_path: Path):
+        """Test verifier detects components at origin (unplaced)."""
+        # Create schematic with U1
+        schematic_content = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols)
+  (symbol
+    (lib_id "Device:R")
+    (at 100 100 0)
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (property "Reference" "U1" (at 100 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "IC" (at 100 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Package_SO:TSSOP-20" (at 100 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 100 100 0) (effects (hide yes)))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "U1")
+          (unit 1)
+        )
+      )
+    )
+  )
+)
+"""
+        # Create PCB with U1 at origin (0, 0) - unplaced
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (footprint "Package_SO:TSSOP-20"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 0 0)
+    (property "Reference" "U1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "IC" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu"))
+  )
+)
+"""
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(schematic_content)
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        verifier = BOMPlacementVerifier(sch_file, pcb_file)
+        result = verifier.verify()
+
+        # Component should be detected as at origin (unplaced)
+        assert len(result.at_origin) == 1
+        assert not result.all_placed
+
+        # Find the unplaced component
+        at_origin = result.at_origin[0]
+        assert at_origin.reference == "U1"
+        assert at_origin.in_pcb
+        assert not at_origin.is_placed
+        assert "origin" in at_origin.issues[0].lower()
+
+    def test_get_unplaced_convenience(self, minimal_schematic: Path, minimal_pcb: Path):
+        """Test get_unplaced convenience method."""
+        verifier = BOMPlacementVerifier(minimal_schematic, minimal_pcb)
+        unplaced = verifier.get_unplaced()
+        # Should return a list (may be empty if all placed)
+        assert isinstance(unplaced, list)
+
+    def test_sort_key(self):
+        """Test reference designator sorting."""
+        # Use the static method directly
+        sort_key = BOMPlacementVerifier._sort_key
+
+        # Test basic sorting
+        assert sort_key("R1") == ("R", 1)
+        assert sort_key("R10") == ("R", 10)
+        assert sort_key("C23") == ("C", 23)
+        assert sort_key("U1") == ("U", 1)
+
+        # Test sorting order
+        refs = ["R10", "R1", "R2", "C1", "U1"]
+        sorted_refs = sorted(refs, key=sort_key)
+        assert sorted_refs == ["C1", "R1", "R2", "R10", "U1"]
+
+    def test_repr(self, minimal_schematic: Path, minimal_pcb: Path):
+        """Test string representation."""
+        verifier = BOMPlacementVerifier(minimal_schematic, minimal_pcb)
+        repr_str = repr(verifier)
+        assert "BOMPlacementVerifier" in repr_str
+        assert "bom_items=" in repr_str
+        assert "pcb_footprints=" in repr_str


### PR DESCRIPTION
## Summary

- Adds `BOMPlacementVerifier` class that checks if all BOM components are placed on the PCB
- Detects components missing from PCB file entirely
- Detects components at origin (0,0) which typically means they haven't been placed yet
- Integrates with existing `validate` CLI command via `--placement` flag

## Usage

```bash
# Verify placement using project file
kct validate --placement project.kicad_pro

# Verify placement with explicit schematic and PCB
kct validate --placement --schematic design.kicad_sch --pcb design.kicad_pcb

# Output as JSON
kct validate --placement project.kicad_pro --format json

# Show only unplaced components
kct validate --placement project.kicad_pro --errors-only
```

## Test plan

- [x] Unit tests for `PlacementStatus` dataclass
- [x] Unit tests for `PlacementResult` aggregation class
- [x] Unit tests for `BOMPlacementVerifier` with various scenarios
- [x] Tests for detecting missing components
- [x] Tests for detecting components at origin
- [x] All existing tests pass (`pnpm check:ci`)

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)