### PR TITLE
Fix parts availability command silent exit

### DIFF
--- a/src/kicad_tools/cli/commands/parts.py
+++ b/src/kicad_tools/cli/commands/parts.py
@@ -7,7 +7,7 @@ def run_parts_command(args) -> int:
     """Handle parts subcommands."""
     if not args.parts_command:
         print("Usage: kicad-tools parts <command> [options]")
-        print("Commands: lookup, search, cache")
+        print("Commands: lookup, search, availability, cache")
         return 1
 
     from ..parts_cmd import main as parts_main
@@ -30,6 +30,18 @@ def run_parts_command(args) -> int:
             sub_argv.append("--in-stock")
         if args.basic:
             sub_argv.append("--basic")
+        return parts_main(sub_argv) or 0
+
+    elif args.parts_command == "availability":
+        sub_argv = ["availability", args.schematic]
+        if args.quantity != 1:
+            sub_argv.extend(["--quantity", str(args.quantity)])
+        if args.format != "table":
+            sub_argv.extend(["--format", args.format])
+        if args.no_alternatives:
+            sub_argv.append("--no-alternatives")
+        if args.issues_only:
+            sub_argv.append("--issues-only")
         return parts_main(sub_argv) or 0
 
     elif args.parts_command == "cache":


### PR DESCRIPTION
## Summary

The `kct parts availability` command was exiting silently with code 1 because the `run_parts_command` function in `commands/parts.py` was missing a handler for the `availability` subcommand. When the subcommand wasn't matched by any of the if/elif branches, it fell through to `return 1` with no output.

## Changes

- Added missing `availability` subcommand handler that routes to `parts_cmd.main` with proper arguments
- Updated help message to include `availability` in the list of available subcommands

## Test Plan

- [x] Verified `kct parts --help` shows availability in the subcommand list
- [x] Verified `kct parts availability --help` shows proper options
- [x] Verified `kct parts availability nonexistent.kicad_sch` shows proper error message instead of silent exit
- [x] Ran linter (`ruff check`) - passes
- [x] Ran existing parts-related tests - 124 pass, 4 pre-existing failures (unrelated mock issues)

Closes #422