### PR TITLE
Add kct sch sync-hierarchy for bidirectional pin↔label sync

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -11,7 +11,7 @@ def run_sch_command(args) -> int:
     if not args.sch_command:
         print("Usage: kicad-tools sch <command> [options] <file>")
         print("Commands: summary, hierarchy, labels, validate, wires, info, pins,")
-        print("          connections, unconnected, replace")
+        print("          connections, unconnected, replace, sync-hierarchy")
         return 1
 
     schematic_path = Path(args.schematic)
@@ -135,5 +135,23 @@ def run_sch_command(args) -> int:
         if args.backup:
             sub_argv.append("--backup")
         return replace_main(sub_argv) or 0
+
+    elif args.sch_command == "sync-hierarchy":
+        from ..sch_sync_hierarchy import main as sync_main
+
+        sub_argv = [str(schematic_path)]
+        if args.add_labels:
+            sub_argv.append("--add-labels")
+        if args.remove_orphan_pins:
+            sub_argv.append("--remove-orphan-pins")
+        if args.interactive:
+            sub_argv.append("--interactive")
+        if args.dry_run:
+            sub_argv.append("--dry-run")
+        if args.format != "text":
+            sub_argv.extend(["--format", args.format])
+        if args.sheet:
+            sub_argv.extend(["--sheet", args.sheet])
+        return sync_main(sub_argv) or 0
 
     return 1

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -41,16 +41,17 @@ Provides CLI commands for common KiCad operations via the `kicad-tools` or `kct`
     kicad-tools interactive            - Launch interactive REPL mode
 
 Schematic subcommands (kct sch <command>):
-    summary      - Quick schematic overview
-    hierarchy    - Show hierarchy tree
-    labels       - List labels
-    validate     - Run validation checks
-    wires        - List wire segments and junctions
-    info         - Show symbol details
-    pins         - Show symbol pin positions
-    connections  - Check pin connections using library positions
-    unconnected  - Find unconnected pins and issues
-    replace      - Replace a symbol's library ID
+    summary        - Quick schematic overview
+    hierarchy      - Show hierarchy tree
+    labels         - List labels
+    validate       - Run validation checks
+    wires          - List wire segments and junctions
+    info           - Show symbol details
+    pins           - Show symbol pin positions
+    connections    - Check pin connections using library positions
+    unconnected    - Find unconnected pins and issues
+    replace        - Replace a symbol's library ID
+    sync-hierarchy - Synchronize sheet pins and hierarchical labels
 
 Examples:
     kct symbols design.kicad_sch --filter "U*"
@@ -385,6 +386,36 @@ def _add_sch_parser(subparsers) -> None:
     sch_replace.add_argument("--footprint", help="New footprint")
     sch_replace.add_argument("--dry-run", action="store_true", help="Show changes without applying")
     sch_replace.add_argument("--backup", action="store_true", help="Create backup before modifying")
+
+    # sch sync-hierarchy
+    sch_sync = sch_subparsers.add_parser(
+        "sync-hierarchy", help="Synchronize sheet pins and hierarchical labels"
+    )
+    sch_sync.add_argument("schematic", help="Path to root .kicad_sch file")
+    sch_sync.add_argument(
+        "--add-labels",
+        action="store_true",
+        help="Add missing hierarchical labels to child sheets",
+    )
+    sch_sync.add_argument(
+        "--remove-orphan-pins",
+        action="store_true",
+        help="Remove sheet pins that have no matching labels",
+    )
+    sch_sync.add_argument(
+        "--interactive",
+        "-i",
+        action="store_true",
+        help="Interactive mode - prompt for each action",
+    )
+    sch_sync.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Preview changes without modifying files",
+    )
+    sch_sync.add_argument("--format", choices=["text", "json"], default="text")
+    sch_sync.add_argument("--sheet", help="Focus on a specific sheet")
 
 
 def _add_pcb_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/sch_sync_hierarchy.py
