### PR TITLE
feat(validate): Add unified validation framework with Pydantic models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "tomli>=2.0; python_version < '3.11'",
     "pyyaml>=6.0",
     "numpy>=1.24",
+    "pydantic>=2.0",
 ]
 
 [project.urls]

--- a/src/kicad_tools/validate/__init__.py
+++ b/src/kicad_tools/validate/__init__.py
@@ -47,12 +47,31 @@ Difference from ``kicad_tools.drc``:
 from .checker import DRCChecker
 from .connectivity import ConnectivityIssue, ConnectivityResult, ConnectivityValidator
 from .consistency import ConsistencyIssue, ConsistencyResult, SchematicPCBChecker
+from .models import (
+    BaseViolation,
+    DRCResult,
+    Location,
+    Severity,
+    ValidationResult,
+    ViolationCategory,
+)
+from .models import (
+    DRCViolation as DRCViolationNew,
+)
 from .netlist import NetlistValidator, SyncIssue, SyncResult
 from .placement import BOMPlacementVerifier, PlacementResult, PlacementStatus
 from .violations import DRCResults, DRCViolation
 
 __all__ = [
-    # DRC validation
+    # New unified models (Pydantic-based)
+    "Severity",
+    "ViolationCategory",
+    "Location",
+    "BaseViolation",
+    "ValidationResult",
+    "DRCViolationNew",
+    "DRCResult",
+    # DRC validation (legacy, for backwards compatibility)
     "DRCChecker",
     "DRCViolation",
     "DRCResults",

--- a/src/kicad_tools/validate/models.py
+++ b/src/kicad_tools/validate/models.py
@@ -1,0 +1,250 @@
+"""Unified validation models using Pydantic.
+
+This module provides type-safe base models for validation results and violations
+across all validators (DRC, connectivity, consistency, netlist, etc.).
+
+The generic `ValidationResult[V]` pattern enables type-safe specialization
+while sharing common aggregation and filtering logic.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Severity(str, Enum):
+    """Severity levels for validation violations."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class ViolationCategory(str, Enum):
+    """Categories of validation violations for filtering and reporting."""
+
+    DRC = "drc"
+    CONNECTIVITY = "connectivity"
+    CONSISTENCY = "consistency"
+    NETLIST = "netlist"
+    THERMAL = "thermal"  # Future
+    IMPEDANCE = "impedance"  # Future
+    SIGNAL_INTEGRITY = "signal_integrity"  # Future
+
+
+class Location(BaseModel):
+    """Standardized location reference for violations.
+
+    Supports various location types: coordinates, layer, component reference, net.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    x: float | None = None
+    y: float | None = None
+    layer: str | None = None
+    ref: str | None = None  # Component reference (e.g., "R1", "U3")
+    net: str | None = None  # Net name
+
+    def to_tuple(self) -> tuple[float, float] | None:
+        """Return (x, y) tuple if both coordinates are set."""
+        if self.x is not None and self.y is not None:
+            return (self.x, self.y)
+        return None
+
+
+class BaseViolation(BaseModel):
+    """Base class for all validation violations.
+
+    Provides common fields and properties shared by all violation types.
+    Subclasses can add domain-specific fields while inheriting the base behavior.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    severity: Severity
+    category: ViolationCategory
+    message: str
+    location: Location | None = None
+
+    @property
+    def is_error(self) -> bool:
+        """Check if this is an error severity violation."""
+        return self.severity == Severity.ERROR
+
+    @property
+    def is_warning(self) -> bool:
+        """Check if this is a warning severity violation."""
+        return self.severity == Severity.WARNING
+
+    @property
+    def is_info(self) -> bool:
+        """Check if this is an info severity violation."""
+        return self.severity == Severity.INFO
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for backwards-compatible serialization."""
+        return self.model_dump(mode="json")
+
+
+V = TypeVar("V", bound=BaseViolation)
+
+
+class ValidationResult(BaseModel, Generic[V]):
+    """Generic validation result container.
+
+    Aggregates violations of a specific type and provides common
+    filtering, counting, and iteration methods.
+
+    Type parameter V must be a subclass of BaseViolation.
+    """
+
+    violations: list[V] = Field(default_factory=list)
+
+    @property
+    def error_count(self) -> int:
+        """Count of violations with ERROR severity."""
+        return sum(1 for v in self.violations if v.is_error)
+
+    @property
+    def warning_count(self) -> int:
+        """Count of violations with WARNING severity."""
+        return sum(1 for v in self.violations if v.is_warning)
+
+    @property
+    def info_count(self) -> int:
+        """Count of violations with INFO severity."""
+        return sum(1 for v in self.violations if v.is_info)
+
+    @property
+    def passed(self) -> bool:
+        """True if no errors (warnings and info are allowed)."""
+        return self.error_count == 0
+
+    def errors(self) -> list[V]:
+        """List of only error violations."""
+        return [v for v in self.violations if v.is_error]
+
+    def warnings(self) -> list[V]:
+        """List of only warning violations."""
+        return [v for v in self.violations if v.is_warning]
+
+    def infos(self) -> list[V]:
+        """List of only info violations."""
+        return [v for v in self.violations if v.is_info]
+
+    def filter_by_category(self, category: ViolationCategory) -> list[V]:
+        """Get violations for a specific category."""
+        return [v for v in self.violations if v.category == category]
+
+    def __iter__(self):
+        """Iterate over all violations."""
+        return iter(self.violations)
+
+    def __len__(self) -> int:
+        """Total number of violations."""
+        return len(self.violations)
+
+    def __bool__(self) -> bool:
+        """True if there are any violations."""
+        return len(self.violations) > 0
+
+    def add(self, violation: V) -> None:
+        """Add a violation to the results."""
+        self.violations.append(violation)
+
+    def merge(self, other: ValidationResult[V]) -> None:
+        """Merge violations from another result into this one."""
+        self.violations.extend(other.violations)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for backwards-compatible serialization."""
+        return {
+            "passed": self.passed,
+            "error_count": self.error_count,
+            "warning_count": self.warning_count,
+            "violations": [v.to_dict() for v in self.violations],
+        }
+
+
+# DRC-specific models
+
+
+class DRCViolation(BaseViolation):
+    """DRC-specific violation with rule and measurement details.
+
+    Extends BaseViolation with fields specific to design rule checks:
+    - rule_id: Identifies which DRC rule was violated
+    - actual_value/required_value: Measured vs required values
+    - items: Component references involved in the violation
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    category: ViolationCategory = ViolationCategory.DRC
+    rule_id: str
+    layer: str | None = None
+    actual_value: float | None = None
+    required_value: float | None = None
+    items: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary matching legacy DRCViolation format."""
+        result = {
+            "rule_id": self.rule_id,
+            "severity": self.severity.value,
+            "message": self.message,
+            "location": (
+                [self.location.x, self.location.y]
+                if self.location and self.location.x is not None
+                else None
+            ),
+            "layer": self.layer,
+            "actual_value": self.actual_value,
+            "required_value": self.required_value,
+            "items": list(self.items),
+        }
+        return result
+
+
+class DRCResult(ValidationResult[DRCViolation]):
+    """DRC-specific result with additional metadata.
+
+    Extends ValidationResult with DRC-specific fields and methods.
+    """
+
+    rules_checked: int = 0
+
+    def merge(self, other: DRCResult) -> None:  # type: ignore[override]
+        """Merge violations from another DRCResult into this one."""
+        super().merge(other)
+        self.rules_checked += other.rules_checked
+
+    def filter_by_rule(self, rule_id: str) -> list[DRCViolation]:
+        """Get violations for a specific rule."""
+        return [v for v in self.violations if v.rule_id == rule_id]
+
+    def filter_by_layer(self, layer: str) -> list[DRCViolation]:
+        """Get violations on a specific layer."""
+        return [v for v in self.violations if v.layer == layer]
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary matching legacy DRCResults format."""
+        return {
+            "passed": self.passed,
+            "error_count": self.error_count,
+            "warning_count": self.warning_count,
+            "rules_checked": self.rules_checked,
+            "violations": [v.to_dict() for v in self.violations],
+        }
+
+    def summary(self) -> str:
+        """Generate a human-readable summary."""
+        status = "PASSED" if self.passed else "FAILED"
+        return (
+            f"DRC {status}: {self.error_count} errors, "
+            f"{self.warning_count} warnings ({self.rules_checked} rules checked)"
+        )

--- a/tests/test_validation_models.py
+++ b/tests/test_validation_models.py
@@ -1,0 +1,467 @@
+"""Tests for unified validation models."""
+
+import pytest
+
+from kicad_tools.validate.models import (
+    BaseViolation,
+    DRCResult,
+    DRCViolation,
+    Location,
+    Severity,
+    ValidationResult,
+    ViolationCategory,
+)
+
+
+class TestSeverity:
+    """Tests for Severity enum."""
+
+    def test_severity_values(self):
+        assert Severity.ERROR.value == "error"
+        assert Severity.WARNING.value == "warning"
+        assert Severity.INFO.value == "info"
+
+    def test_severity_is_string_enum(self):
+        # str enum allows direct string comparison
+        assert Severity.ERROR == "error"
+        assert Severity.WARNING == "warning"
+
+
+class TestViolationCategory:
+    """Tests for ViolationCategory enum."""
+
+    def test_core_categories(self):
+        assert ViolationCategory.DRC.value == "drc"
+        assert ViolationCategory.CONNECTIVITY.value == "connectivity"
+        assert ViolationCategory.CONSISTENCY.value == "consistency"
+        assert ViolationCategory.NETLIST.value == "netlist"
+
+    def test_future_categories(self):
+        # Future categories are defined but not yet used
+        assert ViolationCategory.THERMAL.value == "thermal"
+        assert ViolationCategory.IMPEDANCE.value == "impedance"
+
+
+class TestLocation:
+    """Tests for Location model."""
+
+    def test_empty_location(self):
+        loc = Location()
+        assert loc.x is None
+        assert loc.y is None
+        assert loc.to_tuple() is None
+
+    def test_coordinate_location(self):
+        loc = Location(x=10.5, y=20.3)
+        assert loc.x == 10.5
+        assert loc.y == 20.3
+        assert loc.to_tuple() == (10.5, 20.3)
+
+    def test_partial_coordinates(self):
+        loc = Location(x=10.5)
+        assert loc.to_tuple() is None
+
+    def test_full_location(self):
+        loc = Location(x=10.0, y=20.0, layer="F.Cu", ref="R1", net="VCC")
+        assert loc.layer == "F.Cu"
+        assert loc.ref == "R1"
+        assert loc.net == "VCC"
+
+    def test_location_is_frozen(self):
+        from pydantic import ValidationError
+
+        loc = Location(x=10.0, y=20.0)
+        with pytest.raises(ValidationError):  # Frozen model raises ValidationError
+            loc.x = 15.0  # type: ignore
+
+
+class TestBaseViolation:
+    """Tests for BaseViolation model."""
+
+    def test_create_error_violation(self):
+        v = BaseViolation(
+            severity=Severity.ERROR,
+            category=ViolationCategory.DRC,
+            message="Test error",
+        )
+        assert v.is_error is True
+        assert v.is_warning is False
+        assert v.is_info is False
+
+    def test_create_warning_violation(self):
+        v = BaseViolation(
+            severity=Severity.WARNING,
+            category=ViolationCategory.CONNECTIVITY,
+            message="Test warning",
+        )
+        assert v.is_error is False
+        assert v.is_warning is True
+
+    def test_create_info_violation(self):
+        v = BaseViolation(
+            severity=Severity.INFO,
+            category=ViolationCategory.CONSISTENCY,
+            message="Test info",
+        )
+        assert v.is_info is True
+
+    def test_violation_with_location(self):
+        loc = Location(x=10.0, y=20.0, layer="B.Cu")
+        v = BaseViolation(
+            severity=Severity.ERROR,
+            category=ViolationCategory.DRC,
+            message="Error at location",
+            location=loc,
+        )
+        assert v.location is not None
+        assert v.location.x == 10.0
+        assert v.location.layer == "B.Cu"
+
+    def test_to_dict(self):
+        v = BaseViolation(
+            severity=Severity.ERROR,
+            category=ViolationCategory.DRC,
+            message="Test",
+            location=Location(x=1.0, y=2.0),
+        )
+        d = v.to_dict()
+        assert d["severity"] == "error"
+        assert d["category"] == "drc"
+        assert d["message"] == "Test"
+        assert d["location"]["x"] == 1.0
+
+    def test_violation_is_frozen(self):
+        from pydantic import ValidationError
+
+        v = BaseViolation(
+            severity=Severity.ERROR,
+            category=ViolationCategory.DRC,
+            message="Test",
+        )
+        with pytest.raises(ValidationError):  # Frozen model raises ValidationError
+            v.message = "Changed"  # type: ignore
+
+
+class TestValidationResult:
+    """Tests for generic ValidationResult."""
+
+    def test_empty_result(self):
+        result: ValidationResult[BaseViolation] = ValidationResult()
+        assert len(result) == 0
+        assert result.error_count == 0
+        assert result.warning_count == 0
+        assert result.passed is True
+        assert bool(result) is False
+
+    def test_result_with_errors(self):
+        result: ValidationResult[BaseViolation] = ValidationResult(
+            violations=[
+                BaseViolation(
+                    severity=Severity.ERROR,
+                    category=ViolationCategory.DRC,
+                    message="Error 1",
+                ),
+                BaseViolation(
+                    severity=Severity.ERROR,
+                    category=ViolationCategory.DRC,
+                    message="Error 2",
+                ),
+            ]
+        )
+        assert result.error_count == 2
+        assert result.passed is False
+        assert len(result.errors()) == 2
+
+    def test_result_with_warnings_only(self):
+        result: ValidationResult[BaseViolation] = ValidationResult(
+            violations=[
+                BaseViolation(
+                    severity=Severity.WARNING,
+                    category=ViolationCategory.CONNECTIVITY,
+                    message="Warning 1",
+                ),
+            ]
+        )
+        assert result.warning_count == 1
+        assert result.error_count == 0
+        assert result.passed is True  # Warnings don't fail
+
+    def test_add_violation(self):
+        result: ValidationResult[BaseViolation] = ValidationResult()
+        result.add(
+            BaseViolation(
+                severity=Severity.ERROR,
+                category=ViolationCategory.DRC,
+                message="Added",
+            )
+        )
+        assert len(result) == 1
+
+    def test_merge_results(self):
+        result1: ValidationResult[BaseViolation] = ValidationResult(
+            violations=[
+                BaseViolation(
+                    severity=Severity.ERROR,
+                    category=ViolationCategory.DRC,
+                    message="R1",
+                )
+            ]
+        )
+        result2: ValidationResult[BaseViolation] = ValidationResult(
+            violations=[
+                BaseViolation(
+                    severity=Severity.WARNING,
+                    category=ViolationCategory.DRC,
+                    message="R2",
+                )
+            ]
+        )
+        result1.merge(result2)
+        assert len(result1) == 2
+        assert result1.error_count == 1
+        assert result1.warning_count == 1
+
+    def test_iteration(self):
+        violations = [
+            BaseViolation(
+                severity=Severity.ERROR,
+                category=ViolationCategory.DRC,
+                message=f"V{i}",
+            )
+            for i in range(3)
+        ]
+        result: ValidationResult[BaseViolation] = ValidationResult(violations=violations)
+        collected = list(result)
+        assert len(collected) == 3
+
+    def test_filter_by_category(self):
+        result: ValidationResult[BaseViolation] = ValidationResult(
+            violations=[
+                BaseViolation(
+                    severity=Severity.ERROR,
+                    category=ViolationCategory.DRC,
+                    message="DRC",
+                ),
+                BaseViolation(
+                    severity=Severity.ERROR,
+                    category=ViolationCategory.CONNECTIVITY,
+                    message="Conn",
+                ),
+            ]
+        )
+        drc_only = result.filter_by_category(ViolationCategory.DRC)
+        assert len(drc_only) == 1
+        assert drc_only[0].message == "DRC"
+
+    def test_to_dict(self):
+        result: ValidationResult[BaseViolation] = ValidationResult(
+            violations=[
+                BaseViolation(
+                    severity=Severity.ERROR,
+                    category=ViolationCategory.DRC,
+                    message="Test",
+                )
+            ]
+        )
+        d = result.to_dict()
+        assert d["passed"] is False
+        assert d["error_count"] == 1
+        assert d["warning_count"] == 0
+        assert len(d["violations"]) == 1
+
+
+class TestDRCViolation:
+    """Tests for DRC-specific violation model."""
+
+    def test_create_drc_violation(self):
+        v = DRCViolation(
+            severity=Severity.ERROR,
+            rule_id="clearance_trace_trace",
+            message="Clearance violation",
+            layer="F.Cu",
+            actual_value=0.15,
+            required_value=0.2,
+            items=("D1", "C5"),
+        )
+        assert v.category == ViolationCategory.DRC
+        assert v.rule_id == "clearance_trace_trace"
+        assert v.is_error is True
+
+    def test_drc_violation_to_dict_legacy_format(self):
+        v = DRCViolation(
+            severity=Severity.ERROR,
+            rule_id="clearance",
+            message="Test",
+            location=Location(x=10.0, y=20.0),
+            layer="F.Cu",
+            actual_value=0.1,
+            required_value=0.2,
+            items=("R1", "R2"),
+        )
+        d = v.to_dict()
+        # Verify legacy format compatibility
+        assert d["rule_id"] == "clearance"
+        assert d["severity"] == "error"
+        assert d["location"] == [10.0, 20.0]  # List, not tuple
+        assert d["items"] == ["R1", "R2"]  # List, not tuple
+        assert d["actual_value"] == 0.1
+        assert d["required_value"] == 0.2
+
+    def test_drc_violation_no_location(self):
+        v = DRCViolation(
+            severity=Severity.WARNING,
+            rule_id="test",
+            message="No location",
+        )
+        d = v.to_dict()
+        assert d["location"] is None
+
+
+class TestDRCResult:
+    """Tests for DRC-specific result model."""
+
+    def test_empty_drc_result(self):
+        result = DRCResult()
+        assert result.passed is True
+        assert result.rules_checked == 0
+        assert len(result) == 0
+
+    def test_drc_result_with_violations(self):
+        result = DRCResult(
+            violations=[
+                DRCViolation(
+                    severity=Severity.ERROR,
+                    rule_id="clearance",
+                    message="Clearance error",
+                    layer="F.Cu",
+                ),
+                DRCViolation(
+                    severity=Severity.WARNING,
+                    rule_id="silkscreen",
+                    message="Silkscreen warning",
+                ),
+            ],
+            rules_checked=5,
+        )
+        assert result.error_count == 1
+        assert result.warning_count == 1
+        assert result.passed is False
+        assert result.rules_checked == 5
+
+    def test_filter_by_rule(self):
+        result = DRCResult(
+            violations=[
+                DRCViolation(severity=Severity.ERROR, rule_id="clearance", message="C1"),
+                DRCViolation(severity=Severity.ERROR, rule_id="clearance", message="C2"),
+                DRCViolation(severity=Severity.ERROR, rule_id="trace_width", message="T1"),
+            ]
+        )
+        clearance = result.filter_by_rule("clearance")
+        assert len(clearance) == 2
+
+    def test_filter_by_layer(self):
+        result = DRCResult(
+            violations=[
+                DRCViolation(
+                    severity=Severity.ERROR,
+                    rule_id="test",
+                    message="F",
+                    layer="F.Cu",
+                ),
+                DRCViolation(
+                    severity=Severity.ERROR,
+                    rule_id="test",
+                    message="B",
+                    layer="B.Cu",
+                ),
+            ]
+        )
+        front = result.filter_by_layer("F.Cu")
+        assert len(front) == 1
+        assert front[0].message == "F"
+
+    def test_merge_drc_results(self):
+        r1 = DRCResult(
+            violations=[DRCViolation(severity=Severity.ERROR, rule_id="r1", message="V1")],
+            rules_checked=3,
+        )
+        r2 = DRCResult(
+            violations=[DRCViolation(severity=Severity.WARNING, rule_id="r2", message="V2")],
+            rules_checked=2,
+        )
+        r1.merge(r2)
+        assert len(r1) == 2
+        assert r1.rules_checked == 5
+
+    def test_to_dict_legacy_format(self):
+        result = DRCResult(
+            violations=[DRCViolation(severity=Severity.ERROR, rule_id="test", message="E")],
+            rules_checked=10,
+        )
+        d = result.to_dict()
+        assert d["passed"] is False
+        assert d["error_count"] == 1
+        assert d["warning_count"] == 0
+        assert d["rules_checked"] == 10
+        assert len(d["violations"]) == 1
+
+    def test_summary(self):
+        result = DRCResult(
+            violations=[
+                DRCViolation(severity=Severity.ERROR, rule_id="test", message="E"),
+                DRCViolation(severity=Severity.WARNING, rule_id="test", message="W"),
+            ],
+            rules_checked=5,
+        )
+        summary = result.summary()
+        assert "FAILED" in summary
+        assert "1 errors" in summary
+        assert "1 warnings" in summary
+        assert "5 rules checked" in summary
+
+    def test_summary_passed(self):
+        result = DRCResult(
+            violations=[DRCViolation(severity=Severity.WARNING, rule_id="test", message="W")],
+            rules_checked=3,
+        )
+        summary = result.summary()
+        assert "PASSED" in summary
+
+
+class TestBackwardsCompatibility:
+    """Tests ensuring backwards compatibility with legacy violations.py."""
+
+    def test_drc_violation_matches_legacy_to_dict(self):
+        """Verify new DRCViolation.to_dict() matches legacy format."""
+        v = DRCViolation(
+            severity=Severity.ERROR,
+            rule_id="clearance_trace_trace",
+            message="Trace clearance violation",
+            location=Location(x=100.5, y=200.3),
+            layer="F.Cu",
+            actual_value=0.15,
+            required_value=0.2,
+            items=("D1", "C5"),
+        )
+        d = v.to_dict()
+
+        # Legacy format expectations
+        assert isinstance(d["location"], list)  # Not tuple
+        assert isinstance(d["items"], list)  # Not tuple
+        assert d["severity"] == "error"  # String, not enum
+        assert "category" not in d  # Legacy didn't have category
+
+    def test_drc_result_matches_legacy_to_dict(self):
+        """Verify new DRCResult.to_dict() matches legacy format."""
+        result = DRCResult(
+            violations=[DRCViolation(severity=Severity.ERROR, rule_id="test", message="Test")],
+            rules_checked=5,
+        )
+        d = result.to_dict()
+
+        # Legacy format expectations
+        assert "passed" in d
+        assert "error_count" in d
+        assert "warning_count" in d
+        assert "rules_checked" in d
+        assert "violations" in d

--- a/uv.lock
+++ b/uv.lock
@@ -863,6 +863,7 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -942,6 +943,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.24" },
     { name = "pdfplumber", marker = "extra == 'all'", specifier = ">=0.10.0" },
     { name = "pdfplumber", marker = "extra == 'datasheet'", specifier = ">=0.10.0" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "pydantic", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "pydantic", marker = "extra == 'mcp'", specifier = ">=2.0" },


### PR DESCRIPTION
## Summary

Add type-safe Pydantic base models for validation results, enabling extensibility for future validators (thermal, impedance, signal integrity).

## Changes

- Add `pydantic>=2.0` dependency to `pyproject.toml`
- Create `validate/models.py` with:
  - `Severity` and `ViolationCategory` enums
  - `Location` model for standardized violation locations  
  - `BaseViolation` base class with `is_error`/`is_warning` properties
  - Generic `ValidationResult[V]` for type-safe result aggregation
  - `DRCViolation` and `DRCResult` specialized models
- Export new models from `validate/__init__.py`
- Add comprehensive test suite (36 tests)

## How It Works

The new models use Pydantic v2 for:
- Runtime validation
- JSON schema generation
- IDE autocomplete support
- Frozen (immutable) instances

Legacy `to_dict()` format is preserved for backwards compatibility.

## Test Plan

- [x] All 36 new validation model tests pass
- [x] Ruff formatting check passes
- [x] Ruff linting check passes
- [x] Frozen model immutability verified
- [x] Backwards-compatible `to_dict()` format verified

Closes #721