### PR TITLE
fix(router): Round floating point values in PCB S-expression output

### DIFF
--- a/src/kicad_tools/router/primitives.py
+++ b/src/kicad_tools/router/primitives.py
@@ -17,6 +17,18 @@ from dataclasses import dataclass, field
 from .layers import Layer
 
 
+def _fmt(val: float) -> int | float:
+    """Format float with 4 decimal precision for PCB output.
+
+    Rounds to 4 decimal places (0.1 micron precision in mm).
+    Returns int if no fractional part for cleaner output.
+    """
+    rounded = round(val, 4)
+    if rounded == int(rounded):
+        return int(rounded)
+    return rounded
+
+
 @dataclass
 class Point:
     """A point in 3D routing space (x, y, layer)."""
@@ -98,8 +110,8 @@ class Via:
         layer_end = self.layers[1].kicad_name
         return f"""(via
 \t\t(at {self.x:.4f} {self.y:.4f})
-\t\t(size {self.diameter})
-\t\t(drill {self.drill})
+\t\t(size {_fmt(self.diameter)})
+\t\t(drill {_fmt(self.drill)})
 \t\t(layers "{layer_start}" "{layer_end}")
 \t\t(net {self.net})
 \t\t(uuid "{uuid.uuid4()}")
@@ -124,7 +136,7 @@ class Segment:
         return f"""(segment
 \t\t(start {self.x1:.4f} {self.y1:.4f})
 \t\t(end {self.x2:.4f} {self.y2:.4f})
-\t\t(width {self.width})
+\t\t(width {_fmt(self.width)})
 \t\t(layer "{self.layer.kicad_name}")
 \t\t(net {self.net})
 \t\t(uuid "{uuid.uuid4()}")


### PR DESCRIPTION
## Summary

Fix excessive floating point precision in PCB S-expression output that caused `kicad-cli` to fail loading routed PCB files.

## Changes

- Add `_fmt()` helper function in `primitives.py` that rounds floats to 4 decimal places (0.1 micron precision) and returns integers for whole numbers
- Apply `_fmt()` to `Via.to_sexp()` for `diameter` and `drill` values
- Apply `_fmt()` to `Segment.to_sexp()` for `width` values

## Root Cause

The `to_sexp()` methods were using raw Python float formatting for dimension values (`{self.diameter}`, `{self.drill}`, `{self.width}`), which resulted in IEEE 754 floating point representation artifacts like `0.20000000298023224` instead of `0.2`.

Coordinates were already formatted with `.4f` but the size/dimension parameters were not.

## Test Plan

- [x] Verified `_fmt(0.20000000298023224)` returns `0.2`
- [x] Verified `_fmt(1.0)` returns `1` (integer for cleaner output)
- [x] Verified Via and Segment `to_sexp()` output no longer contains excessive decimals
- [x] All `test_router_primitives.py` tests pass

Closes #953