### PR TITLE
fix: resolve 4 test failures (#1158)

### DIFF
--- a/src/kicad_tools/operations/netlist.py
+++ b/src/kicad_tools/operations/netlist.py
@@ -102,9 +102,11 @@ class NetNode:
         pin_function = ""
         pin_type = ""
 
-        # Reference is in (ref "...") child node in KiCad netlist format
+        # Reference is in (ref "...") child node or as first positional atom
         if ref_node := sexp.find("ref"):
             ref = ref_node.get_string(0) or ""
+        else:
+            ref = sexp.get_string(0) or ""
 
         if pin_node := sexp.find("pin"):
             pin = pin_node.get_string(0) or ""

--- a/tests/test_layout_preservation.py
+++ b/tests/test_layout_preservation.py
@@ -199,8 +199,8 @@ class TestSnapshotCapture:
         # Verify component positions
         r1 = snapshot.get_component("R1")
         if r1:
-            assert r1.x == 100.0
-            assert r1.y == 50.0
+            assert r1.x == 5.0  # Board-relative (origin at 95,35)
+            assert r1.y == 15.0
 
     def test_capture_convenience_function(self, test_project_pcb: Path, test_project_sch: Path):
         """Test capture_layout convenience function."""

--- a/tests/test_mcp_session_manager.py
+++ b/tests/test_mcp_session_manager.py
@@ -313,8 +313,8 @@ class TestSessionIsolation:
         session2 = session_manager.get(info2.id)
         comp_pos = session2.get_component_position("C1")
 
-        assert comp_pos["x"] == 120.0  # Original position
-        assert comp_pos["y"] == 120.0
+        assert comp_pos["x"] == 20.0  # Board-relative (origin at 100,100)
+        assert comp_pos["y"] == 20.0
 
 
 class TestSessionExpiration:

--- a/tests/test_pcb_modules.py
+++ b/tests/test_pcb_modules.py
@@ -130,7 +130,7 @@ class TestLayer:
         """Test layer values."""
         assert Layer.F_CU.value == "F.Cu"
         assert Layer.B_CU.value == "B.Cu"
-        assert Layer.EDGE.value == "Edge.Cuts"
+        assert Layer.EDGE_CUTS.value == "Edge.Cuts"
 
 
 class TestPad:


### PR DESCRIPTION
## Summary

- Fix `Layer.EDGE` → `Layer.EDGE_CUTS` in test (enum member was renamed to match KiCad naming)
- Fix `NetNode.from_sexp()` to handle reference as first positional atom (not just `(ref ...)` wrapper)
- Update coordinate expectations in `test_layout_preservation` and `test_mcp_session_manager` to match board-relative coordinate system introduced by `_detect_board_origin()`

## Test plan

- [x] All 344 tests in the 6 affected test files pass
- [x] Full test suite passes (1 pre-existing unrelated failure in `test_gpu_grid.py`)

Closes #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)