### PR TITLE
feat(cli): Add kct build command for end-to-end workflow orchestration

### DIFF
--- a/boards/02-charlieplex-led/generate_schematic.py
+++ b/boards/02-charlieplex-led/generate_schematic.py
@@ -185,13 +185,17 @@ def create_charlieplex_schematic(output_path: Path) -> bool:
     vcc_pwr = sch.add_power("power:VCC", x=25.4, y=25.4, rotation=0)
     vcc_conn = (vcc_pwr.x, vcc_pwr.y)
     sch.add_wire(vcc_conn, (vcc_conn[0] + WIRE_STUB, vcc_conn[1]), snap=False)
-    sch.add_global_label("VCC", vcc_conn[0] + WIRE_STUB, vcc_conn[1], shape="input", rotation=180, snap=False)
+    sch.add_global_label(
+        "VCC", vcc_conn[0] + WIRE_STUB, vcc_conn[1], shape="input", rotation=180, snap=False
+    )
 
     # GND power rail - use power symbol's position as connection point
     gnd_pwr = sch.add_power("power:GND", x=25.4, y=50.8, rotation=180)
     gnd_conn = (gnd_pwr.x, gnd_pwr.y)
     sch.add_wire(gnd_conn, (gnd_conn[0] + WIRE_STUB, gnd_conn[1]), snap=False)
-    sch.add_global_label("GND", gnd_conn[0] + WIRE_STUB, gnd_conn[1], shape="input", rotation=180, snap=False)
+    sch.add_global_label(
+        "GND", gnd_conn[0] + WIRE_STUB, gnd_conn[1], shape="input", rotation=180, snap=False
+    )
 
     print("   Added VCC and GND power symbols with labels")
 
@@ -255,6 +259,7 @@ def main():
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)
         import traceback
