### PR TITLE
fix(manufacturers): Correct constraint values against source documentation

### DIFF
--- a/src/kicad_tools/manufacturers/data/flashpcb.yaml
+++ b/src/kicad_tools/manufacturers/data/flashpcb.yaml
@@ -1,25 +1,27 @@
 # FlashPCB Design Rules Configuration
 # Source: https://www.flashpcb.com/capabilities
+# Last verified: 2026-01-16
 #
 # All measurements in millimeters unless otherwise noted.
 # Note: FlashPCB is a USA-based PCB fabrication and assembly house.
 # This configuration covers the instant quote tier only.
+# Email quote tier has tighter capabilities (not covered here).
 
 design_rules:
   # 2-layer 1oz copper
   2layer_1oz:
-    min_trace_width_mm: 0.127       # 5 mil
-    min_clearance_mm: 0.127         # 5 mil
+    min_trace_width_mm: 0.13        # 5 mil (per FlashPCB instant tier)
+    min_clearance_mm: 0.13          # 5 mil
     min_via_drill_mm: 0.2           # 8 mil
-    min_via_diameter_mm: 0.45       # ~18 mil (8 mil drill + 5 mil annular ring each side)
-    min_annular_ring_mm: 0.127      # 5 mil
+    min_via_diameter_mm: 0.86       # 34 mil (8 mil drill + 13 mil annular ring each side)
+    min_annular_ring_mm: 0.33       # 13 mil (per FlashPCB instant tier)
     min_hole_diameter_mm: 0.2       # 8 mil
     max_hole_diameter_mm: 6.35      # 250 mil
-    min_copper_to_edge_mm: 0.254    # 10 mil
-    min_hole_to_edge_mm: 0.254      # 10 mil
-    min_silkscreen_width_mm: 0.127  # 5 mil
+    min_copper_to_edge_mm: 1.0      # 40 mil (per FlashPCB instant tier)
+    min_hole_to_edge_mm: 1.0        # 40 mil (same as copper to edge)
+    min_silkscreen_width_mm: 0.08   # 3 mil
     min_silkscreen_height_mm: 0.8   # ~32 mil
-    min_solder_mask_dam_mm: 0.102   # 4 mil
+    min_solder_mask_dam_mm: 0.13    # 5 mil (per FlashPCB instant tier)
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0            # No inner layers
@@ -29,17 +31,17 @@ design_rules:
   # 2-layer 2oz copper
   2layer_2oz:
     min_trace_width_mm: 0.2032      # 8 mil (wider for 2oz)
-    min_clearance_mm: 0.127         # 5 mil
+    min_clearance_mm: 0.2032        # 8 mil (also wider for 2oz, matching trace)
     min_via_drill_mm: 0.2           # 8 mil
-    min_via_diameter_mm: 0.45       # ~18 mil
-    min_annular_ring_mm: 0.127      # 5 mil
+    min_via_diameter_mm: 0.86       # 34 mil (8 mil drill + 13 mil annular ring each side)
+    min_annular_ring_mm: 0.33       # 13 mil (per FlashPCB instant tier)
     min_hole_diameter_mm: 0.2       # 8 mil
     max_hole_diameter_mm: 6.35      # 250 mil
-    min_copper_to_edge_mm: 0.254    # 10 mil
-    min_hole_to_edge_mm: 0.254      # 10 mil
-    min_silkscreen_width_mm: 0.127  # 5 mil
+    min_copper_to_edge_mm: 1.0      # 40 mil (per FlashPCB instant tier)
+    min_hole_to_edge_mm: 1.0        # 40 mil (same as copper to edge)
+    min_silkscreen_width_mm: 0.08   # 3 mil
     min_silkscreen_height_mm: 0.8   # ~32 mil
-    min_solder_mask_dam_mm: 0.102   # 4 mil
+    min_solder_mask_dam_mm: 0.13    # 5 mil (per FlashPCB instant tier)
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.0
@@ -48,18 +50,18 @@ design_rules:
 
   # 4-layer 1oz outer copper (0.5oz inner)
   4layer_1oz:
-    min_trace_width_mm: 0.127       # 5 mil
-    min_clearance_mm: 0.127         # 5 mil
+    min_trace_width_mm: 0.13        # 5 mil (per FlashPCB instant tier)
+    min_clearance_mm: 0.13          # 5 mil
     min_via_drill_mm: 0.2           # 8 mil
