### PR TITLE
fix(boards): Add trace optimization to demo routing scripts

### DIFF
--- a/boards/02-charlieplex-led/route_demo.py
+++ b/boards/02-charlieplex-led/route_demo.py
@@ -22,6 +22,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
 from kicad_tools.router import DesignRules, load_pcb_for_routing
+from kicad_tools.router.optimizer import OptimizationConfig, TraceOptimizer
 
 
 def main():
@@ -79,10 +80,44 @@ def main():
     print("\n--- Routing (standard mode) ---")
     router.route_all()
 
-    # Get statistics
+    # Get statistics before optimization
+    stats_before = router.get_statistics()
+
+    print("\n--- Raw Results (before optimization) ---")
+    print(f"  Routes created: {stats_before['routes']}")
+    print(f"  Segments: {stats_before['segments']}")
+    print(f"  Vias: {stats_before['vias']}")
+    print(f"  Total length: {stats_before['total_length_mm']:.2f}mm")
+    print(f"  Nets routed: {stats_before['nets_routed']}")
+
+    # Optimize traces - merge collinear segments, eliminate zigzags, etc.
+    print("\n--- Optimizing traces ---")
+    opt_config = OptimizationConfig(
+        merge_collinear=True,
+        eliminate_zigzags=True,
+        compress_staircase=True,
+        convert_45_corners=True,
+        minimize_vias=True,
+    )
+    optimizer = TraceOptimizer(config=opt_config)
+
+    optimized_routes = []
+    for route in router.routes:
+        optimized_route = optimizer.optimize_route(route)
+        optimized_routes.append(optimized_route)
+    router.routes = optimized_routes
+
+    # Get statistics after optimization
     stats = router.get_statistics()
 
-    print("\n--- Results ---")
+    segments_before = stats_before["segments"]
+    segments_after = stats["segments"]
+    reduction = (1 - segments_after / segments_before) * 100 if segments_before > 0 else 0
+
+    print(f"  Segments: {segments_before} -> {segments_after} ({reduction:.1f}% reduction)")
+    print(f"  Vias: {stats_before['vias']} -> {stats['vias']}")
+
+    print("\n--- Final Results ---")
     print(f"  Routes created: {stats['routes']}")
     print(f"  Segments: {stats['segments']}")
     print(f"  Vias: {stats['vias']}")


### PR DESCRIPTION
## Summary

Add trace optimization (TraceOptimizer) to the board demo routing scripts. This resolves issue #675 where the autorouter was generating 562 segments for a simple 4-component voltage divider with only 3 nets.

### Root Cause

The demo scripts in `boards/` were calling `router.route_all()` directly without applying `TraceOptimizer` afterward. The CLI route command already applies optimization, but these demo scripts were outputting raw grid-based segments.

### Changes

- **boards/01-voltage-divider/generate_design.py**: Added TraceOptimizer after routing
- **boards/02-charlieplex-led/route_demo.py**: Added TraceOptimizer after routing  
- **boards/03-usb-joystick/route_demo.py**: Added TraceOptimizer after routing

### Results

Voltage divider routing before/after optimization:

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Segments | 562 | 23 | 95.9% reduction |
| Vias | 2 | 1 | 50% reduction |
| Total length | 65.94mm | 63.98mm | 3% shorter |

## Test Plan

- [x] Run voltage divider demo: `uv run python boards/01-voltage-divider/generate_design.py`
- [x] Verify segment count is reduced from 562 to ~23
- [x] Run trace optimizer tests: `uv run pytest tests/test_trace_optimizer.py`
- [x] Run router tests: `uv run pytest tests/test_router.py tests/test_router_core.py`

Closes #675