### PR TITLE
feat: Add export_assembly MCP tool for manufacturing file generation

### DIFF
--- a/src/kicad_tools/mcp/tools/export.py
+++ b/src/kicad_tools/mcp/tools/export.py
@@ -1,22 +1,27 @@
 """
 Export tools for MCP server.
 
-Provides tools for exporting PCB manufacturing files (Gerbers, drill files).
+Provides tools for exporting PCB manufacturing files (Gerbers, drill files, BOM, PnP).
 """
 
 from __future__ import annotations
 
 import logging
+import zipfile
 from pathlib import Path
 
+from kicad_tools.export.assembly import AssemblyPackage
 from kicad_tools.export.gerber import (
     MANUFACTURER_PRESETS,
     GerberConfig,
     GerberExporter,
 )
 from kicad_tools.mcp.types import (
+    AssemblyExportResult,
+    BOMExportResult,
     GerberExportResult,
     GerberFile,
+    PnPExportResult,
     get_file_type,
 )
 
@@ -233,3 +238,256 @@ def _determine_file_type(filename: str, layer: str) -> str:
     }
 
     return extension_types.get(suffix, "other")
+
+
+# Supported assembly manufacturers (subset that supports full assembly)
+ASSEMBLY_MANUFACTURERS = ["generic", "jlcpcb", "pcbway", "seeed"]
+
+
+def export_assembly(
+    pcb_path: str,
+    schematic_path: str,
+    output_dir: str,
+    manufacturer: str = "jlcpcb",
+) -> AssemblyExportResult:
+    """
+    Generate complete assembly package for manufacturing.
+
+    Creates a comprehensive manufacturing package including Gerber files,
+    bill of materials (BOM), and pick-and-place (PnP/CPL) files tailored
+    to the specified manufacturer's requirements.
+
+    Args:
+        pcb_path: Path to .kicad_pcb file
+        schematic_path: Path to .kicad_sch file
+        output_dir: Directory for output files
+        manufacturer: Target manufacturer ("jlcpcb", "pcbway", "seeed", "generic")
+
+    Returns:
+        AssemblyExportResult with paths to all generated files, component counts,
+        and any warnings about missing part numbers or rotation issues.
+
+    Example:
+        >>> result = export_assembly(
+        ...     "/path/to/board.kicad_pcb",
+        ...     "/path/to/board.kicad_sch",
+        ...     "/tmp/manufacturing",
+        ...     manufacturer="jlcpcb",
+        ... )
+        >>> if result.success:
+        ...     print(f"Package ready: {result.zip_file}")
+        ...     print(f"BOM has {result.bom.component_count} components")
+    """
+    pcb = Path(pcb_path)
+    schematic = Path(schematic_path)
+    out_dir = Path(output_dir)
+    warnings: list[str] = []
+
+    # Validate PCB file
+    if not pcb.exists():
+        return AssemblyExportResult(
+            success=False,
+            output_dir=str(out_dir),
+            manufacturer=manufacturer,
+            error=f"PCB file not found: {pcb_path}",
+        )
+
+    if pcb.suffix != ".kicad_pcb":
+        warnings.append(f"Unusual PCB file extension: {pcb.suffix} (expected .kicad_pcb)")
+
+    # Validate schematic file
+    if not schematic.exists():
+        return AssemblyExportResult(
+            success=False,
+            output_dir=str(out_dir),
+            manufacturer=manufacturer,
+            error=f"Schematic file not found: {schematic_path}",
+            warnings=warnings,
+        )
+
+    if schematic.suffix != ".kicad_sch":
+        warnings.append(
+            f"Unusual schematic file extension: {schematic.suffix} (expected .kicad_sch)"
+        )
+
+    # Validate manufacturer
+    manufacturer_lower = manufacturer.lower()
+    if manufacturer_lower not in ASSEMBLY_MANUFACTURERS:
+        return AssemblyExportResult(
+            success=False,
+            output_dir=str(out_dir),
+            manufacturer=manufacturer,
+            error=f"Unknown manufacturer: {manufacturer}. "
+            f"Supported: {', '.join(ASSEMBLY_MANUFACTURERS)}",
+            warnings=warnings,
+        )
+
+    try:
+        # Create assembly package
+        pkg = AssemblyPackage.create(
+            pcb=pcb,
+            schematic=schematic,
+            manufacturer=manufacturer_lower,
+            output_dir=out_dir,
+        )
+
+        # Export all files
+        result = pkg.export(out_dir)
+
+        # Convert to MCP result types
+        gerbers_result = None
+        bom_result = None
+        pnp_result = None
+
+        # Process Gerber results
+        if result.gerber_path:
+            gerber_files: list[GerberFile] = []
+            gerber_dir = (
+                result.gerber_path if result.gerber_path.is_dir() else result.gerber_path.parent
+            )
+
+            if gerber_dir.exists():
+                for file_path in gerber_dir.iterdir():
+                    if file_path.is_file():
+                        layer = _extract_layer_from_filename(file_path.name)
+                        file_type = _determine_file_type(file_path.name, layer)
+                        gerber_files.append(
+                            GerberFile(
+                                filename=file_path.name,
+                                layer=layer,
+                                file_type=file_type,
+                                size_bytes=file_path.stat().st_size,
+                            )
+                        )
+
+            copper_layers = [f for f in gerber_files if f.file_type == "copper"]
+            gerbers_result = GerberExportResult(
+                success=True,
+                output_dir=str(gerber_dir),
+                files=gerber_files,
+                layer_count=len(copper_layers),
+            )
+
+        # Process BOM results
+        if result.bom_path and result.bom_path.exists():
+            # Count components in BOM file
+            bom_content = result.bom_path.read_text()
+            lines = [line for line in bom_content.strip().split("\n") if line.strip()]
+            # Subtract header row
+            component_count = max(0, len(lines) - 1) if lines else 0
+
+            # Count unique parts (assuming grouped BOM)
+            unique_parts = component_count
+
+            # Count missing LCSC parts (if JLCPCB format)
+            missing_lcsc = 0
+            if manufacturer_lower == "jlcpcb":
+                for line in lines[1:]:  # Skip header
+                    parts = line.split(",")
+                    if len(parts) >= 4 and not parts[3].strip().strip('"'):
+                        missing_lcsc += 1
+
+            if missing_lcsc > 0:
+                warnings.append(f"{missing_lcsc} parts missing LCSC part numbers")
+
+            bom_result = BOMExportResult(
+                output_path=str(result.bom_path),
+                component_count=component_count,
+                unique_parts=unique_parts,
+                missing_lcsc=missing_lcsc,
+            )
+
+        # Process PnP results
+        if result.pnp_path and result.pnp_path.exists():
+            pnp_content = result.pnp_path.read_text()
+            lines = [line for line in pnp_content.strip().split("\n") if line.strip()]
+            # Subtract header row
+            component_count = max(0, len(lines) - 1) if lines else 0
+
+            # Determine which layers have components
+            layers: list[str] = []
+            for line in lines[1:]:
+                line_lower = line.lower()
+                if "top" in line_lower and "top" not in layers:
+                    layers.append("top")
+                if "bottom" in line_lower and "bottom" not in layers:
+                    layers.append("bottom")
+
+            pnp_result = PnPExportResult(
+                output_path=str(result.pnp_path),
+                component_count=component_count,
+                layers=layers,
+                rotation_corrections=0,  # Would need manufacturer-specific tracking
+            )
+
+        # Propagate errors from assembly package
+        for error in result.errors:
+            warnings.append(error)
+
+        # Create combined zip file for upload
+        zip_file_path = _create_assembly_zip(out_dir, manufacturer_lower, result)
+
+        return AssemblyExportResult(
+            success=result.success,
+            output_dir=str(out_dir),
+            manufacturer=manufacturer_lower,
+            gerbers=gerbers_result,
+            bom=bom_result,
+            pnp=pnp_result,
+            zip_file=str(zip_file_path) if zip_file_path else None,
+            warnings=warnings,
+            cost_estimate=None,  # Cost estimation could be added as future enhancement
+        )
+
+    except Exception as e:
+        logger.exception("Assembly export failed")
+        return AssemblyExportResult(
+            success=False,
+            output_dir=str(out_dir),
+            manufacturer=manufacturer,
+            error=str(e),
+            warnings=warnings,
+        )
+
+
+def _create_assembly_zip(
+    output_dir: Path,
+    manufacturer: str,
+    result,
+) -> Path | None:
+    """Create a combined zip file with all assembly files."""
+    try:
+        # Get project name from PCB filename
+        project_name = "assembly"
+        if result.bom_path:
+            project_name = result.bom_path.stem.replace(f"_bom_{manufacturer}", "").replace(
+                f"-bom-{manufacturer}", ""
+            )
+
+        zip_name = f"{project_name}-{manufacturer}-assembly.zip"
+        zip_path = output_dir / zip_name
+
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            # Add BOM
+            if result.bom_path and result.bom_path.exists():
+                zf.write(result.bom_path, result.bom_path.name)
+
+            # Add PnP/CPL
+            if result.pnp_path and result.pnp_path.exists():
+                zf.write(result.pnp_path, result.pnp_path.name)
+
+            # Add Gerbers (either directory contents or zip)
+            if result.gerber_path:
+                if result.gerber_path.is_dir():
+                    for file_path in result.gerber_path.iterdir():
+                        if file_path.is_file():
+                            zf.write(file_path, f"gerbers/{file_path.name}")
+                elif result.gerber_path.is_file():
+                    # Gerber path is already a zip, include it
+                    zf.write(result.gerber_path, result.gerber_path.name)
+
+        return zip_path
+
+    except Exception as e:
+        logger.warning(f"Failed to create assembly zip: {e}")
+        return None

