### PR TITLE
feat(drc): add fab-aware severity reclassification to kicad-drc-summary

### DIFF
--- a/tests/test_drc_summary.py
+++ b/tests/test_drc_summary.py
@@ -7,6 +7,8 @@ import pytest
 
 from kicad_tools.cli.drc_summary import (
     IssueSeverity,
+    ManufacturerComparison,
+    _build_fab_annotation,
     compare_with_manufacturer,
     create_summary,
     get_severity,
@@ -412,3 +414,422 @@ class TestManufacturerOptions:
         # Both should work
         assert summary_2l.manufacturer == "jlcpcb"
         assert summary_4l.manufacturer == "jlcpcb"
+
+
+class TestFabReclassification:
+    """Tests for fab-aware severity reclassification."""
+
+    def test_annular_width_reclassified_for_jlcpcb(self):
+        """Annular width violation above JLCPCB limit should be FAB_ACCEPTABLE."""
+        jlcpcb_rules = get_profile("jlcpcb").get_design_rules(2)
+        violation = DRCViolation(
+            type=ViolationType.VIA_ANNULAR_WIDTH,
+            type_str="via_annular_width",
+            severity=Severity.ERROR,
+            message="Annular width violation",
+            actual_value_mm=jlcpcb_rules.min_annular_ring_mm + 0.01,  # Above JLCPCB limit
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+
+        assert summary.fab_acceptable_count == 1
+        assert summary.blocking_count == 0
+        assert summary.warning_count == 0
+
+    def test_annular_width_blocking_for_oshpark(self):
+        """Annular width below OSHPark limit should remain in default severity."""
+        # OSHPark has stricter annular ring requirements
+        oshpark_rules = get_profile("oshpark").get_design_rules(2)
+        # Use a value below OSHPark's limit
+        actual = oshpark_rules.min_annular_ring_mm - 0.01
+
+        violation = DRCViolation(
+            type=ViolationType.VIA_ANNULAR_WIDTH,
+            type_str="via_annular_width",
+            severity=Severity.ERROR,
+            message="Annular width violation",
+            actual_value_mm=actual,
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="oshpark")
+
+        # Via annular width defaults to WARNING, and it fails fab rules,
+        # so it stays as WARNING (not reclassified)
+        assert summary.fab_acceptable_count == 0
+        assert summary.warning_count == 1
+
+    def test_clearance_reclassified_when_above_fab_limit(self):
+        """Clearance above manufacturer limit should be FAB_ACCEPTABLE."""
+        violation = DRCViolation(
+            type=ViolationType.CLEARANCE,
+            type_str="clearance",
+            severity=Severity.ERROR,
+            message="Clearance violation",
+            actual_value_mm=0.15,  # Above JLCPCB 0.1mm limit
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+
+        assert summary.fab_acceptable_count == 1
+        assert summary.blocking_count == 0
+        assert "clearance" in summary.fab_acceptable_by_type
+
+    def test_clearance_stays_blocking_when_below_fab_limit(self):
+        """Clearance below manufacturer limit should stay BLOCKING."""
+        violation = DRCViolation(
+            type=ViolationType.CLEARANCE,
+            type_str="clearance",
+            severity=Severity.ERROR,
+            message="Clearance violation",
+            actual_value_mm=0.05,  # Below JLCPCB 0.1mm limit
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+
+        assert summary.blocking_count == 1
+        assert summary.fab_acceptable_count == 0
+
+    def test_silk_stays_cosmetic_regardless_of_manufacturer(self):
+        """Silk violations always stay cosmetic, even with --fab."""
+        violation = DRCViolation(
+            type=ViolationType.SILK_OVER_COPPER,
+            type_str="silk_over_copper",
+            severity=Severity.WARNING,
+            message="Silk over copper",
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+
+        assert summary.cosmetic_count == 1
+        assert summary.fab_acceptable_count == 0
+
+    def test_no_manufacturer_behavior_unchanged(self):
+        """Without --fab, behavior should be unchanged (backward compatible)."""
+        violations = [
+            DRCViolation(
+                type=ViolationType.CLEARANCE,
+                type_str="clearance",
+                severity=Severity.ERROR,
+                message="Clearance violation",
+                actual_value_mm=0.15,
+            ),
+            DRCViolation(
+                type=ViolationType.VIA_ANNULAR_WIDTH,
+                type_str="via_annular_width",
+                severity=Severity.ERROR,
+                message="Annular width",
+                actual_value_mm=0.125,
+            ),
+            DRCViolation(
+                type=ViolationType.SILK_OVER_COPPER,
+                type_str="silk_over_copper",
+                severity=Severity.WARNING,
+                message="Silk",
+            ),
+        ]
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=violations,
+        )
+        summary = create_summary(report)
+
+        # Without manufacturer, no fab reclassification
+        assert summary.fab_acceptable_count == 0
+        assert summary.blocking_count == 1  # clearance
+        assert summary.warning_count == 1  # via_annular_width
+        assert summary.cosmetic_count == 1  # silk
+
+    def test_mixed_violations_with_fab(self):
+        """Mixed violations should be correctly split with --fab."""
+        violations = [
+            # Clearance above JLCPCB limit → FAB_ACCEPTABLE
+            DRCViolation(
+                type=ViolationType.CLEARANCE,
+                type_str="clearance",
+                severity=Severity.ERROR,
+                message="Clearance above fab limit",
+                actual_value_mm=0.15,
+            ),
+            # Clearance below JLCPCB limit → stays BLOCKING
+            DRCViolation(
+                type=ViolationType.CLEARANCE,
+                type_str="clearance",
+                severity=Severity.ERROR,
+                message="Clearance below fab limit",
+                actual_value_mm=0.05,
+            ),
+            # Short circuit → always BLOCKING (no fab comparison)
+            DRCViolation(
+                type=ViolationType.SHORTING_ITEMS,
+                type_str="shorting_items",
+                severity=Severity.ERROR,
+                message="Short circuit",
+            ),
+            # Unconnected → WARNING (no fab comparison for this type)
+            DRCViolation(
+                type=ViolationType.UNCONNECTED_ITEMS,
+                type_str="unconnected_items",
+                severity=Severity.ERROR,
+                message="Unconnected pin",
+            ),
+            # Silk → COSMETIC
+            DRCViolation(
+                type=ViolationType.SILK_OVER_COPPER,
+                type_str="silk_over_copper",
+                severity=Severity.WARNING,
+                message="Silk",
+            ),
+        ]
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=violations,
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+
+        assert summary.fab_acceptable_count == 1  # clearance above limit
+        assert summary.blocking_count == 2  # clearance below limit + short
+        assert summary.warning_count == 1  # unconnected
+        assert summary.cosmetic_count == 1  # silk
+
+    def test_track_width_reclassified(self):
+        """Track width above fab limit should be FAB_ACCEPTABLE."""
+        violation = DRCViolation(
+            type=ViolationType.TRACK_WIDTH,
+            type_str="track_width",
+            severity=Severity.ERROR,
+            message="Track width violation",
+            actual_value_mm=0.2,  # Above typical JLCPCB limit
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+
+        assert summary.fab_acceptable_count == 1
+        assert summary.blocking_count == 0
+
+
+class TestFabAcceptableOutput:
+    """Tests for fab-acceptable output formatting."""
+
+    def test_fab_acceptable_to_dict(self):
+        """JSON output should include fab_acceptable category."""
+        violation = DRCViolation(
+            type=ViolationType.CLEARANCE,
+            type_str="clearance",
+            severity=Severity.ERROR,
+            message="Clearance violation",
+            actual_value_mm=0.15,
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+        d = summary.to_dict()
+
+        assert "fab_acceptable" in d
+        assert d["fab_acceptable"]["count"] == 1
+        assert "clearance" in d["fab_acceptable"]["by_type"]
+        assert d["counts"]["fab_acceptable"] == 1
+
+    def test_fab_acceptable_json_serializable(self):
+        """Fab-acceptable data in dict should be JSON serializable."""
+        violation = DRCViolation(
+            type=ViolationType.CLEARANCE,
+            type_str="clearance",
+            severity=Severity.ERROR,
+            message="Clearance violation",
+            actual_value_mm=0.15,
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+        d = summary.to_dict()
+
+        # Should not raise
+        json_str = json.dumps(d)
+        assert "fab_acceptable" in json_str
+
+    def test_cli_fab_summary_table(self, fixtures_dir: Path, capsys):
+        """Table output with --fab should show FAB-ACCEPTABLE section."""
+        report_path = fixtures_dir / "sample_drc.rpt"
+        main([str(report_path), "--fab", "jlcpcb"])
+
+        captured = capsys.readouterr()
+        # Output should contain BLOCKING and VERDICT sections
+        assert "BLOCKING" in captured.out
+        assert "VERDICT" in captured.out
+
+    def test_cli_fab_summary_json(self, fixtures_dir: Path, capsys):
+        """JSON output with --fab should include fab_acceptable counts."""
+        report_path = fixtures_dir / "sample_drc.rpt"
+        main([str(report_path), "--fab", "jlcpcb", "--format", "json"])
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+
+        assert "fab_acceptable" in output
+        assert "count" in output["fab_acceptable"]
+        assert output["counts"]["fab_acceptable"] >= 0
+
+    def test_exit_code_zero_when_only_fab_acceptable(self):
+        """Exit code should be 0 when all violations are fab-acceptable."""
+        # Create violation that passes JLCPCB limits
+        violation = DRCViolation(
+            type=ViolationType.CLEARANCE,
+            type_str="clearance",
+            severity=Severity.ERROR,
+            message="Clearance violation",
+            actual_value_mm=0.15,  # Above JLCPCB 0.1mm
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+
+        # Fab-acceptable violations should not trigger blocking
+        assert not summary.has_blocking
+        assert summary.fab_acceptable_count == 1
+
+    def test_verdict_fab_compatible(self):
+        """Verdict should indicate fab compatibility when all pass."""
+        violation = DRCViolation(
+            type=ViolationType.CLEARANCE,
+            type_str="clearance",
+            severity=Severity.ERROR,
+            message="Clearance violation",
+            actual_value_mm=0.15,
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+
+        assert "FAB COMPATIBLE" in summary.verdict
+        assert "JLCPCB" in summary.verdict
+
+    def test_verdict_blocking_with_manufacturer(self):
+        """Verdict with fab and blocking violations should mention manufacturer."""
+        violation = DRCViolation(
+            type=ViolationType.CLEARANCE,
+            type_str="clearance",
+            severity=Severity.ERROR,
+            message="Clearance violation",
+            actual_value_mm=0.05,  # Below JLCPCB limit
+        )
+        report = DRCReport(
+            source_file="test.json",
+            created_at=None,
+            pcb_name="test.kicad_pcb",
+            violations=[violation],
+        )
+        summary = create_summary(report, manufacturer_id="jlcpcb")
+
+        assert "BLOCKING" in summary.verdict
+        assert "JLCPCB" in summary.verdict
+
+    def test_build_fab_annotation(self):
+        """Fab annotation should show actual vs manufacturer limit."""
+        violation = DRCViolation(
+            type=ViolationType.CLEARANCE,
+            type_str="clearance",
+            severity=Severity.ERROR,
+            message="Clearance violation",
+            actual_value_mm=0.15,
+        )
+        comparison = ManufacturerComparison(
+            violation=violation,
+            is_false_positive=True,
+            manufacturer_limit=0.1,
+            actual_value=0.15,
+            message="JLCPCB accepts 0.100mm",
+        )
+        annotation = _build_fab_annotation("clearance", [comparison], "jlcpcb")
+
+        assert "0.150mm" in annotation
+        assert "JLCPCB" in annotation
+        assert "0.100mm" in annotation
+
+    def test_build_fab_annotation_no_match(self):
+        """Fab annotation should return empty string when no match."""
+        annotation = _build_fab_annotation("unknown_type", [], "jlcpcb")
+        assert annotation == ""
+
+
+class TestFabReclassificationWithFixture:
+    """Tests using the sample DRC fixture for fab reclassification."""
+
+    def test_sample_report_with_fab(self, sample_drc_report: DRCReport):
+        """Sample report with --fab should correctly categorize violations."""
+        summary = create_summary(sample_drc_report, manufacturer_id="jlcpcb")
+
+        # All violations should still be accounted for
+        total = (
+            summary.blocking_count
+            + summary.warning_count
+            + summary.fab_acceptable_count
+            + summary.cosmetic_count
+        )
+        assert total == summary.total_violations
+
+    def test_sample_report_without_fab_no_fab_acceptable(self, sample_drc_report: DRCReport):
+        """Without --fab, no violations should be fab-acceptable."""
+        summary = create_summary(sample_drc_report)
+        assert summary.fab_acceptable_count == 0
+
+    def test_all_manufacturers_categorize_correctly(self, sample_drc_report: DRCReport):
+        """All manufacturers should produce valid categorization."""
+        for mfr in ["jlcpcb", "oshpark", "pcbway", "seeed"]:
+            summary = create_summary(sample_drc_report, manufacturer_id=mfr)
+            total = (
+                summary.blocking_count
+                + summary.warning_count
+                + summary.fab_acceptable_count
+                + summary.cosmetic_count
+            )
+            assert total == summary.total_violations, f"Total mismatch for {mfr}"


### PR DESCRIPTION
## Summary

- Adds `FAB_ACCEPTABLE` severity level to `kicad-drc-summary` that reclassifies violations passing manufacturer limits when `--fab` is specified
- Violations with `actual_value_mm >= manufacturer_limit` move from BLOCKING/WARNING to FAB-ACCEPTABLE with per-type annotations showing the comparison
- Exit code 0 when no BLOCKING violations remain (fab-acceptable don't count), backward compatible without `--fab`

Closes #1133

## Changes

**`src/kicad_tools/cli/drc_summary.py`**:
- Added `FAB_ACCEPTABLE` to `IssueSeverity` enum
- Extended `DRCSummary` with `fab_acceptable` list, counter, and count property
- Modified `create_summary()` to reclassify false positives as fab-acceptable when manufacturer is specified
- Updated `output_table()` to show FAB-ACCEPTABLE section with manufacturer annotations
- Updated `to_dict()` to include fab-acceptable data in JSON output
- Enhanced verdict to show manufacturer-specific messaging

**`tests/test_drc_summary.py`**:
- Added `TestFabReclassification` (8 tests): annular width, clearance, silk, track width, mixed violations, backward compatibility
- Added `TestFabAcceptableOutput` (9 tests): JSON serialization, CLI table/JSON output, exit codes, verdicts, annotations
- Added `TestFabReclassificationWithFixture` (3 tests): fixture-based integration tests across all manufacturers

## Test plan

- [x] 50 tests pass in `test_drc_summary.py` (30 existing + 20 new)
- [x] 168 tests pass across all DRC-related test files (zero regressions)
- [x] Backward compatibility verified: without `--fab`, behavior unchanged
- [x] All 4 manufacturers (JLCPCB, OSHPark, PCBWay, Seeed) categorize correctly
- [x] Exit code 0 when only fab-acceptable violations remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)