### PR TITLE
feat(schematic): Add netlist query API for verifying connectivity

### DIFF
--- a/src/kicad_tools/schematic/models/__init__.py
+++ b/src/kicad_tools/schematic/models/__init__.py
@@ -12,6 +12,7 @@ from .elements import (
     Wire,
     WireCollision,
 )
+from .netlist_mixin import PinRef
 from .pin import Pin
 from .schematic import Schematic, SnapMode
 from .symbol import SymbolDef, SymbolInstance
@@ -20,6 +21,7 @@ from .validation_mixin import PowerNetIssue
 __all__ = [
     # Pin
     "Pin",
+    "PinRef",
     # Symbol
     "SymbolDef",
     "SymbolInstance",

--- a/src/kicad_tools/schematic/models/netlist_mixin.py
+++ b/src/kicad_tools/schematic/models/netlist_mixin.py
@@ -1,0 +1,379 @@
+"""
+Schematic Netlist Mixin
+
+Provides netlist extraction and connectivity query functionality.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass(frozen=True)
+class PinRef:
+    """Reference to a specific pin on a symbol.
+
+    Attributes:
+        symbol_ref: The symbol's reference designator (e.g., "R1", "U3")
+        pin: The pin number or name (e.g., "1", "VDD", "PA0")
+    """
+
+    symbol_ref: str
+    pin: str
+
+    def __str__(self) -> str:
+        return f"{self.symbol_ref}.{self.pin}"
+
+
+class SchematicNetlistMixin:
+    """Mixin providing netlist extraction and query operations for Schematic class."""
+
+    def _build_connectivity_graph(self) -> tuple[dict, dict, dict]:
+        """Build a connectivity graph using Union-Find.
+
+        Returns:
+            Tuple of (parent dict, point_to_net_names dict, point_to_pins dict)
+            - parent: Union-Find parent mapping for connectivity
+            - point_to_net_names: Maps points to their net names (from labels/power symbols)
+            - point_to_pins: Maps points to PinRef objects at that location
+        """
+        parent = {}
+        point_to_net_names: dict[tuple, list[str]] = {}
+        point_to_pins: dict[tuple, list[PinRef]] = {}
+
+        def find(p):
+            """Find root of point p in Union-Find structure."""
+            if p not in parent:
+                parent[p] = p
+            if parent[p] != p:
+                parent[p] = find(parent[p])  # Path compression
+            return parent[p]
+
+        def union(p1, p2):
+            """Union two points in the connectivity graph."""
+            r1, r2 = find(p1), find(p2)
+            if r1 != r2:
+                parent[r1] = r2
+
+        # Build wire segments list for T-junction detection
+        wire_segments = []
+        for wire in self.wires:
+            p1 = (round(wire.x1, 2), round(wire.y1, 2))
+            p2 = (round(wire.x2, 2), round(wire.y2, 2))
+            wire_segments.append((p1, p2))
+            # Connect wire endpoints
+            union(p1, p2)
+
+        # Helper to check if point is on a wire segment
+        def point_on_segment(point: tuple, seg_start: tuple, seg_end: tuple) -> bool:
+            """Check if a point lies on a line segment (for orthogonal wires)."""
+            px, py = point
+            x1, y1 = seg_start
+            x2, y2 = seg_end
+            if x1 == x2 == px:  # Vertical segment
+                return min(y1, y2) < py < max(y1, y2)
+            if y1 == y2 == py:  # Horizontal segment
+                return min(x1, x2) < px < max(x1, x2)
+            return False
+
+        def connect_to_wire(pos: tuple) -> None:
+            """Connect a position to any wire it touches."""
+            for seg_start, seg_end in wire_segments:
+                if pos in (seg_start, seg_end) or point_on_segment(pos, seg_start, seg_end):
+                    union(pos, seg_start)
+                    break
+
+        # Connect junctions to wires
+        for junc in self.junctions:
+            junc_pos = (round(junc.x, 2), round(junc.y, 2))
+            for seg_start, seg_end in wire_segments:
+                if (
+                    junc_pos in (seg_start, seg_end)
+                    or point_on_segment(junc_pos, seg_start, seg_end)
+                ):
+                    union(junc_pos, seg_start)
+                    union(junc_pos, seg_end)
+
+        # Connect symbol pins to wires and track pin locations
+        for sym in self.symbols:
+            for pin in sym.symbol_def.pins:
+                pos = sym.pin_position(pin.number)
+                pos_rounded = (round(pos[0], 2), round(pos[1], 2))
+
+                # Track this pin at this position
+                if pos_rounded not in point_to_pins:
+                    point_to_pins[pos_rounded] = []
+                point_to_pins[pos_rounded].append(
+                    PinRef(symbol_ref=sym.reference, pin=pin.number)
+                )
+
+                # Connect to wires
+                connect_to_wire(pos_rounded)
+
+        # Connect power symbols and track their net names
+        for pwr in self.power_symbols:
+            pwr_pos = (round(pwr.x, 2), round(pwr.y, 2))
+            # Power symbol net name comes from lib_id (e.g., "power:+3.3V" -> "+3.3V")
+            net_name = pwr.lib_id.split(":")[1] if ":" in pwr.lib_id else pwr.lib_id
+
+            if pwr_pos not in point_to_net_names:
+                point_to_net_names[pwr_pos] = []
+            point_to_net_names[pwr_pos].append(net_name)
+
+            connect_to_wire(pwr_pos)
+
+        # Connect local labels and track their net names
+        for label in self.labels:
+            label_pos = (round(label.x, 2), round(label.y, 2))
+
+            if label_pos not in point_to_net_names:
+                point_to_net_names[label_pos] = []
+            point_to_net_names[label_pos].append(label.text)
+
+            connect_to_wire(label_pos)
+
+        # Connect global labels and track their net names
+        for gl in self.global_labels:
+            gl_pos = (round(gl.x, 2), round(gl.y, 2))
+
+            if gl_pos not in point_to_net_names:
+                point_to_net_names[gl_pos] = []
+            point_to_net_names[gl_pos].append(gl.text)
+
+            connect_to_wire(gl_pos)
+
+        # Connect hierarchical labels and track their net names
+        for hl in self.hier_labels:
+            hl_pos = (round(hl.x, 2), round(hl.y, 2))
+
+            if hl_pos not in point_to_net_names:
+                point_to_net_names[hl_pos] = []
+            point_to_net_names[hl_pos].append(hl.text)
+
+            connect_to_wire(hl_pos)
+
+        return parent, point_to_net_names, point_to_pins
+
+    def extract_netlist(self) -> dict[str, list[PinRef]]:
+        """Extract netlist from schematic.
+
+        Analyzes schematic connectivity to build a mapping from net names
+        to the pins connected to each net.
+
+        Returns:
+            Dict mapping net names to list of connected pins.
+            Net names are derived from:
+            - Local labels (Label)
+            - Global labels (GlobalLabel)
+            - Hierarchical labels (HierarchicalLabel)
+            - Power symbols (e.g., "+3.3V", "GND")
+            - Auto-generated names for unnamed nets ("Net-(R1-1)")
+
+        Example:
+            >>> netlist = sch.extract_netlist()
+            >>> print(netlist["+3.3V"])
+            [PinRef(symbol_ref='U1', pin='VDD'), PinRef(symbol_ref='C1', pin='1')]
+        """
+        parent, point_to_net_names, point_to_pins = self._build_connectivity_graph()
+
+        def find(p):
+            """Find root with path compression."""
+            if p not in parent:
+                parent[p] = p
+            if parent[p] != p:
+                parent[p] = find(parent[p])
+            return parent[p]
+
+        # Group all points by their root (connected component)
+        root_to_points: dict[tuple, list[tuple]] = {}
+        all_points = set(parent.keys()) | set(point_to_pins.keys()) | set(
+            point_to_net_names.keys()
+        )
+        for point in all_points:
+            root = find(point)
+            if root not in root_to_points:
+                root_to_points[root] = []
+            root_to_points[root].append(point)
+
+        # Build netlist: map net names to pins
+        netlist: dict[str, list[PinRef]] = {}
+
+        for root, points in root_to_points.items():
+            # Collect all pins in this connected component
+            pins_in_net = []
+            for point in points:
+                if point in point_to_pins:
+                    pins_in_net.extend(point_to_pins[point])
+
+            if not pins_in_net:
+                continue  # Skip nets with no pins
+
+            # Collect all net names for this connected component
+            net_names = []
+            for point in points:
+                if point in point_to_net_names:
+                    net_names.extend(point_to_net_names[point])
+
+            # Determine the net name
+            if net_names:
+                # Use the first label/power symbol name
+                # Prefer power symbol names if present (they're more canonical)
+                net_name = net_names[0]
+            else:
+                # Auto-generate net name from first pin
+                first_pin = pins_in_net[0]
+                net_name = f"Net-({first_pin.symbol_ref}-{first_pin.pin})"
+
+            # Add pins to netlist
+            if net_name not in netlist:
+                netlist[net_name] = []
+            netlist[net_name].extend(pins_in_net)
+
+        return netlist
+
+    def get_net_for_pin(self, symbol_ref: str, pin: str) -> str | None:
+        """Get the net name connected to a symbol's pin.
+
+        Args:
+            symbol_ref: Symbol reference designator (e.g., "R1", "U3")
+            pin: Pin number or name (e.g., "1", "VDD")
+
+        Returns:
+            Net name if the pin is connected to a named net, None if floating.
+            For unnamed nets, returns auto-generated name like "Net-(R1-1)".
+
+        Example:
+            >>> net = sch.get_net_for_pin("U1", "VDD")
+            >>> print(net)
+            '+3.3V'
+        """
+        # Find the symbol
+        symbol = None
+        for sym in self.symbols:
+            if sym.reference == symbol_ref:
+                symbol = sym
+                break
+
+        if symbol is None:
+            return None
+
+        # Find the pin on the symbol and get its position
+        pin_pos = None
+        for p in symbol.symbol_def.pins:
+            if p.number == pin or p.name == pin:
+                pos = symbol.pin_position(p.number)
+                pin_pos = (round(pos[0], 2), round(pos[1], 2))
+                break
+
+        if pin_pos is None:
+            return None
+
+        # Build connectivity and find what net this pin is on
+        parent, point_to_net_names, point_to_pins = self._build_connectivity_graph()
+
+        def find(p):
+            if p not in parent:
+                parent[p] = p
+            if parent[p] != p:
+                parent[p] = find(parent[p])
+            return parent[p]
+
+        # Find the root of this pin's position
+        pin_root = find(pin_pos)
+
+        # Look for net names in the same connected component
+        for point, net_names in point_to_net_names.items():
+            if find(point) == pin_root and net_names:
+                return net_names[0]
+
+        # No named net - check if connected to anything
+        # If connected to other pins, return auto-generated name
+        for point, pins in point_to_pins.items():
+            if find(point) == pin_root and point != pin_pos:
+                return f"Net-({symbol_ref}-{pin})"
+
+        # Pin is floating (not connected to anything)
+        return None
+
+    def pins_on_net(self, net_name: str) -> list[PinRef]:
+        """Get all pins connected to a net.
+
+        Args:
+            net_name: Net name (e.g., "+3.3V", "SWDIO", "Net-(R1-1)")
+
+        Returns:
+            List of PinRef objects for all pins on the net.
+            Returns empty list if net doesn't exist.
+
+        Example:
+            >>> pins = sch.pins_on_net("+3.3V")
+            >>> for pin in pins:
+            ...     print(f"{pin.symbol_ref} pin {pin.pin}")
+            U1 pin VDD
+            C1 pin 1
+        """
+        netlist = self.extract_netlist()
+        return netlist.get(net_name, [])
+
+    def are_connected(
+        self, symbol1: str, pin1: str, symbol2: str, pin2: str
+    ) -> bool:
+        """Check if two pins are on the same net.
+
+        Args:
+            symbol1: First symbol's reference designator
+            pin1: First symbol's pin number or name
+            symbol2: Second symbol's reference designator
+            pin2: Second symbol's pin number or name
+
+        Returns:
+            True if both pins are connected to the same net, False otherwise.
+
+        Example:
+            >>> if sch.are_connected("U1", "VO", "C1", "1"):
+            ...     print("Regulator output connected to capacitor")
+        """
+        # Find both symbols and their pin positions
+        sym1 = sym2 = None
+        for sym in self.symbols:
+            if sym.reference == symbol1:
+                sym1 = sym
+            if sym.reference == symbol2:
+                sym2 = sym
+
+        if sym1 is None or sym2 is None:
+            return False
+
+        # Find pin positions
+        pos1 = pos2 = None
+        for p in sym1.symbol_def.pins:
+            if p.number == pin1 or p.name == pin1:
+                pos = sym1.pin_position(p.number)
+                pos1 = (round(pos[0], 2), round(pos[1], 2))
+                break
+
+        for p in sym2.symbol_def.pins:
+            if p.number == pin2 or p.name == pin2:
+                pos = sym2.pin_position(p.number)
+                pos2 = (round(pos[0], 2), round(pos[1], 2))
+                break
+
+        if pos1 is None or pos2 is None:
+            return False
+
+        # Build connectivity graph
+        parent, _, _ = self._build_connectivity_graph()
+
+        def find(p):
+            if p not in parent:
+                parent[p] = p
+            if parent[p] != p:
+                parent[p] = find(parent[p])
+            return parent[p]
+
+        # Check if both pins have the same root
+        return find(pos1) == find(pos2)

--- a/src/kicad_tools/schematic/models/schematic.py
+++ b/src/kicad_tools/schematic/models/schematic.py
@@ -11,6 +11,7 @@ This module composes functionality from specialized mixins:
 - SchematicLayoutMixin: Auto-layout and overlap detection
 - SchematicModificationMixin: Removing elements
 - SchematicValidationMixin: Validation and statistics
+- SchematicNetlistMixin: Netlist extraction and connectivity queries
 """
 
 import uuid
@@ -33,6 +34,7 @@ from .elements_mixin import SchematicElementsMixin
 from .io_mixin import SchematicIOMixin
 from .layout_mixin import SchematicLayoutMixin
 from .modification_mixin import SchematicModificationMixin
+from .netlist_mixin import SchematicNetlistMixin
 from .query_mixin import SchematicQueryMixin
 from .symbol import SymbolDef, SymbolInstance
 from .validation_mixin import SchematicValidationMixin
@@ -56,6 +58,7 @@ class Schematic(
     SchematicLayoutMixin,
     SchematicModificationMixin,
     SchematicValidationMixin,
+    SchematicNetlistMixin,
 ):
     """KiCad schematic document.
 
@@ -70,6 +73,7 @@ class Schematic(
     - Layout: suggest_position(), find_overlapping_symbols()
     - Modification: remove_symbol(), remove_wire(), remove_net(), etc.
     - Validation: validate(), get_statistics()
+    - Netlist: extract_netlist(), get_net_for_pin(), pins_on_net(), are_connected()
 
     Example:
         # Create a new schematic
@@ -82,6 +86,10 @@ class Schematic(
         sch = Schematic.load("existing.kicad_sch")
         sch.add_symbol("Device:C", 200, 100, "C1", "100nF")
         sch.write("existing.kicad_sch")
+
+        # Query connectivity
+        assert sch.are_connected("U1", "VO", "C1", "1")
+        print(sch.pins_on_net("+3.3V"))
     """
 
     def __init__(

--- a/tests/test_netlist_query.py
+++ b/tests/test_netlist_query.py
@@ -1,0 +1,469 @@
+"""Tests for netlist query API.
+
+Tests the netlist extraction and connectivity query methods:
+- extract_netlist()
+- get_net_for_pin()
+- pins_on_net()
+- are_connected()
+"""
+
+from kicad_tools.schematic.models import PinRef, Schematic
+from kicad_tools.schematic.models.elements import Junction, Label, Wire
+from kicad_tools.schematic.models.pin import Pin
+from kicad_tools.schematic.models.symbol import SymbolDef, SymbolInstance
+
+
+def make_simple_symbol(lib_id: str, pins: list[tuple[str, str, float, float]]) -> SymbolDef:
+    """Create a simple symbol definition for testing.
+
+    Args:
+        lib_id: Library ID (e.g., "Device:R")
+        pins: List of (name, number, x, y) tuples for pin positions
+    """
+    return SymbolDef(
+        lib_id=lib_id,
+        name=lib_id.split(":")[-1],
+        raw_sexp="",
+        pins=[
+            Pin(name=name, number=number, x=x, y=y, angle=0, length=2.54, pin_type="passive")
+            for name, number, x, y in pins
+        ],
+    )
+
+
+class TestPinRef:
+    """Tests for PinRef dataclass."""
+
+    def test_pinref_creation(self):
+        """Create PinRef with symbol ref and pin."""
+        ref = PinRef(symbol_ref="R1", pin="1")
+        assert ref.symbol_ref == "R1"
+        assert ref.pin == "1"
+
+    def test_pinref_str(self):
+        """PinRef string representation."""
+        ref = PinRef(symbol_ref="U1", pin="VDD")
+        assert str(ref) == "U1.VDD"
+
+    def test_pinref_hashable(self):
+        """PinRef is hashable for use in sets/dicts."""
+        ref1 = PinRef(symbol_ref="R1", pin="1")
+        ref2 = PinRef(symbol_ref="R1", pin="1")
+        assert ref1 == ref2
+        assert hash(ref1) == hash(ref2)
+
+        # Can use in set
+        refs = {ref1, ref2}
+        assert len(refs) == 1
+
+
+class TestExtractNetlist:
+    """Tests for extract_netlist() method."""
+
+    def test_empty_schematic(self):
+        """Empty schematic returns empty netlist."""
+        sch = Schematic("Test")
+        netlist = sch.extract_netlist()
+        assert netlist == {}
+
+    def test_single_wire_between_two_symbols(self):
+        """Two symbols connected by a wire."""
+        sch = Schematic("Test")
+
+        # Create two resistors with pins
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+
+        # Place R1 at (100, 50) and R2 at (110, 50)
+        r1 = SymbolInstance(
+            symbol_def=r_def,
+            x=100,
+            y=50,
+            rotation=0,
+            reference="R1",
+            value="10k",
+        )
+        r2 = SymbolInstance(
+            symbol_def=r_def,
+            x=110,
+            y=50,
+            rotation=0,
+            reference="R2",
+            value="10k",
+        )
+        sch.symbols.extend([r1, r2])
+
+        # R1 pin 2 at (102.54, 50), R2 pin 1 at (107.46, 50)
+        # Wire connecting them
+        sch.wires.append(Wire(x1=102.54, y1=50, x2=107.46, y2=50))
+
+        netlist = sch.extract_netlist()
+
+        # Should have 3 nets: R1.1 floating, R1.2-R2.1 connected, R2.2 floating
+        assert len(netlist) == 3
+
+        # Find the net with 2 connected pins
+        connected_net = None
+        for net_name, pins in netlist.items():
+            if len(pins) == 2:
+                connected_net = net_name
+                break
+
+        assert connected_net is not None
+        assert connected_net.startswith("Net-(")  # Auto-generated name
+
+        # Check both pins are present in the connected net
+        pins = netlist[connected_net]
+        pin_strs = {str(p) for p in pins}
+        assert "R1.2" in pin_strs
+        assert "R2.1" in pin_strs
+
+    def test_labeled_net(self):
+        """Net with a label gets the label name."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(
+            symbol_def=r_def,
+            x=100,
+            y=50,
+            rotation=0,
+            reference="R1",
+            value="10k",
+        )
+        sch.symbols.append(r1)
+
+        # Wire from pin 2 to label
+        sch.wires.append(Wire(x1=102.54, y1=50, x2=110, y2=50))
+        sch.labels.append(Label(text="SIG_OUT", x=110, y=50))
+
+        netlist = sch.extract_netlist()
+
+        assert "SIG_OUT" in netlist
+        pins = netlist["SIG_OUT"]
+        assert len(pins) == 1
+        assert pins[0].symbol_ref == "R1"
+        assert pins[0].pin == "2"
+
+    def test_power_net(self):
+        """Power symbols create named nets."""
+        sch = Schematic("Test")
+
+        # IC with VDD pin
+        ic_def = make_simple_symbol("MCU:Test", [("VDD", "1", 0, -2.54)])
+        ic = SymbolInstance(
+            symbol_def=ic_def,
+            x=100,
+            y=50,
+            rotation=0,
+            reference="U1",
+            value="MCU",
+        )
+        sch.symbols.append(ic)
+
+        # Power symbol at same position as VDD pin
+        from kicad_tools.schematic.models.elements import PowerSymbol
+
+        pwr = PowerSymbol(lib_id="power:+3.3V", x=100, y=47.46, rotation=0)
+        sch.power_symbols.append(pwr)
+
+        # Wire connecting IC VDD to power symbol
+        sch.wires.append(Wire(x1=100, y1=47.46, x2=100, y2=47.46))
+
+        netlist = sch.extract_netlist()
+
+        assert "+3.3V" in netlist
+        pins = netlist["+3.3V"]
+        assert len(pins) == 1
+        assert pins[0].symbol_ref == "U1"
+        assert pins[0].pin == "1"
+
+
+class TestGetNetForPin:
+    """Tests for get_net_for_pin() method."""
+
+    def test_pin_on_named_net(self):
+        """Get net name for pin connected to labeled net."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(
+            symbol_def=r_def,
+            x=100,
+            y=50,
+            rotation=0,
+            reference="R1",
+            value="10k",
+        )
+        sch.symbols.append(r1)
+
+        # Wire from pin 2 to label
+        sch.wires.append(Wire(x1=102.54, y1=50, x2=110, y2=50))
+        sch.labels.append(Label(text="DATA", x=110, y=50))
+
+        net = sch.get_net_for_pin("R1", "2")
+        assert net == "DATA"
+
+    def test_floating_pin(self):
+        """Floating pin returns None."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(
+            symbol_def=r_def,
+            x=100,
+            y=50,
+            rotation=0,
+            reference="R1",
+            value="10k",
+        )
+        sch.symbols.append(r1)
+
+        # Pin 1 is floating (no wire)
+        net = sch.get_net_for_pin("R1", "1")
+        assert net is None
+
+    def test_nonexistent_symbol(self):
+        """Nonexistent symbol returns None."""
+        sch = Schematic("Test")
+        net = sch.get_net_for_pin("R99", "1")
+        assert net is None
+
+    def test_nonexistent_pin(self):
+        """Nonexistent pin returns None."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(
+            symbol_def=r_def,
+            x=100,
+            y=50,
+            rotation=0,
+            reference="R1",
+            value="10k",
+        )
+        sch.symbols.append(r1)
+
+        net = sch.get_net_for_pin("R1", "99")
+        assert net is None
+
+    def test_unnamed_net(self):
+        """Pin on unnamed net returns auto-generated name."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(
+            symbol_def=r_def,
+            x=100,
+            y=50,
+            rotation=0,
+            reference="R1",
+            value="10k",
+        )
+        r2 = SymbolInstance(
+            symbol_def=r_def,
+            x=110,
+            y=50,
+            rotation=0,
+            reference="R2",
+            value="10k",
+        )
+        sch.symbols.extend([r1, r2])
+
+        # Connect R1 pin 2 to R2 pin 1 (no label)
+        sch.wires.append(Wire(x1=102.54, y1=50, x2=107.46, y2=50))
+
+        net = sch.get_net_for_pin("R1", "2")
+        assert net is not None
+        assert net.startswith("Net-(")
+
+
+class TestPinsOnNet:
+    """Tests for pins_on_net() method."""
+
+    def test_get_all_pins_on_net(self):
+        """Get all pins connected to a named net."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+
+        # Three resistors connected in series
+        r1 = SymbolInstance(symbol_def=r_def, x=100, y=50, rotation=0, reference="R1", value="10k")
+        r2 = SymbolInstance(symbol_def=r_def, x=115, y=50, rotation=0, reference="R2", value="10k")
+        r3 = SymbolInstance(symbol_def=r_def, x=130, y=50, rotation=0, reference="R3", value="10k")
+        sch.symbols.extend([r1, r2, r3])
+
+        # Common net between R1 pin 2 and R2 pin 1, labeled "NODE_A"
+        sch.wires.append(Wire(x1=102.54, y1=50, x2=112.46, y2=50))
+        sch.labels.append(Label(text="NODE_A", x=107.5, y=50))
+
+        pins = sch.pins_on_net("NODE_A")
+        assert len(pins) == 2
+
+        pin_strs = {str(p) for p in pins}
+        assert "R1.2" in pin_strs
+        assert "R2.1" in pin_strs
+
+    def test_nonexistent_net(self):
+        """Nonexistent net returns empty list."""
+        sch = Schematic("Test")
+        pins = sch.pins_on_net("NONEXISTENT")
+        assert pins == []
+
+
+class TestAreConnected:
+    """Tests for are_connected() method."""
+
+    def test_directly_connected_pins(self):
+        """Pins connected by a single wire."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(symbol_def=r_def, x=100, y=50, rotation=0, reference="R1", value="10k")
+        r2 = SymbolInstance(symbol_def=r_def, x=110, y=50, rotation=0, reference="R2", value="10k")
+        sch.symbols.extend([r1, r2])
+
+        # Connect R1 pin 2 to R2 pin 1
+        sch.wires.append(Wire(x1=102.54, y1=50, x2=107.46, y2=50))
+
+        assert sch.are_connected("R1", "2", "R2", "1") is True
+        assert sch.are_connected("R2", "1", "R1", "2") is True  # Order independent
+
+    def test_not_connected_pins(self):
+        """Pins that are not connected."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(symbol_def=r_def, x=100, y=50, rotation=0, reference="R1", value="10k")
+        r2 = SymbolInstance(symbol_def=r_def, x=200, y=50, rotation=0, reference="R2", value="10k")
+        sch.symbols.extend([r1, r2])
+
+        # No wire between them
+        assert sch.are_connected("R1", "2", "R2", "1") is False
+
+    def test_indirectly_connected_via_junction(self):
+        """Pins connected through a junction (T-connection)."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(symbol_def=r_def, x=100, y=50, rotation=0, reference="R1", value="10k")
+        r2 = SymbolInstance(symbol_def=r_def, x=100, y=70, rotation=0, reference="R2", value="10k")
+        r3 = SymbolInstance(symbol_def=r_def, x=120, y=50, rotation=0, reference="R3", value="10k")
+        sch.symbols.extend([r1, r2, r3])
+
+        # R1 pin 2 connects to junction at (102.54, 50)
+        # R2 pin 1 connects to same junction via vertical wire
+        # R3 pin 1 connects to same junction via horizontal wire
+        sch.wires.append(Wire(x1=102.54, y1=50, x2=117.46, y2=50))  # Horizontal
+        sch.wires.append(Wire(x1=102.54, y1=50, x2=102.54, y2=67.46))  # Vertical to R2 pin 1
+        sch.junctions.append(Junction(x=102.54, y=50))
+
+        # Note: R2 pin 1 is at (100-2.54, 70) = (97.46, 70), need to adjust
+        # Actually with rotation=0, R2 at (100, 70), pin 1 at (97.46, 70)
+        # Let me fix the wire endpoint
+        sch.wires[-1] = Wire(x1=102.54, y1=50, x2=97.46, y2=70)  # To R2 pin 1
+
+        # R1 pin 2 should be connected to R3 pin 1 via junction
+        assert sch.are_connected("R1", "2", "R3", "1") is True
+
+    def test_nonexistent_symbol(self):
+        """Nonexistent symbol returns False."""
+        sch = Schematic("Test")
+        assert sch.are_connected("R1", "1", "R99", "1") is False
+
+    def test_same_pin(self):
+        """Same pin compared to itself is connected."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(symbol_def=r_def, x=100, y=50, rotation=0, reference="R1", value="10k")
+        sch.symbols.append(r1)
+
+        assert sch.are_connected("R1", "1", "R1", "1") is True
+
+
+class TestComplexNetlist:
+    """Integration tests with more complex schematics."""
+
+    def test_power_distribution(self):
+        """Multiple components on a power net."""
+        sch = Schematic("Test")
+
+        # IC with multiple power pins
+        ic_def = make_simple_symbol(
+            "MCU:Test",
+            [
+                ("VDD", "1", 0, -5.08),
+                ("VSS", "2", 0, 5.08),
+                ("IO", "3", 5.08, 0),
+            ],
+        )
+        ic = SymbolInstance(symbol_def=ic_def, x=100, y=50, rotation=0, reference="U1", value="MCU")
+        sch.symbols.append(ic)
+
+        # Decoupling capacitor
+        c_def = make_simple_symbol("Device:C", [("~", "1", 0, -2.54), ("~", "2", 0, 2.54)])
+        cap = SymbolInstance(symbol_def=c_def, x=90, y=50, rotation=0, reference="C1", value="100n")
+        sch.symbols.append(cap)
+
+        # Power symbols
+        from kicad_tools.schematic.models.elements import PowerSymbol
+
+        vdd = PowerSymbol(lib_id="power:+3.3V", x=90, y=40, rotation=0)
+        gnd = PowerSymbol(lib_id="power:GND", x=90, y=60, rotation=180)
+        sch.power_symbols.extend([vdd, gnd])
+
+        # Wiring
+        # VDD rail: power symbol -> C1 pin 1 -> U1 VDD
+        sch.wires.append(Wire(x1=90, y1=40, x2=90, y2=47.46))  # Power to C1 pin 1
+        sch.wires.append(Wire(x1=90, y1=47.46, x2=100, y2=47.46))  # C1 to junction
+        sch.wires.append(Wire(x1=100, y1=47.46, x2=100, y2=44.92))  # Junction to U1 VDD
+        sch.junctions.append(Junction(x=90, y=47.46))
+
+        # GND rail: power symbol -> C1 pin 2 -> U1 VSS
+        sch.wires.append(Wire(x1=90, y1=60, x2=90, y2=52.54))  # Power to C1 pin 2
+        sch.wires.append(Wire(x1=90, y1=52.54, x2=100, y2=52.54))  # C1 to junction
+        sch.wires.append(Wire(x1=100, y1=52.54, x2=100, y2=55.08))  # Junction to U1 VSS
+        sch.junctions.append(Junction(x=90, y=52.54))
+
+        netlist = sch.extract_netlist()
+
+        # Check +3.3V net
+        assert "+3.3V" in netlist
+        vdd_pins = netlist["+3.3V"]
+        vdd_pin_strs = {str(p) for p in vdd_pins}
+        assert "U1.1" in vdd_pin_strs
+        assert "C1.1" in vdd_pin_strs
+
+        # Check GND net
+        assert "GND" in netlist
+        gnd_pins = netlist["GND"]
+        gnd_pin_strs = {str(p) for p in gnd_pins}
+        assert "U1.2" in gnd_pin_strs
+        assert "C1.2" in gnd_pin_strs
+
+        # Verify connectivity
+        assert sch.are_connected("U1", "1", "C1", "1") is True
+        assert sch.are_connected("U1", "2", "C1", "2") is True
+        assert sch.are_connected("U1", "1", "C1", "2") is False  # Different nets
+
+    def test_global_label_connectivity(self):
+        """Global labels connect nets across the schematic."""
+        sch = Schematic("Test")
+
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+
+        # R1 with global label on pin 2
+        r1 = SymbolInstance(symbol_def=r_def, x=100, y=50, rotation=0, reference="R1", value="10k")
+        sch.symbols.append(r1)
+        sch.wires.append(Wire(x1=102.54, y1=50, x2=110, y2=50))
+
+        from kicad_tools.schematic.models.elements import GlobalLabel
+
+        gl1 = GlobalLabel(text="I2C_SDA", x=110, y=50, shape="bidirectional")
+        sch.global_labels.append(gl1)
+
+        netlist = sch.extract_netlist()
+        assert "I2C_SDA" in netlist
+        pins = netlist["I2C_SDA"]
+        assert len(pins) == 1
+        assert pins[0].symbol_ref == "R1"


