### PR TITLE
Fix: Add progress indicator and Ctrl+C handling to autorouter

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -398,9 +398,12 @@ class Autorouter:
                 timed_out = True
                 break
 
-            # Progress output every 5 nets or for the last net
-            if i % 5 == 0 or i == total_nets - 1:
-                print(f"  Routing net {i + 1}/{total_nets}... ({elapsed_str()})")
+            # Progress output for every net with percentage
+            net_name = self.net_names.get(net, f"Net {net}")
+            pct = (i / total_nets * 100) if total_nets > 0 else 0
+            print(
+                f"  [{pct:5.1f}%] Routing net {i + 1}/{total_nets}: {net_name}... ({elapsed_str()})"
+            )
 
             routes = self._route_net_negotiated(net, present_factor)
             if routes:


### PR DESCRIPTION
## Summary

- Improve progress output in negotiated routing: print progress for every net instead of every 5 nets, with percentage completion indicator
- Add Ctrl+C signal handling that saves partial routing results to a `*_partial.kicad_pcb` file when interrupted
- Save partial results even on errors to preserve work

## Changes

### Progress Output Improvements (`core.py`)
- Changed from printing every 5 nets to printing every net
- Added percentage completion indicator: `[  5.0%] Routing net 2/23: +3.3V... (1.2s)`
- Shows net name for better feedback on what's being routed

### Ctrl+C Handling (`route_cmd.py`)
- Added signal handler for SIGINT (Ctrl+C)
- Saves partial results immediately when interrupted to `*_partial.kicad_pcb`
- Prints summary of partial results (nets routed, segments, vias)
- Exit code 2 indicates interruption with partial results saved

## Test Plan

- [x] Verified linting passes on modified files (`ruff check`)
- [x] Verified 57 router-related tests pass
- [x] Manual testing: progress output shows percentage for each net
- [x] Manual testing: Ctrl+C saves partial results

## Example Output

Before (every 5 nets, no percentage):
```
  Routing net 1/23... (0.5s)
  Routing net 5/23... (2.3s)
```

After (every net with percentage):
```
  [  0.0%] Routing net 1/23: GND... (0.5s)
  [  4.3%] Routing net 2/23: +3.3V... (1.2s)
  [  8.7%] Routing net 3/23: SCL... (1.8s)
```

On Ctrl+C:
```
⚠ Interrupt received! Saving partial results...

  Partial results saved to: board_routed_partial.kicad_pcb
    Nets routed: 15
    Segments: 142
    Vias: 28
```

Closes #524