### PR TITLE
feat: Add signal-integrity subparser to analyze command

### DIFF
--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1485,6 +1485,41 @@ def _add_analyze_parser(subparsers) -> None:
         help="Disable differential pair analysis",
     )
 
+    # analyze signal-integrity
+    si_parser = analyze_subparsers.add_parser(
+        "signal-integrity",
+        help="Analyze signal integrity (crosstalk and impedance)",
+        description="Identify crosstalk risks and impedance discontinuities",
+    )
+    si_parser.add_argument("pcb", help="PCB file to analyze (.kicad_pcb)")
+    si_parser.add_argument(
+        "--format",
+        "-f",
+        dest="analyze_format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    si_parser.add_argument(
+        "--min-risk",
+        dest="analyze_min_risk",
+        choices=["low", "medium", "high"],
+        default="medium",
+        help="Minimum risk level to report for crosstalk (default: medium)",
+    )
+    si_parser.add_argument(
+        "--crosstalk-only",
+        dest="analyze_crosstalk_only",
+        action="store_true",
+        help="Only analyze crosstalk, skip impedance analysis",
+    )
+    si_parser.add_argument(
+        "--impedance-only",
+        dest="analyze_impedance_only",
+        action="store_true",
+        help="Only analyze impedance, skip crosstalk analysis",
+    )
+
     # analyze thermal
     thermal_parser = analyze_subparsers.add_parser(
         "thermal",

--- a/uv.lock
+++ b/uv.lock
@@ -468,9 +468,10 @@ wheels = [
 
 [[package]]
 name = "kicad-tools"
-version = "0.6.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
+    { name = "pyyaml" },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -517,6 +518,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'all'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'constraints'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary

Adds the missing `signal-integrity` subparser to the CLI parser, enabling the documented command `kct analyze signal-integrity`.

The signal-integrity analyzer was fully implemented in `analyze_cmd.py` with:
- Crosstalk detection between adjacent traces
- Impedance discontinuity analysis (width changes, vias)
- High-speed net identification
- Coupling coefficient calculation
- Risk level classification

However, the CLI subparser registration was missing from `parser.py`, causing the error:
```
error: argument analyze_command: invalid choice: 'signal-integrity' 
(choose from 'congestion', 'trace-lengths', 'thermal')
```

## Changes

- Added `signal-integrity` subparser to `_add_analyze_parser()` in `parser.py`
- Options: `--format`, `--min-risk`, `--crosstalk-only`, `--impedance-only`

## Test Plan

- [x] Verified `kct analyze --help` shows `signal-integrity` subcommand
- [x] Verified `kct analyze signal-integrity --help` shows all options
- [x] Tested command with sample PCB file (text and JSON output)
- [x] All 64 signal integrity tests pass

Closes #438