### PR TITLE
fix(optimizer): Add layer connectivity validation to via optimizer

### DIFF
--- a/src/kicad_tools/router/optimizer/__init__.py
+++ b/src/kicad_tools/router/optimizer/__init__.py
@@ -42,6 +42,7 @@ from .serpentine import (
 )
 from .trace import TraceOptimizer
 from .via_optimizer import (
+    LayerConnectivityError,
     ViaOptimizationConfig,
     ViaOptimizationStats,
     ViaOptimizer,
@@ -51,6 +52,7 @@ from .via_optimizer import (
 __all__ = [
     "CollisionChecker",
     "GridCollisionChecker",
+    "LayerConnectivityError",
     "OptimizationConfig",
     "OptimizationStats",
     "SerpentineConfig",


### PR DESCRIPTION
## Summary

- Add `LayerConnectivityError` dataclass for validation errors
- Add `validate_layer_connectivity()` method to `ViaOptimizer` that checks all layer transitions have corresponding vias
- Integrate validation into `optimize_route()` - if validation fails, the original unoptimized route is returned instead
- Add comprehensive tests for the validation logic

## Root Cause

The via optimizer could remove vias without verifying that segments on different layers remain properly connected. After optimization, traces could span F.Cu and B.Cu without any connecting via, resulting in open circuits.

## Test plan

- [x] All existing via optimizer tests pass
- [x] New tests verify validation correctly detects missing vias
- [x] New tests verify optimization preserves valid routes
- [x] Ruff lint passes

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)