### PR TITLE
feat: Auto-detect layer stack from PCB file for routing

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -70,6 +70,7 @@ from .heuristics import (
 from .io import (
     ClearanceViolation,
     PCBDesignRules,
+    detect_layer_stack,
     generate_netclass_setup,
     load_pcb_for_routing,
     merge_routes_into_pcb,
@@ -181,6 +182,7 @@ __all__ = [
     # I/O
     "route_pcb",
     "load_pcb_for_routing",
+    "detect_layer_stack",
     "generate_netclass_setup",
     "merge_routes_into_pcb",
     # Optimizer


### PR DESCRIPTION
## Summary

The router now auto-detects the layer count and stack configuration from the PCB file instead of defaulting to 2-layer. This fixes issue #446 where 4-layer boards were incorrectly treated as 2-layer.

## Changes

- Add `detect_layer_stack()` function to `io.py` that parses:
  - Copper layers from the `(layers ...)` section
  - Zones on inner layers to detect power/ground planes
- Change `--layers` default from `"2"` to `"auto"`
- Export `detect_layer_stack` from `kicad_tools.router` module
- Add unit tests for the new detection logic

## How it works

For a 4-layer board with zones:
```
(layers
    (0 "F.Cu" signal)
    (1 "In1.Cu" signal)
    (2 "In2.Cu" signal)
    (31 "B.Cu" signal)
)
(zone (net_name "GND") (layer "In1.Cu") ...)
(zone (net_name "+3V3") (layer "In2.Cu") ...)
```

The router now detects:
- 4 copper layers present
- Inner layers have power/ground zones → mark as plane layers
- Signal routing on outer layers (F.Cu, B.Cu) with vias for transitions

## Test plan

- [x] New unit tests for `detect_layer_stack()` function
- [x] All 355 existing router tests pass
- [x] 2-layer boards still detected correctly
- [x] 4-layer boards with zones detected as SIG-PLANE-PLANE-SIG
- [x] Manual override with `--layers` still works

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)