### PR TITLE
fix(parts): Add rate limiting and retry logic to LCSCClient

### DIFF
--- a/src/kicad_tools/parts/__init__.py
+++ b/src/kicad_tools/parts/__init__.py
@@ -58,7 +58,7 @@ from .importer import (
     LayoutStyle,
     PartImporter,
 )
-from .lcsc import LCSCClient
+from .lcsc import LCSCClient, RateLimiter
 from .models import (
     BOMAvailability,
     PackageType,
@@ -72,6 +72,7 @@ from .models import (
 __all__ = [
     # Client
     "LCSCClient",
+    "RateLimiter",
     # Importer
     "PartImporter",
     "ImportResult",


### PR DESCRIPTION
## Summary

Implements exponential backoff and rate limiting to handle JLCPCB API rate limits that cause 403 errors during parts search.

## Changes

- Add `RateLimiter` class for thread-safe request throttling with configurable minimum interval between requests (default: 3 seconds)
- Add `_make_request` method that centralizes HTTP request logic with:
  - Automatic rate limiting before each request
  - Exponential backoff retry on rate limit (403, 429) and server errors (500, 502, 503, 504)
  - Jitter (±25% randomization) to prevent thundering herd on retries
- New configurable parameters in `LCSCClient.__init__`:
  - `rate_limit`: Minimum seconds between requests (default: 3.0, set to 0 to disable)
  - `max_retries`: Maximum retry attempts (default: 3)
  - `base_retry_delay`: Initial delay before first retry (default: 2.0s)
- Export `RateLimiter` class for users who want to customize rate limiting

## Test Plan

- Verify module imports correctly: `from kicad_tools.parts import LCSCClient, RateLimiter`
- Syntax validation passes
- Linting passes with `ruff check`
- Existing search/lookup behavior unchanged for successful requests
- Rate-limited requests now wait between calls instead of flooding API
- 403 errors trigger automatic retry with exponential backoff

## Example Usage

```python
from kicad_tools.parts import LCSCClient

# Default configuration (3s between requests, 3 retries)
client = LCSCClient()

# Aggressive rate limiting for batch operations
client = LCSCClient(rate_limit=5.0, max_retries=5, base_retry_delay=3.0)

# Disable rate limiting (not recommended)
client = LCSCClient(rate_limit=0)
```

Closes #815