+
         traceback.print_exc()
         return 1
 

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -44,6 +44,7 @@ from .commands import (
     run_analyze_command,
     run_audit_command,
     run_benchmark_command,
+    run_build_command,
     run_build_native_command,
     run_check_command,
     run_clean_command,
@@ -368,6 +369,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "init":
         return run_init_command(args)
+
+    elif args.command == "build":
+        return run_build_command(args)
 
     elif args.command == "build-native":
         return run_build_native_command(args)

--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -1,0 +1,640 @@
+"""
+Build command implementation for end-to-end workflow from spec to manufacturable design.
+
+Orchestrates the full build pipeline:
+1. Load project spec (.kct file)
+2. Run schematic generator (if exists)
+3. Run PCB generator (if exists)
+4. Run autorouter
+5. Run verification (DRC, audit)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
+__all__ = ["main"]
+
+
+class BuildStep(str, Enum):
+    """Build pipeline steps."""
+
+    SCHEMATIC = "schematic"
+    PCB = "pcb"
+    ROUTE = "route"
+    VERIFY = "verify"
+    ALL = "all"
+
+
+@dataclass
+class BuildResult:
+    """Result of a build step."""
+
+    step: str
+    success: bool
+    message: str
+    output_file: Path | None = None
+
+
+@dataclass
+class BuildContext:
+    """Context for a build operation."""
+
+    project_dir: Path
+    spec_file: Path | None
+    schematic_file: Path | None = None
+    pcb_file: Path | None = None
+    routed_pcb_file: Path | None = None
+    mfr: str = "jlcpcb"
+    verbose: bool = False
+    dry_run: bool = False
+    quiet: bool = False
+
+
+def _find_spec_file(directory: Path) -> Path | None:
+    """Find a .kct file in the given directory."""
+    kct_files = list(directory.glob("*.kct"))
+    if len(kct_files) == 1:
+        return kct_files[0]
+    elif len(kct_files) > 1:
+        # Prefer 'project.kct' if it exists
+        project_kct = directory / "project.kct"
+        if project_kct.exists():
+            return project_kct
+        # Otherwise return the first one found
+        return kct_files[0]
+    return None
+
+
+def _find_generator_script(directory: Path, script_type: str) -> Path | None:
+    """Find a generator script in the project directory.
+
+    Args:
+        directory: Project directory to search
+        script_type: Type of script ('schematic', 'pcb', 'design')
+
+    Returns:
+        Path to the generator script if found
+    """
+    candidates = [
+        f"generate_{script_type}.py",
+        f"gen_{script_type}.py",
+        f"{script_type}_gen.py",
+    ]
+
+    # Also check for combined 'design' generator
+    if script_type in ("schematic", "pcb"):
+        candidates.append("generate_design.py")
+        candidates.append("design.py")
+
+    for candidate in candidates:
+        script_path = directory / candidate
+        if script_path.exists():
+            return script_path
+
+    return None
+
+
+def _find_artifacts(directory: Path, spec_file: Path | None) -> tuple[Path | None, Path | None]:
+    """Find schematic and PCB files in the project directory.
+
+    Returns:
+        Tuple of (schematic_path, pcb_path)
+    """
+    schematic = None
+    pcb = None
+
+    # Try to load from spec file first
+    if spec_file and spec_file.exists():
+        try:
+            from kicad_tools.spec import load_spec
+
+            spec = load_spec(spec_file)
+            if spec.project.artifacts:
+                if spec.project.artifacts.schematic:
+                    sch_path = directory / spec.project.artifacts.schematic
+                    if sch_path.exists():
+                        schematic = sch_path
+                if spec.project.artifacts.pcb:
+                    pcb_path = directory / spec.project.artifacts.pcb
+                    if pcb_path.exists():
+                        pcb = pcb_path
+        except Exception:
+            pass  # Fall back to directory search
+
+    # Fall back to finding files in directory
+    if not schematic:
+        sch_files = list(directory.glob("*.kicad_sch"))
+        # Filter out backup files
+        sch_files = [f for f in sch_files if not f.name.endswith("-bak.kicad_sch")]
+        if sch_files:
+            schematic = sch_files[0]
+
+    if not pcb:
+        pcb_files = list(directory.glob("*.kicad_pcb"))
+        # Filter out routed and backup files
+        pcb_files = [
+            f
+            for f in pcb_files
+            if not f.name.endswith("_routed.kicad_pcb") and not f.name.endswith("-bak.kicad_pcb")
+        ]
+        if pcb_files:
+            pcb = pcb_files[0]
+
+    return schematic, pcb
+
+
+def _run_python_script(script_path: Path, cwd: Path, verbose: bool = False) -> tuple[bool, str]:
+    """Run a Python generator script.
+
+    Args:
+        script_path: Path to the Python script
+        cwd: Working directory for execution
+        verbose: Whether to show script output
+
+    Returns:
+        Tuple of (success, output/error message)
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, str(script_path)],
+            cwd=str(cwd),
+            capture_output=not verbose,
+            text=True,
+        )
+
+        if result.returncode == 0:
+            return True, f"Script {script_path.name} completed successfully"
+        else:
+            error_msg = result.stderr if result.stderr else f"Exit code: {result.returncode}"
+            return False, f"Script {script_path.name} failed: {error_msg}"
+
+    except Exception as e:
+        return False, f"Failed to run {script_path.name}: {e}"
+
+
+def _run_step_schematic(ctx: BuildContext, console: Console) -> BuildResult:
+    """Run schematic generation step."""
+    script = _find_generator_script(ctx.project_dir, "schematic")
+
+    if not script:
+        # Check if schematic already exists
+        if ctx.schematic_file and ctx.schematic_file.exists():
+            return BuildResult(
+                step="schematic",
+                success=True,
+                message="Schematic already exists, skipping generation",
+                output_file=ctx.schematic_file,
+            )
+        return BuildResult(
+            step="schematic",
+            success=False,
+            message="No schematic generator found (generate_schematic.py)",
+        )
+
+    if ctx.dry_run:
+        return BuildResult(
+            step="schematic",
+            success=True,
+            message=f"[dry-run] Would run: {script.name}",
+        )
+
+    if not ctx.quiet:
+        console.print(f"  Running {script.name}...")
+
+    success, message = _run_python_script(script, ctx.project_dir, ctx.verbose)
+
+    # Re-scan for artifacts after generation
+    schematic, _ = _find_artifacts(ctx.project_dir, ctx.spec_file)
+
+    return BuildResult(
+        step="schematic",
+        success=success,
+        message=message,
+        output_file=schematic,
+    )
+
+
+def _run_step_pcb(ctx: BuildContext, console: Console) -> BuildResult:
+    """Run PCB generation step."""
+    script = _find_generator_script(ctx.project_dir, "pcb")
+
+    if not script:
+        # Check if PCB already exists
+        if ctx.pcb_file and ctx.pcb_file.exists():
+            return BuildResult(
+                step="pcb",
+                success=True,
+                message="PCB already exists, skipping generation",
+                output_file=ctx.pcb_file,
+            )
+        return BuildResult(
+            step="pcb",
+            success=False,
+            message="No PCB generator found (generate_pcb.py)",
+        )
+
+    if ctx.dry_run:
+        return BuildResult(
+            step="pcb",
+            success=True,
+            message=f"[dry-run] Would run: {script.name}",
+        )
+
+    if not ctx.quiet:
+        console.print(f"  Running {script.name}...")
+
+    success, message = _run_python_script(script, ctx.project_dir, ctx.verbose)
+
+    # Re-scan for artifacts after generation
+    _, pcb = _find_artifacts(ctx.project_dir, ctx.spec_file)
+
+    return BuildResult(
+        step="pcb",
+        success=success,
+        message=message,
+        output_file=pcb,
+    )
+
+
+def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
+    """Run autorouting step."""
+    # First check for a route script
+    route_script = ctx.project_dir / "route_demo.py"
+    if not route_script.exists():
+        route_script = ctx.project_dir / "route.py"
+
+    if route_script.exists():
+        if ctx.dry_run:
+            return BuildResult(
+                step="route",
+                success=True,
+                message=f"[dry-run] Would run: {route_script.name}",
+            )
+
+        if not ctx.quiet:
+            console.print(f"  Running {route_script.name}...")
+
+        success, message = _run_python_script(route_script, ctx.project_dir, ctx.verbose)
+
+        # Find routed PCB
+        routed_files = list(ctx.project_dir.glob("*_routed.kicad_pcb"))
+        output_file = routed_files[0] if routed_files else None
+
+        return BuildResult(
+            step="route",
+            success=success,
+            message=message,
+            output_file=output_file,
+        )
+
+    # Fall back to kct route command
+    if not ctx.pcb_file:
+        return BuildResult(
+            step="route",
+            success=False,
+            message="No PCB file found to route",
+        )
+
+    output_file = ctx.pcb_file.with_stem(ctx.pcb_file.stem + "_routed")
+
+    if ctx.dry_run:
+        return BuildResult(
+            step="route",
+            success=True,
+            message=f"[dry-run] Would run: kct route {ctx.pcb_file.name} -o {output_file.name}",
+        )
+
+    if not ctx.quiet:
+        console.print(f"  Running autorouter on {ctx.pcb_file.name}...")
+
+    try:
+        cmd = [
+            sys.executable,
+            "-m",
+            "kicad_tools.cli",
+            "route",
+            str(ctx.pcb_file),
+            "-o",
+            str(output_file),
+        ]
+
+        if ctx.quiet:
+            cmd.append("--quiet")
+
+        result = subprocess.run(
+            cmd,
+            cwd=str(ctx.project_dir),
+            capture_output=not ctx.verbose,
+            text=True,
+        )
+
+        if result.returncode == 0:
+            return BuildResult(
+                step="route",
+                success=True,
+                message="Routing completed successfully",
+                output_file=output_file if output_file.exists() else None,
+            )
+        else:
+            error_msg = result.stderr if result.stderr else f"Exit code: {result.returncode}"
+            return BuildResult(
+                step="route",
+                success=False,
+                message=f"Routing failed: {error_msg}",
+            )
+
+    except Exception as e:
+        return BuildResult(
+            step="route",
+            success=False,
+            message=f"Routing failed: {e}",
+        )
+
+
+def _run_step_verify(ctx: BuildContext, console: Console) -> BuildResult:
+    """Run verification step (DRC + audit)."""
+    # Find the PCB to verify (prefer routed version)
+    pcb_to_verify = ctx.routed_pcb_file or ctx.pcb_file
+
+    if not pcb_to_verify or not pcb_to_verify.exists():
+        return BuildResult(
+            step="verify",
+            success=False,
+            message="No PCB file found to verify",
+        )
+
+    if ctx.dry_run:
+        return BuildResult(
+            step="verify",
+            success=True,
+            message=f"[dry-run] Would run: kct check {pcb_to_verify.name} --mfr {ctx.mfr}",
+        )
+
+    if not ctx.quiet:
+        console.print(f"  Running DRC check on {pcb_to_verify.name}...")
+
+    # Run DRC check
+    try:
+        cmd = [
+            sys.executable,
+            "-m",
+            "kicad_tools.cli",
+            "check",
+            str(pcb_to_verify),
+            "--mfr",
+            ctx.mfr,
+        ]
+
+        result = subprocess.run(
+            cmd,
+            cwd=str(ctx.project_dir),
+            capture_output=True,
+            text=True,
+        )
+
+        drc_success = result.returncode == 0
+        drc_message = "DRC passed" if drc_success else "DRC found issues"
+
+        if ctx.verbose and result.stdout:
+            console.print(result.stdout)
+
+        # Also run validate --sync if we have both schematic and PCB
+        sync_message = ""
+        if ctx.schematic_file and ctx.schematic_file.exists():
+            if not ctx.quiet:
+                console.print("  Running schematic-PCB sync check...")
+
+            sync_cmd = [
+                sys.executable,
+                "-m",
+                "kicad_tools.cli",
+                "validate",
+                "--sync",
+                str(ctx.schematic_file),
+                str(pcb_to_verify),
+            ]
+
+            sync_result = subprocess.run(
+                sync_cmd,
+                cwd=str(ctx.project_dir),
+                capture_output=True,
+                text=True,
+            )
+
+            if sync_result.returncode != 0:
+                sync_message = " (sync check found mismatches)"
+            else:
+                sync_message = " (sync OK)"
+
+        return BuildResult(
+            step="verify",
+            success=drc_success,
+            message=f"{drc_message}{sync_message}",
+            output_file=pcb_to_verify,
+        )
+
+    except Exception as e:
+        return BuildResult(
+            step="verify",
+            success=False,
+            message=f"Verification failed: {e}",
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for kct build command."""
+    parser = argparse.ArgumentParser(
+        prog="kct build",
+        description="Build from spec to manufacturable design",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    kct build                           # Build from .kct in current directory
+    kct build project.kct               # Build from specific spec file
+    kct build --step schematic          # Run only schematic generation
+    kct build --step verify --mfr jlcpcb # Run only verification for JLCPCB
+    kct build --dry-run                 # Preview what would be done
+        """,
+    )
+
+    parser.add_argument(
+        "spec",
+        nargs="?",
+        help="Path to .kct file or project directory (default: current directory)",
+    )
+    parser.add_argument(
+        "--step",
+        "-s",
+        choices=["schematic", "pcb", "route", "verify", "all"],
+        default="all",
+        help="Run specific step or all (default: all)",
+    )
+    parser.add_argument(
+        "--mfr",
+        "-m",
+        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        default="jlcpcb",
+        help="Target manufacturer for verification (default: jlcpcb)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview build steps without executing",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show detailed output",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress progress output",
+    )
+
+    args = parser.parse_args(argv)
+    console = Console(quiet=args.quiet)
+
+    # Determine project directory and spec file
+    if args.spec:
+        spec_path = Path(args.spec).resolve()
+        if spec_path.is_file():
+            project_dir = spec_path.parent
+            spec_file = spec_path
+        else:
+            project_dir = spec_path
+            spec_file = _find_spec_file(project_dir)
+    else:
+        project_dir = Path.cwd()
+        spec_file = _find_spec_file(project_dir)
+
+    if not project_dir.exists():
+        console.print(f"[red]Error:[/red] Directory not found: {project_dir}")
+        return 1
+
+    # Find existing artifacts
+    schematic, pcb = _find_artifacts(project_dir, spec_file)
+
+    # Create build context
+    ctx = BuildContext(
+        project_dir=project_dir,
+        spec_file=spec_file,
+        schematic_file=schematic,
+        pcb_file=pcb,
+        mfr=args.mfr,
+        verbose=args.verbose,
+        dry_run=args.dry_run,
+        quiet=args.quiet,
+    )
+
+    # Print build header
+    if not args.quiet:
+        project_name = project_dir.name
+        if spec_file:
+            try:
+                from kicad_tools.spec import load_spec
+
+                spec = load_spec(spec_file)
+                project_name = spec.project.name
+            except Exception:
+                pass
+
+        console.print(
+            Panel.fit(
+                f"[bold]Building:[/bold] {project_name}\n"
+                f"[dim]Directory:[/dim] {project_dir}\n"
+                f"[dim]Manufacturer:[/dim] {args.mfr}",
+                title="kct build",
+            )
+        )
+
+    # Determine steps to run
+    if args.step == "all":
+        steps = [BuildStep.SCHEMATIC, BuildStep.PCB, BuildStep.ROUTE, BuildStep.VERIFY]
+    else:
+        steps = [BuildStep(args.step)]
+
+    # Run build steps
+    results: list[BuildResult] = []
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        console=console,
+        disable=args.quiet,
+    ) as progress:
+        for step in steps:
+            task = progress.add_task(f"[cyan]{step.value}[/cyan]...", total=None)
+
+            if step == BuildStep.SCHEMATIC:
+                result = _run_step_schematic(ctx, console)
+                if result.output_file:
+                    ctx.schematic_file = result.output_file
+
+            elif step == BuildStep.PCB:
+                result = _run_step_pcb(ctx, console)
+                if result.output_file:
+                    ctx.pcb_file = result.output_file
+
+            elif step == BuildStep.ROUTE:
+                result = _run_step_route(ctx, console)
+                if result.output_file:
+                    ctx.routed_pcb_file = result.output_file
+
+            elif step == BuildStep.VERIFY:
+                result = _run_step_verify(ctx, console)
+
+            else:
+                result = BuildResult(step=step.value, success=False, message="Unknown step")
+
+            results.append(result)
+            progress.remove_task(task)
+
+            # Print step result
+            if not args.quiet:
+                status = "[green]OK[/green]" if result.success else "[red]FAIL[/red]"
+                console.print(f"  [{status}] {step.value}: {result.message}")
+
+            # Stop on failure unless just verifying
+            if not result.success and step != BuildStep.VERIFY:
+                break
+
+    # Print summary
+    if not args.quiet:
+        console.print()
+        success_count = sum(1 for r in results if r.success)
+        total_count = len(results)
+
+        if success_count == total_count:
+            console.print(
+                f"[green]Build completed successfully[/green] ({success_count}/{total_count} steps)"
+            )
+
+            # Show output files
+            if ctx.routed_pcb_file and ctx.routed_pcb_file.exists():
+                console.print(f"\n[dim]Output:[/dim] {ctx.routed_pcb_file}")
+            elif ctx.pcb_file and ctx.pcb_file.exists():
+                console.print(f"\n[dim]Output:[/dim] {ctx.pcb_file}")
+        else:
+            console.print(
+                f"[red]Build failed[/red] ({success_count}/{total_count} steps succeeded)"
+            )
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -17,6 +17,7 @@ This package contains command handler modules organized by domain:
 
 from .analyze import run_analyze_command
 from .benchmark import run_benchmark_command
