### PR TITLE
feat(dev): Add version mismatch detection for pipx vs source conflicts

### DIFF
--- a/boards/00-simple-led/generate_design.py
+++ b/boards/00-simple-led/generate_design.py
@@ -23,7 +23,11 @@ import uuid
 from pathlib import Path
 
 from kicad_tools.core.project_file import create_minimal_project, save_project
+from kicad_tools.dev import warn_if_stale
 from kicad_tools.schematic.models.schematic import Schematic
+
+# Warn if running source scripts with stale pipx install
+warn_if_stale()
 
 
 def generate_uuid() -> str:

--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -22,7 +22,11 @@ import uuid
 from pathlib import Path
 
 from kicad_tools.core.project_file import create_minimal_project, save_project
+from kicad_tools.dev import warn_if_stale
 from kicad_tools.schematic.models.schematic import Schematic
+
+# Warn if running source scripts with stale pipx install
+warn_if_stale()
 
 
 def generate_uuid() -> str:

--- a/boards/02-charlieplex-led/generate_schematic.py
+++ b/boards/02-charlieplex-led/generate_schematic.py
@@ -27,8 +27,12 @@ from design_spec import (
     RESISTOR_VALUE,
 )
 
+from kicad_tools.dev import warn_if_stale
 from kicad_tools.schematic.models.schematic import Schematic, SnapMode
 from kicad_tools.schematic.models.validation_mixin import format_validation_summary
+
+# Warn if running source scripts with stale pipx install
+warn_if_stale()
 
 # Wire stub length for connecting pins to labels
 WIRE_STUB = 5.08  # 200 mils

--- a/boards/02-charlieplex-led/route_demo.py
+++ b/boards/02-charlieplex-led/route_demo.py
@@ -18,11 +18,15 @@ Example:
 import sys
 from pathlib import Path
 
-# Add src to path for development
+# Add src to path for development (ensures source version is used)
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
+from kicad_tools.dev import warn_if_stale
 from kicad_tools.router import DesignRules, load_pcb_for_routing
 from kicad_tools.router.optimizer import OptimizationConfig, TraceOptimizer
+
+# Warn if running source scripts with stale pipx install
+warn_if_stale()
 
 
 def main():

--- a/boards/03-usb-joystick/generate_schematic.py
+++ b/boards/03-usb-joystick/generate_schematic.py
@@ -15,8 +15,12 @@ import argparse
 import sys
 from pathlib import Path
 
+from kicad_tools.dev import warn_if_stale
 from kicad_tools.schematic.models.schematic import Schematic, SnapMode
 from kicad_tools.schematic.models.validation_mixin import format_validation_summary
+
+# Warn if running source scripts with stale pipx install
+warn_if_stale()
 
 # Wire stub length for connecting pins to labels
 WIRE_STUB = 5.08  # 200 mils

--- a/boards/03-usb-joystick/route_demo.py
+++ b/boards/03-usb-joystick/route_demo.py
@@ -18,15 +18,19 @@ Example:
 import sys
 from pathlib import Path
 
-# Add src to path for development
+# Add src to path for development (ensures source version is used)
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
+from kicad_tools.dev import warn_if_stale
 from kicad_tools.router import (
     DesignRules,
     create_net_class_map,
     load_pcb_for_routing,
 )
 from kicad_tools.router.optimizer import OptimizationConfig, TraceOptimizer
+
+# Warn if running source scripts with stale pipx install
+warn_if_stale()
 
 
 def main():

--- a/boards/04-stm32-devboard/design.py
+++ b/boards/04-stm32-devboard/design.py
@@ -22,6 +22,7 @@ If no output directory is specified, files are written to ./output/
 import sys
 from pathlib import Path
 
+from kicad_tools.dev import warn_if_stale
 from kicad_tools.schematic.blocks import (
     CrystalOscillator,
     DebugHeader,
@@ -30,6 +31,9 @@ from kicad_tools.schematic.blocks import (
 
 # Import the schematic builder and circuit blocks
 from kicad_tools.schematic.models.schematic import Schematic
+
+# Warn if running source scripts with stale pipx install
+warn_if_stale()
 
 
 def create_stm32_devboard(output_dir: Path) -> None:

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -40,6 +40,48 @@ This installs:
 - Linting tools (ruff, mypy)
 - Documentation tools
 
+### Important: Pipx vs Source Conflicts
+
+If you have kicad-tools installed via pipx (e.g., from a release) and are also
+working with the source repository, you may encounter import errors:
+
+```
+ImportError: cannot import name 'new_function' from 'kicad_tools.module'
+```
+
+This happens because Python imports from the pipx-installed version instead of
+your source code. New functions added to source won't be available.
+
+**Solution 1: Reinstall from source (recommended for testing)**
+
+```bash
+pipx install --force .
+```
+
+**Solution 2: Use an editable install for development**
+
+```bash
+pipx uninstall kicad-tools
+pip install -e ".[dev]"
+```
+
+**Solution 3: Use a virtual environment (cleanest)**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+The board generation scripts in `boards/` include automatic version mismatch
+detection and will warn you if the installed version differs from source:
+
+```
+⚠️  Version mismatch detected!
+   Installed: 0.9.2
+   Source:    0.9.3
+```
+
 ---
 
 ## Project Structure

--- a/src/kicad_tools/dev.py
+++ b/src/kicad_tools/dev.py
@@ -1,0 +1,223 @@
+"""
+Development utilities for working with kicad-tools source code.
+
+This module helps detect version mismatches when working with the
+kicad-tools source repository while also having a pipx-installed version.
+
+Usage in board scripts:
+    from kicad_tools.dev import warn_if_stale
+    warn_if_stale()  # Prints warning if installed version differs from source
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Cache the warning state to avoid repeated warnings
+_warned = False
+
+
+def get_installed_version() -> str:
+    """Get the version of the installed kicad-tools package.
+
+    Returns:
+        Version string (e.g., "0.9.3") or "unknown" if not installed.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("kicad-tools")
+    except Exception:
+        return "unknown"
+
+
+def get_source_version(source_dir: Path | None = None) -> str | None:
+    """Get the version from pyproject.toml in the source directory.
+
+    Args:
+        source_dir: Path to the source directory containing pyproject.toml.
+                   If None, searches upward from the current file.
+
+    Returns:
+        Version string (e.g., "0.9.3") or None if not found.
+    """
+    if source_dir is None:
+        # Search upward from this file to find pyproject.toml
+        current = Path(__file__).resolve()
+        for parent in [current] + list(current.parents):
+            pyproject = parent / "pyproject.toml"
+            if pyproject.exists():
+                source_dir = parent
+                break
+
+    if source_dir is None:
+        return None
+
+    pyproject_path = source_dir / "pyproject.toml"
+    if not pyproject_path.exists():
+        return None
+
+    try:
+        # Try tomllib (Python 3.11+) first, then tomli
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib  # type: ignore
+
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)
+            return data.get("project", {}).get("version")
+    except Exception:
+        return None
+
+
+def find_source_root() -> Path | None:
+    """Find the kicad-tools source root directory.
+
+    Returns:
+        Path to the source root (containing pyproject.toml) or None.
+    """
+    # Check if we're running from a script in a known location
+    # First, check the caller's location
+    import inspect
+
+    for frame_info in inspect.stack():
+        frame_path = Path(frame_info.filename).resolve()
+
+        # Search upward for pyproject.toml with kicad-tools
+        for parent in [frame_path] + list(frame_path.parents):
+            pyproject = parent / "pyproject.toml"
+            if pyproject.exists():
+                try:
+                    try:
+                        import tomllib
+                    except ImportError:
+                        import tomli as tomllib  # type: ignore
+
+                    with open(pyproject, "rb") as f:
+                        data = tomllib.load(f)
+                        if data.get("project", {}).get("name") == "kicad-tools":
+                            return parent
+                except Exception:
+                    continue
+    return None
+
+
+def check_version_match(source_dir: Path | None = None) -> tuple[bool, str, str | None]:
+    """Check if the installed version matches the source version.
+
+    Args:
+        source_dir: Path to source directory, or None to auto-detect.
+
+    Returns:
+        Tuple of (match, installed_version, source_version).
+        - match: True if versions match or source not found
+        - installed_version: The installed package version
+        - source_version: The source version, or None if not found
+    """
+    installed = get_installed_version()
+
+    if source_dir is None:
+        source_dir = find_source_root()
+
+    if source_dir is None:
+        return True, installed, None
+
+    source = get_source_version(source_dir)
+
+    if source is None:
+        return True, installed, None
+
+    return installed == source, installed, source
+
+
+def warn_if_stale(source_dir: Path | None = None, force: bool = False) -> bool:
+    """Print a warning if the installed version differs from source.
+
+    This is useful for board generation scripts in the repository that
+    import from kicad_tools. If a user has pipx-installed kicad-tools
+    but is running scripts from the source repo, the imports will use
+    the pipx version which may be stale.
+
+    Args:
+        source_dir: Path to source directory, or None to auto-detect.
+        force: If True, always check and warn even if already warned.
+
+    Returns:
+        True if versions match (or source not found), False if mismatch.
+
+    Example:
+        # At the top of a board generation script
+        from kicad_tools.dev import warn_if_stale
+        warn_if_stale()
+    """
+    global _warned
+
+    if _warned and not force:
+        return True
+
+    match, installed, source = check_version_match(source_dir)
+
+    if not match and source is not None:
+        _warned = True
+        print(
+            "\n⚠️  Version mismatch detected!",
+            file=sys.stderr,
+        )
+        print(
+            f"   Installed: {installed}",
+            file=sys.stderr,
+        )
+        print(
+            f"   Source:    {source}",
+            file=sys.stderr,
+        )
+        print(
+            "\n   You may be running source scripts with an older pipx install.",
+            file=sys.stderr,
+        )
+        print(
+            "   To fix, reinstall from source:\n",
+            file=sys.stderr,
+        )
+        print(
+            "       pipx install --force .",
+            file=sys.stderr,
+        )
+        print(
+            "\n   Or use an editable install for development:\n",
+            file=sys.stderr,
+        )
+        print(
+            "       pipx uninstall kicad-tools",
+            file=sys.stderr,
+        )
+        print(
+            "       pip install -e '.[dev]'\n",
+            file=sys.stderr,
+        )
+        return False
+
+    return True
+
+
+def require_source_version(source_dir: Path | None = None) -> None:
+    """Raise an error if the installed version differs from source.
+
+    This is a stricter version of warn_if_stale() that stops execution
+    when a version mismatch is detected.
+
+    Args:
+        source_dir: Path to source directory, or None to auto-detect.
+
+    Raises:
+        RuntimeError: If versions don't match.
+    """
+    match, installed, source = check_version_match(source_dir)
+
+    if not match and source is not None:
+        raise RuntimeError(
+            f"Version mismatch: installed {installed} != source {source}. "
+            f"Run 'pipx install --force .' or 'pip install -e .[dev]' to update."
+        )

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -1,0 +1,243 @@
+"""Tests for the kicad_tools.dev module - version mismatch detection."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestGetInstalledVersion:
+    """Tests for get_installed_version function."""
+
+    def test_returns_version_string(self):
+        """Should return a version string when package is installed."""
+        from kicad_tools.dev import get_installed_version
+
+        version = get_installed_version()
+        # Version should be a string (could be actual version or "unknown")
+        assert isinstance(version, str)
+
+    def test_returns_unknown_on_import_error(self):
+        """Should return 'unknown' if importlib.metadata fails."""
+        from kicad_tools.dev import get_installed_version
+
+        # Patch the version function at the point where it's used
+        with patch("importlib.metadata.version", side_effect=Exception("fail")):
+            version = get_installed_version()
+            assert version == "unknown"
+
+
+class TestGetSourceVersion:
+    """Tests for get_source_version function."""
+
+    def test_finds_source_version_from_pyproject(self, tmp_path: Path):
+        """Should read version from pyproject.toml."""
+        from kicad_tools.dev import get_source_version
+
+        # Create a mock pyproject.toml
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            """
+[project]
+name = "test-project"
+version = "1.2.3"
+"""
+        )
+
+        version = get_source_version(tmp_path)
+        assert version == "1.2.3"
+
+    def test_returns_none_when_no_pyproject(self, tmp_path: Path):
+        """Should return None if pyproject.toml doesn't exist."""
+        from kicad_tools.dev import get_source_version
+
+        version = get_source_version(tmp_path)
+        assert version is None
+
+    def test_returns_none_on_parse_error(self, tmp_path: Path):
+        """Should return None if pyproject.toml is invalid."""
+        from kicad_tools.dev import get_source_version
+
+        # Create invalid TOML
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("this is not valid toml {{{")
+
+        version = get_source_version(tmp_path)
+        assert version is None
+
+
+class TestCheckVersionMatch:
+    """Tests for check_version_match function."""
+
+    def test_returns_true_when_versions_match(self, tmp_path: Path):
+        """Should return match=True when versions are the same."""
+        from kicad_tools.dev import check_version_match, get_installed_version
+
+        # Create pyproject.toml with same version as installed
+        installed = get_installed_version()
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            f"""
+[project]
+name = "kicad-tools"
+version = "{installed}"
+"""
+        )
+
+        match, inst_ver, src_ver = check_version_match(tmp_path)
+        assert match is True
+        assert inst_ver == installed
+        assert src_ver == installed
+
+    def test_returns_false_when_versions_differ(self, tmp_path: Path):
+        """Should return match=False when versions differ."""
+        from kicad_tools.dev import check_version_match
+
+        # Create pyproject.toml with different version
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            """
+[project]
+name = "kicad-tools"
+version = "99.99.99"
+"""
+        )
+
+        match, inst_ver, src_ver = check_version_match(tmp_path)
+        assert match is False
+        assert src_ver == "99.99.99"
+
+    def test_returns_true_when_source_not_found(self, tmp_path: Path):
+        """Should return match=True when source dir has no pyproject.toml."""
+        from kicad_tools.dev import check_version_match
+
+        # Empty directory - no pyproject.toml
+        match, inst_ver, src_ver = check_version_match(tmp_path)
+        assert match is True
+        assert src_ver is None
+
+
+class TestWarnIfStale:
+    """Tests for warn_if_stale function."""
+
+    def test_returns_true_when_versions_match(self, tmp_path: Path, capsys):
+        """Should return True and not print warning when versions match."""
+        from kicad_tools import dev
+        from kicad_tools.dev import get_installed_version, warn_if_stale
+
+        # Reset warning state
+        dev._warned = False
+
+        # Create pyproject.toml with same version as installed
+        installed = get_installed_version()
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            f"""
+[project]
+name = "kicad-tools"
+version = "{installed}"
+"""
+        )
+
+        result = warn_if_stale(tmp_path)
+        assert result is True
+
+        captured = capsys.readouterr()
+        assert "mismatch" not in captured.err.lower()
+
+    def test_returns_false_and_warns_when_mismatch(self, tmp_path: Path, capsys):
+        """Should return False and print warning when versions differ."""
+        from kicad_tools import dev
+        from kicad_tools.dev import warn_if_stale
+
+        # Reset warning state
+        dev._warned = False
+
+        # Create pyproject.toml with different version
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            """
+[project]
+name = "kicad-tools"
+version = "99.99.99"
+"""
+        )
+
+        result = warn_if_stale(tmp_path)
+        assert result is False
+
+        captured = capsys.readouterr()
+        assert "mismatch" in captured.err.lower()
+        assert "99.99.99" in captured.err
+
+    def test_only_warns_once_without_force(self, tmp_path: Path, capsys):
+        """Should only warn once unless force=True."""
+        from kicad_tools import dev
+        from kicad_tools.dev import warn_if_stale
+
+        # Reset warning state
+        dev._warned = False
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            """
+[project]
+name = "kicad-tools"
+version = "99.99.99"
+"""
+        )
+
+        # First call should warn
+        warn_if_stale(tmp_path)
+        captured1 = capsys.readouterr()
+        assert "mismatch" in captured1.err.lower()
+
+        # Second call should not warn (already warned)
+        warn_if_stale(tmp_path)
+        captured2 = capsys.readouterr()
+        assert "mismatch" not in captured2.err.lower()
+
+        # With force=True, should warn again
+        warn_if_stale(tmp_path, force=True)
+        captured3 = capsys.readouterr()
+        assert "mismatch" in captured3.err.lower()
+
+
+class TestRequireSourceVersion:
+    """Tests for require_source_version function."""
+
+    def test_does_not_raise_when_versions_match(self, tmp_path: Path):
+        """Should not raise when versions match."""
+        from kicad_tools.dev import get_installed_version, require_source_version
+
+        installed = get_installed_version()
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            f"""
+[project]
+name = "kicad-tools"
+version = "{installed}"
+"""
+        )
+
+        # Should not raise
+        require_source_version(tmp_path)
+
+    def test_raises_when_versions_differ(self, tmp_path: Path):
+        """Should raise RuntimeError when versions differ."""
+        from kicad_tools.dev import require_source_version
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            """
+[project]
+name = "kicad-tools"
+version = "99.99.99"
+"""
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            require_source_version(tmp_path)
+
+        assert "mismatch" in str(exc_info.value).lower()
+        assert "99.99.99" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- Adds `kicad_tools.dev` module with utilities to detect version mismatches between pipx-installed and source versions
- Updates board generation scripts to warn users when versions are out of sync
- Documents the pipx vs source conflict in the development guide

## Changes

- **New module `src/kicad_tools/dev.py`**: Provides `warn_if_stale()`, `check_version_match()`, and `require_source_version()` functions
- **Updated board scripts**: Added version warning at import time to 7 board generation scripts
- **Documentation**: Added "Pipx vs Source Conflicts" section to `docs/contributing/development.md`
- **Tests**: Comprehensive test coverage for the new dev module (13 tests)

## Test Plan

- [x] All dev module tests pass (`pytest tests/test_dev.py -v`)
- [x] Lint checks pass for new/modified files
- [x] Format checks pass

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)