### PR TITLE
fix(router): Remove semicolon comment from merge_routes_into_pcb output

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1593,7 +1593,6 @@ def merge_routes_into_pcb(
 
     # Insert routes and close the file
     result = content + "\n\n"
-    result += "  ; Autorouted traces\n"
     result += f"  {route_sexp}\n"
     result += ")\n"
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -3588,15 +3588,6 @@ class TestMergeRoutesIntoPcb:
         # Route should be before final paren
         assert result.index("segment") < result.rfind(")")
 
-    def test_adds_autorouted_comment(self):
-        """Test that autorouted comment is added."""
-        pcb_content = "(kicad_pcb\n)"
-        route_sexp = "(segment (start 0 0) (end 10 10) (width 0.2))"
-
-        result = merge_routes_into_pcb(pcb_content, route_sexp)
-
-        assert "; Autorouted traces" in result
-
     def test_handles_trailing_whitespace(self):
         """Test handling of trailing whitespace in PCB content."""
         pcb_content = "(kicad_pcb\n)   \n\n"


### PR DESCRIPTION
## Summary
- Remove `;  Autorouted traces` comment line from `merge_routes_into_pcb()` output that was causing KiCad parse errors
- Remove corresponding test that validated the comment was present
- All routed PCBs will now open correctly in KiCad

## Root Cause
KiCad's S-expression parser does not support semicolon comments at the element level in `.kicad_pcb` files. The comment was inserted before the autorouted segments, causing KiCad to fail with "Expecting '(' in '...', line N, offset 3" error.

## Test plan
- [x] Ran `pytest tests/test_router.py` - all 274 tests pass
- [ ] Manually test opening a routed PCB in KiCad

Closes #1049

🤖 Generated with [Claude Code](https://claude.com/claude-code)