### PR TITLE
feat(acceleration): Create backend abstraction module with GPU detection

### DIFF
--- a/src/kicad_tools/acceleration/__init__.py
+++ b/src/kicad_tools/acceleration/__init__.py
@@ -1,0 +1,43 @@
+"""GPU acceleration module for kicad-tools.
+
+Provides a unified interface for GPU backends with automatic detection
+and selection. Supports CUDA (via CuPy), Metal (via MLX), and CPU (NumPy).
+
+Basic Usage:
+    >>> from kicad_tools.acceleration import get_backend, BackendType
+    >>> backend = get_backend()  # Auto-detect best backend
+    >>> arr = backend.zeros((1000, 1000))
+    >>> result = backend.to_numpy(arr)
+
+Force Specific Backend:
+    >>> backend = get_backend(BackendType.CPU)  # Always use CPU
+    >>> backend = get_backend("cuda")  # Request CUDA
+
+Check Available Backends:
+    >>> from kicad_tools.acceleration import detect_backends
+    >>> available = detect_backends()  # [BackendType.METAL, BackendType.CPU]
+"""
+
+from kicad_tools.acceleration.backend import ArrayBackend, BackendType
+from kicad_tools.acceleration.cpu import CPUBackend
+from kicad_tools.acceleration.cuda import CUDABackend
+from kicad_tools.acceleration.detection import (
+    detect_backends,
+    get_backend,
+    get_backend_info,
+)
+from kicad_tools.acceleration.metal import MetalBackend
+
+__all__ = [
+    # Core types
+    "BackendType",
+    "ArrayBackend",
+    # Backend implementations
+    "CPUBackend",
+    "CUDABackend",
+    "MetalBackend",
+    # Detection and factory functions
+    "detect_backends",
+    "get_backend",
+    "get_backend_info",
+]

--- a/src/kicad_tools/acceleration/backend.py
+++ b/src/kicad_tools/acceleration/backend.py
@@ -1,0 +1,123 @@
+"""Backend enum and base protocol for GPU acceleration.
+
+Defines the BackendType enum and ArrayBackend protocol that all backends
+(CUDA, Metal, CPU) must implement for unified array operations.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike, DTypeLike, NDArray
+
+
+class BackendType(Enum):
+    """Supported GPU backend types."""
+
+    CUDA = "cuda"
+    METAL = "metal"
+    CPU = "cpu"
+
+
+@runtime_checkable
+class ArrayBackend(Protocol):
+    """Protocol for array operations across backends.
+
+    All backend implementations (CUDA, Metal, CPU) must implement this
+    protocol to provide a consistent interface for array operations.
+    """
+
+    @property
+    def backend_type(self) -> BackendType:
+        """Return the backend type."""
+        ...
+
+    def is_available(self) -> bool:
+        """Check if this backend is usable on the current system.
+
+        Returns:
+            True if the backend can be used, False otherwise.
+        """
+        ...
+
+    def array(self, data: ArrayLike, dtype: DTypeLike | None = None) -> Any:
+        """Create an array on this backend.
+
+        Args:
+            data: Input data (list, tuple, numpy array, etc.).
+            dtype: Optional data type for the array.
+
+        Returns:
+            Array on this backend.
+        """
+        ...
+
+    def zeros(self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32) -> Any:
+        """Create a zero-filled array.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            Zero-filled array on this backend.
+        """
+        ...
+
+    def ones(self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32) -> Any:
+        """Create an array filled with ones.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            Array filled with ones on this backend.
+        """
+        ...
+
+    def empty(self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32) -> Any:
+        """Create an uninitialized array.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            Uninitialized array on this backend.
+        """
+        ...
+
+    def to_numpy(self, arr: Any) -> NDArray[Any]:
+        """Transfer array back to CPU as numpy array.
+
+        Args:
+            arr: Array on this backend.
+
+        Returns:
+            NumPy array with the same data.
+        """
+        ...
+
+    def from_numpy(self, arr: NDArray[Any]) -> Any:
+        """Transfer numpy array to this backend.
+
+        Args:
+            arr: NumPy array to transfer.
+
+        Returns:
+            Array on this backend.
+        """
+        ...
+
+    def synchronize(self) -> None:
+        """Synchronize the backend (wait for all operations to complete).
+
+        For GPU backends, this ensures all kernel executions are complete.
+        For CPU backend, this is a no-op.
+        """
+        ...

--- a/src/kicad_tools/acceleration/cpu.py
+++ b/src/kicad_tools/acceleration/cpu.py
@@ -1,0 +1,122 @@
+"""CPU backend using NumPy.
+
+This is the fallback backend that is always available. It provides a
+consistent interface using NumPy arrays.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import ArrayLike, DTypeLike, NDArray
+
+from kicad_tools.acceleration.backend import ArrayBackend, BackendType
+
+
+class CPUBackend:
+    """CPU backend using NumPy arrays.
+
+    This backend is always available and provides a consistent interface
+    for array operations using NumPy.
+    """
+
+    @property
+    def backend_type(self) -> BackendType:
+        """Return the backend type."""
+        return BackendType.CPU
+
+    def is_available(self) -> bool:
+        """CPU backend is always available.
+
+        Returns:
+            Always True.
+        """
+        return True
+
+    def array(self, data: ArrayLike, dtype: DTypeLike | None = None) -> NDArray[Any]:
+        """Create a numpy array.
+
+        Args:
+            data: Input data (list, tuple, numpy array, etc.).
+            dtype: Optional data type for the array.
+
+        Returns:
+            NumPy array.
+        """
+        return np.asarray(data, dtype=dtype)
+
+    def zeros(
+        self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32
+    ) -> NDArray[Any]:
+        """Create a zero-filled numpy array.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            Zero-filled NumPy array.
+        """
+        return np.zeros(shape, dtype=dtype)
+
+    def ones(
+        self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32
+    ) -> NDArray[Any]:
+        """Create a numpy array filled with ones.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            NumPy array filled with ones.
+        """
+        return np.ones(shape, dtype=dtype)
+
+    def empty(
+        self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32
+    ) -> NDArray[Any]:
+        """Create an uninitialized numpy array.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            Uninitialized NumPy array.
+        """
+        return np.empty(shape, dtype=dtype)
+
+    def to_numpy(self, arr: NDArray[Any]) -> NDArray[Any]:
+        """Return the array as-is (already numpy).
+
+        Args:
+            arr: NumPy array.
+
+        Returns:
+            The same NumPy array.
+        """
+        return np.asarray(arr)
+
+    def from_numpy(self, arr: NDArray[Any]) -> NDArray[Any]:
+        """Return the array as-is (already numpy).
+
+        Args:
+            arr: NumPy array.
+
+        Returns:
+            The same NumPy array.
+        """
+        return np.asarray(arr)
+
+    def synchronize(self) -> None:
+        """No-op for CPU backend.
+
+        CPU operations are synchronous, so no synchronization needed.
+        """
+        pass
+
+
+# Verify protocol compliance at module load time
+assert isinstance(CPUBackend(), ArrayBackend)

