### PR TITLE
fix(router): Fix negotiated routing losing nets during escape strategies

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -901,15 +901,15 @@ class Autorouter:
         present_factor = initial_present_factor
         timed_out = False
 
-        # For targeted rip-up: build pads_by_net mapping and track ripup history
+        # Build pads_by_net mapping for escape strategies and targeted rip-up
+        # (Issue #762: escape strategies need this even when use_targeted_ripup=False)
         pads_by_net: dict[int, list[Pad]] = {}
         ripup_history: dict[int, int] = {}
-        if use_targeted_ripup:
-            for net in net_order:
-                if net in self.nets:
-                    pads_for_routing = self.nets[net]
-                    if len(pads_for_routing) >= 2:
-                        pads_by_net[net] = [self.pads[p] for p in pads_for_routing]
+        for net in net_order:
+            if net in self.nets:
+                pads_for_routing = self.nets[net]
+                if len(pads_for_routing) >= 2:
+                    pads_by_net[net] = [self.pads[p] for p in pads_for_routing]
 
         def check_timeout() -> bool:
             """Check if timeout has been reached."""


### PR DESCRIPTION
## Summary

- Fixed negotiated routing escape strategies losing nets during rip-up and reroute
- Escape strategies now correctly track whether all nets were successfully re-routed
- `pads_by_net` mapping is now always populated, not just when `use_targeted_ripup=True`

## Root Cause

Two bugs in the negotiated congestion router's escape strategies:

1. **Missing pad data**: `pads_by_net` was only populated when `use_targeted_ripup=True`, but escape strategies need this mapping regardless. Without it, nets couldn't be re-routed after being ripped up.

2. **False success reporting**: Escape strategies only checked if overflow decreased, without verifying that all ripped-up nets were re-routed. This meant the router could "successfully" reduce overflow by simply not re-routing a net.

## Changes

- `core.py:904-912`: Always populate `pads_by_net` mapping for all nets
- `negotiated.py`: All three escape strategies now track reroute success count and only report success when ALL nets are re-routed AND overflow improves

## Test Results

**Before fix:**
```
=== Negotiated Routing Complete ===
  Total nets: 3
  Successful: 2  ← Lost a net!
  Final overflow: 0
Routes: 2, Nets routed: 2
```

**After fix:**
```
=== Negotiated Routing Complete ===
  Total nets: 3
  Successful: 3  ← All nets routed
  Final overflow: 1
Routes: 4, Nets routed: 3
```

## Test plan

- [x] Router tests pass (466 passed, 1 pre-existing failure unrelated to this change)
- [x] Lint checks pass for modified files
- [x] Verified fix with voltage divider board routing

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)