### PR TITLE
feat: Add export_gerbers MCP tool for manufacturing file generation

### DIFF
--- a/src/kicad_tools/mcp/__init__.py
+++ b/src/kicad_tools/mcp/__init__.py
@@ -1,0 +1,9 @@
+"""
+MCP (Model Context Protocol) server for kicad-tools.
+
+Provides MCP tools for AI agents to interact with KiCad files.
+"""
+
+from kicad_tools.mcp.server import MCPServer, create_server
+
+__all__ = ["MCPServer", "create_server"]

--- a/src/kicad_tools/mcp/server.py
+++ b/src/kicad_tools/mcp/server.py
@@ -1,0 +1,255 @@
+"""
+MCP server for kicad-tools.
+
+Provides a Model Context Protocol server with tools for AI agents
+to interact with KiCad files via stdio transport.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from kicad_tools.mcp.tools.export import export_gerbers
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ToolDefinition:
+    """Definition of an MCP tool."""
+
+    name: str
+    description: str
+    parameters: dict[str, Any]
+    handler: Callable[..., Any]
+
+
+@dataclass
+class MCPServer:
+    """
+    MCP server for kicad-tools.
+
+    Implements the Model Context Protocol for tool invocation via stdio.
+
+    Example:
+        >>> server = create_server()
+        >>> server.run()  # Starts stdio loop
+    """
+
+    name: str = "kicad-tools"
+    version: str = "0.1.0"
+    tools: dict[str, ToolDefinition] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Register default tools."""
+        self._register_export_tools()
+
+    def _register_export_tools(self) -> None:
+        """Register export-related tools."""
+        self.tools["export_gerbers"] = ToolDefinition(
+            name="export_gerbers",
+            description=(
+                "Export Gerber files for PCB manufacturing. Generates all required "
+                "Gerber layers (copper, soldermask, silkscreen, outline) and optionally "
+                "drill files. Supports manufacturer presets for JLCPCB, OSHPark, PCBWay, and Seeed."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "pcb_path": {
+                        "type": "string",
+                        "description": "Path to .kicad_pcb file",
+                    },
+                    "output_dir": {
+                        "type": "string",
+                        "description": "Directory for output files",
+                    },
+                    "manufacturer": {
+                        "type": "string",
+                        "description": "Manufacturer preset",
+                        "enum": ["generic", "jlcpcb", "pcbway", "oshpark", "seeed"],
+                        "default": "generic",
+                    },
+                    "include_drill": {
+                        "type": "boolean",
+                        "description": "Include drill files (Excellon format)",
+                        "default": True,
+                    },
+                    "zip_output": {
+                        "type": "boolean",
+                        "description": "Create zip archive of all files",
+                        "default": True,
+                    },
+                },
+                "required": ["pcb_path", "output_dir"],
+            },
+            handler=self._handle_export_gerbers,
+        )
+
+    def _handle_export_gerbers(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Handle export_gerbers tool call."""
+        result = export_gerbers(
+            pcb_path=params["pcb_path"],
+            output_dir=params["output_dir"],
+            manufacturer=params.get("manufacturer", "generic"),
+            include_drill=params.get("include_drill", True),
+            zip_output=params.get("zip_output", True),
+        )
+        return result.to_dict()
+
+    def get_tools_list(self) -> list[dict[str, Any]]:
+        """Get list of available tools for MCP discovery."""
+        return [
+            {
+                "name": tool.name,
+                "description": tool.description,
+                "inputSchema": tool.parameters,
+            }
+            for tool in self.tools.values()
+        ]
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """
+        Call a tool by name with given arguments.
+
+        Args:
+            name: Tool name
+            arguments: Tool arguments
+
+        Returns:
+            Tool result as dictionary
+
+        Raises:
+            ValueError: If tool not found
+        """
+        if name not in self.tools:
+            raise ValueError(f"Unknown tool: {name}")
+
+        tool = self.tools[name]
+        return tool.handler(arguments)
+
+    def handle_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        """
+        Handle a JSON-RPC request.
+
+        Args:
+            request: JSON-RPC request object
+
+        Returns:
+            JSON-RPC response object
+        """
+        method = request.get("method", "")
+        params = request.get("params", {})
+        request_id = request.get("id")
+
+        try:
+            if method == "initialize":
+                result = {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {
+                        "tools": {"listChanged": False},
+                    },
+                    "serverInfo": {
+                        "name": self.name,
+                        "version": self.version,
+                    },
+                }
+            elif method == "tools/list":
+                result = {"tools": self.get_tools_list()}
+            elif method == "tools/call":
+                tool_name = params.get("name", "")
+                arguments = params.get("arguments", {})
+                tool_result = self.call_tool(tool_name, arguments)
+                result = {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(tool_result, indent=2),
+                        }
+                    ],
+                }
+            elif method == "notifications/initialized":
+                # Client notification, no response needed
+                return {}
+            else:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {
+                        "code": -32601,
+                        "message": f"Method not found: {method}",
+                    },
+                }
+
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": result,
+            }
+
+        except Exception as e:
+            logger.exception(f"Error handling request: {method}")
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": -32603,
+                    "message": str(e),
+                },
+            }
+
+    def run(self) -> None:
+        """
+        Run the MCP server with stdio transport.
+
+        Reads JSON-RPC requests from stdin, processes them,
+        and writes responses to stdout.
+        """
+        logger.info(f"Starting MCP server: {self.name} v{self.version}")
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                request = json.loads(line)
+                response = self.handle_request(request)
+
+                if response:  # Skip empty responses (notifications)
+                    print(json.dumps(response), flush=True)
+
+            except json.JSONDecodeError as e:
+                error_response = {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {
+                        "code": -32700,
+                        "message": f"Parse error: {e}",
+                    },
+                }
+                print(json.dumps(error_response), flush=True)
+
+
+def create_server() -> MCPServer:
+    """Create and return an MCP server instance."""
+    return MCPServer()
+
+
+def main() -> None:
+    """Entry point for MCP server."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stderr,
+    )
+    server = create_server()
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kicad_tools/mcp/tools/__init__.py
+++ b/src/kicad_tools/mcp/tools/__init__.py
@@ -1,0 +1,9 @@
+"""
+MCP tools for kicad-tools.
+
+Each tool module provides specific functionality for AI agents.
+"""
+
+from kicad_tools.mcp.tools.export import export_gerbers
+
+__all__ = ["export_gerbers"]

