### PR TITLE
fix(sexp): Always include rotation angle in at() builder

### DIFF
--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -36,12 +36,12 @@ def xy(x: float, y: float) -> SExp:
 
 
 def at(x: float, y: float, rotation: float = 0) -> SExp:
-    """Build an (at X Y [ROTATION]) position node.
+    """Build an (at X Y ROTATION) position node.
 
-    Omits rotation if 0 for cleaner output.
+    Always includes rotation angle (required by KiCad GUI for symbols,
+    properties, labels, etc.). KiCad-cli is lenient but GUI parser fails
+    without explicit angle.
     """
-    if rotation == 0:
-        return SExp.list("at", fmt(x), fmt(y))
     return SExp.list("at", fmt(x), fmt(y), int(rotation))
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "kicad-tools"
-version = "0.9.1"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Fix the `at()` builder function to always include the rotation angle parameter. KiCad GUI's strict parser requires this for symbols, properties, labels, and other schematic elements.

## Changes

- Modified `at()` function in `src/kicad_tools/sexp/builders.py` to always include the rotation angle (defaulting to 0)
- Updated docstring to explain the KiCad GUI requirement

## Before/After

```python
# Before: omitted angle when 0
at(100, 200)  # → (at 100 200)

# After: always includes angle
at(100, 200)  # → (at 100 200 0)
```

## Test Plan

- [x] Verified `at()` output includes angle for all rotation values (0, 90, 180, 270)
- [x] Ran linting with ruff check/format
- [x] Ran relevant tests (sexp parser, schematic helpers, schematic registry)

Closes #597