### PR TITLE
feat(manufacturers): Add FlashPCB as a supported manufacturer

### DIFF
--- a/src/kicad_tools/manufacturers/__init__.py
+++ b/src/kicad_tools/manufacturers/__init__.py
@@ -9,6 +9,7 @@ Supported manufacturers:
 - Seeed Fusion (seeed) - Chinese fab with OPL parts library
 - PCBWay (pcbway) - Chinese fab with global sourcing
 - OSHPark (oshpark) - US fab, PCB only, per-sq-inch pricing
+- FlashPCB (flashpcb) - US fab with assembly services
 
 Usage:
     from manufacturers import get_profile, list_manufacturers
@@ -29,6 +30,7 @@ from .base import (
     PartsLibrary,
     load_design_rules_from_yaml,
 )
+from .flashpcb import FLASHPCB_PROFILE
 from .jlcpcb import JLCPCB_PROFILE
 from .oshpark import OSHPARK_PROFILE
 from .pcbway import PCBWAY_PROFILE
@@ -46,6 +48,7 @@ __all__ = [
     "get_manufacturer_ids",
     "load_design_rules_from_yaml",
     # Profiles (for direct access)
+    "FLASHPCB_PROFILE",
     "JLCPCB_PROFILE",
     "SEEED_PROFILE",
     "PCBWAY_PROFILE",
@@ -54,6 +57,7 @@ __all__ = [
 
 # Registry of all manufacturer profiles
 _PROFILES: dict[str, ManufacturerProfile] = {
+    "flashpcb": FLASHPCB_PROFILE,
     "jlcpcb": JLCPCB_PROFILE,
     "seeed": SEEED_PROFILE,
     "pcbway": PCBWAY_PROFILE,
@@ -62,6 +66,7 @@ _PROFILES: dict[str, ManufacturerProfile] = {
 
 # Aliases for convenience
 _ALIASES: dict[str, str] = {
+    "flash": "flashpcb",
     "jlc": "jlcpcb",
     "lcsc": "jlcpcb",
     "seeed_fusion": "seeed",

--- a/src/kicad_tools/manufacturers/data/flashpcb.yaml
+++ b/src/kicad_tools/manufacturers/data/flashpcb.yaml
@@ -1,0 +1,87 @@
+# FlashPCB Design Rules Configuration
+# Source: https://www.flashpcb.com/capabilities
+#
+# All measurements in millimeters unless otherwise noted.
+# Note: FlashPCB is a USA-based PCB fabrication and assembly house.
+# This configuration covers the instant quote tier only.
+
+design_rules:
+  # 2-layer 1oz copper
+  2layer_1oz:
+    min_trace_width_mm: 0.127       # 5 mil
+    min_clearance_mm: 0.127         # 5 mil
+    min_via_drill_mm: 0.2           # 8 mil
+    min_via_diameter_mm: 0.45       # ~18 mil (8 mil drill + 5 mil annular ring each side)
+    min_annular_ring_mm: 0.127      # 5 mil
+    min_hole_diameter_mm: 0.2       # 8 mil
+    max_hole_diameter_mm: 6.35      # 250 mil
+    min_copper_to_edge_mm: 0.254    # 10 mil
+    min_hole_to_edge_mm: 0.254      # 10 mil
+    min_silkscreen_width_mm: 0.127  # 5 mil
+    min_silkscreen_height_mm: 0.8   # ~32 mil
+    min_solder_mask_dam_mm: 0.102   # 4 mil
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.0            # No inner layers
+    max_board_width_mm: 254.0       # 10 inches
+    max_board_height_mm: 254.0      # 10 inches
+
+  # 2-layer 2oz copper
+  2layer_2oz:
+    min_trace_width_mm: 0.2032      # 8 mil (wider for 2oz)
+    min_clearance_mm: 0.127         # 5 mil
+    min_via_drill_mm: 0.2           # 8 mil
+    min_via_diameter_mm: 0.45       # ~18 mil
+    min_annular_ring_mm: 0.127      # 5 mil
+    min_hole_diameter_mm: 0.2       # 8 mil
+    max_hole_diameter_mm: 6.35      # 250 mil
+    min_copper_to_edge_mm: 0.254    # 10 mil
+    min_hole_to_edge_mm: 0.254      # 10 mil
+    min_silkscreen_width_mm: 0.127  # 5 mil
+    min_silkscreen_height_mm: 0.8   # ~32 mil
+    min_solder_mask_dam_mm: 0.102   # 4 mil
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0
+    inner_copper_oz: 0.0
+    max_board_width_mm: 254.0
+    max_board_height_mm: 254.0
+
+  # 4-layer 1oz outer copper (0.5oz inner)
+  4layer_1oz:
+    min_trace_width_mm: 0.127       # 5 mil
+    min_clearance_mm: 0.127         # 5 mil
+    min_via_drill_mm: 0.2           # 8 mil
+    min_via_diameter_mm: 0.45       # ~18 mil
+    min_annular_ring_mm: 0.127      # 5 mil
+    min_hole_diameter_mm: 0.2       # 8 mil
+    max_hole_diameter_mm: 6.35      # 250 mil
+    min_copper_to_edge_mm: 0.254    # 10 mil
+    min_hole_to_edge_mm: 0.254      # 10 mil
+    min_silkscreen_width_mm: 0.127  # 5 mil
+    min_silkscreen_height_mm: 0.8   # ~32 mil
+    min_solder_mask_dam_mm: 0.102   # 4 mil
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.5
+    max_board_width_mm: 254.0
+    max_board_height_mm: 254.0
+
+  # 4-layer 2oz outer copper (1oz inner)
+  4layer_2oz:
+    min_trace_width_mm: 0.2032      # 8 mil (wider for 2oz)
+    min_clearance_mm: 0.127         # 5 mil
+    min_via_drill_mm: 0.2           # 8 mil
+    min_via_diameter_mm: 0.45       # ~18 mil
+    min_annular_ring_mm: 0.127      # 5 mil
+    min_hole_diameter_mm: 0.2       # 8 mil
+    max_hole_diameter_mm: 6.35      # 250 mil
+    min_copper_to_edge_mm: 0.254    # 10 mil
+    min_hole_to_edge_mm: 0.254      # 10 mil
+    min_silkscreen_width_mm: 0.127  # 5 mil
+    min_silkscreen_height_mm: 0.8   # ~32 mil
+    min_solder_mask_dam_mm: 0.102   # 4 mil
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0
+    inner_copper_oz: 1.0
+    max_board_width_mm: 254.0
+    max_board_height_mm: 254.0

--- a/src/kicad_tools/manufacturers/flashpcb.py
+++ b/src/kicad_tools/manufacturers/flashpcb.py
@@ -1,0 +1,72 @@
+"""
+FlashPCB manufacturer profile.
+
+Design rules and capabilities for FlashPCB PCB fabrication and assembly.
+FlashPCB is a USA-based manufacturer offering PCB fabrication and PCBA services.
+Source: https://www.flashpcb.com/capabilities
+"""
+
+from .base import (
+    AssemblyCapabilities,
+    ManufacturerProfile,
+    load_design_rules_from_yaml,
+)
+
+# Load design rules from YAML configuration
+_DESIGN_RULES = load_design_rules_from_yaml("flashpcb")
+
+# Assembly capabilities for FlashPCB instant quote tier
+# Note: No parts library like LCSC - components must be sourced separately
+_ASSEMBLY = AssemblyCapabilities(
+    min_component_pitch_mm=0.508,  # 20 mil pad pitch
+    min_bga_pitch_mm=0.5,  # BGA available via email quote only
+    max_component_height_mm=25.0,
+    supported_packages=[
+        "0201",
+        "0402",
+        "0603",
+        "0805",
+        "1206",
+        "1210",
+        "SOT-23",
+        "SOT-223",
+        "SOT-363",
+        "SOIC-8",
+        "SOIC-14",
+        "SOIC-16",
+        "TSSOP-14",
+        "TSSOP-16",
+        "TSSOP-20",
+        "TSSOP-28",
+        "QFN",
+        "QFP",
+        "LQFP",
+    ],
+    supports_double_sided=True,
+    supports_bga=False,  # BGA requires email quote, not instant
+    supports_fine_pitch=False,  # <0.5mm pitch requires email quote
+)
+
+# Complete FlashPCB Profile
+FLASHPCB_PROFILE = ManufacturerProfile(
+    id="flashpcb",
+    name="FlashPCB",
+    website="https://www.flashpcb.com",
+    design_rules=_DESIGN_RULES,
+    assembly=_ASSEMBLY,
+    parts_library=None,  # No integrated parts library
+    lead_times={
+        "pcb_expedited": 3,  # 3 day turnaround
+        "pcb_standard": 5,  # 5 day turnaround
+        "pcb_economy": 10,  # 10 day turnaround
+        "pcba_standard": 10,  # Estimate for assembly
+    },
+    bom_format="generic",
+    supported_layers=[2, 4],  # Instant quote tier only
+    pricing_model="per_pcb",
+)
+
+
+def get_profile() -> ManufacturerProfile:
+    """Get the FlashPCB manufacturer profile."""
+    return FLASHPCB_PROFILE

--- a/src/kicad_tools/manufacturers/rules/flashpcb-2layer-1oz.kicad_dru
+++ b/src/kicad_tools/manufacturers/rules/flashpcb-2layer-1oz.kicad_dru
@@ -1,0 +1,17 @@
+(version 1)
+(rule "Trace Width"
+  (constraint track_width (min 0.127mm)))
+(rule "Clearance"
+  (constraint clearance (min 0.127mm)))
+(rule "Via Drill"
+  (constraint hole_size (min 0.2mm)))
+(rule "Via Diameter"
+  (constraint via_diameter (min 0.45mm)))
+(rule "Annular Ring"
+  (constraint annular_width (min 0.127mm)))
+(rule "Copper to Edge"
+  (constraint edge_clearance (min 0.254mm)))
+(rule "Hole to Edge"
+  (constraint hole_to_hole (min 0.254mm)))
+(rule "Silkscreen Width"
+  (constraint silk_clearance (min 0.127mm)))

--- a/src/kicad_tools/manufacturers/rules/flashpcb-2layer-2oz.kicad_dru
+++ b/src/kicad_tools/manufacturers/rules/flashpcb-2layer-2oz.kicad_dru
@@ -1,0 +1,17 @@
+(version 1)
+(rule "Trace Width"
+  (constraint track_width (min 0.2032mm)))
+(rule "Clearance"
+  (constraint clearance (min 0.127mm)))
+(rule "Via Drill"
+  (constraint hole_size (min 0.2mm)))
+(rule "Via Diameter"
+  (constraint via_diameter (min 0.45mm)))
+(rule "Annular Ring"
+  (constraint annular_width (min 0.127mm)))
+(rule "Copper to Edge"
+  (constraint edge_clearance (min 0.254mm)))
+(rule "Hole to Edge"
+  (constraint hole_to_hole (min 0.254mm)))
+(rule "Silkscreen Width"
+  (constraint silk_clearance (min 0.127mm)))

--- a/src/kicad_tools/manufacturers/rules/flashpcb-4layer-1oz.kicad_dru
+++ b/src/kicad_tools/manufacturers/rules/flashpcb-4layer-1oz.kicad_dru
@@ -1,0 +1,17 @@
+(version 1)
+(rule "Trace Width"
+  (constraint track_width (min 0.127mm)))
+(rule "Clearance"
+  (constraint clearance (min 0.127mm)))
+(rule "Via Drill"
+  (constraint hole_size (min 0.2mm)))
+(rule "Via Diameter"
+  (constraint via_diameter (min 0.45mm)))
+(rule "Annular Ring"
+  (constraint annular_width (min 0.127mm)))
+(rule "Copper to Edge"
+  (constraint edge_clearance (min 0.254mm)))
+(rule "Hole to Edge"
+  (constraint hole_to_hole (min 0.254mm)))
+(rule "Silkscreen Width"
+  (constraint silk_clearance (min 0.127mm)))

--- a/src/kicad_tools/manufacturers/rules/flashpcb-4layer-2oz.kicad_dru
+++ b/src/kicad_tools/manufacturers/rules/flashpcb-4layer-2oz.kicad_dru
@@ -1,0 +1,17 @@
+(version 1)
+(rule "Trace Width"
+  (constraint track_width (min 0.2032mm)))
+(rule "Clearance"
+  (constraint clearance (min 0.127mm)))
+(rule "Via Drill"
+  (constraint hole_size (min 0.2mm)))
+(rule "Via Diameter"
+  (constraint via_diameter (min 0.45mm)))
+(rule "Annular Ring"
+  (constraint annular_width (min 0.127mm)))
+(rule "Copper to Edge"
+  (constraint edge_clearance (min 0.254mm)))
+(rule "Hole to Edge"
+  (constraint hole_to_hole (min 0.254mm)))
+(rule "Silkscreen Width"
+  (constraint silk_clearance (min 0.127mm)))


### PR DESCRIPTION
## Summary

Add FlashPCB as a supported manufacturer for PCB fabrication and assembly. FlashPCB is a USA-based manufacturer that fills the gap between OSHPark (USA, PCB-only) and JLCPCB (China, assembly).

## Changes

- Added `flashpcb.yaml` with design rules for 2-layer and 4-layer boards with 1oz and 2oz copper
- Added `flashpcb.py` profile module with assembly capabilities for instant quote tier
- Added 4 KiCad DRU files for supported configurations
- Registered FlashPCB in `__init__.py` with "flash" alias

## FlashPCB Specifications (Instant Quote Tier)

| Specification | Value |
|---------------|-------|
| Layers | 2, 4 |
| Board Area | 10" × 10" max |
| Min Trace Width | 5 mil (0.127mm) |
| Min Trace Spacing | 5 mil (0.127mm) |
| Min Drill Size | 8 mil (0.2mm) |
| Copper Weight | 1oz, 2oz outer; 0.5oz, 1oz inner |
| Lead Times | 3, 5, or 10 days |
| Assembly | 2-sided, down to 0201 (no BGA/fine pitch in instant quote) |

## Test Plan

- [x] FlashPCB profile loads correctly via `get_profile('flashpcb')`
- [x] Alias "flash" resolves to FlashPCB profile
- [x] Design rules return correct values for all 4 configurations
- [x] Assembly capabilities report correctly
- [x] `list_manufacturers()` includes FlashPCB
- [x] `find_compatible_manufacturers()` returns FlashPCB when appropriate
- [x] `compare_design_rules()` works with FlashPCB

Closes #545