### PR TITLE
Add pyyaml to required dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
 dependencies = [
     "rich>=13.0",
     "tomli>=2.0; python_version < '3.11'",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Add `pyyaml>=6.0` to the required dependencies in `pyproject.toml` so the `kct audit` command works out of the box.

## Problem

The `kct audit` command fails with an `ImportError` when PyYAML is not installed:

```
ImportError: PyYAML is required to load manufacturer configurations from YAML.
Install it with: pip install pyyaml  or  pip install kicad-tools[constraints]
```

This happens because PyYAML was listed only as an optional dependency under `[constraints]`, but the audit command is a core feature that relies on YAML-based manufacturer configuration files.

## Solution

Move `pyyaml>=6.0` from optional dependencies to required dependencies, ensuring the audit command works without requiring additional extras to be installed.

## Test Plan

- [x] Verified `pyyaml` is now listed in required dependencies
- [x] CI checks pass (formatting, linting)

Closes #417