### PR TITLE
fix: remove push trigger from label-external-issues workflow

### DIFF
--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -3,25 +3,12 @@ name: Label external issues
 on:
   issues:
     types: [opened]
-  push:
-    paths:
-      - '.github/workflows/label-external-issues.yml'
 
 permissions:
   issues: write
   contents: read
 
 jobs:
-  # Guard job to prevent workflow failure on push events
-  # GitHub Actions marks runs as failed when no jobs execute, so this ensures
-  # at least one job runs. Using explicit true condition for clarity.
-  validate:
-    if: ${{ true }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Workflow syntax valid
-        run: echo "Workflow file validated successfully"
-
   label_external:
     if: ${{ github.event_name == 'issues' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Remove the `push` trigger and `validate` guard job from the label-external-issues workflow. The push trigger caused GitHub Actions to report failure on every push when no jobs executed, creating persistent red X marks on commits and PRs.

## Changes
- Removed `push` trigger with `paths` filter (lines 6-8)
- Removed `validate` guard job that was only needed for the push trigger (lines 14-23)
- Workflow now only triggers on `issues: [opened]` events

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Workflow no longer triggers on push events | ✅ | `push` trigger removed from `on:` block |
| Workflow still triggers on `issues: [opened]` events | ✅ | `issues: types: [opened]` trigger preserved, `label_external` job unchanged |
| No more red X failure marks from this workflow | ✅ | Without push trigger, workflow won't run on pushes |
| `validate` guard job removed | ✅ | Guard job deleted (only existed to prevent empty-run failures from push trigger) |

## Test Plan
- Push this commit and confirm the label-external-issues workflow does NOT appear in Actions for the push event
- The workflow YAML is valid (only standard GitHub Actions syntax used)
- The `label_external` job logic is completely unchanged

Closes #1179