### PR TITLE
fix(pcb): Add pad.net property for routing compatibility

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -58,6 +58,11 @@ class Pad:
     drill: float = 0.0
     uuid: str = ""
 
+    @property
+    def net(self) -> int:
+        """Net ID (alias for net_number for API consistency)."""
+        return self.net_number
+
     @classmethod
     def from_sexp(cls, sexp: SExp) -> Pad | None:
         """Parse pad from S-expression."""

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -50,6 +50,32 @@ def test_pcb_footprints(minimal_pcb: Path):
     assert len(fp.pads) == 2
 
 
+def test_pcb_pad_nets(minimal_pcb: Path):
+    """Parse pad net assignments.
+
+    Issue #938: PCB loader must populate pad.net attribute for routing.
+    """
+    doc = load_pcb(str(minimal_pcb))
+    pcb = PCB(doc)
+
+    fp = pcb.footprints[0]
+    assert len(fp.pads) == 2
+
+    # Pad 1 should have net 1 (GND)
+    pad1 = fp.pads[0]
+    assert pad1.number == "1"
+    assert pad1.net == 1  # The .net property (alias for net_number)
+    assert pad1.net_number == 1
+    assert pad1.net_name == "GND"
+
+    # Pad 2 should have net 2 (+3.3V)
+    pad2 = fp.pads[1]
+    assert pad2.number == "2"
+    assert pad2.net == 2
+    assert pad2.net_number == 2
+    assert pad2.net_name == "+3.3V"
+
+
 def test_pcb_traces(minimal_pcb: Path):
     """Parse PCB traces."""
     doc = load_pcb(str(minimal_pcb))

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "kicad-tools"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Add `net` property to `schema.pcb.Pad` class as alias for `net_number`
- This provides API consistency with `router.primitives.Pad` which uses `net`
- Add test case for pad net parsing

## Root Cause

The `schema.pcb.Pad` class had `net_number` and `net_name` attributes but code throughout the codebase (router, user scripts) expected a `.net` property. When users loaded a PCB and checked `pad.net`, they got an `AttributeError` making it appear that net assignments weren't being parsed.

## Changes

- **src/kicad_tools/schema/pcb.py**: Add `net` property that returns `net_number`
- **tests/test_pcb.py**: Add `test_pcb_pad_nets` to verify pad net assignments are parsed correctly

## Test plan
- [x] New test `test_pcb_pad_nets` verifies pad.net, pad.net_number, and pad.net_name
- [x] All existing pad-related tests pass (125 tests)
- [x] Router tests pass (16 pad-related tests)

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)