### PR TITLE
fix(stitch): Copy .kicad_pro file alongside PCB output for DRC compatibility

### DIFF
--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -917,6 +917,13 @@ def main(argv: list[str] | None = None) -> int:
         import shutil
 
         shutil.copy(pcb_path, output_path)
+
+        # Also copy project file for DRC compatibility
+        pro_path = pcb_path.with_suffix(".kicad_pro")
+        if pro_path.exists():
+            output_pro = output_path.with_suffix(".kicad_pro")
+            shutil.copy(pro_path, output_pro)
+
         pcb_path = output_path
 
     # Auto-detect power plane nets if none specified


### PR DESCRIPTION
## Summary

- When `-o` is used with the stitch command, the matching `.kicad_pro` file is now copied alongside the output PCB, preventing phantom DRC violations caused by KiCad falling back to embedded default constraints instead of project-level design rules
- Gracefully skips copy if no source `.kicad_pro` exists; respects `--dry-run` mode

Closes #1131

## Test plan

- [x] `test_main_output_copies_project_file` — verifies `.kicad_pro` is copied with matching basename to output directory
- [x] `test_main_output_without_project_file` — verifies stitch works normally when no `.kicad_pro` exists
- [x] `test_main_dry_run_skips_project_copy` — verifies dry-run does not create any files
- [x] Existing `test_main_output_file` still passes (backwards compatible)
- [x] All 74 stitch tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)