### PR TITLE
fix(schematic): Use standard 1.27mm grid for board 03 schematic

### DIFF
--- a/boards/03-usb-joystick/generate_schematic.py
+++ b/boards/03-usb-joystick/generate_schematic.py
@@ -76,7 +76,7 @@ def create_usb_joystick_schematic(output_path: Path, verbose: bool = False) -> b
         comment1="USB game controller with analog joystick",
         comment2="Demonstrates autolayout functionality",
         snap_mode=SnapMode.AUTO,
-        grid=2.54,  # Standard 100mil grid
+        grid=1.27,  # Standard 50mil schematic grid (matches KiCad symbol pins)
     )
 
     # Layout constants

--- a/boards/03-usb-joystick/output/usb_joystick.kicad_sch
+++ b/boards/03-usb-joystick/output/usb_joystick.kicad_sch
@@ -2,7 +2,7 @@
   (version 20231120)
   (generator "eeschema")
   (generator_version "9.0")
-  (uuid "997516ac-8b65-40b5-9935-d684018af00e")
+  (uuid "e45ee506-a9c1-41ce-a509-013b5db41cc7")
   (paper "A4")
   (title_block
     (title "USB Joystick Controller")
@@ -1911,7 +1911,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "460327e4-63dd-47dd-acc2-d7817599aacd")
+    (uuid "ed81fbd7-8205-41f3-8850-6e9462c75386")
     (property "Reference" "U1"
       (at 101.6 83.82 0)
       (effects
@@ -1946,73 +1946,73 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "22d69098-eb26-4d75-b0a0-acf987355e22")
+    (pin "1" (uuid "437a6773-76e9-477f-a68b-51a7c69f5989")
     )
-    (pin "2" (uuid "5a455f94-e0a6-40cf-9009-f1a7469aa632")
+    (pin "2" (uuid "99f3e73e-b812-4eb2-8832-8183395ce059")
     )
-    (pin "3" (uuid "cac87574-1bc5-4bc7-8ce9-c7571542a7eb")
+    (pin "3" (uuid "de327b86-c2da-4507-ac14-4f2f6f434628")
     )
-    (pin "4" (uuid "d2989c41-7086-4451-91cb-4d0b0eb3a3bc")
+    (pin "4" (uuid "99996fe8-5e20-486c-94bc-1f1c4bfe31b5")
     )
-    (pin "5" (uuid "2dd24ba0-128e-432b-b01a-acd0a66157f8")
+    (pin "5" (uuid "717a3e72-738c-4209-9472-8e6bc6057d1a")
     )
-    (pin "6" (uuid "0c4a9575-6b3b-4369-8de9-5f486fb4058f")
+    (pin "6" (uuid "eb10f4fb-aba7-4904-8ec9-2af5eb704cc6")
     )
-    (pin "7" (uuid "fbdb9ca2-e5b7-49e9-b5dc-fba74ad271dd")
+    (pin "7" (uuid "e1a8eb1e-076e-4f33-9205-7bd36ed97aef")
     )
-    (pin "8" (uuid "dd900744-1160-445b-b18b-86bb88811611")
+    (pin "8" (uuid "38058325-8319-4e8d-8dfc-e418b820d1f7")
     )
-    (pin "9" (uuid "4d6bfc03-18b4-4c63-a5e9-41aa7c7cda8a")
+    (pin "9" (uuid "a0c1eee8-5a12-4bbd-8616-d511b8231c2e")
     )
-    (pin "10" (uuid "495f7756-4248-43b4-a643-71c0f7a96feb")
+    (pin "10" (uuid "2e6d214d-597b-4559-8bfa-aedf0de3e593")
     )
-    (pin "11" (uuid "5da2c814-d808-4be7-ba9c-9982b4f9fe01")
+    (pin "11" (uuid "29e5b4ea-2d18-4274-b1a1-cf4e26a7c920")
     )
-    (pin "12" (uuid "fec3b56a-25f3-4b3e-b2aa-18b448548920")
+    (pin "12" (uuid "9794d8c0-586d-49db-86d4-8f5b83357d2b")
     )
-    (pin "13" (uuid "63db63fa-94a7-4a1a-bdac-bbcfc88b8794")
+    (pin "13" (uuid "52a05d00-d720-4597-a35d-dcc80f1b121c")
     )
-    (pin "14" (uuid "c541ffbe-940d-43b5-b0a8-72a57224e65a")
+    (pin "14" (uuid "4cb41c5c-1ade-42b4-8677-5898b1bf3571")
     )
-    (pin "15" (uuid "bbc397fa-a36c-40e8-b523-666d68d6e21d")
+    (pin "15" (uuid "b050e8e0-11b1-42b6-ad02-14acc2b7beef")
     )
-    (pin "16" (uuid "0426e801-cfb7-463e-8056-4e3a1f6534bc")
+    (pin "16" (uuid "c3e3a819-7c0a-45b1-acfc-cebec252f224")
     )
-    (pin "32" (uuid "cd2eb38f-3c86-434b-9128-a6ba853a3446")
+    (pin "32" (uuid "e978be7c-1523-48e7-9f1e-c93c8e6fb6a1")
     )
-    (pin "31" (uuid "19c9c153-ff0a-4de5-a46f-d3a46317838b")
+    (pin "31" (uuid "f8717169-e008-4b40-ad3f-197eb026b962")
     )
-    (pin "30" (uuid "7bf6c7dd-13cd-456c-9990-594291757b22")
+    (pin "30" (uuid "265d795e-a182-49b8-8e1f-e0eeae954291")
     )
-    (pin "29" (uuid "3c2df43d-7ee5-41a1-9e52-1e6f301fc221")
+    (pin "29" (uuid "c38a9953-ebfa-48ea-bf71-9cf19b14cb9a")
     )
-    (pin "28" (uuid "e95b5bd9-91b7-4323-9644-a40a257a7c13")
+    (pin "28" (uuid "0005cbcd-52a9-4168-a621-5eb32e540c5a")
     )
-    (pin "27" (uuid "08440e49-00ce-49cc-8802-e779c0c6ac82")
+    (pin "27" (uuid "7fe8afcb-d934-4634-b0b1-4fcd4d0f48cf")
     )
-    (pin "26" (uuid "e2be151f-7a17-497f-a277-5247b37e1ecf")
+    (pin "26" (uuid "a6ecd0b0-9cc6-4d56-aba2-9318d347cb9a")
     )
-    (pin "25" (uuid "152504c6-5563-4ae2-b14e-f5425a13d025")
+    (pin "25" (uuid "1e1de553-6090-4330-8943-1af509849022")
     )
-    (pin "24" (uuid "231e5e14-29b7-4b42-9748-ff0dcfa0f1ca")
+    (pin "24" (uuid "73701d83-634c-4654-9160-0c996230e48b")
     )
-    (pin "23" (uuid "e389adcf-64d7-4d6f-9841-9c6eb22638b8")
+    (pin "23" (uuid "cf5a8473-d04c-475f-82f8-557d20dbe8c7")
     )
-    (pin "22" (uuid "69284b4b-9913-431e-9286-f54fc66d4add")
+    (pin "22" (uuid "d653bd24-6eaf-47fa-a538-75ece7da46ca")
     )
-    (pin "21" (uuid "a88bc621-ddbf-4b41-80ac-86feff6f8e67")
+    (pin "21" (uuid "33980a27-50a1-4958-b59e-594bce24f1f1")
     )
-    (pin "20" (uuid "46bbb597-9f23-4350-aa55-f3d6955e8667")
+    (pin "20" (uuid "d7c4b860-befe-44a7-9315-8ff26f33c6e4")
     )
-    (pin "19" (uuid "72510c2c-c745-43a2-8bdc-a7b6afbf1517")
+    (pin "19" (uuid "e4b19195-3e48-40c0-b33d-50a49b22c803")
     )
-    (pin "18" (uuid "9d4ca335-d67e-4302-9f1a-65e741f01d97")
+    (pin "18" (uuid "228164fe-e318-4c33-9087-1183af22d137")
     )
-    (pin "17" (uuid "d8e323f4-461c-4184-be7c-c03e5cdcdebe")
+    (pin "17" (uuid "854f6ca6-29d5-4fb2-82df-1e9ac7f53910")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "U1") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "U1") (unit 1)
         )
       )
     )
@@ -2025,7 +2025,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "936436ac-c63c-4e5f-babf-21ddf8b24b54")
+    (uuid "6604b640-9fb4-43e8-a6c4-9584bca96131")
     (property "Reference" "J1"
       (at 50.8 45.72 0)
       (effects
@@ -2060,17 +2060,17 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "5a158a0f-2e6c-48e8-8e8a-3bac72ea77b0")
+    (pin "1" (uuid "62135351-7a8b-4b04-9549-794c7f5fca01")
     )
-    (pin "2" (uuid "17116fff-a265-4d35-87c4-3d1955073b17")
+    (pin "2" (uuid "14a0af72-eb66-4a8c-a049-a86d235da8bb")
     )
-    (pin "3" (uuid "acd9011f-7f46-4a4c-856a-179155eb45ef")
+    (pin "3" (uuid "c4bec67f-0820-498b-8758-b6abec35bd06")
     )
-    (pin "4" (uuid "8d380fba-e4d5-45c5-8a6e-43e16429cedb")
+    (pin "4" (uuid "0b36d563-0b1e-44f8-8085-f75cb3ababaf")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "J1") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "J1") (unit 1)
         )
       )
     )
@@ -2083,7 +2083,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "e8027076-ea2d-487d-ac1a-76c653e4ade2")
+    (uuid "4111b825-6a00-4833-8717-38821f6d3f85")
     (property "Reference" "J2"
       (at 50.8 96.52 0)
       (effects
@@ -2118,19 +2118,19 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "97fcf1a7-77fc-4eab-ab69-0d0cd9c948de")
+    (pin "1" (uuid "73355a3b-042b-4fd7-996b-e1575c6dc2f0")
     )
-    (pin "2" (uuid "61840dd6-a69a-4a0f-83c2-4abf23614fee")
+    (pin "2" (uuid "efd59638-685e-4201-b0e1-f8d0baaa7be9")
     )
-    (pin "3" (uuid "b1529dd4-79c4-47b1-846e-a79f8ef1254f")
+    (pin "3" (uuid "34519831-1e9f-4518-83ef-001e9776bc29")
     )
-    (pin "4" (uuid "1bb8c1b1-0842-4ceb-8c71-5c16acabd04d")
+    (pin "4" (uuid "98f7283d-cbb4-4d02-9abb-57305f8a9c27")
     )
-    (pin "5" (uuid "0a568f8c-d5c5-4144-af33-6ffb4a2db920")
+    (pin "5" (uuid "ab45dea1-cfc7-4ff1-997a-a8d8d9acedca")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "J2") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "J2") (unit 1)
         )
       )
     )
@@ -2143,7 +2143,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "4b7b3411-4a96-4304-9ca8-1b1e4ba0cab9")
+    (uuid "ac2f2cba-ced7-44fe-8db8-d2e7afb4fe59")
     (property "Reference" "Y1"
       (at 127 71.12 0)
       (effects
@@ -2178,13 +2178,13 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "d430b322-f2c8-4b01-a01f-b06421118963")
+    (pin "1" (uuid "d5dc77de-4f65-447e-8687-2a743e0bdf87")
     )
-    (pin "2" (uuid "bdda4a5e-259a-4947-bda5-6fd92f247087")
+    (pin "2" (uuid "4c8853de-80fd-401c-9696-94d69a466c7a")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "Y1") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "Y1") (unit 1)
         )
       )
     )
@@ -2197,7 +2197,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "28d814d4-f709-4a66-bec7-ec06252512b5")
+    (uuid "18c5aab9-628c-4aef-a56d-ac0bc674140d")
     (property "Reference" "SW1"
       (at 152.4 83.82 0)
       (effects
@@ -2232,28 +2232,28 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "81b4be26-f046-4304-a178-597f876d6524")
+    (pin "1" (uuid "567a6e86-63dd-456e-b53f-a28f2a7c0c3a")
     )
-    (pin "2" (uuid "dbb4b4d8-f8bc-4b34-b09a-5cd44cc1c5b1")
+    (pin "2" (uuid "0112f778-5548-4d0b-922c-d3bc49c96bbd")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "SW1") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "SW1") (unit 1)
         )
       )
     )
   )
   (symbol
     (lib_id "Device:R")
-    (at 134.62 96.52 0)
+    (at 135.89 96.52 0)
     (unit 1)
     (exclude_from_sim no)
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "c685bc43-a489-4c4c-9821-e6fe68eb80bf")
+    (uuid "855343bb-fa91-4cc1-9dc7-2cb13b74ce5d")
     (property "Reference" "SW2"
-      (at 134.62 91.44 0)
+      (at 135.89 91.44 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2261,7 +2261,7 @@
       )
     )
     (property "Value" "Button"
-      (at 134.62 93.98 0)
+      (at 135.89 93.98 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2269,7 +2269,7 @@
       )
     )
     (property "Footprint" ""
-      (at 134.62 96.52 0)
+      (at 135.89 96.52 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2278,7 +2278,7 @@
       )
     )
     (property "Datasheet" "~"
-      (at 134.62 96.52 0)
+      (at 135.89 96.52 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2286,28 +2286,28 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "3e9ac5ca-20bd-4a49-8038-9fc827ef6351")
+    (pin "1" (uuid "8d546113-64cb-48bf-81f7-b5a500b9b7ad")
     )
-    (pin "2" (uuid "a47325cc-a983-411b-bff7-ec5cfaca5ef1")
+    (pin "2" (uuid "afd3a21f-c6cf-40d7-bdd2-4a3b81b074ad")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "SW2") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "SW2") (unit 1)
         )
       )
     )
   )
   (symbol
     (lib_id "Device:R")
-    (at 147.32 71.12 0)
+    (at 147.32 72.39 0)
     (unit 1)
     (exclude_from_sim no)
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "c497f738-9640-441e-9114-16e84f7a210e")
+    (uuid "775d4697-cfd1-464e-be8d-4a2493e36773")
     (property "Reference" "SW3"
-      (at 147.32 66.04 0)
+      (at 147.32 67.31 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2315,7 +2315,7 @@
       )
     )
     (property "Value" "Button"
-      (at 147.32 68.58 0)
+      (at 147.32 69.85 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2323,7 +2323,7 @@
       )
     )
     (property "Footprint" ""
-      (at 147.32 71.12 0)
+      (at 147.32 72.39 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2332,7 +2332,7 @@
       )
     )
     (property "Datasheet" "~"
-      (at 147.32 71.12 0)
+      (at 147.32 72.39 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2340,28 +2340,28 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "4172ca2d-26e5-4335-afc9-9e5e26664af8")
+    (pin "1" (uuid "2100afd3-51a1-4955-9bf8-c3a3bfc7ada9")
     )
-    (pin "2" (uuid "8b0f925c-7c34-49a7-879d-d0a15d308d00")
+    (pin "2" (uuid "ef1cd17f-a0d4-4c7b-9d75-976117ebe049")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "SW3") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "SW3") (unit 1)
         )
       )
     )
   )
   (symbol
     (lib_id "Device:R")
-    (at 152.4 106.68 0)
+    (at 152.4 105.41 0)
     (unit 1)
     (exclude_from_sim no)
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "9b3dc603-8f93-48ec-97bb-d7fdbbbd9ed6")
+    (uuid "53e3c1aa-1e57-4cf7-be7a-6abce352fc72")
     (property "Reference" "SW4"
-      (at 152.4 101.6 0)
+      (at 152.4 100.33 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2369,7 +2369,7 @@
       )
     )
     (property "Value" "Button"
-      (at 152.4 104.14 0)
+      (at 152.4 102.87 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2377,7 +2377,7 @@
       )
     )
     (property "Footprint" ""
-      (at 152.4 106.68 0)
+      (at 152.4 105.41 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2386,7 +2386,7 @@
       )
     )
     (property "Datasheet" "~"
-      (at 152.4 106.68 0)
+      (at 152.4 105.41 0)
       (effects
         (font
           (size 1.27 1.27)
@@ -2394,13 +2394,13 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "b9f3ef08-ed62-42ed-afae-87697d5e6baf")
+    (pin "1" (uuid "3e3bbf3b-e270-44e5-a9c5-5ae391a59600")
     )
-    (pin "2" (uuid "92df11c1-ecc1-4b42-9634-9359c88ba230")
+    (pin "2" (uuid "1c731ddc-6dcf-48c8-ad2d-b1ed0f4303e9")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "SW4") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "SW4") (unit 1)
         )
       )
     )
@@ -2413,7 +2413,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "f539897b-222b-4a29-89d4-b3857001bcc4")
+    (uuid "de2e1c6d-5810-4f2e-ab19-25af7ba16116")
     (property "Reference" "C1"
       (at 88.9 58.42 0)
       (effects
@@ -2448,13 +2448,13 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "fd028525-6e4f-4e26-ad16-759b6bea0c3f")
+    (pin "1" (uuid "893aa6d8-cbb5-43d6-ab77-6664ad830d51")
     )
-    (pin "2" (uuid "8e1cbc2e-a6bc-4d89-926f-aac5a2621945")
+    (pin "2" (uuid "f7c84f4d-b800-409c-b0a2-a5af5fb696e9")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "C1") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "C1") (unit 1)
         )
       )
     )
@@ -2467,7 +2467,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "05ecc023-873b-4e77-9ebc-1b0e51bd6dd4")
+    (uuid "4d536482-58cc-409a-ad4f-b9407486aac3")
     (property "Reference" "C2"
       (at 114.3 58.42 0)
       (effects
@@ -2502,13 +2502,13 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "48e2edd8-8a73-429f-baf4-1a0bbf1e0541")
+    (pin "1" (uuid "310995c0-bee3-45f6-895f-29c1ef268e27")
     )
-    (pin "2" (uuid "036bab50-4a6b-42db-9501-fd10978fcbc4")
+    (pin "2" (uuid "7c99eb83-2b99-439a-b625-5a984da6150f")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "C2") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "C2") (unit 1)
         )
       )
     )
@@ -2521,7 +2521,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "29bebfe4-faa3-438a-98ad-fdd0d883cdc1")
+    (uuid "12a27825-63b8-40af-8c65-5f715aaf8a57")
     (property "Reference" "C3"
       (at 88.9 109.22 0)
       (effects
@@ -2556,13 +2556,13 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "05452436-5ece-480f-a9a7-254bdf6e88a3")
+    (pin "1" (uuid "45a996f3-0c6f-4b59-bc50-d6433de424ca")
     )
-    (pin "2" (uuid "c84e9175-dced-46e6-a532-4d22c76dcd39")
+    (pin "2" (uuid "92f8e2df-1a5d-4a88-a3ac-b4ece26aabda")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "C3") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "C3") (unit 1)
         )
       )
     )
@@ -2575,7 +2575,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "cd93eed4-d9a4-4bbe-bf77-ad0b0874a6cb")
+    (uuid "ea556727-045b-4817-a1b4-35e26ba1fc6d")
     (property "Reference" "C4"
       (at 55.88 33.02 0)
       (effects
@@ -2610,13 +2610,13 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "45cec08e-b073-4aab-93e2-3ece922be00e")
+    (pin "1" (uuid "cb156c9d-f908-4514-b43a-37f1e6ebc5c3")
     )
-    (pin "2" (uuid "788cef80-d39c-47af-82bf-2cfd7d286f97")
+    (pin "2" (uuid "1df75b08-9594-4a87-9bcf-c909f4ded1d3")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "C4") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "C4") (unit 1)
         )
       )
     )
@@ -2629,7 +2629,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "f7d10a73-02b3-4bbd-bcf7-aa3958986129")
+    (uuid "2f8a2276-e600-4891-bc31-b86f3a925b29")
     (property "Reference" "#PWR01"
       (at 25.4 27.94 0)
       (effects
@@ -2665,11 +2665,11 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "3121c651-26a1-40eb-a8f3-85f9ddda3420")
+    (pin "1" (uuid "dea26bae-ed87-473e-ab58-c31211e4290a")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "#PWR01") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "#PWR01") (unit 1)
         )
       )
     )
