### PR TITLE
fix(spec): Quote checklist items in simple-led to fix YAML parsing (#746)

### DIFF
--- a/boards/00-simple-led/project.kct
+++ b/boards/00-simple-led/project.kct
@@ -64,7 +64,7 @@ decisions:
 progress:
   phase: complete
   checklist:
-    - [x] Schematic generation
-    - [x] PCB layout
-    - [x] Autorouting
-    - [x] DRC verification
+    - "[x] Schematic generation"
+    - "[x] PCB layout"
+    - "[x] Autorouting"
+    - "[x] DRC verification"


### PR DESCRIPTION
## Summary

Fix YAML parsing error in `boards/00-simple-led/project.kct` by quoting the checklist items.

The markdown-style checklist syntax `- [x] Item` was invalid YAML because YAML interprets `[x]` as a list syntax. This caused `kct spec validate` to fail with:

```
Parse error: Invalid YAML in boards/00-simple-led/project.kct: while parsing a block collection
  expected <block end>, but found '<scalar>'
```

## Changes

- Quote checklist items as `- "[x] Item"` to match the format used in other project.kct files

## Test Plan

- [x] Verify `kct spec validate boards/00-simple-led/project.kct` no longer fails with YAML parsing error
- [x] Confirm other project.kct files still validate (they already use quoted strings)

Closes #746