### PR TITLE
feat(intent): Add SPI, I2C, and Power interface specifications

### DIFF
--- a/src/kicad_tools/intent/interfaces/__init__.py
+++ b/src/kicad_tools/intent/interfaces/__init__.py
@@ -10,9 +10,12 @@ interfaces like USB, SPI, I2C, etc. Each interface spec defines:
 
 Available interface specifications:
     - USB: usb2_low_speed, usb2_full_speed, usb2_high_speed, usb3_gen1, usb3_gen2
+    - SPI: spi_standard, spi_fast, spi_high_speed
+    - I2C: i2c_standard, i2c_fast, i2c_fast_plus
+    - Power: power_rail
 """
 
 # Import interface modules to trigger registration
-from . import usb
+from . import i2c, power, spi, usb
 
-__all__ = ["usb"]
+__all__ = ["i2c", "power", "spi", "usb"]

--- a/src/kicad_tools/intent/interfaces/i2c.py
+++ b/src/kicad_tools/intent/interfaces/i2c.py
@@ -1,0 +1,312 @@
+"""
+I2C interface specifications.
+
+This module implements I2C interface specifications for all common I2C variants,
+from Standard Mode (100kHz) through Fast Mode Plus (1MHz). Each variant defines
+appropriate constraints for bus capacitance, pull-up resistors, and routing.
+
+Example::
+
+    from kicad_tools.intent import REGISTRY, create_intent_declaration
+
+    # Create an I2C Fast Mode declaration
+    declaration = create_intent_declaration(
+        interface_type="i2c_fast",
+        nets=["I2C_SDA", "I2C_SCL"],
+        metadata={"device": "U1"},
+    )
+
+    # Constraints are automatically derived
+    for constraint in declaration.constraints:
+        print(f"{constraint.type}: {constraint.params}")
+
+I2C Interface Features:
+
+    | Feature           | Standard (100kHz) | Fast (400kHz)  | Fast+ (1MHz)   |
+    |-------------------|-------------------|----------------|----------------|
+    | Max capacitance   | 400pF             | 400pF          | 550pF          |
+    | Rise time         | 1000ns            | 300ns          | 120ns          |
+    | Pull-up resistor  | 4.7kΩ             | 2.2kΩ          | 1kΩ            |
+    | Max trace length  | ~1m               | ~0.5m          | ~0.3m          |
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from ..registry import REGISTRY
+from ..types import Constraint, InterfaceCategory
+
+
+@dataclass
+class I2CVariant:
+    """Configuration for an I2C variant.
+
+    Attributes:
+        freq: Clock frequency in Hz.
+        max_capacitance_pf: Maximum bus capacitance in pF.
+        rise_time_ns: Maximum rise time in nanoseconds.
+        pullup_ohms: Typical pull-up resistor value in ohms.
+        max_trace_length_mm: Maximum recommended trace length in mm.
+    """
+
+    freq: float
+    max_capacitance_pf: float
+    rise_time_ns: float
+    pullup_ohms: float
+    max_trace_length_mm: float
+
+
+# I2C variant specifications
+I2C_VARIANTS: dict[str, I2CVariant] = {
+    "i2c_standard": I2CVariant(
+        freq=100e3,
+        max_capacitance_pf=400.0,
+        rise_time_ns=1000.0,
+        pullup_ohms=4700.0,
+        max_trace_length_mm=1000.0,  # ~1m
+    ),
+    "i2c_fast": I2CVariant(
+        freq=400e3,
+        max_capacitance_pf=400.0,
+        rise_time_ns=300.0,
+        pullup_ohms=2200.0,
+        max_trace_length_mm=500.0,  # ~0.5m
+    ),
+    "i2c_fast_plus": I2CVariant(
+        freq=1e6,
+        max_capacitance_pf=550.0,
+        rise_time_ns=120.0,
+        pullup_ohms=1000.0,
+        max_trace_length_mm=300.0,  # ~0.3m
+    ),
+}
+
+
+class I2CInterfaceSpec:
+    """I2C interface specification.
+
+    Implements the InterfaceSpec protocol for I2C interfaces. Supports
+    Standard Mode (100kHz), Fast Mode (400kHz), and Fast Mode Plus (1MHz).
+
+    The variant is determined by the ``variant`` parameter passed to
+    :meth:`derive_constraints`. If not specified, defaults to ``i2c_standard``.
+
+    Attributes:
+        _variant_name: The I2C variant name (e.g., "i2c_standard").
+        _variant: The variant configuration.
+    """
+
+    VARIANTS: ClassVar[dict[str, I2CVariant]] = I2C_VARIANTS
+
+    def __init__(self, variant_name: str = "i2c_standard") -> None:
+        """Initialize I2C interface spec for a specific variant.
+
+        Args:
+            variant_name: I2C variant name. One of: i2c_standard, i2c_fast,
+                i2c_fast_plus.
+
+        Raises:
+            ValueError: If the variant name is not recognized.
+        """
+        if variant_name not in self.VARIANTS:
+            valid = ", ".join(sorted(self.VARIANTS.keys()))
+            raise ValueError(f"Unknown I2C variant: '{variant_name}'. Valid variants: {valid}")
+        self._variant_name = variant_name
+        self._variant = self.VARIANTS[variant_name]
+
+    @property
+    def name(self) -> str:
+        """Interface type name (e.g., 'i2c_standard')."""
+        return self._variant_name
+
+    @property
+    def category(self) -> InterfaceCategory:
+        """Interface category (BUS for all I2C variants)."""
+        return InterfaceCategory.BUS
+
+    def validate_nets(self, nets: list[str]) -> list[str]:
+        """Validate net names/count for I2C interface.
+
+        I2C interfaces require exactly 2 nets (SDA and SCL).
+
+        Args:
+            nets: List of net names to validate.
+
+        Returns:
+            List of validation error messages. Empty list if valid.
+        """
+        errors: list[str] = []
+        if len(nets) != 2:
+            errors.append(
+                f"I2C {self._variant_name} requires exactly 2 nets (SDA and SCL), got {len(nets)}"
+            )
+        return errors
+
+    def derive_constraints(self, nets: list[str], params: dict[str, Any]) -> list[Constraint]:
+        """Derive constraints from I2C interface declaration.
+
+        Generates constraints based on the I2C variant requirements:
+        - Bus capacitance limit (affects trace length)
+        - Pull-up resistor requirements
+        - Maximum trace length
+
+        Args:
+            nets: List of net names (should be exactly 2 for I2C SDA/SCL).
+            params: Additional parameters. Supports:
+                - variant: Override variant (default uses instance variant)
+
+        Returns:
+            List of constraints derived from the I2C specification.
+        """
+        # Allow runtime variant override via params
+        variant_name = params.get("variant", self._variant_name)
+        if isinstance(variant_name, str) and variant_name in self.VARIANTS:
+            variant = self.VARIANTS[variant_name]
+            source = f"i2c:{variant_name}"
+        else:
+            variant = self._variant
+            source = f"i2c:{self._variant_name}"
+
+        constraints: list[Constraint] = []
+
+        # Bus capacitance constraint
+        constraints.append(
+            Constraint(
+                type="max_capacitance",
+                params={
+                    "nets": nets,
+                    "max_pf": variant.max_capacitance_pf,
+                },
+                source=source,
+                severity="warning",
+            )
+        )
+
+        # Pull-up resistor requirement
+        constraints.append(
+            Constraint(
+                type="requires_pullup",
+                params={
+                    "nets": nets,
+                    "typical_ohms": variant.pullup_ohms,
+                },
+                source=source,
+                severity="warning",
+            )
+        )
+
+        # Maximum trace length constraint
+        constraints.append(
+            Constraint(
+                type="max_length",
+                params={
+                    "nets": nets,
+                    "max_mm": variant.max_trace_length_mm,
+                },
+                source=source,
+                severity="warning",
+            )
+        )
+
+        return constraints
+
+    def get_validation_message(self, violation: dict[str, Any]) -> str:
+        """Convert generic DRC violation to I2C-aware message.
+
+        Provides context-aware error messages that explain violations in terms
+        of I2C bus requirements.
+
+        Args:
+            violation: Dictionary containing violation details. Expected keys vary
+                by violation type:
+                - capacitance: {"type": "capacitance", "actual": <pF>}
+                - max_length: {"type": "max_length", "actual": <mm>}
+                - pullup: {"type": "pullup", "missing": True}
+
+        Returns:
+            Human-readable message explaining the violation in I2C context.
+        """
+        violation_type = violation.get("type", "")
+        variant = self._variant
+
+        if violation_type == "capacitance":
+            actual = violation.get("actual", "?")
+            max_cap = variant.max_capacitance_pf
+            freq_str = self._format_freq(variant.freq)
+            return (
+                f"I2C bus capacitance {actual}pF exceeds maximum {max_cap}pF. "
+                f"At {freq_str}, excessive capacitance will slow rise times "
+                f"and may cause communication failures."
+            )
+
+        if violation_type == "max_length":
+            actual = violation.get("actual", "?")
+            max_len = variant.max_trace_length_mm
+            return (
+                f"I2C trace length {actual}mm exceeds recommended maximum {max_len}mm. "
+                f"Long traces increase capacitance and may require stronger pull-ups."
+            )
+
+        if violation_type == "pullup":
+            pullup = variant.pullup_ohms
+            pullup_str = self._format_resistance(pullup)
+            return (
+                f"I2C bus requires pull-up resistors on SDA and SCL. "
+                f"For {self._variant_name.replace('_', ' ')}, typical value is {pullup_str}."
+            )
+
+        if violation_type == "rise_time":
+            actual = violation.get("actual", "?")
+            max_rise = variant.rise_time_ns
+            return (
+                f"I2C rise time {actual}ns exceeds specification {max_rise}ns. "
+                f"Use lower pull-up resistor values or reduce bus capacitance."
+            )
+
+        # Fallback for unknown violation types
+        return violation.get("message", str(violation))
+
+    @staticmethod
+    def _format_freq(freq: float) -> str:
+        """Format frequency in human-readable form.
+
+        Args:
+            freq: Frequency in Hz.
+
+        Returns:
+            Formatted string (e.g., "100kHz", "1MHz").
+        """
+        if freq >= 1e6:
+            return f"{freq / 1e6:.0f}MHz"
+        return f"{freq / 1e3:.0f}kHz"
+
+    @staticmethod
+    def _format_resistance(ohms: float) -> str:
+        """Format resistance in human-readable form.
+
+        Args:
+            ohms: Resistance in ohms.
+
+        Returns:
+            Formatted string (e.g., "4.7kΩ", "1kΩ").
+        """
+        if ohms >= 1000:
+            value = ohms / 1000
+            if value == int(value):
+                return f"{int(value)}kΩ"
+            return f"{value:.1f}kΩ"
+        return f"{int(ohms)}Ω"
+
+
+# Register all I2C variants in the global registry
+def _register_i2c_interfaces() -> None:
+    """Register all I2C interface variants in the global registry."""
+    for variant_name in I2C_VARIANTS:
+        spec = I2CInterfaceSpec(variant_name)
+        REGISTRY.register(spec)
+
+
+# Auto-register on module import
+_register_i2c_interfaces()

