### PR TITLE
fix(route): accept --grid auto in top-level CLI parser

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -159,8 +159,9 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--strategy", args.strategy])
     if args.skip_nets:
         sub_argv.extend(["--skip-nets", args.skip_nets])
-    if args.grid != 0.25:
-        sub_argv.extend(["--grid", str(args.grid)])
+    grid_val = str(args.grid)
+    if grid_val.lower() == "auto" or grid_val != "0.25":
+        sub_argv.extend(["--grid", grid_val])
     if args.trace_width != 0.2:
         sub_argv.extend(["--trace-width", str(args.trace_width)])
     if args.clearance != 0.15:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -853,7 +853,12 @@ def _add_route_parser(subparsers) -> None:
         help="Routing strategy (default: negotiated)",
     )
     route_parser.add_argument("--skip-nets", help="Comma-separated nets to skip")
-    route_parser.add_argument("--grid", type=float, default=0.25, help="Grid resolution in mm")
+    route_parser.add_argument(
+        "--grid",
+        type=str,
+        default="0.25",
+        help="Grid resolution in mm or 'auto' for automatic selection (default: 0.25)",
+    )
     route_parser.add_argument("--trace-width", type=float, default=0.2, help="Trace width in mm")
     route_parser.add_argument("--clearance", type=float, default=0.15, help="Clearance in mm")
     route_parser.add_argument("--via-drill", type=float, default=0.3, help="Via drill size in mm")

--- a/tests/test_route_cmd_params.py
+++ b/tests/test_route_cmd_params.py
@@ -21,7 +21,7 @@ class TestRouteCommandGridParameter:
             output=None,
             strategy="negotiated",
             skip_nets=None,
-            grid=0.1,  # Non-default value
+            grid="0.1",  # Non-default value (string, as parser now emits)
             trace_width=0.2,
             clearance=0.15,
             via_drill=0.3,
@@ -54,7 +54,7 @@ class TestRouteCommandGridParameter:
             output=None,
             strategy="negotiated",
             skip_nets=None,
-            grid=0.25,  # Default value - should not be passed
+            grid="0.25",  # Default value (string) - should not be passed
             trace_width=0.2,
             clearance=0.15,
             via_drill=0.3,
@@ -75,6 +75,68 @@ class TestRouteCommandGridParameter:
             call_args = mock_main.call_args[0][0]
             assert "--grid" not in call_args
 
+    def test_grid_auto_passed_through(self):
+        """Grid 'auto' value is always passed through to route_cmd."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = SimpleNamespace(
+            pcb="test.kicad_pcb",
+            output=None,
+            strategy="negotiated",
+            skip_nets=None,
+            grid="auto",  # Auto mode
+            trace_width=0.2,
+            clearance=0.15,
+            via_drill=0.3,
+            via_diameter=0.6,
+            mc_trials=10,
+            iterations=15,
+            verbose=False,
+            dry_run=True,
+            quiet=True,
+            power_nets=None,
+        )
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--grid" in call_args
+            grid_idx = call_args.index("--grid")
+            assert call_args[grid_idx + 1] == "auto"
+
+    def test_grid_auto_uppercase_passed_through(self):
+        """Grid 'AUTO' (uppercase) value is passed through to route_cmd."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = SimpleNamespace(
+            pcb="test.kicad_pcb",
+            output=None,
+            strategy="negotiated",
+            skip_nets=None,
+            grid="AUTO",  # Auto mode uppercase
+            trace_width=0.2,
+            clearance=0.15,
+            via_drill=0.3,
+            via_diameter=0.6,
+            mc_trials=10,
+            iterations=15,
+            verbose=False,
+            dry_run=True,
+            quiet=True,
+            power_nets=None,
+        )
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--grid" in call_args
+            grid_idx = call_args.index("--grid")
+            assert call_args[grid_idx + 1] == "AUTO"
+
 
 class TestRouteCommandClearanceParameter:
     """Tests for --clearance parameter handling in route command."""
@@ -89,7 +151,7 @@ class TestRouteCommandClearanceParameter:
             output=None,
             strategy="negotiated",
             skip_nets=None,
