### PR TITLE
fix(schema): Exclude lib_symbol definitions from symbol count

### DIFF
--- a/src/kicad_tools/schema/schematic.py
+++ b/src/kicad_tools/schema/schematic.py
@@ -198,7 +198,8 @@ class Schematic:
             # Import here to avoid circular import
             from ..query.symbols import SymbolList
 
-            items = [SymbolInstance.from_sexp(s) for s in self._sexp.find_all("symbol")]
+            # Use find_children to only get direct symbol children, not lib_symbol definitions
+            items = [SymbolInstance.from_sexp(s) for s in self._sexp.find_children("symbol")]
             self._symbols = SymbolList(items)
         return self._symbols
 


### PR DESCRIPTION
## Summary

- Fixed validation tools incorrectly counting lib_symbol definitions as placed components
- Changed from `find_all("symbol")` to `find_children("symbol")` in schematic.py to only get direct symbol children
- Fixes false positives for "D", "J", "R" (templates without reference numbers) being counted as missing

## Test plan

- [x] `kct symbols` now shows 16 actual placed symbols instead of 30
- [x] `kct validate --consistency` now passes without false positives
- [x] All 21 consistency tests pass
- [x] All 92 schematic/CLI tests pass

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)