### PR TITLE
feat(library): add unused symbol/footprint detection for project libraries

### DIFF
--- a/src/kicad_tools/cli/commands/library.py
+++ b/src/kicad_tools/cli/commands/library.py
@@ -102,4 +102,22 @@ def run_lib_command(args) -> int:
     elif args.lib_command == "export":
         return export_library(args.path, args.format)
 
+    elif args.lib_command == "purge":
+        from kicad_tools.library.purge import UnusedLibraryAnalyzer
+
+        project_dir = Path(args.project_dir)
+        if not project_dir.is_dir():
+            print(f"Error: Not a directory: {project_dir}", file=sys.stderr)
+            return 1
+
+        analyzer = UnusedLibraryAnalyzer(project_dir)
+        result = analyzer.analyze()
+
+        if getattr(args, "format", "table") == "json":
+            print(result.format_json())
+        else:
+            print(result.format_table())
+
+        return 0
+
     return 1

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -698,6 +698,23 @@ def _add_lib_parser(subparsers) -> None:
     lib_export.add_argument("path", help="Path to library file or item")
     lib_export.add_argument("--format", choices=["json"], default="json")
 
+    # lib purge
+    lib_purge = lib_subparsers.add_parser(
+        "purge", help="List unused symbols/footprints in project-local libraries"
+    )
+    lib_purge.add_argument(
+        "project_dir",
+        nargs="?",
+        default=".",
+        help="Path to KiCad project directory (default: current directory)",
+    )
+    lib_purge.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+
 
 def _add_footprint_parser(subparsers) -> None:
     """Add footprint subcommand parser."""

