### PR TITLE
feat(units): Add configurable unit system (mm/mils) for CLI output

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -36,7 +36,9 @@ See `kicad-tools --help` for complete documentation.
 
 import sys
 
+from kicad_tools.config import Config
 from kicad_tools.exceptions import KiCadToolsError
+from kicad_tools.units import get_unit_formatter, set_current_formatter
 
 from .commands import (
     run_analyze_command,
@@ -112,6 +114,12 @@ def main(argv: list[str] | None = None) -> int:
 
     # Get global verbose flag (use getattr for backwards compatibility)
     verbose = getattr(args, "global_verbose", False)
+
+    # Initialize unit formatter with CLI > env > config precedence
+    cli_units = getattr(args, "global_units", None)
+    config = Config.load()
+    formatter = get_unit_formatter(cli_units=cli_units, config=config)
+    set_current_formatter(formatter)
 
     try:
         return _dispatch_command(args)

--- a/src/kicad_tools/cli/fab_rules_cmd.py
+++ b/src/kicad_tools/cli/fab_rules_cmd.py
@@ -26,6 +26,7 @@ from kicad_tools.manufacturers import (
     get_profile,
     list_manufacturers,
 )
+from kicad_tools.units import get_current_formatter
 
 
 @dataclass
@@ -207,6 +208,7 @@ def cmd_show(args):
         return 0
 
     # Text format
+    fmt = get_current_formatter()
     print(f"\n{'=' * 60}")
     print(f"{profile.name.upper()} Design Rules")
     print(f"{'=' * 60}")
@@ -214,34 +216,31 @@ def cmd_show(args):
     print(f"\nProfile: {profile.id}")
     print(f"Website: {profile.website}")
     print(f"Configuration: {args.layers}-layer, {args.copper}oz copper")
+    print(f"Units: {fmt.unit_name}")
 
     print(f"\n{'Trace & Spacing':─^40}")
-    print(
-        f"  Min trace width:    {rules.min_trace_width_mm:.4f} mm ({rules.min_trace_width_mil:.1f} mil)"
-    )
-    print(
-        f"  Min clearance:      {rules.min_clearance_mm:.4f} mm ({rules.min_clearance_mil:.1f} mil)"
-    )
+    print(f"  Min trace width:    {fmt.format(rules.min_trace_width_mm)}")
+    print(f"  Min clearance:      {fmt.format(rules.min_clearance_mm)}")
 
     print(f"\n{'Vias':─^40}")
-    print(f"  Min via drill:      {rules.min_via_drill_mm:.3f} mm")
-    print(f"  Min via diameter:   {rules.min_via_diameter_mm:.3f} mm")
-    print(f"  Min annular ring:   {rules.min_annular_ring_mm:.3f} mm")
+    print(f"  Min via drill:      {fmt.format(rules.min_via_drill_mm)}")
+    print(f"  Min via diameter:   {fmt.format(rules.min_via_diameter_mm)}")
+    print(f"  Min annular ring:   {fmt.format(rules.min_annular_ring_mm)}")
 
     print(f"\n{'Holes':─^40}")
-    print(f"  Min hole diameter:  {rules.min_hole_diameter_mm:.3f} mm")
-    print(f"  Max hole diameter:  {rules.max_hole_diameter_mm:.3f} mm")
+    print(f"  Min hole diameter:  {fmt.format(rules.min_hole_diameter_mm)}")
+    print(f"  Max hole diameter:  {fmt.format(rules.max_hole_diameter_mm)}")
 
     print(f"\n{'Edge Clearance':─^40}")
-    print(f"  Copper to edge:     {rules.min_copper_to_edge_mm:.3f} mm")
-    print(f"  Hole to edge:       {rules.min_hole_to_edge_mm:.3f} mm")
+    print(f"  Copper to edge:     {fmt.format(rules.min_copper_to_edge_mm)}")
+    print(f"  Hole to edge:       {fmt.format(rules.min_hole_to_edge_mm)}")
 
     print(f"\n{'Silkscreen':─^40}")
-    print(f"  Min line width:     {rules.min_silkscreen_width_mm:.3f} mm")
-    print(f"  Min text height:    {rules.min_silkscreen_height_mm:.3f} mm")
+    print(f"  Min line width:     {fmt.format(rules.min_silkscreen_width_mm)}")
+    print(f"  Min text height:    {fmt.format(rules.min_silkscreen_height_mm)}")
 
     print(f"\n{'Solder Mask':─^40}")
-    print(f"  Min dam width:      {rules.min_solder_mask_dam_mm:.3f} mm")
+    print(f"  Min dam width:      {fmt.format(rules.min_solder_mask_dam_mm)}")
 
     print(f"\n{'=' * 60}")
     return 0
@@ -296,14 +295,16 @@ def cmd_compare(args):
         return 0
 
     # Text format
+    fmt = get_current_formatter()
     print(f"\nDesign Rules Comparison: {project_path.name} vs {profile.name.upper()}")
     print("=" * 70)
+    print(f"Units: {fmt.unit_name}")
     print(f"\n{'Constraint':<20} {'Project':>12} {profile.id.upper():>12} {'Status':>12}")
     print("-" * 70)
 
     for c in comparisons:
-        project_str = f"{c.project_value:.4f}mm" if c.project_value else "Not set"
-        mfr_str = f"{c.manufacturer_value:.4f}mm"
+        project_str = fmt.format_compact(c.project_value) if c.project_value else "Not set"
+        mfr_str = fmt.format_compact(c.manufacturer_value)
 
         if c.status == "ok":
             status = "✓ OK"

--- a/src/kicad_tools/cli/init_cmd.py
+++ b/src/kicad_tools/cli/init_cmd.py
@@ -19,6 +19,7 @@ from rich.console import Console
 from rich.table import Table
 
 from kicad_tools.manufacturers import DesignRules, get_manufacturer_ids, get_profile
+from kicad_tools.units import get_current_formatter
 
 console = Console()
 err_console = Console(stderr=True)
@@ -111,8 +112,10 @@ def print_init_summary(
         created_project: Whether a new project was created
         created_dru: Whether DRU file was created/updated
     """
+    fmt = get_current_formatter()
     console.print(f"\n[bold green]✓[/bold green] Initialized project for {profile.name}")
-    console.print(f"  Configuration: {layers}-layer, {copper}oz copper\n")
+    console.print(f"  Configuration: {layers}-layer, {copper}oz copper")
+    console.print(f"  Units: {fmt.unit_name}\n")
 
     # Design rules table
     table = Table(title="Design Rules Applied", show_header=True, header_style="bold cyan")
@@ -122,33 +125,33 @@ def print_init_summary(
 
     table.add_row(
         "Via drill",
-        f"{rules.min_via_drill_mm:.2f} mm",
-        "0.20 mm" if created_project else "-",
+        fmt.format(rules.min_via_drill_mm),
+        fmt.format(0.20) if created_project else "-",
     )
     table.add_row(
         "Via diameter",
-        f"{rules.min_via_diameter_mm:.2f} mm",
-        "0.45 mm" if created_project else "-",
+        fmt.format(rules.min_via_diameter_mm),
+        fmt.format(0.45) if created_project else "-",
     )
     table.add_row(
         "Min clearance",
-        f"{rules.min_clearance_mm:.3f} mm ({rules.min_clearance_mil:.1f} mil)",
-        "0.20 mm" if created_project else "-",
+        fmt.format(rules.min_clearance_mm),
+        fmt.format(0.20) if created_project else "-",
     )
     table.add_row(
         "Min trace width",
-        f"{rules.min_trace_width_mm:.3f} mm ({rules.min_trace_width_mil:.1f} mil)",
-        "0.25 mm" if created_project else "-",
+        fmt.format(rules.min_trace_width_mm),
+        fmt.format(0.25) if created_project else "-",
     )
     table.add_row(
         "Annular ring",
-        f"{rules.min_annular_ring_mm:.2f} mm",
-        "0.13 mm" if created_project else "-",
+        fmt.format(rules.min_annular_ring_mm),
+        fmt.format(0.13) if created_project else "-",
     )
     table.add_row(
         "Copper to edge",
-        f"{rules.min_copper_to_edge_mm:.2f} mm",
-        "0.30 mm" if created_project else "-",
+        fmt.format(rules.min_copper_to_edge_mm),
+        fmt.format(0.30) if created_project else "-",
     )
 
     console.print(table)

--- a/src/kicad_tools/cli/mfr.py
+++ b/src/kicad_tools/cli/mfr.py
@@ -28,6 +28,7 @@ from kicad_tools.manufacturers import (
     get_profile,
     list_manufacturers,
 )
+from kicad_tools.units import get_current_formatter
 
 
 def cmd_list(args):
@@ -105,41 +106,39 @@ def cmd_rules(args):
         sys.exit(1)
 
     rules = profile.get_design_rules(args.layers, args.copper)
+    fmt = get_current_formatter()
 
     print(f"\n{'=' * 60}")
     print(f"{profile.name.upper()} - {args.layers}-LAYER {args.copper}oz RULES")
     print(f"{'=' * 60}")
+    print(f"Units: {fmt.unit_name}")
 
     print("\nTrace & Spacing:")
-    print(
-        f"  Min trace width:    {rules.min_trace_width_mm:.4f} mm ({rules.min_trace_width_mil:.1f} mil)"
-    )
-    print(
-        f"  Min clearance:      {rules.min_clearance_mm:.4f} mm ({rules.min_clearance_mil:.1f} mil)"
-    )
+    print(f"  Min trace width:    {fmt.format(rules.min_trace_width_mm)}")
+    print(f"  Min clearance:      {fmt.format(rules.min_clearance_mm)}")
 
     print("\nVias:")
-    print(f"  Min via drill:      {rules.min_via_drill_mm} mm")
-    print(f"  Min via diameter:   {rules.min_via_diameter_mm} mm")
-    print(f"  Min annular ring:   {rules.min_annular_ring_mm} mm")
+    print(f"  Min via drill:      {fmt.format(rules.min_via_drill_mm)}")
+    print(f"  Min via diameter:   {fmt.format(rules.min_via_diameter_mm)}")
+    print(f"  Min annular ring:   {fmt.format(rules.min_annular_ring_mm)}")
 
     print("\nHoles:")
-    print(f"  Min hole diameter:  {rules.min_hole_diameter_mm} mm")
-    print(f"  Max hole diameter:  {rules.max_hole_diameter_mm} mm")
+    print(f"  Min hole diameter:  {fmt.format(rules.min_hole_diameter_mm)}")
+    print(f"  Max hole diameter:  {fmt.format(rules.max_hole_diameter_mm)}")
 
     print("\nEdge Clearance:")
-    print(f"  Copper to edge:     {rules.min_copper_to_edge_mm} mm")
-    print(f"  Hole to edge:       {rules.min_hole_to_edge_mm} mm")
+    print(f"  Copper to edge:     {fmt.format(rules.min_copper_to_edge_mm)}")
+    print(f"  Hole to edge:       {fmt.format(rules.min_hole_to_edge_mm)}")
 
     print("\nSilkscreen:")
-    print(f"  Min line width:     {rules.min_silkscreen_width_mm} mm")
-    print(f"  Min text height:    {rules.min_silkscreen_height_mm} mm")
+    print(f"  Min line width:     {fmt.format(rules.min_silkscreen_width_mm)}")
+    print(f"  Min text height:    {fmt.format(rules.min_silkscreen_height_mm)}")
 
     print("\nSolder Mask:")
-    print(f"  Min dam width:      {rules.min_solder_mask_dam_mm} mm")
+    print(f"  Min dam width:      {fmt.format(rules.min_solder_mask_dam_mm)}")
 
     print("\nBoard:")
-    print(f"  Thickness:          {rules.board_thickness_mm} mm")
+    print(f"  Thickness:          {fmt.format(rules.board_thickness_mm)}")
     print(f"  Outer copper:       {rules.outer_copper_oz} oz")
     if rules.inner_copper_oz > 0:
         print(f"  Inner copper:       {rules.inner_copper_oz} oz")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -117,6 +117,13 @@ def create_parser() -> argparse.ArgumentParser:
         help="Suppress progress output (for scripting)",
         dest="global_quiet",
     )
+    parser.add_argument(
+        "--units",
+        choices=["mm", "mils"],
+        default=None,
+        help="Unit system for output (mm or mils). Overrides config and env var.",
+        dest="global_units",
+    )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 

--- a/src/kicad_tools/units.py
+++ b/src/kicad_tools/units.py
@@ -1,0 +1,313 @@
+"""
+Unit formatting system for kicad-tools.
+
+Provides configurable unit display (mm vs mils) across all CLI output.
+Supports layered configuration: CLI flag > Environment variable > Config file > Default (mm).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .config import Config
+
+__all__ = [
+    "UnitSystem",
+    "UnitFormatter",
+    "MM_PER_MIL",
+    "get_unit_formatter",
+    "format_length",
+    "format_coordinate",
+]
+
+# Conversion constant
+MM_PER_MIL = 0.0254
+
+# Environment variable for unit preference
+UNITS_ENV_VAR = "KICAD_TOOLS_UNITS"
+
+
+class UnitSystem(Enum):
+    """Unit system for display output."""
+
+    MM = "mm"
+    MILS = "mils"
+
+    @classmethod
+    def from_string(cls, value: str | None) -> UnitSystem | None:
+        """Parse a unit system from a string value.
+
+        Args:
+            value: String like "mm", "mils", "mil", or None
+
+        Returns:
+            UnitSystem or None if value is None or invalid
+        """
+        if value is None:
+            return None
+        value = value.lower().strip()
+        if value in ("mm", "millimeters", "millimeter"):
+            return cls.MM
+        if value in ("mils", "mil", "thou", "thousandths"):
+            return cls.MILS
+        return None
+
+
+@dataclass
+class UnitFormatter:
+    """Formatter for length values with configurable unit system.
+
+    Handles conversion between mm (internal storage) and display units.
+    All internal values in kicad-tools are stored in mm.
+
+    Examples:
+        >>> fmt = UnitFormatter(UnitSystem.MM)
+        >>> fmt.format(0.254)
+        '0.254 mm'
+
+        >>> fmt = UnitFormatter(UnitSystem.MILS)
+        >>> fmt.format(0.254)
+        '10.0 mils'
+    """
+
+    system: UnitSystem
+    precision_mm: int = 3
+    precision_mils: int = 1
+
+    def format(self, value_mm: float, include_unit: bool = True) -> str:
+        """Format a mm value in the configured unit system.
+
+        Args:
+            value_mm: Value in millimeters
+            include_unit: Whether to include the unit suffix (default: True)
+
+        Returns:
+            Formatted string with value and optional unit
+        """
+        if self.system == UnitSystem.MILS:
+            value = value_mm / MM_PER_MIL
+            if include_unit:
+                return f"{value:.{self.precision_mils}f} mils"
+            return f"{value:.{self.precision_mils}f}"
+
+        if include_unit:
+            return f"{value_mm:.{self.precision_mm}f} mm"
+        return f"{value_mm:.{self.precision_mm}f}"
+
+    def format_compact(self, value_mm: float) -> str:
+        """Format a mm value compactly (no space before unit).
+
+        Args:
+            value_mm: Value in millimeters
+
+        Returns:
+            Formatted string like "0.254mm" or "10.0mils"
+        """
+        if self.system == UnitSystem.MILS:
+            value = value_mm / MM_PER_MIL
+            return f"{value:.{self.precision_mils}f}mils"
+        return f"{value_mm:.{self.precision_mm}f}mm"
+
+    def format_range(self, min_mm: float, max_mm: float) -> str:
+        """Format a range of values.
+
+        Args:
+            min_mm: Minimum value in mm
+            max_mm: Maximum value in mm
+
+        Returns:
+            Formatted string like "0.1-0.5 mm" or "3.9-19.7 mils"
+        """
+        if self.system == UnitSystem.MILS:
+            min_val = min_mm / MM_PER_MIL
+            max_val = max_mm / MM_PER_MIL
+            return f"{min_val:.{self.precision_mils}f}-{max_val:.{self.precision_mils}f} mils"
+        return f"{min_mm:.{self.precision_mm}f}-{max_mm:.{self.precision_mm}f} mm"
+
+    def format_coordinate(self, x_mm: float, y_mm: float) -> str:
+        """Format a coordinate pair.
+
+        Args:
+            x_mm: X coordinate in mm
+            y_mm: Y coordinate in mm
+
+        Returns:
+            Formatted string like "(1.234, 5.678) mm" or "(48.6, 223.5) mils"
+        """
+        if self.system == UnitSystem.MILS:
+            x = x_mm / MM_PER_MIL
+            y = y_mm / MM_PER_MIL
+            return f"({x:.{self.precision_mils}f}, {y:.{self.precision_mils}f}) mils"
+        return f"({x_mm:.{self.precision_mm}f}, {y_mm:.{self.precision_mm}f}) mm"
+
+    def format_delta(self, delta_mm: float) -> str:
+        """Format a delta/difference value with sign.
+
+        Args:
+            delta_mm: Delta value in mm
+
+        Returns:
+            Formatted string like "+0.050 mm" or "-2.0 mils"
+        """
+        if self.system == UnitSystem.MILS:
+            value = delta_mm / MM_PER_MIL
+            return f"{value:+.{self.precision_mils}f} mils"
+        return f"{delta_mm:+.{self.precision_mm}f} mm"
+
+    def format_comparison(
+        self, actual_mm: float, required_mm: float, *, show_delta: bool = True
+    ) -> str:
+        """Format a comparison between actual and required values.
+
+        Args:
+            actual_mm: Actual value in mm
+            required_mm: Required/limit value in mm
+            show_delta: Whether to show the difference
+
+        Returns:
+            Formatted string like "0.150 mm (required: 0.200 mm, need +0.050 mm)"
+        """
+        actual_str = self.format(actual_mm)
+        required_str = self.format(required_mm)
+
+        if show_delta:
+            delta = required_mm - actual_mm
+            delta_str = self.format_delta(delta)
+            return f"{actual_str} (required: {required_str}, need {delta_str})"
+        return f"{actual_str} (required: {required_str})"
+
+    @property
+    def unit_name(self) -> str:
+        """Get the unit name for this formatter."""
+        return self.system.value
+
+    def convert_to_display(self, value_mm: float) -> float:
+        """Convert a mm value to the display unit (for calculations).
+
+        Args:
+            value_mm: Value in millimeters
+
+        Returns:
+            Value in the display unit system
+        """
+        if self.system == UnitSystem.MILS:
+            return value_mm / MM_PER_MIL
+        return value_mm
+
+    def convert_from_display(self, value: float) -> float:
+        """Convert a display unit value back to mm (for calculations).
+
+        Args:
+            value: Value in display units
+
+        Returns:
+            Value in millimeters
+        """
+        if self.system == UnitSystem.MILS:
+            return value * MM_PER_MIL
+        return value
+
+
+# Global formatter instance (set by CLI initialization)
+_current_formatter: UnitFormatter | None = None
+
+
+def get_unit_formatter(
+    cli_units: str | None = None,
+    config: Config | None = None,
+) -> UnitFormatter:
+    """Get a unit formatter based on precedence: CLI > env > config > default.
+
+    Args:
+        cli_units: Unit system from CLI flag (highest priority)
+        config: Config object to read display.units from
+
+    Returns:
+        Configured UnitFormatter instance
+    """
+    # Priority 1: CLI argument
+    system = UnitSystem.from_string(cli_units)
+
+    # Priority 2: Environment variable
+    if system is None:
+        env_value = os.environ.get(UNITS_ENV_VAR)
+        system = UnitSystem.from_string(env_value)
+
+    # Priority 3: Config file
+    if system is None and config is not None:
+        config_units = getattr(config.display, "units", None)
+        system = UnitSystem.from_string(config_units)
+
+    # Priority 4: Default to mm
+    if system is None:
+        system = UnitSystem.MM
+
+    # Get precision settings from config if available
+    precision_mm = 3
+    precision_mils = 1
+    if config is not None:
+        precision_mm = getattr(config.display, "precision_mm", 3)
+        precision_mils = getattr(config.display, "precision_mils", 1)
+
+    return UnitFormatter(
+        system=system,
+        precision_mm=precision_mm,
+        precision_mils=precision_mils,
+    )
+
+
+def set_current_formatter(formatter: UnitFormatter) -> None:
+    """Set the global unit formatter for the current session.
+
+    This is called during CLI initialization to make the formatter
+    available globally without passing it through every function.
+
+    Args:
+        formatter: The UnitFormatter to use globally
+    """
+    global _current_formatter
+    _current_formatter = formatter
+
+
+def get_current_formatter() -> UnitFormatter:
+    """Get the current global unit formatter.
+
+    Returns:
+        The currently configured UnitFormatter, or a default mm formatter
+    """
+    if _current_formatter is None:
+        return UnitFormatter(UnitSystem.MM)
+    return _current_formatter
+
+
+# Convenience functions that use the global formatter
+
+
+def format_length(value_mm: float, include_unit: bool = True) -> str:
+    """Format a length value using the current unit system.
+
+    Args:
+        value_mm: Value in millimeters
+        include_unit: Whether to include the unit suffix
+
+    Returns:
+        Formatted string
+    """
+    return get_current_formatter().format(value_mm, include_unit)
+
+
+def format_coordinate(x_mm: float, y_mm: float) -> str:
+    """Format a coordinate pair using the current unit system.
+
+    Args:
+        x_mm: X coordinate in mm
+        y_mm: Y coordinate in mm
+
+    Returns:
+        Formatted coordinate string
+    """
+    return get_current_formatter().format_coordinate(x_mm, y_mm)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,252 @@
+"""Tests for the units module."""
+
+import os
+import pytest
+
+from kicad_tools.units import (
+    MM_PER_MIL,
+    UnitFormatter,
+    UnitSystem,
+    get_current_formatter,
+    get_unit_formatter,
+    set_current_formatter,
+)
+from kicad_tools.config import Config, DisplayConfig
+
+
+class TestUnitSystem:
+    """Tests for UnitSystem enum."""
+
+    def test_from_string_mm(self):
+        """Test parsing mm unit strings."""
+        assert UnitSystem.from_string("mm") == UnitSystem.MM
+        assert UnitSystem.from_string("MM") == UnitSystem.MM
+        assert UnitSystem.from_string("millimeters") == UnitSystem.MM
+        assert UnitSystem.from_string("millimeter") == UnitSystem.MM
+
+    def test_from_string_mils(self):
+        """Test parsing mils unit strings."""
+        assert UnitSystem.from_string("mils") == UnitSystem.MILS
+        assert UnitSystem.from_string("MILS") == UnitSystem.MILS
+        assert UnitSystem.from_string("mil") == UnitSystem.MILS
+        assert UnitSystem.from_string("thou") == UnitSystem.MILS
+        assert UnitSystem.from_string("thousandths") == UnitSystem.MILS
+
+    def test_from_string_none(self):
+        """Test parsing None returns None."""
+        assert UnitSystem.from_string(None) is None
+
+    def test_from_string_invalid(self):
+        """Test parsing invalid string returns None."""
+        assert UnitSystem.from_string("invalid") is None
+        assert UnitSystem.from_string("inches") is None
+        assert UnitSystem.from_string("") is None
+
+
+class TestUnitFormatter:
+    """Tests for UnitFormatter class."""
+
+    def test_format_mm(self):
+        """Test formatting in mm mode."""
+        fmt = UnitFormatter(UnitSystem.MM)
+        assert fmt.format(0.254) == "0.254 mm"
+        assert fmt.format(1.0) == "1.000 mm"
+        assert fmt.format(0.1524) == "0.152 mm"
+
+    def test_format_mils(self):
+        """Test formatting in mils mode."""
+        fmt = UnitFormatter(UnitSystem.MILS)
+        # 0.254mm = 10 mils
+        assert fmt.format(0.254) == "10.0 mils"
+        # 0.1524mm = 6 mils
+        assert fmt.format(0.1524) == "6.0 mils"
+        # 1.0mm = ~39.4 mils
+        assert fmt.format(1.0) == "39.4 mils"
+
+    def test_format_without_unit(self):
+        """Test formatting without unit suffix."""
+        fmt = UnitFormatter(UnitSystem.MM)
+        assert fmt.format(0.254, include_unit=False) == "0.254"
+
+        fmt_mils = UnitFormatter(UnitSystem.MILS)
+        assert fmt_mils.format(0.254, include_unit=False) == "10.0"
+
+    def test_format_compact(self):
+        """Test compact formatting (no space)."""
+        fmt = UnitFormatter(UnitSystem.MM)
+        assert fmt.format_compact(0.254) == "0.254mm"
+
+        fmt_mils = UnitFormatter(UnitSystem.MILS)
+        assert fmt_mils.format_compact(0.254) == "10.0mils"
+
+    def test_format_range(self):
+        """Test range formatting."""
+        fmt = UnitFormatter(UnitSystem.MM)
+        assert fmt.format_range(0.1, 0.5) == "0.100-0.500 mm"
+
+        fmt_mils = UnitFormatter(UnitSystem.MILS)
+        # 0.1mm ~= 3.9 mils, 0.5mm ~= 19.7 mils
+        result = fmt_mils.format_range(0.1, 0.5)
+        assert "mils" in result
+        assert "3.9" in result
+        assert "19.7" in result
+
+    def test_format_coordinate(self):
+        """Test coordinate formatting."""
+        fmt = UnitFormatter(UnitSystem.MM)
+        assert fmt.format_coordinate(1.234, 5.678) == "(1.234, 5.678) mm"
+
+        fmt_mils = UnitFormatter(UnitSystem.MILS)
+        result = fmt_mils.format_coordinate(0.254, 0.508)
+        assert "(10.0, 20.0) mils" == result
+
+    def test_format_delta(self):
+        """Test delta formatting with sign."""
+        fmt = UnitFormatter(UnitSystem.MM)
+        assert fmt.format_delta(0.050) == "+0.050 mm"
+        assert fmt.format_delta(-0.050) == "-0.050 mm"
+
+        fmt_mils = UnitFormatter(UnitSystem.MILS)
+        assert fmt_mils.format_delta(0.254) == "+10.0 mils"
+        assert fmt_mils.format_delta(-0.254) == "-10.0 mils"
+
+    def test_format_comparison(self):
+        """Test comparison formatting."""
+        fmt = UnitFormatter(UnitSystem.MM)
+        result = fmt.format_comparison(0.150, 0.200)
+        assert "0.150 mm" in result
+        assert "0.200 mm" in result
+        assert "+0.050 mm" in result
+
+    def test_unit_name(self):
+        """Test unit name property."""
+        assert UnitFormatter(UnitSystem.MM).unit_name == "mm"
+        assert UnitFormatter(UnitSystem.MILS).unit_name == "mils"
+
+    def test_convert_to_display(self):
+        """Test conversion to display units."""
+        fmt_mm = UnitFormatter(UnitSystem.MM)
+        assert fmt_mm.convert_to_display(1.0) == 1.0
+
+        fmt_mils = UnitFormatter(UnitSystem.MILS)
+        # 0.254mm = 10 mils
+        assert abs(fmt_mils.convert_to_display(0.254) - 10.0) < 0.001
+
+    def test_convert_from_display(self):
+        """Test conversion from display units."""
+        fmt_mm = UnitFormatter(UnitSystem.MM)
+        assert fmt_mm.convert_from_display(1.0) == 1.0
+
+        fmt_mils = UnitFormatter(UnitSystem.MILS)
+        # 10 mils = 0.254mm
+        assert abs(fmt_mils.convert_from_display(10.0) - 0.254) < 0.0001
+
+    def test_custom_precision(self):
+        """Test custom precision settings."""
+        fmt = UnitFormatter(UnitSystem.MM, precision_mm=1)
+        assert fmt.format(0.254) == "0.3 mm"
+
+        fmt_mils = UnitFormatter(UnitSystem.MILS, precision_mils=2)
+        assert fmt_mils.format(0.254) == "10.00 mils"
+
+
+class TestGetUnitFormatter:
+    """Tests for get_unit_formatter function with precedence."""
+
+    def test_default_is_mm(self):
+        """Test default unit system is mm."""
+        fmt = get_unit_formatter()
+        assert fmt.system == UnitSystem.MM
+
+    def test_cli_overrides_all(self):
+        """Test CLI argument has highest priority."""
+        # Even with env var and config, CLI should win
+        fmt = get_unit_formatter(cli_units="mils")
+        assert fmt.system == UnitSystem.MILS
+
+    def test_env_overrides_config(self, monkeypatch):
+        """Test environment variable overrides config."""
+        monkeypatch.setenv("KICAD_TOOLS_UNITS", "mils")
+
+        config = Config()
+        config.display.units = "mm"
+
+        fmt = get_unit_formatter(config=config)
+        assert fmt.system == UnitSystem.MILS
+
+    def test_config_overrides_default(self):
+        """Test config file overrides default."""
+        config = Config()
+        config.display = DisplayConfig(units="mils")
+
+        # No CLI, no env var
+        fmt = get_unit_formatter(config=config)
+        assert fmt.system == UnitSystem.MILS
+
+    def test_precedence_cli_over_env(self, monkeypatch):
+        """Test CLI > env precedence."""
+        monkeypatch.setenv("KICAD_TOOLS_UNITS", "mm")
+        fmt = get_unit_formatter(cli_units="mils")
+        assert fmt.system == UnitSystem.MILS
+
+    def test_precision_from_config(self):
+        """Test precision settings from config."""
+        config = Config()
+        config.display = DisplayConfig(units="mm", precision_mm=4, precision_mils=2)
+
+        fmt = get_unit_formatter(config=config)
+        assert fmt.precision_mm == 4
+        assert fmt.precision_mils == 2
+
+
+class TestGlobalFormatter:
+    """Tests for global formatter functions."""
+
+    def test_set_and_get_formatter(self):
+        """Test setting and getting global formatter."""
+        fmt = UnitFormatter(UnitSystem.MILS)
+        set_current_formatter(fmt)
+
+        current = get_current_formatter()
+        assert current.system == UnitSystem.MILS
+
+    def test_get_formatter_default(self):
+        """Test default formatter when none set."""
+        # Reset global formatter
+        set_current_formatter(None)  # type: ignore
+
+        # Should return default mm formatter
+        current = get_current_formatter()
+        assert current.system == UnitSystem.MM
+
+
+class TestConversionAccuracy:
+    """Tests for conversion accuracy."""
+
+    def test_common_pcb_values(self):
+        """Test conversion of common PCB dimensions."""
+        fmt = UnitFormatter(UnitSystem.MILS)
+
+        # 6 mil trace = 0.1524mm
+        assert abs(fmt.convert_to_display(0.1524) - 6.0) < 0.01
+
+        # 10 mil clearance = 0.254mm
+        assert abs(fmt.convert_to_display(0.254) - 10.0) < 0.01
+
+        # 8 mil via drill = 0.2032mm
+        assert abs(fmt.convert_to_display(0.2032) - 8.0) < 0.01
+
+    def test_roundtrip_conversion(self):
+        """Test mm -> mils -> mm roundtrip."""
+        fmt = UnitFormatter(UnitSystem.MILS)
+        original = 0.254
+
+        display = fmt.convert_to_display(original)
+        back = fmt.convert_from_display(display)
+
+        assert abs(back - original) < 0.0001
+
+    def test_mm_per_mil_constant(self):
+        """Test the MM_PER_MIL constant is accurate."""
+        # 1 mil = 0.001 inch = 0.0254 mm
+        assert MM_PER_MIL == 0.0254


### PR DESCRIPTION
## Summary

Add support for configurable display units (millimeters vs mils) across all CLI output.

**Implementation:**
- CLI flag `--units {mm,mils}` (highest priority)
- Environment variable `KICAD_TOOLS_UNITS`
- Config file `[display] units = "mils"`
- Default: mm

**Key changes:**
- New `src/kicad_tools/units.py` module with `UnitFormatter` class
- `[display]` config section with units, precision_mm, precision_mils
- Updated mfr.py, fab_rules_cmd.py, init_cmd.py to use formatter
- 27 unit tests covering conversion accuracy and precedence

## Usage

```bash
# Via CLI flag
kct --units mils mfr rules jlcpcb

# Via environment variable  
KICAD_TOOLS_UNITS=mils kct mfr rules jlcpcb

# Via config file (~/.config/kicad-tools/config.toml)
[display]
units = "mils"
```

## Test Plan

- [x] UnitFormatter correctly converts mm to mils (0.254mm → 10.0 mils)
- [x] CLI flag `--units mils` shows output in mils
- [x] Precedence: CLI > env > config > default
- [x] All 27 unit tests pass

Closes #574