### PR TITLE
feat: Add JLCPCB assembly BOM validation

### DIFF
--- a/src/kicad_tools/assembly/__init__.py
+++ b/src/kicad_tools/assembly/__init__.py
@@ -1,0 +1,21 @@
+"""
+Assembly preparation and validation for PCB manufacturing.
+"""
+
+from .validation import (
+    AssemblyValidationResult,
+    AssemblyValidator,
+    PartTier,
+    PartValidationResult,
+    ValidationStatus,
+    validate_assembly,
+)
+
+__all__ = [
+    "AssemblyValidationResult",
+    "AssemblyValidator",
+    "PartTier",
+    "PartValidationResult",
+    "ValidationStatus",
+    "validate_assembly",
+]

--- a/src/kicad_tools/assembly/validation.py
+++ b/src/kicad_tools/assembly/validation.py
@@ -1,0 +1,475 @@
+"""
+Assembly validation for JLCPCB/LCSC BOM components.
+
+Validates BOM availability and categorizes parts by JLCPCB tier.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.bom import BOM, BOMGroup
+
+
+class PartTier(Enum):
+    """JLCPCB part tier classification."""
+
+    BASIC = "basic"  # No handling fee, fast lead time
+    EXTENDED = "extended"  # $3 handling fee per unique part
+    GLOBAL = "global"  # Global sourcing, longer lead time
+    UNKNOWN = "unknown"
+
+
+class ValidationStatus(Enum):
+    """Validation status for a part."""
+
+    AVAILABLE = "available"
+    LOW_STOCK = "low_stock"
+    OUT_OF_STOCK = "out_of_stock"
+    NOT_FOUND = "not_found"
+    NO_LCSC = "no_lcsc"
+    INVALID_FORMAT = "invalid_format"
+
+
+@dataclass
+class PartValidationResult:
+    """Validation result for a single BOM item."""
+
+    # BOM info
+    references: str
+    value: str
+    footprint: str
+    quantity: int
+    lcsc_part: str | None
+
+    # Validation result
+    status: ValidationStatus
+    tier: PartTier
+
+    # Stock info
+    stock: int = 0
+    in_stock: bool = False
+
+    # Part details (if found)
+    mfr_part: str = ""
+    description: str = ""
+
+    # Error info
+    error: str | None = None
+
+    @property
+    def status_symbol(self) -> str:
+        """Get status symbol for display."""
+        if self.status == ValidationStatus.AVAILABLE:
+            return "✓"
+        elif self.status == ValidationStatus.LOW_STOCK:
+            return "⚠"
+        elif self.status == ValidationStatus.OUT_OF_STOCK:
+            return "✗"
+        elif self.status == ValidationStatus.NOT_FOUND:
+            return "?"
+        elif self.status == ValidationStatus.NO_LCSC:
+            return "-"
+        else:
+            return "!"
+
+    @property
+    def status_text(self) -> str:
+        """Get human-readable status text."""
+        if self.status == ValidationStatus.AVAILABLE:
+            return "Available"
+        elif self.status == ValidationStatus.LOW_STOCK:
+            return f"Low ({self.stock})"
+        elif self.status == ValidationStatus.OUT_OF_STOCK:
+            return "OOS"
+        elif self.status == ValidationStatus.NOT_FOUND:
+            return "Not Found"
+        elif self.status == ValidationStatus.NO_LCSC:
+            return "No LCSC"
+        elif self.status == ValidationStatus.INVALID_FORMAT:
+            return "Invalid"
+        return "Unknown"
+
+    @property
+    def tier_text(self) -> str:
+        """Get tier text for display."""
+        return self.tier.value.capitalize() if self.tier != PartTier.UNKNOWN else "-"
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "references": self.references,
+            "value": self.value,
+            "footprint": self.footprint,
+            "quantity": self.quantity,
+            "lcsc_part": self.lcsc_part,
+            "status": self.status.value,
+            "tier": self.tier.value,
+            "stock": self.stock,
+            "in_stock": self.in_stock,
+            "mfr_part": self.mfr_part,
+            "description": self.description,
+            "error": self.error,
+        }
+
+
+@dataclass
+class AssemblyValidationResult:
+    """Result of validating a BOM for JLCPCB assembly."""
+
+    items: list[PartValidationResult] = field(default_factory=list)
+    validated_at: datetime | None = None
+
+    # Extended part handling fee (USD)
+    EXTENDED_PART_FEE = 3.0
+
+    @property
+    def basic_parts(self) -> list[PartValidationResult]:
+        """Get basic tier parts (no handling fee)."""
+        return [
+            item
+            for item in self.items
+            if item.tier == PartTier.BASIC and item.status == ValidationStatus.AVAILABLE
+        ]
+
+    @property
+    def extended_parts(self) -> list[PartValidationResult]:
+        """Get extended tier parts ($3 fee each)."""
+        return [
+            item
+            for item in self.items
+            if item.tier == PartTier.EXTENDED and item.status == ValidationStatus.AVAILABLE
+        ]
+
+    @property
+    def out_of_stock(self) -> list[PartValidationResult]:
+        """Get out of stock parts (need consignment/wait)."""
+        return [item for item in self.items if item.status == ValidationStatus.OUT_OF_STOCK]
+
+    @property
+    def low_stock(self) -> list[PartValidationResult]:
+        """Get low stock parts (may need attention)."""
+        return [item for item in self.items if item.status == ValidationStatus.LOW_STOCK]
+
+    @property
+    def missing_lcsc(self) -> list[PartValidationResult]:
+        """Get parts without LCSC numbers."""
+        return [item for item in self.items if item.status == ValidationStatus.NO_LCSC]
+
+    @property
+    def not_found(self) -> list[PartValidationResult]:
+        """Get parts with invalid LCSC numbers."""
+        return [item for item in self.items if item.status == ValidationStatus.NOT_FOUND]
+
+    @property
+    def invalid_format(self) -> list[PartValidationResult]:
+        """Get parts with invalid LCSC format."""
+        return [item for item in self.items if item.status == ValidationStatus.INVALID_FORMAT]
+
+    @property
+    def available_count(self) -> int:
+        """Count of available parts (basic + extended available)."""
+        return len(
+            [
+                item
+                for item in self.items
+                if item.status in (ValidationStatus.AVAILABLE, ValidationStatus.LOW_STOCK)
+            ]
+        )
+
+    @property
+    def assembly_ready(self) -> bool:
+        """True if all parts are available for assembly."""
+        problem_statuses = {
+            ValidationStatus.OUT_OF_STOCK,
+            ValidationStatus.NOT_FOUND,
+            ValidationStatus.NO_LCSC,
+            ValidationStatus.INVALID_FORMAT,
+        }
+        return not any(item.status in problem_statuses for item in self.items)
+
+    @property
+    def extended_fee(self) -> float:
+        """Total extended parts fee (unique parts * $3)."""
+        return len(self.extended_parts) * self.EXTENDED_PART_FEE
+
+    def summary(self) -> dict:
+        """Get summary statistics."""
+        return {
+            "total_items": len(self.items),
+            "available": self.available_count,
+            "basic_parts": len(self.basic_parts),
+            "extended_parts": len(self.extended_parts),
+            "low_stock": len(self.low_stock),
+            "out_of_stock": len(self.out_of_stock),
+            "missing_lcsc": len(self.missing_lcsc),
+            "not_found": len(self.not_found),
+            "assembly_ready": self.assembly_ready,
+            "extended_fee": self.extended_fee,
+        }
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "summary": self.summary(),
+            "validated_at": self.validated_at.isoformat() if self.validated_at else None,
+            "items": [item.to_dict() for item in self.items],
+        }
+
+    def format_table(self) -> str:
+        """Format results as a human-readable table."""
+        if not self.items:
+            return "No components to validate."
+
+        lines = []
+
+        # Header
+        lines.append("")
+        lines.append(
+            f"{'LCSC Part #':<12} {'Component':<20} {'Tier':<10} {'Stock':<10} {'Status':<12}"
+        )
+        lines.append("-" * 66)
+
+        # Items
+        for item in self.items:
+            lcsc = item.lcsc_part or "(none)"
+            component = f"{item.value[:18]}" if len(item.value) > 18 else item.value
+            tier = item.tier_text
+            stock = str(item.stock) if item.stock > 0 else "-"
+            status = f"{item.status_symbol} {item.status_text}"
+
+            lines.append(f"{lcsc:<12} {component:<20} {tier:<10} {stock:<10} {status:<12}")
+
+        # Summary
+        lines.append("-" * 66)
+        summary = self.summary()
+        lines.append(f"\nSummary: {summary['available']}/{summary['total_items']} parts available")
+        lines.append(f"  Basic: {summary['basic_parts']} parts (no handling fee)")
+        lines.append(
+            f"  Extended: {summary['extended_parts']} parts "
+            f"(${self.EXTENDED_PART_FEE:.0f} fee each = ${summary['extended_fee']:.2f})"
+        )
+
+        if summary["out_of_stock"] > 0:
+            lines.append(
+                f"  Out of Stock: {summary['out_of_stock']} parts (requires consignment)"
+            )
+        if summary["missing_lcsc"] > 0:
+            lines.append(f"  Missing LCSC: {summary['missing_lcsc']} parts (needs part number)")
+        if summary["not_found"] > 0:
+            lines.append(f"  Not Found: {summary['not_found']} parts (invalid LCSC number)")
+
+        if self.assembly_ready:
+            lines.append("\n✓ All parts available for JLCPCB assembly")
+        else:
+            lines.append("\n✗ Some parts unavailable - review before ordering")
+
+        return "\n".join(lines)
+
+
+class AssemblyValidator:
+    """Validates BOM for JLCPCB assembly."""
+
+    # LCSC part number pattern: C followed by digits
+    LCSC_PATTERN = r"^C\d+$"
+
+    # Low stock threshold
+    LOW_STOCK_THRESHOLD = 100
+
+    def __init__(self, use_cache: bool = True, timeout: float = 30.0):
+        """
+        Initialize the validator.
+
+        Args:
+            use_cache: Whether to cache API responses
+            timeout: API request timeout in seconds
+        """
+        self.use_cache = use_cache
+        self.timeout = timeout
+        self._client = None
+
+    def _get_client(self):
+        """Get or create LCSC client."""
+        if self._client is None:
+            from kicad_tools.parts import LCSCClient
+
+            self._client = LCSCClient(use_cache=self.use_cache, timeout=self.timeout)
+        return self._client
+
+    def validate_bom(self, bom: BOM, quantity: int = 1) -> AssemblyValidationResult:
+        """
+        Validate a BOM for JLCPCB assembly.
+
+        Args:
+            bom: Bill of Materials to validate
+            quantity: Number of boards (multiplies component quantities)
+
+        Returns:
+            AssemblyValidationResult with validation results
+        """
+        import re
+
+        client = self._get_client()
+        results: list[PartValidationResult] = []
+
+        # Group BOM and collect LCSC numbers
+        groups = bom.grouped()
+        valid_lcsc_parts = []
+
+        for group in groups:
+            # Skip DNP items
+            if group.items and group.items[0].dnp:
+                continue
+
+            if group.lcsc:
+                lcsc_upper = group.lcsc.upper()
+                # Normalize: add C prefix if missing
+                if not lcsc_upper.startswith("C"):
+                    lcsc_upper = f"C{lcsc_upper}"
+                # Validate format
+                if re.match(self.LCSC_PATTERN, lcsc_upper):
+                    valid_lcsc_parts.append(lcsc_upper)
+
+        # Bulk fetch parts
+        parts_map = client.lookup_many(list(set(valid_lcsc_parts))) if valid_lcsc_parts else {}
+
+        # Validate each group
+        for group in groups:
+            # Skip DNP items
+            if group.items and group.items[0].dnp:
+                continue
+
+            result = self._validate_group(group, quantity, parts_map)
+            results.append(result)
+
+        return AssemblyValidationResult(
+            items=results,
+            validated_at=datetime.now(),
+        )
+
+    def _validate_group(
+        self,
+        group: BOMGroup,
+        quantity: int,
+        parts_map: dict,
+    ) -> PartValidationResult:
+        """Validate a single BOM group."""
+        import re
+
+        lcsc = group.lcsc
+        qty_needed = group.quantity * quantity
+
+        # No LCSC part number
+        if not lcsc:
+            return PartValidationResult(
+                references=group.references,
+                value=group.value,
+                footprint=group.footprint,
+                quantity=qty_needed,
+                lcsc_part=None,
+                status=ValidationStatus.NO_LCSC,
+                tier=PartTier.UNKNOWN,
+            )
+
+        # Normalize LCSC part number
+        lcsc_upper = lcsc.upper()
+        if not lcsc_upper.startswith("C"):
+            lcsc_upper = f"C{lcsc_upper}"
+
+        # Check format
+        if not re.match(self.LCSC_PATTERN, lcsc_upper):
+            return PartValidationResult(
+                references=group.references,
+                value=group.value,
+                footprint=group.footprint,
+                quantity=qty_needed,
+                lcsc_part=lcsc,
+                status=ValidationStatus.INVALID_FORMAT,
+                tier=PartTier.UNKNOWN,
+                error=f"Invalid LCSC format: {lcsc}",
+            )
+
+        # Look up part
+        part = parts_map.get(lcsc_upper)
+        if part is None:
+            return PartValidationResult(
+                references=group.references,
+                value=group.value,
+                footprint=group.footprint,
+                quantity=qty_needed,
+                lcsc_part=lcsc_upper,
+                status=ValidationStatus.NOT_FOUND,
+                tier=PartTier.UNKNOWN,
+                error="Part not found in LCSC database",
+            )
+
+        # Determine tier
+        if part.is_basic:
+            tier = PartTier.BASIC
+        elif part.is_preferred:
+            tier = PartTier.EXTENDED  # Preferred is still extended tier pricing
+        else:
+            tier = PartTier.EXTENDED
+
+        # Determine status
+        if part.stock == 0:
+            status = ValidationStatus.OUT_OF_STOCK
+        elif part.stock < max(qty_needed * 2, self.LOW_STOCK_THRESHOLD):
+            status = ValidationStatus.LOW_STOCK
+        else:
+            status = ValidationStatus.AVAILABLE
+
+        return PartValidationResult(
+            references=group.references,
+            value=group.value,
+            footprint=group.footprint,
+            quantity=qty_needed,
+            lcsc_part=lcsc_upper,
+            status=status,
+            tier=tier,
+            stock=part.stock,
+            in_stock=part.stock > 0,
+            mfr_part=part.mfr_part,
+            description=part.description,
+        )
+
+    def close(self) -> None:
+        """Close the client connection."""
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+
+def validate_assembly(
+    schematic_path: str,
+    quantity: int = 1,
+    use_cache: bool = True,
+) -> AssemblyValidationResult:
+    """
+    Validate a schematic's BOM for JLCPCB assembly.
+
+    Args:
+        schematic_path: Path to .kicad_sch file
+        quantity: Number of boards
+        use_cache: Whether to cache API responses
+
+    Returns:
+        AssemblyValidationResult with validation results
+    """
+    from kicad_tools.schema.bom import extract_bom
+
+    bom = extract_bom(schematic_path)
+
+    with AssemblyValidator(use_cache=use_cache) as validator:
+        return validator.validate_bom(bom, quantity)

--- a/tests/test_assembly_validation.py
+++ b/tests/test_assembly_validation.py
@@ -1,0 +1,553 @@
+"""Tests for assembly validation module."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.assembly.validation import (
+    AssemblyValidationResult,
+    AssemblyValidator,
+    PartTier,
+    PartValidationResult,
+    ValidationStatus,
+)
+
+
+class TestPartTier:
+    """Tests for PartTier enum."""
+
+    def test_tier_values(self):
+        assert PartTier.BASIC.value == "basic"
+        assert PartTier.EXTENDED.value == "extended"
+        assert PartTier.GLOBAL.value == "global"
+        assert PartTier.UNKNOWN.value == "unknown"
+
+
+class TestValidationStatus:
+    """Tests for ValidationStatus enum."""
+
+    def test_status_values(self):
+        assert ValidationStatus.AVAILABLE.value == "available"
+        assert ValidationStatus.LOW_STOCK.value == "low_stock"
+        assert ValidationStatus.OUT_OF_STOCK.value == "out_of_stock"
+        assert ValidationStatus.NOT_FOUND.value == "not_found"
+        assert ValidationStatus.NO_LCSC.value == "no_lcsc"
+        assert ValidationStatus.INVALID_FORMAT.value == "invalid_format"
+
+
+class TestPartValidationResult:
+    """Tests for PartValidationResult dataclass."""
+
+    @pytest.fixture
+    def available_part(self):
+        return PartValidationResult(
+            references="R1, R2, R3",
+            value="10k",
+            footprint="0402",
+            quantity=3,
+            lcsc_part="C123456",
+            status=ValidationStatus.AVAILABLE,
+            tier=PartTier.BASIC,
+            stock=50000,
+            in_stock=True,
+            mfr_part="RC0402FR-0710KL",
+            description="10K 1% Resistor",
+        )
+
+    @pytest.fixture
+    def oos_part(self):
+        return PartValidationResult(
+            references="U1",
+            value="STM32",
+            footprint="LQFP48",
+            quantity=1,
+            lcsc_part="C999999",
+            status=ValidationStatus.OUT_OF_STOCK,
+            tier=PartTier.EXTENDED,
+            stock=0,
+            in_stock=False,
+        )
+
+    @pytest.fixture
+    def missing_lcsc_part(self):
+        return PartValidationResult(
+            references="J1",
+            value="USB-C",
+            footprint="USB-C",
+            quantity=1,
+            lcsc_part=None,
+            status=ValidationStatus.NO_LCSC,
+            tier=PartTier.UNKNOWN,
+        )
+
+    def test_status_symbol_available(self, available_part):
+        assert available_part.status_symbol == "✓"
+
+    def test_status_symbol_oos(self, oos_part):
+        assert oos_part.status_symbol == "✗"
+
+    def test_status_symbol_no_lcsc(self, missing_lcsc_part):
+        assert missing_lcsc_part.status_symbol == "-"
+
+    def test_status_symbol_low_stock(self):
+        part = PartValidationResult(
+            references="C1",
+            value="100nF",
+            footprint="0402",
+            quantity=1,
+            lcsc_part="C123",
+            status=ValidationStatus.LOW_STOCK,
+            tier=PartTier.BASIC,
+            stock=50,
+        )
+        assert part.status_symbol == "⚠"
+
+    def test_status_symbol_not_found(self):
+        part = PartValidationResult(
+            references="R1",
+            value="10k",
+            footprint="0402",
+            quantity=1,
+            lcsc_part="CINVALID",
+            status=ValidationStatus.NOT_FOUND,
+            tier=PartTier.UNKNOWN,
+        )
+        assert part.status_symbol == "?"
+
+    def test_status_text_available(self, available_part):
+        assert available_part.status_text == "Available"
+
+    def test_status_text_oos(self, oos_part):
+        assert oos_part.status_text == "OOS"
+
+    def test_status_text_low_stock(self):
+        part = PartValidationResult(
+            references="C1",
+            value="100nF",
+            footprint="0402",
+            quantity=1,
+            lcsc_part="C123",
+            status=ValidationStatus.LOW_STOCK,
+            tier=PartTier.BASIC,
+            stock=50,
+        )
+        assert "Low" in part.status_text
+        assert "50" in part.status_text
+
+    def test_tier_text(self, available_part, oos_part, missing_lcsc_part):
+        assert available_part.tier_text == "Basic"
+        assert oos_part.tier_text == "Extended"
+        assert missing_lcsc_part.tier_text == "-"
+
+    def test_to_dict(self, available_part):
+        d = available_part.to_dict()
+        assert d["references"] == "R1, R2, R3"
+        assert d["value"] == "10k"
+        assert d["footprint"] == "0402"
+        assert d["quantity"] == 3
+        assert d["lcsc_part"] == "C123456"
+        assert d["status"] == "available"
+        assert d["tier"] == "basic"
+        assert d["stock"] == 50000
+        assert d["in_stock"] is True
+        assert d["mfr_part"] == "RC0402FR-0710KL"
+        assert d["description"] == "10K 1% Resistor"
+
+
+class TestAssemblyValidationResult:
+    """Tests for AssemblyValidationResult dataclass."""
+
+    @pytest.fixture
+    def validation_result(self):
+        return AssemblyValidationResult(
+            items=[
+                # Basic available
+                PartValidationResult(
+                    references="R1, R2",
+                    value="10k",
+                    footprint="0402",
+                    quantity=2,
+                    lcsc_part="C123",
+                    status=ValidationStatus.AVAILABLE,
+                    tier=PartTier.BASIC,
+                    stock=50000,
+                    in_stock=True,
+                ),
+                # Extended available
+                PartValidationResult(
+                    references="U1",
+                    value="STM32",
+                    footprint="LQFP48",
+                    quantity=1,
+                    lcsc_part="C456",
+                    status=ValidationStatus.AVAILABLE,
+                    tier=PartTier.EXTENDED,
+                    stock=100,
+                    in_stock=True,
+                ),
+                # Extended low stock
+                PartValidationResult(
+                    references="U2",
+                    value="ESP32",
+                    footprint="QFN",
+                    quantity=1,
+                    lcsc_part="C789",
+                    status=ValidationStatus.LOW_STOCK,
+                    tier=PartTier.EXTENDED,
+                    stock=50,
+                    in_stock=True,
+                ),
+                # Out of stock
+                PartValidationResult(
+                    references="C1",
+                    value="100uF",
+                    footprint="0805",
+                    quantity=1,
+                    lcsc_part="COOS",
+                    status=ValidationStatus.OUT_OF_STOCK,
+                    tier=PartTier.EXTENDED,
+                    stock=0,
+                    in_stock=False,
+                ),
+                # Missing LCSC
+                PartValidationResult(
+                    references="J1",
+                    value="USB-C",
+                    footprint="USB-C",
+                    quantity=1,
+                    lcsc_part=None,
+                    status=ValidationStatus.NO_LCSC,
+                    tier=PartTier.UNKNOWN,
+                ),
+            ],
+            validated_at=datetime.now(),
+        )
+
+    def test_basic_parts(self, validation_result):
+        basic = validation_result.basic_parts
+        assert len(basic) == 1
+        assert basic[0].references == "R1, R2"
+
+    def test_extended_parts(self, validation_result):
+        extended = validation_result.extended_parts
+        assert len(extended) == 1
+        assert extended[0].references == "U1"
+
+    def test_out_of_stock(self, validation_result):
+        oos = validation_result.out_of_stock
+        assert len(oos) == 1
+        assert oos[0].references == "C1"
+
+    def test_low_stock(self, validation_result):
+        low = validation_result.low_stock
+        assert len(low) == 1
+        assert low[0].references == "U2"
+
+    def test_missing_lcsc(self, validation_result):
+        missing = validation_result.missing_lcsc
+        assert len(missing) == 1
+        assert missing[0].references == "J1"
+
+    def test_available_count(self, validation_result):
+        # Basic available (1) + Extended available (1) + Low stock (1) = 3
+        assert validation_result.available_count == 3
+
+    def test_assembly_ready_false(self, validation_result):
+        assert validation_result.assembly_ready is False
+
+    def test_assembly_ready_true(self):
+        result = AssemblyValidationResult(
+            items=[
+                PartValidationResult(
+                    references="R1",
+                    value="10k",
+                    footprint="0402",
+                    quantity=1,
+                    lcsc_part="C123",
+                    status=ValidationStatus.AVAILABLE,
+                    tier=PartTier.BASIC,
+                    stock=50000,
+                    in_stock=True,
+                ),
+            ]
+        )
+        assert result.assembly_ready is True
+
+    def test_extended_fee(self, validation_result):
+        # 1 extended available part * $3 = $3
+        assert validation_result.extended_fee == 3.0
+
+    def test_summary(self, validation_result):
+        summary = validation_result.summary()
+        assert summary["total_items"] == 5
+        assert summary["available"] == 3  # Basic + Extended + Low stock
+        assert summary["basic_parts"] == 1
+        assert summary["extended_parts"] == 1
+        assert summary["low_stock"] == 1
+        assert summary["out_of_stock"] == 1
+        assert summary["missing_lcsc"] == 1
+        assert summary["assembly_ready"] is False
+        assert summary["extended_fee"] == 3.0
+
+    def test_to_dict(self, validation_result):
+        d = validation_result.to_dict()
+        assert "summary" in d
+        assert "validated_at" in d
+        assert "items" in d
+        assert len(d["items"]) == 5
+
+    def test_format_table(self, validation_result):
+        table = validation_result.format_table()
+        assert "LCSC Part #" in table
+        assert "Component" in table
+        assert "Tier" in table
+        assert "Status" in table
+        assert "Summary:" in table
+        assert "Basic:" in table
+        assert "Extended:" in table
+
+    def test_format_table_empty(self):
+        result = AssemblyValidationResult()
+        table = result.format_table()
+        assert "No components" in table
+
+
+class TestAssemblyValidator:
+    """Tests for AssemblyValidator class."""
+
+    @pytest.fixture
+    def mock_bom(self):
+        """Create a mock BOM with groups."""
+        from kicad_tools.schema.bom import BOM, BOMGroup, BOMItem
+
+        group1 = BOMGroup(value="10k", footprint="0402")
+        group1.items.append(
+            BOMItem(
+                reference="R1",
+                value="10k",
+                footprint="0402",
+                lib_id="Device:R",
+                lcsc="C123456",
+            )
+        )
+        group1.items.append(
+            BOMItem(
+                reference="R2",
+                value="10k",
+                footprint="0402",
+                lib_id="Device:R",
+                lcsc="C123456",
+            )
+        )
+
+        group2 = BOMGroup(value="100nF", footprint="0402")
+        group2.items.append(
+            BOMItem(
+                reference="C1",
+                value="100nF",
+                footprint="0402",
+                lib_id="Device:C",
+                lcsc="",  # Missing LCSC
+            )
+        )
+
+        group3 = BOMGroup(value="STM32", footprint="LQFP48")
+        group3.items.append(
+            BOMItem(
+                reference="U1",
+                value="STM32",
+                footprint="LQFP48",
+                lib_id="MCU:STM32",
+                lcsc="CINVALID",  # Invalid format
+            )
+        )
+
+        # Create mock BOM
+        bom = MagicMock(spec=BOM)
+        bom.grouped.return_value = [group1, group2, group3]
+
+        return bom
+
+    def test_validator_initialization(self):
+        validator = AssemblyValidator()
+        assert validator.use_cache is True
+        assert validator.timeout == 30.0
+        assert validator._client is None
+
+    def test_validator_initialization_custom(self):
+        validator = AssemblyValidator(use_cache=False, timeout=60.0)
+        assert validator.use_cache is False
+        assert validator.timeout == 60.0
+
+    def test_validator_context_manager(self):
+        with AssemblyValidator() as validator:
+            assert validator is not None
+
+    def test_validate_bom_with_mock(self, mock_bom):
+        """Test validate_bom with mocked LCSC client."""
+        from kicad_tools.parts.models import Part
+
+        validator = AssemblyValidator()
+
+        with patch.object(validator, "_get_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.lookup_many.return_value = {
+                "C123456": Part(
+                    lcsc_part="C123456",
+                    mfr_part="RC0402",
+                    stock=50000,
+                    is_basic=True,
+                ),
+            }
+            mock_get_client.return_value = mock_client
+
+            result = validator.validate_bom(mock_bom)
+
+            assert len(result.items) == 3
+
+            # Check the available part (R1, R2)
+            r_group = next(i for i in result.items if "R1" in i.references)
+            assert r_group.status == ValidationStatus.AVAILABLE
+            assert r_group.tier == PartTier.BASIC
+            assert r_group.quantity == 2
+
+            # Check the missing LCSC part
+            c_group = next(i for i in result.items if "C1" in i.references)
+            assert c_group.status == ValidationStatus.NO_LCSC
+
+            # Check the invalid format part
+            u_group = next(i for i in result.items if "U1" in i.references)
+            # CINVALID gets normalized to CCINVALID which is still invalid format
+            assert u_group.status in (
+                ValidationStatus.INVALID_FORMAT,
+                ValidationStatus.NOT_FOUND,
+            )
+
+    def test_validate_bom_with_quantity(self, mock_bom):
+        """Test validate_bom with board quantity multiplier."""
+        from kicad_tools.parts.models import Part
+
+        validator = AssemblyValidator()
+
+        with patch.object(validator, "_get_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.lookup_many.return_value = {
+                "C123456": Part(
+                    lcsc_part="C123456",
+                    mfr_part="RC0402",
+                    stock=50000,
+                    is_basic=True,
+                ),
+            }
+            mock_get_client.return_value = mock_client
+
+            result = validator.validate_bom(mock_bom, quantity=5)
+
+            # Check the available part quantity is multiplied
+            r_group = next(i for i in result.items if "R1" in i.references)
+            assert r_group.quantity == 10  # 2 * 5
+
+    def test_validate_bom_low_stock(self, mock_bom):
+        """Test that low stock is detected correctly."""
+        from kicad_tools.parts.models import Part
+
+        validator = AssemblyValidator()
+
+        with patch.object(validator, "_get_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.lookup_many.return_value = {
+                "C123456": Part(
+                    lcsc_part="C123456",
+                    mfr_part="RC0402",
+                    stock=50,  # Low stock
+                    is_basic=True,
+                ),
+            }
+            mock_get_client.return_value = mock_client
+
+            result = validator.validate_bom(mock_bom)
+
+            r_group = next(i for i in result.items if "R1" in i.references)
+            assert r_group.status == ValidationStatus.LOW_STOCK
+
+    def test_validate_bom_out_of_stock(self, mock_bom):
+        """Test that out of stock is detected correctly."""
+        from kicad_tools.parts.models import Part
+
+        validator = AssemblyValidator()
+
+        with patch.object(validator, "_get_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.lookup_many.return_value = {
+                "C123456": Part(
+                    lcsc_part="C123456",
+                    mfr_part="RC0402",
+                    stock=0,  # Out of stock
+                    is_basic=True,
+                ),
+            }
+            mock_get_client.return_value = mock_client
+
+            result = validator.validate_bom(mock_bom)
+
+            r_group = next(i for i in result.items if "R1" in i.references)
+            assert r_group.status == ValidationStatus.OUT_OF_STOCK
+
+    def test_validate_bom_extended_tier(self, mock_bom):
+        """Test extended tier detection."""
+        from kicad_tools.parts.models import Part
+
+        validator = AssemblyValidator()
+
+        with patch.object(validator, "_get_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.lookup_many.return_value = {
+                "C123456": Part(
+                    lcsc_part="C123456",
+                    mfr_part="RC0402",
+                    stock=50000,
+                    is_basic=False,  # Extended
+                    is_preferred=True,
+                ),
+            }
+            mock_get_client.return_value = mock_client
+
+            result = validator.validate_bom(mock_bom)
+
+            r_group = next(i for i in result.items if "R1" in i.references)
+            assert r_group.tier == PartTier.EXTENDED
+
+
+class TestValidateAssemblyFunction:
+    """Tests for the validate_assembly convenience function."""
+
+    def test_validate_assembly_file_not_found(self, tmp_path):
+        from kicad_tools.assembly.validation import validate_assembly
+
+        # For nonexistent files, extract_bom may raise an exception or return empty BOM
+        # depending on the code path - test that it doesn't crash
+        try:
+            result = validate_assembly(str(tmp_path / "nonexistent.kicad_sch"))
+            # If we get here, it handled gracefully - likely empty BOM
+            assert len(result.items) == 0
+        except Exception:
+            # Some paths raise exceptions - that's also acceptable behavior
+            pass
+
+    def test_validate_assembly_with_mock_schematic(self, tmp_path):
+        """Test validate_assembly with a simple mock schematic file."""
+        # Create a minimal schematic file that will be parsed but has no components
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(
+            """(kicad_sch (version 20230121) (generator eeschema)
+  (uuid "12345678-1234-1234-1234-123456789012")
+)"""
+        )
+
+        from kicad_tools.assembly.validation import validate_assembly
+
+        # This should work (empty BOM)
+        result = validate_assembly(str(sch_file))
+        assert len(result.items) == 0
+        assert result.assembly_ready is True


### PR DESCRIPTION
## Summary

- Adds validation for BOM components against the JLCPCB/LCSC parts library to verify assembly readiness before ordering
- New `AssemblyValidator` class that categorizes parts by tier (Basic/Extended), stock status, and availability
- CLI flag: `kicad-bom <schematic> --validate [--quantity N]` 
- MCP tool: `validate_assembly_bom` for AI agent integration
- Human-readable table output showing part status and fee summary

## Changes

- **New module**: `src/kicad_tools/assembly/validation.py` - Core validation logic with `AssemblyValidator`, `PartValidationResult`, and `AssemblyValidationResult` types
- **CLI update**: `src/kicad_tools/cli/bom_cmd.py` - Added `--validate` and `--quantity` flags
- **MCP integration**: `src/kicad_tools/mcp/server.py` and `tools/export.py` - New `validate_assembly_bom` tool
- **Tests**: `tests/test_assembly_validation.py` - 35 unit tests covering all functionality

## Test plan

- [x] Run unit tests: `pytest tests/test_assembly_validation.py -v`
- [ ] Test CLI with real schematic: `kicad-bom example.kicad_sch --validate`
- [ ] Test MCP tool via claude-code or mcp-client

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)