### PR TITLE
feat(schematic): Add motor control blocks for power electronics design

### DIFF
--- a/boards/05-bldc-motor-controller/README.md
+++ b/boards/05-bldc-motor-controller/README.md
@@ -1,0 +1,182 @@
+# BLDC Motor Controller
+
+Three-phase brushless DC motor controller for validating kicad-tools thermal analysis, zone generation, and high-current routing capabilities.
+
+## Quick Start
+
+```bash
+# Build schematic (PCB layout not yet implemented)
+kct build boards/05-bldc-motor-controller --step schematic
+
+# Or run directly
+uv run python boards/05-bldc-motor-controller/design.py
+```
+
+> **Status**: Schematic generation implemented. PCB layout and routing pending.
+
+## Overview
+
+This board drives a 3-phase BLDC motor with:
+
+- **Input**: 12-24V DC, up to 15A
+- **Output**: 3-phase to motor, 10A continuous per phase
+- **Control**: STM32G4 MCU with hardware PWM
+- **Feedback**: Hall sensor inputs, phase current sensing
+
+## Block Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│  12-24V ──┬── Buck ── 5V ── LDO ── 3.3V ── MCU                 │
+│           │           │                      │                  │
+│           │           └─── Gate Driver ◄─────┘                  │
+│           │                    │                                │
+│           │            ┌───────┴───────┐                        │
+│           │            │   HS    HS    HS  │  Half-bridges     │
+│           └────────────┤   LS    LS    LS  │  (6 MOSFETs)      │
+│                        │   │     │     │   │                    │
+│                        │  Shunt Shunt Shunt│  Current sense    │
+│                        └───┴─────┴─────┴───┘                    │
+│                             │     │     │                       │
+│                             U     V     W ─── Motor             │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Components (~42 total)
+
+| Section | Key Components | Count |
+|---------|----------------|-------|
+| Power Input | J1 screw terminal, F1 fuse, D1 TVS, C1-C3 bulk caps | 5 |
+| 5V Supply | U1 LM2596, L1 inductor, D2 Schottky, C4-C5 | 5 |
+| 3.3V Supply | U2 AMS1117, C6-C7 | 3 |
+| MCU | U3 STM32G431, C8-C11 bypass, Y1 crystal | 6 |
+| Gate Driver | U4 DRV8301, C12-C17 bootstrap/bypass | 8 |
+| Power Stage | Q1-Q6 MOSFETs (3 half-bridges) | 6 |
+| Current Sense | R1-R3 shunts, U5 amplifier, C18 | 5 |
+| Connectors | J2 motor, J3 hall, J4 SWD, J5 aux | 4 |
+
+## Design Challenges
+
+This board exercises kicad-tools capabilities that simpler boards don't:
+
+### 1. Thermal Management
+
+- 6 power MOSFETs dissipating 1-2W each at full load
+- Requires thermal vias under each MOSFET
+- Ground plane for heat spreading
+- Tests `ThermalAnalyzer` hotspot detection
+
+### 2. High-Current Traces
+
+- Motor phase traces carry 10A continuous
+- Requires 2mm+ trace width or polygon pours
+- Power input traces carry 15A
+- Tests net class differentiation
+
+### 3. Zone Generation
+
+- Ground plane on bottom layer
+- Motor power island on top layer
+- Thermal relief patterns
+- Tests `ZoneGenerator` API
+
+### 4. Multiple Power Domains
+
+- VMOTOR: 12-24V (motor power)
+- VDD_5V: 5V (gate drivers)
+- VDD_3V3: 3.3V (MCU, logic)
+- Requires careful power routing
+
+### 5. Mixed Signal Routing
+
+- High-side gate drive (bootstrap)
+- Low-noise current sense signals
+- Fast PWM switching nodes
+- Separation between power and signal
+
+## Schematic Organization
+
+The schematic is organized into functional sections:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         TITLE BLOCK                             │
+├───────────────────┬───────────────────┬─────────────────────────┤
+│   POWER INPUT     │   POWER SUPPLY    │         MCU             │
+│   (12-24V DC)     │   (Buck + LDO)    │     (STM32G431)         │
+├───────────────────┴───────────────────┴─────────────────────────┤
+│                      GATE DRIVER (DRV8301)                      │
+├─────────────────────────────────────────────────────────────────┤
+│   PHASE A         │    PHASE B        │      PHASE C            │
+│   (HS + LS FET)   │    (HS + LS FET)  │      (HS + LS FET)      │
+├─────────────────────────────────────────────────────────────────┤
+│                    CURRENT SENSING                              │
+├─────────────────────────────────────────────────────────────────┤
+│   CONNECTORS: Motor Output, Hall Sensors, Debug, Power         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## PCB Layout Guidelines
+
+### Power Stage Placement
+
+```
+        Motor Connector (J2)
+             │ │ │
+        ┌────┴─┴─┴────┐
+        │ Q1   Q3   Q5 │  High-side MOSFETs
+        │ Q2   Q4   Q6 │  Low-side MOSFETs
+        │ R1   R2   R3 │  Shunt resistors
+        └──────────────┘
+             │
+        Input Connector (J1)
+```
+
+### Thermal Via Pattern
+
+Each MOSFET pad should have thermal vias:
+```
+┌─────────────────┐
+│  ● ● ● ● ● ●   │  ● = thermal via (0.3mm drill)
+│  ● ● ● ● ● ●   │  Min 6 vias per MOSFET
+│  ● ● ● ● ● ●   │  Connected to ground plane
+└─────────────────┘
+```
+
+### Trace Width Requirements
+
+| Net Class | Min Width | Current |
+|-----------|-----------|---------|
+| Motor Phase | 2.0mm | 10A |
+| Power Input | 2.5mm | 15A |
+| Gate Drive | 0.4mm | 0.5A |
+| Signal | 0.2mm | mA |
+
+## Testing kicad-tools Features
+
+After generating the board, run these analyses:
+
+```bash
+# Thermal analysis
+kct analyze thermal output/bldc_controller.kicad_pcb
+
+# Check net classes
+kct analyze nets output/bldc_controller.kicad_pcb
+
+# Validate DRC with 2oz copper
+kct check output/bldc_controller_routed.kicad_pcb --copper-weight 2oz
+```
+
+## Future Enhancements
+
+- [ ] Add regenerative braking support
+- [ ] Add encoder input (differential)
+- [ ] Add CAN bus interface
+- [ ] 4-layer version with dedicated power planes
+
+## Related Examples
+
+- [examples/07-design-feedback/thermal_demo.py](../../examples/07-design-feedback/thermal_demo.py) - Thermal analysis API
+- [boards/04-stm32-devboard](../04-stm32-devboard/) - MCU schematic patterns

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""
+BLDC Motor Controller - Schematic Generation
+
+This script demonstrates creating a power electronics schematic with:
+1. Multi-voltage power supply (12-24V → 5V → 3.3V)
+2. Gate driver for 3-phase motor control
+3. Power MOSFET half-bridges
+4. Current sensing with shunt resistors
+5. MCU for motor control
+
+The design exercises kicad-tools thermal analysis and high-current
+routing capabilities.
+
+Usage:
+    python design.py [output_dir]
+
+If no output directory is specified, files are written to ./output/
+"""
+
+import sys
+from pathlib import Path
+
+from kicad_tools.dev import warn_if_stale
+from kicad_tools.schematic.blocks import (
+    CrystalOscillator,
+    CurrentSenseShunt,
+    DebugHeader,
+    DecouplingCaps,
+    GateDriverBlock,
+    LEDIndicator,
+    ThreePhaseInverter,
+)
+from kicad_tools.schematic.models.schematic import Schematic
+
+# Warn if running source scripts with stale pipx install
+warn_if_stale()
+
+
+def create_bldc_controller(output_dir: Path) -> None:
+    """
+    Create a BLDC motor controller schematic.
+
+    This demonstrates power electronics design patterns:
+    - High-current power input with protection
+    - Multi-stage power supply (buck + LDO)
+    - 3-phase gate driver
+    - Power MOSFET half-bridges
+    - Current sensing for closed-loop control
+    """
+    print("Creating BLDC Motor Controller schematic...")
+    print("=" * 60)
+
+    # Create schematic with title block
+    sch = Schematic(
+        title="BLDC Motor Controller",
+        date="2025-01",
+        revision="A",
+        company="kicad-tools Example",
+        comment1="3-Phase Brushless DC Motor Driver",
+        comment2="Thermal analysis and high-current routing demo",
+    )
+
+    # Define power rail Y coordinates
+    RAIL_VMOTOR = 25  # 12-24V motor power
+    RAIL_5V = 45  # 5V gate driver supply
+    RAIL_3V3 = 65  # 3.3V logic supply
+    RAIL_GND = 280  # Ground
+
+    # Schematic section X positions
+    X_POWER_IN = 25  # Power input section
+    X_BUCK = 80  # Buck converter
+    X_LDO = 140  # LDO regulator
+    X_MCU = 200  # MCU section
+    X_GATE_DRV = 280  # Gate driver
+    X_PHASE_A = 25  # Phase A half-bridge
+    X_PHASE_B = 100  # Phase B half-bridge
+    X_PHASE_C = 175  # Phase C half-bridge
+    X_CONNECTORS = 260  # Connectors section
+
+    # Y position for power stage (lower section)
+    Y_POWER_STAGE = 160
+
+    # =========================================================================
+    # Section 1: Power Rails
+    # =========================================================================
+    print("\n1. Creating power rails...")
+
+    # Motor power rail (12-24V)
+    sch.add_rail(RAIL_VMOTOR, x_start=X_POWER_IN, x_end=X_PHASE_C + 60, net_label="VMOTOR")
+    sch.add_power("power:+24V", x=X_POWER_IN, y=RAIL_VMOTOR - 10, rotation=0)
+
+    # 5V rail
+    sch.add_rail(RAIL_5V, x_start=X_BUCK + 25, x_end=X_GATE_DRV + 30, net_label="+5V")
+    sch.add_power("power:+5V", x=X_BUCK + 25, y=RAIL_5V - 10, rotation=0)
+
+    # 3.3V rail
+    sch.add_rail(RAIL_3V3, x_start=X_LDO + 25, x_end=X_MCU + 80, net_label="+3.3V")
+    sch.add_power("power:+3V3", x=X_LDO + 25, y=RAIL_3V3 - 10, rotation=0)
+
+    # Ground rail (spans full width)
+    sch.add_rail(RAIL_GND, x_start=X_POWER_IN, x_end=X_CONNECTORS + 40, net_label="GND")
+    sch.add_power("power:GND", x=X_POWER_IN, y=RAIL_GND + 10, rotation=0)
+
+    print("   Added VMOTOR, +5V, +3.3V, and GND rails")
+
+    # =========================================================================
+    # Section 2: Power Input (12-24V DC)
+    # =========================================================================
+    print("\n2. Adding power input section...")
+
+    # Power input connector (2-pin)
+    j_power = sch.add_symbol(
+        "Connector:Conn_01x02_Pin",
+        x=X_POWER_IN,
+        y=100,
+        ref="J1",
+        value="Power Input",
+    )
+    print(f"   Power connector: {j_power.reference}")
+
+    # Input fuse
+    fuse = sch.add_symbol(
+        "Device:Fuse",
+        x=X_POWER_IN + 20,
+        y=100,
+        ref="F1",
+        value="15A",
+    )
+    print(f"   Fuse: {fuse.reference} = 15A")
+
+    # TVS diode for transient protection
+    tvs = sch.add_symbol(
+        "Device:D_TVS",
+        x=X_POWER_IN + 40,
+        y=120,
+        ref="D1",
+        value="SMBJ24A",
+        rotation=90,
+    )
+    print(f"   TVS diode: {tvs.reference}")
+
+    # Bulk input capacitors
+    c_bulk1 = sch.add_symbol(
+        "Device:C",
+        x=X_POWER_IN + 55,
+        y=120,
+        ref="C1",
+        value="470uF",
+    )
+    c_bulk2 = sch.add_symbol(
+        "Device:C",
+        x=X_POWER_IN + 70,
+        y=120,
+        ref="C2",
+        value="100nF",
+    )
+    print(f"   Bulk caps: {c_bulk1.reference} = 470uF, {c_bulk2.reference} = 100nF")
+
+    # Wire power input to VMOTOR rail
+    # Connector pin 1 → Fuse → TVS/Caps → VMOTOR rail
+    pin1_pos = j_power.pin_position("1")
+    fuse_in = fuse.pin_position("1")
+    fuse_out = fuse.pin_position("2")
+
+    sch.add_wire(pin1_pos, fuse_in)
+    sch.add_wire(fuse_out, (fuse_out[0], RAIL_VMOTOR))
+    sch.add_junction(fuse_out[0], RAIL_VMOTOR)
+
+    # Wire TVS and caps to rails (TVS has pins A1, A2 for bidirectional)
+    tvs_a1 = tvs.pin_position("A1")
+    tvs_a2 = tvs.pin_position("A2")
+    sch.add_wire(tvs_a1, (tvs_a1[0], RAIL_VMOTOR))
+    sch.add_junction(tvs_a1[0], RAIL_VMOTOR)
+    sch.add_wire(tvs_a2, (tvs_a2[0], RAIL_GND))
+    sch.add_junction(tvs_a2[0], RAIL_GND)
+
+    sch.wire_decoupling_cap(c_bulk1, RAIL_VMOTOR, RAIL_GND)
+    sch.wire_decoupling_cap(c_bulk2, RAIL_VMOTOR, RAIL_GND)
+
+    # Connector pin 2 → GND
+    pin2_pos = j_power.pin_position("2")
+    sch.add_wire(pin2_pos, (pin2_pos[0], RAIL_GND))
+    sch.add_junction(pin2_pos[0], RAIL_GND)
+
+    # =========================================================================
+    # Section 3: Buck Converter (24V → 5V)
+    # =========================================================================
+    print("\n3. Adding buck converter (24V → 5V)...")
+
+    # Note: Using simplified buck converter representation
+    # In a real design, use the full LM2596 module schematic
+    sch.add_text(
+        "Buck Converter Module\nLM2596 24V→5V\n(See datasheet for full schematic)",
+        x=X_BUCK,
+        y=95,
+    )
+
+    # Input capacitor (represents buck input)
+    c_buck_in = sch.add_symbol(
+        "Device:C",
+        x=X_BUCK - 15,
+        y=120,
+        ref="C3",
+        value="100uF",
+    )
+
+    # Output capacitor (represents buck output)
+    c_buck_out = sch.add_symbol(
+        "Device:C",
+        x=X_BUCK + 35,
+        y=120,
+        ref="C4",
+        value="220uF",
+    )
+
+    # Inductor for buck
+    inductor = sch.add_symbol(
+        "Device:L",
+        x=X_BUCK + 10,
+        y=100,
+        ref="L1",
+        value="33uH",
+    )
+    print(f"   Buck regulator: L1 + caps (simplified)")
+
+    # Wire inductor to 5V rail (output)
+    l_2 = inductor.pin_position("2")
+    sch.add_wire(l_2, (l_2[0], RAIL_5V))
+    sch.add_junction(l_2[0], RAIL_5V)
+
+    # Wire inductor input side to VMOTOR via text block
+    l_1 = inductor.pin_position("1")
+    sch.add_wire(l_1, (l_1[0], RAIL_VMOTOR))
+    sch.add_junction(l_1[0], RAIL_VMOTOR)
+
+    sch.wire_decoupling_cap(c_buck_in, RAIL_VMOTOR, RAIL_GND)
+    sch.wire_decoupling_cap(c_buck_out, RAIL_5V, RAIL_GND)
+
+    # =========================================================================
+    # Section 4: LDO (5V → 3.3V)
+    # =========================================================================
+    print("\n4. Adding LDO (5V → 3.3V)...")
+
+    ldo = sch.add_symbol(
+        "Regulator_Linear:AMS1117-3.3",
+        x=X_LDO,
+        y=100,
+        ref="U2",
+        value="AMS1117-3.3",
+    )
+    print(f"   LDO: {ldo.reference}")
+
+    # LDO capacitors
+    c_ldo_in = sch.add_symbol(
+        "Device:C",
+        x=X_LDO - 15,
+        y=120,
+        ref="C5",
+        value="10uF",
+    )
+    c_ldo_out = sch.add_symbol(
+        "Device:C",
+        x=X_LDO + 25,
+        y=120,
+        ref="C6",
+        value="10uF",
+    )
+
+    # Wire LDO
+    ldo_vin = ldo.pin_position("VI")
+    ldo_vout = ldo.pin_position("VO")
+    ldo_gnd = ldo.pin_position("GND")
+
+    sch.add_wire(ldo_vin, (ldo_vin[0], RAIL_5V))
+    sch.add_junction(ldo_vin[0], RAIL_5V)
+    sch.add_wire(ldo_vout, (ldo_vout[0], RAIL_3V3))
+    sch.add_junction(ldo_vout[0], RAIL_3V3)
+    sch.add_wire(ldo_gnd, (ldo_gnd[0], RAIL_GND))
+    sch.add_junction(ldo_gnd[0], RAIL_GND)
+
+    sch.wire_decoupling_cap(c_ldo_in, RAIL_5V, RAIL_GND)
+    sch.wire_decoupling_cap(c_ldo_out, RAIL_3V3, RAIL_GND)
+
+    # =========================================================================
+    # Section 5: MCU (STM32G431)
+    # =========================================================================
+    print("\n5. Adding MCU section...")
+
+    # MCU placeholder - STM32G4 for motor control
+    # Note: Full MCU symbol would be added from KiCad library
+    sch.add_text(
+        "MCU: STM32G431KB\n(Add from KiCad library:\nMCU_ST_STM32G4)",
+        x=X_MCU + 30,
+        y=115,
+    )
+    print("   MCU: STM32G431KB (placeholder)")
+
+    # Bypass capacitors for MCU
+    c_mcu1 = sch.add_symbol("Device:C", x=X_MCU, y=100, ref="C7", value="100nF")
+    c_mcu2 = sch.add_symbol("Device:C", x=X_MCU + 10, y=100, ref="C8", value="100nF")
+    c_mcu3 = sch.add_symbol("Device:C", x=X_MCU + 20, y=100, ref="C9", value="4.7uF")
+    print(f"   Bypass caps: {c_mcu1.reference}, {c_mcu2.reference}, {c_mcu3.reference}")
+
+    for cap in [c_mcu1, c_mcu2, c_mcu3]:
+        sch.wire_decoupling_cap(cap, RAIL_3V3, RAIL_GND)
+
+    # Crystal oscillator (8MHz)
+    xtal = CrystalOscillator(
+        sch,
+        x=X_MCU + 70,
+        y=100,
+        frequency="8MHz",
+        load_caps="20pF",
+        ref_prefix="Y",
+        cap_ref_start=10,
+    )
+    xtal.connect_to_rails(gnd_rail_y=RAIL_GND)
+    print(f"   Crystal: {xtal.crystal.reference} 8MHz")
+
+    # Debug header (SWD)
+    debug = DebugHeader(
+        sch,
+        x=X_MCU + 100,
+        y=100,
+        interface="swd",
+        pins=6,
+        ref="J4",
+    )
+    debug.connect_to_rails(vcc_rail_y=RAIL_3V3, gnd_rail_y=RAIL_GND)
+    print(f"   Debug header: {debug.header.reference}")
+
+    # =========================================================================
+    # Section 6: Gate Driver (using GateDriverBlock)
+    # =========================================================================
+    print("\n6. Adding gate driver...")
+
+    # 3-phase gate driver with bootstrap capacitors
+    # Note: C10-C11 are used by CrystalOscillator, so start at C12
+    gate_driver = GateDriverBlock(
+        sch,
+        x=X_GATE_DRV,
+        y=95,
+        driver_type="3-phase",
+        ref="U3",
+        value="DRV8301",
+        bootstrap_caps="100nF",
+        bypass_caps=["100nF", "10uF"],
+        cap_ref_start=12,  # C12-C14 for bootstrap, C15-C16 for bypass
+    )
+    gate_driver.connect_to_rails(vcc_rail_y=RAIL_5V, gnd_rail_y=RAIL_GND)
+    print("   Gate driver: DRV8301 (GateDriverBlock)")
+    print(f"   Bootstrap caps: C12, C13, C14")
+    print(f"   Bypass caps: C15, C16")
+
+    # =========================================================================
+    # Section 7: Power Stage (using ThreePhaseInverter and CurrentSenseShunt)
+    # =========================================================================
+    print("\n7. Adding power stage (6 MOSFETs)...")
+
+    # Create 3-phase inverter using ThreePhaseInverter block
+    # This creates 6 MOSFETs (Q1-Q6) in three half-bridge configuration
+    inverter = ThreePhaseInverter(
+        sch,
+        x=X_PHASE_A,
+        y=Y_POWER_STAGE,
+        ref_start=1,
+        ref_prefix="Q",
+        mosfet_value="IRLZ44N",
+        phase_labels=["A", "B", "C"],
+        phase_spacing=75,
+        hs_ls_spacing=40,
+    )
+    inverter.connect_to_rails(vin_rail_y=RAIL_VMOTOR, gnd_rail_y=RAIL_GND)
+    print("   Three-phase inverter: Q1-Q6 (ThreePhaseInverter block)")
+
+    # Add current sense shunts for each phase (R10-R12)
+    # Using CurrentSenseShunt blocks for proper current sensing
+    phases = ["A", "B", "C"]
+    current_sensors = []
+    for i, phase in enumerate(phases):
+        x_phase = X_PHASE_A + (i * 75)
+
+        # Create current sense shunt for this phase
+        sense = CurrentSenseShunt(
+            sch,
+            x=x_phase,
+            y=Y_POWER_STAGE + 80,
+            shunt_value="5mR",
+            shunt_package="2512",
+            ref_start=10 + i,  # R10, R11, R12
+            amplifier=False,  # No amplifier for basic sensing
+        )
+        sense.connect_to_rails(gnd_rail_y=RAIL_GND)
+        current_sensors.append(sense)
+
+        # Wire the inverter LS output to the current sense input
+        # Get the phase output from inverter and wire to shunt
+        phase_gnd = inverter.half_bridges[i].port("GND")
+        sense_in = sense.port("IN_POS")
+        sch.add_wire(phase_gnd, sense_in)
+
+        # Add current sense labels
+        sch.add_label(f"ISENSE_{phase}+", x_phase - 10, sense_in[1], rotation=0)
+        sch.add_label(f"ISENSE_{phase}-", x_phase - 10, sense.port("GND")[1], rotation=0)
+
+        print(f"   Phase {phase}: Current sense R{10 + i} (CurrentSenseShunt block)")
+
+    # =========================================================================
+    # Section 8: Motor Output Connector
+    # =========================================================================
+    print("\n8. Adding motor output connector...")
+
+    j_motor = sch.add_symbol(
+        "Connector:Conn_01x03_Pin",
+        x=X_CONNECTORS,
+        y=Y_POWER_STAGE + 20,
+        ref="J2",
+        value="Motor Output",
+    )
+    print(f"   Motor connector: {j_motor.reference} (U/V/W)")
+
+    # Wire motor phases from inverter block outputs to connector
+    for i, phase in enumerate(phases):
+        pin_pos = j_motor.pin_position(str(i + 1))
+        # Get phase output from inverter block
+        phase_out = inverter.port(f"PHASE_{phase}")
+        # Wire from phase output node to connector
+        sch.add_wire(pin_pos, (phase_out[0] + 15, pin_pos[1]))
+        sch.add_wire((phase_out[0] + 15, pin_pos[1]), (phase_out[0] + 15, Y_POWER_STAGE + 20))
+
+    # =========================================================================
+    # Section 9: Hall Sensor Connector
+    # =========================================================================
+    print("\n9. Adding hall sensor connector...")
+
+    j_hall = sch.add_symbol(
+        "Connector:Conn_01x05_Pin",
+        x=X_CONNECTORS,
+        y=100,
+        ref="J3",
+        value="Hall Sensors",
+    )
+    print(f"   Hall connector: {j_hall.reference}")
+
+    # Add hall signal labels
+    sch.add_label("HALL_A", X_CONNECTORS - 20, 100, rotation=0)
+    sch.add_label("HALL_B", X_CONNECTORS - 20, 105, rotation=0)
+    sch.add_label("HALL_C", X_CONNECTORS - 20, 110, rotation=0)
+
+    # =========================================================================
+    # Section 10: Status LEDs
+    # =========================================================================
+    print("\n10. Adding status LEDs...")
+
+    # Power LED
+    led_pwr = LEDIndicator(
+        sch,
+        x=X_LDO + 50,
+        y=120,
+        ref_prefix="D3",
+        label="PWR",
+        resistor_value="1k",
+    )
+    led_pwr.connect_to_rails(vcc_rail_y=RAIL_3V3, gnd_rail_y=RAIL_GND)
+    print(f"   Power LED: {led_pwr.led.reference}")
+
+    # Status LED
+    led_status = LEDIndicator(
+        sch,
+        x=X_LDO + 70,
+        y=120,
+        ref_prefix="D4",
+        label="STATUS",
+        resistor_value="1k",
+    )
+    led_status.connect_to_rails(vcc_rail_y=RAIL_3V3, gnd_rail_y=RAIL_GND)
+    print(f"   Status LED: {led_status.led.reference}")
+
+    # =========================================================================
+    # Section 11: Design Notes
+    # =========================================================================
+    print("\n11. Adding design notes...")
+
+    sch.add_text(
+        "BLDC Motor Controller Design Notes:\n"
+        "=====================================\n"
+        "1. MOSFETs Q1-Q6 require thermal vias (min 6 per device)\n"
+        "2. Use 2mm+ trace width for motor phase and power traces\n"
+        "3. Ground plane on bottom layer for heat spreading\n"
+        "4. Keep gate drive traces short (<10mm)\n"
+        "5. Kelvin connection for current sense resistors\n"
+        "6. Separate analog ground near current sense\n"
+        "7. Bulk capacitors near MOSFETs for motor current\n",
+        x=X_POWER_IN,
+        y=RAIL_GND + 20,
+    )
+
+    # =========================================================================
+    # Validate Schematic
+    # =========================================================================
+    print("\n12. Validating schematic...")
+
+    issues = sch.validate()
+    errors = [i for i in issues if i["severity"] == "error"]
+    warnings = [i for i in issues if i["severity"] == "warning"]
+
+    if errors:
+        print(f"   Found {len(errors)} errors:")
+        for err in errors[:5]:
+            print(f"      - {err['message']}")
+    else:
+        print("   No errors found")
+
+    if warnings:
+        print(f"   Found {len(warnings)} warnings")
+
+    # Get statistics
+    stats = sch.get_statistics()
+    print("\n   Schematic statistics:")
+    print(f"      Symbols: {stats['symbol_count']}")
+    print(f"      Power symbols: {stats['power_symbol_count']}")
+    print(f"      Wires: {stats['wire_count']}")
+    print(f"      Junctions: {stats['junction_count']}")
+    print(f"      Labels: {stats['label_count']}")
+
+    # =========================================================================
+    # Write Output Files
+    # =========================================================================
+    print("\n13. Writing output files...")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    sch_path = output_dir / "bldc_controller.kicad_sch"
+    sch.write(sch_path)
+    print(f"   Schematic: {sch_path}")
+
+    # =========================================================================
+    # Summary
+    # =========================================================================
+    print("\n" + "=" * 60)
+    print("Design complete!")
+    print(f"\nOutput files in: {output_dir.absolute()}")
+    print("\nComponent summary:")
+    print("   Power input: J1, F1, D1, C1-C2")
+    print("   Buck (24V→5V): L1, C3-C4")
+    print("   LDO (5V→3.3V): U2, C5-C6")
+    print("   MCU: C7-C9, Y1 (C10-C11)")
+    print("   Gate driver: C12-C16 (bootstrap/bypass)")
+    print("   Power stage: Q1-Q6, R10-R12 (shunts)")
+    print("   Connectors: J1-J4")
+    print("   LEDs: D3-D4, R3-R4")
+    print(f"\n   Total: ~{stats['symbol_count']} components")
+    print("\nNext steps:")
+    print("  1. Run ERC check")
+    print("  2. Create PCB layout")
+    print("  3. Run thermal analysis on power stage")
+    print("  4. Add copper pour zones")
+    print("  5. Route with appropriate trace widths")
+
+
+def main() -> int:
+    """Main entry point."""
+    if len(sys.argv) > 1:
+        output_dir = Path(sys.argv[1])
+    else:
+        output_dir = Path(__file__).parent / "output"
+
+    try:
+        create_bldc_controller(output_dir)
+        return 0
+    except Exception as e:
+        print(f"\nError: {e}", file=sys.stderr)
+        import traceback
+
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/boards/05-bldc-motor-controller/output/bldc_controller.kicad_sch
+++ b/boards/05-bldc-motor-controller/output/bldc_controller.kicad_sch
@@ -1,0 +1,5656 @@
+(kicad_sch
+  (version 20231120)
+  (generator "eeschema")
+  (generator_version "9.0")
+  (uuid "a75dbcf5-82df-40a2-967e-d4091cf026da")
+  (paper "A4")
+  (title_block
+    (title "BLDC Motor Controller")
+    (date "2025-01")
+    (rev "A")
+    (company "kicad-tools Example")
+    (comment 1 "3-Phase Brushless DC Motor Driver")
+    (comment 2 "Thermal analysis and high-current routing demo")
+  )
+  (lib_symbols
+    (symbol "power:+24V"
+      (power)
+      (pin_numbers (hide yes))
+      (pin_names (offset 0) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "#PWR"
+        (at 0 -3.81 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Value" "+24V"
+        (at 0 3.556 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Power symbol creates a global label with name \"+24V\""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "global power"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "+24V_0_1"
+        (polyline (pts (xy -0.762 1.27) (xy 0 2.54))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0 2.54) (xy 0.762 1.27))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0 0) (xy 0 2.54))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "+24V_1_1"
+        (pin power_in line (at 0 0 90) (length 0)
+          (name "~"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "power:+5V"
+      (power)
+      (pin_numbers (hide yes))
+      (pin_names (offset 0) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "#PWR"
+        (at 0 -3.81 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Value" "+5V"
+        (at 0 3.556 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Power symbol creates a global label with name \"+5V\""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "global power"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "+5V_0_1"
+        (polyline (pts (xy -0.762 1.27) (xy 0 2.54))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0 2.54) (xy 0.762 1.27))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0 0) (xy 0 2.54))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "+5V_1_1"
+        (pin power_in line (at 0 0 90) (length 0)
+          (name "~"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "power:+3V3"
+      (power)
+      (pin_numbers (hide yes))
+      (pin_names (offset 0) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "#PWR"
+        (at 0 -3.81 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Value" "+3V3"
+        (at 0 3.556 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Power symbol creates a global label with name \"+3V3\""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "global power"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "+3V3_0_1"
+        (polyline (pts (xy -0.762 1.27) (xy 0 2.54))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0 2.54) (xy 0.762 1.27))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0 0) (xy 0 2.54))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "+3V3_1_1"
+        (pin power_in line (at 0 0 90) (length 0)
+          (name "~"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "power:GND"
+      (power)
+      (pin_numbers (hide yes))
+      (pin_names (offset 0) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "#PWR"
+        (at 0 -6.35 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Value" "GND"
+        (at 0 -3.81 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "global power"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "GND_0_1"
+        (polyline
+          (pts (xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+          )
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "GND_1_1"
+        (pin power_in line (at 0 0 270) (length 0)
+          (name "~"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Connector:Conn_01x02_Pin"
+      (pin_names (offset 1.016) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "J"
+        (at 0 2.54 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Value" "Conn_01x02_Pin"
+        (at 0 -5.08 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Generic connector, single row, 01x02, script generated"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_locked" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "ki_keywords" "connector"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "Connector*:*_1x??_*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "Conn_01x02_Pin_1_1"
+        (rectangle (start 0.8636 0.127) (end 0 -0.127)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (rectangle (start 0.8636 -2.413) (end 0 -2.667)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (polyline (pts (xy 1.27 0) (xy 0.8636 0))
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.27 -2.54) (xy 0.8636 -2.54))
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (pin passive line (at 5.08 0 180) (length 3.81)
+          (name "Pin_1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 5.08 -2.54 180) (length 3.81)
+          (name "Pin_2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Device:Fuse"
+      (pin_numbers (hide yes))
+      (pin_names (offset 0))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "F"
+        (at 2.032 0 90)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Value" "Fuse"
+        (at -1.905 0 90)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at -1.778 0 90)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Fuse"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "fuse"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "*Fuse*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "Fuse_0_1"
+        (rectangle (start -0.762 -2.54) (end 0.762 2.54)
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0 2.54) (xy 0 -2.54))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "Fuse_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27)
+          (name "~"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 0 -3.81 90) (length 1.27)
+          (name "~"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Device:D_TVS"
+      (pin_numbers (hide yes))
+      (pin_names (offset 1.016) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "D"
+        (at 0 2.54 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Value" "D_TVS"
+        (at 0 -2.54 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Bidirectional transient-voltage-suppression diode"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "diode TVS thyrector"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "D_TVS_0_1"
+        (polyline
+          (pts (xy -2.54 1.27) (xy -2.54 -1.27) (xy 2.54 1.27) (xy 2.54 -1.27) (xy -2.54 1.27)
+          )
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0.508 1.27) (xy 0 1.27) (xy 0 -1.27) (xy -0.508 -1.27))
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.27 0) (xy -1.27 0))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "D_TVS_1_1"
+        (pin passive line (at -3.81 0 0) (length 2.54)
+          (name "A1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 3.81 0 180) (length 2.54)
+          (name "A2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Device:C"
+      (pin_numbers (hide yes))
+      (pin_names (offset 0.254))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "C"
+        (at 0.635 2.54 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (justify left)
+        )
+      )
+      (property "Value" "C"
+        (at 0.635 -2.54 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (justify left)
+        )
+      )
+      (property "Footprint" ""
+        (at 0.9652 -3.81 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Unpolarized capacitor"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "cap capacitor"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "C_*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "C_0_1"
+        (polyline (pts (xy -2.032 0.762) (xy 2.032 0.762))
+          (stroke
+            (width 0.508)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy -2.032 -0.762) (xy 2.032 -0.762))
+          (stroke
+            (width 0.508)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "C_1_1"
+        (pin passive line (at 0 3.81 270) (length 2.794)
+          (name "~"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 0 -3.81 90) (length 2.794)
+          (name "~"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Device:L"
+      (pin_numbers (hide yes))
+      (pin_names (offset 1.016) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "L"
+        (at -1.27 0 90)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Value" "L"
+        (at 1.905 0 90)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Inductor"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "inductor choke coil reactor magnetic"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "Choke_* *Coil* Inductor_* L_*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "L_0_1"
+        (arc (start 0 2.54) (mid 0.6323 1.905) (end 0 1.27)
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (arc (start 0 1.27) (mid 0.6323 0.635) (end 0 0)
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (arc (start 0 0) (mid 0.6323 -0.635) (end 0 -1.27)
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (arc (start 0 -1.27) (mid 0.6323 -1.905) (end 0 -2.54)
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "L_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27)
+          (name "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 0 -3.81 90) (length 1.27)
+          (name "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Device:Crystal"
+      (pin_numbers (hide yes))
+      (pin_names (offset 1.016) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "Y"
+        (at 0 3.81 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Value" "Crystal"
+        (at 0 -3.81 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Two pin crystal"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "quartz ceramic resonator oscillator"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "Crystal*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "Crystal_0_1"
+        (polyline (pts (xy -2.54 0) (xy -1.905 0))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy -1.905 -1.27) (xy -1.905 1.27))
+          (stroke
+            (width 0.508)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (rectangle (start -1.143 2.54) (end 1.143 -2.54)
+          (stroke
+            (width 0.3048)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.905 -1.27) (xy 1.905 1.27))
+          (stroke
+            (width 0.508)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 2.54 0) (xy 1.905 0))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "Crystal_1_1"
+        (pin passive line (at -3.81 0 0) (length 1.27)
+          (name "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 3.81 0 180) (length 1.27)
+          (name "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Connector_Generic:Conn_01x06"
+      (pin_names (offset 1.016) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "J"
+        (at 0 7.62 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Value" "Conn_01x06"
+        (at 0 -10.16 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Generic connector, single row, 01x06, script generated (kicad-library-utils/schlib/autogen/connector/)"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "connector"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "Connector*:*_1x??_*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "Conn_01x06_1_1"
+        (rectangle (start -1.27 6.35) (end 1.27 -8.89)
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type background)
+          )
+        )
+        (rectangle (start -1.27 5.207) (end 0 4.953)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (rectangle (start -1.27 2.667) (end 0 2.413)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (rectangle (start -1.27 0.127) (end 0 -0.127)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (rectangle (start -1.27 -2.413) (end 0 -2.667)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (rectangle (start -1.27 -4.953) (end 0 -5.207)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (rectangle (start -1.27 -7.493) (end 0 -7.747)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (pin passive line (at -5.08 5.08 0) (length 3.81)
+          (name "Pin_1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at -5.08 2.54 0) (length 3.81)
+          (name "Pin_2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at -5.08 0 0) (length 3.81)
+          (name "Pin_3"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "3"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at -5.08 -2.54 0) (length 3.81)
+          (name "Pin_4"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "4"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at -5.08 -5.08 0) (length 3.81)
+          (name "Pin_5"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "5"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at -5.08 -7.62 0) (length 3.81)
+          (name "Pin_6"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "6"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Device:Q_NMOS"
+      (pin_numbers (hide yes))
+      (pin_names (offset 0) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "Q"
+        (at 5.08 1.27 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (justify left)
+        )
+      )
+      (property "Value" "Q_NMOS"
+        (at 5.08 -1.27 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (justify left)
+        )
+      )
+      (property "Footprint" ""
+        (at 5.08 2.54 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "N-MOSFET transistor"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "NMOS N-MOS"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "Q_NMOS_0_1"
+        (polyline (pts (xy 0.254 1.905) (xy 0.254 -1.905))
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0.254 0) (xy -2.54 0))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0.762 2.286) (xy 0.762 1.27))
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0.762 0.508) (xy 0.762 -0.508))
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0.762 -1.27) (xy 0.762 -2.286))
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 0.762 -1.778) (xy 3.302 -1.778) (xy 3.302 1.778) (xy 0.762 1.778))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.016 0) (xy 2.032 0.381) (xy 2.032 -0.381) (xy 1.016 0))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (circle (center 1.651 0) (radius 2.794)
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 2.54 2.54) (xy 2.54 1.778))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (circle (center 2.54 1.778) (radius 0.254)
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (circle (center 2.54 -1.778) (radius 0.254)
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (polyline (pts (xy 2.54 -2.54) (xy 2.54 0) (xy 0.762 0))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 2.921 0.381) (xy 3.683 0.381))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 3.302 0.381) (xy 2.921 -0.254) (xy 3.683 -0.254) (xy 3.302 0.381))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "Q_NMOS_1_1"
+        (pin input line (at -5.08 0 0) (length 2.54)
+          (name "G"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "G"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 2.54 5.08 270) (length 2.54)
+          (name "D"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "D"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 2.54 -5.08 90) (length 2.54)
+          (name "S"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "S"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Device:R"
+      (pin_numbers (hide yes))
+      (pin_names (offset 0))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "R"
+        (at 2.032 0 90)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Value" "R"
+        (at 0 0 90)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at -1.778 0 90)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Resistor"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "R res resistor"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "R_*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "R_0_1"
+        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "R_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27)
+          (name "~"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 0 -3.81 90) (length 1.27)
+          (name "~"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Connector:Conn_01x03_Pin"
+      (pin_names (offset 1.016) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "J"
+        (at 0 5.08 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Value" "Conn_01x03_Pin"
+        (at 0 -5.08 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Generic connector, single row, 01x03, script generated"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_locked" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "ki_keywords" "connector"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "Connector*:*_1x??_*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "Conn_01x03_Pin_1_1"
+        (rectangle (start 0.8636 2.667) (end 0 2.413)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (rectangle (start 0.8636 0.127) (end 0 -0.127)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (rectangle (start 0.8636 -2.413) (end 0 -2.667)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (polyline (pts (xy 1.27 2.54) (xy 0.8636 2.54))
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.27 0) (xy 0.8636 0))
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.27 -2.54) (xy 0.8636 -2.54))
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (pin passive line (at 5.08 2.54 180) (length 3.81)
+          (name "Pin_1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 5.08 0 180) (length 3.81)
+          (name "Pin_2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 5.08 -2.54 180) (length 3.81)
+          (name "Pin_3"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "3"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Connector:Conn_01x05_Pin"
+      (pin_names (offset 1.016) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "J"
+        (at 0 7.62 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Value" "Conn_01x05_Pin"
+        (at 0 -7.62 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Generic connector, single row, 01x05, script generated"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_locked" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "ki_keywords" "connector"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "Connector*:*_1x??_*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "Conn_01x05_Pin_1_1"
+        (rectangle (start 0.8636 5.207) (end 0 4.953)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (rectangle (start 0.8636 2.667) (end 0 2.413)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (rectangle (start 0.8636 0.127) (end 0 -0.127)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (rectangle (start 0.8636 -2.413) (end 0 -2.667)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (rectangle (start 0.8636 -4.953) (end 0 -5.207)
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type outline)
+          )
+        )
+        (polyline (pts (xy 1.27 5.08) (xy 0.8636 5.08))
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.27 2.54) (xy 0.8636 2.54))
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.27 0) (xy 0.8636 0))
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.27 -2.54) (xy 0.8636 -2.54))
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.27 -5.08) (xy 0.8636 -5.08))
+          (stroke
+            (width 0.1524)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (pin passive line (at 5.08 5.08 180) (length 3.81)
+          (name "Pin_1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 5.08 2.54 180) (length 3.81)
+          (name "Pin_2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 5.08 0 180) (length 3.81)
+          (name "Pin_3"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "3"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 5.08 -2.54 180) (length 3.81)
+          (name "Pin_4"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "4"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 5.08 -5.08 180) (length 3.81)
+          (name "Pin_5"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "5"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+    (symbol "Device:LED"
+      (pin_numbers (hide yes))
+      (pin_names (offset 1.016) (hide yes))
+      (exclude_from_sim no)
+      (in_bom yes)
+      (on_board yes)
+      (property "Reference" "D"
+        (at 0 2.54 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Value" "LED"
+        (at 0 -2.54 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+        )
+      )
+      (property "Footprint" ""
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Datasheet" "~"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Description" "Light emitting diode"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "Sim.Pins" "1=K 2=A"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_keywords" "LED diode"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+        (at 0 0 0)
+        (effects
+          (font
+            (size 1.27 1.27)
+          )
+          (hide yes)
+        )
+      )
+      (symbol "LED_0_1"
+        (polyline
+          (pts (xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+          )
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline
+          (pts (xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+          )
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy -1.27 0) (xy 1.27 0))
+          (stroke
+            (width 0)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy -1.27 -1.27) (xy -1.27 1.27))
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+        (polyline (pts (xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27))
+          (stroke
+            (width 0.254)
+            (type default)
+          )
+          (fill (type none)
+          )
+        )
+      )
+      (symbol "LED_1_1"
+        (pin passive line (at -3.81 0 0) (length 2.54)
+          (name "K"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "1"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+        (pin passive line (at 3.81 0 180) (length 2.54)
+          (name "A"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+          (number "2"
+            (effects
+              (font
+                (size 1.27 1.27)
+              )
+            )
+          )
+        )
+      )
+      (embedded_fonts no)
+    )
+  )
+  (symbol
+    (lib_id "Connector:Conn_01x02_Pin")
+    (at 25.4 100.33 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "5f649850-ab5d-46f5-9820-608b6485f853")
+    (property "Reference" "J1"
+      (at 25.4 95.25 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "Power Input"
+      (at 25.4 97.79 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 25.4 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 25.4 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "4ffdc0e3-5b73-45d0-a889-36668a775877")
+    )
+    (pin "2" (uuid "c322bec9-de3d-4c6e-9dc9-acaa7bd3b52d")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "J1") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:Fuse")
+    (at 44.45 100.33 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "f555bd3d-13dc-4b20-8dbf-5d8580d42c3d")
+    (property "Reference" "F1"
+      (at 44.45 95.25 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "15A"
+      (at 44.45 97.79 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 44.45 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 44.45 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "abe61d5c-930a-450f-96b0-9bea5d6ef190")
+    )
+    (pin "2" (uuid "fbcb45e7-9eb2-40b8-a012-9f1a8d9bd63a")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "F1") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:D_TVS")
+    (at 64.77 119.38 90)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "e1dcff51-8b9d-47c6-a61c-456b7d344300")
+    (property "Reference" "D1"
+      (at 64.77 114.3 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "SMBJ24A"
+      (at 64.77 116.84 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 64.77 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 64.77 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "ec7c6220-1337-483a-947b-4fa88e8ae812")
+    )
+    (pin "2" (uuid "dacc04ec-e647-4165-a14b-dddd2b570c88")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "D1") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 80.01 119.38 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "94f529c2-18e7-4bc7-bc71-df002294b874")
+    (property "Reference" "C1"
+      (at 80.01 114.3 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "470uF"
+      (at 80.01 116.84 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 80.01 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 80.01 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "a1332a16-c1c2-4437-a197-6b0f627421a6")
+    )
+    (pin "2" (uuid "70b3e8dc-81ee-401d-af80-6a6f6ef5d2b1")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C1") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 95.25 119.38 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "4fe2692c-29a2-481f-87d7-824793b1b9fd")
+    (property "Reference" "C2"
+      (at 95.25 114.3 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "100nF"
+      (at 95.25 116.84 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 95.25 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 95.25 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "304b3a6e-4153-43bd-9c42-bf5a193ff049")
+    )
+    (pin "2" (uuid "fac69e21-79d4-4632-a499-42063fb9fff6")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C2") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 64.77 119.38 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "b9b141f1-ead8-4cba-bb3a-56bb1e70715d")
+    (property "Reference" "C3"
+      (at 64.77 114.3 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "100uF"
+      (at 64.77 116.84 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 64.77 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 64.77 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "415e3723-0698-443c-bd86-45eba5c9b612")
+    )
+    (pin "2" (uuid "d68d863a-1d7e-4cf9-96d8-07eaa52b5c3e")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C3") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 115.57 119.38 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "90a451dc-36ad-4cb1-9cdc-0a22543082b7")
+    (property "Reference" "C4"
+      (at 115.57 114.3 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "220uF"
+      (at 115.57 116.84 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 115.57 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 115.57 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "7f02752e-8dcd-4041-81c1-21ac4c38ed78")
+    )
+    (pin "2" (uuid "eeece50a-a349-4c59-ba3c-bb62625427f6")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C4") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:L")
+    (at 90.17 100.33 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "3d12f389-2501-4cf6-8e5d-ece729cedba6")
+    (property "Reference" "L1"
+      (at 90.17 95.25 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "33uH"
+      (at 90.17 97.79 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 90.17 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 90.17 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "11aa1d21-dbd5-4f04-93b3-560872a82571")
+    )
+    (pin "2" (uuid "33a03e8e-c103-4b01-b468-e9befde877ca")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "L1") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Regulator_Linear:AMS1117-3.3")
+    (at 139.7 100.33 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "d3c84965-f019-4b9d-acd2-173949a3e376")
+    (property "Reference" "U2"
+      (at 139.7 95.25 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "AMS1117-3.3"
+      (at 139.7 97.79 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 139.7 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 139.7 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "3" (uuid "460faaa5-977d-4614-8809-b0ade7aa094c")
+    )
+    (pin "1" (uuid "bb9b3648-117f-46b0-ba88-71439efb754f")
+    )
+    (pin "2" (uuid "897e317b-b045-4f64-8c85-d8cd569ccb1f")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "U2") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 124.46 119.38 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "30b0cd22-2274-4c37-b0b2-c6bbd2fdf98f")
+    (property "Reference" "C5"
+      (at 124.46 114.3 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "10uF"
+      (at 124.46 116.84 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 124.46 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 124.46 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "7e235139-cbde-4121-86dc-c3a63835e8d2")
+    )
+    (pin "2" (uuid "0c336aa2-1821-4165-9efd-6f11714b3609")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C5") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 165.1 119.38 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "ebf3a960-56f6-4908-b25a-930048123590")
+    (property "Reference" "C6"
+      (at 165.1 114.3 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "10uF"
+      (at 165.1 116.84 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 165.1 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 165.1 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "d253a510-ce10-4059-a642-2604f8c0e3e6")
+    )
+    (pin "2" (uuid "00dbd694-0e63-48e4-83a7-047f05518052")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C6") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 199.39 100.33 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "90ea2900-6efd-4583-8c38-44abe7dd713c")
+    (property "Reference" "C7"
+      (at 199.39 95.25 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "100nF"
+      (at 199.39 97.79 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 199.39 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 199.39 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "313c61cf-5dd2-404d-92a7-99dd047549f3")
+    )
+    (pin "2" (uuid "733873d9-a129-4c1e-b7a2-425043ada31a")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C7") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 209.55 100.33 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "404e31cf-2336-402b-b0a5-d478647f4e9e")
+    (property "Reference" "C8"
+      (at 209.55 95.25 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "100nF"
+      (at 209.55 97.79 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 209.55 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 209.55 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "e7802285-1c62-4675-b8f2-0f02b4b348da")
+    )
+    (pin "2" (uuid "b7cf666b-210e-4446-aaec-490a925b15ea")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C8") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 219.71 100.33 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "c63ab5ff-ade1-4c26-938e-65e923519d30")
+    (property "Reference" "C9"
+      (at 219.71 95.25 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "4.7uF"
+      (at 219.71 97.79 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 219.71 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 219.71 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "89eb8719-f2c4-425b-b88b-2c899d467d2e")
+    )
+    (pin "2" (uuid "ba8d44a7-f2f5-40f1-80bf-39ae665d112b")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C9") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:Crystal")
+    (at 270.51 100.33 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "574b22f4-2089-4227-892d-08c96898a28e")
+    (property "Reference" "Y1"
+      (at 270.51 95.25 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "8MHz"
+      (at 270.51 97.79 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 270.51 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 270.51 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "1574d915-6a7f-4152-9c14-8d7f37b5c7ca")
+    )
+    (pin "2" (uuid "eb4761a5-fd3a-4dd0-a227-04f10f5ebdcc")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "Y1") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 262.89 115.57 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "b1008999-dce9-45ea-b201-e308300519d7")
+    (property "Reference" "C10"
+      (at 262.89 110.49 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "20pF"
+      (at 262.89 113.03 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 262.89 115.57 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 262.89 115.57 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "cc843590-1bb6-435f-8b0d-7dfab3f2272f")
+    )
+    (pin "2" (uuid "6f1a6bc2-b85f-42ce-8f6a-2e39295aa235")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C10") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 278.13 115.57 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "ff3d811e-32da-463a-a935-4818034906b4")
+    (property "Reference" "C11"
+      (at 278.13 110.49 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "20pF"
+      (at 278.13 113.03 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 278.13 115.57 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 278.13 115.57 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "8cb669a5-b296-4d02-badf-d54e8845e2a5")
+    )
+    (pin "2" (uuid "a269f24a-6bed-4a9b-8d13-aa6c9e8ea7b1")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C11") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Connector_Generic:Conn_01x06")
+    (at 299.72 100.33 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "96e69bc7-6f1d-4be6-b10a-4288a60a76f4")
+    (property "Reference" "J4"
+      (at 299.72 95.25 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "SWD-6"
+      (at 299.72 97.79 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 299.72 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 299.72 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "a14d1918-de14-422d-a656-069d844cc022")
+    )
+    (pin "2" (uuid "c7944d9b-1676-498f-a521-25fd2c3f924f")
+    )
+    (pin "3" (uuid "cddf1e6f-3d52-408d-86e8-2b1240d315ed")
+    )
+    (pin "4" (uuid "d767ad8c-fcdd-4047-9c0f-eefd6a3e92d4")
+    )
+    (pin "5" (uuid "60de91a6-07ab-4fa5-a5e2-eb23c189b541")
+    )
+    (pin "6" (uuid "567396b7-847e-40ca-a9f1-8f65c169fb51")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "J4") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 260.35 80.01 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "99e7f539-f327-45f5-945a-02df45fe60db")
+    (property "Reference" "C12"
+      (at 260.35 74.93 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "100nF"
+      (at 260.35 77.47 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 260.35 80.01 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 260.35 80.01 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "25e7b0f1-db4a-4019-a6dc-0b4061ba1732")
+    )
+    (pin "2" (uuid "9b877003-1e43-43b7-b037-052977d0a051")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C12") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 270.51 80.01 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "1b73c7ce-2544-48f2-b2da-bad0b97eff63")
+    (property "Reference" "C13"
+      (at 270.51 74.93 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "100nF"
+      (at 270.51 77.47 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 270.51 80.01 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 270.51 80.01 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "e38b4c94-c3a6-4d7f-a85c-226d57aba7f3")
+    )
+    (pin "2" (uuid "3e055e56-f4dc-4a99-b71f-02df93c04ad5")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C13") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 279.4 80.01 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "b70c5492-1f55-4201-916b-03444a662b8c")
+    (property "Reference" "C14"
+      (at 279.4 74.93 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "100nF"
+      (at 279.4 77.47 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 279.4 80.01 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 279.4 80.01 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "9867c73e-e45d-4494-9816-429bd0ae459b")
+    )
+    (pin "2" (uuid "edc3d95f-76ae-45a2-b9aa-47ace0c42243")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C14") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 299.72 80.01 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "92ac9616-b1c3-48bd-aff7-6182372958b0")
+    (property "Reference" "C15"
+      (at 299.72 74.93 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "100nF"
+      (at 299.72 77.47 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 299.72 80.01 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 299.72 80.01 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "43f61206-a622-4a55-926a-a192366bca62")
+    )
+    (pin "2" (uuid "81dfc8b0-e61e-4cb0-a053-93a131f6812a")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C15") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 309.88 80.01 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "125ab917-0673-4685-aef5-e5570b876c68")
+    (property "Reference" "C16"
+      (at 309.88 74.93 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "10uF"
+      (at 309.88 77.47 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 309.88 80.01 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 309.88 80.01 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "086c46ce-c48f-45bc-997d-1a2abfe9a42a")
+    )
+    (pin "2" (uuid "adb308e0-7454-4451-b517-dc8a56b5bece")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "C16") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:Q_NMOS")
+    (at 25.4 160.02 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "1cafcc0b-26e0-4cc9-ba0a-4cea6f1836c2")
+    (property "Reference" "Q1"
+      (at 25.4 154.94 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "IRLZ44N"
+      (at 25.4 157.48 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 25.4 160.02 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 25.4 160.02 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "G" (uuid "adb95112-6b46-4e12-8758-1333dd399d0e")
+    )
+    (pin "D" (uuid "831af883-70ee-46db-b04e-21fbf624c038")
+    )
+    (pin "S" (uuid "9edbf525-81f0-47b1-bc88-8eb59b1f717d")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "Q1") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:Q_NMOS")
+    (at 25.4 199.39 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "5c000d21-91df-4243-a5b5-676af963c6b3")
+    (property "Reference" "Q2"
+      (at 25.4 194.31 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "IRLZ44N"
+      (at 25.4 196.85 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 25.4 199.39 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 25.4 199.39 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "G" (uuid "11790beb-7b51-4fbb-a75b-3b40c99a4d62")
+    )
+    (pin "D" (uuid "78e3f2e6-7d36-49b6-93f5-19e242b368c4")
+    )
+    (pin "S" (uuid "65e9b480-2aa9-41be-9289-5374e70290d9")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "Q2") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 25.4 240.03 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "4dbda1b4-15e4-4948-8cfc-ac9a09d49673")
+    (property "Reference" "R10"
+      (at 25.4 234.95 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "5mR"
+      (at 25.4 237.49 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 25.4 240.03 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 25.4 240.03 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "d12a7524-12d1-4b90-bc5b-041b9a725bbb")
+    )
+    (pin "2" (uuid "98cb3f7c-086d-4d00-93b3-86174b5a6f60")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "R10") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:Q_NMOS")
+    (at 100.33 160.02 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "fc72ebf1-c88a-4956-a873-ba5df3676b8b")
+    (property "Reference" "Q3"
+      (at 100.33 154.94 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "IRLZ44N"
+      (at 100.33 157.48 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 100.33 160.02 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 100.33 160.02 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "G" (uuid "a811289a-d291-4dc8-97c5-09a91eaf76aa")
+    )
+    (pin "D" (uuid "0d36691f-7a8e-4e01-826e-6140586c9a07")
+    )
+    (pin "S" (uuid "a06503b8-bf44-4ba4-a1bf-327d22029af8")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "Q3") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:Q_NMOS")
+    (at 100.33 199.39 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "102367cf-18e9-46a6-9df6-a98691edada4")
+    (property "Reference" "Q4"
+      (at 100.33 194.31 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "IRLZ44N"
+      (at 100.33 196.85 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 100.33 199.39 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 100.33 199.39 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "G" (uuid "a477b347-77bb-4b8e-9971-2be38c2cd2b2")
+    )
+    (pin "D" (uuid "664d2f78-1d6d-4ee3-bdad-e618141cdf59")
+    )
+    (pin "S" (uuid "2fe2d842-1fe4-4e70-bce8-9835ba5b8288")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "Q4") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 100.33 240.03 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "19ca038b-7768-4bd0-b232-92e28b78ebd2")
+    (property "Reference" "R11"
+      (at 100.33 234.95 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "5mR"
+      (at 100.33 237.49 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 100.33 240.03 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 100.33 240.03 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "95031fda-b6c8-4b01-8d8b-af8f96182076")
+    )
+    (pin "2" (uuid "52c6d1bc-df97-4cec-9c8f-a5c989a78b42")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "R11") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:Q_NMOS")
+    (at 175.26 160.02 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "45f4be10-c3a5-4a17-9e29-595f1a183e86")
+    (property "Reference" "Q5"
+      (at 175.26 154.94 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "IRLZ44N"
+      (at 175.26 157.48 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 175.26 160.02 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 175.26 160.02 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "G" (uuid "150d1818-c992-449e-b0b6-df300e20c086")
+    )
+    (pin "D" (uuid "eb4d51cd-e147-425c-8d69-934a26c5f1d5")
+    )
+    (pin "S" (uuid "ee0c8392-abe2-4c1d-9d5a-2c1339a07fa7")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "Q5") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:Q_NMOS")
+    (at 175.26 199.39 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "7bd32436-d8c2-415b-a454-a8f15bd62770")
+    (property "Reference" "Q6"
+      (at 175.26 194.31 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "IRLZ44N"
+      (at 175.26 196.85 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 175.26 199.39 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 175.26 199.39 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "G" (uuid "44b7f50b-f3f2-4fdf-9389-88e5eba5ee7b")
+    )
+    (pin "D" (uuid "8ba7c260-3564-405b-90a1-f2b3b1a5b266")
+    )
+    (pin "S" (uuid "93936c98-1689-4a29-ac8a-b007e96fc265")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "Q6") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 175.26 240.03 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "0e8153ce-8b6b-49af-be21-9501a235eb1f")
+    (property "Reference" "R12"
+      (at 175.26 234.95 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "5mR"
+      (at 175.26 237.49 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 175.26 240.03 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 175.26 240.03 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "5f9e6511-5dd7-466d-bdb8-610599d4ecf9")
+    )
+    (pin "2" (uuid "d3707600-ac18-4eb7-b8ce-69db89ffe6fd")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "R12") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Connector:Conn_01x03_Pin")
+    (at 260.35 180.34 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "e4aa7b7b-d14a-4e24-b2e9-709bf7b83504")
+    (property "Reference" "J2"
+      (at 260.35 175.26 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "Motor Output"
+      (at 260.35 177.8 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 260.35 180.34 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 260.35 180.34 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "8c505439-d0af-47d3-9429-0518efcc9436")
+    )
+    (pin "2" (uuid "f02eccc7-e8d4-4036-9e29-17df165aadc3")
+    )
+    (pin "3" (uuid "9f067dba-16ef-4a2c-aa1b-9d624a0ed9a1")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "J2") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Connector:Conn_01x05_Pin")
+    (at 260.35 100.33 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "22d43de4-65d9-49eb-9819-c9474d250fe0")
+    (property "Reference" "J3"
+      (at 260.35 95.25 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "Hall Sensors"
+      (at 260.35 97.79 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 260.35 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 260.35 100.33 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "cbe8e6ae-3b10-4cc8-ac22-d30c958ffa37")
+    )
+    (pin "2" (uuid "55ac40a3-311b-4629-a3c3-0c1c052e39f3")
+    )
+    (pin "3" (uuid "c2abd508-8eb0-49ba-97c0-27b03412e66f")
+    )
+    (pin "4" (uuid "09c4d64e-93ed-4711-a4ec-03d6d611da28")
+    )
+    (pin "5" (uuid "33ecf159-166f-42a5-b19a-1a5661f2a3b0")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "J3") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:LED")
+    (at 190.5 119.38 90)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "7bd840d1-bc60-425a-8952-c05a0c8a5222")
+    (property "Reference" "D3"
+      (at 190.5 114.3 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "PWR"
+      (at 190.5 116.84 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 190.5 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 190.5 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "b9c170cc-508c-4f6c-8741-7d22cdad1a16")
+    )
+    (pin "2" (uuid "14111c2b-9d36-4553-a455-bb6da8f6b720")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "D3") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 190.5 134.62 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "d942ecc1-8952-45a8-b182-d0078b982d7a")
+    (property "Reference" "R3"
+      (at 190.5 129.54 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "1k"
+      (at 190.5 132.08 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 190.5 134.62 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 190.5 134.62 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "0bcac7e2-068e-44b9-93d5-13b9e43ed308")
+    )
+    (pin "2" (uuid "cc30333e-d1c1-4922-ae47-2d4cbd7fb8e2")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "R3") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:LED")
+    (at 209.55 119.38 90)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "60f56066-8ab0-40f3-b046-df618cb4e18a")
+    (property "Reference" "D4"
+      (at 209.55 114.3 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "STATUS"
+      (at 209.55 116.84 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 209.55 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 209.55 119.38 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "97b707bf-9716-45f2-9491-44d478c65475")
+    )
+    (pin "2" (uuid "c3baa0e1-b893-4eb3-a9e2-b3a12f9ab764")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "D4") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 209.55 134.62 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "bc20312b-4bce-4428-b499-c5d511cc5cf0")
+    (property "Reference" "R4"
+      (at 209.55 129.54 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "1k"
+      (at 209.55 132.08 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 209.55 134.62 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 209.55 134.62 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "c0f691d5-aef4-458e-bffc-14fa671be747")
+    )
+    (pin "2" (uuid "e60f71f4-3690-4234-bb33-48f3ec529c67")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "R4") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "power:+24V")
+    (at 25.4 15.24 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "d027cfe8-89b4-4b58-8fb0-7d79e0f64bf5")
+    (property "Reference" "#PWR01"
+      (at 25.4 17.78 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Value" "+24V"
+      (at 25.4 20.32 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 25.4 15.24 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" ""
+      (at 25.4 15.24 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "90e8a18e-de45-4845-aa2d-ba55e5985e57")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "#PWR01") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "power:+5V")
+    (at 105.41 35.56 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "c3c53991-7e10-4b67-af93-f04db744dc17")
+    (property "Reference" "#PWR02"
+      (at 105.41 38.1 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Value" "+5V"
+      (at 105.41 40.64 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 105.41 35.56 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" ""
+      (at 105.41 35.56 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "f2aee6c7-1ead-4bc5-b735-05d8fc05e228")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "#PWR02") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "power:+3V3")
+    (at 165.1 54.61 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "a7fdca22-e787-4664-9d54-6ab01f3673a8")
+    (property "Reference" "#PWR03"
+      (at 165.1 57.15 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Value" "+3V3"
+      (at 165.1 59.69 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 165.1 54.61 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" ""
+      (at 165.1 54.61 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "7270be42-4ac3-484e-a669-775831d7a6fd")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "#PWR03") (unit 1)
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "power:GND")
+    (at 25.4 289.56 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "d859b347-1204-476d-b6e7-bdcfebbb4ce0")
+    (property "Reference" "#PWR04"
+      (at 25.4 292.1 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Value" "GND"
+      (at 25.4 294.64 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 25.4 289.56 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" ""
+      (at 25.4 289.56 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (pin "1" (uuid "ad443bab-a2c2-4526-9d54-38572ded140f")
+    )
+    (instances
+      (project "project"
+        (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (reference "#PWR04") (unit 1)
+        )
+      )
+    )
+  )
+  (wire
+    (pts (xy 25.4 25.4) (xy 234.95 25.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "a371cc26-c833-40d8-9c90-63b8805e9b4f")
+  )
+  (wire
+    (pts (xy 105.41 44.45) (xy 309.88 44.45))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "49fa1699-fb05-4349-9bff-289b1cfccd2d")
+  )
+  (wire
+    (pts (xy 165.1 64.77) (xy 279.4 64.77))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "d4b58634-c489-44a6-a840-7e2b3074bb90")
+  )
+  (wire
+    (pts (xy 25.4 279.4) (xy 299.72 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "08716ada-0472-4a3e-a0c4-ede0fdc7e693")
+  )
+  (wire
+    (pts (xy 30.48 100.33) (xy 44.45 96.52))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "a1154851-814e-44a6-8d4f-de3ab9538c49")
+  )
+  (wire
+    (pts (xy 44.45 104.14) (xy 44.45 25.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "b8f412d2-3af1-4f6b-871d-aa8c8a281606")
+  )
+  (wire
+    (pts (xy 64.77 123.19) (xy 64.77 25.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "334bf97d-ea08-43df-9fb1-92e813442a1a")
+  )
+  (wire
+    (pts (xy 64.77 115.57) (xy 64.77 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "949abe22-799f-477a-ac78-cc17e6072c3f")
+  )
+  (wire
+    (pts (xy 80.01 115.57) (xy 80.01 25.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "722c9daf-760f-4da6-8abb-4e0404b83468")
+  )
+  (wire
+    (pts (xy 80.01 123.19) (xy 80.01 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "3c840381-18ec-4d3c-88f6-424576b03fc7")
+  )
+  (wire
+    (pts (xy 95.25 115.57) (xy 95.25 25.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "4c5cd61f-c815-4b1b-81e9-68fe8ce34c3b")
+  )
+  (wire
+    (pts (xy 95.25 123.19) (xy 95.25 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "9ffecc67-9940-40a2-9bd9-38e4bd34d8fa")
+  )
+  (wire
+    (pts (xy 30.48 102.87) (xy 30.48 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "780bf1b8-37a6-4b7c-9571-06f27492069f")
+  )
+  (wire
+    (pts (xy 90.17 104.14) (xy 90.17 44.45))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "d16fd6b5-f450-4714-bad3-57a0ce416b05")
+  )
+  (wire
+    (pts (xy 90.17 96.52) (xy 90.17 25.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "0bab6850-8a9d-4c37-b005-05f331748b41")
+  )
+  (wire
+    (pts (xy 64.77 115.57) (xy 64.77 25.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "a9e85191-0452-43e2-8826-a030e63162ec")
+  )
+  (wire
+    (pts (xy 64.77 123.19) (xy 64.77 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "d9afcf62-d13f-4c71-8a22-0dc9a4fa146d")
+  )
+  (wire
+    (pts (xy 115.57 115.57) (xy 115.57 44.45))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "4633cc3f-81b8-45e8-9951-229e06175365")
+  )
+  (wire
+    (pts (xy 115.57 123.19) (xy 115.57 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "9658e9be-6dda-48b5-b7da-45a3e129da88")
+  )
+  (wire
+    (pts (xy 132.08 100.33) (xy 132.08 44.45))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "db788908-22e9-4643-9de6-29ccdb87940b")
+  )
+  (wire
+    (pts (xy 147.32 100.33) (xy 147.32 64.77))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "805289fb-b368-4106-b480-4658560dafde")
+  )
+  (wire
+    (pts (xy 139.7 107.95) (xy 139.7 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "1d92ec08-78d8-4646-9ef1-7f43874306a1")
+  )
+  (wire
+    (pts (xy 124.46 115.57) (xy 124.46 44.45))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "d8d8c735-ddba-4194-9fbc-03c34badde23")
+  )
+  (wire
+    (pts (xy 124.46 123.19) (xy 124.46 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "72eb9c47-850b-4141-a9c3-b0e3d71f677d")
+  )
+  (wire
+    (pts (xy 165.1 115.57) (xy 165.1 64.77))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "f7f85e3c-23fb-46bd-84f1-d255d895a166")
+  )
+  (wire
+    (pts (xy 165.1 123.19) (xy 165.1 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "6c33ff91-27f7-4072-8460-b2ba29d179bd")
+  )
+  (wire
+    (pts (xy 199.39 96.52) (xy 199.39 64.77))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "1a524dc3-19e4-4a6b-983c-62f0682a4889")
+  )
+  (wire
+    (pts (xy 199.39 104.14) (xy 199.39 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "0b8eec8e-47bb-42f5-9c19-f75f5a4688e5")
+  )
+  (wire
+    (pts (xy 209.55 96.52) (xy 209.55 64.77))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "c69ed041-0cee-498c-bf2d-7159e617db23")
+  )
+  (wire
+    (pts (xy 209.55 104.14) (xy 209.55 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "69d02dd2-0f0b-410e-8875-a8db41e48891")
+  )
+  (wire
+    (pts (xy 219.71 96.52) (xy 219.71 64.77))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "60bcb3a6-72d0-483e-b02f-9cd48034d549")
+  )
+  (wire
+    (pts (xy 219.71 104.14) (xy 219.71 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "fca8ccee-6e3b-4a6b-860e-6825d943864e")
+  )
+  (wire
+    (pts (xy 266.7 100.33) (xy 262.89 100.33))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "ce519fbd-348b-4d79-b305-2460e39c6a80")
+  )
+  (wire
+    (pts (xy 262.89 100.33) (xy 262.89 111.76))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "78e1e4c3-7140-419a-ace5-5206abca6f38")
+  )
+  (wire
+    (pts (xy 274.32 100.33) (xy 278.13 100.33))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "ebba66fe-1756-4911-a2dc-b2befc250a3d")
+  )
+  (wire
+    (pts (xy 278.13 100.33) (xy 278.13 111.76))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "8bcb0ff8-329d-4a0e-ae1d-636b86628e5c")
+  )
+  (wire
+    (pts (xy 262.89 119.38) (xy 278.13 119.38))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "a20cb3ce-2581-4b81-80a8-c11350d33531")
+  )
+  (wire
+    (pts (xy 270.51 119.38) (xy 270.51 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "0eeedd92-efb0-4069-8359-fb98a295a8a1")
+  )
+  (wire
+    (pts (xy 294.64 95.25) (xy 294.64 64.77))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "61e7406b-c54d-4e94-be9d-a871a1e5caf7")
+  )
+  (wire
+    (pts (xy 294.64 100.33) (xy 294.64 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "66124839-d7c9-4366-a5f9-dae931fe3bd9")
+  )
+  (wire
+    (pts (xy 299.72 76.2) (xy 299.72 44.45))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "e4016bcf-a89d-414d-882c-22025ddaf8da")
+  )
+  (wire
+    (pts (xy 299.72 83.82) (xy 299.72 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "f7f6bc7b-c673-4e2c-bc8b-e81faef64f11")
+  )
+  (wire
+    (pts (xy 309.88 76.2) (xy 309.88 44.45))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "50a90727-ac26-42e5-afd3-fcaf5a8a96b0")
+  )
+  (wire
+    (pts (xy 309.88 83.82) (xy 309.88 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "9b491a5a-8a7c-48d7-93a1-2dffe75fdbb2")
+  )
+  (wire
+    (pts (xy 27.94 154.94) (xy 27.94 25.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "c8bb4515-9b16-4b03-93e6-1bc13538cee5")
+  )
+  (wire
+    (pts (xy 27.94 165.1) (xy 27.94 194.31))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "02c8f0f2-9ae9-4035-bcdb-a42564f9ef85")
+  )
+  (wire
+    (pts (xy 27.94 204.47) (xy 25.4 236.22))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "8fb2288e-9eb1-4392-b8bf-08912e4dd2c7")
+  )
+  (wire
+    (pts (xy 25.4 243.84) (xy 25.4 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "d230372e-1a9a-426d-9060-d8b4ad314fae")
+  )
+  (wire
+    (pts (xy 102.87 154.94) (xy 102.87 25.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "d4701b9b-063c-40e5-bc6c-e61fdcbc8909")
+  )
+  (wire
+    (pts (xy 102.87 165.1) (xy 102.87 194.31))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "0d775473-45ac-4ad6-b913-ff3e9dfd97bc")
+  )
+  (wire
+    (pts (xy 102.87 204.47) (xy 100.33 236.22))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "e60dea33-08ef-4585-86eb-053739e0fe81")
+  )
+  (wire
+    (pts (xy 100.33 243.84) (xy 100.33 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "ce0056e4-a8ed-4b58-9a71-9b83d0a9662b")
+  )
+  (wire
+    (pts (xy 177.8 154.94) (xy 177.8 25.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "41cecd5f-eca4-45e3-a6ff-0c6f3aca8ac6")
+  )
+  (wire
+    (pts (xy 177.8 165.1) (xy 177.8 194.31))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "edebd743-dbf9-40e0-9110-21a44b48c763")
+  )
+  (wire
+    (pts (xy 177.8 204.47) (xy 175.26 236.22))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "2ce102c8-3446-4046-954c-4a78ebe6abcb")
+  )
+  (wire
+    (pts (xy 175.26 243.84) (xy 175.26 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "74a9d7e4-112c-443e-bd7b-acd5f842d90b")
+  )
+  (wire
+    (pts (xy 265.43 177.8) (xy 39.37 177.8))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "7fc47a0e-37d6-4091-8a34-ad6c8b0c72cf")
+  )
+  (wire
+    (pts (xy 39.37 177.8) (xy 39.37 180.34))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "96d4a2f4-d901-465f-82c5-f71473a24ec1")
+  )
+  (wire
+    (pts (xy 265.43 180.34) (xy 115.57 180.34))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "9a94a06b-2168-4d44-9a6c-cbf100a83bd4")
+  )
+  (wire
+    (pts (xy 115.57 180.34) (xy 115.57 180.34))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "7f0d3f3c-22ec-4530-95fa-28cd01d2518d")
+  )
+  (wire
+    (pts (xy 265.43 182.88) (xy 190.5 182.88))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "ca530f24-2a34-456d-a5f0-73c6f98a853c")
+  )
+  (wire
+    (pts (xy 190.5 182.88) (xy 190.5 180.34))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "b2903f3e-7882-4e17-80a9-244bd973c3e1")
+  )
+  (wire
+    (pts (xy 190.5 123.19) (xy 190.5 130.81))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "91bb3b47-280b-4247-a301-28b163c888a4")
+  )
+  (wire
+    (pts (xy 190.5 115.57) (xy 190.5 64.77))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "07277809-dd93-458a-994b-80bf3ea3d6ac")
+  )
+  (wire
+    (pts (xy 190.5 138.43) (xy 190.5 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "f5015cac-880a-49c1-9b4f-00ae3dbe85bb")
+  )
+  (wire
+    (pts (xy 209.55 123.19) (xy 209.55 130.81))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "05ca8fe2-a5ba-4354-a1b2-dd0ae52e1a42")
+  )
+  (wire
+    (pts (xy 209.55 115.57) (xy 209.55 64.77))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "18aa0b27-b6d9-4ee2-8e24-ff0ddd555228")
+  )
+  (wire
+    (pts (xy 209.55 138.43) (xy 209.55 279.4))
+    (stroke
+      (width 0)
+      (type default)
+    )
+    (uuid "a7ddd105-224d-4ff0-a577-24c8881d73b8")
+  )
+  (junction
+    (at 44.45 25.4)
+    (diameter 0)
+    (uuid "e523e7c4-8a6b-48a9-b834-7a18c3c1d998")
+  )
+  (junction
+    (at 64.77 25.4)
+    (diameter 0)
+    (uuid "4dc557d5-9063-4bae-bd32-918be538acad")
+  )
+  (junction
+    (at 64.77 279.4)
+    (diameter 0)
+    (uuid "2c6be889-98ef-45a6-aa46-579d22f7d764")
+  )
+  (junction
+    (at 80.01 25.4)
+    (diameter 0)
+    (uuid "03f9a89a-1b4a-4b59-ae16-1b0e8085ba9c")
+  )
+  (junction
+    (at 80.01 279.4)
+    (diameter 0)
+    (uuid "fbbeaa15-5a1f-4f50-8f85-f8dc2e8e2f50")
+  )
+  (junction
+    (at 95.25 25.4)
+    (diameter 0)
+    (uuid "65d19c6b-1642-4d6d-b5a0-64bbdc707475")
+  )
+  (junction
+    (at 95.25 279.4)
+    (diameter 0)
+    (uuid "185c32ff-ac58-4962-a0fe-287aabdad57c")
+  )
+  (junction
+    (at 30.48 279.4)
+    (diameter 0)
+    (uuid "7811a632-b3a5-4933-a0c4-a1b60208b440")
+  )
+  (junction
+    (at 90.17 44.45)
+    (diameter 0)
+    (uuid "db13971f-3f1a-4ff2-b529-4a9a7bb392a5")
+  )
+  (junction
+    (at 90.17 25.4)
+    (diameter 0)
+    (uuid "9f820ce1-8715-4fbe-ab4a-68a2009de2fa")
+  )
+  (junction
+    (at 64.77 25.4)
+    (diameter 0)
+    (uuid "4273a85f-a71a-46b0-97fe-18575f745b4b")
+  )
+  (junction
+    (at 64.77 279.4)
+    (diameter 0)
+    (uuid "b2b28d8e-047e-4675-9aa6-f3e4d566a438")
+  )
+  (junction
+    (at 115.57 44.45)
+    (diameter 0)
+    (uuid "dda9ca5b-cc4a-4693-a436-624715fc04b2")
+  )
+  (junction
+    (at 115.57 279.4)
+    (diameter 0)
+    (uuid "5991e4f1-3723-4a78-a707-99597bc6d575")
+  )
+  (junction
+    (at 132.08 44.45)
+    (diameter 0)
+    (uuid "ea82ea67-21bf-49cc-b0ea-89131157f3f7")
+  )
+  (junction
+    (at 147.32 64.77)
+    (diameter 0)
+    (uuid "c037288c-0cae-4272-9a5d-444d49d313af")
+  )
+  (junction
+    (at 139.7 279.4)
+    (diameter 0)
+    (uuid "6e7fafe0-744d-4def-a415-45fc4efaabff")
+  )
+  (junction
+    (at 124.46 44.45)
+    (diameter 0)
+    (uuid "d554f20b-684b-4a8b-89ec-7209389803c1")
+  )
+  (junction
+    (at 124.46 279.4)
+    (diameter 0)
+    (uuid "4b4f468c-86b8-4261-9691-e16666352c13")
+  )
+  (junction
+    (at 165.1 64.77)
+    (diameter 0)
+    (uuid "3aa84412-90f3-4dfd-a08e-ef9fda995d0c")
+  )
+  (junction
+    (at 165.1 279.4)
+    (diameter 0)
+    (uuid "1bda5748-0dfd-4662-a3a7-e9e18c0c9f9d")
+  )
+  (junction
+    (at 199.39 64.77)
+    (diameter 0)
+    (uuid "9c47b813-5900-49b4-b46d-990eed205f93")
+  )
+  (junction
+    (at 199.39 279.4)
+    (diameter 0)
+    (uuid "19f4ebfd-a1a5-49ae-a951-dd08a484dbb6")
+  )
+  (junction
+    (at 209.55 64.77)
+    (diameter 0)
+    (uuid "e2688f9f-9669-4dcb-9203-39c99394a6bd")
+  )
+  (junction
+    (at 209.55 279.4)
+    (diameter 0)
+    (uuid "da143365-c2b7-4210-a7b6-47e34db08dab")
+  )
+  (junction
+    (at 219.71 64.77)
+    (diameter 0)
+    (uuid "631cf8b1-d526-4125-8e8c-4bcf625f8551")
+  )
+  (junction
+    (at 219.71 279.4)
+    (diameter 0)
+    (uuid "2951ce7a-b747-4031-80ef-927ff736ed89")
+  )
+  (junction
+    (at 262.89 100.33)
+    (diameter 0)
+    (uuid "2e24d263-82dd-482e-baed-1fa573951af3")
+  )
+  (junction
+    (at 278.13 100.33)
+    (diameter 0)
+    (uuid "46234421-8f3d-444b-9439-fb668f583065")
+  )
+  (junction
+    (at 270.51 279.4)
+    (diameter 0)
+    (uuid "1b891778-6d7e-40d7-90fd-340024c97e6d")
+  )
+  (junction
+    (at 294.64 64.77)
+    (diameter 0)
+    (uuid "0c9dd106-9aea-4ea7-bd46-bb648df80516")
+  )
+  (junction
+    (at 294.64 279.4)
+    (diameter 0)
+    (uuid "de79f034-5064-4e01-add7-b921399872f3")
+  )
+  (junction
+    (at 299.72 44.45)
+    (diameter 0)
+    (uuid "64e158d4-c93a-4ca6-8fb0-c497ec612d93")
+  )
+  (junction
+    (at 299.72 279.4)
+    (diameter 0)
+    (uuid "809fbafc-0c45-4a43-973c-09be875c99d1")
+  )
+  (junction
+    (at 309.88 44.45)
+    (diameter 0)
+    (uuid "df1b9e4a-a1a2-4d11-a8df-ab4fe2d5f915")
+  )
+  (junction
+    (at 309.88 279.4)
+    (diameter 0)
+    (uuid "a677c463-df11-4a42-8d0b-d32d0ff507f9")
+  )
+  (junction
+    (at 27.94 25.4)
+    (diameter 0)
+    (uuid "3dd7306f-933f-4074-8989-382e73da831a")
+  )
+  (junction
+    (at 25.4 279.4)
+    (diameter 0)
+    (uuid "28cb3265-9f9d-47f5-9f10-96380eaf6d3a")
+  )
+  (junction
+    (at 102.87 25.4)
+    (diameter 0)
+    (uuid "a2e84223-cf84-4ee8-b308-d27b1f3e3232")
+  )
+  (junction
+    (at 100.33 279.4)
+    (diameter 0)
+    (uuid "77f90263-fe64-4c07-87b2-c302c6bbfb48")
+  )
+  (junction
+    (at 177.8 25.4)
+    (diameter 0)
+    (uuid "cb18572a-559e-4fe0-a7e5-ec5258c5fa6d")
+  )
+  (junction
+    (at 175.26 279.4)
+    (diameter 0)
+    (uuid "05ea8f83-630a-4da3-8c0a-5539a2a10833")
+  )
+  (junction
+    (at 190.5 64.77)
+    (diameter 0)
+    (uuid "ca567913-3473-4c35-b96b-d0e4bdcb92be")
+  )
+  (junction
+    (at 190.5 279.4)
+    (diameter 0)
+    (uuid "fc4d4b86-ff04-4a1e-9e81-c7df2f43f3cc")
+  )
+  (junction
+    (at 209.55 64.77)
+    (diameter 0)
+    (uuid "975be69c-3d42-4ab3-b795-d15374e49b33")
+  )
+  (junction
+    (at 209.55 279.4)
+    (diameter 0)
+    (uuid "1db5743a-0a08-4f51-abcd-89ed6751fa2c")
+  )
+  (label "VMOTOR"
+    (at 25.4 25.4 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "8c5efb4f-23dd-4bd4-9c94-e06b57aa6572")
+  )
+  (label "+5V"
+    (at 105.41 44.45 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "d6fddede-cd80-4bdd-b5af-ffa075769e3d")
+  )
+  (label "+3.3V"
+    (at 165.1 64.77 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "b272d775-ceb1-41b9-a9d7-dcc358a2597c")
+  )
+  (label "GND"
+    (at 25.4 279.4 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "3d91c677-4752-4c5d-a7d0-5dbaff29eb5a")
+  )
+  (label "PHASE_A"
+    (at 39.37 179.07 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "07c15cc2-8924-46d5-8bc9-172ad70fef10")
+  )
+  (label "ISENSE_A+"
+    (at 15.24 204.47 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "75389b04-f198-474e-99ff-d081f6a82536")
+  )
+  (label "ISENSE_A-"
+    (at 15.24 243.84 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "5581b737-f102-44fd-b33d-1b01d0ea9a9e")
+  )
+  (label "PHASE_B"
+    (at 115.57 179.07 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "0c1bd537-e40c-40ed-95f5-87fbf9b9ae46")
+  )
+  (label "ISENSE_B+"
+    (at 90.17 204.47 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "af465433-d6dd-4c4c-a3fd-1489f47cf64a")
+  )
+  (label "ISENSE_B-"
+    (at 90.17 243.84 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "59a641ca-f8f3-445b-8eaa-d152be7a5ff0")
+  )
+  (label "PHASE_C"
+    (at 190.5 179.07 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "08540e3a-41fd-4673-8ac4-046ec9eaec1b")
+  )
+  (label "ISENSE_C+"
+    (at 165.1 204.47 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "a0127912-3c88-4bda-9df7-ce66fdc23675")
+  )
+  (label "ISENSE_C-"
+    (at 165.1 243.84 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "1e4ad6a5-63e2-4bef-9b13-2489bc70b515")
+  )
+  (label "HALL_A"
+    (at 240.03 100.33 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "f8737173-f737-46b2-93e6-5246f85820e8")
+  )
+  (label "HALL_B"
+    (at 240.03 105.41 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "3f90f1df-1800-458f-8328-d2bd78022c29")
+  )
+  (label "HALL_C"
+    (at 240.03 110.49 0)
+    (fields_autoplaced yes)
+    (effects
+      (font
+        (size 1.27 1.27)
+      )
+      (justify left bottom)
+    )
+    (uuid "09a9aa5f-53d5-493a-a0ec-dd513e99e978")
+  )
+  (text "Buck Converter Module
+LM2596 24V→5V
+(See datasheet for full schematic)" (exclude_from_sim no) (at 80.01 95.25 0)
+    (effects
+      (font
+        (size 1.524 1.524)
+      )
+      (justify left)
+    )
+    (uuid "938b5473-cf3c-494a-89c6-c5593f0dcf56")
+  )
+  (text "MCU: STM32G431KB
+(Add from KiCad library:
+MCU_ST_STM32G4)" (exclude_from_sim no) (at 229.87 115.57 0)
+    (effects
+      (font
+        (size 1.524 1.524)
+      )
+      (justify left)
+    )
+    (uuid "76b2224d-cb66-4dc6-a7ab-3bf315f038e3")
+  )
+  (text "Gate Driver: DRV8301
+3-Phase Brushless
+(Add from TI library)" (exclude_from_sim no) (at 279.4 95.25 0)
+    (effects
+      (font
+        (size 1.524 1.524)
+      )
+      (justify left)
+    )
+    (uuid "5fe6c303-4518-4be8-b7e6-3b173171add5")
+  )
+  (text "BLDC Motor Controller Design Notes:
+=====================================
+1. MOSFETs Q1-Q6 require thermal vias (min 6 per device)
+2. Use 2mm+ trace width for motor phase and power traces
+3. Ground plane on bottom layer for heat spreading
+4. Keep gate drive traces short (<10mm)
+5. Kelvin connection for current sense resistors
+6. Separate analog ground near current sense
+7. Bulk capacitors near MOSFETs for motor current
+" (exclude_from_sim no) (at 25.4 299.72 0)
+    (effects
+      (font
+        (size 1.524 1.524)
+      )
+      (justify left)
+    )
+    (uuid "63649367-3d1f-45d8-9942-7fd9b6d809d1")
+  )
+  (sheet_instances
+    (path "/a75dbcf5-82df-40a2-967e-d4091cf026da" (page "1")
+    )
+  )
+)

--- a/boards/05-bldc-motor-controller/project.kct
+++ b/boards/05-bldc-motor-controller/project.kct
@@ -1,0 +1,190 @@
+kct_version: "1.0"
+
+project:
+  name: "BLDC Motor Controller"
+  revision: "A"
+  author: "kicad-tools"
+  description: |
+    Three-phase brushless DC motor controller demonstrating thermal management,
+    high-current routing, and power electronics design patterns.
+  artifacts:
+    schematic: "output/bldc_controller.kicad_sch"
+    pcb: "output/bldc_controller.kicad_pcb"
+    routed: "output/bldc_controller_routed.kicad_pcb"
+
+intent:
+  summary: |
+    Advanced test board for validating kicad-tools thermal analysis,
+    zone generation, and high-current trace routing capabilities.
+
+  use_cases:
+    - "Validate ThermalAnalyzer with power MOSFET dissipation"
+    - "Test ZoneGenerator for power plane creation"
+    - "Exercise net class differentiation (power vs signal)"
+    - "Demonstrate multi-voltage domain power supply design"
+
+  interfaces:
+    power_input:
+      type: "DC barrel/screw terminal"
+      voltage: "12-24V"
+      current: "15A max"
+
+    motor_output:
+      type: "3-phase BLDC"
+      phases: ["U", "V", "W"]
+      current: "10A per phase continuous"
+
+    hall_sensors:
+      type: "digital"
+      signals: ["HALL_A", "HALL_B", "HALL_C"]
+      voltage: "3.3V logic"
+
+    debug:
+      type: "SWD"
+      signals: ["SWDIO", "SWCLK", "NRST"]
+
+requirements:
+  electrical:
+    input_voltage:
+      min: 12
+      max: 24
+      unit: "V"
+
+    motor_current:
+      continuous: 10
+      peak: 15
+      unit: "A"
+
+    power_domains:
+      - name: "VMOTOR"
+        voltage: "12-24V"
+        description: "Motor power bus"
+      - name: "VDD_5V"
+        voltage: "5V"
+        description: "Gate driver supply"
+      - name: "VDD_3V3"
+        voltage: "3.3V"
+        description: "MCU and logic"
+
+  thermal:
+    max_ambient: 40
+    max_junction: 125
+    unit: "C"
+    notes: |
+      MOSFETs require thermal vias and copper pour for heat dissipation.
+      Expect 1-2W per MOSFET at full load.
+
+  mechanical:
+    board_size:
+      width: 60
+      height: 80
+      unit: "mm"
+    mounting: "4x M3 corner holes"
+
+  manufacturing:
+    layers: 2
+    min_trace: 0.2
+    min_space: 0.2
+    min_drill: 0.3
+    copper_weight: "2oz"
+    unit: "mm"
+    notes: "2oz copper recommended for motor phase traces"
+
+suggestions:
+  components:
+    gate_driver:
+      part: "DRV8301"
+      package: "QFN-56"
+      notes: "Integrated 3-phase gate driver with current sense amps"
+
+    mosfets:
+      part: "IRLZ44N"
+      package: "TO-220"
+      notes: "Logic-level N-channel, 55V 47A, Rds(on) 22mΩ"
+      alternative: "IRF3205 for higher current"
+
+    current_sense:
+      part: "Shunt resistor"
+      value: "0.005Ω"
+      package: "2512"
+      power: "1W"
+
+    buck_regulator:
+      part: "LM2596"
+      notes: "Simple switcher, 24V→5V @ 3A"
+
+    ldo:
+      part: "AMS1117-3.3"
+      notes: "5V→3.3V for MCU"
+
+    mcu:
+      part: "STM32G431"
+      package: "LQFP-48"
+      notes: "Motor control timers, 170MHz, integrated op-amps"
+
+  layout:
+    power_stage:
+      - "Place MOSFETs in H-bridge configuration near motor connector"
+      - "Use thermal vias under MOSFET tab (min 6 per device)"
+      - "Ground plane on bottom layer for heat spreading"
+      - "Keep gate drive traces short (<10mm)"
+
+    current_sense:
+      - "Use Kelvin connection to shunt resistors"
+      - "Route sense traces away from switching nodes"
+      - "Place sense amplifier close to shunts"
+
+    power_supply:
+      - "Separate motor power from logic power at input"
+      - "Use star-ground topology"
+      - "Bulk capacitors near power input and MOSFETs"
+
+    signal_integrity:
+      - "Keep PWM traces away from sense traces"
+      - "Use ground guard traces around sensitive signals"
+
+decisions:
+  - id: "discrete-mosfets"
+    description: "Use discrete MOSFETs instead of integrated driver"
+    rationale: |
+      Discrete MOSFETs provide better thermal visibility for testing
+      ThermalAnalyzer. TO-220 package has well-characterized thermal
+      properties and requires explicit thermal management.
+    alternatives:
+      - "Integrated half-bridge ICs (e.g., IR2184 + dual MOSFET)"
+      - "Smart power modules"
+
+  - id: "2-layer-board"
+    description: "Use 2-layer PCB instead of 4-layer"
+    rationale: |
+      Tests routing capability on constrained layer count.
+      Requires careful copper pour management for power delivery.
+      More challenging thermal design validates thermal analysis.
+    alternatives:
+      - "4-layer with dedicated power planes"
+
+  - id: "through-hole-power"
+    description: "Use through-hole for power components"
+    rationale: |
+      TO-220 MOSFETs and through-hole screw terminals are
+      common in motor control. Tests mixed SMD/THT routing.
+
+progress:
+  phase: "design"
+  checklist:
+    - task: "Create schematic"
+      status: "pending"
+    - task: "Run ERC"
+      status: "pending"
+    - task: "Create PCB"
+      status: "pending"
+    - task: "Place components"
+      status: "pending"
+    - task: "Add zones"
+      status: "pending"
+    - task: "Route traces"
+      status: "pending"
+    - task: "Run thermal analysis"
+      status: "pending"
+    - task: "Run DRC"
+      status: "pending"

--- a/src/kicad_tools/schematic/blocks/__init__.py
+++ b/src/kicad_tools/schematic/blocks/__init__.py
@@ -75,6 +75,17 @@ from .power import (
     create_voltage_divider,
 )
 
+# Motor control blocks
+from .motor import (
+    CurrentSenseShunt,
+    GateDriverBlock,
+    HalfBridge,
+    ThreePhaseInverter,
+    create_3phase_inverter,
+    create_current_sense,
+    create_half_bridge,
+)
+
 # Timing blocks
 from .timing import (
     CrystalOscillator,
@@ -128,4 +139,12 @@ __all__ = [
     "create_generic_boot",
     "create_reset_button",
     "create_stm32_boot",
+    # Motor control
+    "HalfBridge",
+    "ThreePhaseInverter",
+    "CurrentSenseShunt",
+    "GateDriverBlock",
+    "create_half_bridge",
+    "create_3phase_inverter",
+    "create_current_sense",
 ]

--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -1,0 +1,900 @@
+"""Motor control circuit blocks: half-bridges, gate drivers, current sensing."""
+
+from typing import TYPE_CHECKING
+
+from .base import CircuitBlock
+
+if TYPE_CHECKING:
+    from kicad_sch_helper import Schematic
+
+
+class HalfBridge(CircuitBlock):
+    """
+    Half-bridge circuit with high-side and low-side N-channel MOSFETs.
+
+    A half-bridge is the fundamental building block for motor drives,
+    DC-DC converters, and other power electronics applications.
+
+    Schematic:
+        VIN ────────┬────────
+                    │
+                   [Q_HS]  (High-side MOSFET)
+                    │
+                    ├─── GATE_HS
+                    │
+        VOUT ───────┼────────  (Phase output)
+                    │
+                   [Q_LS]  (Low-side MOSFET)
+                    │
+                    ├─── GATE_LS
+                    │
+        GND ────────┴────────
+
+    With bootstrap (optional):
+        VIN ────────┬────────
+                    │
+                   [D_BOOT]──[C_BOOT]──VBOOT
+                    │
+                   [Q_HS]
+                    │
+                    ...
+
+    Ports:
+        - VIN: High-side power supply (motor voltage)
+        - VOUT: Phase output (connects to motor winding)
+        - GND: Ground reference
+        - GATE_HS: High-side gate drive input
+        - GATE_LS: Low-side gate drive input
+        - VBOOT: Bootstrap voltage (if bootstrap enabled)
+
+    Thermal Metadata:
+        MOSFETs are tagged with thermal metadata for ThermalAnalyzer integration.
+
+    Example:
+        from kicad_tools.schematic.blocks import HalfBridge
+
+        hb = HalfBridge(
+            sch, x=100, y=100,
+            ref_prefix="Q",
+            mosfet_value="IRLZ44N",
+            bootstrap_cap="100nF",
+        )
+        hb.connect_to_rails(vin_rail_y=30, gnd_rail_y=200)
+    """
+
+    def __init__(
+        self,
+        sch: "Schematic",
+        x: float,
+        y: float,
+        ref_start: int = 1,
+        ref_prefix: str = "Q",
+        mosfet_value: str = "IRLZ44N",
+        mosfet_symbol: str = "Device:Q_NMOS_GDS",
+        bootstrap_cap: str | None = None,
+        bootstrap_diode: str = "1N4148",
+        cap_ref_prefix: str = "C",
+        diode_ref_prefix: str = "D",
+        cap_ref_start: int | None = None,
+        diode_ref_start: int | None = None,
+        hs_ls_spacing: float = 40,
+    ):
+        """
+        Create a half-bridge circuit.
+
+        Args:
+            sch: Schematic to add to
+            x: X coordinate of MOSFETs
+            y: Y coordinate (center of high-side MOSFET)
+            ref_start: Starting reference number for MOSFETs
+            ref_prefix: Reference designator prefix for MOSFETs
+            mosfet_value: MOSFET part number/value
+            mosfet_symbol: KiCad symbol for N-channel MOSFETs
+            bootstrap_cap: Bootstrap capacitor value (None to disable)
+            bootstrap_diode: Bootstrap diode part number
+            cap_ref_prefix: Reference prefix for bootstrap capacitor
+            diode_ref_prefix: Reference prefix for bootstrap diode
+            cap_ref_start: Starting reference for capacitor (defaults to ref_start)
+            diode_ref_start: Starting reference for diode (defaults to ref_start)
+            hs_ls_spacing: Vertical spacing between HS and LS MOSFETs
+        """
+        super().__init__(sch, x, y)
+        self.has_bootstrap = bootstrap_cap is not None
+
+        # Default ref numbers if not specified
+        if cap_ref_start is None:
+            cap_ref_start = ref_start
+        if diode_ref_start is None:
+            diode_ref_start = ref_start
+
+        # Place high-side MOSFET
+        hs_ref = f"{ref_prefix}{ref_start}"
+        self.mosfet_hs = sch.add_symbol(
+            mosfet_symbol,
+            x,
+            y,
+            hs_ref,
+            mosfet_value,
+            properties={"Thermal_Rth_JC": "0.5", "Power_Dissipation": "5W"},
+        )
+
+        # Place low-side MOSFET
+        ls_ref = f"{ref_prefix}{ref_start + 1}"
+        ls_y = y + hs_ls_spacing
+        self.mosfet_ls = sch.add_symbol(
+            mosfet_symbol,
+            x,
+            ls_y,
+            ls_ref,
+            mosfet_value,
+            properties={"Thermal_Rth_JC": "0.5", "Power_Dissipation": "5W"},
+        )
+
+        self.components = {
+            "Q_HS": self.mosfet_hs,
+            "Q_LS": self.mosfet_ls,
+        }
+
+        # Get MOSFET pin positions
+        hs_drain = self.mosfet_hs.pin_position("D")
+        hs_source = self.mosfet_hs.pin_position("S")
+        hs_gate = self.mosfet_hs.pin_position("G")
+        ls_drain = self.mosfet_ls.pin_position("D")
+        ls_source = self.mosfet_ls.pin_position("S")
+        ls_gate = self.mosfet_ls.pin_position("G")
+
+        # Wire HS source to LS drain (phase output node)
+        sch.add_wire(hs_source, ls_drain)
+        phase_out_pos = (hs_source[0], (hs_source[1] + ls_drain[1]) / 2)
+
+        # Add junction at phase output
+        sch.add_junction(phase_out_pos[0], phase_out_pos[1])
+
+        # Bootstrap circuit (optional)
+        if self.has_bootstrap:
+            # Bootstrap diode from VIN to VBOOT
+            boot_diode_ref = f"{diode_ref_prefix}{diode_ref_start}"
+            boot_diode_x = x - 20
+            boot_diode_y = y - 15
+            self.bootstrap_diode = sch.add_symbol(
+                "Device:D",
+                boot_diode_x,
+                boot_diode_y,
+                boot_diode_ref,
+                bootstrap_diode,
+            )
+            self.components["D_BOOT"] = self.bootstrap_diode
+
+            # Bootstrap capacitor from VBOOT to phase output
+            boot_cap_ref = f"{cap_ref_prefix}{cap_ref_start}"
+            boot_cap_x = x - 20
+            boot_cap_y = y
+            self.bootstrap_cap = sch.add_symbol(
+                "Device:C",
+                boot_cap_x,
+                boot_cap_y,
+                boot_cap_ref,
+                bootstrap_cap,
+            )
+            self.components["C_BOOT"] = self.bootstrap_cap
+
+            # Wire bootstrap circuit
+            diode_cathode = self.bootstrap_diode.pin_position("K")
+            cap_pin1 = self.bootstrap_cap.pin_position("1")
+            cap_pin2 = self.bootstrap_cap.pin_position("2")
+
+            # Diode cathode to cap positive
+            sch.add_wire(diode_cathode, cap_pin1)
+
+            # Cap negative to phase output
+            sch.add_wire(cap_pin2, (cap_pin2[0], phase_out_pos[1]))
+            sch.add_wire((cap_pin2[0], phase_out_pos[1]), phase_out_pos)
+
+            # VBOOT port at diode cathode/cap positive
+            vboot_pos = cap_pin1
+        else:
+            vboot_pos = None
+
+        # Define ports
+        self.ports = {
+            "VIN": hs_drain,
+            "VOUT": phase_out_pos,
+            "GND": ls_source,
+            "GATE_HS": hs_gate,
+            "GATE_LS": ls_gate,
+        }
+
+        if self.has_bootstrap:
+            self.ports["VBOOT"] = vboot_pos
+            # VIN for bootstrap diode anode
+            self.ports["VIN_BOOT"] = self.bootstrap_diode.pin_position("A")
+
+        # Store for rail connections
+        self._vin_pos = hs_drain
+        self._gnd_pos = ls_source
+
+    def connect_to_rails(
+        self,
+        vin_rail_y: float,
+        gnd_rail_y: float,
+        add_junctions: bool = True,
+    ) -> None:
+        """
+        Connect half-bridge to power rails.
+
+        Args:
+            vin_rail_y: Y coordinate of VIN (motor voltage) rail
+            gnd_rail_y: Y coordinate of ground rail
+            add_junctions: Whether to add junction markers
+        """
+        sch = self.schematic
+
+        # Connect HS drain to VIN rail
+        vin_pos = self._vin_pos
+        sch.add_wire(vin_pos, (vin_pos[0], vin_rail_y))
+
+        # Connect LS source to GND rail
+        gnd_pos = self._gnd_pos
+        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y))
+
+        if add_junctions:
+            sch.add_junction(vin_pos[0], vin_rail_y)
+            sch.add_junction(gnd_pos[0], gnd_rail_y)
+
+        # Connect bootstrap diode anode to VIN rail
+        if self.has_bootstrap:
+            boot_vin = self.ports["VIN_BOOT"]
+            sch.add_wire(boot_vin, (boot_vin[0], vin_rail_y))
+            if add_junctions:
+                sch.add_junction(boot_vin[0], vin_rail_y)
+
+
+class ThreePhaseInverter(CircuitBlock):
+    """
+    Three-phase inverter using three half-bridges.
+
+    Commonly used for BLDC motor control, AC motor drives, and
+    3-phase power conversion.
+
+    Schematic:
+        VIN ────┬────────┬────────┬────────
+                │        │        │
+              [HB_A]   [HB_B]   [HB_C]
+                │        │        │
+               U/A      V/B      W/C    (Phase outputs)
+                │        │        │
+        GND ────┴────────┴────────┴────────
+
+    Ports:
+        - VIN: Motor voltage supply
+        - GND: Ground reference
+        - PHASE_A/U: Phase A output
+        - PHASE_B/V: Phase B output
+        - PHASE_C/W: Phase C output
+        - GATE_HS_A/B/C: High-side gate inputs
+        - GATE_LS_A/B/C: Low-side gate inputs
+
+    Example:
+        from kicad_tools.schematic.blocks import ThreePhaseInverter
+
+        inverter = ThreePhaseInverter(
+            sch, x=100, y=100,
+            mosfet_value="IRLZ44N",
+            phase_labels=["U", "V", "W"],
+        )
+        inverter.connect_to_rails(vin_rail_y=30, gnd_rail_y=200)
+    """
+
+    def __init__(
+        self,
+        sch: "Schematic",
+        x: float,
+        y: float,
+        ref_start: int = 1,
+        ref_prefix: str = "Q",
+        mosfet_value: str = "IRLZ44N",
+        mosfet_symbol: str = "Device:Q_NMOS_GDS",
+        bootstrap_cap: str | None = None,
+        phase_labels: list[str] | None = None,
+        phase_spacing: float = 75,
+        hs_ls_spacing: float = 40,
+    ):
+        """
+        Create a three-phase inverter.
+
+        Args:
+            sch: Schematic to add to
+            x: X coordinate of first phase (Phase A)
+            y: Y coordinate (center of high-side MOSFETs)
+            ref_start: Starting reference number for MOSFETs (Q1-Q6)
+            ref_prefix: Reference designator prefix for MOSFETs
+            mosfet_value: MOSFET part number/value
+            mosfet_symbol: KiCad symbol for N-channel MOSFETs
+            bootstrap_cap: Bootstrap capacitor value (None to disable)
+            phase_labels: Labels for phases (default: ["A", "B", "C"])
+            phase_spacing: Horizontal spacing between phases
+            hs_ls_spacing: Vertical spacing between HS and LS MOSFETs
+        """
+        super().__init__(sch, x, y)
+
+        if phase_labels is None:
+            phase_labels = ["A", "B", "C"]
+
+        self.phase_labels = phase_labels
+        self.half_bridges: list[HalfBridge] = []
+
+        # Create three half-bridges
+        for i, label in enumerate(phase_labels):
+            hb_x = x + i * phase_spacing
+            hb_ref_start = ref_start + i * 2  # Q1-Q2, Q3-Q4, Q5-Q6
+
+            hb = HalfBridge(
+                sch,
+                hb_x,
+                y,
+                ref_start=hb_ref_start,
+                ref_prefix=ref_prefix,
+                mosfet_value=mosfet_value,
+                mosfet_symbol=mosfet_symbol,
+                bootstrap_cap=bootstrap_cap,
+                cap_ref_start=i + 1 if bootstrap_cap else None,
+                diode_ref_start=i + 1 if bootstrap_cap else None,
+                hs_ls_spacing=hs_ls_spacing,
+            )
+            self.half_bridges.append(hb)
+
+            # Add phase output label
+            phase_pos = hb.port("VOUT")
+            sch.add_label(f"PHASE_{label}", phase_pos[0] + 10, phase_pos[1], rotation=0)
+
+        # Store all components
+        self.components = {}
+        for i, hb in enumerate(self.half_bridges):
+            label = phase_labels[i]
+            for name, comp in hb.components.items():
+                self.components[f"{name}_{label}"] = comp
+
+        # Define ports
+        self.ports = {
+            "VIN": self.half_bridges[0].port("VIN"),
+            "GND": self.half_bridges[0].port("GND"),
+        }
+
+        # Add phase-specific ports
+        for i, label in enumerate(phase_labels):
+            hb = self.half_bridges[i]
+            self.ports[f"PHASE_{label}"] = hb.port("VOUT")
+            self.ports[f"GATE_HS_{label}"] = hb.port("GATE_HS")
+            self.ports[f"GATE_LS_{label}"] = hb.port("GATE_LS")
+            if bootstrap_cap:
+                self.ports[f"VBOOT_{label}"] = hb.port("VBOOT")
+
+    def connect_to_rails(
+        self,
+        vin_rail_y: float,
+        gnd_rail_y: float,
+        add_junctions: bool = True,
+    ) -> None:
+        """
+        Connect all half-bridges to power rails.
+
+        Args:
+            vin_rail_y: Y coordinate of VIN (motor voltage) rail
+            gnd_rail_y: Y coordinate of ground rail
+            add_junctions: Whether to add junction markers
+        """
+        for hb in self.half_bridges:
+            hb.connect_to_rails(vin_rail_y, gnd_rail_y, add_junctions)
+
+
+class CurrentSenseShunt(CircuitBlock):
+    """
+    Low-side current sensing using a shunt resistor.
+
+    Provides current measurement for motor control applications,
+    with optional current sense amplifier.
+
+    Schematic (basic):
+        IN+ ────┬────
+                │
+              [R_SHUNT]
+                │
+        IN- ────┴──── GND
+
+    Schematic (with amplifier):
+        IN+ ────┬────────────────
+                │        ┌──────┐
+              [R_SHUNT]  │ CSA  │──── OUT
+                │        └──────┘
+        IN- ────┴────────┴────── GND
+
+    Ports:
+        - IN_POS: Positive input (from load/motor)
+        - IN_NEG: Negative input (to ground)
+        - GND: Ground reference
+        - OUT: Amplified output (if amplifier enabled)
+        - VREF: Reference voltage input for amplifier (if present)
+
+    Example:
+        from kicad_tools.schematic.blocks import CurrentSenseShunt
+
+        sense = CurrentSenseShunt(
+            sch, x=100, y=150,
+            shunt_value="5mR",
+            amplifier=True,
+            gain=20,
+        )
+        sense.connect_to_rails(gnd_rail_y=200)
+    """
+
+    def __init__(
+        self,
+        sch: "Schematic",
+        x: float,
+        y: float,
+        shunt_value: str = "10mR",
+        shunt_package: str = "2512",
+        ref_start: int = 1,
+        ref_prefix: str = "R",
+        resistor_symbol: str = "Device:R",
+        amplifier: bool = False,
+        amplifier_symbol: str = "Amplifier_Current:INA240A1",
+        amplifier_ref: str = "U",
+        gain: float = 20,
+        amp_ref_start: int = 1,
+        bypass_caps: list[str] | None = None,
+        cap_ref_start: int = 1,
+    ):
+        """
+        Create a current sense shunt circuit.
+
+        Args:
+            sch: Schematic to add to
+            x: X coordinate of shunt resistor
+            y: Y coordinate of shunt resistor
+            shunt_value: Shunt resistor value (e.g., "5mR", "10mR", "50mR")
+            shunt_package: Shunt resistor package (for power handling)
+            ref_start: Starting reference number for shunt resistor
+            ref_prefix: Reference designator prefix for shunt resistor
+            resistor_symbol: KiCad symbol for resistor
+            amplifier: If True, add a current sense amplifier
+            amplifier_symbol: KiCad symbol for current sense amplifier
+            amplifier_ref: Reference prefix for amplifier
+            gain: Amplifier gain (for labeling purposes)
+            amp_ref_start: Starting reference number for amplifier
+            bypass_caps: Bypass capacitor values for amplifier (default: ["100nF"])
+            cap_ref_start: Starting reference number for capacitors
+        """
+        super().__init__(sch, x, y)
+        self.has_amplifier = amplifier
+        self.shunt_value = shunt_value
+        self.gain = gain
+
+        # Place shunt resistor
+        shunt_ref = f"{ref_prefix}{ref_start}"
+        self.shunt = sch.add_symbol(
+            resistor_symbol,
+            x,
+            y,
+            shunt_ref,
+            shunt_value,
+            properties={"Package": shunt_package, "Power_Rating": "1W"},
+        )
+
+        self.components = {"R_SHUNT": self.shunt}
+
+        # Get shunt pin positions
+        shunt_pin1 = self.shunt.pin_position("1")  # IN+ side (from load)
+        shunt_pin2 = self.shunt.pin_position("2")  # IN- side (to ground)
+
+        # Define basic ports
+        self.ports = {
+            "IN_POS": shunt_pin1,
+            "IN_NEG": shunt_pin2,
+            "GND": shunt_pin2,
+        }
+
+        # Current sense amplifier (optional)
+        if amplifier:
+            if bypass_caps is None:
+                bypass_caps = ["100nF"]
+
+            amp_ref = f"{amplifier_ref}{amp_ref_start}"
+            amp_x = x + 30
+            amp_y = y
+
+            self.amplifier = sch.add_symbol(
+                amplifier_symbol,
+                amp_x,
+                amp_y,
+                amp_ref,
+                f"INA240 G={gain}",
+            )
+            self.components["CSA"] = self.amplifier
+
+            # Get amplifier pin positions
+            amp_inp = self.amplifier.pin_position("IN+")
+            amp_inn = self.amplifier.pin_position("IN-")
+            amp_out = self.amplifier.pin_position("OUT")
+            amp_vs = self.amplifier.pin_position("VS")
+            amp_gnd = self.amplifier.pin_position("GND")
+
+            # Wire shunt to amplifier inputs
+            sch.add_wire(shunt_pin1, amp_inp)
+            sch.add_wire(shunt_pin2, amp_inn)
+
+            # Add bypass capacitor(s)
+            self.bypass_caps = []
+            for i, cap_value in enumerate(bypass_caps):
+                cap_ref = f"C{cap_ref_start + i}"
+                cap_x = amp_x + 15 + i * 10
+                cap_y = amp_y - 10
+                cap = sch.add_symbol("Device:C", cap_x, cap_y, cap_ref, cap_value)
+                self.bypass_caps.append(cap)
+                self.components[f"C_BYPASS{i + 1}"] = cap
+
+            # Add amplifier-specific ports
+            self.ports["OUT"] = amp_out
+            self.ports["VS"] = amp_vs
+            self.ports["AMP_GND"] = amp_gnd
+
+            # Store for rail connections
+            self._amp_vs = amp_vs
+            self._amp_gnd = amp_gnd
+
+    def connect_to_rails(
+        self,
+        gnd_rail_y: float,
+        vcc_rail_y: float | None = None,
+        add_junctions: bool = True,
+    ) -> None:
+        """
+        Connect current sense circuit to power rails.
+
+        Args:
+            gnd_rail_y: Y coordinate of ground rail
+            vcc_rail_y: Y coordinate of VCC rail (for amplifier supply)
+            add_junctions: Whether to add junction markers
+        """
+        sch = self.schematic
+
+        # Connect shunt GND to rail
+        gnd_pos = self.ports["GND"]
+        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y))
+
+        if add_junctions:
+            sch.add_junction(gnd_pos[0], gnd_rail_y)
+
+        # Connect amplifier if present
+        if self.has_amplifier and vcc_rail_y is not None:
+            # Connect VS to VCC
+            vs_pos = self._amp_vs
+            sch.add_wire(vs_pos, (vs_pos[0], vcc_rail_y))
+
+            # Connect amplifier GND
+            amp_gnd = self._amp_gnd
+            sch.add_wire(amp_gnd, (amp_gnd[0], gnd_rail_y))
+
+            # Wire bypass caps
+            for cap in self.bypass_caps:
+                sch.wire_decoupling_cap(cap, vcc_rail_y, gnd_rail_y)
+
+            if add_junctions:
+                sch.add_junction(vs_pos[0], vcc_rail_y)
+                sch.add_junction(amp_gnd[0], gnd_rail_y)
+
+    def get_voltage_output(self, current_amps: float) -> float:
+        """
+        Calculate expected output voltage for a given current.
+
+        Args:
+            current_amps: Current through the shunt in amperes.
+
+        Returns:
+            Output voltage in volts (shunt voltage * gain if amplifier present).
+        """
+        # Parse shunt resistance
+        shunt_ohms = self._parse_resistance(self.shunt_value)
+        shunt_voltage = current_amps * shunt_ohms
+
+        if self.has_amplifier:
+            return shunt_voltage * self.gain
+        return shunt_voltage
+
+    @staticmethod
+    def _parse_resistance(value: str) -> float:
+        """
+        Parse a resistance string to ohms.
+
+        Supports: mR (milliohms), R (ohms), k (kilohms), M (megohms).
+
+        Args:
+            value: Resistance string like "5mR", "10mR", "100R", "10k"
+
+        Returns:
+            Resistance in ohms.
+        """
+        value = value.strip().upper()
+
+        # Handle milliohm notation
+        if value.endswith("MR"):
+            return float(value[:-2]) / 1000
+
+        # Handle inline R notation (e.g., "4R7" = 4.7 ohms)
+        if "R" in value and not value.endswith("R"):
+            parts = value.split("R")
+            if len(parts) == 2:
+                return float(parts[0]) + float(f"0.{parts[1]}")
+
+        # Handle suffix notation
+        if value.endswith("K"):
+            return float(value[:-1]) * 1000
+        elif value.endswith("M"):
+            return float(value[:-1]) * 1_000_000
+        elif value.endswith("R"):
+            return float(value[:-1])
+        else:
+            return float(value)
+
+
+class GateDriverBlock(CircuitBlock):
+    """
+    Gate driver IC block with bootstrap capacitors.
+
+    Provides the gate drive circuitry for half-bridge or three-phase
+    motor control applications.
+
+    Schematic (3-phase example):
+        VCC ──┬─────────────────────────────
+              │    ┌───────────────────┐
+              └────┤ VS                │
+                   │                   │
+        BOOT_A ────┤ HB_A    HO_A ─────┼──── GATE_HS_A
+        BOOT_B ────┤ HB_B    HO_B ─────┼──── GATE_HS_B
+        BOOT_C ────┤ HB_C    HO_C ─────┼──── GATE_HS_C
+                   │                   │
+        PWM_AH ────┤ IN_HA   LO_A ─────┼──── GATE_LS_A
+        PWM_BH ────┤ IN_HB   LO_B ─────┼──── GATE_LS_B
+        PWM_CH ────┤ IN_HC   LO_C ─────┼──── GATE_LS_C
+                   │                   │
+        PWM_AL ────┤ IN_LA             │
+        PWM_BL ────┤ IN_LB             │
+        PWM_CL ────┤ IN_LC             │
+                   │                   │
+        GND ───────┤ GND               │
+                   └───────────────────┘
+
+    Ports:
+        - VCC: Logic supply voltage
+        - GND: Ground reference
+        - BOOT_A/B/C: Bootstrap pin connections
+        - GATE_HS_A/B/C: High-side gate outputs
+        - GATE_LS_A/B/C: Low-side gate outputs
+        - PWM_AH/BH/CH: High-side PWM inputs
+        - PWM_AL/BL/CL: Low-side PWM inputs
+
+    Example:
+        from kicad_tools.schematic.blocks import GateDriverBlock
+
+        driver = GateDriverBlock(
+            sch, x=200, y=100,
+            driver_type="3-phase",
+            ref="U4",
+            value="DRV8301",
+            bootstrap_caps="100nF",
+        )
+    """
+
+    def __init__(
+        self,
+        sch: "Schematic",
+        x: float,
+        y: float,
+        driver_type: str = "3-phase",
+        ref: str = "U1",
+        value: str = "DRV8301",
+        driver_symbol: str | None = None,
+        bootstrap_caps: str = "100nF",
+        bypass_caps: list[str] | None = None,
+        cap_ref_start: int = 1,
+    ):
+        """
+        Create a gate driver block.
+
+        Args:
+            sch: Schematic to add to
+            x: X coordinate of driver IC
+            y: Y coordinate of driver IC
+            driver_type: Type of driver - "3-phase" or "half-bridge"
+            ref: Reference designator for driver IC
+            value: Driver IC part number
+            driver_symbol: KiCad symbol (auto-selected based on driver_type if None)
+            bootstrap_caps: Bootstrap capacitor value per phase
+            bypass_caps: Bypass capacitor values (default: ["10uF", "100nF"])
+            cap_ref_start: Starting reference number for capacitors
+        """
+        super().__init__(sch, x, y)
+        self.driver_type = driver_type
+
+        if bypass_caps is None:
+            bypass_caps = ["10uF", "100nF"]
+
+        # Select symbol based on driver type
+        if driver_symbol is None:
+            if driver_type == "3-phase":
+                driver_symbol = "Driver_FET:DRV8301"
+            else:
+                driver_symbol = "Driver_FET:IR2110"
+
+        # Add placeholder text for the driver IC
+        # (In production, would use actual driver symbol from library)
+        sch.add_text(
+            f"Gate Driver: {value}\nType: {driver_type}\n(Add from library)",
+            x=x,
+            y=y,
+        )
+
+        self.components = {}
+
+        # Number of phases
+        num_phases = 3 if driver_type == "3-phase" else 1
+        phase_labels = ["A", "B", "C"][:num_phases]
+
+        # Add bootstrap capacitors
+        self.bootstrap_caps = []
+        for i in range(num_phases):
+            cap_ref = f"C{cap_ref_start + i}"
+            cap_x = x - 20 + i * 10
+            cap_y = y - 15
+            cap = sch.add_symbol("Device:C", cap_x, cap_y, cap_ref, bootstrap_caps)
+            self.bootstrap_caps.append(cap)
+            self.components[f"C_BOOT_{phase_labels[i]}"] = cap
+
+        # Add bypass capacitors
+        self.bypass_caps = []
+        bypass_start = cap_ref_start + num_phases
+        for i, cap_value in enumerate(bypass_caps):
+            cap_ref = f"C{bypass_start + i}"
+            cap_x = x + 20 + i * 10
+            cap_y = y - 15
+            cap = sch.add_symbol("Device:C", cap_x, cap_y, cap_ref, cap_value)
+            self.bypass_caps.append(cap)
+            self.components[f"C_BYPASS{i + 1}"] = cap
+
+        # Define placeholder ports (positions relative to driver center)
+        # These would be updated with actual pin positions from the symbol
+        self.ports = {
+            "VCC": (x, y - 20),
+            "GND": (x, y + 20),
+        }
+
+        for i, label in enumerate(phase_labels):
+            offset = (i - 1) * 15  # Spread ports horizontally
+            self.ports[f"BOOT_{label}"] = (x + offset - 30, y - 10)
+            self.ports[f"GATE_HS_{label}"] = (x + offset + 30, y - 5)
+            self.ports[f"GATE_LS_{label}"] = (x + offset + 30, y + 5)
+            self.ports[f"PWM_H_{label}"] = (x + offset - 30, y + 5)
+            self.ports[f"PWM_L_{label}"] = (x + offset - 30, y + 10)
+
+    def connect_to_rails(
+        self,
+        vcc_rail_y: float,
+        gnd_rail_y: float,
+        add_junctions: bool = True,
+    ) -> None:
+        """
+        Connect gate driver to power rails.
+
+        Args:
+            vcc_rail_y: Y coordinate of VCC rail
+            gnd_rail_y: Y coordinate of ground rail
+            add_junctions: Whether to add junction markers
+        """
+        sch = self.schematic
+
+        # Wire bypass capacitors
+        for cap in self.bypass_caps:
+            sch.wire_decoupling_cap(cap, vcc_rail_y, gnd_rail_y)
+
+
+# Factory functions
+
+
+def create_half_bridge(
+    sch: "Schematic",
+    x: float,
+    y: float,
+    mosfet_value: str = "IRLZ44N",
+    ref_start: int = 1,
+    with_bootstrap: bool = False,
+) -> HalfBridge:
+    """
+    Create a half-bridge with common defaults.
+
+    Args:
+        sch: Schematic to add to
+        x: X coordinate
+        y: Y coordinate
+        mosfet_value: MOSFET part number
+        ref_start: Starting reference number
+        with_bootstrap: Include bootstrap circuit
+
+    Returns:
+        HalfBridge instance.
+    """
+    return HalfBridge(
+        sch,
+        x,
+        y,
+        ref_start=ref_start,
+        mosfet_value=mosfet_value,
+        bootstrap_cap="100nF" if with_bootstrap else None,
+    )
+
+
+def create_3phase_inverter(
+    sch: "Schematic",
+    x: float,
+    y: float,
+    mosfet_value: str = "IRLZ44N",
+    ref_start: int = 1,
+    with_bootstrap: bool = False,
+) -> ThreePhaseInverter:
+    """
+    Create a 3-phase inverter for motor control.
+
+    Args:
+        sch: Schematic to add to
+        x: X coordinate of first phase
+        y: Y coordinate
+        mosfet_value: MOSFET part number
+        ref_start: Starting reference number
+        with_bootstrap: Include bootstrap circuits
+
+    Returns:
+        ThreePhaseInverter instance.
+    """
+    return ThreePhaseInverter(
+        sch,
+        x,
+        y,
+        ref_start=ref_start,
+        mosfet_value=mosfet_value,
+        bootstrap_cap="100nF" if with_bootstrap else None,
+        phase_labels=["A", "B", "C"],
+    )
+
+
+def create_current_sense(
+    sch: "Schematic",
+    x: float,
+    y: float,
+    shunt_value: str = "10mR",
+    ref_start: int = 1,
+    with_amplifier: bool = False,
+    gain: float = 20,
+) -> CurrentSenseShunt:
+    """
+    Create a current sense circuit.
+
+    Args:
+        sch: Schematic to add to
+        x: X coordinate
+        y: Y coordinate
+        shunt_value: Shunt resistor value
+        ref_start: Starting reference number
+        with_amplifier: Include current sense amplifier
+        gain: Amplifier gain
+
+    Returns:
+        CurrentSenseShunt instance.
+    """
+    return CurrentSenseShunt(
+        sch,
+        x,
+        y,
+        shunt_value=shunt_value,
+        ref_start=ref_start,
+        amplifier=with_amplifier,
+        gain=gain,
+    )


### PR DESCRIPTION
## Summary
- Add `HalfBridge` block with high/low-side MOSFETs and optional bootstrap circuit
- Add `ThreePhaseInverter` convenience block for 3-phase motor control
- Add `CurrentSenseShunt` block with optional amplifier for current measurement
- Add `GateDriverBlock` for gate driver ICs with bootstrap capacitors
- Update board 05 to demonstrate usage of new motor control blocks

## Test plan
- [x] Run unit tests for new blocks (`pytest tests/test_schematic_blocks.py -k Motor`)
- [x] Verify all 29 motor control tests pass
- [x] Verify code passes format check (`pnpm run format:check`)
- [ ] Test board 05 design generation in KiCad

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)