### PR TITLE
feat(router): Add routing failure diagnostics with detailed explanations

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -146,7 +146,11 @@ from .optimizer import (
     OptimizationStats,
     TraceOptimizer,
 )  # noqa: F401 - optimizer is now a package
-from .output import show_routing_summary
+from .output import (
+    get_routing_diagnostics_json,
+    print_routing_diagnostics_json,
+    show_routing_summary,
+)
 from .parallel import (
     BoundingBox,
     NetGroup,
@@ -382,6 +386,8 @@ __all__ = [
     "find_differential_partner",
     # Output and Diagnostics
     "show_routing_summary",
+    "get_routing_diagnostics_json",
+    "print_routing_diagnostics_json",
     # Manufacturer Limits and Adaptive Rules
     "MfrLimits",
     "RelaxationTier",


### PR DESCRIPTION
## Summary

When routing fails or partially succeeds, this PR provides detailed diagnostics explaining *why* each net failed to route, not just *that* it failed.

- Enhanced RoutingFailure dataclass with failure_cause enum and detailed analysis
- Integrated RootCauseAnalyzer to capture diagnostic information during routing
- Added diagnostic categories: PAD_INACCESSIBLE, BLOCKED_BY_COMPONENT, CONGESTION, CLEARANCE_VIOLATION, KEEPOUT, LAYER_CONSTRAINT  
- Enhanced show_routing_summary() with per-net failure details, grouped summaries, and pattern-based suggestions
- Added `--diagnostics` flag for verbose failure analysis
- Added `--format json` option for JSON output suitable for tooling/automation

## Changes

- `src/kicad_tools/router/core.py`: Enhanced RoutingFailure with failure_cause, coordinates, and analysis fields; integrated RootCauseAnalyzer in record_failure()
- `src/kicad_tools/router/output.py`: Rewrote show_routing_summary() with grouped failures and suggestions; added JSON output functions
- `src/kicad_tools/router/__init__.py`: Exported new functions
- `src/kicad_tools/cli/route_cmd.py`: Added --diagnostics and --format flags

## Example Output

```
[✗] USB_D+: FAILED
    Reason: PAD_INACCESSIBLE
    Details: U1.29 at (129.6, 115.5) not on routing grid (0.2mm)
    Suggestion: Adjust grid resolution or pad position

Failure Summary by Cause:
  PAD_INACCESSIBLE: 3 nets (25%)
  BLOCKED_BY_COMPONENT: 5 nets (42%)
  CONGESTION: 4 nets (33%)

Routing Suggestions:
1. GRID ALIGNMENT (3 nets affected)
   Some pads don't align with the 0.2mm routing grid.
   Try: --grid 0.1 or adjust pad positions
```

## Test Plan

- [x] Import test passes
- [x] All existing failure_analysis tests pass (36 tests)
- [x] Lint checks pass (ruff)
- [x] JSON output function tested via import

Closes #870