### PR TITLE
feat(router): improve C++ backend discoverability and performance warnings

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2146,9 +2146,11 @@ def main(argv: list[str] | None = None) -> int:
     if not quiet:
         print(f"  Board size: {router.grid.width}mm x {router.grid.height}mm")
         backend_info = router.backend_info
-        print(
-            f"  Backend:    {backend_info['active']} (C++ available: {backend_info['available']})"
-        )
+        grid_cells = router.grid.cols * router.grid.rows * router.grid.num_layers
+        from kicad_tools.router.cpp_backend import format_backend_status
+        backend_status = format_backend_status(backend_info, grid_cells)
+        print(f"  Backend:    {backend_status}")
+        print(f"  Grid:       {router.grid.cols}x{router.grid.rows}x{router.grid.num_layers} = {grid_cells:,} cells")
         print(f"  Total nets: {len(net_map)}")
         print(f"  Nets to route: {nets_to_route} (multi-pad signal nets)")
 


### PR DESCRIPTION
## Summary

Improves discoverability of the existing C++ router backend by providing actionable guidance in CLI output when routing with the slower Python backend.

**Changes:**
- Enhanced `format_backend_status()` function in `cpp_backend.py` that shows context-aware messages
- When C++ backend is active: displays `cpp v1.0.0 (native, 10-100x faster)`
- When C++ backend is missing: displays `Tip: Run 'kct build-native' for 10-100x faster routing`
- When routing large grids (>50K cells) without C++: displays `WARNING` with explicit build instructions
- Route command now shows grid dimensions (cols x rows x layers = N cells) for diagnostics
- Added `build_hint` field to `get_backend_info()` with multi-line build instructions
- 6 new tests covering all status formatting scenarios

**Before:**
```
Backend:    python (C++ available: False)
```

**After (small grid):**
```
Backend:    python (pure Python) | C++ backend not installed | Tip: Run 'kct build-native' for 10-100x faster routing
Grid:       100x100x2 = 20,000 cells
```

**After (large grid):**
```
Backend:    python (pure Python) | C++ backend not installed | WARNING: Routing 150,000 grid cells with Python backend will be slow. Build C++ backend for 10-100x speedup: kct build-native
Grid:       500x300x1 = 150,000 cells
```

**After (C++ available):**
```
Backend:    cpp v1.0.0 (native, 10-100x faster)
Grid:       500x300x1 = 150,000 cells
```

Closes #1112

## Test plan

- [x] All 377 existing tests pass
- [x] 6 new tests for `format_backend_status()` covering:
  - C++ active: shows "native" label and version
  - Python active, small grid: shows "Tip" not "WARNING"  
  - Python active, large grid: shows "WARNING" with build instructions
  - Zero grid cells: shows tip (default behavior)
  - Threshold constant validation
  - Build hint presence in backend info when unavailable