--- a/src/kicad_tools/mcp/types.py
+++ b/src/kicad_tools/mcp/types.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-
 # =============================================================================
 # Board Analysis Types
 # =============================================================================
@@ -332,3 +331,133 @@ LAYER_FILE_TYPES: dict[str, str] = {
 def get_file_type(layer: str) -> str:
     """Get the file type for a given layer name."""
     return LAYER_FILE_TYPES.get(layer, "other")
+
+
+# =============================================================================
+# Assembly Export Types
+# =============================================================================
+
+
+@dataclass
+class BOMExportResult:
+    """Result of BOM export operation.
+
+    Attributes:
+        output_path: Path to the generated BOM file
+        component_count: Total number of components in BOM
+        unique_parts: Number of unique part numbers
+        missing_lcsc: Number of parts missing LCSC part numbers
+    """
+
+    output_path: str
+    component_count: int
+    unique_parts: int
+    missing_lcsc: int = 0
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "output_path": self.output_path,
+            "component_count": self.component_count,
+            "unique_parts": self.unique_parts,
+            "missing_lcsc": self.missing_lcsc,
+        }
+
+
+@dataclass
+class PnPExportResult:
+    """Result of pick-and-place export operation.
+
+    Attributes:
+        output_path: Path to the generated PnP/CPL file
+        component_count: Total number of placed components
+        layers: Layers with components (["top"], ["bottom"], or ["top", "bottom"])
+        rotation_corrections: Number of components with rotation corrections applied
+    """
+
+    output_path: str
+    component_count: int
+    layers: list[str] = field(default_factory=list)
+    rotation_corrections: int = 0
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "output_path": self.output_path,
+            "component_count": self.component_count,
+            "layers": self.layers,
+            "rotation_corrections": self.rotation_corrections,
+        }
+
+
+@dataclass
+class CostEstimate:
+    """Estimated manufacturing costs.
+
+    Attributes:
+        pcb_cost_usd: Estimated PCB fabrication cost in USD
+        assembly_cost_usd: Estimated assembly labor cost in USD
+        parts_cost_usd: Estimated component parts cost in USD
+        total_usd: Total estimated cost in USD
+        notes: Additional notes about the estimate
+    """
+
+    pcb_cost_usd: float | None = None
+    assembly_cost_usd: float | None = None
+    parts_cost_usd: float | None = None
+    total_usd: float | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "pcb_cost_usd": self.pcb_cost_usd,
+            "assembly_cost_usd": self.assembly_cost_usd,
+            "parts_cost_usd": self.parts_cost_usd,
+            "total_usd": self.total_usd,
+            "notes": self.notes,
+        }
+
+
+@dataclass
+class AssemblyExportResult:
+    """Result of a complete assembly package export.
+
+    Attributes:
+        success: Whether the export completed successfully
+        output_dir: Directory containing all exported files
+        manufacturer: Target manufacturer (jlcpcb, pcbway, seeed, generic)
+        gerbers: Gerber export results if included
+        bom: BOM export results if included
+        pnp: Pick-and-place export results if included
+        zip_file: Path to combined zip archive ready for upload
+        warnings: Any warnings encountered during export
+        cost_estimate: Optional cost estimate for manufacturing
+        error: Error message if success is False
+    """
+
+    success: bool
+    output_dir: str
+    manufacturer: str
+    gerbers: GerberExportResult | None = None
+    bom: BOMExportResult | None = None
+    pnp: PnPExportResult | None = None
+    zip_file: str | None = None
+    warnings: list[str] = field(default_factory=list)
+    cost_estimate: CostEstimate | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "success": self.success,
+            "output_dir": self.output_dir,
+            "manufacturer": self.manufacturer,
+            "gerbers": self.gerbers.to_dict() if self.gerbers else None,
+            "bom": self.bom.to_dict() if self.bom else None,
+            "pnp": self.pnp.to_dict() if self.pnp else None,
+            "zip_file": self.zip_file,
+            "warnings": self.warnings,
+            "cost_estimate": self.cost_estimate.to_dict() if self.cost_estimate else None,
+            "error": self.error,
+        }

