### PR TITLE
Remove 8 unused exports from __all__ declarations

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -83,7 +83,6 @@ __all__ = [
     "symbols_main",
     "nets_main",
     "erc_main",
-    "erc_explain_main",
     "drc_main",
     "drc_summary_main",
     "bom_main",

--- a/src/kicad_tools/cli/build_native_cmd.py
+++ b/src/kicad_tools/cli/build_native_cmd.py
@@ -17,7 +17,7 @@ import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
-__all__ = ["main", "BuildResult", "build_native"]
+__all__ = ["main", "BuildResult"]
 
 
 @dataclass

--- a/src/kicad_tools/cli/utils.py
+++ b/src/kicad_tools/cli/utils.py
@@ -11,7 +11,7 @@ from kicad_tools.exceptions import KiCadToolsError
 if TYPE_CHECKING:
     from rich.console import Console
 
-__all__ = ["format_error", "print_error", "get_error_console"]
+__all__ = ["format_error", "print_error"]
 
 # Module-level console for error output, created lazily
 _error_console: Console | None = None

--- a/src/kicad_tools/drc/__init__.py
+++ b/src/kicad_tools/drc/__init__.py
@@ -29,8 +29,6 @@ from .incremental import (
     IncrementalDRC,
     SpatialIndex,
 )
-from .incremental import Rectangle as DRCRectangle
-from .incremental import Violation as IncrementalViolation
 from .predictive import PredictiveAnalyzer, PredictiveWarning
 from .repair_clearance import ClearanceRepairer, NudgeResult, RepairResult
 from .report import (
@@ -73,8 +71,6 @@ __all__ = [
     "DRCState",
     "DRCDelta",
     "SpatialIndex",
-    "DRCRectangle",
-    "IncrementalViolation",
     # Predictive analysis
     "PredictiveAnalyzer",
     "PredictiveWarning",

--- a/src/kicad_tools/pcb/placement.py
+++ b/src/kicad_tools/pcb/placement.py
@@ -3,7 +3,6 @@ Component placement for PCB blocks.
 
 This module provides:
 - ComponentPlacement: Placement of a component within a block
-- FOOTPRINT_PADS: Standard pad positions for common footprints
 - get_footprint_pads: Get pad positions for a footprint
 """
 
@@ -138,4 +137,4 @@ def get_footprint_pads(footprint: str) -> dict[str, tuple[float, float]]:
     return {"1": (-0.8, 0), "2": (0.8, 0)}
 
 
-__all__ = ["ComponentPlacement", "FOOTPRINT_PADS", "get_footprint_pads"]
+__all__ = ["ComponentPlacement", "get_footprint_pads"]

--- a/src/kicad_tools/units.py
+++ b/src/kicad_tools/units.py
@@ -20,7 +20,6 @@ __all__ = [
     "UnitFormatter",
     "MM_PER_MIL",
     "get_unit_formatter",
-    "format_length",
     "format_coordinate",
 ]
 

--- a/src/kicad_tools/validate/__init__.py
+++ b/src/kicad_tools/validate/__init__.py
@@ -55,9 +55,6 @@ from .models import (
     ValidationResult,
     ViolationCategory,
 )
-from .models import (
-    DRCViolation as DRCViolationNew,
-)
 from .netlist import NetlistValidator, SyncIssue, SyncResult
 from .placement import BOMPlacementVerifier, PlacementResult, PlacementStatus
 from .violations import DRCResults, DRCViolation
@@ -69,7 +66,6 @@ __all__ = [
     "Location",
     "BaseViolation",
     "ValidationResult",
-    "DRCViolationNew",
     "DRCResult",
     # DRC validation (legacy, for backwards compatibility)
     "DRCChecker",


### PR DESCRIPTION
## Summary
- Remove 8 unused symbols from `__all__` declarations across 7 modules
- Removes: `erc_explain_main`, `build_native`, `get_error_console`, `DRCRectangle`, `IncrementalViolation`, `FOOTPRINT_PADS`, `format_length`, `DRCViolationNew`
- Also removes 3 unused import aliases (`DRCRectangle`, `IncrementalViolation`, `DRCViolationNew`) that were only re-exported

Closes #1171

## Test plan
- [x] All changed files pass `ruff check` with zero errors
- [x] Star imports from all affected modules succeed
- [x] No external consumers of these symbols (verified by repo-wide search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)