--- a/src/kicad_tools/acceleration/cuda.py
+++ b/src/kicad_tools/acceleration/cuda.py
@@ -1,0 +1,201 @@
+"""CUDA backend using CuPy.
+
+This backend provides GPU acceleration on NVIDIA GPUs using CuPy.
+CuPy must be installed for this backend to be available.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import ArrayLike, DTypeLike, NDArray
+
+from kicad_tools.acceleration.backend import ArrayBackend, BackendType
+
+# Lazy import flag
+_cupy = None
+_cupy_import_attempted = False
+
+
+def _get_cupy():
+    """Lazy import CuPy to avoid startup overhead."""
+    global _cupy, _cupy_import_attempted
+    if not _cupy_import_attempted:
+        _cupy_import_attempted = True
+        try:
+            import cupy
+
+            _cupy = cupy
+        except ImportError:
+            _cupy = None
+    return _cupy
+
+
+class CUDABackend:
+    """CUDA backend using CuPy arrays.
+
+    This backend provides GPU acceleration on NVIDIA GPUs.
+    Requires CuPy to be installed.
+    """
+
+    def __init__(self, device_id: int = 0):
+        """Initialize CUDA backend.
+
+        Args:
+            device_id: CUDA device ID to use (default: 0).
+        """
+        self._device_id = device_id
+
+    @property
+    def backend_type(self) -> BackendType:
+        """Return the backend type."""
+        return BackendType.CUDA
+
+    def is_available(self) -> bool:
+        """Check if CUDA is available.
+
+        Returns:
+            True if CuPy is installed and CUDA devices are available.
+        """
+        cp = _get_cupy()
+        if cp is None:
+            return False
+        try:
+            device_count = cp.cuda.runtime.getDeviceCount()
+            return device_count > 0 and self._device_id < device_count
+        except Exception:
+            return False
+
+    def array(self, data: ArrayLike, dtype: DTypeLike | None = None) -> Any:
+        """Create a CuPy array on GPU.
+
+        Args:
+            data: Input data (list, tuple, numpy array, etc.).
+            dtype: Optional data type for the array.
+
+        Returns:
+            CuPy array on GPU.
+
+        Raises:
+            RuntimeError: If CUDA is not available.
+        """
+        cp = _get_cupy()
+        if cp is None:
+            raise RuntimeError("CuPy is not installed. Install with: pip install cupy")
+        with cp.cuda.Device(self._device_id):
+            return cp.asarray(data, dtype=dtype)
+
+    def zeros(
+        self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32
+    ) -> Any:
+        """Create a zero-filled CuPy array on GPU.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            Zero-filled CuPy array on GPU.
+
+        Raises:
+            RuntimeError: If CUDA is not available.
+        """
+        cp = _get_cupy()
+        if cp is None:
+            raise RuntimeError("CuPy is not installed. Install with: pip install cupy")
+        with cp.cuda.Device(self._device_id):
+            return cp.zeros(shape, dtype=dtype)
+
+    def ones(self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32) -> Any:
+        """Create a CuPy array filled with ones on GPU.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            CuPy array filled with ones on GPU.
+
+        Raises:
+            RuntimeError: If CUDA is not available.
+        """
+        cp = _get_cupy()
+        if cp is None:
+            raise RuntimeError("CuPy is not installed. Install with: pip install cupy")
+        with cp.cuda.Device(self._device_id):
+            return cp.ones(shape, dtype=dtype)
+
+    def empty(
+        self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32
+    ) -> Any:
+        """Create an uninitialized CuPy array on GPU.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            Uninitialized CuPy array on GPU.
+
+        Raises:
+            RuntimeError: If CUDA is not available.
+        """
+        cp = _get_cupy()
+        if cp is None:
+            raise RuntimeError("CuPy is not installed. Install with: pip install cupy")
+        with cp.cuda.Device(self._device_id):
+            return cp.empty(shape, dtype=dtype)
+
+    def to_numpy(self, arr: Any) -> NDArray[Any]:
+        """Transfer CuPy array back to CPU.
+
+        Args:
+            arr: CuPy array on GPU.
+
+        Returns:
+            NumPy array with the same data.
+        """
+        cp = _get_cupy()
+        if cp is None:
+            # Assume it's already a numpy array
+            return np.asarray(arr)
+        if isinstance(arr, cp.ndarray):
+            return cp.asnumpy(arr)
+        return np.asarray(arr)
+
+    def from_numpy(self, arr: NDArray[Any]) -> Any:
+        """Transfer numpy array to GPU.
+
+        Args:
+            arr: NumPy array to transfer.
+
+        Returns:
+            CuPy array on GPU.
+
+        Raises:
+            RuntimeError: If CUDA is not available.
+        """
+        cp = _get_cupy()
+        if cp is None:
+            raise RuntimeError("CuPy is not installed. Install with: pip install cupy")
+        with cp.cuda.Device(self._device_id):
+            return cp.asarray(arr)
+
+    def synchronize(self) -> None:
+        """Synchronize CUDA stream (wait for all operations to complete).
+
+        Ensures all kernel executions on this device are complete.
+        """
+        cp = _get_cupy()
+        if cp is not None:
+            with cp.cuda.Device(self._device_id):
+                cp.cuda.Stream.null.synchronize()
+
+
+# Protocol compliance check (only if CuPy is available)
+# This is deferred to avoid import errors
+def _check_protocol():
+    backend = CUDABackend()
+    if backend.is_available():
+        assert isinstance(backend, ArrayBackend)

--- a/src/kicad_tools/acceleration/detection.py
+++ b/src/kicad_tools/acceleration/detection.py
@@ -1,0 +1,231 @@
+"""Hardware detection utilities for GPU backends.
+
+Provides functions to detect available GPU backends and select
+the best backend based on system capabilities.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from kicad_tools.acceleration.backend import ArrayBackend, BackendType
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+def detect_backends() -> list[BackendType]:
+    """Return list of available backends in priority order.
+
+    Checks for available GPU backends (CUDA, Metal) and always includes
+    CPU as a fallback. The list is ordered by preference: GPU backends
+    first, then CPU.
+
+    Returns:
+        List of available BackendType values in priority order.
+
+    Examples:
+        >>> backends = detect_backends()
+        >>> BackendType.CPU in backends  # Always available
+        True
+        >>> backends[0] if len(backends) > 1 else None  # Preferred GPU if available
+    """
+    available: list[BackendType] = []
+
+    # Check CUDA (CuPy)
+    if _check_cuda_available():
+        available.append(BackendType.CUDA)
+        logger.debug("CUDA backend available")
+
+    # Check Metal (MLX)
+    if _check_metal_available():
+        available.append(BackendType.METAL)
+        logger.debug("Metal backend available")
+
+    # CPU is always available
+    available.append(BackendType.CPU)
+    logger.debug("CPU backend available (fallback)")
+
+    return available
+
+
+def _check_cuda_available() -> bool:
+    """Check if CUDA is available via CuPy.
+
+    Returns:
+        True if CuPy is installed and CUDA devices are available.
+    """
+    try:
+        import cupy
+
+        device_count = cupy.cuda.runtime.getDeviceCount()
+        return device_count > 0
+    except ImportError:
+        return False
+    except Exception as e:
+        logger.debug(f"CUDA check failed: {e}")
+        return False
+
+
+def _check_metal_available() -> bool:
+    """Check if Metal is available via MLX.
+
+    Returns:
+        True if MLX is installed and running on macOS.
+    """
+    try:
+        import platform
+
+        if platform.system() != "Darwin":
+            return False
+
+        import mlx.core as mx
+
+        # Verify we can get the default device
+        mx.default_device()
+        return True
+    except ImportError:
+        return False
+    except Exception as e:
+        logger.debug(f"Metal check failed: {e}")
+        return False
+
+
+def get_backend(
+    preferred: BackendType | str | None = None,
+    device_id: int = 0,
+) -> ArrayBackend:
+    """Get the best available backend, or preferred if available.
+
+    If a preferred backend is specified and available, it will be used.
+    Otherwise, the best available backend is returned (GPU before CPU).
+
+    Args:
+        preferred: Preferred backend type (BackendType enum or string).
+            If None or "auto", the best available backend is used.
+        device_id: Device ID for multi-GPU systems (CUDA only).
+
+    Returns:
+        An ArrayBackend instance.
+
+    Raises:
+        ValueError: If the preferred backend is not available.
+
+    Examples:
+        >>> backend = get_backend()  # Best available
+        >>> backend = get_backend(BackendType.CPU)  # Force CPU
+        >>> backend = get_backend("cuda")  # Request CUDA
+    """
+    from kicad_tools.acceleration.cpu import CPUBackend
+    from kicad_tools.acceleration.cuda import CUDABackend
+    from kicad_tools.acceleration.metal import MetalBackend
+
+    # Normalize preferred to BackendType
+    if preferred is None or preferred == "auto":
+        preferred_type = None
+    elif isinstance(preferred, str):
+        try:
+            preferred_type = BackendType(preferred.lower())
+        except ValueError:
+            raise ValueError(
+                f"Unknown backend type: {preferred}. "
+                f"Valid options: {[b.value for b in BackendType]}"
+            )
+    else:
+        preferred_type = preferred
+
+    # If specific backend requested, try to use it
+    if preferred_type is not None:
+        if preferred_type == BackendType.CPU:
+            return CPUBackend()
+
+        if preferred_type == BackendType.CUDA:
+            backend = CUDABackend(device_id=device_id)
+            if backend.is_available():
+                logger.info(f"Using CUDA backend (device {device_id})")
+                return backend
+            raise ValueError(
+                "CUDA backend requested but not available. "
+                "Ensure CuPy is installed and NVIDIA GPU is present."
+            )
+
+        if preferred_type == BackendType.METAL:
+            backend = MetalBackend()
+            if backend.is_available():
+                logger.info("Using Metal backend")
+                return backend
+            raise ValueError(
+                "Metal backend requested but not available. "
+                "Ensure MLX is installed and running on macOS with Apple Silicon."
+            )
+
+    # Auto-select best available backend
+    available = detect_backends()
+
+    if not available:
+        # Should never happen since CPU is always available
+        logger.warning("No backends available, falling back to CPU")
+        return CPUBackend()
+
+    best = available[0]
+
+    if best == BackendType.CUDA:
+        logger.info(f"Auto-selected CUDA backend (device {device_id})")
+        return CUDABackend(device_id=device_id)
+
+    if best == BackendType.METAL:
+        logger.info("Auto-selected Metal backend")
+        return MetalBackend()
+
+    logger.info("Using CPU backend")
+    return CPUBackend()
+
+
+def get_backend_info() -> dict[str, bool | str]:
+    """Get information about available backends.
+
+    Returns:
+        Dictionary with backend availability and system info.
+
+    Examples:
+        >>> info = get_backend_info()
+        >>> info["cuda_available"]
+        False
+        >>> info["metal_available"]
+        True
+    """
+    import platform
+
+    available = detect_backends()
+
+    info: dict[str, bool | str] = {
+        "platform": platform.system(),
+        "machine": platform.machine(),
+        "cuda_available": BackendType.CUDA in available,
+        "metal_available": BackendType.METAL in available,
+        "cpu_available": BackendType.CPU in available,  # Always True
+        "preferred_backend": available[0].value if available else "cpu",
+    }
+
+    # Add GPU-specific info if available
+    if BackendType.CUDA in available:
+        try:
+            import cupy
+
+            info["cuda_device_count"] = cupy.cuda.runtime.getDeviceCount()
+            info["cuda_device_name"] = cupy.cuda.Device(0).name
+        except Exception:
+            pass
+
+    if BackendType.METAL in available:
+        try:
+            import mlx.core as mx
+
+            info["metal_device"] = str(mx.default_device())
+        except Exception:
+            pass
+
+    return info

