### PR TITLE
docs(boards): Promote kct build command in demo project READMEs

### DIFF
--- a/boards/01-voltage-divider/README.md
+++ b/boards/01-voltage-divider/README.md
@@ -2,6 +2,22 @@
 
 This demo demonstrates the complete kicad-tools workflow by creating the simplest possible PCB: a 4-component voltage divider.
 
+## Quick Start
+
+```bash
+# One-command build (recommended)
+kct build boards/01-voltage-divider
+
+# Or run specific steps
+kct build boards/01-voltage-divider --step schematic
+kct build boards/01-voltage-divider --step pcb
+kct build boards/01-voltage-divider --step route
+kct build boards/01-voltage-divider --step verify
+
+# Preview what would happen
+kct build boards/01-voltage-divider --dry-run
+```
+
 ## Circuit Overview
 
 ```
@@ -39,7 +55,9 @@ Two 10k resistors divide the 5V input to produce 2.5V output (50% division ratio
 | `output/voltage_divider.kicad_pcb` | Generated unrouted PCB |
 | `output/voltage_divider_routed.kicad_pcb` | Routed PCB |
 
-## Usage
+## Advanced: Manual Build
+
+For more control, run the Python script directly.
 
 ### Step 1: Generate the Design
 

--- a/boards/02-charlieplex-led/README.md
+++ b/boards/02-charlieplex-led/README.md
@@ -2,6 +2,22 @@
 
 This demo demonstrates the kicad-tools autorouter by routing a 3x3 LED grid PCB.
 
+## Quick Start
+
+```bash
+# One-command build (recommended)
+kct build boards/02-charlieplex-led
+
+# Or run specific steps
+kct build boards/02-charlieplex-led --step schematic
+kct build boards/02-charlieplex-led --step pcb
+kct build boards/02-charlieplex-led --step route
+kct build boards/02-charlieplex-led --step verify
+
+# Preview what would happen
+kct build boards/02-charlieplex-led --dry-run
+```
+
 ## What is Charlieplexing?
 
 Charlieplexing is a technique for driving many LEDs with fewer GPIO pins. With N pins,
@@ -47,7 +63,9 @@ With 4 GPIO pins, we can drive 4*(4-1) = 12 LEDs. This demo uses 9 for a 3x3 gri
 | `route_demo.py` | Script to run the autorouter on the PCB |
 | `charlieplex_3x3_routed.kicad_pcb` | Routed PCB (after running route_demo.py) |
 
-## Usage
+## Advanced: Manual Build
+
+For more control over individual steps, you can run Python scripts directly.
 
 ### Step 1: Generate the PCB
 

--- a/boards/03-usb-joystick/README.md
+++ b/boards/03-usb-joystick/README.md
@@ -3,6 +3,22 @@
 This demo demonstrates the kicad-tools autorouter by routing a USB game controller PCB
 with mixed signal types: USB differential pairs, analog inputs, and digital I/O.
 
+## Quick Start
+
+```bash
+# One-command build (recommended)
+kct build boards/03-usb-joystick
+
+# Or run specific steps
+kct build boards/03-usb-joystick --step schematic
+kct build boards/03-usb-joystick --step pcb
+kct build boards/03-usb-joystick --step route
+kct build boards/03-usb-joystick --step verify
+
+# Preview what would happen
+kct build boards/03-usb-joystick --dry-run
+```
+
 ## Circuit Overview
 
 ```
@@ -64,7 +80,9 @@ This design demonstrates routing of different signal classes:
 | `route_demo.py` | Script to run the autorouter |
 | `usb_joystick_routed.kicad_pcb` | Routed PCB output |
 
-## Usage
+## Advanced: Manual Build
+
+For more control over individual steps, you can run Python scripts directly.
 
 ### Step 1: Generate the PCB
 

--- a/boards/04-stm32-devboard/README.md
+++ b/boards/04-stm32-devboard/README.md
@@ -2,6 +2,21 @@
 
 This example demonstrates the complete workflow for creating a PCB design programmatically using kicad-tools.
 
+## Quick Start
+
+```bash
+# One-command build (recommended)
+kct build boards/04-stm32-devboard
+
+# Or run specific steps
+kct build boards/04-stm32-devboard --step schematic
+
+# Preview what would happen
+kct build boards/04-stm32-devboard --dry-run
+```
+
+> **Note:** This board is currently schematic-only. PCB layout and routing are not yet implemented.
+
 ## Overview
 
 We create a simple **STM32 Development Board** (Blue Pill style) with:
