### PR TITLE
feat(pcb): Add PCB.create() method for creating PCBs from scratch

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -5,8 +5,10 @@ Provides classes for parsing and manipulating KiCad PCB files (.kicad_pcb).
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -772,6 +774,238 @@ class PCB:
         """Load PCB from file."""
         sexp = load_pcb(path)
         return cls(sexp)
+
+    @classmethod
+    def create(
+        cls,
+        width: float = 100.0,
+        height: float = 100.0,
+        layers: int = 2,
+        title: str = "",
+        revision: str = "1.0",
+        company: str = "",
+        board_date: str | None = None,
+    ) -> PCB:
+        """Create a new blank PCB from scratch.
+
+        This creates a minimal but valid KiCad PCB file with:
+        - Board outline on Edge.Cuts layer
+        - Layer definitions (2 or 4 copper layers)
+        - Basic design rules
+        - Title block information
+
+        Args:
+            width: Board width in mm (default 100.0)
+            height: Board height in mm (default 100.0)
+            layers: Number of copper layers (2 or 4, default 2)
+            title: Board title for title block
+            revision: Board revision (default "1.0")
+            company: Company name for title block
+            board_date: Date string (default: today's date in YYYY-MM-DD format)
+
+        Returns:
+            A new PCB instance ready for adding footprints and traces.
+
+        Raises:
+            ValueError: If layers is not 2 or 4
+
+        Example:
+            >>> pcb = PCB.create(width=160, height=100, layers=4, title="My Board")
+            >>> pcb.save("my_board.kicad_pcb")
+        """
+        if layers not in (2, 4):
+            raise ValueError(f"Layers must be 2 or 4, got {layers}")
+
+        if board_date is None:
+            board_date = date.today().isoformat()
+
+        sexp = cls._build_blank_pcb_sexp(
+            width=width,
+            height=height,
+            layers=layers,
+            title=title,
+            revision=revision,
+            company=company,
+            board_date=board_date,
+        )
+        return cls(sexp)
+
+    @staticmethod
+    def _build_blank_pcb_sexp(
+        width: float,
+        height: float,
+        layers: int,
+        title: str,
+        revision: str,
+        company: str,
+        board_date: str,
+    ) -> SExp:
+        """Build the S-expression for a blank PCB."""
+        pcb = SExp.list("kicad_pcb")
+
+        # Version and generator info
+        pcb.append(SExp.list("version", 20240108))
+        pcb.append(SExp.list("generator", "kicad_tools"))
+        pcb.append(SExp.list("generator_version", "8.0"))
+
+        # General settings
+        pcb.append(
+            SExp.list(
+                "general",
+                SExp.list("thickness", 1.6),
+                SExp.list("legacy_teardrops", "no"),
+            )
+        )
+
+        # Paper size
+        pcb.append(SExp.list("paper", "A4"))
+
+        # Title block
+        pcb.append(
+            SExp.list(
+                "title_block",
+                SExp.list("title", title),
+                SExp.list("date", board_date),
+                SExp.list("rev", revision),
+                SExp.list("company", company),
+            )
+        )
+
+        # Layers
+        pcb.append(PCB._build_layers_sexp(layers))
+
+        # Setup with design rules
+        pcb.append(PCB._build_setup_sexp(layers))
+
+        # Empty net (required)
+        pcb.append(SExp.list("net", 0, ""))
+
+        # Board outline on Edge.Cuts
+        pcb.append(PCB._build_board_outline_sexp(width, height))
+
+        return pcb
+
+    @staticmethod
+    def _build_layers_sexp(num_layers: int) -> SExp:
+        """Build the layers definition S-expression."""
+        layers_node = SExp.list("layers")
+
+        # Copper layers
+        layers_node.append(SExp.list("0", "F.Cu", "signal"))
+        if num_layers == 4:
+            layers_node.append(SExp.list("1", "In1.Cu", "signal"))
+            layers_node.append(SExp.list("2", "In2.Cu", "signal"))
+        layers_node.append(SExp.list("31", "B.Cu", "signal"))
+
+        # Technical layers (always present)
+        layers_node.append(SExp.list("32", "B.Adhes", "user", "B.Adhesive"))
+        layers_node.append(SExp.list("33", "F.Adhes", "user", "F.Adhesive"))
+        layers_node.append(SExp.list("34", "B.Paste", "user"))
+        layers_node.append(SExp.list("35", "F.Paste", "user"))
+        layers_node.append(SExp.list("36", "B.SilkS", "user", "B.Silkscreen"))
+        layers_node.append(SExp.list("37", "F.SilkS", "user", "F.Silkscreen"))
+        layers_node.append(SExp.list("38", "B.Mask", "user"))
+        layers_node.append(SExp.list("39", "F.Mask", "user"))
+        layers_node.append(SExp.list("40", "Dwgs.User", "user", "User.Drawings"))
+        layers_node.append(SExp.list("44", "Edge.Cuts", "user"))
+        layers_node.append(SExp.list("46", "B.CrtYd", "user", "B.Courtyard"))
+        layers_node.append(SExp.list("47", "F.CrtYd", "user", "F.Courtyard"))
+        layers_node.append(SExp.list("48", "B.Fab", "user"))
+        layers_node.append(SExp.list("49", "F.Fab", "user"))
+
+        return layers_node
+
+    @staticmethod
+    def _build_setup_sexp(num_layers: int) -> SExp:
+        """Build the setup/design rules S-expression."""
+        setup = SExp.list("setup")
+
+        # Stackup for multi-layer boards
+        if num_layers == 4:
+            stackup = SExp.list("stackup")
+            stackup.append(SExp.list("layer", "F.SilkS", SExp.list("type", "Top Silk Screen")))
+            stackup.append(SExp.list("layer", "F.Paste", SExp.list("type", "Top Solder Paste")))
+            stackup.append(
+                SExp.list(
+                    "layer", "F.Mask", SExp.list("type", "Top Solder Mask"), SExp.list("thickness", 0.01)
+                )
+            )
+            stackup.append(
+                SExp.list("layer", "F.Cu", SExp.list("type", "copper"), SExp.list("thickness", 0.035))
+            )
+            stackup.append(
+                SExp.list(
+                    "layer",
+                    "dielectric 1",
+                    SExp.list("type", "prepreg"),
+                    SExp.list("thickness", 0.2),
+                    SExp.list("material", "FR4"),
+                    SExp.list("epsilon_r", 4.5),
+                    SExp.list("loss_tangent", 0.02),
+                )
+            )
+            stackup.append(
+                SExp.list("layer", "In1.Cu", SExp.list("type", "copper"), SExp.list("thickness", 0.035))
+            )
+            stackup.append(
+                SExp.list(
+                    "layer",
+                    "dielectric 2",
+                    SExp.list("type", "core"),
+                    SExp.list("thickness", 1.0),
+                    SExp.list("material", "FR4"),
+                    SExp.list("epsilon_r", 4.5),
+                    SExp.list("loss_tangent", 0.02),
+                )
+            )
+            stackup.append(
+                SExp.list("layer", "In2.Cu", SExp.list("type", "copper"), SExp.list("thickness", 0.035))
+            )
+            stackup.append(
+                SExp.list(
+                    "layer",
+                    "dielectric 3",
+                    SExp.list("type", "prepreg"),
+                    SExp.list("thickness", 0.2),
+                    SExp.list("material", "FR4"),
+                    SExp.list("epsilon_r", 4.5),
+                    SExp.list("loss_tangent", 0.02),
+                )
+            )
+            stackup.append(
+                SExp.list("layer", "B.Cu", SExp.list("type", "copper"), SExp.list("thickness", 0.035))
+            )
+            stackup.append(
+                SExp.list(
+                    "layer",
+                    "B.Mask",
+                    SExp.list("type", "Bottom Solder Mask"),
+                    SExp.list("thickness", 0.01),
+                )
+            )
+            stackup.append(SExp.list("layer", "B.Paste", SExp.list("type", "Bottom Solder Paste")))
+            stackup.append(SExp.list("layer", "B.SilkS", SExp.list("type", "Bottom Silk Screen")))
+            stackup.append(SExp.list("copper_finish", "ENIG"))
+            stackup.append(SExp.list("dielectric_constraints", "no"))
+            setup.append(stackup)
+
+        # Basic design rules
+        setup.append(SExp.list("pad_to_mask_clearance", 0))
+
+        return setup
+
+    @staticmethod
+    def _build_board_outline_sexp(width: float, height: float) -> SExp:
+        """Build a rectangular board outline on Edge.Cuts layer."""
+        return SExp.list(
+            "gr_rect",
+            SExp.list("start", 0, 0),
+            SExp.list("end", width, height),
+            SExp.list("stroke", SExp.list("width", 0.1), SExp.list("type", "default")),
+            SExp.list("fill", "none"),
+            SExp.list("layer", "Edge.Cuts"),
+            SExp.list("uuid", str(uuid.uuid4())),
+        )
 
     def _parse(self):
         """Parse the PCB data structure."""

