### PR TITLE
feat(placement): add slide-off overlap resolution for placement optimization

### DIFF
--- a/src/kicad_tools/cli/commands/optimize_placement.py
+++ b/src/kicad_tools/cli/commands/optimize_placement.py
@@ -19,4 +19,5 @@ def run_optimize_placement_command(args) -> int:
         checkpoint_dir=args.checkpoint,
         verbose=args.verbose,
         quiet=getattr(args, "quiet", False) or getattr(args, "global_quiet", False),
+        no_slide_off=getattr(args, "no_slide_off", False),
     )

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -350,6 +350,7 @@ def run_optimize_placement(
     checkpoint_dir: str | None = None,
     verbose: bool = False,
     quiet: bool = False,
+    no_slide_off: bool = False,
 ) -> int:
     """Run placement optimization.
 
@@ -365,6 +366,7 @@ def run_optimize_placement(
         checkpoint_dir: Directory for checkpoint save/resume.
         verbose: Enable verbose output.
         quiet: Suppress non-essential output.
+        no_slide_off: If True, skip slide-off overlap pre-processing.
 
     Returns:
         Exit code (0 for success, 1 for failure).
@@ -470,6 +472,22 @@ def run_optimize_placement(
 
         # Generate initial seed
         seed_vector = _generate_seed(seed_method, components, nets, board_outline)
+
+        # Apply slide-off pre-processing
+        if not no_slide_off:
+            from kicad_tools.placement.slide_off import slide_off_overlaps
+
+            seed_vector, slide_result = slide_off_overlaps(
+                seed_vector,
+                components,
+                board_outline,
+            )
+            if not quiet:
+                print(
+                    f"  Slide-off: resolved {slide_result.overlaps_resolved} overlaps "
+                    f"({slide_result.overlaps_remaining} remaining, "
+                    f"{slide_result.iterations_run} iterations)"
+                )
 
         # Evaluate seed
         seed_score = _evaluate(

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1794,10 +1794,14 @@ def _add_optimize_placement_parser(subparsers) -> None:
         metavar="DIR",
         help="Directory for checkpoint save/resume of optimizer state",
     )
-    op_parser.add_argument("-v", "--verbose", action="store_true")
     op_parser.add_argument(
-        "-q", "--quiet", action="store_true", help="Suppress progress output"
+        "--no-slide-off",
+        action="store_true",
+        default=False,
+        help="Disable slide-off overlap pre-processing on the seed placement",
     )
+    op_parser.add_argument("-v", "--verbose", action="store_true")
+    op_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress progress output")
 
 
 def _add_interactive_parser(subparsers) -> None:

--- a/src/kicad_tools/mcp/tools/optimize_placement.py
+++ b/src/kicad_tools/mcp/tools/optimize_placement.py
@@ -264,6 +264,7 @@ def optimize_placement(
     weights: dict[str, float] | None = None,
     seed_method: str = "force-directed",
     output_path: str | None = None,
+    pre_slide_off: bool = True,
 ) -> dict[str, Any]:
     """Optimize component placement on a PCB board using CMA-ES.
 
@@ -279,6 +280,8 @@ def optimize_placement(
             overlap, drc, boundary, wirelength, area.
         seed_method: Seed placement method ("force-directed" or "random").
         output_path: Path for output file. If None, does not write to disk.
+        pre_slide_off: If True, run slide-off overlap resolution on the seed
+            placement before passing it to the optimizer.
 
     Returns:
         Dictionary with optimization results:
@@ -365,6 +368,16 @@ def optimize_placement(
             "component_count": len(components),
             "net_count": len(nets),
         }
+
+    # Apply slide-off pre-processing to resolve seed overlaps
+    if pre_slide_off:
+        from kicad_tools.placement.slide_off import slide_off_overlaps
+
+        seed_vector, _slide_result = slide_off_overlaps(
+            seed_vector,
+            components,
+            board_outline,
+        )
 
     # Evaluate seed
     seed_score = _evaluate_vector(
@@ -637,3 +650,118 @@ def _write_placements_to_pcb(
         output_lines.append(line)
 
     Path(output_path).write_text("\n".join(output_lines))
+
+
+# ---------------------------------------------------------------------------
+# Standalone overlap resolution tool
+# ---------------------------------------------------------------------------
+
+
+def resolve_placement_overlaps(
+    pcb_path: str,
+    output_path: str | None = None,
+    margin_mm: float = 0.5,
+    max_iterations: int = 5,
+    max_displacement_mm: float = 20.0,
+) -> dict[str, Any]:
+    """Resolve component overlaps in a PCB using the slide-off algorithm.
+
+    Reads component positions from the board file, runs iterative
+    slide-off overlap resolution, and optionally writes the modified
+    board to *output_path*.
+
+    Args:
+        pcb_path: Absolute path to .kicad_pcb file.
+        output_path: Path for output file. If None, does not write to disk.
+        margin_mm: Extra clearance margin beyond zero overlap (mm).
+        max_iterations: Maximum settling iterations.
+        max_displacement_mm: Maximum per-component displacement (mm).
+
+    Returns:
+        Dictionary with overlap resolution results:
+        - success: Whether resolution completed successfully.
+        - overlaps_resolved: Number of overlap pairs resolved.
+        - overlaps_remaining: Number of overlap pairs still present.
+        - iterations_run: Number of iterations executed.
+        - max_displacement_applied: Maximum component displacement (mm).
+        - component_count: Number of components processed.
+        - output_path: Path to output file (if written).
+        - error_message: Error description if success is False.
+    """
+    _validate_pcb_path(pcb_path)
+
+    try:
+        components, nets, board_outline, rules = _read_board_data(pcb_path)
+    except Exception as e:
+        raise ParseError(f"Failed to parse PCB file: {e}") from e
+
+    if not components:
+        return {
+            "success": False,
+            "error_message": "No components found in PCB file",
+            "component_count": 0,
+        }
+
+    # Build a PlacementVector from current positions
+    from kicad_tools.schema.pcb import PCB as SchemaPCB
+
+    pcb = SchemaPCB.load(pcb_path)
+
+    from kicad_tools.placement.vector import (
+        FIELDS_PER_COMPONENT as FPC,
+    )
+    from kicad_tools.placement.vector import (
+        PlacementVector as PV,
+    )
+
+    # Map reference -> ComponentDef index
+    ref_to_idx = {c.reference: i for i, c in enumerate(components)}
+
+    import numpy as np
+
+    data = np.zeros(len(components) * FPC, dtype=np.float64)
+    for fp in pcb.footprints:
+        ref = fp.reference
+        if not ref or ref not in ref_to_idx:
+            continue
+        idx = ref_to_idx[ref]
+        base = idx * FPC
+        data[base] = fp.position[0]
+        data[base + 1] = fp.position[1]
+        rot_idx = int(round(fp.rotation / 90.0)) % 4
+        data[base + 2] = float(rot_idx)
+        # Determine side from layer
+        layer = getattr(fp, "layer", "F.Cu")
+        data[base + 3] = 1.0 if "B." in str(layer) else 0.0
+
+    vector = PV(data=data)
+
+    # Run slide-off
+    from kicad_tools.placement.slide_off import slide_off_overlaps
+
+    new_vector, slide_result = slide_off_overlaps(
+        vector,
+        components,
+        board_outline,
+        margin_mm=margin_mm,
+        max_iterations=max_iterations,
+        max_displacement_mm=max_displacement_mm,
+    )
+
+    result: dict[str, Any] = {
+        "success": True,
+        "overlaps_resolved": slide_result.overlaps_resolved,
+        "overlaps_remaining": slide_result.overlaps_remaining,
+        "iterations_run": slide_result.iterations_run,
+        "max_displacement_applied": round(slide_result.max_displacement_applied, 4),
+        "component_count": len(components),
+    }
+
+    if output_path:
+        try:
+            _write_placements_to_pcb(pcb_path, output_path, new_vector, components)
+            result["output_path"] = output_path
+        except Exception as e:
+            result["warnings"] = [f"Resolution succeeded but save failed: {e}"]
+
+    return result

--- a/src/kicad_tools/mcp/tools/registry.py
+++ b/src/kicad_tools/mcp/tools/registry.py
@@ -1438,6 +1438,7 @@ def _handler_optimize_placement(params: dict[str, Any]) -> dict[str, Any]:
         weights=params.get("weights"),
         seed_method=params.get("seed_method", "force-directed"),
         output_path=params.get("output_path"),
+        pre_slide_off=params.get("pre_slide_off", True),
     )
 
 
@@ -1504,6 +1505,15 @@ register_tool(
                     "If not specified, the result is not written to disk."
                 ),
             },
+            "pre_slide_off": {
+                "type": "boolean",
+                "description": (
+                    "If true, run slide-off overlap resolution on the seed "
+                    "placement before optimization. Reduces initial overlap "
+                    "penalty for faster convergence. Default: true."
+                ),
+                "default": True,
+            },
         },
         required=["pcb_path"],
     ),
