### PR TITLE
feat(cli): Expose parts suggest command in CLI

### DIFF
--- a/src/kicad_tools/cli/commands/parts.py
+++ b/src/kicad_tools/cli/commands/parts.py
@@ -1,5 +1,11 @@
 """Parts (LCSC) command handlers."""
 
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
 __all__ = ["run_parts_command"]
 
 
@@ -7,7 +13,7 @@ def run_parts_command(args) -> int:
     """Handle parts subcommands."""
     if not args.parts_command:
         print("Usage: kicad-tools parts <command> [options]")
-        print("Commands: lookup, search, availability, cache")
+        print("Commands: lookup, search, availability, cache, suggest")
         return 1
 
     from ..parts_cmd import main as parts_main
@@ -48,4 +54,168 @@ def run_parts_command(args) -> int:
         sub_argv = ["cache", args.cache_action]
         return parts_main(sub_argv) or 0
 
+    elif args.parts_command == "suggest":
+        return _run_suggest_command(args)
+
     return 1
+
+
+def _run_suggest_command(args) -> int:
+    """Suggest LCSC part numbers for components without them."""
+    from kicad_tools.cost.suggest import PartSuggester
+    from kicad_tools.schema.bom import extract_bom
+
+    input_path = Path(args.schematic)
+    if not input_path.exists():
+        print(f"Error: File not found: {input_path}", file=sys.stderr)
+        return 1
+
+    # Load BOM from schematic
+    try:
+        bom = extract_bom(str(input_path))
+    except Exception as e:
+        print(f"Error loading schematic: {e}", file=sys.stderr)
+        return 1
+
+    if not bom.items:
+        print("No components found in schematic.", file=sys.stderr)
+        return 1
+
+    # Filter to non-DNP items
+    active_items = [item for item in bom.items if not item.dnp]
+
+    if not active_items:
+        print("No active (non-DNP) components found.", file=sys.stderr)
+        return 1
+
+    # Count items needing LCSC numbers
+    missing_lcsc = [item for item in active_items if not item.lcsc]
+
+    if not missing_lcsc and not args.show_all:
+        print("All components already have LCSC part numbers.")
+        return 0
+
+    print(
+        f"Analyzing {len(active_items)} components ({len(missing_lcsc)} missing LCSC numbers)...",
+        file=sys.stderr,
+    )
+
+    # Create suggester with options
+    try:
+        with PartSuggester(
+            prefer_basic=not args.no_basic_preference,
+            min_stock=args.min_stock,
+            max_suggestions=args.max_suggestions,
+        ) as suggester:
+            result = suggester.suggest_for_bom(bom)
+    except ImportError:
+        print(
+            "Error: The 'requests' library is required for this feature.",
+            file=sys.stderr,
+        )
+        print("Install with: pip install kicad-tools[parts]", file=sys.stderr)
+        return 1
+
+    # Filter results if not showing all
+    if not args.show_all:
+        result.suggestions = [s for s in result.suggestions if s.needs_lcsc]
+
+    if not result.suggestions:
+        print("No components need suggestions.")
+        return 0
+
+    # Output results
+    if args.format == "json":
+        _print_json_result(result)
+    else:
+        _print_table_result(result)
+
+    return 0
+
+
+def _print_json_result(result) -> None:
+    """Print suggestions as JSON."""
+    output = {
+        "summary": {
+            "total_components": result.total_components,
+            "missing_lcsc": result.missing_lcsc,
+            "found_suggestions": result.found_suggestions,
+            "no_suggestions": result.no_suggestions,
+        },
+        "suggestions": [],
+    }
+
+    for suggestion in result.suggestions:
+        item = {
+            "reference": suggestion.reference,
+            "value": suggestion.value,
+            "footprint": suggestion.footprint,
+            "package": suggestion.package,
+            "existing_lcsc": suggestion.existing_lcsc,
+            "search_query": suggestion.search_query,
+            "error": suggestion.error,
+            "suggestions": [],
+        }
+
+        for s in suggestion.suggestions:
+            item["suggestions"].append(
+                {
+                    "lcsc_part": s.lcsc_part,
+                    "mfr_part": s.mfr_part,
+                    "description": s.description,
+                    "package": s.package,
+                    "stock": s.stock,
+                    "is_basic": s.is_basic,
+                    "is_preferred": s.is_preferred,
+                    "unit_price": s.unit_price,
+                    "confidence": s.confidence,
+                }
+            )
+
+        output["suggestions"].append(item)
+
+    print(json.dumps(output, indent=2))
+
+
+def _print_table_result(result) -> None:
+    """Print suggestions in table format."""
+    print()
+    print(
+        f"{'Component':<12} {'Value':<15} {'Footprint':<15} {'Suggested LCSC':<12} {'Stock':<10} {'Type':<6}"
+    )
+    print("-" * 82)
+
+    for suggestion in result.suggestions:
+        if suggestion.has_suggestion:
+            best = suggestion.best_suggestion
+            print(
+                f"{suggestion.reference:<12} "
+                f"{suggestion.value[:14]:<15} "
+                f"{suggestion.package or '-':<15} "
+                f"{best.lcsc_part:<12} "
+                f"{best.stock:>9,} "
+                f"{best.type_str:<6}"
+            )
+
+            # Print additional suggestions if any
+            for alt in suggestion.suggestions[1:]:
+                print(
+                    f"{'':12} {'':15} {'':15} {alt.lcsc_part:<12} {alt.stock:>9,} {alt.type_str:<6}"
+                )
+        else:
+            error_msg = suggestion.error or "No matches found"
+            print(
+                f"{suggestion.reference:<12} "
+                f"{suggestion.value[:14]:<15} "
+                f"{suggestion.package or '-':<15} "
+                f"{'(none)':<12} "
+                f"{'':<10} "
+                f"{error_msg}"
+            )
+
+    print()
+    print(
+        f"Summary: {result.found_suggestions}/{result.missing_lcsc} components with suggestions found"
+    )
+    if result.no_suggestions > 0:
+        print(f"         {result.no_suggestions} components could not be matched")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1021,6 +1021,38 @@ def _add_parts_parser(subparsers) -> None:
         help="Cache action (default: stats)",
     )
 
