### PR TITLE
feat(zones): add zone fill CLI command delegating to kicad-cli

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -19,7 +19,7 @@ Provides CLI commands for common KiCad operations via the `kicad-tools` or `kct`
     kicad-tools datasheet <command>    - Datasheet search, download, and PDF parsing
     kicad-tools route <pcb>            - Autoroute a PCB
     kicad-tools route-auto <pcb>       - Orchestrator-based smart routing for a net
-    kicad-tools zones <command>        - Add copper pour zones
+    kicad-tools zones <command>        - Add and fill copper pour zones
     kicad-tools reason <pcb>           - LLM-driven PCB layout reasoning
     kicad-tools placement <command>    - Detect and fix placement conflicts
     kicad-tools optimize-traces <pcb>  - Optimize PCB traces

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -12,7 +12,7 @@ def run_zones_command(args) -> int:
     """Handle zones command."""
     if not args.zones_command:
         print("Usage: kicad-tools zones <command> [options] <file>")
-        print("Commands: add, list, batch")
+        print("Commands: add, list, batch, fill")
         return 1
 
     from ..zones_cmd import main as zones_main
@@ -55,6 +55,21 @@ def run_zones_command(args) -> int:
         sub_argv.extend(["--power-nets", args.power_nets])
         if args.clearance != 0.3:
             sub_argv.extend(["--clearance", str(args.clearance)])
+        if args.verbose:
+            sub_argv.append("--verbose")
+        if args.dry_run:
+            sub_argv.append("--dry-run")
+        # Use global quiet flag
+        if getattr(args, "global_quiet", False):
+            sub_argv.append("--quiet")
+        return zones_main(sub_argv) or 0
+
+    elif args.zones_command == "fill":
+        sub_argv = ["fill", args.pcb]
+        if args.output:
+            sub_argv.extend(["-o", args.output])
+        if getattr(args, "net", None):
+            sub_argv.extend(["--net", args.net])
         if args.verbose:
             sub_argv.append("--verbose")
         if args.dry_run:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -827,6 +827,18 @@ def _add_zones_parser(subparsers) -> None:
     zones_batch.add_argument("-v", "--verbose", action="store_true")
     zones_batch.add_argument("--dry-run", action="store_true")
 