--- a/src/kicad_tools/library/purge.py
+++ b/src/kicad_tools/library/purge.py
@@ -1,0 +1,311 @@
+"""Detect unused symbols and footprints in KiCad project-local libraries.
+
+This module scans a KiCad project directory to find symbols defined in local
+``.kicad_sym`` files and footprints defined in local ``.pretty`` directories
+that are not referenced by any schematic (``.kicad_sch``) or PCB
+(``.kicad_pcb``) file in the project.
+
+Usage::
+
+    from kicad_tools.library.purge import UnusedLibraryAnalyzer
+
+    analyzer = UnusedLibraryAnalyzer(Path("/path/to/kicad/project"))
+    result = analyzer.analyze()
+    for item in result.unused_symbols:
+        print(f"Unused symbol: {item.library}:{item.name}")
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from kicad_tools.sexp import parse_sexp
+
+
+@dataclass
+class UnusedItem:
+    """A single unused library item (symbol or footprint)."""
+
+    library: str
+    """Library name (e.g. ``my_project_lib``)."""
+
+    name: str
+    """Item name within the library (e.g. ``MyConnector``)."""
+
+    file_path: Path
+    """Path to the file containing this item."""
+
+    @property
+    def lib_id(self) -> str:
+        """Full library identifier in ``Library:Name`` format."""
+        return f"{self.library}:{self.name}"
+
+
+@dataclass
+class PurgeResult:
+    """Result of analyzing a project for unused library items."""
+
+    project_dir: Path
+    """The project directory that was analyzed."""
+
+    unused_symbols: list[UnusedItem] = field(default_factory=list)
+    """Symbols defined in local ``.kicad_sym`` files but not referenced."""
+
+    unused_footprints: list[UnusedItem] = field(default_factory=list)
+    """Footprints defined in local ``.pretty`` dirs but not referenced."""
+
+    @property
+    def total_unused(self) -> int:
+        """Total number of unused items."""
+        return len(self.unused_symbols) + len(self.unused_footprints)
+
+    def format_table(self) -> str:
+        """Format the result as a human-readable table."""
+        lines: list[str] = []
+
+        if self.unused_symbols:
+            lines.append("Unused Symbols")
+            lines.append("-" * 60)
+            for item in sorted(self.unused_symbols, key=lambda i: i.lib_id):
+                lines.append(f"  {item.file_path.name}  ({item.lib_id})")
+            lines.append("")
+
+        if self.unused_footprints:
+            lines.append("Unused Footprints")
+            lines.append("-" * 60)
+            for item in sorted(self.unused_footprints, key=lambda i: i.lib_id):
+                lines.append(f"  {item.file_path.name}  ({item.lib_id})")
+            lines.append("")
+
+        if not self.unused_symbols and not self.unused_footprints:
+            lines.append("No unused library items found.")
+
+        return "\n".join(lines)
+
+    def format_json(self) -> str:
+        """Format the result as JSON."""
+        data = {
+            "project_dir": str(self.project_dir),
+            "unused_symbols": [
+                {
+                    "library": item.library,
+                    "name": item.name,
+                    "lib_id": item.lib_id,
+                    "file": str(item.file_path),
+                }
+                for item in self.unused_symbols
+            ],
+            "unused_footprints": [
+                {
+                    "library": item.library,
+                    "name": item.name,
+                    "lib_id": item.lib_id,
+                    "file": str(item.file_path),
+                }
+                for item in self.unused_footprints
+            ],
+            "total_unused": self.total_unused,
+        }
+        return json.dumps(data, indent=2)
+
+
+class UnusedLibraryAnalyzer:
+    """Analyze a KiCad project to find unused symbols and footprints.
+
+    Scans project-local ``.kicad_sym`` and ``.pretty`` directories and
+    compares their contents against references in ``.kicad_sch`` and
+    ``.kicad_pcb`` files.
+
+    Parameters
+    ----------
+    project_dir:
+        Path to the KiCad project directory.
+    """
+
+    def __init__(self, project_dir: Path) -> None:
+        self.project_dir = project_dir
+
+    def analyze(self) -> PurgeResult:
+        """Run the analysis and return the result."""
+        result = PurgeResult(project_dir=self.project_dir)
+
+        # Collect what is referenced
+        used_symbol_ids = self._collect_used_symbols()
+        used_footprint_ids = self._collect_used_footprints()
+
+        # Collect what is available in local libraries
+        available_symbols = self._collect_available_symbols()
+        available_footprints = self._collect_available_footprints()
+
+        # Compute unused = available - used
+        for lib_id, (library, name, file_path) in available_symbols.items():
+            if lib_id not in used_symbol_ids:
+                result.unused_symbols.append(
+                    UnusedItem(library=library, name=name, file_path=file_path)
+                )
+
+        for lib_id, (library, name, file_path) in available_footprints.items():
+            if lib_id not in used_footprint_ids:
+                result.unused_footprints.append(
+                    UnusedItem(library=library, name=name, file_path=file_path)
+                )
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Collecting used references
+    # ------------------------------------------------------------------
+
+    def _collect_used_symbols(self) -> set[str]:
+        """Collect all symbol lib_id values referenced in schematics."""
+        used: set[str] = set()
+        for sch_path in self.project_dir.rglob("*.kicad_sch"):
+            used.update(self._extract_symbol_refs(sch_path))
+        return used
+
+    def _collect_used_footprints(self) -> set[str]:
+        """Collect all footprint references from PCB files and schematics.
+
+        Footprint references are found in:
+        - PCB files: ``(footprint "Lib:Name" ...)`` top-level entries
+        - Schematic files: ``(property "Footprint" "Lib:Name" ...)`` on symbols
+        """
+        used: set[str] = set()
+        for pcb_path in self.project_dir.rglob("*.kicad_pcb"):
+            used.update(self._extract_footprint_refs_pcb(pcb_path))
+        for sch_path in self.project_dir.rglob("*.kicad_sch"):
+            used.update(self._extract_footprint_refs_sch(sch_path))
+        return used
+
+    @staticmethod
+    def _extract_symbol_refs(sch_path: Path) -> set[str]:
+        """Extract symbol lib_id values from a schematic file."""
+        refs: set[str] = set()
+        try:
+            text = sch_path.read_text(encoding="utf-8")
+            sexp = parse_sexp(text)
+        except Exception:
+            return refs
+
+        # Top-level (symbol (lib_id "Lib:Name") ...) nodes
+        for child in sexp.children:
+            if child.name == "symbol":
+                lib_id_node = child.get("lib_id")
+                if lib_id_node and lib_id_node.children:
+                    first = lib_id_node.children[0]
+                    if first.is_atom and isinstance(first.value, str):
+                        refs.add(first.value)
+        return refs
+
+    @staticmethod
+    def _extract_footprint_refs_pcb(pcb_path: Path) -> set[str]:
+        """Extract footprint library IDs from a PCB file.
+
+        PCB files have top-level ``(footprint "Lib:Name" ...)`` nodes
+        where the first child atom is the library ID.
+        """
+        refs: set[str] = set()
+        try:
+            text = pcb_path.read_text(encoding="utf-8")
+            sexp = parse_sexp(text)
+        except Exception:
+            return refs
+
+        for child in sexp.children:
+            if child.name == "footprint" and child.children:
+                first = child.children[0]
+                if first.is_atom and isinstance(first.value, str):
+                    refs.add(first.value)
+        return refs
+
+    @staticmethod
+    def _extract_footprint_refs_sch(sch_path: Path) -> set[str]:
+        """Extract footprint references from schematic symbol properties.
+
+        Schematics store footprint assignments as:
+        ``(property "Footprint" "Lib:Name" ...)``
+        """
+        refs: set[str] = set()
+        try:
+            text = sch_path.read_text(encoding="utf-8")
+            sexp = parse_sexp(text)
+        except Exception:
+            return refs
+
+        for symbol_node in sexp.children:
+            if symbol_node.name != "symbol":
+                continue
+            for prop in symbol_node.children:
+                if prop.name != "property":
+                    continue
+                # property children: first atom = key, second atom = value
+                atoms = [c for c in prop.children if c.is_atom]
+                if (
+                    len(atoms) >= 2
+                    and atoms[0].value == "Footprint"
+                    and isinstance(atoms[1].value, str)
+                    and atoms[1].value  # skip empty footprint assignments
+                ):
+                    refs.add(atoms[1].value)
+        return refs
+
+    # ------------------------------------------------------------------
+    # Collecting available items in project-local libraries
+    # ------------------------------------------------------------------
+
+    def _collect_available_symbols(self) -> dict[str, tuple[str, str, Path]]:
+        """Collect symbols from project-local ``.kicad_sym`` files.
+
+        Returns a dict mapping ``lib_id`` to ``(library, name, file_path)``.
+        The library name is derived from the filename stem.
+        """
+        available: dict[str, tuple[str, str, Path]] = {}
+
+        for sym_path in self.project_dir.rglob("*.kicad_sym"):
+            library_name = sym_path.stem  # e.g. "my_project_lib"
+            try:
+                text = sym_path.read_text(encoding="utf-8")
+                sexp = parse_sexp(text)
+            except Exception:
+                continue
+
+            if sexp.name != "kicad_symbol_lib":
+                continue
+
+            for child in sexp.children:
+                if child.name != "symbol":
+                    continue
+                # The first atom child is the symbol name
+                atoms = [c for c in child.children if c.is_atom]
+                if atoms and isinstance(atoms[0].value, str):
+                    symbol_name = atoms[0].value
+                    # Skip sub-units (names like "SymbolName_0_1")
+                    # Top-level symbols have a name like "Lib:Name" or just "Name"
+                    # Sub-units are children of top-level symbols, so they
+                    # appear nested -- we only see top-level here.
+                    lib_id = f"{library_name}:{symbol_name}"
+                    available[lib_id] = (library_name, symbol_name, sym_path)
+
+        return available
+
+    def _collect_available_footprints(self) -> dict[str, tuple[str, str, Path]]:
+        """Collect footprints from project-local ``.pretty`` directories.
+
+        Returns a dict mapping ``lib_id`` to ``(library, name, file_path)``.
+        The library name is derived from the ``.pretty`` directory name stem.
+        """
+        available: dict[str, tuple[str, str, Path]] = {}
+
+        for pretty_dir in self.project_dir.rglob("*.pretty"):
+            if not pretty_dir.is_dir():
+                continue
+            library_name = pretty_dir.stem  # e.g. "my_project_lib"
+
+            for mod_file in pretty_dir.glob("*.kicad_mod"):
+                footprint_name = mod_file.stem
+                lib_id = f"{library_name}:{footprint_name}"
+                available[lib_id] = (library_name, footprint_name, mod_file)
+
+        return available

--- a/tests/fixtures/purge_test_project/my_project_lib.kicad_sym
+++ b/tests/fixtures/purge_test_project/my_project_lib.kicad_sym
@@ -1,0 +1,37 @@
+(kicad_symbol_lib
+	(version 20231120)
+	(generator "kicad_symbol_editor")
+	(symbol "UsedSymbol"
+		(pin_names hide)
+		(symbol "UsedSymbol_0_1"
+			(rectangle
+				(start -1.016 -2.54)
+				(end 1.016 2.54)
+				(stroke (width 0.254))
+				(fill (type none))
+			)
+		)
+	)
+	(symbol "UnusedSymbol"
+		(pin_names hide)
+		(symbol "UnusedSymbol_0_1"
+			(rectangle
+				(start -1.016 -2.54)
+				(end 1.016 2.54)
+				(stroke (width 0.254))
+				(fill (type none))
+			)
+		)
+	)
+	(symbol "AnotherUnused"
+		(pin_names hide)
+		(symbol "AnotherUnused_0_1"
+			(rectangle
+				(start -1.016 -2.54)
+				(end 1.016 2.54)
+				(stroke (width 0.254))
+				(fill (type none))
+			)
+		)
+	)
+)

--- a/tests/fixtures/purge_test_project/my_project_lib.pretty/UnusedFootprint.kicad_mod
+++ b/tests/fixtures/purge_test_project/my_project_lib.pretty/UnusedFootprint.kicad_mod
@@ -1,0 +1,8 @@
+(footprint "UnusedFootprint"
+	(layer "F.Cu")
+	(pad "1" smd rect
+		(at 0 0)
+		(size 1 1)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+	)
+)

--- a/tests/fixtures/purge_test_project/my_project_lib.pretty/UsedFootprint.kicad_mod
+++ b/tests/fixtures/purge_test_project/my_project_lib.pretty/UsedFootprint.kicad_mod
@@ -1,0 +1,8 @@
+(footprint "UsedFootprint"
+	(layer "F.Cu")
+	(pad "1" smd rect
+		(at 0 0)
+		(size 1 1)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+	)
+)

--- a/tests/fixtures/purge_test_project/test_purge.kicad_pcb
+++ b/tests/fixtures/purge_test_project/test_purge.kicad_pcb
@@ -1,0 +1,17 @@
+(kicad_pcb
+	(version 20231120)
+	(generator "kicadtools_test")
+	(general
+		(thickness 1.6)
+	)
+	(paper "A4")
+	(layers
+		(0 "F.Cu" signal)
+		(31 "B.Cu" signal)
+	)
+	(footprint "my_project_lib:UsedFootprint"
+		(layer "F.Cu")
+		(uuid "fp-u1-uuid")
+		(at 100 50)
+	)
+)

--- a/tests/fixtures/purge_test_project/test_purge.kicad_sch
+++ b/tests/fixtures/purge_test_project/test_purge.kicad_sch
@@ -1,0 +1,40 @@
+(kicad_sch
+	(version 20231120)
+	(generator "kicadtools_test")
+	(uuid "aabbccdd-1111-2222-3333-444455556666")
+	(paper "A4")
+	(lib_symbols
+		(symbol "my_project_lib:UsedSymbol"
+			(pin_names hide)
+			(symbol "UsedSymbol_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke (width 0.254))
+					(fill (type none))
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "my_project_lib:UsedSymbol")
+		(at 100 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "11111111-1111-1111-1111-111111111111")
+		(property "Reference" "U1"
+			(at 102 48 0)
+			(effects (font (size 1.27 1.27)) (justify left))
+		)
+		(property "Value" "UsedSymbol"
+			(at 102 50 0)
+			(effects (font (size 1.27 1.27)) (justify left))
+		)
+		(property "Footprint" "my_project_lib:UsedFootprint"
+			(at 100 50 0)
+			(effects (font (size 1.27 1.27)) hide)
+		)
+	)
+)

--- a/tests/test_library_purge.py
+++ b/tests/test_library_purge.py
@@ -1,0 +1,176 @@
+"""Tests for the unused library item detection (purge) feature."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kicad_tools.library.purge import PurgeResult, UnusedItem, UnusedLibraryAnalyzer
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+PURGE_PROJECT = FIXTURES_DIR / "purge_test_project"
+
+
+class TestUnusedLibraryAnalyzer:
+    """Tests for UnusedLibraryAnalyzer."""
+
+    def test_detects_unused_symbols(self) -> None:
+        """Symbols not referenced by any schematic are reported as unused."""
+        analyzer = UnusedLibraryAnalyzer(PURGE_PROJECT)
+        result = analyzer.analyze()
+
+        unused_sym_ids = {item.lib_id for item in result.unused_symbols}
+        assert "my_project_lib:UnusedSymbol" in unused_sym_ids
+        assert "my_project_lib:AnotherUnused" in unused_sym_ids
+
+    def test_used_symbols_not_reported(self) -> None:
+        """Symbols referenced in schematics are NOT reported as unused."""
+        analyzer = UnusedLibraryAnalyzer(PURGE_PROJECT)
+        result = analyzer.analyze()
+
+        unused_sym_ids = {item.lib_id for item in result.unused_symbols}
+        assert "my_project_lib:UsedSymbol" not in unused_sym_ids
+
+    def test_detects_unused_footprints(self) -> None:
+        """Footprints not referenced by any PCB or schematic are reported."""
+        analyzer = UnusedLibraryAnalyzer(PURGE_PROJECT)
+        result = analyzer.analyze()
+
+        unused_fp_ids = {item.lib_id for item in result.unused_footprints}
+        assert "my_project_lib:UnusedFootprint" in unused_fp_ids
+
+    def test_used_footprints_not_reported(self) -> None:
+        """Footprints referenced in PCB or schematic are NOT reported."""
+        analyzer = UnusedLibraryAnalyzer(PURGE_PROJECT)
+        result = analyzer.analyze()
+
+        unused_fp_ids = {item.lib_id for item in result.unused_footprints}
+        assert "my_project_lib:UsedFootprint" not in unused_fp_ids
+
+    def test_total_unused_count(self) -> None:
+        """total_unused property returns the combined count."""
+        analyzer = UnusedLibraryAnalyzer(PURGE_PROJECT)
+        result = analyzer.analyze()
+
+        # 2 unused symbols + 1 unused footprint = 3
+        assert result.total_unused == 3
+
+    def test_empty_project_dir(self, tmp_path: Path) -> None:
+        """Empty directory produces no unused items."""
+        analyzer = UnusedLibraryAnalyzer(tmp_path)
+        result = analyzer.analyze()
+
+        assert result.total_unused == 0
+        assert result.unused_symbols == []
+        assert result.unused_footprints == []
+
+    def test_all_items_used(self, tmp_path: Path) -> None:
+        """When all library items are referenced, nothing is unused."""
+        # Create a minimal project where the only symbol is used
+        sym_file = tmp_path / "mylib.kicad_sym"
+        sym_file.write_text(
+            '(kicad_symbol_lib (version 20231120) (symbol "OnlySymbol"))',
+            encoding="utf-8",
+        )
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(
+            '(kicad_sch (version 20231120) (symbol (lib_id "mylib:OnlySymbol")))',
+            encoding="utf-8",
+        )
+
+        analyzer = UnusedLibraryAnalyzer(tmp_path)
+        result = analyzer.analyze()
+
+        assert len(result.unused_symbols) == 0
+
+    def test_missing_files_handled_gracefully(self, tmp_path: Path) -> None:
+        """Corrupt or unreadable files do not cause crashes."""
+        bad_sym = tmp_path / "bad.kicad_sym"
+        bad_sym.write_text("this is not valid s-expression data!!!", encoding="utf-8")
+
+        analyzer = UnusedLibraryAnalyzer(tmp_path)
+        result = analyzer.analyze()
+
+        # Should not raise, just produce an empty result
+        assert result.total_unused == 0
+
+    def test_library_with_no_unused_footprints(self, tmp_path: Path) -> None:
+        """A .pretty dir where all footprints are used yields zero unused."""
+        pretty_dir = tmp_path / "mylib.pretty"
+        pretty_dir.mkdir()
+        (pretty_dir / "FP1.kicad_mod").write_text(
+            '(footprint "FP1" (layer "F.Cu"))', encoding="utf-8"
+        )
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(
+            '(kicad_pcb (version 20231120) (footprint "mylib:FP1" (layer "F.Cu")))',
+            encoding="utf-8",
+        )
+
+        analyzer = UnusedLibraryAnalyzer(tmp_path)
+        result = analyzer.analyze()
+
+        assert len(result.unused_footprints) == 0
+
+
+class TestPurgeResult:
+    """Tests for PurgeResult formatting."""
+
+    def _make_result(self) -> PurgeResult:
+        return PurgeResult(
+            project_dir=Path("/tmp/test"),
+            unused_symbols=[
+                UnusedItem(
+                    library="mylib",
+                    name="Sym1",
+                    file_path=Path("/tmp/test/mylib.kicad_sym"),
+                ),
+            ],
+            unused_footprints=[
+                UnusedItem(
+                    library="mylib",
+                    name="FP1",
+                    file_path=Path("/tmp/test/mylib.pretty/FP1.kicad_mod"),
+                ),
+            ],
+        )
+
+    def test_format_table(self) -> None:
+        result = self._make_result()
+        table = result.format_table()
+
+        assert "Unused Symbols" in table
+        assert "mylib:Sym1" in table
+        assert "Unused Footprints" in table
+        assert "mylib:FP1" in table
+
+    def test_format_json(self) -> None:
+        result = self._make_result()
+        raw = result.format_json()
+        data = json.loads(raw)
+
+        assert data["total_unused"] == 2
+        assert len(data["unused_symbols"]) == 1
+        assert data["unused_symbols"][0]["lib_id"] == "mylib:Sym1"
+        assert len(data["unused_footprints"]) == 1
+        assert data["unused_footprints"][0]["lib_id"] == "mylib:FP1"
+
+    def test_format_table_empty(self) -> None:
+        result = PurgeResult(project_dir=Path("/tmp/empty"))
+        assert "No unused library items found" in result.format_table()
+
+    def test_format_json_empty(self) -> None:
+        result = PurgeResult(project_dir=Path("/tmp/empty"))
+        data = json.loads(result.format_json())
+        assert data["total_unused"] == 0
+        assert data["unused_symbols"] == []
+        assert data["unused_footprints"] == []
+
+
+class TestUnusedItem:
+    """Tests for UnusedItem dataclass."""
+
+    def test_lib_id_property(self) -> None:
+        item = UnusedItem(library="mylib", name="MySym", file_path=Path("/tmp/mylib.kicad_sym"))
+        assert item.lib_id == "mylib:MySym"