@@ -2682,7 +2682,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "caa2f4fa-9fe6-41b0-bd8a-c95644676b4e")
+    (uuid "f4eb08a1-c88b-4676-8a4f-b076b7f91a01")
     (property "Reference" "#PWR02"
       (at 25.4 27.94 0)
       (effects
@@ -2718,11 +2718,11 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "8a9382d4-aacc-43ec-8834-2c180f11598c")
+    (pin "1" (uuid "efcb82a3-4544-430f-a930-8241e70d5502")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "#PWR02") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "#PWR02") (unit 1)
         )
       )
     )
@@ -2735,7 +2735,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "d7785078-7d8b-462b-b55c-521059652fd5")
+    (uuid "444a0c24-3379-4568-ab6d-b6f1446411c5")
     (property "Reference" "#PWR03"
       (at 25.4 180.34 0)
       (effects
@@ -2771,11 +2771,11 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "e108b636-486a-4d68-8531-09c9f953ece2")
+    (pin "1" (uuid "76f20991-75b7-49c2-a241-e40f8bdcf675")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "#PWR03") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "#PWR03") (unit 1)
         )
       )
     )
@@ -2788,7 +2788,7 @@
     (in_bom yes)
     (on_board yes)
     (dnp no)
-    (uuid "aab677ba-59ef-481b-94bb-a4021701a2d8")
+    (uuid "c9d9fbdb-d3ea-4f47-a565-f1daa401d461")
     (property "Reference" "#PWR04"
       (at 25.4 180.34 0)
       (effects
@@ -2824,11 +2824,11 @@
         (hide yes)
       )
     )
