### PR TITLE
fix(router): guard empty failure analysis section and filter stale strategy suggestions

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -784,6 +784,7 @@ def route_with_layer_escalation(
                 final_result.net_map,
                 final_result.nets_to_route,
                 quiet=quiet,
+                current_strategy=args.strategy,
             )
 
     return 0 if final_result.success else 1
@@ -1130,6 +1131,7 @@ def route_with_rule_relaxation(
                 final_result.net_map,
                 final_result.nets_to_route,
                 quiet=quiet,
+                current_strategy=args.strategy,
             )
 
     return 0 if final_result.success else 1
@@ -1508,6 +1510,7 @@ def route_with_combined_escalation(
                 final_result.net_map,
                 final_result.nets_to_route,
                 quiet=quiet,
+                current_strategy=args.strategy,
             )
 
     return 0 if final_result.success else 1
@@ -2877,11 +2880,16 @@ def main(argv: list[str] | None = None) -> int:
             # Show comprehensive routing summary with successes, failures, and suggestions
             # Use JSON format if requested
             if args.format == "json":
-                print_routing_diagnostics_json(router, net_map, nets_to_route)
+                print_routing_diagnostics_json(
+                    router, net_map, nets_to_route, current_strategy=args.strategy
+                )
             else:
                 # Verbose mode shows detailed path analysis for each failure
                 verbose = args.verbose or args.diagnostics
-                show_routing_summary(router, net_map, nets_to_route, quiet=quiet, verbose=verbose)
+                show_routing_summary(
+                    router, net_map, nets_to_route,
+                    quiet=quiet, verbose=verbose, current_strategy=args.strategy,
+                )
 
     # Exit codes:
     # 0 = All nets routed AND (DRC passed OR DRC not run)

--- a/src/kicad_tools/router/output.py
+++ b/src/kicad_tools/router/output.py
@@ -22,6 +22,7 @@ def show_routing_summary(
     nets_to_route: int,
     quiet: bool = False,
     verbose: bool = False,
+    current_strategy: str = "basic",
 ) -> None:
     """Show comprehensive routing summary with successes, failures, and suggestions.
 
@@ -36,6 +37,9 @@ def show_routing_summary(
         nets_to_route: Total number of nets that should be routed
         quiet: If True, skip output
         verbose: If True, show detailed path analysis for failures
+        current_strategy: The routing strategy that was used (e.g. "basic",
+            "negotiated", "monte-carlo"). Suggestions will exclude this strategy
+            since the user already tried it.
     """
     if quiet:
         return