@@ -1560,5 +1570,63 @@ register_tool(
         required=["pcb_path"],
     ),
     handler=_handler_evaluate_placement,
+    category="placement",
+)
+
+
+def _handler_resolve_placement_overlaps(params: dict[str, Any]) -> dict[str, Any]:
+    """Handle resolve_placement_overlaps tool call."""
+    from kicad_tools.mcp.tools.optimize_placement import resolve_placement_overlaps
+
+    return resolve_placement_overlaps(
+        pcb_path=params["pcb_path"],
+        output_path=params.get("output_path"),
+        margin_mm=params.get("margin_mm", 0.5),
+        max_iterations=params.get("max_iterations", 5),
+        max_displacement_mm=params.get("max_displacement_mm", 20.0),
+    )
+
+
+register_tool(
+    name="resolve_placement_overlaps",
+    description=(
+        "Resolve component placement overlaps using the slide-off algorithm. "
+        "Iteratively pushes overlapping component bounding boxes apart until "
+        "no overlaps remain or limits are reached. Components on opposite "
+        "board sides are not affected. Useful as a standalone cleanup step "
+        "or before running full placement optimization."
+    ),
+    parameters=_make_params(
+        properties={
+            "pcb_path": {
+                "type": "string",
+                "description": "Absolute path to .kicad_pcb file",
+            },
+            "output_path": {
+                "type": "string",
+                "description": (
+                    "Path for output .kicad_pcb file with resolved placements. "
+                    "If not specified, the result is not written to disk."
+                ),
+            },
+            "margin_mm": {
+                "type": "number",
+                "description": ("Extra clearance margin in mm beyond zero overlap. Default: 0.5"),
+                "default": 0.5,
+            },
+            "max_iterations": {
+                "type": "integer",
+                "description": ("Maximum number of settling iterations. Default: 5"),
+                "default": 5,
+            },
+            "max_displacement_mm": {
+                "type": "number",
+                "description": ("Maximum displacement per component in mm. Default: 20.0"),
+                "default": 20.0,
+            },
+        },
+        required=["pcb_path"],
+    ),
+    handler=_handler_resolve_placement_overlaps,
     category="placement",
 )

--- a/src/kicad_tools/placement/__init__.py
+++ b/src/kicad_tools/placement/__init__.py
@@ -63,6 +63,7 @@ from .priors import (
     prior_mean_position,
     schematic_proximity_prior,
 )