--- a/src/kicad_tools/intent/interfaces/power.py
+++ b/src/kicad_tools/intent/interfaces/power.py
@@ -1,0 +1,261 @@
+"""
+Power interface specifications.
+
+This module implements power rail interface specifications for common power
+delivery scenarios. It provides constraints for trace width based on current
+requirements and decoupling capacitor recommendations.
+
+Example::
+
+    from kicad_tools.intent import REGISTRY, create_intent_declaration
+
+    # Create a 3.3V power rail declaration
+    declaration = create_intent_declaration(
+        interface_type="power_rail",
+        nets=["VCC_3V3"],
+        params={"voltage": 3.3, "max_current": 0.5},
+        metadata={"source": "U1"},
+    )
+
+    # Constraints are automatically derived
+    for constraint in declaration.constraints:
+        print(f"{constraint.type}: {constraint.params}")
+
+Power Rail Constraints:
+
+    | Current | Min Width (1oz Cu) | Decoupling                  |
+    |---------|--------------------|-----------------------------|
+    | ≤100mA  | 0.15mm             | 100nF                       |
+    | ≤500mA  | 0.25mm             | 100nF + 10µF                |
+    | ≤1A     | 0.4mm              | 100nF + 10µF + 47µF         |
+    | ≤2A     | 0.7mm              | Bulk + ceramic array        |
+
+Note:
+    Trace width calculations use IPC-2221 approximations for 1oz copper
+    with 10°C temperature rise. Actual requirements depend on copper weight,
+    ambient temperature, and acceptable temperature rise.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from ..registry import REGISTRY
+from ..types import Constraint, InterfaceCategory
+
+
+class PowerInterfaceSpec:
+    """Power rail interface specification.
+
+    Implements the InterfaceSpec protocol for power rail interfaces. Generates
+    constraints based on voltage and current requirements including trace width
+    and decoupling capacitors.
+
+    Unlike other interface specs, PowerInterfaceSpec doesn't have predefined
+    variants. Instead, constraints are derived dynamically from parameters like
+    voltage and max_current.
+    """
+
+    # Current thresholds for decoupling recommendations (in amps)
+    _DECOUPLING_THRESHOLDS: ClassVar[list[tuple[float, list[dict[str, Any]]]]] = [
+        (0.1, [{"value": "100nF", "count": 1}]),
+        (0.5, [{"value": "100nF", "count": 1}, {"value": "10uF", "count": 1}]),
+        (
+            1.0,
+            [
+                {"value": "100nF", "count": 1},
+                {"value": "10uF", "count": 1},
+                {"value": "47uF", "count": 1},
+            ],
+        ),
+        (
+            2.0,
+            [
+                {"value": "100nF", "count": 2},
+                {"value": "10uF", "count": 2},
+                {"value": "47uF", "count": 1},
+                {"value": "100uF", "count": 1},
+            ],
+        ),
+    ]
+
+    def __init__(self) -> None:
+        """Initialize power rail interface spec."""
+
+    @property
+    def name(self) -> str:
+        """Interface type name."""
+        return "power_rail"
+
+    @property
+    def category(self) -> InterfaceCategory:
+        """Interface category (POWER for power rails)."""
+        return InterfaceCategory.POWER
+
+    def validate_nets(self, nets: list[str]) -> list[str]:
+        """Validate net names/count for power rail interface.
+
+        Power rail declarations require exactly 1 net (the power rail).
+
+        Args:
+            nets: List of net names to validate.
+
+        Returns:
+            List of validation error messages. Empty list if valid.
+        """
+        errors: list[str] = []
+        if len(nets) != 1:
+            errors.append(f"Power rail declaration requires exactly 1 net, got {len(nets)}")
+        return errors
+
+    def derive_constraints(self, nets: list[str], params: dict[str, Any]) -> list[Constraint]:
+        """Derive constraints from power rail declaration.
+
+        Generates constraints based on the power rail requirements:
+        - Minimum trace width based on current
+        - Decoupling capacitor requirements based on current
+
+        Args:
+            nets: List of net names (should be exactly 1 for power rail).
+            params: Parameters for constraint generation:
+                - voltage: Rail voltage in volts (optional, for context)
+                - max_current: Maximum current in amps (default: 0.5A)
+
+        Returns:
+            List of constraints derived from the power specification.
+        """
+        source = "power_rail"
+        constraints: list[Constraint] = []
+
+        voltage = params.get("voltage")
+        current = params.get("max_current", 0.5)
+
+        # Trace width for current capacity
+        min_width = self._width_for_current(current)
+        constraints.append(
+            Constraint(
+                type="min_trace_width",
+                params={
+                    "net": nets[0] if nets else None,
+                    "min_mm": min_width,
+                    "current": current,
+                },
+                source=source,
+                severity="error",
+            )
+        )
+
+        # Decoupling capacitor requirements
+        decoupling_spec = self._decoupling_spec(current)
+        decoupling_params: dict[str, Any] = {
+            "net": nets[0] if nets else None,
+            "capacitors": decoupling_spec,
+        }
+        if voltage is not None:
+            decoupling_params["voltage"] = voltage
+
+        constraints.append(
+            Constraint(
+                type="requires_decoupling",
+                params=decoupling_params,
+                source=source,
+                severity="warning",
+            )
+        )
+
+        return constraints
+
+    def get_validation_message(self, violation: dict[str, Any]) -> str:
+        """Convert generic DRC violation to power-aware message.
+
+        Provides context-aware error messages that explain violations in terms
+        of power delivery requirements.
+
+        Args:
+            violation: Dictionary containing violation details. Expected keys vary
+                by violation type:
+                - trace_width: {"type": "trace_width", "actual": <mm>, "required": <mm>}
+                - decoupling: {"type": "decoupling", "missing": <list>}
+
+        Returns:
+            Human-readable message explaining the violation in power context.
+        """
+        violation_type = violation.get("type", "")
+
+        if violation_type == "trace_width":
+            actual = violation.get("actual", "?")
+            required = violation.get("required", "?")
+            current = violation.get("current", "?")
+            return (
+                f"Power trace width {actual}mm is less than required {required}mm "
+                f"for {current}A. Insufficient trace width may cause excessive "
+                f"voltage drop and overheating."
+            )
+
+        if violation_type == "decoupling":
+            missing = violation.get("missing", [])
+            if missing:
+                caps_str = ", ".join(str(c) for c in missing)
+                return (
+                    f"Power rail missing recommended decoupling capacitors: {caps_str}. "
+                    f"Add capacitors near power pins for proper voltage regulation."
+                )
+            return "Power rail requires decoupling capacitors near load."
+
+        if violation_type == "voltage_drop":
+            drop = violation.get("drop", "?")
+            max_drop = violation.get("max_allowed", "?")
+            return (
+                f"Power rail voltage drop {drop}V exceeds maximum {max_drop}V. "
+                f"Increase trace width or use power planes."
+            )
+
+        # Fallback for unknown violation types
+        return violation.get("message", str(violation))
+
+    @staticmethod
+    def _width_for_current(amps: float) -> float:
+        """Calculate minimum trace width for given current.
+
+        Uses IPC-2221 approximation for 1oz copper with 10°C temperature rise.
+        This is a simplified calculation; actual requirements depend on copper
+        weight, ambient temperature, and acceptable temperature rise.
+
+        Args:
+            amps: Current in amperes.
+
+        Returns:
+            Minimum trace width in mm.
+        """
+        # IPC-2221 approximation for external traces, 1oz copper, 10°C rise
+        # Width (mm) ≈ 0.1 + (current * 0.3)
+        # This is conservative for typical PCB applications
+        return round(0.1 + (amps * 0.3), 2)
+
+    def _decoupling_spec(self, current: float) -> list[dict[str, Any]]:
+        """Recommend decoupling capacitors based on current.
+
+        Args:
+            current: Maximum current in amperes.
+
+        Returns:
+            List of recommended capacitors with values and counts.
+        """
+        # Find the appropriate threshold
+        for threshold, caps in reversed(self._DECOUPLING_THRESHOLDS):
+            if current >= threshold:
+                return caps
+
+        # Default for very low current
+        return [{"value": "100nF", "count": 1}]
+
+
+# Register power interface in the global registry
+def _register_power_interface() -> None:
+    """Register power interface in the global registry."""
+    spec = PowerInterfaceSpec()
+    REGISTRY.register(spec)
+
+
+# Auto-register on module import
+_register_power_interface()

--- a/src/kicad_tools/intent/interfaces/spi.py
+++ b/src/kicad_tools/intent/interfaces/spi.py
@@ -1,0 +1,322 @@
+"""
+SPI interface specifications.
+
+This module implements SPI interface specifications for common SPI speed variants,
+from standard 10MHz through high-speed 100MHz. Each variant defines appropriate
+constraints for clock signal routing, length matching, and trace requirements.
+
+Example::
+
+    from kicad_tools.intent import REGISTRY, create_intent_declaration
+
+    # Create a standard SPI declaration
+    declaration = create_intent_declaration(
+        interface_type="spi_standard",
+        nets=["SPI_CLK", "SPI_MOSI", "SPI_MISO", "SPI_CS"],
+        metadata={"device": "U1"},
+    )
+
+    # Constraints are automatically derived
+    for constraint in declaration.constraints:
+        print(f"{constraint.type}: {constraint.params}")
+
+SPI Interface Features:
+
+    | Feature            | Standard (≤10MHz) | Fast (≤50MHz) | High-Speed (≤100MHz) |
+    |--------------------|-------------------|---------------|----------------------|
+    | Max trace length   | 200mm             | 100mm         | 50mm                 |
+    | Length matching    | -                 | ±5mm          | ±2mm                 |
+    | Termination        | -                 | Optional      | Recommended          |
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from ..registry import REGISTRY
+from ..types import Constraint, InterfaceCategory
+
+
+@dataclass
+class SPIVariant:
+    """Configuration for an SPI variant.
+
+    Attributes:
+        max_freq: Maximum clock frequency in Hz.
+        max_trace_length_mm: Maximum recommended trace length in mm.
+        length_tolerance_mm: Maximum length mismatch in mm, or None if not specified.
+        termination_recommended: Whether termination resistors are recommended.
+    """
+
+    max_freq: float
+    max_trace_length_mm: float
+    length_tolerance_mm: float | None
+    termination_recommended: bool
+
+
+# SPI variant specifications
+SPI_VARIANTS: dict[str, SPIVariant] = {
+    "spi_standard": SPIVariant(
+        max_freq=10e6,
+        max_trace_length_mm=200.0,
+        length_tolerance_mm=None,
+        termination_recommended=False,
+    ),
+    "spi_fast": SPIVariant(
+        max_freq=50e6,
+        max_trace_length_mm=100.0,
+        length_tolerance_mm=5.0,
+        termination_recommended=False,
+    ),
+    "spi_high_speed": SPIVariant(
+        max_freq=100e6,
+        max_trace_length_mm=50.0,
+        length_tolerance_mm=2.0,
+        termination_recommended=True,
+    ),
+}
+
+
+class SPIInterfaceSpec:
+    """SPI interface specification.
+
+    Implements the InterfaceSpec protocol for SPI interfaces. Supports multiple
+    SPI variants from standard 10MHz through high-speed 100MHz.
+
+    The variant is determined by the ``variant`` parameter passed to
+    :meth:`derive_constraints`. If not specified, defaults to ``spi_standard``.
+
+    Attributes:
+        _variant_name: The SPI variant name (e.g., "spi_standard").
+        _variant: The variant configuration.
+    """
+
+    VARIANTS: ClassVar[dict[str, SPIVariant]] = SPI_VARIANTS
+
+    def __init__(self, variant_name: str = "spi_standard") -> None:
+        """Initialize SPI interface spec for a specific variant.
+
+        Args:
+            variant_name: SPI variant name. One of: spi_standard, spi_fast,
+                spi_high_speed.
+
+        Raises:
+            ValueError: If the variant name is not recognized.
+        """
+        if variant_name not in self.VARIANTS:
+            valid = ", ".join(sorted(self.VARIANTS.keys()))
+            raise ValueError(f"Unknown SPI variant: '{variant_name}'. Valid variants: {valid}")
+        self._variant_name = variant_name
+        self._variant = self.VARIANTS[variant_name]
+
+    @property
+    def name(self) -> str:
+        """Interface type name (e.g., 'spi_standard')."""
+        return self._variant_name
+
+    @property
+    def category(self) -> InterfaceCategory:
+        """Interface category (BUS for all SPI variants)."""
+        return InterfaceCategory.BUS
+
+    def validate_nets(self, nets: list[str]) -> list[str]:
+        """Validate net names/count for SPI interface.
+
+        SPI interfaces require at least 3 nets (CLK, MOSI/MISO, CS).
+        Typical configurations have 4 nets (CLK, MOSI, MISO, CS).
+
+        Args:
+            nets: List of net names to validate.
+
+        Returns:
+            List of validation error messages. Empty list if valid.
+        """
+        errors: list[str] = []
+        if len(nets) < 3:
+            errors.append(
+                f"SPI {self._variant_name} requires at least 3 nets "
+                f"(CLK, MOSI/MISO, CS), got {len(nets)}"
+            )
+        return errors
+
+    def derive_constraints(self, nets: list[str], params: dict[str, Any]) -> list[Constraint]:
+        """Derive constraints from SPI interface declaration.
+
+        Generates constraints based on the SPI variant requirements:
+        - Maximum trace length for all variants
+        - Length matching for high-speed variants
+        - Termination recommendations for high-speed
+
+        Args:
+            nets: List of net names (should be at least 3 for SPI).
+            params: Additional parameters. Supports:
+                - variant: Override variant (default uses instance variant)
+
+        Returns:
+            List of constraints derived from the SPI specification.
+        """
+        # Allow runtime variant override via params
+        variant_name = params.get("variant", self._variant_name)
+        if isinstance(variant_name, str) and variant_name in self.VARIANTS:
+            variant = self.VARIANTS[variant_name]
+            source = f"spi:{variant_name}"
+        else:
+            variant = self._variant
+            source = f"spi:{self._variant_name}"
+
+        constraints: list[Constraint] = []
+
+        # Find clock signal (typically first net or one containing CLK/SCK)
+        clk_net = self._find_clk_net(nets)
+
+        # Clock signal maximum length constraint
+        if clk_net:
+            constraints.append(
+                Constraint(
+                    type="max_length",
+                    params={
+                        "net": clk_net,
+                        "max_mm": variant.max_trace_length_mm,
+                    },
+                    source=source,
+                    severity="warning",
+                )
+            )
+
+        # Maximum length for all SPI signals
+        constraints.append(
+            Constraint(
+                type="max_length",
+                params={
+                    "nets": nets,
+                    "max_mm": variant.max_trace_length_mm,
+                },
+                source=source,
+                severity="warning",
+            )
+        )
+
+        # Length matching for high-speed SPI variants
+        if variant.length_tolerance_mm is not None:
+            constraints.append(
+                Constraint(
+                    type="length_match",
+                    params={
+                        "nets": nets,
+                        "tolerance_mm": variant.length_tolerance_mm,
+                    },
+                    source=source,
+                    severity="warning",
+                )
+            )
+
+        # Termination recommendation for high-speed
+        if variant.termination_recommended:
+            constraints.append(
+                Constraint(
+                    type="termination",
+                    params={
+                        "nets": nets,
+                        "recommended": True,
+                    },
+                    source=source,
+                    severity="warning",
+                )
+            )
+
+        return constraints
+
+    def get_validation_message(self, violation: dict[str, Any]) -> str:
+        """Convert generic DRC violation to SPI-aware message.
+
+        Provides context-aware error messages that explain violations in terms
+        of SPI signal integrity requirements.
+
+        Args:
+            violation: Dictionary containing violation details. Expected keys vary
+                by violation type:
+                - length_mismatch: {"type": "length_mismatch", "delta": <mm>}
+                - max_length: {"type": "max_length", "actual": <mm>}
+
+        Returns:
+            Human-readable message explaining the violation in SPI context.
+        """
+        violation_type = violation.get("type", "")
+        variant = self._variant
+
+        if violation_type == "length_mismatch":
+            delta = violation.get("delta", "?")
+            tolerance = variant.length_tolerance_mm or 5.0
+            freq_str = self._format_freq(variant.max_freq)
+            return (
+                f"SPI signal length mismatch: {delta}mm. "
+                f"SPI {self._variant_name.replace('_', ' ')} requires "
+                f"+/-{tolerance}mm matching for signal integrity at {freq_str}."
+            )
+
+        if violation_type == "max_length":
+            actual = violation.get("actual", "?")
+            max_len = variant.max_trace_length_mm
+            return (
+                f"SPI trace length {actual}mm exceeds maximum {max_len}mm. "
+                f"Long traces may cause signal integrity issues at "
+                f"{self._format_freq(variant.max_freq)}."
+            )
+
+        if violation_type == "termination":
+            return (
+                f"SPI high-speed signals should have series termination resistors "
+                f"(typically 22-33Ω) near the source to reduce reflections at "
+                f"{self._format_freq(variant.max_freq)}."
+            )
+
+        # Fallback for unknown violation types
+        return violation.get("message", str(violation))
+
+    @staticmethod
+    def _find_clk_net(nets: list[str]) -> str | None:
+        """Find the clock signal net from a list of SPI nets.
+
+        Args:
+            nets: List of net names.
+
+        Returns:
+            The clock net name, or None if not found.
+        """
+        clk_patterns = ["CLK", "SCK", "SCLK"]
+        for net in nets:
+            net_upper = net.upper()
+            for pattern in clk_patterns:
+                if pattern in net_upper:
+                    return net
+        # Default to first net if no clock pattern found
+        return nets[0] if nets else None
+
+    @staticmethod
+    def _format_freq(freq: float) -> str:
+        """Format frequency in human-readable form.
+
+        Args:
+            freq: Frequency in Hz.
+
+        Returns:
+            Formatted string (e.g., "10MHz", "100MHz").
+        """
+        if freq >= 1e9:
+            return f"{freq / 1e9:.0f}GHz"
+        if freq >= 1e6:
+            return f"{freq / 1e6:.0f}MHz"
+        return f"{freq / 1e3:.0f}kHz"
+
+
+# Register all SPI variants in the global registry
+def _register_spi_interfaces() -> None:
+    """Register all SPI interface variants in the global registry."""
+    for variant_name in SPI_VARIANTS:
+        spec = SPIInterfaceSpec(variant_name)
+        REGISTRY.register(spec)
+
+
+# Auto-register on module import
+_register_spi_interfaces()

