### PR TITLE
feat(placement): add force-directed and random seed placement heuristics

### DIFF
--- a/src/kicad_tools/placement/seed.py
+++ b/src/kicad_tools/placement/seed.py
@@ -1,0 +1,362 @@
+"""Initial placement heuristics for generating optimizer seed placements.
+
+Provides two strategies for generating an initial placement that serves as a
+starting point for the CMA-ES optimizer:
+
+- **Force-directed**: iterative simulation where components attract connected
+  neighbours (via shared nets) and repel all other components (to avoid
+  overlap). A boundary force keeps components inside the board outline.
+  Typically produces much better seeds than random placement.
+
+- **Random**: uniform random placement inside the board, followed by an
+  iterative push-apart pass that resolves overlaps. Used as a fallback
+  when no net connectivity information is available.
+
+Usage::
+
+    from kicad_tools.placement.seed import force_directed_placement, random_placement
+    from kicad_tools.placement.cost import BoardOutline, Net
+    from kicad_tools.placement.vector import ComponentDef
+
+    seed = force_directed_placement(components, nets, board)
+    # or
+    seed = random_placement(components, board)
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .cost import BoardOutline, Net
+from .vector import (
+    FIELDS_PER_COMPONENT,
+    ComponentDef,
+    PlacementVector,
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Force-directed defaults
+_FD_MAX_ITERATIONS = 500
+_FD_DT = 0.05  # time-step per iteration
+_FD_DAMPING = 0.95  # velocity damping
+_FD_ATTRACTIVE_STRENGTH = 1.0  # base attractive force per shared net
+_FD_REPULSIVE_STRENGTH = 5.0  # repulsive force constant
+_FD_BOUNDARY_STRENGTH = 10.0  # boundary restoring force constant
+_FD_MIN_SEPARATION = 0.1  # minimum distance to avoid division by zero (mm)
+_FD_EQUILIBRIUM_THRESHOLD = 1e-4  # max displacement to declare equilibrium
+
+# Overlap resolution defaults
+_OR_MAX_ITERATIONS = 200
+_OR_PUSH_FACTOR = 1.1  # fraction of overlap depth to push apart
+
+
+# ---------------------------------------------------------------------------
+# Force-directed placement
+# ---------------------------------------------------------------------------
+
+
+def _build_net_adjacency(
+    components: Sequence[ComponentDef],
+    nets: Sequence[Net],
+) -> NDArray[np.float64]:
+    """Build an NxN matrix of shared-net counts between component pairs.
+
+    ``adj[i][j]`` equals the number of nets that connect component *i* and
+    component *j*. This is used to scale attractive forces proportionally
+    to connectivity density.
+    """
+    n = len(components)
+    ref_to_idx: dict[str, int] = {c.reference: i for i, c in enumerate(components)}
+    adj = np.zeros((n, n), dtype=np.float64)
+
+    for net in nets:
+        # Collect unique component indices touched by this net
+        indices: set[int] = set()
+        for ref, _ in net.pins:
+            if ref in ref_to_idx:
+                indices.add(ref_to_idx[ref])
+        idx_list = sorted(indices)
+        # Add edge weight for every pair
+        for a_pos in range(len(idx_list)):
+            for b_pos in range(a_pos + 1, len(idx_list)):
+                adj[idx_list[a_pos], idx_list[b_pos]] += 1.0
+                adj[idx_list[b_pos], idx_list[a_pos]] += 1.0
+
+    return adj
+
+
+def force_directed_placement(
+    components: Sequence[ComponentDef],
+    nets: Sequence[Net],
+    board: BoardOutline,
+    *,
+    max_iterations: int = _FD_MAX_ITERATIONS,
+    dt: float = _FD_DT,
+    damping: float = _FD_DAMPING,
+    attractive_strength: float = _FD_ATTRACTIVE_STRENGTH,
+    repulsive_strength: float = _FD_REPULSIVE_STRENGTH,
+    boundary_strength: float = _FD_BOUNDARY_STRENGTH,
+) -> PlacementVector:
+    """Generate an initial placement using a force-directed algorithm.
+
+    Components sharing nets attract each other (proportional to net count).
+    All component pairs repel to prevent overlap. Components are pushed back
+    inside the board outline by a boundary restoring force.
+
+    The simulation iterates until forces reach equilibrium (max displacement
+    below threshold) or *max_iterations* is exhausted.
+
+    All components are placed on the front side (side=0) with rotation=0.
+    The optimizer will explore rotations and side assignments from this seed.
+
+    Args:
+        components: Component definitions to place.
+        nets: Net connectivity information.
+        board: Board outline defining placement boundaries.
+        max_iterations: Maximum simulation steps.
+        dt: Time-step per iteration.
+        damping: Velocity damping factor (0-1).
+        attractive_strength: Scaling factor for attractive (net) forces.
+        repulsive_strength: Scaling factor for repulsive (overlap) forces.
+        boundary_strength: Scaling factor for boundary restoring forces.
+
+    Returns:
+        A :class:`PlacementVector` with the computed placement.
+    """
+    n = len(components)
+    if n == 0:
+        return PlacementVector(data=np.empty(0, dtype=np.float64))
+
+    # Board centre and half-dimensions
+    cx = (board.min_x + board.max_x) / 2.0
+    cy = (board.min_y + board.max_y) / 2.0
+    hw = board.width / 2.0
+    hh = board.height / 2.0
+
+    # Place all components initially near the centre with slight jitter
+    rng = np.random.default_rng(42)
+    positions = np.empty((n, 2), dtype=np.float64)
+    for i in range(n):
+        positions[i, 0] = cx + rng.uniform(-hw * 0.3, hw * 0.3)
+        positions[i, 1] = cy + rng.uniform(-hh * 0.3, hh * 0.3)
+
+    # Pre-compute component half-sizes for repulsion sizing
+    half_sizes = np.array([(c.width / 2.0, c.height / 2.0) for c in components], dtype=np.float64)
+
+    # Build connectivity matrix
+    adj = _build_net_adjacency(components, nets)
+
+    # Velocity array for momentum-based simulation
+    velocities = np.zeros((n, 2), dtype=np.float64)
+
+    # Per-component safe bounds (component centre must stay within these)
+    x_lo = np.array([board.min_x + hs[0] for hs in half_sizes], dtype=np.float64)
+    x_hi = np.array([board.max_x - hs[0] for hs in half_sizes], dtype=np.float64)
+    y_lo = np.array([board.min_y + hs[1] for hs in half_sizes], dtype=np.float64)
+    y_hi = np.array([board.max_y - hs[1] for hs in half_sizes], dtype=np.float64)
+
+    for _iteration in range(max_iterations):
+        forces = np.zeros((n, 2), dtype=np.float64)
+
+        # --- Pairwise forces ---
+        for i in range(n):
+            for j in range(i + 1, n):
+                dx = positions[j, 0] - positions[i, 0]
+                dy = positions[j, 1] - positions[i, 1]
+                dist = math.sqrt(dx * dx + dy * dy)
+                if dist < _FD_MIN_SEPARATION:
+                    dist = _FD_MIN_SEPARATION
+                    # Use a deterministic direction when components overlap
+                    dx = _FD_MIN_SEPARATION
+                    dy = 0.0
+
+                ux = dx / dist
+                uy = dy / dist
+
+                # Repulsive force: inversely proportional to distance squared
+                # Scaled by sum of component sizes so larger components repel harder
+                size_scale = (
+                    half_sizes[i, 0] + half_sizes[i, 1] + half_sizes[j, 0] + half_sizes[j, 1]
+                )
+                f_repel = repulsive_strength * size_scale / (dist * dist)
+                forces[i, 0] -= f_repel * ux
+                forces[i, 1] -= f_repel * uy
+                forces[j, 0] += f_repel * ux
+                forces[j, 1] += f_repel * uy
+
+                # Attractive force: proportional to distance and shared-net count
+                net_count = adj[i, j]
+                if net_count > 0:
+                    f_attract = attractive_strength * net_count * dist
+                    forces[i, 0] += f_attract * ux
+                    forces[i, 1] += f_attract * uy
+                    forces[j, 0] -= f_attract * ux
+                    forces[j, 1] -= f_attract * uy
+
+        # --- Boundary restoring force ---
+        for i in range(n):
+            px, py = positions[i]
+            # Push inward if component bounding box extends past board edge
+            if px < x_lo[i]:
+                forces[i, 0] += boundary_strength * (x_lo[i] - px)
+            elif px > x_hi[i]:
+                forces[i, 0] += boundary_strength * (x_hi[i] - px)
+
+            if py < y_lo[i]:
+                forces[i, 1] += boundary_strength * (y_lo[i] - py)
+            elif py > y_hi[i]:
+                forces[i, 1] += boundary_strength * (y_hi[i] - py)
+
+        # --- Update velocities and positions ---
+        velocities = damping * velocities + dt * forces
+        positions += dt * velocities
+
+        # --- Clamp positions to board bounds ---
+        for i in range(n):
+            positions[i, 0] = max(x_lo[i], min(x_hi[i], positions[i, 0]))
+            positions[i, 1] = max(y_lo[i], min(y_hi[i], positions[i, 1]))
+
+        # --- Check equilibrium ---
+        max_displacement = np.max(np.abs(dt * velocities))
+        if max_displacement < _FD_EQUILIBRIUM_THRESHOLD:
+            break
+
+    # --- Encode result as PlacementVector ---
+    data = np.zeros(n * FIELDS_PER_COMPONENT, dtype=np.float64)
+    for i in range(n):
+        base = i * FIELDS_PER_COMPONENT
+        data[base] = positions[i, 0]  # x
+        data[base + 1] = positions[i, 1]  # y
+        data[base + 2] = 0.0  # rotation index (0 = 0 degrees)
+        data[base + 3] = 0.0  # side (0 = front)
+
+    return PlacementVector(data=data)
+
+
+# ---------------------------------------------------------------------------
+# Random placement with overlap resolution
+# ---------------------------------------------------------------------------
+
+
+def random_placement(
+    components: Sequence[ComponentDef],
+    board: BoardOutline,
+    *,
+    seed: int | None = None,
+    max_overlap_iterations: int = _OR_MAX_ITERATIONS,
+    push_factor: float = _OR_PUSH_FACTOR,
+) -> PlacementVector:
+    """Generate a random placement with iterative overlap resolution.
+
+    Places components uniformly at random within the board bounds (accounting
+    for component size), then iteratively pushes overlapping pairs apart
+    until no overlaps remain or *max_overlap_iterations* is exhausted.
+
+    All components are placed on the front side (side=0) with rotation=0.
+
+    Args:
+        components: Component definitions to place.
+        board: Board outline defining placement boundaries.
+        seed: Random seed for reproducibility. ``None`` for non-deterministic.
+        max_overlap_iterations: Maximum push-apart iterations.
+        push_factor: Fraction of overlap depth to apply as push displacement.
+
+    Returns:
+        A :class:`PlacementVector` with the computed placement.
+    """
+    n = len(components)
+    if n == 0:
+        return PlacementVector(data=np.empty(0, dtype=np.float64))
+
+    rng = np.random.default_rng(seed)
+
+    # Half-sizes
+    half_sizes = np.array([(c.width / 2.0, c.height / 2.0) for c in components], dtype=np.float64)
+
+    # Generate random positions within safe bounds
+    positions = np.empty((n, 2), dtype=np.float64)
+    for i in range(n):
+        lo_x = board.min_x + half_sizes[i, 0]
+        hi_x = board.max_x - half_sizes[i, 0]
+        lo_y = board.min_y + half_sizes[i, 1]
+        hi_y = board.max_y - half_sizes[i, 1]
+        # Handle case where component is wider/taller than board
+        if lo_x > hi_x:
+            positions[i, 0] = (board.min_x + board.max_x) / 2.0
+        else:
+            positions[i, 0] = rng.uniform(lo_x, hi_x)
+        if lo_y > hi_y:
+            positions[i, 1] = (board.min_y + board.max_y) / 2.0
+        else:
+            positions[i, 1] = rng.uniform(lo_y, hi_y)
+
+    # Iterative overlap resolution
+    for _iteration in range(max_overlap_iterations):
+        any_overlap = False
+        for i in range(n):
+            for j in range(i + 1, n):
+                # Check axis-aligned bounding box overlap
+                dx = positions[j, 0] - positions[i, 0]
+                dy = positions[j, 1] - positions[i, 1]
+
+                combined_hw = half_sizes[i, 0] + half_sizes[j, 0]
+                combined_hh = half_sizes[i, 1] + half_sizes[j, 1]
+
+                overlap_x = combined_hw - abs(dx)
+                overlap_y = combined_hh - abs(dy)
+
+                if overlap_x > 0 and overlap_y > 0:
+                    any_overlap = True
+                    # Push apart along the axis of minimum overlap
+                    if overlap_x < overlap_y:
+                        push = push_factor * overlap_x / 2.0
+                        if dx >= 0:
+                            positions[i, 0] -= push
+                            positions[j, 0] += push
+                        else:
+                            positions[i, 0] += push
+                            positions[j, 0] -= push
+                    else:
+                        push = push_factor * overlap_y / 2.0
+                        if dy >= 0:
+                            positions[i, 1] -= push
+                            positions[j, 1] += push
+                        else:
+                            positions[i, 1] += push
+                            positions[j, 1] -= push
+
+        # Clamp positions to board bounds
+        for i in range(n):
+            lo_x = board.min_x + half_sizes[i, 0]
+            hi_x = board.max_x - half_sizes[i, 0]
+            lo_y = board.min_y + half_sizes[i, 1]
+            hi_y = board.max_y - half_sizes[i, 1]
+            if lo_x <= hi_x:
+                positions[i, 0] = max(lo_x, min(hi_x, positions[i, 0]))
+            else:
+                positions[i, 0] = (board.min_x + board.max_x) / 2.0
+            if lo_y <= hi_y:
+                positions[i, 1] = max(lo_y, min(hi_y, positions[i, 1]))
+            else:
+                positions[i, 1] = (board.min_y + board.max_y) / 2.0
+
+        if not any_overlap:
+            break
+
+    # Encode result
+    data = np.zeros(n * FIELDS_PER_COMPONENT, dtype=np.float64)
+    for i in range(n):
+        base = i * FIELDS_PER_COMPONENT
+        data[base] = positions[i, 0]
+        data[base + 1] = positions[i, 1]
+        data[base + 2] = 0.0  # rotation index
+        data[base + 3] = 0.0  # side
+
+    return PlacementVector(data=data)

--- a/tests/test_placement_seed.py
+++ b/tests/test_placement_seed.py
@@ -1,0 +1,438 @@
+"""Tests for the initial placement heuristic (seed) module.
+
+Covers both force-directed placement and random placement with overlap
+resolution, verifying the acceptance criteria from issue #1207:
+- Force-directed produces zero-overlap results on simple boards
+- Components sharing many nets are placed closer together
+- Random placement with overlap resolution produces zero-overlap results
+- Both methods respect board boundary constraints
+- Force-directed seed scores better than random seed on HPWL metric
+- Completes in <1s for 20-component boards
+"""
+
+from __future__ import annotations
+
+import math
+import time
+
+import numpy as np
+
+from kicad_tools.placement.cost import (
+    BoardOutline,
+    ComponentPlacement,
+    Net,
+    compute_overlap,
+    compute_wirelength,
+)
+from kicad_tools.placement.seed import (
+    _build_net_adjacency,
+    force_directed_placement,
+    random_placement,
+)
+from kicad_tools.placement.vector import (
+    FIELDS_PER_COMPONENT,
+    ComponentDef,
+    PlacementVector,
+    decode,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_board(width: float = 100.0, height: float = 100.0) -> BoardOutline:
+    """Create a board outline centred at the origin."""
+    return BoardOutline(
+        min_x=-width / 2,
+        min_y=-height / 2,
+        max_x=width / 2,
+        max_y=height / 2,
+    )
+
+
+def _make_components(n: int, size: float = 2.0) -> list[ComponentDef]:
+    """Create *n* identical square components."""
+    return [ComponentDef(reference=f"U{i + 1}", width=size, height=size) for i in range(n)]
+
+
+def _vector_to_component_placements(
+    vec: PlacementVector, components: list[ComponentDef]
+) -> list[ComponentPlacement]:
+    """Convert PlacementVector into ComponentPlacement list for cost functions."""
+    placements = decode(vec, components)
+    return [
+        ComponentPlacement(reference=p.reference, x=p.x, y=p.y, rotation=p.rotation)
+        for p in placements
+    ]
+
+
+def _footprint_sizes(
+    components: list[ComponentDef],
+) -> dict[str, tuple[float, float]]:
+    """Build footprint size map from component defs."""
+    return {c.reference: (c.width, c.height) for c in components}
+
+
+def _check_no_overlap(
+    vec: PlacementVector,
+    components: list[ComponentDef],
+) -> float:
+    """Return total overlap area for the given placement."""
+    cp = _vector_to_component_placements(vec, components)
+    sizes = _footprint_sizes(components)
+    return compute_overlap(cp, sizes)
+
+
+def _check_within_bounds(
+    vec: PlacementVector,
+    components: list[ComponentDef],
+    board: BoardOutline,
+) -> bool:
+    """Check that all components are within the board outline."""
+    placements = decode(vec, components)
+    for i, p in enumerate(placements):
+        hw = components[i].width / 2.0
+        hh = components[i].height / 2.0
+        if p.x - hw < board.min_x - 1e-9:
+            return False
+        if p.x + hw > board.max_x + 1e-9:
+            return False
+        if p.y - hh < board.min_y - 1e-9:
+            return False
+        if p.y + hh > board.max_y + 1e-9:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_net_adjacency
+# ---------------------------------------------------------------------------
+
+
+class TestBuildNetAdjacency:
+    def test_empty_nets(self) -> None:
+        components = _make_components(3)
+        adj = _build_net_adjacency(components, [])
+        assert adj.shape == (3, 3)
+        assert np.all(adj == 0)
+
+    def test_single_net(self) -> None:
+        components = _make_components(3)
+        nets = [Net(name="VCC", pins=[("U1", "1"), ("U3", "1")])]
+        adj = _build_net_adjacency(components, nets)
+        assert adj[0, 2] == 1.0
+        assert adj[2, 0] == 1.0
+        assert adj[0, 1] == 0.0
+
+    def test_multiple_shared_nets(self) -> None:
+        components = _make_components(3)
+        nets = [
+            Net(name="N1", pins=[("U1", "1"), ("U2", "1")]),
+            Net(name="N2", pins=[("U1", "2"), ("U2", "2")]),
+            Net(name="N3", pins=[("U1", "3"), ("U2", "3")]),
+        ]
+        adj = _build_net_adjacency(components, nets)
+        # U1-U2 share 3 nets
+        assert adj[0, 1] == 3.0
+        assert adj[1, 0] == 3.0
+        # U3 is disconnected
+        assert adj[0, 2] == 0.0
+        assert adj[2, 1] == 0.0
+
+    def test_unknown_ref_ignored(self) -> None:
+        components = _make_components(2)
+        nets = [Net(name="N1", pins=[("U1", "1"), ("UNKNOWN", "1")])]
+        adj = _build_net_adjacency(components, nets)
+        # UNKNOWN is not in components, so U1 has no in-component connection
+        assert adj[0, 1] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Tests: force_directed_placement
+# ---------------------------------------------------------------------------
+
+
+class TestForceDirectedPlacement:
+    def test_empty_components(self) -> None:
+        board = _make_board()
+        result = force_directed_placement([], [], board)
+        assert isinstance(result, PlacementVector)
+        assert len(result.data) == 0
+
+    def test_single_component(self) -> None:
+        board = _make_board()
+        components = _make_components(1)
+        result = force_directed_placement(components, [], board)
+        assert result.num_components == 1
+        # Should be within bounds
+        assert _check_within_bounds(result, components, board)
+
+    def test_two_components_no_nets_repel(self) -> None:
+        """Two disconnected components should be pushed apart by repulsion."""
+        board = _make_board(50, 50)
+        components = _make_components(2, size=2.0)
+        result = force_directed_placement(components, [], board)
+        placements = decode(result, components)
+        dist = math.sqrt(
+            (placements[0].x - placements[1].x) ** 2 + (placements[0].y - placements[1].y) ** 2
+        )
+        # They should be separated (not on top of each other)
+        assert dist > 1.0
+
+    def test_connected_components_closer_than_disconnected(self) -> None:
+        """Components sharing nets should end up closer than disconnected ones."""
+        board = _make_board(100, 100)
+        # U1, U2, U3: U1 and U2 share 5 nets, U3 is disconnected
+        components = _make_components(3, size=2.0)
+        nets = [Net(name=f"N{i}", pins=[("U1", str(i)), ("U2", str(i))]) for i in range(5)]
+        result = force_directed_placement(components, nets, board)
+        placements = decode(result, components)
+
+        dist_12 = math.sqrt(
+            (placements[0].x - placements[1].x) ** 2 + (placements[0].y - placements[1].y) ** 2
+        )
+        dist_13 = math.sqrt(
+            (placements[0].x - placements[2].x) ** 2 + (placements[0].y - placements[2].y) ** 2
+        )
+        # Connected pair (U1-U2) should be closer than disconnected pair (U1-U3)
+        assert dist_12 < dist_13
+
+    def test_zero_overlap_simple_board(self) -> None:
+        """Force-directed placement should produce zero overlap on a simple board."""
+        board = _make_board(100, 100)
+        components = _make_components(5, size=3.0)
+        nets = [
+            Net(name="N1", pins=[("U1", "1"), ("U2", "1")]),
+            Net(name="N2", pins=[("U2", "1"), ("U3", "1")]),
+        ]
+        result = force_directed_placement(components, nets, board)
+        overlap = _check_no_overlap(result, components)
+        assert overlap == 0.0, f"Expected zero overlap, got {overlap}"
+
+    def test_boundary_constraints(self) -> None:
+        """All components should stay within board bounds."""
+        board = _make_board(40, 40)
+        components = _make_components(8, size=3.0)
+        nets = [
+            Net(name="N1", pins=[("U1", "1"), ("U5", "1")]),
+            Net(name="N2", pins=[("U3", "1"), ("U7", "1")]),
+        ]
+        result = force_directed_placement(components, nets, board)
+        assert _check_within_bounds(result, components, board)
+
+    def test_rotation_and_side_defaults(self) -> None:
+        """Seed placement should use rotation=0, side=0 for all components."""
+        board = _make_board()
+        components = _make_components(3)
+        result = force_directed_placement(components, [], board)
+        for i in range(3):
+            vals = result.component_slice(i)
+            assert vals[2] == 0.0, "rotation should be 0"
+            assert vals[3] == 0.0, "side should be 0 (front)"
+
+    def test_performance_20_components(self) -> None:
+        """Force-directed placement should complete in <1s for 20 components."""
+        board = _make_board(200, 200)
+        components = _make_components(20, size=5.0)
+        # Create a moderate connectivity (each component connected to 2 neighbours)
+        nets = []
+        for i in range(19):
+            nets.append(
+                Net(
+                    name=f"N{i}",
+                    pins=[
+                        (f"U{i + 1}", "1"),
+                        (f"U{i + 2}", "1"),
+                    ],
+                )
+            )
+        start = time.monotonic()
+        result = force_directed_placement(components, nets, board)
+        elapsed = time.monotonic() - start
+        assert elapsed < 1.0, f"Took {elapsed:.2f}s, expected <1s"
+        assert result.num_components == 20
+
+    def test_many_shared_nets_cluster(self) -> None:
+        """Components sharing many nets should cluster more tightly."""
+        board = _make_board(200, 200)
+        # Group A: U1, U2, U3 share 10 nets each pair
+        # Group B: U4, U5, U6 share 1 net each pair
+        components = _make_components(6, size=3.0)
+
+        nets_a = [
+            Net(
+                name=f"GA{i}",
+                pins=[("U1", str(i)), ("U2", str(i)), ("U3", str(i))],
+            )
+            for i in range(10)
+        ]
+        nets_b = [
+            Net(name="GB1", pins=[("U4", "1"), ("U5", "1"), ("U6", "1")]),
+        ]
+        result = force_directed_placement(components, nets_a + nets_b, board)
+        placements = decode(result, components)
+
+        # Compute average pairwise distance within group A
+        group_a_dists = []
+        for i in range(3):
+            for j in range(i + 1, 3):
+                d = math.sqrt(
+                    (placements[i].x - placements[j].x) ** 2
+                    + (placements[i].y - placements[j].y) ** 2
+                )
+                group_a_dists.append(d)
+
+        # Group B average distance
+        group_b_dists = []
+        for i in range(3, 6):
+            for j in range(i + 1, 6):
+                d = math.sqrt(
+                    (placements[i].x - placements[j].x) ** 2
+                    + (placements[i].y - placements[j].y) ** 2
+                )
+                group_b_dists.append(d)
+
+        avg_a = sum(group_a_dists) / len(group_a_dists)
+        avg_b = sum(group_b_dists) / len(group_b_dists)
+
+        # Group A (10 shared nets) should be tighter than Group B (1 shared net)
+        assert avg_a < avg_b, f"Group A avg dist ({avg_a:.2f}) should be < Group B ({avg_b:.2f})"
+
+
+# ---------------------------------------------------------------------------
+# Tests: random_placement
+# ---------------------------------------------------------------------------
+
+
+class TestRandomPlacement:
+    def test_empty_components(self) -> None:
+        board = _make_board()
+        result = random_placement([], board)
+        assert isinstance(result, PlacementVector)
+        assert len(result.data) == 0
+
+    def test_single_component(self) -> None:
+        board = _make_board()
+        components = _make_components(1)
+        result = random_placement(components, board, seed=42)
+        assert result.num_components == 1
+        assert _check_within_bounds(result, components, board)
+
+    def test_zero_overlap_after_resolution(self) -> None:
+        """Random placement with overlap resolution should produce zero overlap."""
+        board = _make_board(60, 60)
+        components = _make_components(10, size=3.0)
+        result = random_placement(components, board, seed=99)
+        overlap = _check_no_overlap(result, components)
+        assert overlap == 0.0, f"Expected zero overlap, got {overlap}"
+
+    def test_boundary_constraints(self) -> None:
+        """All components should be within board bounds after placement."""
+        board = _make_board(50, 50)
+        components = _make_components(8, size=4.0)
+        result = random_placement(components, board, seed=7)
+        assert _check_within_bounds(result, components, board)
+
+    def test_deterministic_with_seed(self) -> None:
+        """Same seed should produce same result."""
+        board = _make_board()
+        components = _make_components(5)
+        r1 = random_placement(components, board, seed=123)
+        r2 = random_placement(components, board, seed=123)
+        assert np.array_equal(r1.data, r2.data)
+
+    def test_different_seeds_different_results(self) -> None:
+        """Different seeds should produce different results."""
+        board = _make_board()
+        components = _make_components(5)
+        r1 = random_placement(components, board, seed=1)
+        r2 = random_placement(components, board, seed=2)
+        assert not np.array_equal(r1.data, r2.data)
+
+    def test_rotation_and_side_defaults(self) -> None:
+        """Random placement should use rotation=0, side=0."""
+        board = _make_board()
+        components = _make_components(3)
+        result = random_placement(components, board, seed=42)
+        for i in range(3):
+            vals = result.component_slice(i)
+            assert vals[2] == 0.0
+            assert vals[3] == 0.0
+
+    def test_component_larger_than_board(self) -> None:
+        """Component wider than board should be centred."""
+        board = _make_board(5, 5)  # tiny board
+        components = [ComponentDef(reference="U1", width=10.0, height=10.0)]
+        result = random_placement(components, board, seed=42)
+        vals = result.component_slice(0)
+        # Should be at board centre
+        assert abs(vals[0] - 0.0) < 1e-9
+        assert abs(vals[1] - 0.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Tests: force-directed beats random on HPWL
+# ---------------------------------------------------------------------------
+
+
+class TestForceDirectedBeatsRandom:
+    def test_hpwl_improvement(self) -> None:
+        """Force-directed seed should score better (lower) on HPWL than random."""
+        board = _make_board(100, 100)
+        components = _make_components(10, size=3.0)
+
+        # Create rich connectivity
+        nets = [
+            Net(name="N1", pins=[("U1", "1"), ("U2", "1"), ("U3", "1")]),
+            Net(name="N2", pins=[("U2", "1"), ("U4", "1")]),
+            Net(name="N3", pins=[("U3", "1"), ("U5", "1"), ("U6", "1")]),
+            Net(name="N4", pins=[("U5", "1"), ("U7", "1"), ("U8", "1")]),
+            Net(name="N5", pins=[("U7", "1"), ("U9", "1")]),
+            Net(name="N6", pins=[("U8", "1"), ("U10", "1")]),
+            Net(name="N7", pins=[("U1", "2"), ("U10", "2")]),
+        ]
+
+        fd_vec = force_directed_placement(components, nets, board)
+        fd_placements = _vector_to_component_placements(fd_vec, components)
+        fd_hpwl = compute_wirelength(fd_placements, nets)
+
+        # Average HPWL over several random seeds
+        random_hpwls = []
+        for seed in range(10):
+            rand_vec = random_placement(components, board, seed=seed)
+            rand_placements = _vector_to_component_placements(rand_vec, components)
+            random_hpwls.append(compute_wirelength(rand_placements, nets))
+
+        avg_random_hpwl = sum(random_hpwls) / len(random_hpwls)
+
+        assert fd_hpwl < avg_random_hpwl, (
+            f"Force-directed HPWL ({fd_hpwl:.2f}) should be less than "
+            f"average random HPWL ({avg_random_hpwl:.2f})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: Vector structure
+# ---------------------------------------------------------------------------
+
+
+class TestVectorStructure:
+    def test_vector_length(self) -> None:
+        """Output vector should have length 4*N."""
+        board = _make_board()
+        components = _make_components(7)
+        result = force_directed_placement(components, [], board)
+        assert len(result.data) == 7 * FIELDS_PER_COMPONENT
+
+    def test_decode_roundtrip(self) -> None:
+        """Should be decodable back to PlacedComponent list."""
+        board = _make_board()
+        components = _make_components(4)
+        nets = [Net(name="N1", pins=[("U1", "1"), ("U3", "1")])]
+        result = force_directed_placement(components, nets, board)
+        placed = decode(result, components)
+        assert len(placed) == 4
+        for p in placed:
+            assert p.rotation == 0.0
+            assert p.side == 0


### PR DESCRIPTION
## Summary

Implement initial placement heuristics that generate seed placements for the CMA-ES optimizer. A force-directed algorithm produces high-quality seeds by simulating attractive (net-based) and repulsive (overlap-preventing) forces, while a random placement fallback provides overlap-free starting points when no connectivity information is available.

## Changes

- Add `src/kicad_tools/placement/seed.py` with two public functions:
  - `force_directed_placement(components, nets, board) -> PlacementVector`: iterative force simulation with net-based attraction, pairwise repulsion, and boundary restoring forces
  - `random_placement(components, board) -> PlacementVector`: uniform random placement with iterative overlap resolution
- Add `tests/test_placement_seed.py` with 24 tests covering all acceptance criteria

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Force-directed produces zero-overlap on simple boards | PASS | `test_zero_overlap_simple_board` -- 5 components on 100x100 board, overlap == 0.0 |
| Components sharing many nets placed closer | PASS | `test_connected_components_closer_than_disconnected`, `test_many_shared_nets_cluster` -- group with 10 shared nets clusters tighter than group with 1 |
| Random placement with overlap resolution produces zero overlap | PASS | `test_zero_overlap_after_resolution` -- 10 components on 60x60 board, overlap == 0.0 |
| Both methods respect board boundary constraints | PASS | `test_boundary_constraints` for both force-directed and random |
| Force-directed seed scores better than random on HPWL | PASS | `test_hpwl_improvement` -- force-directed HPWL < average of 10 random seeds |
| Completes in <1s for 20-component boards | PASS | `test_performance_20_components` -- 20 components with chain connectivity |

## Test Plan

- `uv run pytest tests/test_placement_seed.py -x -v` -- 24/24 passed
- `uv run pytest tests/test_placement_vector.py -x -v` -- 38/38 passed (no regressions)
- `uv run ruff check` and `uv run ruff format --check` -- clean on changed files

Closes #1207