### PR TITLE
fix(router): Auto-detect layer stack from PCB when not specified

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -906,7 +906,9 @@ def load_pcb_for_routing(
                         applied (default for backward compatibility).
         layer_stack: Layer stack configuration for routing. Controls how many
                      layers are available for routing and which layers are
-                     planes vs signal layers. If None, defaults to 2-layer.
+                     planes vs signal layers. If None, auto-detects from the
+                     PCB file's layer definitions. This ensures pad layers
+                     match the available routing layers.
                      Use LayerStack.four_layer_sig_gnd_pwr_sig() for 4-layer
                      boards with GND/PWR planes, which routes signals on outer
                      layers (F.Cu, B.Cu) with vias for layer transitions.
@@ -1136,6 +1138,12 @@ def load_pcb_for_routing(
             warn=True,
             strict=strict_drc,
         )
+
+    # Auto-detect layer stack from PCB if not provided (Issue #949)
+    # This ensures pad layers match the available routing layers
+    if layer_stack is None:
+        layer_stack = detect_layer_stack(pcb_text)
+        logger.debug(f"Auto-detected layer stack: {layer_stack.name} ({layer_stack.num_layers} layers)")
 
     router = Autorouter(
         width=board_width,


### PR DESCRIPTION
## Summary
- Fixes "Layer value not in stack" error when routing boards without specifying layer_stack parameter
- Auto-detects layer configuration from PCB file's layer definitions
- Ensures pad layers match available routing layers

## Root Cause
When loading a PCB for routing without an explicit `layer_stack` parameter, the router defaulted to a 2-layer configuration. This caused errors when routing boards with more than 2 layers because pads on inner layers (e.g., In1.Cu) had Layer enum values that didn't exist in the 2-layer mapping.

## Changes
- Modified `load_pcb_for_routing()` to call `detect_layer_stack()` when `layer_stack` is None
- Updated docstring to reflect new auto-detection behavior
- Added 4 tests for layer stack auto-detection

## Test plan
- [x] New tests for auto-detection pass
- [x] Existing `load_pcb_for_routing` tests pass
- [x] Existing `detect_layer_stack` tests pass

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)