### PR TITLE
fix(router): Convert layer index to KiCad name for allowed_layers check

### DIFF
--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -461,8 +461,10 @@ class Router:
         if self.rules.allowed_layers is None:
             return True  # No restriction
 
-        layer_name = self.grid.index_to_layer(layer_idx)
-        return layer_name in self.rules.allowed_layers
+        # Convert grid index to Layer enum value, then to KiCad name for comparison
+        layer_value = self.grid.index_to_layer(layer_idx)
+        layer = Layer(layer_value)
+        return layer.kicad_name in self.rules.allowed_layers
 
     def _can_place_via_in_zones(self, gx: int, gy: int, net: int) -> bool:
         """Check if via placement is legal considering zones on all layers.


### PR DESCRIPTION
## Summary

- Fix type mismatch in `_is_layer_allowed()` where grid layer indices (integers) were compared against `allowed_layers` strings
- Convert layer index to `Layer` enum and use `kicad_name` property for correct string comparison

## Root Cause

The `_is_layer_allowed` method at `pathfinder.py:464-465` was doing:

```python
layer_name = self.grid.index_to_layer(layer_idx)  # Returns int (Layer enum value)
return layer_name in self.rules.allowed_layers    # allowed_layers contains strings like "B.Cu"
```

This comparison always failed because integers can never equal strings (e.g., `5 in ["B.Cu"]` is always `False`).

## Test plan

- [x] `test_back_copper_only_routing` now passes
- [x] All 66 router core tests pass

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)