--- a/tests/test_mcp_assembly.py
+++ b/tests/test_mcp_assembly.py
@@ -1,0 +1,356 @@
+"""Tests for MCP assembly export tools."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from kicad_tools.mcp.server import create_server
+from kicad_tools.mcp.tools.export import (
+    ASSEMBLY_MANUFACTURERS,
+    export_assembly,
+)
+from kicad_tools.mcp.types import (
+    AssemblyExportResult,
+    BOMExportResult,
+    CostEstimate,
+    PnPExportResult,
+)
+
+
+class TestBOMExportResult:
+    """Tests for BOMExportResult dataclass."""
+
+    def test_creation(self):
+        result = BOMExportResult(
+            output_path="/tmp/bom.csv",
+            component_count=127,
+            unique_parts=47,
+            missing_lcsc=3,
+        )
+        assert result.output_path == "/tmp/bom.csv"
+        assert result.component_count == 127
+        assert result.unique_parts == 47
+        assert result.missing_lcsc == 3
+
+    def test_to_dict(self):
+        result = BOMExportResult(
+            output_path="/tmp/bom.csv",
+            component_count=127,
+            unique_parts=47,
+            missing_lcsc=3,
+        )
+        d = result.to_dict()
+
+        assert d["output_path"] == "/tmp/bom.csv"
+        assert d["component_count"] == 127
+        assert d["unique_parts"] == 47
+        assert d["missing_lcsc"] == 3
+
+
+class TestPnPExportResult:
+    """Tests for PnPExportResult dataclass."""
+
+    def test_creation(self):
+        result = PnPExportResult(
+            output_path="/tmp/cpl.csv",
+            component_count=92,
+            layers=["top", "bottom"],
+            rotation_corrections=5,
+        )
+        assert result.output_path == "/tmp/cpl.csv"
+        assert result.component_count == 92
+        assert result.layers == ["top", "bottom"]
+        assert result.rotation_corrections == 5
+
+    def test_default_values(self):
+        result = PnPExportResult(
+            output_path="/tmp/cpl.csv",
+            component_count=50,
+        )
+        assert result.layers == []
+        assert result.rotation_corrections == 0
+
+    def test_to_dict(self):
+        result = PnPExportResult(
+            output_path="/tmp/cpl.csv",
+            component_count=92,
+            layers=["top"],
+            rotation_corrections=2,
+        )
+        d = result.to_dict()
+
+        assert d["output_path"] == "/tmp/cpl.csv"
+        assert d["component_count"] == 92
+        assert d["layers"] == ["top"]
+        assert d["rotation_corrections"] == 2
+
+
+class TestCostEstimate:
+    """Tests for CostEstimate dataclass."""
+
+    def test_creation(self):
+        estimate = CostEstimate(
+            pcb_cost_usd=12.00,
+            assembly_cost_usd=28.50,
+            parts_cost_usd=45.20,
+            total_usd=85.70,
+            notes=["5 boards", "Standard shipping"],
+        )
+        assert estimate.pcb_cost_usd == 12.00
+        assert estimate.assembly_cost_usd == 28.50
+        assert estimate.parts_cost_usd == 45.20
+        assert estimate.total_usd == 85.70
+        assert len(estimate.notes) == 2
+
+    def test_default_values(self):
+        estimate = CostEstimate()
+        assert estimate.pcb_cost_usd is None
+        assert estimate.assembly_cost_usd is None
+        assert estimate.parts_cost_usd is None
+        assert estimate.total_usd is None
+        assert estimate.notes == []
+
+    def test_to_dict(self):
+        estimate = CostEstimate(
+            pcb_cost_usd=12.00,
+            total_usd=12.00,
+            notes=["PCB only"],
+        )
+        d = estimate.to_dict()
+
+        assert d["pcb_cost_usd"] == 12.00
+        assert d["assembly_cost_usd"] is None
+        assert d["parts_cost_usd"] is None
+        assert d["total_usd"] == 12.00
+        assert d["notes"] == ["PCB only"]
+
+
+class TestAssemblyExportResult:
+    """Tests for AssemblyExportResult dataclass."""
+
+    def test_success_result(self):
+        bom = BOMExportResult("/tmp/bom.csv", 100, 40, 2)
+        pnp = PnPExportResult("/tmp/cpl.csv", 80, ["top"], 0)
+
+        result = AssemblyExportResult(
+            success=True,
+            output_dir="/tmp/assembly",
+            manufacturer="jlcpcb",
+            bom=bom,
+            pnp=pnp,
+            zip_file="/tmp/assembly/board-jlcpcb-assembly.zip",
+            warnings=["2 parts missing LCSC part numbers"],
+        )
+        assert result.success is True
+        assert result.error is None
+        assert result.bom.component_count == 100
+        assert result.pnp.component_count == 80
+
+    def test_failure_result(self):
+        result = AssemblyExportResult(
+            success=False,
+            output_dir="/tmp/assembly",
+            manufacturer="jlcpcb",
+            error="PCB file not found",
+        )
+        assert result.success is False
+        assert result.error == "PCB file not found"
+
+    def test_to_dict(self):
+        bom = BOMExportResult("/tmp/bom.csv", 100, 40, 0)
+        result = AssemblyExportResult(
+            success=True,
+            output_dir="/tmp/assembly",
+            manufacturer="jlcpcb",
+            bom=bom,
+            warnings=["Test warning"],
+        )
+        d = result.to_dict()
+
+        assert d["success"] is True
+        assert d["output_dir"] == "/tmp/assembly"
+        assert d["manufacturer"] == "jlcpcb"
+        assert d["bom"]["component_count"] == 100
+        assert d["pnp"] is None
+        assert d["gerbers"] is None
+        assert d["warnings"] == ["Test warning"]
+
+    def test_to_dict_with_cost_estimate(self):
+        estimate = CostEstimate(total_usd=100.00)
+        result = AssemblyExportResult(
+            success=True,
+            output_dir="/tmp/assembly",
+            manufacturer="jlcpcb",
+            cost_estimate=estimate,
+        )
+        d = result.to_dict()
+
+        assert d["cost_estimate"]["total_usd"] == 100.00
+
+
+class TestExportAssembly:
+    """Tests for export_assembly function."""
+
+    def test_pcb_file_not_found(self):
+        result = export_assembly(
+            pcb_path="/nonexistent/board.kicad_pcb",
+            schematic_path="/nonexistent/board.kicad_sch",
+            output_dir="/tmp/assembly",
+        )
+        assert result.success is False
+        assert "not found" in result.error.lower()
+        assert "pcb" in result.error.lower()
+
+    def test_schematic_file_not_found(self):
+        with tempfile.NamedTemporaryFile(suffix=".kicad_pcb", delete=False) as f:
+            f.write(b"(kicad_pcb (version 20231014))")
+            pcb_path = f.name
+
+        result = export_assembly(
+            pcb_path=pcb_path,
+            schematic_path="/nonexistent/board.kicad_sch",
+            output_dir="/tmp/assembly",
+        )
+        assert result.success is False
+        assert "not found" in result.error.lower()
+        assert "schematic" in result.error.lower()
+
+        # Cleanup
+        Path(pcb_path).unlink()
+
+    def test_unknown_manufacturer(self):
+        with tempfile.NamedTemporaryFile(suffix=".kicad_pcb", delete=False) as pcb_f:
+            pcb_f.write(b"(kicad_pcb (version 20231014))")
+            pcb_path = pcb_f.name
+
+        with tempfile.NamedTemporaryFile(suffix=".kicad_sch", delete=False) as sch_f:
+            sch_f.write(b"(kicad_sch (version 20231014))")
+            sch_path = sch_f.name
+
+        result = export_assembly(
+            pcb_path=pcb_path,
+            schematic_path=sch_path,
+            output_dir="/tmp/assembly",
+            manufacturer="unknown_mfr",
+        )
+        assert result.success is False
+        assert "Unknown manufacturer" in result.error
+
+        # Cleanup
+        Path(pcb_path).unlink()
+        Path(sch_path).unlink()
+
+    def test_unusual_extension_warning(self):
+        with tempfile.NamedTemporaryFile(suffix=".pcb", delete=False) as pcb_f:
+            pcb_f.write(b"(kicad_pcb (version 20231014))")
+            pcb_path = pcb_f.name
+
+        with tempfile.NamedTemporaryFile(suffix=".kicad_sch", delete=False) as sch_f:
+            sch_f.write(b"(kicad_sch (version 20231014))")
+            sch_path = sch_f.name
+
+        result = export_assembly(
+            pcb_path=pcb_path,
+            schematic_path=sch_path,
+            output_dir="/tmp/assembly",
+            manufacturer="unknown_mfr",  # Will fail before exporter runs
+        )
+        # Should have warning about extension
+        assert any("extension" in w.lower() for w in result.warnings)
+
+        # Cleanup
+        Path(pcb_path).unlink()
+        Path(sch_path).unlink()
+
+    def test_supported_manufacturers(self):
+        """Verify all supported assembly manufacturers are valid."""
+        assert "generic" in ASSEMBLY_MANUFACTURERS
+        assert "jlcpcb" in ASSEMBLY_MANUFACTURERS
+        assert "pcbway" in ASSEMBLY_MANUFACTURERS
+        assert "seeed" in ASSEMBLY_MANUFACTURERS
+        # oshpark is not in assembly manufacturers (gerber-only)
+        assert "oshpark" not in ASSEMBLY_MANUFACTURERS
+
+
+class TestMCPServerAssembly:
+    """Tests for MCP server with assembly tool."""
+
+    def test_create_server_has_assembly_tool(self):
+        server = create_server()
+        assert "export_assembly" in server.tools
+
+    def test_get_tools_list_includes_assembly(self):
+        server = create_server()
+        tools = server.get_tools_list()
+
+        assembly_tool = next((t for t in tools if t["name"] == "export_assembly"), None)
+        assert assembly_tool is not None
+        assert "description" in assembly_tool
+        assert "inputSchema" in assembly_tool
+        assert "pcb_path" in assembly_tool["inputSchema"]["properties"]
+        assert "schematic_path" in assembly_tool["inputSchema"]["properties"]
+        assert "output_dir" in assembly_tool["inputSchema"]["properties"]
+        assert "manufacturer" in assembly_tool["inputSchema"]["properties"]
+
+    def test_assembly_tool_required_params(self):
+        server = create_server()
+        tools = server.get_tools_list()
+
+        assembly_tool = next(t for t in tools if t["name"] == "export_assembly")
+        required = assembly_tool["inputSchema"]["required"]
+
+        assert "pcb_path" in required
+        assert "schematic_path" in required
+        assert "output_dir" in required
+
+    def test_assembly_tool_manufacturer_enum(self):
+        server = create_server()
+        tools = server.get_tools_list()
+
+        assembly_tool = next(t for t in tools if t["name"] == "export_assembly")
+        manufacturer_prop = assembly_tool["inputSchema"]["properties"]["manufacturer"]
+
+        assert "enum" in manufacturer_prop
+        assert "jlcpcb" in manufacturer_prop["enum"]
+        assert "pcbway" in manufacturer_prop["enum"]
+        assert "seeed" in manufacturer_prop["enum"]
+        assert "generic" in manufacturer_prop["enum"]
+
+    def test_handle_tools_call_assembly_missing_file(self):
+        server = create_server()
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "export_assembly",
+                    "arguments": {
+                        "pcb_path": "/nonexistent.kicad_pcb",
+                        "schematic_path": "/nonexistent.kicad_sch",
+                        "output_dir": "/tmp/out",
+                    },
+                },
+            }
+        )
+
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 1
+        assert "result" in response
+        # Result should contain error info
+        result_text = response["result"]["content"][0]["text"]
+        result_data = json.loads(result_text)
+        assert result_data["success"] is False
+        assert "not found" in result_data["error"].lower()
+
+    def test_handle_tools_call_assembly_default_manufacturer(self):
+        """Test that default manufacturer is jlcpcb."""
+        server = create_server()
+        tools = server.get_tools_list()
+
+        assembly_tool = next(t for t in tools if t["name"] == "export_assembly")
+        manufacturer_prop = assembly_tool["inputSchema"]["properties"]["manufacturer"]
+
+        assert manufacturer_prop.get("default") == "jlcpcb"


### PR DESCRIPTION
## Summary

Add a new MCP tool `export_assembly` that generates complete assembly packages for PCB manufacturing. This tool creates Gerber files, BOM (Bill of Materials), and pick-and-place (PnP/CPL) files tailored to specific manufacturers, with a single zip file ready for upload.

- Add `AssemblyExportResult`, `BOMExportResult`, `PnPExportResult`, and `CostEstimate` types
- Implement `export_assembly` function wrapping the existing `AssemblyPackage` class
- Register the tool in the MCP server with proper JSON-RPC schema
- Support JLCPCB, PCBWay, Seeed, and generic manufacturers

## Test plan

- [x] Unit tests for all new types (BOMExportResult, PnPExportResult, CostEstimate, AssemblyExportResult)
- [x] Unit tests for export_assembly function (file not found, schematic not found, unknown manufacturer, extension warnings)
- [x] Unit tests for MCP server integration (tool registration, schema validation, error handling)
- [x] All 56 MCP tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #464