### PR TITLE
fix(optimizer): Prevent 45-degree chamfer from creating trace gaps

### DIFF
--- a/src/kicad_tools/router/optimizer/algorithms.py
+++ b/src/kicad_tools/router/optimizer/algorithms.py
@@ -453,9 +453,19 @@ def convert_corners_45(
 
             # Handle corner with next segment
             if is_90_degree_corner(seg, next_seg):
-                shortened = shorten_segment_end(modified_seg, chamfer, config.min_segment_length)
-                if shortened:
-                    modified_seg = shortened
+                # Only shorten if next segment can also be shortened for the chamfer.
+                # If next segment is too short (e.g., final approach to a pad),
+                # don't create a partial chamfer that would leave a gap.
+                next_can_shorten = (
+                    shorten_segment_start(next_seg, chamfer, config.min_segment_length)
+                    is not None
+                )
+                if next_can_shorten:
+                    shortened = shorten_segment_end(
+                        modified_seg, chamfer, config.min_segment_length
+                    )
+                    if shortened:
+                        modified_seg = shortened
 
             result.append(modified_seg)
 


### PR DESCRIPTION
## Summary
- Fixes issue where autorouter reports SUCCESS but creates disconnected traces with 0.5mm gaps
- Root cause: `convert_corners_45` optimizer shortened segments at 90-degree corners without checking if the adjacent segment could also be shortened
- When the adjacent segment was too short (e.g., a final 0.02mm approach to a pad), the chamfer left a 0.5mm gap

## Root Cause Analysis
The 45-degree corner conversion works by:
1. Shortening the first segment's end by `corner_chamfer_size` (0.5mm default)
2. Shortening the next segment's start by the same amount
3. Adding a 45-degree chamfer segment between them

The bug occurred when the next segment was too short to be shortened (e.g., only 0.02mm long). The code would:
1. Shorten the first segment by 0.5mm ✓
2. Fail to shorten the next segment (too short) ✗
3. Skip adding the chamfer segment ✗
4. Result: 0.5mm gap between segments

## Fix
Before shortening a segment's end for a corner with the next segment, verify the next segment can also be shortened. If not, skip the chamfer entirely to preserve trace continuity.

## Test plan
- [x] Reproduced bug with `boards/00-simple-led` - `net-status` showed 2 incomplete nets
- [x] Verified fix - all 3 nets now complete
- [x] All 58 trace optimizer tests pass
- [x] Router tests pass (1 pre-existing failure unrelated to this change)

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)