### PR TITLE
feat(router): Add failure reason tracking and improved diagnostics

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -44,7 +44,7 @@ from .bus import (
     detect_bus_signals,
     group_buses,
 )
-from .core import AdaptiveAutorouter, Autorouter, RoutingResult
+from .core import AdaptiveAutorouter, Autorouter, RoutingFailure, RoutingResult
 from .cpp_backend import (
     CppGrid,
     CppPathfinder,
@@ -104,6 +104,13 @@ from .io import (
     validate_grid_resolution,
     validate_routes,
 )
+from .layers import Layer, LayerDefinition, LayerStack, LayerType, ViaDefinition, ViaRules, ViaType
+from .length import (
+    LengthTracker,
+    LengthViolation,
+    ViolationType,
+    create_match_group,
+)
 from .net_class import (
     NET_CLASS_PATTERNS,
     SYMBOL_INDICATORS,
@@ -118,13 +125,6 @@ from .net_class import (
     classify_net,
     find_differential_partner,
     is_differential_pair_name,
-)
-from .layers import Layer, LayerDefinition, LayerStack, LayerType, ViaDefinition, ViaRules, ViaType
-from .length import (
-    LengthTracker,
-    LengthViolation,
-    ViolationType,
-    create_match_group,
 )
 from .optimizer import (
     CollisionChecker,
@@ -193,6 +193,7 @@ __all__ = [
     # High-level API
     "Autorouter",
     "AdaptiveAutorouter",
+    "RoutingFailure",
     "RoutingResult",
     # C++ backend
     "is_cpp_available",

--- a/src/kicad_tools/router/algorithms/mst.py
+++ b/src/kicad_tools/router/algorithms/mst.py
@@ -84,12 +84,15 @@ class MSTRouter:
         self,
         pad_objs: list[Pad],
         mark_route_callback: callable,
+        failure_callback: callable | None = None,
     ) -> list[Route]:
         """Route a net using MST ordering.
 
         Args:
             pad_objs: List of Pad objects to connect
             mark_route_callback: Callback to mark a route on the grid
+            failure_callback: Optional callback to record routing failures.
+                Called with (source_pad, target_pad) when routing fails.
 
         Returns:
             List of successfully created routes
@@ -115,12 +118,16 @@ class MSTRouter:
                 if route:
                     mark_route_callback(route)
                     routes.append(route)
+                elif failure_callback:
+                    failure_callback(source_pad, target_pad)
         else:
             # Simple 2-pin net
             route = self.router.route(pad_objs[0], pad_objs[1])
             if route:
                 mark_route_callback(route)
                 routes.append(route)
+            elif failure_callback:
+                failure_callback(pad_objs[0], pad_objs[1])
 
         return routes
 
@@ -128,12 +135,15 @@ class MSTRouter:
         self,
         pad_objs: list[Pad],
         mark_route_callback: callable,
+        failure_callback: callable | None = None,
     ) -> list[Route]:
         """Route a net using star topology from the first pad.
 
         Args:
             pad_objs: List of Pad objects to connect
             mark_route_callback: Callback to mark a route on the grid
+            failure_callback: Optional callback to record routing failures.
+                Called with (source_pad, target_pad) when routing fails.
 
         Returns:
             List of successfully created routes
@@ -151,5 +161,7 @@ class MSTRouter:
             if route:
                 mark_route_callback(route)
                 routes.append(route)
+            elif failure_callback:
+                failure_callback(first_pad, target_pad)
 
         return routes

--- a/src/kicad_tools/router/primitives.py
+++ b/src/kicad_tools/router/primitives.py
@@ -162,6 +162,7 @@ class Pad:
     net_name: str
     layer: Layer = Layer.F_CU
     ref: str = ""  # Component reference
+    pin: str = ""  # Pin number/name
     through_hole: bool = False  # PTH pads block both layers
     drill: float = 0.0  # Drill diameter for PTH pads (0 = use pad size)
 


### PR DESCRIPTION
## Summary

When the router fails to complete all nets, it now captures and displays detailed information about why each net failed. This makes debugging routing failures much easier by explaining what's blocking each failed route.

## Changes

- Add `RoutingFailure` dataclass to track failure information
- Add `failure_callback` parameter to `MSTRouter.route_net()` and `route_net_star()`
- Record failures in `Autorouter.routing_failures` list during routing
- Update `show_failure_diagnostics()` to use recorded failures
- Add `pin` field to `Pad` class for complete pad identification
- Provide actionable suggestions based on failure analysis

## Example Output

Before:
```
PARTIAL: Routed 5/13 nets
  Some nets may require manual routing or a different strategy.
```

After:
```
PARTIAL: Routed 5/13 nets
  Some nets may require manual routing or a different strategy.

============================================================
ROUTING FAILURE DIAGNOSTICS
============================================================

Failed nets (8):

  - BTN1: Blocked by U1
  - BTN2: Blocked by 2 nets
  - USB_D+: No path found (congestion or obstacles)
  - XTAL1: No path found (congestion or obstacles)
  - XTAL2: No path found (congestion or obstacles)

Suggestions:
  - Reposition blocking components: R1, R2, U1
  - Consider using more layers for additional routing space
  - Try negotiated routing: kct route --algorithm negotiated
  - Try Monte Carlo routing: kct route --algorithm monte-carlo --trials 20

============================================================
```

## Test Plan

- [x] Verified `RoutingFailure` class imports correctly
- [x] All 253 router tests pass
- [x] Tested failure recording callback in MSTRouter
- [x] Verified output formatting in `show_failure_diagnostics`

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)