### PR TITLE
fix(pcb): Fix update_footprint_position() rotation not persisting

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1486,10 +1486,12 @@ class PCB:
                 at_node.set_value(1, y)
                 if rotation is not None:
                     # Handle cases where rotation may or may not exist
-                    if len(at_node.values) >= 3:
+                    if len(at_node.children) >= 3:
                         at_node.set_value(2, rotation)
                     elif rotation != 0.0:
-                        at_node.values.append(rotation)
+                        # Use add() instead of values.append() since values
+                        # is a read-only property that returns a new list
+                        at_node.add(rotation)
             return True
 
         return False


### PR DESCRIPTION
## Summary

Fixes a bug where `PCB.update_footprint_position()` would not persist rotation changes when the footprint's `at` node didn't already have a rotation value.

## Root Cause

The `values` property on `SExp` nodes is a read-only property that returns a **new list**. The code was using:

```python
at_node.values.append(rotation)  # BUG: appends to a temporary list
```

This appends to a temporary list that gets immediately discarded.

## Fix

Changed to use the proper `add()` method and check `children` directly:

```python
if len(at_node.children) >= 3:
    at_node.set_value(2, rotation)
elif rotation != 0.0:
    at_node.add(rotation)  # FIXED: properly adds to SExp tree
```

## Changes

- Fixed rotation persistence in `update_footprint_position()` (schema/pcb.py:1482-1494)
- Added comprehensive test suite for `update_footprint_position()`:
  - `test_update_position_basic` - basic position update
  - `test_update_position_with_rotation_existing` - updating existing rotation
  - `test_update_position_with_rotation_new` - adding new rotation (regression test)
  - `test_update_position_nonexistent_footprint` - error handling

## Test Plan

- [x] All existing tests pass
- [x] New regression test specifically verifies rotation persistence
- [x] Linting and formatting pass

Closes #915