### PR TITLE
feat(router): Add allowed_layers constraint for single-layer routing

### DIFF
--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -80,6 +80,11 @@ class DesignRules:
     cost_zone_same_net: float = 0.1  # Low cost - encourage using zone copper
     cost_zone_clearance: float = 2.0  # Cost near zone boundaries
 
+    # Hard layer constraints (Issue #715)
+    # When set, only these layers are allowed for routing (blocks all others)
+    # Use layer names like ["F.Cu"] for single-layer routing
+    allowed_layers: list[str] | None = None
+
 
 @dataclass
 class LengthConstraint:


### PR DESCRIPTION
## Summary
- Add `allowed_layers` field to `DesignRules` for hard layer constraints
- Implement layer restriction in pathfinder to block vias and filter start/end layers
- Simple boards can now be routed on a single layer (e.g., `allowed_layers=["F.Cu"]`)

## Test plan
- [x] Run new `TestSingleLayerRouting` test class (5 tests)
- [x] Verify no regressions in existing router tests (452/453 pass - 1 unrelated failure)
- [ ] Test with `00-simple-led` demo board using `allowed_layers=["F.Cu"]`

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)