### PR TITLE
fix(schematic): Resolve connectivity errors in board 05 BLDC motor controller

### DIFF
--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -343,9 +343,12 @@ class ThreePhaseInverter(CircuitBlock):
             )
             self.half_bridges.append(hb)
 
-            # Add phase output label
+            # Add phase output label with connecting wire
             phase_pos = hb.port("VOUT")
-            sch.add_label(f"PHASE_{label}", phase_pos[0] + 10, phase_pos[1], rotation=0)
+            label_x = phase_pos[0] + 10
+            # Add wire from phase output to label position
+            sch.add_wire(phase_pos, (label_x, phase_pos[1]))
+            sch.add_label(f"PHASE_{label}", label_x, phase_pos[1], rotation=0)
 
         # Store all components
         self.components = {}

--- a/src/kicad_tools/schematic/blocks/power/regulators.py
+++ b/src/kicad_tools/schematic/blocks/power/regulators.py
@@ -634,6 +634,7 @@ def create_5v_buck(
     ref: str = "U1",
     input_voltage: float = 24.0,
     cap_ref_start: int = 1,
+    diode_ref: str = "D1",
 ) -> BuckConverter:
     """
     Create a 5V buck converter with sensible defaults.
@@ -648,6 +649,7 @@ def create_5v_buck(
         ref: Regulator reference designator
         input_voltage: Input voltage (typically 12V or 24V)
         cap_ref_start: Starting reference number for capacitors
+        diode_ref: Reference designator for the Schottky diode
 
     Returns:
         BuckConverter instance configured for 5V output.
@@ -672,6 +674,7 @@ def create_5v_buck(
         diode="SS34",
         feedback_divider=False,
         cap_ref_start=cap_ref_start,
+        diode_ref=diode_ref,
     )
 
 


### PR DESCRIPTION
## Summary

- Fix duplicate reference designator D1 by using D2 for Schottky diode in buck converter
- Add connecting wires for all floating labels (PHASE_A/B/C, ISENSE_A/B/C+/-, HALL_A/B/C)
- Wire hall connector VCC/GND pins to power rails
- Fix motor connector wiring to properly connect to phase outputs
- Tie LM2596 ON/OFF pin to GND for always-on operation

Reduces schematic validation errors from 20 to 7. Remaining errors are:
- Rail endpoint warnings (by design - power rails end without connections)
- MOSFET gate connections (architectural - gate driver is placeholder)
- LM2596 FB pin (architectural - fixed output version doesn't use FB)

## Test plan

- [x] Build schematic with `kct build boards/05-bldc-motor-controller --step schematic`
- [x] Verify error count reduced from 20 to 7
- [x] Verify D1 is TVS diode, D2 is Schottky diode
- [x] Verify labels have connecting wires

Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)