### PR TITLE
feat(router): Integrate trace optimization into routing workflow

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -98,6 +98,8 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--power-nets", args.power_nets])
     if getattr(args, "layers", "auto") != "auto":
         sub_argv.extend(["--layers", args.layers])
+    if getattr(args, "no_optimize", False):
+        sub_argv.append("--no-optimize")
     return route_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -801,6 +801,17 @@ def _add_route_parser(subparsers) -> None:
             "'6' = 6-layer"
         ),
     )
+    route_parser.add_argument(
+        "--no-optimize",
+        action="store_true",
+        help="Skip trace optimization (keep raw grid-step segments)",
+    )
+    route_parser.add_argument(
+        "--raw",
+        action="store_true",
+        dest="no_optimize",
+        help="Alias for --no-optimize (keep raw grid-step segments for debugging)",
+    )
 
 
 def _add_reason_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -535,6 +535,22 @@ def main(argv: list[str] | None = None) -> int:
             "C++ backend provides 10-100x speedup for fine-grid routing."
         ),
     )
+    parser.add_argument(
+        "--no-optimize",
+        action="store_true",
+        help=(
+            "Skip trace optimization after routing. By default, traces are "
+            "optimized to merge collinear segments, eliminate zigzags, and "
+            "convert corners to 45 degrees. Use this flag to keep raw "
+            "grid-step segments for debugging."
+        ),
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        dest="no_optimize",
+        help="Alias for --no-optimize (keep raw grid-step segments for debugging)",
+    )
 
     args = parser.parse_args(argv)
 
@@ -904,6 +920,48 @@ def main(argv: list[str] | None = None) -> int:
     if _interrupt_state["interrupted"]:
         _save_partial_results()
         return 2  # Exit code 2 indicates interruption with partial results saved
+
+    # Optimize traces (unless --no-optimize/--raw flag is set)
+    if not args.no_optimize and router.routes:
+        from kicad_tools.router.optimizer import OptimizationConfig, TraceOptimizer
+
+        if not quiet:
+            print("\n--- Optimizing traces ---")
+
+        # Get pre-optimization statistics
+        pre_segments = sum(len(r.segments) for r in router.routes)
+        pre_vias = sum(len(r.vias) for r in router.routes)
+
+        # Configure and run optimizer
+        opt_config = OptimizationConfig(
+            merge_collinear=True,
+            eliminate_zigzags=True,
+            compress_staircase=True,
+            convert_45_corners=True,
+            corner_chamfer_size=0.5,
+            minimize_vias=True,
+        )
+        optimizer = TraceOptimizer(config=opt_config)
+
+        with spinner("Optimizing traces...", quiet=quiet):
+            optimized_routes = []
+            for route in router.routes:
+                optimized_route = optimizer.optimize_route(route)
+                optimized_routes.append(optimized_route)
+            router.routes = optimized_routes
+
+        # Get post-optimization statistics
+        post_segments = sum(len(r.segments) for r in router.routes)
+        post_vias = sum(len(r.vias) for r in router.routes)
+
+        if not quiet:
+            segment_reduction = (
+                ((pre_segments - post_segments) / pre_segments * 100) if pre_segments > 0 else 0
+            )
+            via_reduction = ((pre_vias - post_vias) / pre_vias * 100) if pre_vias > 0 else 0
+            print(f"  Segments: {pre_segments} -> {post_segments} ({-segment_reduction:+.1f}%)")
+            if pre_vias > 0:
+                print(f"  Vias:     {pre_vias} -> {post_vias} ({-via_reduction:+.1f}%)")
 
     # Get statistics
     stats = router.get_statistics()


### PR DESCRIPTION
## Summary

This PR integrates the existing trace optimization functionality into the routing workflow, automatically optimizing traces after routing completes. This eliminates the need for a separate `kct optimize-traces` step.

**Key changes:**
- Add `--no-optimize` / `--raw` flags to skip optimization for debugging
- Integrate `TraceOptimizer` into `route_cmd.py` after routing completes  
- Display optimization statistics showing before/after segment and via counts

## Test Results

With a simple voltage divider board:
- **With optimization (default)**: 101 segments → 3 segments (**97% reduction**)
- **With `--no-optimize`**: 101 segments preserved for debugging

For the example in the issue (562 segments → 25):
- This would now happen automatically
- No manual `kct optimize-traces` step required

## Test plan

- [x] All 423 existing tests pass
- [x] Verified optimization runs by default and reduces segment count
- [x] Verified `--no-optimize` flag skips optimization
- [x] Verified `--raw` alias works correctly
- [x] Linting passes on modified files

Closes #659