### PR TITLE
fix(cli): Fix mfr compare --layers flag being ignored

### DIFF
--- a/src/kicad_tools/cli/commands/manufacturer.py
+++ b/src/kicad_tools/cli/commands/manufacturer.py
@@ -23,18 +23,16 @@ def run_mfr_command(args) -> int:
 
     elif args.mfr_command == "rules":
         sub_argv = ["rules", args.manufacturer]
-        if args.layers != 4:
-            sub_argv.extend(["--layers", str(args.layers)])
-        if args.copper != 1.0:
-            sub_argv.extend(["--copper", str(args.copper)])
+        # Always pass layers and copper to ensure inner command uses correct values
+        sub_argv.extend(["--layers", str(args.layers)])
+        sub_argv.extend(["--copper", str(args.copper)])
         return mfr_main(sub_argv) or 0
 
     elif args.mfr_command == "compare":
         sub_argv = ["compare"]
-        if args.layers != 4:
-            sub_argv.extend(["--layers", str(args.layers)])
-        if args.copper != 1.0:
-            sub_argv.extend(["--copper", str(args.copper)])
+        # Always pass layers and copper to ensure inner command uses correct values
+        sub_argv.extend(["--layers", str(args.layers)])
+        sub_argv.extend(["--copper", str(args.copper)])
         return mfr_main(sub_argv) or 0
 
     elif args.mfr_command == "apply-rules":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -669,7 +669,7 @@ def _add_mfr_parser(subparsers) -> None:
 
     # mfr compare
     mfr_compare = mfr_subparsers.add_parser("compare", help="Compare manufacturers")
-    mfr_compare.add_argument("-l", "--layers", type=int, default=4, help="Layer count")
+    mfr_compare.add_argument("-l", "--layers", type=int, default=2, help="Layer count (default: 2)")
     mfr_compare.add_argument("-c", "--copper", type=float, default=1.0, help="Copper weight (oz)")
 
     # mfr apply-rules


### PR DESCRIPTION
## Summary

Fixes the `mfr compare --layers N` command ignoring the `--layers` flag, always showing 2-layer rules regardless of the value passed.

## Root Cause

The bridging code in `commands/manufacturer.py` only passed `--layers` to the inner `mfr.py` command when the value differed from the outer parser's default (4), but the inner parser had a different default (2). This caused:

- `mfr compare` → inner parser uses default of 2 ✓
- `mfr compare --layers 4` → outer parser sees 4, condition `args.layers != 4` is False, so `--layers` not passed → inner parser uses default of 2 ✗

## Changes

1. **Always pass `--layers` and `--copper` values** to the inner command to ensure correct values are used regardless of default mismatches
2. **Change `mfr compare` default from 4-layer to 2-layer** to match user expectations and inner parser's default
3. **Apply same fix to `mfr rules` command** for consistency

## Before

```bash
$ kct mfr compare --layers 4
MANUFACTURER COMPARISON - 2-LAYER 1.0oz  # ← Wrong!
```

## After

```bash
$ kct mfr compare --layers 4
MANUFACTURER COMPARISON - 4-LAYER 1.0oz  # ← Correct!

$ kct mfr compare
MANUFACTURER COMPARISON - 2-LAYER 1.0oz  # ← Default is now 2-layer
```

## Test Plan

- [x] `kct mfr compare` shows "2-LAYER" (default)
- [x] `kct mfr compare --layers 4` shows "4-LAYER"
- [x] JLCPCB 4-layer values match YAML config (Via drill 0.20mm, Via diameter 0.45mm, Clearance 4 mil)
- [x] Relevant tests pass (`test_mfr.py` excluding pre-existing failure)

Closes #568