-    (pin "1" (uuid "adff6fc8-1679-4d50-9a04-d888313d778d")
+    (pin "1" (uuid "4239e974-7308-423c-bd2d-ebb48f0ecabe")
     )
     (instances
       (project "project"
-        (path "/997516ac-8b65-40b5-9935-d684018af00e" (reference "#PWR04") (unit 1)
+        (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (reference "#PWR04") (unit 1)
         )
       )
     )
@@ -2839,7 +2839,7 @@
       (width 0)
       (type default)
     )
-    (uuid "dc8e0ee1-df2c-4507-972e-f4251dbda75b")
+    (uuid "8b3b0377-3ea1-42ef-8079-e0e82345505e")
   )
   (wire
     (pts (xy 96.52 109.22) (xy 91.44 109.22))
@@ -2847,7 +2847,7 @@
       (width 0)
       (type default)
     )
-    (uuid "dc27c3ef-fa99-4b24-99eb-ffbfbf48d49a")
+    (uuid "9c01bda0-6165-4492-9370-118dfa2f25c7")
   )
   (wire
     (pts (xy 109.22 109.22) (xy 114.3 109.22))
@@ -2855,7 +2855,7 @@
       (width 0)
       (type default)
     )
-    (uuid "d637491d-0e4c-4fe2-bad0-f94f6495ec03")
+    (uuid "c4c9d2ac-6170-46ab-9c3e-9473554f4a5e")
   )
   (wire
     (pts (xy 109.22 71.12) (xy 114.3 71.12))
@@ -2863,7 +2863,7 @@
       (width 0)
       (type default)
     )
