### PR TITLE
Fix __version__ showing 0.2.0 instead of 0.6.0

### DIFF
--- a/src/kicad_tools/__init__.py
+++ b/src/kicad_tools/__init__.py
@@ -44,7 +44,7 @@ Quick Start::
     # ... use with router, DRC, export functions
 """
 
-__version__ = "0.2.0"
+__version__ = "0.6.0"
 
 # Core S-expression handling
 # Constraints - Multi-stage optimization locking


### PR DESCRIPTION
## Summary

- Updates `__version__` in `src/kicad_tools/__init__.py` from 0.2.0 to 0.6.0 to match pyproject.toml

## Root Cause

The `__version__` variable was not updated when the package version was bumped to 0.6.0 in pyproject.toml.

## Test plan

- [x] `uv run python -c "from kicad_tools import __version__; print(__version__)"` returns 0.6.0
- [x] `pytest tests/test_cli.py -k version` passes

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)