### PR DESCRIPTION
## Summary

Adds a new `kct lib purge` command that scans a KiCad project directory and reports symbols and footprints defined in project-local libraries (`.kicad_sym` files and `.pretty` directories) that are not referenced by any schematic (`.kicad_sch`) or PCB (`.kicad_pcb`) file. This is report-only -- it does not modify or delete any files.

## Changes

- **New module** `src/kicad_tools/library/purge.py`: `UnusedLibraryAnalyzer` class that collects used symbol/footprint references from schematics and PCBs, compares against available items in project-local libraries, and reports the difference. Includes `PurgeResult` with table and JSON output formatters.
- **CLI integration**: Added `purge` subcommand to the `lib` parser (`src/kicad_tools/cli/parser.py`) and command handler (`src/kicad_tools/cli/commands/library.py`). Usage: `kct lib purge [project_dir] [--format table|json]`.
- **Test fixtures**: New `tests/fixtures/purge_test_project/` with `.kicad_sym`, `.kicad_sch`, `.kicad_pcb`, and `.pretty/` files containing both used and unused items.
- **Unit tests**: 14 tests in `tests/test_library_purge.py` covering detection logic, edge cases (empty project, corrupt files, all-used), and output formatting.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Identifies unused symbols in `.kicad_sym` not referenced by `.kicad_sch` | Pass | `test_detects_unused_symbols` passes -- finds `UnusedSymbol` and `AnotherUnused` |
| Identifies unused footprints in `.pretty/` not referenced by `.kicad_pcb` | Pass | `test_detects_unused_footprints` passes -- finds `UnusedFootprint` |
| CLI accepts project directory and outputs unused items | Pass | Wired as `kct lib purge <dir>` via parser and command handler |
| Supports table and JSON output formats | Pass | `test_format_table` and `test_format_json` verify both formats |
| Report-only mode (no file modification) | Pass | Code only reads files, never writes or deletes |
| Handles edge cases: empty libraries, missing files, zero unused | Pass | `test_empty_project_dir`, `test_missing_files_handled_gracefully`, `test_all_items_used` |
| Works with `Library:ItemName` format | Pass | All tests use `lib:name` format via `parse_library_id`-compatible splitting |

