### PR TITLE
feat: Add hierarchical address-based component matching for layout preservation

### DIFF
--- a/src/kicad_tools/layout/__init__.py
+++ b/src/kicad_tools/layout/__init__.py
@@ -1,0 +1,14 @@
+"""
+Layout preservation and component addressing for KiCad designs.
+
+This module provides hierarchical address-based component matching
+to preserve layout when regenerating PCB from schematic changes.
+"""
+
+from .addressing import AddressRegistry
+from .types import ComponentAddress
+
+__all__ = [
+    "AddressRegistry",
+    "ComponentAddress",
+]

--- a/src/kicad_tools/layout/addressing.py
+++ b/src/kicad_tools/layout/addressing.py
@@ -1,0 +1,235 @@
+"""
+Component address registry for layout preservation.
+
+Provides hierarchical address-based component matching to enable
+stable component identification across schematic regenerations.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+from kicad_tools.schema.hierarchy import HierarchyBuilder, HierarchyNode
+from kicad_tools.sexp import parse_file
+
+from .types import ComponentAddress
+
+
+class AddressRegistry:
+    """
+    Registry for hierarchical component addresses.
+
+    Builds a mapping between hierarchical addresses and component UUIDs
+    from a schematic hierarchy.
+
+    Example:
+        >>> registry = AddressRegistry("/path/to/board.kicad_sch")
+        >>> addr = registry.get_address("abc-123-uuid")
+        >>> print(addr)  # "power.ldo.C1"
+        >>> comp = registry.resolve("power.ldo.C1")
+        >>> print(comp.uuid)  # "abc-123-uuid"
+    """
+
+    def __init__(self, schematic_path: str | Path):
+        """
+        Initialize registry from a schematic file.
+
+        Args:
+            schematic_path: Path to the root .kicad_sch file
+        """
+        self._schematic_path = Path(schematic_path)
+        self._addresses: dict[str, ComponentAddress] = {}
+        self._uuid_to_address: dict[str, str] = {}
+        self._build_from_schematic()
+
+    def _build_from_schematic(self) -> None:
+        """Build address registry from schematic hierarchy."""
+        if not self._schematic_path.exists():
+            return
+
+        # Build the hierarchy tree
+        builder = HierarchyBuilder(str(self._schematic_path.parent))
+        root = builder.build(str(self._schematic_path))
+
+        # Visit each node and extract symbols
+        self._visit_node(root, "")
+
+    def _visit_node(self, node: HierarchyNode, path: str) -> None:
+        """
+        Visit a hierarchy node and extract component addresses.
+
+        Args:
+            node: The hierarchy node to process
+            path: Current hierarchical path (e.g., "power.ldo")
+        """
+        # Load the schematic file to get symbols
+        schematic_path = Path(node.path)
+        if not schematic_path.exists():
+            return
+
+        try:
+            doc = parse_file(schematic_path)
+        except Exception:
+            return
+
+        # Find all symbol instances (those with lib_id, excluding power symbols)
+        for child in doc.children:
+            if child.name != "symbol":
+                continue
+
+            lib_id_node = child.get("lib_id")
+            if not lib_id_node:
+                continue
+
+            lib_id = str(lib_id_node.get_first_atom() or "")
+
+            # Skip power symbols (they start with power: and have #PWR reference)
+            if lib_id.startswith("power:"):
+                continue
+
+            # Get UUID
+            uuid_node = child.get("uuid")
+            if not uuid_node:
+                continue
+            uuid_str = str(uuid_node.get_first_atom() or "")
+
+            # Get reference from properties
+            reference = ""
+            for prop_node in child.find_all("property"):
+                atoms = prop_node.get_atoms()
+                if len(atoms) >= 2 and str(atoms[0]) == "Reference":
+                    reference = str(atoms[1])
+                    break
+
+            if not reference or reference.startswith("#"):
+                # Skip power references like #PWR01
+                continue
+
+            # Create component address
+            address = ComponentAddress.from_parts(
+                sheet_path=path,
+                local_ref=reference,
+                uuid=uuid_str,
+            )
+
+            self._addresses[address.full_path] = address
+            self._uuid_to_address[uuid_str] = address.full_path
+
+        # Recursively visit children
+        for sheet in node.sheets:
+            # Build child path
+            child_path = f"{path}.{sheet.name}" if path else sheet.name
+
+            # Find the child node that corresponds to this sheet
+            for child_node in node.children:
+                if child_node.name == sheet.name:
+                    self._visit_node(child_node, child_path)
+                    break
+
+    def resolve(self, address: str) -> ComponentAddress | None:
+        """
+        Resolve a hierarchical address to a ComponentAddress.
+
+        Args:
+            address: Hierarchical address (e.g., "power.ldo.C1")
+
+        Returns:
+            ComponentAddress if found, None otherwise
+        """
+        return self._addresses.get(address)
+
+    def get_address(self, uuid: str) -> str | None:
+        """
+        Get the hierarchical address for a component UUID.
+
+        Args:
+            uuid: KiCad component UUID
+
+        Returns:
+            Hierarchical address string if found, None otherwise
+        """
+        return self._uuid_to_address.get(uuid)
+
+    def get_component(self, uuid: str) -> ComponentAddress | None:
+        """
+        Get ComponentAddress by UUID.
+
+        Args:
+            uuid: KiCad component UUID
+
+        Returns:
+            ComponentAddress if found, None otherwise
+        """
+        address = self.get_address(uuid)
+        if address:
+            return self._addresses.get(address)
+        return None
+
+    def match_by_pattern(self, pattern: str) -> list[ComponentAddress]:
+        """
+        Match components by glob pattern.
+
+        Supports standard glob patterns:
+        - `*` matches any characters within a path segment
+        - `**` matches any characters across path segments
+        - `?` matches any single character
+
+        Args:
+            pattern: Glob pattern (e.g., "power.*.C*", "**.C1")
+
+        Returns:
+            List of matching ComponentAddresses
+
+        Examples:
+            >>> registry.match_by_pattern("power.*.C*")
+            [ComponentAddress("power.ldo.C1"), ComponentAddress("power.buck.C2")]
+            >>> registry.match_by_pattern("*.R1")
+            [ComponentAddress("power.R1"), ComponentAddress("logic.R1")]
+        """
+        # Handle ** pattern for matching across segments
+        if "**" in pattern:
+            # Convert ** to match anything including dots
+            regex_pattern = pattern.replace(".", r"\.").replace("**", ".*")
+            import re
+
+            compiled = re.compile(f"^{regex_pattern}$")
+            return [addr for addr in self._addresses.values() if compiled.match(addr.full_path)]
+
+        # Use fnmatch for standard glob patterns
+        return [
+            addr for addr in self._addresses.values() if fnmatch.fnmatch(addr.full_path, pattern)
+        ]
+
+    def all_addresses(self) -> list[ComponentAddress]:
+        """
+        Get all registered component addresses.
+
+        Returns:
+            List of all ComponentAddresses in the registry
+        """
+        return list(self._addresses.values())
+
+    def components_in_sheet(self, sheet_path: str) -> list[ComponentAddress]:
+        """
+        Get all components in a specific sheet.
+
+        Args:
+            sheet_path: Sheet path (e.g., "power.ldo") or empty for root
+
+        Returns:
+            List of ComponentAddresses in that sheet
+        """
+        return [addr for addr in self._addresses.values() if addr.sheet_path == sheet_path]
+
+    def __len__(self) -> int:
+        """Return number of registered addresses."""
+        return len(self._addresses)
+
+    def __contains__(self, address: str) -> bool:
+        """Check if an address exists in the registry."""
+        return address in self._addresses
+
+    def __iter__(self):
+        """Iterate over all addresses."""
+        return iter(self._addresses.values())

--- a/src/kicad_tools/layout/types.py
+++ b/src/kicad_tools/layout/types.py
@@ -1,0 +1,99 @@
+"""
+Types for layout preservation module.
+
+Defines ComponentAddress dataclass for hierarchical component identification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ComponentAddress:
+    """
+    Hierarchical address for a component in a schematic.
+
+    Uses atopile-inspired hierarchical addressing:
+    - `C1` - Component in root sheet
+    - `power.C1` - Component in power subsheet
+    - `power.ldo.C1` - Component in ldo subsheet of power sheet
+
+    Attributes:
+        full_path: Complete hierarchical path (e.g., "power.ldo.C1")
+        sheet_path: Path to the sheet containing the component (e.g., "power.ldo")
+        local_ref: Local reference designator (e.g., "C1")
+        uuid: KiCad internal UUID for the component
+    """
+
+    full_path: str
+    sheet_path: str
+    local_ref: str
+    uuid: str
+
+    def __post_init__(self):
+        """Validate address format."""
+        if not self.local_ref:
+            raise ValueError("local_ref cannot be empty")
+        if not self.uuid:
+            raise ValueError("uuid cannot be empty")
+
+    @classmethod
+    def from_parts(
+        cls,
+        sheet_path: str,
+        local_ref: str,
+        uuid: str,
+    ) -> ComponentAddress:
+        """
+        Create a ComponentAddress from its parts.
+
+        Args:
+            sheet_path: Path to the containing sheet (empty for root)
+            local_ref: Local reference designator
+            uuid: KiCad component UUID
+
+        Returns:
+            ComponentAddress instance
+        """
+        if sheet_path:
+            full_path = f"{sheet_path}.{local_ref}"
+        else:
+            full_path = local_ref
+
+        return cls(
+            full_path=full_path,
+            sheet_path=sheet_path,
+            local_ref=local_ref,
+            uuid=uuid,
+        )
+
+    @property
+    def depth(self) -> int:
+        """
+        Get the depth of this component in the hierarchy.
+
+        Root level components have depth 0.
+        """
+        if not self.sheet_path:
+            return 0
+        return self.sheet_path.count(".") + 1
+
+    @property
+    def parent_path(self) -> str:
+        """
+        Get the parent sheet path.
+
+        Returns empty string if at root level or one level deep.
+        """
+        if not self.sheet_path:
+            return ""
+        parts = self.sheet_path.rsplit(".", 1)
+        return parts[0] if len(parts) > 1 else ""
+
+    def __str__(self) -> str:
+        """Return the full path as string representation."""
+        return self.full_path
+
+    def __repr__(self) -> str:
+        return f"ComponentAddress({self.full_path!r}, uuid={self.uuid!r})"

