### PR TITLE
fix(tests): Add pytest.importorskip for pydantic in MCP tests

### DIFF
--- a/tests/test_mcp_analysis.py
+++ b/tests/test_mcp_analysis.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("pydantic")
+
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.exceptions import ParseError
 from kicad_tools.mcp.tools.analysis import analyze_board

--- a/tests/test_mcp_assembly.py
+++ b/tests/test_mcp_assembly.py
@@ -6,6 +6,10 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
+pytest.importorskip("pydantic")
+
 from kicad_tools.mcp.server import create_server
 from kicad_tools.mcp.tools.export import (
     ASSEMBLY_MANUFACTURERS,

--- a/tests/test_mcp_bom.py
+++ b/tests/test_mcp_bom.py
@@ -6,6 +6,10 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
+pytest.importorskip("pydantic")
+
 from kicad_tools.mcp.server import create_server
 from kicad_tools.mcp.tools.export import (
     SUPPORTED_BOM_FORMATS,

--- a/tests/test_mcp_context.py
+++ b/tests/test_mcp_context.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import pytest
 
+pytest.importorskip("pydantic")
+
 from kicad_tools.mcp.context import (
     AgentPreferences,
     Decision,

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("pydantic")
+
 from kicad_tools.mcp.server import MCPServer, create_server
 from kicad_tools.mcp.tools.analysis import analyze_board, get_drc_violations
 from kicad_tools.mcp.tools.session import (

--- a/tests/test_mcp_export.py
+++ b/tests/test_mcp_export.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("pydantic")
+
 from kicad_tools.mcp.server import create_server
 from kicad_tools.mcp.tools.export import (
     SUPPORTED_MANUFACTURERS,

--- a/tests/test_mcp_placement_analyze.py
+++ b/tests/test_mcp_placement_analyze.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("pydantic")
+
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.exceptions import ParseError
 from kicad_tools.mcp.tools.placement import placement_analyze

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("pydantic")
+
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.exceptions import ParseError
 from kicad_tools.mcp.tools.routing import get_unrouted_nets, route_net

--- a/tests/test_mcp_session.py
+++ b/tests/test_mcp_session.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("pydantic")
+
 from kicad_tools.mcp.tools.session import (
     apply_move,
     commit_session,

--- a/tests/test_mcp_session_intent.py
+++ b/tests/test_mcp_session_intent.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("pydantic")
+
 from kicad_tools.mcp.tools.session import (
     apply_move,
     clear_intent,

--- a/tests/test_mcp_session_manager.py
+++ b/tests/test_mcp_session_manager.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("pydantic")
+
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.mcp.errors import (
     SessionNotFoundError,


### PR DESCRIPTION
## Summary

MCP tests were failing with import errors when pydantic wasn't installed. This fix adds `pytest.importorskip("pydantic")` at module level in all MCP test files that have module-level imports from `kicad_tools.mcp`.

## Problem

Running `uv run pytest tests/` would fail immediately with:
```
ModuleNotFoundError: No module named 'pydantic'
```

This happened because module-level imports from `kicad_tools.mcp` triggered the pydantic import in `mcp/errors.py` before any skip logic could run.

## Solution

Added `pytest.importorskip("pydantic")` at the module level, before any `kicad_tools.mcp` imports, in all affected test files. This follows the existing pattern used for other optional dependencies like `mcp` (see `test_mcp_http.py`).

## Changes

- `tests/test_mcp_analysis.py`
- `tests/test_mcp_assembly.py`
- `tests/test_mcp_bom.py`
- `tests/test_mcp_context.py`
- `tests/test_mcp_e2e.py`
- `tests/test_mcp_export.py`
- `tests/test_mcp_placement_analyze.py`
- `tests/test_mcp_routing.py`
- `tests/test_mcp_session.py`
- `tests/test_mcp_session_intent.py`
- `tests/test_mcp_session_manager.py`

## Test Plan

- [x] Verified tests skip correctly when pydantic is not installed (`uv run pytest tests/test_mcp_session_manager.py`)
- [x] Verified tests pass when pydantic is installed (`uv run --extra dev pytest tests/test_mcp*.py`)
- [x] All 394 MCP tests pass

Closes #702