## Test Plan

All 14 tests pass:
```
tests/test_library_purge.py::TestUnusedLibraryAnalyzer::test_detects_unused_symbols PASSED
tests/test_library_purge.py::TestUnusedLibraryAnalyzer::test_used_symbols_not_reported PASSED
tests/test_library_purge.py::TestUnusedLibraryAnalyzer::test_detects_unused_footprints PASSED
tests/test_library_purge.py::TestUnusedLibraryAnalyzer::test_used_footprints_not_reported PASSED
tests/test_library_purge.py::TestUnusedLibraryAnalyzer::test_total_unused_count PASSED
tests/test_library_purge.py::TestUnusedLibraryAnalyzer::test_empty_project_dir PASSED
tests/test_library_purge.py::TestUnusedLibraryAnalyzer::test_all_items_used PASSED
tests/test_library_purge.py::TestUnusedLibraryAnalyzer::test_missing_files_handled_gracefully PASSED
tests/test_library_purge.py::TestUnusedLibraryAnalyzer::test_library_with_no_unused_footprints PASSED
tests/test_library_purge.py::TestPurgeResult::test_format_table PASSED
tests/test_library_purge.py::TestPurgeResult::test_format_json PASSED
tests/test_library_purge.py::TestPurgeResult::test_format_table_empty PASSED
tests/test_library_purge.py::TestPurgeResult::test_format_json_empty PASSED
tests/test_library_purge.py::TestUnusedItem::test_lib_id_property PASSED
```

Closes #1181