-    min_via_diameter_mm: 0.45       # ~18 mil
-    min_annular_ring_mm: 0.127      # 5 mil
+    min_via_diameter_mm: 0.86       # 34 mil (8 mil drill + 13 mil annular ring each side)
+    min_annular_ring_mm: 0.33       # 13 mil (per FlashPCB instant tier)
     min_hole_diameter_mm: 0.2       # 8 mil
     max_hole_diameter_mm: 6.35      # 250 mil
-    min_copper_to_edge_mm: 0.254    # 10 mil
-    min_hole_to_edge_mm: 0.254      # 10 mil
-    min_silkscreen_width_mm: 0.127  # 5 mil
+    min_copper_to_edge_mm: 1.0      # 40 mil (per FlashPCB instant tier)
+    min_hole_to_edge_mm: 1.0        # 40 mil (same as copper to edge)
+    min_silkscreen_width_mm: 0.08   # 3 mil
     min_silkscreen_height_mm: 0.8   # ~32 mil
-    min_solder_mask_dam_mm: 0.102   # 4 mil
+    min_solder_mask_dam_mm: 0.13    # 5 mil (per FlashPCB instant tier)
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
@@ -69,17 +71,17 @@ design_rules:
   # 4-layer 2oz outer copper (1oz inner)
   4layer_2oz:
     min_trace_width_mm: 0.2032      # 8 mil (wider for 2oz)
-    min_clearance_mm: 0.127         # 5 mil
+    min_clearance_mm: 0.2032        # 8 mil (also wider for 2oz, matching trace)
     min_via_drill_mm: 0.2           # 8 mil
-    min_via_diameter_mm: 0.45       # ~18 mil
-    min_annular_ring_mm: 0.127      # 5 mil
+    min_via_diameter_mm: 0.86       # 34 mil (8 mil drill + 13 mil annular ring each side)
+    min_annular_ring_mm: 0.33       # 13 mil (per FlashPCB instant tier)
     min_hole_diameter_mm: 0.2       # 8 mil
     max_hole_diameter_mm: 6.35      # 250 mil
-    min_copper_to_edge_mm: 0.254    # 10 mil
-    min_hole_to_edge_mm: 0.254      # 10 mil
-    min_silkscreen_width_mm: 0.127  # 5 mil
+    min_copper_to_edge_mm: 1.0      # 40 mil (per FlashPCB instant tier)
+    min_hole_to_edge_mm: 1.0        # 40 mil (same as copper to edge)
+    min_silkscreen_width_mm: 0.08   # 3 mil
     min_silkscreen_height_mm: 0.8   # ~32 mil
-    min_solder_mask_dam_mm: 0.102   # 4 mil
+    min_solder_mask_dam_mm: 0.13    # 5 mil (per FlashPCB instant tier)
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 1.0

--- a/src/kicad_tools/manufacturers/data/jlcpcb.yaml
+++ b/src/kicad_tools/manufacturers/data/jlcpcb.yaml
@@ -1,6 +1,7 @@
 # JLCPCB Design Rules Configuration
 # Source: https://jlcpcb.com/capabilities/pcb-capabilities
 #         https://github.com/ayberkozgur/jlcpcb-design-rules-stackups
+# Last verified: 2026-01-16
 #
 # All measurements in millimeters unless otherwise noted.
 
@@ -16,7 +17,7 @@ design_rules:
     min_copper_to_edge_mm: 0.3
     min_hole_to_edge_mm: 0.5
     min_silkscreen_width_mm: 0.15
-    min_silkscreen_height_mm: 0.8
+    min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
     min_solder_mask_dam_mm: 0.1
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
@@ -33,7 +34,7 @@ design_rules:
     min_copper_to_edge_mm: 0.3
     min_hole_to_edge_mm: 0.5
     min_silkscreen_width_mm: 0.15
-    min_silkscreen_height_mm: 0.8
+    min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
     min_solder_mask_dam_mm: 0.1
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
@@ -44,13 +45,13 @@ design_rules:
     min_clearance_mm: 0.1016        # 4 mil
     min_via_drill_mm: 0.2
     min_via_diameter_mm: 0.45
-    min_annular_ring_mm: 0.125
+    min_annular_ring_mm: 0.15       # 6 mil (per JLCPCB specs)
     min_hole_diameter_mm: 0.2
     max_hole_diameter_mm: 6.3
     min_copper_to_edge_mm: 0.3
     min_hole_to_edge_mm: 0.4
     min_silkscreen_width_mm: 0.15
