### PR TITLE
fix: Add missing attributes for audit command compatibility

### DIFF
--- a/src/kicad_tools/cost/__init__.py
+++ b/src/kicad_tools/cost/__init__.py
@@ -47,6 +47,7 @@ from .estimator import (
     CostEstimate,
     ManufacturingCostEstimator,
     PCBCost,
+    SimplePCBCostResult,
 )
 
 __all__ = [
@@ -54,6 +55,7 @@ __all__ = [
     "ManufacturingCostEstimator",
     "CostEstimate",
     "PCBCost",
+    "SimplePCBCostResult",
     "ComponentCost",
     "AssemblyCost",
     # Availability checking

--- a/src/kicad_tools/cost/estimator.py
+++ b/src/kicad_tools/cost/estimator.py
@@ -39,6 +39,15 @@ class ComponentCost:
 
 
 @dataclass
+class SimplePCBCostResult:
+    """Simple PCB cost result for audit integration."""
+
+    total: float  # Total cost for the order
+    cost_per_unit: float  # Per-board cost in USD
+    quantity: int
+
+
+@dataclass
 class PCBCost:
     """PCB fabrication cost breakdown."""
 
@@ -422,6 +431,50 @@ class ManufacturingCostEstimator:
             cost_drivers=cost_drivers,
             optimization_suggestions=suggestions,
             manufacturer=self.manufacturer,
+        )
+
+    def estimate_pcb(
+        self,
+        width_mm: float,
+        height_mm: float,
+        layers: int = 2,
+        quantity: int = 5,
+        surface_finish: str = "hasl",
+        solder_mask_color: str = "green",
+        board_thickness_mm: float = 1.6,
+    ) -> SimplePCBCostResult:
+        """
+        Estimate PCB fabrication cost only (no components or assembly).
+
+        This is a simplified method for use by the audit command and other
+        callers that only need PCB fabrication cost.
+
+        Args:
+            width_mm: Board width in mm
+            height_mm: Board height in mm
+            layers: Number of copper layers
+            quantity: Number of boards to manufacture
+            surface_finish: Surface finish type (hasl, enig, etc.)
+            solder_mask_color: Solder mask color
+            board_thickness_mm: Board thickness in mm
+
+        Returns:
+            SimplePCBCostResult with total cost and per-unit cost
+        """
+        pcb_cost = self._estimate_pcb_cost(
+            width_mm=width_mm,
+            height_mm=height_mm,
+            layer_count=layers,
+            surface_finish=surface_finish,
+            solder_mask_color=solder_mask_color,
+            board_thickness_mm=board_thickness_mm,
+            quantity=quantity,
+        )
+
+        return SimplePCBCostResult(
+            total=pcb_cost.total_cost,
+            cost_per_unit=pcb_cost.cost_per_unit,
+            quantity=quantity,
         )
 
     def _bom_from_pcb(self, pcb: PCB) -> BOM | None:

--- a/src/kicad_tools/manufacturers/base.py
+++ b/src/kicad_tools/manufacturers/base.py
@@ -88,6 +88,10 @@ class DesignRules:
     outer_copper_oz: float = 1.0
     inner_copper_oz: float = 0.5
 
+    # Maximum board dimensions (defaults based on common manufacturer limits)
+    max_board_width_mm: float = 400.0
+    max_board_height_mm: float = 500.0
+
     @property
     def min_trace_width_mil(self) -> float:
         """Trace width in mils (thousandths of an inch)."""
@@ -116,6 +120,8 @@ class DesignRules:
             "board_thickness_mm": self.board_thickness_mm,
             "outer_copper_oz": self.outer_copper_oz,
             "inner_copper_oz": self.inner_copper_oz,
+            "max_board_width_mm": self.max_board_width_mm,
+            "max_board_height_mm": self.max_board_height_mm,
         }
 
 

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -364,6 +364,38 @@ class TestManufacturingCostEstimator:
         # Should suggest optimizations
         assert len(estimate.optimization_suggestions) > 0
 
+    def test_estimate_pcb_method(self):
+        """Test the estimate_pcb method for audit integration."""
+        estimator = ManufacturingCostEstimator()
+        result = estimator.estimate_pcb(
+            width_mm=50.0,
+            height_mm=40.0,
+            layers=2,
+            quantity=10,
+        )
+        # Should return SimplePCBCostResult with expected attributes
+        assert result.quantity == 10
+        assert result.total > 0
+        assert result.cost_per_unit > 0
+        assert result.total == result.cost_per_unit * 10
+
+    def test_estimate_pcb_with_all_options(self):
+        """Test estimate_pcb with all optional parameters."""
+        estimator = ManufacturingCostEstimator()
+        result = estimator.estimate_pcb(
+            width_mm=100.0,
+            height_mm=80.0,
+            layers=4,
+            quantity=50,
+            surface_finish="enig",
+            solder_mask_color="black",
+            board_thickness_mm=1.6,
+        )
+        # Should return valid cost estimate
+        assert result.quantity == 50
+        assert result.total > 0
+        assert result.cost_per_unit > 0
+
 
 class TestManufacturingCostEstimatorWithMockPCB:
     """Tests for ManufacturingCostEstimator with mocked PCB."""

--- a/tests/test_mfr.py
+++ b/tests/test_mfr.py
@@ -111,6 +111,20 @@ class TestDesignRules:
         assert "min_trace_width_mm" in d
         assert "min_clearance_mm" in d
         assert "min_via_drill_mm" in d
+        assert "max_board_width_mm" in d
+        assert "max_board_height_mm" in d
+
+    def test_max_board_dimensions(self):
+        """Test max board dimensions are available in design rules."""
+        profile = get_profile("jlcpcb")
+        rules = profile.get_design_rules(layers=2)
+
+        # Max board dimensions should have sensible defaults
+        assert rules.max_board_width_mm > 0
+        assert rules.max_board_height_mm > 0
+        # Default values are 400x500mm
+        assert rules.max_board_width_mm == 400.0
+        assert rules.max_board_height_mm == 500.0
 
     def test_compare_design_rules(self):
         """Test comparing design rules across manufacturers."""


### PR DESCRIPTION
## Summary
- Fixes `AttributeError: 'DesignRules' object has no attribute 'max_board_width_mm'` in audit command
- Fixes `AttributeError: 'ManufacturingCostEstimator' object has no attribute 'estimate_pcb'` in audit command
- Adds `max_board_width_mm` and `max_board_height_mm` to `DesignRules` dataclass with sensible defaults (400x500mm)
- Adds `estimate_pcb()` method to `ManufacturingCostEstimator` for simplified PCB-only cost estimation
- Adds `SimplePCBCostResult` dataclass for audit integration
- Adds tests for the new functionality

## Test plan
- [x] All existing tests pass (30 audit tests, 54 cost tests)
- [x] New tests added for `estimate_pcb` method
- [x] New tests added for `max_board_dimensions` attribute
- [x] Verified `DesignRules.max_board_width_mm` and `max_board_height_mm` are accessible
- [x] Verified `ManufacturingCostEstimator.estimate_pcb()` returns expected `SimplePCBCostResult`

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)