### PR TITLE
docs(router): Clarify merge_routes_into_pcb expects to_sexp() string output

### DIFF
--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -3635,6 +3635,29 @@ class TestMergeRoutesIntoPcb:
         assert "(net_settings" not in result
         assert "(net_class" not in result
 
+    def test_raises_typeerror_for_autorouter_object(self):
+        """Test that passing an Autorouter object raises TypeError with helpful message.
+
+        Issue #1046: Users may incorrectly pass the Autorouter object directly
+        instead of calling router.to_sexp() first.
+        """
+        pcb_content = "(kicad_pcb\n)"
+
+        # Create a mock object with to_sexp method to simulate Autorouter
+        class MockAutorouter:
+            def to_sexp(self) -> str:
+                return "(segment (start 0 0) (end 10 10) (width 0.2))"
+
+        mock_router = MockAutorouter()
+
+        with pytest.raises(TypeError) as exc_info:
+            merge_routes_into_pcb(pcb_content, mock_router)  # type: ignore[arg-type]
+
+        # Check that error message is helpful
+        error_msg = str(exc_info.value)
+        assert "to_sexp()" in error_msg
+        assert "router.to_sexp()" in error_msg or "S-expression string" in error_msg
+
 
 class TestKicad7Compatibility:
     """Integration tests for KiCad 7+ compatibility (Issue #45)."""


### PR DESCRIPTION
## Summary

- Updated docstring for `merge_routes_into_pcb()` to clearly document that `route_sexp` must be a string from `Autorouter.to_sexp()`, not the Autorouter object itself
- Added runtime type validation that raises `TypeError` with helpful error message when an object with `to_sexp()` method is passed
- Added comprehensive usage examples showing correct and incorrect patterns
- Added test case to verify the TypeError behavior

## Details

The `merge_routes_into_pcb()` function signature was confusing - users naturally assumed they could pass the router object directly. This change:

1. **Type validation with helpful error**: Detects when an Autorouter (or any object with `to_sexp()`) is passed and raises `TypeError` with actionable guidance
2. **Expanded docstring**: Includes full workflow example, "Common mistake" section, and explicit Raises documentation
3. **Test coverage**: New test verifies the error is raised with helpful message

Closes #1046

## Test plan

- [ ] Verify new test `test_raises_typeerror_for_autorouter_object` passes
- [ ] Verify existing `TestMergeRoutesIntoPcb` tests still pass
- [ ] Review docstring renders correctly in IDE/docs


Generated with [Claude Code](https://claude.com/claude-code)