### PR TITLE
feat(placement): add DRC clearance checker for courtyard and pad spacing

### DIFF
--- a/src/kicad_tools/placement/drc.py
+++ b/src/kicad_tools/placement/drc.py
@@ -1,0 +1,337 @@
+"""Placement DRC clearance checker for optimization-time constraint evaluation.
+
+Checks component-to-component courtyard clearance and pad-to-pad clearance
+against design rules during placement optimization.  Works with
+:class:`PlacedComponent` and :class:`ComponentDef` types from the placement
+vector module and the :class:`DesignRules` from the router rules module.
+
+Two kinds of clearance check are performed:
+
+* **Courtyard clearance** -- axis-aligned bounding box gap between components
+  on the same board side must meet the minimum clearance from design rules.
+
+* **Pad-to-pad clearance** -- pads belonging to *different* nets must have at
+  least the required clearance between their bounding boxes.  Pads on the
+  same net are excluded (they will eventually be connected by copper).
+
+Usage::
+
+    from kicad_tools.placement.drc import check_placement_drc, DrcResult
+    from kicad_tools.router.rules import DesignRules
+
+    result = check_placement_drc(placements, component_defs, rules)
+    print(result.violation_count, result.total_violation_distance)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from kicad_tools.placement.cost import Net
+from kicad_tools.placement.geometry import _aabb
+from kicad_tools.placement.vector import (
+    ComponentDef,
+    PlacedComponent,
+    TransformedPad,
+)
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ClearanceViolation:
+    """A single clearance violation between two objects.
+
+    Attributes:
+        ref_a: Reference designator of first component.
+        ref_b: Reference designator of second component.
+        kind: Violation kind -- ``"courtyard"`` or ``"pad"``.
+        required_clearance: Minimum clearance required by design rules (mm).
+        actual_clearance: Actual measured clearance (mm).  Negative values
+            indicate overlap.
+        violation_distance: How far below the minimum clearance (mm).
+            Always ``>= 0`` for a true violation.
+        pad_a: Pad name on first component (only for pad violations).
+        pad_b: Pad name on second component (only for pad violations).
+    """
+
+    ref_a: str
+    ref_b: str
+    kind: str
+    required_clearance: float
+    actual_clearance: float
+    violation_distance: float
+    pad_a: str | None = None
+    pad_b: str | None = None
+
+
+@dataclass(frozen=True)
+class DrcResult:
+    """Result of a placement DRC clearance check.
+
+    Attributes:
+        violation_count: Total number of clearance violations.
+        total_violation_distance: Sum of violation distances across all
+            violations (mm).  This is the total amount by which components
+            fall below the required clearance -- useful as a smooth penalty
+            in an optimizer cost function.
+        violations: Detailed list of every violating pair.
+    """
+
+    violation_count: int = 0
+    total_violation_distance: float = 0.0
+    violations: tuple[ClearanceViolation, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _box_gap(
+    box_a: tuple[float, float, float, float],
+    box_b: tuple[float, float, float, float],
+) -> float:
+    """Compute the minimum edge-to-edge gap between two axis-aligned boxes.
+
+    Returns a *negative* value when the boxes overlap.  For separated boxes
+    the gap is the Euclidean distance between the closest edges/corners.
+
+    Args:
+        box_a: ``(min_x, min_y, max_x, max_y)``
+        box_b: ``(min_x, min_y, max_x, max_y)``
+
+    Returns:
+        Minimum gap in mm (negative means overlap).
+    """
+    # Signed distances along each axis.  Positive = separated, negative = overlapping.
+    gap_x = max(box_a[0], box_b[0]) - min(box_a[2], box_b[2])
+    gap_y = max(box_a[1], box_b[1]) - min(box_a[3], box_b[3])
+
+    if gap_x <= 0 and gap_y <= 0:
+        # Overlapping on both axes -- gap is the larger (less-negative) axis distance.
+        # e.g. gap_x=-2, gap_y=-1 => actual gap is -1 (just touching on y).
+        return max(gap_x, gap_y)
+
+    if gap_x > 0 and gap_y > 0:
+        # Separated on both axes -- corner-to-corner Euclidean distance.
+        return (gap_x**2 + gap_y**2) ** 0.5
+
+    # Separated on exactly one axis -- edge-to-edge distance.
+    return max(gap_x, gap_y)
+
+
+def _pad_box(pad: TransformedPad) -> tuple[float, float, float, float]:
+    """Compute the axis-aligned bounding box for a transformed pad.
+
+    Args:
+        pad: Transformed pad with absolute position and size.
+
+    Returns:
+        ``(min_x, min_y, max_x, max_y)``
+    """
+    half_x = pad.size_x / 2.0
+    half_y = pad.size_y / 2.0
+    return (
+        pad.x - half_x,
+        pad.y - half_y,
+        pad.x + half_x,
+        pad.y + half_y,
+    )
+
+
+def _build_pad_net_map(
+    placements: Sequence[PlacedComponent],
+    nets: Sequence[Net],
+) -> dict[tuple[str, str], str]:
+    """Build a mapping from (component_ref, pad_name) to net name.
+
+    Args:
+        placements: Decoded placements (used only for validation context).
+        nets: Net definitions with pin lists.
+
+    Returns:
+        Dictionary mapping ``(reference, pad_name)`` to the net name.
+    """
+    pad_net: dict[tuple[str, str], str] = {}
+    for net in nets:
+        for ref, pin_name in net.pins:
+            pad_net[(ref, pin_name)] = net.name
+    return pad_net
+
+
+def _clearance_for_pair(
+    rules: DesignRules,
+    net_a: str | None,
+    net_b: str | None,
+    net_class_map: dict[str, NetClassRouting] | None,
+) -> float:
+    """Determine the clearance requirement for a pair of nets.
+
+    If both nets have net-class overrides, the *maximum* of the two
+    net-class clearances is used (the stricter rule wins).  Otherwise
+    falls back to ``rules.trace_clearance``.
+
+    Args:
+        rules: Global design rules.
+        net_a: Net name of the first pad (or ``None``).
+        net_b: Net name of the second pad (or ``None``).
+        net_class_map: Optional mapping from net name to net-class routing.
+
+    Returns:
+        Required clearance in mm.
+    """
+    base = rules.trace_clearance
+
+    if net_class_map is None:
+        return base
+
+    clearance_a = net_class_map[net_a].clearance if net_a and net_a in net_class_map else base
+    clearance_b = net_class_map[net_b].clearance if net_b and net_b in net_class_map else base
+
+    # The stricter (larger) clearance wins.
+    return max(clearance_a, clearance_b)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_placement_drc(
+    placements: Sequence[PlacedComponent],
+    component_defs: Sequence[ComponentDef],
+    rules: DesignRules,
+    nets: Sequence[Net] | None = None,
+    net_class_map: dict[str, NetClassRouting] | None = None,
+) -> DrcResult:
+    """Check all placement clearance constraints and return a DRC result.
+
+    Performs two categories of check:
+
+    1. **Courtyard clearance** -- for each pair of components on the same
+       board side, verifies that the edge-to-edge gap between their
+       axis-aligned bounding boxes meets ``rules.trace_clearance``.
+
+    2. **Pad-to-pad clearance** -- for pads on *different* nets, verifies
+       that the edge-to-edge gap between pad bounding boxes meets the
+       clearance requirement (possibly per-net-class).  Pads on the same
+       net are skipped.  Pad checks are only performed when *nets* is
+       provided.
+
+    Components on opposite board sides are not checked against each other.
+
+    Complexity is O(N^2) for courtyard checks and O(P^2) for pad checks
+    in the worst case, which is acceptable for boards with fewer than
+    ~100 components.
+
+    Args:
+        placements: Placed components with positions, rotations, and sides.
+        component_defs: Static component definitions (same order as
+            *placements*).
+        rules: Design rules providing default clearance values.
+        nets: Optional net definitions for pad-to-pad checks.  When
+            ``None``, only courtyard checks are performed.
+        net_class_map: Optional mapping from net name to
+            :class:`NetClassRouting` for per-net-class clearance overrides.
+
+    Returns:
+        :class:`DrcResult` summarizing all violations.
+
+    Raises:
+        ValueError: If *placements* and *component_defs* have different
+            lengths.
+    """
+    n = len(placements)
+    if n != len(component_defs):
+        raise ValueError(f"placements has {n} items but component_defs has {len(component_defs)}")
+
+    violations: list[ClearanceViolation] = []
+    min_clearance = rules.trace_clearance
+
+    # ------------------------------------------------------------------
+    # 1. Courtyard (AABB) clearance checks
+    # ------------------------------------------------------------------
+    boxes = [
+        _aabb(comp, comp_def) for comp, comp_def in zip(placements, component_defs, strict=True)
+    ]
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            # Skip components on different board sides.
+            if placements[i].side != placements[j].side:
+                continue
+
+            gap = _box_gap(boxes[i], boxes[j])
+            if gap < min_clearance:
+                violation_dist = min_clearance - gap
+                violations.append(
+                    ClearanceViolation(
+                        ref_a=placements[i].reference,
+                        ref_b=placements[j].reference,
+                        kind="courtyard",
+                        required_clearance=min_clearance,
+                        actual_clearance=gap,
+                        violation_distance=violation_dist,
+                    )
+                )
+
+    # ------------------------------------------------------------------
+    # 2. Pad-to-pad clearance checks (only if nets are provided)
+    # ------------------------------------------------------------------
+    if nets is not None:
+        pad_net_map = _build_pad_net_map(placements, nets)
+
+        # Collect all pads with their owning component info.
+        all_pads: list[tuple[str, TransformedPad, str | None]] = []
+        for comp in placements:
+            for pad in comp.pads:
+                net_name = pad_net_map.get((comp.reference, pad.name))
+                all_pads.append((comp.reference, pad, net_name))
+
+        p = len(all_pads)
+        for i in range(p):
+            ref_i, pad_i, net_i = all_pads[i]
+            for j in range(i + 1, p):
+                ref_j, pad_j, net_j = all_pads[j]
+
+                # Skip pads on the same component.
+                if ref_i == ref_j:
+                    continue
+
+                # Skip pads on the same net (they will be connected).
+                if net_i is not None and net_i == net_j:
+                    continue
+
+                required = _clearance_for_pair(rules, net_i, net_j, net_class_map)
+                gap = _box_gap(_pad_box(pad_i), _pad_box(pad_j))
+
+                if gap < required:
+                    violation_dist = required - gap
+                    violations.append(
+                        ClearanceViolation(
+                            ref_a=ref_i,
+                            ref_b=ref_j,
+                            kind="pad",
+                            required_clearance=required,
+                            actual_clearance=gap,
+                            violation_distance=violation_dist,
+                            pad_a=pad_i.name,
+                            pad_b=pad_j.name,
+                        )
+                    )
+
+    # ------------------------------------------------------------------
+    # Build result
+    # ------------------------------------------------------------------
+    total_dist = sum(v.violation_distance for v in violations)
+
+    return DrcResult(
+        violation_count=len(violations),
+        total_violation_distance=total_dist,
+        violations=tuple(violations),
+    )

--- a/tests/test_placement_drc.py
+++ b/tests/test_placement_drc.py
@@ -1,0 +1,513 @@
+"""Tests for placement DRC clearance checker.
+
+Tests cover:
+- Courtyard clearance violations between component bounding boxes
+- Pad-to-pad clearance violations for pads on different nets
+- Per-net-class clearance overrides
+- Well-spaced placements returning 0 violations
+- Violation distance scaling linearly with overlap amount
+- Edge cases: single component, opposite sides, same-net pads
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.placement.cost import Net
+from kicad_tools.placement.drc import (
+    ClearanceViolation,
+    DrcResult,
+    check_placement_drc,
+)
+from kicad_tools.placement.vector import (
+    ComponentDef,
+    PadDef,
+    PlacedComponent,
+    TransformedPad,
+)
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_placed(
+    ref: str,
+    x: float,
+    y: float,
+    rotation: float = 0.0,
+    side: int = 0,
+    pads: tuple[TransformedPad, ...] = (),
+) -> PlacedComponent:
+    return PlacedComponent(reference=ref, x=x, y=y, rotation=rotation, side=side, pads=pads)
+
+
+def _make_def(
+    ref: str,
+    width: float = 2.0,
+    height: float = 2.0,
+    pads: tuple[PadDef, ...] = (),
+) -> ComponentDef:
+    return ComponentDef(reference=ref, width=width, height=height, pads=pads)
+
+
+def _default_rules(clearance: float = 0.2) -> DesignRules:
+    return DesignRules(trace_clearance=clearance)
+
+
+# ---------------------------------------------------------------------------
+# Courtyard clearance tests
+# ---------------------------------------------------------------------------
+
+
+class TestCourtyardClearance:
+    """Tests for courtyard (bounding-box) clearance between components."""
+
+    def test_well_spaced_no_violations(self):
+        """Two components far apart should produce zero violations."""
+        placements = [
+            _make_placed("U1", 0.0, 0.0),
+            _make_placed("U2", 10.0, 0.0),
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+
+        result = check_placement_drc(placements, defs, rules)
+
+        assert result.violation_count == 0
+        assert result.total_violation_distance == 0.0
+        assert result.violations == ()
+
+    def test_exactly_at_minimum_clearance(self):
+        """Components exactly at minimum clearance should pass (no violation)."""
+        # Component width = 2.0mm, centered at origin => box from -1 to +1.
+        # Second component needs box starting at 1.0 + 0.2 = 1.2, center at 2.2.
+        placements = [
+            _make_placed("U1", 0.0, 0.0),
+            _make_placed("U2", 2.2, 0.0),
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+
+        result = check_placement_drc(placements, defs, rules)
+
+        assert result.violation_count == 0
+        assert result.total_violation_distance == 0.0
+
+    def test_slightly_below_minimum_clearance(self):
+        """Components slightly closer than minimum clearance should fail."""
+        # Gap = 2.19 - 1.0 - 1.0 = 0.19mm (below 0.2mm minimum)
+        placements = [
+            _make_placed("U1", 0.0, 0.0),
+            _make_placed("U2", 2.19, 0.0),
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+
+        result = check_placement_drc(placements, defs, rules)
+
+        assert result.violation_count == 1
+        assert result.total_violation_distance == pytest.approx(0.01, abs=1e-9)
+        assert result.violations[0].kind == "courtyard"
+        assert result.violations[0].ref_a == "U1"
+        assert result.violations[0].ref_b == "U2"
+
+    def test_overlapping_components(self):
+        """Overlapping components should register a violation with gap < 0."""
+        placements = [
+            _make_placed("U1", 0.0, 0.0),
+            _make_placed("U2", 1.0, 0.0),  # overlap: gap = -1.0
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+
+        result = check_placement_drc(placements, defs, rules)
+
+        assert result.violation_count == 1
+        v = result.violations[0]
+        assert v.actual_clearance < 0.0
+        # violation_distance = 0.2 - (-1.0) = 1.2
+        assert v.violation_distance == pytest.approx(1.2, abs=1e-9)
+
+    def test_opposite_sides_no_violation(self):
+        """Components on opposite board sides should not produce violations."""
+        placements = [
+            _make_placed("U1", 0.0, 0.0, side=0),
+            _make_placed("U2", 0.0, 0.0, side=1),  # same position, different side
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+
+        result = check_placement_drc(placements, defs, rules)
+
+        assert result.violation_count == 0
+
+    def test_single_component_no_violations(self):
+        """A single component should produce zero violations."""
+        placements = [_make_placed("U1", 0.0, 0.0)]
+        defs = [_make_def("U1")]
+        rules = _default_rules(0.2)
+
+        result = check_placement_drc(placements, defs, rules)
+
+        assert result.violation_count == 0
+
+    def test_empty_placement_no_violations(self):
+        """Empty placement list should produce zero violations."""
+        result = check_placement_drc([], [], _default_rules())
+
+        assert result.violation_count == 0
+        assert result.total_violation_distance == 0.0
+
+    def test_violation_distance_scales_linearly(self):
+        """Violation distance should scale linearly with overlap amount."""
+        rules = _default_rules(0.2)
+        defs = [_make_def("U1"), _make_def("U2")]
+
+        # Gap = 0.1 (violation distance = 0.1)
+        placements_a = [
+            _make_placed("U1", 0.0, 0.0),
+            _make_placed("U2", 2.1, 0.0),
+        ]
+        result_a = check_placement_drc(placements_a, defs, rules)
+
+        # Gap = 0.0 (violation distance = 0.2)
+        placements_b = [
+            _make_placed("U1", 0.0, 0.0),
+            _make_placed("U2", 2.0, 0.0),
+        ]
+        result_b = check_placement_drc(placements_b, defs, rules)
+
+        # Double the shortfall => double the violation distance
+        assert result_b.total_violation_distance == pytest.approx(
+            2.0 * result_a.total_violation_distance, abs=1e-9
+        )
+
+    def test_rotated_component_courtyard(self):
+        """Rotation should be accounted for in courtyard clearance.
+
+        A 2x4mm component rotated 90 degrees becomes 4x2mm.
+        """
+        # U1: 2x4 at (0,0) => box [-1,-2,1,2]
+        # U2: 2x4 rotated 90 at (3.2, 0) => 4x2 => box [1.2,-1,5.2,1]
+        # gap_x = max(-1,1.2) - min(1,5.2) = 1.2 - 1.0 = 0.2 (exactly at clearance)
+        placements = [
+            _make_placed("U1", 0.0, 0.0, rotation=0.0),
+            _make_placed("U2", 3.2, 0.0, rotation=90.0),
+        ]
+        defs = [
+            _make_def("U1", width=2.0, height=4.0),
+            _make_def("U2", width=2.0, height=4.0),
+        ]
+        rules = _default_rules(0.2)
+
+        result = check_placement_drc(placements, defs, rules)
+
+        assert result.violation_count == 0
+
+    def test_three_components_multiple_violations(self):
+        """Three components all too close should produce three violations."""
+        placements = [
+            _make_placed("U1", 0.0, 0.0),
+            _make_placed("U2", 1.5, 0.0),  # too close to U1
+            _make_placed("U3", 0.0, 1.5),  # too close to U1
+        ]
+        # Width/height = 2.0 each, so gap between U1-U2 = 1.5 - 1.0 - 1.0 = -0.5
+        # U2-U3: corner case, gap_x = max(-1,0.5) - min(1,2.5) = 0.5-1.0 = -0.5
+        # and gap_y = max(-1,0.5) - min(1,2.5) = 0.5-1.0 = -0.5
+        # both negative => gap = max(-0.5, -0.5) = -0.5 => violation
+        defs = [_make_def("U1"), _make_def("U2"), _make_def("U3")]
+        rules = _default_rules(0.2)
+
+        result = check_placement_drc(placements, defs, rules)
+
+        assert result.violation_count == 3
+
+    def test_diagonal_corner_clearance(self):
+        """Two boxes separated diagonally should use Euclidean distance."""
+        # U1 at (0,0) width=2 => box [-1,-1,1,1]
+        # U2 at (3,3) width=2 => box [2,2,4,4]
+        # gap_x = 2-1 = 1, gap_y = 2-1 = 1 => Euclidean = sqrt(2) ~ 1.414
+        placements = [
+            _make_placed("U1", 0.0, 0.0),
+            _make_placed("U2", 3.0, 3.0),
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(1.5)  # Just above sqrt(2)
+
+        result = check_placement_drc(placements, defs, rules)
+
+        assert result.violation_count == 1
+        v = result.violations[0]
+        assert v.actual_clearance == pytest.approx(math.sqrt(2), abs=1e-9)
+        assert v.violation_distance == pytest.approx(1.5 - math.sqrt(2), abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Pad-to-pad clearance tests
+# ---------------------------------------------------------------------------
+
+
+class TestPadClearance:
+    """Tests for pad-to-pad clearance between pads on different nets."""
+
+    def test_pads_different_nets_well_spaced(self):
+        """Pads on different nets that are well spaced produce no violations."""
+        pads_u1 = (TransformedPad(name="1", x=0.0, y=0.0, size_x=0.5, size_y=0.5),)
+        pads_u2 = (TransformedPad(name="1", x=5.0, y=0.0, size_x=0.5, size_y=0.5),)
+
+        placements = [
+            _make_placed("U1", 0.0, 0.0, pads=pads_u1),
+            _make_placed("U2", 5.0, 0.0, pads=pads_u2),
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+        nets = [
+            Net(name="VCC", pins=[("U1", "1")]),
+            Net(name="GND", pins=[("U2", "1")]),
+        ]
+
+        result = check_placement_drc(placements, defs, rules, nets=nets)
+
+        # Courtyard check passes too (far apart), only care about pad result
+        pad_violations = [v for v in result.violations if v.kind == "pad"]
+        assert len(pad_violations) == 0
+
+    def test_pads_different_nets_too_close(self):
+        """Pads on different nets too close together should produce a violation."""
+        # Pads at (0.5, 0) and (1.0, 0), each 0.5mm wide => gap = 0.25mm
+        pads_u1 = (TransformedPad(name="1", x=0.5, y=0.0, size_x=0.5, size_y=0.5),)
+        pads_u2 = (TransformedPad(name="1", x=1.0, y=0.0, size_x=0.5, size_y=0.5),)
+
+        placements = [
+            _make_placed("U1", 0.0, 0.0, pads=pads_u1),
+            _make_placed("U2", 2.5, 0.0, pads=pads_u2),
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.3)  # require 0.3mm clearance
+        nets = [
+            Net(name="NET_A", pins=[("U1", "1")]),
+            Net(name="NET_B", pins=[("U2", "1")]),
+        ]
+
+        # Pad1 box: [0.25, -0.25, 0.75, 0.25]
+        # Pad2 box: [0.75, -0.25, 1.25, 0.25]
+        # gap_x = 0.75 - 0.75 = 0.0, gap_y = -0.25 - 0.25 = -0.5
+        # separated on neither axis both negative? gap_x = 0, gap_y = -0.5
+        # gap_x <= 0 and gap_y <= 0 => max(0, -0.5) = 0.0
+        # So gap = 0.0 < 0.3 => violation_dist = 0.3
+
+        result = check_placement_drc(placements, defs, rules, nets=nets)
+
+        pad_violations = [v for v in result.violations if v.kind == "pad"]
+        assert len(pad_violations) == 1
+        assert pad_violations[0].pad_a == "1"
+        assert pad_violations[0].pad_b == "1"
+
+    def test_pads_same_net_no_violation(self):
+        """Pads on the same net should not produce pad-to-pad violations."""
+        pads_u1 = (TransformedPad(name="1", x=0.0, y=0.0, size_x=0.5, size_y=0.5),)
+        pads_u2 = (TransformedPad(name="1", x=0.5, y=0.0, size_x=0.5, size_y=0.5),)
+
+        placements = [
+            _make_placed("U1", 0.0, 0.0, pads=pads_u1),
+            _make_placed("U2", 0.5, 0.0, pads=pads_u2),
+        ]
+        defs = [_make_def("U1", width=0.5), _make_def("U2", width=0.5)]
+        rules = _default_rules(0.2)
+        # Both pads on the same net -- should be skipped
+        nets = [
+            Net(name="VCC", pins=[("U1", "1"), ("U2", "1")]),
+        ]
+
+        result = check_placement_drc(placements, defs, rules, nets=nets)
+
+        pad_violations = [v for v in result.violations if v.kind == "pad"]
+        assert len(pad_violations) == 0
+
+    def test_no_nets_skips_pad_checks(self):
+        """When nets=None, pad checks should be skipped entirely."""
+        pads_u1 = (TransformedPad(name="1", x=0.0, y=0.0, size_x=0.5, size_y=0.5),)
+        pads_u2 = (TransformedPad(name="1", x=0.1, y=0.0, size_x=0.5, size_y=0.5),)
+
+        placements = [
+            _make_placed("U1", 0.0, 0.0, pads=pads_u1),
+            _make_placed("U2", 5.0, 0.0, pads=pads_u2),
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+
+        # No nets => no pad checks
+        result = check_placement_drc(placements, defs, rules, nets=None)
+
+        pad_violations = [v for v in result.violations if v.kind == "pad"]
+        assert len(pad_violations) == 0
+
+    def test_pads_on_same_component_skipped(self):
+        """Pads on the same component should not be checked against each other."""
+        pads_u1 = (
+            TransformedPad(name="1", x=0.0, y=0.0, size_x=0.5, size_y=0.5),
+            TransformedPad(name="2", x=0.3, y=0.0, size_x=0.5, size_y=0.5),
+        )
+
+        placements = [
+            _make_placed("U1", 0.0, 0.0, pads=pads_u1),
+        ]
+        defs = [_make_def("U1")]
+        rules = _default_rules(0.2)
+        nets = [
+            Net(name="NET_A", pins=[("U1", "1")]),
+            Net(name="NET_B", pins=[("U1", "2")]),
+        ]
+
+        result = check_placement_drc(placements, defs, rules, nets=nets)
+
+        pad_violations = [v for v in result.violations if v.kind == "pad"]
+        assert len(pad_violations) == 0
+
+
+# ---------------------------------------------------------------------------
+# Net-class clearance tests
+# ---------------------------------------------------------------------------
+
+
+class TestNetClassClearance:
+    """Tests for per-net-class clearance overrides in pad checks."""
+
+    def test_stricter_net_class_clearance_applied(self):
+        """When a net class requires more clearance, it should be used."""
+        pads_u1 = (TransformedPad(name="1", x=0.0, y=0.0, size_x=0.5, size_y=0.5),)
+        pads_u2 = (TransformedPad(name="1", x=1.0, y=0.0, size_x=0.5, size_y=0.5),)
+
+        placements = [
+            _make_placed("U1", 0.0, 0.0, pads=pads_u1),
+            _make_placed("U2", 5.0, 0.0, pads=pads_u2),
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+        nets = [
+            Net(name="HI_SPEED", pins=[("U1", "1")]),
+            Net(name="GND", pins=[("U2", "1")]),
+        ]
+
+        # Pad gap: pad1 at [-0.25,-0.25,0.25,0.25], pad2 at [0.75,-0.25,1.25,0.25]
+        # gap_x = 0.75 - 0.25 = 0.5, gap_y = -0.25 - 0.25 = -0.5
+        # separated on x only => gap = 0.5mm
+        # Default clearance = 0.2 => pass.  But net class = 0.6 => fail.
+        net_class_map = {
+            "HI_SPEED": NetClassRouting(name="HighSpeed", clearance=0.6),
+        }
+
+        result = check_placement_drc(
+            placements, defs, rules, nets=nets, net_class_map=net_class_map
+        )
+
+        pad_violations = [v for v in result.violations if v.kind == "pad"]
+        assert len(pad_violations) == 1
+        assert pad_violations[0].required_clearance == pytest.approx(0.6)
+        assert pad_violations[0].actual_clearance == pytest.approx(0.5)
+        assert pad_violations[0].violation_distance == pytest.approx(0.1)
+
+    def test_net_class_clearance_both_nets(self):
+        """When both nets have net classes, the stricter one should be used."""
+        pads_u1 = (TransformedPad(name="1", x=0.0, y=0.0, size_x=0.5, size_y=0.5),)
+        pads_u2 = (TransformedPad(name="1", x=1.0, y=0.0, size_x=0.5, size_y=0.5),)
+
+        placements = [
+            _make_placed("U1", 0.0, 0.0, pads=pads_u1),
+            _make_placed("U2", 5.0, 0.0, pads=pads_u2),
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+        nets = [
+            Net(name="NET_A", pins=[("U1", "1")]),
+            Net(name="NET_B", pins=[("U2", "1")]),
+        ]
+        # gap between pads = 0.5mm (see above)
+        # NET_A clearance = 0.3, NET_B clearance = 0.4 => max = 0.4 => pass
+        net_class_map = {
+            "NET_A": NetClassRouting(name="ClassA", clearance=0.3),
+            "NET_B": NetClassRouting(name="ClassB", clearance=0.4),
+        }
+
+        result = check_placement_drc(
+            placements, defs, rules, nets=nets, net_class_map=net_class_map
+        )
+
+        pad_violations = [v for v in result.violations if v.kind == "pad"]
+        assert len(pad_violations) == 0
+
+    def test_no_net_class_map_uses_default(self):
+        """Without net class map, default trace_clearance should be used."""
+        pads_u1 = (TransformedPad(name="1", x=0.0, y=0.0, size_x=0.5, size_y=0.5),)
+        pads_u2 = (TransformedPad(name="1", x=0.5, y=0.0, size_x=0.5, size_y=0.5),)
+
+        placements = [
+            _make_placed("U1", 0.0, 0.0, pads=pads_u1),
+            _make_placed("U2", 5.0, 0.0, pads=pads_u2),
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+        nets = [
+            Net(name="NET_A", pins=[("U1", "1")]),
+            Net(name="NET_B", pins=[("U2", "1")]),
+        ]
+
+        # gap = 0.5 - 0.25 - 0.25 = 0.0? No.
+        # pad1 box: [-0.25,-0.25,0.25,0.25], pad2 box: [0.25,-0.25,0.75,0.25]
+        # gap_x = 0.25 - 0.25 = 0.0, gap_y = -0.25 - 0.25 = -0.5
+        # both <= 0 => gap = max(0.0, -0.5) = 0.0 < 0.2 => violation
+        result = check_placement_drc(placements, defs, rules, nets=nets, net_class_map=None)
+
+        pad_violations = [v for v in result.violations if v.kind == "pad"]
+        assert len(pad_violations) == 1
+        assert pad_violations[0].required_clearance == pytest.approx(0.2)
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    """Tests for input validation and error handling."""
+
+    def test_mismatched_lengths_raises(self):
+        """Mismatched placements and component_defs should raise ValueError."""
+        placements = [_make_placed("U1", 0.0, 0.0)]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules()
+
+        with pytest.raises(ValueError, match="placements has 1 items"):
+            check_placement_drc(placements, defs, rules)
+
+    def test_result_type(self):
+        """check_placement_drc should return a DrcResult instance."""
+        result = check_placement_drc([], [], _default_rules())
+        assert isinstance(result, DrcResult)
+
+    def test_violation_fields(self):
+        """ClearanceViolation should have all expected fields."""
+        placements = [
+            _make_placed("U1", 0.0, 0.0),
+            _make_placed("U2", 1.5, 0.0),  # gap = -0.5
+        ]
+        defs = [_make_def("U1"), _make_def("U2")]
+        rules = _default_rules(0.2)
+
+        result = check_placement_drc(placements, defs, rules)
+
+        assert result.violation_count == 1
+        v = result.violations[0]
+        assert isinstance(v, ClearanceViolation)
+        assert v.ref_a == "U1"
+        assert v.ref_b == "U2"
+        assert v.kind == "courtyard"
+        assert v.required_clearance == pytest.approx(0.2)
+        assert v.actual_clearance < 0.0  # overlapping
+        assert v.violation_distance > 0.0
+        assert v.pad_a is None
+        assert v.pad_b is None


### PR DESCRIPTION
## Summary

Implement a placement DRC clearance checker that evaluates component-to-component courtyard clearance and pad-to-pad spacing against design rules during placement optimization. Integrates with the existing `DesignRules` class from `router/rules.py` and supports per-net-class clearance overrides via `NetClassRouting`.

## Changes

- New module `src/kicad_tools/placement/drc.py` with:
  - `ClearanceViolation` dataclass capturing per-violation details (refs, kind, required/actual clearance, violation distance, pad names)
  - `DrcResult` dataclass with violation count, total violation distance (smooth optimizer penalty), and full violation list
  - `check_placement_drc()` function performing courtyard AABB clearance and pad-to-pad clearance checks
  - Per-net-class clearance resolution (stricter rule wins when both nets have overrides)
  - Reuses `_aabb()` from `geometry.py` for rotation-aware bounding boxes
- New test file `tests/test_placement_drc.py` with 22 tests covering:
  - Courtyard clearance (11 tests): well-spaced, exactly-at-limit, slightly-below, overlapping, opposite sides, single component, empty, linear scaling, rotated, multiple violations, diagonal corner
  - Pad-to-pad clearance (5 tests): well-spaced, too-close, same-net skip, no-nets skip, same-component skip
  - Net-class overrides (3 tests): stricter class applied, both-nets max, default fallback
  - Validation (3 tests): mismatched lengths error, result type, violation field completeness

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Detects clearance violations between component courtyards | Pass | Tests: `test_slightly_below_minimum_clearance`, `test_overlapping_components`, `test_three_components_multiple_violations` |
| Detects clearance violations between pads on different nets | Pass | Test: `test_pads_different_nets_too_close` |
| Respects per-net-class clearance rules when available | Pass | Tests: `test_stricter_net_class_clearance_applied`, `test_net_class_clearance_both_nets` |
| Returns 0 violations for well-spaced placements | Pass | Tests: `test_well_spaced_no_violations`, `test_exactly_at_minimum_clearance`, `test_pads_different_nets_well_spaced` |
| Violation distance scales linearly with overlap amount | Pass | Test: `test_violation_distance_scales_linearly` verifies 2x shortfall = 2x violation distance |
| Unit tests with placements at exactly minimum clearance (pass) and slightly below (fail) | Pass | Tests: `test_exactly_at_minimum_clearance` (pass) and `test_slightly_below_minimum_clearance` (fail) |

## Test Plan

- `uv run pytest tests/test_placement_drc.py -x -v` -- 22 tests pass
- `uv run ruff check src/kicad_tools/placement/drc.py tests/test_placement_drc.py` -- no errors
- `uv run ruff format --check src/kicad_tools/placement/drc.py tests/test_placement_drc.py` -- already formatted

Closes #1204