### PR TITLE
fix(placement): Support fp_text reference format in fix apply

### DIFF
--- a/src/kicad_tools/placement/fixer.py
+++ b/src/kicad_tools/placement/fixer.py
@@ -494,13 +494,18 @@ class PlacementFixer:
         ref = fix.component
 
         # Pattern to match the footprint block with this reference.
+        # KiCad PCB files have two reference formats:
+        # 1. KiCad 8 property format: (property "Reference" "REF" ...)
+        # 2. Legacy fp_text format: (fp_text reference "REF" ...)
+        #
         # Key fixes:
         # 1. Use "[^"]+" for quoted footprint name (not [^\)]+)
         # 2. Use [\s\S]*? for lazy match across nested S-expressions (not [^\)]*)
         # 3. The suffix includes the closing ), so don't add another in replacement
+        # 4. Match both reference formats using alternation (?: ... | ... )
         #
-        # Structure: (footprint "name" (layer "...") ... (at X Y [R]) ... property "Reference" "REF" ...)
-        fp_pattern = rf'(\(footprint\s+"[^"]+"\s+\(layer\s+"[^"]+"\)[\s\S]*?\(at\s+)([\d.-]+)\s+([\d.-]+)(\s+[\d.-]+)?(\)[\s\S]*?property\s+"Reference"\s+"{re.escape(ref)}")'
+        # Structure: (footprint "name" (layer "...") ... (at X Y [R]) ... reference identifier ...)
+        fp_pattern = rf'(\(footprint\s+"[^"]+"\s+\(layer\s+"[^"]+"\)[\s\S]*?\(at\s+)([\d.-]+)\s+([\d.-]+)(\s+[\d.-]+)?(\)[\s\S]*?(?:property\s+"Reference"\s+"{re.escape(ref)}"|fp_text\s+reference\s+"{re.escape(ref)}"))'
 
         def update_position(match):
             prefix = match.group(1)


### PR DESCRIPTION
## Summary

Fixes the `kct placement fix` command which was suggesting fixes but applying 0 of them.

The root cause was that the regex in `_apply_fix_to_content` only matched the KiCad 8 `property "Reference"` format, but real KiCad PCB files use the legacy `fp_text reference` format.

## Changes

- Updated regex pattern to match both reference formats using alternation:
  - KiCad 8 property format: `(property "Reference" "REF" ...)`
  - Legacy fp_text format: `(fp_text reference "REF" ...)`
- Added comprehensive tests for the fp_text format

## Test Plan

- [x] All existing placement tests pass (38 tests)
- [x] New tests verify fix application with fp_text format:
  - `test_apply_fixes_with_fp_text_format`
  - `test_fp_text_format_position_changes`
  - `test_cli_fix_with_fp_text_format`
- [x] Lint check passes for modified files

Closes #547