@@ -23,7 +38,9 @@ We create a simple **STM32 Development Board** (Blue Pill style) with:
 | `DebugHeader` | SWD programming interface | J2 |
 | `LEDIndicator` | User LED with resistor | D1, R1 |
 
-## Running the Example
+## Advanced: Manual Build
+
+For more control, run the Python script directly:
 
 ```bash
 # From repository root

--- a/boards/README.md
+++ b/boards/README.md
@@ -2,6 +2,30 @@
 
 Complete PCB designs demonstrating kicad-tools capabilities. Each board includes a `.kct` project specification file describing the design intent, requirements, and progress.
 
+## Quick Start
+
+The easiest way to build any demo is using the `kct build` command:
+
+```bash
+# Build any project (runs full pipeline: schematic → PCB → route → verify)
+kct build boards/01-voltage-divider
+
+# Or specify a .kct file directly
+kct build boards/02-charlieplex-led/project.kct
+
+# Run individual steps
+kct build boards/01-voltage-divider --step schematic
+kct build boards/01-voltage-divider --step pcb
+kct build boards/01-voltage-divider --step route
+kct build boards/01-voltage-divider --step verify
+
+# Preview what would happen without running
+kct build boards/01-voltage-divider --dry-run
+
+# Target a specific manufacturer for DRC verification
+kct build boards/01-voltage-divider --mfr jlcpcb
+```
+
 ## Board Status
 
 | # | Board | Status | Components | Nets | Notes |
@@ -16,37 +40,35 @@ Complete PCB designs demonstrating kicad-tools capabilities. Each board includes
 - ⚠️ Needs optimization - Works but may have routing challenges or require post-processing
 - 🚧 Work in progress - Incomplete implementation
 
-## Quick Start
+## Advanced: Manual Build
+
+For more control, you can run individual Python scripts directly:
 
 ```bash
 # Run any board's generation script
 cd boards/01-voltage-divider
 python generate_design.py
 
-# Or use uv
+# Or use uv from the repo root
 uv run python boards/01-voltage-divider/generate_design.py
 ```
 
-## Complete Workflow
+### Post-Build Commands
 
-For a full design-to-manufacturing workflow:
+After building, you can run additional verification and export commands:
 
 ```bash
-# 1. Generate the design
-cd boards/01-voltage-divider
-python generate_design.py
-
-# 2. Check for DRC violations (optional - use manufacturer rules)
+# Check for DRC violations with manufacturer rules
 kct check output/voltage_divider_routed.kicad_pcb --mfr jlcpcb
 
-# 3. Generate BOM
+# Generate BOM
 kct bom output/voltage_divider.kicad_sch --format csv
 
-# 4. Export Gerbers (via KiCad or kicad-cli)
+# Export Gerbers (via KiCad or kicad-cli)
 # Open the .kicad_pcb file in KiCad and use File > Plot
 ```
 
-See individual board READMEs for board-specific workflows.
+See individual board READMEs for board-specific details.
 
 ## Known Issues
 


### PR DESCRIPTION
## Summary

Adds prominent "Quick Start" sections to all board READMEs featuring the `kct build` command as the recommended way to build projects.

## Changes

### boards/README.md
- Added new Quick Start section at the top with `kct build` examples
- Shows how to build any project, run individual steps, preview with --dry-run
- Renamed old "Quick Start" to "Advanced: Manual Build"

### Individual Board READMEs
All board READMEs now include:

```bash
# One-command build (recommended)
kct build boards/<board-name>

# Or run specific steps
kct build boards/<board-name> --step schematic
kct build boards/<board-name> --step pcb
kct build boards/<board-name> --step route
kct build boards/<board-name> --step verify

# Preview what would happen
kct build boards/<board-name> --dry-run
```

- **01-voltage-divider**: Added Quick Start, renamed Usage to Advanced
- **02-charlieplex-led**: Added Quick Start, renamed Usage to Advanced
- **03-usb-joystick**: Added Quick Start, renamed Usage to Advanced
- **04-stm32-devboard**: Added Quick Start with note about schematic-only status

## Benefits

1. Users get the full automated workflow experience immediately
2. Reduces friction for new users trying the demos
3. Showcases the project's orchestration capabilities
4. Single command is easier to remember and share
5. Manual script instructions preserved as "Advanced" option

## Test Plan

- [x] All Markdown files render correctly
- [x] `kct build` command examples are accurate
- [x] Manual build instructions preserved in Advanced sections

Closes #680