### PR TITLE
feat(mcp): add screenshot_board and screenshot_schematic tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,10 @@ bayesian = [
     "ax-platform>=0.4.0",
     "botorch>=0.12.0",
 ]
+# Screenshot/visualization pipeline (SVG to PNG conversion)
+screenshot = [
+    "cairosvg>=2.6",
+]
 # All optional features
 all = [
     "rtree>=1.0",
@@ -149,6 +153,7 @@ all = [
     "matplotlib>=3.5",
     "ax-platform>=0.4.0",
     "botorch>=0.12.0",
+    "cairosvg>=2.6",
 ]
 # Development dependencies
 dev = [

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -413,6 +413,9 @@ def _dispatch_command(args) -> int:
     elif args.command == "calibrate":
         return _run_calibrate_command(args)
 
+    elif args.command == "screenshot":
+        return _run_screenshot_command(args)
+
     return 0
 
 
@@ -563,6 +566,26 @@ def net_status_main() -> int:
     from .net_status_cmd import main
 
     return main()
+
+
+def _run_screenshot_command(args) -> int:
+    """Run the screenshot command."""
+    from .screenshot_cmd import main as screenshot_cmd
+
+    sub_argv = [args.screenshot_input]
+
+    if hasattr(args, "screenshot_output") and args.screenshot_output:
+        sub_argv.extend(["-o", args.screenshot_output])
+    if hasattr(args, "screenshot_layers") and args.screenshot_layers:
+        sub_argv.extend(["--layers", args.screenshot_layers])
+    if hasattr(args, "screenshot_max_size") and args.screenshot_max_size != 1568:
+        sub_argv.extend(["--max-size", str(args.screenshot_max_size)])
+    if hasattr(args, "screenshot_bw") and args.screenshot_bw:
+        sub_argv.append("--bw")
+    if hasattr(args, "screenshot_theme") and args.screenshot_theme:
+        sub_argv.extend(["--theme", args.screenshot_theme])
+
+    return screenshot_cmd(sub_argv)
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -177,6 +177,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_explain_parser(subparsers)
     _add_detect_mistakes_parser(subparsers)
     _add_calibrate_parser(subparsers)
+    _add_screenshot_parser(subparsers)
 
     return parser
 
@@ -3315,4 +3316,52 @@ def _add_calibrate_parser(subparsers) -> None:
         action="store_true",
         dest="calibrate_verbose",
         help="Show detailed progress information",
+    )
+
+
+def _add_screenshot_parser(subparsers) -> None:
+    """Add screenshot subcommand parser."""
+    screenshot_parser = subparsers.add_parser(
+        "screenshot",
+        help="Capture a PNG screenshot of a KiCad board or schematic",
+    )
+    screenshot_parser.add_argument(
+        "screenshot_input",
+        help="Path to .kicad_pcb or .kicad_sch file",
+    )
+    screenshot_parser.add_argument(
+        "-o",
+        "--output",
+        dest="screenshot_output",
+        help="Output PNG file path (default: <input>.png)",
+    )
+    screenshot_parser.add_argument(
+        "--layers",
+        dest="screenshot_layers",
+        default=None,
+        help=(
+            "Layer specification for PCB screenshots. "
+            "Preset name (default, copper, assembly, front, back) "
+            "or comma-separated layer list"
+        ),
+    )
+    screenshot_parser.add_argument(
+        "--max-size",
+        type=int,
+        dest="screenshot_max_size",
+        default=1568,
+        help="Maximum image dimension in pixels (default: 1568)",
+    )
+    screenshot_parser.add_argument(
+        "--bw",
+        "--black-and-white",
+        action="store_true",
+        dest="screenshot_bw",
+        help="Use black and white rendering",
+    )
+    screenshot_parser.add_argument(
+        "--theme",
+        dest="screenshot_theme",
+        default=None,
+        help="KiCad color theme name",
     )

--- a/src/kicad_tools/cli/screenshot_cmd.py
+++ b/src/kicad_tools/cli/screenshot_cmd.py
@@ -1,0 +1,113 @@
+"""screenshot CLI command: capture a PNG image of a KiCad board or schematic.
+
+Usage:
+    kct screenshot board.kicad_pcb
+    kct screenshot board.kicad_pcb -o board.png
+    kct screenshot board.kicad_pcb --layers copper --bw
+    kct screenshot schematic.kicad_sch -o schematic.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the screenshot CLI command."""
+    parser = argparse.ArgumentParser(
+        prog="kct screenshot",
+        description="Capture a PNG screenshot of a KiCad board or schematic.",
+    )
+    parser.add_argument(
+        "input",
+        help="Path to .kicad_pcb or .kicad_sch file",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output PNG file path (default: <input>.png)",
+    )
+    parser.add_argument(
+        "--layers",
+        default=None,
+        help=(
+            "Layer specification for PCB screenshots. "
+            "Preset name (default, copper, assembly, front, back) "
+            "or comma-separated layer list (e.g. 'F.Cu,B.Cu,Edge.Cuts')"
+        ),
+    )
+    parser.add_argument(
+        "--max-size",
+        type=int,
+        default=1568,
+        help="Maximum image dimension in pixels (default: 1568)",
+    )
+    parser.add_argument(
+        "--bw",
+        "--black-and-white",
+        action="store_true",
+        dest="black_and_white",
+        help="Use black and white rendering",
+    )
+    parser.add_argument(
+        "--theme",
+        default=None,
+        help="KiCad color theme name",
+    )
+
+    args = parser.parse_args(argv)
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"Error: File not found: {args.input}", file=sys.stderr)
+        return 1
+
+    # Determine output path
+    output_path = args.output
+    if output_path is None:
+        output_path = str(input_path.with_suffix(".png"))
+
+    # Import screenshot functions (lazy to avoid import cost)
+    from kicad_tools.mcp.tools.screenshot import screenshot_board, screenshot_schematic
+
+    if input_path.suffix == ".kicad_pcb":
+        result = screenshot_board(
+            pcb_path=str(input_path),
+            layers=args.layers,
+            max_size_px=args.max_size,
+            output_path=output_path,
+            black_and_white=args.black_and_white,
+            theme=args.theme,
+        )
+    elif input_path.suffix == ".kicad_sch":
+        result = screenshot_schematic(
+            sch_path=str(input_path),
+            max_size_px=args.max_size,
+            output_path=output_path,
+            black_and_white=args.black_and_white,
+            theme=args.theme,
+        )
+    else:
+        print(
+            f"Error: Unsupported file type: {input_path.suffix} "
+            "(expected .kicad_pcb or .kicad_sch)",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not result["success"]:
+        print(f"Error: {result['error_message']}", file=sys.stderr)
+        return 1
+
+    print(f"Screenshot saved to {result['output_path']}")
+    print(f"  Size: {result['width_px']}x{result['height_px']} px")
+    if result.get("layers_rendered"):
+        print(f"  Layers: {', '.join(result['layers_rendered'])}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/mcp/server.py
+++ b/src/kicad_tools/mcp/server.py
@@ -129,14 +129,20 @@ class MCPServer:
                 tool_name = params.get("name", "")
                 arguments = params.get("arguments", {})
                 tool_result = self.call_tool(tool_name, arguments)
-                result = {
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": json.dumps(tool_result, indent=2),
-                        }
-                    ],
-                }
+
+                # If the handler provides pre-built MCP content blocks
+                # (e.g. with image data), use those directly.
+                if isinstance(tool_result, dict) and "_mcp_content" in tool_result:
+                    result = {"content": tool_result["_mcp_content"]}
+                else:
+                    result = {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": json.dumps(tool_result, indent=2),
+                            }
+                        ],
+                    }
             elif method == "notifications/initialized":
                 # Client notification, no response needed
                 return {}