-    (uuid "cf181d0d-c466-4727-b50b-052e74028732")
+    (uuid "e2484676-7b5f-4649-b14a-5267d988061f")
   )
   (wire
     (pts (xy 109.22 78.74) (xy 114.3 78.74))
@@ -2871,7 +2871,7 @@
       (width 0)
       (type default)
     )
-    (uuid "16ba41ab-fd36-4386-a71d-e1e8ac255e43")
+    (uuid "cc25c5be-0088-4ca8-a34a-c66d9cffb216")
   )
   (wire
     (pts (xy 109.22 76.2) (xy 114.3 76.2))
@@ -2879,7 +2879,7 @@
       (width 0)
       (type default)
     )
-    (uuid "fdb98ba4-fdae-4635-af38-cec898e5de38")
+    (uuid "54be2c85-fdae-4774-8bfa-4f1cbb5bcdd1")
   )
   (wire
     (pts (xy 96.52 86.36) (xy 91.44 86.36))
@@ -2887,7 +2887,7 @@
       (width 0)
       (type default)
     )
-    (uuid "6cb90994-cf6a-4915-aa39-0cf2c61e4149")
+    (uuid "4ac72f28-98a5-442a-8dfd-cb2f934376d5")
   )
   (wire
     (pts (xy 96.52 88.9) (xy 91.44 88.9))
@@ -2895,7 +2895,7 @@
       (width 0)
       (type default)
     )
-    (uuid "29fdb200-5492-40c0-a359-9e44795e9c7d")
+    (uuid "b0650563-fd39-4df9-9442-5782b2818026")
   )
   (wire
     (pts (xy 96.52 73.66) (xy 91.44 73.66))
@@ -2903,7 +2903,7 @@
       (width 0)
       (type default)
     )
-    (uuid "b31ca4c6-c1f1-48f1-9d18-9979174c3427")
+    (uuid "c24f8665-ca17-4f85-9e97-c55092905dba")
   )
   (wire
     (pts (xy 96.52 76.2) (xy 91.44 76.2))
@@ -2911,7 +2911,7 @@
       (width 0)
       (type default)
     )
-    (uuid "7dc3e60c-3664-47e5-8152-9d653c4d36dc")
+    (uuid "83a22ac9-a5a3-4674-8138-cf20c9d38de1")
   )
   (wire
     (pts (xy 96.52 91.44) (xy 91.44 91.44))
@@ -2919,7 +2919,7 @@
       (width 0)
       (type default)
     )
-    (uuid "354f32f9-ef71-4858-a343-e82be87a5967")
+    (uuid "9d31a9aa-971d-4633-b8fe-7c16ad126e04")
   )
   (wire
     (pts (xy 96.52 93.98) (xy 91.44 93.98))
@@ -2927,7 +2927,7 @@
       (width 0)
       (type default)
     )
-    (uuid "ea94b380-dbf9-4441-af6e-e5c9252789d1")
+    (uuid "3451162b-3043-46d8-92af-b54ef941a7fb")
   )
   (wire
     (pts (xy 96.52 96.52) (xy 91.44 96.52))
@@ -2935,7 +2935,7 @@
       (width 0)
       (type default)
     )
-    (uuid "715a9c27-d795-41a0-a1ec-a43ad505e455")
+    (uuid "303ef3a2-f496-493e-8fc2-fe1fa934e2f6")
   )
   (wire
     (pts (xy 96.52 99.06) (xy 91.44 99.06))
@@ -2943,7 +2943,7 @@
       (width 0)
       (type default)
     )
-    (uuid "8c74b917-bf38-463f-9858-683afb7a07f4")
+    (uuid "6cad7e1d-ae25-4bc9-9fa5-a1b68c95505c")
   )
   (wire
     (pts (xy 96.52 101.6) (xy 91.44 101.6))
@@ -2951,7 +2951,7 @@
       (width 0)
       (type default)
     )
-    (uuid "e5f3acd3-4054-4792-b260-a7889b699452")
+    (uuid "57407ee0-1097-42c1-a021-88f136676d56")
   )
   (wire
     (pts (xy 45.72 48.26) (xy 50.8 48.26))
@@ -2959,7 +2959,7 @@
       (width 0)
       (type default)
     )
-    (uuid "95b36d13-8f91-46ec-9f88-ad0756ccfac0")
+    (uuid "634e2aeb-721f-46ae-b6d7-a3ff89084ea7")
   )
   (wire
     (pts (xy 45.72 50.8) (xy 50.8 50.8))
@@ -2967,7 +2967,7 @@
       (width 0)
       (type default)
     )
-    (uuid "66901c77-f3d3-440d-a888-3ba26a49b06d")
+    (uuid "2dcc1cd3-4e75-4a0b-98d0-6a67b3004b49")
   )
   (wire
     (pts (xy 45.72 53.34) (xy 50.8 53.34))
@@ -2975,7 +2975,7 @@
       (width 0)
       (type default)
     )
-    (uuid "d1c5e6aa-b9c6-47dd-af74-860329ded8c1")
+    (uuid "1f1c46d9-5b9e-407a-9161-f512e989e92a")
   )
   (wire
     (pts (xy 45.72 55.88) (xy 50.8 55.88))
@@ -2983,7 +2983,7 @@
       (width 0)
       (type default)
     )
-    (uuid "2ebdbdec-b133-4e29-8fc3-34c06a2a22ee")
+    (uuid "debfedc5-1f94-4862-b9f9-928f2c7a4139")
   )
   (wire
     (pts (xy 45.72 96.52) (xy 50.8 96.52))
@@ -2991,7 +2991,7 @@
       (width 0)
       (type default)
     )
-    (uuid "fa7f0f48-1282-4140-9b7f-d326c76146de")
+    (uuid "bae39cf7-3df6-450a-bfed-14e4bcf9a5c6")
   )
   (wire
     (pts (xy 45.72 99.06) (xy 50.8 99.06))
@@ -2999,7 +2999,7 @@
       (width 0)
       (type default)
     )
-    (uuid "24a4c98e-c66c-45f2-951f-ff583ccc4ec8")
+    (uuid "e648371a-c56e-4a30-9f7b-074c4c97f7e8")
   )
   (wire
     (pts (xy 45.72 101.6) (xy 50.8 101.6))
@@ -3007,7 +3007,7 @@
       (width 0)
       (type default)
     )
-    (uuid "f73b372f-6676-4475-bda2-774a1375b4aa")
+    (uuid "cc9b5664-1639-4e05-b9da-808b63ecccdc")
   )
   (wire
     (pts (xy 45.72 104.14) (xy 50.8 104.14))
@@ -3015,7 +3015,7 @@
       (width 0)
       (type default)
     )
-    (uuid "a1f5f1be-d1b6-432d-8cde-8c8502868d32")
+    (uuid "2cfe7000-e3b8-4104-a912-72b0769d8e8f")
   )
   (wire
     (pts (xy 45.72 106.68) (xy 50.8 106.68))
@@ -3023,7 +3023,7 @@
       (width 0)
       (type default)
     )
