### PR TITLE
fix(router): Correct footprint rotation for pad position calculation

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1072,7 +1072,9 @@ def load_pcb_for_routing(
                 net_num = 0  # Treat as obstacle, not a routable net
 
             # Transform pad position by footprint rotation
-            rot_rad = math.radians(-fp_rot)
+            # KiCad stores rotation in degrees, positive = counter-clockwise
+            # Standard 2D rotation matrix applies directly (no negation needed)
+            rot_rad = math.radians(fp_rot)
             cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
             abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
             abs_y = fp_y + pad_x * sin_r + pad_y * cos_r

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -487,8 +487,8 @@ class ConnectivityValidator:
         import math
 
         # Convert rotation to radians
-        # KiCad uses clockwise-positive rotation, negate for standard math
-        angle = math.radians(-rotation)
+        # KiCad uses counter-clockwise positive rotation (standard math convention)
+        angle = math.radians(rotation)
 
         # Rotate pad position
         px, py = pad_local

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -82,11 +82,10 @@ class CopperElement:
 def _transform_pad_position(pad: Pad, footprint: Footprint) -> tuple[float, float]:
     """Transform pad position from footprint-local to board coordinates.
 
-    Note: KiCad uses clockwise-positive rotation when Y points down.
-    Standard math rotation is counterclockwise-positive, so we negate the angle.
+    KiCad uses counter-clockwise positive rotation (standard math convention).
     """
-    # Apply rotation - negate angle for KiCad's clockwise-positive convention
-    angle_rad = math.radians(-footprint.rotation)
+    # Apply rotation using standard 2D rotation matrix
+    angle_rad = math.radians(footprint.rotation)
     cos_a = math.cos(angle_rad)
     sin_a = math.sin(angle_rad)
 
@@ -135,8 +134,8 @@ def _transform_pad_dimensions(pad: Pad, footprint: Footprint) -> tuple[float, fl
         return width, height
 
     # For arbitrary rotations, compute the axis-aligned bounding box
-    # of the rotated rectangle
-    angle_rad = math.radians(-total_rotation)  # Negate for KiCad convention
+    # of the rotated rectangle (sign doesn't matter since we use abs values)
+    angle_rad = math.radians(total_rotation)
     cos_a = abs(math.cos(angle_rad))
     sin_a = abs(math.sin(angle_rad))
 

--- a/tests/test_footprint_rotation.py
+++ b/tests/test_footprint_rotation.py
@@ -1,0 +1,142 @@
+"""Tests for footprint rotation handling in router and validation.
+
+Verifies that pad positions are correctly transformed when footprints
+are rotated (issue #727).
+"""
+
+import math
+
+import pytest
+
+
+class TestPadPositionRotation:
+    """Tests for pad position rotation transformation."""
+
+    def test_router_io_pad_rotation_90_degrees(self):
+        """Test that router correctly transforms pad position with 90° rotation."""
+        # Simulate the transformation from router/io.py
+        fp_x, fp_y = 112.5, 110.0
+        fp_rot = 90  # degrees
+        pad_x, pad_y = -1.0, 0  # local pad position
+
+        # Apply rotation (fixed: no negation)
+        rot_rad = math.radians(fp_rot)
+        cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+        abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
+        abs_y = fp_y + pad_x * sin_r + pad_y * cos_r
+
+        # Expected: pad at (-1, 0) rotated 90° CCW becomes (0, -1)
+        # So absolute position should be (112.5, 109.0)
+        assert abs_x == pytest.approx(112.5, abs=0.001)
+        assert abs_y == pytest.approx(109.0, abs=0.001)
+
+    def test_router_io_pad_rotation_180_degrees(self):
+        """Test pad position with 180° rotation."""
+        fp_x, fp_y = 100.0, 100.0
+        fp_rot = 180
+        pad_x, pad_y = 1.0, 0.5
+
+        rot_rad = math.radians(fp_rot)
+        cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+        abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
+        abs_y = fp_y + pad_x * sin_r + pad_y * cos_r
+
+        # Pad at (1, 0.5) rotated 180° becomes (-1, -0.5)
+        assert abs_x == pytest.approx(99.0, abs=0.001)
+        assert abs_y == pytest.approx(99.5, abs=0.001)
+
+    def test_router_io_pad_rotation_270_degrees(self):
+        """Test pad position with 270° rotation."""
+        fp_x, fp_y = 100.0, 100.0
+        fp_rot = 270
+        pad_x, pad_y = 1.0, 0
+
+        rot_rad = math.radians(fp_rot)
+        cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+        abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
+        abs_y = fp_y + pad_x * sin_r + pad_y * cos_r
+
+        # Pad at (1, 0) rotated 270° CCW (or 90° CW) becomes (0, 1)
+        assert abs_x == pytest.approx(100.0, abs=0.001)
+        assert abs_y == pytest.approx(99.0, abs=0.001)
+
+    def test_router_io_pad_rotation_0_degrees(self):
+        """Test pad position with no rotation."""
+        fp_x, fp_y = 100.0, 100.0
+        fp_rot = 0
+        pad_x, pad_y = 2.0, 1.0
+
+        rot_rad = math.radians(fp_rot)
+        cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+        abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
+        abs_y = fp_y + pad_x * sin_r + pad_y * cos_r
+
+        # No rotation - pad position is simply offset
+        assert abs_x == pytest.approx(102.0, abs=0.001)
+        assert abs_y == pytest.approx(101.0, abs=0.001)
+
+    def test_router_io_pad_rotation_45_degrees(self):
+        """Test pad position with 45° rotation."""
+        fp_x, fp_y = 100.0, 100.0
+        fp_rot = 45
+        pad_x, pad_y = 1.0, 0
+
+        rot_rad = math.radians(fp_rot)
+        cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+        abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
+        abs_y = fp_y + pad_x * sin_r + pad_y * cos_r
+
+        # Pad at (1, 0) rotated 45° becomes (cos45, sin45) ≈ (0.707, 0.707)
+        sqrt2_2 = math.sqrt(2) / 2
+        assert abs_x == pytest.approx(100.0 + sqrt2_2, abs=0.001)
+        assert abs_y == pytest.approx(100.0 + sqrt2_2, abs=0.001)
+
+
+class TestConnectivityValidationRotation:
+    """Tests for connectivity validation rotation handling."""
+
+    def test_connectivity_pad_rotation(self):
+        """Test that connectivity validation uses correct rotation."""
+        from kicad_tools.validate.connectivity import ConnectivityValidator
+
+        validator = ConnectivityValidator.__new__(ConnectivityValidator)
+
+        # Test the _transform_pad_position method
+        pad_local = (-1.0, 0)
+        fp_x, fp_y = 112.5, 110.0
+        rotation = 90
+
+        board_x, board_y = validator._transform_pad_position(
+            pad_local, fp_x, fp_y, rotation
+        )
+
+        # Expected: (112.5, 109.0)
+        assert board_x == pytest.approx(112.5, abs=0.001)
+        assert board_y == pytest.approx(109.0, abs=0.001)
+
+
+class TestClearanceValidationRotation:
+    """Tests for clearance validation rotation handling."""
+
+    def test_clearance_pad_position_transform(self):
+        """Test that clearance validation transforms pad positions correctly."""
+        from kicad_tools.validate.rules.clearance import _transform_pad_position
+        from dataclasses import dataclass
+
+        @dataclass
+        class MockPad:
+            position: tuple[float, float]
+
+        @dataclass
+        class MockFootprint:
+            position: tuple[float, float]
+            rotation: float
+
+        pad = MockPad(position=(-1.0, 0))
+        footprint = MockFootprint(position=(112.5, 110.0), rotation=90)
+
+        abs_x, abs_y = _transform_pad_position(pad, footprint)
+
+        # Expected: (112.5, 109.0)
+        assert abs_x == pytest.approx(112.5, abs=0.001)
+        assert abs_y == pytest.approx(109.0, abs=0.001)


### PR DESCRIPTION
## Summary
- Fixes incorrect rotation transformation for pad positions when footprints are rotated
- The code was incorrectly negating the rotation angle, causing traces to miss pads on rotated components
- Applied fix consistently across router/io.py, validate/connectivity.py, and validate/rules/clearance.py

## Root Cause
The code assumed KiCad uses clockwise-positive rotation, but KiCad actually uses counter-clockwise positive (standard math convention). The incorrect `-rotation` was changed to `rotation`.

For example, with R1 at (112.5, 110) rotated 90°, pad at local (-1, 0):
- **Before (wrong)**: `abs_y = 110 + (-1)*(-1) = 111` (missed pad)
- **After (correct)**: `abs_y = 110 + (-1)*(1) = 109` (hits pad)

## Test plan
- [x] Added 7 unit tests for rotation transformation at 0°, 45°, 90°, 180°, 270°
- [x] Verified simple-led board routes correctly (3/3 nets vs 0/3 before)
- [x] DRC passes on routed board

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)