-    min_silkscreen_height_mm: 0.8
+    min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
     min_solder_mask_dam_mm: 0.1
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
@@ -61,13 +62,13 @@ design_rules:
     min_clearance_mm: 0.1016        # 4 mil
     min_via_drill_mm: 0.2
     min_via_diameter_mm: 0.45
-    min_annular_ring_mm: 0.125
+    min_annular_ring_mm: 0.15       # 6 mil (per JLCPCB specs)
     min_hole_diameter_mm: 0.2
     max_hole_diameter_mm: 6.3
     min_copper_to_edge_mm: 0.3
     min_hole_to_edge_mm: 0.4
     min_silkscreen_width_mm: 0.15
-    min_silkscreen_height_mm: 0.8
+    min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
     min_solder_mask_dam_mm: 0.1
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
@@ -78,13 +79,13 @@ design_rules:
     min_clearance_mm: 0.0889        # 3.5 mil
     min_via_drill_mm: 0.2
     min_via_diameter_mm: 0.45
-    min_annular_ring_mm: 0.125
+    min_annular_ring_mm: 0.15       # 6 mil (per JLCPCB specs)
     min_hole_diameter_mm: 0.2
     max_hole_diameter_mm: 6.3
     min_copper_to_edge_mm: 0.3
     min_hole_to_edge_mm: 0.4
     min_silkscreen_width_mm: 0.15
-    min_silkscreen_height_mm: 0.8
+    min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
     min_solder_mask_dam_mm: 0.1
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0

--- a/src/kicad_tools/manufacturers/data/oshpark.yaml
+++ b/src/kicad_tools/manufacturers/data/oshpark.yaml
@@ -1,5 +1,6 @@
 # OSHPark Design Rules Configuration
-# Source: https://docs.oshpark.com/design-tools/
+# Source: https://docs.oshpark.com/services/
+# Last verified: 2026-01-16
 #
 # All measurements in millimeters unless otherwise noted.
 # Note: OSHPark is PCB-only, no assembly services.

--- a/src/kicad_tools/manufacturers/data/pcbway.yaml
+++ b/src/kicad_tools/manufacturers/data/pcbway.yaml
@@ -1,5 +1,6 @@
 # PCBWay Design Rules Configuration
 # Source: https://www.pcbway.com/capabilities.html
+# Last verified: 2026-01-16
 #
 # All measurements in millimeters unless otherwise noted.
 
@@ -9,14 +10,14 @@ design_rules:
     min_clearance_mm: 0.127         # 5 mil
     min_via_drill_mm: 0.2
     min_via_diameter_mm: 0.4
-    min_annular_ring_mm: 0.1
+    min_annular_ring_mm: 0.15      # 6 mil (per PCBWay specs)
     min_hole_diameter_mm: 0.2
     max_hole_diameter_mm: 6.3
     min_copper_to_edge_mm: 0.25
     min_hole_to_edge_mm: 0.4
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
-    min_solder_mask_dam_mm: 0.08
+    min_solder_mask_dam_mm: 0.1    # 4 mil (per PCBWay specs)
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0
@@ -26,14 +27,14 @@ design_rules:
     min_clearance_mm: 0.2           # 8 mil
     min_via_drill_mm: 0.2
     min_via_diameter_mm: 0.4
-    min_annular_ring_mm: 0.1
+    min_annular_ring_mm: 0.15      # 6 mil (per PCBWay specs)
     min_hole_diameter_mm: 0.2
     max_hole_diameter_mm: 6.3
     min_copper_to_edge_mm: 0.25
     min_hole_to_edge_mm: 0.4
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
-    min_solder_mask_dam_mm: 0.08
+    min_solder_mask_dam_mm: 0.1    # 4 mil (per PCBWay specs)
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.0
@@ -43,14 +44,14 @@ design_rules:
     min_clearance_mm: 0.1016        # 4 mil
     min_via_drill_mm: 0.2
     min_via_diameter_mm: 0.4
-    min_annular_ring_mm: 0.1
+    min_annular_ring_mm: 0.15      # 6 mil (per PCBWay specs)
     min_hole_diameter_mm: 0.2
     max_hole_diameter_mm: 6.3
     min_copper_to_edge_mm: 0.25
     min_hole_to_edge_mm: 0.4
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
-    min_solder_mask_dam_mm: 0.08
+    min_solder_mask_dam_mm: 0.1    # 4 mil (per PCBWay specs)
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
@@ -60,14 +61,14 @@ design_rules:
     min_clearance_mm: 0.0889        # 3.5 mil
     min_via_drill_mm: 0.15
     min_via_diameter_mm: 0.35
