### PR TITLE
fix(schematic): Correct pin connection_point to return wire position

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -572,7 +572,9 @@ class Autorouter:
             # Determine failure reason
             if blocking_nets:
                 if len(blocking_nets) == 1:
-                    reason = f"Blocked by {blocking_components[0] if blocking_components else 'unknown'}"
+                    reason = (
+                        f"Blocked by {blocking_components[0] if blocking_components else 'unknown'}"
+                    )
                 else:
                     reason = f"Blocked by {len(blocking_nets)} nets"
             else:

--- a/src/kicad_tools/schematic/models/elements_mixin.py
+++ b/src/kicad_tools/schematic/models/elements_mixin.py
@@ -67,9 +67,7 @@ class SchematicElementsMixin:
         dist = abs(dy * x - dx * y + x2 * y1 - y2 * x1) / length
         return dist < tolerance
 
-    def _point_on_any_wire(
-        self, x: float, y: float, tolerance: float = POINT_TOLERANCE
-    ) -> bool:
+    def _point_on_any_wire(self, x: float, y: float, tolerance: float = POINT_TOLERANCE) -> bool:
         """Check if a point lies on any wire in the schematic.
 
         Args:

--- a/src/kicad_tools/schematic/models/pin.py
+++ b/src/kicad_tools/schematic/models/pin.py
@@ -4,7 +4,6 @@ KiCad Pin Model
 Represents a symbol pin with position and properties.
 """
 
-import math
 from dataclasses import dataclass
 
 from kicad_tools.sexp import SExp
@@ -15,38 +14,34 @@ class Pin:
     """Represents a symbol pin with position and properties.
 
     Pin coordinates in KiCad symbol definitions:
-    - (x, y) is the pin's BASE position (where it attaches to the symbol body)
-    - angle is the direction the pin points (0=right, 90=up, 180=left, 270=down)
-    - length is how far the pin extends from the base
+    - (x, y) is the wire CONNECTION point (where wires attach to the pin)
+    - angle is the direction the pin graphic extends INTO the symbol body
+    - length is how far the pin graphic extends into the symbol
 
-    The wire connection point is at the END of the pin, calculated as:
-        connection_x = x + length * cos(angle)
-        connection_y = y + length * sin(angle)
+    For example, a resistor's left pin might have:
+    - (x, y) = (-2.54, 0) - where wires connect, outside the symbol
+    - angle = 0 (extending right, toward the symbol body)
+    - length = 2.54 (reaching the symbol body edge)
     """
 
     name: str
     number: str
-    x: float  # Base position relative to symbol center (NOT wire connection point)
+    x: float  # Wire connection point relative to symbol center
     y: float
-    angle: float  # Pin direction in degrees (0=right, 90=up, 180=left, 270=down)
+    angle: float  # Direction pin extends INTO symbol (0=right, 90=up, 180=left, 270=down)
     length: float
     pin_type: str = "passive"
 
     def connection_point(self) -> tuple[float, float]:
-        """Get the wire connection point (end of pin).
+        """Get the wire connection point.
 
         The connection point is where wires attach to the pin.
-        It's at the END of the pin, not the base.
+        In KiCad symbol definitions, this is the (x, y) position.
 
         Returns:
             (x, y) tuple of the wire connection point in symbol-local coordinates
         """
-        # Calculate the end point of the pin based on angle and length
-        # KiCad angles: 0=right, 90=up, 180=left, 270=down
-        rad = math.radians(self.angle)
-        conn_x = self.x + self.length * math.cos(rad)
-        conn_y = self.y + self.length * math.sin(rad)
-        return (conn_x, conn_y)
+        return (self.x, self.y)
 
     @classmethod
     def from_sexp(cls, node: SExp) -> "Pin":

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -826,7 +826,9 @@ class TestSchematicConstruction:
     def test_add_hier_label(self):
         """Add hierarchical label to schematic."""
         sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
-        hl = sch.add_hier_label("DATA", 10, 20, shape="output", snap=False, validate_connection=False)
+        hl = sch.add_hier_label(
+            "DATA", 10, 20, shape="output", snap=False, validate_connection=False
+        )
         assert len(sch.hier_labels) == 1
         assert hl.text == "DATA"
         assert hl.shape == "output"


### PR DESCRIPTION
## Summary

Fixed `Pin.connection_point()` method that was incorrectly returning the inner end of the pin (where it touches the symbol body) instead of the wire connection point (where wires attach).

## Root Cause

The method was calculating `x + length * cos(angle)` which moves from the connection point TOWARD the symbol body. In KiCad symbol definitions:
- `(x, y)` is already the wire connection point (outside the symbol)
- `angle` is the direction the pin graphic extends INTO the symbol
- `length` is how far the pin extends toward the symbol body

## Changes

- Simplified `connection_point()` to return `(self.x, self.y)` directly
- Updated docstrings to clarify KiCad pin coordinate semantics
- Removed unused `math` import

## Test Plan

- Verified `test_connection_point` now passes: Pin at (10.0, 20.0) returns (10.0, 20.0)
- Verified `test_symbol_instance_pin_position` now passes: Pin position correctly calculated
- Ran full test suite (5947 passed)

Closes #701