### PR TITLE
feat(schematic): Add intelligent footprint selection for passive components

### DIFF
--- a/src/kicad_tools/schematic/footprint_selector.py
+++ b/src/kicad_tools/schematic/footprint_selector.py
@@ -1,0 +1,492 @@
+"""
+Footprint Selector for Passive Components.
+
+Provides intelligent footprint selection for passive components (capacitors, resistors,
+inductors) based on their values. Different component values often require different
+package sizes for optimal performance characteristics.
+
+Supports configurable profiles:
+- machine: Optimized for pick & place assembly (smaller packages)
+- hand_solder: Larger packages easier to hand solder
+- compact: Smallest packages that can handle the values
+- default: Balanced profile for general use
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class FootprintProfile(str, Enum):
+    """Predefined footprint selection profiles."""
+
+    DEFAULT = "default"
+    MACHINE = "machine"
+    HAND_SOLDER = "hand_solder"
+    COMPACT = "compact"
+
+
+@dataclass
+class FootprintRule:
+    """A rule mapping a value range to a footprint."""
+
+    max_value: float  # Maximum value (in base units) for this footprint
+    footprint: str  # KiCad footprint string
+
+
+@dataclass
+class ProfileRules:
+    """Footprint selection rules for a specific profile."""
+
+    capacitor_rules: list[FootprintRule] = field(default_factory=list)
+    resistor_rules: list[FootprintRule] = field(default_factory=list)
+    inductor_rules: list[FootprintRule] = field(default_factory=list)
+
+
+# Default profiles with footprint mappings
+# Values are in base units: Farads for capacitors, Ohms for resistors, Henries for inductors
+# Note: Boundary values use 1.01x multiplier to handle floating-point precision
+# (e.g., 100nF parsed as 100 * 1e-9 may be slightly > 1e-7 due to float representation)
+DEFAULT_PROFILES: dict[str, ProfileRules] = {
+    "default": ProfileRules(
+        capacitor_rules=[
+            FootprintRule(1.01e-7, "Capacitor_SMD:C_0402_1005Metric"),  # ≤100nF
+            FootprintRule(1.01e-6, "Capacitor_SMD:C_0603_1608Metric"),  # ≤1µF
+            FootprintRule(1.01e-5, "Capacitor_SMD:C_0805_2012Metric"),  # ≤10µF
+            FootprintRule(float("inf"), "Capacitor_SMD:C_1206_3216Metric"),  # >10µF
+        ],
+        resistor_rules=[
+            FootprintRule(1.01e4, "Resistor_SMD:R_0402_1005Metric"),  # ≤10k
+            FootprintRule(float("inf"), "Resistor_SMD:R_0603_1608Metric"),  # >10k
+        ],
+        inductor_rules=[
+            FootprintRule(1.01e-6, "Inductor_SMD:L_0603_1608Metric"),  # ≤1µH
+            FootprintRule(1.01e-5, "Inductor_SMD:L_0805_2012Metric"),  # ≤10µH
+            FootprintRule(float("inf"), "Inductor_SMD:L_1206_3216Metric"),  # >10µH
+        ],
+    ),
+    "machine": ProfileRules(
+        capacitor_rules=[
+            FootprintRule(1.01e-6, "Capacitor_SMD:C_0402_1005Metric"),  # ≤1µF
+            FootprintRule(1.01e-5, "Capacitor_SMD:C_0603_1608Metric"),  # ≤10µF
+            FootprintRule(4.71e-5, "Capacitor_SMD:C_0805_2012Metric"),  # ≤47µF
+            FootprintRule(float("inf"), "Capacitor_SMD:C_1206_3216Metric"),  # >47µF
+        ],
+        resistor_rules=[
+            FootprintRule(float("inf"), "Resistor_SMD:R_0402_1005Metric"),  # All values
+        ],
+        inductor_rules=[
+            FootprintRule(1.01e-6, "Inductor_SMD:L_0402_1005Metric"),  # ≤1µH
+            FootprintRule(1.01e-5, "Inductor_SMD:L_0603_1608Metric"),  # ≤10µH
+            FootprintRule(float("inf"), "Inductor_SMD:L_0805_2012Metric"),  # >10µH
+        ],
+    ),
+    "hand_solder": ProfileRules(
+        capacitor_rules=[
+            FootprintRule(1.01e-7, "Capacitor_SMD:C_0603_1608Metric"),  # ≤100nF
+            FootprintRule(1.01e-6, "Capacitor_SMD:C_0805_2012Metric"),  # ≤1µF
+            FootprintRule(1.01e-5, "Capacitor_SMD:C_1206_3216Metric"),  # ≤10µF
+            FootprintRule(float("inf"), "Capacitor_SMD:C_1210_3225Metric"),  # >10µF
+        ],
+        resistor_rules=[
+            FootprintRule(1.01e4, "Resistor_SMD:R_0603_1608Metric"),  # ≤10k
+            FootprintRule(float("inf"), "Resistor_SMD:R_0805_2012Metric"),  # >10k
+        ],
+        inductor_rules=[
+            FootprintRule(1.01e-5, "Inductor_SMD:L_0805_2012Metric"),  # ≤10µH
+            FootprintRule(float("inf"), "Inductor_SMD:L_1206_3216Metric"),  # >10µH
+        ],
+    ),
+    "compact": ProfileRules(
+        capacitor_rules=[
+            FootprintRule(1.01e-5, "Capacitor_SMD:C_0402_1005Metric"),  # ≤10µF
+            FootprintRule(4.71e-5, "Capacitor_SMD:C_0603_1608Metric"),  # ≤47µF
+            FootprintRule(1.01e-4, "Capacitor_SMD:C_0805_2012Metric"),  # ≤100µF
+            FootprintRule(float("inf"), "Capacitor_SMD:C_1206_3216Metric"),  # >100µF
+        ],
+        resistor_rules=[
+            FootprintRule(float("inf"), "Resistor_SMD:R_0402_1005Metric"),  # All values
+        ],
+        inductor_rules=[
+            FootprintRule(1.01e-5, "Inductor_SMD:L_0402_1005Metric"),  # ≤10µH
+            FootprintRule(float("inf"), "Inductor_SMD:L_0603_1608Metric"),  # >10µH
+        ],
+    ),
+}
+
+
+class FootprintSelector:
+    """
+    Select appropriate footprints for passive components based on value.
+
+    Supports capacitors, resistors, and inductors with configurable profiles
+    for different assembly requirements.
+
+    Example:
+        selector = FootprintSelector(profile="hand_solder")
+
+        # Get footprint for a capacitor
+        fp = selector.select_capacitor_footprint("100nF")
+        # Returns: "Capacitor_SMD:C_0603_1608Metric"
+
+        # Get footprint for a resistor
+        fp = selector.select_resistor_footprint("10k")
+        # Returns: "Resistor_SMD:R_0603_1608Metric"
+    """
+
+    def __init__(
+        self,
+        profile: str = "default",
+        custom_rules: dict[str, Any] | None = None,
+    ):
+        """
+        Initialize the footprint selector.
+
+        Args:
+            profile: Profile name - one of "default", "machine", "hand_solder", "compact"
+            custom_rules: Optional custom rules to override or extend default profiles.
+                         Format: {"capacitor": {"0-100nF": "Footprint:Name", ...}, ...}
+        """
+        self.profile = profile
+        self._rules = self._load_rules(profile, custom_rules)
+
+    def _load_rules(self, profile: str, custom_rules: dict[str, Any] | None) -> ProfileRules:
+        """Load rules for the specified profile, with optional custom overrides."""
+        # Start with default profile if specified profile not found
+        if profile in DEFAULT_PROFILES:
+            rules = DEFAULT_PROFILES[profile]
+        else:
+            rules = DEFAULT_PROFILES["default"]
+
+        # Apply custom rules if provided
+        if custom_rules:
+            rules = self._apply_custom_rules(rules, custom_rules)
+
+        return rules
+
+    def _apply_custom_rules(
+        self, base_rules: ProfileRules, custom_rules: dict[str, Any]
+    ) -> ProfileRules:
+        """Apply custom rules on top of base rules."""
+        capacitor_rules = list(base_rules.capacitor_rules)
+        resistor_rules = list(base_rules.resistor_rules)
+        inductor_rules = list(base_rules.inductor_rules)
+
+        # Parse custom capacitor rules
+        if "capacitor" in custom_rules:
+            capacitor_rules = self._parse_custom_component_rules(
+                custom_rules["capacitor"], "capacitor"
+            )
+
+        # Parse custom resistor rules
+        if "resistor" in custom_rules:
+            resistor_rules = self._parse_custom_component_rules(
+                custom_rules["resistor"], "resistor"
+            )
+
+        # Parse custom inductor rules
+        if "inductor" in custom_rules:
+            inductor_rules = self._parse_custom_component_rules(
+                custom_rules["inductor"], "inductor"
+            )
+
+        return ProfileRules(
+            capacitor_rules=capacitor_rules,
+            resistor_rules=resistor_rules,
+            inductor_rules=inductor_rules,
+        )
+
+    def _parse_custom_component_rules(
+        self, rules_dict: dict[str, str], component_type: str
+    ) -> list[FootprintRule]:
+        """
+        Parse custom rules from config format to FootprintRule objects.
+
+        Config format: {"0-100nF": "Footprint:Name", "100nF-1uF": "Other:Footprint", ...}
+        """
+        rules = []
+        for range_str, footprint in rules_dict.items():
+            # Parse range like "0-100nF" or "100nF-1uF" or "10uF+"
+            if range_str.endswith("+"):
+                # "10uF+" means > 10uF
+                max_value = float("inf")
+            elif "-" in range_str:
+                # "100nF-1uF" - use the upper bound
+                parts = range_str.split("-")
+                if len(parts) == 2:
+                    max_value = parse_component_value(parts[1], component_type)
+                else:
+                    continue
+            else:
+                # Single value - treat as max
+                max_value = parse_component_value(range_str, component_type)
+
+            rules.append(FootprintRule(max_value, footprint))
+
+        # Sort by max_value for proper rule matching
+        rules.sort(key=lambda r: r.max_value)
+        return rules
+
+    def select_capacitor_footprint(self, value: str, voltage: float | None = None) -> str:
+        """
+        Select footprint for a capacitor based on its value.
+
+        Args:
+            value: Capacitor value string (e.g., "100nF", "10uF", "4.7µF")
+            voltage: Optional voltage rating (for future derating support)
+
+        Returns:
+            KiCad footprint string (e.g., "Capacitor_SMD:C_0603_1608Metric")
+        """
+        try:
+            value_farads = parse_component_value(value, "capacitor")
+            return self._select_from_rules(value_farads, self._rules.capacitor_rules)
+        except ValueError:
+            # Fallback to default footprint if value can't be parsed
+            return "Capacitor_SMD:C_0603_1608Metric"
+
+    def select_resistor_footprint(self, value: str, power: float | None = None) -> str:
+        """
+        Select footprint for a resistor based on its value.
+
+        Args:
+            value: Resistor value string (e.g., "10k", "4.7k", "100R")
+            power: Optional power rating in watts (for future support)
+
+        Returns:
+            KiCad footprint string (e.g., "Resistor_SMD:R_0402_1005Metric")
+        """
+        try:
+            value_ohms = parse_component_value(value, "resistor")
+            return self._select_from_rules(value_ohms, self._rules.resistor_rules)
+        except ValueError:
+            # Fallback to default footprint if value can't be parsed
+            return "Resistor_SMD:R_0603_1608Metric"
+
+    def select_inductor_footprint(self, value: str, current: float | None = None) -> str:
+        """
+        Select footprint for an inductor based on its value.
+
+        Args:
+            value: Inductor value string (e.g., "10uH", "100nH", "4.7µH")
+            current: Optional current rating in amps (for future support)
+
+        Returns:
+            KiCad footprint string (e.g., "Inductor_SMD:L_0603_1608Metric")
+        """
+        try:
+            value_henries = parse_component_value(value, "inductor")
+            return self._select_from_rules(value_henries, self._rules.inductor_rules)
+        except ValueError:
+            # Fallback to default footprint if value can't be parsed
+            return "Inductor_SMD:L_0805_2012Metric"
+
+    def select_footprint(
+        self,
+        lib_id: str,
+        value: str,
+    ) -> str | None:
+        """
+        Auto-select footprint based on component type and value.
+
+        Determines component type from lib_id and selects appropriate footprint.
+
+        Args:
+            lib_id: KiCad library ID (e.g., "Device:C", "Device:R", "Device:L")
+            value: Component value string
+
+        Returns:
+            Footprint string if component type is recognized, None otherwise
+        """
+        lib_id_lower = lib_id.lower()
+
+        # Detect component type from lib_id
+        if ":c" in lib_id_lower or lib_id_lower.endswith(":c"):
+            return self.select_capacitor_footprint(value)
+        elif ":r" in lib_id_lower or lib_id_lower.endswith(":r"):
+            return self.select_resistor_footprint(value)
+        elif ":l" in lib_id_lower or lib_id_lower.endswith(":l"):
+            return self.select_inductor_footprint(value)
+
+        # Check for common passive component symbols
+        if "capacitor" in lib_id_lower or "cap" in lib_id_lower:
+            return self.select_capacitor_footprint(value)
+        elif "resistor" in lib_id_lower or "res" in lib_id_lower:
+            return self.select_resistor_footprint(value)
+        elif "inductor" in lib_id_lower or "ind" in lib_id_lower:
+            return self.select_inductor_footprint(value)
+
+        return None
+
+    def _select_from_rules(self, value: float, rules: list[FootprintRule]) -> str:
+        """Select footprint from rules based on value."""
+        for rule in rules:
+            if value <= rule.max_value:
+                return rule.footprint
+
+        # Fallback to last rule (should have inf max_value)
+        if rules:
+            return rules[-1].footprint
+
+        raise ValueError("No rules defined")
+
+
+def parse_component_value(value_str: str, component_type: str = "capacitor") -> float:
+    """
+    Parse a component value string to its base unit value.
+
+    Supports various formats:
+    - Capacitors: "100nF", "10uF", "4.7µF", "1pF", "0.1uF"
+    - Resistors: "10k", "4.7k", "100R", "1M", "4R7" (inline decimal)
+    - Inductors: "10uH", "100nH", "4.7µH", "1mH"
+
+    Args:
+        value_str: Value string to parse
+        component_type: Type of component ("capacitor", "resistor", "inductor")
+
+    Returns:
+        Value in base units (Farads, Ohms, or Henries)
+
+    Raises:
+        ValueError: If the value cannot be parsed
+    """
+    value_str = value_str.strip()
+
+    if component_type == "resistor":
+        return _parse_resistance(value_str)
+    elif component_type == "capacitor":
+        return _parse_capacitance(value_str)
+    elif component_type == "inductor":
+        return _parse_inductance(value_str)
+    else:
+        raise ValueError(f"Unknown component type: {component_type}")
+
+
+def _parse_capacitance(value_str: str) -> float:
+    """Parse capacitance value to Farads."""
+    value_str = value_str.strip().upper()
+
+    # Replace common unicode characters
+    value_str = value_str.replace("Μ", "U").replace("μ", "U")
+
+    # Multiplier map for capacitors (to Farads)
+    multipliers = {
+        "F": 1,
+        "MF": 1e-3,  # millifarads (rare)
+        "UF": 1e-6,  # microfarads
+        "NF": 1e-9,  # nanofarads
+        "PF": 1e-12,  # picofarads
+    }
+
+    # Try to match value with unit
+    match = re.match(r"^([\d.]+)\s*([A-Z]+)?$", value_str)
+    if match:
+        number = float(match.group(1))
+        unit = match.group(2) or "F"
+
+        if unit in multipliers:
+            return number * multipliers[unit]
+
+    raise ValueError(f"Cannot parse capacitance value: {value_str}")
+
+
+def _parse_resistance(value_str: str) -> float:
+    """Parse resistance value to Ohms."""
+    value_str = value_str.strip().upper()
+
+    # Handle inline decimal notation (e.g., "4R7" = 4.7 ohms, "4K7" = 4.7k)
+    inline_match = re.match(r"^(\d+)([RKM])(\d+)$", value_str)
+    if inline_match:
+        whole = inline_match.group(1)
+        unit = inline_match.group(2)
+        decimal = inline_match.group(3)
+        number = float(f"{whole}.{decimal}")
+
+        if unit == "R":
+            return number
+        elif unit == "K":
+            return number * 1000
+        elif unit == "M":
+            return number * 1_000_000
+
+    # Standard notation (e.g., "10k", "4.7k", "100R")
+    match = re.match(r"^([\d.]+)\s*([RKOM])?$", value_str)
+    if match:
+        number = float(match.group(1))
+        unit = match.group(2) or "R"
+
+        if unit == "R" or unit == "O":  # ohms
+            return number
+        elif unit == "K":
+            return number * 1000
+        elif unit == "M":
+            return number * 1_000_000
+
+    raise ValueError(f"Cannot parse resistance value: {value_str}")
+
+
+def _parse_inductance(value_str: str) -> float:
+    """Parse inductance value to Henries."""
+    value_str = value_str.strip().upper()
+
+    # Replace common unicode characters
+    value_str = value_str.replace("Μ", "U").replace("μ", "U")
+
+    # Multiplier map for inductors (to Henries)
+    multipliers = {
+        "H": 1,
+        "MH": 1e-3,  # millihenries
+        "UH": 1e-6,  # microhenries
+        "NH": 1e-9,  # nanohenries
+        "PH": 1e-12,  # picohenries (very rare)
+    }
+
+    # Try to match value with unit
+    match = re.match(r"^([\d.]+)\s*([A-Z]+)?$", value_str)
+    if match:
+        number = float(match.group(1))
+        unit = match.group(2) or "H"
+
+        if unit in multipliers:
+            return number * multipliers[unit]
+
+    raise ValueError(f"Cannot parse inductance value: {value_str}")
+
+
+# Module-level convenience function
+_default_selector: FootprintSelector | None = None
+
+
+def get_default_selector() -> FootprintSelector:
+    """Get or create the default footprint selector."""
+    global _default_selector
+    if _default_selector is None:
+        _default_selector = FootprintSelector()
+    return _default_selector
+
+
+def select_footprint_for_passive(
+    lib_id: str,
+    value: str,
+    profile: str = "default",
+) -> str | None:
+    """
+    Convenience function to select footprint for a passive component.
+
+    Args:
+        lib_id: KiCad library ID
+        value: Component value string
+        profile: Footprint profile to use
+
+    Returns:
+        Footprint string or None if not applicable
+    """
+    if profile == "default":
+        selector = get_default_selector()
+    else:
+        selector = FootprintSelector(profile=profile)
+
+    return selector.select_footprint(lib_id, value)

--- a/tests/test_footprint_selector.py
+++ b/tests/test_footprint_selector.py
@@ -1,0 +1,322 @@
+"""Tests for the footprint selector module."""
+
+import pytest
+
+from kicad_tools.schematic.footprint_selector import (
+    FootprintSelector,
+    parse_component_value,
+    select_footprint_for_passive,
+)
+
+
+class TestParseCapacitance:
+    """Tests for capacitance value parsing."""
+
+    def test_parse_nanofarads(self):
+        """Test parsing nanofarad values."""
+        assert parse_component_value("100nF", "capacitor") == pytest.approx(1e-7)
+        assert parse_component_value("10nF", "capacitor") == pytest.approx(1e-8)
+        assert parse_component_value("1nF", "capacitor") == pytest.approx(1e-9)
+        assert parse_component_value("4.7nF", "capacitor") == pytest.approx(4.7e-9)
+
+    def test_parse_microfarads(self):
+        """Test parsing microfarad values."""
+        assert parse_component_value("10uF", "capacitor") == pytest.approx(1e-5)
+        assert parse_component_value("1uF", "capacitor") == pytest.approx(1e-6)
+        assert parse_component_value("4.7uF", "capacitor") == pytest.approx(4.7e-6)
+        assert parse_component_value("0.1uF", "capacitor") == pytest.approx(1e-7)
+
+    def test_parse_picofarads(self):
+        """Test parsing picofarad values."""
+        assert parse_component_value("100pF", "capacitor") == pytest.approx(1e-10)
+        assert parse_component_value("10pF", "capacitor") == pytest.approx(1e-11)
+        assert parse_component_value("1pF", "capacitor") == pytest.approx(1e-12)
+
+    def test_parse_case_insensitive(self):
+        """Test that value parsing is case insensitive."""
+        assert parse_component_value("100NF", "capacitor") == pytest.approx(1e-7)
+        assert parse_component_value("10UF", "capacitor") == pytest.approx(1e-5)
+        assert parse_component_value("100Pf", "capacitor") == pytest.approx(1e-10)
+
+    def test_parse_with_spaces(self):
+        """Test parsing values with leading/trailing spaces."""
+        assert parse_component_value(" 100nF ", "capacitor") == pytest.approx(1e-7)
+        assert parse_component_value("  10uF", "capacitor") == pytest.approx(1e-5)
+
+    def test_parse_unicode_mu(self):
+        """Test parsing values with unicode micro symbol (µ)."""
+        assert parse_component_value("10µF", "capacitor") == pytest.approx(1e-5)
+        assert parse_component_value("4.7µF", "capacitor") == pytest.approx(4.7e-6)
+
+    def test_invalid_capacitance_raises(self):
+        """Test that invalid values raise ValueError."""
+        with pytest.raises(ValueError):
+            parse_component_value("invalid", "capacitor")
+        with pytest.raises(ValueError):
+            parse_component_value("10X", "capacitor")
+
+
+class TestParseResistance:
+    """Tests for resistance value parsing."""
+
+    def test_parse_ohms(self):
+        """Test parsing ohm values."""
+        assert parse_component_value("100R", "resistor") == pytest.approx(100)
+        assert parse_component_value("10R", "resistor") == pytest.approx(10)
+        assert parse_component_value("4.7R", "resistor") == pytest.approx(4.7)
+
+    def test_parse_kilohms(self):
+        """Test parsing kilohm values."""
+        assert parse_component_value("10k", "resistor") == pytest.approx(10000)
+        assert parse_component_value("4.7k", "resistor") == pytest.approx(4700)
+        assert parse_component_value("100k", "resistor") == pytest.approx(100000)
+
+    def test_parse_megohms(self):
+        """Test parsing megohm values."""
+        assert parse_component_value("1M", "resistor") == pytest.approx(1e6)
+        assert parse_component_value("4.7M", "resistor") == pytest.approx(4.7e6)
+        assert parse_component_value("10M", "resistor") == pytest.approx(1e7)
+
+    def test_parse_inline_decimal(self):
+        """Test parsing inline decimal notation (e.g., 4R7)."""
+        assert parse_component_value("4R7", "resistor") == pytest.approx(4.7)
+        assert parse_component_value("4K7", "resistor") == pytest.approx(4700)
+        assert parse_component_value("1M5", "resistor") == pytest.approx(1.5e6)
+
+    def test_parse_case_insensitive_resistance(self):
+        """Test that resistance parsing is case insensitive."""
+        assert parse_component_value("10K", "resistor") == pytest.approx(10000)
+        assert parse_component_value("10k", "resistor") == pytest.approx(10000)
+
+    def test_invalid_resistance_raises(self):
+        """Test that invalid values raise ValueError."""
+        with pytest.raises(ValueError):
+            parse_component_value("invalid", "resistor")
+
+
+class TestParseInductance:
+    """Tests for inductance value parsing."""
+
+    def test_parse_microhenries(self):
+        """Test parsing microhenry values."""
+        assert parse_component_value("10uH", "inductor") == pytest.approx(1e-5)
+        assert parse_component_value("1uH", "inductor") == pytest.approx(1e-6)
+        assert parse_component_value("4.7uH", "inductor") == pytest.approx(4.7e-6)
+
+    def test_parse_nanohenries(self):
+        """Test parsing nanohenry values."""
+        assert parse_component_value("100nH", "inductor") == pytest.approx(1e-7)
+        assert parse_component_value("10nH", "inductor") == pytest.approx(1e-8)
+
+    def test_parse_millihenries(self):
+        """Test parsing millihenry values."""
+        assert parse_component_value("1mH", "inductor") == pytest.approx(1e-3)
+        assert parse_component_value("10mH", "inductor") == pytest.approx(1e-2)
+
+
+class TestFootprintSelectorCapacitors:
+    """Tests for capacitor footprint selection."""
+
+    def test_default_profile_capacitor_selection(self):
+        """Test capacitor footprint selection with default profile."""
+        selector = FootprintSelector(profile="default")
+
+        # ≤100nF -> 0402
+        assert selector.select_capacitor_footprint("100nF") == "Capacitor_SMD:C_0402_1005Metric"
+        assert selector.select_capacitor_footprint("10nF") == "Capacitor_SMD:C_0402_1005Metric"
+
+        # ≤1µF -> 0603
+        assert selector.select_capacitor_footprint("1uF") == "Capacitor_SMD:C_0603_1608Metric"
+        assert selector.select_capacitor_footprint("0.5uF") == "Capacitor_SMD:C_0603_1608Metric"
+
+        # ≤10µF -> 0805
+        assert selector.select_capacitor_footprint("10uF") == "Capacitor_SMD:C_0805_2012Metric"
+        assert selector.select_capacitor_footprint("4.7uF") == "Capacitor_SMD:C_0805_2012Metric"
+
+        # >10µF -> 1206
+        assert selector.select_capacitor_footprint("22uF") == "Capacitor_SMD:C_1206_3216Metric"
+        assert selector.select_capacitor_footprint("100uF") == "Capacitor_SMD:C_1206_3216Metric"
+
+    def test_machine_profile_capacitor_selection(self):
+        """Test capacitor footprint selection with machine profile."""
+        selector = FootprintSelector(profile="machine")
+
+        # Machine profile allows larger values in smaller packages
+        assert selector.select_capacitor_footprint("1uF") == "Capacitor_SMD:C_0402_1005Metric"
+        assert selector.select_capacitor_footprint("10uF") == "Capacitor_SMD:C_0603_1608Metric"
+
+    def test_hand_solder_profile_capacitor_selection(self):
+        """Test capacitor footprint selection with hand_solder profile."""
+        selector = FootprintSelector(profile="hand_solder")
+
+        # Hand solder uses larger packages
+        assert selector.select_capacitor_footprint("100nF") == "Capacitor_SMD:C_0603_1608Metric"
+        assert selector.select_capacitor_footprint("1uF") == "Capacitor_SMD:C_0805_2012Metric"
+
+    def test_compact_profile_capacitor_selection(self):
+        """Test capacitor footprint selection with compact profile."""
+        selector = FootprintSelector(profile="compact")
+
+        # Compact uses smallest viable packages
+        assert selector.select_capacitor_footprint("10uF") == "Capacitor_SMD:C_0402_1005Metric"
+        assert selector.select_capacitor_footprint("47uF") == "Capacitor_SMD:C_0603_1608Metric"
+
+
+class TestFootprintSelectorResistors:
+    """Tests for resistor footprint selection."""
+
+    def test_default_profile_resistor_selection(self):
+        """Test resistor footprint selection with default profile."""
+        selector = FootprintSelector(profile="default")
+
+        # ≤10k -> 0402
+        assert selector.select_resistor_footprint("10k") == "Resistor_SMD:R_0402_1005Metric"
+        assert selector.select_resistor_footprint("1k") == "Resistor_SMD:R_0402_1005Metric"
+
+        # >10k -> 0603
+        assert selector.select_resistor_footprint("100k") == "Resistor_SMD:R_0603_1608Metric"
+        assert selector.select_resistor_footprint("1M") == "Resistor_SMD:R_0603_1608Metric"
+
+    def test_machine_profile_resistor_selection(self):
+        """Test resistor footprint selection with machine profile."""
+        selector = FootprintSelector(profile="machine")
+
+        # Machine profile uses 0402 for all values
+        assert selector.select_resistor_footprint("10k") == "Resistor_SMD:R_0402_1005Metric"
+        assert selector.select_resistor_footprint("100k") == "Resistor_SMD:R_0402_1005Metric"
+        assert selector.select_resistor_footprint("1M") == "Resistor_SMD:R_0402_1005Metric"
+
+
+class TestFootprintSelectorInductors:
+    """Tests for inductor footprint selection."""
+
+    def test_default_profile_inductor_selection(self):
+        """Test inductor footprint selection with default profile."""
+        selector = FootprintSelector(profile="default")
+
+        # ≤1µH -> 0603
+        assert selector.select_inductor_footprint("1uH") == "Inductor_SMD:L_0603_1608Metric"
+
+        # ≤10µH -> 0805
+        assert selector.select_inductor_footprint("10uH") == "Inductor_SMD:L_0805_2012Metric"
+
+        # >10µH -> 1206
+        assert selector.select_inductor_footprint("100uH") == "Inductor_SMD:L_1206_3216Metric"
+
+
+class TestFootprintSelectorAutoDetection:
+    """Tests for automatic component type detection."""
+
+    def test_select_footprint_capacitor(self):
+        """Test auto-detection of capacitor from lib_id."""
+        selector = FootprintSelector(profile="default")
+
+        fp = selector.select_footprint("Device:C", "100nF")
+        assert fp == "Capacitor_SMD:C_0402_1005Metric"
+
+        fp = selector.select_footprint("Device:C_Polarized", "10uF")
+        assert fp == "Capacitor_SMD:C_0805_2012Metric"
+
+    def test_select_footprint_resistor(self):
+        """Test auto-detection of resistor from lib_id."""
+        selector = FootprintSelector(profile="default")
+
+        fp = selector.select_footprint("Device:R", "10k")
+        assert fp == "Resistor_SMD:R_0402_1005Metric"
+
+        fp = selector.select_footprint("Device:R_Small", "100k")
+        assert fp == "Resistor_SMD:R_0603_1608Metric"
+
+    def test_select_footprint_inductor(self):
+        """Test auto-detection of inductor from lib_id."""
+        selector = FootprintSelector(profile="default")
+
+        fp = selector.select_footprint("Device:L", "10uH")
+        assert fp == "Inductor_SMD:L_0805_2012Metric"
+
+    def test_select_footprint_unknown_returns_none(self):
+        """Test that unknown components return None."""
+        selector = FootprintSelector(profile="default")
+
+        fp = selector.select_footprint("Device:D", "1N4148")
+        assert fp is None
+
+        fp = selector.select_footprint("Connector:USB_C", "USB-C")
+        assert fp is None
+
+
+class TestSelectFootprintForPassive:
+    """Tests for the convenience function."""
+
+    def test_select_footprint_for_passive_default(self):
+        """Test convenience function with default profile."""
+        fp = select_footprint_for_passive("Device:C", "100nF")
+        assert fp == "Capacitor_SMD:C_0402_1005Metric"
+
+    def test_select_footprint_for_passive_custom_profile(self):
+        """Test convenience function with custom profile."""
+        fp = select_footprint_for_passive("Device:C", "100nF", profile="hand_solder")
+        assert fp == "Capacitor_SMD:C_0603_1608Metric"
+
+
+class TestFootprintSelectorFallback:
+    """Tests for fallback behavior with invalid inputs."""
+
+    def test_invalid_capacitor_value_fallback(self):
+        """Test fallback for invalid capacitor values."""
+        selector = FootprintSelector()
+        fp = selector.select_capacitor_footprint("invalid")
+        assert fp == "Capacitor_SMD:C_0603_1608Metric"  # Default fallback
+
+    def test_invalid_resistor_value_fallback(self):
+        """Test fallback for invalid resistor values."""
+        selector = FootprintSelector()
+        fp = selector.select_resistor_footprint("invalid")
+        assert fp == "Resistor_SMD:R_0603_1608Metric"  # Default fallback
+
+    def test_invalid_inductor_value_fallback(self):
+        """Test fallback for invalid inductor values."""
+        selector = FootprintSelector()
+        fp = selector.select_inductor_footprint("invalid")
+        assert fp == "Inductor_SMD:L_0805_2012Metric"  # Default fallback
+
+
+class TestFootprintSelectorCustomRules:
+    """Tests for custom rule configuration."""
+
+    def test_custom_capacitor_rules(self):
+        """Test custom capacitor rules override defaults."""
+        custom_rules = {
+            "capacitor": {
+                "0-1uF": "Capacitor_SMD:C_0201_0603Metric",
+                "1uF+": "Capacitor_SMD:C_0402_1005Metric",
+            }
+        }
+        selector = FootprintSelector(profile="default", custom_rules=custom_rules)
+
+        assert selector.select_capacitor_footprint("100nF") == "Capacitor_SMD:C_0201_0603Metric"
+        assert selector.select_capacitor_footprint("10uF") == "Capacitor_SMD:C_0402_1005Metric"
+
+
+class TestFootprintSelectorBoundaryValues:
+    """Tests for boundary value conditions."""
+
+    def test_exactly_at_boundary_capacitor(self):
+        """Test values exactly at boundary thresholds."""
+        selector = FootprintSelector(profile="default")
+
+        # Exactly 100nF should be ≤100nF
+        assert selector.select_capacitor_footprint("100nF") == "Capacitor_SMD:C_0402_1005Metric"
+
+        # Exactly 1uF should be ≤1uF
+        assert selector.select_capacitor_footprint("1uF") == "Capacitor_SMD:C_0603_1608Metric"
+
+        # Exactly 10uF should be ≤10uF
+        assert selector.select_capacitor_footprint("10uF") == "Capacitor_SMD:C_0805_2012Metric"
+
+    def test_exactly_at_boundary_resistor(self):
+        """Test values exactly at boundary thresholds."""
+        selector = FootprintSelector(profile="default")
+
+        # Exactly 10k should be ≤10k
+        assert selector.select_resistor_footprint("10k") == "Resistor_SMD:R_0402_1005Metric"


### PR DESCRIPTION
## Summary

- Implement `FootprintSelector` class that automatically selects appropriate footprints for capacitors, resistors, and inductors based on their values
- Add value parsing with SI prefix support (nF, uF, pF, kΩ, MΩ, µH, etc.)
- Provide four built-in profiles: default, machine, hand_solder, compact
- Add configuration support via `.kicad-tools.toml` for custom rules

## Changes

### New Files
- `src/kicad_tools/schematic/footprint_selector.py` - Core implementation
- `tests/test_footprint_selector.py` - 35 unit tests

### Modified Files
- `src/kicad_tools/config.py` - Added `footprint_selection` config section
- `src/kicad_tools/schematic/models/elements_mixin.py` - Added `auto_footprint` parameter to `add_symbol()`
- `src/kicad_tools/schematic/blocks/power.py` - Added `auto_footprint` support to `DecouplingCaps`, `LDOBlock`, and `VoltageDivider`

## Usage Example

```python
from kicad_tools.schematic import Schematic

sch = Schematic(title="My Schematic")

# Auto-select footprint based on value
cap = sch.add_symbol("Device:C", x=100, y=50, ref="C1", value="100nF", auto_footprint=True)
# Result: footprint = "Capacitor_SMD:C_0402_1005Metric"

res = sch.add_symbol("Device:R", x=150, y=50, ref="R1", value="10k", auto_footprint=True)
# Result: footprint = "Resistor_SMD:R_0402_1005Metric"

# Circuit blocks also support auto_footprint
from kicad_tools.schematic.blocks import DecouplingCaps
caps = DecouplingCaps(sch, x=100, y=100, values=["10uF", "100nF"], auto_footprint=True)
```

## Test plan
- [x] All 35 new unit tests pass
- [x] Existing 127 schematic model tests pass
- [x] Lint checks pass (ruff)
- [x] Format checks pass

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)