### PR TITLE
fix(schematic): Place OSC_IN/OSC_OUT labels at wire start points

### DIFF
--- a/boards/04-stm32-devboard/design.py
+++ b/boards/04-stm32-devboard/design.py
@@ -184,12 +184,14 @@ def create_stm32_devboard(output_dir: Path) -> None:
     xtal.connect_to_rails(gnd_rail_y=RAIL_GND)
 
     # Add labels for oscillator connections
+    # Labels must be placed at wire start points (port positions) to avoid ERC errors.
+    # Placing labels at offset endpoints causes "label not on wire" warnings.
     in_pos = xtal.port("IN")
     out_pos = xtal.port("OUT")
-    sch.add_label("OSC_IN", in_pos[0] - 10, in_pos[1], rotation=0)
     sch.add_wire(in_pos, (in_pos[0] - 10, in_pos[1]))
-    sch.add_label("OSC_OUT", out_pos[0] + 10, out_pos[1], rotation=0)
+    sch.add_label("OSC_IN", in_pos[0], in_pos[1], rotation=0)
     sch.add_wire(out_pos, (out_pos[0] + 10, out_pos[1]))
+    sch.add_label("OSC_OUT", out_pos[0], out_pos[1], rotation=0)
     print("   Added OSC_IN and OSC_OUT labels")
 
     # =========================================================================


### PR DESCRIPTION
## Summary

Fix label placement in STM32 devboard schematic to avoid ERC warnings. Labels for OSC_IN and OSC_OUT were placed at offset positions that didn't coincide with wires, causing "label not on wire" warnings during validation.

## Changes

- Place OSC_IN label at the IN port position (wire start) instead of offset endpoint
- Place OSC_OUT label at the OUT port position (wire start) instead of offset endpoint
- Add explanatory comments about label placement requirements

## Test Plan

- [x] Ran `design.py` - OSC_IN/OSC_OUT label warnings no longer appear
- [x] Verified schematic generates with correct labels
- [x] Ran schematic tests - all pass

Closes #792