### PR TITLE
Add name property to PadState for state export

### DIFF
--- a/src/kicad_tools/reasoning/state.py
+++ b/src/kicad_tools/reasoning/state.py
@@ -31,6 +31,11 @@ class PadState:
     through_hole: bool = False
 
     @property
+    def name(self) -> str:
+        """Human-readable pad identifier (e.g., 'U1:1')."""
+        return f"{self.ref}:{self.number}"
+
+    @property
     def position(self) -> tuple[float, float]:
         return (self.x, self.y)
 


### PR DESCRIPTION
## Summary

Fix AttributeError in `kct reason --export-state` command by adding a `name` property to the `PadState` dataclass. The command was failing when serializing pad data because `reason_cmd.py` attempted to access `p.name`, but `PadState` only had `ref` and `number` attributes.

## Changes

- Add `name` property to `PadState` that returns `"ref:number"` (e.g., "U1:1")
- This provides a human-readable pad identifier for JSON serialization

## Test Plan

- [x] Verified `PadState.name` property works correctly
- [x] Verified the export logic path in `reason_cmd.py` now works
- [x] Ran reasoning tests - all pass

Closes #421