@@ -243,6 +249,7 @@ def _register_fastmcp_tool(mcp: FastMCP, tool_spec: ToolSpec) -> None:
         mcp: The FastMCP server instance
         tool_spec: The tool specification from the registry
     """
+
     # Create a dynamic wrapper function that FastMCP can introspect
     # The function calls the registry handler with its kwargs as a dict
     def create_handler(spec: ToolSpec) -> Callable:

--- a/src/kicad_tools/mcp/tools/__init__.py
+++ b/src/kicad_tools/mcp/tools/__init__.py
@@ -59,6 +59,10 @@ from kicad_tools.mcp.tools.routing import (
     get_unrouted_nets,
     route_net,
 )
+from kicad_tools.mcp.tools.screenshot import (
+    screenshot_board,
+    screenshot_schematic,
+)
 
 __all__ = [
     # Registry exports
@@ -96,6 +100,8 @@ __all__ = [
     "record_decision",
     "restore_checkpoint",
     "route_net",
+    "screenshot_board",
+    "screenshot_schematic",
     "search_available_rules",
     "validate_design",
     "validate_move",

--- a/src/kicad_tools/mcp/tools/registry.py
+++ b/src/kicad_tools/mcp/tools/registry.py
@@ -12,6 +12,7 @@ Example:
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -1730,4 +1731,165 @@ register_tool(
     ),
     handler=_handler_resolve_placement_overlaps,
     category="placement",
+)
+
+
+# -----------------------------------------------------------------------------
+# Screenshot Tools
+# -----------------------------------------------------------------------------
+
+
+def _handler_screenshot_board(params: dict[str, Any]) -> dict[str, Any]:
+    """Handle screenshot_board tool call.
+
+    Returns a dict with a special ``_mcp_content`` key so that the MCP
+    server can emit an ``image`` content block alongside the JSON text.
+    """
+    from kicad_tools.mcp.tools.screenshot import screenshot_board
+
+    result = screenshot_board(
+        pcb_path=params["pcb_path"],
+        layers=params.get("layers"),
+        max_size_px=params.get("max_size_px", 1568),
+        output_path=params.get("output_path"),
+        black_and_white=params.get("black_and_white", False),
+        theme=params.get("theme"),
+    )
+
+    # Build MCP content blocks: text metadata + image if available
+    if result.get("success") and result.get("image_base64"):
+        meta = {k: v for k, v in result.items() if k != "image_base64"}
+        content = [
+            {"type": "text", "text": json.dumps(meta, indent=2)},
+            {
+                "type": "image",
+                "data": result["image_base64"],
+                "mimeType": "image/png",
+            },
+        ]
+        result["_mcp_content"] = content
+
+    return result
+
+
+register_tool(
+    name="screenshot_board",
+    description=(
+        "Capture a screenshot of a KiCad PCB board. Exports the board as SVG "
+        "using kicad-cli, converts to PNG, and returns a base64-encoded image "
+        "suitable for vision API analysis. Supports layer selection via named "
+        "presets ('default', 'copper', 'assembly', 'front', 'back') or explicit "
+        "layer lists. The image is automatically resized to fit within the vision "
+        "API maximum dimension (1568px). Use this to visually inspect board layout, "
+        "component placement, and routing before or after modifications."
+    ),
+    parameters=_make_params(
+        properties={
+            "pcb_path": {
+                "type": "string",
+                "description": "Absolute path to .kicad_pcb file",
+            },
+            "layers": {
+                "type": "string",
+                "description": (
+                    "Layer specification. Either a preset name ('default', 'copper', "
+                    "'assembly', 'front', 'back') or a comma-separated list of KiCad "
+                    "layer names (e.g. 'F.Cu,B.Cu,Edge.Cuts'). Default: composite view "
+                    "with copper, silkscreen, mask, and edge cuts."
+                ),
+            },
+            "max_size_px": {
+                "type": "integer",
+                "description": (
+                    "Maximum image dimension in pixels. Default: 1568 (Claude vision API limit)."
+                ),
+                "default": 1568,
+            },
+            "output_path": {
+                "type": "string",
+                "description": "Optional file path to save the PNG image to disk.",
+            },
+            "black_and_white": {
+                "type": "boolean",
+                "description": "Use black and white rendering for compact, high-contrast images.",
+                "default": False,
+            },
+            "theme": {
+                "type": "string",
+                "description": "KiCad color theme name (optional, uses default if not specified).",
+            },
+        },
+        required=["pcb_path"],
+    ),
+    handler=_handler_screenshot_board,
+    category="screenshot",
+)
+
+
+def _handler_screenshot_schematic(params: dict[str, Any]) -> dict[str, Any]:
+    """Handle screenshot_schematic tool call."""
+    from kicad_tools.mcp.tools.screenshot import screenshot_schematic
+
+    result = screenshot_schematic(
+        sch_path=params["sch_path"],
+        max_size_px=params.get("max_size_px", 1568),
+        output_path=params.get("output_path"),
+        black_and_white=params.get("black_and_white", False),
+        theme=params.get("theme"),
+    )
+
+    if result.get("success") and result.get("image_base64"):
+        meta = {k: v for k, v in result.items() if k != "image_base64"}
+        content = [
+            {"type": "text", "text": json.dumps(meta, indent=2)},
+            {
+                "type": "image",
+                "data": result["image_base64"],
+                "mimeType": "image/png",
+            },
+        ]
+        result["_mcp_content"] = content
+
+    return result
+
+
+register_tool(
+    name="screenshot_schematic",
+    description=(
+        "Capture a screenshot of a KiCad schematic. Exports the schematic as SVG "
+        "using kicad-cli, converts to PNG, and returns a base64-encoded image. "
+        "Useful for reviewing circuit design, verifying connections, and providing "
+        "visual context to AI agents."
+    ),
+    parameters=_make_params(
+        properties={
+            "sch_path": {
+                "type": "string",
+                "description": "Absolute path to .kicad_sch file",
+            },
+            "max_size_px": {
+                "type": "integer",
+                "description": (
+                    "Maximum image dimension in pixels. Default: 1568 (Claude vision API limit)."
+                ),
+                "default": 1568,
+            },
+            "output_path": {
+                "type": "string",
+                "description": "Optional file path to save the PNG image to disk.",
+            },
+            "black_and_white": {
+                "type": "boolean",
+                "description": "Use black and white rendering.",
+                "default": False,
+            },
+            "theme": {
+                "type": "string",
+                "description": "KiCad color theme name (optional).",
+            },
+        },
+        required=["sch_path"],
+    ),
+    handler=_handler_screenshot_schematic,
+    category="screenshot",
 )

--- a/src/kicad_tools/mcp/tools/screenshot.py
+++ b/src/kicad_tools/mcp/tools/screenshot.py
@@ -1,0 +1,566 @@
+"""Screenshot/visualization pipeline for MCP AI feedback.
+
+Provides tools to capture board (and optionally schematic) images
+via kicad-cli SVG export, convert to PNG, and return base64-encoded
+images suitable for vision API consumption.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from kicad_tools.cli.runner import find_kicad_cli
+
+logger = logging.getLogger(__name__)
+
+# Default layers for a useful composite board view
+DEFAULT_LAYERS = ["F.Cu", "B.Cu", "Edge.Cuts", "F.SilkS", "B.SilkS", "F.Mask", "B.Mask"]
+
+# Named layer presets
+LAYER_PRESETS: dict[str, list[str]] = {
+    "default": DEFAULT_LAYERS,
+    "copper": ["F.Cu", "B.Cu", "Edge.Cuts"],
+    "assembly": ["F.Cu", "B.Cu", "Edge.Cuts", "F.SilkS", "B.SilkS"],
+    "front": ["F.Cu", "Edge.Cuts", "F.SilkS", "F.Mask"],
+    "back": ["B.Cu", "Edge.Cuts", "B.SilkS", "B.Mask"],
+}
+
+# Maximum image dimension for Claude vision API
+MAX_VISION_API_PX = 1568
+
+KICAD_INSTALL_URL = "https://www.kicad.org/download/"
+
+
+def _check_cairosvg() -> bool:
+    """Check if cairosvg is available."""
+    try:
+        import cairosvg  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _resolve_layers(layers: list[str] | str | None) -> list[str]:
+    """Resolve layer specification to a list of layer names.
+
+    Args:
+        layers: List of layer names, a preset name string, or None for defaults.
+
+    Returns:
+        List of KiCad layer names.
+    """
+    if layers is None:
+        return DEFAULT_LAYERS
+
+    if isinstance(layers, str):
+        if layers in LAYER_PRESETS:
+            return LAYER_PRESETS[layers]
+        # Treat as comma-separated layer list
+        return [layer.strip() for layer in layers.split(",")]
+
+    return layers
+
+
+def _export_svg(
+    pcb_path: Path,
+    svg_path: Path,
+    layers: list[str],
+    black_and_white: bool = False,
+    theme: str | None = None,
+    kicad_cli: Path | None = None,
+) -> tuple[bool, str]:
+    """Export PCB to SVG using kicad-cli.
+
+    Args:
+        pcb_path: Path to .kicad_pcb file
+        svg_path: Path for output SVG
+        layers: List of layers to render
+        black_and_white: Use black and white mode
+        theme: KiCad color theme name
+        kicad_cli: Path to kicad-cli executable
+
+    Returns:
+        Tuple of (success, error_message)
+    """
+    if kicad_cli is None:
+        kicad_cli = find_kicad_cli()
+        if kicad_cli is None:
+            return False, (f"kicad-cli not found. Install KiCad 8+ from {KICAD_INSTALL_URL}")
+
+    cmd = [
+        str(kicad_cli),
+        "pcb",
+        "export",
+        "svg",
+        "--output",
+        str(svg_path),
+        "--layers",
+        ",".join(layers),
+        "--page-size-mode",
+        "2",  # fit page to board
+        "--mode-single",
+    ]
+
+    if black_and_white:
+        cmd.append("--black-and-white")
+
+    if theme:
+        cmd.extend(["--theme", theme])
+
+    cmd.append(str(pcb_path))
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        if svg_path.exists() and svg_path.stat().st_size > 0:
+            return True, ""
+
+        stderr = result.stderr.strip() if result.stderr else "SVG export produced no output"
+        return False, f"kicad-cli SVG export failed: {stderr}"
+
+    except FileNotFoundError:
+        return False, (
+            f"kicad-cli not found at {kicad_cli}. Install KiCad 8+ from {KICAD_INSTALL_URL}"
+        )
+    except subprocess.TimeoutExpired:
+        return False, "kicad-cli SVG export timed out after 60 seconds"
+    except subprocess.SubprocessError as e:
+        return False, f"kicad-cli SVG export failed: {e}"
+
+
+def _svg_to_png(
+    svg_path: Path,
+    png_path: Path,
+    max_size_px: int = MAX_VISION_API_PX,
+) -> tuple[bool, str, int, int]:
+    """Convert SVG to PNG with size constraints.
+
+    Args:
+        svg_path: Path to input SVG file
+        png_path: Path for output PNG file
+        max_size_px: Maximum dimension in pixels
+
+    Returns:
+        Tuple of (success, error_message, width, height)
+    """
+    try:
+        import cairosvg
+    except ImportError:
+        return (
+            False,
+            (
+                "cairosvg is required for SVG to PNG conversion. "
+                "Install with: pip install 'kicad-tools[screenshot]'"
+            ),
+            0,
+            0,
+        )
+
+    try:
+        # First pass: render at native resolution to determine dimensions
+        # Use a reasonable default output width to get aspect ratio
+        png_bytes = cairosvg.svg2png(
+            url=str(svg_path),
+        )
+
+        # Determine actual dimensions using the PNG header
+        width, height = _png_dimensions(png_bytes)
+
+        if width == 0 or height == 0:
+            return False, "SVG rendered to empty image", 0, 0
+
+        # Calculate scale factor to fit within max_size_px
+        scale = 1.0
+        if width > max_size_px or height > max_size_px:
+            scale = max_size_px / max(width, height)
+
+        target_width = int(width * scale)
+        target_height = int(height * scale)
+
+        # Ensure at least 1px
+        target_width = max(1, target_width)
+        target_height = max(1, target_height)
+
+        # Re-render at target size
+        png_bytes = cairosvg.svg2png(
+            url=str(svg_path),
+            output_width=target_width,
+            output_height=target_height,
+        )
+
+        png_path.write_bytes(png_bytes)
+
+        return True, "", target_width, target_height
+
+    except Exception as e:
+        return False, f"SVG to PNG conversion failed: {e}", 0, 0
+
+
+def _png_dimensions(png_bytes: bytes) -> tuple[int, int]:
+    """Extract width and height from PNG header bytes.
+
+    PNG format: first 8 bytes are signature, then IHDR chunk
+    starting at byte 16 with 4-byte width and 4-byte height.
+
+    Args:
+        png_bytes: Raw PNG file bytes
+
+    Returns:
+        Tuple of (width, height)
+    """
+    if len(png_bytes) < 24:
+        return 0, 0
+
+    # PNG IHDR chunk: width at offset 16, height at offset 20 (big-endian)
+    width = int.from_bytes(png_bytes[16:20], byteorder="big")
+    height = int.from_bytes(png_bytes[20:24], byteorder="big")
+
+    return width, height
+
+
+def screenshot_board(
+    pcb_path: str,
+    layers: list[str] | str | None = None,
+    max_size_px: int = MAX_VISION_API_PX,
+    output_path: str | None = None,
+    black_and_white: bool = False,
+    theme: str | None = None,
+) -> dict[str, Any]:
+    """Capture a screenshot of a KiCad PCB board.
+
+    Exports the board as SVG using kicad-cli, converts to PNG using cairosvg,
+    resizes to fit vision API constraints, and returns base64-encoded image data.
+
+    Args:
+        pcb_path: Path to .kicad_pcb file
+        layers: Layer specification - list of layer names, a preset name
+                ("default", "copper", "assembly", "front", "back"), or None
+                for the default composite view.
+        max_size_px: Maximum dimension in pixels (default: 1568 for Claude vision)
+        output_path: Optional path to save PNG file to disk
+        black_and_white: Use black and white rendering (good for compact AI images)
+        theme: KiCad color theme name (optional)
+
+    Returns:
+        Dictionary with keys:
+            success: bool
+            image_base64: str (base64-encoded PNG data) or None
+            width_px: int
+            height_px: int
+            layers_rendered: list[str]
+            output_path: str or None
+            error_message: str or None
+    """
+    # Validate PCB path
+    pcb = Path(pcb_path)
+    if not pcb.exists():
+        return {
+            "success": False,
+            "image_base64": None,
+            "width_px": 0,
+            "height_px": 0,
+            "layers_rendered": [],
+            "output_path": None,
+            "error_message": f"PCB file not found: {pcb_path}",
+        }
+
+    if pcb.suffix != ".kicad_pcb":
+        return {
+            "success": False,
+            "image_base64": None,
+            "width_px": 0,
+            "height_px": 0,
+            "layers_rendered": [],
+            "output_path": None,
+            "error_message": (f"Invalid file extension: {pcb.suffix} (expected .kicad_pcb)"),
+        }
+
+    # Check dependencies
+    kicad_cli = find_kicad_cli()
+    if kicad_cli is None:
+        return {
+            "success": False,
+            "image_base64": None,
+            "width_px": 0,
+            "height_px": 0,
+            "layers_rendered": [],
+            "output_path": None,
+            "error_message": (f"kicad-cli not found. Install KiCad 8+ from {KICAD_INSTALL_URL}"),
+        }
+
+    if not _check_cairosvg():
+        return {
+            "success": False,
+            "image_base64": None,
+            "width_px": 0,
+            "height_px": 0,
+            "layers_rendered": [],
+            "output_path": None,
+            "error_message": (
+                "cairosvg is required for screenshot support. "
+                "Install with: pip install 'kicad-tools[screenshot]'"
+            ),
+        }
+
+    # Resolve layers
+    resolved_layers = _resolve_layers(layers)
+
+    # Create temp directory for intermediate files
+    with tempfile.TemporaryDirectory(prefix="kicad_screenshot_") as tmpdir:
+        svg_path = Path(tmpdir) / "board.svg"
+        png_path = Path(tmpdir) / "board.png"
+
+        # Step 1: Export SVG
+        svg_ok, svg_err = _export_svg(
+            pcb_path=pcb,
+            svg_path=svg_path,
+            layers=resolved_layers,
+            black_and_white=black_and_white,
+            theme=theme,
+            kicad_cli=kicad_cli,
+        )
+        if not svg_ok:
+            return {
+                "success": False,
+                "image_base64": None,
+                "width_px": 0,
+                "height_px": 0,
+                "layers_rendered": resolved_layers,
+                "output_path": None,
+                "error_message": svg_err,
+            }
+
+        # Step 2: Convert SVG to PNG
+        png_ok, png_err, width, height = _svg_to_png(
+            svg_path=svg_path,
+            png_path=png_path,
+            max_size_px=max_size_px,
+        )
+        if not png_ok:
+            return {
+                "success": False,
+                "image_base64": None,
+                "width_px": 0,
+                "height_px": 0,
+                "layers_rendered": resolved_layers,
+                "output_path": None,
+                "error_message": png_err,
+            }
+
+        # Step 3: Read PNG and base64 encode
+        png_bytes = png_path.read_bytes()
+        image_base64 = base64.b64encode(png_bytes).decode("ascii")
+
+        # Step 4: Optionally save to output path
+        saved_path = None
+        if output_path:
+            out = Path(output_path)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(png_bytes)
+            saved_path = str(out)
+
+    return {
+        "success": True,
+        "image_base64": image_base64,
+        "width_px": width,
+        "height_px": height,
+        "layers_rendered": resolved_layers,
+        "output_path": saved_path,
+        "error_message": None,
+    }
+
+
+def screenshot_schematic(
+    sch_path: str,
+    max_size_px: int = MAX_VISION_API_PX,
+    output_path: str | None = None,
+    black_and_white: bool = False,
+    theme: str | None = None,
+) -> dict[str, Any]:
+    """Capture a screenshot of a KiCad schematic.
+
+    Exports the schematic as SVG using kicad-cli, converts to PNG,
+    and returns base64-encoded image data.
+
+    Args:
+        sch_path: Path to .kicad_sch file
+        max_size_px: Maximum dimension in pixels (default: 1568 for Claude vision)
+        output_path: Optional path to save PNG file to disk
+        black_and_white: Use black and white rendering
+        theme: KiCad color theme name (optional)
+
+    Returns:
+        Dictionary with same shape as screenshot_board result.
+    """
+    sch = Path(sch_path)
+    if not sch.exists():
+        return {
+            "success": False,
+            "image_base64": None,
+            "width_px": 0,
+            "height_px": 0,
+            "layers_rendered": [],
+            "output_path": None,
+            "error_message": f"Schematic file not found: {sch_path}",
+        }
+
+    if sch.suffix != ".kicad_sch":
+        return {
+            "success": False,
+            "image_base64": None,
+            "width_px": 0,
+            "height_px": 0,
+            "layers_rendered": [],
+            "output_path": None,
+            "error_message": (f"Invalid file extension: {sch.suffix} (expected .kicad_sch)"),
+        }
+
+    kicad_cli = find_kicad_cli()
+    if kicad_cli is None:
+        return {
+            "success": False,
+            "image_base64": None,
+            "width_px": 0,
+            "height_px": 0,
+            "layers_rendered": [],
+            "output_path": None,
+            "error_message": (f"kicad-cli not found. Install KiCad 8+ from {KICAD_INSTALL_URL}"),
+        }
+
+    if not _check_cairosvg():
+        return {
+            "success": False,
+            "image_base64": None,
+            "width_px": 0,
+            "height_px": 0,
+            "layers_rendered": [],
+            "output_path": None,
+            "error_message": (
+                "cairosvg is required for screenshot support. "
+                "Install with: pip install 'kicad-tools[screenshot]'"
+            ),
+        }
+
+    with tempfile.TemporaryDirectory(prefix="kicad_screenshot_") as tmpdir:
+        svg_path = Path(tmpdir) / "schematic.svg"
+        png_path = Path(tmpdir) / "schematic.png"
+
+        # Export schematic to SVG
+        cmd = [
+            str(kicad_cli),
+            "sch",
+            "export",
+            "svg",
+            "--output",
+            str(svg_path),
+        ]
+
+        if black_and_white:
+            cmd.append("--black-and-white")
+
+        if theme:
+            cmd.extend(["--theme", theme])
+
+        cmd.append(str(sch))
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+            if not svg_path.exists() or svg_path.stat().st_size == 0:
+                stderr = result.stderr.strip() if result.stderr else "SVG export produced no output"
+                return {
+                    "success": False,
+                    "image_base64": None,
+                    "width_px": 0,
+                    "height_px": 0,
+                    "layers_rendered": [],
+                    "output_path": None,
+                    "error_message": f"kicad-cli schematic SVG export failed: {stderr}",
+                }
+
+        except FileNotFoundError:
+            return {
+                "success": False,
+                "image_base64": None,
+                "width_px": 0,
+                "height_px": 0,
+                "layers_rendered": [],
+                "output_path": None,
+                "error_message": (
+                    f"kicad-cli not found at {kicad_cli}. Install KiCad 8+ from {KICAD_INSTALL_URL}"
+                ),
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "success": False,
+                "image_base64": None,
+                "width_px": 0,
+                "height_px": 0,
+                "layers_rendered": [],
+                "output_path": None,
+                "error_message": "kicad-cli schematic SVG export timed out after 60 seconds",
+            }
+        except subprocess.SubprocessError as e:
+            return {
+                "success": False,
+                "image_base64": None,
+                "width_px": 0,
+                "height_px": 0,
+                "layers_rendered": [],
+                "output_path": None,
+                "error_message": f"kicad-cli schematic SVG export failed: {e}",
+            }
+
+        # Convert SVG to PNG
+        png_ok, png_err, width, height = _svg_to_png(
+            svg_path=svg_path,
+            png_path=png_path,
+            max_size_px=max_size_px,
+        )
+        if not png_ok:
+            return {
+                "success": False,
+                "image_base64": None,
+                "width_px": 0,
+                "height_px": 0,
+                "layers_rendered": [],
+                "output_path": None,
+                "error_message": png_err,
+            }
+
+        # Read and encode
+        png_bytes = png_path.read_bytes()
+        image_base64 = base64.b64encode(png_bytes).decode("ascii")
+
+        saved_path = None
+        if output_path:
+            out = Path(output_path)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(png_bytes)
+            saved_path = str(out)
+
+    return {
+        "success": True,
+        "image_base64": image_base64,
+        "width_px": width,
+        "height_px": height,
+        "layers_rendered": [],
+        "output_path": saved_path,
+        "error_message": None,
+    }

