### PR TITLE
feat(router): add crossing-aware A* pathfinding for route quality

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -480,9 +480,16 @@ class Autorouter:
 
         This is the unified method that should be used instead of calling
         self.grid.mark_route() directly, to ensure grid synchronization.
+
+        Issue #1250: Also feeds committed segments to the pathfinder for
+        crossing-aware cost computation in subsequent A* searches.
         """
         self.grid.mark_route(route)
         self._mark_route_on_cpp_grid(route)
+
+        # Issue #1250: Feed committed segments to pathfinder for crossing detection
+        if hasattr(self.router, "add_routed_segments"):
+            self.router.add_routed_segments(route.segments)
 
     @property
     def physics_available(self) -> bool:

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -172,6 +172,108 @@ class Router:
         self._via_impact_enabled: bool = False
         self._init_via_impact_scoring()
 
+        # Issue #1250: Crossing-aware routing
+        # Stores previously routed segments for crossing detection.
+        # Each entry is (x1, y1, x2, y2, layer_index, net_id) in grid coordinates.
+        self._routed_segments: list[tuple[int, int, int, int, int, int]] = []
+
+    def add_routed_segments(self, segments: list[Segment]) -> None:
+        """Add committed route segments for crossing detection.
+
+        Issue #1250: Called after each route is committed so that subsequent
+        A* searches can penalize edges that cross these segments.
+
+        Args:
+            segments: List of Segment objects from a committed route.
+        """
+        for seg in segments:
+            gx1, gy1 = self.grid.world_to_grid(seg.x1, seg.y1)
+            gx2, gy2 = self.grid.world_to_grid(seg.x2, seg.y2)
+            layer_idx = self.grid.layer_to_index(seg.layer.value)
+            self._routed_segments.append((gx1, gy1, gx2, gy2, layer_idx, seg.net))
+
+    def clear_routed_segments(self) -> None:
+        """Clear the routed segments list.
+
+        Call this when starting a fresh routing session or when all routes
+        have been removed.
+        """
+        self._routed_segments.clear()
+
+    @staticmethod
+    def _segments_intersect(
+        ax1: int,
+        ay1: int,
+        ax2: int,
+        ay2: int,
+        bx1: int,
+        by1: int,
+        bx2: int,
+        by2: int,
+    ) -> bool:
+        """Test whether two line segments intersect using cross-product sign changes.
+
+        Uses the standard computational geometry approach: two segments intersect
+        if and only if each segment straddles the line containing the other.
+
+        Args:
+            ax1, ay1, ax2, ay2: Endpoints of segment A (grid coords).
+            bx1, by1, bx2, by2: Endpoints of segment B (grid coords).
+
+        Returns:
+            True if the segments properly intersect (share an interior point).
+            Shared endpoints are NOT counted as intersections.
+        """
+
+        def cross(ox: int, oy: int, px: int, py: int, qx: int, qy: int) -> int:
+            """Sign of cross product (OP x OQ)."""
+            return (px - ox) * (qy - oy) - (py - oy) * (qx - ox)
+
+        d1 = cross(bx1, by1, bx2, by2, ax1, ay1)
+        d2 = cross(bx1, by1, bx2, by2, ax2, ay2)
+        d3 = cross(ax1, ay1, ax2, ay2, bx1, by1)
+        d4 = cross(ax1, ay1, ax2, ay2, bx2, by2)
+
+        # Proper intersection: each segment straddles the line of the other
+        if ((d1 > 0 and d2 < 0) or (d1 < 0 and d2 > 0)) and (
+            (d3 > 0 and d4 < 0) or (d3 < 0 and d4 > 0)
+        ):
+            return True
+
+        # Collinear / endpoint touching are NOT counted as crossings
+        return False
+
+    def _count_edge_crossings(
+        self,
+        cx: int,
+        cy: int,
+        nx: int,
+        ny: int,
+        nlayer: int,
+        current_net: int,
+    ) -> int:
+        """Count how many routed segments the candidate edge crosses.
+
+        Only counts crossings on the same layer with a different net.
+
+        Args:
+            cx, cy: Current node grid coordinates (edge start).
+            nx, ny: Neighbor node grid coordinates (edge end).
+            nlayer: Layer index of the candidate edge.
+            current_net: Net ID of the route being searched.
+
+        Returns:
+            Number of crossing segments.
+        """
+        count = 0
+        for sx1, sy1, sx2, sy2, seg_layer, seg_net in self._routed_segments:
+            # Only same layer, different net
+            if seg_layer != nlayer or seg_net == current_net:
+                continue
+            if self._segments_intersect(cx, cy, nx, ny, sx1, sy1, sx2, sy2):
+                count += 1
+        return count
+
     def _init_via_impact_scoring(self) -> None:
         """Initialize via impact scoring based on design rules.
 
