### PR TITLE
fix(dx): Auto-detect directory argument in generate_schematic.py

### DIFF
--- a/boards/02-charlieplex-led/generate_schematic.py
+++ b/boards/02-charlieplex-led/generate_schematic.py
@@ -239,7 +239,7 @@ def main():
         "output",
         nargs="?",
         default=None,
-        help="Output file path (default: output/charlieplex_3x3.kicad_sch)",
+        help="Output file path or directory (default: output/charlieplex_3x3.kicad_sch)",
     )
     parser.add_argument(
         "-v",
@@ -250,10 +250,17 @@ def main():
 
     args = parser.parse_args()
 
+    # Default output filename
+    default_filename = "charlieplex_3x3.kicad_sch"
+
     if args.output:
         output_path = Path(args.output)
+        # If user passes a directory, auto-append the default filename
+        if output_path.is_dir():
+            output_path = output_path / default_filename
+            print(f"Note: Directory provided, using {output_path}")
     else:
-        output_path = Path(__file__).parent / "output" / "charlieplex_3x3.kicad_sch"
+        output_path = Path(__file__).parent / "output" / default_filename
 
     try:
         success = create_charlieplex_schematic(output_path, verbose=args.verbose)

--- a/boards/03-usb-joystick/README.md
+++ b/boards/03-usb-joystick/README.md
@@ -86,7 +86,22 @@ This design demonstrates routing of different signal classes:
 
 For more control over individual steps, you can run Python scripts directly.
 
-### Step 1: Generate the PCB
+### Step 1: Generate the Schematic
+
+```bash
+# Default output (recommended)
+python3 generate_schematic.py
+
+# Or specify an output directory (auto-appends filename)
+python3 generate_schematic.py output/
+
+# Or specify an explicit file path
+python3 generate_schematic.py output/usb_joystick.kicad_sch
+```
+
+Creates `output/usb_joystick.kicad_sch` with all components and wiring.
+
+### Step 2: Generate the PCB
 
 ```bash
 python3 generate_pcb.py
@@ -94,7 +109,7 @@ python3 generate_pcb.py
 
 Creates `output/usb_joystick.kicad_pcb` with all components placed and nets defined.
 
-### Step 2: Run the Autorouter
+### Step 3: Run the Autorouter
 
 ```bash
 python3 route_demo.py
@@ -111,7 +126,7 @@ signal types. The autorouter demonstrates its capabilities but may not complete 
 routes on a 2-layer board. This is realistic for complex designs requiring manual
 intervention or additional layers.
 
-### Step 3: View in KiCad (Optional)
+### Step 4: View in KiCad (Optional)
 
 Open `usb_joystick_routed.kicad_pcb` in KiCad to visualize the routes.
 

--- a/boards/03-usb-joystick/generate_schematic.py
+++ b/boards/03-usb-joystick/generate_schematic.py
@@ -464,7 +464,7 @@ def main():
         "output",
         nargs="?",
         default=None,
-        help="Output file path (default: output/usb_joystick.kicad_sch)",
+        help="Output file path or directory (default: output/usb_joystick.kicad_sch)",
     )
     parser.add_argument(
         "-v",
@@ -475,10 +475,17 @@ def main():
 
     args = parser.parse_args()
 
+    # Default output filename
+    default_filename = "usb_joystick.kicad_sch"
+
     if args.output:
         output_path = Path(args.output)
+        # If user passes a directory, auto-append the default filename
+        if output_path.is_dir():
+            output_path = output_path / default_filename
+            print(f"Note: Directory provided, using {output_path}")
     else:
-        output_path = Path(__file__).parent / "output" / "usb_joystick.kicad_sch"
+        output_path = Path(__file__).parent / "output" / default_filename
 
     try:
         success = create_usb_joystick_schematic(output_path, verbose=args.verbose)


### PR DESCRIPTION
## Summary

Improves developer experience for `generate_schematic.py` by auto-detecting when a directory path is passed as the output argument and automatically appending the default filename.

**Before**: Passing `output/` would run all the way through schematic generation before failing with `IsADirectoryError` at the final write step.

**After**: Passing `output/` is detected early and the default filename is auto-appended, with an informative note printed to the user.

## Changes

- **boards/03-usb-joystick/generate_schematic.py**: Add early directory detection with auto-append
- **boards/02-charlieplex-led/generate_schematic.py**: Apply same fix for consistency
- **boards/03-usb-joystick/README.md**: Update documentation with clearer usage examples

## Test Plan

- [x] Verified directory argument detection works: `python generate_schematic.py output/` now succeeds
- [x] Verified explicit file path still works: `python generate_schematic.py output/usb_joystick.kicad_sch`
- [x] Verified default (no argument) still works: `python generate_schematic.py`
- [x] Ruff lint passes on modified files
- [x] Ruff format passes on modified files

Closes #796