### PR TITLE
fix(export): Correct --use-drill-file-origin duplicate flag bug

### DIFF
--- a/src/kicad_tools/export/gerber.py
+++ b/src/kicad_tools/export/gerber.py
@@ -296,8 +296,8 @@ class GerberExporter:
         ]
 
         # Add options
-        if config.use_protel_extensions:
-            cmd.append("--use-drill-file-origin")
+        if not config.use_protel_extensions:
+            cmd.append("--no-protel-ext")
 
         if config.use_aux_origin:
             cmd.append("--use-drill-file-origin")


### PR DESCRIPTION
## Summary

Fix copy-paste error in Gerber export where `use_protel_extensions` was incorrectly mapped to `--use-drill-file-origin` instead of `--no-protel-ext`. This caused kicad-cli to fail with "Duplicate argument" when both `use_protel_extensions` and `use_aux_origin` were enabled (e.g., JLCPCB preset).

## Changes

- Changed `use_protel_extensions` to control `--no-protel-ext` flag (negated, so it's added when protel extensions are NOT used)
- `use_aux_origin` continues to control `--use-drill-file-origin` flag

## Test Plan

- All gerber-related tests pass (33 tests)
- The file passes linting and formatting checks
- Fix verified by code inspection: each flag is now added at most once

Closes #987