+from .build import run_build_command
 from .config import run_config_command, run_interactive_command
 from .datasheet import run_datasheet_command
 from .estimate import run_estimate_command
@@ -46,6 +47,8 @@ from .validation import (
 )
 
 __all__ = [
+    # Build
+    "run_build_command",
     # Schematic
     "run_sch_command",
     # PCB

--- a/src/kicad_tools/cli/commands/build.py
+++ b/src/kicad_tools/cli/commands/build.py
@@ -1,0 +1,35 @@
+"""Build command handler for end-to-end workflow orchestration."""
+
+__all__ = ["run_build_command"]
+
+
+def run_build_command(args) -> int:
+    """Handle build command for end-to-end workflow."""
+    from ..build_cmd import main as build_main
+
+    sub_argv = []
+
+    # Positional spec argument
+    if getattr(args, "build_spec", None):
+        sub_argv.append(args.build_spec)
+
+    # Step selection
+    if getattr(args, "build_step", "all") != "all":
+        sub_argv.extend(["--step", args.build_step])
+
+    # Manufacturer
+    if getattr(args, "build_mfr", "jlcpcb") != "jlcpcb":
+        sub_argv.extend(["--mfr", args.build_mfr])
+
+    # Flags
+    if getattr(args, "build_dry_run", False):
+        sub_argv.append("--dry-run")
+
+    if getattr(args, "build_verbose", False):
+        sub_argv.append("--verbose")
+
+    # Use global quiet or command-level quiet
+    if getattr(args, "global_quiet", False):
+        sub_argv.append("--quiet")
+
+    return build_main(sub_argv)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -163,6 +163,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_impedance_parser(subparsers)
     _add_mcp_parser(subparsers)
     _add_init_parser(subparsers)
+    _add_build_parser(subparsers)
     _add_build_native_parser(subparsers)
     _add_spec_parser(subparsers)
     _add_benchmark_parser(subparsers)
@@ -2299,6 +2300,53 @@ def _add_init_parser(subparsers) -> None:
         choices=["text", "json"],
         default="text",
         help="Output format (default: text)",
+    )
+
+
+def _add_build_parser(subparsers) -> None:
+    """Add build subcommand parser for end-to-end workflow."""
+    build_parser = subparsers.add_parser(
+        "build",
+        help="Build from spec to manufacturable design",
+        description=(
+            "Orchestrate the full build workflow from .kct specification to routed, verified PCB. "
+            "Runs schematic generation, PCB generation, autorouting, and verification in sequence."
+        ),
+    )
+    build_parser.add_argument(
+        "build_spec",
+        metavar="SPEC",
+        nargs="?",
+        help="Path to .kct file or project directory (default: current directory)",
+    )
+    build_parser.add_argument(
+        "--step",
+        "-s",
+        dest="build_step",
+        choices=["schematic", "pcb", "route", "verify", "all"],
+        default="all",
+        help="Run specific step or all (default: all)",
+    )
+    build_parser.add_argument(
+        "--mfr",
+        "-m",
+        dest="build_mfr",
+        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        default="jlcpcb",
+        help="Target manufacturer for verification (default: jlcpcb)",
+    )
+    build_parser.add_argument(
+        "--dry-run",
+        dest="build_dry_run",
+        action="store_true",
+        help="Preview build steps without executing",
+    )
+    build_parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="build_verbose",
+        action="store_true",
+        help="Show detailed output",
     )
 
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -922,9 +922,7 @@ class Autorouter:
                 # Calculate adaptive parameters (Issue #633)
                 if adaptive:
                     # Calculate congestion ratio for adaptive present cost
