### PR TITLE
docs(voltage-divider): Use python3 for macOS compatibility

### DIFF
--- a/boards/01-voltage-divider/README.md
+++ b/boards/01-voltage-divider/README.md
@@ -62,7 +62,7 @@ For more control, run the Python script directly.
 ### Step 1: Generate the Design
 
 ```bash
-python generate_design.py
+python3 generate_design.py
 ```
 
 This creates:


### PR DESCRIPTION
## Summary

Update the voltage divider README to use `python3` instead of `python` for cross-platform compatibility.

## Changes

- Changed `python generate_design.py` to `python3 generate_design.py` in the "Advanced: Manual Build" section

## Why

On macOS, `python` is not in PATH by default (only `python3`), causing the documented command to fail with "command not found: python".

## Test Plan

- Verified the command works on macOS with `python3`
- The `kct build` commands (the recommended approach) are unaffected

Closes #742