@@ -1244,6 +1346,14 @@ class Router:
                 # Add layer preference cost (Issue #625)
                 layer_pref_mult = self._get_layer_preference_cost(nlayer, net_class)
 
+                # Issue #1250: Crossing penalty for edges crossing routed segments
+                crossing_cost = 0.0
+                if self.rules.crossing_penalty > 0.0 and self._routed_segments:
+                    num_crossings = self._count_edge_crossings(
+                        current.x, current.y, nx, ny, nlayer, start.net
+                    )
+                    crossing_cost = self.rules.crossing_penalty * num_crossings
+
                 new_g = (
                     current.g_score
                     + neighbor_cost_mult * self.rules.cost_straight * layer_pref_mult
@@ -1251,6 +1361,7 @@ class Router:
                     + congestion_cost
                     + negotiated_cost
                     + zone_cost
+                    + crossing_cost
                 ) * cost_mult
 
                 if neighbor_key not in g_scores or new_g < g_scores[neighbor_key]:
@@ -2025,6 +2136,14 @@ class Router:
             net_class = self._get_net_class(source_pad.net_name)
             layer_pref_mult = self._get_layer_preference_cost(nlayer, net_class)
 
+            # Issue #1250: Crossing penalty for edges crossing routed segments
+            crossing_cost = 0.0
+            if self.rules.crossing_penalty > 0.0 and self._routed_segments:
+                num_crossings = self._count_edge_crossings(
+                    current.x, current.y, nx, ny, nlayer, source_pad.net
+                )
+                crossing_cost = self.rules.crossing_penalty * num_crossings
+
             new_g = (
                 current.g_score
                 + neighbor_cost_mult * self.rules.cost_straight * layer_pref_mult
@@ -2032,6 +2151,7 @@ class Router:
                 + congestion_cost
                 + negotiated_cost
                 + zone_cost
+                + crossing_cost
             ) * cost_mult
 
             if neighbor_key not in g_scores or new_g < g_scores[neighbor_key]:

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -92,6 +92,12 @@ class DesignRules:
     congestion_threshold: float = 0.3  # Density above which region is congested
     congestion_grid_size: int = 10  # Cells per congestion region
 
+    # Crossing-aware routing (Issue #1250)
+    # Penalizes candidate edges that cross already-routed segments on the same layer.
+    # This steers A* toward non-crossing paths while still permitting crossings when
+    # no alternative exists. Default 0.0 disables the feature for backward compatibility.
+    crossing_penalty: float = 0.0  # Additive cost per crossing with a routed segment
+
     # Zone-specific rules
     zone_rules: ZoneRules = field(default_factory=ZoneRules)
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -280,6 +280,16 @@ class TestDesignRules:
         assert rules.cost_turn == 5.0
         assert rules.cost_via == 10.0
 
+    def test_crossing_penalty_default(self):
+        """Test that crossing_penalty defaults to 0.0 for backward compatibility."""
+        rules = DesignRules()
+        assert rules.crossing_penalty == 0.0
+
+    def test_crossing_penalty_custom(self):
+        """Test setting a custom crossing_penalty value."""
+        rules = DesignRules(crossing_penalty=5.0)
+        assert rules.crossing_penalty == 5.0
+
 
 class TestNetClassRouting:
     """Tests for NetClassRouting class."""
@@ -4599,14 +4609,14 @@ class TestInsertSexpBeforeClosing:
     def test_removes_only_last_closing_paren(self):
         """Verify only the last ')' is removed, not all trailing ones."""
         # This PCB has nested structure with ')' at end of inner elements
