### PR TITLE
fix(check): auto-detect copper layer count from PCB

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -99,8 +99,8 @@ def main(argv: list[str] | None = None) -> int:
         "--layers",
         "-l",
         type=int,
-        default=2,
-        help="Number of copper layers (default: 2)",
+        default=None,
+        help="Number of copper layers (auto-detected from board if not specified)",
     )
     parser.add_argument(
         "--copper",
@@ -182,12 +182,19 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error loading PCB: {e}", file=sys.stderr)
         return 1
 
+    # Auto-detect layer count from PCB if not explicitly provided
+    if args.layers is not None:
+        layers = args.layers
+    else:
+        detected = len(pcb.copper_layers)
+        layers = detected if detected > 0 else 2
+
     # Create checker with manufacturer rules
     try:
         checker = DRCChecker(
             pcb,
             manufacturer=args.mfr,
-            layers=args.layers,
+            layers=layers,
             copper_oz=args.copper,
         )
     except ValueError as e:
@@ -204,11 +211,11 @@ def main(argv: list[str] | None = None) -> int:
 
     # Output results
     if args.format == "json":
-        output_json(violations, results, pcb_path, args.mfr, args.layers)
+        output_json(violations, results, pcb_path, args.mfr, layers)
     elif args.format == "summary":
         output_summary(violations, results, pcb_path)
     else:
-        output_table(violations, results, pcb_path, args.mfr, args.layers, args.verbose)
+        output_table(violations, results, pcb_path, args.mfr, layers, args.verbose)
 
     # Determine exit code
     error_count = sum(1 for v in violations if v.is_error)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,6 +202,114 @@ def drc_clean_pcb(tmp_path: Path) -> Path:
     return pcb_file
 
 
+# 4-layer PCB for testing layer auto-detection
+# Has F.Cu, In1.Cu, In2.Cu, B.Cu as copper layers
+FOUR_LAYER_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" power)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 125 125)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (segment (start 122 125) (end 115 125) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000020"))
+)
+"""
+
+
+@pytest.fixture
+def four_layer_pcb(tmp_path: Path) -> Path:
+    """Create a 4-layer PCB file for testing layer auto-detection."""
+    pcb_file = tmp_path / "four_layer.kicad_pcb"
+    pcb_file.write_text(FOUR_LAYER_PCB)
+    return pcb_file
+
+
+# 6-layer PCB for testing layer auto-detection
+# Has F.Cu, In1.Cu, In2.Cu, In3.Cu, In4.Cu, B.Cu as copper layers
+SIX_LAYER_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" power)
+    (3 "In3.Cu" power)
+    (4 "In4.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 125 125)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (segment (start 122 125) (end 115 125) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000020"))
+)
+"""
+
+
+@pytest.fixture
+def six_layer_pcb(tmp_path: Path) -> Path:
+    """Create a 6-layer PCB file for testing layer auto-detection."""
+    pcb_file = tmp_path / "six_layer.kicad_pcb"
+    pcb_file.write_text(SIX_LAYER_PCB)
+    return pcb_file
+
+
 # PCB with edge cuts and multiple components for routing tests
 ROUTING_TEST_PCB = """(kicad_pcb
   (version 20240108)

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -274,3 +274,72 @@ class TestCheckJsonSchema:
         # CI-friendly check: counts are integers
         assert isinstance(data["summary"]["errors"], int)
         assert isinstance(data["summary"]["warnings"], int)
+
+
+class TestCheckLayerAutoDetection:
+    """Tests for automatic copper layer count detection."""
+
+    def test_auto_detect_2_layer_board(self, drc_clean_pcb: Path, capsys):
+        """Test that a 2-layer board auto-detects 2 layers (no regression)."""
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(drc_clean_pcb), "--format", "json"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["layers"] == 2
+
+    def test_auto_detect_4_layer_board(self, four_layer_pcb: Path, capsys):
+        """Test that a 4-layer board auto-detects 4 layers without --layers flag."""
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(four_layer_pcb), "--format", "json"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["layers"] == 4
+
+    def test_auto_detect_6_layer_board(self, six_layer_pcb: Path, capsys):
+        """Test that a 6-layer board auto-detects 6 layers."""
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(six_layer_pcb), "--format", "json"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["layers"] == 6
+
+    def test_explicit_layers_overrides_detection(self, four_layer_pcb: Path, capsys):
+        """Test that --layers flag overrides auto-detection."""
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(four_layer_pcb), "--layers", "2", "--format", "json"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["layers"] == 2
+
+    def test_auto_detect_4_layer_table_output(self, four_layer_pcb: Path, capsys):
+        """Test that table output shows auto-detected layer count."""
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(four_layer_pcb)])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Layers: 4" in captured.out
+
+    def test_help_text_mentions_auto_detection(self, capsys):
+        """Test that --layers help text indicates auto-detection."""
+        from kicad_tools.cli.check_cmd import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--help"])
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "auto-detect" in captured.out.lower()


### PR DESCRIPTION
## Summary
The `kct check` command hardcoded `--layers 2` as the default, causing incorrect manufacturer DRU rule selection on 4-layer and 6-layer boards. This changes the default to `None` and auto-detects the copper layer count from `pcb.copper_layers`.

## Changes
- Changed `--layers` argument default from `2` to `None` in `check_cmd.py`
- Added auto-detection logic: after loading the PCB, resolve the layer count from `len(pcb.copper_layers)` when `--layers` is not explicitly provided
- Updated help text to indicate auto-detection behavior
- Passed the resolved `layers` value (instead of `args.layers`) to `DRCChecker` and output functions
- Added `FOUR_LAYER_PCB` and `SIX_LAYER_PCB` fixtures to `tests/conftest.py`
- Added 6 new tests in `TestCheckLayerAutoDetection` class

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 4-layer board selects 4-layer rules without `--layers 4` | PASS | `test_auto_detect_4_layer_board` asserts `data["layers"] == 4` in JSON output |
| `--layers 2` on a 4-layer board honours explicit override | PASS | `test_explicit_layers_overrides_detection` asserts `data["layers"] == 2` |
| JSON output includes `"layers": 4` on 4-layer board | PASS | `test_auto_detect_4_layer_board` verifies JSON |
| 2-layer board behaves identically (no regression) | PASS | `test_auto_detect_2_layer_board` + all 22 existing tests pass |
| 6-layer board auto-detects 6 | PASS | `test_auto_detect_6_layer_board` asserts `data["layers"] == 6` |
| Help text updated to indicate auto-detection | PASS | `test_help_text_mentions_auto_detection` asserts "auto-detect" in help output |

## Test Plan
All 28 tests in `tests/test_cli_check.py` pass (22 existing + 6 new). Linting and formatting checks pass on all changed files.

Closes #1263