### PR TITLE
feat(init): Add netclass generation for project initialization

### DIFF
--- a/src/kicad_tools/cli/commands/project.py
+++ b/src/kicad_tools/cli/commands/project.py
@@ -12,6 +12,7 @@ def run_init_command(args) -> int:
         manufacturer=args.init_mfr,
         layers=args.init_layers,
         copper=args.init_copper,
+        design_type=args.init_design_type,
         dry_run=args.init_dry_run,
         output_format=args.init_format,
     )

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2277,6 +2277,15 @@ def _add_init_parser(subparsers) -> None:
         help="Copper weight in oz (default: 1.0)",
     )
     init_parser.add_argument(
+        "-t",
+        "--design-type",
+        dest="init_design_type",
+        choices=["audio", "power_supply", "digital", "mixed_signal", "rf"],
+        default=None,
+        metavar="TYPE",
+        help="Design type for netclass configuration (audio, power_supply, digital, mixed_signal, rf)",
+    )
+    init_parser.add_argument(
         "--dry-run",
         dest="init_dry_run",
         action="store_true",

--- a/src/kicad_tools/core/netclass_templates.py
+++ b/src/kicad_tools/core/netclass_templates.py
@@ -1,0 +1,501 @@
+"""
+Netclass templates for common design types.
+
+Provides predefined netclass configurations for different PCB design types
+(audio, power supply, digital, mixed-signal). Each template includes
+appropriate trace widths, clearances, and pattern assignments.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .project_file import (
+    add_netclass_definition,
+    add_netclass_patterns,
+    get_netclass_definitions,
+)
+
+
+@dataclass
+class NetclassTemplate:
+    """Template for a single netclass."""
+
+    name: str
+    track_width: float
+    clearance: float
+    via_diameter: float = 0.6
+    via_drill: float = 0.3
+    pcb_color: str | None = None
+    patterns: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DesignTypeTemplate:
+    """Template for a complete design type with multiple netclasses."""
+
+    name: str
+    description: str
+    netclasses: list[NetclassTemplate] = field(default_factory=list)
+
+
+# =============================================================================
+# NETCLASS COLOR PALETTE
+# =============================================================================
+
+NETCLASS_COLORS = {
+    "Power": "rgba(255, 0, 0, 0.800)",  # Red
+    "Ground": "rgba(139, 69, 19, 0.800)",  # Brown
+    "Audio": "rgba(0, 128, 0, 0.800)",  # Green
+    "Clock": "rgba(255, 165, 0, 0.800)",  # Orange
+    "I2S": "rgba(0, 191, 255, 0.800)",  # Deep Sky Blue
+    "SPI": "rgba(138, 43, 226, 0.800)",  # Blue Violet
+    "I2C": "rgba(255, 20, 147, 0.800)",  # Deep Pink
+    "HighSpeed": "rgba(255, 215, 0, 0.800)",  # Gold
+    "Debug": "rgba(128, 128, 128, 0.800)",  # Gray
+    "Control": "rgba(0, 128, 128, 0.800)",  # Teal
+    "HighCurrent": "rgba(178, 34, 34, 0.800)",  # Firebrick
+    "Analog": "rgba(46, 139, 87, 0.800)",  # Sea Green
+    "RF": "rgba(255, 140, 0, 0.800)",  # Dark Orange
+}
+
+
+# =============================================================================
+# DESIGN TYPE TEMPLATES
+# =============================================================================
+
+AUDIO_TEMPLATE = DesignTypeTemplate(
+    name="audio",
+    description="Audio DAC/ADC design with I2S and analog paths",
+    netclasses=[
+        NetclassTemplate(
+            name="Power",
+            track_width=0.4,
+            clearance=0.15,
+            via_diameter=0.8,
+            via_drill=0.4,
+            pcb_color=NETCLASS_COLORS["Power"],
+            patterns=["VCC*", "VDD*", "+*V", "V_*", "PWR_*", "VBUS*"],
+        ),
+        NetclassTemplate(
+            name="Ground",
+            track_width=0.5,
+            clearance=0.15,
+            via_diameter=0.8,
+            via_drill=0.4,
+            pcb_color=NETCLASS_COLORS["Ground"],
+            patterns=["GND", "GND*", "AGND*", "DGND*", "PGND*", "*_GND"],
+        ),
+        NetclassTemplate(
+            name="Audio",
+            track_width=0.3,
+            clearance=0.2,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Audio"],
+            patterns=["AUDIO_*", "AUD_*", "DAC_*", "ADC_*", "LINE_*", "HP_*", "SPK_*"],
+        ),
+        NetclassTemplate(
+            name="I2S",
+            track_width=0.2,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["I2S"],
+            patterns=["I2S_*", "I2S*", "BCLK*", "LRCLK*", "MCLK*", "SDATA*", "DOUT*", "DIN*"],
+        ),
+        NetclassTemplate(
+            name="Clock",
+            track_width=0.2,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Clock"],
+            patterns=["CLK*", "*_CLK", "OSC*", "XTAL*"],
+        ),
+        NetclassTemplate(
+            name="SPI",
+            track_width=0.2,
+            clearance=0.1,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["SPI"],
+            patterns=["SPI_*", "MOSI*", "MISO*", "SCK*", "CS_*", "SS_*"],
+        ),
+        NetclassTemplate(
+            name="I2C",
+            track_width=0.2,
+            clearance=0.1,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["I2C"],
+            patterns=["I2C_*", "SDA*", "SCL*"],
+        ),
+        NetclassTemplate(
+            name="Debug",
+            track_width=0.2,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Debug"],
+            patterns=["SWDIO*", "SWCLK*", "NRST*", "TDI*", "TDO*", "TCK*", "TMS*", "JTAG_*"],
+        ),
+    ],
+)
+
+POWER_SUPPLY_TEMPLATE = DesignTypeTemplate(
+    name="power_supply",
+    description="Power supply design with high current paths",
+    netclasses=[
+        NetclassTemplate(
+            name="HighCurrent",
+            track_width=0.8,
+            clearance=0.2,
+            via_diameter=1.0,
+            via_drill=0.5,
+            pcb_color=NETCLASS_COLORS["HighCurrent"],
+            patterns=["VIN*", "VOUT*", "SW*", "PHASE*", "BOOST*", "BUCK*"],
+        ),
+        NetclassTemplate(
+            name="Power",
+            track_width=0.5,
+            clearance=0.15,
+            via_diameter=0.8,
+            via_drill=0.4,
+            pcb_color=NETCLASS_COLORS["Power"],
+            patterns=["VCC*", "VDD*", "+*V", "V_*", "VBUS*", "VREG*"],
+        ),
+        NetclassTemplate(
+            name="Ground",
+            track_width=0.8,
+            clearance=0.2,
+            via_diameter=1.0,
+            via_drill=0.5,
+            pcb_color=NETCLASS_COLORS["Ground"],
+            patterns=["GND*", "PGND*", "AGND*", "*_GND"],
+        ),
+        NetclassTemplate(
+            name="Control",
+            track_width=0.2,
+            clearance=0.1,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Control"],
+            patterns=["FB_*", "EN_*", "COMP*", "SS_*", "PGOOD*", "FAULT*"],
+        ),
+        NetclassTemplate(
+            name="Analog",
+            track_width=0.25,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Analog"],
+            patterns=["SENSE*", "ISENSE*", "VSENSE*", "REF*"],
+        ),
+    ],
+)
+
+DIGITAL_TEMPLATE = DesignTypeTemplate(
+    name="digital",
+    description="Digital design with high-speed signals",
+    netclasses=[
+        NetclassTemplate(
+            name="Power",
+            track_width=0.4,
+            clearance=0.15,
+            via_diameter=0.8,
+            via_drill=0.4,
+            pcb_color=NETCLASS_COLORS["Power"],
+            patterns=["VCC*", "VDD*", "+*V", "V_*", "VCORE*", "VIO*"],
+        ),
+        NetclassTemplate(
+            name="Ground",
+            track_width=0.5,
+            clearance=0.15,
+            via_diameter=0.8,
+            via_drill=0.4,
+            pcb_color=NETCLASS_COLORS["Ground"],
+            patterns=["GND*", "DGND*", "*_GND"],
+        ),
+        NetclassTemplate(
+            name="HighSpeed",
+            track_width=0.2,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["HighSpeed"],
+            patterns=["USB_*", "HDMI_*", "ETH_*", "LVDS_*", "DP_*", "DDR_*"],
+        ),
+        NetclassTemplate(
+            name="Clock",
+            track_width=0.2,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Clock"],
+            patterns=["CLK*", "*_CLK", "OSC*", "XTAL*", "REF_CLK*"],
+        ),
+        NetclassTemplate(
+            name="SPI",
+            track_width=0.2,
+            clearance=0.1,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["SPI"],
+            patterns=["SPI_*", "MOSI*", "MISO*", "SCK*", "CS_*", "QSPI_*"],
+        ),
+        NetclassTemplate(
+            name="I2C",
+            track_width=0.2,
+            clearance=0.1,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["I2C"],
+            patterns=["I2C_*", "SDA*", "SCL*"],
+        ),
+        NetclassTemplate(
+            name="Debug",
+            track_width=0.2,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Debug"],
+            patterns=["SWDIO*", "SWCLK*", "NRST*", "TDI*", "TDO*", "TCK*", "TMS*", "JTAG_*", "UART_*", "TX*", "RX*"],
+        ),
+    ],
+)
+
+MIXED_SIGNAL_TEMPLATE = DesignTypeTemplate(
+    name="mixed_signal",
+    description="Mixed-signal design with analog and digital domains",
+    netclasses=[
+        NetclassTemplate(
+            name="Power",
+            track_width=0.4,
+            clearance=0.15,
+            via_diameter=0.8,
+            via_drill=0.4,
+            pcb_color=NETCLASS_COLORS["Power"],
+            patterns=["VCC*", "VDD*", "+*V", "V_*", "AVDD*", "DVDD*"],
+        ),
+        NetclassTemplate(
+            name="Ground",
+            track_width=0.5,
+            clearance=0.15,
+            via_diameter=0.8,
+            via_drill=0.4,
+            pcb_color=NETCLASS_COLORS["Ground"],
+            patterns=["GND", "GND*", "AGND*", "DGND*", "*_GND"],
+        ),
+        NetclassTemplate(
+            name="Analog",
+            track_width=0.3,
+            clearance=0.2,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Analog"],
+            patterns=["AIN*", "AOUT*", "ADC_*", "DAC_*", "VREF*", "SENSE*"],
+        ),
+        NetclassTemplate(
+            name="Clock",
+            track_width=0.2,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Clock"],
+            patterns=["CLK*", "*_CLK", "OSC*", "XTAL*"],
+        ),
+        NetclassTemplate(
+            name="SPI",
+            track_width=0.2,
+            clearance=0.1,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["SPI"],
+            patterns=["SPI_*", "MOSI*", "MISO*", "SCK*", "CS_*"],
+        ),
+        NetclassTemplate(
+            name="I2C",
+            track_width=0.2,
+            clearance=0.1,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["I2C"],
+            patterns=["I2C_*", "SDA*", "SCL*"],
+        ),
+        NetclassTemplate(
+            name="Debug",
+            track_width=0.2,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Debug"],
+            patterns=["SWDIO*", "SWCLK*", "NRST*", "TDI*", "TDO*", "TCK*", "TMS*", "JTAG_*"],
+        ),
+    ],
+)
+
+RF_TEMPLATE = DesignTypeTemplate(
+    name="rf",
+    description="RF design with controlled impedance traces",
+    netclasses=[
+        NetclassTemplate(
+            name="Power",
+            track_width=0.4,
+            clearance=0.15,
+            via_diameter=0.8,
+            via_drill=0.4,
+            pcb_color=NETCLASS_COLORS["Power"],
+            patterns=["VCC*", "VDD*", "+*V", "V_*", "VPA*", "VRF*"],
+        ),
+        NetclassTemplate(
+            name="Ground",
+            track_width=0.5,
+            clearance=0.15,
+            via_diameter=0.8,
+            via_drill=0.4,
+            pcb_color=NETCLASS_COLORS["Ground"],
+            patterns=["GND*", "RFGND*", "*_GND"],
+        ),
+        NetclassTemplate(
+            name="RF",
+            track_width=0.35,  # Typical 50-ohm trace on FR4
+            clearance=0.25,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["RF"],
+            patterns=["RF_*", "ANT*", "LNA_*", "PA_*", "MIX_*", "LO_*", "IF_*"],
+        ),
+        NetclassTemplate(
+            name="Clock",
+            track_width=0.2,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Clock"],
+            patterns=["CLK*", "*_CLK", "OSC*", "XTAL*", "TCXO*", "REFCLK*"],
+        ),
+        NetclassTemplate(
+            name="Control",
+            track_width=0.2,
+            clearance=0.1,
+            via_diameter=0.6,
+            via_drill=0.3,
+            pcb_color=NETCLASS_COLORS["Control"],
+            patterns=["SPI_*", "I2C_*", "EN_*", "CTRL_*"],
+        ),
+    ],
+)
+
+
+# Registry of all available templates
+DESIGN_TYPE_TEMPLATES: dict[str, DesignTypeTemplate] = {
+    "audio": AUDIO_TEMPLATE,
+    "power_supply": POWER_SUPPLY_TEMPLATE,
+    "digital": DIGITAL_TEMPLATE,
+    "mixed_signal": MIXED_SIGNAL_TEMPLATE,
+    "rf": RF_TEMPLATE,
+}
+
+
+def get_available_design_types() -> list[str]:
+    """Get list of available design type names."""
+    return list(DESIGN_TYPE_TEMPLATES.keys())
+
+
+def get_design_template(design_type: str) -> DesignTypeTemplate:
+    """
+    Get a design type template by name.
+
+    Args:
+        design_type: Name of the design type
+
+    Returns:
+        DesignTypeTemplate for the specified type
+
+    Raises:
+        ValueError: If design type is not found
+    """
+    if design_type not in DESIGN_TYPE_TEMPLATES:
+        available = ", ".join(DESIGN_TYPE_TEMPLATES.keys())
+        raise ValueError(f"Unknown design type '{design_type}'. Available: {available}")
+    return DESIGN_TYPE_TEMPLATES[design_type]
+
+
+def apply_design_template(
+    data: dict[str, Any],
+    design_type: str,
+    update_default: bool = True,
+) -> None:
+    """
+    Apply a design type template to project data.
+
+    This adds netclass definitions and patterns from the template
+    to the project's net_settings section.
+
+    Args:
+        data: Project data dictionary
+        design_type: Name of the design type template to apply
+        update_default: If True, update the Default netclass with reasonable values
+    """
+    template = get_design_template(design_type)
+
+    # Optionally update Default netclass
+    if update_default:
+        # Use values from the most generic netclass in the template
+        add_netclass_definition(
+            data,
+            name="Default",
+            track_width=0.2,
+            clearance=0.15,
+            via_diameter=0.6,
+            via_drill=0.3,
+        )
+
+    # Add netclasses from template
+    for netclass in template.netclasses:
+        add_netclass_definition(
+            data,
+            name=netclass.name,
+            track_width=netclass.track_width,
+            clearance=netclass.clearance,
+            via_diameter=netclass.via_diameter,
+            via_drill=netclass.via_drill,
+            pcb_color=netclass.pcb_color,
+        )
+
+        # Add patterns for this netclass
+        if netclass.patterns:
+            add_netclass_patterns(data, netclass.name, netclass.patterns)
+
+
+def get_netclass_summary(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """
+    Get a summary of netclasses defined in project data.
+
+    Args:
+        data: Project data dictionary
+
+    Returns:
+        List of dictionaries with netclass info (name, track_width, clearance, pattern_count)
+    """
+    from .project_file import get_netclass_patterns
+
+    classes = get_netclass_definitions(data)
+    patterns = get_netclass_patterns(data)
+
+    # Count patterns per netclass
+    pattern_counts: dict[str, int] = {}
+    for p in patterns:
+        nc = p.get("netclass", "")
+        pattern_counts[nc] = pattern_counts.get(nc, 0) + 1
+
+    return [
+        {
+            "name": cls.get("name", "Unknown"),
+            "track_width": cls.get("track_width", 0.25),
+            "clearance": cls.get("clearance", 0.2),
+            "via_diameter": cls.get("via_diameter", 0.6),
+            "pattern_count": pattern_counts.get(cls.get("name", ""), 0),
+        }
+        for cls in classes
+    ]

--- a/tests/test_netclass.py
+++ b/tests/test_netclass.py
@@ -1,0 +1,407 @@
+"""Tests for netclass functionality in project files."""
+
+import json
+
+import pytest
+
+from kicad_tools.core.netclass_templates import (
+    AUDIO_TEMPLATE,
+    DESIGN_TYPE_TEMPLATES,
+    DIGITAL_TEMPLATE,
+    MIXED_SIGNAL_TEMPLATE,
+    POWER_SUPPLY_TEMPLATE,
+    RF_TEMPLATE,
+    DesignTypeTemplate,
+    NetclassTemplate,
+    apply_design_template,
+    get_available_design_types,
+    get_design_template,
+    get_netclass_summary,
+)
+from kicad_tools.core.project_file import (
+    DEFAULT_NETCLASS_DEFINITION,
+    add_netclass_definition,
+    add_netclass_pattern,
+    add_netclass_patterns,
+    clear_netclass_definitions,
+    clear_netclass_patterns,
+    create_netclass_definition,
+    get_net_settings,
+    get_netclass_definitions,
+    get_netclass_patterns,
+    load_project,
+    save_project,
+)
+
+
+class TestNetclassDefinition:
+    """Tests for netclass definition creation."""
+
+    def test_create_netclass_definition_defaults(self):
+        """Test creating a netclass definition with default values."""
+        definition = create_netclass_definition("Power")
+
+        assert definition["name"] == "Power"
+        assert definition["track_width"] == 0.25
+        assert definition["clearance"] == 0.2
+        assert definition["via_diameter"] == 0.6
+        assert definition["via_drill"] == 0.3
+
+    def test_create_netclass_definition_custom_values(self):
+        """Test creating a netclass definition with custom values."""
+        definition = create_netclass_definition(
+            name="HighCurrent",
+            track_width=0.8,
+            clearance=0.25,
+            via_diameter=1.0,
+            via_drill=0.5,
+        )
+
+        assert definition["name"] == "HighCurrent"
+        assert definition["track_width"] == 0.8
+        assert definition["clearance"] == 0.25
+        assert definition["via_diameter"] == 1.0
+        assert definition["via_drill"] == 0.5
+
+    def test_create_netclass_definition_with_color(self):
+        """Test creating a netclass definition with custom color."""
+        definition = create_netclass_definition(
+            name="Power",
+            pcb_color="rgba(255, 0, 0, 0.800)",
+        )
+
+        assert definition["pcb_color"] == "rgba(255, 0, 0, 0.800)"
+
+    def test_default_netclass_definition_has_all_fields(self):
+        """Test that default netclass definition has all required fields."""
+        required_fields = [
+            "bus_width",
+            "clearance",
+            "diff_pair_gap",
+            "diff_pair_via_gap",
+            "diff_pair_width",
+            "line_style",
+            "microvia_diameter",
+            "microvia_drill",
+            "name",
+            "pcb_color",
+            "schematic_color",
+            "track_width",
+            "via_diameter",
+            "via_drill",
+            "wire_width",
+        ]
+        for field in required_fields:
+            assert field in DEFAULT_NETCLASS_DEFINITION
+
+
+class TestNetSettings:
+    """Tests for net_settings management."""
+
+    def test_get_net_settings_creates_if_missing(self):
+        """Test that get_net_settings creates structure if missing."""
+        data = {}
+        net_settings = get_net_settings(data)
+
+        assert "net_settings" in data
+        assert "classes" in net_settings
+        assert "netclass_patterns" in net_settings
+        assert len(net_settings["classes"]) == 1
+        assert net_settings["classes"][0]["name"] == "Default"
+
+    def test_get_net_settings_preserves_existing(self):
+        """Test that get_net_settings preserves existing data."""
+        data = {
+            "net_settings": {
+                "classes": [{"name": "Custom", "track_width": 0.5}],
+                "netclass_patterns": [{"netclass": "Custom", "pattern": "VCC*"}],
+            }
+        }
+        net_settings = get_net_settings(data)
+
+        assert len(net_settings["classes"]) == 1
+        assert net_settings["classes"][0]["name"] == "Custom"
+
+    def test_get_netclass_definitions(self):
+        """Test getting netclass definitions from project data."""
+        data = {}
+        classes = get_netclass_definitions(data)
+
+        assert len(classes) == 1
+        assert classes[0]["name"] == "Default"
+
+    def test_get_netclass_patterns(self):
+        """Test getting netclass patterns from project data."""
+        data = {}
+        patterns = get_netclass_patterns(data)
+
+        assert patterns == []
+
+
+class TestAddNetclass:
+    """Tests for adding netclass definitions."""
+
+    def test_add_netclass_definition(self):
+        """Test adding a new netclass definition."""
+        data = {}
+        definition = add_netclass_definition(
+            data,
+            name="Power",
+            track_width=0.5,
+            clearance=0.2,
+        )
+
+        classes = get_netclass_definitions(data)
+        assert len(classes) == 2  # Default + Power
+        assert definition["name"] == "Power"
+        assert definition["track_width"] == 0.5
+
+    def test_add_netclass_definition_updates_existing(self):
+        """Test that adding an existing netclass updates it."""
+        data = {}
+        add_netclass_definition(data, name="Power", track_width=0.3)
+        add_netclass_definition(data, name="Power", track_width=0.5)
+
+        classes = get_netclass_definitions(data)
+        power_classes = [c for c in classes if c["name"] == "Power"]
+        assert len(power_classes) == 1
+        assert power_classes[0]["track_width"] == 0.5
+
+    def test_add_netclass_pattern(self):
+        """Test adding a netclass pattern."""
+        data = {}
+        pattern = add_netclass_pattern(data, "Power", "VCC*")
+
+        patterns = get_netclass_patterns(data)
+        assert len(patterns) == 1
+        assert patterns[0]["netclass"] == "Power"
+        assert patterns[0]["pattern"] == "VCC*"
+
+    def test_add_netclass_pattern_no_duplicates(self):
+        """Test that duplicate patterns are not added."""
+        data = {}
+        add_netclass_pattern(data, "Power", "VCC*")
+        add_netclass_pattern(data, "Power", "VCC*")
+
+        patterns = get_netclass_patterns(data)
+        assert len(patterns) == 1
+
+    def test_add_netclass_patterns_bulk(self):
+        """Test adding multiple patterns at once."""
+        data = {}
+        add_netclass_patterns(data, "Power", ["VCC*", "+*V", "GND*"])
+
+        patterns = get_netclass_patterns(data)
+        assert len(patterns) == 3
+
+
+class TestClearNetclass:
+    """Tests for clearing netclass definitions and patterns."""
+
+    def test_clear_netclass_definitions_keeps_default(self):
+        """Test clearing netclass definitions keeps Default."""
+        data = {}
+        add_netclass_definition(data, "Power", track_width=0.5)
+        add_netclass_definition(data, "Clock", track_width=0.2)
+
+        clear_netclass_definitions(data, keep_default=True)
+
+        classes = get_netclass_definitions(data)
+        assert len(classes) == 1
+        assert classes[0]["name"] == "Default"
+
+    def test_clear_netclass_definitions_removes_all(self):
+        """Test clearing all netclass definitions."""
+        data = {}
+        add_netclass_definition(data, "Power", track_width=0.5)
+
+        clear_netclass_definitions(data, keep_default=False)
+
+        classes = get_netclass_definitions(data)
+        assert len(classes) == 0
+
+    def test_clear_netclass_patterns(self):
+        """Test clearing all netclass patterns."""
+        data = {}
+        add_netclass_patterns(data, "Power", ["VCC*", "+*V"])
+
+        clear_netclass_patterns(data)
+
+        patterns = get_netclass_patterns(data)
+        assert len(patterns) == 0
+
+
+class TestDesignTypeTemplates:
+    """Tests for design type templates."""
+
+    def test_get_available_design_types(self):
+        """Test getting list of available design types."""
+        types = get_available_design_types()
+
+        assert "audio" in types
+        assert "power_supply" in types
+        assert "digital" in types
+        assert "mixed_signal" in types
+        assert "rf" in types
+
+    def test_get_design_template(self):
+        """Test getting a design template by name."""
+        template = get_design_template("audio")
+
+        assert template.name == "audio"
+        assert len(template.netclasses) > 0
+
+    def test_get_design_template_invalid(self):
+        """Test getting an invalid design template."""
+        with pytest.raises(ValueError) as excinfo:
+            get_design_template("invalid_type")
+
+        assert "Unknown design type" in str(excinfo.value)
+
+    def test_audio_template_has_expected_classes(self):
+        """Test that audio template has expected netclasses."""
+        class_names = [nc.name for nc in AUDIO_TEMPLATE.netclasses]
+
+        assert "Power" in class_names
+        assert "Ground" in class_names
+        assert "Audio" in class_names
+        assert "I2S" in class_names
+
+    def test_power_supply_template_has_high_current(self):
+        """Test that power supply template has HighCurrent class."""
+        class_names = [nc.name for nc in POWER_SUPPLY_TEMPLATE.netclasses]
+
+        assert "HighCurrent" in class_names
+
+    def test_rf_template_has_rf_class(self):
+        """Test that RF template has RF class."""
+        class_names = [nc.name for nc in RF_TEMPLATE.netclasses]
+
+        assert "RF" in class_names
+
+    def test_all_templates_have_patterns(self):
+        """Test that all templates have patterns defined."""
+        for name, template in DESIGN_TYPE_TEMPLATES.items():
+            for nc in template.netclasses:
+                # Most netclasses should have patterns (except Default)
+                if nc.name != "Default":
+                    assert len(nc.patterns) > 0, f"{name}.{nc.name} has no patterns"
+
+
+class TestApplyDesignTemplate:
+    """Tests for applying design templates to project data."""
+
+    def test_apply_audio_template(self):
+        """Test applying audio template to project data."""
+        data = {}
+        apply_design_template(data, "audio")
+
+        classes = get_netclass_definitions(data)
+        class_names = [c["name"] for c in classes]
+
+        assert "Default" in class_names
+        assert "Power" in class_names
+        assert "Audio" in class_names
+        assert "I2S" in class_names
+
+    def test_apply_template_adds_patterns(self):
+        """Test that applying template adds patterns."""
+        data = {}
+        apply_design_template(data, "audio")
+
+        patterns = get_netclass_patterns(data)
+        assert len(patterns) > 0
+
+        # Check for specific patterns
+        power_patterns = [p for p in patterns if p["netclass"] == "Power"]
+        assert len(power_patterns) > 0
+
+    def test_apply_template_sets_correct_widths(self):
+        """Test that applying template sets correct trace widths."""
+        data = {}
+        apply_design_template(data, "power_supply")
+
+        classes = get_netclass_definitions(data)
+        high_current = next(c for c in classes if c["name"] == "HighCurrent")
+
+        assert high_current["track_width"] == 0.8
+
+    def test_get_netclass_summary(self):
+        """Test getting netclass summary from project data."""
+        data = {}
+        apply_design_template(data, "audio")
+
+        summary = get_netclass_summary(data)
+
+        assert len(summary) > 1
+        for nc in summary:
+            assert "name" in nc
+            assert "track_width" in nc
+            assert "clearance" in nc
+            assert "pattern_count" in nc
+
+
+class TestProjectFileIntegration:
+    """Integration tests for netclass handling in project files."""
+
+    def test_save_and_load_with_netclasses(self, tmp_path):
+        """Test saving and loading project file with netclasses."""
+        project_path = tmp_path / "test.kicad_pro"
+
+        # Create project with netclasses
+        data = {
+            "meta": {"filename": "test.kicad_pro", "version": 1},
+        }
+        apply_design_template(data, "audio")
+
+        # Save
+        save_project(data, project_path)
+
+        # Load and verify
+        loaded = load_project(project_path)
+
+        assert "net_settings" in loaded
+        classes = loaded["net_settings"]["classes"]
+        class_names = [c["name"] for c in classes]
+        assert "Audio" in class_names
+
+    def test_netclass_patterns_roundtrip(self, tmp_path):
+        """Test that netclass patterns survive save/load."""
+        project_path = tmp_path / "test.kicad_pro"
+
+        data = {"meta": {"filename": "test.kicad_pro", "version": 1}}
+        add_netclass_definition(data, "Power", track_width=0.5)
+        add_netclass_patterns(data, "Power", ["VCC*", "+*V", "GND*"])
+
+        save_project(data, project_path)
+        loaded = load_project(project_path)
+
+        patterns = loaded["net_settings"]["netclass_patterns"]
+        assert len(patterns) == 3
+
+    def test_kicad_format_compatibility(self, tmp_path):
+        """Test that generated net_settings matches KiCad format."""
+        project_path = tmp_path / "test.kicad_pro"
+
+        data = {"meta": {"filename": "test.kicad_pro", "version": 1}}
+        apply_design_template(data, "audio")
+
+        save_project(data, project_path)
+
+        # Verify JSON structure matches KiCad expectations
+        with open(project_path) as f:
+            parsed = json.load(f)
+
+        net_settings = parsed["net_settings"]
+        assert "classes" in net_settings
+        assert "meta" in net_settings
+        assert net_settings["meta"]["version"] == 3
+        assert "netclass_patterns" in net_settings
+
+        # Verify class structure
+        for cls in net_settings["classes"]:
+            assert "name" in cls
+            assert "track_width" in cls
+            assert "clearance" in cls
+            assert "via_diameter" in cls
+            assert "via_drill" in cls

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "kicad-tools"
-version = "0.9.1"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Adds netclass management functions to `project_file.py` for creating and managing net_settings in .kicad_pro files
- Creates `netclass_templates.py` with predefined templates for common design types (audio, power_supply, digital, mixed_signal, rf)
- Adds `--design-type` (`-t`) option to `kct init` command for applying netclass templates
- Displays netclass configuration in the initialization summary

## Design Type Templates

Each template includes appropriate netclasses with trace widths, clearances, and pattern matching:

| Template | Key Netclasses | Use Case |
|----------|---------------|----------|
| audio | Power, Ground, Audio, I2S, Clock, SPI, I2C, Debug | Audio DAC/ADC designs |
| power_supply | HighCurrent, Power, Ground, Control, Analog | Power supply designs |
| digital | Power, Ground, HighSpeed, Clock, SPI, I2C, Debug | Digital/MCU designs |
| mixed_signal | Power, Ground, Analog, Clock, SPI, I2C, Debug | Mixed-signal designs |
| rf | Power, Ground, RF, Clock, Control | RF designs |

## Example Usage

```bash
# Create audio project with appropriate netclasses
kct init my_dac --mfr jlcpcb -t audio

# Create power supply project
kct init my_psu --mfr jlcpcb -t power_supply --layers 4
```

## Test plan

- [x] Unit tests for netclass functions in `test_netclass.py` (30 tests passing)
- [x] Integration tests for project file round-trip with netclasses
- [x] Manual testing of `kct init` with various design types
- [x] Verified generated .kicad_pro matches KiCad 7+ format

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)