--- a/src/kicad_tools/acceleration/metal.py
+++ b/src/kicad_tools/acceleration/metal.py
@@ -1,0 +1,248 @@
+"""Metal backend using MLX.
+
+This backend provides GPU acceleration on Apple Silicon using MLX.
+MLX must be installed for this backend to be available.
+"""
+
+from __future__ import annotations
+
+import platform
+from typing import Any
+
+import numpy as np
+from numpy.typing import ArrayLike, DTypeLike, NDArray
+
+from kicad_tools.acceleration.backend import ArrayBackend, BackendType
+
+# Lazy import flag
+_mlx = None
+_mlx_import_attempted = False
+
+
+def _get_mlx():
+    """Lazy import MLX to avoid startup overhead."""
+    global _mlx, _mlx_import_attempted
+    if not _mlx_import_attempted:
+        _mlx_import_attempted = True
+        # MLX only works on macOS
+        if platform.system() != "Darwin":
+            _mlx = None
+        else:
+            try:
+                import mlx.core as mx
+
+                _mlx = mx
+            except ImportError:
+                _mlx = None
+    return _mlx
+
+
+def _numpy_dtype_to_mlx(dtype: DTypeLike) -> Any:
+    """Convert numpy dtype to MLX dtype.
+
+    Args:
+        dtype: NumPy dtype.
+
+    Returns:
+        MLX dtype.
+    """
+    mx = _get_mlx()
+    if mx is None:
+        return dtype
+
+    dtype = np.dtype(dtype)
+    dtype_map = {
+        np.float16: mx.float16,
+        np.float32: mx.float32,
+        np.float64: mx.float32,  # MLX doesn't support float64, downcast
+        np.int8: mx.int8,
+        np.int16: mx.int16,
+        np.int32: mx.int32,
+        np.int64: mx.int64,
+        np.uint8: mx.uint8,
+        np.uint16: mx.uint16,
+        np.uint32: mx.uint32,
+        np.uint64: mx.uint64,
+        np.bool_: mx.bool_,
+    }
+    return dtype_map.get(dtype.type, mx.float32)
+
+
+class MetalBackend:
+    """Metal backend using MLX arrays.
+
+    This backend provides GPU acceleration on Apple Silicon.
+    Requires MLX to be installed and macOS to be running.
+    """
+
+    @property
+    def backend_type(self) -> BackendType:
+        """Return the backend type."""
+        return BackendType.METAL
+
+    def is_available(self) -> bool:
+        """Check if Metal is available.
+
+        Returns:
+            True if MLX is installed and running on macOS.
+        """
+        if platform.system() != "Darwin":
+            return False
+        mx = _get_mlx()
+        if mx is None:
+            return False
+        try:
+            # Verify we can get the default device
+            mx.default_device()
+            return True
+        except Exception:
+            return False
+
+    def array(self, data: ArrayLike, dtype: DTypeLike | None = None) -> Any:
+        """Create an MLX array.
+
+        Args:
+            data: Input data (list, tuple, numpy array, etc.).
+            dtype: Optional data type for the array.
+
+        Returns:
+            MLX array.
+
+        Raises:
+            RuntimeError: If MLX is not available.
+        """
+        mx = _get_mlx()
+        if mx is None:
+            raise RuntimeError(
+                "MLX is not installed or not available on this system. "
+                "Install with: pip install mlx (macOS only)"
+            )
+        # Convert to numpy first for consistent handling
+        np_arr = np.asarray(data)
+        if dtype is not None:
+            mlx_dtype = _numpy_dtype_to_mlx(dtype)
+            return mx.array(np_arr, dtype=mlx_dtype)
+        return mx.array(np_arr)
+
+    def zeros(
+        self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32
+    ) -> Any:
+        """Create a zero-filled MLX array.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            Zero-filled MLX array.
+
+        Raises:
+            RuntimeError: If MLX is not available.
+        """
+        mx = _get_mlx()
+        if mx is None:
+            raise RuntimeError(
+                "MLX is not installed or not available on this system. "
+                "Install with: pip install mlx (macOS only)"
+            )
+        if isinstance(shape, int):
+            shape = (shape,)
+        mlx_dtype = _numpy_dtype_to_mlx(dtype)
+        return mx.zeros(shape, dtype=mlx_dtype)
+
+    def ones(self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32) -> Any:
+        """Create an MLX array filled with ones.
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            MLX array filled with ones.
+
+        Raises:
+            RuntimeError: If MLX is not available.
+        """
+        mx = _get_mlx()
+        if mx is None:
+            raise RuntimeError(
+                "MLX is not installed or not available on this system. "
+                "Install with: pip install mlx (macOS only)"
+            )
+        if isinstance(shape, int):
+            shape = (shape,)
+        mlx_dtype = _numpy_dtype_to_mlx(dtype)
+        return mx.ones(shape, dtype=mlx_dtype)
+
+    def empty(
+        self, shape: tuple[int, ...] | int, dtype: DTypeLike = np.float32
+    ) -> Any:
+        """Create an uninitialized MLX array.
+
+        Note: MLX doesn't have a true empty(), so we use zeros().
+
+        Args:
+            shape: Shape of the array.
+            dtype: Data type for the array.
+
+        Returns:
+            MLX array (zero-filled).
+
+        Raises:
+            RuntimeError: If MLX is not available.
+        """
+        # MLX doesn't have empty, use zeros instead
+        return self.zeros(shape, dtype)
+
+    def to_numpy(self, arr: Any) -> NDArray[Any]:
+        """Transfer MLX array back to CPU.
+
+        Args:
+            arr: MLX array.
+
+        Returns:
+            NumPy array with the same data.
+        """
+        mx = _get_mlx()
+        if mx is None:
+            return np.asarray(arr)
+        if hasattr(arr, "__array__"):
+            # MLX arrays support numpy conversion via __array__
+            return np.array(arr)
+        return np.asarray(arr)
+
+    def from_numpy(self, arr: NDArray[Any]) -> Any:
+        """Transfer numpy array to MLX.
+
+        Args:
+            arr: NumPy array to transfer.
+
+        Returns:
+            MLX array.
+
+        Raises:
+            RuntimeError: If MLX is not available.
+        """
+        mx = _get_mlx()
+        if mx is None:
+            raise RuntimeError(
+                "MLX is not installed or not available on this system. "
+                "Install with: pip install mlx (macOS only)"
+            )
+        return mx.array(arr)
+
+    def synchronize(self) -> None:
+        """Synchronize MLX operations.
+
+        Ensures all operations are complete and evaluated.
+        """
+        mx = _get_mlx()
+        if mx is not None:
+            mx.eval()  # Force evaluation of lazy operations
+
+
+# Protocol compliance check (only if MLX is available)
+def _check_protocol():
+    backend = MetalBackend()
+    if backend.is_available():
+        assert isinstance(backend, ArrayBackend)