-    (uuid "ab8099c4-5090-4ab2-a890-3bf9b7719f18")
+    (uuid "06eb4d58-43c0-4205-aa3a-8e45148599aa")
   )
   (wire
     (pts (xy 123.19 76.2) (xy 118.11 76.2))
@@ -3031,7 +3031,7 @@
       (width 0)
       (type default)
     )
-    (uuid "c73c4cef-9e4d-4b89-b73c-9966ced799ea")
+    (uuid "ef415ff7-216f-41fe-96ad-ae2f178fdbd8")
   )
   (wire
     (pts (xy 130.81 76.2) (xy 135.89 76.2))
@@ -3039,7 +3039,7 @@
       (width 0)
       (type default)
     )
-    (uuid "d001f5a6-da68-4ef5-9e07-1f80b0b6500d")
+    (uuid "d884cc37-7e73-4905-9ce8-7028a132d3b6")
   )
   (wire
     (pts (xy 152.4 85.09) (xy 147.32 85.09))
@@ -3047,7 +3047,7 @@
       (width 0)
       (type default)
     )
-    (uuid "534760bb-30db-4905-8c3e-1bcee52e5514")
+    (uuid "51e4ee1b-8b87-4353-a54a-a5c7d4e43376")
   )
   (wire
     (pts (xy 152.4 92.71) (xy 157.48 92.71))
@@ -3055,55 +3055,55 @@
       (width 0)
       (type default)
     )
-    (uuid "a7aebb65-6f3d-4114-a960-4072aae001bd")
+    (uuid "79c4899b-62f8-47f2-8624-e61153062f96")
   )
   (wire
-    (pts (xy 134.62 92.71) (xy 129.54 92.71))
+    (pts (xy 135.89 92.71) (xy 130.81 92.71))
     (stroke
       (width 0)
       (type default)
     )
-    (uuid "4fbe00a0-7865-4da0-9451-465e75c98ae6")
+    (uuid "18907b56-d140-4dbe-a81f-80c9f95d5662")
   )
   (wire
-    (pts (xy 134.62 100.33) (xy 139.7 100.33))
+    (pts (xy 135.89 100.33) (xy 140.97 100.33))
     (stroke
       (width 0)
       (type default)
     )
-    (uuid "056dfcf8-7978-40d7-9dc3-3cda821b4067")
+    (uuid "b6fec034-8206-44e2-95ad-3ef9c21d05d5")
   )
   (wire
-    (pts (xy 147.32 67.31) (xy 142.24 67.31))
+    (pts (xy 147.32 68.58) (xy 142.24 68.58))
     (stroke
       (width 0)
       (type default)
     )
-    (uuid "2a732932-03f4-4603-b6e3-2331cb0a3ce9")
+    (uuid "8b11b0fe-ba42-4c94-a1fd-13ed925ebca8")
   )
   (wire
-    (pts (xy 147.32 74.93) (xy 152.4 74.93))
+    (pts (xy 147.32 76.2) (xy 152.4 76.2))
     (stroke
       (width 0)
       (type default)
     )
-    (uuid "c17683b5-92cf-4638-88a1-fb758325b710")
+    (uuid "29eeb77c-66e8-4eb3-aeaa-174a86969837")
   )
   (wire
-    (pts (xy 152.4 102.87) (xy 147.32 102.87))
+    (pts (xy 152.4 101.6) (xy 147.32 101.6))
     (stroke
       (width 0)
       (type default)
     )
-    (uuid "cef0cc5a-36e9-4914-9837-f9a441ec69f4")
+    (uuid "281f4e8d-9bf3-465a-95ba-a75aa71f2605")
   )
   (wire
-    (pts (xy 152.4 110.49) (xy 157.48 110.49))
+    (pts (xy 152.4 109.22) (xy 157.48 109.22))
     (stroke
       (width 0)
       (type default)
     )
-    (uuid "1c41630d-5816-492d-9af9-1599f03caa02")
+    (uuid "19c16864-8d48-4719-bd67-53a1f7f76665")
   )
   (wire
     (pts (xy 88.9 59.69) (xy 83.82 59.69))
@@ -3111,7 +3111,7 @@
       (width 0)
       (type default)
     )
-    (uuid "de4ab384-5fe3-4a79-81b9-93f7f75648d1")
+    (uuid "27163048-14f5-46d1-bcbf-896b2635127a")
   )
   (wire
     (pts (xy 88.9 67.31) (xy 93.98 67.31))
@@ -3119,7 +3119,7 @@
       (width 0)
       (type default)
     )
-    (uuid "22619b66-25b1-469c-bc1c-66974206acf5")
+    (uuid "a6307069-db0d-4477-9448-547a01830df8")
   )
   (wire
     (pts (xy 114.3 59.69) (xy 109.22 59.69))
@@ -3127,7 +3127,7 @@
       (width 0)
       (type default)
     )
-    (uuid "e62cecc3-33d0-44bf-8c4c-9afa4b1159fa")
+    (uuid "efdd3bb0-7399-4b19-a133-a1440493449e")
   )
   (wire
     (pts (xy 114.3 67.31) (xy 119.38 67.31))
@@ -3135,7 +3135,7 @@
       (width 0)
       (type default)
     )
-    (uuid "f6174c1a-02ee-45eb-b197-81d63c50baf6")
+    (uuid "06b012d8-4462-439e-b766-20701e2044ed")
   )
   (wire
     (pts (xy 88.9 110.49) (xy 83.82 110.49))
@@ -3143,7 +3143,7 @@
       (width 0)
       (type default)
     )
-    (uuid "ef613f5a-f07e-4125-8d21-d64ad6d91a47")
+    (uuid "c6ee9403-7ffc-4d90-b1c3-fdeea122948f")
   )
   (wire
     (pts (xy 88.9 118.11) (xy 93.98 118.11))
@@ -3151,7 +3151,7 @@
       (width 0)
       (type default)
     )
-    (uuid "9ee2455e-2db7-4081-9d82-00a78b7e8375")
+    (uuid "b0a17b2b-268c-4aef-bdab-9d8761143c39")
   )
   (wire
     (pts (xy 55.88 34.29) (xy 50.8 34.29))
@@ -3159,7 +3159,7 @@
       (width 0)
       (type default)
     )
-    (uuid "3e047966-644d-4e21-bb5b-6cd24f7fce8d")
+    (uuid "d2a74295-3dc2-43db-8851-feadfe3bc33d")
   )
   (wire
     (pts (xy 55.88 41.91) (xy 60.96 41.91))
@@ -3167,7 +3167,7 @@
       (width 0)
       (type default)
     )
-    (uuid "7891c68d-e5b6-4fda-af23-0c90802601bb")
+    (uuid "238d9e66-208a-45a4-936f-021f3251e2cc")
   )
   (wire
     (pts (xy 25.4 25.4) (xy 30.48 25.4))
@@ -3175,7 +3175,7 @@
       (width 0)
       (type default)
     )
-    (uuid "0487e21d-0a77-496f-aabc-b182ce06fdbc")
+    (uuid "fe9675b3-933b-4275-bd6b-b313524c670b")
   )
   (wire
     (pts (xy 25.4 177.8) (xy 30.48 177.8))
@@ -3183,41 +3183,41 @@
       (width 0)
       (type default)
     )
-    (uuid "04acc206-08a7-4b78-9093-1978d40b117a")
+    (uuid "8b63fbc4-b34a-49af-b58f-61c10894b1be")
   )