--- a/src/kicad_tools/mcp/tools/export.py
+++ b/src/kicad_tools/mcp/tools/export.py
@@ -1,0 +1,235 @@
+"""
+Export tools for MCP server.
+
+Provides tools for exporting PCB manufacturing files (Gerbers, drill files).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from kicad_tools.export.gerber import (
+    MANUFACTURER_PRESETS,
+    GerberConfig,
+    GerberExporter,
+)
+from kicad_tools.mcp.types import (
+    GerberExportResult,
+    GerberFile,
+    get_file_type,
+)
+
+logger = logging.getLogger(__name__)
+
+# Supported manufacturers
+SUPPORTED_MANUFACTURERS = ["generic", "jlcpcb", "pcbway", "oshpark", "seeed"]
+
+
+def export_gerbers(
+    pcb_path: str,
+    output_dir: str,
+    manufacturer: str = "generic",
+    include_drill: bool = True,
+    zip_output: bool = True,
+) -> GerberExportResult:
+    """
+    Export Gerber files for PCB manufacturing.
+
+    Generates all required Gerber layers (copper, soldermask, silkscreen, outline)
+    and optionally drill files in Excellon format. Supports manufacturer presets
+    for JLCPCB, OSHPark, PCBWay, and Seeed.
+
+    Args:
+        pcb_path: Path to .kicad_pcb file
+        output_dir: Directory for output files
+        manufacturer: Manufacturer preset ("generic", "jlcpcb", "pcbway", "oshpark", "seeed")
+        include_drill: Include drill files (Excellon format)
+        zip_output: Create zip archive of all files
+
+    Returns:
+        GerberExportResult with file paths, layer count, and any warnings.
+
+    Example:
+        >>> result = export_gerbers(
+        ...     "/path/to/board.kicad_pcb",
+        ...     "/tmp/gerbers",
+        ...     manufacturer="jlcpcb",
+        ... )
+        >>> if result.success:
+        ...     print(f"Generated {len(result.files)} files")
+        ...     if result.zip_file:
+        ...         print(f"Zip: {result.zip_file}")
+    """
+    pcb = Path(pcb_path)
+    out_dir = Path(output_dir)
+    warnings: list[str] = []
+
+    # Validate inputs
+    if not pcb.exists():
+        return GerberExportResult(
+            success=False,
+            output_dir=str(out_dir),
+            error=f"PCB file not found: {pcb_path}",
+        )
+
+    if pcb.suffix != ".kicad_pcb":
+        warnings.append(f"Unusual file extension: {pcb.suffix} (expected .kicad_pcb)")
+
+    manufacturer_lower = manufacturer.lower()
+    if manufacturer_lower not in SUPPORTED_MANUFACTURERS:
+        return GerberExportResult(
+            success=False,
+            output_dir=str(out_dir),
+            error=f"Unknown manufacturer: {manufacturer}. "
+            f"Supported: {', '.join(SUPPORTED_MANUFACTURERS)}",
+            warnings=warnings,
+        )
+
+    try:
+        # Create exporter
+        exporter = GerberExporter(pcb)
+
+        # Configure based on manufacturer
+        if manufacturer_lower in MANUFACTURER_PRESETS:
+            config = MANUFACTURER_PRESETS[manufacturer_lower].config
+        else:
+            config = GerberConfig()
+
+        # Override settings based on parameters
+        config.generate_drill = include_drill
+        config.create_zip = zip_output
+
+        # Export
+        result_path = exporter.export(config, out_dir)
+
+        # Collect file information
+        files: list[GerberFile] = []
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        for file_path in out_dir.iterdir():
+            if file_path.is_file():
+                # Determine layer from filename
+                layer = _extract_layer_from_filename(file_path.name)
+                file_type = _determine_file_type(file_path.name, layer)
+
+                files.append(
+                    GerberFile(
+                        filename=file_path.name,
+                        layer=layer,
+                        file_type=file_type,
+                        size_bytes=file_path.stat().st_size,
+                    )
+                )
+
+        # Determine zip file path
+        zip_file: str | None = None
+        if zip_output:
+            zip_path = out_dir / config.zip_name
+            if zip_path.exists():
+                zip_file = str(zip_path)
+            elif result_path.suffix == ".zip":
+                zip_file = str(result_path)
+
+        # Count copper layers
+        copper_layers = [f for f in files if f.file_type == "copper"]
+        layer_count = len(copper_layers)
+
+        return GerberExportResult(
+            success=True,
+            output_dir=str(out_dir),
+            zip_file=zip_file,
+            files=files,
+            layer_count=layer_count,
+            warnings=warnings,
+        )
+
+    except Exception as e:
+        logger.exception("Gerber export failed")
+        return GerberExportResult(
+            success=False,
+            output_dir=str(out_dir),
+            error=str(e),
+            warnings=warnings,
+        )
+
+
+def _extract_layer_from_filename(filename: str) -> str:
+    """Extract layer name from Gerber filename."""
+    # Common patterns:
+    # - project-F_Cu.gbr
+    # - project-B_Cu.gbr
+    # - project-F_Mask.gbr
+    # - project-Edge_Cuts.gbr
+    # - project-PTH.drl
+    # - project-NPTH.drl
+
+    name = Path(filename).stem
+    parts = name.split("-")
+
+    if len(parts) >= 2:
+        layer_part = parts[-1]
+        # Convert underscore back to dot for standard KiCad names
+        layer_candidates = [
+            ("F_Cu", "F.Cu"),
+            ("B_Cu", "B.Cu"),
+            ("In1_Cu", "In1.Cu"),
+            ("In2_Cu", "In2.Cu"),
+            ("In3_Cu", "In3.Cu"),
+            ("In4_Cu", "In4.Cu"),
+            ("F_Mask", "F.Mask"),
+            ("B_Mask", "B.Mask"),
+            ("F_SilkS", "F.SilkS"),
+            ("B_SilkS", "B.SilkS"),
+            ("F_Paste", "F.Paste"),
+            ("B_Paste", "B.Paste"),
+            ("Edge_Cuts", "Edge.Cuts"),
+            ("F_Silkscreen", "F.SilkS"),
+            ("B_Silkscreen", "B.SilkS"),
+        ]
+        for pattern, layer in layer_candidates:
+            if pattern in layer_part:
+                return layer
+
+    # Drill files - check NPTH first since "NPTH" contains "PTH"
+    if "NPTH" in filename.upper():
+        return "NPTH"
+    if "PTH" in filename.upper():
+        return "PTH"
+    if filename.endswith(".drl"):
+        return "drill"
+
+    return "unknown"
+
+
+def _determine_file_type(filename: str, layer: str) -> str:
+    """Determine file type from filename and layer."""
+    suffix = Path(filename).suffix.lower()
+
+    if suffix in (".drl", ".xln"):
+        return "drill"
+
+    if suffix == ".zip":
+        return "archive"
+
+    file_type = get_file_type(layer)
+    if file_type != "other":
+        return file_type
+
+    # Fallback based on Protel extensions
+    extension_types = {
+        ".gtl": "copper",  # Top copper
+        ".gbl": "copper",  # Bottom copper
+        ".g2": "copper",  # Inner layer 2
+        ".g3": "copper",  # Inner layer 3
+        ".gts": "soldermask",  # Top soldermask
+        ".gbs": "soldermask",  # Bottom soldermask
+        ".gto": "silkscreen",  # Top silkscreen
+        ".gbo": "silkscreen",  # Bottom silkscreen
+        ".gtp": "paste",  # Top paste
+        ".gbp": "paste",  # Bottom paste
+        ".gm1": "outline",  # Mechanical layer / outline
+        ".gko": "outline",  # Keep-out / outline
+    }
+
+    return extension_types.get(suffix, "other")

--- a/src/kicad_tools/mcp/types.py
+++ b/src/kicad_tools/mcp/types.py
@@ -1,0 +1,97 @@
+"""
+Type definitions for MCP tools.
+
+Provides dataclasses for tool inputs and outputs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class GerberFile:
+    """Information about a generated Gerber file."""
+
+    filename: str
+    """Name of the generated file."""
+
+    layer: str
+    """KiCad layer name (e.g., 'F.Cu', 'B.Mask')."""
+
+    file_type: str
+    """File category: 'copper', 'soldermask', 'silkscreen', 'paste', 'outline', 'drill'."""
+
+    size_bytes: int
+    """File size in bytes."""
+
+
+@dataclass
+class GerberExportResult:
+    """Result of a Gerber export operation."""
+
+    success: bool
+    """Whether the export completed successfully."""
+
+    output_dir: str
+    """Directory containing the exported files."""
+
+    zip_file: str | None = None
+    """Path to zip archive if created, None otherwise."""
+
+    files: list[GerberFile] = field(default_factory=list)
+    """List of generated files with metadata."""
+
+    layer_count: int = 0
+    """Number of copper layers in the board."""
+
+    warnings: list[str] = field(default_factory=list)
+    """Any warnings encountered during export."""
+
+    error: str | None = None
+    """Error message if success is False."""
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "success": self.success,
+            "output_dir": self.output_dir,
+            "zip_file": self.zip_file,
+            "files": [
+                {
+                    "filename": f.filename,
+                    "layer": f.layer,
+                    "file_type": f.file_type,
+                    "size_bytes": f.size_bytes,
+                }
+                for f in self.files
+            ],
+            "layer_count": self.layer_count,
+            "warnings": self.warnings,
+            "error": self.error,
+        }
+
+
+# Layer name to file type mapping
+LAYER_FILE_TYPES: dict[str, str] = {
+    "F.Cu": "copper",
+    "B.Cu": "copper",
+    "In1.Cu": "copper",
+    "In2.Cu": "copper",
+    "In3.Cu": "copper",
+    "In4.Cu": "copper",
+    "In5.Cu": "copper",
+    "In6.Cu": "copper",
+    "F.Mask": "soldermask",
+    "B.Mask": "soldermask",
+    "F.SilkS": "silkscreen",
+    "B.SilkS": "silkscreen",
+    "F.Paste": "paste",
+    "B.Paste": "paste",
+    "Edge.Cuts": "outline",
+}
+
+
+def get_file_type(layer: str) -> str:
+    """Get the file type for a given layer name."""
+    return LAYER_FILE_TYPES.get(layer, "other")

--- a/tests/test_mcp_export.py
+++ b/tests/test_mcp_export.py
@@ -1,0 +1,368 @@
+"""Tests for MCP export tools."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.mcp.server import create_server
+from kicad_tools.mcp.tools.export import (
+    SUPPORTED_MANUFACTURERS,
+    _determine_file_type,
+    _extract_layer_from_filename,
+    export_gerbers,
+)
+from kicad_tools.mcp.types import GerberExportResult, GerberFile, get_file_type
+
+
+class TestGerberFile:
+    """Tests for GerberFile dataclass."""
+
+    def test_creation(self):
+        gf = GerberFile(
+            filename="board-F_Cu.gbr",
+            layer="F.Cu",
+            file_type="copper",
+            size_bytes=12345,
+        )
+        assert gf.filename == "board-F_Cu.gbr"
+        assert gf.layer == "F.Cu"
+        assert gf.file_type == "copper"
+        assert gf.size_bytes == 12345
+
+
+class TestGerberExportResult:
+    """Tests for GerberExportResult dataclass."""
+
+    def test_success_result(self):
+        result = GerberExportResult(
+            success=True,
+            output_dir="/tmp/gerbers",
+            zip_file="/tmp/gerbers/board.zip",
+            files=[
+                GerberFile("board-F_Cu.gbr", "F.Cu", "copper", 1000),
+                GerberFile("board-B_Cu.gbr", "B.Cu", "copper", 1000),
+            ],
+            layer_count=2,
+        )
+        assert result.success is True
+        assert result.error is None
+        assert len(result.files) == 2
+        assert result.layer_count == 2
+
+    def test_failure_result(self):
+        result = GerberExportResult(
+            success=False,
+            output_dir="/tmp/gerbers",
+            error="PCB file not found",
+        )
+        assert result.success is False
+        assert result.error == "PCB file not found"
+
+    def test_to_dict(self):
+        result = GerberExportResult(
+            success=True,
+            output_dir="/tmp/gerbers",
+            zip_file="/tmp/gerbers/board.zip",
+            files=[GerberFile("board-F_Cu.gbr", "F.Cu", "copper", 1000)],
+            layer_count=2,
+            warnings=["Test warning"],
+        )
+        d = result.to_dict()
+
+        assert d["success"] is True
+        assert d["output_dir"] == "/tmp/gerbers"
+        assert d["zip_file"] == "/tmp/gerbers/board.zip"
+        assert len(d["files"]) == 1
+        assert d["files"][0]["filename"] == "board-F_Cu.gbr"
+        assert d["layer_count"] == 2
+        assert d["warnings"] == ["Test warning"]
+
+
+class TestGetFileType:
+    """Tests for get_file_type function."""
+
+    def test_copper_layers(self):
+        assert get_file_type("F.Cu") == "copper"
+        assert get_file_type("B.Cu") == "copper"
+        assert get_file_type("In1.Cu") == "copper"
+
+    def test_soldermask_layers(self):
+        assert get_file_type("F.Mask") == "soldermask"
+        assert get_file_type("B.Mask") == "soldermask"
+
+    def test_silkscreen_layers(self):
+        assert get_file_type("F.SilkS") == "silkscreen"
+        assert get_file_type("B.SilkS") == "silkscreen"
+
+    def test_paste_layers(self):
+        assert get_file_type("F.Paste") == "paste"
+        assert get_file_type("B.Paste") == "paste"
+
+    def test_outline(self):
+        assert get_file_type("Edge.Cuts") == "outline"
+
+    def test_unknown(self):
+        assert get_file_type("Unknown.Layer") == "other"
+
+
+class TestExtractLayerFromFilename:
+    """Tests for _extract_layer_from_filename function."""
+
+    def test_copper_layers(self):
+        assert _extract_layer_from_filename("board-F_Cu.gbr") == "F.Cu"
+        assert _extract_layer_from_filename("board-B_Cu.gbr") == "B.Cu"
+        assert _extract_layer_from_filename("board-In1_Cu.gbr") == "In1.Cu"
+
+    def test_mask_layers(self):
+        assert _extract_layer_from_filename("board-F_Mask.gbr") == "F.Mask"
+        assert _extract_layer_from_filename("board-B_Mask.gbr") == "B.Mask"
+
+    def test_silkscreen_layers(self):
+        assert _extract_layer_from_filename("board-F_SilkS.gbr") == "F.SilkS"
+        assert _extract_layer_from_filename("board-F_Silkscreen.gbr") == "F.SilkS"
+
+    def test_edge_cuts(self):
+        assert _extract_layer_from_filename("board-Edge_Cuts.gbr") == "Edge.Cuts"
+
+    def test_drill_files(self):
+        assert _extract_layer_from_filename("board-PTH.drl") == "PTH"
+        assert _extract_layer_from_filename("board-NPTH.drl") == "NPTH"
+        assert _extract_layer_from_filename("board.drl") == "drill"
+
+
+class TestDetermineFileType:
+    """Tests for _determine_file_type function."""
+
+    def test_drill_by_extension(self):
+        assert _determine_file_type("board.drl", "PTH") == "drill"
+        assert _determine_file_type("board.xln", "NPTH") == "drill"
+
+    def test_archive(self):
+        assert _determine_file_type("board.zip", "unknown") == "archive"
+
+    def test_protel_extensions(self):
+        assert _determine_file_type("board.gtl", "unknown") == "copper"
+        assert _determine_file_type("board.gbl", "unknown") == "copper"
+        assert _determine_file_type("board.gts", "unknown") == "soldermask"
+        assert _determine_file_type("board.gto", "unknown") == "silkscreen"
+
+    def test_by_layer(self):
+        assert _determine_file_type("board-F_Cu.gbr", "F.Cu") == "copper"
+
+
+class TestExportGerbers:
+    """Tests for export_gerbers function."""
+
+    def test_file_not_found(self):
+        result = export_gerbers(
+            pcb_path="/nonexistent/board.kicad_pcb",
+            output_dir="/tmp/gerbers",
+        )
+        assert result.success is False
+        assert "not found" in result.error.lower()
+
+    def test_unknown_manufacturer(self):
+        with tempfile.NamedTemporaryFile(suffix=".kicad_pcb", delete=False) as f:
+            f.write(b"(kicad_pcb (version 20231014))")
+            pcb_path = f.name
+
+        result = export_gerbers(
+            pcb_path=pcb_path,
+            output_dir="/tmp/gerbers",
+            manufacturer="unknown_mfr",
+        )
+        assert result.success is False
+        assert "Unknown manufacturer" in result.error
+
+        # Cleanup
+        Path(pcb_path).unlink()
+
+    def test_unusual_extension_warning(self):
+        with tempfile.NamedTemporaryFile(suffix=".pcb", delete=False) as f:
+            f.write(b"(kicad_pcb (version 20231014))")
+            pcb_path = f.name
+
+        result = export_gerbers(
+            pcb_path=pcb_path,
+            output_dir="/tmp/gerbers",
+            manufacturer="unknown_mfr",  # Will fail before exporter runs
+        )
+        # Should have warning about extension
+        assert any("extension" in w.lower() for w in result.warnings)
+
+        # Cleanup
+        Path(pcb_path).unlink()
+
+    def test_supported_manufacturers(self):
+        """Verify all supported manufacturers are valid."""
+        assert "generic" in SUPPORTED_MANUFACTURERS
+        assert "jlcpcb" in SUPPORTED_MANUFACTURERS
+        assert "pcbway" in SUPPORTED_MANUFACTURERS
+        assert "oshpark" in SUPPORTED_MANUFACTURERS
+        assert "seeed" in SUPPORTED_MANUFACTURERS
+
+    @patch("kicad_tools.mcp.tools.export.GerberExporter")
+    def test_export_with_mock(self, mock_exporter_class):
+        """Test export with mocked GerberExporter."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a fake PCB file
+            pcb_path = Path(tmpdir) / "board.kicad_pcb"
+            pcb_path.write_text("(kicad_pcb (version 20231014))")
+
+            # Create fake output files
+            output_dir = Path(tmpdir) / "gerbers"
+            output_dir.mkdir()
+            (output_dir / "board-F_Cu.gbr").write_text("gerber content")
+            (output_dir / "board-B_Cu.gbr").write_text("gerber content")
+            (output_dir / "gerbers.zip").write_bytes(b"PK...")
+
+            # Mock the exporter
+            mock_exporter = MagicMock()
+            mock_exporter.export.return_value = output_dir / "gerbers.zip"
+            mock_exporter_class.return_value = mock_exporter
+
+            result = export_gerbers(
+                pcb_path=str(pcb_path),
+                output_dir=str(output_dir),
+                manufacturer="jlcpcb",
+            )
+
+            assert result.success is True
+            assert result.layer_count == 2
+            assert len(result.files) >= 2
+
+
+class TestMCPServer:
+    """Tests for MCP server."""
+
+    def test_create_server(self):
+        server = create_server()
+        assert server.name == "kicad-tools"
+        assert "export_gerbers" in server.tools
+
+    def test_get_tools_list(self):
+        server = create_server()
+        tools = server.get_tools_list()
+
+        assert len(tools) >= 1
+
+        export_tool = next(t for t in tools if t["name"] == "export_gerbers")
+        assert "description" in export_tool
+        assert "inputSchema" in export_tool
+        assert "pcb_path" in export_tool["inputSchema"]["properties"]
+        assert "output_dir" in export_tool["inputSchema"]["properties"]
+
+    def test_handle_initialize(self):
+        server = create_server()
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {},
+            }
+        )
+
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 1
+        assert "result" in response
+        assert "protocolVersion" in response["result"]
+        assert "serverInfo" in response["result"]
+
+    def test_handle_tools_list(self):
+        server = create_server()
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+                "params": {},
+            }
+        )
+
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 2
+        assert "result" in response
+        assert "tools" in response["result"]
+
+    def test_handle_tools_call_missing_file(self):
+        server = create_server()
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "export_gerbers",
+                    "arguments": {
+                        "pcb_path": "/nonexistent.kicad_pcb",
+                        "output_dir": "/tmp/out",
+                    },
+                },
+            }
+        )
+
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 3
+        assert "result" in response
+        # Result should contain error info
+        result_text = response["result"]["content"][0]["text"]
+        result_data = json.loads(result_text)
+        assert result_data["success"] is False
+
+    def test_handle_unknown_tool(self):
+        server = create_server()
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "unknown_tool",
+                    "arguments": {},
+                },
+            }
+        )
+
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 4
+        assert "error" in response
+
+    def test_handle_unknown_method(self):
+        server = create_server()
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "unknown/method",
+                "params": {},
+            }
+        )
+
+        assert "error" in response
+        assert response["error"]["code"] == -32601
+
+    def test_handle_notification(self):
+        server = create_server()
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            }
+        )
+
+        # Notifications return empty response
+        assert response == {}
+
+    def test_call_tool_directly(self):
+        server = create_server()
+
+        # Should raise for unknown tool
+        with pytest.raises(ValueError, match="Unknown tool"):
+            server.call_tool("nonexistent", {})


### PR DESCRIPTION
## Summary

Implements the `export_gerbers` MCP tool that enables AI agents to generate manufacturing-ready Gerber files for PCB fabrication. This wraps the existing `GerberExporter` class with a structured MCP interface.

## Changes

- **MCP Server Infrastructure** (`src/kicad_tools/mcp/`)
  - `server.py`: MCPServer class with stdio JSON-RPC transport, tool registration system
  - `types.py`: GerberExportResult and GerberFile dataclasses for structured responses
  - `tools/export.py`: export_gerbers function wrapping GerberExporter

- **Features**
  - Generates all required Gerber layers (copper, soldermask, silkscreen, outline)
  - Generates Excellon drill files (PTH/NPTH) when requested
  - Supports manufacturer presets: JLCPCB, PCBWay, OSHPark, Seeed, generic
  - Creates zip archive of all files for easy upload
  - Returns file list with sizes, layer count, and warnings
  - Comprehensive error handling with actionable messages

- **Tests** (`tests/test_mcp_export.py`)
  - 33 tests covering types, layer extraction, file type detection
  - MCP server protocol tests (initialize, tools/list, tools/call)
  - Mock-based export tests for CI compatibility

## Test Plan

- [x] All 33 new tests pass
- [x] Linting passes (ruff check, ruff format)
- [x] Type annotations consistent with codebase patterns
- [ ] Integration test with real KiCad file (requires kicad-cli)

## Example Usage

```python
from kicad_tools.mcp.tools.export import export_gerbers

result = export_gerbers(
    pcb_path="/path/to/board.kicad_pcb",
    output_dir="/tmp/gerbers",
    manufacturer="jlcpcb",
    include_drill=True,
    zip_output=True,
)

if result.success:
    print(f"Generated {len(result.files)} files")
    print(f"Zip: {result.zip_file}")
    print(f"Layers: {result.layer_count}")
```

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)