### PR TITLE
fix(cli): restore net declarations after kicad-cli DRC zone fill

### DIFF
--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -396,6 +396,82 @@ def _kicad_drc_supports_refill(kicad_cli: Path) -> bool:
         return False
 
 
+def _snapshot_net_declarations(pcb_path: Path) -> list:
+    """Snapshot net declaration S-expression nodes from a PCB file.
+
+    Returns a list of ``(net N "name")`` SExp nodes extracted from the
+    PCB's top-level children.  These can be used later by
+    :func:`_restore_net_declarations` to repair a PCB whose net table
+    was stripped by kicad-cli.
+
+    Returns an empty list if the file cannot be read (e.g. it does not
+    exist).  In that scenario the subsequent DRC subprocess call will
+    also fail, so skipping the snapshot is harmless.
+    """
+    from kicad_tools.core.sexp_file import load_pcb
+
+    try:
+        sexp = load_pcb(str(pcb_path))
+    except Exception:
+        return []
+    return [child for child in sexp.children if child.name == "net"]
+
+
+def _restore_net_declarations(target_pcb: Path, net_nodes: list) -> None:
+    """Restore net declarations in *target_pcb* from a snapshot.
+
+    kicad-cli may strip ``(net N "name")`` header declarations when
+    re-serializing a PCB that was not originally written by KiCad itself.
+    This function replaces the output file's net declarations with those
+    captured before the DRC run, preserving all other content (including
+    filled zone polygons).
+
+    The function is a no-op when the output already has at least as many
+    net declarations as the snapshot (i.e. kicad-cli kept them intact).
+    """
+    from kicad_tools.core.sexp_file import load_pcb, save_pcb
+
+    output_sexp = load_pcb(str(target_pcb))
+
+    # Count existing nets in the output
+    output_net_nodes = [child for child in output_sexp.children if child.name == "net"]
+
+    if len(output_net_nodes) >= len(net_nodes):
+        # Net table was not stripped — nothing to do.
+        return
+
+    # Remove whatever net declarations remain in the output.
+    for node in output_net_nodes:
+        output_sexp.children.remove(node)
+
+    # Find insertion point: nets go after ``setup`` / ``title_block`` and
+    # before ``footprint`` / ``segment`` / ``via`` / ``zone`` / ``gr_*``.
+    # Walk backward from the first content element to find the right spot.
+    insert_index = len(output_sexp.children)
+    content_tags = {
+        "footprint",
+        "segment",
+        "via",
+        "zone",
+        "gr_line",
+        "gr_arc",
+        "gr_text",
+        "gr_rect",
+        "gr_circle",
+        "gr_poly",
+    }
+    for i, child in enumerate(output_sexp.children):
+        if child.name in content_tags:
+            insert_index = i
+            break
+
+    # Insert the snapshotted net declarations at the computed position.
+    for offset, net_node in enumerate(net_nodes):
+        output_sexp.children.insert(insert_index + offset, net_node)
+
+    save_pcb(output_sexp, target_pcb)
+
+
 def _run_fill_zones_via_drc(
     pcb_path: Path,
     output_path: Path | None,
@@ -409,8 +485,18 @@ def _run_fill_zones_via_drc(
 
     A non-zero exit code caused by DRC *violations* does **not** indicate
     a fill failure.
+
+    After a successful DRC run the output PCB's net declarations are
+    verified against the input.  If kicad-cli stripped the net table
+    (a known issue when the PCB was serialized by kicad-tools rather
+    than KiCad itself), the original net declarations are restored so
+    that segments and vias retain their net assignments.
     """
     import os
+
+    # Snapshot input net declarations *before* DRC runs — the DRC
+    # may modify the file in-place when no output_path is given.
+    input_net_nodes = _snapshot_net_declarations(pcb_path)
 
     # DRC modifies the input file in-place.  If the caller requested a
     # separate output file, copy the source first and run DRC on the copy.
@@ -448,6 +534,9 @@ def _run_fill_zones_via_drc(
         # are still filled.  We treat it as success when the DRC report
         # was actually produced (meaning the command ran to completion).
         if drc_report.exists() and drc_report.stat().st_size > 0:
+            # Restore net declarations if kicad-cli stripped them.
+            _restore_net_declarations(target_pcb, input_net_nodes)
+
             return KiCadCLIResult(
                 success=True,
                 output_path=target_pcb,

--- a/tests/test_zones_cmd.py
+++ b/tests/test_zones_cmd.py
@@ -472,6 +472,171 @@ class TestRunFillZonesDRCFallback:
         assert "--refill-zones" in cmd
         assert "--save-board" in cmd
 
+    def test_drc_fallback_preserves_net_count(self, tmp_pcb, tmp_path):
+        """Net declarations survive DRC fallback even when kicad-cli strips them."""
+        from kicad_tools.cli.runner import run_fill_zones
+        from kicad_tools.schema.pcb import PCB
+
+        input_pcb = PCB.load(str(tmp_pcb))
+        input_net_count = input_pcb.net_count
+        assert input_net_count > 1, "Fixture must have named nets for this test"
+
+        def fake_run_strips_nets(cmd, **kwargs):
+            """Simulate kicad-cli stripping net declarations from the PCB."""
+            report_path = cmd[cmd.index("--output") + 1]
+            Path(report_path).write_text('{"violations": []}')
+
+            # Read the target PCB (last arg), strip net declarations,
+            # and write it back -- mimicking kicad-cli's broken behaviour.
+            target = Path(cmd[-1])
+            content = target.read_text()
+            import re
+
+            # Remove all (net N "name") top-level declarations but keep
+            # the rest (zones, segments, etc.) intact.  Replace with a
+            # single (net 0 "") to simulate kicad-cli's output.
+            content = re.sub(r'\n\t\(net \d+ "[^"]*"\)', "", content)
+            # Ensure at least the empty net 0 exists (kicad-cli always writes it)
+            content = content.replace('(net 0 "")', '(net 0 "")', 1)
+            target.write_text(content)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        out = tmp_path / "filled.kicad_pcb"
+
+        with (
+            patch(_HAS_FILL_ZONES, return_value=False),
+            patch(_DRC_SUPPORTS_REFILL, return_value=False),
+            patch(_SUBPROCESS_RUN, side_effect=fake_run_strips_nets),
+        ):
+            result = run_fill_zones(tmp_pcb, output_path=out, kicad_cli=Path("/usr/bin/kicad-cli"))
+
+        assert result.success is True
+        output_pcb = PCB.load(str(out))
+        assert output_pcb.net_count == input_net_count
+
+    def test_drc_fallback_preserves_nets_inplace(self, tmp_pcb):
+        """Net declarations are restored when DRC modifies the PCB in place."""
+        from kicad_tools.cli.runner import run_fill_zones
+        from kicad_tools.schema.pcb import PCB
+
+        input_pcb = PCB.load(str(tmp_pcb))
+        input_net_count = input_pcb.net_count
+        input_net_names = {n.name for n in input_pcb.nets.values()}
+
+        def fake_run_strips_nets(cmd, **kwargs):
+            report_path = cmd[cmd.index("--output") + 1]
+            Path(report_path).write_text('{"violations": []}')
+
+            target = Path(cmd[-1])
+            content = target.read_text()
+            import re
+
+            content = re.sub(r'\n\t\(net \d+ "[^"]*"\)', "", content)
+            target.write_text(content)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch(_HAS_FILL_ZONES, return_value=False),
+            patch(_DRC_SUPPORTS_REFILL, return_value=False),
+            patch(_SUBPROCESS_RUN, side_effect=fake_run_strips_nets),
+        ):
+            result = run_fill_zones(tmp_pcb, kicad_cli=Path("/usr/bin/kicad-cli"))
+
+        assert result.success is True
+        output_pcb = PCB.load(str(tmp_pcb))
+        assert output_pcb.net_count == input_net_count
+        output_net_names = {n.name for n in output_pcb.nets.values()}
+        assert output_net_names == input_net_names
+
+    def test_drc_fallback_noop_when_nets_intact(self, tmp_pcb, tmp_path):
+        """Restoration is a no-op when kicad-cli keeps nets intact."""
+        from kicad_tools.cli.runner import run_fill_zones
+        from kicad_tools.schema.pcb import PCB
+
+        input_pcb = PCB.load(str(tmp_pcb))
+        input_net_count = input_pcb.net_count
+
+        def fake_run_keeps_nets(cmd, **kwargs):
+            """Simulate kicad-cli that does NOT strip nets."""
+            report_path = cmd[cmd.index("--output") + 1]
+            Path(report_path).write_text('{"violations": []}')
+            # Don't modify the PCB at all -- nets stay intact.
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        out = tmp_path / "filled.kicad_pcb"
+
+        with (
+            patch(_HAS_FILL_ZONES, return_value=False),
+            patch(_DRC_SUPPORTS_REFILL, return_value=False),
+            patch(_SUBPROCESS_RUN, side_effect=fake_run_keeps_nets),
+        ):
+            result = run_fill_zones(tmp_pcb, output_path=out, kicad_cli=Path("/usr/bin/kicad-cli"))
+
+        assert result.success is True
+        output_pcb = PCB.load(str(out))
+        assert output_pcb.net_count == input_net_count
+
+    def test_drc_fallback_preserves_net_names(self, tmp_pcb, tmp_path):
+        """Individual net names (GND, +3V3, +5V) are preserved after restoration."""
+        from kicad_tools.cli.runner import run_fill_zones
+        from kicad_tools.schema.pcb import PCB
+
+        input_pcb = PCB.load(str(tmp_pcb))
+        input_nets = {n.number: n.name for n in input_pcb.nets.values()}
+
+        def fake_run_strips_nets(cmd, **kwargs):
+            report_path = cmd[cmd.index("--output") + 1]
+            Path(report_path).write_text('{"violations": []}')
+
+            target = Path(cmd[-1])
+            content = target.read_text()
+            import re
+
+            content = re.sub(r'\n\t\(net \d+ "[^"]*"\)', "", content)
+            target.write_text(content)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        out = tmp_path / "filled.kicad_pcb"
+
+        with (
+            patch(_HAS_FILL_ZONES, return_value=False),
+            patch(_DRC_SUPPORTS_REFILL, return_value=False),
+            patch(_SUBPROCESS_RUN, side_effect=fake_run_strips_nets),
+        ):
+            result = run_fill_zones(tmp_pcb, output_path=out, kicad_cli=Path("/usr/bin/kicad-cli"))
+
+        assert result.success is True
+        output_pcb = PCB.load(str(out))
+        output_nets = {n.number: n.name for n in output_pcb.nets.values()}
+        assert output_nets == input_nets
+
+    def test_drc_fallback_only_net0_noop(self, tmp_path):
+        """A PCB with only net 0 should not trigger restoration."""
+        from kicad_tools.cli.runner import run_fill_zones
+        from kicad_tools.schema.pcb import PCB
+
+        # Create a minimal PCB with only the default net 0
+        pcb = PCB.create(width=50, height=50)
+        pcb_path = tmp_path / "minimal.kicad_pcb"
+        pcb.save(str(pcb_path))
+
+        def fake_run(cmd, **kwargs):
+            report_path = cmd[cmd.index("--output") + 1]
+            Path(report_path).write_text('{"violations": []}')
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch(_HAS_FILL_ZONES, return_value=False),
+            patch(_DRC_SUPPORTS_REFILL, return_value=False),
+            patch(_SUBPROCESS_RUN, side_effect=fake_run),
+        ):
+            result = run_fill_zones(pcb_path, kicad_cli=Path("/usr/bin/kicad-cli"))
+
+        assert result.success is True
+        output_pcb = PCB.load(str(pcb_path))
+        # Should still have net 0 at minimum
+        assert output_pcb.net_count >= 1
+
 
 # ---------------------------------------------------------------------------
 # Integration test: requires kicad-cli


### PR DESCRIPTION
## Summary

kicad-cli may strip `(net N "name")` header declarations when re-serializing a PCB that was not originally written by KiCad itself. This causes zone-filled output to report `Nets: 0` and lose segment/via net assignments. This PR adds a post-fill net restoration step to the DRC-based zone fill fallback in `_run_fill_zones_via_drc()`.

## Changes

- Add `_snapshot_net_declarations()` helper that captures net S-expression nodes from the input PCB before DRC runs
- Add `_restore_net_declarations()` helper that replaces the output's net table with the snapshot when kicad-cli has stripped entries (no-op when nets are intact)
- Call the snapshot/restore pair around the DRC subprocess invocation in `_run_fill_zones_via_drc()`
- Add 5 new tests covering: net count preservation with output path, in-place net preservation, no-op when nets intact, individual net name verification, and minimal PCB edge case

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Output net count matches input after DRC fill | PASS | `test_drc_fallback_preserves_net_count` asserts `output_pcb.net_count == input_net_count` after simulated net stripping |
| Segment/via net references preserved | PASS | `test_drc_fallback_preserves_net_names` verifies exact `{number: name}` mapping matches input |
| Works for both KiCad 8/9 and KiCad 10+ paths | PASS | Existing `test_kicad8_no_refill_flags` and `test_kicad10_includes_refill_flags` still pass; new tests cover both `_DRC_SUPPORTS_REFILL=False` and the general flow |
| kicad-cli unavailable behavior unchanged | PASS | Existing `test_no_kicad_cli_returns_failure` and `test_file_not_found_error` still pass |
| No regression in existing tests | PASS | All 28 unit tests in `test_zones_cmd.py` pass |
| New test verifies net count preserved | PASS | 5 new tests added to `TestRunFillZonesDRCFallback` |

## Test Plan

- Ran `uv run pytest tests/test_zones_cmd.py -k "not TestFillIntegration"` -- 28 passed (integration test is a pre-existing failure on main due to kicad-cli fixture loading)
- Ran `uv run ruff check` and `uv run ruff format --check` on changed files -- clean

Closes #1291