### PR TITLE
feat(router): wire real router strategies into orchestrator placeholders

### DIFF
--- a/src/kicad_tools/router/adaptive.py
+++ b/src/kicad_tools/router/adaptive.py
@@ -133,6 +133,8 @@ class AdaptiveAutorouter:
         )
 
         # Create autorouter with custom grid
+        # Uses __new__ to bypass __init__ for custom grid injection.
+        # Must manually initialize all attributes that __init__ sets.
         autorouter = Autorouter.__new__(Autorouter)
         autorouter.rules = self.rules
         autorouter.net_class_map = DEFAULT_NET_CLASS_MAP
@@ -143,6 +145,19 @@ class AdaptiveAutorouter:
         autorouter.nets = {}
         autorouter.net_names = {}
         autorouter.routes = []
+        autorouter.routing_failures = []
+        autorouter.record_decisions = False
+        autorouter._decision_store = None
+        autorouter._component_pitches = None
+        autorouter._force_python = False
+        autorouter._stackup = None
+        autorouter._physics_enabled = False
+        autorouter._transmission_line = None
+
+        # Initialize length tracker
+        from .length import LengthTracker
+
+        autorouter._length_tracker = LengthTracker()
 
         # Initialize zone manager
         from .zones import ZoneManager


### PR DESCRIPTION
## Summary

- Replace placeholder implementations in `RoutingOrchestrator` with calls to real router classes:
  - `_route_global()` → calls `GlobalRouter.route_net()`, computes length from corridor waypoints
  - `_route_escape_then_global()` → chains `EscapeRouter` (Phase 1: escape dense packages) → `GlobalRouter` (Phase 2: route connections)
  - `_route_hierarchical()` → builds component data from pads, calls `AdaptiveAutorouter.route()`
  - `_has_via_conflicts()` → queries `ViaConflictManager.find_blocking_vias()` to detect real conflicts
- Fix `Pad` constructor calls in tests (broken positional args → proper keyword args)
- Fix `AdaptiveAutorouter._create_autorouter()` missing attribute initialization (`_component_pitches`, `_length_tracker`, etc.) when using `__new__` bypass
- Update lazy properties (`global_router`, `escape_router`, `via_manager`) with real initialization

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_route_global()` calls real `GlobalRouter` | PASS | Calls `self.global_router.route_net()`, computes metrics from `CorridorAssignment` waypoints |
| `_route_escape_then_global()` chains `EscapeRouter` → `GlobalRouter` | PASS | Phase 1 uses `EscapeRouter.analyze_package()` + `generate_escapes()`, Phase 2 calls `_route_global()` |
| `_route_hierarchical()` calls real `AdaptiveAutorouter` | PASS | Builds components/net_map from pads, calls `AdaptiveAutorouter.route()`, converts result |
| `_has_via_conflicts()` queries real `ViaConflictManager` | PASS | Initializes `ViaConflictManager` with pcb grid, calls `find_blocking_vias()` per pad |
| All existing tests pass | PASS | 21/21 orchestrator tests pass; 2412 total tests pass (1 pre-existing unrelated failure in `test_gpu_grid.py`) |

## Test plan

- [x] All 21 orchestrator tests pass (`uv run pytest tests/test_routing_orchestrator.py`)
- [x] Full test suite passes (2412 passed, 1 pre-existing failure in `test_gpu_grid.py`)
- [x] New tests cover: global routing length computation, insufficient pads error, escape-then-global chaining, hierarchical routing with intent, via conflicts without grid, via conflicts without pads

Closes #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)