-  (no_connect (at 96.52 78.74) (uuid "0998d18d-2861-4233-8507-99b22517506f")
+  (no_connect (at 96.52 78.74) (uuid "83b5246a-e8d5-4558-8278-614e2869acb8")
   )
-  (no_connect (at 96.52 81.28) (uuid "5c6db00e-98ad-4701-8826-921d9121ec5b")
+  (no_connect (at 96.52 81.28) (uuid "47b9215c-3d8a-4461-a459-628bf8df6624")
   )
-  (no_connect (at 96.52 83.82) (uuid "d7dbb3d7-072b-4683-ade8-42450c2fa8bf")
+  (no_connect (at 96.52 83.82) (uuid "7e5ad155-091f-42cf-bf7b-7f6cb6dd10e0")
   )
-  (no_connect (at 96.52 104.14) (uuid "fafee0a2-8944-4747-b47c-9a3af94fcd10")
+  (no_connect (at 96.52 104.14) (uuid "59dfb183-c4aa-4cb3-a8f1-17d75678b224")
   )
-  (no_connect (at 96.52 106.68) (uuid "7ef296c1-0a57-4ade-b0df-1bcca29d2fa1")
+  (no_connect (at 96.52 106.68) (uuid "07f21368-e36f-495c-bfb8-5d8bdf7828a1")
   )
-  (no_connect (at 109.22 106.68) (uuid "4877250b-d9b8-492e-a167-8cdaedcc52ad")
+  (no_connect (at 109.22 106.68) (uuid "93d60f69-e964-4007-9304-ecad1b64305a")
   )
-  (no_connect (at 109.22 104.14) (uuid "4ee5d710-7c0c-4f25-834a-e2dd1d287676")
+  (no_connect (at 109.22 104.14) (uuid "320727a6-1ac3-47c3-b4b7-1145d954667e")
   )
-  (no_connect (at 109.22 101.6) (uuid "1699fe61-4f6b-4598-85be-d9fdd41758ad")
+  (no_connect (at 109.22 101.6) (uuid "1c3dc5aa-9d89-4fef-af11-c7b3fd69f20c")
   )
-  (no_connect (at 109.22 99.06) (uuid "02d34c7d-2878-4747-80e6-89b47a782d0b")
+  (no_connect (at 109.22 99.06) (uuid "dbb50898-a993-4d9e-a5a5-06d66c72afc5")
   )
-  (no_connect (at 109.22 96.52) (uuid "e9e6383d-0589-4aaf-b3bd-ee86b614280d")
+  (no_connect (at 109.22 96.52) (uuid "48b862ef-ea09-4b0c-8184-ede7143e47f4")
   )
-  (no_connect (at 109.22 93.98) (uuid "2ef251ff-4d0c-4f45-b459-8fa5d6593948")
+  (no_connect (at 109.22 93.98) (uuid "e2b70cdb-03f6-4de7-b8fc-88105dfa0e1e")
   )
-  (no_connect (at 109.22 91.44) (uuid "31e2faf6-0dc4-443a-b773-7739a840767c")
+  (no_connect (at 109.22 91.44) (uuid "4cd3fc55-1042-4eb3-b372-ffadb0038966")
   )
-  (no_connect (at 109.22 88.9) (uuid "38df4930-a842-40fb-a830-1dba3b5f3ece")
+  (no_connect (at 109.22 88.9) (uuid "9987acce-9e8e-4aaa-91cd-beef49dd5d6a")
   )
-  (no_connect (at 109.22 86.36) (uuid "39b05deb-8973-4c61-8d87-699db2c814bc")
+  (no_connect (at 109.22 86.36) (uuid "03f57852-4a53-43cf-b3e2-e0cb3e8db68d")
   )
-  (no_connect (at 109.22 83.82) (uuid "b6dfa38f-e600-4826-89e4-fefaa250f3a9")
+  (no_connect (at 109.22 83.82) (uuid "cca3da6b-80d3-467d-865f-88376de6a9a8")
   )
-  (no_connect (at 109.22 81.28) (uuid "bf999ce8-dead-4736-94e8-8adde2b5cb20")
+  (no_connect (at 109.22 81.28) (uuid "10c394c3-ec86-4d9d-9333-d57d3658826c")
   )
-  (no_connect (at 109.22 73.66) (uuid "f8cf765d-1184-4881-9fee-907d6613bcac")
+  (no_connect (at 109.22 73.66) (uuid "5254fb15-a637-4577-b1bf-25837cd3b90c")
   )
   (global_label "VCC" (shape bidirectional) (at 91.44 71.12 0) (fields_autoplaced yes)
     (effects
@@ -3226,7 +3226,7 @@
       )
       (justify left)
     )
-    (uuid "7aeabba2-c443-4f5d-8660-41d1536f5019")
+    (uuid "44c1d587-4ed7-4443-89db-f8426c1e582d")
   )
   (global_label "GND" (shape bidirectional) (at 91.44 109.22 0) (fields_autoplaced yes)
     (effects
@@ -3235,7 +3235,7 @@
       )
       (justify left)
     )
-    (uuid "a373445a-9abd-49f5-8c85-b7ef119408bd")
+    (uuid "1934064f-25ce-4c30-9829-d6baa98c1add")
   )
   (global_label "VCC" (shape bidirectional) (at 114.3 109.22 180) (fields_autoplaced yes)
     (effects
@@ -3244,7 +3244,7 @@
       )
       (justify right)
     )
-    (uuid "c52ab3ea-82ea-411c-99d7-3d6099a09c1f")
+    (uuid "d8ce9c2b-f8be-497d-80a5-54b6b4d72241")
   )
   (global_label "GND" (shape bidirectional) (at 114.3 71.12 180) (fields_autoplaced yes)
     (effects
@@ -3253,7 +3253,7 @@
       )
       (justify right)
     )
-    (uuid "4758323b-8c5d-48b9-918d-ca4a5fa21888")
+    (uuid "43791dfc-310b-4fa9-9a2f-7845b9298dc9")
   )
   (global_label "USB_D+" (shape bidirectional) (at 114.3 78.74 180) (fields_autoplaced yes)
     (effects
@@ -3262,7 +3262,7 @@
       )
       (justify right)
     )
-    (uuid "5f06e9a0-cd75-47f1-b7b2-074902ca56d6")
+    (uuid "e3727acd-ea90-428d-a50c-87385445da2c")
   )
   (global_label "USB_D-" (shape bidirectional) (at 114.3 76.2 180) (fields_autoplaced yes)
     (effects
@@ -3271,7 +3271,7 @@
       )
       (justify right)
     )
-    (uuid "df821e96-5186-4a6f-bcb3-6d8b84f3ecca")
+    (uuid "7c8b2626-23d8-4793-beb3-4e98a5442637")
   )
   (global_label "XTAL1" (shape bidirectional) (at 91.44 86.36 0) (fields_autoplaced yes)
     (effects
@@ -3280,7 +3280,7 @@
       )
       (justify left)
     )
-    (uuid "53c500dd-b32f-473d-bfe3-b0b86f779e4b")
+    (uuid "7cee4486-452e-4d4c-9d20-9c1d96b2f96f")
   )
   (global_label "XTAL2" (shape bidirectional) (at 91.44 88.9 0) (fields_autoplaced yes)
     (effects
@@ -3289,7 +3289,7 @@
       )
       (justify left)
     )
-    (uuid "5646595b-57f8-4562-b688-c87fa56f98c9")
+    (uuid "89dfae56-0255-44fd-81b1-571602c71dc4")
   )
   (global_label "JOY_X" (shape bidirectional) (at 91.44 73.66 0) (fields_autoplaced yes)
     (effects
@@ -3298,7 +3298,7 @@
       )
       (justify left)
     )
-    (uuid "ca3d3aef-d75b-4b61-b93a-8d3e63ae7d02")
+    (uuid "59c955d9-7797-4673-9996-2cd8e8ebf26b")
   )
   (global_label "JOY_Y" (shape bidirectional) (at 91.44 76.2 0) (fields_autoplaced yes)
     (effects
@@ -3307,7 +3307,7 @@
       )
       (justify left)
     )
-    (uuid "e3f9f6a3-d83e-4dda-9dcc-70f6c073b207")
+    (uuid "87e738f9-6d12-4b24-8fa8-baa2357f7aa4")
   )
   (global_label "BTN1" (shape bidirectional) (at 91.44 91.44 0) (fields_autoplaced yes)
     (effects
@@ -3316,7 +3316,7 @@
       )
       (justify left)
     )
-    (uuid "81aa0a2a-a0f5-4f9a-b2f9-f9a8ebbb9448")
+    (uuid "b9e3bbb5-f62b-416d-9093-734277373670")
   )
   (global_label "BTN2" (shape bidirectional) (at 91.44 93.98 0) (fields_autoplaced yes)
     (effects
@@ -3325,7 +3325,7 @@
       )
       (justify left)
     )
-    (uuid "f4ba8d17-f0b3-4590-991c-3695e8be241f")
+    (uuid "346b3da3-ea06-4dba-b402-56d6cfa829b3")
   )
   (global_label "BTN3" (shape bidirectional) (at 91.44 96.52 0) (fields_autoplaced yes)
     (effects
@@ -3334,7 +3334,7 @@
       )
       (justify left)
     )
-    (uuid "d509e922-591e-478d-806f-d7de74aeec4e")
+    (uuid "a1383791-bd1b-4687-b6e3-25922fb62c17")
   )
   (global_label "BTN4" (shape bidirectional) (at 91.44 99.06 0) (fields_autoplaced yes)
     (effects
@@ -3343,7 +3343,7 @@
       )
       (justify left)
     )
-    (uuid "e97e9c25-d1b3-41d9-b4eb-0f1f5b9a116c")
+    (uuid "3a968135-59a9-4f5b-94df-4bbd6f2fcb03")
   )
   (global_label "JOY_BTN" (shape bidirectional) (at 91.44 101.6 0) (fields_autoplaced yes)
     (effects
@@ -3352,7 +3352,7 @@
       )
       (justify left)
     )
-    (uuid "e6a2b9ac-ccf0-4540-b1ef-62ad07d6a7ca")
+    (uuid "391fbddb-40ee-4566-9884-92a6845c011f")
   )
   (global_label "VCC" (shape bidirectional) (at 50.8 48.26 180) (fields_autoplaced yes)
     (effects
@@ -3361,7 +3361,7 @@
       )
       (justify right)
     )
-    (uuid "0714bcab-1f5c-41ce-a8b9-ecb533c0655b")
+    (uuid "5d91cb5a-8742-48b5-a7e6-955d19652902")
   )
   (global_label "USB_D-" (shape bidirectional) (at 50.8 50.8 180) (fields_autoplaced yes)
     (effects
@@ -3370,7 +3370,7 @@
       )
       (justify right)
     )
-    (uuid "aa11e34d-a85b-4744-8f03-b12a52e89b43")
+    (uuid "c18a3625-c120-4acb-8a8d-6f139db8f043")
   )
   (global_label "USB_D+" (shape bidirectional) (at 50.8 53.34 180) (fields_autoplaced yes)
     (effects
@@ -3379,7 +3379,7 @@
       )
       (justify right)
     )