-            grid=0.25,
+            grid="0.25",
             trace_width=0.2,
             clearance=0.127,  # Non-default value
             via_drill=0.3,
@@ -122,7 +184,7 @@ class TestRouteCommandClearanceParameter:
             output=None,
             strategy="negotiated",
             skip_nets=None,
-            grid=0.25,
+            grid="0.25",
             trace_width=0.2,
             clearance=0.15,  # Default value - should not be passed
             via_drill=0.3,
@@ -159,11 +221,27 @@ class TestRouteCommandDefaultConsistency:
         args = parser.parse_args(["route", "test.kicad_pcb", "--dry-run"])
 
         # These should match the checks in routing.py
-        assert args.grid == 0.25, "Grid default should be 0.25"
+        assert args.grid == "0.25", "Grid default should be '0.25'"
         assert args.clearance == 0.15, "Clearance default should be 0.15"
         assert args.trace_width == 0.2, "Trace width default should be 0.2"
         assert args.via_drill == 0.3, "Via drill default should be 0.3"
         assert args.via_diameter == 0.6, "Via diameter default should be 0.6"
+
+    def test_parser_accepts_grid_auto(self):
+        """Top-level parser accepts --grid auto without error."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["route", "test.kicad_pcb", "--grid", "auto"])
+        assert args.grid == "auto", "Parser should accept 'auto' as a grid value"
+
+    def test_parser_accepts_grid_numeric(self):
+        """Top-level parser accepts --grid with numeric values as strings."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["route", "test.kicad_pcb", "--grid", "0.1"])
+        assert args.grid == "0.1", "Parser should accept '0.1' as a grid value"
 
     def test_route_cmd_defaults_match_parser_defaults(self):
         """Verify route_cmd.py defaults match parser.py defaults."""


### PR DESCRIPTION
## Summary

The top-level CLI parser (`parser.py`) declared `--grid` as `type=float`, causing argparse to reject `--grid auto` with "invalid float value: 'auto'". The auto-grid selection logic already worked in `route_cmd.py` but was unreachable through the `kct route` entry point. This change makes `--grid` accept string values so "auto" passes through correctly.

## Changes

- `src/kicad_tools/cli/parser.py`: Changed `--grid` argument from `type=float, default=0.25` to `type=str, default="0.25"` and updated help text to document the `auto` option
- `src/kicad_tools/cli/commands/routing.py`: Updated the default-omission check from `args.grid != 0.25` (float comparison) to string comparison, ensuring "auto" is always passed through
- `tests/test_route_cmd_params.py`: Updated existing `SimpleNamespace` fixtures from float to string grid values; added 4 new tests for auto grid pass-through, uppercase auto, and parser acceptance

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct route board.kicad_pcb --grid auto` succeeds (no rejection) | PASS | Parser now accepts string values; `--grid auto` parses without error |
| `--grid auto` triggers `auto_select_grid_resolution()` | PASS | "auto" string passes through to `route_cmd.main()` which has working auto-grid logic at lines 1998-2027 |
| `--grid auto` prints selected grid resolution unless `--quiet` | PASS | Existing logic in `route_cmd.py:2007-2017` handles this |
| `kct route board.kicad_pcb --grid 0.1` continues to work | PASS | Numeric strings pass through and are converted to float by `route_cmd.py:2021` |
| `kct route board.kicad_pcb --grid invalid` produces clear error | PASS | `route_cmd.py:2023-2027` catches ValueError and prints helpful message |
| `kct route --help` describes the `auto` option | PASS | Help text now reads: "Grid resolution in mm or 'auto' for automatic selection (default: 0.25)" |
| Default-omission check works correctly with string type | PASS | `grid_val != "0.25"` correctly skips redundant pass-through; "auto" always passes through |

## Test Plan

All 14 tests in `tests/test_route_cmd_params.py` pass, including 4 new tests:
- `test_grid_auto_passed_through` -- verifies "auto" appears in sub_argv
- `test_grid_auto_uppercase_passed_through` -- verifies "AUTO" is passed through
- `test_parser_accepts_grid_auto` -- verifies top-level parser accepts `--grid auto`
- `test_parser_accepts_grid_numeric` -- verifies top-level parser accepts `--grid 0.1`

Closes #1264