### PR TITLE
feat(router): Add congestion-aware net ordering strategies

### DIFF
--- a/src/kicad_tools/optim/__init__.py
+++ b/src/kicad_tools/optim/__init__.py
@@ -113,7 +113,11 @@ from kicad_tools.optim.query import (
     query_position,
     query_swap,
 )
-from kicad_tools.optim.routing import FigureOfMerit, RoutingOptimizer
+from kicad_tools.optim.routing import (
+    FigureOfMerit,
+    RoutingOptimizer,
+    estimate_net_congestion,
+)
 from kicad_tools.optim.session import (
     Move,
     MoveResult,
@@ -165,6 +169,7 @@ __all__ = [
     "EvolutionaryPlacementOptimizer",
     "RoutingOptimizer",
     "FigureOfMerit",
+    "estimate_net_congestion",
     # Session and query API
     "PlacementSession",
     "MoveResult",


### PR DESCRIPTION
## Summary

- Adds `estimate_net_congestion()` function that samples congestion along a net's routing corridor
- Adds `congestion` ordering strategy - routes highest-congestion nets first to give them more path choices
- Adds `hybrid` ordering strategy - combines power/clock priority with congestion awareness within each tier

The new strategies leverage the existing `CongestionMap` infrastructure from `failure_analysis.py`, connecting congestion analysis to net ordering decisions for improved routing success rates in congested areas.

## Test plan

- [x] Added unit tests for `estimate_net_congestion()` with edge cases (empty/single pad)
- [x] Added tests for `congestion` method requiring congestion_map parameter
- [x] Added tests for `hybrid` method validating power/clock nets are ordered first
- [x] All 119 optim tests pass
- [x] Linting and formatting checks pass

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)