--- a/src/kicad_tools/mcp/tools/screenshot.py
+++ b/src/kicad_tools/mcp/tools/screenshot.py
@@ -453,17 +453,19 @@ def screenshot_schematic(
         }
 
     with tempfile.TemporaryDirectory(prefix="kicad_screenshot_") as tmpdir:
-        svg_path = Path(tmpdir) / "schematic.svg"
-        png_path = Path(tmpdir) / "schematic.png"
+        tmp_path = Path(tmpdir)
+        png_path = tmp_path / "schematic.png"
 
-        # Export schematic to SVG
+        # Export schematic to SVG.
+        # kicad-cli sch export svg --output expects a DIRECTORY, not a file
+        # path. It auto-generates filenames based on sheet names inside tmpdir.
         cmd = [
             str(kicad_cli),
             "sch",
             "export",
             "svg",
             "--output",
-            str(svg_path),
+            str(tmp_path),
         ]
 
         if black_and_white:
@@ -482,7 +484,11 @@ def screenshot_schematic(
                 timeout=60,
             )
 
-            if not svg_path.exists() or svg_path.stat().st_size == 0:
+            # Find the generated SVG file(s) in the output directory.
+            # For single-sheet schematics there will be one file; for
+            # multi-sheet there may be several — use the first (main sheet).
+            svg_files = sorted(tmp_path.glob("*.svg"))
+            if not svg_files:
                 stderr = result.stderr.strip() if result.stderr else "SVG export produced no output"
                 return {
                     "success": False,
@@ -493,6 +499,7 @@ def screenshot_schematic(
                     "output_path": None,
                     "error_message": f"kicad-cli schematic SVG export failed: {stderr}",
                 }
+            svg_path = svg_files[0]
 
         except FileNotFoundError:
             return {

--- a/tests/test_mcp_screenshot.py
+++ b/tests/test_mcp_screenshot.py
@@ -1,0 +1,458 @@
+"""Tests for MCP screenshot_board and screenshot_schematic tools.
+
+Tests the screenshot pipeline: kicad-cli SVG export -> cairosvg PNG
+conversion -> base64 encoding -> MCP response.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.mcp.tools.screenshot import (
+    DEFAULT_LAYERS,
+    LAYER_PRESETS,
+    _check_cairosvg,
+    _png_dimensions,
+    _resolve_layers,
+    screenshot_board,
+    screenshot_schematic,
+)
+
+# Test fixture: small voltage divider board
+VOLTAGE_DIVIDER_PCB = str(
+    Path(__file__).parent.parent
+    / "boards"
+    / "01-voltage-divider"
+    / "output"
+    / "voltage_divider.kicad_pcb"
+)
+
+VOLTAGE_DIVIDER_SCH = str(
+    Path(__file__).parent.parent
+    / "boards"
+    / "01-voltage-divider"
+    / "output"
+    / "voltage_divider.kicad_sch"
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for internal helpers
+# ---------------------------------------------------------------------------
+
+
+class TestResolveLayers:
+    """Tests for _resolve_layers helper."""
+
+    def test_none_returns_defaults(self):
+        """None input returns default layer list."""
+        result = _resolve_layers(None)
+        assert result == DEFAULT_LAYERS
+
+    def test_preset_name(self):
+        """Preset name string resolves to known layer list."""
+        result = _resolve_layers("copper")
+        assert result == LAYER_PRESETS["copper"]
+
+    def test_comma_separated_string(self):
+        """Comma-separated string is split into layer list."""
+        result = _resolve_layers("F.Cu,B.Cu,Edge.Cuts")
+        assert result == ["F.Cu", "B.Cu", "Edge.Cuts"]
+
+    def test_list_passthrough(self):
+        """List input is passed through unchanged."""
+        layers = ["F.Cu", "B.Cu"]
+        result = _resolve_layers(layers)
+        assert result == layers
+
+    def test_all_presets_exist(self):
+        """All documented presets resolve successfully."""
+        for name in ["default", "copper", "assembly", "front", "back"]:
+            result = _resolve_layers(name)
+            assert isinstance(result, list)
+            assert len(result) > 0
+
+
+class TestPngDimensions:
+    """Tests for _png_dimensions helper."""
+
+    def test_too_short_returns_zero(self):
+        """Bytes shorter than 24 returns (0, 0)."""
+        assert _png_dimensions(b"short") == (0, 0)
+
+    def test_valid_png_header(self):
+        """Valid PNG header bytes return correct dimensions."""
+        # Create a minimal PNG-like header with known dimensions
+        # PNG signature (8 bytes) + IHDR length (4 bytes) + "IHDR" (4 bytes)
+        # + width (4 bytes) + height (4 bytes)
+        header = b"\x89PNG\r\n\x1a\n"  # 8 bytes signature
+        header += b"\x00\x00\x00\r"  # IHDR length
+        header += b"IHDR"  # chunk type
+        header += (100).to_bytes(4, byteorder="big")  # width = 100
+        header += (200).to_bytes(4, byteorder="big")  # height = 200
+        header += b"\x00" * 5  # bit depth, color type, etc.
+
+        w, h = _png_dimensions(header)
+        assert w == 100
+        assert h == 200
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for error handling
+# ---------------------------------------------------------------------------
+
+
+class TestScreenshotBoardErrors:
+    """Tests for screenshot_board error handling."""
+
+    def test_nonexistent_file(self):
+        """Non-existent PCB file returns error."""
+        result = screenshot_board(pcb_path="/nonexistent/board.kicad_pcb")
+        assert result["success"] is False
+        assert "not found" in result["error_message"]
+        assert result["image_base64"] is None
+
+    def test_wrong_extension(self, tmp_path):
+        """Wrong file extension returns error."""
+        bad_file = tmp_path / "board.txt"
+        bad_file.write_text("not a pcb")
+        result = screenshot_board(pcb_path=str(bad_file))
+        assert result["success"] is False
+        assert "Invalid file extension" in result["error_message"]
+
+    @patch("kicad_tools.mcp.tools.screenshot.find_kicad_cli", return_value=None)
+    def test_kicad_cli_not_found(self, mock_find, tmp_path):
+        """Missing kicad-cli returns error with install URL."""
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb ...)")
+        result = screenshot_board(pcb_path=str(pcb_file))
+        assert result["success"] is False
+        assert "kicad-cli not found" in result["error_message"]
+        assert "kicad.org/download" in result["error_message"]
+
+    @patch("kicad_tools.mcp.tools.screenshot._check_cairosvg", return_value=False)
+    @patch(
+        "kicad_tools.mcp.tools.screenshot.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli")
+    )
+    def test_cairosvg_not_installed(self, mock_find, mock_cairo, tmp_path):
+        """Missing cairosvg returns error with install hint."""
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb ...)")
+        result = screenshot_board(pcb_path=str(pcb_file))
+        assert result["success"] is False
+        assert "cairosvg" in result["error_message"]
+        assert "kicad-tools[screenshot]" in result["error_message"]
+
+
+class TestScreenshotSchematicErrors:
+    """Tests for screenshot_schematic error handling."""
+
+    def test_nonexistent_file(self):
+        """Non-existent schematic file returns error."""
+        result = screenshot_schematic(sch_path="/nonexistent/schematic.kicad_sch")
+        assert result["success"] is False
+        assert "not found" in result["error_message"]
+
+    def test_wrong_extension(self, tmp_path):
+        """Wrong file extension returns error."""
+        bad_file = tmp_path / "schematic.txt"
+        bad_file.write_text("not a schematic")
+        result = screenshot_schematic(sch_path=str(bad_file))
+        assert result["success"] is False
+        assert "Invalid file extension" in result["error_message"]
+
+    @patch("kicad_tools.mcp.tools.screenshot.find_kicad_cli", return_value=None)
+    def test_kicad_cli_not_found(self, mock_find, tmp_path):
+        """Missing kicad-cli returns error with install URL."""
+        sch_file = tmp_path / "schematic.kicad_sch"
+        sch_file.write_text("(kicad_sch ...)")
+        result = screenshot_schematic(sch_path=str(sch_file))
+        assert result["success"] is False
+        assert "kicad-cli not found" in result["error_message"]
+        assert "kicad.org/download" in result["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# Registry integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestScreenshotRegistry:
+    """Tests for screenshot tool registration."""
+
+    def test_screenshot_board_in_registry(self):
+        """screenshot_board appears in TOOL_REGISTRY after import."""
+        from kicad_tools.mcp.tools.registry import TOOL_REGISTRY
+
+        assert "screenshot_board" in TOOL_REGISTRY
+
+    def test_screenshot_schematic_in_registry(self):
+        """screenshot_schematic appears in TOOL_REGISTRY after import."""
+        from kicad_tools.mcp.tools.registry import TOOL_REGISTRY
+
+        assert "screenshot_schematic" in TOOL_REGISTRY
+
+    def test_screenshot_board_tool_spec(self):
+        """screenshot_board has valid tool spec."""
+        from kicad_tools.mcp.tools.registry import get_tool
+
+        tool = get_tool("screenshot_board")
+        assert tool is not None
+        assert tool.name == "screenshot_board"
+        assert tool.category == "screenshot"
+        assert "pcb_path" in tool.parameters["properties"]
+        assert callable(tool.handler)
+
+    def test_screenshot_schematic_tool_spec(self):
+        """screenshot_schematic has valid tool spec."""
+        from kicad_tools.mcp.tools.registry import get_tool
+
+        tool = get_tool("screenshot_schematic")
+        assert tool is not None
+        assert tool.name == "screenshot_schematic"
+        assert tool.category == "screenshot"
+        assert "sch_path" in tool.parameters["properties"]
+        assert callable(tool.handler)
+
+    def test_screenshot_tools_in_category(self):
+        """Screenshot tools appear in their category."""
+        from kicad_tools.mcp.tools.registry import list_tools
+
+        screenshot_tools = list_tools(category="screenshot")
+        names = [t.name for t in screenshot_tools]
+        assert "screenshot_board" in names
+        assert "screenshot_schematic" in names
+
+
+# ---------------------------------------------------------------------------
+# MCP server integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestScreenshotMCPServer:
+    """Tests for screenshot tool integration with MCP server."""
+
+    def test_screenshot_board_in_server(self):
+        """screenshot_board appears in MCPServer tools."""
+        from kicad_tools.mcp.server import MCPServer
+
+        server = MCPServer()
+        assert "screenshot_board" in server.tools
+
+    def test_screenshot_schematic_in_server(self):
+        """screenshot_schematic appears in MCPServer tools."""
+        from kicad_tools.mcp.server import MCPServer
+
+        server = MCPServer()
+        assert "screenshot_schematic" in server.tools
+
+    def test_server_tool_list_includes_screenshots(self):
+        """tools/list response includes screenshot tools."""
+        from kicad_tools.mcp.server import MCPServer
+
+        server = MCPServer()
+        tools_list = server.get_tools_list()
+        tool_names = [t["name"] for t in tools_list]
+        assert "screenshot_board" in tool_names
+        assert "screenshot_schematic" in tool_names
+
+
+# ---------------------------------------------------------------------------
+# MCP content block tests (unit)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPContentBlocks:
+    """Tests for _mcp_content passthrough in MCP server."""
+
+    def test_mcp_content_passthrough(self):
+        """Server uses _mcp_content blocks when present in handler result."""
+        from kicad_tools.mcp.server import MCPServer
+
+        server = MCPServer()
+
+        # Create a mock tool that returns _mcp_content
+        from kicad_tools.mcp.server import ToolDefinition
+
+        mock_content = [
+            {"type": "text", "text": '{"success": true}'},
+            {"type": "image", "data": "base64data", "mimeType": "image/png"},
+        ]
+
+        def mock_handler(params):
+            return {"success": True, "_mcp_content": mock_content}
+
+        server.tools["test_image_tool"] = ToolDefinition(
+            name="test_image_tool",
+            description="Test",
+            parameters={"type": "object", "properties": {}},
+            handler=mock_handler,
+        )
+
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "test_image_tool", "arguments": {}},
+            }
+        )
+
+        assert response["result"]["content"] == mock_content
+
+    def test_no_mcp_content_uses_json(self):
+        """Server wraps result as JSON text when no _mcp_content."""
+        from kicad_tools.mcp.server import MCPServer
+
+        server = MCPServer()
+
+        from kicad_tools.mcp.server import ToolDefinition
+
+        def mock_handler(params):
+            return {"success": True, "value": 42}
+
+        server.tools["test_plain_tool"] = ToolDefinition(
+            name="test_plain_tool",
+            description="Test",
+            parameters={"type": "object", "properties": {}},
+            handler=mock_handler,
+        )
+
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "test_plain_tool", "arguments": {}},
+            }
+        )
+
+        content = response["result"]["content"]
+        assert len(content) == 1
+        assert content[0]["type"] == "text"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require kicad-cli)
+# ---------------------------------------------------------------------------
+
+
+class TestScreenshotBoardIntegration:
+    """Integration tests for screenshot_board with real kicad-cli."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_kicad_cli(self):
+        """Skip if kicad-cli is not available."""
+        from kicad_tools.cli.runner import find_kicad_cli
+
+        if find_kicad_cli() is None:
+            pytest.skip("kicad-cli not found")
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_cairosvg(self):
+        """Skip if cairosvg is not installed."""
+        if not _check_cairosvg():
+            pytest.skip("cairosvg not installed")
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_PCB).exists(),
+        reason="voltage divider board fixture not found",
+    )
+    def test_screenshot_board_success(self):
+        """Screenshot of voltage divider board succeeds."""
+        result = screenshot_board(pcb_path=VOLTAGE_DIVIDER_PCB)
+
+        assert result["success"] is True
+        assert result["image_base64"] is not None
+        assert len(result["image_base64"]) > 0
+        assert result["width_px"] > 0
+        assert result["height_px"] > 0
+        assert result["error_message"] is None
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_PCB).exists(),
+        reason="voltage divider board fixture not found",
+    )
+    def test_screenshot_max_size_respected(self):
+        """Image dimensions respect max_size_px constraint."""
+        result = screenshot_board(
+            pcb_path=VOLTAGE_DIVIDER_PCB,
+            max_size_px=800,
+        )
+
+        assert result["success"] is True
+        assert max(result["width_px"], result["height_px"]) <= 800
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_PCB).exists(),
+        reason="voltage divider board fixture not found",
+    )
+    def test_screenshot_output_path(self, tmp_path):
+        """Screenshot is saved to output_path when specified."""
+        output = tmp_path / "test_board.png"
+        result = screenshot_board(
+            pcb_path=VOLTAGE_DIVIDER_PCB,
+            output_path=str(output),
+        )
+
+        assert result["success"] is True
+        assert output.exists()
+        assert output.stat().st_size > 0
+        assert result["output_path"] == str(output)
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_PCB).exists(),
+        reason="voltage divider board fixture not found",
+    )
+    def test_screenshot_base64_decodes_to_valid_png(self):
+        """Base64 data decodes to valid PNG bytes."""
+        result = screenshot_board(pcb_path=VOLTAGE_DIVIDER_PCB)
+
+        assert result["success"] is True
+        png_bytes = base64.b64decode(result["image_base64"])
+        # PNG signature
+        assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_PCB).exists(),
+        reason="voltage divider board fixture not found",
+    )
+    def test_screenshot_copper_preset(self):
+        """Copper layer preset produces valid screenshot."""
+        result = screenshot_board(
+            pcb_path=VOLTAGE_DIVIDER_PCB,
+            layers="copper",
+        )
+
+        assert result["success"] is True
+        assert result["layers_rendered"] == LAYER_PRESETS["copper"]
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_PCB).exists(),
+        reason="voltage divider board fixture not found",
+    )
+    def test_screenshot_black_and_white(self):
+        """Black and white mode produces valid screenshot."""
+        result = screenshot_board(
+            pcb_path=VOLTAGE_DIVIDER_PCB,
+            black_and_white=True,
+        )
+
+        assert result["success"] is True
+        assert result["image_base64"] is not None
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_PCB).exists(),
+        reason="voltage divider board fixture not found",
+    )
+    def test_screenshot_vision_api_size(self):
+        """Default screenshot fits within vision API 1568px limit."""
+        result = screenshot_board(pcb_path=VOLTAGE_DIVIDER_PCB)
+
+        assert result["success"] is True
+        assert result["width_px"] <= 1568
+        assert result["height_px"] <= 1568

