### PR TITLE
fix(boards): Correct artifact paths in simple-led project.kct

### DIFF
--- a/boards/00-simple-led/project.kct
+++ b/boards/00-simple-led/project.kct
@@ -9,7 +9,8 @@ project:
     the complete kicad-tools workflow with just 3 components.
   artifacts:
     schematic: "output/simple_led.kicad_sch"
-    pcb: "output/simple_led_routed.kicad_pcb"
+    pcb: "output/simple_led.kicad_pcb"
+    pcb_routed: "output/simple_led_routed.kicad_pcb"
 
 intent:
   summary: |


### PR DESCRIPTION
## Summary

Fix incorrect artifact paths in `boards/00-simple-led/project.kct`:
- Change `pcb` to point to unrouted file (`simple_led.kicad_pcb`)
- Add explicit `pcb_routed` field for consistency with `01-voltage-divider`

## Changes

Before:
```yaml
artifacts:
  schematic: "output/simple_led.kicad_sch"
  pcb: "output/simple_led_routed.kicad_pcb"
```

After:
```yaml
artifacts:
  schematic: "output/simple_led.kicad_sch"
  pcb: "output/simple_led.kicad_pcb"
  pcb_routed: "output/simple_led_routed.kicad_pcb"
```

## Test Plan

- [x] Verified format matches `boards/01-voltage-divider/project.kct`
- [x] Configuration file syntax is valid YAML

Closes #757