### PR TITLE
fix(cli): Correct --grid argument type handling in route command

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -73,8 +73,8 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--strategy", args.strategy])
     if args.skip_nets:
         sub_argv.extend(["--skip-nets", args.skip_nets])
-    if args.grid != "0.25":
-        sub_argv.extend(["--grid", args.grid])
+    if args.grid != 0.25:
+        sub_argv.extend(["--grid", str(args.grid)])
     if args.trace_width != 0.2:
         sub_argv.extend(["--trace-width", str(args.trace_width)])
     if args.clearance != 0.15:


### PR DESCRIPTION
## Summary

- Fix TypeError when running `kicad-tools route` command due to `--grid` argument type mismatch
- Change float-to-string comparison (`args.grid != "0.25"`) to float-to-float comparison (`args.grid != 0.25`)
- Convert float value to string when appending to sub_argv (`str(args.grid)`)

Closes #1043

## Test plan

- [ ] Run `kicad-tools route board.kicad_pcb --layers 4` without --grid flag (uses default 0.25)
- [ ] Run `kicad-tools route board.kicad_pcb --layers 4 --grid 0.5` with custom grid value
- [ ] Verify no TypeError is raised in either case

## Root Cause

In `cli/commands/routing.py`, the `--grid` argument (defined as `type=float` in the parser) was:
1. Compared to a string `"0.25"` instead of the float `0.25` - this comparison was always True
2. Passed as a float to `sub_argv.extend()` instead of being converted to a string

When the downstream `route_cmd.py` parsed this argv list, argparse failed because it expected strings but received a float.

---

Generated with [Claude Code](https://claude.com/claude-code)