### PR TITLE
fix(router): pass extracted pads to orchestrator in route_net_auto

### DIFF
--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -537,8 +537,13 @@ def route_net_auto(
 
         orchestrator._select_strategy = _forced_select  # type: ignore[method-assign]
 
+    # Build pad list from PCB footprints so the orchestrator can
+    # perform strategy selection and routing (without pads every
+    # strategy returns "Insufficient pads").
+    pads = _build_pads_for_net(pcb, net_number, net_name)
+
     # Route the net
-    result = orchestrator.route_net(net=net_name)
+    result = orchestrator.route_net(net=net_name, pads=pads)
 
     # Convert to dict with net_name included
     result_dict = result.to_dict()
@@ -585,6 +590,68 @@ def _build_pad_positions(pcb: PCB) -> dict[int, list[tuple[float, float]]]:
                 positions[pad.net_number].append((fp_x + rx, fp_y + ry))
 
     return positions
+
+
+def _build_pads_for_net(pcb: PCB, net_number: int, net_name: str) -> list:
+    """Build a list of router Pad objects for a specific net.
+
+    Extracts pad positions from the loaded PCB footprints and converts
+    them to the router's Pad primitive type, which the RoutingOrchestrator
+    needs for strategy selection and routing execution.
+
+    Args:
+        pcb: Loaded PCB object
+        net_number: Numeric net ID to filter pads
+        net_name: Name of the net (stored on each Pad)
+
+    Returns:
+        List of router Pad objects for the given net
+    """
+    from kicad_tools.router.layers import Layer
+    from kicad_tools.router.primitives import Pad as RouterPad
+
+    pads: list[RouterPad] = []
+    for fp in pcb.footprints:
+        if not fp.reference or fp.reference.startswith("#"):
+            continue
+
+        fp_x, fp_y = fp.position
+        rot_rad = math.radians(-fp.rotation)
+        cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+
+        for pad in fp.pads:
+            if pad.net_number != net_number:
+                continue
+
+            px, py = pad.position
+            abs_x = fp_x + px * cos_r - py * sin_r
+            abs_y = fp_y + px * sin_r + py * cos_r
+
+            # Determine layer
+            pad_layer = Layer.F_CU
+            pad_layers = pad.layers or []
+            if "B.Cu" in pad_layers and "F.Cu" not in pad_layers:
+                pad_layer = Layer.B_CU
+
+            is_through_hole = "*.Cu" in pad_layers
+
+            pads.append(
+                RouterPad(
+                    x=abs_x,
+                    y=abs_y,
+                    width=pad.size[0] if pad.size else 1.0,
+                    height=pad.size[1] if pad.size else 1.0,
+                    net=net_number,
+                    net_name=net_name,
+                    layer=pad_layer,
+                    ref=fp.reference,
+                    pin=pad.number,
+                    through_hole=is_through_hole,
+                    drill=pad.drill,
+                )
+            )
+
+    return pads
 
 
 def _estimate_routing_length(pad_positions: list[tuple[float, float]]) -> float:

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -520,10 +520,13 @@ class TestRouteNetAuto:
         Regression test for GH-1268: the old code assigned to the read-only
         PCB.path property, causing ``AttributeError: can't set attribute 'path'``
         on every real board.
+
+        Strengthened for GH-1282: also asserts routing actually succeeds
+        (not silently failing with 'Insufficient pads').
         """
         from kicad_tools.mcp.tools.routing import route_net_auto
 
-        # The fixture has NET1 with pads on two footprints.
+        # The fixture has NET1 with pads on three footprints (R1, U1, J1).
         result = route_net_auto(
             pcb_path=str(self.FIXTURE),
             net_name="NET1",
@@ -532,6 +535,77 @@ class TestRouteNetAuto:
         assert isinstance(result, dict)
         assert "success" in result
         assert result["net_name"] == "NET1"
+        # Routing must actually succeed for a net with 3 pads.
+        assert result["success"] is True, (
+            f"Expected routing success but got error: {result.get('error_message')}"
+        )
+        # Must not contain the old "Insufficient pads" error.
+        assert "Insufficient pads" not in (result.get("error_message") or "")
+
+    def test_route_net_auto_routes_multi_pad_net(self) -> None:
+        """A net with 3+ pads in routing-diagnostic.kicad_pcb returns success.
+
+        Regression test for GH-1282: route_net_auto() was not passing pad
+        positions to the orchestrator, so every strategy guard returned
+        'Insufficient pads for global routing' even for nets with many pads.
+        """
+        from kicad_tools.mcp.tools.routing import route_net_auto
+
+        # NET1 has 3 pads: R1:1, U1:1, J1:1
+        result = route_net_auto(
+            pcb_path=str(self.FIXTURE),
+            net_name="NET1",
+        )
+
+        assert isinstance(result, dict)
+        assert result["success"] is True, (
+            f"Routing NET1 (3 pads) should succeed, got: {result.get('error_message')}"
+        )
+        assert result["net_name"] == "NET1"
+        # Strategy should have been selected and applied
+        assert "strategy_used" in result
+        assert result["strategy_used"] != "unknown"
+
+    def test_route_net_auto_single_pad_net_graceful_failure(self, tmp_path: Path) -> None:
+        """A net with only 1 pad should fail gracefully, not crash."""
+        from kicad_tools.mcp.tools.routing import route_net_auto
+
+        pcb_text = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "SOLO")
+  (gr_line (start 0 0) (end 50 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 0) (end 50 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 40) (end 0 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 0 40) (end 0 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 10 10)
+    (attr smd)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SOLO"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+        pcb_file = tmp_path / "single_pad.kicad_pcb"
+        pcb_file.write_text(pcb_text)
+
+        result = route_net_auto(pcb_path=str(pcb_file), net_name="SOLO")
+        assert isinstance(result, dict)
+        assert "success" in result
+        # Should fail gracefully (not enough pads to route) but not crash
+        assert result["success"] is False
+        assert "Insufficient pads" in (result.get("error_message") or "")
 
     def test_pcb_path_property_not_overwritten(self) -> None:
         """PCB.path should remain the value set by PCB.load(), not be monkey-patched."""


### PR DESCRIPTION
## Summary

`route_net_auto()` called `orchestrator.route_net(net=net_name)` without passing `pads=`, so every orchestrator strategy guard returned "Insufficient pads for global routing" regardless of how many pads the net actually had. This adds a `_build_pads_for_net()` helper that extracts router `Pad` objects from the loaded PCB footprints and passes them to the orchestrator.

## Changes

- Add `_build_pads_for_net()` helper in `src/kicad_tools/mcp/tools/routing.py` that iterates PCB footprints, transforms pad positions to board coordinates (with rotation), and constructs `router.primitives.Pad` objects including layer, through-hole, drill, ref, and pin info
- Pass the extracted pads to `orchestrator.route_net(net=net_name, pads=pads)` at line 545
- Strengthen `test_no_attribute_error_on_fixture` to assert `result["success"] is True` and verify no "Insufficient pads" error
- Add `test_route_net_auto_routes_multi_pad_net` verifying NET1 (3 pads) routes successfully
- Add `test_route_net_auto_single_pad_net_graceful_failure` verifying a 1-pad net fails gracefully

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| route-auto no longer returns "Insufficient pads" for nets with 2+ pads | Pass | `test_no_attribute_error_on_fixture` asserts success and no "Insufficient pads" error |
| `result["success"]` is True for NET1 in routing-diagnostic fixture | Pass | Both `test_no_attribute_error_on_fixture` and `test_route_net_auto_routes_multi_pad_net` assert `result["success"] is True` |
| Existing test strengthened with `assert result["success"] is True` | Pass | Added to `test_no_attribute_error_on_fixture` |
| New test for multi-pad net success | Pass | `test_route_net_auto_routes_multi_pad_net` added |
| All test_mcp_routing.py and test_routing_orchestrator.py pass | Pass | 33/33 and 21/21 tests pass |
| ruff check clean on changed files | Pass | `ruff check` and `ruff format --check` both pass |

## Test Plan

- `uv run pytest tests/test_mcp_routing.py tests/test_routing_orchestrator.py -v --no-cov` -- all 54 tests pass
- Single-pad edge case returns graceful failure (not crash)

Closes #1282