### PR TITLE
fix(router): Add fail-fast validation for grid resolution vs clearance

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -94,6 +94,7 @@ from .heuristics import (
 )
 from .io import (
     ClearanceViolation,
+    GridResolutionError,
     PCBDesignRules,
     detect_layer_stack,
     generate_netclass_setup,
@@ -103,6 +104,13 @@ from .io import (
     route_pcb,
     validate_grid_resolution,
     validate_routes,
+)
+from .layers import Layer, LayerDefinition, LayerStack, LayerType, ViaDefinition, ViaRules, ViaType
+from .length import (
+    LengthTracker,
+    LengthViolation,
+    ViolationType,
+    create_match_group,
 )
 from .net_class import (
     NET_CLASS_PATTERNS,
@@ -118,13 +126,6 @@ from .net_class import (
     classify_net,
     find_differential_partner,
     is_differential_pair_name,
-)
-from .layers import Layer, LayerDefinition, LayerStack, LayerType, ViaDefinition, ViaRules, ViaType
-from .length import (
-    LengthTracker,
-    LengthViolation,
-    ViolationType,
-    create_match_group,
 )
 from .optimizer import (
     CollisionChecker,
@@ -299,6 +300,7 @@ __all__ = [
     "generate_netclass_setup",
     "merge_routes_into_pcb",
     "ClearanceViolation",
+    "GridResolutionError",
     "PCBDesignRules",
     "parse_pcb_design_rules",
     "validate_grid_resolution",


### PR DESCRIPTION
## Summary

When the router's grid resolution is too coarse for the required clearance, the build now fails fast with a clear error message instead of completing and producing DRC-failing output. This addresses issue #687 where users were getting successful routing that failed DRC, wasting time and potentially leading to manufacturing issues.

## Changes

- Add `GridResolutionError` exception class with descriptive attributes (grid_resolution, clearance, recommended)
- `validate_grid_resolution` now raises immediately when `grid > clearance` (guaranteed DRC violations)
- Add `strict` mode (default `True`) that also fails when `grid > clearance/2` (likely DRC violations)
- Add `strict_drc` parameter to `load_pcb_for_routing` for flexibility
- Export `GridResolutionError` from router module

## Backward Compatibility

The change is backward compatible with opt-out options:
- Use `validate_drc=False` to skip validation entirely
- Use `strict_drc=False` to only fail on guaranteed violations (grid > clearance)

## Example

```python
# Strict mode (default) - fails on any DRC risk
try:
    router, nets = load_pcb_for_routing("board.kicad_pcb")
except GridResolutionError as e:
    print(f"Grid {e.grid_resolution}mm too coarse for {e.clearance}mm clearance")
    print(f"Recommended: {e.recommended}mm")

# Lenient mode - only fails on guaranteed violations
router, nets = load_pcb_for_routing("board.kicad_pcb", strict_drc=False)

# Skip validation entirely (not recommended)
router, nets = load_pcb_for_routing("board.kicad_pcb", validate_drc=False)
```

## Test Plan

- [x] Unit tests for GridResolutionError exception
- [x] Test strict mode raises on grid > clearance/2
- [x] Test lenient mode only raises on grid > clearance
- [x] Test backward compatibility with validate_drc=False

Closes #687