### PR TITLE
docs(boards): Add status table, workflow docs, and voltage divider README

### DIFF
--- a/boards/01-voltage-divider/README.md
+++ b/boards/01-voltage-divider/README.md
@@ -1,0 +1,95 @@
+# Voltage Divider Demo
+
+This demo demonstrates the complete kicad-tools workflow by creating the simplest possible PCB: a 4-component voltage divider.
+
+## Circuit Overview
+
+```
+    +5V ─────┬─────────── J1 (Input)
+             │
+            [R1]
+            10k
+             │
+    VOUT ────┼─────────── J2 (Output)
+             │
+            [R2]
+            10k
+             │
+    GND ─────┴─────────── (Common)
+```
+
+Two 10k resistors divide the 5V input to produce 2.5V output (50% division ratio).
+
+## Components
+
+| Reference | Description | Footprint |
+|-----------|-------------|-----------|
+| J1 | Input connector (5V, GND) | 2.54mm pin header |
+| J2 | Output connector (VOUT, GND) | 2.54mm pin header |
+| R1 | Voltage divider (top) | 0805 SMD 10k |
+| R2 | Voltage divider (bottom) | 0805 SMD 10k |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `generate_design.py` | Script to generate schematic, PCB, and route |
+| `project.kct` | Project specification with requirements |
+| `output/voltage_divider.kicad_sch` | Generated schematic |
+| `output/voltage_divider.kicad_pcb` | Generated unrouted PCB |
+| `output/voltage_divider_routed.kicad_pcb` | Routed PCB |
+
+## Usage
+
+### Step 1: Generate the Design
+
+```bash
+python generate_design.py
+```
+
+This creates:
+- Schematic with all components and nets
+- PCB with components placed on 30mm x 25mm board
+- Routed PCB with all traces complete
+
+### Step 2: Verify Output (Optional)
+
+```bash
+# Check for DRC violations
+kct check output/voltage_divider_routed.kicad_pcb --mfr jlcpcb
+
+# Generate BOM
+kct bom output/voltage_divider.kicad_sch --format csv
+```
+
+### Step 3: View in KiCad (Optional)
+
+Open `output/voltage_divider_routed.kicad_pcb` in KiCad to visualize the design.
+
+## Design Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Input Voltage | 5V |
+| Output Voltage | 2.5V |
+| Division Ratio | 0.5 (50%) |
+| Board Size | 30mm x 25mm |
+| Layers | 2 |
+| Target Fab | JLCPCB |
+
+## Why This Board?
+
+This is the **simplest possible validation project** for kicad-tools. It exercises:
+
+1. **Schematic Generation** - Creating symbols, wires, and net labels
+2. **PCB Creation** - Placing footprints and defining the board outline
+3. **Autorouting** - Connecting all nets with copper traces
+4. **DRC Checking** - Validating against manufacturer rules
+
+If the voltage divider routes successfully, the core workflow is verified.
+
+## Related
+
+- [02-charlieplex-led](../02-charlieplex-led/) - More complex routing challenge
+- [03-usb-joystick](../03-usb-joystick/) - Mixed-signal design
+- [04-stm32-devboard](../04-stm32-devboard/) - Programmatic schematic generation

--- a/boards/README.md
+++ b/boards/README.md
@@ -2,14 +2,19 @@
 
 Complete PCB designs demonstrating kicad-tools capabilities. Each board includes a `.kct` project specification file describing the design intent, requirements, and progress.
 
-## Boards by Complexity
+## Board Status
 
-| # | Board | Components | Nets | Key Concepts |
-|---|-------|------------|------|--------------|
-| 01 | [Voltage Divider](01-voltage-divider/) | 4 | 3 | Simplest possible design, workflow validation |
-| 02 | [Charlieplex LED](02-charlieplex-led/) | 14 | 8 | Dense topology, crossing nets, Monte Carlo routing |
-| 03 | [USB Joystick](03-usb-joystick/) | ~20 | 13 | Mixed signals, USB differential pairs, analog inputs |
-| 04 | [STM32 Dev Board](04-stm32-devboard/) | ~30 | - | Programmatic schematic generation (layout pending) |
+| # | Board | Status | Components | Nets | Notes |
+|---|-------|--------|------------|------|-------|
+| 01 | [Voltage Divider](01-voltage-divider/) | ✅ Working | 4 | 3 | Simplest possible design, workflow validation |
+| 02 | [Charlieplex LED](02-charlieplex-led/) | ⚠️ Needs optimization | 14 | 8 | Dense topology, may need trace optimization ([#659]) |
+| 03 | [USB Joystick](03-usb-joystick/) | ⚠️ Complex routing | ~20 | 13 | Mixed signals, may not complete all routes on 2-layer |
+| 04 | [STM32 Dev Board](04-stm32-devboard/) | 🚧 Schematic only | ~30 | - | Layout pending, demonstrates programmatic schematic generation |
+
+**Status Legend:**
+- ✅ Working - Generates manufacturable output
+- ⚠️ Needs optimization - Works but may have routing challenges or require post-processing
+- 🚧 Work in progress - Incomplete implementation
 
 ## Quick Start
 
@@ -21,6 +26,39 @@ python generate_design.py
 # Or use uv
 uv run python boards/01-voltage-divider/generate_design.py
 ```
+
+## Complete Workflow
+
+For a full design-to-manufacturing workflow:
+
+```bash
+# 1. Generate the design
+cd boards/01-voltage-divider
+python generate_design.py
+
+# 2. Check for DRC violations (optional - use manufacturer rules)
+kct check output/voltage_divider_routed.kicad_pcb --mfr jlcpcb
+
+# 3. Generate BOM
+kct bom output/voltage_divider.kicad_sch --format csv
+
+# 4. Export Gerbers (via KiCad or kicad-cli)
+# Open the .kicad_pcb file in KiCad and use File > Plot
+```
+
+See individual board READMEs for board-specific workflows.
+
+## Known Issues
+
+These are known limitations that may affect your experience:
+
+| Issue | Affects | Description |
+|-------|---------|-------------|
+| [#659] | 02, 03 | Trace optimization may be needed for dense designs |
+| [#661] | All | Router doesn't always warn about DRC violations |
+
+[#659]: https://github.com/rjwalters/kicad-tools/issues/659
+[#661]: https://github.com/rjwalters/kicad-tools/issues/661
 
 ## Project Files (.kct)
 


### PR DESCRIPTION
## Summary

Improve example boards documentation by adding clear status indicators, complete workflow documentation, and linking known issues to GitHub issues.

## Changes

- **boards/README.md**: 
  - Add status table showing working/needs-optimization/WIP status for each board
  - Add "Complete Workflow" section with design-to-manufacturing steps
  - Add "Known Issues" section linking to #659 and #661
  - Update status legend with clear definitions

- **boards/01-voltage-divider/README.md** (new):
  - Circuit overview with ASCII diagram
  - Component documentation table
  - Step-by-step usage instructions
  - Design specifications and rationale
  - Links to related boards

## Acceptance Criteria

- [x] README.md has accurate status for each board
- [x] Each board directory has workflow documentation (or reference to main README)
- [x] Known issues are linked to GitHub issues
- [x] Users can tell which examples work before investing time

Note: CI badge for example board DRC status is not included as it would require CI infrastructure changes beyond documentation scope.

Closes #662