### PR TITLE
feat: Add intent module with core types and interface protocol

### DIFF
--- a/src/kicad_tools/intent/__init__.py
+++ b/src/kicad_tools/intent/__init__.py
@@ -1,0 +1,110 @@
+"""
+Design intent declaration and constraint derivation.
+
+This module provides infrastructure for declaring design intent and
+automatically deriving constraints from interface specifications. It bridges
+the gap between high-level design intent (e.g., "these nets form a USB
+interface") and low-level DRC constraints (e.g., "differential impedance
+must be 90Ω ±10%").
+
+Example::
+
+    from kicad_tools.intent import (
+        REGISTRY,
+        InterfaceCategory,
+        InterfaceSpec,
+        Constraint,
+        IntentDeclaration,
+        create_intent_declaration,
+    )
+
+    # Register a custom interface specification
+    class USB2HighSpeedSpec:
+        @property
+        def name(self) -> str:
+            return "usb2_high_speed"
+
+        @property
+        def category(self) -> InterfaceCategory:
+            return InterfaceCategory.DIFFERENTIAL
+
+        def validate_nets(self, nets: list[str]) -> list[str]:
+            if len(nets) != 2:
+                return ["USB 2.0 High Speed requires exactly 2 nets (D+ and D-)"]
+            return []
+
+        def derive_constraints(
+            self, nets: list[str], params: dict
+        ) -> list[Constraint]:
+            return [
+                Constraint(
+                    type="impedance",
+                    params={"target": 90.0, "tolerance": 0.1},
+                    source=self.name,
+                    severity="error",
+                ),
+            ]
+
+        def get_validation_message(self, violation: dict) -> str:
+            return f"USB 2.0 HS: {violation.get('message', '')}"
+
+    REGISTRY.register(USB2HighSpeedSpec())
+
+    # Create an intent declaration with automatic constraint derivation
+    declaration = create_intent_declaration(
+        interface_type="usb2_high_speed",
+        nets=["USB_DP", "USB_DM"],
+        metadata={"connector": "J1"},
+    )
+
+    # Access derived constraints
+    for constraint in declaration.constraints:
+        print(f"Constraint: {constraint.type} - {constraint.params}")
+
+Classes:
+    InterfaceCategory: Enum for interface categories (DIFFERENTIAL, BUS, etc.)
+    ConstraintSeverity: Enum for constraint violation severity
+    Constraint: A constraint derived from design intent
+    IntentDeclaration: A declared design intent for a set of nets
+    InterfaceSpec: Protocol for interface specifications
+    InterfaceRegistry: Registry of available interface types
+
+Functions:
+    derive_constraints: Derive constraints from an interface declaration
+    validate_intent: Validate an intent declaration
+    create_intent_declaration: Create an intent declaration with constraints
+
+Constants:
+    REGISTRY: Global interface type registry
+"""
+
+from .constraints import (
+    create_intent_declaration,
+    derive_constraints,
+    validate_intent,
+)
+from .protocol import InterfaceSpec
+from .registry import REGISTRY, InterfaceRegistry
+from .types import (
+    Constraint,
+    ConstraintSeverity,
+    IntentDeclaration,
+    InterfaceCategory,
+)
+
+__all__ = [
+    # Types
+    "InterfaceCategory",
+    "ConstraintSeverity",
+    "Constraint",
+    "IntentDeclaration",
+    # Protocol
+    "InterfaceSpec",
+    # Registry
+    "InterfaceRegistry",
+    "REGISTRY",
+    # Functions
+    "derive_constraints",
+    "validate_intent",
+    "create_intent_declaration",
+]

