### PR TITLE
fix(drc): infer segment-to-via type from kicad-cli reports and add pure-Python DRC fallback

### DIFF
--- a/src/kicad_tools/cli/fix_drc_cmd.py
+++ b/src/kicad_tools/cli/fix_drc_cmd.py
@@ -202,7 +202,14 @@ Examples:
 
 
 def _get_drc_report(drc_report_path: str | None, pcb_path: Path) -> DRCReport | None:
-    """Load or generate a DRC report."""
+    """Load or generate a DRC report.
+
+    Resolution order:
+    1. If ``--drc-report`` is given, load the file directly.
+    2. If kicad-cli is available, run it and parse the resulting report.
+    3. Fall back to the pure-Python ``DRCChecker`` so that segment-to-via
+       violations are detected even without kicad-cli installed.
+    """
     if drc_report_path:
         report_path = Path(drc_report_path)
         if not report_path.exists():
@@ -219,34 +226,75 @@ def _get_drc_report(drc_report_path: str | None, pcb_path: Path) -> DRCReport | 
         from kicad_tools.cli.runner import find_kicad_cli, run_drc
 
         kicad_cli = find_kicad_cli()
-        if not kicad_cli:
-            print(
-                "Error: No DRC report provided and kicad-cli not found.",
-                file=sys.stderr,
-            )
-            print(
-                "Provide a DRC report with --drc-report, or install KiCad 8.",
-                file=sys.stderr,
-            )
-            return None
+        if kicad_cli:
+            print(f"Running DRC on: {pcb_path.name}")
+            drc_result = run_drc(pcb_path)
+            if not drc_result.success:
+                print(f"Error running DRC: {drc_result.stderr}", file=sys.stderr)
+                return None
 
-        print(f"Running DRC on: {pcb_path.name}")
-        drc_result = run_drc(pcb_path)
-        if not drc_result.success:
-            print(f"Error running DRC: {drc_result.stderr}", file=sys.stderr)
-            return None
-
-        report = DRCReport.load(drc_result.output_path)
-        if drc_result.output_path:
-            drc_result.output_path.unlink(missing_ok=True)
-        return report
+            report = DRCReport.load(drc_result.output_path)
+            if drc_result.output_path:
+                drc_result.output_path.unlink(missing_ok=True)
+            return report
     except ImportError:
