### PR TITLE
fix: Handle empty reference in BOM grouped() to prevent IndexError

### DIFF
--- a/src/kicad_tools/schema/bom.py
+++ b/src/kicad_tools/schema/bom.py
@@ -150,7 +150,7 @@ class BOM:
         return sorted(
             groups.values(),
             key=lambda g: (
-                g.items[0].reference[0] if g.items else "",
+                g.items[0].reference[0] if g.items and g.items[0].reference else "",
                 g.value,
             ),
         )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -554,6 +554,21 @@ class TestBOM:
         assert len(groups) == 1
         assert groups[0].items[0].reference == "R1"
 
+    def test_bom_grouped_with_empty_reference(self):
+        """Test that grouped() handles items with empty reference (issue #439)."""
+        bom = BOM(
+            items=[
+                BOMItem(reference="R1", value="10k", footprint="R_0402", lib_id="Device:R"),
+                BOMItem(reference="", value="10k", footprint="R_0402", lib_id="Device:R"),
+                BOMItem(reference="C1", value="100nF", footprint="C_0402", lib_id="Device:C"),
+            ]
+        )
+        # This should not raise IndexError even with empty reference
+        groups = bom.grouped()
+        # Should group the two 10k resistors together (even with empty reference)
+        # and the capacitor separately
+        assert len(groups) == 2
+
     def test_bom_unique_parts(self):
         """Test unique parts count."""
         bom = BOM(


### PR DESCRIPTION
## Summary

Fix for issue #439 where `kct parts availability` command crashes with IndexError when processing schematics containing components without reference designators.

## Changes

- Added safety check in `BOM.grouped()` method at `src/kicad_tools/schema/bom.py:153`
- The sort key now checks both `g.items` AND `g.items[0].reference` before accessing `reference[0]`
- Added regression test `test_bom_grouped_with_empty_reference` in `tests/test_schema.py`

## Root Cause

When a symbol in the schematic has no "Reference" property, `SymbolInstance.reference` returns an empty string. The `grouped()` method was checking only if `g.items` was non-empty before accessing `g.items[0].reference[0]`, which raises an IndexError when `reference` is an empty string.

## Test Plan

- [x] Added new test `test_bom_grouped_with_empty_reference` 
- [x] All 12 `TestBOM` tests pass
- [x] Fix handles edge case of empty reference without breaking normal behavior

Closes #439