### PR TITLE
Add typed interface ports for type-checked connections

### DIFF
--- a/src/kicad_tools/schematic/blocks/__init__.py
+++ b/src/kicad_tools/schematic/blocks/__init__.py
@@ -27,6 +27,18 @@ Usage:
 """
 
 # Base classes
+# Analog blocks
+from .analog import (
+    ADCInputFilterBlock,
+    OpAmpBlock,
+    ThermistorSense,
+    VoltageDividerSense,
+    create_adc_filter,
+    create_opamp_buffer,
+    create_opamp_gain,
+    create_temperature_sense,
+    create_voltage_sense,
+)
 from .base import CircuitBlock, Port
 
 # Indicator blocks
@@ -48,6 +60,9 @@ from .interface import (
     create_usb_micro_b,
     create_usb_type_c,
 )
+
+# Typed port interfaces
+from .interfaces import DataPort, PowerPort
 
 # MCU blocks
 from .mcu import (
@@ -90,26 +105,6 @@ from .power import (
     create_voltage_divider,
 )
 
-# Timing blocks
-from .timing import (
-    CrystalOscillator,
-    OscillatorBlock,
-    create_mclk_oscillator,
-)
-
-# Analog blocks
-from .analog import (
-    ADCInputFilterBlock,
-    OpAmpBlock,
-    ThermistorSense,
-    VoltageDividerSense,
-    create_adc_filter,
-    create_opamp_buffer,
-    create_opamp_gain,
-    create_temperature_sense,
-    create_voltage_sense,
-)
-
 # Protection blocks
 from .protection import (
     ESDProtectionBlock,
@@ -127,10 +122,26 @@ from .protection import (
     create_thermal_cutoff,
 )
 
+# Timing blocks
+from .timing import (
+    CrystalOscillator,
+    OscillatorBlock,
+    create_mclk_oscillator,
+)
+
+# Connection validation
+from .validator import ConnectionValidator, ConnectionWarning, WarningSeverity
+
 __all__ = [
     # Base classes
     "Port",
     "CircuitBlock",
+    # Typed ports and validation
+    "PowerPort",
+    "DataPort",
+    "ConnectionValidator",
+    "ConnectionWarning",
+    "WarningSeverity",
     # Indicators
     "LEDIndicator",
     "create_power_led",

--- a/src/kicad_tools/schematic/blocks/base.py
+++ b/src/kicad_tools/schematic/blocks/base.py
@@ -1,20 +1,48 @@
 """Base classes for circuit blocks."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from kicad_sch_helper import Schematic, SymbolInstance
 
+    from kicad_tools.intent.types import InterfaceCategory
+
 
 @dataclass
 class Port:
-    """A connection point on a circuit block."""
+    """A connection point on a circuit block.
+
+    Ports represent named electrical connection points with position and
+    optional interface metadata for type-checked connections.
+
+    The interface metadata fields are all optional to maintain backward
+    compatibility — existing blocks continue to work with position-only ports.
+
+    Attributes:
+        name: Port identifier (e.g., "VIN", "D+", "SDA").
+        x: X coordinate in schematic units.
+        y: Y coordinate in schematic units.
+        direction: Signal direction — "input", "output", "bidirectional",
+            "passive", or "power".
+        interface: High-level interface category (POWER, DIFFERENTIAL, BUS, etc.).
+        interface_type: Specific interface variant (e.g., "usb2_high_speed",
+            "i2c_fast", "power_3v3").
+        parameters: Electrical parameters (e.g., {"voltage_min": 3.0,
+            "voltage_max": 3.6}).
+        group: Groups related ports (e.g., "usb_data", "spi_bus").
+    """
 
     name: str
     x: float
     y: float
     direction: str = "passive"  # input, output, bidirectional, passive, power
+    interface: InterfaceCategory | None = None
+    interface_type: str | None = None
+    parameters: dict[str, object] | None = None
+    group: str | None = None
 
     def pos(self) -> tuple[float, float]:
         """Get position as tuple."""
@@ -31,6 +59,10 @@ class CircuitBlock:
     - Wires internal connections
     - Exposes ports for external connections
 
+    Ports are available in two forms:
+    - ``ports``: dict mapping name to (x, y) tuple (backward compatible).
+    - ``typed_ports``: dict mapping name to ``Port`` object with full metadata.
+
     Subclasses should implement their setup logic in __init__, calling
     super().__init__(sch, x, y) first and then setting up components,
     wiring, and ports.
@@ -38,7 +70,7 @@ class CircuitBlock:
 
     def __init__(
         self,
-        sch: "Schematic" = None,
+        sch: Schematic = None,
         x: float = 0,
         y: float = 0,
     ):
@@ -54,6 +86,7 @@ class CircuitBlock:
         self.x: float = x
         self.y: float = y
         self.ports: dict[str, tuple[float, float]] = {}
+        self.typed_ports: dict[str, Port] = {}
         self.components: dict[str, SymbolInstance] = {}
 
     def port(self, name: str) -> tuple[float, float]:
@@ -62,3 +95,26 @@ class CircuitBlock:
             available = list(self.ports.keys())
             raise KeyError(f"Port '{name}' not found. Available: {available}")
         return self.ports[name]
