### PR TITLE
feat(mcp): add board_summary and board_inspect analysis tools

### DIFF
--- a/src/kicad_tools/mcp/tools/__init__.py
+++ b/src/kicad_tools/mcp/tools/__init__.py
@@ -8,6 +8,7 @@ used by both stdio and HTTP transports.
 
 from kicad_tools.mcp.tools.analysis import (
     analyze_board,
+    board_inspect,
     get_drc_violations,
     measure_clearance,
 )
@@ -71,6 +72,7 @@ __all__ = [
     "adapt_pattern",
     "add_subsystem",
     "analyze_board",
+    "board_inspect",
     "annotate_decision",
     "create_checkpoint",
     "detect_mistakes",

--- a/src/kicad_tools/mcp/tools/analysis.py
+++ b/src/kicad_tools/mcp/tools/analysis.py
@@ -13,7 +13,7 @@ import re
 import uuid
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from kicad_tools.analysis.net_status import NetStatusAnalyzer
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
@@ -82,6 +82,298 @@ def analyze_board(pcb_path: str) -> BoardAnalysis:
         zones=_extract_zones(pcb),
         routing_status=_compute_routing_status(pcb),
     )
+
+
+VALID_ASPECTS = ("footprints", "nets", "layers", "design_rules", "zones")
+
+
+def board_inspect(
+    pcb_path: str,
+    aspect: str,
+    *,
+    layer: str | None = None,
+    reference_prefix: str | None = None,
+    unrouted_only: bool = False,
+    net_name: str | None = None,
+) -> dict[str, Any]:
+    """Inspect a specific aspect of a KiCad PCB file.
+
+    Returns focused, structured data for a single aspect of the board,
+    keeping responses concise enough for LLM context windows.
+
+    Args:
+        pcb_path: Absolute path to .kicad_pcb file
+        aspect: What to inspect. One of: footprints, nets, layers,
+                design_rules, zones
+        layer: Filter by layer name (applies to footprints, zones)
+        reference_prefix: Filter footprints by reference prefix (e.g. "R", "C", "U")
+        unrouted_only: If True, only return unrouted/incomplete nets
+                       (applies to nets aspect)
+        net_name: Filter zones by net name (applies to zones aspect)
+
+    Returns:
+        Dict with aspect-specific structured data
+
+    Raises:
+        FileNotFoundError: If the PCB file does not exist
+        ParseError: If the PCB file cannot be parsed
+        ValueError: If aspect is not one of the valid values
+    """
+    if aspect not in VALID_ASPECTS:
+        raise ValueError(f"Invalid aspect: {aspect!r}. Must be one of: {', '.join(VALID_ASPECTS)}")
+
+    path = Path(pcb_path)
+    if not path.exists():
+        raise KiCadFileNotFoundError(f"PCB file not found: {pcb_path}")
+
+    if path.suffix != ".kicad_pcb":
+        raise ParseError(f"Invalid file extension: {path.suffix} (expected .kicad_pcb)")
+
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        raise ParseError(f"Failed to parse PCB file: {e}") from e
+
+    if aspect == "footprints":
+        return _inspect_footprints(pcb, layer=layer, reference_prefix=reference_prefix)
+    elif aspect == "nets":
+        return _inspect_nets(pcb, unrouted_only=unrouted_only)
+    elif aspect == "layers":
+        return _inspect_layers(pcb)
+    elif aspect == "design_rules":
+        return _inspect_design_rules(pcb)
+    elif aspect == "zones":
+        return _inspect_zones(pcb, layer=layer, net_name=net_name)
+    else:
+        # Should not reach here due to validation above
+        raise ValueError(f"Invalid aspect: {aspect!r}")
+
+
+def _inspect_footprints(
+    pcb: PCB,
+    *,
+    layer: str | None = None,
+    reference_prefix: str | None = None,
+) -> dict[str, Any]:
+    """Inspect footprints on the board.
+
+    Args:
+        pcb: Loaded PCB object
+        layer: Filter by layer name
+        reference_prefix: Filter by reference prefix (e.g. "R", "C")
+
+    Returns:
+        Dict with footprint list and count
+    """
+    footprints_iter = pcb.footprints_on_layer(layer) if layer else pcb.footprints
+
+    items = []
+    for fp in footprints_iter:
+        if not fp.reference or fp.reference.startswith("#"):
+            continue
+
+        if reference_prefix:
+            prefix_match = re.match(r"^([A-Za-z]+)", fp.reference)
+            if not prefix_match or prefix_match.group(1).upper() != reference_prefix.upper():
+                continue
+
+        pad_count = len(fp.pads)
+        pad_nets = set()
+        for pad in fp.pads:
+            if pad.net_number > 0:
+                pad_nets.add(pad.net_name)
+
+        items.append(
+            {
+                "reference": fp.reference,
+                "value": fp.value,
+                "footprint": fp.name,
+                "layer": fp.layer,
+                "position": {"x": round(fp.position[0], 3), "y": round(fp.position[1], 3)},
+                "rotation": fp.rotation,
+                "type": fp.attr or "unknown",
+                "pad_count": pad_count,
+                "nets": sorted(pad_nets),
+            }
+        )
+
+    return {
+        "aspect": "footprints",
+        "count": len(items),
+        "filters": {
+            "layer": layer,
+            "reference_prefix": reference_prefix,
+        },
+        "footprints": items,
+    }
+
+
+def _inspect_nets(pcb: PCB, *, unrouted_only: bool = False) -> dict[str, Any]:
+    """Inspect nets on the board.
+
+    Args:
+        pcb: Loaded PCB object
+        unrouted_only: If True, only return unrouted/incomplete nets
+
+    Returns:
+        Dict with per-net routing status
+    """
+    analyzer = NetStatusAnalyzer(pcb)
+    result = analyzer.analyze()
+
+    nets = []
+    for net_status in result.nets:
+        if unrouted_only and net_status.status == "complete":
+            continue
+
+        nets.append(net_status.to_dict())
+
+    return {
+        "aspect": "nets",
+        "count": len(nets),
+        "filters": {
+            "unrouted_only": unrouted_only,
+        },
+        "summary": {
+            "total_nets": result.total_nets,
+            "complete": result.complete_count,
+            "incomplete": result.incomplete_count,
+            "unrouted": result.unrouted_count,
+        },
+        "nets": nets,
+    }
+
+
+def _inspect_layers(pcb: PCB) -> dict[str, Any]:
+    """Inspect layer information on the board.
+
+    Args:
+        pcb: Loaded PCB object
+
+    Returns:
+        Dict with copper layer details and stackup info
+    """
+    copper_layers = pcb.copper_layers
+    layer_details = []
+    for layer_obj in copper_layers:
+        layer_details.append(
+            {
+                "number": layer_obj.number,
+                "name": layer_obj.name,
+                "type": layer_obj.type,
+            }
+        )
+
+    # Stackup information from setup
+    stackup_info = []
+    if pcb.setup and pcb.setup.stackup:
+        for sl in pcb.setup.stackup:
+            stackup_info.append(
+                {
+                    "name": sl.name,
+                    "type": sl.type,
+                    "thickness_mm": sl.thickness,
+                    "material": sl.material,
+                    "epsilon_r": sl.epsilon_r,
+                }
+            )
+
+    return {
+        "aspect": "layers",
+        "copper_layer_count": len(copper_layers),
+        "has_internal_planes": any(l.type == "power" for l in copper_layers),
+        "copper_layers": layer_details,
+        "stackup": stackup_info,
+    }
+
+
+def _inspect_design_rules(pcb: PCB) -> dict[str, Any]:
+    """Inspect design rules / setup on the board.
+
+    Args:
+        pcb: Loaded PCB object
+
+    Returns:
+        Dict with setup parameters and design rule info
+    """
+    setup_data: dict[str, Any] = {}
+    if pcb.setup:
+        setup_data["pad_to_mask_clearance_mm"] = pcb.setup.pad_to_mask_clearance
+        setup_data["copper_finish"] = pcb.setup.copper_finish
+
+        if pcb.setup.stackup:
+            setup_data["stackup_layer_count"] = len(pcb.setup.stackup)
+    else:
+        setup_data["pad_to_mask_clearance_mm"] = 0.0
+        setup_data["copper_finish"] = ""
+
+    # Check for design rules on the PCB object
+    design_rules: dict[str, Any] = {}
+    if hasattr(pcb, "_design_rules") and pcb._design_rules is not None:
+        dr = pcb._design_rules
+        if hasattr(dr, "min_clearance"):
+            design_rules["min_clearance_mm"] = dr.min_clearance
+        if hasattr(dr, "min_track_width"):
+            design_rules["min_track_width_mm"] = dr.min_track_width
+        if hasattr(dr, "min_via_diameter"):
+            design_rules["min_via_diameter_mm"] = dr.min_via_diameter
+        if hasattr(dr, "min_via_drill"):
+            design_rules["min_via_drill_mm"] = dr.min_via_drill
+
+    return {
+        "aspect": "design_rules",
+        "setup": setup_data,
+        "design_rules": design_rules,
+    }
+
+
+def _inspect_zones(
+    pcb: PCB,
+    *,
+    layer: str | None = None,
+    net_name: str | None = None,
+) -> dict[str, Any]:
+    """Inspect copper zones on the board.
+
+    Args:
+        pcb: Loaded PCB object
+        layer: Filter by layer name
+        net_name: Filter by net name
+
+    Returns:
+        Dict with zone list and count
+    """
+    zones = []
+    for zone in pcb.zones:
+        if layer and zone.layer != layer:
+            continue
+        if net_name and zone.net_name != net_name:
+            continue
+
+        zones.append(
+            {
+                "net_name": zone.net_name,
+                "layer": zone.layer,
+                "priority": zone.priority,
+                "is_filled": zone.is_filled,
+                "fill_type": zone.fill_type,
+                "clearance_mm": zone.clearance,
+                "thermal_gap_mm": zone.thermal_gap,
+                "thermal_bridge_width_mm": zone.thermal_bridge_width,
+                "connect_pads": zone.connect_pads,
+                "min_thickness_mm": zone.min_thickness,
+            }
+        )
+
+    return {
+        "aspect": "zones",
+        "count": len(zones),
+        "filters": {
+            "layer": layer,
+            "net_name": net_name,
+        },
+        "zones": zones,
+    }
 
 
 def _extract_dimensions(pcb: PCB) -> BoardDimensions:

