### PR TITLE
fix(cli): Resolve relative paths in check and audit commands

### DIFF
--- a/src/kicad_tools/cli/audit_cmd.py
+++ b/src/kicad_tools/cli/audit_cmd.py
@@ -93,8 +93,8 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    # Validate input file
-    path = Path(args.project_or_pcb)
+    # Validate input file - resolve to absolute path for reliable file access
+    path = Path(args.project_or_pcb).resolve()
     if not path.exists():
         print(f"Error: File not found: {path}", file=sys.stderr)
         return 1

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -125,8 +125,8 @@ def main(argv: list[str] | None = None) -> int:
                 return 1
             skip_set.add(cat)
 
-    # Load PCB
-    pcb_path = Path(args.pcb)
+    # Load PCB - resolve to absolute path for reliable file access
+    pcb_path = Path(args.pcb).resolve()
     if not pcb_path.exists():
         print(f"Error: PCB file not found: {pcb_path}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

Fix CLI commands `kct check` and `kct audit` failing with relative file paths by using `Path.resolve()` to convert relative paths to absolute paths.

## Changes

- Use `Path().resolve()` in `check_cmd.py` to resolve PCB path
- Use `Path().resolve()` in `audit_cmd.py` to resolve project/PCB path

## Test Plan

- All 168 related tests pass
- Format and lint checks pass on changed files
- Commands now correctly resolve relative paths from the current working directory

Closes #729