### PR TITLE
fix(export): Capture and display kicad-cli error output properly

### DIFF
--- a/src/kicad_tools/export/gerber.py
+++ b/src/kicad_tools/export/gerber.py
@@ -324,11 +324,25 @@ class GerberExporter:
             )
             logger.debug(f"kicad-cli output: {result.stdout}")
         except subprocess.CalledProcessError as e:
-            logger.error(f"kicad-cli failed: {e.stderr}")
+            # Capture both stdout and stderr - kicad-cli may output errors to either
+            error_output = e.stderr.strip() if e.stderr else ""
+            stdout_output = e.stdout.strip() if e.stdout else ""
+            combined_output = error_output or stdout_output or "No error output captured"
+
+            logger.error(f"kicad-cli failed (exit code {e.returncode}): {combined_output}")
             raise ExportError(
                 "Gerber export failed",
-                context={"pcb": str(self.pcb_path), "error": e.stderr},
-                suggestions=["Check the KiCad log for details"],
+                context={
+                    "pcb": str(self.pcb_path),
+                    "exit_code": e.returncode,
+                    "stderr": error_output or "(empty)",
+                    "stdout": stdout_output or "(empty)",
+                },
+                suggestions=[
+                    "Check the KiCad log for details",
+                    "Verify the PCB file is valid and can be opened in KiCad",
+                    "Ensure all layers referenced exist in the PCB",
+                ],
             )
 
     def _export_drill(self, config: GerberConfig, output_dir: Path) -> None:
@@ -366,11 +380,24 @@ class GerberExporter:
             )
             logger.debug(f"kicad-cli output: {result.stdout}")
         except subprocess.CalledProcessError as e:
-            logger.error(f"kicad-cli failed: {e.stderr}")
+            # Capture both stdout and stderr - kicad-cli may output errors to either
+            error_output = e.stderr.strip() if e.stderr else ""
+            stdout_output = e.stdout.strip() if e.stdout else ""
+            combined_output = error_output or stdout_output or "No error output captured"
+
+            logger.error(f"kicad-cli failed (exit code {e.returncode}): {combined_output}")
             raise ExportError(
                 "Drill export failed",
-                context={"pcb": str(self.pcb_path), "error": e.stderr},
-                suggestions=["Check the KiCad log for details"],
+                context={
+                    "pcb": str(self.pcb_path),
+                    "exit_code": e.returncode,
+                    "stderr": error_output or "(empty)",
+                    "stdout": stdout_output or "(empty)",
+                },
+                suggestions=[
+                    "Check the KiCad log for details",
+                    "Verify the PCB file is valid and can be opened in KiCad",
+                ],
             )
 
     def _get_default_layers(self, config: GerberConfig) -> list[str]:


### PR DESCRIPTION
## Summary

Fix for issue #980 - Gerber export fails silently with kicad-cli.

The Gerber export was failing silently because error output from kicad-cli was not being captured or displayed when the subprocess failed. The error message showed an empty `error:` field, making debugging difficult.

## Changes

- Capture both stdout and stderr from kicad-cli subprocess calls (kicad-cli may output errors to either stream)
- Include exit code in error context for better debugging
- Show both stdout and stderr in error output (with "(empty)" marker when not available)
- Add more helpful suggestions for debugging export failures
- Apply fix to both `_export_gerbers` and `_export_drill` methods

## Before (issue #980)

```
kicad-cli failed: 
  Export error: Gerber export failed

Context:
  pcb: /path/to/file.kicad_pcb
  error: 
```

## After

```
kicad-cli failed (exit code 1): <actual error message from kicad-cli>
  Export error: Gerber export failed

Context:
  pcb: /path/to/file.kicad_pcb
  exit_code: 1
  stderr: (empty)
  stdout: <error details>

Suggestions:
  - Check the KiCad log for details
  - Verify the PCB file is valid and can be opened in KiCad
  - Ensure all layers referenced exist in the PCB
```

## Test Plan

- [x] Verified changes pass linting (`ruff check`)
- [x] All existing export tests pass
- [x] Changes localized to error handling paths only

Closes #980