--- a/src/kicad_tools/mcp/tools/registry.py
+++ b/src/kicad_tools/mcp/tools/registry.py
@@ -1032,6 +1032,107 @@ register_tool(
 )
 
 
+def _handler_board_summary(params: dict[str, Any]) -> dict[str, Any]:
+    """Handle board_summary tool call."""
+    from kicad_tools.mcp.tools.analysis import analyze_board
+
+    result = analyze_board(pcb_path=params["pcb_path"])
+    return result.to_dict()
+
+
+register_tool(
+    name="board_summary",
+    description=(
+        "Get a comprehensive summary of a KiCad PCB file. Returns board dimensions, "
+        "layer information, component counts by type, net summary with routing status, "
+        "zone list, and overall routing completion percentage. Works entirely offline "
+        "(no running KiCad required). Use this as a first step to understand a board "
+        "before performing more detailed inspection or analysis."
+    ),
+    parameters=_make_params(
+        properties={
+            "pcb_path": {
+                "type": "string",
+                "description": "Absolute path to .kicad_pcb file",
+            },
+        },
+        required=["pcb_path"],
+    ),
+    handler=_handler_board_summary,
+    category="analysis",
+)
+
+
+def _handler_board_inspect(params: dict[str, Any]) -> dict[str, Any]:
+    """Handle board_inspect tool call."""
+    from kicad_tools.mcp.tools.analysis import board_inspect
+
+    return board_inspect(
+        pcb_path=params["pcb_path"],
+        aspect=params["aspect"],
+        layer=params.get("layer"),
+        reference_prefix=params.get("reference_prefix"),
+        unrouted_only=params.get("unrouted_only", False),
+        net_name=params.get("net_name"),
+    )
+
+
+register_tool(
+    name="board_inspect",
+    description=(
+        "Inspect a specific aspect of a KiCad PCB file in detail. Unlike board_summary "
+        "which returns a high-level overview, board_inspect returns focused, detailed "
+        "data for one aspect at a time: footprints (with position, type, pads), nets "
+        "(with per-net routing status), layers (with stackup info), design_rules "
+        "(setup parameters), or zones (with thermal relief settings). Supports "
+        "optional filters to narrow results. Works entirely offline."
+    ),
+    parameters=_make_params(
+        properties={
+            "pcb_path": {
+                "type": "string",
+                "description": "Absolute path to .kicad_pcb file",
+            },
+            "aspect": {
+                "type": "string",
+                "description": "Which aspect to inspect",
+                "enum": ["footprints", "nets", "layers", "design_rules", "zones"],
+            },
+            "layer": {
+                "type": "string",
+                "description": (
+                    "Filter by layer name (e.g., 'F.Cu', 'B.Cu'). "
+                    "Applies to footprints and zones aspects."
+                ),
+            },
+            "reference_prefix": {
+                "type": "string",
+                "description": (
+                    "Filter footprints by reference prefix (e.g., 'R' for resistors, "
+                    "'C' for capacitors, 'U' for ICs). Applies to footprints aspect only."
+                ),
+            },
+            "unrouted_only": {
+                "type": "boolean",
+                "description": (
+                    "If true, only return unrouted or incomplete nets. Applies to nets aspect only."
+                ),
+                "default": False,
+            },
+            "net_name": {
+                "type": "string",
+                "description": (
+                    "Filter zones by net name (e.g., 'GND'). Applies to zones aspect only."
+                ),
+            },
+        },
+        required=["pcb_path", "aspect"],
+    ),
+    handler=_handler_board_inspect,
+    category="analysis",
+)
+
+
 # -----------------------------------------------------------------------------
 # Routing Tools
 # -----------------------------------------------------------------------------

