### PR TITLE
feat(route): add --auto-fix flag and fix-drc suggestions to DRC output

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -364,6 +364,8 @@ def run_post_route_drc(
                         print(f"    ... and {warning_count - (5 - shown)} more warnings")
 
                 print(f"\n  Run 'kct check {output_path} --mfr {manufacturer}' for full details")
+                if error_count > 0:
+                    print(f"  Run 'kct fix-drc {output_path}' to auto-repair clearance violations")
 
         return error_count, warning_count
 
@@ -372,6 +374,62 @@ def run_post_route_drc(
             print("\n--- DRC Validation ---")
             print(f"  Warning: DRC check failed: {e}")
         return -1, -1  # Indicate failure to run DRC
+
+
+def _run_auto_fix(
+    output_path: Path,
+    max_passes: int = 1,
+    quiet: bool = False,
+) -> int:
+    """Run fix-drc on the routed PCB to auto-repair DRC violations.
+
+    Args:
+        output_path: Path to the routed PCB file to repair.
+        max_passes: Number of iterative repair passes.
+        quiet: If True, suppress output.
+
+    Returns:
+        Exit code from fix_drc_cmd.main() (0 = all violations fixed).
+    """
+    from kicad_tools.cli.fix_drc_cmd import main as fix_drc_main
+
+    if not quiet:
+        print("\n--- Auto-Fix DRC Violations ---")
+
+    fix_argv = [
+        str(output_path),
+        "--max-passes",
+        str(max_passes),
+    ]
+    if quiet:
+        fix_argv.append("--quiet")
+
+    result = fix_drc_main(fix_argv)
+
+    if not quiet:
+        if result == 0:
+            print("  Auto-fix: all targeted violations repaired!")
+        else:
+            print("  Auto-fix: some violations remain (manual repair may be needed)")
+
+    return result
+
+
+def _should_auto_fix(args) -> bool:
+    """Determine whether auto-fix should run based on CLI flags.
+
+    Auto-fix runs when --auto-fix is set (which is also implied by
+    --auto-fix-passes), but is suppressed by --dry-run and --skip-drc.
+    """
+    auto_fix = getattr(args, "auto_fix", False)
+    dry_run = getattr(args, "dry_run", False)
+    skip_drc = getattr(args, "skip_drc", False)
+
+    if not auto_fix:
+        return False
+    if dry_run or skip_drc:
+        return False
+    return True
 
 
 @dataclass
@@ -618,7 +676,8 @@ def route_with_layer_escalation(
                 router.route_all_negotiated(
                     max_iterations=args.iterations,
                     timeout=args.timeout,
-                    batch_routing=getattr(args, "batch_routing", False) or getattr(args, "high_performance", False),
+                    batch_routing=getattr(args, "batch_routing", False)
+                    or getattr(args, "high_performance", False),
                     hierarchical=getattr(args, "hierarchical", False),
                 )
             elif args.strategy == "basic":
@@ -769,12 +828,20 @@ def route_with_layer_escalation(
 
     # Run DRC validation unless skipped
     if not args.skip_drc and final_result.nets_routed > 0:
-        run_post_route_drc(
+        drc_errors, _ = run_post_route_drc(
             output_path=output_path,
             manufacturer=args.manufacturer,
             layers=final_result.layer_count,
             quiet=quiet,
         )
+
+        # Auto-fix DRC violations if requested
+        if drc_errors > 0 and _should_auto_fix(args):
+            _run_auto_fix(
+                output_path=output_path,
+                max_passes=getattr(args, "auto_fix_passes", 1),
+                quiet=quiet,
+            )
 
     # Final summary
     if not quiet:
@@ -954,7 +1021,8 @@ def route_with_rule_relaxation(
                 router.route_all_negotiated(
                     max_iterations=args.iterations,
                     timeout=args.timeout,
-                    batch_routing=getattr(args, "batch_routing", False) or getattr(args, "high_performance", False),
+                    batch_routing=getattr(args, "batch_routing", False)
+                    or getattr(args, "high_performance", False),
                     hierarchical=getattr(args, "hierarchical", False),
                 )
             elif args.strategy == "basic":
@@ -1118,12 +1186,20 @@ def route_with_rule_relaxation(
 
     # Run DRC validation unless skipped
     if not args.skip_drc and final_result.nets_routed > 0:
-        run_post_route_drc(
+        drc_errors, _ = run_post_route_drc(
             output_path=output_path,
             manufacturer=args.manufacturer,
             layers=final_result.layer_count,
             quiet=quiet,
         )
+
+        # Auto-fix DRC violations if requested
+        if drc_errors > 0 and _should_auto_fix(args):
+            _run_auto_fix(
+                output_path=output_path,
+                max_passes=getattr(args, "auto_fix_passes", 1),
+                quiet=quiet,
+            )
 
     # Final summary
     if not quiet:
@@ -1308,7 +1384,8 @@ def route_with_combined_escalation(
                     router.route_all_negotiated(
                         max_iterations=args.iterations,
                         timeout=args.timeout,
-                        batch_routing=getattr(args, "batch_routing", False) or getattr(args, "high_performance", False),
+                        batch_routing=getattr(args, "batch_routing", False)
+                        or getattr(args, "high_performance", False),
                         hierarchical=getattr(args, "hierarchical", False),
                     )
                 elif args.strategy == "basic":
@@ -1506,12 +1583,20 @@ def route_with_combined_escalation(
 
     # Run DRC validation unless skipped
     if not args.skip_drc and final_result.nets_routed > 0:
-        run_post_route_drc(
+        drc_errors, _ = run_post_route_drc(
             output_path=output_path,
             manufacturer=args.manufacturer,
             layers=final_result.layer_count,
             quiet=quiet,
         )
+
+        # Auto-fix DRC violations if requested
+        if drc_errors > 0 and _should_auto_fix(args):
+            _run_auto_fix(
+                output_path=output_path,
+                max_passes=getattr(args, "auto_fix_passes", 1),
+                quiet=quiet,
+            )
 
     # Final summary
     if not quiet:
@@ -1807,6 +1892,26 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--auto-fix",
+        action="store_true",
+        help=(
+            "Automatically run 'kct fix-drc' after routing if DRC violations are "
+            "detected. Suppressed by --dry-run and --skip-drc. Uses iterative "
+            "repair to fix clearance and drill violations."
+        ),
+    )
+    parser.add_argument(
+        "--auto-fix-passes",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Number of repair passes for --auto-fix (default: 3). "
+            "Implies --auto-fix. Multiple passes can fix cascading violations "
+            "where fixing one violation exposes or resolves others."
+        ),
+    )
+    parser.add_argument(
         "--no-optimize",
         action="store_true",
         help=(
@@ -2034,6 +2139,16 @@ def main(argv: list[str] | None = None) -> int:
     if pcb_path.suffix != ".kicad_pcb":
         print(f"Warning: Expected .kicad_pcb file, got {pcb_path.suffix}")
 
+    # Normalize --auto-fix-passes: explicit value implies --auto-fix
+    if args.auto_fix_passes is not None:
+        if args.auto_fix_passes < 1:
+            print("Error: --auto-fix-passes must be at least 1", file=sys.stderr)
+            return 1
+        args.auto_fix = True
+    else:
+        # Default to 3 passes when --auto-fix is used without explicit --auto-fix-passes
+        args.auto_fix_passes = 3
+
     # Validate --auto-layers is not used with explicit --layers
     if args.auto_layers and args.layers != "auto":
         print(
@@ -2201,10 +2316,7 @@ def main(argv: list[str] | None = None) -> int:
             if auto_skip:
                 skip_nets.extend(auto_skip)
                 if not args.quiet:
-                    print(
-                        f"Auto-skip: {', '.join(sorted(auto_skip))} "
-                        f"(pour nets — use zone fill)"
-                    )
+                    print(f"Auto-skip: {', '.join(sorted(auto_skip))} (pour nets — use zone fill)")
     except Exception:
         pass  # Fall back to user-supplied skip_nets only
 
@@ -2376,9 +2488,12 @@ def main(argv: list[str] | None = None) -> int:
         backend_info = router.backend_info
         grid_cells = router.grid.cols * router.grid.rows * router.grid.num_layers
         from kicad_tools.router.cpp_backend import format_backend_status
+
         backend_status = format_backend_status(backend_info, grid_cells)
         print(f"  Backend:    {backend_status}")
-        print(f"  Grid:       {router.grid.cols}x{router.grid.rows}x{router.grid.num_layers} = {grid_cells:,} cells")
+        print(
+            f"  Grid:       {router.grid.cols}x{router.grid.rows}x{router.grid.num_layers} = {grid_cells:,} cells"
+        )
         print(f"  Total nets: {len(net_map)}")
         print(f"  Nets to route: {nets_to_route} (multi-pad signal nets)")
 
@@ -2589,7 +2704,9 @@ def main(argv: list[str] | None = None) -> int:
             if cached_result is not None:
                 if not quiet:
                     print(f"  Cache HIT: {cached_result.success_count} nets routed")
-                    print(f"  Segments: {cached_result.total_segments}, Vias: {cached_result.total_vias}")
+                    print(
+                        f"  Segments: {cached_result.total_segments}, Vias: {cached_result.total_vias}"
+                    )
                     print(f"  Original compute time: {cached_result.compute_time_ms}ms")
 
                 # Deserialize and apply cached routes
@@ -2604,7 +2721,9 @@ def main(argv: list[str] | None = None) -> int:
                 if not quiet:
                     print(f"  Cache MISS (key: {cache_key.full_key[:32]}...)")
                 if args.cache_only:
-                    print("Error: --cache-only specified but no cached result found", file=sys.stderr)
+                    print(
+                        "Error: --cache-only specified but no cached result found", file=sys.stderr
+                    )
                     return 1
         except Exception as e:
             if not quiet:
@@ -2634,6 +2753,7 @@ def main(argv: list[str] | None = None) -> int:
                 flush_print(f"  Profiling enabled: {profile_output}")
 
         import time
+
         routing_start_time = time.time()
 
         # Resolve escape routing flag: True=force on, False=force off, None=auto-detect
@@ -2669,7 +2789,8 @@ def main(argv: list[str] | None = None) -> int:
                 return router.route_all_negotiated(
                     max_iterations=args.iterations,
                     timeout=args.timeout,
-                    batch_routing=getattr(args, "batch_routing", False) or getattr(args, "high_performance", False),
+                    batch_routing=getattr(args, "batch_routing", False)
+                    or getattr(args, "high_performance", False),
                     hierarchical=getattr(args, "hierarchical", False),
                 )
             elif args.differential_pairs and args.strategy == "basic":
@@ -2735,8 +2856,11 @@ def main(argv: list[str] | None = None) -> int:
         # Cache the routing result (if caching enabled and routing succeeded)
         if use_cache and cache_key is not None and router.routes:
             import time
+
             try:
-                routing_time_ms = int((time.time() - routing_start_time) * 1000) if routing_start_time else 0
+                routing_time_ms = (
+                    int((time.time() - routing_start_time) * 1000) if routing_start_time else 0
+                )
                 stats = router.get_statistics()
                 cache.put(cache_key, router.routes, stats, routing_time_ms)
                 if not quiet:
@@ -2883,9 +3007,7 @@ def main(argv: list[str] | None = None) -> int:
                 if route_sexp:
                     fragments.append(route_sexp)
                 combined_sexp = "\n  ".join(fragments)
-                output_content = _insert_sexp_before_closing(
-                    original_content, combined_sexp
-                )
+                output_content = _insert_sexp_before_closing(original_content, combined_sexp)
             else:
                 output_content = original_content
                 if not quiet:
@@ -2956,6 +3078,16 @@ def main(argv: list[str] | None = None) -> int:
             quiet=quiet,
         )
 
+        # Auto-fix DRC violations if requested
+        if drc_errors > 0 and _should_auto_fix(args):
+            fix_result = _run_auto_fix(
+                output_path=output_path,
+                max_passes=getattr(args, "auto_fix_passes", 1),
+                quiet=quiet,
+            )
+            if fix_result == 0:
+                drc_errors = 0
+
     # Summary
     all_nets_routed = stats["nets_routed"] == nets_to_route
     drc_passed = drc_errors <= 0  # -1 means DRC failed to run, treat as passed
@@ -2995,10 +3127,12 @@ def main(argv: list[str] | None = None) -> int:
             print("This board cannot be manufactured without fixing DRC errors.")
             print()
             print("Suggestions:")
+            print(f"  - Auto-repair DRC violations: kct fix-drc {output_path} --max-passes 3")
             print("  - Try Monte Carlo routing: kct route --trials 10")
             print("  - Increase board area")
             print("  - Reduce component density")
             print("  - Try 4-layer routing: kct route --layers 4")
+            print(f"  - Or re-route with auto-fix: kct route {args.pcb} --auto-fix")
             print()
             print(f"  Run 'kct check {output_path} --mfr {args.manufacturer}' for full details")
         else:
@@ -3018,8 +3152,12 @@ def main(argv: list[str] | None = None) -> int:
                 # Verbose mode shows detailed path analysis for each failure
                 verbose = args.verbose or args.diagnostics
                 show_routing_summary(
-                    router, net_map, nets_to_route,
-                    quiet=quiet, verbose=verbose, current_strategy=args.strategy,
+                    router,
+                    net_map,
+                    nets_to_route,
+                    quiet=quiet,
+                    verbose=verbose,
+                    current_strategy=args.strategy,
                 )
 
     # Exit codes:

--- a/tests/test_route_auto_fix.py
+++ b/tests/test_route_auto_fix.py
@@ -1,0 +1,361 @@
+"""Tests for --auto-fix and --auto-fix-passes flags in route command.
+
+Verifies:
+- fix-drc suggestion appears in DRC failure output
+- --auto-fix flag triggers fix_drc_cmd.main() after DRC errors
+- --auto-fix-passes implies --auto-fix when > 1
+- --dry-run suppresses auto-fix
+- --skip-drc suppresses auto-fix
+- _should_auto_fix helper logic
+- _run_auto_fix invokes fix_drc_cmd.main with correct arguments
+"""
+
+import contextlib
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from kicad_tools.cli.route_cmd import _run_auto_fix, _should_auto_fix
+
+
+class TestShouldAutoFix:
+    """Tests for _should_auto_fix helper function."""
+
+    def test_auto_fix_enabled(self):
+        """Returns True when --auto-fix is set."""
+        args = SimpleNamespace(auto_fix=True, dry_run=False, skip_drc=False)
+        assert _should_auto_fix(args) is True
+
+    def test_auto_fix_disabled(self):
+        """Returns False when --auto-fix is not set."""
+        args = SimpleNamespace(auto_fix=False, dry_run=False, skip_drc=False)
+        assert _should_auto_fix(args) is False
+
+    def test_auto_fix_passes_implies_auto_fix_after_normalization(self):
+        """--auto-fix-passes sets auto_fix=True after normalization in main()."""
+        # After main() normalization, auto_fix is True when auto_fix_passes is set
+        args = SimpleNamespace(auto_fix=True, dry_run=False, skip_drc=False)
+        assert _should_auto_fix(args) is True
+
+    def test_auto_fix_false_without_flag(self):
+        """auto_fix=False means no auto-fix."""
+        args = SimpleNamespace(auto_fix=False, dry_run=False, skip_drc=False)
+        assert _should_auto_fix(args) is False
+
+    def test_dry_run_suppresses_auto_fix(self):
+        """--dry-run suppresses auto-fix even when --auto-fix is set."""
+        args = SimpleNamespace(auto_fix=True, dry_run=True, skip_drc=False)
+        assert _should_auto_fix(args) is False
+
+    def test_skip_drc_suppresses_auto_fix(self):
+        """--skip-drc suppresses auto-fix even when --auto-fix is set."""
+        args = SimpleNamespace(auto_fix=True, dry_run=False, skip_drc=True)
+        assert _should_auto_fix(args) is False
+
+    def test_dry_run_and_skip_drc_suppress_auto_fix(self):
+        """Both --dry-run and --skip-drc suppress auto-fix."""
+        args = SimpleNamespace(auto_fix=True, dry_run=True, skip_drc=True)
+        assert _should_auto_fix(args) is False
+
+    def test_missing_attributes_uses_defaults(self):
+        """Missing attributes fall back to safe defaults via getattr."""
+        args = SimpleNamespace()
+        assert _should_auto_fix(args) is False
+
+    def test_auto_fix_with_dry_run_still_suppressed(self):
+        """--auto-fix with --dry-run is still suppressed."""
+        args = SimpleNamespace(auto_fix=True, dry_run=True, skip_drc=False)
+        assert _should_auto_fix(args) is False
+
+
+class TestRunAutoFix:
+    """Tests for _run_auto_fix helper function."""
+
+    @patch("kicad_tools.cli.fix_drc_cmd.main")
+    def test_run_auto_fix_calls_fix_drc(self, mock_fix_drc):
+        """_run_auto_fix calls fix_drc_cmd.main with correct arguments."""
+        from pathlib import Path
+
+        mock_fix_drc.return_value = 0
+        result = _run_auto_fix(Path("/tmp/board.kicad_pcb"), max_passes=1, quiet=True)
+
+        assert result == 0
+        mock_fix_drc.assert_called_once()
+        call_args = mock_fix_drc.call_args[0][0]
+        assert "/tmp/board.kicad_pcb" in call_args
+        assert "--max-passes" in call_args
+        assert "1" in call_args
+        assert "--quiet" in call_args
+
+    @patch("kicad_tools.cli.fix_drc_cmd.main")
+    def test_run_auto_fix_passes_max_passes(self, mock_fix_drc):
+        """_run_auto_fix forwards max_passes to fix_drc_cmd."""
+        from pathlib import Path
+
+        mock_fix_drc.return_value = 0
+        _run_auto_fix(Path("/tmp/board.kicad_pcb"), max_passes=5, quiet=True)
+
+        call_args = mock_fix_drc.call_args[0][0]
+        passes_idx = call_args.index("--max-passes")
+        assert call_args[passes_idx + 1] == "5"
+
+    @patch("kicad_tools.cli.fix_drc_cmd.main")
+    def test_run_auto_fix_returns_nonzero_on_failure(self, mock_fix_drc):
+        """_run_auto_fix returns non-zero when fix-drc fails."""
+        from pathlib import Path
+
+        mock_fix_drc.return_value = 1
+        result = _run_auto_fix(Path("/tmp/board.kicad_pcb"), max_passes=1, quiet=True)
+        assert result == 1
+
+    @patch("kicad_tools.cli.fix_drc_cmd.main")
+    def test_run_auto_fix_not_quiet(self, mock_fix_drc, capsys):
+        """_run_auto_fix prints status when not quiet."""
+        from pathlib import Path
+
+        mock_fix_drc.return_value = 0
+        _run_auto_fix(Path("/tmp/board.kicad_pcb"), max_passes=1, quiet=False)
+
+        captured = capsys.readouterr()
+        assert "Auto-Fix DRC Violations" in captured.out
+        assert "all targeted violations repaired" in captured.out
+
+    @patch("kicad_tools.cli.fix_drc_cmd.main")
+    def test_run_auto_fix_not_quiet_failure(self, mock_fix_drc, capsys):
+        """_run_auto_fix prints failure message when not quiet and fix fails."""
+        from pathlib import Path
+
+        mock_fix_drc.return_value = 1
+        _run_auto_fix(Path("/tmp/board.kicad_pcb"), max_passes=1, quiet=False)
+
+        captured = capsys.readouterr()
+        assert "Auto-Fix DRC Violations" in captured.out
+        assert "some violations remain" in captured.out
+
+    @patch("kicad_tools.cli.fix_drc_cmd.main")
+    def test_run_auto_fix_quiet_no_output(self, mock_fix_drc, capsys):
+        """_run_auto_fix suppresses output when quiet."""
+        from pathlib import Path
+
+        mock_fix_drc.return_value = 0
+        _run_auto_fix(Path("/tmp/board.kicad_pcb"), max_passes=1, quiet=True)
+
+        captured = capsys.readouterr()
+        assert "Auto-Fix DRC Violations" not in captured.out
+
+
+class TestFixDrcSuggestionInDrcOutput:
+    """Tests that fix-drc suggestion appears in run_post_route_drc output."""
+
+    @patch("kicad_tools.validate.DRCChecker")
+    @patch("kicad_tools.schema.pcb.PCB")
+    def test_fix_drc_suggestion_shown_on_errors(
+        self, mock_pcb_cls, mock_checker_cls, capsys, tmp_path
+    ):
+        """run_post_route_drc shows fix-drc suggestion when there are DRC errors."""
+        from kicad_tools.cli.route_cmd import run_post_route_drc
+
+        # Create a mock PCB file
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+
+        # Set up mock DRC results with errors
+        mock_violation = MagicMock()
+        mock_violation.rule_id = "clearance"
+        mock_violation.message = "Clearance violation"
+        mock_violation.location = (100.0, 100.0)
+
+        mock_results = MagicMock()
+        mock_results.error_count = 3
+        mock_results.warning_count = 0
+        mock_results.errors = [mock_violation]
+        mock_results.warnings = []
+
+        mock_checker = MagicMock()
+        mock_checker.check_all.return_value = mock_results
+        mock_checker_cls.return_value = mock_checker
+        mock_pcb_cls.load.return_value = MagicMock()
+
+        run_post_route_drc(
+            output_path=pcb_file,
+            manufacturer="jlcpcb",
+            layers=2,
+            quiet=False,
+        )
+
+        captured = capsys.readouterr()
+        assert "kct fix-drc" in captured.out
+        assert "auto-repair clearance violations" in captured.out
+
+    @patch("kicad_tools.validate.DRCChecker")
+    @patch("kicad_tools.schema.pcb.PCB")
+    def test_fix_drc_suggestion_not_shown_when_no_errors(
+        self, mock_pcb_cls, mock_checker_cls, capsys, tmp_path
+    ):
+        """run_post_route_drc does not show fix-drc suggestion when DRC passes."""
+        from kicad_tools.cli.route_cmd import run_post_route_drc
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+
+        mock_results = MagicMock()
+        mock_results.error_count = 0
+        mock_results.warning_count = 0
+        mock_results.errors = []
+        mock_results.warnings = []
+
+        mock_checker = MagicMock()
+        mock_checker.check_all.return_value = mock_results
+        mock_checker_cls.return_value = mock_checker
+        mock_pcb_cls.load.return_value = MagicMock()
+
+        run_post_route_drc(
+            output_path=pcb_file,
+            manufacturer="jlcpcb",
+            layers=2,
+            quiet=False,
+        )
+
+        captured = capsys.readouterr()
+        assert "kct fix-drc" not in captured.out
+
+    @patch("kicad_tools.validate.DRCChecker")
+    @patch("kicad_tools.schema.pcb.PCB")
+    def test_fix_drc_suggestion_not_shown_when_quiet(
+        self, mock_pcb_cls, mock_checker_cls, capsys, tmp_path
+    ):
+        """run_post_route_drc does not show any output when quiet."""
+        from kicad_tools.cli.route_cmd import run_post_route_drc
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+
+        mock_results = MagicMock()
+        mock_results.error_count = 3
+        mock_results.warning_count = 0
+        mock_results.errors = []
+        mock_results.warnings = []
+
+        mock_checker = MagicMock()
+        mock_checker.check_all.return_value = mock_results
+        mock_checker_cls.return_value = mock_checker
+        mock_pcb_cls.load.return_value = MagicMock()
+
+        run_post_route_drc(
+            output_path=pcb_file,
+            manufacturer="jlcpcb",
+            layers=2,
+            quiet=True,
+        )
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+
+class TestAutoFixCLIArgs:
+    """Tests for --auto-fix and --auto-fix-passes CLI argument parsing."""
+
+    def test_auto_fix_flag_parsed(self):
+        """Parser correctly parses --auto-fix flag."""
+        from kicad_tools.cli.route_cmd import main
+
+        buf = StringIO()
+        with contextlib.redirect_stdout(buf), contextlib.suppress(SystemExit):
+            main(["--help"])
+
+        text = buf.getvalue()
+        assert "--auto-fix" in text
+        assert "--auto-fix-passes" in text
+
+    def test_auto_fix_passes_validation_rejects_zero(self, tmp_path):
+        """Parser rejects --auto-fix-passes 0."""
+        from kicad_tools.cli.route_cmd import main
+
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb (version 20240101) (generator test))")
+
+        result = main(
+            [
+                str(pcb_file),
+                "--auto-fix-passes",
+                "0",
+                "--dry-run",
+                "--quiet",
+            ]
+        )
+        assert result == 1
+
+    def test_auto_fix_passes_normalization(self, tmp_path):
+        """--auto-fix-passes implies --auto-fix after normalization."""
+        import argparse
+
+        # Parse arguments directly to check normalization
+        parser = argparse.ArgumentParser()
+        parser.add_argument("pcb")
+        parser.add_argument("--auto-fix", action="store_true")
+        parser.add_argument("--auto-fix-passes", type=int, default=None)
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument("--skip-drc", action="store_true")
+
+        args = parser.parse_args(["test.kicad_pcb", "--auto-fix-passes", "5"])
+
+        # Before normalization, auto_fix is False
+        assert args.auto_fix is False
+
+        # After normalization (as done in main)
+        if args.auto_fix_passes is not None:
+            args.auto_fix = True
+        else:
+            args.auto_fix_passes = 3
+        assert args.auto_fix is True
+        assert args.auto_fix_passes == 5
+
+    def test_auto_fix_passes_default_applied(self, tmp_path):
+        """Default auto_fix_passes is 3 when not explicitly provided."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("pcb")
+        parser.add_argument("--auto-fix", action="store_true")
+        parser.add_argument("--auto-fix-passes", type=int, default=None)
+
+        args = parser.parse_args(["test.kicad_pcb", "--auto-fix"])
+
+        # auto_fix_passes is None (not provided), auto_fix is True
+        assert args.auto_fix is True
+        assert args.auto_fix_passes is None
+
+        # After normalization
+        if args.auto_fix_passes is None:
+            args.auto_fix_passes = 3
+        assert args.auto_fix_passes == 3
+
+
+class TestFixDrcSuggestionInMainOutput:
+    """Tests that fix-drc suggestions appear in main() DRC failure output."""
+
+    def test_suggestions_block_includes_fix_drc(self):
+        """The suggestions block in route_cmd source includes fix-drc command."""
+        from pathlib import Path
+
+        route_cmd_path = (
+            Path(__file__).parent.parent / "src" / "kicad_tools" / "cli" / "route_cmd.py"
+        )
+        source = route_cmd_path.read_text()
+
+        # Check the suggestions block includes fix-drc
+        assert "kct fix-drc" in source
+        assert "--auto-fix" in source
+
+    def test_suggestions_block_includes_auto_fix_hint(self):
+        """The suggestions block mentions --auto-fix re-route option."""
+        from pathlib import Path
+
+        route_cmd_path = (
+            Path(__file__).parent.parent / "src" / "kicad_tools" / "cli" / "route_cmd.py"
+        )
+        source = route_cmd_path.read_text()
+
+        # Check for the auto-fix suggestion in the DRC failure block
+        assert "kct route" in source
+        assert "--auto-fix" in source


### PR DESCRIPTION
## Summary

Add fix-drc suggestion text and --auto-fix / --auto-fix-passes CLI flags to the route command so users can automatically repair DRC violations after routing.

## Changes

- Add fix-drc suggestion to `run_post_route_drc()` output when DRC errors are detected (all 4 call sites covered)
- Add fix-drc and --auto-fix suggestions to the "ROUTING FAILED" suggestions block in main()
- Add `--auto-fix` flag that automatically invokes `fix_drc_cmd.main()` after post-route DRC detects errors
- Add `--auto-fix-passes N` flag (default: 3, implies --auto-fix) to control repair iterations
- Add `_run_auto_fix()` helper that delegates to `fix_drc_cmd.main()` with appropriate argv
- Add `_should_auto_fix()` helper to check flag state (suppressed by --dry-run and --skip-drc)
- All 4 `run_post_route_drc` call sites (layer escalation, rule relaxation, combined escalation, default routing) capture DRC error counts and trigger auto-fix when appropriate
- In the main routing path, successful auto-fix resets drc_errors to 0 so exit code reflects post-fix state

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Suggestions block includes `kct fix-drc <pcb> --max-passes 3` | PASS | Added as first suggestion in the ROUTING FAILED block |
| `--auto-fix` runs fix-drc when DRC violations present | PASS | `_run_auto_fix()` calls `fix_drc_cmd.main()` at all 4 call sites |
| `--auto-fix --dry-run` suppresses auto-fix | PASS | `_should_auto_fix()` returns False when dry_run=True; verified by test |
| `--auto-fix --skip-drc` silently ignores auto-fix | PASS | `_should_auto_fix()` returns False when skip_drc=True; verified by test |
| Auto-fix success exits 0 | PASS | In main(), `fix_result == 0` resets `drc_errors = 0`, leading to exit 0 |
| Auto-fix partial repair exits 1 | PASS | `drc_errors` remains positive when `fix_result != 0` |
| `--auto-fix-passes N` controls max-passes | PASS | Forwarded to `fix_drc_cmd.main()` via argv; default is 3 |
| All 3 additional call sites covered | PASS | Lines 837, 1194, 1590 all capture drc_errors and call auto-fix |

## Test Plan

- 24 new tests in `tests/test_route_auto_fix.py` covering:
  - `_should_auto_fix()` logic: enabled, disabled, dry-run suppression, skip-drc suppression, missing attrs
  - `_run_auto_fix()`: correct argv forwarding, max_passes, quiet mode, success/failure output
  - DRC suggestion: shown on errors, hidden on no errors, hidden when quiet
  - CLI args: --auto-fix in help, --auto-fix-passes validation (rejects 0), normalization
  - Source verification: fix-drc and --auto-fix text present in route_cmd.py
- All 80 existing tests in `test_route_cmd_params.py` and `test_fix_drc_cmd.py` pass unchanged
- `uv run pytest tests/test_route_auto_fix.py tests/test_route_cmd_params.py tests/test_fix_drc_cmd.py` = 104 passed

Closes #1303