### PR TITLE
docs(boards): Add environment setup prerequisites for manual builds

### DIFF
--- a/boards/01-voltage-divider/README.md
+++ b/boards/01-voltage-divider/README.md
@@ -57,12 +57,13 @@ Two 10k resistors divide the 5V input to produce 2.5V output (50% division ratio
 
 ## Advanced: Manual Build
 
-For more control, run the Python script directly.
+For more control, run the Python script directly. See [Prerequisites](../README.md#prerequisites-for-manual-build) for environment setup.
 
 ### Step 1: Generate the Design
 
 ```bash
-python3 generate_design.py
+# From repository root
+uv run python boards/01-voltage-divider/generate_design.py
 ```
 
 This creates:

--- a/boards/02-charlieplex-led/README.md
+++ b/boards/02-charlieplex-led/README.md
@@ -67,12 +67,13 @@ With 4 GPIO pins, we can drive 4*(4-1) = 12 LEDs. This demo uses 9 for a 3x3 gri
 
 ## Advanced: Manual Build
 
-For more control over individual steps, you can run Python scripts directly.
+For more control over individual steps, you can run Python scripts directly. See [Prerequisites](../README.md#prerequisites-for-manual-build) for environment setup.
 
 ### Step 1: Generate the PCB
 
 ```bash
-python3 generate_pcb.py
+# From repository root
+uv run python boards/02-charlieplex-led/generate_pcb.py
 ```
 
 This creates `output/charlieplex_3x3.kicad_pcb` with:
@@ -85,7 +86,8 @@ This creates `output/charlieplex_3x3.kicad_pcb` with:
 ### Step 2: Run the Autorouter
 
 ```bash
-python3 route_demo.py
+# From repository root
+uv run python boards/02-charlieplex-led/route_demo.py
 ```
 
 This:

--- a/boards/03-usb-joystick/README.md
+++ b/boards/03-usb-joystick/README.md
@@ -84,19 +84,19 @@ This design demonstrates routing of different signal classes:
 
 ## Advanced: Manual Build
 
-For more control over individual steps, you can run Python scripts directly.
+For more control over individual steps, you can run Python scripts directly. See [Prerequisites](../README.md#prerequisites-for-manual-build) for environment setup.
 
 ### Step 1: Generate the Schematic
 
 ```bash
-# Default output (recommended)
-python3 generate_schematic.py
+# From repository root (default output)
+uv run python boards/03-usb-joystick/generate_schematic.py
 
 # Or specify an output directory (auto-appends filename)
-python3 generate_schematic.py output/
+uv run python boards/03-usb-joystick/generate_schematic.py output/
 
 # Or specify an explicit file path
-python3 generate_schematic.py output/usb_joystick.kicad_sch
+uv run python boards/03-usb-joystick/generate_schematic.py output/usb_joystick.kicad_sch
 ```
 
 Creates `output/usb_joystick.kicad_sch` with all components and wiring.
@@ -104,7 +104,8 @@ Creates `output/usb_joystick.kicad_sch` with all components and wiring.
 ### Step 2: Generate the PCB
 
 ```bash
-python3 generate_pcb.py
+# From repository root
+uv run python boards/03-usb-joystick/generate_pcb.py
 ```
 
 Creates `output/usb_joystick.kicad_pcb` with all components placed and nets defined.
@@ -112,7 +113,8 @@ Creates `output/usb_joystick.kicad_pcb` with all components placed and nets defi
 ### Step 3: Run the Autorouter
 
 ```bash
-python3 route_demo.py
+# From repository root
+uv run python boards/03-usb-joystick/route_demo.py
 ```
 
 This:

--- a/boards/README.md
+++ b/boards/README.md
@@ -40,17 +40,28 @@ kct build boards/01-voltage-divider --mfr jlcpcb
 - ⚠️ Needs optimization - Works but may have routing challenges or require post-processing
 - 🚧 Work in progress - Incomplete implementation
 
+## Prerequisites for Manual Build
+
+Before running board generation scripts directly, set up the development environment:
+
+```bash
+# From repository root
+uv sync --extra dev
+```
+
+This installs kicad-tools and all dependencies. See the [main README](../README.md#development) for details.
+
 ## Advanced: Manual Build
 
 For more control, you can run individual Python scripts directly:
 
 ```bash
-# Run any board's generation script
-cd boards/01-voltage-divider
-python3 generate_design.py
-
-# Or use uv from the repo root
+# Run any board's generation script (from repo root)
 uv run python boards/01-voltage-divider/generate_design.py
+
+# Or activate the virtual environment first
+source .venv/bin/activate  # Linux/macOS
+python boards/01-voltage-divider/generate_design.py
 ```
 
 ### Post-Build Commands


### PR DESCRIPTION
## Summary

- Add "Prerequisites for Manual Build" section to boards/README.md explaining the need to run `uv sync --extra dev` first
- Update all Manual Build command examples to use `uv run python` instead of plain `python3` for consistency
- Add cross-references from individual board READMEs to the prerequisites section

## Problem

Previously, users who cloned the repo and tried to run `python3 generate_design.py` would get a `ModuleNotFoundError: No module named 'kicad_tools'` because the development environment wasn't set up. The main README explained setup, but board READMEs didn't cross-reference it.

## Changes

- `boards/README.md`: Added Prerequisites section, updated command examples
- `boards/01-voltage-divider/README.md`: Updated to use `uv run` and reference prerequisites
- `boards/02-charlieplex-led/README.md`: Updated to use `uv run` and reference prerequisites
- `boards/03-usb-joystick/README.md`: Updated to use `uv run` and reference prerequisites

## Test Plan

- [x] Verified markdown links are correct
- [x] Documentation-only changes (no code changes)

Closes #804