### PR TITLE
fix(cli): Expose --force flag in route command help

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -98,6 +98,8 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--power-nets", args.power_nets])
     if getattr(args, "layers", "auto") != "auto":
         sub_argv.extend(["--layers", args.layers])
+    if getattr(args, "force", False):
+        sub_argv.append("--force")
     if getattr(args, "no_optimize", False):
         sub_argv.append("--no-optimize")
     return route_main(sub_argv)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -804,6 +804,11 @@ def _add_route_parser(subparsers) -> None:
         ),
     )
     route_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force routing even when grid > clearance (may cause DRC violations)",
+    )
+    route_parser.add_argument(
         "--no-optimize",
         action="store_true",
         help="Skip trace optimization (keep raw grid-step segments)",


### PR DESCRIPTION
## Summary

Fix the route command to expose the `--force` flag through the main CLI parser. The flag was defined in the internal parser (`route_cmd.py`) but not exposed through the main CLI interface, making it invisible in `--help` output and unusable.

## Changes

- Add `--force` argument to `_add_route_parser` in `parser.py`
- Add `--force` passthrough in `run_route_command` in `commands/routing.py`

## Test Plan

- Verified `--force` now appears in `kct route --help`
- Verified error is shown without `--force` when grid > clearance
- Verified warning is shown with `--force` when grid > clearance
- Ran linting checks on modified files

Closes #761