### PR TITLE
feat(router): Integrate C++ backend into Autorouter class

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -45,6 +45,13 @@ from .bus import (
     group_buses,
 )
 from .core import AdaptiveAutorouter, Autorouter, RoutingResult
+from .cpp_backend import (
+    CppGrid,
+    CppPathfinder,
+    create_hybrid_router,
+    get_backend_info,
+    is_cpp_available,
+)
 from .diffpair import (
     DifferentialPair,
     DifferentialPairConfig,
@@ -127,6 +134,12 @@ __all__ = [
     "Autorouter",
     "AdaptiveAutorouter",
     "RoutingResult",
+    # C++ backend
+    "is_cpp_available",
+    "get_backend_info",
+    "create_hybrid_router",
+    "CppGrid",
+    "CppPathfinder",
     # Bus routing
     "BusGroup",
     "BusRoutingConfig",

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .grid import RoutingGrid
     from .primitives import Pad, Route
-    from .rules import DesignRules
+    from .rules import DesignRules, NetClassRouting
 
 # Try to import C++ module
 try:
@@ -177,22 +177,25 @@ class CppPathfinder:
         self,
         start: Pad,
         end: Pad,
-        start_layers: list[int] | None = None,
-        end_layers: list[int] | None = None,
+        net_class: NetClassRouting | None = None,
         negotiated_mode: bool = False,
         present_cost_factor: float = 0.0,
         weight: float = 1.0,
+        start_layers: list[int] | None = None,
+        end_layers: list[int] | None = None,
     ) -> Route | None:
         """Route between two pads.
 
         Args:
             start: Source pad
             end: Destination pad
-            start_layers: Valid start layers (for PTH pads)
-            end_layers: Valid end layers (for PTH pads)
+            net_class: Optional net class for routing parameters (for interface
+                compatibility with Python Router; not fully used by C++ backend)
             negotiated_mode: Enable negotiated congestion routing
             present_cost_factor: Multiplier for sharing penalty
             weight: A* weight (1.0 = optimal, >1.0 = faster)
+            start_layers: Valid start layers (for PTH pads)
+            end_layers: Valid end layers (for PTH pads)
 
         Returns:
             Route object if successful, None if no path found

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -750,6 +750,7 @@ def load_pcb_for_routing(
     validate_drc: bool = True,
     edge_clearance: float | None = None,
     layer_stack: LayerStack | None = None,
+    force_python: bool = False,
 ) -> tuple[Autorouter, dict[str, int]]:
     """
     Load a KiCad PCB file and create an Autorouter with all components.
@@ -776,6 +777,9 @@ def load_pcb_for_routing(
                      Use LayerStack.four_layer_sig_gnd_pwr_sig() for 4-layer
                      boards with GND/PWR planes, which routes signals on outer
                      layers (F.Cu, B.Cu) with vias for layer transitions.
+        force_python: If True, force use of Python router backend even if the
+                     C++ backend is available. Default False uses C++ when
+                     available for 10-100x performance improvement.
 
     Returns:
         Tuple of (Autorouter instance, net_map dict)
@@ -971,6 +975,7 @@ def load_pcb_for_routing(
         rules=rules,
         net_class_map=DEFAULT_NET_CLASS_MAP,
         layer_stack=layer_stack,
+        force_python=force_python,
     )
 
     # Add all components


### PR DESCRIPTION
## Summary

- Integrates the existing C++ router backend (added in d4f8628) into the main Autorouter class
- Adds `--backend` CLI flag to select between auto/cpp/python backends
- Exposes backend utilities through the router module's public API

Closes #579

## Changes

- **core.py**: Use `create_hybrid_router()` instead of directly instantiating `Router`. Added `force_python` parameter and `backend_info` property
- **cpp_backend.py**: Updated `CppPathfinder.route()` signature to accept `net_class` parameter for interface compatibility
- **io.py**: Added `force_python` parameter to `load_pcb_for_routing()`
- **route_cmd.py**: Added `--backend` CLI flag with auto/cpp/python options
- **__init__.py**: Export `is_cpp_available`, `get_backend_info`, `create_hybrid_router`, `CppGrid`, `CppPathfinder`

## Test plan

- [x] Verify Python fallback works when C++ backend unavailable
- [x] Verify `--backend cpp` fails gracefully when C++ not available
- [x] Verify `--backend python` forces Python backend
- [x] Verify `backend_info` property shows correct active backend
- [ ] (When C++ available) Verify C++ backend is used by default
- [ ] (When C++ available) Verify routing produces equivalent results

🤖 Generated with [Claude Code](https://claude.com/claude-code)