### PR TITLE
fix(schematic): Correct symbol unit names to exclude library prefix

### DIFF
--- a/src/kicad_tools/schematic/models/symbol.py
+++ b/src/kicad_tools/schematic/models/symbol.py
@@ -214,14 +214,11 @@ class SymbolDef:
                     if not re.match(r".+_\d+_\d+$", sym_name):
                         new_node.append(SExp.atom(f"{lib_name}:{sym_name}"))
                     else:
-                        # Unit symbol - prefix the base name part
-                        # e.g., "AP2204K-1.5_0_1" -> "Lib:AP2204K-1.5_0_1"
-                        match = re.match(r"(.+?)(_\d+_\d+)$", sym_name)
-                        if match:
-                            base, suffix = match.groups()
-                            new_node.append(SExp.atom(f"{lib_name}:{base}{suffix}"))
-                        else:
-                            new_node.append(child)
+                        # Unit symbol - keep as-is without library prefix
+                        # KiCad expects: parent "(symbol "Lib:Name" ...)"
+                        #                unit   "(symbol "Name_0_1" ...)"
+                        # NOT: unit "(symbol "Lib:Name_0_1" ...)"
+                        new_node.append(child)
                 elif node.name == "extends" and i == 0:
                     # First child of extends is parent name
                     new_node.append(SExp.atom(f"{lib_name}:{child.value}"))

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -1515,14 +1515,21 @@ class TestSymbolDefParsing:
         assert str(first_child.value) == "MyLib:TestSymbol"
 
     def test_add_prefix_to_node_unit_symbol(self):
-        """Unit symbols (with _N_N suffix) get prefixed correctly."""
+        """Unit symbols (with _N_N suffix) should NOT have library prefix.
+
+        KiCad expects:
+        - Parent symbol: (symbol "Lib:Name" ...)
+        - Unit symbols: (symbol "Name_0_1" ...) - NO library prefix
+
+        This was fixed in issue #596.
+        """
         sym_def = SymbolDef(lib_id="Test:Sym", name="Sym", raw_sexp="")
         sym_node = SExp.list("symbol", "TestSymbol_0_1")
 
         result = sym_def._add_prefix_to_node(sym_node, "MyLib")
         first_child = result.children[0]
-        # Should be prefixed as MyLib:TestSymbol_0_1
-        assert str(first_child.value) == "MyLib:TestSymbol_0_1"
+        # Unit symbols should NOT have library prefix
+        assert str(first_child.value) == "TestSymbol_0_1"
 
     def test_to_sexp_nodes_with_sexp_node(self):
         """Get SExp nodes when _sexp_node is available."""


### PR DESCRIPTION
## Summary

Fixes a bug where symbol unit names incorrectly included the library prefix, causing KiCad to fail loading schematics.

**The problem:**
- KiCad expects parent symbols to use `(symbol "Lib:Name" ...)`
- KiCad expects unit symbols to use `(symbol "Name_0_1" ...)` - NO library prefix
- The code was producing `(symbol "Lib:Name_0_1" ...)` which is invalid

**The fix:**
- Modified `_add_prefix_to_node` in `symbol.py` to keep unit symbol names as-is without prefixing
- Updated the test to expect the correct behavior

## Test Plan

- [x] All 127 schematic model tests pass
- [x] All 169 schema and registry tests pass  
- [x] Test `test_add_prefix_to_node_unit_symbol` now verifies unit symbols are NOT prefixed

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)