### PR TITLE
fix(sexp): Preserve actual newlines in text serialization

### DIFF
--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -489,7 +489,7 @@ class SExp:
             # Check if needs quoting
             if self._needs_quoting(self.value):
                 escaped = self.value.replace("\\", "\\\\").replace('"', '\\"')
-                escaped = escaped.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+                # Do NOT escape newlines/tabs - KiCad expects actual control chars in quoted strings
                 return f'"{escaped}"'
             return self.value
         # For numbers, use original string if available (for round-trip preservation)


### PR DESCRIPTION
## Summary

KiCad expects actual newline characters in quoted strings within `.kicad_sch` files, not escape sequences like `\n`. The `_format_atom()` method was incorrectly converting actual newlines to escape sequences, causing text labels to display literal `\n` instead of line breaks.

## Changes

- Remove escape sequence conversion for `\n`, `\r`, `\t` in `_format_atom()` method
- Add 3 unit tests for multiline text serialization:
  - `test_serialize_multiline_text` - verifies actual newlines are preserved
  - `test_serialize_multiline_roundtrip` - verifies parse-serialize-parse preserves content
  - `test_serialize_tabs_preserved` - verifies tabs are preserved

## Test Plan

- [x] All serialization tests pass (9/9)
- [x] Multiline text roundtrip works correctly
- [x] Tab characters preserved as actual tabs
- [x] Existing test suite passes (2 pre-existing failures in unrelated `at` builder tests)

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)