### PR TITLE
fix(router): Add missing has_movable_blockers to FailureAnalysis

### DIFF
--- a/src/kicad_tools/router/failure_analysis.py
+++ b/src/kicad_tools/router/failure_analysis.py
@@ -353,6 +353,19 @@ class FailureAnalysis:
     # Actionable suggestions - structured for tooling
     actionable_suggestions: list[ActionableSuggestion] = field(default_factory=list)
 
+    # Net that failed (for strategy generation)
+    net: str | None = None
+
+    @property
+    def has_movable_blockers(self) -> bool:
+        """Check if any blocking elements can be moved."""
+        return any(el.movable for el in self.blocking_elements)
+
+    @property
+    def has_reroutable_nets(self) -> bool:
+        """Check if blocking elements include traces that could be rerouted."""
+        return any(el.type == "trace" and el.net != self.net for el in self.blocking_elements)
+
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
         return {
@@ -381,6 +394,7 @@ class FailureAnalysis:
             ),
             "suggestions": self.suggestions,
             "actionable_suggestions": [s.to_dict() for s in self.actionable_suggestions],
+            "net": self.net,
         }
 
     def format_summary(self, net_name: str) -> str:
@@ -795,6 +809,7 @@ class RootCauseAnalyzer:
             clearance_margin=clearance_margin,
             suggestions=suggestions,
             actionable_suggestions=actionable,
+            net=net,
         )
 
     def _is_near_point(


### PR DESCRIPTION
## Summary
- Adds missing `has_movable_blockers` property to `FailureAnalysis` class in `router/failure_analysis.py`
- Adds missing `has_reroutable_nets` property for strategy generation compatibility
- Adds `net` attribute to track the net that failed routing
- Updates `to_dict()` to include the net field
- Fixes `AttributeError` when using `route_with_placement_feedback()`

## Root Cause
The `FailureAnalysis` class in `router/failure_analysis.py` was missing properties that `recovery/strategy.py` expected. When `route_with_placement_feedback()` called `analyze_routing_failure()` and passed the result to `StrategyGenerator.generate_strategies()`, it failed because the strategy generator checked `failure.has_movable_blockers` which didn't exist on the router's FailureAnalysis.

## Test Plan
- [x] Added tests for `has_movable_blockers` property
- [x] Added tests for `has_reroutable_nets` property  
- [x] Added tests for `net` field
- [x] All 46 failure analysis tests pass
- [x] All 43 recovery tests pass
- [x] All 19 placement feedback tests pass
- [x] All 499 router tests pass

Closes #1044