### PR TITLE
fix(router): Correct layer mapping for 4-layer boards

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -88,6 +88,23 @@ def _run_monte_carlo_trial(config: dict) -> tuple[list, float, int]:
     # Add pads from serialized data
     for pad_data in config["pads_data"]:
         ref = pad_data["ref"]
+        # Convert layer data to Layer enum
+        layer_data = pad_data["layer"]
+        if isinstance(layer_data, int):
+            # Serialized as Layer enum value (integer)
+            pad_layer = Layer(layer_data)
+        elif isinstance(layer_data, str):
+            # Serialized as KiCad layer name (string)
+            try:
+                pad_layer = Layer.from_kicad_name(layer_data)
+            except ValueError:
+                pad_layer = Layer.F_CU  # Default for unknown layers
+        elif isinstance(layer_data, Layer):
+            # Already a Layer enum
+            pad_layer = layer_data
+        else:
+            pad_layer = Layer.F_CU  # Default fallback
+
         pad_info = {
             "number": pad_data["number"],
             "x": pad_data["x"],
@@ -96,9 +113,7 @@ def _run_monte_carlo_trial(config: dict) -> tuple[list, float, int]:
             "height": pad_data["height"],
             "net": pad_data["net"],
             "net_name": pad_data["net_name"],
-            "layer": Layer(pad_data["layer"])
-            if isinstance(pad_data["layer"], str)
-            else pad_data["layer"],
+            "layer": pad_layer,
             "through_hole": pad_data.get("through_hole", False),
             "drill": pad_data.get("drill", 0.0),
         }

--- a/src/kicad_tools/router/optimizer/pcb.py
+++ b/src/kicad_tools/router/optimizer/pcb.py
@@ -67,11 +67,10 @@ def parse_segments(pcb_text: str) -> dict[str, list[Segment]]:
         net_name = net_names.get(net, f"Net{net}")
 
         # Convert layer name to Layer enum
-        layer = Layer.F_CU  # Default
-        for l in Layer:
-            if l.kicad_name == layer_name:
-                layer = l
-                break
+        try:
+            layer = Layer.from_kicad_name(layer_name)
+        except ValueError:
+            layer = Layer.F_CU  # Default for unknown layers
 
         seg = Segment(
             x1=x1,


### PR DESCRIPTION
## Summary
- Fixes the "Layer value not in stack" error when routing 4-layer PCBs
- `LayerDefinition.layer_enum` now correctly maps by layer name instead of stack index
- Added `Layer.from_kicad_name()` classmethod for consistent KiCad layer name to enum conversion
- Parse pad copper layers from KiCad files instead of defaulting all pads to F.Cu

## Test plan
- [x] Verify `Layer.from_kicad_name("B.Cu")` returns `Layer.B_CU` (value 5)
- [x] Verify `LayerDefinition("B.Cu", 3, ...).layer_enum` returns `Layer.B_CU`
- [x] Verify pad layer parsing extracts correct layer from `(layers "B.Cu" ...)`
- [x] Run test_router_core.py - all 59 tests pass
- [x] Run manual layer mapping verification script

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)