--- a/tests/test_mcp_analysis.py
+++ b/tests/test_mcp_analysis.py
@@ -601,3 +601,375 @@ class TestTypeDataclasses:
         assert data["total_airwires"] == 3
         assert data["total_trace_length_mm"] == 1234.57
         assert data["via_count"] == 25
+
+
+# =============================================================================
+# board_inspect tests
+# =============================================================================
+
+
+class TestBoardInspectFootprints:
+    """Tests for board_inspect with aspect='footprints'."""
+
+    def test_inspect_footprints_basic(self):
+        """Test inspecting footprints returns expected structure."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            result = board_inspect(pcb_path, "footprints")
+
+            assert result["aspect"] == "footprints"
+            assert result["count"] == 2
+            assert len(result["footprints"]) == 2
+
+            refs = {fp["reference"] for fp in result["footprints"]}
+            assert "R1" in refs
+            assert "C1" in refs
+
+            # Verify footprint structure
+            r1 = next(fp for fp in result["footprints"] if fp["reference"] == "R1")
+            assert r1["value"] == "10k"
+            assert r1["layer"] == "F.Cu"
+            assert "position" in r1
+            assert r1["position"]["x"] == 10.0
+            assert r1["position"]["y"] == 10.0
+            assert r1["type"] == "smd"
+            assert r1["pad_count"] == 2
+            assert isinstance(r1["nets"], list)
+        finally:
+            Path(pcb_path).unlink()
+
+    def test_inspect_footprints_filter_by_layer(self):
+        """Test filtering footprints by layer."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(PCB_WITH_VIAS)
+        try:
+            result = board_inspect(pcb_path, "footprints", layer="F.Cu")
+
+            assert result["count"] == 1
+            assert result["footprints"][0]["reference"] == "R1"
+            assert result["filters"]["layer"] == "F.Cu"
+        finally:
+            Path(pcb_path).unlink()
+
+    def test_inspect_footprints_filter_by_reference_prefix(self):
+        """Test filtering footprints by reference prefix."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            result = board_inspect(pcb_path, "footprints", reference_prefix="R")
+
+            assert result["count"] == 1
+            assert result["footprints"][0]["reference"] == "R1"
+            assert result["filters"]["reference_prefix"] == "R"
+        finally:
+            Path(pcb_path).unlink()
+
+    def test_inspect_footprints_through_hole(self):
+        """Test inspecting through-hole footprints."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(THROUGH_HOLE_PCB)
+        try:
+            result = board_inspect(pcb_path, "footprints")
+
+            assert result["count"] == 1
+            u1 = result["footprints"][0]
+            assert u1["reference"] == "U1"
+            assert u1["type"] == "through_hole"
+            assert u1["pad_count"] == 8
+        finally:
+            Path(pcb_path).unlink()
+
+
+class TestBoardInspectNets:
+    """Tests for board_inspect with aspect='nets'."""
+
+    def test_inspect_nets_basic(self):
+        """Test inspecting nets returns per-net routing status."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            result = board_inspect(pcb_path, "nets")
+
+            assert result["aspect"] == "nets"
+            assert result["count"] > 0
+            assert "summary" in result
+            assert result["summary"]["total_nets"] == 3
+
+            # Verify net structure
+            assert len(result["nets"]) > 0
+            net = result["nets"][0]
+            assert "net_name" in net
+            assert "status" in net
+            assert "total_pads" in net
+        finally:
+            Path(pcb_path).unlink()
+
+    def test_inspect_nets_unrouted_only(self):
+        """Test filtering to unrouted nets only."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            result = board_inspect(pcb_path, "nets", unrouted_only=True)
+
+            assert result["filters"]["unrouted_only"] is True
+            # All returned nets should be non-complete
+            for net in result["nets"]:
+                assert net["status"] != "complete"
+        finally:
+            Path(pcb_path).unlink()
+
+
+class TestBoardInspectLayers:
+    """Tests for board_inspect with aspect='layers'."""
+
+    def test_inspect_layers_two_layer(self):
+        """Test inspecting layers on a 2-layer board."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            result = board_inspect(pcb_path, "layers")
+
+            assert result["aspect"] == "layers"
+            assert result["copper_layer_count"] == 2
+            assert result["has_internal_planes"] is False
+
+            layer_names = [l["name"] for l in result["copper_layers"]]
+            assert "F.Cu" in layer_names
+            assert "B.Cu" in layer_names
+        finally:
+            Path(pcb_path).unlink()
+
+    def test_inspect_layers_four_layer(self):
+        """Test inspecting layers on a 4-layer board with internal planes."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(MULTILAYER_PCB)
+        try:
+            result = board_inspect(pcb_path, "layers")
+
+            assert result["copper_layer_count"] == 4
+            assert result["has_internal_planes"] is True
+
+            layer_names = [l["name"] for l in result["copper_layers"]]
+            assert "In1.Cu" in layer_names
+            assert "In2.Cu" in layer_names
+
+            # Verify layer detail structure
+            in1 = next(l for l in result["copper_layers"] if l["name"] == "In1.Cu")
+            assert in1["type"] == "power"
+        finally:
+            Path(pcb_path).unlink()
+
+
+class TestBoardInspectDesignRules:
+    """Tests for board_inspect with aspect='design_rules'."""
+
+    def test_inspect_design_rules_basic(self):
+        """Test inspecting design rules returns setup data."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            result = board_inspect(pcb_path, "design_rules")
+
+            assert result["aspect"] == "design_rules"
+            assert "setup" in result
+            assert "design_rules" in result
+            assert "pad_to_mask_clearance_mm" in result["setup"]
+        finally:
+            Path(pcb_path).unlink()
+
+
+class TestBoardInspectZones:
+    """Tests for board_inspect with aspect='zones'."""
+
+    def test_inspect_zones_with_zones(self):
+        """Test inspecting zones on a board with zones."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(MULTILAYER_PCB)
+        try:
+            result = board_inspect(pcb_path, "zones")
+
+            assert result["aspect"] == "zones"
+            assert result["count"] == 1
+
+            zone = result["zones"][0]
+            assert zone["net_name"] == "GND"
+            assert zone["layer"] == "In1.Cu"
+            assert zone["is_filled"] is True
+            assert "thermal_gap_mm" in zone
+            assert "clearance_mm" in zone
+        finally:
+            Path(pcb_path).unlink()
+
+    def test_inspect_zones_empty(self):
+        """Test inspecting zones on a board with no zones."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            result = board_inspect(pcb_path, "zones")
+
+            assert result["count"] == 0
+            assert result["zones"] == []
+        finally:
+            Path(pcb_path).unlink()
+
+    def test_inspect_zones_filter_by_net_name(self):
+        """Test filtering zones by net name."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(MULTILAYER_PCB)
+        try:
+            result = board_inspect(pcb_path, "zones", net_name="GND")
+            assert result["count"] == 1
+
+            result = board_inspect(pcb_path, "zones", net_name="NONEXISTENT")
+            assert result["count"] == 0
+        finally:
+            Path(pcb_path).unlink()
+
+    def test_inspect_zones_filter_by_layer(self):
+        """Test filtering zones by layer."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(MULTILAYER_PCB)
+        try:
+            result = board_inspect(pcb_path, "zones", layer="In1.Cu")
+            assert result["count"] == 1
+
+            result = board_inspect(pcb_path, "zones", layer="F.Cu")
+            assert result["count"] == 0
+        finally:
+            Path(pcb_path).unlink()
+
+
+class TestBoardInspectErrors:
+    """Tests for board_inspect error handling."""
+
+    def test_invalid_aspect(self):
+        """Test that ValueError is raised for invalid aspect."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            with pytest.raises(ValueError, match="Invalid aspect"):
+                board_inspect(pcb_path, "invalid_aspect")
+        finally:
+            Path(pcb_path).unlink()
+
+    def test_file_not_found(self):
+        """Test that FileNotFoundError is raised for missing files."""
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        with pytest.raises(KiCadFileNotFoundError):
+            board_inspect("/nonexistent/path/to/board.kicad_pcb", "footprints")
+
+    def test_invalid_file_extension(self):
+        """Test that ParseError is raised for invalid file extensions."""
+        import tempfile
+
+        from kicad_tools.mcp.tools.analysis import board_inspect
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"not a pcb file")
+            path = f.name
+        try:
+            with pytest.raises(ParseError):
+                board_inspect(path, "footprints")
+        finally:
+            Path(path).unlink()
+
+
+class TestBoardSummaryRegistry:
+    """Tests for board_summary tool registration in registry."""
+
+    def test_board_summary_registered(self):
+        """Test that board_summary is in the tool registry."""
+        from kicad_tools.mcp.tools.registry import get_tool
+
+        tool = get_tool("board_summary")
+        assert tool is not None
+        assert tool.name == "board_summary"
+        assert tool.category == "analysis"
+
+    def test_board_summary_handler(self):
+        """Test that board_summary handler works via registry."""
+        from kicad_tools.mcp.tools.registry import get_tool
+
+        tool = get_tool("board_summary")
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            result = tool.handler({"pcb_path": pcb_path})
+
+            assert isinstance(result, dict)
+            assert "file_path" in result
+            assert "board_dimensions" in result
+            assert "layers" in result
+            assert "components" in result
+            assert "nets" in result
+            assert "zones" in result
+            assert "routing_status" in result
+
+            # Verify specific values
+            assert result["components"]["total_count"] == 2
+            assert result["layers"]["copper_layers"] == 2
+        finally:
+            Path(pcb_path).unlink()
+
+
+class TestBoardInspectRegistry:
+    """Tests for board_inspect tool registration in registry."""
+
+    def test_board_inspect_registered(self):
+        """Test that board_inspect is in the tool registry."""
+        from kicad_tools.mcp.tools.registry import get_tool
+
+        tool = get_tool("board_inspect")
+        assert tool is not None
+        assert tool.name == "board_inspect"
+        assert tool.category == "analysis"
+
+    def test_board_inspect_handler(self):
+        """Test that board_inspect handler works via registry."""
+        from kicad_tools.mcp.tools.registry import get_tool
+
+        tool = get_tool("board_inspect")
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            result = tool.handler({"pcb_path": pcb_path, "aspect": "footprints"})
+
+            assert isinstance(result, dict)
+            assert result["aspect"] == "footprints"
+            assert result["count"] == 2
+        finally:
+            Path(pcb_path).unlink()
+
+    def test_board_inspect_handler_with_filters(self):
+        """Test that board_inspect handler passes filter params correctly."""
+        from kicad_tools.mcp.tools.registry import get_tool
+
+        tool = get_tool("board_inspect")
+        pcb_path = write_temp_pcb(SIMPLE_PCB)
+        try:
+            result = tool.handler(
+                {
+                    "pcb_path": pcb_path,
+                    "aspect": "footprints",
+                    "reference_prefix": "C",
+                }
+            )
+
+            assert result["count"] == 1
+            assert result["footprints"][0]["reference"] == "C1"
+        finally:
+            Path(pcb_path).unlink()

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -78,6 +78,8 @@ class TestToolRegistry:
             "restore_checkpoint",
             "get_session_summary",
             "measure_clearance",
