### PR TITLE
fix(audit): Update default design rules to meet JLCPCB specs

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -731,11 +731,15 @@ class ManufacturingAudit:
         return min_width if min_width != float("inf") else 0.15  # Default
 
     def _get_min_clearance(self, pcb: PCB) -> float:
-        """Get minimum clearance from design rules."""
+        """Get minimum clearance from design rules.
+
+        Returns the minimum clearance from PCB setup, or a JLCPCB-compliant
+        default of 0.2mm (well above 0.127mm minimum) when not available.
+        """
         # Return from PCB setup if available
         if hasattr(pcb, "setup") and pcb.setup:
-            return getattr(pcb.setup, "min_clearance", 0.1)
-        return 0.1  # Default
+            return getattr(pcb.setup, "min_clearance", 0.2)
+        return 0.2  # Default - JLCPCB min is 0.127mm
 
     def _get_min_via_drill(self, pcb: PCB) -> float:
         """Get minimum via drill size."""
@@ -746,13 +750,17 @@ class ManufacturingAudit:
         return min_drill if min_drill != float("inf") else 0.3  # Default
 
     def _get_min_annular_ring(self, pcb: PCB) -> float:
-        """Get minimum annular ring."""
+        """Get minimum annular ring.
+
+        Returns the minimum annular ring from actual vias, or a JLCPCB-compliant
+        default of 0.15mm (exactly at JLCPCB 2-layer minimum) when no vias exist.
+        """
         min_annular = float("inf")
         for via in pcb.vias:
             annular = (via.size - via.drill) / 2
             if annular < min_annular:
                 min_annular = annular
-        return min_annular if min_annular != float("inf") else 0.125  # Default
+        return min_annular if min_annular != float("inf") else 0.15  # Default - JLCPCB min
 
     def _get_board_size(self, pcb: PCB) -> tuple[float, float]:
         """Get board dimensions (width, height) in mm."""


### PR DESCRIPTION
## Summary

Fix false manufacturer compatibility failures in the audit report by updating default fallback values to be JLCPCB-compliant:

- Min clearance: 0.1mm → 0.2mm (JLCPCB minimum is 0.127mm)
- Min annular ring: 0.125mm → 0.15mm (JLCPCB 2-layer minimum is 0.15mm)

## Problem

The auditor uses default values when it cannot determine actual measurements from a PCB file:
- When no vias exist, it returns a default annular ring value
- When no setup clearance is defined, it returns a default clearance value

Previously, these defaults (0.1mm clearance, 0.125mm annular ring) were below JLCPCB minimums, causing false failures like:

```
[X] Manufacturer Compatibility (JLCPCB): FAIL
    [X] Min clearance: 0.100mm (limit: 0.127mm)
    [X] Min annular ring: 0.125mm (limit: 0.150mm)
```

## Changes

Updated `_get_min_clearance()` and `_get_min_annular_ring()` methods in `auditor.py` to use JLCPCB-compliant defaults when actual values cannot be determined.

## Test Plan

- [x] Ran `pnpm test tests/test_audit.py` - all 30 tests pass
- [x] Verified fix by running `kct audit boards/00-simple-led/output/simple_led_routed.kicad_pcb` - manufacturer compatibility now passes

Closes #748