### PR TITLE
feat(router): Add auto_adjust_grid option for DRC compliance

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -94,8 +94,10 @@ from .heuristics import (
 )
 from .io import (
     ClearanceViolation,
+    GridAdjustment,
     GridResolutionError,
     PCBDesignRules,
+    adjust_grid_for_compliance,
     detect_layer_stack,
     generate_netclass_setup,
     load_pcb_for_routing,
@@ -301,8 +303,10 @@ __all__ = [
     "generate_netclass_setup",
     "merge_routes_into_pcb",
     "ClearanceViolation",
+    "GridAdjustment",
     "GridResolutionError",
     "PCBDesignRules",
+    "adjust_grid_for_compliance",
     "parse_pcb_design_rules",
     "validate_grid_resolution",
     "validate_routes",

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -37,7 +37,7 @@ import logging
 import math
 import re
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -1120,15 +1120,8 @@ def load_pcb_for_routing(
         )
         if adjustment.was_adjusted:
             logger.info(adjustment.message)
-            # Create new rules with adjusted grid resolution
-            rules = DesignRules(
-                grid_resolution=adjustment.adjusted,
-                trace_width=rules.trace_width,
-                trace_clearance=rules.trace_clearance,
-                via_drill=rules.via_drill,
-                via_diameter=rules.via_diameter,
-                via_clearance=rules.via_clearance,
-            )
+            # Update grid resolution while preserving all other rule settings
+            rules = replace(rules, grid_resolution=adjustment.adjusted)
 
     # Validate grid resolution for DRC compliance
     if validate_drc:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2676,8 +2676,10 @@ class TestLoadPcbForRouting:
 import warnings
 
 from kicad_tools.router.io import (
+    GridAdjustment,
     GridResolutionError,
     PCBDesignRules,
+    adjust_grid_for_compliance,
     parse_pcb_design_rules,
     validate_grid_resolution,
     validate_routes,
@@ -2855,6 +2857,70 @@ class TestValidateGridResolution:
         # Default behavior should raise for grid > clearance/2
         with pytest.raises(GridResolutionError):
             validate_grid_resolution(0.15, 0.2)  # 0.15 > 0.1 (half of 0.2)
+
+
+class TestAdjustGridForCompliance:
+    """Tests for adjust_grid_for_compliance function (Issue #705)."""
+
+    def test_no_adjustment_when_compliant(self):
+        """Test no adjustment when grid resolution is already compliant."""
+        adjustment = adjust_grid_for_compliance(0.1, 0.2)
+
+        assert adjustment.was_adjusted is False
+        assert adjustment.original == 0.1
+        assert adjustment.adjusted == 0.1
+        assert adjustment.clearance == 0.2
+
+    def test_adjustment_when_too_coarse(self):
+        """Test adjustment when grid resolution exceeds clearance/2."""
+        adjustment = adjust_grid_for_compliance(0.25, 0.2)
+
+        assert adjustment.was_adjusted is True
+        assert adjustment.original == 0.25
+        assert adjustment.adjusted == 0.1  # clearance / 2
+        assert adjustment.clearance == 0.2
+
+    def test_adjustment_at_boundary(self):
+        """Test no adjustment at exact boundary (grid == clearance/2)."""
+        adjustment = adjust_grid_for_compliance(0.1, 0.2)
+
+        assert adjustment.was_adjusted is False
+        assert adjustment.adjusted == 0.1
+
+    def test_adjustment_slightly_over_boundary(self):
+        """Test adjustment when grid is slightly over clearance/2."""
+        adjustment = adjust_grid_for_compliance(0.11, 0.2)
+
+        assert adjustment.was_adjusted is True
+        assert adjustment.adjusted == 0.1
+
+    def test_message_when_adjusted(self):
+        """Test message property when adjustment was made."""
+        adjustment = adjust_grid_for_compliance(0.25, 0.2)
+
+        assert "adjusted" in adjustment.message.lower()
+        assert "0.25" in adjustment.message
+        assert "0.1" in adjustment.message
+
+    def test_message_when_compliant(self):
+        """Test message property when no adjustment needed."""
+        adjustment = adjust_grid_for_compliance(0.1, 0.2)
+
+        assert "compliant" in adjustment.message.lower()
+
+    def test_adjustment_dataclass_immutable_fields(self):
+        """Test GridAdjustment has expected fields."""
+        adjustment = GridAdjustment(
+            original=0.25,
+            adjusted=0.1,
+            clearance=0.2,
+            was_adjusted=True,
+        )
+
+        assert adjustment.original == 0.25
+        assert adjustment.adjusted == 0.1
+        assert adjustment.clearance == 0.2
+        assert adjustment.was_adjusted is True
 
 
 class TestValidateRoutes:
@@ -3098,6 +3164,142 @@ class TestLoadPcbForRoutingDrcCompliance:
         # Custom rules should be used, not PCB rules
         assert router.rules.trace_width == 0.3
         assert router.rules.trace_clearance == 0.25
+
+    def test_auto_adjust_grid_adjusts_coarse_resolution(self, tmp_path):
+        """Test that auto_adjust_grid=True adjusts coarse grid resolution."""
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+  )
+  (gr_rect (start 100 100) (end 150 140) (layer "Edge.Cuts"))
+  (net 0 "")
+  (footprint "Test"
+    (layer "F.Cu")
+    (at 120 120)
+    (fp_text reference "R1" (at 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+)"""
+        pcb_file = tmp_path / "test_auto_adjust.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        # Use rules with coarse grid resolution (0.25 > 0.2/2 = 0.1)
+        rules = DesignRules(grid_resolution=0.25, trace_clearance=0.2)
+
+        router, net_map = load_pcb_for_routing(
+            str(pcb_file), rules=rules, auto_adjust_grid=True, validate_drc=True
+        )
+
+        # Grid should be adjusted to clearance/2
+        assert router.rules.grid_resolution == 0.1
+        # Other rules should be preserved
+        assert router.rules.trace_clearance == 0.2
+
+    def test_auto_adjust_grid_no_change_when_compliant(self, tmp_path):
+        """Test that auto_adjust_grid=True doesn't change compliant grid."""
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+  )
+  (gr_rect (start 100 100) (end 150 140) (layer "Edge.Cuts"))
+  (net 0 "")
+  (footprint "Test"
+    (layer "F.Cu")
+    (at 120 120)
+    (fp_text reference "R1" (at 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+)"""
+        pcb_file = tmp_path / "test_auto_adjust.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        # Use rules with compliant grid resolution
+        rules = DesignRules(grid_resolution=0.1, trace_clearance=0.2)
+
+        router, net_map = load_pcb_for_routing(
+            str(pcb_file), rules=rules, auto_adjust_grid=True, validate_drc=True
+        )
+
+        # Grid should not be changed
+        assert router.rules.grid_resolution == 0.1
+
+    def test_auto_adjust_grid_false_raises_error(self, tmp_path):
+        """Test that auto_adjust_grid=False (default) raises error for bad grid."""
+        import pytest
+
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+  )
+  (gr_rect (start 100 100) (end 150 140) (layer "Edge.Cuts"))
+  (net 0 "")
+  (footprint "Test"
+    (layer "F.Cu")
+    (at 120 120)
+    (fp_text reference "R1" (at 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+)"""
+        pcb_file = tmp_path / "test_auto_adjust.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        # Use rules with coarse grid resolution
+        rules = DesignRules(grid_resolution=0.25, trace_clearance=0.2)
+
+        # Should raise GridResolutionError when auto_adjust_grid=False
+        with pytest.raises(GridResolutionError):
+            load_pcb_for_routing(
+                str(pcb_file), rules=rules, auto_adjust_grid=False, validate_drc=True
+            )
+
+    def test_auto_adjust_grid_preserves_other_rules(self, tmp_path):
+        """Test that auto_adjust_grid preserves all other design rules."""
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+  )
+  (gr_rect (start 100 100) (end 150 140) (layer "Edge.Cuts"))
+  (net 0 "")
+  (footprint "Test"
+    (layer "F.Cu")
+    (at 120 120)
+    (fp_text reference "R1" (at 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+)"""
+        pcb_file = tmp_path / "test_auto_adjust.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        # Use rules with specific values
+        rules = DesignRules(
+            grid_resolution=0.25,  # Will be adjusted
+            trace_width=0.15,
+            trace_clearance=0.2,
+            via_drill=0.3,
+            via_diameter=0.6,
+            via_clearance=0.25,
+        )
+
+        router, net_map = load_pcb_for_routing(
+            str(pcb_file), rules=rules, auto_adjust_grid=True, validate_drc=True
+        )
+
+        # Grid should be adjusted
+        assert router.rules.grid_resolution == 0.1
+        # All other rules should be preserved
+        assert router.rules.trace_width == 0.15
+        assert router.rules.trace_clearance == 0.2
+        assert router.rules.via_drill == 0.3
+        assert router.rules.via_diameter == 0.6
+        assert router.rules.via_clearance == 0.25
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Add automatic grid resolution adjustment when loading PCBs for routing. When `auto_adjust_grid=True`, the router automatically adjusts grid resolution to `clearance/2` if it's too coarse, instead of raising `GridResolutionError`.

- Add `GridAdjustment` dataclass to track adjustment details
- Add `adjust_grid_for_compliance()` function for calculation logic  
- Add `auto_adjust_grid` parameter to `load_pcb_for_routing()`
- Add INFO logging when grid resolution is adjusted
- Add comprehensive tests for the new functionality

## Usage

```python
# Auto-adjust grid resolution for DRC compliance
router, nets = load_pcb_for_routing(
    "board.kicad_pcb",
    auto_adjust_grid=True,  # Adjust instead of fail
)
# Logs: INFO: Grid resolution adjusted from 0.25mm to 0.1mm for DRC compliance
```

## Test Plan

- [x] Tests pass for `adjust_grid_for_compliance()` function
- [x] Tests pass for `auto_adjust_grid=True` adjusting coarse grid
- [x] Tests pass for `auto_adjust_grid=True` leaving compliant grid unchanged
- [x] Tests pass for `auto_adjust_grid=False` raising error (default behavior)
- [x] Tests pass for preserving all other design rules when adjusting

Closes #705