### PR TITLE
fix(designer): Change default trace_clearance from 0.15mm to 0.2mm

### DIFF
--- a/boards/03-usb-joystick/route_demo.py
+++ b/boards/03-usb-joystick/route_demo.py
@@ -83,7 +83,7 @@ def _get_routing_params() -> dict[str, float]:
     return {
         "grid_resolution": float(os.environ.get("KCT_ROUTE_GRID", "0.1")),
         "trace_width": float(os.environ.get("KCT_ROUTE_TRACE_WIDTH", "0.2")),
-        "trace_clearance": float(os.environ.get("KCT_ROUTE_CLEARANCE", "0.15")),
+        "trace_clearance": float(os.environ.get("KCT_ROUTE_CLEARANCE", "0.2")),
         "via_drill": float(os.environ.get("KCT_ROUTE_VIA_DRILL", "0.3")),
         "via_diameter": float(os.environ.get("KCT_ROUTE_VIA_DIAMETER", "0.6")),
     }


### PR DESCRIPTION
## Summary

Fix GridResolutionError when running route_demo.py standalone for the USB joystick board.

The USB joystick route_demo.py had incompatible default parameters:
- `grid_resolution`: 0.1mm
- `trace_clearance`: 0.15mm

The router validator requires `grid_resolution <= clearance/2`, meaning 0.1mm grid needs clearance >= 0.2mm. This caused `GridResolutionError` when running route_demo.py standalone (without `kct build` passing compatible parameters via environment variables).

## Changes

- Changed default `trace_clearance` from 0.15mm to 0.2mm in `boards/03-usb-joystick/route_demo.py`
- This satisfies the constraint: 0.1mm <= 0.2mm/2 = 0.1mm
- Matches the charlieplex-led board's route_demo.py which already had the correct 0.2mm default

## Test Plan

- [x] Verified parameters are compatible: `grid (0.1) <= clearance/2 (0.1)`
- [x] Routing params tests pass: `pytest tests/test_build_routing_params.py`

Closes #794