### PR TITLE
fix(api): Prevent silent data loss when modifying PCB.segments/vias

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1403,6 +1403,21 @@ class PCB:
         """All trace segments."""
         return self._segments
 
+    @segments.setter
+    def segments(self, value: list[Segment]) -> None:
+        """Prevent direct assignment to segments.
+
+        Raises:
+            AttributeError: Always raised to prevent silent data loss.
+                Modifying segments directly does not update the S-expression
+                tree used by save(), causing changes to be silently discarded.
+        """
+        raise AttributeError(
+            "Cannot modify segments directly. Changes would not persist to save(). "
+            "Use add_trace() to add segments, or reload the PCB after modifying "
+            "the file with merge_routes_into_pcb()."
+        )
+
     def segments_on_layer(self, layer: str) -> Iterator[Segment]:
         """Get segments on a specific layer."""
         for seg in self._segments:
@@ -1419,6 +1434,21 @@ class PCB:
     def vias(self) -> list[Via]:
         """All vias."""
         return self._vias
+
+    @vias.setter
+    def vias(self, value: list[Via]) -> None:
+        """Prevent direct assignment to vias.
+
+        Raises:
+            AttributeError: Always raised to prevent silent data loss.
+                Modifying vias directly does not update the S-expression
+                tree used by save(), causing changes to be silently discarded.
+        """
+        raise AttributeError(
+            "Cannot modify vias directly. Changes would not persist to save(). "
+            "Use add_via() to add vias, or reload the PCB after modifying "
+            "the file with merge_routes_into_pcb()."
+        )
 
     def vias_in_net(self, net_number: int) -> Iterator[Via]:
         """Get vias in a specific net."""


### PR DESCRIPTION
## Summary
- Add property setters for `segments` and `vias` that raise `AttributeError` on direct assignment
- Error messages guide users to correct APIs: `add_trace()`, `add_via()`, or `merge_routes_into_pcb()`
- Add comprehensive tests for the new property setter behavior

## Root Cause
The `PCB` class has read-only `segments` and `vias` properties that return internal lists. However, modifying these lists (e.g., `pcb.segments = []` or `pcb._segments.clear()`) does not update the S-expression tree that `save()` uses, causing changes to be silently lost.

## Solution
Rather than making the properties read-only (which could break code that iterates over them), this PR adds explicit setters that raise `AttributeError` with helpful guidance. This approach:
1. Fails fast with a clear error when users try direct assignment
2. Preserves backward compatibility for read operations
3. Provides guidance to correct APIs

## Test plan
- [x] New tests verify `AttributeError` is raised on direct assignment
- [x] Tests verify getter operations still work correctly
- [x] Tests verify `add_trace()` and `add_via()` still work correctly
- [x] All new tests pass: `uv run pytest tests/test_pcb.py -k "TestPropertySetterProtection"`

Closes #1047

:robot: Generated with [Claude Code](https://claude.com/claude-code)