### PR TITLE
feat(footprints): Implement Footprint.to_sexp() for programmatic footprint generation

### DIFF
--- a/src/kicad_tools/footprints/__init__.py
+++ b/src/kicad_tools/footprints/__init__.py
@@ -1,16 +1,14 @@
 """
-Programmatic footprint generation module (EXPERIMENTAL).
-
-.. warning::
-    This module is experimental. The ``Footprint.to_sexp()`` method
-    is not yet implemented and will raise NotImplementedError.
+Programmatic footprint generation module.
 
 Provides classes for generating KiCad footprints programmatically,
 including common package types (0402, 0603, SOT-23, QFN, etc.).
 """
 
-import warnings
 from enum import Enum
+
+from kicad_tools.sexp import SExp
+from kicad_tools.sexp.builders import fmt
 
 __all__ = [
     "PadType",
@@ -19,13 +17,6 @@ __all__ = [
     "Pad",
     "Footprint",
 ]
-
-# Emit warning on import
-warnings.warn(
-    "kicad_tools.footprints is experimental. Footprint.to_sexp() is not yet implemented.",
-    category=FutureWarning,
-    stacklevel=2,
-)
 
 
 class PadType(Enum):
@@ -75,6 +66,7 @@ class Pad:
         size: tuple[float, float],
         layers: list[Layer],
         drill: float = 0,
+        roundrect_rratio: float = 0.25,
     ):
         self.number = number
         self.pad_type = pad_type
@@ -83,17 +75,95 @@ class Pad:
         self.size = size
         self.layers = layers
         self.drill = drill
+        self.roundrect_rratio = roundrect_rratio
+
+    def to_sexp(self) -> SExp:
+        """Convert to KiCad S-expression format.
+
+        Returns:
+            SExp node representing this pad.
+
+        Example output::
+
+            (pad "1" smd roundrect
+                (at -0.48 0)
+                (size 0.56 0.62)
+                (layers "F.Cu" "F.Paste" "F.Mask")
+                (roundrect_rratio 0.25)
+            )
+        """
+        # Build pad node: (pad "number" type shape ...)
+        pad = SExp.list("pad", self.number, self.pad_type.value, self.shape.value)
+
+        # Position: (at x y)
+        x, y = self.position
+        pad.append(SExp.list("at", fmt(x), fmt(y)))
+
+        # Size: (size w h)
+        w, h = self.size
+        pad.append(SExp.list("size", fmt(w), fmt(h)))
+
+        # Drill for THT pads: (drill d)
+        if self.pad_type in (PadType.THT, PadType.NPTH) and self.drill > 0:
+            pad.append(SExp.list("drill", fmt(self.drill)))
+
+        # Layers: (layers "F.Cu" "F.Paste" "F.Mask")
+        layers_node = SExp.list("layers")
+        for layer in self.layers:
+            layers_node.append(SExp.atom(layer.value))
+        pad.append(layers_node)
+
+        # Roundrect ratio for rounded rectangle pads
+        if self.shape == PadShape.ROUNDRECT:
+            pad.append(SExp.list("roundrect_rratio", fmt(self.roundrect_rratio)))
+
+        return pad
 
 
 class Footprint:
     """
     A KiCad footprint definition.
 
-    Note: Full implementation with footprint generators is pending.
+    Example::
+
+        from kicad_tools.footprints import Footprint, Pad, PadType, PadShape, Layer
+
+        fp = Footprint(
+            name="C_0402_1005Metric",
+            description="Capacitor SMD 0402 (1005 Metric)",
+            tags="capacitor smd 0402",
+        )
+        fp.add_pad(Pad(
+            number="1",
+            pad_type=PadType.SMD,
+            shape=PadShape.ROUNDRECT,
+            position=(-0.48, 0),
+            size=(0.56, 0.62),
+            layers=[Layer.F_CU, Layer.F_PASTE, Layer.F_MASK],
+        ))
+        fp.add_pad(Pad(
+            number="2",
+            pad_type=PadType.SMD,
+            shape=PadShape.ROUNDRECT,
+            position=(0.48, 0),
+            size=(0.56, 0.62),
+            layers=[Layer.F_CU, Layer.F_PASTE, Layer.F_MASK],
+        ))
+
+        sexp_str = fp.to_sexp()
     """
 
