### PR TITLE
Add positional argument support to validate --sync command

### DIFF
--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1334,9 +1334,9 @@ def _add_validate_parser(subparsers) -> None:
     """Add validate subcommand parser."""
     validate_parser = subparsers.add_parser("validate", help="Validation tools")
     validate_parser.add_argument(
-        "validate_project",
-        nargs="?",
-        help="Path to .kicad_pro or .kicad_pcb file",
+        "validate_files",
+        nargs="*",
+        help="Path(s) to project/schematic/PCB files. Accepts: .kicad_pro, .kicad_sch, .kicad_pcb",
     )
     validate_parser.add_argument(
         "--sync",


### PR DESCRIPTION
## Summary

- Adds support for positional arguments to `kct validate --sync` command
- Files are classified by extension (`.kicad_pro`, `.kicad_sch`, `.kicad_pcb`), so order doesn't matter
- Backward compatible with existing project file and explicit flag usage

**New usage:**
```bash
kct validate --sync design.kicad_sch design.kicad_pcb
```

**Still works:**
```bash
kct validate --sync project.kicad_pro
kct validate --sync -s design.kicad_sch -p design.kicad_pcb
```

## Test plan

- [x] Tests pass for file type classification
- [x] Tests pass for two positional arguments (schematic + PCB)
- [x] Tests pass for project file argument
- [x] Tests pass for explicit flags
- [x] Tests pass for error cases (missing files, unrecognized types)
- [x] Tests pass for mixing positional and flag arguments
- [x] Tests pass for JSON output format

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)