### PR TITLE
fix(build): Warn when schematic-PCB sync check is skipped

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -680,6 +680,26 @@ def _run_step_verify(ctx: BuildContext, console: Console) -> BuildResult:
                 sync_message = " (sync check found mismatches)"
             else:
                 sync_message = " (sync OK)"
+        else:
+            # Sync check was skipped - determine why and inform user
+            spec_defines_schematic = (
+                ctx.spec
+                and ctx.spec.project.artifacts
+                and ctx.spec.project.artifacts.schematic
+            )
+
+            if spec_defines_schematic:
+                # Spec defines a schematic but it wasn't found - always warn
+                expected_path = ctx.spec.project.artifacts.schematic
+                if not ctx.quiet:
+                    console.print(
+                        f"  [yellow]⚠[/yellow] Skipping sync check: "
+                        f"schematic '{expected_path}' not found"
+                    )
+                sync_message = " (sync skipped: schematic not found)"
+            elif ctx.verbose:
+                # No schematic defined in spec and verbose mode - inform user
+                console.print("  [dim]Skipping sync check: no schematic available[/dim]")
 
         return BuildResult(
             step="verify",


### PR DESCRIPTION
## Summary
- Adds clear feedback when schematic-PCB sync check is skipped during `kct build --step verify`
- If spec defines a schematic path but file isn't found: shows warning message
- If no schematic available and verbose mode: shows info message

Closes #759

## Test plan
- [x] Run `kct build boards/01-voltage-divider --step verify` to verify sync check still runs normally
- [x] Run existing tests (`pytest tests/test_build_routing_params.py tests/test_cli_commands.py tests/test_validate.py`)
- [ ] Test with a project where spec defines schematic that doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)