-                    total_cells = (
-                        self.grid.cols * self.grid.rows * self.grid.num_layers
-                    )
+                    total_cells = self.grid.cols * self.grid.rows * self.grid.num_layers
                     overflow_ratio = overflow / max(total_cells, 1)
 
                     # Adaptive history increment based on convergence progress

--- a/tests/test_diffpair.py
+++ b/tests/test_diffpair.py
@@ -1,6 +1,5 @@
 """Tests for differential pair routing module."""
 
-
 from kicad_tools.router.diffpair import (
     DifferentialPair,
     DifferentialPairConfig,

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,6 +1,5 @@
 """Tests for the units module."""
 
-
 from kicad_tools.config import Config, DisplayConfig
 from kicad_tools.units import (
     MM_PER_MIL,

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1496,10 +1496,7 @@ class TestSilkscreenRules:
 
         # Use the example PCB that has fp_text elements
         pcb_file = (
-            Path(__file__).parent.parent
-            / "boards"
-            / "03-usb-joystick"
-            / "usb_joystick.kicad_pcb"
+            Path(__file__).parent.parent / "boards" / "03-usb-joystick" / "usb_joystick.kicad_pcb"
         )
 
         if not pcb_file.exists():

--- a/tests/test_via_optimizer.py
+++ b/tests/test_via_optimizer.py
@@ -1,6 +1,5 @@
 """Tests for via optimization in post-routing cleanup."""
 
-
 from kicad_tools.router.layers import Layer
 from kicad_tools.router.optimizer import (
     OptimizationConfig,


### PR DESCRIPTION
## Summary

Adds a new `kct build` command that orchestrates the full design workflow from `.kct` specification to manufacturable PCB, significantly reducing friction for users.

### Current workflow (manual)
1. Create/edit `project.kct` with design intent
2. Run `python generate_schematic.py`
3. Run `python generate_pcb.py`
4. Run `python route_demo.py` or `kct route board.kicad_pcb`
5. Run `kct check board.kicad_pcb --mfr jlcpcb`
6. Run `kct validate --sync` to check consistency

### New workflow with `kct build`
```bash
kct build project.kct --mfr jlcpcb
```

That's it! The command orchestrates all the above steps automatically.

## Features

- **Auto-discovery**: Finds `.kct` spec file and project artifacts automatically
- **Step execution**: Run all steps or individual ones via `--step {schematic,pcb,route,verify,all}`
- **Dry-run mode**: Preview what would run without executing (`--dry-run`)
- **Manufacturer targeting**: Pass `--mfr` for verification rules
- **Rich output**: Progress indicators and clear status reporting
- **Graceful fallbacks**: Works even when some generators don't exist

## Usage Examples

```bash
# Build from current directory
kct build

# Build from specific spec file
kct build project.kct

# Run only routing step
kct build --step route

# Preview build steps
kct build --dry-run

# Target specific manufacturer
kct build --mfr jlcpcb
```

## Test Plan

- [x] Verified `kct build --help` shows correct options
- [x] Tested dry-run on `boards/03-usb-joystick` - correctly identifies all steps
- [x] Lint passes: `ruff check` on new files
- [x] Format passes: `ruff format` applied

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)