--- a/tests/test_layout_addressing.py
+++ b/tests/test_layout_addressing.py
@@ -1,0 +1,402 @@
+"""
+Tests for layout addressing module.
+
+Tests hierarchical component address generation and pattern matching.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.layout import AddressRegistry, ComponentAddress
+
+
+class TestComponentAddress:
+    """Tests for ComponentAddress dataclass."""
+
+    def test_create_root_component(self):
+        """Component at root level."""
+        addr = ComponentAddress.from_parts(
+            sheet_path="",
+            local_ref="C1",
+            uuid="test-uuid-123",
+        )
+        assert addr.full_path == "C1"
+        assert addr.sheet_path == ""
+        assert addr.local_ref == "C1"
+        assert addr.uuid == "test-uuid-123"
+        assert addr.depth == 0
+
+    def test_create_nested_component(self):
+        """Component in nested sheet."""
+        addr = ComponentAddress.from_parts(
+            sheet_path="power.ldo",
+            local_ref="C1",
+            uuid="test-uuid-456",
+        )
+        assert addr.full_path == "power.ldo.C1"
+        assert addr.sheet_path == "power.ldo"
+        assert addr.local_ref == "C1"
+        assert addr.depth == 2
+
+    def test_depth_calculation(self):
+        """Test depth at various levels."""
+        root = ComponentAddress.from_parts("", "R1", "uuid1")
+        level1 = ComponentAddress.from_parts("power", "R1", "uuid2")
+        level2 = ComponentAddress.from_parts("power.ldo", "R1", "uuid3")
+        level3 = ComponentAddress.from_parts("power.ldo.filter", "R1", "uuid4")
+
+        assert root.depth == 0
+        assert level1.depth == 1
+        assert level2.depth == 2
+        assert level3.depth == 3
+
+    def test_parent_path(self):
+        """Test parent path extraction."""
+        root = ComponentAddress.from_parts("", "R1", "uuid1")
+        level1 = ComponentAddress.from_parts("power", "R1", "uuid2")
+        level2 = ComponentAddress.from_parts("power.ldo", "R1", "uuid3")
+
+        assert root.parent_path == ""
+        assert level1.parent_path == ""
+        assert level2.parent_path == "power"
+
+    def test_string_representation(self):
+        """Test str and repr."""
+        addr = ComponentAddress.from_parts("power", "C1", "uuid-123")
+        assert str(addr) == "power.C1"
+        assert "power.C1" in repr(addr)
+        assert "uuid-123" in repr(addr)
+
+    def test_validation_empty_local_ref(self):
+        """Empty local_ref should raise error."""
+        with pytest.raises(ValueError, match="local_ref"):
+            ComponentAddress(
+                full_path="",
+                sheet_path="",
+                local_ref="",
+                uuid="uuid",
+            )
+
+    def test_validation_empty_uuid(self):
+        """Empty uuid should raise error."""
+        with pytest.raises(ValueError, match="uuid"):
+            ComponentAddress(
+                full_path="C1",
+                sheet_path="",
+                local_ref="C1",
+                uuid="",
+            )
+
+    def test_frozen_immutability(self):
+        """ComponentAddress should be immutable."""
+        addr = ComponentAddress.from_parts("power", "C1", "uuid")
+        with pytest.raises(AttributeError):
+            addr.full_path = "new.path"  # type: ignore
+
+    def test_hashable(self):
+        """ComponentAddress should be hashable for use in sets/dicts."""
+        addr1 = ComponentAddress.from_parts("power", "C1", "uuid1")
+        addr2 = ComponentAddress.from_parts("power", "C2", "uuid2")
+        addr_set = {addr1, addr2}
+        assert len(addr_set) == 2
+        assert addr1 in addr_set
+
+
+class TestAddressRegistryBasic:
+    """Basic tests for AddressRegistry."""
+
+    def test_empty_registry(self, tmp_path: Path):
+        """Registry with non-existent file should be empty."""
+        registry = AddressRegistry(tmp_path / "nonexistent.kicad_sch")
+        assert len(registry) == 0
+
+    def test_len_and_contains(self, hierarchical_schematic: Path):
+        """Test len and contains operations."""
+        registry = AddressRegistry(hierarchical_schematic)
+        # The hierarchical_main.kicad_sch has C1 in root
+        assert len(registry) >= 1
+        if "C1" in registry:
+            assert registry.resolve("C1") is not None
+
+
+class TestAddressRegistryHierarchical:
+    """Tests for hierarchical schematic parsing."""
+
+    def test_parse_hierarchical_schematic(self, hierarchical_schematic: Path):
+        """Parse a hierarchical schematic with sub-sheets."""
+        registry = AddressRegistry(hierarchical_schematic)
+
+        # Should have at least the C1 from root
+        c1 = registry.resolve("C1")
+        assert c1 is not None
+        assert c1.local_ref == "C1"
+        assert c1.sheet_path == ""
+
+    def test_uuid_lookup(self, hierarchical_schematic: Path):
+        """Look up address by UUID."""
+        registry = AddressRegistry(hierarchical_schematic)
+
+        # Get C1 and verify we can find it by UUID
+        c1 = registry.resolve("C1")
+        if c1:
+            found_addr = registry.get_address(c1.uuid)
+            assert found_addr == "C1"
+
+            # Also test get_component
+            found_comp = registry.get_component(c1.uuid)
+            assert found_comp is not None
+            assert found_comp.full_path == "C1"
+
+    def test_components_in_sheet(self, hierarchical_schematic: Path):
+        """Get components in a specific sheet."""
+        registry = AddressRegistry(hierarchical_schematic)
+
+        # Root sheet components
+        root_components = registry.components_in_sheet("")
+        refs = [c.local_ref for c in root_components]
+        assert "C1" in refs
+
+    def test_all_addresses(self, hierarchical_schematic: Path):
+        """Get all registered addresses."""
+        registry = AddressRegistry(hierarchical_schematic)
+        all_addrs = registry.all_addresses()
+        assert len(all_addrs) >= 1
+        assert all(isinstance(a, ComponentAddress) for a in all_addrs)
+
+
+class TestAddressRegistryPatternMatching:
+    """Tests for pattern matching functionality."""
+
+    def test_exact_match(self, hierarchical_schematic: Path):
+        """Exact pattern should match exactly one component."""
+        registry = AddressRegistry(hierarchical_schematic)
+        matches = registry.match_by_pattern("C1")
+        c1_matches = [m for m in matches if m.full_path == "C1"]
+        assert len(c1_matches) <= 1
+
+    def test_wildcard_in_ref(self, hierarchical_schematic: Path):
+        """Wildcard in reference should match multiple."""
+        registry = AddressRegistry(hierarchical_schematic)
+        matches = registry.match_by_pattern("C*")
+        assert all(m.local_ref.startswith("C") for m in matches)
+
+    def test_star_star_pattern(self, hierarchical_schematic: Path):
+        """** pattern should match across sheet levels."""
+        registry = AddressRegistry(hierarchical_schematic)
+        # Match any component starting with C at any level
+        matches = registry.match_by_pattern("**C*")
+        assert len(matches) >= 0  # May or may not find matches
+
+    def test_single_level_wildcard(self, hierarchical_schematic: Path):
+        """Single * should only match within one level."""
+        registry = AddressRegistry(hierarchical_schematic)
+        matches = registry.match_by_pattern("*")
+        # Should only match root-level components
+        for m in matches:
+            assert m.sheet_path == ""
+
+    def test_question_mark_pattern(self, hierarchical_schematic: Path):
+        """? should match single character."""
+        registry = AddressRegistry(hierarchical_schematic)
+        matches = registry.match_by_pattern("C?")
+        # Matches C1, C2, etc. but not C10
+        for m in matches:
+            assert m.local_ref.startswith("C")
+            assert len(m.local_ref) == 2
+
+    def test_pattern_with_sheet_path(self, hierarchical_schematic: Path):
+        """Pattern with sheet path component."""
+        registry = AddressRegistry(hierarchical_schematic)
+        # This may or may not match depending on if Logic sheet has components
+        matches = registry.match_by_pattern("Logic.*")
+        # Just verify it doesn't crash and returns a list
+        assert isinstance(matches, list)
+
+
+class TestAddressRegistryIteration:
+    """Tests for iteration and container protocols."""
+
+    def test_iterate_addresses(self, hierarchical_schematic: Path):
+        """Should be able to iterate over addresses."""
+        registry = AddressRegistry(hierarchical_schematic)
+        addresses = list(registry)
+        assert all(isinstance(a, ComponentAddress) for a in addresses)
+
+    def test_contains_check(self, hierarchical_schematic: Path):
+        """Test 'in' operator."""
+        registry = AddressRegistry(hierarchical_schematic)
+        if registry.resolve("C1"):
+            assert "C1" in registry
+        assert "nonexistent.component" not in registry
+
+
+class TestAddressRegistryFlatSchematic:
+    """Tests with flat (non-hierarchical) schematics."""
+
+    def test_flat_schematic(self, simple_rc_schematic: Path):
+        """Flat schematic should work correctly."""
+        registry = AddressRegistry(simple_rc_schematic)
+
+        # All components should be at root level
+        for addr in registry:
+            assert addr.depth == 0
+            assert addr.sheet_path == ""
+
+
+class TestAddressRegistryDeepHierarchy:
+    """Tests for deeply nested hierarchies."""
+
+    def test_three_level_hierarchy(self, tmp_path: Path):
+        """Test a 3-level nested hierarchy."""
+        # Create a 3-level hierarchy
+        root_sch = tmp_path / "root.kicad_sch"
+        level1_sch = tmp_path / "level1.kicad_sch"
+        level2_sch = tmp_path / "level2.kicad_sch"
+
+        # Level 2 schematic with a component
+        level2_sch.write_text("""(kicad_sch
+    (version 20231120)
+    (generator "test")
+    (generator_version "8.0")
+    (uuid "level2-uuid")
+    (paper "A4")
+    (lib_symbols
+        (symbol "Device:R"
+            (symbol "R_1_1"
+                (pin passive line (at 0 3.81 270) (length 2.794) (name "~") (number "1"))
+                (pin passive line (at 0 -3.81 90) (length 2.794) (name "~") (number "2"))
+            )
+        )
+    )
+    (symbol
+        (lib_id "Device:R")
+        (at 100 50 0)
+        (unit 1)
+        (uuid "r1-deep-uuid")
+        (property "Reference" "R1" (at 104 48 0))
+        (property "Value" "10k" (at 104 52 0))
+    )
+)
+""")
+
+        # Level 1 schematic with sheet to level 2
+        level1_sch.write_text("""(kicad_sch
+    (version 20231120)
+    (generator "test")
+    (generator_version "8.0")
+    (uuid "level1-uuid")
+    (paper "A4")
+    (lib_symbols)
+    (sheet
+        (at 130 40) (size 40 30)
+        (uuid "sheet-l2-uuid")
+        (property "Sheetname" "SubLevel" (at 130 39 0))
+        (property "Sheetfile" "level2.kicad_sch" (at 130 71 0))
+    )
+)
+""")
+
+        # Root schematic with sheet to level 1
+        root_sch.write_text("""(kicad_sch
+    (version 20231120)
+    (generator "test")
+    (generator_version "8.0")
+    (uuid "root-uuid")
+    (paper "A4")
+    (lib_symbols
+        (symbol "Device:C"
+            (symbol "C_1_1"
+                (pin passive line (at 0 3.81 270) (length 2.794) (name "~") (number "1"))
+                (pin passive line (at 0 -3.81 90) (length 2.794) (name "~") (number "2"))
+            )
+        )
+    )
+    (symbol
+        (lib_id "Device:C")
+        (at 50 50 0)
+        (unit 1)
+        (uuid "c1-root-uuid")
+        (property "Reference" "C1" (at 54 48 0))
+        (property "Value" "100nF" (at 54 52 0))
+    )
+    (sheet
+        (at 130 40) (size 40 30)
+        (uuid "sheet-l1-uuid")
+        (property "Sheetname" "MainLevel" (at 130 39 0))
+        (property "Sheetfile" "level1.kicad_sch" (at 130 71 0))
+    )
+)
+""")
+
+        registry = AddressRegistry(root_sch)
+
+        # Root component
+        c1 = registry.resolve("C1")
+        assert c1 is not None
+        assert c1.depth == 0
+        assert c1.uuid == "c1-root-uuid"
+
+        # Level 3 component (MainLevel.SubLevel.R1)
+        r1 = registry.resolve("MainLevel.SubLevel.R1")
+        assert r1 is not None
+        assert r1.depth == 2
+        assert r1.sheet_path == "MainLevel.SubLevel"
+        assert r1.uuid == "r1-deep-uuid"
+
+
+class TestAddressRegistryStability:
+    """Tests for address stability across modifications."""
+
+    def test_address_stability_with_same_uuid(self, tmp_path: Path):
+        """Same UUID should produce same address."""
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text("""(kicad_sch
+    (version 20231120)
+    (generator "test")
+    (generator_version "8.0")
+    (uuid "root-uuid")
+    (paper "A4")
+    (lib_symbols
+        (symbol "Device:C"
+            (symbol "C_1_1"
+                (pin passive line (at 0 3.81 270) (length 2.794) (name "~") (number "1"))
+            )
+        )
+    )
+    (symbol
+        (lib_id "Device:C")
+        (at 50 50 0)
+        (unit 1)
+        (uuid "stable-uuid-123")
+        (property "Reference" "C1" (at 54 48 0))
+        (property "Value" "100nF" (at 54 52 0))
+    )
+)
+""")
+
+        registry1 = AddressRegistry(sch)
+        c1_addr = registry1.get_address("stable-uuid-123")
+        assert c1_addr == "C1"
+
+        # Rebuild registry - should get same result
+        registry2 = AddressRegistry(sch)
+        c1_addr2 = registry2.get_address("stable-uuid-123")
+        assert c1_addr2 == c1_addr
+
+
+# Fixtures
+
+
+@pytest.fixture
+def hierarchical_schematic() -> Path:
+    """Return path to hierarchical test schematic."""
+    return Path(__file__).parent / "fixtures" / "projects" / "hierarchical_main.kicad_sch"
+
+
+@pytest.fixture
+def simple_rc_schematic() -> Path:
+    """Return path to simple RC schematic."""
+    return Path(__file__).parent / "fixtures" / "simple_rc.kicad_sch"


### PR DESCRIPTION
## Summary

Implement hierarchical address-based component matching to preserve layout when regenerating PCB from schematic changes.

- Adds `ComponentAddress` dataclass with hierarchical path support (e.g., `power.ldo.C1`)
- Adds `AddressRegistry` that builds addresses from schematic hierarchy
- Supports pattern matching with glob-style wildcards (`*`, `**`, `?`)
- Enables UUID-based component lookup for stable identification
- Works with flat and deeply nested hierarchies (3+ levels tested)

## Changes

- `src/kicad_tools/layout/__init__.py` - New package
- `src/kicad_tools/layout/types.py` - ComponentAddress dataclass
- `src/kicad_tools/layout/addressing.py` - AddressRegistry implementation
- `tests/test_layout_addressing.py` - Comprehensive unit tests (26 tests)

## Test Plan

- [x] Unit tests for ComponentAddress creation and validation
- [x] Unit tests for AddressRegistry with hierarchical schematics
- [x] Unit tests for pattern matching functionality
- [x] Unit tests for flat (non-hierarchical) schematics
- [x] Unit tests for 3-level deep hierarchies
- [x] Address stability test (same UUID produces same address)

Closes #470