### PR TITLE
fix: Expose --layers option in route CLI

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -96,6 +96,8 @@ def run_route_command(args) -> int:
         sub_argv.append("--quiet")
     if getattr(args, "power_nets", None):
         sub_argv.extend(["--power-nets", args.power_nets])
+    if getattr(args, "layers", "auto") != "auto":
+        sub_argv.extend(["--layers", args.layers])
     return route_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -766,6 +766,19 @@ def _add_route_parser(subparsers) -> None:
         "--power-nets",
         help="Generate zones: 'NET:LAYER,...' (e.g., 'GND:B.Cu,+3.3V:F.Cu')",
     )
+    route_parser.add_argument(
+        "--layers",
+        choices=["auto", "2", "4", "4-sig", "6"],
+        default="auto",
+        help=(
+            "Layer stack configuration: "
+            "'auto' = auto-detect (default); "
+            "'2' = 2-layer; "
+            "'4' = 4-layer with GND/PWR planes; "
+            "'4-sig' = 4-layer with 2 signal layers; "
+            "'6' = 6-layer"
+        ),
+    )
 
 
 def _add_reason_parser(subparsers) -> None:


### PR DESCRIPTION
## Summary

The `--layers` option was documented in the changelog for v0.7.1 (#426) but wasn't exposed in the main CLI. Users running `kct route --help` didn't see the option, and providing `--layers` resulted in an unrecognized argument error.

## Changes

- Add `--layers` argument to `_add_route_parser()` in `parser.py`
- Forward `--layers` argument in `run_route_command()` in `routing.py`

The option accepts: `auto` (default), `2`, `4`, `4-sig`, or `6` to configure the layer stack for multi-layer board routing.

## Test Plan

- [x] Verified `kct route --help` now shows `--layers {auto,2,4,4-sig,6}`
- [x] Verified argument parsing works correctly
- [x] All 257 router tests pass
- [x] Linting and formatting pass on changed files

Closes #481