+    # parts suggest
+    parts_suggest = parts_subparsers.add_parser(
+        "suggest", help="Suggest LCSC part numbers for components without them"
+    )
+    parts_suggest.add_argument("schematic", help="Path to .kicad_sch file")
+    parts_suggest.add_argument(
+        "--format", choices=["table", "json"], default="table", help="Output format"
+    )
+    parts_suggest.add_argument(
+        "--all",
+        action="store_true",
+        dest="show_all",
+        help="Show suggestions for all components (including those with LCSC numbers)",
+    )
+    parts_suggest.add_argument(
+        "--no-basic-preference",
+        action="store_true",
+        help="Don't prefer JLCPCB basic parts",
+    )
+    parts_suggest.add_argument(
+        "--min-stock",
+        type=int,
+        default=100,
+        help="Minimum stock level to consider (default: 100)",
+    )
+    parts_suggest.add_argument(
+        "--max-suggestions",
+        type=int,
+        default=3,
+        help="Maximum suggestions per component (default: 3)",
+    )
+
 
 def _add_datasheet_parser(subparsers) -> None:
     """Add datasheet subcommand parser with its subcommands."""


### PR DESCRIPTION
## Summary

Exposes the `parts suggest` command in the CLI as documented in the v0.9.0 release notes. This command analyzes schematic components and automatically recommends LCSC part numbers for those without them.

## Changes

- Added `suggest` subparser to the parts command in `parser.py`
- Implemented `_run_suggest_command()` handler in `commands/parts.py`
- Supports table and JSON output formats
- Configurable options for basic part preference, minimum stock, and max suggestions

## Usage

```bash
# Basic usage - suggest parts for components without LCSC numbers
kct parts suggest design.kicad_sch

# JSON output with all components
kct parts suggest design.kicad_sch --format json --all

# Customize part selection preferences
kct parts suggest design.kicad_sch --no-basic-preference --min-stock 500
```

## Test Plan

- [x] Verified command help displays correctly (`kct parts suggest --help`)
- [x] All existing parts tests pass (`pytest tests/test_parts.py`)
- [x] Format and lint checks pass on modified files

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)