### PR TITLE
fix(ux): Show detailed validation output instead of dismissive summary

### DIFF
--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -201,12 +201,20 @@ def create_voltage_divider_schematic(output_dir: Path) -> Path:
     warnings = [i for i in issues if i["severity"] == "warning"]
 
     if errors:
-        print(f"   Found {len(errors)} errors (rail endpoints expected)")
+        print(f"   Found {len(errors)} errors:")
+        for err in errors:
+            print(f"      [{err['type']}] {err['message']}")
+            if err.get("location"):
+                print(f"                  at {err['location']}")
     else:
         print("   No errors found")
 
     if warnings:
-        print(f"   Found {len(warnings)} warnings")
+        print(f"   Found {len(warnings)} warnings:")
+        for warn in warnings[:5]:  # Limit to first 5
+            print(f"      [{warn['type']}] {warn['message']}")
+        if len(warnings) > 5:
+            print(f"      ... and {len(warnings) - 5} more")
 
     # Get statistics
     stats = sch.get_statistics()


### PR DESCRIPTION
## Summary

Replace the vague "(rail endpoints expected)" message with detailed validation output that shows:
- Error type in brackets (e.g., `[floating_wire]`)
- Full error message with context
- Location coordinates for each issue

**Before:**
```
5. Validating schematic...
   Found 2 errors (rail endpoints expected)
```

**After:**
```
5. Validating schematic...
   Found 2 errors:
      [floating_wire] Wire endpoint at (199.39, 30.48) is not connected to anything
                  at (199.39, 30.48)
      [floating_wire] Wire endpoint at (199.39, 149.86) is not connected to anything
                  at (199.39, 149.86)
```

## Changes

- Updated `boards/01-voltage-divider/generate_design.py` validation output section
- Show detailed error information (type, message, location) instead of just count
- Show detailed warning information (capped at 5 to avoid overwhelming output)
- Matches pattern already used in other board examples (charlieplex-led, usb-joystick)

## Test Plan

- [x] Ran `uv run python boards/01-voltage-divider/generate_design.py` - output shows detailed validation info
- [x] Ran `uv run ruff check boards/01-voltage-divider/generate_design.py` - passes linting
- [x] Ran `uv run pytest tests/test_schematic_models.py` - all 149 tests pass

Closes #660