-        pcb_content = "(kicad_pcb\n  (version 20240108)\n  (net 1 \"VCC\")\n)"
+        pcb_content = '(kicad_pcb\n  (version 20240108)\n  (net 1 "VCC")\n)'
         route_sexp = "(segment (start 0 0) (end 10 10) (width 0.2))"
 
         result = _insert_sexp_before_closing(pcb_content, route_sexp)
 
         # Should still contain the inner closing parens
         assert "(version 20240108)" in result
-        assert "(net 1 \"VCC\")" in result
+        assert '(net 1 "VCC")' in result
         assert "(segment" in result
         assert result.strip().endswith(")")
 
@@ -4626,8 +4636,8 @@ class TestInsertSexpBeforeClosing:
 
     def test_balanced_parentheses_in_result(self):
         """The critical test: output must have balanced parentheses."""
-        pcb_content = "(kicad_pcb\n  (version 20240108)\n  (generator \"test\")\n)"
-        route_sexp = "(segment (start 1 2) (end 3 4) (width 0.25) (layer \"F.Cu\") (net 1))"
+        pcb_content = '(kicad_pcb\n  (version 20240108)\n  (generator "test")\n)'
+        route_sexp = '(segment (start 1 2) (end 3 4) (width 0.25) (layer "F.Cu") (net 1))'
 
         result = _insert_sexp_before_closing(pcb_content, route_sexp)
 