--- a/tests/test_acceleration_backend.py
+++ b/tests/test_acceleration_backend.py
@@ -1,0 +1,310 @@
+"""Tests for GPU acceleration backend abstraction module."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from kicad_tools.acceleration import (
+    ArrayBackend,
+    BackendType,
+    CPUBackend,
+    CUDABackend,
+    MetalBackend,
+    detect_backends,
+    get_backend,
+    get_backend_info,
+)
+
+
+class TestBackendType:
+    """Tests for BackendType enum."""
+
+    def test_backend_type_values(self):
+        """Test BackendType enum values."""
+        assert BackendType.CUDA.value == "cuda"
+        assert BackendType.METAL.value == "metal"
+        assert BackendType.CPU.value == "cpu"
+
+    def test_backend_type_from_string(self):
+        """Test creating BackendType from string."""
+        assert BackendType("cuda") == BackendType.CUDA
+        assert BackendType("metal") == BackendType.METAL
+        assert BackendType("cpu") == BackendType.CPU
+
+
+class TestCPUBackend:
+    """Tests for CPU backend."""
+
+    @pytest.fixture
+    def backend(self):
+        """Create CPU backend instance."""
+        return CPUBackend()
+
+    def test_backend_type(self, backend):
+        """Test backend type property."""
+        assert backend.backend_type == BackendType.CPU
+
+    def test_is_available(self, backend):
+        """Test CPU backend is always available."""
+        assert backend.is_available() is True
+
+    def test_implements_protocol(self, backend):
+        """Test CPU backend implements ArrayBackend protocol."""
+        assert isinstance(backend, ArrayBackend)
+
+    def test_array_from_list(self, backend):
+        """Test creating array from list."""
+        arr = backend.array([1, 2, 3])
+        assert isinstance(arr, np.ndarray)
+        np.testing.assert_array_equal(arr, [1, 2, 3])
+
+    def test_array_with_dtype(self, backend):
+        """Test creating array with specific dtype."""
+        arr = backend.array([1, 2, 3], dtype=np.float32)
+        assert arr.dtype == np.float32
+
+    def test_zeros(self, backend):
+        """Test creating zero-filled array."""
+        arr = backend.zeros((3, 4))
+        assert arr.shape == (3, 4)
+        assert arr.dtype == np.float32
+        assert np.all(arr == 0)
+
+    def test_zeros_with_dtype(self, backend):
+        """Test zeros with specific dtype."""
+        arr = backend.zeros((2, 2), dtype=np.int32)
+        assert arr.dtype == np.int32
+
+    def test_ones(self, backend):
+        """Test creating array filled with ones."""
+        arr = backend.ones((2, 3))
+        assert arr.shape == (2, 3)
+        assert np.all(arr == 1)
+
+    def test_empty(self, backend):
+        """Test creating empty array."""
+        arr = backend.empty((5, 5))
+        assert arr.shape == (5, 5)
+
+    def test_to_numpy(self, backend):
+        """Test to_numpy returns numpy array."""
+        arr = backend.array([1, 2, 3])
+        result = backend.to_numpy(arr)
+        assert isinstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, [1, 2, 3])
+
+    def test_from_numpy(self, backend):
+        """Test from_numpy returns numpy array."""
+        np_arr = np.array([1, 2, 3])
+        result = backend.from_numpy(np_arr)
+        assert isinstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, np_arr)
+
+    def test_synchronize(self, backend):
+        """Test synchronize is a no-op for CPU."""
+        # Should not raise
+        backend.synchronize()
+
+
+class TestCUDABackend:
+    """Tests for CUDA backend."""
+
+    @pytest.fixture
+    def backend(self):
+        """Create CUDA backend instance."""
+        return CUDABackend()
+
+    def test_backend_type(self, backend):
+        """Test backend type property."""
+        assert backend.backend_type == BackendType.CUDA
+
+    def test_is_available_returns_bool(self, backend):
+        """Test is_available returns boolean."""
+        result = backend.is_available()
+        assert isinstance(result, bool)
+
+    @pytest.mark.skipif(
+        not CUDABackend().is_available(),
+        reason="CUDA not available",
+    )
+    def test_implements_protocol_when_available(self, backend):
+        """Test CUDA backend implements ArrayBackend protocol when available."""
+        assert isinstance(backend, ArrayBackend)
+
+    @pytest.mark.skipif(
+        not CUDABackend().is_available(),
+        reason="CUDA not available",
+    )
+    def test_array_operations_when_available(self, backend):
+        """Test array operations when CUDA is available."""
+        arr = backend.zeros((100, 100))
+        result = backend.to_numpy(arr)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (100, 100)
+
+    def test_raises_when_unavailable(self):
+        """Test proper error when CUDA unavailable."""
+        backend = CUDABackend()
+        if not backend.is_available():
+            with pytest.raises(RuntimeError, match="CuPy"):
+                backend.zeros((10, 10))
+
+
+class TestMetalBackend:
+    """Tests for Metal backend."""
+
+    @pytest.fixture
+    def backend(self):
+        """Create Metal backend instance."""
+        return MetalBackend()
+
+    def test_backend_type(self, backend):
+        """Test backend type property."""
+        assert backend.backend_type == BackendType.METAL
+
+    def test_is_available_returns_bool(self, backend):
+        """Test is_available returns boolean."""
+        result = backend.is_available()
+        assert isinstance(result, bool)
+
+    @pytest.mark.skipif(
+        not MetalBackend().is_available(),
+        reason="Metal not available",
+    )
+    def test_implements_protocol_when_available(self, backend):
+        """Test Metal backend implements ArrayBackend protocol when available."""
+        assert isinstance(backend, ArrayBackend)
+
+    @pytest.mark.skipif(
+        not MetalBackend().is_available(),
+        reason="Metal not available",
+    )
+    def test_array_operations_when_available(self, backend):
+        """Test array operations when Metal is available."""
+        arr = backend.zeros((100, 100))
+        result = backend.to_numpy(arr)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (100, 100)
+
+    def test_raises_when_unavailable(self):
+        """Test proper error when Metal unavailable."""
+        import platform
+
+        backend = MetalBackend()
+        if not backend.is_available():
+            expected_msg = "MLX" if platform.system() == "Darwin" else "MLX"
+            with pytest.raises(RuntimeError, match=expected_msg):
+                backend.zeros((10, 10))
+
+
+class TestDetection:
+    """Tests for backend detection functions."""
+
+    def test_detect_backends_returns_list(self):
+        """Test detect_backends returns a list."""
+        result = detect_backends()
+        assert isinstance(result, list)
+
+    def test_detect_backends_contains_cpu(self):
+        """Test CPU is always in detected backends."""
+        result = detect_backends()
+        assert BackendType.CPU in result
+
+    def test_detect_backends_cpu_is_last(self):
+        """Test CPU is last in priority order."""
+        result = detect_backends()
+        assert result[-1] == BackendType.CPU
+
+    def test_get_backend_returns_backend(self):
+        """Test get_backend returns an ArrayBackend."""
+        backend = get_backend()
+        assert isinstance(backend, ArrayBackend)
+
+    def test_get_backend_cpu_always_works(self):
+        """Test get_backend with CPU always works."""
+        backend = get_backend(BackendType.CPU)
+        assert backend.backend_type == BackendType.CPU
+
+    def test_get_backend_accepts_string(self):
+        """Test get_backend accepts string backend type."""
+        backend = get_backend("cpu")
+        assert backend.backend_type == BackendType.CPU
+
+    def test_get_backend_invalid_string(self):
+        """Test get_backend raises for invalid string."""
+        with pytest.raises(ValueError, match="Unknown backend"):
+            get_backend("invalid_backend")
+
+    def test_get_backend_unavailable_cuda(self):
+        """Test get_backend raises for unavailable CUDA."""
+        if not CUDABackend().is_available():
+            with pytest.raises(ValueError, match="CUDA"):
+                get_backend(BackendType.CUDA)
+
+    def test_get_backend_unavailable_metal(self):
+        """Test get_backend raises for unavailable Metal."""
+        if not MetalBackend().is_available():
+            with pytest.raises(ValueError, match="Metal"):
+                get_backend(BackendType.METAL)
+
+    def test_get_backend_info_returns_dict(self):
+        """Test get_backend_info returns a dictionary."""
+        info = get_backend_info()
+        assert isinstance(info, dict)
+
+    def test_get_backend_info_contains_required_keys(self):
+        """Test get_backend_info contains required keys."""
+        info = get_backend_info()
+        assert "platform" in info
+        assert "cuda_available" in info
+        assert "metal_available" in info
+        assert "cpu_available" in info
+        assert "preferred_backend" in info
+
+    def test_get_backend_info_cpu_always_available(self):
+        """Test CPU is always reported as available."""
+        info = get_backend_info()
+        assert info["cpu_available"] is True
+
+
+class TestBackendInteroperability:
+    """Tests for backend interoperability with numpy."""
+
+    @pytest.fixture
+    def backend(self):
+        """Get the best available backend."""
+        return get_backend()
+
+    def test_round_trip(self, backend):
+        """Test numpy -> backend -> numpy round trip."""
+        original = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
+
+        # To backend
+        on_backend = backend.from_numpy(original)
+
+        # Back to numpy
+        result = backend.to_numpy(on_backend)
+
+        np.testing.assert_array_equal(result, original)
+
+    def test_zeros_to_numpy(self, backend):
+        """Test zeros array converts correctly to numpy."""
+        arr = backend.zeros((10, 10))
+        result = backend.to_numpy(arr)
+        assert np.all(result == 0)
+
+    def test_ones_to_numpy(self, backend):
+        """Test ones array converts correctly to numpy."""
+        arr = backend.ones((10, 10))
+        result = backend.to_numpy(arr)
+        assert np.all(result == 1)
+
+    def test_dtype_preservation(self, backend):
+        """Test dtype is preserved through operations."""
+        for dtype in [np.float32, np.int32]:
+            arr = backend.zeros((5, 5), dtype=dtype)
+            result = backend.to_numpy(arr)
+            # Note: Metal may not preserve all dtypes exactly
+            if backend.backend_type != BackendType.METAL:
+                assert result.dtype == dtype


### PR DESCRIPTION
## Summary

- Implements unified `ArrayBackend` protocol for GPU/CPU array operations
- Adds `BackendType` enum (CUDA, Metal, CPU) for backend identification
- Creates three backend implementations:
  - `CUDABackend`: NVIDIA GPU support via CuPy with lazy imports
  - `MetalBackend`: Apple Silicon GPU support via MLX with lazy imports
  - `CPUBackend`: NumPy fallback that's always available
- Adds `detect_backends()` for hardware detection in priority order
- Adds `get_backend()` factory function for automatic or manual backend selection
- Includes comprehensive test suite (40 tests)

Closes #1023

## Test plan

- [x] All 40 unit tests pass
- [x] `get_backend()` returns working backend on Mac (CPU in this case, Metal requires MLX)
- [x] `get_backend(BackendType.CPU)` always works regardless of GPU availability
- [x] All backends implement the same `ArrayBackend` protocol
- [x] Graceful error messages when preferred backend unavailable
- [x] No hard dependencies on GPU packages (lazy imports verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)