### PR TITLE
feat: Add --format jlcpcb to BOM export

### DIFF
--- a/src/kicad_tools/cli/interactive.py
+++ b/src/kicad_tools/cli/interactive.py
@@ -196,7 +196,7 @@ Type 'help' for available commands, 'quit' to exit.
     def do_bom(self, arg: str) -> None:
         """Generate bill of materials from loaded schematic.
 
-        Usage: bom [--format table|csv|json] [--group]
+        Usage: bom [--format table|csv|json|jlcpcb] [--group]
 
         Requires a schematic to be loaded first.
         """

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -320,7 +320,12 @@ def _add_bom_parser(subparsers) -> None:
     """Add BOM subcommand parser."""
     bom_parser = subparsers.add_parser("bom", help="Generate bill of materials")
     bom_parser.add_argument("schematic", help="Path to .kicad_sch file")
-    bom_parser.add_argument("--format", choices=["table", "csv", "json"], default="table")
+    bom_parser.add_argument(
+        "--format",
+        choices=["table", "csv", "json", "jlcpcb"],
+        default="table",
+        help="Output format (jlcpcb: JLCPCB assembly BOM)",
+    )
     bom_parser.add_argument("--group", action="store_true", help="Group identical components")
     bom_parser.add_argument(
         "--exclude", action="append", default=[], help="Exclude references matching pattern"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -335,6 +335,23 @@ class TestBOMCommand:
         data = json.loads(captured.out)
         assert isinstance(data, (list, dict))
 
+    def test_bom_jlcpcb_format(self, simple_rc_schematic: Path, capsys):
+        """Test bom command with JLCPCB assembly format."""
+        from kicad_tools.cli import main
+
+        result = main(["bom", str(simple_rc_schematic), "--format", "jlcpcb"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        # Should have JLCPCB headers
+        lines = captured.out.strip().split("\n")
+        assert len(lines) >= 1  # At least header
+        header = lines[0]
+        assert "Comment" in header
+        assert "Designator" in header
+        assert "Footprint" in header
+        assert "LCSC" in header
+
     def test_bom_group(self, simple_rc_schematic: Path, capsys):
         """Test bom command with grouping."""
         from kicad_tools.cli import main

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -171,6 +171,17 @@ class TestBomCmdMain:
         data = json.loads(captured.out)
         assert "items" in data
 
+    def test_main_jlcpcb_format(self, simple_rc_schematic, capsys):
+        """Main with JLCPCB assembly format."""
+        result = bom_cmd.main([str(simple_rc_schematic), "--format", "jlcpcb"])
+        assert result == 0
+        captured = capsys.readouterr()
+        # Should have JLCPCB headers
+        assert "Comment" in captured.out
+        assert "Designator" in captured.out
+        assert "Footprint" in captured.out
+        assert "LCSC Part #" in captured.out
+
     def test_main_grouped(self, simple_rc_schematic, capsys):
         """Main with grouping enabled."""
         result = bom_cmd.main([str(simple_rc_schematic), "--group"])


### PR DESCRIPTION
## Summary
- Adds `--format jlcpcb` option to the `kct bom` command
- Exports BOM in JLCPCB assembly format with headers: Comment, Designator, Footprint, LCSC Part #
- Wires up the existing `JLCPCBBOMFormatter` from `bom_formats.py` to the CLI interface

## Test plan
- [x] Run `kct bom project.kicad_sch --format jlcpcb` and verify output format
- [x] Verify JLCPCB headers are present: Comment, Designator, Footprint, LCSC Part #
- [x] Run existing BOM tests to ensure no regressions
- [x] Verify new JLCPCB format tests pass

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)