--- a/src/kicad_tools/intent/constraints.py
+++ b/src/kicad_tools/intent/constraints.py
@@ -1,0 +1,158 @@
+"""
+Constraint derivation from design intent.
+
+This module provides utilities for deriving constraints from intent
+declarations and validating them against interface specifications.
+
+Example::
+
+    from kicad_tools.intent.constraints import derive_constraints, validate_intent
+    from kicad_tools.intent.registry import REGISTRY
+
+    # Derive constraints from an interface declaration
+    constraints = derive_constraints(
+        interface_type="usb2_high_speed",
+        nets=["USB_DP", "USB_DM"],
+        params={"connector": "J1"},
+        registry=REGISTRY,
+    )
+
+    # Validate an intent declaration
+    errors = validate_intent(
+        interface_type="usb2_high_speed",
+        nets=["USB_DP", "USB_DM"],
+        registry=REGISTRY,
+    )
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .types import Constraint, IntentDeclaration
+
+if TYPE_CHECKING:
+    from .registry import InterfaceRegistry
+
+
+def derive_constraints(
+    interface_type: str,
+    nets: list[str],
+    params: dict[str, object] | None = None,
+    registry: InterfaceRegistry | None = None,
+) -> list[Constraint]:
+    """Derive constraints from an interface declaration.
+
+    Looks up the interface specification and generates the appropriate
+    constraints for the given nets.
+
+    Args:
+        interface_type: The interface type name (e.g., "usb2_high_speed").
+        nets: List of net names in the interface.
+        params: Additional parameters for constraint derivation.
+        registry: Interface registry to use. Uses global REGISTRY if None.
+
+    Returns:
+        List of constraints derived from the interface specification.
+
+    Raises:
+        ValueError: If the interface type is not registered.
+    """
+    if registry is None:
+        from .registry import REGISTRY
+
+        registry = REGISTRY
+
+    spec = registry.get(interface_type)
+    if spec is None:
+        raise ValueError(
+            f"Unknown interface type: '{interface_type}'. "
+            f"Available types: {', '.join(registry.list_interfaces()) or '(none)'}"
+        )
+
+    return spec.derive_constraints(nets, params or {})
+
+
+def validate_intent(
+    interface_type: str,
+    nets: list[str],
+    registry: InterfaceRegistry | None = None,
+) -> list[str]:
+    """Validate an intent declaration against its interface specification.
+
+    Checks whether the nets are appropriate for the specified interface type.
+
+    Args:
+        interface_type: The interface type name to validate against.
+        nets: List of net names to validate.
+        registry: Interface registry to use. Uses global REGISTRY if None.
+
+    Returns:
+        List of validation error messages. Empty list if valid.
+
+    Raises:
+        ValueError: If the interface type is not registered.
+    """
+    if registry is None:
+        from .registry import REGISTRY
+
+        registry = REGISTRY
+
+    spec = registry.get(interface_type)
+    if spec is None:
+        raise ValueError(
+            f"Unknown interface type: '{interface_type}'. "
+            f"Available types: {', '.join(registry.list_interfaces()) or '(none)'}"
+        )
+
+    return spec.validate_nets(nets)
+
+
+def create_intent_declaration(
+    interface_type: str,
+    nets: list[str],
+    params: dict[str, object] | None = None,
+    metadata: dict[str, object] | None = None,
+    registry: InterfaceRegistry | None = None,
+    validate: bool = True,
+) -> IntentDeclaration:
+    """Create an intent declaration with derived constraints.
+
+    Convenience function that validates the interface, derives constraints,
+    and creates an IntentDeclaration in one step.
+
+    Args:
+        interface_type: The interface type name.
+        nets: List of net names in the interface.
+        params: Parameters for constraint derivation.
+        metadata: Additional metadata for the declaration.
+        registry: Interface registry to use. Uses global REGISTRY if None.
+        validate: Whether to validate nets before creating declaration.
+
+    Returns:
+        An IntentDeclaration with derived constraints.
+
+    Raises:
+        ValueError: If the interface type is not registered or validation fails.
+    """
+    if registry is None:
+        from .registry import REGISTRY
+
+        registry = REGISTRY
+
+    if validate:
+        errors = validate_intent(interface_type, nets, registry)
+        if errors:
+            raise ValueError(
+                f"Invalid intent declaration for '{interface_type}': "
+                + "; ".join(errors)
+            )
+
+    constraints = derive_constraints(interface_type, nets, params, registry)
+
+    return IntentDeclaration(
+        interface_type=interface_type,
+        nets=nets,
+        constraints=constraints,
+        metadata=metadata or {},
+    )

--- a/src/kicad_tools/intent/protocol.py
+++ b/src/kicad_tools/intent/protocol.py
@@ -1,0 +1,126 @@
+"""
+Interface protocol definition.
+
+This module defines the Protocol that all interface specifications must
+implement. The protocol enables a consistent API for validating nets,
+deriving constraints, and generating context-aware DRC messages.
+
+Example::
+
+    from kicad_tools.intent.protocol import InterfaceSpec
+    from kicad_tools.intent.types import Constraint, InterfaceCategory
+
+    class USB2HighSpeedSpec:
+        '''USB 2.0 High Speed interface specification.'''
+
+        @property
+        def name(self) -> str:
+            return "usb2_high_speed"
+
+        @property
+        def category(self) -> InterfaceCategory:
+            return InterfaceCategory.DIFFERENTIAL
+
+        def validate_nets(self, nets: list[str]) -> list[str]:
+            if len(nets) != 2:
+                return ["USB 2.0 High Speed requires exactly 2 nets (D+ and D-)"]
+            return []
+
+        def derive_constraints(
+            self, nets: list[str], params: dict[str, object]
+        ) -> list[Constraint]:
+            return [
+                Constraint(
+                    type="impedance",
+                    params={"target": 90.0, "tolerance": 0.1},
+                    source=self.name,
+                    severity="error",
+                ),
+            ]
+
+        def get_validation_message(self, violation: dict[str, object]) -> str:
+            return f"USB differential pair: {violation.get('message', '')}"
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from .types import Constraint, InterfaceCategory
+
+
+class InterfaceSpec(Protocol):
+    """Protocol for interface specifications.
+
+    Interface specifications define the requirements and constraints for
+    specific interface types (e.g., USB, SPI, I2C). Implementations provide:
+
+    - Validation of net configuration
+    - Constraint derivation from interface rules
+    - Context-aware DRC violation messages
+    """
+
+    @property
+    def name(self) -> str:
+        """Interface type name (e.g., 'usb2_high_speed').
+
+        Returns:
+            A unique identifier for this interface type.
+        """
+        ...
+
+    @property
+    def category(self) -> InterfaceCategory:
+        """Interface category.
+
+        Returns:
+            The high-level category this interface belongs to.
+        """
+        ...
+
+    def validate_nets(self, nets: list[str]) -> list[str]:
+        """Validate net names/count for this interface.
+
+        Checks whether the provided nets are appropriate for this interface
+        type. This includes verifying the number of nets and any naming
+        conventions.
+
+        Args:
+            nets: List of net names to validate.
+
+        Returns:
+            List of validation error messages. Empty list if valid.
+        """
+        ...
+
+    def derive_constraints(
+        self, nets: list[str], params: dict[str, object]
+    ) -> list[Constraint]:
+        """Derive constraints from interface declaration.
+
+        Generates the set of constraints that apply to the given nets
+        based on the interface specification.
+
+        Args:
+            nets: List of net names in this interface.
+            params: Additional parameters for constraint generation.
+
+        Returns:
+            List of constraints derived from the interface specification.
+        """
+        ...
+
+    def get_validation_message(self, violation: dict[str, object]) -> str:
+        """Convert generic DRC violation to intent-aware message.
+
+        Transforms a generic DRC violation into a message that explains
+        the violation in terms of the design intent.
+
+        Args:
+            violation: Dictionary containing violation details.
+
+        Returns:
+            Human-readable message explaining the violation in context.
+        """
+        ...