--- a/tests/test_mcp_screenshot.py
+++ b/tests/test_mcp_screenshot.py
@@ -456,3 +456,79 @@ class TestScreenshotBoardIntegration:
         assert result["success"] is True
         assert result["width_px"] <= 1568
         assert result["height_px"] <= 1568
+
+
+class TestScreenshotSchematicIntegration:
+    """Integration tests for screenshot_schematic with real kicad-cli."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_kicad_cli(self):
+        """Skip if kicad-cli is not available."""
+        from kicad_tools.cli.runner import find_kicad_cli
+
+        if find_kicad_cli() is None:
+            pytest.skip("kicad-cli not found")
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_cairosvg(self):
+        """Skip if cairosvg is not installed."""
+        if not _check_cairosvg():
+            pytest.skip("cairosvg not installed")
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_SCH).exists(),
+        reason="voltage divider schematic fixture not found",
+    )
+    def test_screenshot_schematic_success(self):
+        """Screenshot of voltage divider schematic succeeds."""
+        result = screenshot_schematic(sch_path=VOLTAGE_DIVIDER_SCH)
+
+        assert result["success"] is True
+        assert result["image_base64"] is not None
+        assert len(result["image_base64"]) > 0
+        assert result["width_px"] > 0
+        assert result["height_px"] > 0
+        assert result["error_message"] is None
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_SCH).exists(),
+        reason="voltage divider schematic fixture not found",
+    )
+    def test_screenshot_schematic_base64_decodes_to_valid_png(self):
+        """Base64 data from schematic screenshot decodes to valid PNG bytes."""
+        result = screenshot_schematic(sch_path=VOLTAGE_DIVIDER_SCH)
+
+        assert result["success"] is True
+        png_bytes = base64.b64decode(result["image_base64"])
+        assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_SCH).exists(),
+        reason="voltage divider schematic fixture not found",
+    )
+    def test_screenshot_schematic_max_size_respected(self):
+        """Schematic image dimensions respect max_size_px constraint."""
+        result = screenshot_schematic(
+            sch_path=VOLTAGE_DIVIDER_SCH,
+            max_size_px=800,
+        )
+
+        assert result["success"] is True
+        assert max(result["width_px"], result["height_px"]) <= 800
+
+    @pytest.mark.skipif(
+        not Path(VOLTAGE_DIVIDER_SCH).exists(),
+        reason="voltage divider schematic fixture not found",
+    )
+    def test_screenshot_schematic_output_path(self, tmp_path):
+        """Schematic screenshot is saved to output_path when specified."""
+        output = tmp_path / "test_schematic.png"
+        result = screenshot_schematic(
+            sch_path=VOLTAGE_DIVIDER_SCH,
+            output_path=str(output),
+        )
+
+        assert result["success"] is True
+        assert output.exists()
+        assert output.stat().st_size > 0
+        assert result["output_path"] == str(output)

--- a/uv.lock
+++ b/uv.lock
@@ -273,6 +273,34 @@ wheels = [
 ]
 
 [[package]]
+name = "cairocffi"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/c5/1a4dc131459e68a173cbdab5fad6b524f53f9c1ef7861b7698e998b837cc/cairocffi-1.7.1.tar.gz", hash = "sha256:2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b", size = 88096, upload-time = "2024-06-18T10:56:06.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d8/ba13451aa6b745c49536e87b6bf8f629b950e84bd0e8308f7dc6883b67e2/cairocffi-1.7.1-py3-none-any.whl", hash = "sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f", size = 75611, upload-time = "2024-06-18T10:55:59.489Z" },
+]
+
+[[package]]
+name = "cairosvg"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cairocffi" },
+    { name = "cssselect2" },
+    { name = "defusedxml" },
+    { name = "pillow" },
+    { name = "tinycss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/07/e8412a13019b3f737972dea23a2c61ca42becafc16c9338f4ca7a0caa993/cairosvg-2.9.0.tar.gz", hash = "sha256:1debb00cd2da11350d8b6f5ceb739f1b539196d71d5cf5eb7363dbd1bfbc8dc5", size = 40877, upload-time = "2026-03-13T15:42:00.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5011747466414c12cac8a8df77aa235068669a6a5a5df301a96209db6054/cairosvg-2.9.0-py3-none-any.whl", hash = "sha256:4b82d07d145377dffdfc19d9791bd5fb65539bb4da0adecf0bdbd9cd4ffd7c68", size = 45962, upload-time = "2026-03-14T13:56:33.512Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -885,6 +913,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/99/55/181022996c4063fc0e7666a47049a1ca705abb9c8a13830f074edb347495/cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:9394673a9f4de09e28b5356e7fff97d778f8abad85c9d5ac4a4b7e25a0de7717", size = 4242957, upload-time = "2025-10-15T23:18:22.18Z" },
     { url = "https://files.pythonhosted.org/packages/ba/af/72cd6ef29f9c5f731251acadaeb821559fe25f10852f44a63374c9ca08c1/cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:94cd0549accc38d1494e1f8de71eca837d0509d0d44bf11d158524b0e12cebf9", size = 4409447, upload-time = "2025-10-15T23:18:24.209Z" },
     { url = "https://files.pythonhosted.org/packages/0d/c3/e90f4a4feae6410f914f8ebac129b9ae7a8c92eb60a638012dde42030a9d/cryptography-46.0.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6b5063083824e5509fdba180721d55909ffacccc8adbec85268b48439423d78c", size = 3438528, upload-time = "2025-10-15T23:18:26.227Z" },
+]
+
+[[package]]
+name = "cssselect2"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
 ]
 
 [[package]]
@@ -1644,6 +1685,7 @@ all = [
     { name = "ax-platform", version = "1.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "botorch", version = "0.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "botorch", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cairosvg" },
     { name = "cupy-cuda12x" },
     { name = "fastmcp" },
     { name = "markitdown" },
@@ -1711,6 +1753,9 @@ native = [
 parts = [
     { name = "requests" },
 ]
+screenshot = [
+    { name = "cairosvg" },
+]
 visualization = [
     { name = "matplotlib" },
 ]
@@ -1726,6 +1771,8 @@ requires-dist = [
     { name = "ax-platform", marker = "extra == 'bayesian'", specifier = ">=0.4.0" },
     { name = "botorch", marker = "extra == 'all'", specifier = ">=0.12.0" },
     { name = "botorch", marker = "extra == 'bayesian'", specifier = ">=0.12.0" },
+    { name = "cairosvg", marker = "extra == 'all'", specifier = ">=2.6" },
+    { name = "cairosvg", marker = "extra == 'screenshot'", specifier = ">=2.6" },
     { name = "cmaes", specifier = ">=0.12.0" },
     { name = "cmake", marker = "extra == 'native'", specifier = ">=3.15" },
     { name = "cupy-cuda12x", marker = "extra == 'all'", specifier = ">=13.0" },
@@ -1774,7 +1821,7 @@ requires-dist = [
     { name = "scikit-build-core", marker = "extra == 'native'", specifier = ">=0.8" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]
-provides-extras = ["drc", "parts", "datasheet", "constraints", "mcp", "native", "cuda", "metal", "visualization", "bayesian", "all", "dev"]
+provides-extras = ["drc", "parts", "datasheet", "constraints", "mcp", "native", "cuda", "metal", "visualization", "bayesian", "screenshot", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest-cov", specifier = ">=7.0.0" }]
@@ -4622,6 +4669,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4706,6 +4765,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },
@@ -4868,6 +4934,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a screenshot/visualization pipeline that captures KiCad board and schematic images for AI agent visual feedback. The pipeline exports SVG via kicad-cli, converts to PNG with cairosvg, resizes to vision API limits, and returns base64-encoded images through MCP content blocks.

## Changes

- New `src/kicad_tools/mcp/tools/screenshot.py` -- core pipeline with `screenshot_board()` and `screenshot_schematic()` functions
- Register `screenshot_board` and `screenshot_schematic` MCP tools in `registry.py` with `_mcp_content` passthrough for image content blocks
- Update `src/kicad_tools/mcp/server.py` `handle_request()` to support `_mcp_content` key for image/text mixed content responses
- Export new functions from `src/kicad_tools/mcp/tools/__init__.py`
- Add `[screenshot]` extras group (`cairosvg>=2.6`) to `pyproject.toml`
- New `src/kicad_tools/cli/screenshot_cmd.py` -- `kct screenshot` CLI command
- Register screenshot subcommand in CLI parser and dispatch
- New `tests/test_mcp_screenshot.py` -- 31 tests (unit, registry, server, integration)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `screenshot_board` MCP tool registered and in `tools/list` | PASS | Registry test + server tool list test both pass |
| Tool accepts `pcb_path` (required), `layers`, `max_size_px`, `black_and_white`, `output_path`, `theme` (optional) | PASS | All parameters defined in tool spec, tested via registry tests |
| Returns base64-encoded PNG <= 1568px longest dimension | PASS | Enforced by `_svg_to_png()` with `max_size_px`, integration tests verify |
| kicad-cli not found error includes install URL | PASS | Unit test `test_kicad_cli_not_found` asserts "kicad.org/download" in message |
| cairosvg not installed error says to install `kicad-tools[screenshot]` | PASS | Unit test `test_cairosvg_not_installed` asserts message content |
| cairosvg in `[screenshot]` extras group | PASS | Added to `pyproject.toml` |
| Default layers produce useful composite view | PASS | DEFAULT_LAYERS = F.Cu, B.Cu, Edge.Cuts, F.SilkS, B.SilkS, F.Mask, B.Mask |
| `screenshot_schematic` MCP tool for .kicad_sch files | PASS | Implemented and registered |
| `kct screenshot` CLI command | PASS | `kct screenshot --help` works correctly |

## Test Plan

- 24 unit/registry/server tests pass (all non-integration)
- 7 integration tests skip gracefully when kicad-cli or cairosvg unavailable
- All 18 existing registry tests continue to pass
- Ruff lint + format clean on all changed files

Closes #1241