+from .slide_off import SlideOffResult, slide_off_overlaps
 from .strategy import PlacementStrategy, StrategyConfig
 from .vector import (
     ComponentDef,
@@ -93,6 +94,7 @@ from .wirelength import (
 
 __all__ = [
     "AffinityGraph",
+    "SlideOffResult",
     "BayesianOptStrategy",
     "CMAESStrategy",
     "CollisionResult",
@@ -147,4 +149,5 @@ __all__ = [
     "power_domain_clustering",
     "prior_mean_position",
     "schematic_proximity_prior",
+    "slide_off_overlaps",
 ]

--- a/src/kicad_tools/placement/slide_off.py
+++ b/src/kicad_tools/placement/slide_off.py
@@ -1,0 +1,567 @@
+"""Iterative overlap resolution (slide-off) for placement vectors.
+
+Provides a self-contained, configurable settling pass that pushes
+overlapping component bounding boxes apart until no overlaps remain
+(or iteration/displacement limits are reached).
+
+Key properties:
+
+- Operates on :class:`PlacementVector` / :class:`ComponentDef` data
+  (not on ``.kicad_pcb`` files via regex).
+- Supports a configurable clearance margin (the Zeo-equivalent 0.5 mm).
+- Caps total displacement per component per call.
+- Re-clamps to board bounds after each settling iteration.
+- Can be called as pure pre-processing or post-processing without
+  modifying disk state.
+- Components on opposite sides (front/back) are not pushed apart.
+- Deterministic fallback direction for coincident components.
+
+Usage::
+
+    from kicad_tools.placement.slide_off import slide_off_overlaps, SlideOffResult
+    from kicad_tools.placement.cost import BoardOutline
+    from kicad_tools.placement.vector import ComponentDef, PlacementVector
+
+    new_vector, result = slide_off_overlaps(vector, component_defs, board)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from .cost import BoardOutline
+from .vector import (
+    FIELDS_PER_COMPONENT,
+    ComponentDef,
+    PlacementVector,
+)
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SlideOffResult:
+    """Result of running the slide-off overlap resolver.
+
+    Attributes:
+        iterations_run: Number of settling iterations executed.
+        overlaps_resolved: Total number of overlap pairs resolved.
+        overlaps_remaining: Number of overlap pairs still present after
+            the final iteration.
+        max_displacement_applied: Maximum Euclidean displacement applied
+            to any single component (mm).
+    """
+
+    iterations_run: int
+    overlaps_resolved: int
+    overlaps_remaining: int
+    max_displacement_applied: float
+
+
+# ---------------------------------------------------------------------------
+# Spatial index (grid-based)
+# ---------------------------------------------------------------------------
+
+
+class _SpatialGrid:
+    """Simple grid-based spatial index for fast neighbor lookup.
+
+    Partitions the board into square cells and maps component indices
+    to their occupied cells.  Querying potential overlap candidates
+    for a given component returns only components sharing at least one
+    cell, reducing the O(N^2) pairwise check for sparse boards.
+
+    Args:
+        cell_size: Side length of each grid cell in mm.
+    """
+
+    def __init__(self, cell_size: float = 10.0) -> None:
+        self._cell_size = cell_size
+        self._grid: dict[tuple[int, int], list[int]] = {}
+        self._comp_cells: dict[int, list[tuple[int, int]]] = {}
+
+    def _cell_range(
+        self,
+        min_val: float,
+        max_val: float,
+    ) -> range:
+        """Return the range of cell indices spanning [min_val, max_val]."""
+        lo = int(math.floor(min_val / self._cell_size))
+        hi = int(math.floor(max_val / self._cell_size))
+        return range(lo, hi + 1)
+
+    def build(
+        self,
+        positions: np.ndarray,
+        half_sizes: np.ndarray,
+        margin: float,
+    ) -> None:
+        """Rebuild the grid from current positions.
+
+        Args:
+            positions: (N, 2) array of component center positions.
+            half_sizes: (N, 2) array of component half-widths/heights.
+            margin: Extra clearance margin to expand AABBs.
+        """
+        self._grid.clear()
+        self._comp_cells.clear()
+        n = positions.shape[0]
+        for i in range(n):
+            min_x = positions[i, 0] - half_sizes[i, 0] - margin
+            max_x = positions[i, 0] + half_sizes[i, 0] + margin
+            min_y = positions[i, 1] - half_sizes[i, 1] - margin
+            max_y = positions[i, 1] + half_sizes[i, 1] + margin
+
+            cells: list[tuple[int, int]] = []
+            for cx in self._cell_range(min_x, max_x):
+                for cy in self._cell_range(min_y, max_y):
+                    key = (cx, cy)
+                    cells.append(key)
+                    self._grid.setdefault(key, []).append(i)
+            self._comp_cells[i] = cells
+
+    def potential_pairs(self) -> set[tuple[int, int]]:
+        """Return all candidate overlap pairs (i < j)."""
+        pairs: set[tuple[int, int]] = set()
+        for cell_members in self._grid.values():
+            for a_idx in range(len(cell_members)):
+                for b_idx in range(a_idx + 1, len(cell_members)):
+                    i = cell_members[a_idx]
+                    j = cell_members[b_idx]
+                    if i < j:
+                        pairs.add((i, j))
+                    else:
+                        pairs.add((j, i))
+        return pairs
+
+
+# ---------------------------------------------------------------------------
+# Deterministic fallback direction
+# ---------------------------------------------------------------------------
+
+# When two components are at the exact same position, we push them apart
+# along this vector instead of producing NaN from a zero-length direction.
+_FALLBACK_DX = 1.0
+_FALLBACK_DY = 0.0
+
+# Minimum push factor to avoid zero-push degenerate iterations
+_MIN_PUSH = 1e-6
+
+# Jitter radius for coincident components (mm) -- small enough to be
+# invisible, large enough to break the axis-alignment degeneracy.
+_JITTER_RADIUS = 0.01
+
+
+# ---------------------------------------------------------------------------
+# Coincident-component jitter
+# ---------------------------------------------------------------------------
+
+
+def _apply_coincident_jitter(
+    positions: np.ndarray,
+    sides: np.ndarray,
+    n: int,
+) -> None:
+    """Add a small deterministic radial offset to coincident components.
+
+    Groups of same-side components that share the exact same (x, y)
+    position are spread in a circular pattern so that the subsequent
+    pairwise push-apart has distinct axis differences to work with.
+
+    Modifies *positions* in place.
+    """
+    # Group by (x, y, side) -- use rounded key to catch near-coincidences
+    from collections import defaultdict
+
+    groups: dict[tuple[float, float, int], list[int]] = defaultdict(list)
+    for i in range(n):
+        key = (
+            round(positions[i, 0], 6),
+            round(positions[i, 1], 6),
+            int(sides[i]),
+        )
+        groups[key].append(i)
+
+    for key, members in groups.items():
+        if len(members) < 2:
+            continue
+        # Spread members in a circle around their shared centre
+        cx, cy = positions[members[0], 0], positions[members[0], 1]
+        count = len(members)
+        for rank, idx in enumerate(members):
+            angle = 2.0 * math.pi * rank / count
+            positions[idx, 0] = cx + _JITTER_RADIUS * math.cos(angle)
+            positions[idx, 1] = cy + _JITTER_RADIUS * math.sin(angle)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def slide_off_overlaps(
+    vector: PlacementVector,
+    component_defs: Sequence[ComponentDef],
+    board: BoardOutline,
+    *,
+    margin_mm: float = 0.5,
+    max_iterations: int = 5,
+    max_displacement_mm: float = 20.0,
+    use_spatial_index: bool | None = None,
+) -> tuple[PlacementVector, SlideOffResult]:
+    """Resolve component overlaps by iteratively sliding components apart.
+
+    For each pair of overlapping components (on the same board side), the
+    minimum translation vector is computed and each component is pushed
+    by half that vector in opposite directions.  After every push the
+    positions are clamped to the board outline so components never leave
+    the board.  Per-component cumulative displacement is tracked and
+    capped at *max_displacement_mm*.
+
+    Args:
+        vector: Input placement vector.
+        component_defs: Static component definitions (same order as
+            encoded in *vector*).
+        board: Rectangular board outline.
+        margin_mm: Extra clearance margin to enforce beyond zero overlap.
+            Each AABB is expanded by this amount before checking.
+        max_iterations: Maximum number of settling iterations.
+        max_displacement_mm: Maximum total Euclidean displacement per
+            component per call.
+        use_spatial_index: Whether to use a grid-based spatial index.
+            ``None`` (default) enables it automatically when the number
+            of components exceeds 50.
+
+    Returns:
+        Tuple of ``(new_vector, result)`` where *new_vector* is the
+        adjusted placement vector and *result* is a :class:`SlideOffResult`
+        with diagnostic fields.
+    """
+    n = len(component_defs)
+    if n != vector.num_components:
+        raise ValueError(
+            f"vector encodes {vector.num_components} components "
+            f"but {n} component definitions provided"
+        )
+
+    if n < 2:
+        return vector, SlideOffResult(
+            iterations_run=0,
+            overlaps_resolved=0,
+            overlaps_remaining=0,
+            max_displacement_applied=0.0,
+        )
+
+    # Work on a mutable copy of the underlying data
+    data = vector.data.copy()
+
+    # Extract positions and sides
+    positions = np.empty((n, 2), dtype=np.float64)
+    sides = np.empty(n, dtype=np.int32)
+    for i in range(n):
+        base = i * FIELDS_PER_COMPONENT
+        positions[i, 0] = data[base]
+        positions[i, 1] = data[base + 1]
+        # Determine effective side
+        sides[i] = int(round(data[base + 3]))
+
+    # Compute rotation-aware half-sizes per component
+    half_sizes = np.empty((n, 2), dtype=np.float64)
+    for i in range(n):
+        base = i * FIELDS_PER_COMPONENT
+        rot_idx = int(round(data[base + 2])) % 4
+        if rot_idx in (1, 3):
+            half_sizes[i, 0] = component_defs[i].height / 2.0
+            half_sizes[i, 1] = component_defs[i].width / 2.0
+        else:
+            half_sizes[i, 0] = component_defs[i].width / 2.0
+            half_sizes[i, 1] = component_defs[i].height / 2.0
+
+    # Pre-compute per-component safe bounds (component centre stays within)
+    x_lo = np.array(
+        [board.min_x + half_sizes[i, 0] for i in range(n)],
+        dtype=np.float64,
+    )
+    x_hi = np.array(
+        [board.max_x - half_sizes[i, 0] for i in range(n)],
+        dtype=np.float64,
+    )
+    y_lo = np.array(
+        [board.min_y + half_sizes[i, 1] for i in range(n)],
+        dtype=np.float64,
+    )
+    y_hi = np.array(
+        [board.max_y - half_sizes[i, 1] for i in range(n)],
+        dtype=np.float64,
+    )
+
+    # Pre-jitter: deterministically spread coincident components.
+    # When multiple components share the exact same centre, the
+    # axis-aligned push loop cannot spread them in 2D because every
+    # pair picks the same push direction.  We apply a tiny radial
+    # offset (proportional to component index) so that subsequent
+    # pairwise pushes have distinct axes to work with.
+    _apply_coincident_jitter(positions, sides, n)
+
+    # Save initial positions to track cumulative displacement
+    initial_positions = positions.copy()
+
+    # Cumulative displacement per component
+    cumulative_disp = np.zeros(n, dtype=np.float64)
+
+    # Decide whether to use spatial index
+    if use_spatial_index is None:
+        use_spatial_index = n > 50
+
+    spatial_grid: _SpatialGrid | None = None
+    if use_spatial_index:
+        spatial_grid = _SpatialGrid(cell_size=10.0)
+
+    total_resolved = 0
+    iterations_run = 0
+    remaining_overlaps = 0
+
+    for iteration in range(max_iterations):
+        iterations_run = iteration + 1
+
+        # Build spatial index if enabled
+        if spatial_grid is not None:
+            spatial_grid.build(positions, half_sizes, margin_mm)
+            candidate_pairs = spatial_grid.potential_pairs()
+        else:
+            candidate_pairs = None
+
+        any_overlap = False
+        overlap_count = 0
+
+        if candidate_pairs is not None:
+            pairs_to_check = sorted(candidate_pairs)
+        else:
+            # Full pairwise check
+            pairs_to_check = [(i, j) for i in range(n) for j in range(i + 1, n)]
+
+        for i, j in pairs_to_check:
+            # Skip components on different sides
+            if sides[i] != sides[j]:
+                continue
+
+            # Check if both components have exhausted their displacement budget
+            if (
+                cumulative_disp[i] >= max_displacement_mm
+                and cumulative_disp[j] >= max_displacement_mm
+            ):
+                continue
+
+            # Compute overlap with margin
+            dx = positions[j, 0] - positions[i, 0]
+            dy = positions[j, 1] - positions[i, 1]
+
+            combined_hw = half_sizes[i, 0] + half_sizes[j, 0] + margin_mm
+            combined_hh = half_sizes[i, 1] + half_sizes[j, 1] + margin_mm
+
+            overlap_x = combined_hw - abs(dx)
+            overlap_y = combined_hh - abs(dy)
+
+            if overlap_x > 0 and overlap_y > 0:
+                any_overlap = True
+                overlap_count += 1
+
+                # Compute push along the minimum-overlap axis.
+                # Use a push factor > 1.0 to overshoot slightly,
+                # preventing oscillation in dense configurations
+                # (matches seed.py push_factor=1.1).
+                _push_factor = 1.1
+
+                # Determine which axis to push along.  When one axis
+                # overlap is negligible (< 1e-3 mm) while the other is
+                # substantial, pushing along the negligible axis produces
+                # near-zero movement that never converges.  In that case
+                # push along the larger axis instead.
+                _NEGLIGIBLE = 1e-3
+                if overlap_y < _NEGLIGIBLE < overlap_x:
+                    # Y overlap is negligible; push in X
+                    push_x = True
+                elif overlap_x < _NEGLIGIBLE < overlap_y:
+                    # X overlap is negligible; push in Y
+                    push_x = False
+                else:
+                    push_x = overlap_x < overlap_y
+
+                if push_x:
+                    push_amount = _push_factor * overlap_x / 2.0
+                    if push_amount < _MIN_PUSH:
+                        push_amount = _MIN_PUSH
+                    if dx >= 0:
+                        push_i_x = -push_amount
+                        push_j_x = push_amount
+                    else:
+                        push_i_x = push_amount
+                        push_j_x = -push_amount
+                    push_i_y = 0.0
+                    push_j_y = 0.0
+                else:
+                    push_amount = _push_factor * overlap_y / 2.0
+                    if push_amount < _MIN_PUSH:
+                        push_amount = _MIN_PUSH
+                    if dy >= 0:
+                        push_i_y = -push_amount
+                        push_j_y = push_amount
+                    else:
+                        push_i_y = push_amount
+                        push_j_y = -push_amount
+                    push_i_x = 0.0
+                    push_j_x = 0.0
+
+                # Apply displacement cap to component i
+                remaining_i = max(0.0, max_displacement_mm - cumulative_disp[i])
+                push_i_mag = math.sqrt(push_i_x * push_i_x + push_i_y * push_i_y)
+                if push_i_mag > remaining_i and push_i_mag > 0:
+                    scale = remaining_i / push_i_mag
+                    push_i_x *= scale
+                    push_i_y *= scale
+
+                # Apply displacement cap to component j
+                remaining_j = max(0.0, max_displacement_mm - cumulative_disp[j])
+                push_j_mag = math.sqrt(push_j_x * push_j_x + push_j_y * push_j_y)
+                if push_j_mag > remaining_j and push_j_mag > 0:
+                    scale = remaining_j / push_j_mag
+                    push_j_x *= scale
+                    push_j_y *= scale
+
+                # Apply pushes
+                positions[i, 0] += push_i_x
+                positions[i, 1] += push_i_y
+                positions[j, 0] += push_j_x
+                positions[j, 1] += push_j_y
+
+                # Update cumulative displacement from initial position
+                cumulative_disp[i] = math.sqrt(
+                    (positions[i, 0] - initial_positions[i, 0]) ** 2
+                    + (positions[i, 1] - initial_positions[i, 1]) ** 2
+                )
+                cumulative_disp[j] = math.sqrt(
+                    (positions[j, 0] - initial_positions[j, 0]) ** 2
+                    + (positions[j, 1] - initial_positions[j, 1]) ** 2
+                )
+
+        # Clamp all positions to board bounds
+        for i in range(n):
+            if x_lo[i] <= x_hi[i]:
+                positions[i, 0] = max(x_lo[i], min(x_hi[i], positions[i, 0]))
+            else:
+                # Component wider than board: center it
+                positions[i, 0] = (board.min_x + board.max_x) / 2.0
+            if y_lo[i] <= y_hi[i]:
+                positions[i, 1] = max(y_lo[i], min(y_hi[i], positions[i, 1]))
+            else:
+                positions[i, 1] = (board.min_y + board.max_y) / 2.0
+
+        # Recompute cumulative displacement after clamping
+        for i in range(n):
+            cumulative_disp[i] = math.sqrt(
+                (positions[i, 0] - initial_positions[i, 0]) ** 2
+                + (positions[i, 1] - initial_positions[i, 1]) ** 2
+            )
+
+        if not any_overlap:
+            # Count resolved overlaps from previous iterations
+            total_resolved += 0  # No new overlaps to resolve
+            remaining_overlaps = 0
+            break
+        else:
+            # We attempted to resolve overlap_count pairs this iteration
+            total_resolved += overlap_count
+            remaining_overlaps = overlap_count
+    else:
+        # Exhausted max_iterations; count remaining overlaps
+        remaining_overlaps = _count_overlaps(
+            positions,
+            half_sizes,
+            sides,
+            margin_mm,
+            n,
+            spatial_grid,
+        )
+
+    # If we broke out with no overlaps, recount to be precise
+    if remaining_overlaps == 0 and iterations_run > 0:
+        remaining_overlaps = _count_overlaps(
+            positions,
+            half_sizes,
+            sides,
+            margin_mm,
+            n,
+            spatial_grid,
+        )
+
+    # Compute final total_resolved as the initial overlaps minus remaining
+    initial_overlaps = _count_overlaps(
+        initial_positions,
+        half_sizes,
+        sides,
+        margin_mm,
+        n,
+        spatial_grid=None,  # Use brute force for accurate initial count
+    )
+    # Resolved = how many we started with minus how many remain
+    actual_resolved = max(0, initial_overlaps - remaining_overlaps)
+
+    # Build output vector
+    out_data = data.copy()
+    for i in range(n):
+        base = i * FIELDS_PER_COMPONENT
+        out_data[base] = positions[i, 0]
+        out_data[base + 1] = positions[i, 1]
+
+    max_disp = float(np.max(cumulative_disp)) if n > 0 else 0.0
+
+    return PlacementVector(data=out_data), SlideOffResult(
+        iterations_run=iterations_run,
+        overlaps_resolved=actual_resolved,
+        overlaps_remaining=remaining_overlaps,
+        max_displacement_applied=max_disp,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_overlaps(
+    positions: np.ndarray,
+    half_sizes: np.ndarray,
+    sides: np.ndarray,
+    margin: float,
+    n: int,
+    spatial_grid: _SpatialGrid | None = None,
+) -> int:
+    """Count the number of overlapping pairs."""
+    count = 0
+
+    if spatial_grid is not None:
+        spatial_grid.build(positions, half_sizes, margin)
+        pairs = sorted(spatial_grid.potential_pairs())
+    else:
+        pairs = [(i, j) for i in range(n) for j in range(i + 1, n)]
+
+    for i, j in pairs:
+        if sides[i] != sides[j]:
+            continue
+
+        dx = abs(positions[j, 0] - positions[i, 0])
+        dy = abs(positions[j, 1] - positions[i, 1])
+
+        combined_hw = half_sizes[i, 0] + half_sizes[j, 0] + margin
+        combined_hh = half_sizes[i, 1] + half_sizes[j, 1] + margin
+
+        if (combined_hw - dx) > 0 and (combined_hh - dy) > 0:
+            count += 1
+
+    return count

--- a/tests/test_placement_slide_off.py
+++ b/tests/test_placement_slide_off.py
@@ -1,0 +1,808 @@
+"""Tests for the slide-off overlap resolution module.
+
+Covers unit tests, integration with MCP tools, edge cases, and performance
+requirements from issue #1243 acceptance criteria.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+
+import numpy as np
+import pytest
+
+from kicad_tools.placement.cost import BoardOutline
+from kicad_tools.placement.slide_off import (
+    SlideOffResult,
+    slide_off_overlaps,
+)
+from kicad_tools.placement.vector import (
+    FIELDS_PER_COMPONENT,
+    ComponentDef,
+    PlacementVector,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_board(width: float = 100.0, height: float = 100.0) -> BoardOutline:
+    """Create a board outline centred at the origin."""
+    return BoardOutline(
+        min_x=-width / 2,
+        min_y=-height / 2,
+        max_x=width / 2,
+        max_y=height / 2,
+    )
+
+
+def _make_components(n: int, size: float = 2.0) -> list[ComponentDef]:
+    """Create *n* identical square components."""
+    return [ComponentDef(reference=f"U{i + 1}", width=size, height=size) for i in range(n)]
+
+
+def _make_vector_at_same_position(
+    n: int,
+    x: float = 0.0,
+    y: float = 0.0,
+    side: int = 0,
+) -> PlacementVector:
+    """Create a vector with all components at the same position."""
+    data = np.zeros(n * FIELDS_PER_COMPONENT, dtype=np.float64)
+    for i in range(n):
+        base = i * FIELDS_PER_COMPONENT
+        data[base] = x
+        data[base + 1] = y
+        data[base + 2] = 0.0  # rotation
+        data[base + 3] = float(side)
+    return PlacementVector(data=data)
+
+
+def _make_vector_spread(
+    n: int,
+    spacing: float = 20.0,
+    side: int = 0,
+) -> PlacementVector:
+    """Create a vector with components spread apart (no overlaps)."""
+    data = np.zeros(n * FIELDS_PER_COMPONENT, dtype=np.float64)
+    for i in range(n):
+        base = i * FIELDS_PER_COMPONENT
+        data[base] = -((n - 1) * spacing / 2) + i * spacing
+        data[base + 1] = 0.0
+        data[base + 2] = 0.0
+        data[base + 3] = float(side)
+    return PlacementVector(data=data)
+
+
+def _count_overlaps_manual(
+    vector: PlacementVector,
+    components: list[ComponentDef],
+    margin: float = 0.5,
+) -> int:
+    """Count overlapping pairs by brute force."""
+    n = len(components)
+    count = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            base_i = i * FIELDS_PER_COMPONENT
+            base_j = j * FIELDS_PER_COMPONENT
+            side_i = int(round(vector.data[base_i + 3]))
+            side_j = int(round(vector.data[base_j + 3]))
+            if side_i != side_j:
+                continue
+
+            rot_i = int(round(vector.data[base_i + 2])) % 4
+            rot_j = int(round(vector.data[base_j + 2])) % 4
+
+            if rot_i in (1, 3):
+                hw_i = components[i].height / 2.0
+                hh_i = components[i].width / 2.0
+            else:
+                hw_i = components[i].width / 2.0
+                hh_i = components[i].height / 2.0
+
+            if rot_j in (1, 3):
+                hw_j = components[j].height / 2.0
+                hh_j = components[j].width / 2.0
+            else:
+                hw_j = components[j].width / 2.0
+                hh_j = components[j].height / 2.0
+
+            dx = abs(vector.data[base_j] - vector.data[base_i])
+            dy = abs(vector.data[base_j + 1] - vector.data[base_i + 1])
+
+            combined_hw = hw_i + hw_j + margin
+            combined_hh = hh_i + hh_j + margin
+
+            if (combined_hw - dx) > 0 and (combined_hh - dy) > 0:
+                count += 1
+    return count
+
+
+def _within_board(
+    vector: PlacementVector,
+    components: list[ComponentDef],
+    board: BoardOutline,
+) -> bool:
+    """Check that all component AABBs are within the board."""
+    n = len(components)
+    for i in range(n):
+        base = i * FIELDS_PER_COMPONENT
+        x = vector.data[base]
+        y = vector.data[base + 1]
+        rot_idx = int(round(vector.data[base + 2])) % 4
+
+        if rot_idx in (1, 3):
+            hw = components[i].height / 2.0
+            hh = components[i].width / 2.0
+        else:
+            hw = components[i].width / 2.0
+            hh = components[i].height / 2.0
+
+        if x - hw < board.min_x - 1e-6:
+            return False
+        if x + hw > board.max_x + 1e-6:
+            return False
+        if y - hh < board.min_y - 1e-6:
+            return False
+        if y + hh > board.max_y + 1e-6:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: zero overlaps after slide-off
+# ---------------------------------------------------------------------------
+
+
+class TestSlideOffBasic:
+    """Tests that slide-off resolves overlaps on typical configurations."""
+
+    def test_10_components_at_same_position(self):
+        """10 components at origin on a 100x100 board -> zero overlaps.
+
+        This is a degenerate case (all coincident) that requires more
+        iterations than the default.  The algorithm resolves it within
+        50 iterations on a board large enough to fit all components.
+        """
+        board = _make_board(100.0, 100.0)
+        components = _make_components(10, size=2.0)
+        vector = _make_vector_at_same_position(10)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+            max_iterations=50,
+        )
+
+        assert result.overlaps_remaining == 0
+        assert result.overlaps_resolved > 0
+        assert result.iterations_run <= 50
+
+    def test_two_overlapping_components(self):
+        """Two components slightly overlapping get separated."""
+        board = _make_board(100.0, 100.0)
+        components = _make_components(2, size=4.0)
+
+        data = np.zeros(2 * FIELDS_PER_COMPONENT, dtype=np.float64)
+        # Place them 1mm apart (overlap: combined half-widths = 4, dx = 1)
+        data[0] = -0.5
+        data[1] = 0.0
+        data[4] = 0.5
+        data[5] = 0.0
+        vector = PlacementVector(data=data)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+        )
+
+        assert result.overlaps_remaining == 0
+
+    def test_empty_components(self):
+        """Zero components: no-op."""
+        board = _make_board()
+        components: list[ComponentDef] = []
+        vector = PlacementVector(data=np.empty(0, dtype=np.float64))
+
+        new_vector, result = slide_off_overlaps(vector, components, board)
+
+        assert result.iterations_run == 0
+        assert result.overlaps_resolved == 0
+        assert result.overlaps_remaining == 0
+        assert result.max_displacement_applied == 0.0
+
+    def test_single_component(self):
+        """Single component: no pairs to check."""
+        board = _make_board()
+        components = _make_components(1)
+        vector = _make_vector_at_same_position(1)
+
+        new_vector, result = slide_off_overlaps(vector, components, board)
+
+        assert result.iterations_run == 0
+        assert result.overlaps_resolved == 0
+        assert result.overlaps_remaining == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: displacement cap
+# ---------------------------------------------------------------------------
+
+
+class TestDisplacementCap:
+    """Verify that per-component displacement is capped."""
+
+    def test_displacement_capped_at_1mm(self):
+        """With max_displacement_mm=1.0, no component moves more than 1mm.
+
+        A small tolerance (0.02 mm) accounts for the pre-jitter that
+        separates coincident components before the main loop.
+        """
+        board = _make_board(100.0, 100.0)
+        components = _make_components(5, size=3.0)
+        vector = _make_vector_at_same_position(5)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+            max_iterations=10,
+            max_displacement_mm=1.0,
+        )
+
+        # Allow tolerance for pre-jitter offset (up to _JITTER_RADIUS = 0.01mm)
+        jitter_tolerance = 0.02
+        for i in range(5):
+            base = i * FIELDS_PER_COMPONENT
+            dx = new_vector.data[base] - vector.data[base]
+            dy = new_vector.data[base + 1] - vector.data[base + 1]
+            disp = math.sqrt(dx * dx + dy * dy)
+            assert disp <= 1.0 + jitter_tolerance, (
+                f"Component {i} moved {disp:.4f}mm, exceeds cap of 1.0mm"
+            )
+
+    def test_max_displacement_reported_correctly(self):
+        """SlideOffResult.max_displacement_applied tracks displacement.
+
+        The result reports displacement from the post-jitter initial
+        position, while the test measures from the original vector.
+        We verify they are within the jitter tolerance (0.02 mm).
+        """
+        board = _make_board(100.0, 100.0)
+        components = _make_components(3, size=5.0)
+        # Use non-coincident positions to avoid jitter offset
+        data = np.zeros(3 * FIELDS_PER_COMPONENT, dtype=np.float64)
+        data[0] = -1.0  # U1 x
+        data[4] = 0.0  # U2 x
+        data[8] = 1.0  # U3 x
+        vector = PlacementVector(data=data)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.0,
+            max_iterations=10,
+            max_displacement_mm=20.0,
+        )
+
+        max_disp = 0.0
+        for i in range(3):
+            base = i * FIELDS_PER_COMPONENT
+            dx = new_vector.data[base] - vector.data[base]
+            dy = new_vector.data[base + 1] - vector.data[base + 1]
+            disp = math.sqrt(dx * dx + dy * dy)
+            max_disp = max(max_disp, disp)
+
+        assert abs(result.max_displacement_applied - max_disp) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: board containment
+# ---------------------------------------------------------------------------
+
+
+class TestBoardContainment:
+    """All component AABBs remain within the board after slide-off."""
+
+    def test_components_stay_in_board(self):
+        """After slide-off, all AABBs are within the board bounds."""
+        board = _make_board(50.0, 50.0)
+        components = _make_components(8, size=3.0)
+        vector = _make_vector_at_same_position(8)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+            max_iterations=10,
+        )
+
+        assert _within_board(new_vector, components, board)
+
+    def test_component_wider_than_board(self):
+        """A component wider than the board is centred."""
+        board = _make_board(5.0, 5.0)
+        components = [ComponentDef(reference="U1", width=10.0, height=2.0)]
+        data = np.zeros(FIELDS_PER_COMPONENT, dtype=np.float64)
+        vector = PlacementVector(data=data)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+        )
+
+        # Component centre should be at board centre
+        assert abs(new_vector.data[0] - 0.0) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: side isolation
+# ---------------------------------------------------------------------------
+
+
+class TestSideIsolation:
+    """Components on opposite sides are not pushed apart."""
+
+    def test_opposite_sides_not_affected(self):
+        """Components on front (0) and back (1) at the same position stay put."""
+        board = _make_board(100.0, 100.0)
+        components = _make_components(2, size=4.0)
+
+        data = np.zeros(2 * FIELDS_PER_COMPONENT, dtype=np.float64)
+        # Component 0: front side at origin
+        data[0] = 0.0
+        data[1] = 0.0
+        data[2] = 0.0
+        data[3] = 0.0
+        # Component 1: back side at origin
+        data[4] = 0.0
+        data[5] = 0.0
+        data[6] = 0.0
+        data[7] = 1.0
+        vector = PlacementVector(data=data)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+        )
+
+        # Neither component should have moved
+        assert result.overlaps_resolved == 0
+        assert result.overlaps_remaining == 0
+        assert abs(new_vector.data[0] - 0.0) < 1e-6
+        assert abs(new_vector.data[4] - 0.0) < 1e-6
+
+    def test_same_side_pushed_apart(self):
+        """Two components on the same side at the same position get pushed."""
+        board = _make_board(100.0, 100.0)
+        components = _make_components(2, size=4.0)
+
+        data = np.zeros(2 * FIELDS_PER_COMPONENT, dtype=np.float64)
+        data[0] = 0.0
+        data[1] = 0.0
+        data[3] = 0.0  # front
+        data[4] = 0.0
+        data[5] = 0.0
+        data[7] = 0.0  # front
+        vector = PlacementVector(data=data)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+        )
+
+        assert result.overlaps_resolved > 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: deterministic on coincident components
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministic:
+    """Coincident components produce deterministic, finite positions."""
+
+    def test_same_position_no_nan(self):
+        """Two components at identical (x, y) produce finite positions."""
+        board = _make_board(100.0, 100.0)
+        components = _make_components(2, size=4.0)
+        vector = _make_vector_at_same_position(2)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+        )
+
+        assert np.all(np.isfinite(new_vector.data))
+        # They should have separated
+        dx = abs(new_vector.data[0] - new_vector.data[4])
+        dy = abs(new_vector.data[1] - new_vector.data[5])
+        assert dx > 0 or dy > 0
+
+    def test_deterministic_repeated_calls(self):
+        """Repeated calls with same input produce same output."""
+        board = _make_board(100.0, 100.0)
+        components = _make_components(5, size=3.0)
+        vector = _make_vector_at_same_position(5)
+
+        result1_vec, result1 = slide_off_overlaps(vector, components, board)
+        result2_vec, result2 = slide_off_overlaps(vector, components, board)
+
+        np.testing.assert_array_equal(result1_vec.data, result2_vec.data)
+        assert result1 == result2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: idempotent on clean placement
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotent:
+    """A placement with no overlaps is unchanged by slide-off."""
+
+    def test_no_overlaps_unchanged(self):
+        """Components spread far apart are not moved."""
+        board = _make_board(200.0, 200.0)
+        components = _make_components(5, size=2.0)
+        vector = _make_vector_spread(5, spacing=20.0)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+        )
+
+        assert result.overlaps_resolved == 0
+        assert result.overlaps_remaining == 0
+        np.testing.assert_allclose(new_vector.data, vector.data, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: SlideOffResult fields
+# ---------------------------------------------------------------------------
+
+
+class TestSlideOffResult:
+    """Verify result dataclass fields are populated correctly."""
+
+    def test_iterations_within_limit(self):
+        """iterations_run never exceeds max_iterations."""
+        board = _make_board(100.0, 100.0)
+        components = _make_components(10, size=2.0)
+        vector = _make_vector_at_same_position(10)
+
+        _, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            max_iterations=3,
+        )
+
+        assert result.iterations_run <= 3
+        assert result.iterations_run >= 1
+
+    def test_overlaps_non_negative(self):
+        """overlaps_resolved and overlaps_remaining are non-negative."""
+        board = _make_board(100.0, 100.0)
+        components = _make_components(5, size=2.0)
+        vector = _make_vector_at_same_position(5)
+
+        _, result = slide_off_overlaps(vector, components, board)
+
+        assert result.overlaps_resolved >= 0
+        assert result.overlaps_remaining >= 0
+
+    def test_result_is_frozen_dataclass(self):
+        """SlideOffResult is immutable."""
+        result = SlideOffResult(
+            iterations_run=3,
+            overlaps_resolved=10,
+            overlaps_remaining=0,
+            max_displacement_applied=5.0,
+        )
+        with pytest.raises(AttributeError):
+            result.iterations_run = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: spatial index
+# ---------------------------------------------------------------------------
+
+
+class TestSpatialIndex:
+    """Verify the grid-based spatial index correctness."""
+
+    def test_spatial_index_gives_same_result(self):
+        """Spatial index produces the same resolved count as brute force.
+
+        Uses a large enough iteration limit and board so both methods
+        can fully resolve all overlaps, despite potentially different
+        pair processing order.
+        """
+        board = _make_board(200.0, 200.0)
+        components = _make_components(10, size=3.0)
+        vector = _make_vector_at_same_position(10)
+
+        vec_brute, res_brute = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            use_spatial_index=False,
+            max_iterations=100,
+        )
+        vec_grid, res_grid = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            use_spatial_index=True,
+            max_iterations=100,
+        )
+
+        # Both should resolve all overlaps (final states may differ
+        # due to iteration order, but overlap count should match)
+        assert res_brute.overlaps_remaining == 0
+        assert res_grid.overlaps_remaining == 0
+
+    def test_auto_enable_spatial_index(self):
+        """use_spatial_index=None enables automatically for > 50 components."""
+        board = _make_board(500.0, 500.0)
+        # Create 55 components
+        components = _make_components(55, size=2.0)
+        vector = _make_vector_at_same_position(55)
+
+        # Should not raise and should use spatial index internally
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            use_spatial_index=None,
+        )
+
+        assert np.all(np.isfinite(new_vector.data))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: margin parameter
+# ---------------------------------------------------------------------------
+
+
+class TestMargin:
+    """Verify the margin parameter enforces extra clearance."""
+
+    def test_zero_margin_allows_touching(self):
+        """With margin=0, components can touch but not overlap."""
+        board = _make_board(100.0, 100.0)
+        components = _make_components(2, size=4.0)
+
+        # Place components touching: distance = exactly combined half-widths
+        data = np.zeros(2 * FIELDS_PER_COMPONENT, dtype=np.float64)
+        data[0] = -2.0  # left edge at -4, right edge at 0
+        data[4] = 2.0  # left edge at 0, right edge at 4
+        vector = PlacementVector(data=data)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.0,
+        )
+
+        # They are touching but not overlapping with margin=0
+        assert result.overlaps_remaining == 0
+
+    def test_positive_margin_separates_touching(self):
+        """With margin > 0, touching components get pushed apart."""
+        board = _make_board(100.0, 100.0)
+        components = _make_components(2, size=4.0)
+
+        # Place components touching: distance = exactly combined half-widths
+        data = np.zeros(2 * FIELDS_PER_COMPONENT, dtype=np.float64)
+        data[0] = -2.0
+        data[4] = 2.0
+        vector = PlacementVector(data=data)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=1.0,
+        )
+
+        # With margin=1.0, the touching pair should now have been pushed apart
+        dx = abs(new_vector.data[4] - new_vector.data[0])
+        # Expected minimum separation: 4.0 (combined widths) + 1.0 (margin)
+        assert dx >= 4.0 + 1.0 - 0.1  # slight tolerance
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: rotation awareness
+# ---------------------------------------------------------------------------
+
+
+class TestRotation:
+    """Verify rotation is accounted for in AABB computation."""
+
+    def test_rotated_components_use_swapped_dimensions(self):
+        """A 10x2 component rotated 90 degrees uses 2x10 AABB."""
+        board = _make_board(100.0, 100.0)
+        components = [
+            ComponentDef(reference="U1", width=10.0, height=2.0),
+            ComponentDef(reference="U2", width=10.0, height=2.0),
+        ]
+
+        data = np.zeros(2 * FIELDS_PER_COMPONENT, dtype=np.float64)
+        # U1 at origin, rotated 90 degrees (rot_idx = 1)
+        data[0] = 0.0
+        data[1] = 0.0
+        data[2] = 1.0  # 90 degrees
+        # U2 at (3, 0), no rotation -- should overlap in Y
+        data[4] = 3.0
+        data[5] = 0.0
+        data[6] = 0.0
+        vector = PlacementVector(data=data)
+
+        # U1 rotated: half_w = 2/2=1.0, half_h = 10/2=5.0
+        # U2 unrotated: half_w = 10/2=5.0, half_h = 2/2=1.0
+        # X overlap: (1.0 + 5.0 + 0.5) - 3.0 = 3.5 > 0
+        # Y overlap: (5.0 + 1.0 + 0.5) - 0.0 = 6.5 > 0
+        # These overlap with default margin
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+        )
+
+        assert result.overlaps_resolved > 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    """Input validation."""
+
+    def test_mismatched_lengths_raises(self):
+        """Mismatched vector and component_defs raises ValueError."""
+        board = _make_board()
+        components = _make_components(3)
+        data = np.zeros(2 * FIELDS_PER_COMPONENT, dtype=np.float64)
+        vector = PlacementVector(data=data)
+
+        with pytest.raises(ValueError, match="component definitions"):
+            slide_off_overlaps(vector, components, board)
+
+
+# ---------------------------------------------------------------------------
+# Performance tests
+# ---------------------------------------------------------------------------
+
+
+class TestPerformance:
+    """Verify slide-off completes within time budgets."""
+
+    def test_20_components_under_100ms(self):
+        """20 components complete in < 100ms."""
+        board = _make_board(100.0, 100.0)
+        components = _make_components(20, size=3.0)
+        vector = _make_vector_at_same_position(20)
+
+        start = time.perf_counter()
+        slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+            max_iterations=5,
+        )
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 0.1, f"Took {elapsed:.3f}s, expected < 0.1s"
+
+    def test_100_components_with_spatial_index_under_500ms(self):
+        """100 components with spatial index complete in < 500ms."""
+        board = _make_board(200.0, 200.0)
+        components = _make_components(100, size=2.0)
+        vector = _make_vector_at_same_position(100)
+
+        start = time.perf_counter()
+        slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+            max_iterations=5,
+            use_spatial_index=True,
+        )
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 0.5, f"Took {elapsed:.3f}s, expected < 0.5s"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Unusual configurations."""
+
+    def test_very_tight_board(self):
+        """Board barely fits all components; overlaps may persist."""
+        board = _make_board(10.0, 10.0)
+        components = _make_components(10, size=3.0)
+        vector = _make_vector_at_same_position(10)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+            max_iterations=20,
+        )
+
+        # May not resolve all, but should not crash and should respect bounds
+        assert np.all(np.isfinite(new_vector.data))
+        assert result.iterations_run > 0
+
+    def test_all_components_different_sides(self):
+        """All components on alternating sides: fewer same-side overlaps."""
+        board = _make_board(100.0, 100.0)
+        n = 6
+        components = _make_components(n, size=4.0)
+
+        data = np.zeros(n * FIELDS_PER_COMPONENT, dtype=np.float64)
+        for i in range(n):
+            base = i * FIELDS_PER_COMPONENT
+            data[base] = 0.0
+            data[base + 1] = 0.0
+            data[base + 3] = float(i % 2)  # alternating sides
+        vector = PlacementVector(data=data)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=0.5,
+        )
+
+        # With alternating sides, fewer pairs overlap
+        assert np.all(np.isfinite(new_vector.data))
+
+    def test_large_margin_small_board(self):
+        """Large margin on small board: may not resolve all overlaps."""
+        board = _make_board(20.0, 20.0)
+        components = _make_components(4, size=3.0)
+        vector = _make_vector_at_same_position(4)
+
+        new_vector, result = slide_off_overlaps(
+            vector,
+            components,
+            board,
+            margin_mm=5.0,  # large margin
+            max_iterations=10,
+        )
+
+        # Should not crash, components should be within board
+        assert np.all(np.isfinite(new_vector.data))


### PR DESCRIPTION
## Summary

Add a self-contained, configurable iterative settling pass that resolves component placement overlaps by sliding overlapping bounding boxes apart. This fills the gap between the embedded push-apart logic in `seed.py` and the need for a standalone, reusable overlap resolver with configurable margin, displacement cap, and board containment.

## Changes

- **New `src/kicad_tools/placement/slide_off.py`**: Core `slide_off_overlaps()` function and `SlideOffResult` dataclass with:
  - Configurable clearance margin (`margin_mm`), max iterations, and per-component displacement cap
  - Board containment re-clamping after each iteration
  - Front/back side isolation (components on opposite sides not pushed apart)
  - Deterministic pre-jitter for coincident components to ensure 2D spreading
  - Optional grid-based spatial index (auto-enabled for >50 components)
  - Negligible-axis detection to prevent convergence stalls on near-touching pairs
- **MCP `optimize_placement` tool**: Added `pre_slide_off` parameter (default: `true`) that runs slide-off on the seed before optimization
- **New MCP `resolve_placement_overlaps` tool**: Standalone tool accepting `pcb_path`, `output_path`, `margin_mm`, `max_iterations`, `max_displacement_mm`
- **CLI `optimize-placement`**: Added `--no-slide-off` flag to disable pre-processing
- **`src/kicad_tools/placement/__init__.py`**: Exports `slide_off_overlaps` and `SlideOffResult`
- **New `tests/test_placement_slide_off.py`**: 27 tests covering unit, edge case, and performance scenarios

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `slide_off_overlaps()` in `slide_off.py` | Done | New module with full API |
| `SlideOffResult` with required fields | Done | Frozen dataclass with `iterations_run`, `overlaps_resolved`, `overlaps_remaining`, `max_displacement_applied` |
| 10-component overlap resolution | Done | Test `test_10_components_at_same_position` passes (50 iterations for degenerate case) |
| Per-component displacement cap | Done | Test `test_displacement_capped_at_1mm` verifies cap enforcement |
| Board containment | Done | Test `test_components_stay_in_board` verifies all AABBs within bounds |
| Front/back side isolation | Done | Test `test_opposite_sides_not_affected` verifies no push across sides |
| Deterministic on coincident components | Done | Test `test_same_position_no_nan` and `test_deterministic_repeated_calls` verify finite, reproducible results |
| MCP `optimize_placement` pre-processing | Done | `pre_slide_off=True` parameter wired in |
| New `resolve_placement_overlaps` MCP tool | Done | Registered in tool registry with full parameter schema |
| CLI `--no-slide-off` flag | Done | Added to parser and wired through to `run_optimize_placement` |
| Grid-based spatial index | Done | `_SpatialGrid` class, auto-enabled for N>50, tested in `test_auto_enable_spatial_index` |

## Test Plan

27 tests passing covering:
- Zero overlaps after slide-off (basic, two-component, 10-component)
- Displacement cap enforcement and reporting
- Board containment after resolution
- Side isolation (front vs back)
- Deterministic behavior on coincident components
- Idempotence on clean placements
- SlideOffResult field validation
- Spatial index correctness and auto-enable
- Margin parameter behavior
- Rotation awareness
- Input validation
- Performance: 20 components < 100ms, 100 components with spatial index < 500ms
- Edge cases: tight board, alternating sides, large margin

Closes #1243