+            "board_summary",
+            "board_inspect",
             "get_unrouted_nets",
             "route_net",
             "validate_pattern",


### PR DESCRIPTION
## Summary

Register the existing `analyze_board()` function as a `board_summary` MCP tool and implement a new `board_inspect` tool with five aspect-specific inspection modes. Both tools work entirely offline (no running KiCad required) and return concise, structured JSON suitable for LLM context windows.

## Changes

- **`src/kicad_tools/mcp/tools/analysis.py`** -- Added `board_inspect()` function with five aspect handlers: `_inspect_footprints`, `_inspect_nets`, `_inspect_layers`, `_inspect_design_rules`, `_inspect_zones`. Each returns focused data with optional filters (layer, reference_prefix, unrouted_only, net_name).
- **`src/kicad_tools/mcp/tools/registry.py`** -- Added `_handler_board_summary` + `register_tool("board_summary", ...)` and `_handler_board_inspect` + `register_tool("board_inspect", ...)` in the Analysis Tools section, both under category `"analysis"`.
- **`src/kicad_tools/mcp/tools/__init__.py`** -- Added `board_inspect` to imports and `__all__`.
- **`tests/test_mcp_analysis.py`** -- Added 21 new tests covering all five aspects, filter parameters, error handling (invalid aspect, missing file, bad extension), and registry integration for both tools.
- **`tests/test_mcp_registry.py`** -- Added `board_summary` and `board_inspect` to the expected tools list.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `board_summary` registered under category `"analysis"` | PASS | `get_tool("board_summary").category == "analysis"` in test |
| `board_summary` accepts required `pcb_path` parameter | PASS | JSON Schema has `required: ["pcb_path"]` |
| `board_summary` returns `BoardAnalysis.to_dict()` structure | PASS | Handler test verifies all 7 top-level keys present |
| `board_summary` works offline | PASS | Uses `PCB.load()` only, no KiCad process |
| `board_inspect` registered under category `"analysis"` | PASS | `get_tool("board_inspect").category == "analysis"` in test |
| `board_inspect` accepts required `pcb_path` and `aspect` enum | PASS | JSON Schema has `required: ["pcb_path", "aspect"]` with enum |
| `board_inspect` accepts optional filters per aspect | PASS | layer, reference_prefix, unrouted_only, net_name all tested |
| Each aspect returns concise, structured JSON | PASS | All 5 aspects tested with structure assertions |
| Both tools appear in registry | PASS | Registry test includes both in expected tools list |
| Both tools respond via FastMCP HTTP transport | PASS | Registry-based, same as all other tools |

## Test Plan

All 67 tests pass (49 analysis + 18 registry):
- `board_summary` with SIMPLE_PCB fixture: verifies 2 components, 2 copper layers, all JSON keys
- `board_inspect(aspect="footprints")`: verifies reference, value, position, type, pad_count, nets per footprint
- `board_inspect(aspect="footprints", layer="F.Cu")`: verifies layer filter
- `board_inspect(aspect="footprints", reference_prefix="R")`: verifies prefix filter
- `board_inspect(aspect="nets")`: verifies per-net routing status structure
- `board_inspect(aspect="nets", unrouted_only=True)`: verifies only non-complete nets returned
- `board_inspect(aspect="layers")`: verifies copper layer count, names, internal planes flag
- `board_inspect(aspect="design_rules")`: verifies setup data structure
- `board_inspect(aspect="zones")`: verifies zone details including thermal relief settings
- `board_inspect(aspect="zones", net_name/layer)`: verifies zone filters
- Error cases: invalid aspect, missing file, bad extension

Closes #1242