--- a/tests/test_pcb_create.py
+++ b/tests/test_pcb_create.py
@@ -1,0 +1,169 @@
+"""Tests for PCB.create() functionality."""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.schema.pcb import PCB
+
+
+class TestPCBCreate:
+    """Tests for creating new PCBs from scratch."""
+
+    def test_create_default_pcb(self):
+        """Test creating a PCB with default parameters."""
+        pcb = PCB.create()
+
+        # Check layers exist
+        assert len(pcb.layers) > 0
+        assert len(pcb.copper_layers) == 2
+
+        # Check that there is an Edge.Cuts graphic (gr_rect for outline)
+        edge_cuts_graphics = list(pcb.graphics_on_layer("Edge.Cuts"))
+        assert len(edge_cuts_graphics) > 0
+
+    def test_create_2layer_pcb(self):
+        """Test creating a 2-layer PCB."""
+        pcb = PCB.create(width=160, height=100, layers=2)
+
+        # Check copper layers
+        assert len(pcb.copper_layers) == 2
+        layer_names = [layer.name for layer in pcb.copper_layers]
+        assert "F.Cu" in layer_names
+        assert "B.Cu" in layer_names
+        assert "In1.Cu" not in layer_names
+
+    def test_create_4layer_pcb(self):
+        """Test creating a 4-layer PCB."""
+        pcb = PCB.create(width=160, height=100, layers=4)
+
+        # Check copper layers
+        assert len(pcb.copper_layers) == 4
+        layer_names = [layer.name for layer in pcb.copper_layers]
+        assert "F.Cu" in layer_names
+        assert "In1.Cu" in layer_names
+        assert "In2.Cu" in layer_names
+        assert "B.Cu" in layer_names
+
+        # Check stackup exists
+        assert pcb.setup is not None
+        assert len(pcb.setup.stackup) > 0
+
+    def test_create_with_title_block(self):
+        """Test creating a PCB with title block information."""
+        pcb = PCB.create(
+            width=100,
+            height=80,
+            title="Test Board",
+            revision="2.0",
+            company="Test Corp",
+            board_date="2024-01-15",
+        )
+
+        assert pcb.title == "Test Board"
+        assert pcb.revision == "2.0"
+        assert pcb.date == "2024-01-15"
+
+    def test_create_invalid_layers(self):
+        """Test that invalid layer count raises ValueError."""
+        with pytest.raises(ValueError, match="Layers must be 2 or 4"):
+            PCB.create(layers=3)
+
+        with pytest.raises(ValueError, match="Layers must be 2 or 4"):
+            PCB.create(layers=6)
+
+    def test_create_and_save(self, tmp_path: Path):
+        """Test creating a PCB and saving it to a file."""
+        pcb = PCB.create(
+            width=150,
+            height=100,
+            layers=2,
+            title="Save Test",
+        )
+
+        # Save to file
+        output_path = tmp_path / "test_board.kicad_pcb"
+        pcb.save(output_path)
+
+        # Verify file was created
+        assert output_path.exists()
+
+        # Reload and verify
+        reloaded = PCB.load(str(output_path))
+        assert reloaded.title == "Save Test"
+        assert len(reloaded.copper_layers) == 2
+
+    def test_create_4layer_and_save(self, tmp_path: Path):
+        """Test creating a 4-layer PCB and saving it to a file."""
+        pcb = PCB.create(
+            width=200,
+            height=150,
+            layers=4,
+            title="4-Layer Test",
+        )
+
+        # Save to file
+        output_path = tmp_path / "test_4layer.kicad_pcb"
+        pcb.save(output_path)
+
+        # Reload and verify
+        reloaded = PCB.load(str(output_path))
+        assert reloaded.title == "4-Layer Test"
+        assert len(reloaded.copper_layers) == 4
+
+        # Verify stackup was preserved
+        assert reloaded.setup is not None
+        assert len(reloaded.setup.stackup) > 0
+
+    def test_create_has_empty_net(self):
+        """Test that created PCB has the required empty net."""
+        pcb = PCB.create()
+
+        # Should have at least net 0 (empty net)
+        assert 0 in pcb.nets
+        assert pcb.nets[0].name == ""
+
+    def test_create_has_edge_cuts(self):
+        """Test that created PCB has Edge.Cuts layer."""
+        pcb = PCB.create(width=100, height=50)
+
+        # Should have Edge.Cuts in layers
+        layer_names = [layer.name for layer in pcb.layers.values()]
+        assert "Edge.Cuts" in layer_names
+
+        # Should have a board outline graphic on Edge.Cuts
+        # Note: gr_rect is parsed as BoardGraphic, not as individual lines
+        edge_cuts = list(pcb.graphics_on_layer("Edge.Cuts"))
+        assert len(edge_cuts) > 0
+
+    def test_create_date_default(self):
+        """Test that created PCB has today's date by default."""
+        from datetime import date as dt_date
+
+        pcb = PCB.create()
+
+        # Date should be today
+        expected_date = dt_date.today().isoformat()
+        assert pcb.date == expected_date
+
+    def test_create_custom_date(self):
+        """Test creating a PCB with a custom date."""
+        pcb = PCB.create(board_date="2023-06-15")
+        assert pcb.date == "2023-06-15"
+
+    def test_create_summary(self):
+        """Test that created PCB summary method works."""
+        pcb = PCB.create(
+            width=100,
+            height=100,
+            layers=2,
+            title="Summary Test",
+        )
+
+        summary = pcb.summary()
+        assert summary["title"] == "Summary Test"
+        assert summary["copper_layers"] == 2
+        assert summary["footprints"] == 0
+        assert summary["nets"] == 1  # Just the empty net
+        assert summary["segments"] == 0
+        assert summary["vias"] == 0


