### PR TITLE
feat(deps): Add optional GPU dependency groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,25 @@ Whether you're building an AI assistant that reviews PCB designs, automating DRC
 ## Installation
 
 ```bash
+# Base install (CPU only)
 pip install kicad-tools
+
+# With CUDA GPU acceleration (NVIDIA GPUs on Linux/Windows)
+pip install kicad-tools[cuda]
+
+# With Metal GPU acceleration (Apple Silicon Macs)
+pip install kicad-tools[metal]
+
+# With native C++ router backend
+pip install kicad-tools[native]
+
+# Everything (all optional dependencies)
+pip install kicad-tools[all]
+```
+
+To check GPU acceleration status:
+```bash
+kct calibrate --show-gpu
 ```
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,14 @@ native = [
     "cmake>=3.15",
     "ninja>=1.10",
 ]
+# CUDA GPU acceleration (NVIDIA GPUs on Linux/Windows)
+cuda = [
+    "cupy-cuda12x>=13.0",
+]
+# Metal GPU acceleration (Apple Silicon Macs)
+metal = [
+    "mlx>=0.5",
+]
 # All optional features
 all = [
     "rtree>=1.0",
@@ -126,6 +134,8 @@ all = [
     "pyyaml>=6.0",
     "fastmcp>=2.0,<3",
     "pydantic>=2.0",
+    "cupy-cuda12x>=13.0",
+    "mlx>=0.5",
 ]
 # Development dependencies
 dev = [

--- a/src/kicad_tools/acceleration/__init__.py
+++ b/src/kicad_tools/acceleration/__init__.py
@@ -1,0 +1,22 @@
+"""
+GPU acceleration detection and management.
+
+This module provides utilities for detecting available GPU acceleration
+backends and suggesting appropriate installation commands.
+"""
+
+from kicad_tools.acceleration.detection import (
+    GPUBackend,
+    GPUInfo,
+    detect_gpu,
+    get_available_backends,
+    suggest_install_command,
+)
+
+__all__ = [
+    "GPUBackend",
+    "GPUInfo",
+    "detect_gpu",
+    "get_available_backends",
+    "suggest_install_command",
+]

--- a/src/kicad_tools/acceleration/detection.py
+++ b/src/kicad_tools/acceleration/detection.py
@@ -1,0 +1,204 @@
+"""
+GPU detection and installation suggestion utilities.
+
+Provides platform-aware GPU detection and recommends the appropriate
+pip install command for GPU acceleration.
+"""
+
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+class GPUBackend(Enum):
+    """Available GPU acceleration backends."""
+
+    NONE = "none"
+    CUDA = "cuda"
+    METAL = "metal"
+
+
+@dataclass
+class GPUInfo:
+    """Information about detected GPU capabilities."""
+
+    backend: GPUBackend
+    available: bool
+    device_name: str | None = None
+    reason: str | None = None
+
+    def __str__(self) -> str:
+        if self.available:
+            return f"{self.backend.value}: {self.device_name}"
+        return f"{self.backend.value}: not available ({self.reason})"
+
+
+def _check_cuda() -> GPUInfo:
+    """Check for CUDA availability via CuPy."""
+    try:
+        import cupy as cp
+
+        device = cp.cuda.Device(0)
+        props = cp.cuda.runtime.getDeviceProperties(device.id)
+        device_name = props["name"].decode() if isinstance(props["name"], bytes) else props["name"]
+        return GPUInfo(
+            backend=GPUBackend.CUDA,
+            available=True,
+            device_name=device_name,
+        )
+    except ImportError:
+        return GPUInfo(
+            backend=GPUBackend.CUDA,
+            available=False,
+            reason="cupy not installed",
+        )
+    except Exception as e:
+        return GPUInfo(
+            backend=GPUBackend.CUDA,
+            available=False,
+            reason=str(e),
+        )
+
+
+def _check_metal() -> GPUInfo:
+    """Check for Metal availability via MLX."""
+    try:
+        import mlx.core as mx
+
+        # MLX automatically uses Metal on Apple Silicon
+        # Check if we can create a simple array (validates Metal is working)
+        _ = mx.array([1.0, 2.0, 3.0])
+        return GPUInfo(
+            backend=GPUBackend.METAL,
+            available=True,
+            device_name="Apple Silicon GPU",
+        )
+    except ImportError:
+        return GPUInfo(
+            backend=GPUBackend.METAL,
+            available=False,
+            reason="mlx not installed",
+        )
+    except Exception as e:
+        return GPUInfo(
+            backend=GPUBackend.METAL,
+            available=False,
+            reason=str(e),
+        )
+
+
+def detect_gpu() -> GPUInfo:
+    """Detect the best available GPU backend for the current platform.
+
+    Returns:
+        GPUInfo with details about the detected GPU backend.
+    """
+    system = platform.system()
+    machine = platform.machine()
+
+    # On macOS with Apple Silicon, prefer Metal
+    if system == "Darwin" and machine == "arm64":
+        metal_info = _check_metal()
+        if metal_info.available:
+            return metal_info
+        # Fall through to check CUDA (unlikely but possible via external GPU)
+
+    # On Linux/Windows or Intel Mac, try CUDA
+    if system in ("Linux", "Windows") or (system == "Darwin" and machine != "arm64"):
+        cuda_info = _check_cuda()
+        if cuda_info.available:
+            return cuda_info
+
+    # Also check Metal on macOS even if not arm64 (in case of future support)
+    if system == "Darwin":
+        metal_info = _check_metal()
+        if metal_info.available:
+            return metal_info
+
+    return GPUInfo(
+        backend=GPUBackend.NONE,
+        available=False,
+        reason="no GPU acceleration available",
+    )
+
+
+def get_available_backends() -> list[GPUInfo]:
+    """Get information about all potentially available GPU backends.
+
+    Returns:
+        List of GPUInfo for each backend (CUDA, Metal).
+    """
+    backends = []
+
+    # Check CUDA
+    backends.append(_check_cuda())
+
+    # Check Metal (only on macOS)
+    if platform.system() == "Darwin":
+        backends.append(_check_metal())
+
+    return backends
+
+
+def suggest_install_command() -> str:
+    """Suggest the right pip install command for GPU acceleration on this platform.
+
+    Returns:
+        A pip install command string appropriate for the current platform.
+    """
+    system = platform.system()
+    machine = platform.machine()
+
+    if system == "Darwin":
+        if machine == "arm64":
+            return "pip install kicad-tools[metal]"
+        return "pip install kicad-tools  # No GPU acceleration for Intel Mac"
+    elif system == "Linux":
+        return "pip install kicad-tools[cuda]"
+    else:
+        # Windows or other
+        return "pip install kicad-tools[cuda]  # Requires NVIDIA GPU"
+
+
+def show_gpu_status(verbose: bool = False) -> None:
+    """Print GPU acceleration status to stdout.
+
+    Args:
+        verbose: If True, show detailed information about all backends.
+    """
+    print("GPU Acceleration Status")
+    print("=" * 40)
+    print()
+
+    # Current detection
+    gpu = detect_gpu()
+    if gpu.available:
+        print(f"Active backend: {gpu.backend.value.upper()}")
+        print(f"Device: {gpu.device_name}")
+    else:
+        print("No GPU acceleration available")
+
+    print()
+
+    if verbose:
+        print("Backend Details:")
+        print("-" * 40)
+        for backend in get_available_backends():
+            status = "available" if backend.available else "not available"
+            print(f"  {backend.backend.value.upper()}: {status}")
+            if backend.available:
+                print(f"    Device: {backend.device_name}")
+            elif backend.reason:
+                print(f"    Reason: {backend.reason}")
+        print()
+
+    # Installation suggestion
+    print("Suggested installation:")
+    print(f"  {suggest_install_command()}")
+    print()

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -476,6 +476,8 @@ def _run_calibrate_command(args) -> int:
     # Handle flags
     if hasattr(args, "calibrate_show") and args.calibrate_show:
         sub_argv.append("--show")
+    if hasattr(args, "calibrate_show_gpu") and args.calibrate_show_gpu:
+        sub_argv.append("--show-gpu")
     if hasattr(args, "calibrate_benchmark") and args.calibrate_benchmark:
         sub_argv.append("--benchmark")
     if hasattr(args, "calibrate_quick") and args.calibrate_quick:

--- a/src/kicad_tools/cli/calibrate_cmd.py
+++ b/src/kicad_tools/cli/calibrate_cmd.py
@@ -32,6 +32,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Show current performance configuration without running calibration",
     )
     parser.add_argument(
+        "--show-gpu",
+        action="store_true",
+        help="Show GPU acceleration status and suggest install command",
+    )
+    parser.add_argument(
         "--benchmark",
         action="store_true",
         help="Run full benchmarks with detailed output",
@@ -60,6 +65,13 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
+
+    # Handle --show-gpu: display GPU acceleration status
+    if args.show_gpu:
+        from kicad_tools.acceleration.detection import show_gpu_status
+
+        show_gpu_status(verbose=args.verbose)
+        return 0
 
     # Handle --show: just display current config
     if args.show:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3016,6 +3016,12 @@ def _add_calibrate_parser(subparsers) -> None:
         help="Show current performance configuration without running calibration",
     )
     calibrate_parser.add_argument(
+        "--show-gpu",
+        action="store_true",
+        dest="calibrate_show_gpu",
+        help="Show GPU acceleration status and suggest install command",
+    )
+    calibrate_parser.add_argument(
         "--benchmark",
         action="store_true",
         dest="calibrate_benchmark",


### PR DESCRIPTION
## Summary

- Add `cuda` and `metal` optional dependency groups for GPU acceleration
- Add `acceleration/` module with platform-aware GPU detection
- Add `kct calibrate --show-gpu` CLI command to check GPU status

## Installation Options

```bash
# CUDA support (NVIDIA GPUs on Linux/Windows)
pip install kicad-tools[cuda]

# Metal support (Apple Silicon Macs)
pip install kicad-tools[metal]
```

## Test plan

- [x] `pip install kicad-tools` works without GPU packages
- [x] `kct calibrate --show-gpu` shows GPU status
- [x] `kct calibrate --show-gpu -v` shows detailed backend info
- [ ] Import errors for GPU packages are caught gracefully (verified in detection code)
- [ ] CI tests pass without GPU packages installed

Closes #1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)