### PR TITLE
fix(schematic): Correct Y coordinate calculation in pin_position()

### DIFF
--- a/src/kicad_tools/schematic/models/symbol.py
+++ b/src/kicad_tools/schematic/models/symbol.py
@@ -357,19 +357,18 @@ class SymbolInstance:
         conn_x, conn_y = pin.connection_point()
 
         # Apply rotation transformation
-        # Note: KiCad schematic uses Y-down, but symbol definitions use Y-up
-        # So we negate the Y component when translating
+        # Note: Both KiCad schematics and symbol definitions use Y-down coordinates
         rad = math.radians(self.rotation)
         cos_r = math.cos(rad)
         sin_r = math.sin(rad)
 
-        # Rotate connection point around origin (in symbol's Y-up coordinate system)
+        # Rotate connection point around origin
         rx = conn_x * cos_r - conn_y * sin_r
         ry = conn_x * sin_r + conn_y * cos_r
 
-        # Translate to symbol position (flip Y for schematic's Y-down system)
+        # Translate to symbol position
         # Round to 2 decimal places for consistent wire matching
-        return (round(self.x + rx, 2), round(self.y - ry, 2))
+        return (round(self.x + rx, 2), round(self.y + ry, 2))
 
     def all_pin_positions(self) -> dict[str, tuple[float, float]]:
         """Get positions of all pins."""

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -577,9 +577,9 @@ class TestSymbolInstance:
 
         pos = inst.pin_position("1")
         # At 90 degrees, (-2.54, 0) rotates to (0, -2.54)
-        # With Y flip in schematic coords: (100+0, 100-(-2.54)) = (100, 102.54)
+        # Both schematic and symbol use Y-down: (100+0, 100+(-2.54)) = (100, 97.46)
         assert abs(pos[0] - 100.0) < 0.01
-        assert abs(pos[1] - 102.54) < 0.01
+        assert abs(pos[1] - 97.46) < 0.01
 
     def test_symbol_instance_pin_position_by_number(self, mock_symbol_def):
         """Get pin position by pin number."""
@@ -1684,6 +1684,67 @@ class TestSymbolInstanceAdvanced:
         # Should find VCC even with lowercase
         pos = inst.pin_position("vcc")
         assert pos is not None
+
+    def test_pin_position_vertical_ordering(self):
+        """Verify pins maintain correct vertical ordering (issue #889).
+
+        This test ensures that pins with positive Y in symbol-local coordinates
+        result in higher Y in schematic coordinates, and vice versa. The bug was
+        that Y coordinates were incorrectly negated, swapping vertical positions.
+        """
+        # Create a symbol with pins at different Y positions (like a gate driver)
+        pins = [
+            Pin(
+                name="OUTH",
+                number="1",
+                x=10.16,
+                y=2.54,  # Positive Y in symbol
+                angle=0,
+                length=2.54,
+                pin_type="output",
+            ),
+            Pin(
+                name="OUTL",
+                number="2",
+                x=10.16,
+                y=-2.54,  # Negative Y in symbol
+                angle=0,
+                length=2.54,
+                pin_type="output",
+            ),
+        ]
+        sym_def = SymbolDef(
+            lib_id="Driver_FET:TestGateDriver",
+            name="TestGateDriver",
+            raw_sexp="",
+            pins=pins,
+        )
+
+        # Place symbol at a known position with no rotation
+        inst = SymbolInstance(
+            symbol_def=sym_def,
+            x=320.04,
+            y=35.56,
+            rotation=0,
+            reference="U1",
+            value="TestGateDriver",
+        )
+
+        outh_pos = inst.pin_position("OUTH")
+        outl_pos = inst.pin_position("OUTL")
+
+        # In Y-down screen coords, positive symbol Y should result in higher screen Y
+        # OUTH (symbol y=+2.54) should have HIGHER screen Y than OUTL (symbol y=-2.54)
+        assert outh_pos[1] > outl_pos[1], (
+            f"OUTH y={outh_pos[1]} should be > OUTL y={outl_pos[1]}. "
+            "Pins appear to be vertically swapped due to incorrect Y negation."
+        )
+
+        # Verify exact positions
+        # OUTH: x = 320.04 + 10.16 = 330.2, y = 35.56 + 2.54 = 38.1
+        # OUTL: x = 320.04 + 10.16 = 330.2, y = 35.56 + (-2.54) = 33.02
+        assert outh_pos == (330.2, 38.1), f"OUTH position incorrect: {outh_pos}"
+        assert outl_pos == (330.2, 33.02), f"OUTL position incorrect: {outl_pos}"
 
 
 class TestSchematicAutoLayout:


### PR DESCRIPTION
## Summary

Fixes incorrect Y coordinate negation in `Symbol.pin_position()` that caused pins to be vertically swapped, leading to KiCad crashes when opening generated schematics.

## Changes

- **src/kicad_tools/schematic/models/symbol.py**: Changed `self.y - ry` to `self.y + ry` in the translation step, and updated comments to reflect that both symbol definitions and schematics use Y-down coordinates
- **tests/test_schematic_models.py**: 
  - Updated existing rotation test to expect correct (non-negated) Y value
  - Added new `test_pin_position_vertical_ordering` regression test that specifically verifies pins maintain correct vertical ordering

## Root Cause

The code incorrectly assumed symbol definitions use Y-up coordinates while schematics use Y-down. Both actually use Y-down coordinates, so the Y negation was incorrect.

## Test Plan

- [x] All existing pin_position tests pass
- [x] New vertical ordering test passes
- [x] Full test suite passes (180 tests in test_schematic_models.py)
- [x] Linting passes on changed files

Closes #889