### PR TITLE
feat(router): wire escape routing into default pipeline and add CLI flag

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -600,8 +600,15 @@ def route_with_layer_escalation(
         if not quiet:
             print(f"\n  Routing ({args.strategy})...")
 
+        escape_flag = _resolve_escape_routing_flag(args)
+
         try:
-            if getattr(args, "multi_resolution", False):
+            if _should_use_escape_routing(router, escape_flag, quiet):
+                router.route_with_escape(
+                    use_negotiated=(args.strategy == "negotiated"),
+                    timeout=args.timeout,
+                )
+            elif getattr(args, "multi_resolution", False):
                 router.route_all_multi_resolution(
                     use_negotiated=(args.strategy == "negotiated"),
                     max_iterations=args.iterations,
@@ -929,8 +936,15 @@ def route_with_rule_relaxation(
         if not quiet:
             print(f"\n  Routing ({args.strategy})...")
 
+        escape_flag = _resolve_escape_routing_flag(args)
+
         try:
-            if getattr(args, "multi_resolution", False):
+            if _should_use_escape_routing(router, escape_flag, quiet):
+                router.route_with_escape(
+                    use_negotiated=(args.strategy == "negotiated"),
+                    timeout=args.timeout,
+                )
+            elif getattr(args, "multi_resolution", False):
                 router.route_all_multi_resolution(
                     use_negotiated=(args.strategy == "negotiated"),
                     max_iterations=args.iterations,
@@ -1276,8 +1290,15 @@ def route_with_combined_escalation(
             nets_to_route = len(multi_pad_nets)
 
             # Route
+            escape_flag = _resolve_escape_routing_flag(args)
+
             try:
-                if getattr(args, "multi_resolution", False):
+                if _should_use_escape_routing(router, escape_flag, quiet):
+                    router.route_with_escape(
+                        use_negotiated=(args.strategy == "negotiated"),
+                        timeout=args.timeout,
+                    )
+                elif getattr(args, "multi_resolution", False):
                     router.route_all_multi_resolution(
                         use_negotiated=(args.strategy == "negotiated"),
                         max_iterations=args.iterations,
@@ -1514,6 +1535,52 @@ def route_with_combined_escalation(
             )
 
     return 0 if final_result.success else 1
+
+
+def _resolve_escape_routing_flag(args) -> bool | None:
+    """Resolve --escape-routing / --no-escape-routing into a tri-state value.
+
+    Returns:
+        True if escape routing is explicitly enabled,
+        False if explicitly disabled,
+        None for auto-detect (default).
+    """
+    no_escape = getattr(args, "no_escape_routing", False)
+    escape = getattr(args, "escape_routing", None)
+
+    if no_escape:
+        return False
+    if escape:
+        return True
+    return None
+
+
+def _should_use_escape_routing(router, escape_flag: bool | None, quiet: bool) -> bool:
+    """Determine whether to use escape routing for the current board.
+
+    Args:
+        router: The Autorouter instance.
+        escape_flag: True=force on, False=force off, None=auto-detect.
+        quiet: Suppress progress output.
+
+    Returns:
+        True if escape routing should be used.
+    """
+    if escape_flag is True:
+        if not quiet:
+            print("  Escape routing: enabled (--escape-routing)")
+        return True
+    if escape_flag is False:
+        return False
+
+    # Auto-detect dense packages
+    dense_packages = router.detect_dense_packages()
+    if dense_packages:
+        if not quiet:
+            refs = [p.ref for p in dense_packages]
+            print(f"  Escape routing: auto-enabled (dense packages: {refs})")
+        return True
+    return False
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1888,6 +1955,28 @@ def main(argv: list[str] | None = None) -> int:
             "nets on a finer grid (2x resolution) scoped to their bounding "
             "boxes. Useful for boards where some nets fail due to grid "
             "resolution limitations."
+        ),
+    )
+    parser.add_argument(
+        "--escape-routing",
+        action="store_true",
+        default=None,
+        help=(
+            "Enable escape routing phase before global routing. "
+            "Generates escape routes for dense QFP/QFN/BGA packages "
+            "where pin pitch is too small for traces to pass between "
+            "adjacent pins. Without this flag, escape routing is "
+            "auto-detected based on package density."
+        ),
+    )
+    parser.add_argument(
+        "--no-escape-routing",
+        action="store_true",
+        help=(
+            "Disable automatic escape routing detection. By default, "
+            "the router auto-detects dense packages and enables escape "
+            "routing when needed. Use this flag to skip escape routing "
+            "even when dense packages are present."
         ),
     )
     parser.add_argument(
@@ -2516,9 +2605,20 @@ def main(argv: list[str] | None = None) -> int:
         import time
         routing_start_time = time.time()
 
+        # Resolve escape routing flag: True=force on, False=force off, None=auto-detect
+        escape_routing_flag = _resolve_escape_routing_flag(args)
+
         # Define routing function for profiling
         def do_routing():
             nonlocal diffpair_warnings, relaxed_nets_report
+
+            # Check if escape routing should run as a pre-phase
+            if _should_use_escape_routing(router, escape_routing_flag, quiet):
+                return router.route_with_escape(
+                    use_negotiated=(args.strategy == "negotiated"),
+                    timeout=args.timeout,
+                )
+
             # Progressive clearance relaxation mode
             if getattr(args, "progressive_clearance", False):
                 routes, relaxed_nets_report = router.route_with_progressive_clearance(

--- a/src/kicad_tools/optimize/place_route.py
+++ b/src/kicad_tools/optimize/place_route.py
@@ -150,6 +150,7 @@ class PlaceRouteOptimizer:
         router_factory: Callable[[], Autorouter],
         drc_checker_factory: Callable[[PCB], DRCChecker] | None = None,
         verbose: bool = True,
+        escape_routing: bool | None = None,
     ) -> None:
         """Initialize the optimizer.
 
@@ -163,6 +164,10 @@ class PlaceRouteOptimizer:
                 Receives the PCB object and returns a DRCChecker.
                 If None, DRC checking is skipped.
             verbose: Print progress messages during optimization
+            escape_routing: Enable escape routing for dense packages.
+                True = always use escape routing before global routing.
+                False = never use escape routing.
+                None = auto-detect dense packages (default).
         """
         self.pcb_path = Path(pcb_path)
         self.analyzer = analyzer
@@ -170,6 +175,7 @@ class PlaceRouteOptimizer:
         self.router_factory = router_factory
         self.drc_checker_factory = drc_checker_factory
         self.verbose = verbose
+        self.escape_routing = escape_routing
 
         # Track state across iterations
         self._current_routes: list[Route] = []
@@ -501,6 +507,11 @@ class PlaceRouteOptimizer:
     def _run_routing_phase(self) -> tuple[list[Route], list[int]]:
         """Run autorouting phase.
 
+        Uses escape routing when dense packages are detected (or when
+        escape_routing is explicitly enabled). Escape routing runs as a
+        pre-phase that generates escape routes for dense package pins
+        before global routing begins.
+
         Returns:
             Tuple of (routes, failed_net_ids)
         """
@@ -513,8 +524,13 @@ class PlaceRouteOptimizer:
         # Get total nets to route
         total_nets = len([n for n in router.nets if n != 0])
 
-        # Route all nets
-        routes = router.route_all()
+        # Determine whether to use escape routing
+        use_escape = self._should_use_escape_routing(router)
+
+        if use_escape:
+            routes = router.route_with_escape()
+        else:
+            routes = router.route_all()
 
         # Determine which nets failed
         routed_nets = {r.net for r in routes if r.net != 0}
@@ -530,6 +546,37 @@ class PlaceRouteOptimizer:
                 print(f"    Failed nets: {failed_nets[:5]}{'...' if len(failed_nets) > 5 else ''}")
 
         return routes, failed_nets
+
+    def _should_use_escape_routing(self, router: Autorouter) -> bool:
+        """Determine whether escape routing should be used.
+
+        Checks the escape_routing flag: True forces it on, False forces
+        it off, and None (default) auto-detects by scanning for dense
+        packages.
+
+        Args:
+            router: The Autorouter instance to check for dense packages.
+
+        Returns:
+            True if escape routing should be used.
+        """
+        if self.escape_routing is True:
+            if self.verbose:
+                print("    Escape routing: enabled (explicit)")
+            return True
+        if self.escape_routing is False:
+            return False
+
+        # Auto-detect: check for dense packages
+        if not hasattr(router, "detect_dense_packages"):
+            return False
+        dense_packages = router.detect_dense_packages()
+        if isinstance(dense_packages, list) and len(dense_packages) > 0:
+            if self.verbose:
+                refs = [p.ref for p in dense_packages]
+                print(f"    Escape routing: auto-enabled (dense packages: {refs})")
+            return True
+        return False
 
     def _run_drc_phase(self) -> DRCResults:
         """Run DRC checking phase.

--- a/src/kicad_tools/router/orchestrator.py
+++ b/src/kicad_tools/router/orchestrator.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 
 from .adaptive import AdaptiveAutorouter
 from .adaptive_grid import AdaptiveGridRouter, identify_fine_pitch_components
-from .escape import EscapeRouter
+from .escape import EscapeRouter, is_dense_package
 from .global_router import GlobalRouter
 from .region_graph import RegionGraph
 from .strategies import (
@@ -326,28 +326,41 @@ class RoutingOrchestrator:
     def _needs_escape_routing(self, pads: list[Pad]) -> bool:
         """Check if any pads require escape routing (fine-pitch components).
 
+        Evaluates density per component rather than across net endpoints.
+        A net connecting an MCU pin (fine-pitch QFP) to a peripheral pad
+        (far away) would have large inter-endpoint distance but the MCU
+        component itself is dense and needs escape routing.
+
         Args:
             pads: List of pads to analyze
 
         Returns:
-            True if escape routing is needed
+            True if any component owning these pads is dense
         """
-        # Check for fine-pitch packages (pitch < 0.8mm typical for escape routing)
         if len(pads) < 2:
             return False
 
-        # Calculate minimum pitch between adjacent pads
-        min_pitch = float("inf")
-        for i, pad1 in enumerate(pads):
-            for pad2 in pads[i + 1 :]:
-                dx = pad1.x - pad2.x
-                dy = pad1.y - pad2.y
-                distance = math.sqrt(dx * dx + dy * dy)
-                min_pitch = min(min_pitch, distance)
+        # Group pads by component reference
+        by_ref: dict[str, list[Pad]] = {}
+        for pad in pads:
+            ref = pad.ref or ""
+            if ref:
+                by_ref.setdefault(ref, []).append(pad)
 
-        # Fine pitch threshold from design rules or default 0.8mm
-        threshold = getattr(self.rules, "fine_pitch_threshold", 0.8)
-        return min_pitch < threshold
+        # Check each component for density using escape.is_dense_package()
+        # which accounts for pin count, pitch, and design rule thresholds
+        trace_width = getattr(self.rules, "trace_width", None)
+        clearance = getattr(self.rules, "trace_clearance", None)
+
+        return any(
+            is_dense_package(
+                ref_pads,
+                trace_width=trace_width,
+                clearance=clearance,
+            )
+            for ref_pads in by_ref.values()
+            if len(ref_pads) >= 2
+        )
 
     def _check_density(self, pads: list[Pad]) -> float:
         """Calculate routing density around pads (0.0 to 1.0).

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -282,6 +282,33 @@ class TestIsDensePackage:
         # With larger clearance, becomes dense: 2 * (0.25 + 0.3) = 1.1mm > 1.0mm
         assert is_dense_package(pads, trace_width=0.25, clearance=0.3) is True
 
+    def test_qfp64_lqfp_dense(self):
+        """LQFP-64 at 0.5mm pitch is dense due to pin count > 48."""
+        pads = create_qfp_pads(16, pitch=0.5)  # 4 * 16 = 64 pins
+        assert len(pads) == 64
+        assert is_dense_package(pads) is True
+
+    def test_through_hole_not_dense(self):
+        """Through-hole package with wide pitch should not be dense."""
+        pads = []
+        for i in range(8):
+            pads.append(
+                Pad(
+                    x=i * 2.54,
+                    y=0,
+                    width=1.6,
+                    height=1.6,
+                    net=i + 1,
+                    net_name=f"NET_{i + 1}",
+                    layer=Layer.F_CU,
+                    ref="U1",
+                    through_hole=True,
+                )
+            )
+        # 8 pins at 2.54mm pitch, not dense
+        assert is_dense_package(pads) is False
+        assert is_dense_package(pads, trace_width=0.2, clearance=0.2) is False
+
 
 class TestDetectPackageType:
     """Tests for detect_package_type function."""

--- a/tests/test_place_route_optimizer.py
+++ b/tests/test_place_route_optimizer.py
@@ -596,3 +596,121 @@ class TestPlaceRouteOptimizerIntegration:
 
         assert result.success is False
         assert "Could not route" in result.message
+
+
+class TestEscapeRoutingIntegration:
+    """Tests for escape routing integration in PlaceRouteOptimizer."""
+
+    def test_escape_routing_enabled_calls_route_with_escape(self, tmp_path):
+        """When escape_routing=True, optimizer calls route_with_escape."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        mock_router = MagicMock()
+        mock_router.nets = {1: [("R1", "1"), ("R2", "1")]}
+        mock_router.pads = {}
+        mock_router.route_with_escape.return_value = [MagicMock(net=1)]
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(analyze=MagicMock(return_value=[])),
+            fixer=MagicMock(),
+            router_factory=lambda: mock_router,
+            verbose=False,
+            escape_routing=True,
+        )
+
+        routes, failed = optimizer._run_routing_phase()
+
+        mock_router.route_with_escape.assert_called_once()
+        mock_router.route_all.assert_not_called()
+
+    def test_escape_routing_disabled_calls_route_all(self, tmp_path):
+        """When escape_routing=False, optimizer calls route_all."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        mock_router = MagicMock()
+        mock_router.nets = {1: [("R1", "1"), ("R2", "1")]}
+        mock_router.pads = {}
+        mock_router.route_all.return_value = [MagicMock(net=1)]
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(analyze=MagicMock(return_value=[])),
+            fixer=MagicMock(),
+            router_factory=lambda: mock_router,
+            verbose=False,
+            escape_routing=False,
+        )
+
+        routes, failed = optimizer._run_routing_phase()
+
+        mock_router.route_all.assert_called_once()
+        mock_router.route_with_escape.assert_not_called()
+
+    def test_escape_routing_auto_detects_dense(self, tmp_path):
+        """When escape_routing=None, auto-detection checks for dense packages."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        mock_router = MagicMock()
+        mock_router.nets = {1: [("R1", "1"), ("R2", "1")]}
+        mock_router.pads = {}
+        mock_router.detect_dense_packages.return_value = [MagicMock(ref="U1")]
+        mock_router.route_with_escape.return_value = [MagicMock(net=1)]
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(analyze=MagicMock(return_value=[])),
+            fixer=MagicMock(),
+            router_factory=lambda: mock_router,
+            verbose=False,
+            escape_routing=None,
+        )
+
+        routes, failed = optimizer._run_routing_phase()
+
+        mock_router.detect_dense_packages.assert_called_once()
+        mock_router.route_with_escape.assert_called_once()
+
+    def test_escape_routing_auto_no_dense_packages(self, tmp_path):
+        """When auto-detect finds no dense packages, uses route_all."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        mock_router = MagicMock()
+        mock_router.nets = {1: [("R1", "1"), ("R2", "1")]}
+        mock_router.pads = {}
+        mock_router.detect_dense_packages.return_value = []
+        mock_router.route_all.return_value = [MagicMock(net=1)]
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(analyze=MagicMock(return_value=[])),
+            fixer=MagicMock(),
+            router_factory=lambda: mock_router,
+            verbose=False,
+            escape_routing=None,
+        )
+
+        routes, failed = optimizer._run_routing_phase()
+
+        mock_router.detect_dense_packages.assert_called_once()
+        mock_router.route_all.assert_called_once()
+        mock_router.route_with_escape.assert_not_called()
+
+    def test_default_escape_routing_is_none(self, tmp_path):
+        """Verify escape_routing defaults to None (auto-detect)."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(),
+            fixer=MagicMock(),
+            router_factory=MagicMock,
+            verbose=False,
+        )
+
+        assert optimizer.escape_routing is None

--- a/tests/test_route_cmd_params.py
+++ b/tests/test_route_cmd_params.py
@@ -373,3 +373,93 @@ class TestRouteCommandGridClearanceValidation:
 
         assert "--force" in help_text, "Help text should document --force flag"
         assert "clearance" in help_text.lower(), "Help text should mention clearance"
+
+
+class TestEscapeRoutingFlag:
+    """Tests for --escape-routing / --no-escape-routing CLI flag handling."""
+
+    def test_resolve_escape_routing_default(self):
+        """Default: neither flag set returns None (auto-detect)."""
+        from kicad_tools.cli.route_cmd import _resolve_escape_routing_flag
+
+        args = SimpleNamespace(escape_routing=None, no_escape_routing=False)
+        assert _resolve_escape_routing_flag(args) is None
+
+    def test_resolve_escape_routing_enabled(self):
+        """--escape-routing returns True."""
+        from kicad_tools.cli.route_cmd import _resolve_escape_routing_flag
+
+        args = SimpleNamespace(escape_routing=True, no_escape_routing=False)
+        assert _resolve_escape_routing_flag(args) is True
+
+    def test_resolve_escape_routing_disabled(self):
+        """--no-escape-routing returns False."""
+        from kicad_tools.cli.route_cmd import _resolve_escape_routing_flag
+
+        args = SimpleNamespace(escape_routing=None, no_escape_routing=True)
+        assert _resolve_escape_routing_flag(args) is False
+
+    def test_no_escape_routing_overrides_escape(self):
+        """--no-escape-routing takes precedence over --escape-routing."""
+        from kicad_tools.cli.route_cmd import _resolve_escape_routing_flag
+
+        args = SimpleNamespace(escape_routing=True, no_escape_routing=True)
+        assert _resolve_escape_routing_flag(args) is False
+
+    def test_should_use_escape_routing_forced(self):
+        """escape_flag=True forces escape routing on."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.cli.route_cmd import _should_use_escape_routing
+
+        router = MagicMock()
+        assert _should_use_escape_routing(router, True, quiet=True) is True
+        router.detect_dense_packages.assert_not_called()
+
+    def test_should_use_escape_routing_disabled(self):
+        """escape_flag=False forces escape routing off."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.cli.route_cmd import _should_use_escape_routing
+
+        router = MagicMock()
+        assert _should_use_escape_routing(router, False, quiet=True) is False
+        router.detect_dense_packages.assert_not_called()
+
+    def test_should_use_escape_routing_auto_with_dense(self):
+        """Auto-detect finds dense packages and enables escape routing."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.cli.route_cmd import _should_use_escape_routing
+
+        router = MagicMock()
+        router.detect_dense_packages.return_value = [MagicMock(ref="U1")]
+        assert _should_use_escape_routing(router, None, quiet=True) is True
+
+    def test_should_use_escape_routing_auto_no_dense(self):
+        """Auto-detect finds no dense packages and skips escape routing."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.cli.route_cmd import _should_use_escape_routing
+
+        router = MagicMock()
+        router.detect_dense_packages.return_value = []
+        assert _should_use_escape_routing(router, None, quiet=True) is False
+
+    def test_escape_routing_in_help(self):
+        """Verify --escape-routing appears in help text."""
+        import contextlib
+        import sys
+        from io import StringIO
+        from unittest.mock import patch
+
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        help_output = StringIO()
+        with patch.object(sys, "stdout", help_output):
+            with contextlib.suppress(SystemExit):
+                route_main(["--help"])
+
+        help_text = help_output.getvalue()
+        assert "--escape-routing" in help_text
+        assert "--no-escape-routing" in help_text

--- a/tests/test_routing_orchestrator.py
+++ b/tests/test_routing_orchestrator.py
@@ -310,6 +310,55 @@ class TestRoutingOrchestrator:
         needs_escape = orchestrator._needs_escape_routing(pads)
         assert needs_escape is True
 
+    def test_needs_escape_routing_per_component(self, orchestrator):
+        """Verify escape routing checks per-component, not across net endpoints.
+
+        A net connecting an MCU pin (dense QFP) to a far-away peripheral
+        pad has large inter-endpoint distance but should still trigger escape
+        routing because the MCU component is dense.
+        """
+        # Build pads from two different components on the same net:
+        # U1 is a dense QFP (many pads at fine pitch 0.5mm)
+        dense_pads = []
+        for i in range(20):
+            dense_pads.append(
+                _pad(x=i * 0.5, y=0.0, width=0.3, height=0.8, ref="U1", pin=str(i + 1))
+            )
+
+        # R1 is a far-away resistor pad (single pad on the same net)
+        far_pad = _pad(x=50.0, y=50.0, width=1.0, height=1.0, ref="R1", pin="1")
+
+        # Combined pads for a net that spans both components
+        all_pads = dense_pads + [far_pad]
+
+        # Old behavior would check inter-pad distance across all pads,
+        # which might not detect density because the far pad inflates distances.
+        # New behavior checks per-component: U1 has 20 pads at 0.5mm pitch,
+        # which is dense with trace_width=0.2, clearance=0.2 (threshold=0.8mm).
+        assert orchestrator._needs_escape_routing(all_pads) is True
+
+    def test_needs_escape_routing_no_dense_components(self, orchestrator):
+        """Verify escape routing not triggered when no component is dense."""
+        # Two components with wide pitch (2mm apart)
+        pads = [
+            _pad(x=0, y=0, ref="R1", pin="1"),
+            _pad(x=2.0, y=0, ref="R1", pin="2"),
+            _pad(x=10.0, y=0, ref="R2", pin="1"),
+            _pad(x=12.0, y=0, ref="R2", pin="2"),
+        ]
+
+        assert orchestrator._needs_escape_routing(pads) is False
+
+    def test_needs_escape_routing_empty_ref(self, orchestrator):
+        """Verify pads with empty ref are handled gracefully."""
+        pads = [
+            _pad(x=0, y=0, ref="", pin="1"),
+            _pad(x=0.5, y=0, ref="", pin="2"),
+        ]
+
+        # Empty ref pads are skipped (no component grouping possible)
+        assert orchestrator._needs_escape_routing(pads) is False
+
     def test_check_density_sparse(self, orchestrator):
         """Verify density calculation for sparse pads."""
         pads = [


### PR DESCRIPTION
## Summary
Wire the existing escape routing infrastructure into the default routing pipeline so dense QFP/QFN/BGA packages get proper pin escape before global routing. Add `--escape-routing` / `--no-escape-routing` CLI flags and fix the orchestrator's per-net density check to evaluate per-component instead.

## Changes
- **`src/kicad_tools/optimize/place_route.py`**: `_run_routing_phase()` now calls `route_with_escape()` when dense packages are detected (auto) or `escape_routing=True`. Added `_should_use_escape_routing()` helper and `escape_routing` parameter to constructor.
- **`src/kicad_tools/router/orchestrator.py`**: Rewrote `_needs_escape_routing()` to group pads by component reference and check per-component density via `is_dense_package()`, fixing the bug where cross-net endpoint distance masked dense MCU packages.
- **`src/kicad_tools/cli/route_cmd.py`**: Added `--escape-routing` / `--no-escape-routing` flags with auto-detect default. Wired into all four routing dispatch sites (main do_routing, auto-layers loop, adaptive-rules loop, matrix loop). Added `_resolve_escape_routing_flag()` and `_should_use_escape_routing()` helpers.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_needs_escape_routing()` evaluates per-component, not per net-endpoint distance | Done | New test `test_needs_escape_routing_per_component` verifies dense QFP pads + far resistor pad returns True |
| `optimize/place_route.py::_run_routing_phase()` uses `route_with_escape()` when dense packages present | Done | `test_escape_routing_auto_detects_dense` and `test_escape_routing_enabled_calls_route_with_escape` verify dispatch |
| No regressions on boards without dense packages | Done | `test_escape_routing_auto_no_dense_packages` and `test_escape_routing_disabled_calls_route_all` verify fallback to `route_all()` |
| `--escape-routing` CLI flag added to `route_cmd.py` | Done | `test_escape_routing_in_help` confirms both flags appear in help text |
| Existing `tests/test_escape.py` suite continues to pass | Done | All 37 escape tests pass |

## Test Plan
- 19 new tests across 4 test files, all passing
- All 122 tests in affected test suites pass (test_escape, test_routing_orchestrator, test_place_route_optimizer, test_route_cmd_params)
- No new lint errors introduced (pre-existing ruff issues unchanged)

Closes #1294