### PR TITLE
feat(router): Add hierarchical routing foundation with global router (#1095)

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -205,6 +205,8 @@ from .rules import (
     ZoneRules,
     create_net_class_map,
 )
+from .global_router import CorridorAssignment, GlobalRouter, GlobalRoutingResult
+from .region_graph import Region, RegionEdge, RegionGraph
 from .sparse import SparseRouter, SparseRoutingGraph, Waypoint
 from .tuning import (
     COST_PROFILES,
@@ -267,6 +269,13 @@ __all__ = [
     "SparseRouter",
     "SparseRoutingGraph",
     "Waypoint",
+    # Hierarchical routing (Issue #1095)
+    "RegionGraph",
+    "Region",
+    "RegionEdge",
+    "GlobalRouter",
+    "GlobalRoutingResult",
+    "CorridorAssignment",
     # Parallel routing
     "ParallelRouter",
     "ParallelRoutingResult",

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -61,6 +61,8 @@ from .rules import (
     NetClassRouting,
     assign_layer_preferences,
 )
+from .global_router import CorridorAssignment, GlobalRouter, GlobalRoutingResult
+from .region_graph import RegionGraph
 from .sparse import Corridor, SparseRouter, Waypoint
 from .tuning import (
     COST_PROFILES,
@@ -2657,6 +2659,334 @@ class Autorouter:
         routes.extend(new_routes)
         return routes
 
+    # =========================================================================
+    # HIERARCHICAL ROUTING (Issue #1095 - Phase A)
+    # =========================================================================
+
+    def route_all_hierarchical(
+        self,
+        num_cols: int = 10,
+        num_rows: int = 10,
+        corridor_width_factor: float = 2.0,
+        use_negotiated: bool = True,
+        progress_callback: ProgressCallback | None = None,
+        timeout: float | None = None,
+    ) -> list[Route]:
+        """Route all nets using hierarchical global-to-detailed flow.
+
+        This strategy uses a RegionGraph to plan coarse routing corridors
+        for each net before performing detailed routing. The flow is:
+
+        1. Build a RegionGraph partitioning the board into regions
+        2. Use GlobalRouter to assign each net a corridor (sequence of regions)
+        3. Convert corridors to grid-level preferences
+        4. Run detailed routing (standard or negotiated) with corridor guidance
+        5. Fallback: nets that fail global routing are routed without corridors
+
+        This approach provides better resource allocation than direct routing
+        because nets are guided into non-overlapping channels, reducing
+        contention during detailed routing.
+
+        Args:
+            num_cols: Number of region columns for the RegionGraph (default: 10)
+            num_rows: Number of region rows for the RegionGraph (default: 10)
+            corridor_width_factor: Corridor width as multiple of clearance
+                (default: 2.0). The actual corridor half-width is
+                corridor_width_factor * trace_clearance.
+            use_negotiated: Use negotiated congestion routing in detailed
+                phase (default: True)
+            progress_callback: Optional callback for progress updates.
+                Signature: callback(progress: float, message: str, active: bool) -> bool
+            timeout: Optional timeout in seconds for the entire operation
+
+        Returns:
+            List of Route objects (may be partial if timeout reached)
+        """
+        import time
+
+        start_time = time.time()
+
+        flush_print("\n=== Hierarchical Routing (Global + Detailed) ===")
+
+        # Get nets to route in priority order
+        net_order = sorted(self.nets.keys(), key=lambda n: self._get_net_priority(n))
+        net_order = [n for n in net_order if n != 0]
+        total_nets = len(net_order)
+
+        if total_nets == 0:
+            flush_print("  No nets to route")
+            return []
+
+        def check_timeout() -> bool:
+            if timeout is None:
+                return False
+            return time.time() - start_time >= timeout
+
+        def elapsed_str() -> str:
+            return f"{time.time() - start_time:.1f}s"
+
+        # =================================================================
+        # Phase 1: Build RegionGraph and run GlobalRouter
+        # =================================================================
+        flush_print("\n--- Phase 1: Global Routing via RegionGraph ---")
+        if progress_callback is not None:
+            if not progress_callback(0.0, "Phase 1: Building region graph", True):
+                return list(self.routes)
+
+        corridor_width = corridor_width_factor * self.rules.trace_clearance
+
+        # Build region graph
+        region_graph = RegionGraph(
+            board_width=self.grid.width,
+            board_height=self.grid.height,
+            origin_x=self.grid.origin_x,
+            origin_y=self.grid.origin_y,
+            num_cols=num_cols,
+            num_rows=num_rows,
+        )
+
+        # Register obstacles (pads reduce region capacity)
+        all_pads = list(self.pads.values())
+        region_graph.register_obstacles(all_pads)
+
+        rg_stats = region_graph.get_statistics()
+        flush_print(
+            f"  Region graph: {rg_stats['num_regions']} regions "
+            f"({rg_stats['num_rows']}x{rg_stats['num_cols']}), "
+            f"{rg_stats['num_edges']} edges, "
+            f"{rg_stats['regions_with_obstacles']} regions with obstacles"
+        )
+
+        # Run global router
+        global_router = GlobalRouter(
+            region_graph=region_graph,
+            corridor_width=corridor_width,
+            default_layer=0,
+        )
+
+        if progress_callback is not None:
+            if not progress_callback(0.05, "Phase 1: Assigning corridors", True):
+                return list(self.routes)
+
+        global_result = global_router.route_all(
+            nets=self.nets,
+            pad_dict=self.pads,
+            net_order=net_order,
+        )
+
+        flush_print(
+            f"  Global routing: {len(global_result.assignments)}/{total_nets} "
+            f"nets assigned corridors ({elapsed_str()})"
+        )
+        if global_result.failed_nets:
+            flush_print(
+                f"  Warning: {len(global_result.failed_nets)} nets failed "
+                f"global routing (will attempt without corridors)"
+            )
+
+        # =================================================================
+        # Phase 2: Detailed Routing with Corridor Guidance
+        # =================================================================
+        flush_print("\n--- Phase 2: Detailed Routing with Corridors ---")
+        if progress_callback is not None:
+            if not progress_callback(0.2, "Phase 2: Detailed routing", True):
+                return list(self.routes)
+
+        # Set corridor preferences on the grid for nets with assignments
+        corridor_penalty = 5.0
+        for net, assignment in global_result.assignments.items():
+            self.grid.set_corridor_preference(
+                assignment.corridor, net, corridor_penalty
+            )
+
+        # Route all nets (corridor-assigned nets get guidance, others route freely)
+        if use_negotiated:
+            detailed_routes = self._route_hierarchical_detailed_negotiated(
+                net_order=net_order,
+                progress_callback=progress_callback,
+                timeout=timeout,
+                start_time=start_time,
+            )
+        else:
+            detailed_routes = self._route_hierarchical_detailed_standard(
+                net_order=net_order,
+                progress_callback=progress_callback,
+                timeout=timeout,
+                start_time=start_time,
+            )
+
+        # Clear corridor preferences
+        self.grid.clear_all_corridor_preferences()
+
+        # Summary
+        successful_nets = len({r.net for r in detailed_routes})
+        total_elapsed = time.time() - start_time
+        flush_print("\n=== Hierarchical Routing Complete ===")
+        flush_print(f"  Total nets: {total_nets}")
+        flush_print(
+            f"  Global routing: {len(global_result.assignments)} corridors assigned"
+        )
+        flush_print(f"  Detailed routing: {successful_nets} nets routed")
+        flush_print(f"  Total time: {total_elapsed:.1f}s")
+
+        if self.routing_failures:
+            failure_summary = format_failed_nets_summary(self.routing_failures)
+            if failure_summary:
+                print(failure_summary)
+
+        if progress_callback is not None:
+            progress_callback(
+                1.0,
+                f"Complete: {successful_nets}/{total_nets} nets in {total_elapsed:.1f}s",
+                False,
+            )
+
+        return detailed_routes
+
+    def _route_hierarchical_detailed_negotiated(
+        self,
+        net_order: list[int],
+        progress_callback: ProgressCallback | None,
+        timeout: float | None,
+        start_time: float,
+    ) -> list[Route]:
+        """Detailed phase of hierarchical routing using negotiated congestion.
+
+        Uses the same negotiated routing infrastructure as two-phase routing
+        but with corridor preferences set by the hierarchical global router.
+        """
+        import time
+
+        def check_timeout() -> bool:
+            if timeout is None:
+                return False
+            return time.time() - start_time >= timeout
+
+        total_nets = len(net_order)
+
+        neg_router = NegotiatedRouter(self.grid, self.router, self.rules, self.net_class_map)
+        net_routes: dict[int, list[Route]] = {}
+        present_factor = 0.5
+
+        # Initial routing pass
+        for i, net in enumerate(net_order):
+            if check_timeout():
+                flush_print(
+                    f"  Timeout during detailed routing at net {i}/{total_nets}"
+                )
+                break
+
+            if progress_callback is not None:
+                progress = 0.2 + 0.6 * (i / total_nets)
+                net_name = self.net_names.get(net, f"Net {net}")
+                if not progress_callback(progress, f"Routing {net_name}", True):
+                    break
+
+            routes = self._route_net_with_corridor(net, present_factor)
+            if routes:
+                net_routes[net] = routes
+                for route in routes:
+                    self.grid.mark_route_usage(route)
+                    self.routes.append(route)
+
+        overflow = self.grid.get_total_overflow()
+        flush_print(
+            f"  Initial pass: {len(net_routes)}/{total_nets} nets, overflow: {overflow}"
+        )
+
+        # Rip-up and reroute if overflow remains
+        if overflow > 0:
+            max_iterations = 10
+            history_increment = 1.0
+            present_factor_increment = 0.5
+
+            for iteration in range(1, max_iterations + 1):
+                if check_timeout():
+                    flush_print(f"  Timeout at iteration {iteration}")
+                    break
+
+                if progress_callback is not None:
+                    progress = 0.8 + 0.15 * (iteration / max_iterations)
+                    if not progress_callback(
+                        progress, f"Iteration {iteration}/{max_iterations}", True
+                    ):
+                        break
+
+                present_factor += present_factor_increment
+                self.grid.update_history_costs(history_increment)
+
+                overused = self.grid.find_overused_cells()
+                nets_to_reroute = neg_router.find_nets_through_overused_cells(
+                    net_routes, overused
+                )
+                flush_print(
+                    f"  Iteration {iteration}: ripping up {len(nets_to_reroute)} nets"
+                )
+
+                neg_router.rip_up_nets(nets_to_reroute, net_routes, self.routes)
+
+                for net in nets_to_reroute:
+                    if check_timeout():
+                        break
+                    routes = self._route_net_with_corridor(net, present_factor)
+                    if routes:
+                        net_routes[net] = routes
+                        for route in routes:
+                            self.grid.mark_route_usage(route)
+                            self.routes.append(route)
+
+                new_overflow = self.grid.get_total_overflow()
+                if new_overflow == 0:
+                    flush_print(f"  Overflow resolved at iteration {iteration}")
+                    break
+                overflow = new_overflow
+
+        # Collect all routes
+        all_routes: list[Route] = []
+        for routes in net_routes.values():
+            all_routes.extend(routes)
+
+        return all_routes
+
+    def _route_hierarchical_detailed_standard(
+        self,
+        net_order: list[int],
+        progress_callback: ProgressCallback | None,
+        timeout: float | None,
+        start_time: float,
+    ) -> list[Route]:
+        """Detailed phase of hierarchical routing using standard sequential routing.
+
+        Routes each net sequentially with corridor guidance. This is simpler
+        than negotiated routing and works well when the global routing provides
+        good corridor assignments.
+        """
+        import time
+
+        def check_timeout() -> bool:
+            if timeout is None:
+                return False
+            return time.time() - start_time >= timeout
+
+        total_nets = len(net_order)
+        all_routes: list[Route] = []
+
+        for i, net in enumerate(net_order):
+            if check_timeout():
+                flush_print(f"  Timeout at net {i}/{total_nets}")
+                break
+
+            if progress_callback is not None:
+                progress = 0.2 + 0.7 * (i / total_nets)
+                net_name = self.net_names.get(net, f"Net {net}")
+                if not progress_callback(progress, f"Routing {net_name}", True):
+                    break
+
+            routes = self.route_net(net)
+            all_routes.extend(routes)
+
+        return all_routes
+
     def _reset_for_new_trial(self):
         """Reset the router to initial state for a new trial."""
         width, height = self.grid.width, self.grid.height
@@ -2933,6 +3263,7 @@ class Autorouter:
         monte_carlo_trials: int = 0,
         use_negotiated: bool = False,
         use_two_phase: bool = False,
+        use_hierarchical: bool = False,
         progress_callback: ProgressCallback | None = None,
     ) -> list[Route]:
         """Unified entry point for advanced routing strategies.
@@ -2941,17 +3272,24 @@ class Autorouter:
             monte_carlo_trials: Number of Monte Carlo trials (0 = disabled)
             use_negotiated: Use negotiated congestion routing
             use_two_phase: Use two-phase global+detailed routing
+            use_hierarchical: Use hierarchical global-to-detailed routing
+                (Issue #1095). This builds a RegionGraph for coarse-grid
+                corridor assignment before detailed routing.
             progress_callback: Optional callback for progress updates
 
         Returns:
             List of routes
 
         Note:
-            Priority order: monte_carlo > two_phase > negotiated > standard
+            Priority order: monte_carlo > hierarchical > two_phase > negotiated > standard
         """
         if monte_carlo_trials > 0:
             return self.route_all_monte_carlo(
                 monte_carlo_trials, use_negotiated, progress_callback=progress_callback
+            )
+        elif use_hierarchical:
+            return self.route_all_hierarchical(
+                use_negotiated=use_negotiated, progress_callback=progress_callback
             )
         elif use_two_phase:
             return self.route_all_two_phase(

--- a/src/kicad_tools/router/global_router.py
+++ b/src/kicad_tools/router/global_router.py
@@ -1,0 +1,306 @@
+"""
+Global router for hierarchical routing.
+
+This module provides the GlobalRouter class that assigns nets to routing
+corridors using the RegionGraph abstraction. The global router operates
+at a coarse granularity, planning approximate paths through board regions
+before detailed routing fills in exact trace geometry.
+
+The global router builds on the existing Corridor class from sparse.py,
+converting region-level paths into corridor assignments that guide the
+detailed router.
+
+Phase A of hierarchical routing (Issue #1095).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .primitives import Pad
+
+from .region_graph import RegionGraph
+from .sparse import Corridor, Waypoint
+
+
+@dataclass
+class CorridorAssignment:
+    """Assignment of a net to a routing corridor via the global router.
+
+    Attributes:
+        net: Net ID
+        region_path: Sequence of region IDs the net traverses
+        corridor: The Corridor object for detailed routing guidance
+        waypoint_coords: Waypoint coordinates along the corridor centerline
+    """
+
+    net: int
+    region_path: list[int]
+    corridor: Corridor
+    waypoint_coords: list[tuple[float, float]] = field(default_factory=list)
+
+
+@dataclass
+class GlobalRoutingResult:
+    """Result of global routing for all nets.
+
+    Attributes:
+        assignments: Dictionary mapping net ID to CorridorAssignment
+        failed_nets: List of net IDs that could not be globally routed
+        region_graph: The RegionGraph used for planning
+    """
+
+    assignments: dict[int, CorridorAssignment] = field(default_factory=dict)
+    failed_nets: list[int] = field(default_factory=list)
+    region_graph: RegionGraph | None = None
+
+
+class GlobalRouter:
+    """Assigns nets to routing corridors using coarse-grid path planning.
+
+    The GlobalRouter takes a RegionGraph and a set of nets (with their pad
+    positions) and produces a corridor assignment for each net. These corridors
+    guide the detailed router to stay within planned routing channels, reducing
+    congestion and improving routability.
+
+    The router processes nets in the provided order, updating region/edge
+    utilization after each assignment so that later nets route around earlier
+    ones. This sequential greedy approach is simple and effective for Phase A;
+    min-cost flow optimization can be added in future phases.
+
+    Usage:
+        region_graph = RegionGraph(board_width=65, board_height=56)
+        region_graph.register_obstacles(all_pads)
+        global_router = GlobalRouter(
+            region_graph=region_graph,
+            corridor_width=0.5,
+        )
+        result = global_router.route_all(nets, pads)
+
+    Args:
+        region_graph: The coarse-grid board representation
+        corridor_width: Half-width of corridors in mm (default: 2x clearance)
+        default_layer: Default routing layer index (default: 0)
+    """
+
+    def __init__(
+        self,
+        region_graph: RegionGraph,
+        corridor_width: float = 0.5,
+        default_layer: int = 0,
+    ):
+        self.region_graph = region_graph
+        self.corridor_width = corridor_width
+        self.default_layer = default_layer
+
+    def route_net(
+        self,
+        net: int,
+        pad_positions: list[tuple[float, float]],
+    ) -> CorridorAssignment | None:
+        """Assign a corridor for a single net.
+
+        Finds the source and target regions from pad positions, routes
+        through the region graph, and constructs a Corridor from the
+        resulting path.
+
+        For multi-pad nets, routes between the two most distant pads.
+        The corridor will cover intermediate pads as well.
+
+        Args:
+            net: Net ID
+            pad_positions: List of (x, y) coordinates for the net's pads
+
+        Returns:
+            CorridorAssignment if successful, None if routing fails
+        """
+        if len(pad_positions) < 2:
+            return None
+
+        # Find source and target regions
+        # For multi-pad nets, pick the two most distant pads to define
+        # the corridor spanning the full extent of the net.
+        src_pos, tgt_pos = self._pick_endpoints(pad_positions)
+
+        src_region = self.region_graph.get_region_at(src_pos[0], src_pos[1])
+        tgt_region = self.region_graph.get_region_at(tgt_pos[0], tgt_pos[1])
+
+        if src_region is None or tgt_region is None:
+            return None
+
+        # Find path through region graph
+        region_path = self.region_graph.find_path(src_region.id, tgt_region.id)
+        if region_path is None:
+            return None
+
+        # Update utilization
+        self.region_graph.update_utilization(region_path)
+
+        # Convert region path to waypoints
+        waypoint_coords = self._build_waypoint_coords(
+            region_path, src_pos, tgt_pos
+        )
+
+        # Build Corridor from waypoints
+        waypoints = [
+            Waypoint(x=x, y=y, layer=self.default_layer, waypoint_type="global")
+            for x, y in waypoint_coords
+        ]
+
+        corridor = Corridor.from_waypoints(
+            waypoints=waypoints,
+            net=net,
+            width=self.corridor_width,
+        )
+
+        return CorridorAssignment(
+            net=net,
+            region_path=region_path,
+            corridor=corridor,
+            waypoint_coords=waypoint_coords,
+        )
+
+    def route_all(
+        self,
+        nets: dict[int, list[tuple[str, str]]],
+        pad_dict: dict[tuple[str, str], Pad],
+        net_order: list[int] | None = None,
+    ) -> GlobalRoutingResult:
+        """Assign corridors for all nets.
+
+        Processes nets in order, updating utilization after each assignment
+        so later nets avoid congested regions. Nets that cannot be globally
+        routed are recorded as failures but do not block other nets.
+
+        Args:
+            nets: Dictionary mapping net ID to list of (ref, pin) tuples
+            pad_dict: Dictionary mapping (ref, pin) to Pad objects
+            net_order: Optional ordering of net IDs (default: sorted by ID)
+
+        Returns:
+            GlobalRoutingResult with corridor assignments and failures
+        """
+        result = GlobalRoutingResult(region_graph=self.region_graph)
+
+        if net_order is None:
+            net_order = sorted(n for n in nets.keys() if n != 0)
+        else:
+            net_order = [n for n in net_order if n != 0]
+
+        for net in net_order:
+            if net not in nets:
+                continue
+
+            pad_keys = nets[net]
+            if len(pad_keys) < 2:
+                continue
+
+            # Collect pad positions
+            pad_positions: list[tuple[float, float]] = []
+            for key in pad_keys:
+                pad = pad_dict.get(key)
+                if pad is not None:
+                    pad_positions.append((pad.x, pad.y))
+
+            if len(pad_positions) < 2:
+                continue
+
+            assignment = self.route_net(net, pad_positions)
+            if assignment is not None:
+                result.assignments[net] = assignment
+            else:
+                result.failed_nets.append(net)
+
+        return result
+
+    def _pick_endpoints(
+        self,
+        pad_positions: list[tuple[float, float]],
+    ) -> tuple[tuple[float, float], tuple[float, float]]:
+        """Pick the two most distant pads as corridor endpoints.
+
+        For 2-pad nets this is trivial. For multi-pad nets, using the
+        most distant pair ensures the corridor spans the full net extent.
+
+        Args:
+            pad_positions: List of (x, y) pad coordinates
+
+        Returns:
+            Tuple of (source_pos, target_pos)
+        """
+        if len(pad_positions) == 2:
+            return pad_positions[0], pad_positions[1]
+
+        # Find the two most distant pads (diameter of the point set)
+        max_dist = -1.0
+        best_pair = (pad_positions[0], pad_positions[1])
+
+        for i, p1 in enumerate(pad_positions):
+            for p2 in pad_positions[i + 1 :]:
+                dx = p1[0] - p2[0]
+                dy = p1[1] - p2[1]
+                dist = dx * dx + dy * dy  # Skip sqrt for comparison
+                if dist > max_dist:
+                    max_dist = dist
+                    best_pair = (p1, p2)
+
+        return best_pair
+
+    def _build_waypoint_coords(
+        self,
+        region_path: list[int],
+        src_pos: tuple[float, float],
+        tgt_pos: tuple[float, float],
+    ) -> list[tuple[float, float]]:
+        """Build waypoint coordinates from a region path.
+
+        The waypoints start at the source pad position, pass through
+        region centers, and end at the target pad position. This gives
+        the corridor a smooth centerline anchored to the actual pads.
+
+        Args:
+            region_path: List of region IDs
+            src_pos: Source pad (x, y) position
+            tgt_pos: Target pad (x, y) position
+
+        Returns:
+            List of (x, y) waypoint coordinates
+        """
+        coords: list[tuple[float, float]] = []
+
+        # Start at source pad
+        coords.append(src_pos)
+
+        # Add region centers (skip first/last if they're close to pad positions)
+        region_centers = self.region_graph.path_to_waypoint_coords(region_path)
+        for center in region_centers:
+            # Skip if too close to source or target (within half a region width)
+            min_dim = min(
+                self.region_graph.board_width / self.region_graph.num_cols,
+                self.region_graph.board_height / self.region_graph.num_rows,
+            ) / 2.0
+            dx_src = center[0] - src_pos[0]
+            dy_src = center[1] - src_pos[1]
+            dx_tgt = center[0] - tgt_pos[0]
+            dy_tgt = center[1] - tgt_pos[1]
+
+            dist_src = (dx_src * dx_src + dy_src * dy_src) ** 0.5
+            dist_tgt = (dx_tgt * dx_tgt + dy_tgt * dy_tgt) ** 0.5
+
+            if dist_src > min_dim and dist_tgt > min_dim:
+                coords.append(center)
+
+        # End at target pad
+        coords.append(tgt_pos)
+
+        return coords
+
+    def get_statistics(self) -> dict:
+        """Get global routing statistics.
+
+        Returns:
+            Dictionary with routing statistics
+        """
+        return self.region_graph.get_statistics()

--- a/src/kicad_tools/router/region_graph.py
+++ b/src/kicad_tools/router/region_graph.py
@@ -1,0 +1,516 @@
+"""
+Region graph abstraction for hierarchical routing.
+
+This module provides a coarse-grid representation of the board for global
+routing. The board is partitioned into rectangular regions, and a graph
+is constructed where edges represent routing capacity between adjacent
+regions.
+
+The RegionGraph enables global path planning at a much coarser granularity
+than the detailed routing grid, allowing the GlobalRouter to quickly assign
+corridors (sequences of regions) to each net before detailed routing begins.
+
+Phase A of hierarchical routing (Issue #1095).
+"""
+
+from __future__ import annotations
+
+import heapq
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .primitives import Pad
+
+
+@dataclass
+class Region:
+    """A rectangular region on the board for global routing.
+
+    Each region represents a coarse-grid area. Regions track their
+    spatial bounds, routing capacity, and current utilization.
+
+    Attributes:
+        id: Unique region identifier
+        row: Row index in the region grid
+        col: Column index in the region grid
+        min_x: Minimum X coordinate (mm)
+        min_y: Minimum Y coordinate (mm)
+        max_x: Maximum X coordinate (mm)
+        max_y: Maximum Y coordinate (mm)
+        capacity: Maximum number of nets that can traverse this region
+        utilization: Current number of nets using this region
+        obstacle_count: Number of obstacles (pads, keepouts) in this region
+    """
+
+    id: int
+    row: int
+    col: int
+    min_x: float
+    min_y: float
+    max_x: float
+    max_y: float
+    capacity: int = 10
+    utilization: int = 0
+    obstacle_count: int = 0
+
+    @property
+    def center_x(self) -> float:
+        """X coordinate of the region center."""
+        return (self.min_x + self.max_x) / 2.0
+
+    @property
+    def center_y(self) -> float:
+        """Y coordinate of the region center."""
+        return (self.min_y + self.max_y) / 2.0
+
+    @property
+    def width(self) -> float:
+        """Width of the region in mm."""
+        return self.max_x - self.min_x
+
+    @property
+    def height(self) -> float:
+        """Height of the region in mm."""
+        return self.max_y - self.min_y
+
+    def contains_point(self, x: float, y: float) -> bool:
+        """Check if a point falls within this region.
+
+        Args:
+            x: X coordinate in mm
+            y: Y coordinate in mm
+
+        Returns:
+            True if the point is inside this region
+        """
+        return self.min_x <= x <= self.max_x and self.min_y <= y <= self.max_y
+
+    @property
+    def remaining_capacity(self) -> int:
+        """Available routing capacity (capacity minus utilization)."""
+        return max(0, self.capacity - self.utilization)
+
+
+@dataclass
+class RegionEdge:
+    """An edge between two adjacent regions in the region graph.
+
+    Attributes:
+        source: Source region ID
+        target: Target region ID
+        capacity: Maximum number of nets that can cross this boundary
+        utilization: Current number of nets crossing this boundary
+        distance: Euclidean distance between region centers (mm)
+    """
+
+    source: int
+    target: int
+    capacity: int = 10
+    utilization: int = 0
+    distance: float = 0.0
+
+    @property
+    def remaining_capacity(self) -> int:
+        """Available crossing capacity."""
+        return max(0, self.capacity - self.utilization)
+
+    @property
+    def congestion_cost(self) -> float:
+        """Cost multiplier based on congestion level.
+
+        Returns higher cost as the edge approaches full utilization,
+        discouraging global paths through congested boundaries.
+
+        Returns:
+            Cost multiplier (1.0 = uncongested, increases with utilization)
+        """
+        if self.capacity <= 0:
+            return 100.0
+        ratio = self.utilization / self.capacity
+        if ratio >= 1.0:
+            return 10.0
+        return 1.0 + 4.0 * ratio * ratio
+
+
+@dataclass
+class _GlobalSearchNode:
+    """Node for A* search on the region graph."""
+
+    f_score: float
+    g_score: float = field(compare=False)
+    region_id: int = field(compare=False)
+    parent: _GlobalSearchNode | None = field(compare=False, default=None)
+
+    def __lt__(self, other: _GlobalSearchNode) -> bool:
+        return self.f_score < other.f_score
+
+
+class RegionGraph:
+    """Coarse-grid board representation for global routing.
+
+    Partitions the board into a grid of rectangular regions and builds
+    a graph of adjacency relationships. This enables fast global path
+    planning using Dijkstra/A* on the region graph rather than the
+    detailed routing grid.
+
+    The region graph is constructed once from board dimensions and
+    component positions, then reused for all nets during global routing.
+
+    Usage:
+        graph = RegionGraph(
+            board_width=65.0,
+            board_height=56.0,
+            origin_x=0.0,
+            origin_y=0.0,
+            num_cols=10,
+            num_rows=10,
+        )
+        graph.register_obstacles(pads)
+        path = graph.find_path(source_region_id, target_region_id)
+
+    Args:
+        board_width: Board width in mm
+        board_height: Board height in mm
+        origin_x: Board origin X coordinate in mm
+        origin_y: Board origin Y coordinate in mm
+        num_cols: Number of region columns (default: 10)
+        num_rows: Number of region rows (default: 10)
+        base_capacity: Base routing capacity per region (default: 10)
+    """
+
+    def __init__(
+        self,
+        board_width: float,
+        board_height: float,
+        origin_x: float = 0.0,
+        origin_y: float = 0.0,
+        num_cols: int = 10,
+        num_rows: int = 10,
+        base_capacity: int = 10,
+    ):
+        self.board_width = board_width
+        self.board_height = board_height
+        self.origin_x = origin_x
+        self.origin_y = origin_y
+        self.num_cols = max(1, num_cols)
+        self.num_rows = max(1, num_rows)
+        self.base_capacity = base_capacity
+
+        # Build regions
+        self.regions: dict[int, Region] = {}
+        self._region_grid: list[list[int]] = []  # [row][col] -> region_id
+        self._build_regions()
+
+        # Build edges between adjacent regions
+        self.edges: dict[int, list[RegionEdge]] = {}
+        self._build_edges()
+
+    def _build_regions(self) -> None:
+        """Construct the grid of regions covering the board area."""
+        region_width = self.board_width / self.num_cols
+        region_height = self.board_height / self.num_rows
+        region_id = 0
+
+        self._region_grid = []
+        for row in range(self.num_rows):
+            row_ids: list[int] = []
+            for col in range(self.num_cols):
+                min_x = self.origin_x + col * region_width
+                min_y = self.origin_y + row * region_height
+                max_x = min_x + region_width
+                max_y = min_y + region_height
+
+                region = Region(
+                    id=region_id,
+                    row=row,
+                    col=col,
+                    min_x=min_x,
+                    min_y=min_y,
+                    max_x=max_x,
+                    max_y=max_y,
+                    capacity=self.base_capacity,
+                )
+                self.regions[region_id] = region
+                row_ids.append(region_id)
+                region_id += 1
+
+            self._region_grid.append(row_ids)
+
+    def _build_edges(self) -> None:
+        """Build edges between adjacent regions (4-connected: up/down/left/right)."""
+        for region in self.regions.values():
+            self.edges[region.id] = []
+
+        for row in range(self.num_rows):
+            for col in range(self.num_cols):
+                region_id = self._region_grid[row][col]
+                region = self.regions[region_id]
+
+                # Right neighbor
+                if col + 1 < self.num_cols:
+                    neighbor_id = self._region_grid[row][col + 1]
+                    neighbor = self.regions[neighbor_id]
+                    dist = math.sqrt(
+                        (region.center_x - neighbor.center_x) ** 2
+                        + (region.center_y - neighbor.center_y) ** 2
+                    )
+                    edge_capacity = self.base_capacity
+                    self.edges[region_id].append(
+                        RegionEdge(
+                            source=region_id,
+                            target=neighbor_id,
+                            capacity=edge_capacity,
+                            distance=dist,
+                        )
+                    )
+                    self.edges[neighbor_id].append(
+                        RegionEdge(
+                            source=neighbor_id,
+                            target=region_id,
+                            capacity=edge_capacity,
+                            distance=dist,
+                        )
+                    )
+
+                # Bottom neighbor
+                if row + 1 < self.num_rows:
+                    neighbor_id = self._region_grid[row + 1][col]
+                    neighbor = self.regions[neighbor_id]
+                    dist = math.sqrt(
+                        (region.center_x - neighbor.center_x) ** 2
+                        + (region.center_y - neighbor.center_y) ** 2
+                    )
+                    edge_capacity = self.base_capacity
+                    self.edges[region_id].append(
+                        RegionEdge(
+                            source=region_id,
+                            target=neighbor_id,
+                            capacity=edge_capacity,
+                            distance=dist,
+                        )
+                    )
+                    self.edges[neighbor_id].append(
+                        RegionEdge(
+                            source=neighbor_id,
+                            target=region_id,
+                            capacity=edge_capacity,
+                            distance=dist,
+                        )
+                    )
+
+    def get_region_at(self, x: float, y: float) -> Region | None:
+        """Find the region containing a given board coordinate.
+
+        Args:
+            x: X coordinate in mm
+            y: Y coordinate in mm
+
+        Returns:
+            The Region containing the point, or None if outside the board
+        """
+        if not (self.origin_x <= x <= self.origin_x + self.board_width):
+            return None
+        if not (self.origin_y <= y <= self.origin_y + self.board_height):
+            return None
+
+        region_width = self.board_width / self.num_cols
+        region_height = self.board_height / self.num_rows
+
+        col = min(int((x - self.origin_x) / region_width), self.num_cols - 1)
+        row = min(int((y - self.origin_y) / region_height), self.num_rows - 1)
+
+        region_id = self._region_grid[row][col]
+        return self.regions[region_id]
+
+    def register_obstacles(self, pads: list[Pad]) -> None:
+        """Register component pads as obstacles, reducing region capacity.
+
+        Regions with more obstacles have reduced routing capacity, which
+        guides global routing paths around congested areas.
+
+        Args:
+            pads: List of Pad objects representing component pins
+        """
+        for pad in pads:
+            region = self.get_region_at(pad.x, pad.y)
+            if region is not None:
+                region.obstacle_count += 1
+
+        # Reduce capacity of regions with many obstacles
+        for region in self.regions.values():
+            if region.obstacle_count > 0:
+                # Each obstacle reduces capacity by 1, but keep minimum of 1
+                reduction = min(region.obstacle_count, region.capacity - 1)
+                region.capacity = max(1, region.capacity - reduction)
+
+    def find_path(
+        self,
+        source_id: int,
+        target_id: int,
+    ) -> list[int] | None:
+        """Find a path between two regions using A* search.
+
+        The search considers edge distances, congestion costs, and
+        remaining capacity to find a good global routing path.
+
+        Args:
+            source_id: Source region ID
+            target_id: Target region ID
+
+        Returns:
+            List of region IDs forming the path (inclusive of source and
+            target), or None if no path exists
+        """
+        if source_id not in self.regions or target_id not in self.regions:
+            return None
+
+        if source_id == target_id:
+            return [source_id]
+
+        target = self.regions[target_id]
+
+        open_set: list[_GlobalSearchNode] = []
+        closed_set: set[int] = set()
+        g_scores: dict[int, float] = {}
+
+        source = self.regions[source_id]
+        h = math.sqrt(
+            (source.center_x - target.center_x) ** 2
+            + (source.center_y - target.center_y) ** 2
+        )
+        start_node = _GlobalSearchNode(f_score=h, g_score=0.0, region_id=source_id)
+        heapq.heappush(open_set, start_node)
+        g_scores[source_id] = 0.0
+
+        while open_set:
+            current = heapq.heappop(open_set)
+
+            if current.region_id in closed_set:
+                continue
+            closed_set.add(current.region_id)
+
+            # Goal check
+            if current.region_id == target_id:
+                return self._reconstruct_path(current)
+
+            # Explore neighbors
+            for edge in self.edges.get(current.region_id, []):
+                neighbor_id = edge.target
+                if neighbor_id in closed_set:
+                    continue
+
+                # Cost = distance * congestion factor
+                edge_cost = edge.distance * edge.congestion_cost
+                new_g = current.g_score + edge_cost
+
+                if neighbor_id not in g_scores or new_g < g_scores[neighbor_id]:
+                    g_scores[neighbor_id] = new_g
+                    neighbor = self.regions[neighbor_id]
+                    h = math.sqrt(
+                        (neighbor.center_x - target.center_x) ** 2
+                        + (neighbor.center_y - target.center_y) ** 2
+                    )
+                    f = new_g + h
+                    neighbor_node = _GlobalSearchNode(
+                        f_score=f,
+                        g_score=new_g,
+                        region_id=neighbor_id,
+                        parent=current,
+                    )
+                    heapq.heappush(open_set, neighbor_node)
+
+        return None
+
+    def _reconstruct_path(self, end_node: _GlobalSearchNode) -> list[int]:
+        """Reconstruct the region path from the A* search result.
+
+        Args:
+            end_node: The goal search node
+
+        Returns:
+            List of region IDs from source to target
+        """
+        path: list[int] = []
+        node: _GlobalSearchNode | None = end_node
+        while node is not None:
+            path.append(node.region_id)
+            node = node.parent
+        path.reverse()
+        return path
+
+    def update_utilization(self, path: list[int]) -> None:
+        """Update region and edge utilization after assigning a path.
+
+        This increases the utilization counters for all regions and edges
+        along the path, making future paths prefer less congested areas.
+
+        Args:
+            path: List of region IDs forming the assigned path
+        """
+        # Update region utilization
+        for region_id in path:
+            if region_id in self.regions:
+                self.regions[region_id].utilization += 1
+
+        # Update edge utilization
+        for i in range(len(path) - 1):
+            src = path[i]
+            tgt = path[i + 1]
+            for edge in self.edges.get(src, []):
+                if edge.target == tgt:
+                    edge.utilization += 1
+                    break
+
+    def path_to_waypoint_coords(self, path: list[int]) -> list[tuple[float, float]]:
+        """Convert a region path to a sequence of waypoint coordinates.
+
+        Each waypoint is placed at the center of its region. This provides
+        the centerline for corridor construction.
+
+        Args:
+            path: List of region IDs
+
+        Returns:
+            List of (x, y) coordinate tuples at region centers
+        """
+        coords: list[tuple[float, float]] = []
+        for region_id in path:
+            region = self.regions[region_id]
+            coords.append((region.center_x, region.center_y))
+        return coords
+
+    def get_region_count(self) -> int:
+        """Return the total number of regions."""
+        return len(self.regions)
+
+    def get_edge_count(self) -> int:
+        """Return the total number of directed edges."""
+        return sum(len(edges) for edges in self.edges.values())
+
+    def get_statistics(self) -> dict:
+        """Get statistics about the region graph.
+
+        Returns:
+            Dictionary with region count, edge count, capacity, and
+            utilization statistics
+        """
+        total_utilization = sum(r.utilization for r in self.regions.values())
+        total_capacity = sum(r.capacity for r in self.regions.values())
+        max_utilization = (
+            max(r.utilization for r in self.regions.values()) if self.regions else 0
+        )
+
+        return {
+            "num_regions": len(self.regions),
+            "num_rows": self.num_rows,
+            "num_cols": self.num_cols,
+            "num_edges": self.get_edge_count(),
+            "total_capacity": total_capacity,
+            "total_utilization": total_utilization,
+            "max_utilization": max_utilization,
+            "regions_with_obstacles": sum(
+                1 for r in self.regions.values() if r.obstacle_count > 0
+            ),
+        }

--- a/tests/test_global_router.py
+++ b/tests/test_global_router.py
@@ -1,0 +1,858 @@
+"""Tests for hierarchical routing foundation (Issue #1095 Phase A).
+
+Tests cover:
+1. RegionGraph construction and spatial queries
+2. GlobalRouter corridor assignment
+3. Integration with existing sparse router corridor infrastructure
+4. Hierarchical strategy integration via Autorouter
+5. Regression: existing routing strategies remain unaffected
+"""
+
+import math
+
+import pytest
+
+from kicad_tools.router import DesignRules, Pad
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.global_router import (
+    CorridorAssignment,
+    GlobalRouter,
+    GlobalRoutingResult,
+)
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.region_graph import Region, RegionEdge, RegionGraph
+from kicad_tools.router.sparse import Corridor, SparseRouter, Waypoint
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def rules():
+    """Standard design rules for testing."""
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.2,
+        via_drill=0.35,
+        via_diameter=0.7,
+        grid_resolution=0.1,
+    )
+
+
+@pytest.fixture
+def small_board_graph():
+    """A 20x20mm board with 4x4 region grid."""
+    return RegionGraph(
+        board_width=20.0,
+        board_height=20.0,
+        origin_x=0.0,
+        origin_y=0.0,
+        num_cols=4,
+        num_rows=4,
+    )
+
+
+@pytest.fixture
+def standard_board_graph():
+    """A 65x56mm board (representative of chorus-test-revA) with 10x10 grid."""
+    return RegionGraph(
+        board_width=65.0,
+        board_height=56.0,
+        origin_x=0.0,
+        origin_y=0.0,
+        num_cols=10,
+        num_rows=10,
+    )
+
+
+@pytest.fixture
+def sample_pads():
+    """Sample pads for a simple 2-net board."""
+    return [
+        # Net 1: left-to-right connection
+        Pad(x=2.0, y=10.0, width=1.0, height=1.0, net=1, net_name="VCC",
+            ref="R1", pin="1", layer=Layer.F_CU),
+        Pad(x=18.0, y=10.0, width=1.0, height=1.0, net=1, net_name="VCC",
+            ref="R1", pin="2", layer=Layer.F_CU),
+        # Net 2: top-to-bottom connection
+        Pad(x=10.0, y=2.0, width=1.0, height=1.0, net=2, net_name="GND",
+            ref="R2", pin="1", layer=Layer.F_CU),
+        Pad(x=10.0, y=18.0, width=1.0, height=1.0, net=2, net_name="GND",
+            ref="R2", pin="2", layer=Layer.F_CU),
+    ]
+
+
+@pytest.fixture
+def sample_nets():
+    """Net-to-pad mapping for the sample board."""
+    return {
+        1: [("R1", "1"), ("R1", "2")],
+        2: [("R2", "1"), ("R2", "2")],
+    }
+
+
+@pytest.fixture
+def sample_pad_dict(sample_pads):
+    """Pad dictionary mapping (ref, pin) to Pad objects."""
+    return {
+        ("R1", "1"): sample_pads[0],
+        ("R1", "2"): sample_pads[1],
+        ("R2", "1"): sample_pads[2],
+        ("R2", "2"): sample_pads[3],
+    }
+
+
+# =============================================================================
+# RegionGraph Construction Tests
+# =============================================================================
+
+
+class TestRegionGraphConstruction:
+    """Test RegionGraph is correctly built from board parameters."""
+
+    def test_region_count_matches_grid(self, small_board_graph):
+        """RegionGraph creates correct number of regions."""
+        assert small_board_graph.get_region_count() == 16  # 4x4
+
+    def test_standard_board_region_count(self, standard_board_graph):
+        """Standard board gets 100 regions from 10x10 grid."""
+        assert standard_board_graph.get_region_count() == 100
+
+    def test_region_covers_board_area(self, small_board_graph):
+        """Regions collectively cover the entire board area."""
+        graph = small_board_graph
+        # Check corners are within some region
+        corners = [
+            (0.0, 0.0),      # top-left
+            (19.9, 0.0),     # top-right
+            (0.0, 19.9),     # bottom-left
+            (19.9, 19.9),    # bottom-right
+            (10.0, 10.0),    # center
+        ]
+        for x, y in corners:
+            region = graph.get_region_at(x, y)
+            assert region is not None, f"No region at ({x}, {y})"
+
+    def test_region_has_correct_bounds(self, small_board_graph):
+        """Regions have correct spatial bounds."""
+        graph = small_board_graph
+        # First region (top-left) should span (0,0) to (5,5)
+        region = graph.get_region_at(2.5, 2.5)
+        assert region is not None
+        assert region.row == 0
+        assert region.col == 0
+        assert abs(region.min_x - 0.0) < 0.01
+        assert abs(region.min_y - 0.0) < 0.01
+        assert abs(region.max_x - 5.0) < 0.01
+        assert abs(region.max_y - 5.0) < 0.01
+
+    def test_region_center_computation(self):
+        """Region center is correctly computed."""
+        region = Region(
+            id=0, row=0, col=0,
+            min_x=0.0, min_y=0.0, max_x=10.0, max_y=8.0,
+        )
+        assert abs(region.center_x - 5.0) < 0.01
+        assert abs(region.center_y - 4.0) < 0.01
+
+    def test_edges_connect_adjacent_regions(self, small_board_graph):
+        """Adjacent regions are connected by edges."""
+        graph = small_board_graph
+        edge_count = graph.get_edge_count()
+        # 4x4 grid: 3 horizontal edges per row * 4 rows + 4 vertical edges per col * 3 cols
+        # = 12 + 12 = 24 edges, but each is bidirectional = 48 directed edges
+        assert edge_count == 48
+
+    def test_non_adjacent_regions_not_connected(self, small_board_graph):
+        """Non-adjacent regions should not have direct edges."""
+        graph = small_board_graph
+        # Region at (0,0) should not be directly connected to (0,2)
+        top_left = graph.get_region_at(2.5, 2.5)
+        assert top_left is not None
+        for edge in graph.edges[top_left.id]:
+            target = graph.regions[edge.target]
+            # Should only connect to row 0 col 1, or row 1 col 0
+            assert (target.row == 0 and target.col == 1) or \
+                   (target.row == 1 and target.col == 0)
+
+    def test_single_region_graph(self):
+        """A 1x1 region graph has one region and no edges."""
+        graph = RegionGraph(
+            board_width=10.0, board_height=10.0,
+            num_cols=1, num_rows=1,
+        )
+        assert graph.get_region_count() == 1
+        assert graph.get_edge_count() == 0
+
+    def test_minimum_dimensions(self):
+        """RegionGraph enforces minimum 1 column and 1 row."""
+        graph = RegionGraph(
+            board_width=10.0, board_height=10.0,
+            num_cols=0, num_rows=0,
+        )
+        assert graph.num_cols >= 1
+        assert graph.num_rows >= 1
+        assert graph.get_region_count() >= 1
+
+    def test_point_outside_board(self, small_board_graph):
+        """Points outside the board return None."""
+        assert small_board_graph.get_region_at(-1.0, 10.0) is None
+        assert small_board_graph.get_region_at(10.0, -1.0) is None
+        assert small_board_graph.get_region_at(21.0, 10.0) is None
+        assert small_board_graph.get_region_at(10.0, 21.0) is None
+
+
+# =============================================================================
+# RegionGraph Obstacle Registration Tests
+# =============================================================================
+
+
+class TestRegionGraphObstacles:
+    """Test obstacle registration and capacity adjustment."""
+
+    def test_obstacle_reduces_capacity(self, small_board_graph, sample_pads):
+        """Registering obstacles reduces region capacity."""
+        graph = small_board_graph
+        # Get initial capacity of region containing first pad
+        region = graph.get_region_at(2.0, 10.0)
+        assert region is not None
+        initial_capacity = region.capacity
+
+        graph.register_obstacles(sample_pads)
+
+        # Capacity should be reduced
+        assert region.capacity <= initial_capacity
+        assert region.obstacle_count > 0
+
+    def test_empty_region_has_full_capacity(self, small_board_graph, sample_pads):
+        """Regions without obstacles retain full capacity."""
+        graph = small_board_graph
+        graph.register_obstacles(sample_pads)
+
+        # Region in far corner (no pads nearby)
+        empty_region = graph.get_region_at(17.5, 2.5)
+        assert empty_region is not None
+        # Should have full capacity (no obstacles)
+        assert empty_region.obstacle_count == 0
+        assert empty_region.capacity == graph.base_capacity
+
+
+# =============================================================================
+# RegionGraph Path Finding Tests
+# =============================================================================
+
+
+class TestRegionGraphPathFinding:
+    """Test A* path finding on the region graph."""
+
+    def test_path_between_adjacent_regions(self, small_board_graph):
+        """Path between adjacent regions is a direct 2-region path."""
+        graph = small_board_graph
+        r1 = graph.get_region_at(2.5, 2.5)
+        r2 = graph.get_region_at(7.5, 2.5)
+        assert r1 is not None and r2 is not None
+
+        path = graph.find_path(r1.id, r2.id)
+        assert path is not None
+        assert len(path) == 2
+        assert path[0] == r1.id
+        assert path[-1] == r2.id
+
+    def test_path_across_board(self, small_board_graph):
+        """Path from corner to corner traverses multiple regions."""
+        graph = small_board_graph
+        top_left = graph.get_region_at(2.5, 2.5)
+        bottom_right = graph.get_region_at(17.5, 17.5)
+        assert top_left is not None and bottom_right is not None
+
+        path = graph.find_path(top_left.id, bottom_right.id)
+        assert path is not None
+        # Manhattan distance in grid: 3 cols + 3 rows = 6 steps + 1 = 7 regions minimum
+        assert len(path) >= 7
+        assert path[0] == top_left.id
+        assert path[-1] == bottom_right.id
+
+    def test_same_region_path(self, small_board_graph):
+        """Path from a region to itself is a single-element list."""
+        graph = small_board_graph
+        r = graph.get_region_at(10.0, 10.0)
+        assert r is not None
+
+        path = graph.find_path(r.id, r.id)
+        assert path == [r.id]
+
+    def test_path_with_invalid_regions(self, small_board_graph):
+        """Invalid region IDs return None."""
+        assert small_board_graph.find_path(999, 0) is None
+        assert small_board_graph.find_path(0, 999) is None
+
+    def test_path_continuity(self, small_board_graph):
+        """Each consecutive pair of regions in a path should be adjacent."""
+        graph = small_board_graph
+        r1 = graph.get_region_at(2.5, 2.5)
+        r2 = graph.get_region_at(17.5, 17.5)
+        assert r1 is not None and r2 is not None
+
+        path = graph.find_path(r1.id, r2.id)
+        assert path is not None
+
+        for i in range(len(path) - 1):
+            region_a = graph.regions[path[i]]
+            region_b = graph.regions[path[i + 1]]
+            # Adjacent means differing by exactly 1 in row or col (not both)
+            row_diff = abs(region_a.row - region_b.row)
+            col_diff = abs(region_a.col - region_b.col)
+            assert (row_diff == 1 and col_diff == 0) or \
+                   (row_diff == 0 and col_diff == 1), \
+                f"Non-adjacent step: ({region_a.row},{region_a.col}) -> ({region_b.row},{region_b.col})"
+
+
+# =============================================================================
+# RegionGraph Utilization Tests
+# =============================================================================
+
+
+class TestRegionGraphUtilization:
+    """Test utilization tracking and congestion effects."""
+
+    def test_utilization_increases_after_path(self, small_board_graph):
+        """Assigning a path increases region utilization."""
+        graph = small_board_graph
+        r1 = graph.get_region_at(2.5, 2.5)
+        r2 = graph.get_region_at(7.5, 2.5)
+        assert r1 is not None and r2 is not None
+
+        path = graph.find_path(r1.id, r2.id)
+        assert path is not None
+
+        # Check initial utilization is 0
+        for rid in path:
+            assert graph.regions[rid].utilization == 0
+
+        graph.update_utilization(path)
+
+        # Check utilization increased
+        for rid in path:
+            assert graph.regions[rid].utilization == 1
+
+    def test_congestion_cost_increases_with_utilization(self):
+        """Edge congestion cost increases with utilization."""
+        edge = RegionEdge(source=0, target=1, capacity=10, utilization=0, distance=5.0)
+        low_cost = edge.congestion_cost
+
+        edge.utilization = 5
+        mid_cost = edge.congestion_cost
+
+        edge.utilization = 9
+        high_cost = edge.congestion_cost
+
+        assert low_cost < mid_cost < high_cost
+
+    def test_waypoint_coords_from_path(self, small_board_graph):
+        """Path can be converted to waypoint coordinates."""
+        graph = small_board_graph
+        r1 = graph.get_region_at(2.5, 2.5)
+        r2 = graph.get_region_at(7.5, 2.5)
+        assert r1 is not None and r2 is not None
+
+        path = graph.find_path(r1.id, r2.id)
+        assert path is not None
+
+        coords = graph.path_to_waypoint_coords(path)
+        assert len(coords) == len(path)
+        for x, y in coords:
+            assert 0.0 <= x <= 20.0
+            assert 0.0 <= y <= 20.0
+
+
+# =============================================================================
+# RegionGraph Statistics Tests
+# =============================================================================
+
+
+class TestRegionGraphStatistics:
+    """Test statistics reporting."""
+
+    def test_statistics_keys(self, small_board_graph):
+        """Statistics dict has expected keys."""
+        stats = small_board_graph.get_statistics()
+        expected_keys = {
+            "num_regions", "num_rows", "num_cols", "num_edges",
+            "total_capacity", "total_utilization", "max_utilization",
+            "regions_with_obstacles",
+        }
+        assert set(stats.keys()) == expected_keys
+
+    def test_initial_statistics(self, small_board_graph):
+        """Initial statistics show zero utilization."""
+        stats = small_board_graph.get_statistics()
+        assert stats["num_regions"] == 16
+        assert stats["num_rows"] == 4
+        assert stats["num_cols"] == 4
+        assert stats["total_utilization"] == 0
+        assert stats["max_utilization"] == 0
+        assert stats["regions_with_obstacles"] == 0
+
+
+# =============================================================================
+# GlobalRouter Tests
+# =============================================================================
+
+
+class TestGlobalRouter:
+    """Test the GlobalRouter for corridor assignment."""
+
+    def test_route_single_net(self, small_board_graph, sample_pads):
+        """Route a single net and get a corridor assignment."""
+        graph = small_board_graph
+        graph.register_obstacles(sample_pads)
+
+        router = GlobalRouter(
+            region_graph=graph,
+            corridor_width=0.5,
+        )
+
+        # Route net 1 (left-to-right)
+        assignment = router.route_net(
+            net=1,
+            pad_positions=[(2.0, 10.0), (18.0, 10.0)],
+        )
+
+        assert assignment is not None
+        assert assignment.net == 1
+        assert len(assignment.region_path) >= 2
+        assert isinstance(assignment.corridor, Corridor)
+        assert assignment.corridor.net == 1
+        assert assignment.corridor.width == 0.5
+
+    def test_corridor_waypoints_span_pads(self, small_board_graph):
+        """Corridor waypoints should start near source pad and end near target pad."""
+        router = GlobalRouter(
+            region_graph=small_board_graph,
+            corridor_width=1.0,
+        )
+
+        assignment = router.route_net(
+            net=1,
+            pad_positions=[(2.0, 10.0), (18.0, 10.0)],
+        )
+
+        assert assignment is not None
+        coords = assignment.waypoint_coords
+        assert len(coords) >= 2
+
+        # First waypoint should be at source pad
+        assert abs(coords[0][0] - 2.0) < 0.01
+        assert abs(coords[0][1] - 10.0) < 0.01
+
+        # Last waypoint should be at target pad
+        assert abs(coords[-1][0] - 18.0) < 0.01
+        assert abs(coords[-1][1] - 10.0) < 0.01
+
+    def test_route_all_nets(self, small_board_graph, sample_nets, sample_pad_dict, sample_pads):
+        """Route all nets and get assignments for each."""
+        graph = small_board_graph
+        graph.register_obstacles(sample_pads)
+
+        router = GlobalRouter(
+            region_graph=graph,
+            corridor_width=0.5,
+        )
+
+        result = router.route_all(
+            nets=sample_nets,
+            pad_dict=sample_pad_dict,
+        )
+
+        assert isinstance(result, GlobalRoutingResult)
+        assert len(result.assignments) == 2  # Both nets should succeed
+        assert 1 in result.assignments
+        assert 2 in result.assignments
+        assert len(result.failed_nets) == 0
+
+    def test_corridors_contain_pad_positions(self, small_board_graph, sample_pads):
+        """Corridors should contain their source and target pad positions."""
+        graph = small_board_graph
+        graph.register_obstacles(sample_pads)
+
+        router = GlobalRouter(
+            region_graph=graph,
+            corridor_width=3.0,  # Wide corridor for containment check
+        )
+
+        assignment = router.route_net(
+            net=1,
+            pad_positions=[(2.0, 10.0), (18.0, 10.0)],
+        )
+
+        assert assignment is not None
+        corridor = assignment.corridor
+
+        # Both pad positions should be within the corridor
+        assert corridor.contains_point(2.0, 10.0, 0)
+        assert corridor.contains_point(18.0, 10.0, 0)
+
+    def test_multi_pad_net_uses_most_distant_pair(self, small_board_graph):
+        """Multi-pad nets use the most distant pair as corridor endpoints."""
+        router = GlobalRouter(
+            region_graph=small_board_graph,
+            corridor_width=1.0,
+        )
+
+        # 3-pad net: endpoints should be the two most distant
+        assignment = router.route_net(
+            net=3,
+            pad_positions=[(2.0, 10.0), (10.0, 10.0), (18.0, 10.0)],
+        )
+
+        assert assignment is not None
+        coords = assignment.waypoint_coords
+
+        # Corridor should span from leftmost to rightmost pad
+        assert abs(coords[0][0] - 2.0) < 0.01 or abs(coords[-1][0] - 2.0) < 0.01
+        assert abs(coords[0][0] - 18.0) < 0.01 or abs(coords[-1][0] - 18.0) < 0.01
+
+    def test_insufficient_pads_returns_none(self, small_board_graph):
+        """Net with fewer than 2 pads cannot be routed."""
+        router = GlobalRouter(
+            region_graph=small_board_graph,
+            corridor_width=0.5,
+        )
+
+        result = router.route_net(net=1, pad_positions=[(5.0, 5.0)])
+        assert result is None
+
+        result = router.route_net(net=1, pad_positions=[])
+        assert result is None
+
+    def test_pads_outside_board_returns_none(self, small_board_graph):
+        """Pads outside board bounds result in failed routing."""
+        router = GlobalRouter(
+            region_graph=small_board_graph,
+            corridor_width=0.5,
+        )
+
+        result = router.route_net(
+            net=1,
+            pad_positions=[(-10.0, 10.0), (30.0, 10.0)],
+        )
+        assert result is None
+
+    def test_utilization_updates_after_routing(self, small_board_graph, sample_nets, sample_pad_dict):
+        """Region utilization increases after global routing."""
+        graph = small_board_graph
+        router = GlobalRouter(region_graph=graph, corridor_width=0.5)
+
+        # Initial utilization should be zero
+        stats = graph.get_statistics()
+        assert stats["total_utilization"] == 0
+
+        router.route_all(nets=sample_nets, pad_dict=sample_pad_dict)
+
+        # Utilization should have increased
+        stats = graph.get_statistics()
+        assert stats["total_utilization"] > 0
+
+    def test_net_order_is_respected(self, small_board_graph, sample_nets, sample_pad_dict):
+        """Nets are routed in the specified order."""
+        router = GlobalRouter(
+            region_graph=small_board_graph,
+            corridor_width=0.5,
+        )
+
+        # Route net 2 first, then net 1
+        result = router.route_all(
+            nets=sample_nets,
+            pad_dict=sample_pad_dict,
+            net_order=[2, 1],
+        )
+
+        # Both should succeed regardless of order
+        assert len(result.assignments) == 2
+
+
+# =============================================================================
+# Integration with Existing Sparse Router
+# =============================================================================
+
+
+class TestSparseRouterIntegration:
+    """Test that global routing integrates with the existing Corridor infrastructure."""
+
+    def test_corridor_from_global_router_is_valid(self, small_board_graph, rules):
+        """Corridors from GlobalRouter are compatible with SparseRoutingGraph."""
+        router = GlobalRouter(
+            region_graph=small_board_graph,
+            corridor_width=rules.trace_clearance * 2,
+        )
+
+        assignment = router.route_net(
+            net=1,
+            pad_positions=[(2.0, 10.0), (18.0, 10.0)],
+        )
+
+        assert assignment is not None
+        corridor = assignment.corridor
+
+        # Corridor should have valid structure
+        assert corridor.net == 1
+        assert corridor.width == rules.trace_clearance * 2
+        assert len(corridor.waypoints) >= 2
+        assert len(corridor.layer_segments) >= 1
+
+        # Bounding box should be valid
+        bbox = corridor.get_bounding_box()
+        assert bbox[0] < bbox[2]  # min_x < max_x
+        assert bbox[1] < bbox[3]  # min_y < max_y
+
+    def test_corridor_can_be_reserved_in_sparse_router(self, rules):
+        """Corridors from GlobalRouter can be reserved in SparseRouter."""
+        sparse_router = SparseRouter(
+            width=20.0,
+            height=20.0,
+            rules=rules,
+        )
+
+        # Create a corridor like GlobalRouter would
+        waypoints = [
+            Waypoint(x=2.0, y=10.0, layer=0, waypoint_type="global"),
+            Waypoint(x=10.0, y=10.0, layer=0, waypoint_type="global"),
+            Waypoint(x=18.0, y=10.0, layer=0, waypoint_type="global"),
+        ]
+
+        corridor = Corridor.from_waypoints(
+            waypoints=waypoints,
+            net=1,
+            width=rules.trace_clearance * 2,
+        )
+
+        # Reserve in sparse router
+        sparse_router.graph.reserved_corridors[1] = corridor
+        assert sparse_router.get_corridor(1) is not None
+        assert sparse_router.get_corridor(1).net == 1
+
+    def test_corridor_containment_check(self, rules):
+        """Corridor containment works correctly for global routing corridors."""
+        waypoints = [
+            Waypoint(x=0.0, y=10.0, layer=0, waypoint_type="global"),
+            Waypoint(x=20.0, y=10.0, layer=0, waypoint_type="global"),
+        ]
+
+        corridor = Corridor.from_waypoints(
+            waypoints=waypoints,
+            net=1,
+            width=2.0,  # 2mm half-width
+        )
+
+        # Points within 2mm of the centerline (y=10) should be contained
+        assert corridor.contains_point(10.0, 10.0, 0)  # On centerline
+        assert corridor.contains_point(10.0, 11.0, 0)  # 1mm from centerline
+        assert corridor.contains_point(10.0, 11.9, 0)  # Just inside
+
+        # Points far from centerline should not be contained
+        assert not corridor.contains_point(10.0, 13.0, 0)  # 3mm away
+        assert not corridor.contains_point(10.0, 0.0, 0)   # Far away
+
+        # Points on wrong layer should not be contained
+        assert not corridor.contains_point(10.0, 10.0, 1)
+
+
+# =============================================================================
+# Autorouter Hierarchical Strategy Integration Tests
+# =============================================================================
+
+
+class TestHierarchicalStrategyIntegration:
+    """Test hierarchical routing via Autorouter API."""
+
+    @pytest.fixture
+    def autorouter(self, rules):
+        """Create an Autorouter with a small board."""
+        router = Autorouter(
+            width=20.0,
+            height=20.0,
+            rules=rules,
+            force_python=True,
+        )
+
+        # Add pads for two nets
+        router.add_component(
+            ref="R1",
+            pads=[
+                {"number": "1", "x": 3.0, "y": 10.0, "net": 1, "net_name": "VCC"},
+                {"number": "2", "x": 17.0, "y": 10.0, "net": 1, "net_name": "VCC"},
+            ],
+        )
+        router.add_component(
+            ref="R2",
+            pads=[
+                {"number": "1", "x": 10.0, "y": 3.0, "net": 2, "net_name": "GND"},
+                {"number": "2", "x": 10.0, "y": 17.0, "net": 2, "net_name": "GND"},
+            ],
+        )
+
+        return router
+
+    def test_hierarchical_routing_runs(self, autorouter):
+        """Hierarchical routing completes without errors."""
+        routes = autorouter.route_all_hierarchical(
+            num_cols=4,
+            num_rows=4,
+            use_negotiated=False,
+        )
+        # Should return a list (may be empty if routing fails on small board)
+        assert isinstance(routes, list)
+
+    def test_hierarchical_via_advanced_entry_point(self, autorouter):
+        """Hierarchical routing accessible via route_all_advanced."""
+        routes = autorouter.route_all_advanced(
+            use_hierarchical=True,
+            use_negotiated=False,
+        )
+        assert isinstance(routes, list)
+
+    def test_standard_routing_unchanged(self, autorouter):
+        """Standard routing is not affected by hierarchical additions."""
+        routes = autorouter.route_all()
+        assert isinstance(routes, list)
+
+    def test_negotiated_routing_unchanged(self, autorouter):
+        """Negotiated routing is not affected by hierarchical additions."""
+        routes = autorouter.route_all_negotiated()
+        assert isinstance(routes, list)
+
+    def test_two_phase_routing_unchanged(self, autorouter):
+        """Two-phase routing is not affected by hierarchical additions."""
+        routes = autorouter.route_all_two_phase(use_negotiated=False)
+        assert isinstance(routes, list)
+
+    def test_advanced_default_unchanged(self, autorouter):
+        """Default route_all_advanced behavior is not changed."""
+        routes = autorouter.route_all_advanced()
+        assert isinstance(routes, list)
+
+
+# =============================================================================
+# Region Data Structure Tests
+# =============================================================================
+
+
+class TestRegionDataStructure:
+    """Test Region dataclass behavior."""
+
+    def test_contains_point(self):
+        """Region correctly identifies contained points."""
+        region = Region(
+            id=0, row=0, col=0,
+            min_x=0.0, min_y=0.0, max_x=10.0, max_y=10.0,
+        )
+        assert region.contains_point(5.0, 5.0)
+        assert region.contains_point(0.0, 0.0)   # Inclusive lower bound
+        assert region.contains_point(10.0, 10.0)  # Inclusive upper bound
+        assert not region.contains_point(-1.0, 5.0)
+        assert not region.contains_point(5.0, -1.0)
+        assert not region.contains_point(11.0, 5.0)
+        assert not region.contains_point(5.0, 11.0)
+
+    def test_remaining_capacity(self):
+        """Remaining capacity is correctly computed."""
+        region = Region(
+            id=0, row=0, col=0,
+            min_x=0.0, min_y=0.0, max_x=10.0, max_y=10.0,
+            capacity=10, utilization=3,
+        )
+        assert region.remaining_capacity == 7
+
+    def test_remaining_capacity_never_negative(self):
+        """Remaining capacity is clamped to 0."""
+        region = Region(
+            id=0, row=0, col=0,
+            min_x=0.0, min_y=0.0, max_x=10.0, max_y=10.0,
+            capacity=5, utilization=10,
+        )
+        assert region.remaining_capacity == 0
+
+    def test_width_and_height(self):
+        """Region width and height computed from bounds."""
+        region = Region(
+            id=0, row=0, col=0,
+            min_x=5.0, min_y=10.0, max_x=15.0, max_y=25.0,
+        )
+        assert abs(region.width - 10.0) < 0.01
+        assert abs(region.height - 15.0) < 0.01
+
+
+# =============================================================================
+# RegionEdge Data Structure Tests
+# =============================================================================
+
+
+class TestRegionEdgeDataStructure:
+    """Test RegionEdge dataclass behavior."""
+
+    def test_congestion_cost_uncongested(self):
+        """Uncongested edge has base cost of 1.0."""
+        edge = RegionEdge(source=0, target=1, capacity=10, utilization=0)
+        assert abs(edge.congestion_cost - 1.0) < 0.01
+
+    def test_congestion_cost_full_capacity(self):
+        """Full capacity edge has high cost."""
+        edge = RegionEdge(source=0, target=1, capacity=10, utilization=10)
+        assert edge.congestion_cost >= 5.0
+
+    def test_congestion_cost_zero_capacity(self):
+        """Zero capacity edge has very high cost."""
+        edge = RegionEdge(source=0, target=1, capacity=0, utilization=0)
+        assert edge.congestion_cost >= 50.0
+
+    def test_remaining_capacity(self):
+        """Remaining edge capacity is correctly computed."""
+        edge = RegionEdge(source=0, target=1, capacity=10, utilization=7)
+        assert edge.remaining_capacity == 3
+
+
+# =============================================================================
+# CorridorAssignment Tests
+# =============================================================================
+
+
+class TestCorridorAssignment:
+    """Test CorridorAssignment data structure."""
+
+    def test_assignment_fields(self):
+        """CorridorAssignment stores all expected fields."""
+        waypoints = [
+            Waypoint(x=0.0, y=0.0, layer=0),
+            Waypoint(x=10.0, y=10.0, layer=0),
+        ]
+        corridor = Corridor.from_waypoints(waypoints, net=1, width=0.5)
+
+        assignment = CorridorAssignment(
+            net=1,
+            region_path=[0, 1, 2],
+            corridor=corridor,
+            waypoint_coords=[(0.0, 0.0), (5.0, 5.0), (10.0, 10.0)],
+        )
+
+        assert assignment.net == 1
+        assert assignment.region_path == [0, 1, 2]
+        assert assignment.corridor.net == 1
+        assert len(assignment.waypoint_coords) == 3
+
+
+# =============================================================================
+# GlobalRoutingResult Tests
+# =============================================================================
+
+
+class TestGlobalRoutingResult:
+    """Test GlobalRoutingResult data structure."""
+
+    def test_empty_result(self):
+        """Empty result has no assignments or failures."""
+        result = GlobalRoutingResult()
+        assert len(result.assignments) == 0
+        assert len(result.failed_nets) == 0
+        assert result.region_graph is None


### PR DESCRIPTION
Closes #1095

## Summary
- Introduces `RegionGraph` abstraction for coarse-grid board representation (partitions board into configurable rectangular regions with capacity tracking and A* path finding)
- Adds `GlobalRouter` for net-to-corridor assignment using the region graph, building on the existing `Corridor` class from `sparse.py`
- Integrates `route_all_hierarchical()` method into `Autorouter` as an opt-in strategy via `route_all_advanced(use_hierarchical=True)` -- all existing strategies remain unchanged
- Phase A of 3-phase hierarchical routing proposal (global router foundation only; no min-cost flow, no GPU parallelization, no corridor-constrained detailed routing)

## New files
- `src/kicad_tools/router/region_graph.py` -- `RegionGraph`, `Region`, `RegionEdge` classes
- `src/kicad_tools/router/global_router.py` -- `GlobalRouter`, `CorridorAssignment`, `GlobalRoutingResult` classes
- `tests/test_global_router.py` -- 50 tests

## Modified files
- `src/kicad_tools/router/core.py` -- Added `route_all_hierarchical()` and `use_hierarchical` parameter to `route_all_advanced()`
- `src/kicad_tools/router/__init__.py` -- Exported new public API classes

## Test plan
- [x] RegionGraph construction tests (region count, bounds, adjacency, edge connectivity)
- [x] RegionGraph spatial query tests (get_region_at, point containment, out-of-bounds)
- [x] RegionGraph obstacle registration and capacity reduction
- [x] A* path finding tests (adjacent, cross-board, same-region, invalid IDs, continuity)
- [x] Utilization tracking and congestion cost tests
- [x] GlobalRouter single-net and multi-net corridor assignment
- [x] Corridor waypoint spanning and containment checks
- [x] Integration with SparseRouter corridor infrastructure
- [x] Hierarchical strategy accessible via Autorouter API
- [x] Regression: standard, negotiated, and two-phase routing unchanged
- [x] All 50 new tests pass + 207 existing tests pass

Generated with [Claude Code](https://claude.com/claude-code)