### PR TITLE
fix(router): load existing routes as obstacles for multi-pass routing

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1720,7 +1720,7 @@ def _remove_conflicting_vias(pcb_text: str, clearance: float) -> str:
         r"\(drill\s+[\d.]+\)\s*"
         r'\(layers\s+"[^"]+"\s+"[^"]+"\)\s*'
         r"\(net\s+(\d+)\)"
-        r"[^)]*\))",
+        r"[^)]*\)[^)]*\))",
         re.DOTALL,
     )
 

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1187,6 +1187,7 @@ def load_pcb_for_routing(
     edge_clearance: float | None = None,
     layer_stack: LayerStack | None = None,
     force_python: bool = False,
+    load_existing_routes: bool = False,
 ) -> tuple[Autorouter, dict[str, int]]:
     """
     Load a KiCad PCB file and create an Autorouter with all components.
@@ -1228,6 +1229,12 @@ def load_pcb_for_routing(
         force_python: If True, force use of Python router backend even if the
                      C++ backend is available. Default False uses C++ when
                      available for 10-100x performance improvement.
+        load_existing_routes: If True, parse existing ``(segment ...)`` and
+                     ``(via ...)`` elements from the PCB file and mark them as
+                     obstacles on the routing grid. This is essential for
+                     multi-pass routing where Pass 2 must see Pass 1 geometry
+                     to avoid overlapping traces and co-located vias.
+                     Default is False for backward compatibility.
 
     Returns:
         Tuple of (Autorouter instance, net_map dict)
@@ -1253,6 +1260,10 @@ def load_pcb_for_routing(
         >>> from kicad_tools.router import LayerStack
         >>> stack = LayerStack.four_layer_sig_gnd_pwr_sig()
         >>> router, nets = load_pcb_for_routing("board.kicad_pcb", layer_stack=stack)
+        >>>
+        >>> # Load existing routes as obstacles for multi-pass routing
+        >>> router, nets = load_pcb_for_routing("pass1.kicad_pcb",
+        ...     load_existing_routes=True)
     """
     pcb_text = Path(pcb_path).read_text()
     skip_nets = skip_nets or []
