### PR TITLE
feat(router): Report which net's clearance is blocking failed routes (#1007)

### DIFF
--- a/src/kicad_tools/router/output.py
+++ b/src/kicad_tools/router/output.py
@@ -479,6 +479,24 @@ def format_failed_nets_summary(
 
         lines.append(f'  - Net {failure.net} "{failure.net_name}": {cause} ({details})')
 
+        # Add detailed pad access blocker information if available
+        if (
+            hasattr(failure, "analysis")
+            and failure.analysis
+            and hasattr(failure.analysis, "pad_access_blockers")
+            and failure.analysis.pad_access_blockers
+        ):
+            for blocker in failure.analysis.pad_access_blockers[:2]:  # Show top 2 blockers
+                lines.append(
+                    f'    Pad {blocker.pad_ref}: blocked by clearance from "{blocker.blocking_net_name}" '
+                    f"({blocker.blocking_type} at {blocker.distance:.2f}mm distance)"
+                )
+            # Add suggestion if available
+            if failure.analysis.suggestions:
+                for suggestion in failure.analysis.suggestions[:1]:  # Show top suggestion
+                    if "clearance" in suggestion.lower():
+                        lines.append(f"    Suggestion: {suggestion}")
+
     # Show count of remaining failures if truncated
     remaining = len(unique_failures) - max_display
     if remaining > 0:


### PR DESCRIPTION
## Summary

When a net fails to route due to clearance blocking at pad entry/exit, this PR reports which specific net's clearance zone is causing the blockage. This helps users understand *why* routing failed and provides actionable suggestions.

## Changes

- **New PadAccessBlocker dataclass**: Tracks which net is blocking pad access, the distance, and suggested clearance reduction
- **analyze_pad_access_blockers method**: Analyzes the grid around a pad to find which nets' clearance zones are preventing access
- **Enhanced failure analysis**: FailureAnalysis now includes pad_access_blockers list for PIN_ACCESS failures
- **Improved failure messages**: PIN_ACCESS failures now show blocking net details and clearance suggestions
- **Better output formatting**: format_failed_nets_summary shows detailed blocker info for each pad

## Example Output

Before:
```
Failed nets:
  - Net 16 "DRV_POS_HI": pin_access (PADS_OFF_GRID: U1.13 off by 0.163mm, U2.5 off by 0.079mm)
```

After:
```
Failed nets:
  - Net 16 "DRV_POS_HI": pin_access (PADS_OFF_GRID: U1.13 off by 0.163mm, U2.5 off by 0.079mm | Clearance blocked by: U1.13: blocked by SC_POS_PLUS (trace at 0.12mm))
    Pad U1.13: blocked by clearance from "SC_POS_PLUS" (trace at 0.12mm distance)
    Suggestion: Reduce clearance to 0.10mm to allow pad access
```

## Test Plan

- [x] Added tests for PadAccessBlocker dataclass
- [x] Added tests for analyze_pad_access_blockers method
- [x] Added tests for FailureAnalysis with pad_access_blockers
- [x] All existing failure_analysis tests pass (43 tests)
- [x] Router core tests pass

Closes #1007