### PR TITLE
fix(netlist): Parse reference from (ref ...) child node in NetNode.from_sexp()

### DIFF
--- a/src/kicad_tools/operations/netlist.py
+++ b/src/kicad_tools/operations/netlist.py
@@ -94,10 +94,14 @@ class NetNode:
     @classmethod
     def from_sexp(cls, sexp: SExp) -> NetNode:
         """Parse node from netlist S-expression."""
-        ref = sexp.get_string(0) or ""
+        ref = ""
         pin = ""
         pin_function = ""
         pin_type = ""
+
+        # Reference is in (ref "...") child node in KiCad netlist format
+        if ref_node := sexp.find("ref"):
+            ref = ref_node.get_string(0) or ""
 
         if pin_node := sexp.find("pin"):
             pin = pin_node.get_string(0) or ""


### PR DESCRIPTION
## Summary

Fixed `import_from_schematic()` reporting 0 nets assigned by correcting `NetNode.from_sexp()` to properly parse the component reference from the `(ref ...)` child node in KiCad's netlist format.

## Root Cause

The `NetNode.from_sexp()` method was incorrectly extracting the component reference as a direct string value:

```python
# Before (incorrect)
ref = sexp.get_string(0) or ""
```

But KiCad's netlist format uses a child node for the reference:

```sexp
(node (ref "R1") (pin "1") (pinfunction "~") (pintype "passive"))
```

This caused all `NetNode` objects to have empty references, which meant `assign_nets_from_netlist()` couldn't match any pads to nets.

## Changes

- Fixed `NetNode.from_sexp()` to parse reference from `(ref ...)` child node
- Added unit tests covering the parsing fix

## Test Plan

- [x] New unit tests for `NetNode.from_sexp()` parsing
- [x] All existing netlist tests pass
- [x] Verified fix with manual testing of node parsing

Closes #923