### PR TITLE
test(sexp): Update at() builder tests to match new behavior

### DIFF
--- a/tests/test_sexp_builders.py
+++ b/tests/test_sexp_builders.py
@@ -85,12 +85,13 @@ class TestAtBuilder:
     """Tests for the at() position builder."""
 
     def test_at_without_rotation(self):
-        """at() without rotation omits rotation value."""
+        """at() without rotation defaults to 0 (KiCad GUI requires angle)."""
         node = at(100, 200)
         assert node.name == "at"
-        assert len(node.children) == 2
+        assert len(node.children) == 3
         assert node.children[0].value == 100
         assert node.children[1].value == 200
+        assert node.children[2].value == 0
 
     def test_at_with_rotation(self):
         """at() with rotation includes rotation value."""
@@ -101,10 +102,11 @@ class TestAtBuilder:
         assert node.children[1].value == 200
         assert node.children[2].value == 90
 
-    def test_at_zero_rotation_omitted(self):
-        """Zero rotation should be omitted."""
+    def test_at_zero_rotation_included(self):
+        """Zero rotation is explicitly included (KiCad GUI requires angle)."""
         node = at(100, 200, 0)
-        assert len(node.children) == 2
+        assert len(node.children) == 3
+        assert node.children[2].value == 0
 
 
 class TestStrokeBuilder:


### PR DESCRIPTION
## Summary

Fix failing tests on main after PR #606 was merged. The `at()` builder now always includes rotation angle (required by KiCad GUI), but the tests weren't updated.

## Changes

- `test_at_without_rotation`: Now expects 3 children with rotation=0
- `test_at_zero_rotation_omitted` → `test_at_zero_rotation_included`: Renamed and updated to expect 3 children

## Test Results

```
tests/test_sexp_builders.py::TestAtBuilder::test_at_without_rotation PASSED
tests/test_sexp_builders.py::TestAtBuilder::test_at_with_rotation PASSED
tests/test_sexp_builders.py::TestAtBuilder::test_at_zero_rotation_included PASSED
```

All 116 sexp-related tests pass.

Follow-up to #606 (which closed #597).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
