### PR TITLE
fix(router): Include clearance in trace blocking radius

### DIFF
--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -30,9 +30,16 @@ Pathfinder::Pathfinder(Grid3D& grid, const DesignRules& rules, bool diagonal_rou
         neighbors_2d_.push_back({-1, -1, 0, 1.414f}); // Up-Left
     }
 
-    // Pre-compute trace half-width in grid cells
+    // Pre-compute trace clearance radius in grid cells
+    // This is the total radius from trace centerline that must be clear:
+    // - trace_width/2: half-width of the trace copper
+    // - trace_clearance: required clearance from trace edge to obstacles
+    // This enforces clearance as a hard constraint during routing.
+    // Issue #553: Previously only checked trace_width/2, causing DRC violations
+    // when traces were placed too close to obstacles.
     trace_half_width_cells_ = std::max(
-        1, static_cast<int>(std::ceil((rules.trace_width / 2) / grid.resolution())));
+        1, static_cast<int>(std::ceil(
+            (rules.trace_width / 2 + rules.trace_clearance) / grid.resolution())));
 
     // Pre-compute via blocking radius in grid cells
     via_half_cells_ = std::max(

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -92,11 +92,19 @@ class Router:
                 ]
             )
 
-        # Pre-calculate trace body radius in grid cells
-        # Only trace_width/2 - clearance is already in pad blocking
-        # Add 1 cell minimum to ensure blocking check works
+        # Pre-calculate trace clearance radius in grid cells
+        # This is the total radius from trace centerline that must be clear:
+        # - trace_width/2: half-width of the trace copper
+        # - trace_clearance: required clearance from trace edge to obstacles
+        # This enforces clearance as a hard constraint during routing.
+        # Issue #553: Previously only checked trace_width/2, causing DRC violations
+        # when traces were placed too close to obstacles.
         self._trace_half_width_cells = max(
-            1, math.ceil((self.rules.trace_width / 2) / self.grid.resolution)
+            1,
+            math.ceil(
+                (self.rules.trace_width / 2 + self.rules.trace_clearance)
+                / self.grid.resolution
+            ),
         )
 
         # Pre-calculate via blocking radius in grid cells


### PR DESCRIPTION
## Summary

- Fix clearance violations by including `trace_clearance` in the trace blocking radius calculation
- The `_trace_half_width_cells` calculation now uses: `ceil((trace_width/2 + trace_clearance) / resolution)`
- This enforces clearance as a hard constraint during routing, preventing DRC violations
- Applied fix to both Python (`pathfinder.py`) and C++ (`pathfinder.cpp`) implementations

## Root Cause

Previously, the router's pathfinder only checked cells within `trace_width/2` radius of the trace centerline when determining if a position was blocked. This meant traces could be placed closer to obstacles than the specified clearance, resulting in DRC violations like:

```
Clearance violation (netclass 'Default' clearance 0.1270 mm; actual 0.0074 mm)
```

## Solution

Changed the trace blocking radius calculation from:
```
ceil(trace_width / 2 / resolution)
```
to:
```
ceil((trace_width / 2 + trace_clearance) / resolution)
```

This ensures that when checking if a trace position is valid, we consider not just where the trace copper would be, but also the required clearance zone around it.

## Test Plan

- [x] Added unit test `test_trace_half_width_cells_includes_clearance` to verify formula
- [x] Added functional test `test_trace_clearance_prevents_drc_violations` to verify routing behavior
- [x] All 357 router tests pass
- [x] All 8 C++ backend tests pass

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)