### PR TITLE
fix(export): Use comma-separated list for Gerber --layers flag

### DIFF
--- a/src/kicad_tools/export/gerber.py
+++ b/src/kicad_tools/export/gerber.py
@@ -308,10 +308,10 @@ class GerberExporter:
         if config.disable_aperture_macros:
             cmd.append("--disable-aperture-macros")
 
-        # Layer selection
+        # Layer selection - kicad-cli 9.x requires comma-separated list
         layers = config.layers if config.layers else self._get_default_layers(config)
-        for layer in layers:
-            cmd.extend(["--layers", layer])
+        if layers:
+            cmd.extend(["--layers", ",".join(layers)])
 
         logger.debug(f"Running: {' '.join(cmd)}")
 


### PR DESCRIPTION
## Summary

Fixes the Gerber export to use kicad-cli 9.x's required comma-separated list format for the `--layers` argument instead of passing multiple `--layers` flags.

## Changes

- Modified `GerberExporter._export_gerbers()` to join layers with commas
- Changed from `for layer in layers: cmd.extend(["--layers", layer])` to `cmd.extend(["--layers", ",".join(layers)])`

## Root Cause

kicad-cli 9.x requires `-l, --layers` to receive a comma-separated list (e.g., `F.Cu,B.Cu,F.SilkS`) but the code was passing multiple `--layers` flags, causing a "Duplicate argument" error.

## Test Plan

- All 33 gerber-related tests pass
- Changed file passes ruff linting and formatting

Closes #995