@@ -4651,13 +4661,15 @@ class TestInsertSexpBeforeClosing:
         S-expression structure.
         """
         # PCB content that ends with nested closing parens
-        pcb_content = "(kicad_pcb\n  (footprint \"R0603\"\n    (pad 1 smd rect (at 0 0) (size 0.6 0.5))\n  )\n)"
+        pcb_content = (
+            '(kicad_pcb\n  (footprint "R0603"\n    (pad 1 smd rect (at 0 0) (size 0.6 0.5))\n  )\n)'
+        )
         route_sexp = "(segment (start 0 0) (end 10 10) (width 0.2))"
 
         result = _insert_sexp_before_closing(pcb_content, route_sexp)
 
         # The footprint block must remain intact
-        assert "(footprint \"R0603\"" in result
+        assert '(footprint "R0603"' in result
         assert "(pad 1 smd rect" in result
         # Parentheses must be balanced
         assert _validate_sexp_parentheses(result)
@@ -4681,7 +4693,7 @@ class TestValidateSexpParentheses:
         assert _validate_sexp_parentheses("(kicad_pcb)")
 
     def test_balanced_nested(self):
-        assert _validate_sexp_parentheses("(kicad_pcb (version 1) (net 1 \"VCC\"))")
+        assert _validate_sexp_parentheses('(kicad_pcb (version 1) (net 1 "VCC"))')
 
     def test_balanced_with_strings(self):
         """Parentheses inside quoted strings should be ignored."""

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -2100,3 +2100,291 @@ class TestAutorouterOffGridPads:
             "Bidirectional A* should succeed with sub-grid pad connections (Issue #996)"
         )
         assert len(route.segments) > 0, "Route should have segments"
+
+
+class TestCrossingPenalty:
+    """Tests for crossing-aware A* pathfinding (Issue #1250)."""
+
+    def test_segments_intersect_crossing(self):
+        """Test that intersecting segments are detected."""
+        from kicad_tools.router.pathfinder import Router
+
+        # X-shaped crossing
+        assert Router._segments_intersect(0, 0, 10, 10, 0, 10, 10, 0) is True
+
+    def test_segments_intersect_parallel(self):
+        """Test that parallel segments are not detected as crossing."""
+        from kicad_tools.router.pathfinder import Router
+
+        # Parallel horizontal segments
+        assert Router._segments_intersect(0, 0, 10, 0, 0, 5, 10, 5) is False
+
+    def test_segments_intersect_shared_endpoint(self):
+        """Test that segments sharing an endpoint do not count as crossing."""
+        from kicad_tools.router.pathfinder import Router
+
+        # T-junction: share endpoint at (5,5)
+        assert Router._segments_intersect(0, 5, 5, 5, 5, 0, 5, 10) is False
+
+    def test_segments_intersect_non_overlapping(self):
+        """Test that non-overlapping segments are not detected."""
+        from kicad_tools.router.pathfinder import Router
+
+        # Segments in different quadrants
+        assert Router._segments_intersect(0, 0, 1, 1, 5, 5, 6, 6) is False
+
+    def test_add_and_clear_routed_segments(self):
+        """Test add_routed_segments and clear_routed_segments API on Router."""
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.pathfinder import Router
+
+        rules = DesignRules(crossing_penalty=5.0, grid_resolution=0.5)
+        grid = RoutingGrid(20.0, 20.0, rules)
+        router = Router(grid, rules)
+
+        assert len(router._routed_segments) == 0
+
+        seg = Segment(x1=2.0, y1=2.0, x2=8.0, y2=2.0, width=0.2, layer=Layer.F_CU, net=1)
+        router.add_routed_segments([seg])
+        assert len(router._routed_segments) == 1
+
+        router.clear_routed_segments()
+        assert len(router._routed_segments) == 0
+
+    def test_count_edge_crossings_same_layer_different_net(self):
+        """Test that crossings are counted for same-layer, different-net segments."""
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.pathfinder import Router
+
+        rules = DesignRules(crossing_penalty=5.0, grid_resolution=0.5)
+        grid = RoutingGrid(20.0, 20.0, rules)
+        router = Router(grid, rules)
+
+        # Add a horizontal routed segment on layer 0, net 1, from (5,10) to (15,10)
+        # in grid coords
+        router._routed_segments.append((5, 10, 15, 10, 0, 1))
+
+        # Vertical edge from (10,5) to (10,15) on layer 0 for net 2 should cross it
+        count = router._count_edge_crossings(10, 5, 10, 15, 0, 2)
+        assert count == 1
+
+    def test_count_edge_crossings_same_net_ignored(self):
+        """Test that same-net segments are NOT counted as crossings."""
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.pathfinder import Router
+
+        rules = DesignRules(crossing_penalty=5.0, grid_resolution=0.5)
+        grid = RoutingGrid(20.0, 20.0, rules)
+        router = Router(grid, rules)
+
+        # Segment on net 1
+        router._routed_segments.append((5, 10, 15, 10, 0, 1))
+
+        # Edge for net 1 should not count
+        count = router._count_edge_crossings(10, 5, 10, 15, 0, 1)
+        assert count == 0
+
+    def test_count_edge_crossings_different_layer_ignored(self):
+        """Test that crossings on different layers are NOT counted."""
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.pathfinder import Router
+
+        rules = DesignRules(crossing_penalty=5.0, grid_resolution=0.5)
+        grid = RoutingGrid(20.0, 20.0, rules)
+        router = Router(grid, rules)
+
+        # Segment on layer 0, net 1
+        router._routed_segments.append((5, 10, 15, 10, 0, 1))
+
+        # Edge on layer 1, net 2 should not cross (different layer)
+        count = router._count_edge_crossings(10, 5, 10, 15, 1, 2)
+        assert count == 0
+
+    def test_mark_route_feeds_routed_segments(self):
+        """Test that _mark_route updates router._routed_segments."""
+        rules = DesignRules(crossing_penalty=5.0)
+        router = Autorouter(width=20.0, height=20.0, rules=rules)
+
+        # Check initial state -- the Python pathfinder should have the attribute
+        from kicad_tools.router.pathfinder import Router as PyRouter
+
+        if isinstance(router.router, PyRouter):
+            assert len(router.router._routed_segments) == 0
+
+            route = Route(
+                net=1,
+                net_name="NET1",
+                segments=[
+                    Segment(
+                        x1=2.0,
+                        y1=5.0,
+                        x2=8.0,
+                        y2=5.0,
+                        width=0.2,
+                        layer=Layer.F_CU,
+                        net=1,
+                    ),
+                    Segment(
+                        x1=8.0,
+                        y1=5.0,
+                        x2=8.0,
+                        y2=10.0,
+                        width=0.2,
+                        layer=Layer.F_CU,
+                        net=1,
+                    ),
+                ],
+            )
+            router._mark_route(route)
+            assert len(router.router._routed_segments) == 2
+
+    def test_crossing_penalty_zero_no_regression(self):
+        """Test that crossing_penalty=0.0 produces same behavior as before."""
+        rules = DesignRules(crossing_penalty=0.0)
+        router = Autorouter(width=30.0, height=20.0, rules=rules)
+
+        pads = [
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": 10.0,
+                "net": 1,
+                "net_name": "NET1",
+                "through_hole": True,
+                "drill": 0.8,
+            },
+            {
+                "number": "2",
+                "x": 25.0,
+                "y": 10.0,
+                "net": 1,
+                "net_name": "NET1",
+                "through_hole": True,
+                "drill": 0.8,
+            },
+        ]
+        router.add_component("J1", pads)
+        routes = router.route_net(1)
+        assert len(routes) > 0, "Should route successfully with crossing_penalty=0.0"
+
+    def test_crossing_penalty_reduces_crossings(self):
+        """Test that crossing_penalty > 0 reduces crossings on a synthetic layout.
+
+        Sets up a board where two nets must cross unless the router detours.
+        With crossing_penalty=0.0 the router may take the shortest (crossing) path.
+        With crossing_penalty=5.0 the router should find a non-crossing or
+        fewer-crossing alternative.
+        """
+
+        def _count_route_crossings(
+            route_segments: list[Segment], other_segments: list[Segment]
+        ) -> int:
+            """Count crossings between two sets of segments."""
+            from kicad_tools.router.pathfinder import Router
+
+            crossings = 0
+            for seg_a in route_segments:
+                for seg_b in other_segments:
+                    if seg_a.layer != seg_b.layer:
+                        continue
+                    # Convert to int grid-like coords (multiply by 10 for precision)
+                    ax1 = int(seg_a.x1 * 10)
+                    ay1 = int(seg_a.y1 * 10)
+                    ax2 = int(seg_a.x2 * 10)
+                    ay2 = int(seg_a.y2 * 10)
+                    bx1 = int(seg_b.x1 * 10)
+                    by1 = int(seg_b.y1 * 10)
+                    bx2 = int(seg_b.x2 * 10)
+                    by2 = int(seg_b.y2 * 10)
+                    if Router._segments_intersect(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2):
+                        crossings += 1
+            return crossings
+
+        # Board: 20x20mm, two nets arranged to encourage crossing
+        # Net 1: top-left to bottom-right (diagonal tendency)
+        # Net 2: bottom-left to top-right (diagonal tendency)
+        def _route_board(penalty: float) -> tuple[list[Segment], list[Segment]]:
+            rules = DesignRules(crossing_penalty=penalty)
+            router = Autorouter(width=20.0, height=20.0, rules=rules)
+
+            # Net 1: pads on opposite corners (top-left -> bottom-right)
+            pads_net1 = [
+                {
+                    "number": "1",
+                    "x": 3.0,
+                    "y": 3.0,
+                    "net": 1,
+                    "net_name": "NET1",
+                    "through_hole": True,
+                    "drill": 0.8,
+                },
+                {
+                    "number": "2",
+                    "x": 17.0,
+                    "y": 17.0,
+                    "net": 1,
+                    "net_name": "NET1",
+                    "through_hole": True,
+                    "drill": 0.8,
+                },
+            ]
+            router.add_component("J1", pads_net1)
+
+            # Net 2: pads on opposite corners (bottom-left -> top-right)
+            pads_net2 = [
+                {
+                    "number": "1",
+                    "x": 3.0,
+                    "y": 17.0,
+                    "net": 2,
+                    "net_name": "NET2",
+                    "through_hole": True,
+                    "drill": 0.8,
+                },
+                {
+                    "number": "2",
+                    "x": 17.0,
+                    "y": 3.0,
+                    "net": 2,
+                    "net_name": "NET2",
+                    "through_hole": True,
+                    "drill": 0.8,
+                },
+            ]
+            router.add_component("J2", pads_net2)
+
+            # Route net 1 first, then net 2
+            routes1 = router.route_net(1)
+            routes2 = router.route_net(2)
+
+            segs1 = [s for r in routes1 for s in r.segments]
+            segs2 = [s for r in routes2 for s in r.segments]
+            return segs1, segs2
+
+        # Route without penalty
+        segs1_no_penalty, segs2_no_penalty = _route_board(0.0)
+        crossings_no_penalty = _count_route_crossings(segs1_no_penalty, segs2_no_penalty)
+
+        # Route with penalty
+        segs1_with_penalty, segs2_with_penalty = _route_board(5.0)
+        crossings_with_penalty = _count_route_crossings(segs1_with_penalty, segs2_with_penalty)
+
+        # With penalty, crossings should be <= without penalty
+        assert crossings_with_penalty <= crossings_no_penalty, (
+            f"Crossing penalty should reduce crossings: "
+            f"got {crossings_with_penalty} with penalty vs "
+            f"{crossings_no_penalty} without"
+        )
+
+    def test_empty_routed_segments_no_penalty(self):
+        """Test that first net to route never gets penalized (empty segments list)."""
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.pathfinder import Router
+
+        rules = DesignRules(crossing_penalty=5.0, grid_resolution=0.5)
+        grid = RoutingGrid(20.0, 20.0, rules)
+        router = Router(grid, rules)
+
+        # No routed segments -- count should be 0
+        count = router._count_edge_crossings(0, 0, 10, 10, 0, 1)
+        assert count == 0


