### PR TITLE
fix(boards): Renumber generate_design.py steps sequentially

### DIFF
--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -192,9 +192,9 @@ def create_voltage_divider_schematic(output_dir: Path) -> Path:
     print(f"   Output voltage: {5.0 * ratio:.2f}V")
 
     # =========================================================================
-    # Validate Schematic
+    # Section 4: Validate Schematic
     # =========================================================================
-    print("\n5. Validating schematic...")
+    print("\n4. Validating schematic...")
 
     issues = sch.validate()
     errors = [i for i in issues if i["severity"] == "error"]
@@ -226,9 +226,9 @@ def create_voltage_divider_schematic(output_dir: Path) -> Path:
     print(f"      Labels: {stats['label_count']}")
 
     # =========================================================================
-    # Write Output Files
+    # Section 5: Write Output Files
     # =========================================================================
-    print("\n6. Writing schematic...")
+    print("\n5. Writing schematic...")
 
     output_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary

Fixes the step numbering in `boards/01-voltage-divider/generate_design.py` which was showing steps 1, 2, 3, 5, 6 (missing step 4).

## Changes

- Changed step 5 → step 4 (Validate Schematic)
- Changed step 6 → step 5 (Write Output Files)
- Updated section comments to match

## Before

```
1. Placing components...
2. Creating segmented power rails...
3. Wiring components...
5. Validating schematic...
6. Writing schematic...
```

## After

```
1. Placing components...
2. Creating segmented power rails...
3. Wiring components...
4. Validating schematic...
5. Writing schematic...
```

## Test Plan

- [x] Formatting passes
- [x] Linting passes

Closes #676