--- a/src/kicad_tools/intent/registry.py
+++ b/src/kicad_tools/intent/registry.py
@@ -1,0 +1,123 @@
+"""
+Interface type registry.
+
+This module provides a registry for interface specifications, enabling
+lookup and organization of available interface types.
+
+Example::
+
+    from kicad_tools.intent.registry import REGISTRY, InterfaceRegistry
+    from kicad_tools.intent.types import InterfaceCategory
+
+    # Check if an interface is registered
+    if spec := REGISTRY.get("usb2_high_speed"):
+        print(f"Found: {spec.name}")
+
+    # List all interfaces
+    for name in REGISTRY.list_interfaces():
+        print(f"- {name}")
+
+    # List interfaces by category
+    differential_interfaces = REGISTRY.list_by_category(
+        InterfaceCategory.DIFFERENTIAL
+    )
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .protocol import InterfaceSpec
+    from .types import InterfaceCategory
+
+
+class InterfaceRegistry:
+    """Registry of available interface types.
+
+    The registry provides centralized management of interface specifications,
+    enabling lookup by name and filtering by category.
+
+    Attributes:
+        _interfaces: Internal mapping of interface names to specifications.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty registry."""
+        self._interfaces: dict[str, InterfaceSpec] = {}
+
+    def register(self, spec: InterfaceSpec) -> None:
+        """Register an interface specification.
+
+        Args:
+            spec: The interface specification to register.
+
+        Raises:
+            ValueError: If an interface with the same name is already registered.
+        """
+        if spec.name in self._interfaces:
+            raise ValueError(
+                f"Interface '{spec.name}' is already registered. "
+                "Use a unique name or unregister the existing interface first."
+            )
+        self._interfaces[spec.name] = spec
+
+    def unregister(self, name: str) -> bool:
+        """Unregister an interface specification.
+
+        Args:
+            name: The name of the interface to unregister.
+
+        Returns:
+            True if the interface was unregistered, False if it wasn't registered.
+        """
+        if name in self._interfaces:
+            del self._interfaces[name]
+            return True
+        return False
+
+    def get(self, name: str) -> InterfaceSpec | None:
+        """Get interface spec by name.
+
+        Args:
+            name: The interface type name to look up.
+
+        Returns:
+            The interface specification, or None if not found.
+        """
+        return self._interfaces.get(name)
+
+    def list_interfaces(self) -> list[str]:
+        """List all registered interface names.
+
+        Returns:
+            Sorted list of all registered interface type names.
+        """
+        return sorted(self._interfaces.keys())
+
+    def list_by_category(self, category: InterfaceCategory) -> list[str]:
+        """List interfaces in a category.
+
+        Args:
+            category: The category to filter by.
+
+        Returns:
+            Sorted list of interface names in the specified category.
+        """
+        return sorted(
+            name
+            for name, spec in self._interfaces.items()
+            if spec.category == category
+        )
+
+    def __len__(self) -> int:
+        """Return the number of registered interfaces."""
+        return len(self._interfaces)
+
+    def __contains__(self, name: str) -> bool:
+        """Check if an interface is registered."""
+        return name in self._interfaces
+
+
+# Global registry with built-in interfaces
+REGISTRY = InterfaceRegistry()

--- a/src/kicad_tools/intent/types.py
+++ b/src/kicad_tools/intent/types.py
@@ -1,0 +1,102 @@
+"""
+Base types for the intent module.
+
+This module defines the foundational data structures for declaring design
+intent and deriving constraints from interface specifications.
+
+Example::
+
+    from kicad_tools.intent.types import (
+        InterfaceCategory,
+        Constraint,
+        IntentDeclaration,
+    )
+
+    # Create a constraint for USB differential impedance
+    constraint = Constraint(
+        type="impedance",
+        params={"target": 90.0, "tolerance": 0.1},
+        source="usb2_high_speed",
+        severity="error",
+    )
+
+    # Declare intent for a USB interface
+    declaration = IntentDeclaration(
+        interface_type="usb2_high_speed",
+        nets=["USB_DP", "USB_DM"],
+        constraints=[constraint],
+        metadata={"connector": "J1"},
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class InterfaceCategory(Enum):
+    """High-level interface categories.
+
+    Categories group related interface types for organization and filtering.
+    Each category shares common characteristics in terms of signal integrity
+    requirements and routing considerations.
+    """
+
+    DIFFERENTIAL = "differential"  # USB, LVDS, Ethernet
+    BUS = "bus"  # SPI, I2C, parallel
+    SINGLE_ENDED = "single_ended"  # GPIO, analog
+    POWER = "power"  # Power rails
+
+
+class ConstraintSeverity(Enum):
+    """Severity level for constraint violations."""
+
+    ERROR = "error"  # Must be fixed before manufacturing
+    WARNING = "warning"  # Should be reviewed, may be acceptable
+
+
+@dataclass
+class Constraint:
+    """A constraint derived from design intent.
+
+    Constraints are generated from interface specifications and represent
+    concrete design rules that must be satisfied. They link back to their
+    source interface for context-aware error messages.
+
+    Attributes:
+        type: Constraint type identifier (e.g., "impedance", "length_match").
+        params: Constraint parameters specific to the type.
+        source: Interface type that generated this constraint.
+        severity: Whether violations are errors or warnings.
+    """
+
+    type: str
+    params: dict[str, object]
+    source: str
+    severity: ConstraintSeverity | str
+
+    def __post_init__(self) -> None:
+        """Convert string severity to enum if needed."""
+        if isinstance(self.severity, str):
+            self.severity = ConstraintSeverity(self.severity)
+
+
+@dataclass
+class IntentDeclaration:
+    """A declared design intent for a set of nets.
+
+    An intent declaration associates a group of nets with an interface type,
+    along with the constraints derived from that interface specification.
+
+    Attributes:
+        interface_type: Interface type name (e.g., "usb2_high_speed").
+        nets: List of net names affected by this intent.
+        constraints: Constraints derived from the interface specification.
+        metadata: Additional context about the declaration.
+    """
+
+    interface_type: str
+    nets: list[str]
+    constraints: list[Constraint] = field(default_factory=list)
+    metadata: dict[str, object] = field(default_factory=dict)

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -1,0 +1,457 @@
+"""
+Unit tests for the intent module.
+
+Tests cover:
+- InterfaceCategory enumeration
+- ConstraintSeverity enumeration
+- Constraint dataclass
+- IntentDeclaration dataclass
+- InterfaceRegistry operations
+- Constraint derivation functions
+"""
+
+import pytest
+
+from kicad_tools.intent import (
+    REGISTRY,
+    Constraint,
+    ConstraintSeverity,
+    IntentDeclaration,
+    InterfaceCategory,
+    InterfaceRegistry,
+    InterfaceSpec,
+    create_intent_declaration,
+    derive_constraints,
+    validate_intent,
+)
+
+
+class TestInterfaceCategory:
+    """Tests for InterfaceCategory enumeration."""
+
+    def test_category_values(self):
+        """Test InterfaceCategory enum values."""
+        assert InterfaceCategory.DIFFERENTIAL.value == "differential"
+        assert InterfaceCategory.BUS.value == "bus"
+        assert InterfaceCategory.SINGLE_ENDED.value == "single_ended"
+        assert InterfaceCategory.POWER.value == "power"
+
+    def test_category_from_string(self):
+        """Test creating InterfaceCategory from string value."""
+        assert InterfaceCategory("differential") == InterfaceCategory.DIFFERENTIAL
+        assert InterfaceCategory("bus") == InterfaceCategory.BUS
+        assert InterfaceCategory("single_ended") == InterfaceCategory.SINGLE_ENDED
+        assert InterfaceCategory("power") == InterfaceCategory.POWER
+
+
+class TestConstraintSeverity:
+    """Tests for ConstraintSeverity enumeration."""
+
+    def test_severity_values(self):
+        """Test ConstraintSeverity enum values."""
+        assert ConstraintSeverity.ERROR.value == "error"
+        assert ConstraintSeverity.WARNING.value == "warning"
+
+    def test_severity_from_string(self):
+        """Test creating ConstraintSeverity from string value."""
+        assert ConstraintSeverity("error") == ConstraintSeverity.ERROR
+        assert ConstraintSeverity("warning") == ConstraintSeverity.WARNING
+
+
+class TestConstraint:
+    """Tests for Constraint dataclass."""
+
+    def test_constraint_creation(self):
+        """Test creating a Constraint."""
+        constraint = Constraint(
+            type="impedance",
+            params={"target": 90.0, "tolerance": 0.1},
+            source="usb2_high_speed",
+            severity=ConstraintSeverity.ERROR,
+        )
+        assert constraint.type == "impedance"
+        assert constraint.params == {"target": 90.0, "tolerance": 0.1}
+        assert constraint.source == "usb2_high_speed"
+        assert constraint.severity == ConstraintSeverity.ERROR
+
+    def test_constraint_with_string_severity(self):
+        """Test Constraint with string severity (auto-converted)."""
+        constraint = Constraint(
+            type="length_match",
+            params={"tolerance_mm": 2.0},
+            source="usb2_high_speed",
+            severity="warning",
+        )
+        assert constraint.severity == ConstraintSeverity.WARNING
+
+    def test_constraint_with_enum_severity(self):
+        """Test Constraint with enum severity."""
+        constraint = Constraint(
+            type="spacing",
+            params={"min_mm": 0.2},
+            source="spi",
+            severity=ConstraintSeverity.ERROR,
+        )
+        assert constraint.severity == ConstraintSeverity.ERROR
+
+
+class TestIntentDeclaration:
+    """Tests for IntentDeclaration dataclass."""
+
+    def test_declaration_creation(self):
+        """Test creating an IntentDeclaration."""
+        declaration = IntentDeclaration(
+            interface_type="usb2_high_speed",
+            nets=["USB_DP", "USB_DM"],
+        )
+        assert declaration.interface_type == "usb2_high_speed"
+        assert declaration.nets == ["USB_DP", "USB_DM"]
+        assert declaration.constraints == []
+        assert declaration.metadata == {}
+
+    def test_declaration_with_constraints(self):
+        """Test IntentDeclaration with constraints."""
+        constraints = [
+            Constraint(
+                type="impedance",
+                params={"target": 90.0},
+                source="usb2_high_speed",
+                severity="error",
+            )
+        ]
+        declaration = IntentDeclaration(
+            interface_type="usb2_high_speed",
+            nets=["USB_DP", "USB_DM"],
+            constraints=constraints,
+        )
+        assert len(declaration.constraints) == 1
+        assert declaration.constraints[0].type == "impedance"
+
+    def test_declaration_with_metadata(self):
+        """Test IntentDeclaration with metadata."""
+        declaration = IntentDeclaration(
+            interface_type="usb2_high_speed",
+            nets=["USB_DP", "USB_DM"],
+            metadata={"connector": "J1", "layer": "top"},
+        )
+        assert declaration.metadata == {"connector": "J1", "layer": "top"}
+
+
+class MockUSBSpec:
+    """Mock USB interface specification for testing."""
+
+    @property
+    def name(self) -> str:
+        return "usb2_high_speed"
+
+    @property
+    def category(self) -> InterfaceCategory:
+        return InterfaceCategory.DIFFERENTIAL
+
+    def validate_nets(self, nets: list[str]) -> list[str]:
+        if len(nets) != 2:
+            return ["USB 2.0 High Speed requires exactly 2 nets (D+ and D-)"]
+        return []
+
+    def derive_constraints(
+        self, nets: list[str], params: dict[str, object]
+    ) -> list[Constraint]:
+        return [
+            Constraint(
+                type="impedance",
+                params={"target": 90.0, "tolerance": 0.1},
+                source=self.name,
+                severity="error",
+            ),
+            Constraint(
+                type="length_match",
+                params={"tolerance_mm": 2.0},
+                source=self.name,
+                severity="warning",
+            ),
+        ]
+
+    def get_validation_message(self, violation: dict[str, object]) -> str:
+        return f"USB 2.0 HS: {violation.get('message', '')}"
+
+
+class MockSPISpec:
+    """Mock SPI interface specification for testing."""
+
+    @property
+    def name(self) -> str:
+        return "spi"
+
+    @property
+    def category(self) -> InterfaceCategory:
+        return InterfaceCategory.BUS
+
+    def validate_nets(self, nets: list[str]) -> list[str]:
+        if len(nets) < 3:
+            return ["SPI requires at least 3 nets (CLK, MOSI, MISO)"]
+        return []
+
+    def derive_constraints(
+        self, nets: list[str], params: dict[str, object]
+    ) -> list[Constraint]:
+        return [
+            Constraint(
+                type="timing",
+                params={"max_skew_ns": 1.0},
+                source=self.name,
+                severity="error",
+            ),
+        ]
+
+    def get_validation_message(self, violation: dict[str, object]) -> str:
+        return f"SPI: {violation.get('message', '')}"
+
+
+class MockPowerSpec:
+    """Mock power interface specification for testing."""
+
+    @property
+    def name(self) -> str:
+        return "power_3v3"
+
+    @property
+    def category(self) -> InterfaceCategory:
+        return InterfaceCategory.POWER
+
+    def validate_nets(self, nets: list[str]) -> list[str]:
+        return []
+
+    def derive_constraints(
+        self, nets: list[str], params: dict[str, object]
+    ) -> list[Constraint]:
+        return []
+
+    def get_validation_message(self, violation: dict[str, object]) -> str:
+        return f"Power 3.3V: {violation.get('message', '')}"
+
+
+class TestInterfaceRegistry:
+    """Tests for InterfaceRegistry."""
+
+    def test_registry_creation(self):
+        """Test creating an empty registry."""
+        registry = InterfaceRegistry()
+        assert len(registry) == 0
+        assert registry.list_interfaces() == []
+
+    def test_register_interface(self):
+        """Test registering an interface specification."""
+        registry = InterfaceRegistry()
+        spec = MockUSBSpec()
+        registry.register(spec)
+        assert len(registry) == 1
+        assert "usb2_high_speed" in registry
+        assert registry.list_interfaces() == ["usb2_high_speed"]
+
+    def test_register_duplicate_raises(self):
+        """Test that registering duplicate interface raises ValueError."""
+        registry = InterfaceRegistry()
+        spec = MockUSBSpec()
+        registry.register(spec)
+        with pytest.raises(ValueError, match="already registered"):
+            registry.register(spec)
+
+    def test_get_interface(self):
+        """Test getting an interface by name."""
+        registry = InterfaceRegistry()
+        spec = MockUSBSpec()
+        registry.register(spec)
+        retrieved = registry.get("usb2_high_speed")
+        assert retrieved is not None
+        assert retrieved.name == "usb2_high_speed"
+
+    def test_get_nonexistent_returns_none(self):
+        """Test getting a nonexistent interface returns None."""
+        registry = InterfaceRegistry()
+        assert registry.get("nonexistent") is None
+
+    def test_unregister_interface(self):
+        """Test unregistering an interface."""
+        registry = InterfaceRegistry()
+        spec = MockUSBSpec()
+        registry.register(spec)
+        assert registry.unregister("usb2_high_speed") is True
+        assert "usb2_high_speed" not in registry
+        assert len(registry) == 0
+
+    def test_unregister_nonexistent_returns_false(self):
+        """Test unregistering nonexistent interface returns False."""
+        registry = InterfaceRegistry()
+        assert registry.unregister("nonexistent") is False
+
+    def test_list_interfaces_sorted(self):
+        """Test that list_interfaces returns sorted names."""
+        registry = InterfaceRegistry()
+        registry.register(MockSPISpec())
+        registry.register(MockUSBSpec())
+        registry.register(MockPowerSpec())
+        assert registry.list_interfaces() == ["power_3v3", "spi", "usb2_high_speed"]
+
+    def test_list_by_category(self):
+        """Test listing interfaces by category."""
+        registry = InterfaceRegistry()
+        registry.register(MockUSBSpec())
+        registry.register(MockSPISpec())
+        registry.register(MockPowerSpec())
+
+        differential = registry.list_by_category(InterfaceCategory.DIFFERENTIAL)
+        assert differential == ["usb2_high_speed"]
+
+        bus = registry.list_by_category(InterfaceCategory.BUS)
+        assert bus == ["spi"]
+
+        power = registry.list_by_category(InterfaceCategory.POWER)
+        assert power == ["power_3v3"]
+
+        single_ended = registry.list_by_category(InterfaceCategory.SINGLE_ENDED)
+        assert single_ended == []
+
+    def test_contains_operator(self):
+        """Test the 'in' operator."""
+        registry = InterfaceRegistry()
+        registry.register(MockUSBSpec())
+        assert "usb2_high_speed" in registry
+        assert "nonexistent" not in registry
+
+
+class TestConstraintDerivation:
+    """Tests for constraint derivation functions."""
+
+    @pytest.fixture
+    def registry(self):
+        """Create a registry with mock interfaces."""
+        reg = InterfaceRegistry()
+        reg.register(MockUSBSpec())
+        reg.register(MockSPISpec())
+        return reg
+
+    def test_derive_constraints(self, registry):
+        """Test deriving constraints from an interface."""
+        constraints = derive_constraints(
+            interface_type="usb2_high_speed",
+            nets=["USB_DP", "USB_DM"],
+            registry=registry,
+        )
+        assert len(constraints) == 2
+        assert constraints[0].type == "impedance"
+        assert constraints[1].type == "length_match"
+
+    def test_derive_constraints_with_params(self, registry):
+        """Test deriving constraints with params."""
+        constraints = derive_constraints(
+            interface_type="spi",
+            nets=["CLK", "MOSI", "MISO"],
+            params={"speed_mhz": 10},
+            registry=registry,
+        )
+        assert len(constraints) == 1
+        assert constraints[0].type == "timing"
+
+    def test_derive_constraints_unknown_interface(self, registry):
+        """Test that unknown interface raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown interface type"):
+            derive_constraints(
+                interface_type="unknown",
+                nets=["A", "B"],
+                registry=registry,
+            )
+
+    def test_validate_intent_valid(self, registry):
+        """Test validating a valid intent."""
+        errors = validate_intent(
+            interface_type="usb2_high_speed",
+            nets=["USB_DP", "USB_DM"],
+            registry=registry,
+        )
+        assert errors == []
+
+    def test_validate_intent_invalid_net_count(self, registry):
+        """Test validating intent with wrong number of nets."""
+        errors = validate_intent(
+            interface_type="usb2_high_speed",
+            nets=["USB_DP"],  # Only 1 net, need 2
+            registry=registry,
+        )
+        assert len(errors) == 1
+        assert "exactly 2 nets" in errors[0]
+
+    def test_validate_intent_unknown_interface(self, registry):
+        """Test validating unknown interface raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown interface type"):
+            validate_intent(
+                interface_type="unknown",
+                nets=["A", "B"],
+                registry=registry,
+            )
+
+    def test_create_intent_declaration(self, registry):
+        """Test creating an intent declaration."""
+        declaration = create_intent_declaration(
+            interface_type="usb2_high_speed",
+            nets=["USB_DP", "USB_DM"],
+            metadata={"connector": "J1"},
+            registry=registry,
+        )
+        assert declaration.interface_type == "usb2_high_speed"
+        assert declaration.nets == ["USB_DP", "USB_DM"]
+        assert len(declaration.constraints) == 2
+        assert declaration.metadata == {"connector": "J1"}
+
+    def test_create_intent_declaration_validation_fails(self, registry):
+        """Test that create_intent_declaration validates by default."""
+        with pytest.raises(ValueError, match="Invalid intent declaration"):
+            create_intent_declaration(
+                interface_type="usb2_high_speed",
+                nets=["USB_DP"],  # Wrong number of nets
+                registry=registry,
+            )
+
+    def test_create_intent_declaration_skip_validation(self, registry):
+        """Test creating declaration with validation disabled."""
+        declaration = create_intent_declaration(
+            interface_type="usb2_high_speed",
+            nets=["USB_DP"],  # Wrong number, but validation disabled
+            registry=registry,
+            validate=False,
+        )
+        assert len(declaration.nets) == 1
+
+
+class TestGlobalRegistry:
+    """Tests for the global REGISTRY instance."""
+
+    def test_global_registry_exists(self):
+        """Test that global REGISTRY exists."""
+        assert REGISTRY is not None
+        assert isinstance(REGISTRY, InterfaceRegistry)
+
+    def test_global_registry_initially_empty(self):
+        """Test that global REGISTRY starts empty (no built-in interfaces yet)."""
+        # Note: Future issues will add built-in interfaces
+        # For now, we just verify it's an InterfaceRegistry
+        pass
+
+
+class TestInterfaceSpecProtocol:
+    """Tests for InterfaceSpec protocol compliance."""
+
+    def test_mock_usb_implements_protocol(self):
+        """Test that MockUSBSpec implements InterfaceSpec protocol."""
+        spec = MockUSBSpec()
+        # Protocol requires these attributes/methods
+        assert hasattr(spec, "name")
+        assert hasattr(spec, "category")
+        assert hasattr(spec, "validate_nets")
+        assert hasattr(spec, "derive_constraints")
+        assert hasattr(spec, "get_validation_message")
+        # Verify they work
+        assert spec.name == "usb2_high_speed"
+        assert spec.category == InterfaceCategory.DIFFERENTIAL
+        assert spec.validate_nets(["A", "B"]) == []
+        assert len(spec.derive_constraints(["A", "B"], {})) == 2
+        assert "USB 2.0" in spec.get_validation_message({"message": "test"})


### PR DESCRIPTION
## Summary

- Creates foundational `intent` module with base types and interface protocol
- Implements `InterfaceCategory` enum for categorizing interfaces (DIFFERENTIAL, BUS, SINGLE_ENDED, POWER)
- Adds `Constraint` and `IntentDeclaration` dataclasses for representing design intent
- Defines `InterfaceSpec` protocol that all interface implementations must follow
- Implements `InterfaceRegistry` for registering and looking up interface types
- Adds constraint derivation utilities (`derive_constraints`, `validate_intent`, `create_intent_declaration`)

## Test plan

- [x] All 32 unit tests pass
- [x] Module imports correctly
- [x] Types are properly defined with full type hints
- [ ] Verify documentation is clear and accurate

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)