--- a/tests/test_i2c_interface.py
+++ b/tests/test_i2c_interface.py
@@ -1,0 +1,362 @@
+"""
+Unit tests for I2C interface specification.
+
+Tests cover:
+- I2CInterfaceSpec implements InterfaceSpec protocol
+- All I2C variants defined and registered
+- Constraint derivation for capacitance, pull-ups, trace length
+- Intent-aware validation messages for common I2C violations
+"""
+
+import pytest
+
+from kicad_tools.intent import (
+    REGISTRY,
+    ConstraintSeverity,
+    InterfaceCategory,
+    create_intent_declaration,
+    derive_constraints,
+    validate_intent,
+)
+from kicad_tools.intent.interfaces.i2c import (
+    I2C_VARIANTS,
+    I2CInterfaceSpec,
+    I2CVariant,
+)
+
+
+class TestI2CVariants:
+    """Tests for I2C variant definitions."""
+
+    def test_all_variants_defined(self):
+        """Test that all I2C variants are defined."""
+        expected_variants = ["i2c_standard", "i2c_fast", "i2c_fast_plus"]
+        for variant in expected_variants:
+            assert variant in I2C_VARIANTS, f"Missing variant: {variant}"
+
+    def test_variant_dataclass_fields(self):
+        """Test I2CVariant has all required fields."""
+        variant = I2C_VARIANTS["i2c_standard"]
+        assert isinstance(variant, I2CVariant)
+        assert hasattr(variant, "freq")
+        assert hasattr(variant, "max_capacitance_pf")
+        assert hasattr(variant, "rise_time_ns")
+        assert hasattr(variant, "pullup_ohms")
+        assert hasattr(variant, "max_trace_length_mm")
+
+    def test_i2c_standard_params(self):
+        """Test I2C standard mode parameters."""
+        variant = I2C_VARIANTS["i2c_standard"]
+        assert variant.freq == 100e3
+        assert variant.max_capacitance_pf == 400.0
+        assert variant.rise_time_ns == 1000.0
+        assert variant.pullup_ohms == 4700.0
+        assert variant.max_trace_length_mm == 1000.0
+
+    def test_i2c_fast_params(self):
+        """Test I2C fast mode parameters."""
+        variant = I2C_VARIANTS["i2c_fast"]
+        assert variant.freq == 400e3
+        assert variant.max_capacitance_pf == 400.0
+        assert variant.rise_time_ns == 300.0
+        assert variant.pullup_ohms == 2200.0
+        assert variant.max_trace_length_mm == 500.0
+
+    def test_i2c_fast_plus_params(self):
+        """Test I2C fast mode plus parameters."""
+        variant = I2C_VARIANTS["i2c_fast_plus"]
+        assert variant.freq == 1e6
+        assert variant.max_capacitance_pf == 550.0
+        assert variant.rise_time_ns == 120.0
+        assert variant.pullup_ohms == 1000.0
+        assert variant.max_trace_length_mm == 300.0
+
+
+class TestI2CInterfaceSpec:
+    """Tests for I2CInterfaceSpec class."""
+
+    def test_spec_creation_default_variant(self):
+        """Test creating spec with default variant."""
+        spec = I2CInterfaceSpec()
+        assert spec.name == "i2c_standard"
+
+    def test_spec_creation_with_variant(self):
+        """Test creating spec with specific variant."""
+        spec = I2CInterfaceSpec("i2c_fast_plus")
+        assert spec.name == "i2c_fast_plus"
+
+    def test_spec_creation_invalid_variant(self):
+        """Test that invalid variant raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown I2C variant"):
+            I2CInterfaceSpec("i2c_invalid")
+
+    def test_category_is_bus(self):
+        """Test that all I2C specs have BUS category."""
+        for variant_name in I2C_VARIANTS:
+            spec = I2CInterfaceSpec(variant_name)
+            assert spec.category == InterfaceCategory.BUS
+
+    def test_implements_interface_spec_protocol(self):
+        """Test that I2CInterfaceSpec implements InterfaceSpec protocol."""
+        spec = I2CInterfaceSpec()
+        assert hasattr(spec, "name")
+        assert hasattr(spec, "category")
+        assert hasattr(spec, "validate_nets")
+        assert hasattr(spec, "derive_constraints")
+        assert hasattr(spec, "get_validation_message")
+
+
+class TestI2CNetValidation:
+    """Tests for I2C net validation."""
+
+    def test_validate_nets_correct_count(self):
+        """Test validation passes with 2 nets."""
+        spec = I2CInterfaceSpec()
+        errors = spec.validate_nets(["I2C_SDA", "I2C_SCL"])
+        assert errors == []
+
+    def test_validate_nets_too_few(self):
+        """Test validation fails with 1 net."""
+        spec = I2CInterfaceSpec()
+        errors = spec.validate_nets(["I2C_SDA"])
+        assert len(errors) == 1
+        assert "exactly 2 nets" in errors[0]
+
+    def test_validate_nets_too_many(self):
+        """Test validation fails with 3 nets."""
+        spec = I2CInterfaceSpec()
+        errors = spec.validate_nets(["I2C_SDA", "I2C_SCL", "I2C_INT"])
+        assert len(errors) == 1
+        assert "exactly 2 nets" in errors[0]
+
+    def test_validate_nets_empty(self):
+        """Test validation fails with no nets."""
+        spec = I2CInterfaceSpec()
+        errors = spec.validate_nets([])
+        assert len(errors) == 1
+
+
+class TestI2CConstraintDerivation:
+    """Tests for I2C constraint derivation."""
+
+    def test_i2c_standard_constraints(self):
+        """Test I2C standard generates correct constraints."""
+        spec = I2CInterfaceSpec("i2c_standard")
+        constraints = spec.derive_constraints(["SDA", "SCL"], {})
+
+        constraint_types = {c.type for c in constraints}
+        assert "max_capacitance" in constraint_types
+        assert "requires_pullup" in constraint_types
+        assert "max_length" in constraint_types
+
+    def test_capacitance_constraint_params(self):
+        """Test capacitance constraint has correct parameters."""
+        spec = I2CInterfaceSpec("i2c_standard")
+        constraints = spec.derive_constraints(["SDA", "SCL"], {})
+
+        cap_constraint = next(c for c in constraints if c.type == "max_capacitance")
+        assert cap_constraint.params["nets"] == ["SDA", "SCL"]
+        assert cap_constraint.params["max_pf"] == 400.0
+        assert cap_constraint.source == "i2c:i2c_standard"
+        assert cap_constraint.severity == ConstraintSeverity.WARNING
+
+    def test_pullup_constraint_params(self):
+        """Test pull-up constraint has correct parameters."""
+        spec = I2CInterfaceSpec("i2c_fast")
+        constraints = spec.derive_constraints(["SDA", "SCL"], {})
+
+        pullup_constraint = next(c for c in constraints if c.type == "requires_pullup")
+        assert pullup_constraint.params["nets"] == ["SDA", "SCL"]
+        assert pullup_constraint.params["typical_ohms"] == 2200.0
+
+    def test_max_length_constraint_params(self):
+        """Test max length constraint has correct parameters."""
+        spec = I2CInterfaceSpec("i2c_fast_plus")
+        constraints = spec.derive_constraints(["SDA", "SCL"], {})
+
+        length_constraint = next(c for c in constraints if c.type == "max_length")
+        assert length_constraint.params["max_mm"] == 300.0
+        assert length_constraint.severity == ConstraintSeverity.WARNING
+
+    def test_fast_plus_higher_capacitance(self):
+        """Test I2C Fast+ has higher capacitance limit than standard/fast."""
+        standard_spec = I2CInterfaceSpec("i2c_standard")
+        fast_plus_spec = I2CInterfaceSpec("i2c_fast_plus")
+
+        standard_constraints = standard_spec.derive_constraints(["SDA", "SCL"], {})
+        fast_plus_constraints = fast_plus_spec.derive_constraints(["SDA", "SCL"], {})
+
+        standard_cap = next(c for c in standard_constraints if c.type == "max_capacitance")
+        fast_plus_cap = next(c for c in fast_plus_constraints if c.type == "max_capacitance")
+
+        # Fast+ has 550pF vs 400pF for standard/fast
+        assert fast_plus_cap.params["max_pf"] > standard_cap.params["max_pf"]
+
+    def test_variant_override_via_params(self):
+        """Test variant can be overridden via params."""
+        spec = I2CInterfaceSpec("i2c_standard")
+        constraints = spec.derive_constraints(["SDA", "SCL"], {"variant": "i2c_fast"})
+
+        # Should use fast constraints
+        pullup = next(c for c in constraints if c.type == "requires_pullup")
+        assert pullup.params["typical_ohms"] == 2200.0  # Fast value, not standard
+
+    def test_constraint_source_format(self):
+        """Test constraint source uses i2c:variant format."""
+        spec = I2CInterfaceSpec("i2c_fast")
+        constraints = spec.derive_constraints(["SDA", "SCL"], {})
+
+        for constraint in constraints:
+            assert constraint.source == "i2c:i2c_fast"
+
+
+class TestI2CValidationMessages:
+    """Tests for I2C validation message formatting."""
+
+    def test_capacitance_message(self):
+        """Test capacitance violation message."""
+        spec = I2CInterfaceSpec("i2c_standard")
+        msg = spec.get_validation_message({"type": "capacitance", "actual": 500})
+
+        assert "I2C" in msg
+        assert "500pF" in msg
+        assert "400" in msg  # 400 or 400.0
+        assert "capacitance" in msg.lower()
+
+    def test_max_length_message(self):
+        """Test max length violation message."""
+        spec = I2CInterfaceSpec("i2c_fast")
+        msg = spec.get_validation_message({"type": "max_length", "actual": 700})
+
+        assert "700mm" in msg
+        assert "500" in msg  # Max for fast mode
+        assert "capacitance" in msg.lower() or "pull-up" in msg.lower()
+
+    def test_pullup_message(self):
+        """Test pull-up requirement message."""
+        spec = I2CInterfaceSpec("i2c_standard")
+        msg = spec.get_validation_message({"type": "pullup"})
+
+        assert "pull-up" in msg.lower()
+        assert "4.7k" in msg  # Standard pull-up value
+
+    def test_rise_time_message(self):
+        """Test rise time violation message."""
+        spec = I2CInterfaceSpec("i2c_fast")
+        msg = spec.get_validation_message({"type": "rise_time", "actual": 400})
+
+        assert "400ns" in msg
+        assert "300" in msg  # Fast mode rise time (300 or 300.0)
+        assert "pull-up" in msg.lower() or "capacitance" in msg.lower()
+
+    def test_unknown_violation_fallback(self):
+        """Test fallback for unknown violation types."""
+        spec = I2CInterfaceSpec()
+        msg = spec.get_validation_message({"type": "unknown", "message": "Custom message"})
+        assert msg == "Custom message"
+
+
+class TestI2CFormatting:
+    """Tests for formatting helpers."""
+
+    def test_format_freq_khz(self):
+        """Test formatting frequencies in kHz."""
+        assert I2CInterfaceSpec._format_freq(100e3) == "100kHz"
+        assert I2CInterfaceSpec._format_freq(400e3) == "400kHz"
+
+    def test_format_freq_mhz(self):
+        """Test formatting frequencies in MHz."""
+        assert I2CInterfaceSpec._format_freq(1e6) == "1MHz"
+
+    def test_format_resistance_kohms(self):
+        """Test formatting resistance in kΩ."""
+        assert I2CInterfaceSpec._format_resistance(4700.0) == "4.7kΩ"
+        assert I2CInterfaceSpec._format_resistance(2200.0) == "2.2kΩ"
+        assert I2CInterfaceSpec._format_resistance(1000.0) == "1kΩ"
+
+    def test_format_resistance_ohms(self):
+        """Test formatting resistance in Ω."""
+        assert I2CInterfaceSpec._format_resistance(470.0) == "470Ω"
+
+
+class TestI2CRegistryIntegration:
+    """Tests for I2C interface registration in global registry."""
+
+    def test_all_variants_registered(self):
+        """Test all I2C variants are registered in global REGISTRY."""
+        for variant_name in I2C_VARIANTS:
+            assert variant_name in REGISTRY, f"Variant not registered: {variant_name}"
+
+    def test_registered_spec_is_i2c_interface_spec(self):
+        """Test registered specs are I2CInterfaceSpec instances."""
+        spec = REGISTRY.get("i2c_standard")
+        assert spec is not None
+        assert isinstance(spec, I2CInterfaceSpec)
+
+    def test_derive_constraints_via_registry(self):
+        """Test deriving constraints through the registry."""
+        constraints = derive_constraints(
+            interface_type="i2c_fast",
+            nets=["SDA", "SCL"],
+        )
+        assert len(constraints) > 0
+        assert any(c.type == "max_capacitance" for c in constraints)
+
+    def test_validate_intent_via_registry(self):
+        """Test validating intent through the registry."""
+        errors = validate_intent(
+            interface_type="i2c_standard",
+            nets=["SDA", "SCL"],
+        )
+        assert errors == []
+
+    def test_create_intent_declaration_via_registry(self):
+        """Test creating intent declaration through the registry."""
+        declaration = create_intent_declaration(
+            interface_type="i2c_fast_plus",
+            nets=["SDA", "SCL"],
+            metadata={"device": "U1"},
+        )
+        assert declaration.interface_type == "i2c_fast_plus"
+        assert len(declaration.constraints) > 0
+
+    def test_i2c_specs_in_bus_category(self):
+        """Test I2C specs appear in BUS category listing."""
+        bus_interfaces = REGISTRY.list_by_category(InterfaceCategory.BUS)
+        for variant_name in I2C_VARIANTS:
+            assert variant_name in bus_interfaces
+
+
+class TestI2CAcceptanceCriteria:
+    """Tests verifying issue acceptance criteria."""
+
+    def test_implements_interface_spec_protocol(self):
+        """AC: I2CInterfaceSpec implements InterfaceSpec protocol."""
+        spec = I2CInterfaceSpec()
+        assert isinstance(spec.name, str)
+        assert isinstance(spec.category, InterfaceCategory)
+        assert callable(spec.validate_nets)
+        assert callable(spec.derive_constraints)
+        assert callable(spec.get_validation_message)
+
+    def test_three_speed_variants(self):
+        """AC: I2CInterfaceSpec with Standard/Fast/Fast+ variants."""
+        assert "i2c_standard" in I2C_VARIANTS
+        assert "i2c_fast" in I2C_VARIANTS
+        assert "i2c_fast_plus" in I2C_VARIANTS
+        assert len(I2C_VARIANTS) == 3
+
+    def test_intent_aware_messages(self):
+        """AC: Intent-aware validation messages for I2C violations."""
+        spec = I2CInterfaceSpec("i2c_fast")
+
+        msg = spec.get_validation_message({"type": "capacitance", "actual": 500})
+        assert "I2C" in msg
+
+        msg = spec.get_validation_message({"type": "pullup"})
+        assert "pull-up" in msg.lower()
+
+    def test_registered_in_global_registry(self):
+        """AC: Registered in global REGISTRY on module import."""
+        for variant in I2C_VARIANTS:
+            assert REGISTRY.get(variant) is not None

--- a/tests/test_power_interface.py
+++ b/tests/test_power_interface.py
@@ -1,0 +1,361 @@
+"""
+Unit tests for Power interface specification.
+
+Tests cover:
+- PowerInterfaceSpec implements InterfaceSpec protocol
+- Constraint derivation for trace width and decoupling
+- Current-based trace width calculation
+- Intent-aware validation messages for power violations
+"""
+
+from kicad_tools.intent import (
+    REGISTRY,
+    ConstraintSeverity,
+    InterfaceCategory,
+    create_intent_declaration,
+    derive_constraints,
+    validate_intent,
+)
+from kicad_tools.intent.interfaces.power import PowerInterfaceSpec
+
+
+class TestPowerInterfaceSpec:
+    """Tests for PowerInterfaceSpec class."""
+
+    def test_spec_creation(self):
+        """Test creating power spec."""
+        spec = PowerInterfaceSpec()
+        assert spec.name == "power_rail"
+
+    def test_category_is_power(self):
+        """Test that power spec has POWER category."""
+        spec = PowerInterfaceSpec()
+        assert spec.category == InterfaceCategory.POWER
+
+    def test_implements_interface_spec_protocol(self):
+        """Test that PowerInterfaceSpec implements InterfaceSpec protocol."""
+        spec = PowerInterfaceSpec()
+        assert hasattr(spec, "name")
+        assert hasattr(spec, "category")
+        assert hasattr(spec, "validate_nets")
+        assert hasattr(spec, "derive_constraints")
+        assert hasattr(spec, "get_validation_message")
+
+
+class TestPowerNetValidation:
+    """Tests for power net validation."""
+
+    def test_validate_nets_correct_count(self):
+        """Test validation passes with 1 net."""
+        spec = PowerInterfaceSpec()
+        errors = spec.validate_nets(["VCC_3V3"])
+        assert errors == []
+
+    def test_validate_nets_too_few(self):
+        """Test validation fails with 0 nets."""
+        spec = PowerInterfaceSpec()
+        errors = spec.validate_nets([])
+        assert len(errors) == 1
+        assert "exactly 1 net" in errors[0]
+
+    def test_validate_nets_too_many(self):
+        """Test validation fails with 2 nets."""
+        spec = PowerInterfaceSpec()
+        errors = spec.validate_nets(["VCC_3V3", "VCC_5V"])
+        assert len(errors) == 1
+        assert "exactly 1 net" in errors[0]
+
+
+class TestPowerConstraintDerivation:
+    """Tests for power constraint derivation."""
+
+    def test_basic_constraints_generated(self):
+        """Test power generates trace width and decoupling constraints."""
+        spec = PowerInterfaceSpec()
+        constraints = spec.derive_constraints(["VCC"], {"max_current": 0.5})
+
+        constraint_types = {c.type for c in constraints}
+        assert "min_trace_width" in constraint_types
+        assert "requires_decoupling" in constraint_types
+
+    def test_trace_width_constraint_params(self):
+        """Test trace width constraint has correct parameters."""
+        spec = PowerInterfaceSpec()
+        constraints = spec.derive_constraints(["VCC_3V3"], {"max_current": 0.5})
+
+        width_constraint = next(c for c in constraints if c.type == "min_trace_width")
+        assert width_constraint.params["net"] == "VCC_3V3"
+        assert width_constraint.params["current"] == 0.5
+        assert width_constraint.params["min_mm"] == 0.25  # 0.1 + 0.5*0.3
+        assert width_constraint.source == "power_rail"
+        assert width_constraint.severity == ConstraintSeverity.ERROR
+
+    def test_decoupling_constraint_params(self):
+        """Test decoupling constraint has correct parameters."""
+        spec = PowerInterfaceSpec()
+        constraints = spec.derive_constraints(["VCC_3V3"], {"voltage": 3.3, "max_current": 0.5})
+
+        decoupling = next(c for c in constraints if c.type == "requires_decoupling")
+        assert decoupling.params["net"] == "VCC_3V3"
+        assert decoupling.params["voltage"] == 3.3
+        assert "capacitors" in decoupling.params
+        assert decoupling.severity == ConstraintSeverity.WARNING
+
+    def test_default_current_used(self):
+        """Test default current (0.5A) is used when not specified."""
+        spec = PowerInterfaceSpec()
+        constraints = spec.derive_constraints(["VCC"], {})
+
+        width_constraint = next(c for c in constraints if c.type == "min_trace_width")
+        assert width_constraint.params["current"] == 0.5
+
+    def test_voltage_optional(self):
+        """Test voltage is optional in params."""
+        spec = PowerInterfaceSpec()
+        constraints = spec.derive_constraints(["VCC"], {"max_current": 0.2})
+
+        decoupling = next(c for c in constraints if c.type == "requires_decoupling")
+        assert "voltage" not in decoupling.params
+
+
+class TestPowerTraceWidthCalculation:
+    """Tests for trace width calculation."""
+
+    def test_width_for_100ma(self):
+        """Test trace width for 100mA."""
+        width = PowerInterfaceSpec._width_for_current(0.1)
+        assert width == 0.13
+
+    def test_width_for_500ma(self):
+        """Test trace width for 500mA."""
+        width = PowerInterfaceSpec._width_for_current(0.5)
+        assert width == 0.25
+
+    def test_width_for_1a(self):
+        """Test trace width for 1A."""
+        width = PowerInterfaceSpec._width_for_current(1.0)
+        assert width == 0.4
+
+    def test_width_for_2a(self):
+        """Test trace width for 2A."""
+        width = PowerInterfaceSpec._width_for_current(2.0)
+        assert width == 0.7
+
+    def test_width_increases_with_current(self):
+        """Test that width increases proportionally with current."""
+        width_low = PowerInterfaceSpec._width_for_current(0.5)
+        width_high = PowerInterfaceSpec._width_for_current(1.0)
+        assert width_high > width_low
+
+
+class TestPowerDecouplingSpec:
+    """Tests for decoupling capacitor recommendations."""
+
+    def test_decoupling_for_low_current(self):
+        """Test decoupling for <100mA."""
+        spec = PowerInterfaceSpec()
+        caps = spec._decoupling_spec(0.05)
+        assert len(caps) == 1
+        assert caps[0]["value"] == "100nF"
+
+    def test_decoupling_for_100ma(self):
+        """Test decoupling for 100mA threshold."""
+        spec = PowerInterfaceSpec()
+        caps = spec._decoupling_spec(0.1)
+        values = [c["value"] for c in caps]
+        assert "100nF" in values
+
+    def test_decoupling_for_500ma(self):
+        """Test decoupling for 500mA threshold."""
+        spec = PowerInterfaceSpec()
+        caps = spec._decoupling_spec(0.5)
+        values = [c["value"] for c in caps]
+        assert "100nF" in values
+        assert "10uF" in values
+
+    def test_decoupling_for_1a(self):
+        """Test decoupling for 1A threshold."""
+        spec = PowerInterfaceSpec()
+        caps = spec._decoupling_spec(1.0)
+        values = [c["value"] for c in caps]
+        assert "100nF" in values
+        assert "10uF" in values
+        assert "47uF" in values
+
+    def test_decoupling_for_2a(self):
+        """Test decoupling for 2A threshold."""
+        spec = PowerInterfaceSpec()
+        caps = spec._decoupling_spec(2.0)
+        values = [c["value"] for c in caps]
+        assert "100nF" in values
+        assert "10uF" in values
+        assert "47uF" in values
+        assert "100uF" in values
+
+    def test_decoupling_increases_with_current(self):
+        """Test that more capacitors are recommended for higher current."""
+        spec = PowerInterfaceSpec()
+        caps_low = spec._decoupling_spec(0.05)
+        caps_high = spec._decoupling_spec(2.0)
+        assert len(caps_high) > len(caps_low)
+
+
+class TestPowerValidationMessages:
+    """Tests for power validation message formatting."""
+
+    def test_trace_width_message(self):
+        """Test trace width violation message."""
+        spec = PowerInterfaceSpec()
+        msg = spec.get_validation_message(
+            {
+                "type": "trace_width",
+                "actual": 0.15,
+                "required": 0.25,
+                "current": 0.5,
+            }
+        )
+
+        assert "0.15mm" in msg
+        assert "0.25mm" in msg
+        assert "0.5A" in msg
+        assert "voltage drop" in msg.lower() or "overheating" in msg.lower()
+
+    def test_decoupling_message_with_missing(self):
+        """Test decoupling violation message with missing caps."""
+        spec = PowerInterfaceSpec()
+        msg = spec.get_validation_message(
+            {
+                "type": "decoupling",
+                "missing": ["100nF", "10uF"],
+            }
+        )
+
+        assert "decoupling" in msg.lower()
+        assert "100nF" in msg
+        assert "10uF" in msg
+
+    def test_decoupling_message_generic(self):
+        """Test generic decoupling message."""
+        spec = PowerInterfaceSpec()
+        msg = spec.get_validation_message({"type": "decoupling"})
+
+        assert "decoupling" in msg.lower()
+        assert "capacitor" in msg.lower()
+
+    def test_voltage_drop_message(self):
+        """Test voltage drop violation message."""
+        spec = PowerInterfaceSpec()
+        msg = spec.get_validation_message(
+            {
+                "type": "voltage_drop",
+                "drop": 0.15,
+                "max_allowed": 0.1,
+            }
+        )
+
+        assert "0.15V" in msg
+        assert "0.1V" in msg
+        assert "trace width" in msg.lower() or "power plane" in msg.lower()
+
+    def test_unknown_violation_fallback(self):
+        """Test fallback for unknown violation types."""
+        spec = PowerInterfaceSpec()
+        msg = spec.get_validation_message({"type": "unknown", "message": "Custom message"})
+        assert msg == "Custom message"
+
+
+class TestPowerRegistryIntegration:
+    """Tests for power interface registration in global registry."""
+
+    def test_power_rail_registered(self):
+        """Test power_rail is registered in global REGISTRY."""
+        assert "power_rail" in REGISTRY
+
+    def test_registered_spec_is_power_interface_spec(self):
+        """Test registered spec is PowerInterfaceSpec instance."""
+        spec = REGISTRY.get("power_rail")
+        assert spec is not None
+        assert isinstance(spec, PowerInterfaceSpec)
+
+    def test_derive_constraints_via_registry(self):
+        """Test deriving constraints through the registry."""
+        constraints = derive_constraints(
+            interface_type="power_rail",
+            nets=["VCC_3V3"],
+            params={"max_current": 0.5},
+        )
+        assert len(constraints) > 0
+        assert any(c.type == "min_trace_width" for c in constraints)
+
+    def test_validate_intent_via_registry(self):
+        """Test validating intent through the registry."""
+        errors = validate_intent(
+            interface_type="power_rail",
+            nets=["VCC"],
+        )
+        assert errors == []
+
+    def test_create_intent_declaration_via_registry(self):
+        """Test creating intent declaration through the registry."""
+        declaration = create_intent_declaration(
+            interface_type="power_rail",
+            nets=["VCC_5V"],
+            params={"voltage": 5.0, "max_current": 1.0},
+            metadata={"regulator": "U2"},
+        )
+        assert declaration.interface_type == "power_rail"
+        assert len(declaration.constraints) > 0
+
+    def test_power_spec_in_power_category(self):
+        """Test power spec appears in POWER category listing."""
+        power_interfaces = REGISTRY.list_by_category(InterfaceCategory.POWER)
+        assert "power_rail" in power_interfaces
+
+
+class TestPowerAcceptanceCriteria:
+    """Tests verifying issue acceptance criteria."""
+
+    def test_implements_interface_spec_protocol(self):
+        """AC: PowerInterfaceSpec implements InterfaceSpec protocol."""
+        spec = PowerInterfaceSpec()
+        assert isinstance(spec.name, str)
+        assert isinstance(spec.category, InterfaceCategory)
+        assert callable(spec.validate_nets)
+        assert callable(spec.derive_constraints)
+        assert callable(spec.get_validation_message)
+
+    def test_current_based_trace_width(self):
+        """AC: PowerInterfaceSpec with current-based trace width calculation."""
+        spec = PowerInterfaceSpec()
+
+        # Test that trace width varies with current
+        constraints_low = spec.derive_constraints(["VCC"], {"max_current": 0.1})
+        constraints_high = spec.derive_constraints(["VCC"], {"max_current": 2.0})
+
+        width_low = next(c for c in constraints_low if c.type == "min_trace_width").params["min_mm"]
+        width_high = next(c for c in constraints_high if c.type == "min_trace_width").params[
+            "min_mm"
+        ]
+
+        assert width_high > width_low
+
+    def test_intent_aware_messages(self):
+        """AC: Intent-aware validation messages for power violations."""
+        spec = PowerInterfaceSpec()
+
+        msg = spec.get_validation_message(
+            {
+                "type": "trace_width",
+                "actual": 0.1,
+                "required": 0.4,
+                "current": 1.0,
+            }
+        )
+        assert "trace" in msg.lower() or "width" in msg.lower()
+
+        msg = spec.get_validation_message({"type": "decoupling"})
+        assert "decoupling" in msg.lower()
+
+    def test_registered_in_global_registry(self):
+        """AC: Registered in global REGISTRY on module import."""
+        assert REGISTRY.get("power_rail") is not None

--- a/tests/test_spi_interface.py
+++ b/tests/test_spi_interface.py
@@ -1,0 +1,341 @@
+"""
+Unit tests for SPI interface specification.
+
+Tests cover:
+- SPIInterfaceSpec implements InterfaceSpec protocol
+- All SPI variants defined and registered
+- Constraint derivation for max length, length matching
+- Intent-aware validation messages for common SPI violations
+"""
+
+import pytest
+
+from kicad_tools.intent import (
+    REGISTRY,
+    ConstraintSeverity,
+    InterfaceCategory,
+    create_intent_declaration,
+    derive_constraints,
+    validate_intent,
+)
+from kicad_tools.intent.interfaces.spi import (
+    SPI_VARIANTS,
+    SPIInterfaceSpec,
+    SPIVariant,
+)
+
+
+class TestSPIVariants:
+    """Tests for SPI variant definitions."""
+
+    def test_all_variants_defined(self):
+        """Test that all SPI variants are defined."""
+        expected_variants = ["spi_standard", "spi_fast", "spi_high_speed"]
+        for variant in expected_variants:
+            assert variant in SPI_VARIANTS, f"Missing variant: {variant}"
+
+    def test_variant_dataclass_fields(self):
+        """Test SPIVariant has all required fields."""
+        variant = SPI_VARIANTS["spi_standard"]
+        assert isinstance(variant, SPIVariant)
+        assert hasattr(variant, "max_freq")
+        assert hasattr(variant, "max_trace_length_mm")
+        assert hasattr(variant, "length_tolerance_mm")
+        assert hasattr(variant, "termination_recommended")
+
+    def test_spi_standard_params(self):
+        """Test SPI standard parameters."""
+        variant = SPI_VARIANTS["spi_standard"]
+        assert variant.max_freq == 10e6
+        assert variant.max_trace_length_mm == 200.0
+        assert variant.length_tolerance_mm is None
+        assert variant.termination_recommended is False
+
+    def test_spi_fast_params(self):
+        """Test SPI fast parameters."""
+        variant = SPI_VARIANTS["spi_fast"]
+        assert variant.max_freq == 50e6
+        assert variant.max_trace_length_mm == 100.0
+        assert variant.length_tolerance_mm == 5.0
+        assert variant.termination_recommended is False
+
+    def test_spi_high_speed_params(self):
+        """Test SPI high-speed parameters."""
+        variant = SPI_VARIANTS["spi_high_speed"]
+        assert variant.max_freq == 100e6
+        assert variant.max_trace_length_mm == 50.0
+        assert variant.length_tolerance_mm == 2.0
+        assert variant.termination_recommended is True
+
+
+class TestSPIInterfaceSpec:
+    """Tests for SPIInterfaceSpec class."""
+
+    def test_spec_creation_default_variant(self):
+        """Test creating spec with default variant."""
+        spec = SPIInterfaceSpec()
+        assert spec.name == "spi_standard"
+
+    def test_spec_creation_with_variant(self):
+        """Test creating spec with specific variant."""
+        spec = SPIInterfaceSpec("spi_high_speed")
+        assert spec.name == "spi_high_speed"
+
+    def test_spec_creation_invalid_variant(self):
+        """Test that invalid variant raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown SPI variant"):
+            SPIInterfaceSpec("spi_invalid")
+
+    def test_category_is_bus(self):
+        """Test that all SPI specs have BUS category."""
+        for variant_name in SPI_VARIANTS:
+            spec = SPIInterfaceSpec(variant_name)
+            assert spec.category == InterfaceCategory.BUS
+
+    def test_implements_interface_spec_protocol(self):
+        """Test that SPIInterfaceSpec implements InterfaceSpec protocol."""
+        spec = SPIInterfaceSpec()
+        assert hasattr(spec, "name")
+        assert hasattr(spec, "category")
+        assert hasattr(spec, "validate_nets")
+        assert hasattr(spec, "derive_constraints")
+        assert hasattr(spec, "get_validation_message")
+
+
+class TestSPINetValidation:
+    """Tests for SPI net validation."""
+
+    def test_validate_nets_correct_count(self):
+        """Test validation passes with 3+ nets."""
+        spec = SPIInterfaceSpec()
+        errors = spec.validate_nets(["SPI_CLK", "SPI_MOSI", "SPI_MISO", "SPI_CS"])
+        assert errors == []
+
+    def test_validate_nets_minimum_count(self):
+        """Test validation passes with minimum 3 nets."""
+        spec = SPIInterfaceSpec()
+        errors = spec.validate_nets(["SPI_CLK", "SPI_MOSI", "SPI_CS"])
+        assert errors == []
+
+    def test_validate_nets_too_few(self):
+        """Test validation fails with 2 nets."""
+        spec = SPIInterfaceSpec()
+        errors = spec.validate_nets(["SPI_CLK", "SPI_MOSI"])
+        assert len(errors) == 1
+        assert "at least 3 nets" in errors[0]
+
+    def test_validate_nets_empty(self):
+        """Test validation fails with no nets."""
+        spec = SPIInterfaceSpec()
+        errors = spec.validate_nets([])
+        assert len(errors) == 1
+
+
+class TestSPIConstraintDerivation:
+    """Tests for SPI constraint derivation."""
+
+    def test_spi_standard_constraints(self):
+        """Test SPI standard generates correct constraints."""
+        spec = SPIInterfaceSpec("spi_standard")
+        constraints = spec.derive_constraints(["SPI_CLK", "SPI_MOSI", "SPI_MISO", "SPI_CS"], {})
+
+        constraint_types = {c.type for c in constraints}
+        assert "max_length" in constraint_types
+        # Standard doesn't have length matching
+        assert "length_match" not in constraint_types
+
+    def test_spi_high_speed_constraints(self):
+        """Test SPI high-speed generates length matching and termination."""
+        spec = SPIInterfaceSpec("spi_high_speed")
+        constraints = spec.derive_constraints(["SPI_CLK", "SPI_MOSI", "SPI_MISO", "SPI_CS"], {})
+
+        constraint_types = {c.type for c in constraints}
+        assert "max_length" in constraint_types
+        assert "length_match" in constraint_types
+        assert "termination" in constraint_types
+
+    def test_max_length_constraint_params(self):
+        """Test max length constraint has correct parameters."""
+        spec = SPIInterfaceSpec("spi_standard")
+        constraints = spec.derive_constraints(["CLK", "MOSI", "MISO", "CS"], {})
+
+        # Find max_length constraint for all nets
+        max_length = next(c for c in constraints if c.type == "max_length" and "nets" in c.params)
+        assert max_length.params["max_mm"] == 200.0
+        assert max_length.source == "spi:spi_standard"
+        assert max_length.severity == ConstraintSeverity.WARNING
+
+    def test_length_match_constraint_params(self):
+        """Test length match constraint has correct parameters."""
+        spec = SPIInterfaceSpec("spi_high_speed")
+        constraints = spec.derive_constraints(["CLK", "MOSI", "MISO", "CS"], {})
+
+        length_constraint = next(c for c in constraints if c.type == "length_match")
+        assert length_constraint.params["tolerance_mm"] == 2.0
+        assert length_constraint.severity == ConstraintSeverity.WARNING
+
+    def test_clock_net_detection(self):
+        """Test clock net is detected from various naming patterns."""
+        spec = SPIInterfaceSpec()
+
+        # Test SCK pattern
+        constraints = spec.derive_constraints(["SCK", "MOSI", "MISO", "CS"], {})
+        clk_constraints = [c for c in constraints if c.params.get("net") == "SCK"]
+        assert len(clk_constraints) > 0
+
+        # Test SCLK pattern
+        constraints = spec.derive_constraints(["SCLK", "MOSI", "MISO", "CS"], {})
+        clk_constraints = [c for c in constraints if c.params.get("net") == "SCLK"]
+        assert len(clk_constraints) > 0
+
+    def test_variant_override_via_params(self):
+        """Test variant can be overridden via params."""
+        spec = SPIInterfaceSpec("spi_standard")
+        constraints = spec.derive_constraints(
+            ["CLK", "MOSI", "MISO", "CS"], {"variant": "spi_high_speed"}
+        )
+
+        # Should use high speed constraints even though spec is standard
+        constraint_types = {c.type for c in constraints}
+        assert "length_match" in constraint_types
+
+    def test_constraint_source_format(self):
+        """Test constraint source uses spi:variant format."""
+        spec = SPIInterfaceSpec("spi_fast")
+        constraints = spec.derive_constraints(["CLK", "MOSI", "MISO", "CS"], {})
+
+        for constraint in constraints:
+            assert constraint.source == "spi:spi_fast"
+
+
+class TestSPIValidationMessages:
+    """Tests for SPI validation message formatting."""
+
+    def test_length_mismatch_message(self):
+        """Test length mismatch validation message."""
+        spec = SPIInterfaceSpec("spi_high_speed")
+        msg = spec.get_validation_message({"type": "length_mismatch", "delta": 3.5})
+
+        assert "SPI" in msg
+        assert "3.5mm" in msg
+        assert "signal integrity" in msg.lower()
+
+    def test_max_length_message(self):
+        """Test max length violation message."""
+        spec = SPIInterfaceSpec("spi_standard")
+        msg = spec.get_validation_message({"type": "max_length", "actual": 250})
+
+        assert "250mm" in msg
+        assert "200" in msg  # Max for standard
+        assert "signal integrity" in msg.lower()
+
+    def test_termination_message(self):
+        """Test termination recommendation message."""
+        spec = SPIInterfaceSpec("spi_high_speed")
+        msg = spec.get_validation_message({"type": "termination"})
+
+        assert "termination" in msg.lower()
+        assert "22-33" in msg  # Typical resistor range
+
+    def test_unknown_violation_fallback(self):
+        """Test fallback for unknown violation types."""
+        spec = SPIInterfaceSpec()
+        msg = spec.get_validation_message({"type": "unknown", "message": "Custom message"})
+        assert msg == "Custom message"
+
+
+class TestSPIFrequencyFormatting:
+    """Tests for frequency formatting helper."""
+
+    def test_format_mhz(self):
+        """Test formatting frequencies in MHz."""
+        assert SPIInterfaceSpec._format_freq(10e6) == "10MHz"
+        assert SPIInterfaceSpec._format_freq(50e6) == "50MHz"
+        assert SPIInterfaceSpec._format_freq(100e6) == "100MHz"
+
+    def test_format_ghz(self):
+        """Test formatting frequencies in GHz."""
+        assert SPIInterfaceSpec._format_freq(1e9) == "1GHz"
+
+
+class TestSPIRegistryIntegration:
+    """Tests for SPI interface registration in global registry."""
+
+    def test_all_variants_registered(self):
+        """Test all SPI variants are registered in global REGISTRY."""
+        for variant_name in SPI_VARIANTS:
+            assert variant_name in REGISTRY, f"Variant not registered: {variant_name}"
+
+    def test_registered_spec_is_spi_interface_spec(self):
+        """Test registered specs are SPIInterfaceSpec instances."""
+        spec = REGISTRY.get("spi_standard")
+        assert spec is not None
+        assert isinstance(spec, SPIInterfaceSpec)
+
+    def test_derive_constraints_via_registry(self):
+        """Test deriving constraints through the registry."""
+        constraints = derive_constraints(
+            interface_type="spi_standard",
+            nets=["CLK", "MOSI", "MISO", "CS"],
+        )
+        assert len(constraints) > 0
+        assert any(c.type == "max_length" for c in constraints)
+
+    def test_validate_intent_via_registry(self):
+        """Test validating intent through the registry."""
+        errors = validate_intent(
+            interface_type="spi_standard",
+            nets=["CLK", "MOSI", "MISO", "CS"],
+        )
+        assert errors == []
+
+    def test_create_intent_declaration_via_registry(self):
+        """Test creating intent declaration through the registry."""
+        declaration = create_intent_declaration(
+            interface_type="spi_fast",
+            nets=["CLK", "MOSI", "MISO", "CS"],
+            metadata={"device": "U1"},
+        )
+        assert declaration.interface_type == "spi_fast"
+        assert len(declaration.constraints) > 0
+
+    def test_spi_specs_in_bus_category(self):
+        """Test SPI specs appear in BUS category listing."""
+        bus_interfaces = REGISTRY.list_by_category(InterfaceCategory.BUS)
+        for variant_name in SPI_VARIANTS:
+            assert variant_name in bus_interfaces
+
+
+class TestSPIAcceptanceCriteria:
+    """Tests verifying issue acceptance criteria."""
+
+    def test_implements_interface_spec_protocol(self):
+        """AC: SPIInterfaceSpec implements InterfaceSpec protocol."""
+        spec = SPIInterfaceSpec()
+        assert isinstance(spec.name, str)
+        assert isinstance(spec.category, InterfaceCategory)
+        assert callable(spec.validate_nets)
+        assert callable(spec.derive_constraints)
+        assert callable(spec.get_validation_message)
+
+    def test_three_speed_variants(self):
+        """AC: SPIInterfaceSpec with 3 speed variants."""
+        assert "spi_standard" in SPI_VARIANTS
+        assert "spi_fast" in SPI_VARIANTS
+        assert "spi_high_speed" in SPI_VARIANTS
+        assert len(SPI_VARIANTS) == 3
+
+    def test_intent_aware_messages(self):
+        """AC: Intent-aware validation messages for SPI violations."""
+        spec = SPIInterfaceSpec("spi_high_speed")
+
+        msg = spec.get_validation_message({"type": "length_mismatch", "delta": 5.0})
+        assert "SPI" in msg
+
+        msg = spec.get_validation_message({"type": "max_length", "actual": 100})
+        assert "SPI" in msg or "trace" in msg.lower()
+
+    def test_registered_in_global_registry(self):
+        """AC: Registered in global REGISTRY on module import."""
+        for variant in SPI_VARIANTS:
+            assert REGISTRY.get(variant) is not None


