### PR TITLE
fix(router): Parse footprints with negative X/Y coordinates

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -983,7 +983,8 @@ def load_pcb_for_routing(
             continue
 
         # Get footprint position
-        at_match = re.search(r"\(at\s+([\d.]+)\s+([\d.]+)(?:\s+([\d.]+))?\)", section)
+        # Note: coordinates can be negative (footprints outside board origin)
+        at_match = re.search(r"\(at\s+([-\d.]+)\s+([-\d.]+)(?:\s+([-\d.]+))?\)", section)
         if not at_match:
             continue
 


### PR DESCRIPTION
## Summary

Fixes #942 - The `load_pcb_for_routing()` function was returning an empty `Autorouter` (0 nets, 0 pads) despite the PCB file having valid footprints.

**Root Cause**: The regex pattern for parsing footprint positions used `[\d.]+` which doesn't match negative numbers. When a PCB has footprints with negative X or Y coordinates (e.g., placed outside the board origin), these footprints were silently skipped.

**Fix**: Added `-` to the regex character class: `[-\d.]+` to match negative coordinates, consistent with the pattern already used for pad coordinates.

## Changes

- Updated footprint position regex in `src/kicad_tools/router/io.py` to allow negative coordinates
- Added test case `test_load_pcb_negative_coordinates` to verify the fix

## Test Plan

- [x] Added unit test for footprints with negative X, negative Y, and negative X+Y with rotation
- [x] All existing `TestLoadPcbForRouting` tests pass (12/12)
- [x] Verified new test correctly catches the regression

Closes #942