### PR TITLE
fix(stitch): Remove invalid rotation parameter from via at-node format

### DIFF
--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -370,7 +370,7 @@ def via_node(
     layers_node = SExp.list("layers", *layers)
     return SExp.list(
         "via",
-        at(x, y),
+        SExp.list("at", fmt(x), fmt(y)),
         SExp.list("size", fmt(size)),
         SExp.list("drill", fmt(drill)),
         layers_node,

--- a/tests/test_sexp_builders.py
+++ b/tests/test_sexp_builders.py
@@ -519,6 +519,21 @@ class TestViaNode:
         layers_node = node.get("layers")
         assert len(layers_node.children) == 2
 
+    def test_via_node_at_has_no_rotation(self):
+        """Via at node must use (at X Y) without rotation parameter.
+
+        KiCad vias do not support a rotation parameter. Including rotation
+        (e.g., (at X Y 0)) causes KiCad to fail loading the PCB file.
+        See: https://github.com/rjwalters/kicad-tools/issues/1104
+        """
+        node = via_node(162.5, 97.25, 0.6, 0.3, ("F.Cu", "B.Cu"), 12, "via-uuid")
+        at_node = node.get("at")
+        assert at_node is not None
+        # Via (at) must have exactly 2 children: x and y, no rotation
+        assert len(at_node.children) == 2
+        assert at_node.children[0].value == 162.5
+        assert at_node.children[1].value == 97.25
+
 
 class TestZoneNode:
     """Tests for the zone_node() PCB builder."""


### PR DESCRIPTION
## Summary

- Fixes `via_node` builder to emit `(at X Y)` instead of `(at X Y 0)` for PCB vias
- The `at()` helper always includes rotation (correct for schematic elements), but KiCad vias use the simpler format without rotation
- Adds regression tests in both `test_sexp_builders.py` and `test_stitch_cmd.py`

Closes #1104

## Test plan

- [x] `test_via_node_at_has_no_rotation` - verifies via_node builder produces exactly 2 children in at-node (x, y only)
- [x] `test_run_stitch_via_format_no_rotation` - verifies end-to-end that written PCB file contains no rotation in via at-nodes
- [x] All 98 existing builder and stitch tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)