### PR TITLE
Physics: Crosstalk estimation (NEXT/FEXT)

### DIFF
--- a/src/kicad_tools/physics/__init__.py
+++ b/src/kicad_tools/physics/__init__.py
@@ -71,6 +71,10 @@ from .coupled_lines import (
     CoupledLines,
     DifferentialPairResult,
 )
+from .crosstalk import (
+    CrosstalkAnalyzer,
+    CrosstalkResult,
+)
 from .stackup import (
     LayerType,
     Stackup,
@@ -110,4 +114,7 @@ __all__ = [
     # Coupled Lines
     "CoupledLines",
     "DifferentialPairResult",
+    # Crosstalk
+    "CrosstalkAnalyzer",
+    "CrosstalkResult",
 ]

--- a/src/kicad_tools/physics/crosstalk.py
+++ b/src/kicad_tools/physics/crosstalk.py
@@ -1,0 +1,429 @@
+"""Crosstalk estimation between parallel traces.
+
+Provides NEXT (near-end crosstalk) and FEXT (far-end crosstalk) calculations
+based on coupling coefficients and signal characteristics.
+
+Example::
+
+    from kicad_tools.physics import Stackup
+    from kicad_tools.physics.crosstalk import CrosstalkAnalyzer
+
+    stackup = Stackup.jlcpcb_4layer()
+    xt = CrosstalkAnalyzer(stackup)
+
+    # Analyze crosstalk between parallel traces
+    result = xt.analyze(
+        aggressor_width_mm=0.2,
+        victim_width_mm=0.2,
+        spacing_mm=0.2,
+        parallel_length_mm=20,
+        layer="F.Cu",
+        rise_time_ns=1.0,
+    )
+    print(f"NEXT: {result.next_percent:.1f}%, FEXT: {result.fext_percent:.1f}%")
+    print(f"Severity: {result.severity}")
+
+    # Calculate spacing for crosstalk budget
+    spacing = xt.spacing_for_crosstalk_budget(
+        max_crosstalk_percent=5.0,
+        width_mm=0.2,
+        parallel_length_mm=20,
+        layer="F.Cu",
+    )
+    print(f"Need {spacing:.3f}mm spacing for <5% crosstalk")
+
+References:
+    IPC-2141A Section 5: Crosstalk and Near-End/Far-End Considerations
+    Howard Johnson, "High-Speed Digital Design"
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from .constants import SPEED_OF_LIGHT
+from .coupled_lines import CoupledLines
+from .stackup import Stackup
+
+
+@dataclass
+class CrosstalkResult:
+    """Result of crosstalk analysis.
+
+    Attributes:
+        next_coefficient: Near-end crosstalk coefficient (0-1)
+        fext_coefficient: Far-end crosstalk coefficient (0-1)
+        next_db: NEXT in dB (negative value, more negative = less crosstalk)
+        fext_db: FEXT in dB (negative value, more negative = less crosstalk)
+        next_percent: NEXT as percentage
+        fext_percent: FEXT as percentage
+        coupled_length_mm: Length of parallel run
+        saturation_length_mm: Length where NEXT saturates
+        severity: "acceptable", "marginal", or "excessive"
+        recommendation: Actionable suggestion (or None if acceptable)
+    """
+
+    next_coefficient: float
+    fext_coefficient: float
+    next_db: float
+    fext_db: float
+    next_percent: float
+    fext_percent: float
+    coupled_length_mm: float
+    saturation_length_mm: float
+    severity: str
+    recommendation: str | None
+
+    def __repr__(self) -> str:
+        return (
+            f"CrosstalkResult(NEXT={self.next_percent:.1f}%, "
+            f"FEXT={self.fext_percent:.1f}%, severity={self.severity})"
+        )
+
+
+class CrosstalkAnalyzer:
+    """Crosstalk estimation for parallel traces.
+
+    Uses coupled line theory to estimate near-end and far-end crosstalk
+    between parallel traces based on geometry and signal characteristics.
+
+    Attributes:
+        stackup: PCB stackup for geometry and material properties
+    """
+
+    def __init__(self, stackup: Stackup) -> None:
+        """Initialize with a stackup.
+
+        Args:
+            stackup: PCB stackup for geometry and material properties
+        """
+        self.stackup = stackup
+        self._coupled_lines = CoupledLines(stackup)
+
+    def analyze(
+        self,
+        aggressor_width_mm: float,
+        victim_width_mm: float,
+        spacing_mm: float,
+        parallel_length_mm: float,
+        layer: str,
+        rise_time_ns: float = 1.0,
+        aggressor_amplitude_v: float = 3.3,
+    ) -> CrosstalkResult:
+        """Estimate crosstalk between parallel traces.
+
+        Calculates near-end crosstalk (NEXT) and far-end crosstalk (FEXT)
+        based on geometry and signal characteristics.
+
+        NEXT (backward crosstalk):
+        - Travels backward from coupling region
+        - Saturates after saturation length
+        - Coefficient: Kb = k/2 (for saturated case)
+
+        FEXT (forward crosstalk):
+        - Travels forward with the signal
+        - Proportional to coupled length
+        - Depends on rise time
+
+        Args:
+            aggressor_width_mm: Aggressor trace width in mm
+            victim_width_mm: Victim trace width in mm
+            spacing_mm: Edge-to-edge spacing in mm
+            parallel_length_mm: Length of parallel run in mm
+            layer: Layer name (e.g., "F.Cu")
+            rise_time_ns: Signal rise time in nanoseconds (default 1ns)
+            aggressor_amplitude_v: Signal amplitude in volts (for reference)
+
+        Returns:
+            CrosstalkResult with NEXT, FEXT, and recommendations
+
+        Raises:
+            ValueError: If any dimension is non-positive
+        """
+        if aggressor_width_mm <= 0:
+            raise ValueError(f"Aggressor width must be positive, got {aggressor_width_mm}")
+        if victim_width_mm <= 0:
+            raise ValueError(f"Victim width must be positive, got {victim_width_mm}")
+        if spacing_mm <= 0:
+            raise ValueError(f"Spacing must be positive, got {spacing_mm}")
+        if parallel_length_mm <= 0:
+            raise ValueError(f"Parallel length must be positive, got {parallel_length_mm}")
+        if rise_time_ns <= 0:
+            raise ValueError(f"Rise time must be positive, got {rise_time_ns}")
+
+        # Use average width for coupling calculation
+        avg_width = (aggressor_width_mm + victim_width_mm) / 2
+
+        # Get coupling coefficient from coupled lines analysis
+        # Use microstrip for outer layers, stripline for inner
+        if self.stackup.is_outer_layer(layer):
+            coupled_result = self._coupled_lines.edge_coupled_microstrip(
+                width_mm=avg_width, gap_mm=spacing_mm, layer=layer
+            )
+        else:
+            coupled_result = self._coupled_lines.edge_coupled_stripline(
+                width_mm=avg_width, gap_mm=spacing_mm, layer=layer
+            )
+
+        k = coupled_result.coupling_coefficient
+        eps_eff = (coupled_result.epsilon_eff_even + coupled_result.epsilon_eff_odd) / 2
+
+        # Calculate NEXT and FEXT
+        next_coeff, fext_coeff, lsat = self._calculate_crosstalk(
+            k=k,
+            length_mm=parallel_length_mm,
+            rise_time_ns=rise_time_ns,
+            eps_eff=eps_eff,
+        )
+
+        # Convert to percentages and dB
+        next_pct = next_coeff * 100
+        fext_pct = fext_coeff * 100
+
+        # dB = 20 * log10(coefficient), clamp to avoid log(0)
+        next_db = 20 * math.log10(max(next_coeff, 1e-6))
+        fext_db = 20 * math.log10(max(fext_coeff, 1e-6))
+
+        # Determine severity
+        severity = self._severity(next_pct, fext_pct)
+
+        # Generate recommendation if needed
+        recommendation = self._recommendation(
+            severity=severity,
+            next_pct=next_pct,
+            fext_pct=fext_pct,
+            spacing_mm=spacing_mm,
+            parallel_length_mm=parallel_length_mm,
+            lsat=lsat,
+        )
+
+        return CrosstalkResult(
+            next_coefficient=next_coeff,
+            fext_coefficient=fext_coeff,
+            next_db=next_db,
+            fext_db=fext_db,
+            next_percent=next_pct,
+            fext_percent=fext_pct,
+            coupled_length_mm=parallel_length_mm,
+            saturation_length_mm=lsat,
+            severity=severity,
+            recommendation=recommendation,
+        )
+
+    def _calculate_crosstalk(
+        self,
+        k: float,
+        length_mm: float,
+        rise_time_ns: float,
+        eps_eff: float,
+    ) -> tuple[float, float, float]:
+        """Calculate NEXT and FEXT coefficients.
+
+        NEXT (backward crosstalk):
+        - Saturates at saturation length
+        - Kb = k/2 for L > Lsat
+
+        FEXT (forward crosstalk):
+        - Proportional to length
+        - Depends on rise time
+        - Kf = 2 * k * L / rise_distance
+
+        Args:
+            k: Coupling coefficient from CoupledLines (0-1)
+            length_mm: Coupled length in mm
+            rise_time_ns: Signal rise time in ns
+            eps_eff: Effective dielectric constant
+
+        Returns:
+            Tuple of (next_coefficient, fext_coefficient, saturation_length_mm)
+        """
+        # Phase velocity
+        v_p = SPEED_OF_LIGHT / math.sqrt(eps_eff) if eps_eff > 0 else SPEED_OF_LIGHT
+
+        # Rise distance in mm
+        # rise_time (ns) * velocity (m/s) * 1e-6 = mm
+        rise_distance_mm = rise_time_ns * v_p * 1e-6
+
+        # Saturation length (where NEXT reaches maximum)
+        # NEXT saturates when coupled length exceeds rise_distance/2
+        lsat = rise_distance_mm / 2
+
+        # NEXT coefficient (backward crosstalk)
+        # Kb = k/2 is the maximum (saturated) value
+        kb = k / 2
+        if length_mm < lsat:
+            # Linear rise before saturation
+            next_coeff = kb * (length_mm / lsat)
+        else:
+            # Saturated
+            next_coeff = kb
+
+        # FEXT coefficient (forward crosstalk)
+        # FEXT = 2 * k * L / rise_distance for weak coupling
+        # This is an approximation; actual FEXT depends on mode velocity difference
+        kf = 2 * k * (length_mm / rise_distance_mm) if rise_distance_mm > 0 else 0
+
+        # Clamp to [0, 1]
+        next_coeff = max(0, min(next_coeff, 1.0))
+        fext_coeff = max(0, min(kf, 1.0))
+
+        return next_coeff, fext_coeff, lsat
+
+    def _severity(self, next_pct: float, fext_pct: float) -> str:
+        """Classify crosstalk severity.
+
+        Thresholds based on typical digital signal integrity budgets:
+        - <3%: Acceptable for most applications
+        - 3-10%: Marginal, may cause issues with sensitive signals
+        - >10%: Excessive, likely to cause signal integrity problems
+
+        Args:
+            next_pct: NEXT as percentage
+            fext_pct: FEXT as percentage
+
+        Returns:
+            Severity classification string
+        """
+        max_xt = max(next_pct, fext_pct)
+        if max_xt < 3:
+            return "acceptable"
+        elif max_xt < 10:
+            return "marginal"
+        else:
+            return "excessive"
+
+    def _recommendation(
+        self,
+        severity: str,
+        next_pct: float,
+        fext_pct: float,
+        spacing_mm: float,
+        parallel_length_mm: float,
+        lsat: float,
+    ) -> str | None:
+        """Generate actionable recommendation.
+
+        Args:
+            severity: Current severity level
+            next_pct: NEXT as percentage
+            fext_pct: FEXT as percentage
+            spacing_mm: Current spacing in mm
+            parallel_length_mm: Current parallel length in mm
+            lsat: Saturation length in mm
+
+        Returns:
+            Recommendation string or None if acceptable
+        """
+        if severity == "acceptable":
+            return None
+
+        recommendations = []
+
+        # Primary mitigation: increase spacing
+        # Rule of thumb: doubling spacing reduces coupling by ~75%
+        if spacing_mm < 0.5:
+            target_spacing = spacing_mm * 2
+            recommendations.append(f"Increase spacing to {target_spacing:.2f}mm or more")
+
+        # Secondary mitigation: reduce parallel length
+        if fext_pct > next_pct and parallel_length_mm > lsat:
+            # FEXT is proportional to length, so reducing length helps
+            target_length = parallel_length_mm * 0.5
+            recommendations.append(f"Reduce parallel run to {target_length:.1f}mm")
+
+        # Tertiary mitigation: route on different layers
+        if severity == "excessive":
+            recommendations.append("Consider routing on different layers with ground between")
+
+        if recommendations:
+            return "; ".join(recommendations)
+        return "Increase trace spacing or reduce parallel coupling length"
+
+    def spacing_for_crosstalk_budget(
+        self,
+        max_crosstalk_percent: float,
+        width_mm: float,
+        parallel_length_mm: float,
+        layer: str,
+        rise_time_ns: float = 1.0,
+        tolerance: float = 0.1,
+        max_iterations: int = 50,
+    ) -> float:
+        """Calculate minimum spacing for crosstalk budget.
+
+        Uses bisection to find the minimum edge-to-edge spacing that
+        keeps both NEXT and FEXT below the specified percentage.
+
+        Args:
+            max_crosstalk_percent: Maximum acceptable crosstalk (e.g., 5%)
+            width_mm: Trace width in mm
+            parallel_length_mm: Expected parallel run length in mm
+            layer: Layer name
+            rise_time_ns: Signal rise time in ns
+            tolerance: Relative tolerance for convergence (default 10%)
+            max_iterations: Maximum iterations for solver
+
+        Returns:
+            Minimum edge-to-edge spacing in mm
+
+        Raises:
+            ValueError: If parameters are invalid or convergence fails
+        """
+        if max_crosstalk_percent <= 0:
+            raise ValueError(f"Max crosstalk must be positive, got {max_crosstalk_percent}")
+        if width_mm <= 0:
+            raise ValueError(f"Width must be positive, got {width_mm}")
+        if parallel_length_mm <= 0:
+            raise ValueError(f"Parallel length must be positive, got {parallel_length_mm}")
+
+        # Get reference height for initial bounds
+        h = self.stackup.get_reference_plane_distance(layer)
+
+        # Initial spacing bounds
+        # Very tight spacing gives high crosstalk
+        # Very loose spacing gives low crosstalk
+        spacing_min = h * 0.1  # 10% of dielectric height
+        spacing_max = h * 10.0  # 10x dielectric height
+
+        def get_max_crosstalk(spacing: float) -> float:
+            """Get maximum of NEXT and FEXT for given spacing."""
+            result = self.analyze(
+                aggressor_width_mm=width_mm,
+                victim_width_mm=width_mm,
+                spacing_mm=spacing,
+                parallel_length_mm=parallel_length_mm,
+                layer=layer,
+                rise_time_ns=rise_time_ns,
+            )
+            return max(result.next_percent, result.fext_percent)
+
+        # Check max bound
+        xt_at_max = get_max_crosstalk(spacing_max)
+
+        # Adjust bounds if needed
+        while xt_at_max > max_crosstalk_percent and spacing_max < h * 100:
+            spacing_max *= 2
+            xt_at_max = get_max_crosstalk(spacing_max)
+
+        # If max spacing still gives too much crosstalk, return it anyway
+        # (caller should check the result)
+        if xt_at_max > max_crosstalk_percent:
+            return spacing_max
+
+        # Bisection search
+        for _ in range(max_iterations):
+            spacing_mid = (spacing_min + spacing_max) / 2
+            xt_mid = get_max_crosstalk(spacing_mid)
+
+            if abs(xt_mid - max_crosstalk_percent) / max_crosstalk_percent < tolerance:
+                return spacing_mid
+
+            # Higher spacing = lower crosstalk
+            if xt_mid > max_crosstalk_percent:
+                spacing_min = spacing_mid  # Need wider spacing
+            else:
+                spacing_max = spacing_mid  # Can use tighter spacing
+
+        # Return best estimate
+        return (spacing_min + spacing_max) / 2

--- a/tests/test_crosstalk.py
+++ b/tests/test_crosstalk.py
@@ -1,0 +1,724 @@
+"""Tests for crosstalk estimation (NEXT/FEXT)."""
+
+import math
+
+import pytest
+
+from kicad_tools.physics import (
+    CrosstalkAnalyzer,
+    CrosstalkResult,
+    Stackup,
+)
+
+
+class TestCrosstalkResult:
+    """Tests for CrosstalkResult dataclass."""
+
+    def test_basic_result(self):
+        """Test creating a CrosstalkResult."""
+        result = CrosstalkResult(
+            next_coefficient=0.05,
+            fext_coefficient=0.03,
+            next_db=-26.0,
+            fext_db=-30.5,
+            next_percent=5.0,
+            fext_percent=3.0,
+            coupled_length_mm=20.0,
+            saturation_length_mm=75.0,
+            severity="marginal",
+            recommendation="Increase spacing",
+        )
+        assert result.next_coefficient == 0.05
+        assert result.fext_coefficient == 0.03
+        assert result.next_percent == 5.0
+        assert result.fext_percent == 3.0
+        assert result.severity == "marginal"
+        assert result.recommendation == "Increase spacing"
+
+    def test_repr(self):
+        """Test string representation."""
+        result = CrosstalkResult(
+            next_coefficient=0.05,
+            fext_coefficient=0.03,
+            next_db=-26.0,
+            fext_db=-30.5,
+            next_percent=5.0,
+            fext_percent=3.0,
+            coupled_length_mm=20.0,
+            saturation_length_mm=75.0,
+            severity="marginal",
+            recommendation=None,
+        )
+        repr_str = repr(result)
+        assert "5.0%" in repr_str
+        assert "3.0%" in repr_str
+        assert "marginal" in repr_str
+
+
+class TestCrosstalkAnalyzerBasic:
+    """Basic tests for CrosstalkAnalyzer."""
+
+    def test_basic_analysis(self):
+        """Test basic crosstalk analysis."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        result = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        # Should get reasonable values
+        assert 0 <= result.next_coefficient <= 1
+        assert 0 <= result.fext_coefficient <= 1
+        assert result.next_percent >= 0
+        assert result.fext_percent >= 0
+        assert result.coupled_length_mm == 20
+        assert result.saturation_length_mm > 0
+        assert result.severity in ("acceptable", "marginal", "excessive")
+
+    def test_db_values_negative(self):
+        """Test that dB values are negative (smaller = better)."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        result = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        # dB values should be negative (20*log10 of coefficient < 1)
+        assert result.next_db < 0
+        assert result.fext_db < 0
+
+    def test_db_calculation_correct(self):
+        """Test dB calculation: dB = 20 * log10(coefficient)."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        result = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        expected_next_db = 20 * math.log10(max(result.next_coefficient, 1e-6))
+        expected_fext_db = 20 * math.log10(max(result.fext_coefficient, 1e-6))
+
+        assert result.next_db == pytest.approx(expected_next_db, rel=0.01)
+        assert result.fext_db == pytest.approx(expected_fext_db, rel=0.01)
+
+    def test_percent_calculation_correct(self):
+        """Test percent is coefficient * 100."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        result = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        assert result.next_percent == pytest.approx(result.next_coefficient * 100, rel=0.001)
+        assert result.fext_percent == pytest.approx(result.fext_coefficient * 100, rel=0.001)
+
+
+class TestCrosstalkPhysicalBehavior:
+    """Tests for physically correct crosstalk behavior."""
+
+    def test_fext_increases_with_length(self):
+        """FEXT should increase with parallel length."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        short = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=10,
+            layer="F.Cu",
+        )
+        long = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=50,
+            layer="F.Cu",
+        )
+
+        assert long.fext_percent > short.fext_percent
+
+    def test_next_saturates(self):
+        """NEXT should saturate beyond saturation length."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        # Get saturation length
+        baseline = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=10,
+            layer="F.Cu",
+            rise_time_ns=1.0,
+        )
+        lsat = baseline.saturation_length_mm
+
+        # Short (below saturation)
+        short = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=lsat * 0.5,
+            layer="F.Cu",
+            rise_time_ns=1.0,
+        )
+
+        # At saturation
+        at_sat = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=lsat,
+            layer="F.Cu",
+            rise_time_ns=1.0,
+        )
+
+        # Well beyond saturation
+        beyond_sat = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=lsat * 3,
+            layer="F.Cu",
+            rise_time_ns=1.0,
+        )
+
+        # NEXT should increase before saturation
+        assert short.next_coefficient < at_sat.next_coefficient
+
+        # NEXT should be nearly the same at and beyond saturation
+        assert beyond_sat.next_coefficient == pytest.approx(at_sat.next_coefficient, rel=0.05)
+
+    def test_crosstalk_decreases_with_spacing(self):
+        """Both NEXT and FEXT should decrease with spacing."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        tight = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.15,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+        loose = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.4,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        assert loose.next_percent < tight.next_percent
+        assert loose.fext_percent < tight.fext_percent
+
+    def test_faster_rise_time_increases_fext(self):
+        """Faster rise time (shorter) should increase FEXT."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        slow = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=30,
+            layer="F.Cu",
+            rise_time_ns=2.0,
+        )
+        fast = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=30,
+            layer="F.Cu",
+            rise_time_ns=0.5,
+        )
+
+        # Faster rise time → smaller rise distance → higher FEXT
+        assert fast.fext_percent > slow.fext_percent
+
+    def test_slower_rise_time_increases_saturation_length(self):
+        """Slower rise time should increase saturation length."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        slow = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+            rise_time_ns=2.0,
+        )
+        fast = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+            rise_time_ns=0.5,
+        )
+
+        assert slow.saturation_length_mm > fast.saturation_length_mm
+
+
+class TestSeverityClassification:
+    """Tests for crosstalk severity classification."""
+
+    def test_acceptable_severity(self):
+        """Test acceptable severity (< 3%)."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        # Very wide spacing should give low crosstalk
+        result = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=1.0,  # Very wide
+            parallel_length_mm=5,  # Short length
+            layer="F.Cu",
+        )
+
+        # With wide spacing and short length, should be acceptable
+        assert max(result.next_percent, result.fext_percent) < 3
+        assert result.severity == "acceptable"
+        assert result.recommendation is None
+
+    def test_marginal_severity(self):
+        """Test marginal severity (3-10%)."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        # Find geometry that gives marginal crosstalk
+        result = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        # Check if this is in marginal range, adjust if needed
+        if result.severity == "marginal":
+            assert 3 <= max(result.next_percent, result.fext_percent) < 10
+            assert result.recommendation is not None
+
+    def test_excessive_severity(self):
+        """Test excessive severity (> 10%)."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        # Very tight spacing and long length
+        result = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.1,
+            parallel_length_mm=100,
+            layer="F.Cu",
+        )
+
+        # Should likely be excessive
+        if result.severity == "excessive":
+            assert max(result.next_percent, result.fext_percent) >= 10
+            assert result.recommendation is not None
+            assert (
+                "layer" in result.recommendation.lower()
+                or "spacing" in result.recommendation.lower()
+            )
+
+
+class TestSpacingForCrosstalkBudget:
+    """Tests for inverse calculation (crosstalk budget → spacing)."""
+
+    def test_spacing_for_5_percent_budget(self):
+        """Test calculating spacing for 5% crosstalk budget."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        spacing = xt.spacing_for_crosstalk_budget(
+            max_crosstalk_percent=5.0,
+            width_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        # Verify by forward calculation
+        result = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=spacing,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        max_xt = max(result.next_percent, result.fext_percent)
+        # Should be at or below budget (with some tolerance)
+        assert max_xt <= 5.5  # Allow 10% tolerance
+
+    def test_spacing_for_3_percent_budget(self):
+        """Test calculating spacing for 3% crosstalk budget."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        spacing = xt.spacing_for_crosstalk_budget(
+            max_crosstalk_percent=3.0,
+            width_mm=0.2,
+            parallel_length_mm=15,
+            layer="F.Cu",
+        )
+
+        # Verify by forward calculation
+        result = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=spacing,
+            parallel_length_mm=15,
+            layer="F.Cu",
+        )
+
+        max_xt = max(result.next_percent, result.fext_percent)
+        # Allow 10% tolerance - if we asked for 3%, we should get close
+        assert max_xt <= 3.3
+        # Note: 3% is right at threshold, so severity might be marginal
+        assert result.severity in ("acceptable", "marginal")
+
+    def test_tighter_budget_requires_wider_spacing(self):
+        """Test that tighter budget requires wider spacing."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        spacing_5pct = xt.spacing_for_crosstalk_budget(
+            max_crosstalk_percent=5.0,
+            width_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+        spacing_3pct = xt.spacing_for_crosstalk_budget(
+            max_crosstalk_percent=3.0,
+            width_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        # Tighter budget (3%) should require wider spacing
+        assert spacing_3pct > spacing_5pct
+
+    def test_longer_run_requires_wider_spacing(self):
+        """Test that longer parallel run requires wider spacing."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        spacing_short = xt.spacing_for_crosstalk_budget(
+            max_crosstalk_percent=5.0,
+            width_mm=0.2,
+            parallel_length_mm=10,
+            layer="F.Cu",
+        )
+        spacing_long = xt.spacing_for_crosstalk_budget(
+            max_crosstalk_percent=5.0,
+            width_mm=0.2,
+            parallel_length_mm=50,
+            layer="F.Cu",
+        )
+
+        # Longer run should require wider spacing to stay within budget
+        assert spacing_long > spacing_short
+
+
+class TestInnerLayerCrosstalk:
+    """Tests for crosstalk on inner layers (stripline)."""
+
+    def test_inner_layer_analysis(self):
+        """Test crosstalk analysis on inner layer."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        result = xt.analyze(
+            aggressor_width_mm=0.15,
+            victim_width_mm=0.15,
+            spacing_mm=0.15,
+            parallel_length_mm=20,
+            layer="In1.Cu",
+        )
+
+        assert result.next_coefficient >= 0
+        assert result.fext_coefficient >= 0
+        assert result.severity in ("acceptable", "marginal", "excessive")
+
+    def test_inner_layer_has_different_saturation_length(self):
+        """Test that inner layer has different saturation length due to eps_eff."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        outer = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+            rise_time_ns=1.0,
+        )
+        inner = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="In1.Cu",
+            rise_time_ns=1.0,
+        )
+
+        # Stripline has higher eps_eff → slower velocity → shorter saturation length
+        # (Actually, saturation length = rise_distance/2 = (rise_time * v_p)/2)
+        # Higher eps_eff → lower v_p → shorter saturation length
+        assert inner.saturation_length_mm != outer.saturation_length_mm
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    def test_invalid_aggressor_width(self):
+        """Test error handling for invalid aggressor width."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        with pytest.raises(ValueError, match="positive"):
+            xt.analyze(
+                aggressor_width_mm=0,
+                victim_width_mm=0.2,
+                spacing_mm=0.2,
+                parallel_length_mm=20,
+                layer="F.Cu",
+            )
+
+        with pytest.raises(ValueError, match="positive"):
+            xt.analyze(
+                aggressor_width_mm=-0.1,
+                victim_width_mm=0.2,
+                spacing_mm=0.2,
+                parallel_length_mm=20,
+                layer="F.Cu",
+            )
+
+    def test_invalid_victim_width(self):
+        """Test error handling for invalid victim width."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        with pytest.raises(ValueError, match="positive"):
+            xt.analyze(
+                aggressor_width_mm=0.2,
+                victim_width_mm=0,
+                spacing_mm=0.2,
+                parallel_length_mm=20,
+                layer="F.Cu",
+            )
+
+    def test_invalid_spacing(self):
+        """Test error handling for invalid spacing."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        with pytest.raises(ValueError, match="positive"):
+            xt.analyze(
+                aggressor_width_mm=0.2,
+                victim_width_mm=0.2,
+                spacing_mm=0,
+                parallel_length_mm=20,
+                layer="F.Cu",
+            )
+
+    def test_invalid_parallel_length(self):
+        """Test error handling for invalid parallel length."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        with pytest.raises(ValueError, match="positive"):
+            xt.analyze(
+                aggressor_width_mm=0.2,
+                victim_width_mm=0.2,
+                spacing_mm=0.2,
+                parallel_length_mm=0,
+                layer="F.Cu",
+            )
+
+    def test_invalid_rise_time(self):
+        """Test error handling for invalid rise time."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        with pytest.raises(ValueError, match="positive"):
+            xt.analyze(
+                aggressor_width_mm=0.2,
+                victim_width_mm=0.2,
+                spacing_mm=0.2,
+                parallel_length_mm=20,
+                layer="F.Cu",
+                rise_time_ns=0,
+            )
+
+    def test_spacing_budget_invalid_crosstalk(self):
+        """Test error handling for invalid crosstalk budget."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        with pytest.raises(ValueError, match="positive"):
+            xt.spacing_for_crosstalk_budget(
+                max_crosstalk_percent=0,
+                width_mm=0.2,
+                parallel_length_mm=20,
+                layer="F.Cu",
+            )
+
+    def test_spacing_budget_invalid_width(self):
+        """Test error handling for invalid width in spacing budget."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        with pytest.raises(ValueError, match="positive"):
+            xt.spacing_for_crosstalk_budget(
+                max_crosstalk_percent=5.0,
+                width_mm=0,
+                parallel_length_mm=20,
+                layer="F.Cu",
+            )
+
+    def test_spacing_budget_invalid_length(self):
+        """Test error handling for invalid length in spacing budget."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        with pytest.raises(ValueError, match="positive"):
+            xt.spacing_for_crosstalk_budget(
+                max_crosstalk_percent=5.0,
+                width_mm=0.2,
+                parallel_length_mm=0,
+                layer="F.Cu",
+            )
+
+
+class TestStackupIntegration:
+    """Tests for integration with different stackups."""
+
+    def test_2layer_stackup(self):
+        """Test with 2-layer stackup."""
+        stackup = Stackup.default_2layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        result = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        assert result.next_coefficient >= 0
+        assert result.fext_coefficient >= 0
+
+    def test_6layer_stackup(self):
+        """Test with 6-layer stackup."""
+        stackup = Stackup.default_6layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        # Outer layer
+        result_outer = xt.analyze(
+            aggressor_width_mm=0.2,
+            victim_width_mm=0.2,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+        assert result_outer.next_coefficient >= 0
+
+        # Inner layer
+        result_inner = xt.analyze(
+            aggressor_width_mm=0.15,
+            victim_width_mm=0.15,
+            spacing_mm=0.15,
+            parallel_length_mm=20,
+            layer="In2.Cu",
+        )
+        assert result_inner.next_coefficient >= 0
+
+    def test_oshpark_4layer(self):
+        """Test with OSH Park 4-layer stackup."""
+        stackup = Stackup.oshpark_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        result = xt.analyze(
+            aggressor_width_mm=0.15,
+            victim_width_mm=0.15,
+            spacing_mm=0.15,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        assert result.next_coefficient >= 0
+        assert result.fext_coefficient >= 0
+        assert result.severity in ("acceptable", "marginal", "excessive")
+
+
+class TestAsymmetricTraces:
+    """Tests for asymmetric aggressor/victim configurations."""
+
+    def test_different_widths(self):
+        """Test with different aggressor and victim widths."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        result = xt.analyze(
+            aggressor_width_mm=0.3,
+            victim_width_mm=0.15,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        # Should still work with asymmetric widths
+        assert result.next_coefficient >= 0
+        assert result.fext_coefficient >= 0
+
+    def test_symmetric_vs_asymmetric(self):
+        """Test that asymmetric widths use average for coupling."""
+        stackup = Stackup.jlcpcb_4layer()
+        xt = CrosstalkAnalyzer(stackup)
+
+        symmetric = xt.analyze(
+            aggressor_width_mm=0.225,  # Average of 0.3 and 0.15
+            victim_width_mm=0.225,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        asymmetric = xt.analyze(
+            aggressor_width_mm=0.3,
+            victim_width_mm=0.15,
+            spacing_mm=0.2,
+            parallel_length_mm=20,
+            layer="F.Cu",
+        )
+
+        # Should give similar results since we use average width
+        assert symmetric.next_coefficient == pytest.approx(asymmetric.next_coefficient, rel=0.01)


### PR DESCRIPTION
## Summary

Add crosstalk estimation to the physics module, implementing NEXT (near-end crosstalk) and FEXT (far-end crosstalk) calculations for parallel traces.

## Changes

- Add `CrosstalkAnalyzer` class in `src/kicad_tools/physics/crosstalk.py`
- Add `CrosstalkResult` dataclass with coefficients, dB values, severity, and recommendations
- Export new classes from `physics/__init__.py`
- Add comprehensive test suite with 33 tests

## Key Features

- **NEXT calculation**: Saturates at rise_distance/2 (backward crosstalk)
- **FEXT calculation**: Proportional to coupled length and rise time (forward crosstalk)
- **Severity classification**: acceptable (<3%), marginal (3-10%), excessive (>10%)
- **Inverse calculation**: `spacing_for_crosstalk_budget()` to find minimum spacing
- **Integration**: Uses `CoupledLines` for coupling coefficients

## Test Plan

- [x] All 33 new crosstalk tests pass
- [x] All related physics tests pass (100 total)
- [x] Lint checks pass for new files
- [x] Code formatted with ruff

Closes #353