+++ b/src/kicad_tools/cli/sch_sync_hierarchy.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+"""
+Synchronize sheet pins and hierarchical labels in KiCad hierarchical schematics.
+
+Detects mismatches between sheet pins (in parent) and hierarchical labels (in child),
+and can automatically fix them by adding missing labels or removing orphan pins.
+
+Usage:
+    kct sch sync-hierarchy project.kicad_sch              # Analyze mismatches
+    kct sch sync-hierarchy project.kicad_sch --add-labels # Add missing labels
+    kct sch sync-hierarchy project.kicad_sch --remove-orphan-pins  # Remove orphans
+    kct sch sync-hierarchy project.kicad_sch --interactive # Interactive mode
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from kicad_tools.schema.hierarchy import (
+    HierarchicalLabelInfo,
+    build_hierarchy,
+)
+from kicad_tools.schema.hierarchy_validation import (
+    ValidationIssueType,
+    validate_hierarchy,
+)
+from kicad_tools.sexp import SExp, parse_sexp
+from kicad_tools.sexp.builders import hier_label_node
+
+
+@dataclass
+class SyncAction:
+    """Represents a synchronization action to take."""
+
+    action_type: str  # "add_label" or "remove_pin"
+    name: str  # Signal name
+    direction: str  # Direction/shape
+    file_path: str  # File to modify
+    sheet_name: str  # Sheet this affects
+    parent_file: str  # Parent schematic file
+    # For add_label: position info
+    position: tuple[float, float] | None = None
+    rotation: float = 0
+
+
+@dataclass
+class SyncResult:
+    """Result of a sync operation."""
+
+    success: bool
+    action: SyncAction
+    message: str
+
+
+def _get_schematic_size(sexp: SExp) -> tuple[float, float]:
+    """Get the schematic page size from paper node."""
+    paper = sexp.find("paper")
+    if paper:
+        paper_size = paper.get_string(0)
+        # Common paper sizes
+        sizes = {
+            "A4": (297, 210),
+            "A3": (420, 297),
+            "A2": (594, 420),
+            "A1": (841, 594),
+            "A0": (1189, 841),
+            "A": (279.4, 215.9),  # US Letter
+            "B": (431.8, 279.4),  # US Legal
+            "C": (558.8, 431.8),
+            "D": (863.6, 558.8),
+            "E": (1117.6, 863.6),
+        }
+        if paper_size in sizes:
+            return sizes[paper_size]
+    # Default to A4
+    return (297, 210)
+
+
+def _calculate_label_position(
+    direction: str,
+    existing_labels: list[HierarchicalLabelInfo],
+    page_size: tuple[float, float],
+) -> tuple[tuple[float, float], float]:
+    """Calculate position and rotation for a new hierarchical label.
+
+    Places labels at schematic edges based on direction:
+    - input: left edge (rotation 0)
+    - output: right edge (rotation 180)
+    - bidirectional/passive: left edge (rotation 0)
+
+    Returns:
+        Tuple of ((x, y), rotation)
+    """
+    width, height = page_size
+    margin = 10.0  # Distance from edge
+    spacing = 5.08  # Standard KiCad spacing (200 mil)
+
+    # Determine side and rotation based on direction
+    if direction in ("output",):
+        # Output labels go on right edge, pointing left
+        base_x = width - margin
+        rotation = 180
+    else:
+        # Input, bidirectional, passive go on left edge
+        base_x = margin
+        rotation = 0
+
+    # Find Y position - avoid existing labels on same edge
+    same_edge_labels = [lbl for lbl in existing_labels if lbl.rotation == rotation]
+    used_y = {lbl.position[1] for lbl in same_edge_labels}
+
+    # Start from top quarter of page, work down
+    base_y = height * 0.25
+    y = base_y
+    while y in used_y or any(abs(y - uy) < spacing for uy in used_y):
+        y += spacing
+        if y > height - margin:
+            # Wrap to next column
+            y = base_y
+
+    return (base_x, y), rotation
+
+
+def _add_hierarchical_label(
+    file_path: str,
+    name: str,
+    direction: str,
+    position: tuple[float, float],
+    rotation: float,
+    dry_run: bool = False,
+) -> bool:
+    """Add a hierarchical label to a schematic file.
+
+    Args:
+        file_path: Path to the .kicad_sch file
+        name: Label name/text
+        direction: Label shape (input, output, bidirectional, passive)
+        position: (x, y) position
+        rotation: Rotation in degrees
+        dry_run: If True, don't actually write the file
+
+    Returns:
+        True if successful
+    """
+    path = Path(file_path)
+    content = path.read_text()
+
+    # Generate new label S-expression
+    new_uuid = str(uuid.uuid4())
+    label = hier_label_node(name, position[0], position[1], direction, rotation, new_uuid)
+    label_sexp = label.to_string(indent=1)
+
+    # Find a good insertion point - after existing hierarchical_label nodes
+    # or before first symbol if no hier labels exist
+    lines = content.split("\n")
+    insert_idx = None
+
+    # Look for last hierarchical_label
+    for i in range(len(lines) - 1, -1, -1):
+        if "(hierarchical_label" in lines[i]:
+            # Find closing paren of this label block
+            depth = 0
+            for j in range(i, len(lines)):
+                depth += lines[j].count("(") - lines[j].count(")")
+                if depth == 0:
+                    insert_idx = j + 1
+                    break
+            break
+
+    # If no hierarchical_label found, insert before first symbol
+    if insert_idx is None:
+        for i, line in enumerate(lines):
+            if "(symbol" in line and "(lib_id" in lines[i + 1] if i + 1 < len(lines) else "":
+                insert_idx = i
+                break
+
+    # If still not found, insert before closing paren
+    if insert_idx is None:
+        for i in range(len(lines) - 1, -1, -1):
+            if lines[i].strip() == ")":
+                insert_idx = i
+                break
+
+    if insert_idx is None:
+        return False
+
+    if dry_run:
+        return True
+
+    # Insert the new label
+    lines.insert(insert_idx, "")
+    lines.insert(insert_idx + 1, label_sexp)
+
+    path.write_text("\n".join(lines))
+    return True
+
+
+def _remove_sheet_pin(
+    file_path: str,
+    sheet_name: str,
+    pin_name: str,
+    dry_run: bool = False,
+) -> bool:
+    """Remove a sheet pin from a schematic file.
+
+    Args:
+        file_path: Path to the parent .kicad_sch file
+        sheet_name: Name of the sheet containing the pin
+        pin_name: Name of the pin to remove
+        dry_run: If True, don't actually write the file
+
+    Returns:
+        True if successful
+    """
+    path = Path(file_path)
+    content = path.read_text()
+
+    # Parse and find the sheet block
+    sexp = parse_sexp(content)
+
+    # Find the sheet by name
+    target_sheet = None
+    for sheet in sexp.find_all("sheet"):
+        for prop in sheet.find_all("property"):
+            if prop.get_string(0) == "Sheetname" and prop.get_string(1) == sheet_name:
+                target_sheet = sheet
+                break
+        if target_sheet:
+            break
+
+    if not target_sheet:
+        return False
+
+    # Find the pin by name
+    pin_to_remove = None
+    for pin in target_sheet.find_all("pin"):
+        if pin.get_string(0) == pin_name:
+            pin_to_remove = pin
+            break
+
+    if not pin_to_remove:
+        return False
+
+    if dry_run:
+        return True
+
+    # Remove the pin from the sheet using text-based approach to preserve formatting
+    # Find and remove the pin in the content
+    # The pin format is: (pin "NAME" (shape) (at X Y R) (effects ...) (uuid ...))
+    # We need to find the complete pin block
+
+    # Build a regex pattern for the pin
+    # This is a simplified approach - find lines containing the pin and remove them
+    lines = content.split("\n")
+    new_lines = []
+    skip_until_close = False
+    skip_depth = 0
+    in_target_sheet = False
+    sheet_depth = 0
+
+    for line in lines:
+        # Track if we're in the target sheet
+        if "(sheet" in line:
+            in_target_sheet = False
+            sheet_depth = 1
+        elif in_target_sheet or sheet_depth > 0:
+            sheet_depth += line.count("(") - line.count(")")
+            if sheet_depth == 0:
+                in_target_sheet = False
+
+        # Check if this is the start of our target sheet
+        if f'Sheetname" "{sheet_name}"' in line or f'Sheetname"{sheet_name}"' in line:
+            in_target_sheet = True
+
+        # If we're in target sheet and hit the pin to remove
+        if in_target_sheet and f'(pin "{pin_name}"' in line:
+            skip_until_close = True
+            skip_depth = line.count("(") - line.count(")")
+            continue
+
+        if skip_until_close:
+            skip_depth += line.count("(") - line.count(")")
+            if skip_depth <= 0:
+                skip_until_close = False
+            continue
+
+        new_lines.append(line)
+
+    path.write_text("\n".join(new_lines))
+    return True
+
+
+def analyze_hierarchy(root_schematic: str, specific_sheet: str | None = None) -> list[SyncAction]:
+    """Analyze hierarchy and return list of potential sync actions.
+
+    Args:
+        root_schematic: Path to root schematic
+        specific_sheet: Optional specific sheet to analyze
+
+    Returns:
+        List of SyncAction objects representing fixes
+    """
+    result = validate_hierarchy(root_schematic, specific_sheet=specific_sheet)
+    actions = []
+
+    for issue in result.issues:
+        if issue.issue_type == ValidationIssueType.MISSING_LABEL:
+            # Pin exists but no label - can add label
+            actions.append(
+                SyncAction(
+                    action_type="add_label",
+                    name=issue.pin_name,
+                    direction=issue.pin.direction if issue.pin else "passive",
+                    file_path=issue.sheet_file,
+                    sheet_name=issue.sheet_name,
+                    parent_file=issue.parent_sheet_file,
+                )
+            )
+        elif issue.issue_type == ValidationIssueType.MISSING_PIN:
+            # Label exists but no pin (orphan) - can remove pin
+            # Actually this is an orphan label - the action is to suggest
+            # either adding a pin OR removing the label
+            # For sync-hierarchy, we focus on pins, so this suggests
+            # that a pin should be added to parent OR label removed from child
+            pass  # We'll handle this differently
+
+    return actions
+
+
+def find_orphan_labels(root_schematic: str) -> list[SyncAction]:
+    """Find orphan labels (labels without corresponding pins).
+
+    Returns actions to remove the orphan labels from child sheets.
+    """
+    result = validate_hierarchy(root_schematic)
+    actions = []
+
+    for issue in result.issues:
+        if issue.issue_type == ValidationIssueType.MISSING_PIN:
+            # Label exists but no pin - orphan label
+            # Action would be to remove the label from child
+            actions.append(
+                SyncAction(
+                    action_type="remove_label",
+                    name=issue.label_name,
+                    direction=issue.label.shape if issue.label else "passive",
+                    file_path=issue.sheet_file,
+                    sheet_name=issue.sheet_name,
+                    parent_file=issue.parent_sheet_file,
+                )
+            )
+
+    return actions
+
+
+def find_orphan_pins(root_schematic: str) -> list[SyncAction]:
+    """Find orphan pins (pins without corresponding labels).
+
+    Returns actions to remove the orphan pins from parent sheets.
+    """
+    result = validate_hierarchy(root_schematic)
+    actions = []
+
+    for issue in result.issues:
+        if issue.issue_type == ValidationIssueType.MISSING_LABEL:
+            # Pin exists but no label
+            actions.append(
+                SyncAction(
+                    action_type="remove_pin",
+                    name=issue.pin_name,
+                    direction=issue.pin.direction if issue.pin else "passive",
+                    file_path=issue.parent_sheet_file,
+                    sheet_name=issue.sheet_name,
+                    parent_file=issue.parent_sheet_file,
+                )
+            )
+
+    return actions
+
+
+def execute_add_labels(
+    root_schematic: str,
+    dry_run: bool = False,
+    interactive: bool = False,
+) -> list[SyncResult]:
+    """Add missing hierarchical labels to child sheets.
+
+    For each sheet pin without a matching label, adds the label to the child.
+    """
+    results = []
+    actions = analyze_hierarchy(root_schematic)
+
+    # Build hierarchy to get label positions
+    hierarchy = build_hierarchy(root_schematic)
+
+    for action in actions:
+        if action.action_type != "add_label":
+            continue
+
+        # Find the child node to get existing labels and page size
+        child_node = None
+        for node in hierarchy.all_nodes():
+            if Path(node.path).name == action.file_path or node.path == action.file_path:
+                child_node = node
+                break
+
+        if not child_node:
+            # Try resolving relative path
+            child_path = Path(root_schematic).parent / action.file_path
+            for node in hierarchy.all_nodes():
+                if Path(node.path) == child_path:
+                    child_node = node
+                    break
+
+        if not child_node:
+            results.append(
+                SyncResult(
+                    success=False,
+                    action=action,
+                    message=f"Could not find child schematic: {action.file_path}",
+                )
+            )
+            continue
+
+        # Get page size
+        child_path = Path(child_node.path)
+        child_content = child_path.read_text()
+        child_sexp = parse_sexp(child_content)
+        page_size = _get_schematic_size(child_sexp)
+
+        # Calculate position for new label
+        position, rotation = _calculate_label_position(
+            action.direction, child_node.hierarchical_label_info, page_size
+        )
+
+        if interactive:
+            print(f"\nAdd hierarchical label '{action.name}' ({action.direction})?")
+            print(f"  To: {action.file_path}")
+            print(f"  Position: ({position[0]:.2f}, {position[1]:.2f})")
+            response = input("  [A]dd / [S]kip / [Q]uit: ").strip().lower()
+            if response == "q":
+                break
+            if response == "s":
+                results.append(SyncResult(success=False, action=action, message="Skipped by user"))
+                continue
+
+        if dry_run:
+            results.append(
+                SyncResult(
+                    success=True,
+                    action=action,
+                    message=f"Would add label '{action.name}' to {action.file_path}",
+                )
+            )
+        else:
+            success = _add_hierarchical_label(
+                child_node.path,
+                action.name,
+                action.direction,
+                position,
+                rotation,
+                dry_run=False,
+            )
+            results.append(
+                SyncResult(
+                    success=success,
+                    action=action,
+                    message=f"Added label '{action.name}'" if success else "Failed to add label",
+                )
+            )
+
+    return results
+
+
+def execute_remove_orphan_pins(
+    root_schematic: str,
+    dry_run: bool = False,
+    interactive: bool = False,
+) -> list[SyncResult]:
+    """Remove orphan pins from parent sheets.
+
+    For each sheet pin without a matching label, removes the pin from parent.
+    """
+    results = []
+    actions = find_orphan_pins(root_schematic)
+
+    for action in actions:
+        if interactive:
+            print(f"\nRemove orphan pin '{action.name}' ({action.direction})?")
+            print(f"  From: {action.file_path} (sheet: {action.sheet_name})")
+            response = input("  [R]emove / [S]kip / [Q]uit: ").strip().lower()
+            if response == "q":
+                break
+            if response == "s":
+                results.append(SyncResult(success=False, action=action, message="Skipped by user"))
+                continue
+
+        if dry_run:
+            results.append(
+                SyncResult(
+                    success=True,
+                    action=action,
+                    message=f"Would remove pin '{action.name}' from {action.sheet_name}",
+                )
+            )
+        else:
+            success = _remove_sheet_pin(
+                action.file_path,
+                action.sheet_name,
+                action.name,
+                dry_run=False,
+            )
+            results.append(
+                SyncResult(
+                    success=success,
+                    action=action,
+                    message=f"Removed pin '{action.name}'" if success else "Failed to remove pin",
+                )
+            )
+
+    return results
+
+
+def format_analysis_report(root_schematic: str) -> str:
+    """Generate a formatted analysis report."""
+    result = validate_hierarchy(root_schematic)
+    lines = []
+
+    lines.append("Hierarchy Sync Analysis")
+    lines.append("=" * 60)
+    lines.append("")
+
+    # Group issues by sheet
+    sheets: dict[str, list] = {}
+    for issue in result.issues:
+        key = f"{issue.sheet_name} ({issue.sheet_file})"
+        if key not in sheets:
+            sheets[key] = {"missing_labels": [], "orphan_labels": []}
+
+        if issue.issue_type == ValidationIssueType.MISSING_LABEL:
+            sheets[key]["missing_labels"].append(issue)
+        elif issue.issue_type == ValidationIssueType.MISSING_PIN:
+            sheets[key]["orphan_labels"].append(issue)
+
+    if not sheets:
+        lines.append("No sync issues found. Hierarchy is synchronized.")
+        return "\n".join(lines)
+
+    for sheet_key, issues in sheets.items():
+        lines.append(f"{sheet_key}:")
+
+        if issues["missing_labels"]:
+            lines.append("  Sheet pins without matching labels:")
+            for issue in issues["missing_labels"]:
+                direction = issue.pin.direction if issue.pin else "?"
+                lines.append(f"    x {issue.pin_name} ({direction}) - no label in sub-schematic")
+
+        if issues["orphan_labels"]:
+            lines.append("  Labels without matching sheet pins:")
+            for issue in issues["orphan_labels"]:
+                shape = issue.label.shape if issue.label else "?"
+                lines.append(f"    x {issue.label_name} ({shape}) - orphaned")
+
+        if issues["missing_labels"]:
+            lines.append("")
+            lines.append("  Sync options:")
+            lines.append(
+                f"    [A] Add hierarchical labels for {len(issues['missing_labels'])} pin(s)"
+            )
+            lines.append(f"    [R] Remove {len(issues['missing_labels'])} sheet pin(s)")
+
+        lines.append("")
+
+    # Summary
+    total_missing = sum(len(s["missing_labels"]) for s in sheets.values())
+    total_orphan = sum(len(s["orphan_labels"]) for s in sheets.values())
+    lines.append(f"Summary: {total_missing} pins without labels, {total_orphan} orphaned labels")
+
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Synchronize sheet pins and hierarchical labels",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", help="Path to root .kicad_sch file")
+    parser.add_argument(
+        "--add-labels",
+        action="store_true",
+        help="Add missing hierarchical labels to child sheets",
+    )
+    parser.add_argument(
+        "--remove-orphan-pins",
+        action="store_true",
+        help="Remove sheet pins that have no matching labels",
+    )
+    parser.add_argument(
+        "--interactive",
+        "-i",
+        action="store_true",
+        help="Interactive mode - prompt for each action",
+    )
+    parser.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Preview changes without modifying files",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--sheet",
+        help="Focus on a specific sheet (by name or filename)",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Validate schematic exists
+    if not Path(args.schematic).exists():
+        print(f"Error: File not found: {args.schematic}", file=sys.stderr)
+        return 1
+
+    # Execute requested actions
+    if args.add_labels:
+        results = execute_add_labels(
+            args.schematic,
+            dry_run=args.dry_run,
+            interactive=args.interactive,
+        )
+
+        if args.format == "json":
+            output = {
+                "action": "add_labels",
+                "dry_run": args.dry_run,
+                "results": [
+                    {
+                        "success": r.success,
+                        "name": r.action.name,
+                        "file": r.action.file_path,
+                        "message": r.message,
+                    }
+                    for r in results
+                ],
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            if args.dry_run:
+                print("Dry run - no files modified\n")
+
+            for r in results:
+                status = "+" if r.success else "x"
+                print(f"  {status} {r.message}")
+
+            success_count = sum(1 for r in results if r.success)
+            print(
+                f"\n{success_count}/{len(results)} labels {'would be ' if args.dry_run else ''}added"
+            )
+
+    elif args.remove_orphan_pins:
+        results = execute_remove_orphan_pins(
+            args.schematic,
+            dry_run=args.dry_run,
+            interactive=args.interactive,
+        )
+
+        if args.format == "json":
+            output = {
+                "action": "remove_orphan_pins",
+                "dry_run": args.dry_run,
+                "results": [
+                    {
+                        "success": r.success,
+                        "name": r.action.name,
+                        "sheet": r.action.sheet_name,
+                        "message": r.message,
+                    }
+                    for r in results
+                ],
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            if args.dry_run:
+                print("Dry run - no files modified\n")
+
+            for r in results:
+                status = "-" if r.success else "x"
+                print(f"  {status} {r.message}")
+
+            success_count = sum(1 for r in results if r.success)
+            print(
+                f"\n{success_count}/{len(results)} pins {'would be ' if args.dry_run else ''}removed"
+            )
+
+    else:
+        # Analysis mode (default)
+        if args.format == "json":
+            result = validate_hierarchy(args.schematic)
+            output = {
+                "schematic": args.schematic,
+                "issues": [],
+            }
+            for issue in result.issues:
+                output["issues"].append(
+                    {
+                        "type": issue.issue_type.value,
+                        "sheet_name": issue.sheet_name,
+                        "sheet_file": issue.sheet_file,
+                        "pin_name": issue.pin_name,
+                        "label_name": issue.label_name,
+                        "message": issue.message,
+                    }
+                )
+            print(json.dumps(output, indent=2))
+        else:
+            print(format_analysis_report(args.schematic))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sync_hierarchy.py
+++ b/tests/test_sync_hierarchy.py
@@ -1,0 +1,348 @@
+"""Tests for sync-hierarchy command."""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_sync_hierarchy import (
+    SyncAction,
+    SyncResult,
+    _calculate_label_position,
+    _get_schematic_size,
+    analyze_hierarchy,
+    execute_add_labels,
+    execute_remove_orphan_pins,
+    find_orphan_pins,
+    format_analysis_report,
+    main,
+)
+from kicad_tools.schema.hierarchy import HierarchicalLabelInfo
+from kicad_tools.sexp import parse_sexp
+
+
+@pytest.fixture
+def hierarchical_project(tmp_path: Path) -> Path:
+    """Copy hierarchical test project to temp directory for modification tests."""
+    fixtures = Path(__file__).parent / "fixtures" / "projects"
+
+    # Copy all files
+    for f in [
+        "hierarchical_main.kicad_sch",
+        "logic_subsheet.kicad_sch",
+        "output_subsheet.kicad_sch",
+    ]:
+        src = fixtures / f
+        if src.exists():
+            shutil.copy(src, tmp_path / f)
+
+    return tmp_path / "hierarchical_main.kicad_sch"
+
+
+class TestGetSchematicSize:
+    """Tests for schematic size detection."""
+
+    def test_a4_paper(self):
+        """A4 paper should return correct size."""
+        sexp = parse_sexp('(kicad_sch (paper "A4"))')
+        width, height = _get_schematic_size(sexp)
+        assert width == 297
+        assert height == 210
+
+    def test_us_letter(self):
+        """US Letter should return correct size."""
+        sexp = parse_sexp('(kicad_sch (paper "A"))')
+        width, height = _get_schematic_size(sexp)
+        assert width == 279.4
+        assert height == 215.9
+
+    def test_default_size(self):
+        """Missing paper should default to A4."""
+        sexp = parse_sexp("(kicad_sch)")
+        width, height = _get_schematic_size(sexp)
+        assert width == 297
+        assert height == 210
+
+
+class TestCalculateLabelPosition:
+    """Tests for label position calculation."""
+
+    def test_output_on_right_edge(self):
+        """Output labels should be on right edge."""
+        position, rotation = _calculate_label_position(
+            direction="output",
+            existing_labels=[],
+            page_size=(297, 210),
+        )
+        # Right edge should be near width minus margin
+        assert position[0] > 280
+        assert rotation == 180
+
+    def test_input_on_left_edge(self):
+        """Input labels should be on left edge."""
+        position, rotation = _calculate_label_position(
+            direction="input",
+            existing_labels=[],
+            page_size=(297, 210),
+        )
+        # Left edge should be near margin
+        assert position[0] < 20
+        assert rotation == 0
+
+    def test_bidirectional_on_left_edge(self):
+        """Bidirectional labels should default to left edge."""
+        position, rotation = _calculate_label_position(
+            direction="bidirectional",
+            existing_labels=[],
+            page_size=(297, 210),
+        )
+        assert position[0] < 20
+        assert rotation == 0
+
+    def test_avoids_existing_labels(self):
+        """New labels should avoid existing label positions."""
+        existing = [
+            HierarchicalLabelInfo(
+                name="TEST",
+                shape="input",
+                position=(10.0, 52.5),  # Base Y position
+                rotation=0,
+                uuid="test-uuid",
+            )
+        ]
+        position, rotation = _calculate_label_position(
+            direction="input",
+            existing_labels=existing,
+            page_size=(297, 210),
+        )
+        # Should be offset from existing label
+        assert abs(position[1] - 52.5) >= 5.08  # At least one spacing unit
+
+
+class TestAnalyzeHierarchy:
+    """Tests for hierarchy analysis."""
+
+    def test_analyze_finds_missing_labels(self, hierarchical_project: Path):
+        """Analysis should find missing labels."""
+        actions = analyze_hierarchy(str(hierarchical_project))
+
+        # The output_subsheet is missing a label for "LED" pin
+        missing_led = [a for a in actions if a.name == "LED"]
+        assert len(missing_led) == 1
+        assert missing_led[0].action_type == "add_label"
+
+    def test_analyze_correct_direction(self, hierarchical_project: Path):
+        """Analysis should preserve pin direction."""
+        actions = analyze_hierarchy(str(hierarchical_project))
+
+        missing_led = [a for a in actions if a.name == "LED"]
+        assert len(missing_led) == 1
+        assert missing_led[0].direction == "output"
+
+
+class TestFindOrphanPins:
+    """Tests for finding orphan pins."""
+
+    def test_find_orphan_pins(self, hierarchical_project: Path):
+        """Should find pins without matching labels."""
+        actions = find_orphan_pins(str(hierarchical_project))
+
+        # The output sheet has pin "LED" without label
+        orphan_led = [a for a in actions if a.name == "LED"]
+        assert len(orphan_led) == 1
+        assert orphan_led[0].action_type == "remove_pin"
+
+
+class TestFormatAnalysisReport:
+    """Tests for analysis report formatting."""
+
+    def test_format_report_basic(self, hierarchical_project: Path):
+        """Report should include basic sections."""
+        report = format_analysis_report(str(hierarchical_project))
+
+        assert "Hierarchy Sync Analysis" in report
+        assert "Summary" in report
+
+    def test_format_report_shows_missing(self, hierarchical_project: Path):
+        """Report should show missing labels."""
+        report = format_analysis_report(str(hierarchical_project))
+
+        # Should mention the LED pin without label
+        assert "LED" in report or "pins without labels" in report
+
+
+class TestExecuteAddLabels:
+    """Tests for adding missing labels."""
+
+    def test_add_labels_dry_run(self, hierarchical_project: Path):
+        """Dry run should not modify files."""
+        results = execute_add_labels(str(hierarchical_project), dry_run=True)
+
+        # Should have results for missing labels
+        led_results = [r for r in results if r.action.name == "LED"]
+        assert len(led_results) == 1
+        assert led_results[0].success is True
+        assert "Would add" in led_results[0].message
+
+        # File should be unchanged
+        output_subsheet = hierarchical_project.parent / "output_subsheet.kicad_sch"
+        content = output_subsheet.read_text()
+        assert 'hierarchical_label "LED"' not in content
+
+    def test_add_labels_actual(self, hierarchical_project: Path):
+        """Actual add should modify files."""
+        results = execute_add_labels(str(hierarchical_project), dry_run=False)
+
+        # Should have succeeded
+        led_results = [r for r in results if r.action.name == "LED"]
+        assert len(led_results) == 1
+        assert led_results[0].success is True
+
+        # File should be modified
+        output_subsheet = hierarchical_project.parent / "output_subsheet.kicad_sch"
+        content = output_subsheet.read_text()
+        assert 'hierarchical_label "LED"' in content
+
+
+class TestExecuteRemoveOrphanPins:
+    """Tests for removing orphan pins."""
+
+    def test_remove_orphan_pins_dry_run(self, hierarchical_project: Path):
+        """Dry run should not modify files."""
+        results = execute_remove_orphan_pins(str(hierarchical_project), dry_run=True)
+
+        # Should have results for orphan pins
+        led_results = [r for r in results if r.action.name == "LED"]
+        assert len(led_results) == 1
+        assert led_results[0].success is True
+        assert "Would remove" in led_results[0].message
+
+        # File should be unchanged
+        content = hierarchical_project.read_text()
+        assert '(pin "LED"' in content
+
+
+class TestCliMain:
+    """Tests for CLI main function."""
+
+    def test_analysis_mode_text(self, hierarchical_project: Path, capsys):
+        """Analysis mode should output text report."""
+        result = main([str(hierarchical_project)])
+
+        captured = capsys.readouterr()
+        assert "Hierarchy Sync Analysis" in captured.out
+        assert result == 0
+
+    def test_analysis_mode_json(self, hierarchical_project: Path, capsys):
+        """Analysis mode with --format json should output valid JSON."""
+        result = main([str(hierarchical_project), "--format", "json"])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        assert "schematic" in data
+        assert "issues" in data
+        assert result == 0
+
+    def test_add_labels_dry_run(self, hierarchical_project: Path, capsys):
+        """--add-labels --dry-run should preview changes."""
+        result = main([str(hierarchical_project), "--add-labels", "--dry-run"])
+
+        captured = capsys.readouterr()
+        assert "Dry run" in captured.out or "Would add" in captured.out
+        assert result == 0
+
+    def test_add_labels_json(self, hierarchical_project: Path, capsys):
+        """--add-labels --format json should output valid JSON."""
+        result = main([str(hierarchical_project), "--add-labels", "--dry-run", "--format", "json"])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        assert data["action"] == "add_labels"
+        assert data["dry_run"] is True
+        assert "results" in data
+        assert result == 0
+
+    def test_remove_orphan_pins_dry_run(self, hierarchical_project: Path, capsys):
+        """--remove-orphan-pins --dry-run should preview changes."""
+        result = main([str(hierarchical_project), "--remove-orphan-pins", "--dry-run"])
+
+        captured = capsys.readouterr()
+        assert "Dry run" in captured.out or "Would remove" in captured.out
+        assert result == 0
+
+    def test_missing_file_error(self, capsys):
+        """Should return error for missing file."""
+        result = main(["nonexistent.kicad_sch"])
+
+        captured = capsys.readouterr()
+        assert "not found" in captured.err or result == 1
+
+
+class TestSyncAction:
+    """Tests for SyncAction dataclass."""
+
+    def test_sync_action_add_label(self):
+        """SyncAction for add_label should have correct fields."""
+        action = SyncAction(
+            action_type="add_label",
+            name="TEST",
+            direction="output",
+            file_path="child.kicad_sch",
+            sheet_name="Child",
+            parent_file="parent.kicad_sch",
+        )
+
+        assert action.action_type == "add_label"
+        assert action.name == "TEST"
+        assert action.direction == "output"
+
+    def test_sync_action_remove_pin(self):
+        """SyncAction for remove_pin should have correct fields."""
+        action = SyncAction(
+            action_type="remove_pin",
+            name="ORPHAN",
+            direction="input",
+            file_path="parent.kicad_sch",
+            sheet_name="Child",
+            parent_file="parent.kicad_sch",
+        )
+
+        assert action.action_type == "remove_pin"
+        assert action.name == "ORPHAN"
+
+
+class TestSyncResult:
+    """Tests for SyncResult dataclass."""
+
+    def test_sync_result_success(self):
+        """SyncResult should track success state."""
+        action = SyncAction(
+            action_type="add_label",
+            name="TEST",
+            direction="output",
+            file_path="child.kicad_sch",
+            sheet_name="Child",
+            parent_file="parent.kicad_sch",
+        )
+        result = SyncResult(success=True, action=action, message="Added label")
+
+        assert result.success is True
+        assert "Added" in result.message
+
+    def test_sync_result_failure(self):
+        """SyncResult should track failure state."""
+        action = SyncAction(
+            action_type="add_label",
+            name="TEST",
+            direction="output",
+            file_path="child.kicad_sch",
+            sheet_name="Child",
+            parent_file="parent.kicad_sch",
+        )
+        result = SyncResult(success=False, action=action, message="Failed to add")
+
+        assert result.success is False
+        assert "Failed" in result.message


### PR DESCRIPTION
## Summary

- Adds new `kct sch sync-hierarchy` command to synchronize sheet pins and hierarchical labels
- Analysis mode detects mismatches between pins in parent sheets and labels in child sheets
- `--add-labels` auto-adds missing hierarchical labels to child schematics
- `--remove-orphan-pins` removes sheet pins without matching labels
- Interactive (`-i`) and dry-run (`-n`) modes supported
- JSON output format for scripting

Closes #382

## Test plan

- [x] Run `pytest tests/test_sync_hierarchy.py` - 25 tests pass
- [x] Run `pytest tests/test_hierarchy_validation.py` - existing tests still pass
- [x] Verify `kct sch sync-hierarchy <file>` shows analysis report
- [x] Verify `--add-labels --dry-run` previews label additions
- [x] Verify `--remove-orphan-pins --dry-run` previews pin removals
- [x] Verify `--format json` produces valid JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)