### PR TITLE
feat(cli): Add performance calibration and high-performance routing mode

### DIFF
--- a/src/kicad_tools/calibration.py
+++ b/src/kicad_tools/calibration.py
@@ -1,0 +1,312 @@
+"""
+Performance calibration for kicad-tools routing operations.
+
+Provides benchmarking and calibration utilities to determine optimal
+routing parameters for the local machine.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from kicad_tools.performance import (
+    PERFORMANCE_CONFIG_FILE,
+    PerformanceConfig,
+    detect_available_memory_gb,
+    detect_cpu_count,
+)
+
+
+@dataclass
+class BenchmarkResult:
+    """Result of a single benchmark run.
+
+    Attributes:
+        worker_count: Number of workers used.
+        trial_count: Number of trials used.
+        duration_ms: Total duration in milliseconds.
+        throughput: Operations per second.
+    """
+
+    worker_count: int
+    trial_count: int
+    duration_ms: float
+    throughput: float
+
+
+@dataclass
+class CalibrationResult:
+    """Result of the full calibration process.
+
+    Attributes:
+        cpu_cores: Detected CPU cores.
+        memory_gb: Available memory in GB.
+        optimal_workers: Optimal worker count from benchmark.
+        optimal_trials: Optimal trial count from benchmark.
+        benchmarks: List of individual benchmark results.
+        duration_seconds: Total calibration time.
+    """
+
+    cpu_cores: int
+    memory_gb: float
+    optimal_workers: int
+    optimal_trials: int
+    benchmarks: list[BenchmarkResult] = field(default_factory=list)
+    duration_seconds: float = 0.0
+
+    def to_performance_config(self) -> PerformanceConfig:
+        """Convert calibration result to PerformanceConfig.
+
+        Returns:
+            PerformanceConfig with calibrated settings.
+        """
+        return PerformanceConfig(
+            cpu_cores=self.cpu_cores,
+            available_memory_gb=self.memory_gb,
+            monte_carlo_trials=self.optimal_trials,
+            parallel_workers=self.optimal_workers,
+            grid_memory_limit_mb=min(2000, int(self.memory_gb * 150)),
+            negotiated_iterations=15 + min(10, self.cpu_cores // 2),
+            partition_rows=max(2, int(self.cpu_cores**0.5)),
+            partition_cols=max(2, int(self.cpu_cores**0.5)),
+            calibrated=True,
+        )
+
+
+def _run_parallel_benchmark(worker_count: int, iterations: int = 100) -> float:
+    """Run a parallel computation benchmark.
+
+    Args:
+        worker_count: Number of workers to use.
+        iterations: Number of iterations to run.
+
+    Returns:
+        Duration in milliseconds.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    def work_unit(n: int) -> float:
+        """Simple CPU-bound work unit."""
+        total = 0.0
+        for i in range(1000):
+            total += (i * n) ** 0.5
+        return total
+
+    start = time.perf_counter()
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        list(executor.map(work_unit, range(iterations)))
+
+    duration_ms = (time.perf_counter() - start) * 1000
+    return duration_ms
+
+
+def _run_memory_benchmark(size_mb: int) -> tuple[float, bool]:
+    """Run a memory allocation benchmark.
+
+    Args:
+        size_mb: Size to allocate in MB.
+
+    Returns:
+        Tuple of (duration_ms, success).
+    """
+    try:
+        start = time.perf_counter()
+
+        # Allocate a numpy array if available, otherwise use list
+        try:
+            import numpy as np
+
+            arr = np.zeros((size_mb * 1024 * 1024 // 8,), dtype=np.float64)
+            _ = arr.sum()  # Touch the memory
+            del arr
+        except ImportError:
+            # Fallback: allocate a large list
+            arr = [0.0] * (size_mb * 1024 * 128)  # Approximate MB
+            _ = sum(arr[:1000])
+            del arr
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        return duration_ms, True
+    except MemoryError:
+        return 0.0, False
+
+
+def run_calibration(
+    verbose: bool = False,
+    quick: bool = False,
+) -> CalibrationResult:
+    """Run performance calibration benchmarks.
+
+    Benchmarks parallel execution and memory allocation to determine
+    optimal settings for the current machine.
+
+    Args:
+        verbose: If True, print progress information.
+        quick: If True, run abbreviated benchmarks.
+
+    Returns:
+        CalibrationResult with optimal settings.
+    """
+    start_time = time.perf_counter()
+
+    cpu_cores = detect_cpu_count()
+    memory_gb = detect_available_memory_gb()
+
+    if verbose:
+        print(f"Detected {cpu_cores} CPU cores")
+        print(f"Available memory: {memory_gb:.1f} GB")
+        print()
+
+    benchmarks: list[BenchmarkResult] = []
+    best_throughput = 0.0
+    optimal_workers = max(1, cpu_cores - 1)
+
+    # Benchmark different worker counts
+    worker_counts = [1, 2, 4, cpu_cores // 2, cpu_cores - 1, cpu_cores]
+    worker_counts = sorted({w for w in worker_counts if w >= 1 and w <= cpu_cores * 2})
+
+    if quick:
+        # Quick mode: fewer worker counts, fewer iterations
+        worker_counts = [cpu_cores // 2, cpu_cores - 1, cpu_cores]
+        worker_counts = sorted({w for w in worker_counts if w >= 1})
+        iterations = 50
+    else:
+        iterations = 100
+
+    if verbose:
+        print("Benchmarking parallel execution...")
+
+    for worker_count in worker_counts:
+        if verbose:
+            print(f"  Testing {worker_count} workers...", end=" ", flush=True)
+
+        duration_ms = _run_parallel_benchmark(worker_count, iterations)
+        throughput = iterations / (duration_ms / 1000)
+
+        benchmark = BenchmarkResult(
+            worker_count=worker_count,
+            trial_count=iterations,
+            duration_ms=duration_ms,
+            throughput=throughput,
+        )
+        benchmarks.append(benchmark)
+
+        if verbose:
+            print(f"{throughput:.1f} ops/sec")
+
+        if throughput > best_throughput:
+            best_throughput = throughput
+            optimal_workers = worker_count
+
+    # Determine optimal trial count based on throughput
+    # More cores = more trials make sense
+    optimal_trials = max(4, optimal_workers * 2)
+
+    # Benchmark memory allocation if not quick mode
+    if not quick and verbose:
+        print()
+        print("Benchmarking memory allocation...")
+
+        for size_mb in [100, 250, 500, 1000]:
+            duration_ms, success = _run_memory_benchmark(size_mb)
+            if success:
+                if verbose:
+                    print(f"  {size_mb} MB: {duration_ms:.1f} ms")
+            else:
+                if verbose:
+                    print(f"  {size_mb} MB: allocation failed")
+                break
+
+    duration_seconds = time.perf_counter() - start_time
+
+    if verbose:
+        print()
+        print(f"Calibration complete in {duration_seconds:.1f}s")
+        print(f"  Optimal workers: {optimal_workers}")
+        print(f"  Optimal trials: {optimal_trials}")
+
+    return CalibrationResult(
+        cpu_cores=cpu_cores,
+        memory_gb=memory_gb,
+        optimal_workers=optimal_workers,
+        optimal_trials=optimal_trials,
+        benchmarks=benchmarks,
+        duration_seconds=duration_seconds,
+    )
+
+
+def calibrate_and_save(
+    output_path: Path | None = None,
+    verbose: bool = False,
+    quick: bool = False,
+) -> PerformanceConfig:
+    """Run calibration and save results to config file.
+
+    Args:
+        output_path: Path to save config, or None for default.
+        verbose: If True, print progress.
+        quick: If True, run abbreviated benchmarks.
+
+    Returns:
+        PerformanceConfig with calibrated settings.
+    """
+    result = run_calibration(verbose=verbose, quick=quick)
+    config = result.to_performance_config()
+
+    save_path = output_path or PERFORMANCE_CONFIG_FILE
+    config.save(save_path)
+
+    if verbose:
+        print()
+        print(f"Configuration saved to: {save_path}")
+
+    return config
+
+
+def show_current_config(verbose: bool = False) -> PerformanceConfig:
+    """Display the current performance configuration.
+
+    Args:
+        verbose: If True, show detailed information.
+
+    Returns:
+        Current PerformanceConfig.
+    """
+    config = PerformanceConfig.load_calibrated()
+
+    print("Performance Configuration")
+    print("=" * 40)
+
+    if config.calibrated:
+        print(f"Status: Calibrated ({config.calibration_date})")
+    else:
+        print("Status: Using auto-detected defaults")
+
+    print()
+    print("System Resources:")
+    print(f"  CPU cores:         {config.cpu_cores}")
+    print(f"  Available memory:  {config.available_memory_gb:.1f} GB")
+
+    print()
+    print("Routing Settings:")
+    print(f"  Monte Carlo trials:    {config.monte_carlo_trials}")
+    print(f"  Parallel workers:      {config.parallel_workers}")
+    print(f"  Negotiated iterations: {config.negotiated_iterations}")
+    print(f"  Partition grid:        {config.partition_rows}x{config.partition_cols}")
+
+    print()
+    print("Grid Settings:")
+    print(f"  Memory limit: {config.grid_memory_limit_mb} MB")
+
+    if verbose:
+        print()
+        print(f"Config file: {PERFORMANCE_CONFIG_FILE}")
+        print(f"  Exists: {PERFORMANCE_CONFIG_FILE.exists()}")
+
+    return config

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -397,6 +397,9 @@ def _dispatch_command(args) -> int:
     elif args.command == "detect-mistakes":
         return _run_detect_mistakes_command(args)
 
+    elif args.command == "calibrate":
+        return _run_calibrate_command(args)
+
     return 0
 
 
@@ -462,6 +465,29 @@ def _run_detect_mistakes_command(args) -> int:
         sub_argv.append("--verbose")
 
     return mistakes_cmd(sub_argv)
+
+
+def _run_calibrate_command(args) -> int:
+    """Run the calibrate command."""
+    from .calibrate_cmd import main as calibrate_cmd
+
+    sub_argv = []
+
+    # Handle flags
+    if hasattr(args, "calibrate_show") and args.calibrate_show:
+        sub_argv.append("--show")
+    if hasattr(args, "calibrate_benchmark") and args.calibrate_benchmark:
+        sub_argv.append("--benchmark")
+    if hasattr(args, "calibrate_quick") and args.calibrate_quick:
+        sub_argv.append("--quick")
+    if hasattr(args, "calibrate_output") and args.calibrate_output:
+        sub_argv.extend(["-o", args.calibrate_output])
+    if hasattr(args, "calibrate_json") and args.calibrate_json:
+        sub_argv.append("--json")
+    if hasattr(args, "calibrate_verbose") and args.calibrate_verbose:
+        sub_argv.append("--verbose")
+
+    return calibrate_cmd(sub_argv)
 
 
 def symbols_main() -> int:

--- a/src/kicad_tools/cli/calibrate_cmd.py
+++ b/src/kicad_tools/cli/calibrate_cmd.py
@@ -1,0 +1,112 @@
+"""
+Performance calibration CLI command.
+
+Provides command-line access to calibrate routing performance settings:
+
+    kicad-tools calibrate               # Run calibration and save
+    kicad-tools calibrate --show        # Show current settings
+    kicad-tools calibrate --quick       # Quick calibration
+    kicad-tools calibrate --benchmark   # Full benchmark with details
+"""
+
+import argparse
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for calibrate command.
+
+    Args:
+        argv: Command line arguments (defaults to sys.argv[1:]).
+
+    Returns:
+        Exit code (0 for success).
+    """
+    parser = argparse.ArgumentParser(
+        prog="kicad-tools calibrate",
+        description="Calibrate routing performance settings for your machine",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Show current performance configuration without running calibration",
+    )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run full benchmarks with detailed output",
+    )
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="Run abbreviated calibration (faster but less accurate)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="Output path for configuration file",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output configuration as JSON",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show detailed progress information",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Handle --show: just display current config
+    if args.show:
+        from kicad_tools.calibration import show_current_config
+
+        config = show_current_config(verbose=args.verbose)
+
+        if args.json:
+            import json
+
+            print()
+            print(json.dumps(config.to_dict(), indent=2))
+
+        return 0
+
+    # Run calibration
+    from pathlib import Path
+
+    from kicad_tools.calibration import calibrate_and_save
+
+    output_path = Path(args.output) if args.output else None
+    verbose = args.verbose or args.benchmark
+
+    print("kicad-tools Performance Calibration")
+    print("=" * 40)
+    print()
+
+    config = calibrate_and_save(
+        output_path=output_path,
+        verbose=verbose,
+        quick=args.quick,
+    )
+
+    if args.json:
+        import json
+
+        print()
+        print(json.dumps(config.to_dict(), indent=2))
+    else:
+        print()
+        print("Calibration complete! Use --show to view saved settings.")
+        print()
+        print("To use high-performance mode when routing:")
+        print("  kicad-tools route board.kicad_pcb --high-performance")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -116,6 +116,8 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--min-clearance-floor", str(args.min_clearance_floor)])
     if getattr(args, "manufacturer", "jlcpcb") != "jlcpcb":
         sub_argv.extend(["--manufacturer", args.manufacturer])
+    if getattr(args, "high_performance", False):
+        sub_argv.append("--high-performance")
     return route_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -172,6 +172,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_run_parser(subparsers)
     _add_explain_parser(subparsers)
     _add_detect_mistakes_parser(subparsers)
+    _add_calibrate_parser(subparsers)
 
     return parser
 
@@ -867,6 +868,14 @@ def _add_route_parser(subparsers) -> None:
         "--mfr",
         default="jlcpcb",
         help="Manufacturer for DRC validation and adaptive rules (default: jlcpcb)",
+    )
+    route_parser.add_argument(
+        "--high-performance",
+        action="store_true",
+        help=(
+            "Use high-performance mode with aggressive parallelization and more trials. "
+            "Uses calibrated settings if available (run 'kicad-tools calibrate' first)."
+        ),
     )
 
 
@@ -2991,4 +3000,49 @@ def _add_detect_mistakes_parser(subparsers) -> None:
         action="store_true",
         dest="mistakes_verbose",
         help="Show detailed information",
+    )
+
+
+def _add_calibrate_parser(subparsers) -> None:
+    """Add calibrate subcommand parser."""
+    calibrate_parser = subparsers.add_parser(
+        "calibrate",
+        help="Calibrate routing performance settings for your machine",
+    )
+    calibrate_parser.add_argument(
+        "--show",
+        action="store_true",
+        dest="calibrate_show",
+        help="Show current performance configuration without running calibration",
+    )
+    calibrate_parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        dest="calibrate_benchmark",
+        help="Run full benchmarks with detailed output",
+    )
+    calibrate_parser.add_argument(
+        "--quick",
+        action="store_true",
+        dest="calibrate_quick",
+        help="Run abbreviated calibration (faster but less accurate)",
+    )
+    calibrate_parser.add_argument(
+        "-o",
+        "--output",
+        dest="calibrate_output",
+        help="Output path for configuration file",
+    )
+    calibrate_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="calibrate_json",
+        help="Output configuration as JSON",
+    )
+    calibrate_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        dest="calibrate_verbose",
+        help="Show detailed progress information",
     )

--- a/src/kicad_tools/performance.py
+++ b/src/kicad_tools/performance.py
@@ -1,0 +1,303 @@
+"""
+Performance configuration for kicad-tools routing operations.
+
+Provides resource-aware defaults and calibrated settings for optimal
+routing performance based on the local machine's capabilities.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        tomllib = None  # type: ignore[assignment]
+
+# User config directory for performance calibration
+PERFORMANCE_CONFIG_DIR = Path.home() / ".config" / "kicad-tools"
+PERFORMANCE_CONFIG_FILE = PERFORMANCE_CONFIG_DIR / "performance.toml"
+
+
+def detect_cpu_count() -> int:
+    """Detect the number of CPU cores available.
+
+    Returns:
+        Number of CPU cores, or 4 as a fallback.
+    """
+    try:
+        # Try to get usable CPU count (respects cgroups, affinity)
+        if hasattr(os, "sched_getaffinity"):
+            return len(os.sched_getaffinity(0))
+        return os.cpu_count() or 4
+    except Exception:
+        return 4
+
+
+def detect_available_memory_gb() -> float:
+    """Detect available system memory in gigabytes.
+
+    Returns:
+        Available memory in GB, or 8.0 as a fallback.
+    """
+    try:
+        # Try psutil first (most accurate)
+        import psutil
+
+        mem = psutil.virtual_memory()
+        return mem.available / (1024**3)
+    except ImportError:
+        pass
+
+    # Fallback: try reading from /proc/meminfo on Linux
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    kb = int(line.split()[1])
+                    return kb / (1024**2)
+    except Exception:
+        pass
+
+    # macOS fallback
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            bytes_total = int(result.stdout.strip())
+            # Estimate available as 60% of total
+            return (bytes_total * 0.6) / (1024**3)
+    except Exception:
+        pass
+
+    # Default fallback
+    return 8.0
+
+
+@dataclass
+class PerformanceConfig:
+    """Configuration for routing performance optimization.
+
+    This class provides auto-detected or calibrated settings for optimal
+    routing performance. Settings can be loaded from a calibration file
+    or use sensible defaults based on detected system resources.
+
+    Attributes:
+        cpu_cores: Number of CPU cores available for parallel work.
+        available_memory_gb: Available system memory in GB.
+        monte_carlo_trials: Number of Monte Carlo trials (0 = auto).
+        parallel_workers: Number of parallel routing workers (0 = auto).
+        grid_memory_limit_mb: Maximum memory for routing grid.
+        negotiated_iterations: Max iterations for negotiated routing.
+        partition_rows: Number of partition rows for region-based routing.
+        partition_cols: Number of partition columns for region-based routing.
+        calibrated: Whether these settings came from calibration.
+        calibration_date: ISO date string of last calibration.
+    """
+
+    cpu_cores: int = field(default_factory=detect_cpu_count)
+    available_memory_gb: float = field(default_factory=detect_available_memory_gb)
+    monte_carlo_trials: int = 0  # 0 = auto (2x CPU cores)
+    parallel_workers: int = 0  # 0 = auto (CPU cores - 1)
+    grid_memory_limit_mb: int = 500
+    negotiated_iterations: int = 15
+    partition_rows: int = 2
+    partition_cols: int = 2
+    calibrated: bool = False
+    calibration_date: str = ""
+
+    def __post_init__(self):
+        """Apply auto-detection for zero values."""
+        if self.monte_carlo_trials == 0:
+            self.monte_carlo_trials = max(4, self.cpu_cores * 2)
+        if self.parallel_workers == 0:
+            self.parallel_workers = max(1, self.cpu_cores - 1)
+
+    @property
+    def effective_monte_carlo_trials(self) -> int:
+        """Get the effective number of Monte Carlo trials."""
+        if self.monte_carlo_trials == 0:
+            return max(4, self.cpu_cores * 2)
+        return self.monte_carlo_trials
+
+    @property
+    def effective_parallel_workers(self) -> int:
+        """Get the effective number of parallel workers."""
+        if self.parallel_workers == 0:
+            return max(1, self.cpu_cores - 1)
+        return self.parallel_workers
+
+    @classmethod
+    def detect(cls) -> PerformanceConfig:
+        """Create config with auto-detected system resources.
+
+        Returns:
+            PerformanceConfig with detected CPU cores and memory.
+        """
+        return cls(
+            cpu_cores=detect_cpu_count(),
+            available_memory_gb=detect_available_memory_gb(),
+        )
+
+    @classmethod
+    def load_calibrated(cls) -> PerformanceConfig:
+        """Load calibrated settings or fall back to auto-detection.
+
+        Returns:
+            PerformanceConfig from calibration file, or auto-detected if not available.
+        """
+        if not PERFORMANCE_CONFIG_FILE.exists():
+            return cls.detect()
+
+        if tomllib is None:
+            return cls.detect()
+
+        try:
+            with open(PERFORMANCE_CONFIG_FILE, "rb") as f:
+                data = tomllib.load(f)
+
+            cal = data.get("calibration", {})
+            routing = data.get("routing", {})
+            grid = data.get("grid", {})
+
+            return cls(
+                cpu_cores=cal.get("cpu_cores", detect_cpu_count()),
+                available_memory_gb=cal.get("memory_gb", detect_available_memory_gb()),
+                monte_carlo_trials=routing.get("monte_carlo_trials", 0),
+                parallel_workers=routing.get("parallel_workers", 0),
+                negotiated_iterations=routing.get("negotiated_iterations", 15),
+                partition_rows=routing.get("partition_rows", 2),
+                partition_cols=routing.get("partition_cols", 2),
+                grid_memory_limit_mb=grid.get("max_memory_mb", 500),
+                calibrated=True,
+                calibration_date=cal.get("date", ""),
+            )
+        except Exception:
+            return cls.detect()
+
+    @classmethod
+    def high_performance(cls) -> PerformanceConfig:
+        """Create aggressive settings for maximum throughput.
+
+        Uses all available CPU cores and higher trial counts for
+        better routing results at the cost of longer runtime.
+
+        Returns:
+            PerformanceConfig optimized for maximum performance.
+        """
+        cpu_cores = detect_cpu_count()
+        memory_gb = detect_available_memory_gb()
+
+        return cls(
+            cpu_cores=cpu_cores,
+            available_memory_gb=memory_gb,
+            # Use all cores for Monte Carlo
+            monte_carlo_trials=max(8, cpu_cores * 3),
+            # Use all cores minus 1 for parallel routing
+            parallel_workers=max(2, cpu_cores),
+            # More memory for grid if available
+            grid_memory_limit_mb=min(2000, int(memory_gb * 200)),
+            # More iterations for better results
+            negotiated_iterations=25,
+            # More partitions for parallelism
+            partition_rows=max(2, int(cpu_cores**0.5)),
+            partition_cols=max(2, int(cpu_cores**0.5)),
+            calibrated=False,
+            calibration_date="",
+        )
+
+    def save(self, path: Path | None = None) -> None:
+        """Save configuration to TOML file.
+
+        Args:
+            path: Path to save to, or None to use default location.
+        """
+        if path is None:
+            path = PERFORMANCE_CONFIG_FILE
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        from datetime import datetime
+
+        date_str = datetime.now().isoformat()
+
+        content = f'''# kicad-tools performance configuration
+# Generated by: kicad-tools calibrate
+# Machine-specific settings for optimal routing performance
+
+[calibration]
+date = "{date_str}"
+cpu_cores = {self.cpu_cores}
+memory_gb = {self.available_memory_gb:.1f}
+
+[routing]
+# Monte Carlo trials for multi-start routing
+monte_carlo_trials = {self.monte_carlo_trials}
+
+# Parallel workers for concurrent routing
+parallel_workers = {self.parallel_workers}
+
+# Negotiated routing iterations
+negotiated_iterations = {self.negotiated_iterations}
+
+# Region partitioning for parallel negotiated routing
+partition_rows = {self.partition_rows}
+partition_cols = {self.partition_cols}
+
+[grid]
+# Maximum memory for routing grid (MB)
+max_memory_mb = {self.grid_memory_limit_mb}
+'''
+        path.write_text(content)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON/TOML output.
+
+        Returns:
+            Dictionary representation of the config.
+        """
+        return {
+            "calibration": {
+                "cpu_cores": self.cpu_cores,
+                "memory_gb": self.available_memory_gb,
+                "calibrated": self.calibrated,
+                "date": self.calibration_date,
+            },
+            "routing": {
+                "monte_carlo_trials": self.monte_carlo_trials,
+                "parallel_workers": self.parallel_workers,
+                "negotiated_iterations": self.negotiated_iterations,
+                "partition_rows": self.partition_rows,
+                "partition_cols": self.partition_cols,
+            },
+            "grid": {
+                "max_memory_mb": self.grid_memory_limit_mb,
+            },
+        }
+
+
+def get_performance_config(high_performance: bool = False) -> PerformanceConfig:
+    """Get the appropriate performance configuration.
+
+    Args:
+        high_performance: If True, use aggressive high-performance settings.
+
+    Returns:
+        PerformanceConfig instance with appropriate settings.
+    """
+    if high_performance:
+        return PerformanceConfig.high_performance()
+    return PerformanceConfig.load_calibrated()


### PR DESCRIPTION
## Summary

Add performance calibration and high-performance routing mode for agents and users to easily configure optimal routing performance.

**New features:**
- `kicad-tools calibrate` command that benchmarks the local machine and saves optimal settings
- `--high-performance` flag for the route command that uses aggressive parallelization
- `PerformanceConfig` class with auto-detection and calibrated settings loading
- Settings stored in `~/.config/kicad-tools/performance.toml`

## Changes

- New `src/kicad_tools/performance.py`: PerformanceConfig dataclass with resource detection
- New `src/kicad_tools/calibration.py`: Benchmarking and calibration utilities
- New `src/kicad_tools/cli/calibrate_cmd.py`: CLI command implementation
- Updated `src/kicad_tools/cli/parser.py`: Added calibrate and --high-performance args
- Updated `src/kicad_tools/cli/route_cmd.py`: Apply high-performance settings
- Updated `src/kicad_tools/cli/__init__.py`: Dispatch calibrate command

## Usage

```bash
# Run calibration (stores settings in ~/.config/kicad-tools/performance.toml)
kicad-tools calibrate

# Quick calibration
kicad-tools calibrate --quick

# View current settings
kicad-tools calibrate --show

# Use high-performance mode when routing
kicad-tools route board.kicad_pcb --high-performance
```

## Test plan

- [x] `kicad-tools calibrate --help` shows correct options
- [x] `kicad-tools calibrate --quick --verbose` runs successfully
- [x] `kicad-tools calibrate --show` displays saved settings
- [x] `kicad-tools route --help` shows `--high-performance` flag
- [x] All 297 existing tests pass
- [x] Ruff linting passes

Closes #1014