-    (uuid "49df2076-8fd3-4059-b920-fcbb24b85285")
+    (uuid "bbd69f39-27f4-4974-a9e8-4940742cb7e0")
   )
   (global_label "GND" (shape bidirectional) (at 50.8 55.88 180) (fields_autoplaced yes)
     (effects
@@ -3388,7 +3388,7 @@
       )
       (justify right)
     )
-    (uuid "e9008c8d-de1f-471b-92c6-b80359baf9f6")
+    (uuid "705c2b7a-0d08-46cd-ba92-d15711afffda")
   )
   (global_label "VCC" (shape bidirectional) (at 50.8 96.52 180) (fields_autoplaced yes)
     (effects
@@ -3397,7 +3397,7 @@
       )
       (justify right)
     )
-    (uuid "1565a8f5-2047-47db-85d6-46cffe0dbc48")
+    (uuid "c8faacaf-cb90-4105-866d-b665fe16f7e3")
   )
   (global_label "GND" (shape bidirectional) (at 50.8 99.06 180) (fields_autoplaced yes)
     (effects
@@ -3406,7 +3406,7 @@
       )
       (justify right)
     )
-    (uuid "0944b574-be1b-4c7e-a832-548877331724")
+    (uuid "d17fe9bd-e25c-4db2-a79c-29516ef12f34")
   )
   (global_label "JOY_X" (shape bidirectional) (at 50.8 101.6 180) (fields_autoplaced yes)
     (effects
@@ -3415,7 +3415,7 @@
       )
       (justify right)
     )
-    (uuid "164b3983-e32a-4ab9-b066-510a802bb9f4")
+    (uuid "66dd5631-c775-4277-ae3f-816162bddf5e")
   )
   (global_label "JOY_Y" (shape bidirectional) (at 50.8 104.14 180) (fields_autoplaced yes)
     (effects
@@ -3424,7 +3424,7 @@
       )
       (justify right)
     )
-    (uuid "8e17c82d-fb91-4370-afdf-d6352ee72853")
+    (uuid "8af2d2c0-ea2c-4d8a-85e7-b90687ddcc52")
   )
   (global_label "JOY_BTN" (shape bidirectional) (at 50.8 106.68 180) (fields_autoplaced yes)
     (effects
@@ -3433,7 +3433,7 @@
       )
       (justify right)
     )
-    (uuid "0477dfbb-64fa-4c59-b3fd-237950507b5c")
+    (uuid "8561d36a-ced3-49f0-945a-55c7b0c13f93")
   )
   (global_label "XTAL1" (shape bidirectional) (at 118.11 76.2 0) (fields_autoplaced yes)
     (effects
@@ -3442,7 +3442,7 @@
       )
       (justify left)
     )
-    (uuid "2c20f83d-31e2-481c-b45c-c275f79c264b")
+    (uuid "ef7dca14-3a0d-44b2-9949-2791058b1b2b")
   )
   (global_label "XTAL2" (shape bidirectional) (at 135.89 76.2 180) (fields_autoplaced yes)
     (effects
@@ -3451,7 +3451,7 @@
       )
       (justify right)
     )
-    (uuid "81258161-4896-4494-8c05-44b54b58af0b")
+    (uuid "0840852e-c77b-4593-9dd4-4b98f86f0b07")
   )
   (global_label "BTN1" (shape bidirectional) (at 147.32 85.09 0) (fields_autoplaced yes)
     (effects
@@ -3460,7 +3460,7 @@
       )
       (justify left)
     )
-    (uuid "4d1178e9-9e9e-4343-ad1b-d4ab6729fe23")
+    (uuid "b4a5c52e-a646-447a-8861-cf8339f23905")
   )
   (global_label "GND" (shape bidirectional) (at 157.48 92.71 180) (fields_autoplaced yes)
     (effects
@@ -3469,61 +3469,61 @@
       )
       (justify right)
     )
-    (uuid "085135ac-1304-455a-9dbf-7dc03ac365ba")
+    (uuid "c00cd25d-e834-42bd-833e-694c74619adc")
   )
