### PR TITLE
feat(router): Constraint-aware net ordering for routing

### DIFF
--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -117,6 +117,14 @@ class DesignRules:
         1.0  # Weight for via impact scoring (0=disabled, higher=stronger avoidance)
     )
 
+    # Constraint-aware net ordering (Issue #1020)
+    # Routes highly-constrained nets first to give them access to routing resources
+    # before less-constrained nets consume available channels.
+    constraint_ordering_enabled: bool = True  # Enable constraint-aware ordering
+    constraint_fine_pitch_weight: float = 10.0  # Weight for fine-pitch component connections
+    constraint_pad_count_weight: float = 0.5  # Weight for number of pads in net
+    constraint_congestion_weight: float = 5.0  # Weight for nets in congested areas
+
     def get_clearance_for_component(self, ref: str, pin_pitch: float | None = None) -> float:
         """Get the clearance to use for a specific component.
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1309,7 +1309,8 @@ class TestAutorouter:
             ],
         )
 
-        priority, pad_count, distance = router._get_net_priority(1)
+        # Issue #1020: Return is now 4-tuple (priority, -constraint_score, pad_count, distance)
+        priority, neg_constraint, pad_count, distance = router._get_net_priority(1)
         assert priority == 1  # Power net has highest priority
         assert pad_count == 1
         assert distance == 0.0  # Single pad has no distance
@@ -1325,7 +1326,8 @@ class TestAutorouter:
             ],
         )
 
-        priority, pad_count, distance = router._get_net_priority(1)
+        # Issue #1020: Return is now 4-tuple (priority, -constraint_score, pad_count, distance)
+        priority, neg_constraint, pad_count, distance = router._get_net_priority(1)
         assert priority == 10  # Default low priority
         assert distance == 0.0  # Single pad has no distance
 


### PR DESCRIPTION
## Summary

Implements constraint-aware net ordering (Issue #1020) to route highly-constrained nets first, giving them access to routing resources before less-constrained nets consume available channels.

## Changes

- Add `_calculate_constraint_score()` method to compute routing difficulty based on:
  - Fine-pitch component connections (10.0 / pitch for components < 0.8mm pitch)
  - Pad count penalty (0.5 per pad)
- Modify `_get_net_priority()` to return 4-tuple including negated constraint score
- Add configuration options to `DesignRules`:
  - `constraint_ordering_enabled`: Toggle feature (default True)
  - `constraint_fine_pitch_weight`: Weight for fine-pitch connections
  - `constraint_pad_count_weight`: Weight for pad count  
  - `constraint_congestion_weight`: Weight for congested areas (for future use)
- Add `component_pitches` property for lazy-loaded pitch cache

## Test Plan

- [x] Unit tests for `_calculate_constraint_score()` with fine-pitch components
- [x] Unit tests for disabled constraint scoring
- [x] Unit tests for pad count contribution to score
- [x] Unit tests for net priority tuple including constraint score
- [x] Integration test verifying fine-pitch nets ordered before standard nets
- [x] All existing routing tests pass (275 in test_router.py, 87 in test_router_core.py)

Closes #1020