### PR DESCRIPTION
## Summary

Adds a new `PCB.create()` class method that allows creating blank PCB files programmatically without needing an existing template file.

## Features

- Create 2-layer or 4-layer PCBs with proper layer definitions
- Configure board dimensions (width/height in mm)
- Set title block information (title, revision, company, date)
- Generates proper stackup for 4-layer boards (FR4 dielectric, copper thickness)
- Creates rectangular board outline on Edge.Cuts layer
- Includes required empty net definition

## API

```python
from kicad_tools.schema.pcb import PCB

# Simple usage with defaults
pcb = PCB.create()
pcb.save("blank.kicad_pcb")

# Full customization
pcb = PCB.create(
    width=160,           # mm
    height=100,          # mm
    layers=4,            # 2 or 4
    title="My Board",
    revision="2.0",
    company="My Company",
    board_date="2024-01-15",
)
pcb.save("my_board.kicad_pcb")
```

## Test Plan

- [x] Test 2-layer PCB creation with correct layer definitions
- [x] Test 4-layer PCB creation with stackup
- [x] Test title block information is preserved
- [x] Test invalid layer count (3, 6) raises ValueError
- [x] Test save and reload preserves all data
- [x] Test empty net is included
- [x] Test Edge.Cuts outline is created
- [x] Test date defaults to today
- [x] All 12 tests pass

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)