### PR TITLE
Fix 8 test failures from API and coordinate changes

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -715,7 +715,7 @@ class TestRouterBenchmarks:
         return f
 
     def test_route_small_board(self, benchmark, small_routable_pcb_file):
-        """Benchmark routing small board (~10 nets, 0.25mm grid).
+        """Benchmark routing small board (~10 nets, 0.1mm grid).
 
         Target: <5 seconds
         """
@@ -724,10 +724,10 @@ class TestRouterBenchmarks:
         def route_board():
             rules = DesignRules(
                 trace_width=0.2,
-                trace_clearance=0.15,
+                trace_clearance=0.2,
                 via_drill=0.3,
                 via_diameter=0.6,
-                grid_resolution=0.25,
+                grid_resolution=0.1,
             )
             router, _ = load_pcb_for_routing(
                 str(small_routable_pcb_file),
@@ -741,7 +741,7 @@ class TestRouterBenchmarks:
         assert result is not None
 
     def test_route_medium_board(self, benchmark, medium_routable_pcb_file):
-        """Benchmark routing medium board (~30 nets, 0.25mm grid).
+        """Benchmark routing medium board (~30 nets, 0.1mm grid).
 
         Target: <15 seconds
         """
@@ -750,10 +750,10 @@ class TestRouterBenchmarks:
         def route_board():
             rules = DesignRules(
                 trace_width=0.2,
-                trace_clearance=0.15,
+                trace_clearance=0.2,
                 via_drill=0.3,
                 via_diameter=0.6,
-                grid_resolution=0.25,
+                grid_resolution=0.1,
             )
             router, _ = load_pcb_for_routing(
                 str(medium_routable_pcb_file),
@@ -766,7 +766,7 @@ class TestRouterBenchmarks:
         assert result is not None
 
     def test_route_large_board_4layer(self, benchmark, large_routable_pcb_file):
-        """Benchmark routing large board (~50 nets, 4-layer, 0.25mm grid).
+        """Benchmark routing large board (~50 nets, 4-layer, 0.1mm grid).
 
         Target: <30 seconds
         """
@@ -775,10 +775,10 @@ class TestRouterBenchmarks:
         def route_board():
             rules = DesignRules(
                 trace_width=0.2,
-                trace_clearance=0.15,
+                trace_clearance=0.2,
                 via_drill=0.3,
                 via_diameter=0.6,
-                grid_resolution=0.25,
+                grid_resolution=0.1,
             )
             router, _ = load_pcb_for_routing(
                 str(large_routable_pcb_file),
@@ -800,7 +800,7 @@ class TestRouterBenchmarks:
         def route_board():
             rules = DesignRules(
                 trace_width=0.2,
-                trace_clearance=0.15,
+                trace_clearance=0.2,
                 via_drill=0.3,
                 via_diameter=0.6,
                 grid_resolution=0.1,

--- a/tests/test_gpu_grid.py
+++ b/tests/test_gpu_grid.py
@@ -220,9 +220,11 @@ class TestBackendAbstraction:
     """Tests for backend abstraction module."""
 
     def test_get_cpu_backend(self):
-        """Test getting CPU backend."""
+        """Test getting CPU backend returns an ArrayBackend wrapping numpy."""
+        from kicad_tools.acceleration.backend import ArrayBackend
+
         backend = get_backend(BackendType.CPU)
-        assert backend is np
+        assert isinstance(backend, ArrayBackend)
 
     def test_to_numpy_passthrough(self):
         """Test to_numpy with numpy array."""

--- a/tests/test_incremental_drc.py
+++ b/tests/test_incremental_drc.py
@@ -438,8 +438,8 @@ class TestIncrementalDRC:
         violations = drc.full_check()
         assert len(violations) == 0  # Start clean
 
-        # Move R1 very close to R2 (R2 is at 140, 140)
-        delta = drc.check_move("R1", 141.0, 140.0)
+        # Move R1 very close to R2 (R2 is at board-relative 40, 40)
+        delta = drc.check_move("R1", 41.0, 40.0)
 
         # Should detect new violations
         assert len(delta.new_violations) > 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -266,7 +266,7 @@ class TestPCBParsing:
         u1 = pcb.get_footprint("U1")
         assert u1 is not None
         assert u1.value == "STM32F103"
-        assert u1.position == (130, 130)
+        assert u1.position == (30.0, 30.0)
         assert len(u1.pads) >= 8
 
         # Query footprints on layer

--- a/tests/test_router_integration.py
+++ b/tests/test_router_integration.py
@@ -155,7 +155,7 @@ class TestRealBoardRouting:
 
         # Merge routes into PCB (validates output structure)
         try:
-            merged_pcb = merge_routes_into_pcb(original_pcb_text, router)
+            merged_pcb = merge_routes_into_pcb(original_pcb_text, router.to_sexp())
             assert merged_pcb is not None
             assert len(merged_pcb) > len(original_pcb_text), "Output should contain routes"
 


### PR DESCRIPTION
## Summary
- Fix 8 remaining test failures on main (down from original 30 in #1173)
- Benchmark tests: use valid grid_resolution/clearance values that pass `GridResolutionError` validation
- GPU grid: test for `ArrayBackend` wrapper instead of raw numpy
- Incremental DRC: use board-relative coordinates for proximity check
- Integration: update expected footprint position to board-relative coordinates
- Router integration: call `router.to_sexp()` before passing to `merge_routes_into_pcb()`

## Test plan
- [x] `test_gpu_grid::test_get_cpu_backend` passes
- [x] `test_incremental_drc::test_check_move_detects_new_violations` passes
- [x] `test_integration::test_pcb_footprint_query` passes
- [x] `test_router_integration::test_usb_joystick_valid_output` passes
- [ ] Benchmark tests (require `pytest-benchmark` - not verifiable in worktree, but fix is mechanical: grid_resolution 0.25->0.1, clearance 0.15->0.2)

Closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)