### PR TITLE
Add project cleanup utility (kicad-project-clean)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ kicad-net-status = "kicad_tools.cli:net_status_main"
 # Manufacturer design rules
 kicad-fab-rules = "kicad_tools.cli.fab_rules_cmd:main"
 
+# Project tools
+kicad-project-clean = "kicad_tools.cli.clean_cmd:main"
+
 [project.optional-dependencies]
 # LCSC parts API access
 parts = [

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -41,6 +41,7 @@ from .commands import (
     run_analyze_command,
     run_audit_command,
     run_check_command,
+    run_clean_command,
     run_config_command,
     run_constraints_command,
     run_datasheet_command,
@@ -301,6 +302,9 @@ def _dispatch_command(args) -> int:
         if hasattr(args, "net_status_verbose") and args.net_status_verbose:
             sub_argv.append("--verbose")
         return net_status_cmd(sub_argv)
+
+    elif args.command == "clean":
+        return run_clean_command(args)
 
     return 0
 

--- a/src/kicad_tools/cli/clean_cmd.py
+++ b/src/kicad_tools/cli/clean_cmd.py
@@ -1,0 +1,572 @@
+"""
+Project cleanup command for kicad-tools.
+
+Cleans up old/orphaned files from KiCad projects including intermediate
+PCB versions, stale reports, and backup files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = ["main", "CleanResult", "find_cleanable_files"]
+
+
+@dataclass
+class CleanableFile:
+    """A file that can be cleaned up."""
+
+    path: Path
+    category: str  # "pcb_version", "stale_report", "backup"
+    reason: str
+    size_bytes: int
+
+    @property
+    def size_kb(self) -> float:
+        """Size in kilobytes."""
+        return self.size_bytes / 1024
+
+    @property
+    def size_str(self) -> str:
+        """Human-readable size string."""
+        if self.size_bytes < 1024:
+            return f"{self.size_bytes} B"
+        elif self.size_bytes < 1024 * 1024:
+            return f"{self.size_bytes / 1024:.1f} KB"
+        else:
+            return f"{self.size_bytes / (1024 * 1024):.1f} MB"
+
+
+@dataclass
+class ProtectedFile:
+    """A file that will be kept."""
+
+    path: Path
+    reason: str
+
+
+@dataclass
+class CleanResult:
+    """Result of analyzing a project for cleanup."""
+
+    project_dir: Path
+    project_name: str
+    to_delete: list[CleanableFile] = field(default_factory=list)
+    to_keep: list[ProtectedFile] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def total_size_bytes(self) -> int:
+        """Total size of files to delete in bytes."""
+        return sum(f.size_bytes for f in self.to_delete)
+
+    @property
+    def total_size_str(self) -> str:
+        """Human-readable total size to delete."""
+        size = self.total_size_bytes
+        if size < 1024:
+            return f"{size} B"
+        elif size < 1024 * 1024:
+            return f"{size / 1024:.1f} KB"
+        else:
+            return f"{size / (1024 * 1024):.1f} MB"
+
+    def by_category(self, category: str) -> list[CleanableFile]:
+        """Get files to delete by category."""
+        return [f for f in self.to_delete if f.category == category]
+
+
+# Patterns for detecting old PCB versions
+PCB_VERSION_PATTERNS = [
+    # Versioned files: *-v1.kicad_pcb, *-v2.kicad_pcb, etc.
+    re.compile(r"-v\d+\.kicad_pcb$", re.IGNORECASE),
+    # Routed versions: *-routed.kicad_pcb, *-routed-v34.kicad_pcb
+    re.compile(r"-routed(-v?\d+)?\.kicad_pcb$", re.IGNORECASE),
+    # Autorouted: *-autorouted.kicad_pcb
+    re.compile(r"-autorouted\.kicad_pcb$", re.IGNORECASE),
+    # Generated: *-generated.kicad_pcb
+    re.compile(r"-generated\.kicad_pcb$", re.IGNORECASE),
+    # Draft versions: *-draft.kicad_pcb
+    re.compile(r"-draft\.kicad_pcb$", re.IGNORECASE),
+    # Old versions: *-old.kicad_pcb
+    re.compile(r"-old\.kicad_pcb$", re.IGNORECASE),
+    # Backup copies: *-backup.kicad_pcb
+    re.compile(r"-backup\.kicad_pcb$", re.IGNORECASE),
+    # Copy files: *-copy.kicad_pcb, * copy.kicad_pcb
+    re.compile(r"[-_ ]copy\.kicad_pcb$", re.IGNORECASE),
+]
+
+# Patterns for detecting stale reports
+REPORT_PATTERNS = [
+    # DRC reports with version suffix
+    re.compile(r"drc[-_]?v?\d+\.(txt|rpt|json)$", re.IGNORECASE),
+    # ERC reports with version suffix
+    re.compile(r"erc[-_]?v?\d+\.(txt|rpt|json)$", re.IGNORECASE),
+    # Generic old reports
+    re.compile(r"drc[-_](old|prev|backup)\.(txt|rpt|json)$", re.IGNORECASE),
+    re.compile(r"erc[-_](old|prev|backup)\.(txt|rpt|json)$", re.IGNORECASE),
+]
+
+# Patterns for detecting backup files
+BACKUP_PATTERNS = [
+    # .bak files
+    re.compile(r"\.bak$", re.IGNORECASE),
+    # ~ backup files
+    re.compile(r"~$"),
+    # KiCad backup format: *-bak.kicad_*
+    re.compile(r"-bak\.kicad_", re.IGNORECASE),
+    # Backup with date: *-backup-*.kicad_*
+    re.compile(r"-backup-\d+\.kicad_", re.IGNORECASE),
+    # KiCad autosave files
+    re.compile(r"\.kicad_.*\.lck$", re.IGNORECASE),
+    # Rescue files
+    re.compile(r"-rescue\.kicad_", re.IGNORECASE),
+]
+
+# Additional patterns for deep clean mode
+DEEP_CLEAN_PATTERNS = [
+    # Gerber and drill files
+    re.compile(r"\.(gbr|drl|gbl|gtl|gbs|gts|gbo|gto|gm1|gko|gpt|gpb)$", re.IGNORECASE),
+    # Position/placement files
+    re.compile(r"[-_]pos\.(csv|txt)$", re.IGNORECASE),
+    re.compile(r"[-_]cpl\.(csv|txt)$", re.IGNORECASE),
+    # BOM output files
+    re.compile(r"[-_]bom\.(csv|xml|html)$", re.IGNORECASE),
+    # Netlist exports
+    re.compile(r"\.net$", re.IGNORECASE),
+    # STEP/3D exports
+    re.compile(r"\.(step|stp|wrl)$", re.IGNORECASE),
+    # PDF exports
+    re.compile(r"[-_](schematic|pcb|layout)\.pdf$", re.IGNORECASE),
+]
+
+
+def get_project_pcb_name(project_path: Path) -> str | None:
+    """
+    Get the main PCB filename from a project file.
+
+    Args:
+        project_path: Path to .kicad_pro file
+
+    Returns:
+        Expected main PCB filename (without path) or None if cannot determine
+    """
+    # The main PCB should match the project name
+    return project_path.stem + ".kicad_pcb"
+
+
+def get_project_schematic_name(project_path: Path) -> str | None:
+    """
+    Get the main schematic filename from a project file.
+
+    Args:
+        project_path: Path to .kicad_pro file
+
+    Returns:
+        Expected main schematic filename (without path) or None if cannot determine
+    """
+    return project_path.stem + ".kicad_sch"
+
+
+def find_cleanable_files(
+    project_path: Path,
+    deep: bool = False,
+) -> CleanResult:
+    """
+    Find files that can be cleaned up in a KiCad project directory.
+
+    Args:
+        project_path: Path to .kicad_pro file
+        deep: If True, also include generated output files (gerbers, etc.)
+
+    Returns:
+        CleanResult with files categorized for deletion or keeping
+    """
+    if not project_path.exists():
+        raise FileNotFoundError(f"Project file not found: {project_path}")
+
+    if not project_path.suffix == ".kicad_pro":
+        raise ValueError(f"Expected .kicad_pro file, got: {project_path}")
+
+    project_dir = project_path.parent
+    project_name = project_path.stem
+
+    result = CleanResult(
+        project_dir=project_dir,
+        project_name=project_name,
+    )
+
+    # Get expected main files
+    main_pcb = get_project_pcb_name(project_path)
+    main_sch = get_project_schematic_name(project_path)
+
+    # Add protected main files
+    if main_pcb:
+        main_pcb_path = project_dir / main_pcb
+        if main_pcb_path.exists():
+            result.to_keep.append(ProtectedFile(main_pcb_path, "main project PCB"))
+
+    if main_sch:
+        main_sch_path = project_dir / main_sch
+        if main_sch_path.exists():
+            result.to_keep.append(ProtectedFile(main_sch_path, "main schematic"))
+
+    # Protect the project file itself
+    result.to_keep.append(ProtectedFile(project_path, "project file"))
+
+    # Scan directory for cleanable files
+    protected_names = {p.path.name for p in result.to_keep}
+
+    for file_path in project_dir.iterdir():
+        if not file_path.is_file():
+            continue
+
+        filename = file_path.name
+
+        # Skip protected files
+        if filename in protected_names:
+            continue
+
+        # Check for old PCB versions
+        if filename.endswith(".kicad_pcb"):
+            matched = False
+            for pattern in PCB_VERSION_PATTERNS:
+                if pattern.search(filename):
+                    try:
+                        size = file_path.stat().st_size
+                    except OSError:
+                        size = 0
+                    result.to_delete.append(
+                        CleanableFile(
+                            path=file_path,
+                            category="pcb_version",
+                            reason=f"matches pattern: {pattern.pattern}",
+                            size_bytes=size,
+                        )
+                    )
+                    matched = True
+                    break
+
+            if not matched and filename != main_pcb:
+                # Check if it matches a backup pattern before categorizing as additional PCB
+                is_backup = False
+                for pattern in BACKUP_PATTERNS:
+                    if pattern.search(filename):
+                        try:
+                            size = file_path.stat().st_size
+                        except OSError:
+                            size = 0
+                        result.to_delete.append(
+                            CleanableFile(
+                                path=file_path,
+                                category="backup",
+                                reason=f"backup file: {pattern.pattern}",
+                                size_bytes=size,
+                            )
+                        )
+                        is_backup = True
+                        break
+
+                if not is_backup:
+                    # Truly an additional PCB file
+                    try:
+                        size = file_path.stat().st_size
+                    except OSError:
+                        size = 0
+                    result.to_delete.append(
+                        CleanableFile(
+                            path=file_path,
+                            category="pcb_version",
+                            reason="additional PCB file (not main project PCB)",
+                            size_bytes=size,
+                        )
+                    )
+            continue
+
+        # Check for stale reports
+        for pattern in REPORT_PATTERNS:
+            if pattern.search(filename):
+                try:
+                    size = file_path.stat().st_size
+                except OSError:
+                    size = 0
+                result.to_delete.append(
+                    CleanableFile(
+                        path=file_path,
+                        category="stale_report",
+                        reason=f"versioned/backup report: {pattern.pattern}",
+                        size_bytes=size,
+                    )
+                )
+                break
+
+        # Check for backup files
+        for pattern in BACKUP_PATTERNS:
+            if pattern.search(filename):
+                try:
+                    size = file_path.stat().st_size
+                except OSError:
+                    size = 0
+                result.to_delete.append(
+                    CleanableFile(
+                        path=file_path,
+                        category="backup",
+                        reason=f"backup file: {pattern.pattern}",
+                        size_bytes=size,
+                    )
+                )
+                break
+
+        # Deep clean patterns
+        if deep:
+            for pattern in DEEP_CLEAN_PATTERNS:
+                if pattern.search(filename):
+                    try:
+                        size = file_path.stat().st_size
+                    except OSError:
+                        size = 0
+                    result.to_delete.append(
+                        CleanableFile(
+                            path=file_path,
+                            category="generated",
+                            reason=f"generated output: {pattern.pattern}",
+                            size_bytes=size,
+                        )
+                    )
+                    break
+
+    # Find most recent report of each type and protect it
+    _protect_latest_reports(result, project_dir)
+
+    return result
+
+
+def _protect_latest_reports(result: CleanResult, project_dir: Path) -> None:
+    """
+    Protect the most recent DRC/ERC report of each type.
+
+    Modifies result in place to move the newest report from to_delete to to_keep.
+    """
+    # Group stale reports by type (drc/erc)
+    drc_reports: list[CleanableFile] = []
+    erc_reports: list[CleanableFile] = []
+
+    for f in result.to_delete:
+        if f.category == "stale_report":
+            name_lower = f.path.name.lower()
+            if name_lower.startswith("drc"):
+                drc_reports.append(f)
+            elif name_lower.startswith("erc"):
+                erc_reports.append(f)
+
+    # Find and protect newest of each type
+    for reports, report_type in [(drc_reports, "DRC"), (erc_reports, "ERC")]:
+        if not reports:
+            continue
+
+        # Sort by modification time (newest first)
+        try:
+            reports_with_mtime = [(f, f.path.stat().st_mtime) for f in reports]
+            reports_with_mtime.sort(key=lambda x: x[1], reverse=True)
+            newest = reports_with_mtime[0][0]
+
+            # Move newest to keep list
+            result.to_delete.remove(newest)
+            result.to_keep.append(ProtectedFile(newest.path, f"most recent {report_type} report"))
+        except (OSError, IndexError):
+            pass
+
+
+def format_output_text(result: CleanResult, verbose: bool = False) -> str:
+    """Format clean result as text output."""
+    lines = []
+    lines.append(f"Project cleanup: {result.project_dir.name}/")
+    lines.append("═" * 55)
+    lines.append("")
+
+    # Group files to delete by category
+    pcb_versions = result.by_category("pcb_version")
+    stale_reports = result.by_category("stale_report")
+    backups = result.by_category("backup")
+    generated = result.by_category("generated")
+
+    if pcb_versions:
+        lines.append(f"Would delete ({len(pcb_versions)} old PCB versions):")
+        for f in pcb_versions:
+            lines.append(f"  ✗ {f.path.name} ({f.size_str})")
+        lines.append("")
+
+    if stale_reports:
+        lines.append(f"Would delete ({len(stale_reports)} stale reports):")
+        for f in stale_reports:
+            lines.append(f"  ✗ {f.path.name}")
+        lines.append("")
+
+    if backups:
+        lines.append(f"Would delete ({len(backups)} backup files):")
+        for f in backups:
+            lines.append(f"  ✗ {f.path.name} ({f.size_str})")
+        lines.append("")
+
+    if generated:
+        lines.append(f"Would delete ({len(generated)} generated files):")
+        for f in generated:
+            lines.append(f"  ✗ {f.path.name} ({f.size_str})")
+        lines.append("")
+
+    if result.to_keep:
+        lines.append("Would keep:")
+        for f in result.to_keep:
+            lines.append(f"  ✓ {f.path.name} ({f.reason})")
+        lines.append("")
+
+    if result.to_delete:
+        lines.append(f"Space savings: {result.total_size_str}")
+    else:
+        lines.append("No files to clean up.")
+
+    return "\n".join(lines)
+
+
+def format_output_json(result: CleanResult) -> str:
+    """Format clean result as JSON output."""
+    data = {
+        "project_dir": str(result.project_dir),
+        "project_name": result.project_name,
+        "to_delete": [
+            {
+                "path": str(f.path),
+                "name": f.path.name,
+                "category": f.category,
+                "reason": f.reason,
+                "size_bytes": f.size_bytes,
+            }
+            for f in result.to_delete
+        ],
+        "to_keep": [
+            {
+                "path": str(f.path),
+                "name": f.path.name,
+                "reason": f.reason,
+            }
+            for f in result.to_keep
+        ],
+        "total_size_bytes": result.total_size_bytes,
+        "errors": result.errors,
+    }
+    return json.dumps(data, indent=2)
+
+
+def delete_files(result: CleanResult, verbose: bool = False) -> tuple[int, int]:
+    """
+    Delete the files marked for cleanup.
+
+    Args:
+        result: CleanResult with files to delete
+        verbose: Print each file as it's deleted
+
+    Returns:
+        Tuple of (files_deleted, bytes_freed)
+    """
+    deleted = 0
+    freed = 0
+
+    for f in result.to_delete:
+        try:
+            f.path.unlink()
+            deleted += 1
+            freed += f.size_bytes
+            if verbose:
+                print(f"  Deleted: {f.path.name}")
+        except OSError as e:
+            result.errors.append(f"Failed to delete {f.path.name}: {e}")
+
+    return deleted, freed
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create argument parser for clean command."""
+    parser = argparse.ArgumentParser(
+        prog="kicad-project-clean",
+        description="Clean up old/orphaned files from KiCad projects",
+    )
+    parser.add_argument(
+        "project",
+        help="Path to .kicad_pro file",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be cleaned without deleting (default behavior)",
+    )
+    parser.add_argument(
+        "--deep",
+        action="store_true",
+        help="Also delete generated output files (gerbers, BOM exports, etc.)",
+    )
+    parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Delete files without confirmation (for CI/automation)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show detailed output",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for project clean command."""
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    project_path = Path(args.project).resolve()
+
+    try:
+        result = find_cleanable_files(project_path, deep=args.deep)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    # Output format
+    if args.format == "json":
+        print(format_output_json(result))
+    else:
+        print(format_output_text(result, verbose=args.verbose))
+
+    # Force mode - delete without confirmation
+    if args.force and result.to_delete:
+        deleted, freed = delete_files(result, verbose=args.verbose)
+        if args.format != "json":
+            print(f"\nDeleted {deleted} files, freed {freed / 1024:.1f} KB")
+        if result.errors:
+            for err in result.errors:
+                print(f"Error: {err}", file=sys.stderr)
+            return 1
+        return 0
+
+    # Default is dry-run: show what would be cleaned but don't delete
+    # Use --force to actually delete files
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -25,6 +25,7 @@ from .manufacturer import run_mfr_command
 from .parts import run_parts_command
 from .pcb import run_pcb_command
 from .placement import run_placement_command
+from .project import run_clean_command
 from .reasoning import run_reason_command
 from .routing import run_optimize_command, run_route_command, run_zones_command
 from .schematic import run_sch_command
@@ -78,4 +79,6 @@ __all__ = [
     "run_audit_command",
     # Suggest
     "run_suggest_command",
+    # Project
+    "run_clean_command",
 ]

--- a/src/kicad_tools/cli/commands/project.py
+++ b/src/kicad_tools/cli/commands/project.py
@@ -1,0 +1,21 @@
+"""Project-level command handlers."""
+
+__all__ = ["run_clean_command"]
+
+
+def run_clean_command(args) -> int:
+    """Handle clean command."""
+    from ..clean_cmd import main as clean_main
+
+    sub_argv = [args.clean_project]
+    if args.clean_dry_run:
+        sub_argv.append("--dry-run")
+    if args.clean_deep:
+        sub_argv.append("--deep")
+    if args.clean_force:
+        sub_argv.append("--force")
+    if args.clean_format != "text":
+        sub_argv.extend(["--format", args.clean_format])
+    if args.clean_verbose:
+        sub_argv.append("--verbose")
+    return clean_main(sub_argv)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -37,6 +37,8 @@ Provides CLI commands for common KiCad operations via the `kicad-tools` or `kct`
     kicad-tools validate-footprints    - Validate footprint pad spacing
     kicad-tools fix-footprints <pcb>   - Fix footprint pad spacing issues
     kicad-tools analyze <command>      - PCB analysis tools
+    kicad-tools audit <project>        - Manufacturing readiness audit
+    kicad-tools clean <project>        - Clean up old/orphaned files
     kicad-tools config                 - View/manage configuration
     kicad-tools interactive            - Launch interactive REPL mode
 
@@ -81,6 +83,11 @@ Examples:
     kct footprint generate --list
     kct interactive
     kct interactive --project myboard.kicad_pro
+    kct audit project.kicad_pro --mfr jlcpcb
+    kct audit board.kicad_pcb --mfr jlcpcb --skip-erc
+    kct audit project.kicad_pro --format json --strict
+    kct clean project.kicad_pro
+    kct clean project.kicad_pro --deep --force
 """
 
 
@@ -137,7 +144,10 @@ def create_parser() -> argparse.ArgumentParser:
     _add_analyze_parser(subparsers)
     _add_constraints_parser(subparsers)
     _add_estimate_parser(subparsers)
+    _add_audit_parser(subparsers)
+    _add_suggest_parser(subparsers)
     _add_net_status_parser(subparsers)
+    _add_clean_parser(subparsers)
 
     return parser
 
@@ -1661,4 +1671,50 @@ def _add_net_status_parser(subparsers) -> None:
         dest="net_status_verbose",
         action="store_true",
         help="Show all pads with coordinates",
+    )
+
+
+def _add_clean_parser(subparsers) -> None:
+    """Add clean subcommand parser for project cleanup."""
+    clean_parser = subparsers.add_parser(
+        "clean",
+        help="Clean up old/orphaned files from KiCad projects",
+    )
+    clean_parser.add_argument(
+        "clean_project",
+        metavar="project",
+        help="Path to .kicad_pro file",
+    )
+    clean_parser.add_argument(
+        "--dry-run",
+        dest="clean_dry_run",
+        action="store_true",
+        help="Show what would be cleaned without deleting (default behavior)",
+    )
+    clean_parser.add_argument(
+        "--deep",
+        dest="clean_deep",
+        action="store_true",
+        help="Also delete generated output files (gerbers, BOM exports, etc.)",
+    )
+    clean_parser.add_argument(
+        "--force",
+        "-f",
+        dest="clean_force",
+        action="store_true",
+        help="Delete files without confirmation (for CI/automation)",
+    )
+    clean_parser.add_argument(
+        "--format",
+        dest="clean_format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    clean_parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="clean_verbose",
+        action="store_true",
+        help="Show detailed output",
     )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,335 @@
+"""Tests for project cleanup command (kct clean)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.clean_cmd import (
+    CleanableFile,
+    CleanResult,
+    find_cleanable_files,
+    format_output_json,
+    format_output_text,
+)
+from kicad_tools.cli.clean_cmd import (
+    main as clean_main,
+)
+
+# Minimal KiCad project file content
+MINIMAL_PROJECT = """{
+  "meta": {
+    "filename": "test_project.kicad_pro",
+    "version": 1
+  }
+}
+"""
+
+
+@pytest.fixture
+def temp_project(tmp_path: Path) -> Path:
+    """Create a minimal project structure for testing."""
+    project_dir = tmp_path / "test_project"
+    project_dir.mkdir()
+
+    # Create project file
+    project_file = project_dir / "test_project.kicad_pro"
+    project_file.write_text(MINIMAL_PROJECT)
+
+    # Create main PCB file
+    main_pcb = project_dir / "test_project.kicad_pcb"
+    main_pcb.write_text("(kicad_pcb)")
+
+    # Create main schematic file
+    main_sch = project_dir / "test_project.kicad_sch"
+    main_sch.write_text("(kicad_sch)")
+
+    return project_file
+
+
+@pytest.fixture
+def project_with_old_versions(temp_project: Path) -> Path:
+    """Create a project with old PCB versions."""
+    project_dir = temp_project.parent
+
+    # Create old PCB versions
+    (project_dir / "test_project-v1.kicad_pcb").write_text("(old version 1)")
+    (project_dir / "test_project-v2.kicad_pcb").write_text("(old version 2)")
+    (project_dir / "test_project-routed.kicad_pcb").write_text("(routed version)")
+    (project_dir / "test_project-autorouted.kicad_pcb").write_text("(autorouted)")
+
+    return temp_project
+
+
+@pytest.fixture
+def project_with_stale_reports(temp_project: Path) -> Path:
+    """Create a project with stale DRC/ERC reports."""
+    project_dir = temp_project.parent
+
+    # Create stale reports
+    (project_dir / "drc-v1.txt").write_text("old drc report 1")
+    (project_dir / "drc-v2.txt").write_text("old drc report 2")
+    (project_dir / "erc-v1.rpt").write_text("old erc report")
+    (project_dir / "drc-old.txt").write_text("backup drc report")
+
+    return temp_project
+
+
+@pytest.fixture
+def project_with_backups(temp_project: Path) -> Path:
+    """Create a project with backup files."""
+    project_dir = temp_project.parent
+
+    # Create backup files
+    (project_dir / "test_project.kicad_sch.bak").write_text("backup")
+    (project_dir / "test_project.kicad_pcb~").write_text("tilde backup")
+    (project_dir / "test_project-bak.kicad_pcb").write_text("kicad backup")
+    (project_dir / "test_project.kicad_pcb.lck").write_text("lock file")
+
+    return temp_project
+
+
+class TestCleanableFile:
+    """Tests for CleanableFile dataclass."""
+
+    def test_size_str_bytes(self):
+        """Test size string for small files."""
+        f = CleanableFile(Path("test.txt"), "backup", "test", size_bytes=500)
+        assert f.size_str == "500 B"
+
+    def test_size_str_kilobytes(self):
+        """Test size string for KB files."""
+        f = CleanableFile(Path("test.txt"), "backup", "test", size_bytes=2048)
+        assert f.size_str == "2.0 KB"
+
+    def test_size_str_megabytes(self):
+        """Test size string for MB files."""
+        f = CleanableFile(Path("test.txt"), "backup", "test", size_bytes=2 * 1024 * 1024)
+        assert f.size_str == "2.0 MB"
+
+
+class TestCleanResult:
+    """Tests for CleanResult dataclass."""
+
+    def test_total_size_bytes(self):
+        """Test total size calculation."""
+        result = CleanResult(
+            project_dir=Path("/test"),
+            project_name="test",
+            to_delete=[
+                CleanableFile(Path("a.txt"), "backup", "test", size_bytes=100),
+                CleanableFile(Path("b.txt"), "backup", "test", size_bytes=200),
+            ],
+        )
+        assert result.total_size_bytes == 300
+
+    def test_by_category(self):
+        """Test filtering by category."""
+        result = CleanResult(
+            project_dir=Path("/test"),
+            project_name="test",
+            to_delete=[
+                CleanableFile(Path("a.pcb"), "pcb_version", "test", size_bytes=100),
+                CleanableFile(Path("b.bak"), "backup", "test", size_bytes=200),
+                CleanableFile(Path("c.pcb"), "pcb_version", "test", size_bytes=300),
+            ],
+        )
+        pcb_versions = result.by_category("pcb_version")
+        assert len(pcb_versions) == 2
+        assert all(f.category == "pcb_version" for f in pcb_versions)
+
+
+class TestFindCleanableFiles:
+    """Tests for find_cleanable_files function."""
+
+    def test_empty_project(self, temp_project: Path):
+        """Test that empty project has no files to clean."""
+        result = find_cleanable_files(temp_project)
+
+        assert len(result.to_delete) == 0
+        assert len(result.to_keep) == 3  # project, main pcb, main sch
+
+    def test_detects_old_pcb_versions(self, project_with_old_versions: Path):
+        """Test detection of old PCB versions."""
+        result = find_cleanable_files(project_with_old_versions)
+
+        pcb_versions = result.by_category("pcb_version")
+        assert len(pcb_versions) == 4
+
+        # Check specific patterns matched
+        names = {f.path.name for f in pcb_versions}
+        assert "test_project-v1.kicad_pcb" in names
+        assert "test_project-v2.kicad_pcb" in names
+        assert "test_project-routed.kicad_pcb" in names
+        assert "test_project-autorouted.kicad_pcb" in names
+
+    def test_detects_stale_reports(self, project_with_stale_reports: Path):
+        """Test detection of stale reports."""
+        result = find_cleanable_files(project_with_stale_reports)
+
+        stale_reports = result.by_category("stale_report")
+        # Should detect all versioned reports, keeping the most recent
+        assert len(stale_reports) >= 2
+
+    def test_detects_backup_files(self, project_with_backups: Path):
+        """Test detection of backup files."""
+        result = find_cleanable_files(project_with_backups)
+
+        backups = result.by_category("backup")
+        assert len(backups) == 4
+
+        names = {f.path.name for f in backups}
+        assert "test_project.kicad_sch.bak" in names
+        assert "test_project.kicad_pcb~" in names
+        assert "test_project-bak.kicad_pcb" in names
+        assert "test_project.kicad_pcb.lck" in names
+
+    def test_protects_main_files(self, project_with_old_versions: Path):
+        """Test that main project files are protected."""
+        result = find_cleanable_files(project_with_old_versions)
+
+        protected_names = {f.path.name for f in result.to_keep}
+        assert "test_project.kicad_pro" in protected_names
+        assert "test_project.kicad_pcb" in protected_names
+        assert "test_project.kicad_sch" in protected_names
+
+    def test_file_not_found(self, tmp_path: Path):
+        """Test error handling for missing project file."""
+        with pytest.raises(FileNotFoundError):
+            find_cleanable_files(tmp_path / "nonexistent.kicad_pro")
+
+    def test_invalid_project_extension(self, tmp_path: Path):
+        """Test error handling for wrong file extension."""
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("not a project")
+        with pytest.raises(ValueError):
+            find_cleanable_files(txt_file)
+
+
+class TestFormatOutput:
+    """Tests for output formatting functions."""
+
+    def test_format_text_empty(self, temp_project: Path):
+        """Test text output for empty project."""
+        result = find_cleanable_files(temp_project)
+        output = format_output_text(result)
+
+        assert "No files to clean up" in output
+        assert "test_project" in output
+
+    def test_format_text_with_files(self, project_with_old_versions: Path):
+        """Test text output with files to clean."""
+        result = find_cleanable_files(project_with_old_versions)
+        output = format_output_text(result)
+
+        assert "Would delete" in output
+        assert "old PCB versions" in output
+        assert "Would keep" in output
+        assert "Space savings" in output
+
+    def test_format_json(self, project_with_old_versions: Path):
+        """Test JSON output."""
+        result = find_cleanable_files(project_with_old_versions)
+        output = format_output_json(result)
+
+        # Should be valid JSON
+        data = json.loads(output)
+
+        assert "project_name" in data
+        assert "to_delete" in data
+        assert "to_keep" in data
+        assert "total_size_bytes" in data
+        assert isinstance(data["to_delete"], list)
+
+
+class TestCleanCLI:
+    """Tests for the clean command CLI."""
+
+    def test_dry_run_default(self, project_with_old_versions: Path, capsys):
+        """Test that dry-run is the default behavior."""
+        # Run without --dry-run flag, should still not delete
+        result = clean_main([str(project_with_old_versions)])
+        assert result == 0
+
+        # Files should still exist
+        project_dir = project_with_old_versions.parent
+        assert (project_dir / "test_project-v1.kicad_pcb").exists()
+
+    def test_dry_run_explicit(self, project_with_old_versions: Path, capsys):
+        """Test explicit dry-run flag."""
+        result = clean_main([str(project_with_old_versions), "--dry-run"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Would delete" in captured.out
+
+    def test_json_format(self, project_with_old_versions: Path, capsys):
+        """Test JSON output format."""
+        result = clean_main([str(project_with_old_versions), "--format", "json"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "to_delete" in data
+
+    def test_force_deletes_files(self, project_with_old_versions: Path, capsys):
+        """Test that --force actually deletes files."""
+        project_dir = project_with_old_versions.parent
+
+        # Verify files exist before
+        assert (project_dir / "test_project-v1.kicad_pcb").exists()
+
+        result = clean_main([str(project_with_old_versions), "--force"])
+        assert result == 0
+
+        # Files should be deleted
+        assert not (project_dir / "test_project-v1.kicad_pcb").exists()
+        assert not (project_dir / "test_project-v2.kicad_pcb").exists()
+
+        # Main files should still exist
+        assert (project_dir / "test_project.kicad_pcb").exists()
+
+        captured = capsys.readouterr()
+        assert "Deleted" in captured.out
+
+    def test_deep_clean(self, temp_project: Path, capsys):
+        """Test --deep flag includes generated files."""
+        project_dir = temp_project.parent
+
+        # Create some generated files
+        (project_dir / "test-F.Cu.gbr").write_text("gerber")
+        (project_dir / "test.drl").write_text("drill")
+        (project_dir / "test_pos.csv").write_text("position")
+
+        result = clean_main([str(temp_project), "--deep"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "generated" in captured.out.lower() or "Would delete" in captured.out
+
+    def test_missing_project_file(self, tmp_path: Path, capsys):
+        """Test error handling for missing project file."""
+        result = clean_main([str(tmp_path / "nonexistent.kicad_pro")])
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "Error" in captured.err
+
+    def test_verbose_output(self, project_with_old_versions: Path, capsys):
+        """Test verbose output flag."""
+        result = clean_main([str(project_with_old_versions), "-v"])
+        assert result == 0
+
+
+class TestIntegration:
+    """Integration tests for clean command with unified CLI."""
+
+    def test_unified_cli_clean_command(self, project_with_old_versions: Path, capsys):
+        """Test clean command through unified CLI."""
+        from kicad_tools.cli import main
+
+        result = main(["clean", str(project_with_old_versions), "--dry-run"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Would delete" in captured.out or "No files to clean" in captured.out


### PR DESCRIPTION
## Summary
- Add `kct clean` command for cleaning up old/orphaned files from KiCad projects
- Detects and removes old PCB versions, stale reports, and backup files
- Protects main project files and shows space savings summary
- Dry-run by default, use `--force` to delete files

## Test plan
- [x] All existing tests pass
- [x] New tests added for clean command (23 tests)
- [x] Test detection of old PCB versions
- [x] Test detection of stale reports
- [x] Test detection of backup files
- [x] Test dry-run default behavior
- [x] Test force mode deletes files
- [x] Test deep clean mode
- [x] Test JSON output format

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)