### PR TITLE
feat(build): Auto-calculate grid from manufacturer clearance

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -266,6 +266,43 @@ def _run_step_pcb(ctx: BuildContext, console: Console) -> BuildResult:
     )
 
 
+def _get_routing_params(mfr: str) -> tuple[float, float, float, float, float]:
+    """Get routing parameters from manufacturer rules.
+
+    Auto-calculates grid to be compatible with clearance.
+    Grid must be ≤ clearance / 2 to allow routing without DRC violations.
+
+    Args:
+        mfr: Manufacturer ID (e.g., "jlcpcb")
+
+    Returns:
+        Tuple of (grid, clearance, trace_width, via_drill, via_diameter)
+    """
+    from kicad_tools.manufacturers import get_profile
+
+    try:
+        profile = get_profile(mfr)
+        rules = profile.get_design_rules(layers=2)  # Use 2-layer defaults
+
+        clearance = rules.min_clearance_mm
+        trace_width = rules.min_trace_width_mm
+        via_drill = rules.min_via_drill_mm
+        via_diameter = rules.min_via_diameter_mm
+
+        # Auto-calculate grid: must be ≤ clearance / 2 for DRC compliance
+        # Round DOWN to a clean value (0.05mm increments) to ensure compliance
+        import math
+        grid = clearance / 2
+        grid = max(0.05, math.floor(grid / 0.05) * 0.05)  # Round DOWN to 0.05mm, min 0.05mm
+
+        return grid, clearance, trace_width, via_drill, via_diameter
+
+    except Exception:
+        # Fall back to safe defaults if manufacturer lookup fails
+        # These defaults ensure grid < clearance
+        return 0.075, 0.15, 0.15, 0.3, 0.6
+
+
 def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
     """Run autorouting step."""
     # First check for a route script
@@ -307,15 +344,23 @@ def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
 
     output_file = ctx.pcb_file.with_stem(ctx.pcb_file.stem + "_routed")
 
+    # Get routing parameters from manufacturer rules
+    grid, clearance, trace_width, via_drill, via_diameter = _get_routing_params(ctx.mfr)
+
     if ctx.dry_run:
         return BuildResult(
             step="route",
             success=True,
-            message=f"[dry-run] Would run: kct route {ctx.pcb_file.name} -o {output_file.name}",
+            message=(
+                f"[dry-run] Would run: kct route {ctx.pcb_file.name} "
+                f"--grid {grid} --clearance {clearance}"
+            ),
         )
 
     if not ctx.quiet:
         console.print(f"  Running autorouter on {ctx.pcb_file.name}...")
+        if ctx.verbose:
+            console.print(f"    Grid: {grid}mm, Clearance: {clearance}mm")
 
     try:
         cmd = [
@@ -326,6 +371,16 @@ def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
             str(ctx.pcb_file),
             "-o",
             str(output_file),
+            "--grid",
+            str(grid),
+            "--clearance",
+            str(clearance),
+            "--trace-width",
+            str(trace_width),
+            "--via-drill",
+            str(via_drill),
+            "--via-diameter",
+            str(via_diameter),
         ]
 
         if ctx.quiet:

