### PR TITLE
fix: Ensure pnpm kct uses local source version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "uv run mypy src/",
     "check:ci": "uv run ruff format . --check && uv run ruff check . && uv run pytest",
     "check:all": "uv run ruff format . --check && uv run ruff check . && uv run mypy src/ && uv run pytest",
-    "worktree:return": "./.loom/scripts/worktree-return.sh"
+    "worktree:return": "./.loom/scripts/worktree-return.sh",
+    "kct": "uv run kct"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `kct` script to package.json that invokes `uv run kct`
- Ensures `pnpm kct` uses the local source version instead of globally installed binary

## Problem

The globally installed `kct` binary (via pipx) was using an older version of the clearance calculation code that had a bug with rectangular pads. It treated ALL pads as circles using `max(w, h) / 2` as radius, which caused false clearance violations.

For the MCU's TQFP-32 pads with size (1.2mm, 0.5mm) and 0.8mm pitch:
- **Bug (old code)**: `r = max(1.2, 0.5) / 2 = 0.6mm` → clearance = 0.8 - 0.6 - 0.6 = **-0.4mm** (false violation)
- **Fixed (source)**: Uses proper rectangle clearance: `gap_y = 0.8 - 0.5 = 0.3mm` (passes)

## Solution

The source code already has the fix (`_rect_rect_clearance` function for rectangular pads). This PR ensures `pnpm kct` uses the local source version via `uv run kct`.

## Test Plan

- [x] Verified `pnpm kct check boards/03-usb-joystick/usb_joystick.kicad_pcb` now passes with 0 errors
- [x] Verified the fix correctly calculates 0.3mm clearance for MCU pads

Closes #698