### PR TITLE
fix(cli): show correct DRC regression message in optimize-traces output

### DIFF
--- a/src/kicad_tools/cli/optimize_cmd.py
+++ b/src/kicad_tools/cli/optimize_cmd.py
@@ -221,9 +221,16 @@ Examples:
         )
 
         if args.drc_aware:
+            delta = stats.drc_errors_after - stats.drc_errors_before
+            if delta > 0:
+                suffix = f"({delta} new errors, {stats.nets_rolled_back} nets rolled back)"
+            elif stats.nets_rolled_back > 0:
+                suffix = f"(no regressions, {stats.nets_rolled_back} nets rolled back)"
+            else:
+                suffix = "(no regressions)"
             print(
                 f"  DRC errors:      {stats.drc_errors_before:>6} -> "
-                f"{stats.drc_errors_after:>6}  (no regressions)"
+                f"{stats.drc_errors_after:>6}  {suffix}"
             )
         print()
 

--- a/tests/test_optimize_cmd.py
+++ b/tests/test_optimize_cmd.py
@@ -383,3 +383,134 @@ class TestDrcAwareStatsFields:
         assert config.drc_manufacturer is None
         assert config.drc_layers == 2
         assert config.drc_copper_oz == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Tests: DRC-aware display message formatting
+# ---------------------------------------------------------------------------
+
+
+class TestDrcAwareDisplayMessage:
+    """Test that the DRC summary line correctly reflects error changes."""
+
+    def _make_stats(self, **kwargs):
+        """Create an OptimizationStats with given overrides."""
+        from kicad_tools.router.optimizer.config import OptimizationStats
+
+        return OptimizationStats(**kwargs)
+
+    def test_drc_output_shows_regression_count(self, simple_pcb_path: Path, capsys):
+        """When errors increase, output should show new error count, not 'no regressions'."""
+        stats = self._make_stats(
+            drc_errors_before=5,
+            drc_errors_after=10,
+            nets_rolled_back=3,
+            nets_optimized=5,
+            segments_before=20,
+            segments_after=15,
+            length_before=100.0,
+            length_after=95.0,
+        )
+        with patch(
+            "kicad_tools.router.optimizer.TraceOptimizer.optimize_pcb",
+            return_value=stats,
+        ):
+            result = main([str(simple_pcb_path), "--drc-aware", "--mfr", "jlcpcb", "--dry-run"])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "5 new errors" in captured.out
+        assert "3 nets rolled back" in captured.out
+        assert "no regressions" not in captured.out
+
+    def test_drc_output_shows_no_regressions_with_rollback(self, simple_pcb_path: Path, capsys):
+        """When errors do not increase but rollbacks occurred, show both facts."""
+        stats = self._make_stats(
+            drc_errors_before=5,
+            drc_errors_after=3,
+            nets_rolled_back=1,
+            nets_optimized=4,
+            segments_before=20,
+            segments_after=15,
+            length_before=100.0,
+            length_after=95.0,
+        )
+        with patch(
+            "kicad_tools.router.optimizer.TraceOptimizer.optimize_pcb",
+            return_value=stats,
+        ):
+            result = main([str(simple_pcb_path), "--drc-aware", "--mfr", "jlcpcb", "--dry-run"])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "no regressions" in captured.out
+        assert "1 nets rolled back" in captured.out
+        assert "new errors" not in captured.out
+
+    def test_drc_output_shows_no_regressions_without_rollback(self, simple_pcb_path: Path, capsys):
+        """When errors unchanged and no rollbacks, show simple 'no regressions'."""
+        stats = self._make_stats(
+            drc_errors_before=5,
+            drc_errors_after=5,
+            nets_rolled_back=0,
+            nets_optimized=4,
+            segments_before=20,
+            segments_after=15,
+            length_before=100.0,
+            length_after=95.0,
+        )
+        with patch(
+            "kicad_tools.router.optimizer.TraceOptimizer.optimize_pcb",
+            return_value=stats,
+        ):
+            result = main([str(simple_pcb_path), "--drc-aware", "--mfr", "jlcpcb", "--dry-run"])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "(no regressions)" in captured.out
+        assert "nets rolled back" not in captured.out
+        assert "new errors" not in captured.out
+
+    def test_drc_output_shows_no_regressions_when_errors_decrease(
+        self, simple_pcb_path: Path, capsys
+    ):
+        """When errors decrease with no rollbacks, show simple 'no regressions'."""
+        stats = self._make_stats(
+            drc_errors_before=10,
+            drc_errors_after=7,
+            nets_rolled_back=0,
+            nets_optimized=4,
+            segments_before=20,
+            segments_after=15,
+            length_before=100.0,
+            length_after=95.0,
+        )
+        with patch(
+            "kicad_tools.router.optimizer.TraceOptimizer.optimize_pcb",
+            return_value=stats,
+        ):
+            result = main([str(simple_pcb_path), "--drc-aware", "--mfr", "jlcpcb", "--dry-run"])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "(no regressions)" in captured.out
+        assert "new errors" not in captured.out
+
+    def test_drc_output_error_count_is_correct_delta(self, simple_pcb_path: Path, capsys):
+        """The new error count should be exactly drc_errors_after - drc_errors_before."""
+        stats = self._make_stats(
+            drc_errors_before=79,
+            drc_errors_after=120,
+            nets_rolled_back=3,
+            nets_optimized=10,
+            segments_before=200,
+            segments_after=150,
+            length_before=500.0,
+            length_after=480.0,
+        )
+        with patch(
+            "kicad_tools.router.optimizer.TraceOptimizer.optimize_pcb",
+            return_value=stats,
+        ):
+            result = main([str(simple_pcb_path), "--drc-aware", "--mfr", "jlcpcb", "--dry-run"])
+        assert result == 0
+        captured = capsys.readouterr()
+        # delta = 120 - 79 = 41
+        assert "41 new errors" in captured.out
+        assert "3 nets rolled back" in captured.out


### PR DESCRIPTION
## Summary
Fix the hardcoded "(no regressions)" suffix in the DRC-aware optimize-traces CLI output so it correctly reflects whether DRC errors actually increased.

## Changes
- Replace the unconditional "(no regressions)" string on line 226 of `optimize_cmd.py` with a conditional that computes the delta between `drc_errors_after` and `drc_errors_before`
- When errors increase: show `(N new errors, M nets rolled back)`
- When errors do not increase but rollbacks occurred: show `(no regressions, M nets rolled back)`
- When no regressions and no rollbacks: show `(no regressions)`
- Add 5 new tests in `TestDrcAwareDisplayMessage` covering all branches and edge cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| errors_after > errors_before shows new error count | Pass | `test_drc_output_shows_regression_count` asserts "5 new errors" present and "no regressions" absent |
| errors_after <= errors_before with rollbacks shows both facts | Pass | `test_drc_output_shows_no_regressions_with_rollback` asserts "no regressions, 1 nets rolled back" |
| nets_rolled_back == 0 and no regressions shows simple message | Pass | `test_drc_output_shows_no_regressions_without_rollback` asserts "(no regressions)" with no "nets rolled back" |
| Delta computed as after - before | Pass | `test_drc_output_error_count_is_correct_delta` verifies 120-79=41 |
| Existing tests continue to pass | Pass | All 12 pre-existing tests pass (17 total including 5 new) |
| New test verifies regression message | Pass | `test_drc_output_shows_regression_count` |

## Test Plan
- `uv run pytest tests/test_optimize_cmd.py -v` -- 17 tests pass (12 existing + 5 new)
- `uv run ruff check` and `uv run ruff format --check` pass on both changed files

Closes #1283