### PR TITLE
feat(pcb): Add 'pcb strip' command to remove traces while preserving placement

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -1,5 +1,6 @@
 """PCB (pcb) subcommand handlers."""
 
+import json
 import sys
 from pathlib import Path
 
@@ -10,13 +11,17 @@ def run_pcb_command(args) -> int:
     """Handle PCB subcommands."""
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
-        print("Commands: summary, footprints, nets, traces, stackup")
+        print("Commands: summary, footprints, nets, traces, stackup, strip")
         return 1
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
         print(f"Error: File not found: {pcb_path}", file=sys.stderr)
         return 1
+
+    # Handle strip command separately (doesn't use pcb_query)
+    if args.pcb_command == "strip":
+        return _run_strip_command(args, pcb_path)
 
     from ..pcb_query import main as pcb_main
 
@@ -61,3 +66,102 @@ def run_pcb_command(args) -> int:
         return pcb_main(sub_argv) or 0
 
     return 1
+
+
+def _run_strip_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb strip' command."""
+    from kicad_tools.schema.pcb import PCB
+
+    # Parse net names if provided
+    nets = None
+    if args.nets:
+        nets = [n.strip() for n in args.nets.split(",")]
+
+    # Load PCB
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    # Get initial counts for reporting
+    initial_segments = len(pcb.segments)
+    initial_vias = len(pcb.vias)
+    initial_zones = len(pcb.zones)
+
+    # Perform strip operation
+    keep_zones = getattr(args, "keep_zones", True)
+    stats = pcb.strip_traces(nets=nets, keep_zones=keep_zones)
+
+    # Determine output path
+    output_path = pcb_path
+    if args.output:
+        output_path = Path(args.output)
+    elif not args.dry_run:
+        # If no output specified and not dry-run, add -stripped suffix
+        output_path = pcb_path.with_stem(f"{pcb_path.stem}-stripped")
+
+    # Format output
+    output_format = getattr(args, "format", "text")
+    dry_run = getattr(args, "dry_run", False)
+
+    result = {
+        "input": str(pcb_path),
+        "output": str(output_path) if not dry_run else None,
+        "dry_run": dry_run,
+        "nets_filtered": nets,
+        "keep_zones": keep_zones,
+        "before": {
+            "segments": initial_segments,
+            "vias": initial_vias,
+            "zones": initial_zones,
+        },
+        "removed": stats,
+        "after": {
+            "segments": initial_segments - stats["segments"],
+            "vias": initial_vias - stats["vias"],
+            "zones": initial_zones - stats["zones"],
+        },
+    }
+
+    if output_format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        # Text format
+        print(f"PCB Strip {'(dry run)' if dry_run else ''}")
+        print(f"  Input:  {pcb_path}")
+        if not dry_run:
+            print(f"  Output: {output_path}")
+        print()
+
+        if nets:
+            print(f"  Filtering nets: {', '.join(nets)}")
+        else:
+            print("  Stripping all nets")
+        print(f"  Keep zones: {keep_zones}")
+        print()
+
+        print("  Removed:")
+        print(f"    Segments: {stats['segments']:,}")
+        print(f"    Vias:     {stats['vias']:,}")
+        if not keep_zones:
+            print(f"    Zones:    {stats['zones']:,}")
+        print()
+
+        print("  Remaining:")
+        print(f"    Segments: {result['after']['segments']:,}")
+        print(f"    Vias:     {result['after']['vias']:,}")
+        print(f"    Zones:    {result['after']['zones']:,}")
+
+    # Save unless dry-run
+    if not dry_run:
+        try:
+            pcb.save(output_path)
+            if output_format == "text":
+                print()
+                print(f"  Saved to: {output_path}")
+        except Exception as e:
+            print(f"Error saving PCB: {e}", file=sys.stderr)
+            return 1
+
+    return 0

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -570,6 +570,44 @@ def _add_pcb_parser(subparsers) -> None:
     pcb_stackup.add_argument("pcb", help="Path to .kicad_pcb file")
     pcb_stackup.add_argument("--format", choices=["text", "json"], default="text")
 
+    # pcb strip
+    pcb_strip = pcb_subparsers.add_parser(
+        "strip",
+        help="Remove traces while preserving placement",
+        description="Remove trace segments and vias from a PCB while preserving "
+        "component placement, zones, and other board elements. Useful for "
+        "re-routing a board from scratch with different routing strategies.",
+    )
+    pcb_strip.add_argument("pcb", help="Path to .kicad_pcb file")
+    pcb_strip.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        help="Output file path (default: overwrite input or add -stripped suffix)",
+    )
+    pcb_strip.add_argument(
+        "--nets",
+        help="Comma-separated list of net names to strip (default: all nets)",
+    )
+    pcb_strip.add_argument(
+        "--no-keep-zones",
+        dest="keep_zones",
+        action="store_false",
+        default=True,
+        help="Also remove copper pour zones (default: keep zones)",
+    )
+    pcb_strip.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for results",
+    )
+    pcb_strip.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be removed without modifying files",
+    )
+
 
 def _add_lib_parser(subparsers) -> None:
     """Add library subcommand parser with its subcommands."""


### PR DESCRIPTION
## Summary

- Adds `PCB.strip_traces()` method to programmatically remove routing from PCBs while preserving component placement
- Adds `kicad-tools pcb strip` CLI command for command-line workflow
- Supports filtering by specific net names with `--nets` option
- Supports removing zones with `--no-keep-zones` option
- Includes dry-run mode for previewing changes
- Returns statistics on removed elements

## Test plan

- [x] Run `pytest tests/test_pcb.py::TestStripTraces` - all 8 tests pass
- [x] Run `pytest tests/test_cli_pcb.py::TestPcbStrip` - all 7 tests pass
- [ ] Manual test: `kicad-tools pcb strip board.kicad_pcb --dry-run`
- [ ] Manual test: `kicad-tools pcb strip board.kicad_pcb -o board-stripped.kicad_pcb`
- [ ] Verify stripped board opens correctly in KiCad and retains component placement

Closes #1045

:robot: Generated with [Claude Code](https://claude.com/claude-code)