### PR TITLE
feat(cli): Add kct run command to execute scripts with pipx interpreter

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -30,6 +30,7 @@ Provides CLI commands for common KiCad operations via the `kicad-tools` or `kct`
     kicad-tools interactive            - Launch interactive REPL mode
     kicad-tools net-status <pcb>       - Report net connectivity status
     kicad-tools init <project>         - Initialize project with manufacturer rules
+    kicad-tools run <script>           - Run Python script with kicad-tools interpreter
 
 See `kicad-tools --help` for complete documentation.
 """
@@ -66,6 +67,7 @@ from .commands import (
     run_placement_command,
     run_reason_command,
     run_route_command,
+    run_run_command,
     run_sch_command,
     run_spec_command,
     run_suggest_command,
@@ -381,6 +383,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "benchmark":
         return run_benchmark_command(args)
+
+    elif args.command == "run":
+        return run_run_command(args)
 
     return 0
 

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -33,6 +33,7 @@ from .placement import run_placement_command
 from .project import run_clean_command, run_init_command
 from .reasoning import run_reason_command
 from .routing import run_optimize_command, run_route_command, run_zones_command
+from .run import run_run_command
 from .schematic import run_sch_command
 from .spec import run_spec_command
 from .suggest import run_suggest_command
@@ -102,4 +103,6 @@ __all__ = [
     "run_mcp_command",
     # Native build
     "run_build_native_command",
+    # Run
+    "run_run_command",
 ]

--- a/src/kicad_tools/cli/commands/run.py
+++ b/src/kicad_tools/cli/commands/run.py
@@ -1,0 +1,46 @@
+"""Run Python scripts with the kicad-tools interpreter.
+
+This command solves the problem of running board generation scripts when
+kicad-tools is installed via pipx. Instead of:
+
+    python generate_design.py  # Fails: ModuleNotFoundError: kicad_tools
+
+Users can run:
+
+    kct run generate_design.py  # Works: uses pipx-installed Python
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+__all__ = ["run_run_command"]
+
+
+def run_run_command(args) -> int:
+    """Execute a Python script using the kicad-tools Python interpreter.
+
+    This allows board generation scripts to import kicad_tools modules
+    even when kicad-tools is installed in an isolated environment (pipx).
+    """
+    script_path = Path(args.run_script)
+
+    if not script_path.exists():
+        print(f"Error: Script not found: {script_path}", file=sys.stderr)
+        return 1
+
+    if script_path.suffix != ".py":
+        print(f"Error: Not a Python script: {script_path}", file=sys.stderr)
+        return 1
+
+    # Build command: use current Python interpreter
+    cmd = [sys.executable, str(script_path.resolve())]
+
+    # Add any additional arguments passed to the script
+    if args.run_args:
+        cmd.extend(args.run_args)
+
+    # Run the script, inheriting stdio
+    result = subprocess.run(cmd)
+
+    return result.returncode

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -40,6 +40,7 @@ Provides CLI commands for common KiCad operations via the `kicad-tools` or `kct`
     kicad-tools audit <project>        - Manufacturing readiness audit
     kicad-tools clean <project>        - Clean up old/orphaned files
     kicad-tools init <project>         - Initialize project with manufacturer rules
+    kicad-tools run <script>           - Run Python script with kicad-tools interpreter
     kicad-tools config                 - View/manage configuration
     kicad-tools interactive            - Launch interactive REPL mode
 
@@ -167,6 +168,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_build_native_parser(subparsers)
     _add_spec_parser(subparsers)
     _add_benchmark_parser(subparsers)
+    _add_run_parser(subparsers)
 
     return parser
 
@@ -2634,4 +2636,37 @@ def _add_benchmark_parser(subparsers) -> None:
         choices=["text", "json"],
         default="text",
         help="Output format (default: text)",
+    )
+
+
+def _add_run_parser(subparsers) -> None:
+    """Add run subcommand parser for executing Python scripts.
+
+    This command solves the common issue where users install kicad-tools
+    via pipx but cannot run board generation scripts with `python3 script.py`
+    because the kicad_tools module is not available in the system Python.
+    """
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Run a Python script using the kicad-tools interpreter",
+        description=(
+            "Execute a Python script using the same Python interpreter that runs kicad-tools. "
+            "This is useful when kicad-tools is installed via pipx, as board generation scripts "
+            "can import kicad_tools modules that would otherwise be unavailable.\n\n"
+            "Example:\n"
+            "  kct run generate_design.py           # Run script\n"
+            "  kct run generate_design.py output/   # Pass arguments to script"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    run_parser.add_argument(
+        "run_script",
+        metavar="SCRIPT",
+        help="Path to Python script to run",
+    )
+    run_parser.add_argument(
+        "run_args",
+        nargs="*",
+        metavar="ARGS",
+        help="Arguments to pass to the script",
     )


### PR DESCRIPTION
## Summary

- Add `kct run` command to execute Python scripts using the kicad-tools interpreter
- Solves `ModuleNotFoundError: kicad_tools` when running board generation scripts
- Enables users to run scripts that import kicad-tools modules when installed via pipx

## Problem

When kicad-tools is installed via pipx, running `python3 generate_design.py` fails:

```
Traceback (most recent call last):
  File "generate_design.py", line 24, in <module>
    from kicad_tools.core.project_file import create_minimal_project, save_project
ModuleNotFoundError: No module named 'kicad_tools'
```

This happens because pipx installs packages in isolated virtual environments.

## Solution

Add a `kct run <script.py>` command that uses `sys.executable` to run scripts with the same Python interpreter that runs kicad-tools:

```bash
# Before: fails
python3 generate_design.py

# After: works
kct run generate_design.py
kct run generate_design.py output/  # Pass arguments
```

## Test Plan

- [x] `kct run --help` shows correct usage
- [x] `kct run generate_design.py` successfully runs board generation script
- [x] Script arguments are passed correctly
- [x] Error handling for missing/invalid scripts works

Closes #743