### PR TITLE
fix(spec): Make Decision date and phase fields optional

### DIFF
--- a/boards/00-simple-led/project.kct
+++ b/boards/00-simple-led/project.kct
@@ -49,16 +49,22 @@ requirements:
 decisions:
   - topic: Resistor value
     choice: 330 ohm
+    date: "2025-01-10"
+    phase: schematic
     rationale: |
       Standard E24 value closest to ideal (5V - 2V) / 10mA = 300 ohm.
       Provides approximately 9mA LED current, which is safe and visible.
   - topic: LED footprint
     choice: 5mm THT
+    date: "2025-01-10"
+    phase: schematic
     rationale: |
       Through-hole LED is visible and easy to assemble manually.
       Good for prototyping and educational purposes.
   - topic: Resistor footprint
     choice: 0805 SMD
+    date: "2025-01-10"
+    phase: schematic
     rationale: |
       Common size, easy to hand-solder, demonstrates mixed THT/SMD design.
 

--- a/src/kicad_tools/spec/schema.py
+++ b/src/kicad_tools/spec/schema.py
@@ -286,11 +286,13 @@ class Suggestions(BaseModel):
 class Decision(BaseModel):
     """Design decision with rationale."""
 
-    date: datetime.date = Field(..., description="Decision date")
-    phase: DesignPhase | str = Field(..., description="Design phase when decision was made")
     topic: str = Field(..., description="Decision topic")
     choice: str = Field(..., description="Chosen option")
     rationale: str = Field(..., description="Reasoning for the decision")
+    date: datetime.date | None = Field(default=None, description="Decision date")
+    phase: DesignPhase | str | None = Field(
+        default=None, description="Design phase when decision was made"
+    )
     alternatives: list[str] | None = Field(
         default=None, description="Alternative options considered"
     )

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -365,6 +365,26 @@ class TestDecisions:
         assert spec.decisions[0].choice == "LM7805"
         assert len(spec.decisions[0].alternatives) == 2
 
+    def test_decision_optional_date_and_phase(self):
+        """Test that date and phase fields are optional on Decision.
+
+        Validates fix for issue #806: project.kct files should not require
+        date and phase fields on decisions.
+        """
+        from kicad_tools.spec import Decision
+
+        # Should not raise ValidationError even without date and phase
+        decision = Decision(
+            topic="Resistor value",
+            choice="330 ohm",
+            rationale="Standard E24 value closest to ideal",
+        )
+
+        assert decision.topic == "Resistor value"
+        assert decision.choice == "330 ohm"
+        assert decision.date is None
+        assert decision.phase is None
+
 
 class TestProgress:
     """Tests for progress tracking."""


### PR DESCRIPTION
## Summary

Fix DX friction issue where `project.kct` files would emit multiple validation errors during builds when the `decisions` section didn't include `date` and `phase` fields.

## Changes

- **Schema update**: Made `date` and `phase` fields optional in the `Decision` model with `None` defaults
- **Field reordering**: Put required fields first (topic, choice, rationale) for better clarity
- **Example update**: Updated `boards/00-simple-led/project.kct` to demonstrate the recommended format with date and phase included
- **Test coverage**: Added test case to verify decisions work correctly without date/phase fields

## Test Plan

- [x] `pytest tests/test_spec.py` - All 27 tests pass including new test
- [x] Verified loading spec without date/phase fields works
- [x] Verified loading spec with date/phase fields still works
- [x] Ruff format and lint pass on changed files

Closes #806