### PR DESCRIPTION
## Summary

Implements three new interface specifications for the intent module, covering the most common embedded system interfaces after USB:

- **SPIInterfaceSpec**: 3 speed variants (standard ≤10MHz, fast ≤50MHz, high-speed ≤100MHz) with length matching and termination constraints
- **I2CInterfaceSpec**: Standard/Fast/Fast+ variants with capacitance limits, pull-up requirements, and trace length constraints  
- **PowerInterfaceSpec**: Current-based trace width calculation (IPC-2221) with decoupling capacitor recommendations

## Changes

- `src/kicad_tools/intent/interfaces/spi.py` - SPI interface with 3 speed variants
- `src/kicad_tools/intent/interfaces/i2c.py` - I2C interface with Standard/Fast/Fast+ variants
- `src/kicad_tools/intent/interfaces/power.py` - Power rail interface with current-based constraints
- `src/kicad_tools/intent/interfaces/__init__.py` - Updated to register new interfaces
- `tests/test_spi_interface.py` - 37 tests for SPI interface
- `tests/test_i2c_interface.py` - 40 tests for I2C interface
- `tests/test_power_interface.py` - 37 tests for Power interface

## Test Plan

- [x] All 114 new tests pass
- [x] All interfaces implement InterfaceSpec protocol
- [x] Interfaces registered in global REGISTRY
- [x] Intent-aware validation messages for each interface type

Closes #515