### PR TITLE
feat(schematic): Add runtime warning for T-connections on continuous rails

### DIFF
--- a/src/kicad_tools/schematic/models/schematic.py
+++ b/src/kicad_tools/schematic/models/schematic.py
@@ -148,6 +148,10 @@ class Schematic(
         # Embedded lib_symbols from loaded schematics (preserved for round-trip)
         self._embedded_lib_symbols: dict[str, SExp] = {}
 
+        # Track continuous rails for T-connection warnings
+        # Each entry: (y, x_start, x_end) for horizontal rails
+        self._continuous_rails: list[tuple[float, float, float]] = []
+
     @property
     def sheet_path(self) -> str:
         """Get the sheet path for this schematic."""


### PR DESCRIPTION
## Summary

Implements Option A from issue #629 - adds runtime warning when `wire_to_rail()` creates a T-connection on a rail created by `add_rail()`.

This is the least disruptive approach that guides users to use `add_segmented_rail()` instead, without breaking existing code.

## Changes

- Add `_continuous_rails` tracking to `Schematic` class
- Track rails created by `add_rail()` for T-connection detection  
- Emit warning when `wire_to_rail()` creates interior T-connection
- No warning at rail endpoints (proper connections)
- `add_segmented_rail()` does not trigger warnings (already correct)
- Updated `add_rail()` docstring to reference `add_segmented_rail()`

## Test Plan

- [x] Added test for T-connection warning on continuous rail
- [x] Added test for no warning at rail endpoints
- [x] Added test for tracking continuous rails
- [x] Added test for segmented rail not triggering warnings
- [x] All 199 schematic tests pass

## Example

```python
from kicad_tools.schematic.logging import enable_verbose
enable_verbose("WARNING")

sch = Schematic("Test")
sch.add_rail(y=30, x_start=25, x_end=150)  # Continuous rail
sch.wire_to_rail(cap, "1", rail_y=30)  # Warning: T-connection at (64.77, 30.0)...

# Fix: Use add_segmented_rail() instead
sch.add_segmented_rail(y=30, x_points=[25, cap_x, 150])
```

Closes #629