### PR TITLE
docs(boards): Use python3 for macOS compatibility

### DIFF
--- a/boards/02-charlieplex-led/README.md
+++ b/boards/02-charlieplex-led/README.md
@@ -70,7 +70,7 @@ For more control over individual steps, you can run Python scripts directly.
 ### Step 1: Generate the PCB
 
 ```bash
-python generate_pcb.py
+python3 generate_pcb.py
 ```
 
 This creates `charlieplex_3x3.kicad_pcb` with:
@@ -83,7 +83,7 @@ This creates `charlieplex_3x3.kicad_pcb` with:
 ### Step 2: Run the Autorouter
 
 ```bash
-python route_demo.py
+python3 route_demo.py
 ```
 
 This:

--- a/boards/03-usb-joystick/README.md
+++ b/boards/03-usb-joystick/README.md
@@ -87,7 +87,7 @@ For more control over individual steps, you can run Python scripts directly.
 ### Step 1: Generate the PCB
 
 ```bash
-python generate_pcb.py
+python3 generate_pcb.py
 ```
 
 Creates `usb_joystick.kicad_pcb` with all components placed and nets defined.
@@ -95,7 +95,7 @@ Creates `usb_joystick.kicad_pcb` with all components placed and nets defined.
 ### Step 2: Run the Autorouter
 
 ```bash
-python route_demo.py
+python3 route_demo.py
 ```
 
 This:

--- a/boards/README.md
+++ b/boards/README.md
@@ -47,7 +47,7 @@ For more control, you can run individual Python scripts directly:
 ```bash
 # Run any board's generation script
 cd boards/01-voltage-divider
-python generate_design.py
+python3 generate_design.py
 
 # Or use uv from the repo root
 uv run python boards/01-voltage-divider/generate_design.py


### PR DESCRIPTION
## Summary

Update board README files to use `python3` instead of `python` in command examples for cross-platform compatibility.

## Changes

- `boards/02-charlieplex-led/README.md`: Updated lines 73, 86
- `boards/03-usb-joystick/README.md`: Updated lines 90, 98
- `boards/README.md`: Updated line 50

## Context

macOS does not include `python` in PATH by default (only `python3`), so documentation examples using `python` fail on fresh macOS installations. This is the same fix applied to the voltage-divider README in #742.

## Test Plan

- [x] Verified all `python` → `python3` changes in affected files
- [x] Changes are documentation-only (no code impact)

Closes #764