### PR TITLE
fix(validate): Use correct KiCad rotation convention for pad positions

### DIFF
--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -487,7 +487,8 @@ class ConnectivityValidator:
         import math
 
         # Convert rotation to radians
-        angle = math.radians(rotation)
+        # KiCad uses clockwise-positive rotation, negate for standard math
+        angle = math.radians(-rotation)
 
         # Rotate pad position
         px, py = pad_local

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -78,9 +78,13 @@ class CopperElement:
 
 
 def _transform_pad_position(pad: Pad, footprint: Footprint) -> tuple[float, float]:
-    """Transform pad position from footprint-local to board coordinates."""
-    # Apply rotation
-    angle_rad = math.radians(footprint.rotation)
+    """Transform pad position from footprint-local to board coordinates.
+
+    Note: KiCad uses clockwise-positive rotation when Y points down.
+    Standard math rotation is counterclockwise-positive, so we negate the angle.
+    """
+    # Apply rotation - negate angle for KiCad's clockwise-positive convention
+    angle_rad = math.radians(-footprint.rotation)
     cos_a = math.cos(angle_rad)
     sin_a = math.sin(angle_rad)
 

--- a/src/kicad_tools/validate/rules/edge.py
+++ b/src/kicad_tools/validate/rules/edge.py
@@ -158,7 +158,8 @@ class EdgeClearanceRule(DRCRule):
 
         for footprint in pcb.footprints:
             fp_x, fp_y = footprint.position
-            fp_rotation = math.radians(footprint.rotation)
+            # KiCad uses clockwise-positive rotation, negate for standard math
+            fp_rotation = math.radians(-footprint.rotation)
             cos_rot = math.cos(fp_rotation)
             sin_rot = math.sin(fp_rotation)
 


### PR DESCRIPTION
## Summary

- Fixed KiCad rotation convention mismatch in the validate module
- The DRC checker was using counterclockwise-positive rotation (standard math) while KiCad uses clockwise-positive rotation when Y points down
- This caused false DRC clearance violations for rotated footprints because pad positions were calculated incorrectly

## Root Cause Analysis

The router correctly loads pad positions using `-fp_rot` (negated angle) in `io.py:940`, but the DRC validation module was using `footprint.rotation` directly without negation:

- **Router**: `math.radians(-fp_rot)` → clockwise rotation (correct)
- **DRC**: `math.radians(footprint.rotation)` → counterclockwise rotation (incorrect)

This caused pads R2-1 and R2-2 to appear swapped in the DRC checker's view, resulting in 45 clearance violations when traces correctly connected to pads.

## Changes

- `src/kicad_tools/validate/rules/clearance.py`: Negate rotation angle in `_transform_pad_position()`
- `src/kicad_tools/validate/rules/edge.py`: Negate rotation angle in `_check_pad_clearances()`
- `src/kicad_tools/validate/connectivity.py`: Negate rotation angle in `_transform_pad_position()`

## Test Plan

- [x] Voltage divider example now routes and passes DRC with 0 violations
- [x] All existing validation tests pass (216 passed, 4 skipped)
- [x] Pre-existing failures in `test_drc_regression.py` are unrelated (separate `grid_width` attribute bug)

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)