--- a/tests/test_build_routing_params.py
+++ b/tests/test_build_routing_params.py
@@ -1,0 +1,95 @@
+"""Tests for build command routing parameter auto-calculation.
+
+Verifies that the grid is auto-calculated from clearance to prevent
+DRC violations when routing (issue #723).
+"""
+
+import pytest
+
+from kicad_tools.cli.build_cmd import _get_routing_params
+
+
+class TestGetRoutingParams:
+    """Tests for _get_routing_params function."""
+
+    def test_jlcpcb_grid_compatible_with_clearance(self):
+        """JLCPCB grid should be compatible with its clearance (issue #723)."""
+        grid, clearance, trace_width, via_drill, via_diameter = _get_routing_params("jlcpcb")
+
+        # Grid must be <= clearance / 2 to allow routing without DRC violations
+        assert grid <= clearance / 2, (
+            f"Grid {grid}mm must be <= clearance/2 ({clearance/2}mm) "
+            f"to prevent DRC violations"
+        )
+
+        # Verify we got JLCPCB-specific values (~5 mil = 0.127mm clearance)
+        assert clearance > 0.1  # JLCPCB has reasonable clearance
+        assert trace_width > 0
+        assert via_drill > 0
+        assert via_diameter > via_drill
+
+    def test_seeed_grid_compatible_with_clearance(self):
+        """Seeed grid should be compatible with its clearance."""
+        grid, clearance, trace_width, via_drill, via_diameter = _get_routing_params("seeed")
+
+        assert grid <= clearance / 2, (
+            f"Grid {grid}mm must be <= clearance/2 ({clearance/2}mm)"
+        )
+
+    def test_pcbway_grid_compatible_with_clearance(self):
+        """PCBWay grid should be compatible with its clearance."""
+        grid, clearance, trace_width, via_drill, via_diameter = _get_routing_params("pcbway")
+
+        assert grid <= clearance / 2, (
+            f"Grid {grid}mm must be <= clearance/2 ({clearance/2}mm)"
+        )
+
+    def test_oshpark_grid_compatible_with_clearance(self):
+        """OSH Park grid should be compatible with its clearance."""
+        grid, clearance, trace_width, via_drill, via_diameter = _get_routing_params("oshpark")
+
+        assert grid <= clearance / 2, (
+            f"Grid {grid}mm must be <= clearance/2 ({clearance/2}mm)"
+        )
+
+    def test_grid_rounded_to_clean_value(self):
+        """Grid should be rounded to 0.05mm increments."""
+        grid, _, _, _, _ = _get_routing_params("jlcpcb")
+
+        # Check grid is a multiple of 0.05mm
+        assert grid * 20 == pytest.approx(round(grid * 20), abs=0.001), (
+            f"Grid {grid}mm should be rounded to 0.05mm increments"
+        )
+
+    def test_grid_minimum_value(self):
+        """Grid should have a minimum value of 0.05mm."""
+        grid, _, _, _, _ = _get_routing_params("jlcpcb")
+
+        assert grid >= 0.05, "Grid should be at least 0.05mm"
+
+    def test_unknown_manufacturer_uses_safe_defaults(self):
+        """Unknown manufacturer should use safe fallback defaults."""
+        grid, clearance, trace_width, via_drill, via_diameter = _get_routing_params(
+            "unknown_mfr_xyz"
+        )
+
+        # Fallback defaults should still be DRC-compatible
+        assert grid <= clearance / 2, "Fallback grid should be <= clearance/2"
+        assert grid == pytest.approx(0.075, rel=0.01)
+        assert clearance == pytest.approx(0.15, rel=0.01)
+
+    def test_via_diameter_greater_than_drill(self):
+        """Via diameter should always be greater than via drill."""
+        for mfr in ["jlcpcb", "seeed", "pcbway", "oshpark"]:
+            _, _, _, via_drill, via_diameter = _get_routing_params(mfr)
+            assert via_diameter > via_drill, (
+                f"{mfr}: via_diameter ({via_diameter}) should be > via_drill ({via_drill})"
+            )
+
+    def test_trace_width_reasonable(self):
+        """Trace width should be within reasonable bounds."""
+        for mfr in ["jlcpcb", "seeed", "pcbway", "oshpark"]:
+            _, _, trace_width, _, _ = _get_routing_params(mfr)
+            assert 0.1 <= trace_width <= 0.5, (
+                f"{mfr}: trace_width ({trace_width}) should be between 0.1mm and 0.5mm"
+            )


### PR DESCRIPTION
## Summary

- Fixes #723: `kct build` now auto-calculates the routing grid from the target manufacturer's clearance rules
- Adds `_get_routing_params()` function to calculate DRC-compatible routing parameters
- Grid is calculated as `floor(clearance / 2)` rounded to 0.05mm increments
- Comprehensive tests verify grid compatibility for all supported manufacturers

## Test plan

- [x] Run `pnpm test tests/test_build_routing_params.py` - all 9 tests pass
- [x] Verify `kct build boards/01-voltage-divider --dry-run` shows correct grid/clearance
- [x] Verify actual routing uses correct parameters and DRC passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)