+    # zones fill
+    zones_fill = zones_subparsers.add_parser("fill", help="Fill all zones in a PCB")
+    zones_fill.add_argument("pcb", help="Path to .kicad_pcb file")
+    zones_fill.add_argument(
+        "-o", "--output", help="Output file path (default: overwrites input)"
+    )
+    zones_fill.add_argument("--net", help="Fill only zones for this net (e.g., GND)")
+    zones_fill.add_argument("-v", "--verbose", action="store_true")
+    zones_fill.add_argument(
+        "--dry-run", action="store_true", help="Show what would be done, no output"
+    )
+
 
 def _add_route_parser(subparsers) -> None:
     """Add route subcommand parser."""

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -281,6 +281,67 @@ def run_netlist_export(
         return KiCadCLIResult(success=False, stderr=f"Failed to export netlist: {e}")
 
 
+def run_fill_zones(
+    pcb_path: Path,
+    output_path: Path | None = None,
+    kicad_cli: Path | None = None,
+) -> KiCadCLIResult:
+    """Fill all copper zones in a PCB using kicad-cli.
+
+    Delegates to ``kicad-cli pcb fill-zones`` (KiCad 8+).
+
+    Args:
+        pcb_path: Path to .kicad_pcb file
+        output_path: Where to save the filled PCB (default: overwrites input)
+        kicad_cli: Path to kicad-cli (auto-detected if not provided)
+
+    Returns:
+        KiCadCLIResult with success status and output path
+    """
+    if kicad_cli is None:
+        kicad_cli = find_kicad_cli()
+        if kicad_cli is None:
+            return KiCadCLIResult(
+                success=False,
+                stderr="kicad-cli not found. Install KiCad 8 from https://www.kicad.org/download/",
+            )
+
+    # Build command
+    cmd = [str(kicad_cli), "pcb", "fill-zones"]
+
+    if output_path is not None:
+        cmd.extend(["--output", str(output_path)])
+
+    cmd.append(str(pcb_path))
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        # Determine which file should exist after the operation
+        expected_path = output_path if output_path is not None else pcb_path
+
+        if result.returncode == 0:
+            return KiCadCLIResult(
+                success=True,
+                output_path=expected_path,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                return_code=result.returncode,
+            )
+        else:
+            return KiCadCLIResult(
+                success=False,
+                stdout=result.stdout,
+                stderr=result.stderr or "Zone fill failed",
+                return_code=result.returncode,
+            )
+
+    except FileNotFoundError as e:
+        return KiCadCLIResult(success=False, stderr=f"kicad-cli not found: {e}")
+    except subprocess.SubprocessError as e:
+        return KiCadCLIResult(success=False, stderr=f"Failed to fill zones: {e}")
+
+
 def get_kicad_version(kicad_cli: Path | None = None) -> str | None:
     """Get KiCad version string.
 

--- a/src/kicad_tools/cli/zones_cmd.py
+++ b/src/kicad_tools/cli/zones_cmd.py
@@ -1,9 +1,11 @@
 """
-CLI command for zone generation.
+CLI command for zone generation and fill.
 
-Provides commands for adding copper pour zones to PCB files:
+Provides commands for adding copper pour zones to PCB files and
+filling zones using kicad-cli:
     kicad-tools zones add board.kicad_pcb --net GND --layer B.Cu
     kicad-tools zones list board.kicad_pcb
+    kicad-tools zones fill board.kicad_pcb
 """
 
 import argparse
@@ -133,6 +135,36 @@ def main(argv: list[str] | None = None) -> int:
         help="Suppress progress output",
     )
 
+    # zones fill
+    fill_parser = subparsers.add_parser("fill", help="Fill all zones in a PCB")
+    fill_parser.add_argument("pcb", help="Path to .kicad_pcb file")
+    fill_parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file path (default: overwrites input)",
+    )
+    fill_parser.add_argument(
+        "--net",
+        help="Fill only zones for this net (e.g., GND)",
+    )
+    fill_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Verbose output",
+    )
+    fill_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without writing output",
+    )
+    fill_parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress progress output",
+    )
+
     args = parser.parse_args(argv)
 
     if not args.zones_command:
@@ -145,6 +177,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_list(args)
     elif args.zones_command == "batch":
         return _run_batch(args)
+    elif args.zones_command == "fill":
+        return _run_fill(args)
 
     return 0
 
@@ -354,6 +388,62 @@ def _run_batch(args) -> int:
         print(f"\nCreated {stats['zone_count']} zone(s)")
 
     return 0 if not errors else 1
+
+
+def _run_fill(args) -> int:
+    """Fill zones in a PCB using kicad-cli."""
+    from .runner import find_kicad_cli, run_fill_zones
+
+    pcb_path = Path(args.pcb)
+    if not pcb_path.exists():
+        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
+        return 1
+
+    kicad_cli = find_kicad_cli()
+    if not kicad_cli:
+        print(
+            "Error: kicad-cli not found. Install KiCad 8 from https://www.kicad.org/download/",
+            file=sys.stderr,
+        )
+        return 1
+
+    output_path = Path(args.output) if args.output else None
+
+    quiet = getattr(args, "quiet", False)
+
+    if args.dry_run:
+        print(f"Would fill zones in: {pcb_path}")
+        if args.net:
+            print(f"  Net filter: {args.net}")
+        if output_path:
+            print(f"  Output: {output_path}")
+        else:
+            print(f"  Output: {pcb_path} (in-place)")
+        return 0
+
+    if args.net:
+        # kicad-cli fill-zones does not support per-net filtering.
+        # Document the limitation and fill all zones.
+        if not quiet:
+            print(
+                f"Note: --net filter is not supported by kicad-cli. "
+                f"All zones will be filled (requested net: {args.net}).",
+            )
+
+    if not quiet:
+        print(f"Filling zones in: {pcb_path}")
+
+    result = run_fill_zones(pcb_path, output_path, kicad_cli=kicad_cli)
+
+    if not result.success:
+        print(f"Error: {result.stderr}", file=sys.stderr)
+        return 1
+
+    if not quiet:
+        target = output_path if output_path else pcb_path
+        print(f"Zones filled: {target}")
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_zones_cmd.py
+++ b/tests/test_zones_cmd.py
@@ -1,0 +1,345 @@
+"""Tests for the zones CLI command, focusing on the fill subcommand."""
+
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.cli.zones_cmd import main
+
+# Patch targets -- _run_fill imports from .runner at call time, so we patch
+# the names in the runner module itself.
+_FIND_CLI = "kicad_tools.cli.runner.find_kicad_cli"
+_RUN_FILL = "kicad_tools.cli.runner.run_fill_zones"
+_SUBPROCESS_RUN = "kicad_tools.cli.runner.subprocess.run"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+FIXTURE_PCB = Path(__file__).parent / "fixtures" / "projects" / "multilayer_zones.kicad_pcb"
+
+
+@pytest.fixture
+def tmp_pcb(tmp_path: Path) -> Path:
+    """Copy the multilayer_zones fixture to a temp dir so tests can write."""
+    dest = tmp_path / "board.kicad_pcb"
+    shutil.copy2(FIXTURE_PCB, dest)
+    return dest
+
+
+@pytest.fixture
+def _mock_no_kicad_cli():
+    """Patch find_kicad_cli to return None (kicad-cli not available)."""
+    with patch(_FIND_CLI, return_value=None):
+        yield
+
+
+@pytest.fixture
+def _mock_kicad_cli():
+    """Patch find_kicad_cli to return a fake path."""
+    with patch(_FIND_CLI, return_value=Path("/usr/bin/kicad-cli")):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Test: fill subcommand appears in help
+# ---------------------------------------------------------------------------
+
+
+class TestFillSubcommandPresence:
+    """Verify the fill subcommand is registered."""
+
+    def test_fill_in_zones_help(self, capsys):
+        """The fill subcommand should appear in `zones --help` output."""
+        # main() with no args prints help and returns 0
+        ret = main([])
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "fill" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Test: missing input file
+# ---------------------------------------------------------------------------
+
+
+class TestFillMissingFile:
+    """Verify error when input file does not exist."""
+
+    @pytest.mark.usefixtures("_mock_kicad_cli")
+    def test_missing_pcb_returns_1(self, capsys):
+        ret = main(["fill", "/nonexistent/board.kicad_pcb"])
+        assert ret == 1
+        captured = capsys.readouterr()
+        assert "File not found" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Test: kicad-cli not found
+# ---------------------------------------------------------------------------
+
+
+class TestFillNoKicadCli:
+    """Verify error when kicad-cli is not installed."""
+
+    @pytest.mark.usefixtures("_mock_no_kicad_cli")
+    def test_no_kicad_cli_returns_1(self, tmp_pcb, capsys):
+        ret = main(["fill", str(tmp_pcb)])
+        assert ret == 1
+        captured = capsys.readouterr()
+        assert "kicad-cli not found" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Test: --dry-run does not invoke run_fill_zones
+# ---------------------------------------------------------------------------
+
+
+class TestFillDryRun:
+    """Verify --dry-run prints info but does not call run_fill_zones."""
+
+    @pytest.mark.usefixtures("_mock_kicad_cli")
+    def test_dry_run_does_not_fill(self, tmp_pcb, capsys):
+        with patch(_RUN_FILL) as mock_fill:
+            ret = main(["fill", str(tmp_pcb), "--dry-run"])
+            assert ret == 0
+            mock_fill.assert_not_called()
+        captured = capsys.readouterr()
+        assert "Would fill zones in" in captured.out
+
+    @pytest.mark.usefixtures("_mock_kicad_cli")
+    def test_dry_run_shows_net_filter(self, tmp_pcb, capsys):
+        with patch(_RUN_FILL):
+            ret = main(["fill", str(tmp_pcb), "--dry-run", "--net", "GND"])
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "GND" in captured.out
+
+    @pytest.mark.usefixtures("_mock_kicad_cli")
+    def test_dry_run_shows_output_path(self, tmp_pcb, tmp_path, capsys):
+        out = tmp_path / "filled.kicad_pcb"
+        with patch(_RUN_FILL):
+            ret = main(["fill", str(tmp_pcb), "--dry-run", "-o", str(out)])
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert str(out) in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Test: successful fill delegates to run_fill_zones
+# ---------------------------------------------------------------------------
+
+
+class TestFillSuccess:
+    """Verify a successful fill invocation."""
+
+    @pytest.mark.usefixtures("_mock_kicad_cli")
+    def test_fill_calls_run_fill_zones(self, tmp_pcb, capsys):
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        mock_result = KiCadCLIResult(
+            success=True,
+            output_path=tmp_pcb,
+            stdout="",
+            stderr="",
+            return_code=0,
+        )
+        with patch(_RUN_FILL, return_value=mock_result) as mock_fill:
+            ret = main(["fill", str(tmp_pcb)])
+            assert ret == 0
+            mock_fill.assert_called_once()
+            call_args = mock_fill.call_args
+            assert call_args[0][0] == tmp_pcb  # pcb_path
+            assert call_args[0][1] is None  # output_path (in-place)
+        captured = capsys.readouterr()
+        assert "Zones filled" in captured.out
+
+    @pytest.mark.usefixtures("_mock_kicad_cli")
+    def test_fill_with_output_path(self, tmp_pcb, tmp_path):
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        out = tmp_path / "filled.kicad_pcb"
+        mock_result = KiCadCLIResult(
+            success=True,
+            output_path=out,
+            stdout="",
+            stderr="",
+            return_code=0,
+        )
+        with patch(_RUN_FILL, return_value=mock_result) as mock_fill:
+            ret = main(["fill", str(tmp_pcb), "-o", str(out)])
+            assert ret == 0
+            call_args = mock_fill.call_args
+            assert call_args[0][1] == out
+
+
+# ---------------------------------------------------------------------------
+# Test: fill failure propagates error
+# ---------------------------------------------------------------------------
+
+
+class TestFillFailure:
+    """Verify errors from kicad-cli are reported."""
+
+    @pytest.mark.usefixtures("_mock_kicad_cli")
+    def test_fill_failure_returns_1(self, tmp_pcb, capsys):
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        mock_result = KiCadCLIResult(
+            success=False,
+            stderr="kicad-cli crashed",
+            return_code=1,
+        )
+        with patch(_RUN_FILL, return_value=mock_result):
+            ret = main(["fill", str(tmp_pcb)])
+            assert ret == 1
+        captured = capsys.readouterr()
+        assert "kicad-cli crashed" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Test: --net filter note
+# ---------------------------------------------------------------------------
+
+
+class TestFillNetFilter:
+    """Verify --net filter behavior (not supported by kicad-cli)."""
+
+    @pytest.mark.usefixtures("_mock_kicad_cli")
+    def test_net_filter_prints_note(self, tmp_pcb, capsys):
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        mock_result = KiCadCLIResult(success=True, output_path=tmp_pcb, return_code=0)
+        with patch(_RUN_FILL, return_value=mock_result):
+            ret = main(["fill", str(tmp_pcb), "--net", "GND"])
+            assert ret == 0
+        captured = capsys.readouterr()
+        assert "--net filter is not supported" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Test: run_fill_zones function in runner.py
+# ---------------------------------------------------------------------------
+
+
+class TestRunFillZones:
+    """Unit tests for the run_fill_zones runner function."""
+
+    def test_no_kicad_cli_returns_failure(self):
+        from kicad_tools.cli.runner import run_fill_zones
+
+        with patch(_FIND_CLI, return_value=None):
+            result = run_fill_zones(Path("/some/board.kicad_pcb"))
+        assert result.success is False
+        assert "kicad-cli not found" in result.stderr
+
+    def test_builds_correct_command_in_place(self, tmp_pcb):
+        from kicad_tools.cli.runner import run_fill_zones
+
+        with patch(_SUBPROCESS_RUN) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = run_fill_zones(tmp_pcb, kicad_cli=Path("/usr/bin/kicad-cli"))
+        assert result.success is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "/usr/bin/kicad-cli"
+        assert cmd[1:3] == ["pcb", "fill-zones"]
+        # No --output flag for in-place
+        assert "--output" not in cmd
+        assert str(tmp_pcb) == cmd[-1]
+
+    def test_builds_correct_command_with_output(self, tmp_pcb, tmp_path):
+        from kicad_tools.cli.runner import run_fill_zones
+
+        out = tmp_path / "filled.kicad_pcb"
+        with patch(_SUBPROCESS_RUN) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = run_fill_zones(tmp_pcb, output_path=out, kicad_cli=Path("/usr/bin/kicad-cli"))
+        assert result.success is True
+        cmd = mock_run.call_args[0][0]
+        assert "--output" in cmd
+        idx = cmd.index("--output")
+        assert cmd[idx + 1] == str(out)
+
+    def test_nonzero_return_code_is_failure(self, tmp_pcb):
+        from kicad_tools.cli.runner import run_fill_zones
+
+        with patch(_SUBPROCESS_RUN) as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="zone fill error")
+            result = run_fill_zones(tmp_pcb, kicad_cli=Path("/usr/bin/kicad-cli"))
+        assert result.success is False
+        assert "zone fill error" in result.stderr
+
+    def test_file_not_found_error(self):
+        from kicad_tools.cli.runner import run_fill_zones
+
+        with patch(
+            _SUBPROCESS_RUN,
+            side_effect=FileNotFoundError("not found"),
+        ):
+            result = run_fill_zones(
+                Path("/some/board.kicad_pcb"),
+                kicad_cli=Path("/usr/bin/kicad-cli"),
+            )
+        assert result.success is False
+        assert "kicad-cli not found" in result.stderr
+
+    def test_subprocess_error(self, tmp_pcb):
+        import subprocess
+
+        from kicad_tools.cli.runner import run_fill_zones
+
+        with patch(
+            _SUBPROCESS_RUN,
+            side_effect=subprocess.SubprocessError("boom"),
+        ):
+            result = run_fill_zones(tmp_pcb, kicad_cli=Path("/usr/bin/kicad-cli"))
+        assert result.success is False
+        assert "Failed to fill zones" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Integration test: requires kicad-cli
+# ---------------------------------------------------------------------------
+
+
+def _kicad_cli_has_fill_zones() -> bool:
+    """Check whether the installed kicad-cli supports 'pcb fill-zones'."""
+    import subprocess
+
+    cli = shutil.which("kicad-cli")
+    if cli is None:
+        return False
+    try:
+        result = subprocess.run(
+            [cli, "pcb", "fill-zones", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        # kicad-cli returns 0 and prints the parent help when a subcommand
+        # is unknown, so we check stdout for "fill-zones" to confirm support.
+        return result.returncode == 0 and "fill-zones" in result.stdout
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _kicad_cli_has_fill_zones(),
+    reason="kicad-cli does not support 'pcb fill-zones'",
+)
+class TestFillIntegration:
+    """Integration tests that actually run kicad-cli fill-zones.
+
+    Note: 'kicad-cli pcb fill-zones' may not exist in all KiCad versions.
+    These tests are skipped when the subcommand is unavailable.
+    """
+
+    def test_fill_zones_on_fixture(self, tmp_pcb, tmp_path):
+        """Fill zones on the multilayer fixture and check output has filled_polygon."""
+        out = tmp_path / "filled_board.kicad_pcb"
+        ret = main(["fill", str(tmp_pcb), "-o", str(out)])
+        assert ret == 0
+        assert out.exists()
+        content = out.read_text()
+        assert "filled_polygon" in content


### PR DESCRIPTION
## Summary
Add a `zones fill` CLI subcommand that delegates copper zone filling to `kicad-cli pcb fill-zones`. This command fills all copper zones in a PCB file and writes the result back, eliminating false DRC violations caused by unfilled zone definitions.

## Changes
- Add `run_fill_zones()` to `src/kicad_tools/cli/runner.py` following the existing `run_drc()` pattern
- Add `fill` subparser to `_add_zones_parser()` in `parser.py` with `--output`, `--net`, `--dry-run`, `--verbose` options
- Add `_run_fill()` handler to `zones_cmd.py` with proper error handling for missing file, missing kicad-cli, and kicad-cli failure
- Wire `fill` dispatch in `commands/routing.py` alongside existing `add`, `list`, `batch` cases
- Document that `--net` filtering is not supported by kicad-cli (all zones are filled, with a user-facing note)
- Create comprehensive test suite in `tests/test_zones_cmd.py` (16 unit tests + 1 integration test)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `zones fill board.kicad_pcb` fills all zones in-place | Done | Unit test `test_fill_calls_run_fill_zones` verifies correct args passed |
| `zones fill board.kicad_pcb -o output.kicad_pcb` saves to new file | Done | Unit test `test_fill_with_output_path` verifies output_path arg |
| `zones fill board.kicad_pcb --net GND` documents limitation | Done | `test_net_filter_prints_note` verifies user note is printed |
| `zones fill board.kicad_pcb --dry-run` shows plan without writing | Done | `test_dry_run_does_not_fill` confirms run_fill_zones not called |
| Missing kicad-cli exits with clear error | Done | `test_no_kicad_cli_returns_1` verifies exit 1 + error message |
| `fill` subcommand visible in `zones --help` | Done | `test_fill_in_zones_help` verifies "fill" in help output |
| `zones list` shows `Filled: Yes/No` for zones | Pre-existing | Already implemented in `_run_list()` |

## Test Plan
- 16 unit tests pass covering: help text, missing file, missing kicad-cli, dry-run (3 tests), success (2 tests), failure, net filter note, and runner function (6 tests)
- 1 integration test (skipped when kicad-cli lacks fill-zones support)
- All 39 existing zone tests still pass
- All changed files pass ruff check and ruff format

Closes #1257