-    def __init__(self, name: str):
+    def __init__(
+        self,
+        name: str,
+        description: str = "",
+        tags: str = "",
+        layer: Layer = Layer.F_CU,
+    ):
         self.name = name
+        self.description = description
+        self.tags = tags
+        self.layer = layer
         self.pads: list[Pad] = []
         self.silkscreen: list[str] = []
         self.courtyard: list[str] = []
@@ -102,8 +172,65 @@ class Footprint:
         """Add a pad to the footprint."""
         self.pads.append(pad)
 
+    def _get_attr(self) -> str:
+        """Determine footprint attribute (smd or through_hole) from pad types."""
+        has_tht = any(p.pad_type in (PadType.THT, PadType.NPTH) for p in self.pads)
+        has_smd = any(p.pad_type == PadType.SMD for p in self.pads)
+
+        # If only SMD pads, return smd
+        if has_smd and not has_tht:
+            return "smd"
+        # If any THT pads, return through_hole
+        if has_tht:
+            return "through_hole"
+        # Default to smd if no pads yet
+        return "smd"
+
     def to_sexp(self) -> str:
-        """Export to KiCad S-expression format."""
-        raise NotImplementedError(
-            "Footprint.to_sexp() is not yet implemented. This is an experimental feature."
-        )
+        """Convert to KiCad S-expression format (.kicad_mod).
+
+        Returns:
+            String containing the complete footprint S-expression.
+
+        Example output::
+
+            (footprint "C_0402_1005Metric"
+                (version 20240108)
+                (generator "kicad-tools")
+                (layer "F.Cu")
+                (descr "Capacitor SMD 0402")
+                (tags "capacitor smd 0402")
+                (attr smd)
+                (pad "1" smd roundrect
+                    (at -0.48 0)
+                    (size 0.56 0.62)
+                    (layers "F.Cu" "F.Paste" "F.Mask")
+                    (roundrect_rratio 0.25)
+                )
+                ...
+            )
+        """
+        # Build footprint node
+        footprint = SExp.list("footprint", self.name)
+
+        # Version and generator
+        footprint.append(SExp.list("version", 20240108))
+        footprint.append(SExp.list("generator", "kicad-tools"))
+
+        # Layer
+        footprint.append(SExp.list("layer", self.layer.value))
+
+        # Description and tags (if provided)
+        if self.description:
+            footprint.append(SExp.list("descr", self.description))
+        if self.tags:
+            footprint.append(SExp.list("tags", self.tags))
+
+        # Attribute (smd or through_hole)
+        footprint.append(SExp.list("attr", self._get_attr()))
+
+        # Add all pads
+        for pad in self.pads:
+            footprint.append(pad.to_sexp())
+
+        return footprint.to_string()


### PR DESCRIPTION
## Summary

Implements the previously stub `to_sexp()` method on the `Footprint` and `Pad` classes to enable programmatic generation of KiCad footprint files (.kicad_mod).

**Key changes:**
- Add `Pad.to_sexp()` method supporting SMD and THT pad types
- Add `Footprint.to_sexp()` method generating valid KiCad format
- Add `roundrect_rratio` parameter to `Pad` class
- Remove experimental warning since feature is now implemented

## Example Usage

```python
from kicad_tools.footprints import Footprint, Pad, PadType, PadShape, Layer

fp = Footprint(
    name="C_0402_1005Metric",
    description="Capacitor SMD 0402",
    tags="capacitor smd 0402",
)
fp.add_pad(Pad(
    number="1",
    pad_type=PadType.SMD,
    shape=PadShape.ROUNDRECT,
    position=(-0.48, 0),
    size=(0.56, 0.62),
    layers=[Layer.F_CU, Layer.F_PASTE, Layer.F_MASK],
))

sexp_str = fp.to_sexp()  # Now works!
```

## Test Plan

- [x] Run `pytest tests/test_footprints.py` - all 42 tests pass
- [x] Verify generated S-expressions can be parsed back
- [x] Test SMD pad generation with roundrect shape
- [x] Test THT pad generation with drill parameter
- [x] Verify roundtrip parsing preserves structure

Closes #836