### PR TITLE
Add graphic_items property to PCB schema

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1007,6 +1007,17 @@ class PCB:
         """All board-level graphic elements (gr_line, gr_rect, etc.)."""
         return self._graphics
 
+    @property
+    def graphic_items(self) -> Iterator[GraphicLine | GraphicArc | BoardGraphic]:
+        """All board-level graphic items (lines, arcs, rects, circles).
+
+        Yields all graphic elements from Edge.Cuts and other layers.
+        Used for board outline calculations and layer analysis.
+        """
+        yield from self._graphic_lines
+        yield from self._graphic_arcs
+        yield from self._graphics
+
     def graphics_on_layer(self, layer: str) -> Iterator[BoardGraphic]:
         """Get graphic elements on a specific layer."""
         for graphic in self._graphics:


### PR DESCRIPTION
## Summary

Adds the missing `graphic_items` property to the PCB schema class. This property was being accessed by the audit command but didn't exist, causing:

- Manufacturer compatibility checks to fail
- Layer utilization calculations to fail
- Cost estimation to fail

The new property yields all board-level graphic elements (lines, arcs, rects, circles) as a combined iterator, enabling the auditor to calculate board dimensions from Edge.Cuts layer elements.

## Changes

- Added `graphic_items` property to `PCB` class in `src/kicad_tools/schema/pcb.py`
- Property yields from `_graphic_lines`, `_graphic_arcs`, and `_graphics` collections
- Proper type hints using `Iterator[GraphicLine | GraphicArc | BoardGraphic]`

## Test Plan

- [x] Verified property exists and returns iterator
- [x] Tested with real PCB file - correctly returns Edge.Cuts elements
- [x] Ran audit tests - core functionality tests pass
- [x] Linting passes for modified file

Closes #420