-  (global_label "BTN2" (shape bidirectional) (at 129.54 92.71 0) (fields_autoplaced yes)
+  (global_label "BTN2" (shape bidirectional) (at 130.81 92.71 0) (fields_autoplaced yes)
     (effects
       (font
         (size 1.27 1.27)
       )
       (justify left)
     )
-    (uuid "517c0026-deb2-4fc2-bf88-7a4623351270")
+    (uuid "e3579b94-2aaf-4972-b750-f889e8d1e0ad")
   )
-  (global_label "GND" (shape bidirectional) (at 139.7 100.33 180) (fields_autoplaced yes)
+  (global_label "GND" (shape bidirectional) (at 140.97 100.33 180) (fields_autoplaced yes)
     (effects
       (font
         (size 1.27 1.27)
       )
       (justify right)
     )
-    (uuid "c15bf81e-7095-461e-9500-f2c254f611cb")
+    (uuid "12264ef2-10f7-42e9-85d9-3520f64a2dbf")
   )
-  (global_label "BTN3" (shape bidirectional) (at 142.24 67.31 0) (fields_autoplaced yes)
+  (global_label "BTN3" (shape bidirectional) (at 142.24 68.58 0) (fields_autoplaced yes)
     (effects
       (font
         (size 1.27 1.27)
       )
       (justify left)
     )
-    (uuid "8b7e20f0-06e7-424d-b2e3-d16f281ae272")
+    (uuid "413538a8-6255-490b-8ce7-60f895f749f3")
   )
-  (global_label "GND" (shape bidirectional) (at 152.4 74.93 180) (fields_autoplaced yes)
+  (global_label "GND" (shape bidirectional) (at 152.4 76.2 180) (fields_autoplaced yes)
     (effects
       (font
         (size 1.27 1.27)
       )
       (justify right)
     )
-    (uuid "bef2b20e-f89b-4ca7-aab5-3067a795bb3a")
+    (uuid "b7a0b345-6654-4fa7-9f52-76286bf505fb")
   )
-  (global_label "BTN4" (shape bidirectional) (at 147.32 102.87 0) (fields_autoplaced yes)
+  (global_label "BTN4" (shape bidirectional) (at 147.32 101.6 0) (fields_autoplaced yes)
     (effects
       (font
         (size 1.27 1.27)
       )
       (justify left)
     )
-    (uuid "08382d66-ebb4-45c0-953f-3935b091cfd7")
+    (uuid "20f7fb5e-4e40-4365-a211-6050dbe8a20d")
   )
-  (global_label "GND" (shape bidirectional) (at 157.48 110.49 180) (fields_autoplaced yes)
+  (global_label "GND" (shape bidirectional) (at 157.48 109.22 180) (fields_autoplaced yes)
     (effects
       (font
         (size 1.27 1.27)
       )
       (justify right)
     )
-    (uuid "c5027951-a298-45dd-864a-ec6562a535b1")
+    (uuid "d3422cc2-7162-4fee-987e-8fba63b959a1")
   )
   (global_label "VCC" (shape bidirectional) (at 83.82 59.69 0) (fields_autoplaced yes)
     (effects
@@ -3532,7 +3532,7 @@
       )
       (justify left)
     )
-    (uuid "f7d69fe5-af95-4a67-99c0-3ad5c1c534ec")
+    (uuid "a91eb8ea-075a-416f-abbe-2afa0ac92a8b")
   )
   (global_label "GND" (shape bidirectional) (at 93.98 67.31 180) (fields_autoplaced yes)
     (effects
@@ -3541,7 +3541,7 @@
       )
       (justify right)
     )
-    (uuid "daf42594-f290-4a6b-a79b-bd9b9cd98393")
+    (uuid "da4130c8-dc24-4cd9-bd2e-3725f2253bc2")
   )
   (global_label "VCC" (shape bidirectional) (at 109.22 59.69 0) (fields_autoplaced yes)
     (effects
@@ -3550,7 +3550,7 @@
       )
       (justify left)
     )
-    (uuid "2d691194-f5a3-40f4-af4e-5e5adeda6b27")
+    (uuid "d78568f7-ac92-4219-8845-24a550e0e923")
   )
   (global_label "GND" (shape bidirectional) (at 119.38 67.31 180) (fields_autoplaced yes)
     (effects
@@ -3559,7 +3559,7 @@
       )
       (justify right)
     )
-    (uuid "d970ecb7-fc2e-4353-b657-8bef8ae18987")
+    (uuid "1868e92b-7612-42d4-969c-539e463789ce")
   )
   (global_label "VCC" (shape bidirectional) (at 83.82 110.49 0) (fields_autoplaced yes)
     (effects
@@ -3568,7 +3568,7 @@
       )
       (justify left)
     )
-    (uuid "d938708a-4410-488c-ade1-1e1a264c4746")
+    (uuid "e93967ca-2ca8-49e5-b2c2-eb519ae7b0c8")
   )
   (global_label "GND" (shape bidirectional) (at 93.98 118.11 180) (fields_autoplaced yes)
     (effects
@@ -3577,7 +3577,7 @@
       )
       (justify right)
     )
-    (uuid "cea5f7df-b3fd-465b-8994-1a85a035934f")
+    (uuid "0f1d3a4b-112b-4c15-9a2b-d4136f63e05a")
   )
   (global_label "VCC" (shape bidirectional) (at 50.8 34.29 0) (fields_autoplaced yes)
     (effects
@@ -3586,7 +3586,7 @@
       )
       (justify left)
     )
-    (uuid "25315c03-9c05-4e78-a85f-c2785bf3c424")
+    (uuid "46ea03e8-530a-4475-8ebe-9b0669507fd3")
   )
   (global_label "GND" (shape bidirectional) (at 60.96 41.91 180) (fields_autoplaced yes)
     (effects
@@ -3595,7 +3595,7 @@
       )
       (justify right)
     )
-    (uuid "7ee0798c-9c1c-4f43-865b-3e83fa726bd0")
+    (uuid "42bb817f-3c75-4f3a-8471-7f241d4ec30b")
   )
   (global_label "VCC" (shape input) (at 30.48 25.4 180) (fields_autoplaced yes)
     (effects
@@ -3604,7 +3604,7 @@
       )
       (justify right)
     )
-    (uuid "257e7b51-c6ce-4f66-9f28-28904bcf9dfa")
+    (uuid "140ff29e-517b-4bb5-bd18-5475b27a257b")
   )
   (global_label "GND" (shape input) (at 30.48 177.8 180) (fields_autoplaced yes)
     (effects
@@ -3613,10 +3613,10 @@
       )
       (justify right)
     )
-    (uuid "2f270b8c-0c7a-452d-a44c-a87b70a2fa69")
+    (uuid "2e40e61d-745e-46a2-a6a8-fc90f06c4fb1")
   )
   (sheet_instances
-    (path "/997516ac-8b65-40b5-9935-d684018af00e" (page "1")
+    (path "/e45ee506-a9c1-41ce-a509-013b5db41cc7" (page "1")
     )
   )
 )


### PR DESCRIPTION
## Summary

Fix 36 `off_grid_wire` validation warnings in board 03 (USB joystick) schematic by changing the grid from 2.54mm (100mil) to 1.27mm (50mil).

## Root Cause

KiCad symbol pins are defined on a 1.27mm (50mil) grid in library files. When the schematic was configured with a 2.54mm grid, wire endpoints drawn to pin positions ended up off-grid relative to the validation check, causing warnings.

## Changes

- Change `grid=2.54` to `grid=1.27` in `generate_schematic.py`
- Regenerate schematic output with proper grid alignment

## Test Plan

- [x] Regenerate schematic - now shows `Errors: 0, Warnings: 0` (previously 36 warnings)
- [x] Verify file passes ruff format/lint checks
- [x] Run schematic tests - all 560 passed

Closes #816