### PR TITLE
feat(cli): Add real-time progress output with flush_print helper

### DIFF
--- a/src/kicad_tools/cli/progress.py
+++ b/src/kicad_tools/cli/progress.py
@@ -20,6 +20,9 @@ Usage:
     # Spinner for operations without measurable progress
     with spinner("Loading PCB...", quiet=args.quiet):
         pcb = load_pcb(path)
+
+    # Immediate flushed output for long operations (no buffering)
+    flush_print(f"Processing net {i}/{total}...")
 """
 
 import sys
@@ -144,6 +147,32 @@ def print_status(message: str, style: str = "bold", quiet: bool = False) -> None
 
     console = _get_stderr_console()
     console.print(message, style=style)
+
+
+def flush_print(*args, quiet: bool = False, **kwargs) -> None:
+    """Print with immediate flush for real-time progress output.
+
+    This function is a drop-in replacement for print() that ensures output
+    is immediately visible, even when stdout is buffered (e.g., when piped
+    or when running long operations). Essential for providing real-time
+    feedback during multi-hour routing operations.
+
+    Args:
+        *args: Arguments passed to print()
+        quiet: If True, nothing is printed
+        **kwargs: Keyword arguments passed to print()
+
+    Example:
+        # Instead of:
+        print(f"  Net {i}: routing...")  # May be buffered
+
+        # Use:
+        flush_print(f"  Net {i}: routing...")  # Immediate output
+    """
+    if quiet:
+        return
+    print(*args, **kwargs)
+    sys.stdout.flush()
 
 
 def _get_stderr_console():

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1874,7 +1874,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     # Import progress helpers
-    from kicad_tools.cli.progress import spinner
+    from kicad_tools.cli.progress import flush_print, spinner
 
     quiet = args.quiet
 
@@ -1915,7 +1915,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # Load PCB
     if not quiet:
-        print("\n--- Loading PCB ---")
+        flush_print("\n--- Loading PCB ---")
     try:
         with spinner("Loading PCB...", quiet=quiet):
             router, net_map = load_pcb_for_routing(
@@ -1985,12 +1985,8 @@ def main(argv: list[str] | None = None) -> int:
             print(f"\n{'=' * 60}")
             print("COMPLEXITY ANALYSIS")
             print(f"{'=' * 60}")
-            print(
-                f"Board: {complexity.board_width_mm:.1f}mm x {complexity.board_height_mm:.1f}mm"
-            )
-            print(
-                f"Pads: {complexity.total_pads}, Nets: {complexity.total_nets}"
-            )
+            print(f"Board: {complexity.board_width_mm:.1f}mm x {complexity.board_height_mm:.1f}mm")
+            print(f"Pads: {complexity.total_pads}, Nets: {complexity.total_nets}")
 
             # Show complexity rating with color
             rating_symbols = {
@@ -2017,9 +2013,7 @@ def main(argv: list[str] | None = None) -> int:
             if complexity.bottlenecks:
                 print(f"\nBottlenecks ({len(complexity.bottlenecks)}):")
                 for bottleneck in complexity.bottlenecks[:3]:
-                    print(
-                        f"  - {bottleneck.component_ref}: {bottleneck.description}"
-                    )
+                    print(f"  - {bottleneck.component_ref}: {bottleneck.description}")
 
             print(f"{'=' * 60}")
         except Exception as e:
@@ -2141,12 +2135,12 @@ def main(argv: list[str] | None = None) -> int:
 
     # Route
     if not quiet:
-        print(f"\n--- Routing ({args.strategy}) ---")
+        flush_print(f"\n--- Routing ({args.strategy}) ---")
         if args.timeout:
-            print(f"  Timeout: {args.timeout}s")
+            flush_print(f"  Timeout: {args.timeout}s")
         if args.profile:
             profile_output = args.profile_output or "route_profile.prof"
-            print(f"  Profiling enabled: {profile_output}")
+            flush_print(f"  Profiling enabled: {profile_output}")
 
     # Define routing function for profiling
     def do_routing():

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from kicad_tools.physics import Stackup, TransmissionLine
     from kicad_tools.progress import ProgressCallback
 
+from kicad_tools.cli.progress import flush_print
+
 from .adaptive import AdaptiveAutorouter, RoutingResult
 from .algorithms import (
     MonteCarloRouter,
@@ -853,7 +855,7 @@ class Autorouter:
             routes = self.route_net(net)
             all_routes.extend(routes)
             if routes:
-                print(
+                flush_print(
                     f"  Net {net}: {len(routes)} routes, "
                     f"{sum(len(r.segments) for r in routes)} segments, "
                     f"{sum(len(r.vias) for r in routes)} vias"
@@ -1092,8 +1094,8 @@ class Autorouter:
 
         start_time = time.time()
 
-        print("\n=== Negotiated Congestion Routing ===")
-        print(f"  Max iterations: {max_iterations}")
+        flush_print("\n=== Negotiated Congestion Routing ===")
+        flush_print(f"  Max iterations: {max_iterations}")
         if adaptive:
             print("  Mode: Adaptive (Issue #633)")
             print(f"  Present factor: {initial_present_factor} (adaptive)")
@@ -1186,7 +1188,7 @@ class Autorouter:
             elapsed = time.time() - start_time
             return f"{elapsed:.1f}s"
 
-        print("\n--- Iteration 0: Initial routing with sharing ---")
+        flush_print("\n--- Iteration 0: Initial routing with sharing ---")
         if progress_callback is not None:
             if not progress_callback(0.0, "Initial routing pass", True):
                 return list(self.routes)
@@ -1223,7 +1225,7 @@ class Autorouter:
                 # Progress output for every net with percentage
                 net_name = self.net_names.get(net, f"Net {net}")
                 pct = (i / total_nets * 100) if total_nets > 0 else 0
-                print(
+                flush_print(
                     f"  [{pct:5.1f}%] Routing net {i + 1}/{total_nets}: {net_name}... ({elapsed_str()})"
                 )
 
@@ -1237,7 +1239,7 @@ class Autorouter:
         overflow = self.grid.get_total_overflow()
         overused = self.grid.find_overused_cells()
         overflow_history.append(overflow)  # Track for adaptive mode
-        print(
+        flush_print(
             f"  Routed {len(net_routes)}/{total_nets} nets, overflow: {overflow} ({elapsed_str()})"
         )
 
@@ -1277,7 +1279,7 @@ class Autorouter:
                     ):
                         break
 
-                print(f"\n--- Iteration {iteration}: Rip-up and reroute ---")
+                flush_print(f"\n--- Iteration {iteration}: Rip-up and reroute ---")
 
                 # Calculate adaptive parameters (Issue #633)
                 if adaptive:
@@ -1318,7 +1320,7 @@ class Autorouter:
                 if use_targeted_ripup:
                     # Targeted rip-up: for each conflicting net, find its specific blockers
                     # and only rip up those instead of all conflicting nets at once
-                    print(
+                    flush_print(
                         f"  Using targeted rip-up for {len(nets_to_reroute)} nets with conflicts ({elapsed_str()})"
                     )
                     targeted_ripup_count = 0
@@ -1414,7 +1416,7 @@ class Autorouter:
                     overused = self.grid.find_overused_cells()
                     # Track overflow for both branches (Issue #633)
                     overflow_history.append(overflow)
-                    print(
+                    flush_print(
                         f"  Targeted rip-up resolved {targeted_ripup_count}/{len(nets_to_reroute)} nets, "
                         f"overflow: {overflow} ({elapsed_str()})"
                     )
@@ -1459,7 +1461,7 @@ class Autorouter:
 
                 else:
                     # Full rip-up: rip up all nets through overused cells
-                    print(
+                    flush_print(
                         f"  Ripping up {len(nets_to_reroute)} nets with conflicts ({elapsed_str()})"
                     )
 
@@ -1512,7 +1514,7 @@ class Autorouter:
 
                     overflow = self.grid.get_total_overflow()
                     overused = self.grid.find_overused_cells()
-                    print(
+                    flush_print(
                         f"  Rerouted {rerouted_count}/{len(nets_to_reroute)} nets, overflow: {overflow} ({elapsed_str()})"
                     )
 


### PR DESCRIPTION
## Summary
- Add `flush_print()` helper function to ensure progress messages are immediately visible during long-running routing operations
- Apply `flush_print()` to key progress messages in the negotiated routing algorithm and route command
- Eliminates the need for users to set `PYTHONUNBUFFERED=1` to see incremental progress

## Changes
- `src/kicad_tools/cli/progress.py`: Add `flush_print()` function that prints and flushes stdout immediately
- `src/kicad_tools/cli/route_cmd.py`: Use `flush_print()` for routing status messages
- `src/kicad_tools/router/core.py`: Use `flush_print()` for negotiated routing iteration progress

## Test Plan
- Verified module imports work correctly
- Ran `ruff check` and `ruff format` on changed files
- Ran router unit tests to verify no regressions

Closes #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)