### PR TITLE
feat: Add --format json flag to placement optimize command

### DIFF
--- a/src/kicad_tools/cli/commands/placement.py
+++ b/src/kicad_tools/cli/commands/placement.py
@@ -78,6 +78,8 @@ def run_placement_command(args) -> int:
             sub_argv.append("--auto-keepout")
         if args.dry_run:
             sub_argv.append("--dry-run")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         if args.verbose:
             sub_argv.append("--verbose")
         # Use command-level quiet or global quiet

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1135,6 +1135,12 @@ def _add_placement_parser(subparsers) -> None:
         help="Enable thermal-aware placement (keeps heat sources away from sensitive components)",
     )
     placement_optimize.add_argument("--dry-run", action="store_true", help="Preview only")
+    placement_optimize.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
     placement_optimize.add_argument("-v", "--verbose", action="store_true")
     placement_optimize.add_argument(
         "-q", "--quiet", action="store_true", help="Suppress progress output"


### PR DESCRIPTION
## Summary
- Add `--format json` flag to `kct placement optimize` command
- Output structured JSON for automated pipelines and LLM-driven workflows
- Consistent with other kct commands that support `--format json`

## Test plan
- [x] Verify `--help` shows the new `--format` flag
- [x] Test JSON output with `--dry-run --format json`
- [x] Test error handling outputs JSON when `--format json` is set
- [x] Verify text output (default) still works correctly
- [x] All existing placement tests pass

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)