### PR DESCRIPTION
## Summary
Add a `crossing_penalty` cost parameter to the A* pathfinder that penalizes candidate edges crossing previously routed segments on the same layer. This steers the router toward non-crossing paths while still permitting crossings when no alternative exists. Default of 0.0 preserves full backward compatibility.

## Changes
- Add `crossing_penalty: float = 0.0` field to `DesignRules` in `rules.py`
- Add `_routed_segments` tracking list, `add_routed_segments()`, and `clear_routed_segments()` API to `Router` in `pathfinder.py`
- Add `_segments_intersect()` static method using cross-product sign-change algorithm for 2D segment intersection
- Add `_count_edge_crossings()` method that filters by same-layer and different-net before counting intersections
- Wire `crossing_cost` into the A* inner loop in both `route()` and `_expand_bidirectional_neighbors()` (bidirectional A*)
- Wire `Autorouter._mark_route()` in `core.py` to feed committed segments to the pathfinder via `add_routed_segments()`
- Add 2 unit tests for `DesignRules.crossing_penalty` field defaults and custom values
- Add 12 tests covering segment intersection detection, layer/net filtering, API behavior, backward compatibility, and crossing reduction on a synthetic layout

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `DesignRules` has `crossing_penalty: float = 0.0` | Pass | `test_crossing_penalty_default` asserts `DesignRules().crossing_penalty == 0.0` |
| `Router` tracks committed segments via `add_routed_segments`/`clear_routed_segments` | Pass | `test_add_and_clear_routed_segments` verifies add/clear lifecycle |
| A* expansion computes crossing cost in `route()` and `route_bidirectional()` | Pass | Both inner loops updated; integration test routes with penalty |
| Crossing detection is layer-aware (same layer, different net only) | Pass | `test_count_edge_crossings_same_net_ignored` and `test_count_edge_crossings_different_layer_ignored` |
| `_mark_route()` feeds segments to pathfinder | Pass | `test_mark_route_feeds_routed_segments` checks `_routed_segments` length after `_mark_route()` |
| `crossing_penalty=5.0` produces fewer or equal crossings | Pass | `test_crossing_penalty_reduces_crossings` on synthetic 2-net crossing-prone board |
| Falls back to brute-force without R-tree (no error) | Pass | All tests use brute-force (no R-tree); 390 tests pass |
| MCP/CLI tools unaffected | Pass | No changes to MCP or CLI modules |

## Test Plan
- `uv run pytest tests/test_router.py::TestDesignRules` -- 5 passed
- `uv run pytest tests/test_router_core.py::TestCrossingPenalty` -- 12 passed
- `uv run pytest tests/test_router.py tests/test_router_core.py` -- 390 passed, 0 failures

Closes #1250