-        print(
-            "Error: No DRC report provided and kicad-cli runner not available.",
-            file=sys.stderr,
+        pass
+
+    # Fall back to the pure-Python DRC checker
+    return _run_python_drc(pcb_path)
+
+
+def _run_python_drc(pcb_path: Path) -> DRCReport | None:
+    """Run pure-Python DRC and convert results into a DRCReport.
+
+    This allows ``fix-drc`` to detect segment-to-via clearance violations
+    even when kicad-cli is not installed.
+    """
+    try:
+        from kicad_tools.core.types import Severity
+        from kicad_tools.drc.violation import DRCViolation as ReportViolation
+        from kicad_tools.drc.violation import Location, ViolationType
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.checker import DRCChecker
+
+        print(f"Running pure-Python DRC on: {pcb_path.name}")
+        pcb = PCB.load(pcb_path)
+        checker = DRCChecker(pcb)
+        results = checker.check_clearances()
+
+        violations: list[ReportViolation] = []
+        for v in results.violations:
+            vtype = ViolationType.from_string(v.rule_id)
+            loc_list: list[Location] = []
+            if v.location:
+                loc_list.append(
+                    Location(x_mm=v.location[0], y_mm=v.location[1], layer=v.layer or "")
+                )
+
+            violations.append(
+                ReportViolation(
+                    type=vtype,
+                    type_str=v.rule_id,
+                    severity=Severity.from_string(v.severity),
+                    message=v.message,
+                    locations=loc_list,
+                    items=list(v.items),
+                    required_value_mm=v.required_value,
+                    actual_value_mm=v.actual_value,
+                )
+            )
+
+        return DRCReport(
+            source_file=str(pcb_path),
+            created_at=None,
+            pcb_name=pcb_path.name,
+            violations=violations,
         )
+
+    except Exception as e:
+        print(f"Error running pure-Python DRC: {e}", file=sys.stderr)
         print(
-            "Provide a DRC report with --drc-report.",
+            "Provide a DRC report with --drc-report, or install KiCad 8.",
             file=sys.stderr,
         )
         return None

--- a/src/kicad_tools/drc/report.py
+++ b/src/kicad_tools/drc/report.py
@@ -295,8 +295,11 @@ def parse_json_report(content: str, source_file: str = "") -> DRCReport:
                 if net and net not in nets:
                     nets.append(net)
 
+        raw_type = ViolationType.from_string(type_str)
+        refined_type = _infer_segment_via_type(raw_type, items)
+
         violation = DRCViolation(
-            type=ViolationType.from_string(type_str),
+            type=refined_type,
             type_str=type_str,
             severity=severity,
             message=message,
@@ -350,18 +353,49 @@ def _extract_values(data: dict, message: str) -> None:
         data["actual_value_mm"] = float(width_match.group(2))
 
 
+def _infer_segment_via_type(vtype: ViolationType, items: list[str]) -> ViolationType:
+    """Refine a generic CLEARANCE type to CLEARANCE_SEGMENT_VIA when items indicate it.
+
+    kicad-cli emits ``[clearance]`` for all clearance sub-types in its text
+    and JSON reports.  The item descriptions, however, distinguish "Track"
+    (segment) from "Via".  When one item is a Track and the other is a Via
+    the violation is actually segment-to-via and should be classified as
+    ``CLEARANCE_SEGMENT_VIA`` so that ``fix-drc`` can detect and repair it.
+    """
+    if vtype != ViolationType.CLEARANCE:
+        return vtype
+
+    has_track = False
+    has_via = False
+    for item in items:
+        item_lower = item.lower()
+        if item_lower.startswith("track ") or item_lower.startswith("track\t"):
+            has_track = True
+        elif item_lower.startswith("via ") or item_lower.startswith("via\t"):
+            has_via = True
+
+    if has_track and has_via:
+        return ViolationType.CLEARANCE_SEGMENT_VIA
+
+    return vtype
+
+
 def _build_violation(data: dict) -> DRCViolation:
     """Build a DRCViolation from parsed data."""
     from kicad_tools.feedback import generate_drc_suggestions
 
+    raw_type = ViolationType.from_string(data["type_str"])
+    items = data.get("items", [])
+    refined_type = _infer_segment_via_type(raw_type, items)
+
     violation = DRCViolation(
-        type=ViolationType.from_string(data["type_str"]),
+        type=refined_type,
         type_str=data["type_str"],
         severity=data["severity"],
         message=data["message"],
         rule=data.get("rule", ""),
         locations=data.get("locations", []),
-        items=data.get("items", []),
+        items=items,
         nets=data.get("nets", []),
         required_value_mm=data.get("required_value_mm"),
         actual_value_mm=data.get("actual_value_mm"),

--- a/tests/test_fix_drc_cmd.py
+++ b/tests/test_fix_drc_cmd.py
@@ -970,3 +970,254 @@ class TestEdgeCases:
         result = repairer.repair(violations, max_displacement=0.5, dry_run=True)
         # Should succeed via direct push (no connected trace)
         assert result.repaired == 1 or result.skipped_infeasible >= 0
+
+
+# ── Report inference: kicad-cli clearance -> CLEARANCE_SEGMENT_VIA ──
+
+
+# DRC text report where kicad-cli outputs [clearance] for a Track-to-Via pair.
+# This is the real-world scenario: kicad-cli doesn't emit [clearance_segment_via].
+DRC_REPORT_KICAD_CLI_SEGMENT_VIA = """\
+** Drc report for test.kicad_pcb **
+** Created on 2025-12-28T21:29:34-08:00 **
+
+** Found 1 DRC violations **
+[clearance]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.0500 mm)
+    Rule: netclass 'Default'; error
+    @(105.0000 mm, 100.1000 mm): Track [+3.3V] on F.Cu
+    @(105.0000 mm, 100.0000 mm): Via [GND] on F.Cu - B.Cu
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+
+# DRC text report with a Track-to-Track pair (should stay CLEARANCE).
+DRC_REPORT_KICAD_CLI_SEGMENT_SEGMENT = """\
+** Drc report for test.kicad_pcb **
+** Created on 2025-12-28T21:29:34-08:00 **
+
+** Found 1 DRC violations **
+[clearance]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.1500 mm)
+    Rule: netclass 'Default'; error
+    @(105.0000 mm, 100.0000 mm): Track [GND] on F.Cu
+    @(105.0000 mm, 100.1500 mm): Track [+3.3V] on F.Cu
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+
+# DRC text report with both Track-to-Track and Track-to-Via violations.
+DRC_REPORT_KICAD_CLI_MIXED_CLEARANCE = """\
+** Drc report for test.kicad_pcb **
+** Created on 2025-12-28T21:29:34-08:00 **
+
+** Found 2 DRC violations **
+[clearance]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.1500 mm)
+    Rule: netclass 'Default'; error
+    @(105.0000 mm, 100.0000 mm): Track [GND] on F.Cu
+    @(105.0000 mm, 100.1500 mm): Track [+3.3V] on F.Cu
+
+[clearance]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.0500 mm)
+    Rule: netclass 'Default'; error
+    @(108.0000 mm, 100.1000 mm): Track [+3.3V] on F.Cu
+    @(108.0000 mm, 100.0000 mm): Via [GND] on F.Cu - B.Cu
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+
+# JSON report where kicad-cli uses "clearance" for a Track-to-Via pair.
+DRC_JSON_KICAD_CLI_SEGMENT_VIA = json.dumps(
+    {
+        "source": "test.kicad_pcb",
+        "date": "2025-12-28T21:29:34-08:00",
+        "violations": [
+            {
+                "type": "clearance",
+                "description": "Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.0500 mm)",
+                "severity": "error",
+                "items": [
+                    {
+                        "description": "Track [+3.3V] on F.Cu",
+                        "pos": {"x": 105.0, "y": 100.1},
+                        "net": "+3.3V",
+                    },
+                    {
+                        "description": "Via [GND] on F.Cu - B.Cu",
+                        "pos": {"x": 105.0, "y": 100.0},
+                        "net": "GND",
+                    },
+                ],
+            }
+        ],
+    }
+)
+
+
+class TestSegmentViaInference:
+    """Tests that kicad-cli's generic [clearance] is reclassified when items indicate a via."""
+
+    def test_text_report_track_via_becomes_segment_via(self):
+        """Text report with [clearance] + Track + Via -> CLEARANCE_SEGMENT_VIA."""
+        from kicad_tools.drc.report import parse_text_report
+
+        report = parse_text_report(DRC_REPORT_KICAD_CLI_SEGMENT_VIA)
+        assert len(report.violations) == 1
+        assert report.violations[0].type == ViolationType.CLEARANCE_SEGMENT_VIA
+
+    def test_text_report_track_track_stays_clearance(self):
+        """Text report with [clearance] + Track + Track -> CLEARANCE (unchanged)."""
+        from kicad_tools.drc.report import parse_text_report
+
+        report = parse_text_report(DRC_REPORT_KICAD_CLI_SEGMENT_SEGMENT)
+        assert len(report.violations) == 1
+        assert report.violations[0].type == ViolationType.CLEARANCE
+
+    def test_text_report_mixed_no_double_counting(self):
+        """Mixed Track-Track and Track-Via should not double-count."""
+        from kicad_tools.drc.report import parse_text_report
+
+        report = parse_text_report(DRC_REPORT_KICAD_CLI_MIXED_CLEARANCE)
+        assert len(report.violations) == 2
+
+        clearance_only = report.by_type(ViolationType.CLEARANCE)
+        segment_via = report.by_type(ViolationType.CLEARANCE_SEGMENT_VIA)
+
+        assert len(clearance_only) == 1
+        assert len(segment_via) == 1
+
+    def test_json_report_track_via_becomes_segment_via(self):
+        """JSON report with "clearance" type + Track + Via -> CLEARANCE_SEGMENT_VIA."""
+        from kicad_tools.drc.report import parse_json_report
+
+        report = parse_json_report(DRC_JSON_KICAD_CLI_SEGMENT_VIA)
+        assert len(report.violations) == 1
+        assert report.violations[0].type == ViolationType.CLEARANCE_SEGMENT_VIA
+
+    def test_explicit_segment_via_not_reclassified(self):
+        """Pre-classified [clearance_segment_via] is preserved, not double-reclassified."""
+        from kicad_tools.drc.report import parse_text_report
+
+        # Re-use the existing fixture that already uses [clearance_segment_via] tag
+        report = parse_text_report(DRC_REPORT_SEGMENT_VIA)
+        assert len(report.violations) == 1
+        assert report.violations[0].type == ViolationType.CLEARANCE_SEGMENT_VIA
+
+    def test_pad_clearance_stays_clearance(self):
+        """[clearance] with Pad + Track should remain CLEARANCE (not segment-via)."""
+        from kicad_tools.drc.report import parse_text_report
+
+        pad_report = """\
+** Drc report for test.kicad_pcb **
+** Created on 2025-12-28T21:29:34-08:00 **
+
+** Found 1 DRC violations **
+[clearance]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.0500 mm)
+    Rule: netclass 'Default'; error
+    @(105.0000 mm, 100.0000 mm): Pad 1 [+3.3V] of U1 on F.Cu
+    @(105.0000 mm, 100.1000 mm): Track [GND] on F.Cu
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+        report = parse_text_report(pad_report)
+        assert len(report.violations) == 1
+        assert report.violations[0].type == ViolationType.CLEARANCE
+
+    def test_kicad_cli_report_fix_drc_detects_segment_via(
+        self, pcb_segment_via: Path, tmp_path: Path, capsys
+    ):
+        """fix-drc CLI with kicad-cli-style [clearance] report finds segment-to-via violations."""
+        report_file = tmp_path / "kicad-cli-drc.rpt"
+        report_file.write_text(DRC_REPORT_KICAD_CLI_SEGMENT_VIA)
+
+        main(
+            [
+                str(pcb_segment_via),
+                "--drc-report",
+                str(report_file),
+                "--dry-run",
+                "--format",
+                "json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # The segment-via violation should appear in the clearance count
+        assert data["clearance"]["violations"] >= 1
+
+
+# ── Pure-Python DRC fallback tests ────────────────────────────────────
+
+
+class TestPurePythonDRCFallback:
+    """Tests for _run_python_drc() which converts DRCChecker results to DRCReport."""
+
+    def test_fallback_detects_clearance_violations(self, tmp_path: Path):
+        """Pure-Python DRC should detect segment clearance violations."""
+        from kicad_tools.cli.fix_drc_cmd import _run_python_drc
+
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_CLEARANCE)
+
+        report = _run_python_drc(pcb_file)
+        assert report is not None
+        assert report.violation_count > 0
+
+    def test_fallback_detects_segment_via_violations(self, tmp_path: Path):
+        """Pure-Python DRC should detect segment-to-via clearance violations."""
+        from kicad_tools.cli.fix_drc_cmd import _run_python_drc
+
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_SEGMENT_VIA_CLEARANCE)
+
+        report = _run_python_drc(pcb_file)
+        assert report is not None
+
+        segment_via_violations = report.by_type(ViolationType.CLEARANCE_SEGMENT_VIA)
+        assert len(segment_via_violations) > 0
+
+    def test_fallback_violations_have_locations(self, tmp_path: Path):
+        """Converted violations should carry location data."""
+        from kicad_tools.cli.fix_drc_cmd import _run_python_drc
+
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_CLEARANCE)
+
+        report = _run_python_drc(pcb_file)
+        assert report is not None
+
+        for v in report.violations:
+            assert len(v.locations) > 0, "Converted violation should have at least one location"
+
+    def test_fallback_violations_have_values(self, tmp_path: Path):
+        """Converted violations should carry required and actual values."""
+        from kicad_tools.cli.fix_drc_cmd import _run_python_drc
+
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_CLEARANCE)
+
+        report = _run_python_drc(pcb_file)
+        assert report is not None
+
+        for v in report.violations:
+            assert v.required_value_mm is not None
+            assert v.actual_value_mm is not None
+
+    def test_fallback_used_when_no_kicad_cli(self, tmp_path: Path, monkeypatch):
+        """_get_drc_report should fall back to pure-Python DRC when kicad-cli is missing."""
+        from kicad_tools.cli import fix_drc_cmd
+
+        # Make find_kicad_cli return None
+        monkeypatch.setattr(
+            "kicad_tools.cli.runner.find_kicad_cli",
+            lambda: None,
+        )
+
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_SEGMENT_VIA_CLEARANCE)
+
+        report = fix_drc_cmd._get_drc_report(None, pcb_file)
+        assert report is not None
+        assert report.violation_count > 0


### PR DESCRIPTION
## Summary

kicad-cli emits a generic `[clearance]` type string for all clearance sub-types (segment-to-segment, segment-to-via, pad-to-track, etc.) in both text and JSON DRC reports. The report parser previously passed this through to `ViolationType.from_string()` which mapped it to `CLEARANCE`, causing `fix-drc` to miss segment-to-via violations entirely when using kicad-cli output.

Additionally, when kicad-cli is unavailable and no `--drc-report` is provided, `fix-drc` would fail with an error instead of using the pure-Python `DRCChecker` which already correctly detects segment-to-via violations.

## Changes

- Add `_infer_segment_via_type()` to `report.py` that examines item descriptions ("Track" vs "Via") to reclassify generic `CLEARANCE` violations as `CLEARANCE_SEGMENT_VIA` when the items indicate a segment-to-via pair
- Apply the inference in both `_build_violation()` (text reports) and `parse_json_report()` (JSON reports)
- Add `_run_python_drc()` to `fix_drc_cmd.py` as a fallback that converts `DRCChecker` results into `DRCReport` objects when kicad-cli is unavailable
- Restructure `_get_drc_report()` to try kicad-cli first, then fall back to pure-Python DRC, instead of failing when kicad-cli is missing
- Add 12 new tests covering: text/JSON report inference, no-double-counting, pad-clearance-not-reclassified, pure-Python fallback detection, and monkeypatched kicad-cli-missing scenario

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| fix-drc correctly classifies segment-to-via violations as CLEARANCE_SEGMENT_VIA | Done | `test_text_report_track_via_becomes_segment_via`, `test_json_report_track_via_becomes_segment_via` |
| fix-drc without --drc-report detects segment-to-via violations | Done | `test_fallback_detects_segment_via_violations`, `test_fallback_used_when_no_kicad_cli` |
| No regression: segment-to-segment clearance detection still works | Done | `test_text_report_track_track_stays_clearance`, all 35 original tests pass |
| No double-counting when both CLEARANCE and CLEARANCE_SEGMENT_VIA present | Done | `test_text_report_mixed_no_double_counting` |
| Existing test_segment_via_clearance_counted continues to pass | Done | All 150 related tests pass |

## Test Plan

All 150 tests in `test_fix_drc_cmd.py`, `test_repair_clearance.py`, and `test_drc.py` pass. 12 new tests added covering both the report inference logic and the pure-Python DRC fallback path.

Closes #1281