### PR DESCRIPTION
## Summary

Add a netlist query API to the Schematic class that allows programmatic verification of schematic connectivity. This enables agents generating schematics to verify design intent without having to visually inspect in KiCad or parse raw .kicad_sch files.

## Changes

- Add `SchematicNetlistMixin` with connectivity query methods
- Add `PinRef` dataclass for representing pin references
- Add comprehensive tests for all new functionality

### New Methods

| Method | Description |
|--------|-------------|
| `extract_netlist()` | Extract mapping of net names to connected pins |
| `get_net_for_pin(symbol_ref, pin)` | Get the net name connected to a symbol's pin |
| `pins_on_net(net_name)` | Get all pins connected to a net |
| `are_connected(sym1, pin1, sym2, pin2)` | Check if two pins are on the same net |

## Usage Example

```python
sch = Schematic("Power Supply")
# ... generate schematic ...

# Verify design intent
assert sch.are_connected("U1", "VO", "C1", "1"), "Regulator output should connect to cap"
assert sch.get_net_for_pin("U2", "VDD") == "+3.3V", "MCU VDD should be on +3.3V net"

# Debug connectivity issues  
print(f"Pins on +3.3V: {sch.pins_on_net('+3.3V')}")
```

## Test Plan

- [x] 21 unit tests covering all new methods
- [x] Tests for edge cases (floating pins, nonexistent symbols, junctions)
- [x] Integration tests with power distribution and global labels
- [x] All tests pass

Closes #901