-    min_annular_ring_mm: 0.1
+    min_annular_ring_mm: 0.15      # 6 mil (per PCBWay specs)
     min_hole_diameter_mm: 0.15
     max_hole_diameter_mm: 6.3
     min_copper_to_edge_mm: 0.25
     min_hole_to_edge_mm: 0.4
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
-    min_solder_mask_dam_mm: 0.08
+    min_solder_mask_dam_mm: 0.1    # 4 mil (per PCBWay specs)
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5

--- a/src/kicad_tools/manufacturers/data/seeed.yaml
+++ b/src/kicad_tools/manufacturers/data/seeed.yaml
@@ -1,9 +1,12 @@
 # Seeed Fusion Design Rules Configuration
 # Source: https://www.seeedstudio.com/fusion_pcb.html
 #         https://support.seeedstudio.com/knowledgebase/articles/447362-fusion-pcb-specification
+# Last verified: 2026-01-16
 #
 # All measurements in millimeters unless otherwise noted.
-# Note: Seeed values are slightly more conservative than JLCPCB.
+# Note: Seeed offers comparable capabilities to JLCPCB with some differences:
+#       - More conservative trace/clearance for 2-layer (6 mil vs 5 mil)
+#       - Supports 1oz inner copper for 4-layer 2oz boards (vs JLCPCB's 0.5oz)
 
 design_rules:
   2layer_1oz:

--- a/tests/test_mfr.py
+++ b/tests/test_mfr.py
@@ -18,13 +18,14 @@ class TestManufacturerProfiles:
     def test_list_manufacturers(self):
         """Test listing all manufacturers."""
         manufacturers = list_manufacturers()
-        assert len(manufacturers) == 4
+        assert len(manufacturers) == 5
 
         names = {m.name for m in manufacturers}
         assert "JLCPCB" in names
         assert "Seeed Fusion" in names
         assert "PCBWay" in names
         assert "OSHPark" in names
+        assert "FlashPCB" in names
 
     def test_get_manufacturer_ids(self):
         """Test getting manufacturer IDs."""
@@ -33,6 +34,7 @@ class TestManufacturerProfiles:
         assert "seeed" in ids
         assert "pcbway" in ids
         assert "oshpark" in ids
+        assert "flashpcb" in ids
 
     def test_get_profile_by_id(self):
         """Test getting a profile by ID."""


### PR DESCRIPTION
## Summary

Verified all manufacturer constraint files against their documented sources and corrected several discrepancies that could cause PCB designs to fail manufacturing DRC unexpectedly.

### Key Corrections

**FlashPCB (Major corrections)**
- `min_annular_ring_mm`: 0.127mm → 0.33mm (13 mil per instant tier specs)
- `min_copper_to_edge_mm`: 0.254mm → 1.0mm (40 mil per instant tier specs)
- `min_clearance_mm` for 2oz: Now matches trace width (was asymmetric)

**PCBWay**
- `min_annular_ring_mm`: 0.1mm → 0.15mm (6 mil per specs)
- `min_solder_mask_dam_mm`: 0.08mm → 0.1mm (4 mil per specs)

**JLCPCB**
- `min_annular_ring_mm` for 4/6-layer: 0.125mm → 0.15mm (6 mil per specs)
- `min_silkscreen_height_mm`: 0.8mm → 1.0mm (40 mil per specs)

**Seeed**
- Updated header comment to accurately describe capabilities

**All Files**
- Added "Last verified: 2026-01-16" date to each file header

## Test Plan

- [x] All existing tests pass (`pytest tests/test_mfr.py`)
- [x] Updated `test_list_manufacturers` to include FlashPCB (was missing)
- [x] DRU file generation verified to produce valid output

## Sources Verified

| Manufacturer | Source URL |
|--------------|-----------|
| JLCPCB | https://jlcpcb.com/capabilities/pcb-capabilities |
| PCBWay | https://www.pcbway.com/capabilities.html |
| OSHPark | https://docs.oshpark.com/services/ |
| Seeed | https://www.seeedstudio.com/fusion_pcb.html |
| FlashPCB | https://www.flashpcb.com/capabilities |

Closes #842