@@ -98,9 +102,7 @@ def show_routing_summary(
             else:
                 # Fallback to basic format
                 cause_name = (
-                    failure.failure_cause.value
-                    if hasattr(failure, "failure_cause")
-                    else "unknown"
+                    failure.failure_cause.value if hasattr(failure, "failure_cause") else "unknown"
                 )
                 print(f"  {net_name}: {cause_name} - {failure.reason}")
         else:
@@ -132,16 +134,18 @@ def show_routing_summary(
 
     # Show verbose details for each failed net
     if verbose and unrouted_ids:
-        print(f"\n{'=' * 60}")
-        print("Detailed Failure Analysis")
-        print(f"{'=' * 60}")
+        # Only print section if at least one net has failure records
+        nets_with_detail = [
+            net_id for net_id in sorted(unrouted_ids) if failures_by_net.get(net_id)
+        ]
+        if nets_with_detail:
+            print(f"\n{'=' * 60}")
+            print("Detailed Failure Analysis")
+            print(f"{'=' * 60}")
 
-        for net_id in sorted(unrouted_ids):
+        for net_id in nets_with_detail:
             net_name = reverse_net.get(net_id, f"Net_{net_id}")
-            net_failures = failures_by_net.get(net_id, [])
-
-            if not net_failures:
-                continue
+            net_failures = failures_by_net[net_id]
 
             failure = net_failures[0]
             analysis = getattr(failure, "analysis", None)
@@ -152,17 +156,31 @@ def show_routing_summary(
             if hasattr(failure, "source_coords") and failure.source_coords:
                 src = failure.source_coords
                 tgt = failure.target_coords
-                src_ref = f"{failure.source_pad[0]}.{failure.source_pad[1]}" if failure.source_pad else "?"
-                tgt_ref = f"{failure.target_pad[0]}.{failure.target_pad[1]}" if failure.target_pad else "?"
-                print(f"  Path: {src_ref} ({src[0]:.1f}, {src[1]:.1f}) -> {tgt_ref} ({tgt[0]:.1f}, {tgt[1]:.1f})")
+                src_ref = (
+                    f"{failure.source_pad[0]}.{failure.source_pad[1]}"
+                    if failure.source_pad
+                    else "?"
+                )
+                tgt_ref = (
+                    f"{failure.target_pad[0]}.{failure.target_pad[1]}"
+                    if failure.target_pad
+                    else "?"
+                )
+                print(
+                    f"  Path: {src_ref} ({src[0]:.1f}, {src[1]:.1f}) -> {tgt_ref} ({tgt[0]:.1f}, {tgt[1]:.1f})"
+                )
 
             if analysis:
-                print(f"  Root cause: {analysis.root_cause.value} ({analysis.confidence:.0%} confidence)")
+                print(
+                    f"  Root cause: {analysis.root_cause.value} ({analysis.confidence:.0%} confidence)"
+                )
                 print(f"  Congestion score: {analysis.congestion_score:.0%}")
 
                 # Show blocked area info
                 area = analysis.failure_area
-                print(f"  Blocked area: ({area.min_x:.1f}, {area.min_y:.1f}) to ({area.max_x:.1f}, {area.max_y:.1f})")
+                print(
+                    f"  Blocked area: ({area.min_x:.1f}, {area.min_y:.1f}) to ({area.max_x:.1f}, {area.max_y:.1f})"
+                )
                 print(f"                Size: {area.width:.1f}mm x {area.height:.1f}mm")
 
                 if analysis.clearance_margin != float("inf"):
@@ -270,7 +288,14 @@ def show_routing_summary(
                 if len(blocking_nets) > 5:
                     net_list += f" +{len(blocking_nets) - 5} more"
                 print(f"   Blocking nets: {net_list}")
-            print("   Try: kct route --strategy negotiated (allows rip-up and reroute)\n")
+            if current_strategy != "negotiated":
+                print("   Try: kct route --strategy negotiated (allows rip-up and reroute)\n")
+            elif current_strategy != "monte-carlo":
+                print(
+                    "   Try: kct route --strategy monte-carlo --mc-trials 20 (randomized rerouting)\n"
+                )
+            else:
+                print("   Try: Reposition components to reduce routing-order conflicts\n")
 
         # Check for BLOCKED_PATH issues
         blocked_failures = failures_by_cause.get("blocked_path", [])
@@ -305,10 +330,18 @@ def show_routing_summary(
         # General suggestions if nothing specific
         if suggestions_shown == 0:
             num_layers = getattr(router.grid, "num_layers", 2)
-            print("1. Try negotiated routing: kct route --strategy negotiated")
-            print("2. Try Monte Carlo routing: kct route --strategy monte-carlo --mc-trials 20")
+            suggestion_num = 0
+            all_strategies = {
+                "negotiated": "Try negotiated routing: kct route --strategy negotiated",
+                "monte-carlo": "Try Monte Carlo routing: kct route --strategy monte-carlo --mc-trials 20",
+            }
+            for strategy_name, suggestion_text in all_strategies.items():
+                if strategy_name != current_strategy:
+                    suggestion_num += 1
+                    print(f"{suggestion_num}. {suggestion_text}")
             if num_layers <= 2:
-                print("3. Consider 4-layer routing: kct route --layers 4")
+                suggestion_num += 1
+                print(f"{suggestion_num}. Consider 4-layer routing: kct route --layers 4")
 
     print(f"\n{'=' * 60}")
 
@@ -334,6 +367,7 @@ def get_routing_diagnostics_json(
     router: Autorouter,
     net_map: dict[str, int],
     nets_to_route: int,
+    current_strategy: str = "basic",
 ) -> dict:
     """Get routing diagnostics as a JSON-serializable dictionary.
 
@@ -343,6 +377,8 @@ def get_routing_diagnostics_json(
         router: The Autorouter instance with completed routing
         net_map: Mapping of net names to net IDs
         nets_to_route: Total number of nets that should be routed
+        current_strategy: The routing strategy that was used. Suggestions will
+            exclude this strategy since the user already tried it.
 
     Returns:
         Dictionary with routing diagnostics in JSON-serializable format
@@ -454,6 +490,41 @@ def get_routing_diagnostics_json(
             }
         )
 
+    if failures_by_cause.get("routing_order", 0) > 0:
+        fix_text = (
+            "--strategy negotiated (allows rip-up and reroute)"
+            if current_strategy != "negotiated"
+            else "--strategy monte-carlo --mc-trials 20 (randomized rerouting)"
+            if current_strategy != "monte-carlo"
+            else "Reposition components to reduce routing-order conflicts"
+        )
+        suggestions.append(
+            {
+                "category": "ROUTING_ORDER",
+                "affected_nets": failures_by_cause["routing_order"],
+                "description": "Earlier routed nets are blocking paths",
+                "fix": fix_text,
+            }
+        )
+
+    # Add general strategy suggestions if no cause-specific suggestions
+    if not suggestions:
+        all_strategy_suggestions = {
+            "negotiated": {
+                "category": "STRATEGY",
+                "description": "Try negotiated routing for rip-up and reroute",
+                "fix": "--strategy negotiated",
+            },
+            "monte-carlo": {
+                "category": "STRATEGY",
+                "description": "Try Monte Carlo routing for randomized optimization",
+                "fix": "--strategy monte-carlo --mc-trials 20",
+            },
+        }
+        for strategy_name, suggestion in all_strategy_suggestions.items():
+            if strategy_name != current_strategy:
+                suggestions.append(suggestion)
+
     return {
         "summary": {
             "nets_requested": nets_to_route,
@@ -474,6 +545,7 @@ def print_routing_diagnostics_json(
     router: Autorouter,
     net_map: dict[str, int],
     nets_to_route: int,
+    current_strategy: str = "basic",
 ) -> None:
     """Print routing diagnostics as JSON to stdout.
 
@@ -481,8 +553,12 @@ def print_routing_diagnostics_json(
         router: The Autorouter instance with completed routing
         net_map: Mapping of net names to net IDs
         nets_to_route: Total number of nets that should be routed
+        current_strategy: The routing strategy that was used. Suggestions will
+            exclude this strategy since the user already tried it.
     """
-    diagnostics = get_routing_diagnostics_json(router, net_map, nets_to_route)
+    diagnostics = get_routing_diagnostics_json(
+        router, net_map, nets_to_route, current_strategy=current_strategy
+    )
     print(json.dumps(diagnostics, indent=2))
 
 

--- a/tests/test_routing_output.py
+++ b/tests/test_routing_output.py
@@ -1,0 +1,371 @@
+"""Tests for routing output and diagnostics display.
+
+Verifies:
+- Bug #1267a: Empty "Detailed Failure Analysis" section is not printed when
+  no RoutingFailure objects have detailed analysis.
+- Bug #1267b: Strategy suggestions are filtered to exclude the current strategy.
+- JSON diagnostics also filter strategy suggestions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from unittest.mock import MagicMock
+
+from kicad_tools.router.output import (
+    get_routing_diagnostics_json,
+    show_routing_summary,
+)
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs so we don't need to instantiate real Autorouter / Grid
+# ---------------------------------------------------------------------------
+
+
+class _FailureCause(Enum):
+    UNKNOWN = "unknown"
+    ROUTING_ORDER = "routing_order"
+    CONGESTION = "congestion"
+
+
+@dataclass
+class _RoutingFailure:
+    net: int
+    net_name: str
+    source_pad: tuple[str, str]
+    target_pad: tuple[str, str]
+    source_coords: tuple[float, float] | None = None
+    target_coords: tuple[float, float] | None = None
+    blocking_nets: set[int] = field(default_factory=set)
+    blocking_components: list[str] = field(default_factory=list)
+    reason: str = "No path found"
+    failure_cause: _FailureCause = _FailureCause.UNKNOWN
+    analysis: object | None = None
+
+
+def _make_router(
+    routes=None,
+    routing_failures=None,
+    grid_num_layers=2,
+    grid_resolution=0.25,
+):
+    """Build a minimal mock that satisfies show_routing_summary / get_routing_diagnostics_json."""
+    router = MagicMock()
+    router.routes = routes or []
+    router.routing_failures = routing_failures or []
+    router.grid.num_layers = grid_num_layers
+    router.grid.resolution = grid_resolution
+    return router
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: Empty "Detailed Failure Analysis" section
+# ---------------------------------------------------------------------------
+
+
+class TestDetailedFailureAnalysisSection:
+    """The 'Detailed Failure Analysis' header must not appear when there are
+    no RoutingFailure records with content."""
+
+    def test_no_header_when_no_failures(self, capsys):
+        """verbose=True with unrouted nets but no failure records should NOT
+        print the 'Detailed Failure Analysis' header."""
+        router = _make_router()
+        net_map = {"NetA": 1, "NetB": 2}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=2,
+            verbose=True,
+        )
+
+        output = capsys.readouterr().out
+        assert "Detailed Failure Analysis" not in output
+
+    def test_no_header_when_failures_lack_detail(self, capsys):
+        """Even with RoutingFailure objects, if they belong to *routed* nets
+        (not in unrouted_ids), the section should not appear."""
+        # Net 1 is routed (has a route), net 2 is unrouted but has no failures
+        route = MagicMock()
+        route.net = 1
+        route.segments = []
+        route.vias = []
+        router = _make_router(routes=[route])
+        net_map = {"NetA": 1, "NetB": 2}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=2,
+            verbose=True,
+        )
+
+        output = capsys.readouterr().out
+        # Net 2 is unrouted but there are no failure records for it
+        assert "Detailed Failure Analysis" not in output
+
+    def test_header_appears_when_failures_exist(self, capsys):
+        """When there are unrouted nets with failure records, the header
+        SHOULD appear."""
+        failure = _RoutingFailure(
+            net=1,
+            net_name="NetA",
+            source_pad=("R1", "1"),
+            target_pad=("R2", "1"),
+            failure_cause=_FailureCause.UNKNOWN,
+        )
+        router = _make_router(routing_failures=[failure])
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            verbose=True,
+        )
+
+        output = capsys.readouterr().out
+        assert "Detailed Failure Analysis" in output
+
+    def test_no_header_when_verbose_false(self, capsys):
+        """The section is verbose-only, so verbose=False should never show it."""
+        failure = _RoutingFailure(
+            net=1,
+            net_name="NetA",
+            source_pad=("R1", "1"),
+            target_pad=("R2", "1"),
+            failure_cause=_FailureCause.UNKNOWN,
+        )
+        router = _make_router(routing_failures=[failure])
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            verbose=False,
+        )
+
+        output = capsys.readouterr().out
+        assert "Detailed Failure Analysis" not in output
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: Strategy-aware suggestions in show_routing_summary
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyAwareSuggestions:
+    """Routing suggestions must exclude the strategy that was just used."""
+
+    def test_basic_strategy_shows_both_alternatives(self, capsys):
+        """With current_strategy='basic', both negotiated and monte-carlo
+        should be suggested."""
+        router = _make_router()
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            current_strategy="basic",
+        )
+
+        output = capsys.readouterr().out
+        assert "--strategy negotiated" in output
+        assert "--strategy monte-carlo" in output
+
+    def test_negotiated_strategy_excludes_negotiated(self, capsys):
+        """With current_strategy='negotiated', the suggestion must NOT
+        recommend --strategy negotiated."""
+        router = _make_router()
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            current_strategy="negotiated",
+        )
+
+        output = capsys.readouterr().out
+        assert "--strategy negotiated" not in output
+        assert "--strategy monte-carlo" in output
+
+    def test_monte_carlo_strategy_excludes_monte_carlo(self, capsys):
+        """With current_strategy='monte-carlo', the suggestion must NOT
+        recommend --strategy monte-carlo."""
+        router = _make_router()
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            current_strategy="monte-carlo",
+        )
+
+        output = capsys.readouterr().out
+        assert "--strategy monte-carlo" not in output
+        assert "--strategy negotiated" in output
+
+    def test_routing_order_suggestion_excludes_negotiated(self, capsys):
+        """When routing_order failures exist and current_strategy is 'negotiated',
+        the ROUTING ORDER section should NOT suggest negotiated."""
+        failure = _RoutingFailure(
+            net=1,
+            net_name="NetA",
+            source_pad=("R1", "1"),
+            target_pad=("R2", "1"),
+            failure_cause=_FailureCause.ROUTING_ORDER,
+            reason="Blocked by earlier route",
+        )
+        router = _make_router(routing_failures=[failure])
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            current_strategy="negotiated",
+        )
+
+        output = capsys.readouterr().out
+        assert "ROUTING ORDER" in output
+        assert "--strategy negotiated" not in output
+
+    def test_routing_order_suggestion_suggests_negotiated_when_basic(self, capsys):
+        """When routing_order failures exist and current_strategy is 'basic',
+        the suggestion should recommend negotiated."""
+        failure = _RoutingFailure(
+            net=1,
+            net_name="NetA",
+            source_pad=("R1", "1"),
+            target_pad=("R2", "1"),
+            failure_cause=_FailureCause.ROUTING_ORDER,
+            reason="Blocked by earlier route",
+        )
+        router = _make_router(routing_failures=[failure])
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            current_strategy="basic",
+        )
+
+        output = capsys.readouterr().out
+        assert "ROUTING ORDER" in output
+        assert "--strategy negotiated" in output
+
+    def test_default_strategy_is_basic(self, capsys):
+        """When current_strategy is not specified, it defaults to 'basic'
+        and both negotiated and monte-carlo are suggested."""
+        router = _make_router()
+        net_map = {"NetA": 1}
+
+        # Don't pass current_strategy -- should default to "basic"
+        show_routing_summary(router, net_map, nets_to_route=1)
+
+        output = capsys.readouterr().out
+        assert "--strategy negotiated" in output
+        assert "--strategy monte-carlo" in output
+
+
+# ---------------------------------------------------------------------------
+# Strategy-aware suggestions in JSON output
+# ---------------------------------------------------------------------------
+
+
+class TestJsonStrategyAwareSuggestions:
+    """get_routing_diagnostics_json must also filter strategies."""
+
+    def test_json_basic_shows_both(self):
+        router = _make_router()
+        net_map = {"NetA": 1}
+
+        result = get_routing_diagnostics_json(
+            router,
+            net_map,
+            nets_to_route=1,
+            current_strategy="basic",
+        )
+
+        suggestion_fixes = [s.get("fix", "") for s in result["suggestions"]]
+        fix_text = " ".join(suggestion_fixes)
+        assert "negotiated" in fix_text
+        assert "monte-carlo" in fix_text
+
+    def test_json_negotiated_excludes_negotiated(self):
+        router = _make_router()
+        net_map = {"NetA": 1}
+
+        result = get_routing_diagnostics_json(
+            router,
+            net_map,
+            nets_to_route=1,
+            current_strategy="negotiated",
+        )
+
+        suggestion_fixes = [s.get("fix", "") for s in result["suggestions"]]
+        fix_text = " ".join(suggestion_fixes)
+        assert "--strategy negotiated" not in fix_text
+        assert "monte-carlo" in fix_text
+
+    def test_json_monte_carlo_excludes_monte_carlo(self):
+        router = _make_router()
+        net_map = {"NetA": 1}
+
+        result = get_routing_diagnostics_json(
+            router,
+            net_map,
+            nets_to_route=1,
+            current_strategy="monte-carlo",
+        )
+
+        suggestion_fixes = [s.get("fix", "") for s in result["suggestions"]]
+        fix_text = " ".join(suggestion_fixes)
+        assert "--strategy monte-carlo" not in fix_text
+        assert "negotiated" in fix_text
+
+    def test_json_routing_order_with_negotiated_strategy(self):
+        """Routing order failures in JSON should suggest an alternative
+        to the current strategy."""
+        failure = _RoutingFailure(
+            net=1,
+            net_name="NetA",
+            source_pad=("R1", "1"),
+            target_pad=("R2", "1"),
+            failure_cause=_FailureCause.ROUTING_ORDER,
+            reason="Blocked by earlier route",
+        )
+        router = _make_router(routing_failures=[failure])
+        net_map = {"NetA": 1}
+
+        result = get_routing_diagnostics_json(
+            router,
+            net_map,
+            nets_to_route=1,
+            current_strategy="negotiated",
+        )
+
+        routing_order_suggestions = [
+            s for s in result["suggestions"] if s.get("category") == "ROUTING_ORDER"
+        ]
+        assert len(routing_order_suggestions) == 1
+        assert "--strategy negotiated" not in routing_order_suggestions[0]["fix"]
+
+    def test_json_default_strategy_is_basic(self):
+        """When current_strategy is not specified, it defaults to 'basic'."""
+        router = _make_router()
+        net_map = {"NetA": 1}
+
+        result = get_routing_diagnostics_json(router, net_map, nets_to_route=1)
+
+        suggestion_fixes = [s.get("fix", "") for s in result["suggestions"]]
+        fix_text = " ".join(suggestion_fixes)
+        assert "negotiated" in fix_text
+        assert "monte-carlo" in fix_text