+
+    def get_typed_port(self, name: str) -> Port:
+        """Get a typed port by name.
+
+        Returns the full Port object with interface metadata. Falls back to
+        creating a basic Port from the position tuple if no typed port exists.
+
+        Args:
+            name: Port name.
+
+        Returns:
+            Port object with position and any interface metadata.
+
+        Raises:
+            KeyError: If port name not found.
+        """
+        if name in self.typed_ports:
+            return self.typed_ports[name]
+        if name in self.ports:
+            pos = self.ports[name]
+            return Port(name=name, x=pos[0], y=pos[1])
+        available = list(self.ports.keys())
+        raise KeyError(f"Port '{name}' not found. Available: {available}")

--- a/src/kicad_tools/schematic/blocks/interface/i2c.py
+++ b/src/kicad_tools/schematic/blocks/interface/i2c.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from ..base import CircuitBlock
+from ..interfaces import DataPort, PowerPort
 
 if TYPE_CHECKING:
     from kicad_sch_helper import Schematic
@@ -202,6 +203,49 @@ class I2CPullups(CircuitBlock):
 
         # Store VCC bus Y position for rail connection
         self._vcc_y = r1_pin1[1]
+
+        # Register typed ports with I2C interface metadata
+        self._register_typed_ports()
+
+    def _register_typed_ports(self) -> None:
+        """Register typed ports with I2C interface metadata."""
+        for name, pos in self.ports.items():
+            if name == "SDA":
+                self.typed_ports[name] = DataPort(
+                    name=name,
+                    x=pos[0],
+                    y=pos[1],
+                    direction="bidirectional",
+                    protocol="i2c",
+                    signal_role="sda",
+                    group="i2c_bus",
+                )
+            elif name == "SCL":
+                self.typed_ports[name] = DataPort(
+                    name=name,
+                    x=pos[0],
+                    y=pos[1],
+                    direction="bidirectional",
+                    protocol="i2c",
+                    signal_role="scl",
+                    group="i2c_bus",
+                )
+            elif name == "VCC":
+                self.typed_ports[name] = PowerPort(
+                    name=name,
+                    x=pos[0],
+                    y=pos[1],
+                    direction="power",
+                )
+            elif name == "GND":
+                self.typed_ports[name] = PowerPort(
+                    name=name,
+                    x=pos[0],
+                    y=pos[1],
+                    direction="passive",
+                    voltage_min=0.0,
+                    voltage_max=0.0,
+                )
 
     def connect_to_rails(
         self,

--- a/src/kicad_tools/schematic/blocks/interfaces.py
+++ b/src/kicad_tools/schematic/blocks/interfaces.py
@@ -1,0 +1,99 @@
+"""Typed port subclasses for interface-aware circuit connections.
+
+Provides specialized Port types that carry electrical and protocol metadata,
+enabling type-checked connections between circuit blocks.
+
+Example::
+
+    from kicad_tools.schematic.blocks.interfaces import PowerPort, DataPort
+    from kicad_tools.intent.types import InterfaceCategory
+
+    # Power port with voltage range
+    vout = PowerPort(
+        name="VOUT", x=100, y=50,
+        direction="output",
+        voltage_min=3.135, voltage_max=3.465,
+    )
+
+    # USB data port
+    dp = DataPort(
+        name="D+", x=120, y=60,
+        direction="bidirectional",
+        protocol="usb2",
+        signal_role="d+",
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from kicad_tools.intent.types import InterfaceCategory
+
+from .base import Port
+
+
+@dataclass
+class PowerPort(Port):
+    """Port carrying power with voltage and current ratings.
+
+    Attributes:
+        voltage_min: Minimum voltage in volts (e.g., 3.135 for 3.3V -5%).
+        voltage_max: Maximum voltage in volts (e.g., 3.465 for 3.3V +5%).
+        max_current: Maximum current in amps.
+    """
+
+    voltage_min: float | None = None
+    voltage_max: float | None = None
+    max_current: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.interface is None:
+            self.interface = InterfaceCategory.POWER
+        if self.direction == "passive":
+            self.direction = "power"
+
+    def voltage_overlaps(self, other: PowerPort) -> bool:
+        """Check if voltage ranges overlap with another power port.
+
+        Returns True if ranges overlap or if either port has no voltage info.
+        """
+        if (
+            self.voltage_min is None
+            or self.voltage_max is None
+            or other.voltage_min is None
+            or other.voltage_max is None
+        ):
+            return True
+        return self.voltage_min <= other.voltage_max and other.voltage_min <= self.voltage_max
+
+
+@dataclass
+class DataPort(Port):
+    """Port carrying a data signal with protocol information.
+
+    Attributes:
+        protocol: Communication protocol (e.g., "usb2", "spi", "i2c", "uart").
+        signal_role: Role within the protocol (e.g., "clock", "data",
+            "chip_select", "d+", "d-", "sda", "scl").
+    """
+
+    protocol: str | None = None
+    signal_role: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.interface is None and self.protocol:
+            self.interface = _protocol_to_category(self.protocol)
+        if self.interface_type is None and self.protocol:
+            self.interface_type = self.protocol
+
+
+def _protocol_to_category(protocol: str) -> InterfaceCategory:
+    """Map protocol name to InterfaceCategory."""
+    differential = {"usb2", "usb3", "lvds", "ethernet"}
+    bus = {"spi", "i2c", "parallel", "can"}
+    if protocol.lower() in differential:
+        return InterfaceCategory.DIFFERENTIAL
+    if protocol.lower() in bus:
+        return InterfaceCategory.BUS
+    return InterfaceCategory.SINGLE_ENDED

--- a/src/kicad_tools/schematic/blocks/power/regulators.py
+++ b/src/kicad_tools/schematic/blocks/power/regulators.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from ..base import CircuitBlock
+from ..interfaces import PowerPort
 
 if TYPE_CHECKING:
     from kicad_sch_helper import Schematic
@@ -118,6 +119,30 @@ class LDOBlock(CircuitBlock):
             "VOUT": vout_pos,
             "GND": gnd_pos,
             "EN": en_pos,
+        }
+
+        # Register typed ports with power interface metadata
+        self.typed_ports = {
+            "VIN": PowerPort(
+                name="VIN",
+                x=vin_pos[0],
+                y=vin_pos[1],
+                direction="input",
+            ),
+            "VOUT": PowerPort(
+                name="VOUT",
+                x=vout_pos[0],
+                y=vout_pos[1],
+                direction="output",
+            ),
+            "GND": PowerPort(
+                name="GND",
+                x=gnd_pos[0],
+                y=gnd_pos[1],
+                direction="passive",
+                voltage_min=0.0,
+                voltage_max=0.0,
+            ),
         }
 
         # Tie EN to VIN if requested

--- a/src/kicad_tools/schematic/blocks/validator.py
+++ b/src/kicad_tools/schematic/blocks/validator.py
@@ -1,0 +1,159 @@
+"""Connection validation for typed circuit block ports.
+
+Validates that wired ports are electrically and protocol-compatible,
+catching misconnections (e.g., I2C wired to SPI) at design time.
+
+Example::
+
+    from kicad_tools.schematic.blocks.validator import ConnectionValidator
+
+    validator = ConnectionValidator()
+    warnings = validator.validate_connection(usb_dp_port, spi_mosi_port)
+    for w in warnings:
+        print(f"[{w.severity}] {w.message}")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .base import Port
+from .interfaces import DataPort, PowerPort
+
+
+class WarningSeverity(Enum):
+    """Severity of a connection warning."""
+
+    ERROR = "error"
+    WARNING = "warning"
+
+
+@dataclass
+class ConnectionWarning:
+    """A warning or error from connection validation.
+
+    Attributes:
+        severity: Whether this is an error (must fix) or warning (review).
+        message: Human-readable description of the issue.
+        source_port: The source port in the connection.
+        target_port: The target port in the connection.
+    """
+
+    severity: WarningSeverity
+    message: str
+    source_port: Port
+    target_port: Port
+
+
+class ConnectionValidator:
+    """Validate that wired ports are compatible.
+
+    Checks interface category compatibility, protocol matching,
+    and voltage range overlap between typed ports.
+    """
+
+    # Protocols that are compatible with each other
+    COMPATIBLE_PROTOCOLS: dict[str, set[str]] = {
+        "usb2": {"usb2", "usb3"},
+        "usb3": {"usb2", "usb3"},
+    }
+
+    def validate_connection(self, source: Port, target: Port) -> list[ConnectionWarning]:
+        """Validate a connection between two ports.
+
+        Args:
+            source: Source port.
+            target: Target port.
+
+        Returns:
+            List of warnings/errors. Empty list means connection is valid.
+        """
+        warnings: list[ConnectionWarning] = []
+
+        # Skip validation for untyped ports (no interface metadata)
+        if source.interface is None and target.interface is None:
+            return warnings
+
+        # Check interface category compatibility
+        if source.interface is not None and target.interface is not None:
+            if not self._categories_compatible(source, target):
+                warnings.append(
+                    ConnectionWarning(
+                        severity=WarningSeverity.ERROR,
+                        message=(
+                            f"Interface category mismatch: "
+                            f"{source.interface.value} ({source.name}) "
+                            f"-> {target.interface.value} ({target.name})"
+                        ),
+                        source_port=source,
+                        target_port=target,
+                    )
+                )
+                return warnings  # Category mismatch is fatal, skip further checks
+
+        # Check protocol compatibility for data ports
+        if isinstance(source, DataPort) and isinstance(target, DataPort):
+            if source.protocol and target.protocol:
+                if not self._protocols_compatible(source.protocol, target.protocol):
+                    warnings.append(
+                        ConnectionWarning(
+                            severity=WarningSeverity.ERROR,
+                            message=(
+                                f"Protocol mismatch: "
+                                f"{source.protocol} ({source.name}) "
+                                f"-> {target.protocol} ({target.name})"
+                            ),
+                            source_port=source,
+                            target_port=target,
+                        )
+                    )
+
+        # Check voltage compatibility for power ports
+        if isinstance(source, PowerPort) and isinstance(target, PowerPort):
+            if not source.voltage_overlaps(target):
+                warnings.append(
+                    ConnectionWarning(
+                        severity=WarningSeverity.ERROR,
+                        message=(
+                            f"Voltage mismatch: "
+                            f"{source.voltage_min}-{source.voltage_max}V ({source.name}) "
+                            f"-> {target.voltage_min}-{target.voltage_max}V ({target.name})"
+                        ),
+                        source_port=source,
+                        target_port=target,
+                    )
+                )
+
+        # Check power-to-data misconnection
+        if isinstance(source, PowerPort) and isinstance(target, DataPort):
+            warnings.append(
+                ConnectionWarning(
+                    severity=WarningSeverity.WARNING,
+                    message=(f"Power port connected to data port: {source.name} -> {target.name}"),
+                    source_port=source,
+                    target_port=target,
+                )
+            )
+        elif isinstance(source, DataPort) and isinstance(target, PowerPort):
+            warnings.append(
+                ConnectionWarning(
+                    severity=WarningSeverity.WARNING,
+                    message=(f"Data port connected to power port: {source.name} -> {target.name}"),
+                    source_port=source,
+                    target_port=target,
+                )
+            )
+
+        return warnings
+
+    def _categories_compatible(self, source: Port, target: Port) -> bool:
+        """Check if interface categories are compatible."""
+        return source.interface == target.interface
+
+    def _protocols_compatible(self, source_proto: str, target_proto: str) -> bool:
+        """Check if two protocols are compatible."""
+        if source_proto == target_proto:
+            return True
+        compatible = self.COMPATIBLE_PROTOCOLS.get(source_proto, set())
+        return target_proto in compatible

--- a/tests/test_typed_ports.py
+++ b/tests/test_typed_ports.py
@@ -1,0 +1,629 @@
+"""Tests for typed interface ports and connection validation."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from kicad_tools.intent.types import InterfaceCategory
+from kicad_tools.schematic.blocks import (
+    CircuitBlock,
+    ConnectionValidator,
+    DataPort,
+    Port,
+    PowerPort,
+    WarningSeverity,
+)
+
+
+class TestPortExtensions:
+    """Tests for extended Port dataclass fields."""
+
+    def test_port_backward_compat(self):
+        """Port still works with only original fields."""
+        port = Port(name="VCC", x=10.0, y=20.0, direction="power")
+        assert port.name == "VCC"
+        assert port.pos() == (10.0, 20.0)
+        assert port.interface is None
+        assert port.interface_type is None
+        assert port.parameters is None
+        assert port.group is None
+
+    def test_port_with_interface_metadata(self):
+        """Port accepts optional interface metadata."""
+        port = Port(
+            name="D+",
+            x=50.0,
+            y=60.0,
+            direction="bidirectional",
+            interface=InterfaceCategory.DIFFERENTIAL,
+            interface_type="usb2_high_speed",
+            parameters={"impedance": 90.0},
+            group="usb_data",
+        )
+        assert port.interface == InterfaceCategory.DIFFERENTIAL
+        assert port.interface_type == "usb2_high_speed"
+        assert port.parameters == {"impedance": 90.0}
+        assert port.group == "usb_data"
+
+    def test_port_pos_unchanged(self):
+        """pos() method still works with extended fields."""
+        port = Port(
+            name="SDA",
+            x=100.0,
+            y=200.0,
+            interface=InterfaceCategory.BUS,
+        )
+        assert port.pos() == (100.0, 200.0)
+
+
+class TestPowerPort:
+    """Tests for PowerPort subclass."""
+
+    def test_power_port_defaults(self):
+        """PowerPort sets interface to POWER automatically."""
+        port = PowerPort(name="VCC", x=10.0, y=20.0)
+        assert port.interface == InterfaceCategory.POWER
+        assert port.direction == "power"
+        assert port.voltage_min is None
+        assert port.voltage_max is None
+        assert port.max_current is None
+
+    def test_power_port_with_voltage(self):
+        """PowerPort with voltage range."""
+        port = PowerPort(
+            name="VOUT",
+            x=50.0,
+            y=60.0,
+            direction="output",
+            voltage_min=3.135,
+            voltage_max=3.465,
+            max_current=0.5,
+        )
+        assert port.voltage_min == 3.135
+        assert port.voltage_max == 3.465
+        assert port.max_current == 0.5
+        assert port.interface == InterfaceCategory.POWER
+
+    def test_power_port_voltage_overlaps(self):
+        """Voltage overlap check between power ports."""
+        source = PowerPort(
+            name="VOUT",
+            x=0,
+            y=0,
+            voltage_min=3.0,
+            voltage_max=3.6,
+        )
+        target = PowerPort(
+            name="VIN",
+            x=10,
+            y=10,
+            voltage_min=3.0,
+            voltage_max=3.6,
+        )
+        assert source.voltage_overlaps(target) is True
+
+    def test_power_port_voltage_no_overlap(self):
+        """Voltage ranges that don't overlap."""
+        source = PowerPort(
+            name="VOUT",
+            x=0,
+            y=0,
+            voltage_min=3.0,
+            voltage_max=3.6,
+        )
+        target = PowerPort(
+            name="VIN",
+            x=10,
+            y=10,
+            voltage_min=4.5,
+            voltage_max=5.5,
+        )
+        assert source.voltage_overlaps(target) is False
+
+    def test_power_port_voltage_overlap_partial(self):
+        """Partially overlapping voltage ranges."""
+        source = PowerPort(
+            name="VOUT",
+            x=0,
+            y=0,
+            voltage_min=3.0,
+            voltage_max=3.6,
+        )
+        target = PowerPort(
+            name="VIN",
+            x=10,
+            y=10,
+            voltage_min=3.3,
+            voltage_max=5.0,
+        )
+        assert source.voltage_overlaps(target) is True
+
+    def test_power_port_voltage_overlap_none_values(self):
+        """Overlap returns True when voltage info is missing."""
+        source = PowerPort(name="VOUT", x=0, y=0)
+        target = PowerPort(name="VIN", x=10, y=10, voltage_min=3.0, voltage_max=3.6)
+        assert source.voltage_overlaps(target) is True
+
+    def test_power_port_is_port(self):
+        """PowerPort is a subclass of Port."""
+        port = PowerPort(name="VCC", x=0, y=0)
+        assert isinstance(port, Port)
+        assert port.pos() == (0.0, 0.0)
+
+
+class TestDataPort:
+    """Tests for DataPort subclass."""
+
+    def test_data_port_usb(self):
+        """DataPort for USB sets DIFFERENTIAL category."""
+        port = DataPort(
+            name="D+",
+            x=50.0,
+            y=60.0,
+            direction="bidirectional",
+            protocol="usb2",
+            signal_role="d+",
+        )
+        assert port.protocol == "usb2"
+        assert port.signal_role == "d+"
+        assert port.interface == InterfaceCategory.DIFFERENTIAL
+        assert port.interface_type == "usb2"
+
+    def test_data_port_i2c(self):
+        """DataPort for I2C sets BUS category."""
+        port = DataPort(
+            name="SDA",
+            x=100.0,
+            y=200.0,
+            direction="bidirectional",
+            protocol="i2c",
+            signal_role="sda",
+        )
+        assert port.interface == InterfaceCategory.BUS
+        assert port.interface_type == "i2c"
+
+    def test_data_port_spi(self):
+        """DataPort for SPI sets BUS category."""
+        port = DataPort(
+            name="MOSI",
+            x=100.0,
+            y=200.0,
+            direction="output",
+            protocol="spi",
+            signal_role="mosi",
+        )
+        assert port.interface == InterfaceCategory.BUS
+
+    def test_data_port_no_protocol(self):
+        """DataPort without protocol has no interface set."""
+        port = DataPort(name="GPIO1", x=0, y=0)
+        assert port.protocol is None
+        assert port.interface is None
+
+    def test_data_port_explicit_interface_preserved(self):
+        """Explicit interface is not overridden by protocol mapping."""
+        port = DataPort(
+            name="D+",
+            x=0,
+            y=0,
+            interface=InterfaceCategory.SINGLE_ENDED,
+            protocol="usb2",
+        )
+        assert port.interface == InterfaceCategory.SINGLE_ENDED
+
+    def test_data_port_is_port(self):
+        """DataPort is a subclass of Port."""
+        port = DataPort(name="TX", x=0, y=0, protocol="uart")
+        assert isinstance(port, Port)
+
+
+class TestCircuitBlockTypedPorts:
+    """Tests for CircuitBlock typed port support."""
+
+    def test_typed_ports_initialized(self):
+        """CircuitBlock has empty typed_ports dict."""
+        block = CircuitBlock()
+        assert block.typed_ports == {}
+
+    def test_get_typed_port_exists(self):
+        """get_typed_port returns typed port when available."""
+        block = CircuitBlock()
+        tp = PowerPort(name="VCC", x=10.0, y=20.0)
+        block.typed_ports["VCC"] = tp
+        block.ports["VCC"] = (10.0, 20.0)
+
+        result = block.get_typed_port("VCC")
+        assert result is tp
+        assert isinstance(result, PowerPort)
+
+    def test_get_typed_port_fallback(self):
+        """get_typed_port creates basic Port from position tuple."""
+        block = CircuitBlock()
+        block.ports["GND"] = (30.0, 40.0)
+
+        result = block.get_typed_port("GND")
+        assert isinstance(result, Port)
+        assert result.name == "GND"
+        assert result.pos() == (30.0, 40.0)
+        assert result.interface is None
+
+    def test_get_typed_port_not_found(self):
+        """get_typed_port raises KeyError for missing port."""
+        block = CircuitBlock()
+        with pytest.raises(KeyError, match="MISSING"):
+            block.get_typed_port("MISSING")
+
+    def test_backward_compat_port_method(self):
+        """Original port() method still works."""
+        block = CircuitBlock()
+        block.ports = {"VCC": (10.0, 20.0), "GND": (10.0, 30.0)}
+        assert block.port("VCC") == (10.0, 20.0)
+
+
+class TestConnectionValidator:
+    """Tests for ConnectionValidator."""
+
+    def setup_method(self):
+        self.validator = ConnectionValidator()
+
+    def test_untyped_ports_no_warnings(self):
+        """Untyped ports skip validation."""
+        source = Port(name="A", x=0, y=0)
+        target = Port(name="B", x=10, y=10)
+        warnings = self.validator.validate_connection(source, target)
+        assert warnings == []
+
+    def test_same_protocol_compatible(self):
+        """Same protocol is compatible."""
+        source = DataPort(name="SDA1", x=0, y=0, protocol="i2c", signal_role="sda")
+        target = DataPort(name="SDA2", x=10, y=10, protocol="i2c", signal_role="sda")
+        warnings = self.validator.validate_connection(source, target)
+        assert warnings == []
+
+    def test_different_protocol_error(self):
+        """Different protocols produce an error."""
+        source = DataPort(name="D+", x=0, y=0, protocol="usb2", signal_role="d+")
+        target = DataPort(name="MOSI", x=10, y=10, protocol="spi", signal_role="mosi")
+        warnings = self.validator.validate_connection(source, target)
+        # Should have category mismatch (DIFFERENTIAL vs BUS)
+        assert len(warnings) >= 1
+        assert any(w.severity == WarningSeverity.ERROR for w in warnings)
+
+    def test_usb2_usb3_compatible(self):
+        """USB2 and USB3 are compatible protocols."""
+        source = DataPort(name="D+", x=0, y=0, protocol="usb2", signal_role="d+")
+        target = DataPort(name="D+", x=10, y=10, protocol="usb3", signal_role="d+")
+        warnings = self.validator.validate_connection(source, target)
+        assert warnings == []
+
+    def test_i2c_to_spi_error(self):
+        """I2C to SPI connection produces protocol error."""
+        source = DataPort(name="SDA", x=0, y=0, protocol="i2c", signal_role="sda")
+        target = DataPort(name="MOSI", x=10, y=10, protocol="spi", signal_role="mosi")
+        warnings = self.validator.validate_connection(source, target)
+        assert len(warnings) >= 1
+        error_msgs = [w.message for w in warnings if w.severity == WarningSeverity.ERROR]
+        assert any("Protocol mismatch" in msg or "mismatch" in msg.lower() for msg in error_msgs)
+
+    def test_voltage_compatible(self):
+        """Compatible voltage ranges produce no warnings."""
+        source = PowerPort(name="VOUT", x=0, y=0, voltage_min=3.0, voltage_max=3.6)
+        target = PowerPort(name="VIN", x=10, y=10, voltage_min=3.0, voltage_max=3.6)
+        warnings = self.validator.validate_connection(source, target)
+        assert warnings == []
+
+    def test_voltage_mismatch_error(self):
+        """Incompatible voltage ranges produce an error."""
+        source = PowerPort(name="VOUT", x=0, y=0, voltage_min=3.0, voltage_max=3.6)
+        target = PowerPort(name="VIN", x=10, y=10, voltage_min=4.5, voltage_max=5.5)
+        warnings = self.validator.validate_connection(source, target)
+        assert len(warnings) == 1
+        assert warnings[0].severity == WarningSeverity.ERROR
+        assert "Voltage mismatch" in warnings[0].message
+
+    def test_power_to_data_category_mismatch(self):
+        """Connecting power port to data port produces category mismatch error."""
+        source = PowerPort(name="VOUT", x=0, y=0, voltage_min=3.0, voltage_max=3.6)
+        target = DataPort(name="SDA", x=10, y=10, protocol="i2c", signal_role="sda")
+        warnings = self.validator.validate_connection(source, target)
+        # POWER vs BUS category mismatch is caught as error
+        errors = [w for w in warnings if w.severity == WarningSeverity.ERROR]
+        assert len(errors) >= 1
+        assert "category mismatch" in errors[0].message.lower()
+
+    def test_data_to_power_category_mismatch(self):
+        """Connecting data port to power port produces category mismatch error."""
+        source = DataPort(name="D+", x=0, y=0, protocol="usb2", signal_role="d+")
+        target = PowerPort(name="VCC", x=10, y=10, voltage_min=3.0, voltage_max=3.6)
+        warnings = self.validator.validate_connection(source, target)
+        errors = [w for w in warnings if w.severity == WarningSeverity.ERROR]
+        assert len(errors) >= 1
+
+    def test_power_to_data_warning_same_category(self):
+        """Power-to-data warning when both have same interface category."""
+        source = PowerPort(
+            name="VOUT",
+            x=0,
+            y=0,
+            voltage_min=3.0,
+            voltage_max=3.6,
+            interface=InterfaceCategory.SINGLE_ENDED,
+        )
+        target = DataPort(
+            name="GPIO",
+            x=10,
+            y=10,
+            interface=InterfaceCategory.SINGLE_ENDED,
+        )
+        warnings = self.validator.validate_connection(source, target)
+        warning_msgs = [w for w in warnings if w.severity == WarningSeverity.WARNING]
+        assert len(warning_msgs) >= 1
+        assert "Power port connected to data port" in warning_msgs[0].message
+
+    def test_one_typed_one_untyped_no_error(self):
+        """Mixed typed/untyped skips category check if one is None."""
+        source = DataPort(name="D+", x=0, y=0, protocol="usb2")
+        target = Port(name="PIN1", x=10, y=10)
+        warnings = self.validator.validate_connection(source, target)
+        # No category mismatch when target has no interface
+        assert not any(
+            w.severity == WarningSeverity.ERROR and "category" in w.message.lower()
+            for w in warnings
+        )
+
+    def test_connection_warning_fields(self):
+        """ConnectionWarning stores port references."""
+        source = PowerPort(name="VOUT", x=0, y=0, voltage_min=3.0, voltage_max=3.6)
+        target = PowerPort(name="VIN", x=10, y=10, voltage_min=5.0, voltage_max=5.5)
+        warnings = self.validator.validate_connection(source, target)
+        assert len(warnings) == 1
+        assert warnings[0].source_port is source
+        assert warnings[0].target_port is target
+
+
+class TestUSBConnectorTypedPorts:
+    """Tests for USBConnector typed port annotations."""
+
+    @pytest.fixture
+    def mock_schematic(self):
+        """Create mock schematic for USB connector."""
+        sch = Mock()
+
+        def make_mock_symbol(symbol, x, y, ref, *args, **kwargs):
+            mock = Mock()
+            # Simulate connector pin positions
+            pin_map = {
+                "VBUS": (x, y - 20),
+                "GND": (x, y + 20),
+                "D+": (x + 5, y - 10),
+                "D-": (x + 5, y + 10),
+                "CC1": (x + 5, y - 5),
+                "CC2": (x + 5, y + 5),
+                "SHIELD": (x, y + 30),
+                "A": (x + 20, y - 10),
+                "K": (x + 20, y + 10),
+            }
+            mock.pin_position.side_effect = lambda name: pin_map.get(name, (0, 0))
+            return mock
+
+        sch.add_symbol = Mock(side_effect=make_mock_symbol)
+        sch.add_wire = Mock()
+        sch.add_junction = Mock()
+        return sch
+
+    def test_usb_typed_ports_exist(self, mock_schematic):
+        """USBConnector creates typed ports."""
+        from kicad_tools.schematic.blocks import USBConnector
+
+        usb = USBConnector(mock_schematic, x=50, y=100, esd_protection=False)
+        assert len(usb.typed_ports) > 0
+
+    def test_usb_data_ports_are_data_port(self, mock_schematic):
+        """USB D+/D- ports are DataPort instances."""
+        from kicad_tools.schematic.blocks import USBConnector
+
+        usb = USBConnector(mock_schematic, x=50, y=100, esd_protection=False)
+        dp = usb.typed_ports.get("D+")
+        dm = usb.typed_ports.get("D-")
+        assert isinstance(dp, DataPort)
+        assert isinstance(dm, DataPort)
+        assert dp.protocol == "usb2"
+        assert dm.protocol == "usb2"
+        assert dp.group == "usb_data"
+
+    def test_usb_vbus_is_power_port(self, mock_schematic):
+        """USB VBUS port is a PowerPort."""
+        from kicad_tools.schematic.blocks import USBConnector
+
+        usb = USBConnector(mock_schematic, x=50, y=100, esd_protection=False)
+        vbus = usb.typed_ports.get("VBUS")
+        assert isinstance(vbus, PowerPort)
+        assert vbus.voltage_min == 4.75
+        assert vbus.voltage_max == 5.25
+
+    def test_usb_backward_compat(self, mock_schematic):
+        """USBConnector still exposes tuple ports."""
+        from kicad_tools.schematic.blocks import USBConnector
+
+        usb = USBConnector(mock_schematic, x=50, y=100, esd_protection=False)
+        pos = usb.port("D+")
+        assert isinstance(pos, tuple)
+        assert len(pos) == 2
+
+
+class TestI2CPullupsTypedPorts:
+    """Tests for I2CPullups typed port annotations."""
+
+    @pytest.fixture
+    def mock_schematic(self):
+        """Create mock schematic for I2C block."""
+        sch = Mock()
+
+        def make_mock_symbol(symbol, x, y, ref, *args, **kwargs):
+            mock = Mock()
+            pin_map = {
+                "1": (x, y - 5),
+                "2": (x, y + 5),
+            }
+            mock.pin_position.side_effect = lambda name: pin_map.get(name, (0, 0))
+            return mock
+
+        sch.add_symbol = Mock(side_effect=make_mock_symbol)
+        sch.add_wire = Mock()
+        sch.add_junction = Mock()
+        return sch
+
+    def test_i2c_typed_ports_exist(self, mock_schematic):
+        """I2CPullups creates typed ports."""
+        from kicad_tools.schematic.blocks import I2CPullups
+
+        i2c = I2CPullups(mock_schematic, x=100, y=50)
+        assert len(i2c.typed_ports) > 0
+
+    def test_i2c_sda_scl_are_data_ports(self, mock_schematic):
+        """I2C SDA/SCL ports are DataPort instances."""
+        from kicad_tools.schematic.blocks import I2CPullups
+
+        i2c = I2CPullups(mock_schematic, x=100, y=50)
+        sda = i2c.typed_ports.get("SDA")
+        scl = i2c.typed_ports.get("SCL")
+        assert isinstance(sda, DataPort)
+        assert isinstance(scl, DataPort)
+        assert sda.protocol == "i2c"
+        assert scl.protocol == "i2c"
+        assert sda.signal_role == "sda"
+        assert scl.signal_role == "scl"
+
+    def test_i2c_vcc_is_power_port(self, mock_schematic):
+        """I2C VCC port is a PowerPort."""
+        from kicad_tools.schematic.blocks import I2CPullups
+
+        i2c = I2CPullups(mock_schematic, x=100, y=50)
+        vcc = i2c.typed_ports.get("VCC")
+        assert isinstance(vcc, PowerPort)
+
+
+class TestLDOBlockTypedPorts:
+    """Tests for LDOBlock typed port annotations."""
+
+    @pytest.fixture
+    def mock_schematic(self):
+        """Create mock schematic for LDO block."""
+        sch = Mock()
+
+        def make_mock_symbol(symbol, x, y, ref, *args, **kwargs):
+            mock = Mock()
+            pin_map = {
+                "VIN": (x - 10, y),
+                "VOUT": (x + 10, y),
+                "GND": (x, y + 10),
+                "EN": (x - 5, y + 5),
+                "1": (x, y - 5),
+                "2": (x, y + 5),
+            }
+            mock.pin_position.side_effect = lambda name: pin_map.get(name, (0, 0))
+            return mock
+
+        sch.add_symbol = Mock(side_effect=make_mock_symbol)
+        sch.add_wire = Mock()
+        sch.add_junction = Mock()
+        return sch
+
+    def test_ldo_typed_ports_exist(self, mock_schematic):
+        """LDOBlock creates typed ports."""
+        from kicad_tools.schematic.blocks import LDOBlock
+
+        ldo = LDOBlock(mock_schematic, x=100, y=50)
+        assert len(ldo.typed_ports) > 0
+
+    def test_ldo_ports_are_power_ports(self, mock_schematic):
+        """LDO VIN/VOUT/GND ports are PowerPort instances."""
+        from kicad_tools.schematic.blocks import LDOBlock
+
+        ldo = LDOBlock(mock_schematic, x=100, y=50)
+        assert isinstance(ldo.typed_ports["VIN"], PowerPort)
+        assert isinstance(ldo.typed_ports["VOUT"], PowerPort)
+        assert isinstance(ldo.typed_ports["GND"], PowerPort)
+
+    def test_ldo_port_directions(self, mock_schematic):
+        """LDO typed ports have correct directions."""
+        from kicad_tools.schematic.blocks import LDOBlock
+
+        ldo = LDOBlock(mock_schematic, x=100, y=50)
+        assert ldo.typed_ports["VIN"].direction == "input"
+        assert ldo.typed_ports["VOUT"].direction == "output"
+
+    def test_ldo_backward_compat(self, mock_schematic):
+        """LDOBlock still exposes tuple ports."""
+        from kicad_tools.schematic.blocks import LDOBlock
+
+        ldo = LDOBlock(mock_schematic, x=100, y=50)
+        pos = ldo.port("VIN")
+        assert isinstance(pos, tuple)
+
+
+class TestCrossBockValidation:
+    """Integration tests: validate connections between different blocks."""
+
+    def test_usb_to_i2c_detected(self):
+        """Connecting USB data to I2C data produces error."""
+        validator = ConnectionValidator()
+        usb_dp = DataPort(name="D+", x=0, y=0, protocol="usb2", signal_role="d+")
+        i2c_sda = DataPort(name="SDA", x=10, y=10, protocol="i2c", signal_role="sda")
+
+        warnings = validator.validate_connection(usb_dp, i2c_sda)
+        errors = [w for w in warnings if w.severity == WarningSeverity.ERROR]
+        assert len(errors) >= 1
+
+    def test_i2c_to_i2c_valid(self):
+        """Connecting I2C to I2C produces no errors."""
+        validator = ConnectionValidator()
+        sda1 = DataPort(name="SDA", x=0, y=0, protocol="i2c", signal_role="sda")
+        sda2 = DataPort(name="SDA", x=10, y=10, protocol="i2c", signal_role="sda")
+
+        warnings = validator.validate_connection(sda1, sda2)
+        assert warnings == []
+
+    def test_3v3_to_5v_voltage_mismatch(self):
+        """Connecting 3.3V output to 5V input produces error."""
+        validator = ConnectionValidator()
+        vout_3v3 = PowerPort(
+            name="VOUT",
+            x=0,
+            y=0,
+            voltage_min=3.135,
+            voltage_max=3.465,
+        )
+        vin_5v = PowerPort(
+            name="VIN",
+            x=10,
+            y=10,
+            voltage_min=4.5,
+            voltage_max=5.5,
+        )
+
+        warnings = validator.validate_connection(vout_3v3, vin_5v)
+        errors = [w for w in warnings if w.severity == WarningSeverity.ERROR]
+        assert len(errors) == 1
+        assert "Voltage mismatch" in errors[0].message
+
+    def test_3v3_to_3v3_compatible(self):
+        """Connecting matching voltage ranges produces no errors."""
+        validator = ConnectionValidator()
+        source = PowerPort(
+            name="VOUT",
+            x=0,
+            y=0,
+            voltage_min=3.0,
+            voltage_max=3.6,
+        )
+        target = PowerPort(
+            name="VIN",
+            x=10,
+            y=10,
+            voltage_min=2.7,
+            voltage_max=3.6,
+        )
+
+        warnings = validator.validate_connection(source, target)
+        assert warnings == []


### PR DESCRIPTION
## Summary

- Extend `Port` dataclass with optional interface metadata fields (`interface`, `interface_type`, `parameters`, `group`) for backward-compatible typed ports
- Add `PowerPort` and `DataPort` subclasses with voltage/current and protocol metadata
- Add `ConnectionValidator` that checks interface category, protocol, and voltage compatibility between ports
- Annotate `USBConnector`, `I2CPullups`, and `LDOBlock` with typed ports via `typed_ports` dict
- Add `CircuitBlock.get_typed_port()` method with fallback to basic Port from position tuple

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Port extension with optional fields | Verified | `base.py` Port has interface, interface_type, parameters, group — all default None |
| PowerPort/DataPort subclasses | Verified | `interfaces.py` with voltage overlap check and protocol-to-category mapping |
| ConnectionValidator catches misconnections | Verified | USB→SPI, I2C→SPI, 3.3V→5V all caught in tests |
| Backward compatibility | Verified | All 250 existing tests pass unchanged |
| Incremental adoption | Verified | Blocks opt-in via typed_ports; existing tuple ports untouched |
| USB/I2C/LDO blocks annotated | Verified | USBConnector (D+/D-/VBUS/GND), I2CPullups (SDA/SCL/VCC/GND), LDOBlock (VIN/VOUT/GND) |

## Test plan

- [x] 48 new tests in `test_typed_ports.py` covering Port extensions, PowerPort, DataPort, CircuitBlock typed ports, ConnectionValidator, block annotations, and cross-block validation
- [x] All 250 existing tests in `test_schematic_blocks.py` pass (backward compatibility)
- [x] `ruff format` and `ruff check` pass on all modified files

Closes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)