### PR TITLE
feat(mcp): add kct mcp setup command to auto-configure MCP clients

### DIFF
--- a/docs/mcp/setup.md
+++ b/docs/mcp/setup.md
@@ -53,7 +53,64 @@ pipx ensurepath
 pipx install "kicad-tools[mcp]"
 ```
 
-## Client Configuration
+## Quick Setup (Recommended)
+
+The easiest way to configure MCP is with the built-in setup command:
+
+```bash
+# For Claude Code (default)
+kct mcp setup
+
+# For Claude Desktop
+kct mcp setup --client claude-desktop
+
+# Preview without making changes
+kct mcp setup --dry-run
+```
+
+If you're developing from source with `uv`:
+
+```bash
+uv run kct mcp setup
+```
+
+This auto-detects the correct `kct` binary path and writes the
+appropriate MCP config file. It handles development installs (uv),
+global installs (pip/pipx), and virtual environments.
+
+## Manual Client Configuration
+
+### Claude Code
+
+1. **Config file**: `~/.claude/mcp.json`
+
+2. **For development installs** (using uv from the repo):
+   ```json
+   {
+     "mcpServers": {
+       "kicad-tools": {
+         "command": "uv",
+         "args": ["run", "--project", "/path/to/kicad-tools", "kct", "mcp", "serve"],
+         "env": {}
+       }
+     }
+   }
+   ```
+
+3. **For global installs** (pip/pipx):
+   ```json
+   {
+     "mcpServers": {
+       "kicad-tools": {
+         "command": "kct",
+         "args": ["mcp", "serve"],
+         "env": {}
+       }
+     }
+   }
+   ```
+
+4. **Restart Claude Code** to pick up the new MCP server.
 
 ### Claude Desktop (macOS)
 

--- a/docs/mcp/troubleshooting.md
+++ b/docs/mcp/troubleshooting.md
@@ -4,6 +4,24 @@ Solutions for common issues with the kicad-tools MCP server.
 
 ## Installation Issues
 
+### "kct binary not found" / MCP server fails on startup
+
+**Cause:** The MCP config references a `kct` binary path that doesn't exist
+(e.g., `~/.local/bin/kct`).
+
+**Solution:** Re-run setup to auto-detect the correct path:
+
+```bash
+# From the kicad-tools repo
+uv run kct mcp setup
+
+# Or for a global install
+kct mcp setup
+```
+
+This writes the correct command to `~/.claude/mcp.json` (Claude Code) or
+the Claude Desktop config file.
+
 ### "No module named 'kicad_tools'"
 
 **Cause:** kicad-tools is not installed or not in the Python path.
@@ -366,6 +384,7 @@ Include:
 
 | Error | Likely Cause | Quick Fix |
 |-------|--------------|-----------|
+| "kct binary not found" | Wrong path in MCP config | `uv run kct mcp setup` |
 | "No module named" | Not installed | `pip install "kicad-tools[mcp]"` |
 | "PCB file not found" | Wrong path | Use absolute path |
 | "Session not found" | Expired session | Start new session |

--- a/src/kicad_tools/cli/commands/mcp.py
+++ b/src/kicad_tools/cli/commands/mcp.py
@@ -1,5 +1,11 @@
 """MCP server command handlers."""
 
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
 __all__ = ["run_mcp_command"]
 
 
@@ -16,12 +22,15 @@ def run_mcp_command(args) -> int:
 
     if mcp_subcommand == "serve":
         return _run_serve(args)
+    elif mcp_subcommand == "setup":
+        return _run_setup(args)
     else:
         # Default to showing help
-        print("Usage: kct mcp serve [OPTIONS]")
+        print("Usage: kct mcp <command> [OPTIONS]")
         print()
         print("Commands:")
         print("  serve    Start the MCP server")
+        print("  setup    Configure MCP client integration")
         return 0
 
 
@@ -55,3 +64,149 @@ def _run_serve(args) -> int:
     except Exception as e:
         print(f"Error starting server: {e}")
         return 1
+
+
+def _find_kct_command() -> tuple[str, list[str]]:
+    """Find the best way to invoke 'kct mcp serve'.
+
+    Priority order:
+    1. uv run (if in a uv-managed project) — most portable for dev installs
+    2. Global kct binary (if on PATH and not inside a .venv)
+    3. python -m fallback
+
+    Returns:
+        Tuple of (command, args) for the MCP server config.
+    """
+    # 1. Check if we're in a uv-managed project (dev install)
+    uv_path = shutil.which("uv")
+    project_root = _find_project_root()
+    if uv_path and project_root:
+        return (uv_path, ["run", "--project", str(project_root), "kct", "mcp", "serve"])
+
+    # 2. Check if kct is globally installed (not in a .venv)
+    kct_path = shutil.which("kct")
+    if kct_path and ".venv" not in kct_path:
+        return (kct_path, ["mcp", "serve"])
+
+    # 3. Fall back to python -m
+    python_path = sys.executable
+    return (python_path, ["-m", "kicad_tools.mcp.server"])
+
+
+def _find_project_root() -> Path | None:
+    """Find the kicad-tools project root by looking for pyproject.toml."""
+    # Start from this file's location and walk up
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        pyproject = parent / "pyproject.toml"
+        if pyproject.exists():
+            try:
+                content = pyproject.read_text()
+                if "kicad-tools" in content or "kicad_tools" in content:
+                    return parent
+            except OSError:
+                continue
+    return None
+
+
+def _get_claude_code_config_path() -> Path:
+    """Get the Claude Code MCP config file path."""
+    return Path.home() / ".claude" / "mcp.json"
+
+
+def _get_claude_desktop_config_path() -> Path:
+    """Get the Claude Desktop MCP config file path."""
+    if sys.platform == "darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
+    elif sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", "")
+        return Path(appdata) / "Claude" / "claude_desktop_config.json"
+    else:
+        return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def _run_setup(args) -> int:
+    """Configure MCP client integration.
+
+    Detects the best way to invoke kct and writes the MCP config
+    for the specified client.
+
+    Args:
+        args: Parsed command line arguments
+
+    Returns:
+        Exit code (0 for success)
+    """
+    client = getattr(args, "client", "claude-code")
+    dry_run = getattr(args, "dry_run", False)
+
+    command, cmd_args = _find_kct_command()
+
+    server_config = {
+        "command": command,
+        "args": cmd_args,
+        "env": {},
+    }
+
+    if client == "claude-code":
+        config_path = _get_claude_code_config_path()
+    else:
+        config_path = _get_claude_desktop_config_path()
+
+    # Show what we'll do
+    print(f"MCP client: {client}")
+    print(f"Config file: {config_path}")
+    print(f"Command: {command} {' '.join(cmd_args)}")
+    print()
+
+    if dry_run:
+        print("Dry run — no changes made.")
+        print()
+        print("Would write:")
+        print(json.dumps({"mcpServers": {"kicad-tools": server_config}}, indent=2))
+        return 0
+
+    # Read existing config or create new
+    existing: dict = {}
+    if config_path.exists():
+        try:
+            existing = json.loads(config_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+
+    # Merge in the kicad-tools server
+    if "mcpServers" not in existing:
+        existing["mcpServers"] = {}
+
+    if "kicad-tools" in existing["mcpServers"]:
+        old = existing["mcpServers"]["kicad-tools"]
+        old_cmd = f"{old.get('command', '')} {' '.join(old.get('args', []))}"
+        print("Replacing existing kicad-tools config:")
+        print(f"  was: {old_cmd}")
+        print(f"  now: {command} {' '.join(cmd_args)}")
+    else:
+        print("Adding kicad-tools MCP server config.")
+
+    existing["mcpServers"]["kicad-tools"] = server_config
+
+    # Write config
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(existing, indent=2) + "\n")
+
+    print()
+    print(f"Wrote {config_path}")
+
+    if client == "claude-code":
+        print()
+        print("Restart Claude Code to pick up the new MCP server.")
+    else:
+        print()
+        print("Restart Claude Desktop to pick up the new MCP server.")
+
+    return 0

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2462,6 +2462,29 @@ def _add_mcp_parser(subparsers) -> None:
         help="Port for HTTP mode (default: 8080)",
     )
 
+    # mcp setup subcommand
+    setup_parser = mcp_subparsers.add_parser(
+        "setup",
+        help="Configure MCP client integration",
+        description=(
+            "Auto-detect the kct binary and write the MCP server config "
+            "for Claude Code or Claude Desktop."
+        ),
+    )
+    setup_parser.add_argument(
+        "--client",
+        "-c",
+        choices=["claude-code", "claude-desktop"],
+        default="claude-code",
+        help="MCP client to configure (default: claude-code)",
+    )
+    setup_parser.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Show what would be written without making changes",
+    )
+
 
 def _add_init_parser(subparsers) -> None:
     """Add init subcommand parser for project initialization."""

--- a/tests/test_mcp_setup.py
+++ b/tests/test_mcp_setup.py
@@ -1,0 +1,221 @@
+"""Tests for the MCP setup command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from kicad_tools.cli.commands.mcp import (
+    _find_kct_command,
+    _find_project_root,
+    _get_claude_code_config_path,
+    _run_setup,
+)
+
+
+class TestFindProjectRoot:
+    """Tests for _find_project_root."""
+
+    def test_finds_project_root(self):
+        """Should find the kicad-tools project root."""
+        root = _find_project_root()
+        assert root is not None
+        assert (root / "pyproject.toml").exists()
+
+    def test_project_root_contains_kicad_tools(self):
+        """Project root pyproject.toml should mention kicad-tools."""
+        root = _find_project_root()
+        assert root is not None
+        content = (root / "pyproject.toml").read_text()
+        assert "kicad-tools" in content or "kicad_tools" in content
+
+
+class TestFindKctCommand:
+    """Tests for _find_kct_command."""
+
+    def test_returns_command_and_args(self):
+        """Should return a (command, args) tuple."""
+        command, args = _find_kct_command()
+        assert isinstance(command, str)
+        assert isinstance(args, list)
+        assert len(command) > 0
+        assert len(args) > 0
+
+    def test_uv_preferred_for_dev_installs(self):
+        """If uv is available and in a project, prefer uv run."""
+
+        def mock_which(cmd):
+            if cmd == "uv":
+                return "/usr/local/bin/uv"
+            if cmd == "kct":
+                return "/usr/local/bin/kct"
+            return None
+
+        with patch("shutil.which", side_effect=mock_which):
+            command, args = _find_kct_command()
+            assert command == "/usr/local/bin/uv"
+            assert args[0] == "run"
+            assert "kct" in args
+            assert "mcp" in args
+            assert "serve" in args
+
+    def test_global_kct_when_no_uv(self):
+        """If kct is globally installed but uv is not, use kct directly."""
+        with patch(
+            "shutil.which", side_effect=lambda cmd: "/usr/local/bin/kct" if cmd == "kct" else None
+        ):
+            command, args = _find_kct_command()
+            assert command == "/usr/local/bin/kct"
+            assert args == ["mcp", "serve"]
+
+    def test_venv_kct_skipped(self):
+        """kct inside a .venv should not be used directly."""
+
+        def mock_which(cmd):
+            if cmd == "kct":
+                return "/some/project/.venv/bin/kct"
+            return None
+
+        with patch("shutil.which", side_effect=mock_which):
+            command, args = _find_kct_command()
+            # Should fall back to python -m, not use the .venv kct
+            assert command != "/some/project/.venv/bin/kct"
+            assert args == ["-m", "kicad_tools.mcp.server"]
+
+    def test_python_module_fallback(self):
+        """If neither kct nor uv is available, fall back to python -m."""
+        with patch("shutil.which", return_value=None):
+            command, args = _find_kct_command()
+            assert "python" in command.lower() or command.endswith("python3")
+            assert args == ["-m", "kicad_tools.mcp.server"]
+
+
+class TestGetClaudeCodeConfigPath:
+    """Tests for _get_claude_code_config_path."""
+
+    def test_returns_path(self):
+        """Should return a Path to ~/.claude/mcp.json."""
+        path = _get_claude_code_config_path()
+        assert isinstance(path, Path)
+        assert path.name == "mcp.json"
+        assert ".claude" in str(path)
+
+
+class TestRunSetup:
+    """Tests for _run_setup."""
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        """Dry run should not create any files."""
+        config_path = tmp_path / "mcp.json"
+
+        class Args:
+            client = "claude-code"
+            dry_run = True
+
+        with patch(
+            "kicad_tools.cli.commands.mcp._get_claude_code_config_path",
+            return_value=config_path,
+        ):
+            result = _run_setup(Args())
+
+        assert result == 0
+        assert not config_path.exists()
+
+    def test_writes_config_file(self, tmp_path):
+        """Setup should write a valid MCP config."""
+        config_path = tmp_path / "mcp.json"
+
+        class Args:
+            client = "claude-code"
+            dry_run = False
+
+        with patch(
+            "kicad_tools.cli.commands.mcp._get_claude_code_config_path",
+            return_value=config_path,
+        ):
+            result = _run_setup(Args())
+
+        assert result == 0
+        assert config_path.exists()
+
+        config = json.loads(config_path.read_text())
+        assert "mcpServers" in config
+        assert "kicad-tools" in config["mcpServers"]
+
+        server = config["mcpServers"]["kicad-tools"]
+        assert "command" in server
+        assert "args" in server
+
+    def test_merges_with_existing_config(self, tmp_path):
+        """Setup should preserve other MCP servers in existing config."""
+        config_path = tmp_path / "mcp.json"
+        existing = {
+            "mcpServers": {
+                "other-server": {
+                    "command": "other",
+                    "args": ["serve"],
+                }
+            }
+        }
+        config_path.write_text(json.dumps(existing))
+
+        class Args:
+            client = "claude-code"
+            dry_run = False
+
+        with patch(
+            "kicad_tools.cli.commands.mcp._get_claude_code_config_path",
+            return_value=config_path,
+        ):
+            result = _run_setup(Args())
+
+        assert result == 0
+        config = json.loads(config_path.read_text())
+        assert "other-server" in config["mcpServers"]
+        assert "kicad-tools" in config["mcpServers"]
+
+    def test_replaces_existing_kicad_tools_config(self, tmp_path):
+        """Setup should replace an existing kicad-tools entry."""
+        config_path = tmp_path / "mcp.json"
+        existing = {
+            "mcpServers": {
+                "kicad-tools": {
+                    "command": "/nonexistent/path/kct",
+                    "args": ["mcp", "serve"],
+                }
+            }
+        }
+        config_path.write_text(json.dumps(existing))
+
+        class Args:
+            client = "claude-code"
+            dry_run = False
+
+        with patch(
+            "kicad_tools.cli.commands.mcp._get_claude_code_config_path",
+            return_value=config_path,
+        ):
+            result = _run_setup(Args())
+
+        assert result == 0
+        config = json.loads(config_path.read_text())
+        server = config["mcpServers"]["kicad-tools"]
+        assert server["command"] != "/nonexistent/path/kct"
+
+    def test_creates_parent_directories(self, tmp_path):
+        """Setup should create parent dirs if they don't exist."""
+        config_path = tmp_path / "nested" / "dir" / "mcp.json"
+
+        class Args:
+            client = "claude-code"
+            dry_run = False
+
+        with patch(
+            "kicad_tools.cli.commands.mcp._get_claude_code_config_path",
+            return_value=config_path,
+        ):
+            result = _run_setup(Args())
+
+        assert result == 0
+        assert config_path.exists()


### PR DESCRIPTION
## Summary

- Adds `kct mcp setup` command that auto-detects the correct `kct` binary path and writes MCP server config for Claude Code (`~/.claude/mcp.json`) or Claude Desktop
- Supports `--client {claude-code,claude-desktop}` and `--dry-run` flags
- Updates MCP setup docs with Claude Code configuration instructions and quick setup section
- Adds "kct binary not found" troubleshooting entry

Closes #1149

## Test plan

- [x] 13 new unit tests pass (`tests/test_mcp_setup.py`)
- [x] `kct mcp setup --dry-run` correctly detects uv and project root
- [x] `kct mcp setup --client claude-desktop --dry-run` targets correct config path
- [x] Merges with existing MCP config (preserves other servers)
- [x] Replaces stale kicad-tools entries
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)