### PR DESCRIPTION
## Summary

Fixes two bugs in routing output: (1) the "Detailed Failure Analysis" header printed unconditionally even when no failure records existed, producing a blank section; (2) strategy suggestions hardcoded `--strategy negotiated` and `--strategy monte-carlo` regardless of which strategy the user actually ran.

## Changes

- Guard the "Detailed Failure Analysis" section header in `show_routing_summary` so it only prints when at least one unrouted net has failure records with content.
- Add `current_strategy` parameter (default `"basic"`) to `show_routing_summary`, `get_routing_diagnostics_json`, and `print_routing_diagnostics_json`.
- Filter general strategy suggestions and routing-order suggestions to exclude the current strategy.
- Update all four call sites in `route_cmd.py` to forward `args.strategy`.
- Add `tests/test_routing_output.py` with 15 unit tests covering both bugs across text and JSON output paths.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Empty "Detailed Failure Analysis" section not printed when no failure records | Pass | `test_no_header_when_no_failures`, `test_no_header_when_failures_lack_detail` |
| `--strategy negotiated` not recommended when already using negotiated | Pass | `test_negotiated_strategy_excludes_negotiated`, `test_routing_order_suggestion_excludes_negotiated` |
| `--strategy monte-carlo` not recommended when already using monte-carlo | Pass | `test_monte_carlo_strategy_excludes_monte_carlo` |
| `--strategy basic` shows both alternatives | Pass | `test_basic_strategy_shows_both_alternatives` |
| `show_routing_summary` accepts `current_strategy` with default `"basic"` | Pass | `test_default_strategy_is_basic` |
| All call sites in `route_cmd.py` pass the active strategy | Pass | Verified four call sites updated |
| JSON output path applies same strategy-filter logic | Pass | `test_json_negotiated_excludes_negotiated`, `test_json_monte_carlo_excludes_monte_carlo`, `test_json_routing_order_with_negotiated_strategy` |

## Test Plan

- 15 new unit tests in `tests/test_routing_output.py`, all passing
- `uv run ruff check` clean on changed files
- `uv run ruff format --check` clean on changed files

Closes #1267