@@ -1484,6 +1495,48 @@ def load_pcb_for_routing(
             if blocked_cells > 0:
                 print(f"  Edge clearance: {edge_clearance}mm, {blocked_cells} cells blocked")
 
+    # Load existing routes as obstacles for multi-pass routing
+    if load_existing_routes:
+        from .optimizer.pcb import parse_segments, parse_vias
+        from .primitives import Route
+
+        existing_segments = parse_segments(pcb_text)
+        existing_vias = parse_vias(pcb_text)
+
+        # Collect all net names across segments and vias
+        all_net_names = set(existing_segments.keys()) | set(existing_vias.keys())
+
+        route_count = 0
+        for net_name in all_net_names:
+            segs = existing_segments.get(net_name, [])
+            vias = existing_vias.get(net_name, [])
+            if not segs and not vias:
+                continue
+
+            # Determine net ID from first available element
+            net_id = segs[0].net if segs else vias[0].net
+
+            route = Route(
+                net=net_id,
+                net_name=net_name,
+                segments=segs,
+                vias=vias,
+            )
+            # Mark on grid as obstacles (blocked cells) but do NOT add to
+            # router.routes — these are fixed geometry, not re-routable nets.
+            router.grid.mark_route(route)
+            route_count += 1
+
+        if route_count > 0:
+            total_segs = sum(len(s) for s in existing_segments.values())
+            total_vias = sum(len(v) for v in existing_vias.values())
+            logger.info(
+                "Loaded %d existing routes as obstacles (%d segments, %d vias)",
+                route_count,
+                total_segs,
+                total_vias,
+            )
+
     return router, net_map
 
 
@@ -1555,6 +1608,8 @@ def generate_netclass_setup(
 def merge_routes_into_pcb(
     pcb_content: str,
     route_sexp: str,
+    detect_via_conflicts: bool = False,
+    via_clearance: float = 0.2,
 ) -> str:
     """
     Merge routed traces into an existing PCB file content.
@@ -1564,10 +1619,21 @@ def merge_routes_into_pcb(
     add any net_settings or net_class blocks, as routes already have
     correct trace widths and via sizes embedded.
 
+    When ``detect_via_conflicts`` is enabled, the merged result is scanned
+    for co-located vias belonging to different nets.  Any duplicate vias
+    whose centres fall within ``via_clearance`` mm of each other on
+    different nets are removed from the output and a warning is logged.
+
     Args:
         pcb_content: Original PCB file content as string
         route_sexp: Route S-expressions as a string. This must be the output
             of ``Autorouter.to_sexp()``, NOT the Autorouter object itself.
+        detect_via_conflicts: If True, scan the merged output for co-located
+            vias on different nets and remove duplicates.  Default False for
+            backward compatibility.
+        via_clearance: Minimum centre-to-centre distance (mm) below which
+            two vias on different nets are considered co-located.  Only used
+            when ``detect_via_conflicts`` is True.  Default is 0.2 mm.
 
     Returns:
         Modified PCB content with routes inserted.
@@ -1623,5 +1689,90 @@ def merge_routes_into_pcb(
     result = content + "\n\n"
     result += f"  {route_sexp}\n"
     result += ")\n"
+
+    # Post-merge co-located via detection
+    if detect_via_conflicts:
+        result = _remove_conflicting_vias(result, via_clearance)
+
+    return result
+
+
+def _remove_conflicting_vias(pcb_text: str, clearance: float) -> str:
+    """Remove co-located vias on different nets from merged PCB text.
+
+    Scans all ``(via ...)`` blocks, groups them by position (within
+    *clearance* mm), and removes duplicates where two vias from
+    different nets occupy the same location.  The first via encountered
+    is kept; later conflicting vias are stripped.
+
+    Args:
+        pcb_text: Full PCB text content (after merge).
+        clearance: Centre-to-centre distance threshold in mm.
+
+    Returns:
+        PCB text with conflicting vias removed.
+    """
+    # Parse via positions and net IDs from the text
+    via_pattern = re.compile(
+        r"(\(via\s+"
+        r"\(at\s+([\d.-]+)\s+([\d.-]+)\)\s*"
+        r"\(size\s+[\d.]+\)\s*"
+        r"\(drill\s+[\d.]+\)\s*"
+        r'\(layers\s+"[^"]+"\s+"[^"]+"\)\s*'
+        r"\(net\s+(\d+)\)"
+        r"[^)]*\))",
+        re.DOTALL,
+    )
+
+    # Collect all vias with their positions, nets, and match spans
+    vias: list[tuple[float, float, int, re.Match]] = []  # type: ignore[type-arg]
+    for match in via_pattern.finditer(pcb_text):
+        x = float(match.group(2))
+        y = float(match.group(3))
+        net = int(match.group(4))
+        vias.append((x, y, net, match))
+
+    if len(vias) < 2:
+        return pcb_text
+
+    # Identify conflicting vias (different net, within clearance distance)
+    # Keep the first via encountered at each location; remove later conflicts
+    spans_to_remove: list[tuple[int, int]] = []
+    for i in range(len(vias)):
+        x_i, y_i, net_i, match_i = vias[i]
+        # Skip vias already marked for removal
+        if (match_i.start(), match_i.end()) in spans_to_remove:
+            continue
+        for j in range(i + 1, len(vias)):
+            x_j, y_j, net_j, match_j = vias[j]
+            if net_i == net_j:
+                continue
+            dist = math.sqrt((x_i - x_j) ** 2 + (y_i - y_j) ** 2)
+            if dist < clearance:
+                span = (match_j.start(), match_j.end())
+                if span not in spans_to_remove:
+                    spans_to_remove.append(span)
+                    logger.warning(
+                        "Removed conflicting via at (%.4f, %.4f) net %d "
+                        "(co-located with net %d, distance %.4fmm)",
+                        x_j,
+                        y_j,
+                        net_j,
+                        net_i,
+                        dist,
+                    )
+
+    if not spans_to_remove:
+        return pcb_text
+
+    # Remove spans in reverse order to preserve character offsets
+    spans_to_remove.sort(reverse=True)
+    result = pcb_text
+    for start, end in spans_to_remove:
+        # Also strip trailing whitespace/newline after the removed via
+        trail = end
+        while trail < len(result) and result[trail] in (" ", "\t", "\n", "\r"):
+            trail += 1
+        result = result[:start] + result[trail:]
 
     return result

--- a/src/kicad_tools/router/optimizer/pcb.py
+++ b/src/kicad_tools/router/optimizer/pcb.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
 from ..layers import Layer
-from ..primitives import Segment
+from ..primitives import Segment, Via
 from .config import OptimizationConfig, OptimizationStats
 from .geometry import count_corners, total_length
 
@@ -88,6 +88,79 @@ def parse_segments(pcb_text: str) -> dict[str, list[Segment]]:
         segments_by_net[net_name].append(seg)
 
     return segments_by_net
+
+
+def parse_vias(pcb_text: str) -> dict[str, list[Via]]:
+    """Parse vias from PCB file text, grouped by net name.
+
+    Parses ``(via ...)`` S-expressions and returns ``Via`` objects keyed
+    by net name, mirroring the structure of ``parse_segments``.
+
+    Args:
+        pcb_text: Raw text content of a ``.kicad_pcb`` file.
+
+    Returns:
+        Dictionary mapping net names to lists of ``Via`` objects.
+    """
+    vias_by_net: dict[str, list[Via]] = {}
+
+    # Reuse existing net-name mapping
+    net_names = parse_net_names(pcb_text)
+
+    # Match via S-expressions (multiline format)
+    # (via
+    #     (at X Y)
+    #     (size S)
+    #     (drill D)
+    #     (layers "L1" "L2")
+    #     (net N)
+    #     ...
+    # )
+    pattern = re.compile(
+        r"\(via\s+"
+        r"\(at\s+([\d.-]+)\s+([\d.-]+)\)\s*"
+        r"\(size\s+([\d.]+)\)\s*"
+        r"\(drill\s+([\d.]+)\)\s*"
+        r'\(layers\s+"([^"]+)"\s+"([^"]+)"\)\s*'
+        r"\(net\s+(\d+)\)",
+        re.DOTALL,
+    )
+
+    for match in pattern.finditer(pcb_text):
+        x = float(match.group(1))
+        y = float(match.group(2))
+        diameter = float(match.group(3))
+        drill = float(match.group(4))
+        layer_start_name = match.group(5)
+        layer_end_name = match.group(6)
+        net = int(match.group(7))
+        net_name = net_names.get(net, f"Net{net}")
+
+        # Convert layer names to Layer enum
+        try:
+            layer_start = Layer.from_kicad_name(layer_start_name)
+        except ValueError:
+            layer_start = Layer.F_CU
+        try:
+            layer_end = Layer.from_kicad_name(layer_end_name)
+        except ValueError:
+            layer_end = Layer.B_CU
+
+        via = Via(
+            x=x,
+            y=y,
+            drill=drill,
+            diameter=diameter,
+            layers=(layer_start, layer_end),
+            net=net,
+            net_name=net_name,
+        )
+
+        if net_name not in vias_by_net:
+            vias_by_net[net_name] = []
+        vias_by_net[net_name].append(via)
+
+    return vias_by_net
 
 
 def replace_segments(

--- a/tests/test_router_io.py
+++ b/tests/test_router_io.py
@@ -2438,3 +2438,272 @@ class TestValidateSexpParentheses:
   (segment (start 100 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 1))
 )"""
         assert _validate_sexp_parentheses(pcb)
+
+
+# ============================================================================
+# TWO-PASS MERGE / EXISTING ROUTE OBSTACLE LOADING TESTS (Issue #1256)
+# ============================================================================
+
+# PCB fixture with pre-existing routed geometry (segments + vias) for
+# multi-pass routing tests.  Board is 50x40mm at origin (100, 100).
+_PCB_WITH_EXISTING_ROUTES = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+    (legacy_teardrops no)
+  )
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "NET_A")
+  (net 2 "NET_B")
+  (net 3 "NET_C")
+  (gr_rect (start 100 100) (end 150 140)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000100")
+    (at 115 115)
+    (fp_text reference "U1" (at 0 -3.5) (layer "F.SilkS"))
+    (pad "1" smd rect (at -2.7 -1.905) (size 1.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET_A"))
+    (pad "2" smd rect (at -2.7 -0.635) (size 1.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "NET_B"))
+    (pad "3" smd rect (at -2.7 0.635) (size 1.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 3 "NET_C"))
+    (pad "4" smd rect (at -2.7 1.905) (size 1.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+    (pad "5" smd rect (at 2.7 1.905) (size 1.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+    (pad "6" smd rect (at 2.7 0.635) (size 1.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 3 "NET_C"))
+    (pad "7" smd rect (at 2.7 -0.635) (size 1.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "NET_B"))
+    (pad "8" smd rect (at 2.7 -1.905) (size 1.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET_A"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000200")
+    (at 135 115)
+    (fp_text reference "R1" (at 0 -1.5) (layer "F.SilkS"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "NET_A"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "NET_B"))
+  )
+  (segment (start 112.3000 113.0950) (end 120.0000 113.0950) (width 0.2500) (layer "F.Cu") (net 1) (uuid "seg-a1"))
+  (segment (start 120.0000 113.0950) (end 134.4900 115.0000) (width 0.2500) (layer "F.Cu") (net 1) (uuid "seg-a2"))
+  (via (at 125.0000 120.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 2) (uuid "via-b1"))
+  (segment (start 112.3000 114.3650) (end 125.0000 120.0000) (width 0.2500) (layer "F.Cu") (net 2) (uuid "seg-b1"))
+)
+"""
+
+
+class TestParseVias:
+    """Tests for the parse_vias function in optimizer/pcb.py."""
+
+    def test_parse_vias_basic(self):
+        """parse_vias extracts via coordinates, drill, diameter, net and layers."""
+        from kicad_tools.router.optimizer.pcb import parse_vias
+
+        vias_by_net = parse_vias(_PCB_WITH_EXISTING_ROUTES)
+        assert "NET_B" in vias_by_net
+        net_b_vias = vias_by_net["NET_B"]
+        assert len(net_b_vias) == 1
+
+        via = net_b_vias[0]
+        assert via.x == pytest.approx(125.0, abs=0.01)
+        assert via.y == pytest.approx(120.0, abs=0.01)
+        assert via.diameter == pytest.approx(0.6, abs=0.01)
+        assert via.drill == pytest.approx(0.3, abs=0.01)
+        assert via.net == 2
+        assert via.layers[0] == Layer.F_CU
+        assert via.layers[1] == Layer.B_CU
+
+    def test_parse_vias_empty(self):
+        """parse_vias returns empty dict when no vias exist."""
+        from kicad_tools.router.optimizer.pcb import parse_vias
+
+        pcb_no_vias = """(kicad_pcb
+  (net 0 "")
+  (net 1 "A")
+  (segment (start 100 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 1))
+)"""
+        result = parse_vias(pcb_no_vias)
+        assert result == {}
+
+    def test_parse_vias_multiple_nets(self):
+        """parse_vias groups vias by net name correctly."""
+        from kicad_tools.router.optimizer.pcb import parse_vias
+
+        pcb = """(kicad_pcb
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+  (via (at 105.0000 110.0000) (size 0.8000) (drill 0.4000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v1"))
+  (via (at 115.0000 120.0000) (size 0.8000) (drill 0.4000) (layers "F.Cu" "B.Cu") (net 2) (uuid "v2"))
+  (via (at 125.0000 120.0000) (size 0.8000) (drill 0.4000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v3"))
+)"""
+        result = parse_vias(pcb)
+        assert len(result["VCC"]) == 2
+        assert len(result["GND"]) == 1
+
+
+class TestLoadExistingRoutes:
+    """Tests for load_pcb_for_routing with load_existing_routes=True."""
+
+    def _write_pcb(self, tmp_path, content=_PCB_WITH_EXISTING_ROUTES):
+        pcb_file = tmp_path / "pass1_routed.kicad_pcb"
+        pcb_file.write_text(content)
+        return pcb_file
+
+    def test_default_no_existing_routes(self, tmp_path):
+        """Default load_existing_routes=False does not block route cells."""
+        pcb_file = self._write_pcb(tmp_path)
+        router, net_map = load_pcb_for_routing(str(pcb_file), validate_drc=False)
+        # With default (False), the existing segment cells should NOT be
+        # marked as blocked (only pad cells are blocked).
+        # Verify at least that routing completed without error.
+        assert router is not None
+        assert "NET_A" in net_map
+
+    def test_existing_routes_mark_grid_cells(self, tmp_path):
+        """When load_existing_routes=True, existing segment cells are blocked."""
+        pcb_file = self._write_pcb(tmp_path)
+        router, net_map = load_pcb_for_routing(
+            str(pcb_file), validate_drc=False, load_existing_routes=True
+        )
+        # The existing segment for NET_A goes from (112.3, 113.095)
+        # to (120.0, 113.095).  Pick a point along that segment and
+        # verify the grid cell is blocked.
+        mid_x, mid_y = 116.0, 113.095
+        gx, gy = router.grid.world_to_grid(mid_x, mid_y)
+        layer_idx = router.grid.layer_to_index(Layer.F_CU.value)
+
+        cell = router.grid.grid[layer_idx][gy][gx]
+        assert cell.blocked, (
+            "Grid cell along existing segment should be blocked when load_existing_routes=True"
+        )
+
+    def test_existing_via_marks_grid_cells(self, tmp_path):
+        """When load_existing_routes=True, existing via cells are blocked."""
+        pcb_file = self._write_pcb(tmp_path)
+        router, net_map = load_pcb_for_routing(
+            str(pcb_file), validate_drc=False, load_existing_routes=True
+        )
+        # The existing via for NET_B is at (125.0, 120.0)
+        gx, gy = router.grid.world_to_grid(125.0, 120.0)
+        # Via blocks all layers
+        for layer_idx in range(router.grid.num_layers):
+            cell = router.grid.grid[layer_idx][gy][gx]
+            assert cell.blocked, (
+                f"Grid cell at via position should be blocked on layer {layer_idx} "
+                "when load_existing_routes=True"
+            )
+
+    def test_single_pass_unchanged(self, routing_test_pcb):
+        """Regression: load_existing_routes=False behaves identically to before."""
+        # Load with default (False)
+        router1, net_map1 = load_pcb_for_routing(str(routing_test_pcb), validate_drc=False)
+        # Load again explicitly False
+        router2, net_map2 = load_pcb_for_routing(
+            str(routing_test_pcb), validate_drc=False, load_existing_routes=False
+        )
+        assert net_map1 == net_map2
+        assert len(router1.pads) == len(router2.pads)
+        assert len(router1.nets) == len(router2.nets)
+
+
+class TestMergeRoutesViaConflicts:
+    """Tests for merge_routes_into_pcb with co-located via detection."""
+
+    def test_merge_no_conflicts_default(self):
+        """Default merge (detect_via_conflicts=False) appends without scanning."""
+        original = """(kicad_pcb
+  (net 0 "")
+  (net 1 "A")
+  (via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v1"))
+)"""
+        new_routes = '(via (at 120.0000 120.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v2"))'
+        result = merge_routes_into_pcb(original, new_routes)
+        # Both vias should be present
+        assert result.count("(via") == 2
+
+    def test_merge_detects_colocated_vias(self):
+        """detect_via_conflicts=True removes co-located vias on different nets."""
+        original = """(kicad_pcb
+  (net 0 "")
+  (net 1 "A")
+  (net 2 "B")
+  (via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v1"))
+)"""
+        # New route adds a via at the same location but on a different net
+        new_routes = '(via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 2) (uuid "v2"))'
+        result = merge_routes_into_pcb(
+            original, new_routes, detect_via_conflicts=True, via_clearance=0.2
+        )
+        # The conflicting via (net 2) should have been removed; only net 1 remains
+        assert result.count("(via") == 1
+        assert "(net 1)" in result
+
+    def test_merge_keeps_same_net_vias(self):
+        """Co-located vias on the same net are not removed."""
+        original = """(kicad_pcb
+  (net 0 "")
+  (net 1 "A")
+  (via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v1"))
+)"""
+        # Another via at same position, same net
+        new_routes = '(via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v2"))'
+        result = merge_routes_into_pcb(
+            original, new_routes, detect_via_conflicts=True, via_clearance=0.2
+        )
+        # Both vias should remain (same net, no conflict)
+        assert result.count("(via") == 2
+
+    def test_merge_conflict_within_clearance(self):
+        """Vias within clearance distance on different nets are flagged."""
+        original = """(kicad_pcb
+  (net 0 "")
+  (net 1 "A")
+  (net 2 "B")
+  (via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v1"))
+)"""
+        # Via 0.1mm away on a different net (within default 0.2mm clearance)
+        new_routes = '(via (at 110.0500 110.0500) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 2) (uuid "v2"))'
+        result = merge_routes_into_pcb(
+            original, new_routes, detect_via_conflicts=True, via_clearance=0.2
+        )
+        assert result.count("(via") == 1
+        assert "(net 1)" in result
+
+    def test_merge_no_conflict_outside_clearance(self):
+        """Vias outside clearance distance on different nets are kept."""
+        original = """(kicad_pcb
+  (net 0 "")
+  (net 1 "A")
+  (net 2 "B")
+  (via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v1"))
+)"""
+        # Via 5mm away on different net (well outside clearance)
+        new_routes = '(via (at 115.0000 115.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 2) (uuid "v2"))'
+        result = merge_routes_into_pcb(
+            original, new_routes, detect_via_conflicts=True, via_clearance=0.2
+        )
+        assert result.count("(via") == 2
+
+    def test_backward_compatible_default(self):
+        """Default detect_via_conflicts=False preserves exact existing behaviour."""
+        original = """(kicad_pcb
+  (net 0 "")
+  (net 1 "A")
+  (net 2 "B")
+  (via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v1"))
+)"""
+        new_routes = '(via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 2) (uuid "v2"))'
+        # Without flag, both vias stay (backward compat)
+        result = merge_routes_into_pcb(original, new_routes)
+        assert result.count("(via") == 2

--- a/tests/test_router_io.py
+++ b/tests/test_router_io.py
@@ -2648,6 +2648,7 @@ class TestMergeRoutesViaConflicts:
         # The conflicting via (net 2) should have been removed; only net 1 remains
         assert result.count("(via") == 1
         assert "(net 1)" in result
+        assert _validate_sexp_parentheses(result), "Removal of conflicting via must not leave orphaned parentheses"
 
     def test_merge_keeps_same_net_vias(self):
         """Co-located vias on the same net are not removed."""
@@ -2679,6 +2680,7 @@ class TestMergeRoutesViaConflicts:
         )
         assert result.count("(via") == 1
         assert "(net 1)" in result
+        assert _validate_sexp_parentheses(result), "Removal of within-clearance via must not leave orphaned parentheses"
 
     def test_merge_no_conflict_outside_clearance(self):
         """Vias outside clearance distance on different nets are kept."""


### PR DESCRIPTION
## Summary

Prevent two-pass merge from creating overlapping vias and traces by teaching
`load_pcb_for_routing` to parse existing routed geometry and mark it as obstacles
on the routing grid, and by adding optional post-merge co-located via detection
to `merge_routes_into_pcb`.

## Changes

- Add `parse_vias(pcb_text)` to `src/kicad_tools/router/optimizer/pcb.py` as a
  companion to `parse_segments()` -- parses `(via ...)` S-expressions into `Via`
  objects grouped by net name.
- Add `load_existing_routes: bool = False` parameter to `load_pcb_for_routing()`
  in `src/kicad_tools/router/io.py`. When True, existing segments and vias are
  parsed and marked as blocked on the routing grid via `grid.mark_route()`.
- Add `detect_via_conflicts: bool = False` and `via_clearance: float = 0.2`
  parameters to `merge_routes_into_pcb()`. When enabled, scans merged output
  for co-located vias on different nets and removes duplicates.
- Add `_remove_conflicting_vias()` helper for post-merge via de-duplication.
- Add 13 new tests across 3 test classes covering obstacle loading, via parsing,
  conflict detection, and backward compatibility.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `load_pcb_for_routing` accepts `load_existing_routes` parameter | PASS | Function signature updated, imports verified |
| When True, segments and vias parsed and marked as obstacles | PASS | `test_existing_routes_mark_grid_cells` and `test_existing_via_marks_grid_cells` confirm grid cells blocked |
| `merge_routes_into_pcb` optionally de-duplicates co-located vias | PASS | `test_merge_detects_colocated_vias` and `test_merge_conflict_within_clearance` confirm removal |
| No regression in single-pass use case | PASS | `test_single_pass_unchanged` and `test_default_no_existing_routes` confirm default=False unchanged |
| `parse_vias` added to optimizer/pcb.py | PASS | `TestParseVias` class with 3 tests confirms correct parsing |
| All 139 existing tests pass | PASS | Full `test_router_io.py` suite: 139 passed in 15.7s |

## Test Plan

- `TestParseVias` (3 tests): via coordinate/net/layer parsing, empty input, multi-net grouping
- `TestLoadExistingRoutes` (4 tests): default unchanged, segment cells blocked, via cells blocked, single-pass regression
- `TestMergeRoutesViaConflicts` (6 tests): default no-scan, co-located detection, same-net kept, within-clearance, outside-clearance, backward compat

Closes #1256