### PR TITLE
fix(router): Remove unused variable in route_with_progressive_clearance()

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3733,9 +3733,6 @@ class Autorouter:
                     self.grid, relaxed_router, relaxed_rules, self.net_class_map
                 )
 
-                # Track routes added by this attempt
-                routes_before = len(self.routes)
-
                 def mark_route(route: Route) -> None:
                     self._mark_route(route)
 


### PR DESCRIPTION
## Summary

Remove the unused `routes_before` variable from `route_with_progressive_clearance()` in `src/kicad_tools/router/core.py`.

## Changes

- Removed line 3737: `routes_before = len(self.routes)` 
- This variable was assigned but never used - leftover from development/debugging

## Test Plan

- All 9 progressive clearance tests pass
- Ruff linting passes for the changed file
- No functional change to routing behavior

Closes #1006