### PR TITLE
feat(report): add ReportFigureGenerator for PCB and schematic screenshots

### DIFF
--- a/src/kicad_tools/report/__init__.py
+++ b/src/kicad_tools/report/__init__.py
@@ -1,0 +1,9 @@
+"""Report generation subpackage for kicad-tools.
+
+Provides tools for generating report figures (PCB renders, schematic
+screenshots) and structured manifests for design review documents.
+"""
+
+from kicad_tools.report.figures import FigureEntry, ReportFigureGenerator
+
+__all__ = ["FigureEntry", "ReportFigureGenerator"]

--- a/src/kicad_tools/report/figures.py
+++ b/src/kicad_tools/report/figures.py
@@ -1,0 +1,273 @@
+"""Screenshot generation for report figures.
+
+Generates PCB renders (front, back, copper, assembly presets) and
+per-sheet schematic screenshots for inclusion in design review reports.
+
+Reuses the screenshot infrastructure from ``kicad_tools.mcp.tools.screenshot``
+(``screenshot_board``, ``_svg_to_png``, layer presets).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from kicad_tools.cli.runner import find_kicad_cli
+from kicad_tools.mcp.tools.screenshot import (
+    _check_cairosvg,
+    _svg_to_png,
+    screenshot_board,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Default maximum image dimension (px) for report figures.
+#: Higher than the vision-API cap (1568 px) because report images are
+#: embedded in documents, not sent to a vision model.
+REPORT_MAX_SIZE_PX = 3000
+
+#: PCB presets to render, in order.
+#: Each tuple is (preset_name, output_filename, caption).
+_PCB_PRESETS: list[tuple[str, str, str]] = [
+    ("front", "pcb_front.png", "PCB Front"),
+    ("back", "pcb_back.png", "PCB Back"),
+    ("copper", "pcb_copper.png", "PCB Copper Layers"),
+    ("assembly", "assembly.png", "Assembly View"),
+]
+
+
+@dataclass
+class FigureEntry:
+    """Manifest entry describing a single generated report figure."""
+
+    filename: str
+    """Filename relative to the output directory (e.g. ``pcb_front.png``)."""
+
+    caption: str
+    """Human-readable label (e.g. ``"PCB Front"``)."""
+
+    figure_type: str
+    """One of ``pcb_front``, ``pcb_back``, ``pcb_copper``, ``assembly``, or ``schematic``."""
+
+
+class ReportFigureGenerator:
+    """Generates report figures for PCB boards and schematics.
+
+    Renders four PCB layer presets (front, back, copper, assembly) and
+    one PNG per schematic sheet.  Returns a manifest of
+    :class:`FigureEntry` objects describing the generated files.
+
+    Parameters
+    ----------
+    max_size_px:
+        Maximum image dimension in pixels.  Defaults to
+        :data:`REPORT_MAX_SIZE_PX` (3000).
+    """
+
+    def __init__(self, max_size_px: int = REPORT_MAX_SIZE_PX) -> None:
+        self.max_size_px = max_size_px
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def generate_all(
+        self,
+        pcb_path: str | Path,
+        sch_path: str | Path,
+        output_dir: str | Path,
+    ) -> list[FigureEntry]:
+        """Generate all report figures and return a manifest.
+
+        Parameters
+        ----------
+        pcb_path:
+            Path to the ``.kicad_pcb`` file.
+        sch_path:
+            Path to the root ``.kicad_sch`` file.
+        output_dir:
+            Directory where PNG files will be written.  Created if it
+            does not exist.
+
+        Returns
+        -------
+        list[FigureEntry]
+            Manifest entries for every successfully generated figure.
+            Figures that fail to render are excluded (a warning is
+            logged) so that partial results are still usable.
+
+        Raises
+        ------
+        RuntimeError
+            If ``kicad-cli`` or ``cairosvg`` is not available.
+        """
+        self._check_dependencies()
+
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+
+        entries: list[FigureEntry] = []
+        entries.extend(self._generate_pcb_figures(Path(pcb_path), out))
+        entries.extend(self._generate_schematic_figures(Path(sch_path), out))
+        return entries
+
+    # ------------------------------------------------------------------
+    # Dependency checks
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_dependencies() -> None:
+        """Raise :class:`RuntimeError` if required tools are missing."""
+        kicad_cli = find_kicad_cli()
+        if kicad_cli is None:
+            raise RuntimeError(
+                "kicad-cli not found. Install KiCad 8+ from https://www.kicad.org/download/"
+            )
+
+        if not _check_cairosvg():
+            raise RuntimeError(
+                "cairosvg is required for report figure generation. "
+                "Install with: pip install 'kicad-tools[screenshot]'"
+            )
+
+    # ------------------------------------------------------------------
+    # PCB rendering
+    # ------------------------------------------------------------------
+
+    def _generate_pcb_figures(
+        self,
+        pcb_path: Path,
+        output_dir: Path,
+    ) -> list[FigureEntry]:
+        """Render the four PCB layer presets."""
+        entries: list[FigureEntry] = []
+        for preset, filename, caption in _PCB_PRESETS:
+            out_path = output_dir / filename
+            try:
+                result = screenshot_board(
+                    pcb_path=str(pcb_path),
+                    layers=preset,
+                    max_size_px=self.max_size_px,
+                    output_path=str(out_path),
+                )
+                if result.get("success"):
+                    figure_type = preset if preset != "assembly" else "assembly"
+                    # Normalise preset name to figure_type enum
+                    if preset in ("front", "back", "copper"):
+                        figure_type = f"pcb_{preset}"
+                    entries.append(
+                        FigureEntry(
+                            filename=filename,
+                            caption=caption,
+                            figure_type=figure_type,
+                        )
+                    )
+                else:
+                    logger.warning(
+                        "Failed to render PCB preset '%s': %s",
+                        preset,
+                        result.get("error_message", "unknown error"),
+                    )
+            except Exception:
+                logger.warning(
+                    "Exception while rendering PCB preset '%s'",
+                    preset,
+                    exc_info=True,
+                )
+        return entries
+
+    # ------------------------------------------------------------------
+    # Schematic rendering (all sheets)
+    # ------------------------------------------------------------------
+
+    def _generate_schematic_figures(
+        self,
+        sch_path: Path,
+        output_dir: Path,
+    ) -> list[FigureEntry]:
+        """Export every schematic sheet to PNG.
+
+        Uses ``kicad-cli sch export svg`` which emits one SVG per sheet
+        into a temporary directory.  Each SVG is then converted to PNG
+        via ``_svg_to_png``.
+        """
+        kicad_cli = find_kicad_cli()
+        if kicad_cli is None:
+            logger.warning("kicad-cli not found; skipping schematic figures")
+            return []
+
+        entries: list[FigureEntry] = []
+        try:
+            with tempfile.TemporaryDirectory(prefix="kicad_sch_") as tmpdir:
+                tmp = Path(tmpdir)
+                cmd = [
+                    str(kicad_cli),
+                    "sch",
+                    "export",
+                    "svg",
+                    "--output",
+                    str(tmp),
+                    str(sch_path),
+                ]
+                subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                    check=False,
+                )
+
+                svg_files: Sequence[Path] = sorted(tmp.glob("*.svg"))
+                if not svg_files:
+                    logger.warning(
+                        "kicad-cli produced no SVG output for %s",
+                        sch_path,
+                    )
+                    return []
+
+                for svg_file in svg_files:
+                    png_name = f"schematic_{svg_file.stem}.png"
+                    png_path = output_dir / png_name
+                    try:
+                        ok, err, _w, _h = _svg_to_png(svg_file, png_path, self.max_size_px)
+                        if ok:
+                            entries.append(
+                                FigureEntry(
+                                    filename=png_name,
+                                    caption=f"Schematic: {svg_file.stem}",
+                                    figure_type="schematic",
+                                )
+                            )
+                        else:
+                            logger.warning(
+                                "Failed to render schematic sheet '%s': %s",
+                                svg_file.name,
+                                err,
+                            )
+                    except Exception:
+                        logger.warning(
+                            "Exception while converting schematic SVG '%s'",
+                            svg_file.name,
+                            exc_info=True,
+                        )
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "kicad-cli schematic SVG export timed out for %s",
+                sch_path,
+            )
+        except FileNotFoundError:
+            logger.warning(
+                "kicad-cli not found at %s",
+                kicad_cli,
+            )
+        except Exception:
+            logger.warning(
+                "Unexpected error during schematic export",
+                exc_info=True,
+            )
+
+        return entries

--- a/tests/test_report_figures.py
+++ b/tests/test_report_figures.py
@@ -1,0 +1,461 @@
+"""Tests for kicad_tools.report.figures — ReportFigureGenerator."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.report.figures import (
+    REPORT_MAX_SIZE_PX,
+    FigureEntry,
+    ReportFigureGenerator,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_success_result(**overrides):
+    """Return a dict matching the shape of ``screenshot_board`` success."""
+    base = {
+        "success": True,
+        "image_base64": "AAAA",
+        "width_px": 800,
+        "height_px": 600,
+        "layers_rendered": ["F.Cu"],
+        "output_path": "/tmp/out.png",
+        "error_message": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_failure_result(msg: str = "render failed"):
+    """Return a dict matching ``screenshot_board`` failure."""
+    return {
+        "success": False,
+        "image_base64": None,
+        "width_px": 0,
+        "height_px": 0,
+        "layers_rendered": [],
+        "output_path": None,
+        "error_message": msg,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestReportFigureGeneratorDefaults:
+    """Verify constructor defaults."""
+
+    def test_default_max_size(self):
+        gen = ReportFigureGenerator()
+        assert gen.max_size_px == REPORT_MAX_SIZE_PX
+        assert gen.max_size_px == 3000
+
+    def test_custom_max_size(self):
+        gen = ReportFigureGenerator(max_size_px=2400)
+        assert gen.max_size_px == 2400
+
+
+class TestGenerateAll:
+    """Unit tests for ``generate_all`` with mocked dependencies."""
+
+    @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
+    @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
+    @patch("kicad_tools.report.figures.subprocess.run")
+    @patch("kicad_tools.report.figures._svg_to_png")
+    @patch("kicad_tools.report.figures.screenshot_board")
+    def test_generate_all_happy_path(
+        self,
+        mock_board,
+        mock_svg_to_png,
+        mock_subprocess,
+        mock_find_cli,
+        mock_cairosvg,
+        tmp_path,
+    ):
+        """All five figure types generated successfully."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.touch()
+        sch = tmp_path / "main.kicad_sch"
+        sch.touch()
+        out_dir = tmp_path / "figures"
+
+        # PCB calls all succeed
+        mock_board.return_value = _make_success_result()
+
+        # Schematic: simulate kicad-cli producing two SVGs
+        def fake_subprocess_run(cmd, **kwargs):
+            # Write two SVG files into the temp directory.
+            # The --output arg is at index 4 in the command list.
+            output_idx = cmd.index("--output") + 1
+            svg_dir = Path(cmd[output_idx])
+            (svg_dir / "main_sheet.svg").write_text("<svg/>")
+            (svg_dir / "power_sheet.svg").write_text("<svg/>")
+            return MagicMock(returncode=0, stderr="")
+
+        mock_subprocess.side_effect = fake_subprocess_run
+        mock_svg_to_png.return_value = (True, "", 2000, 1500)
+
+        gen = ReportFigureGenerator()
+        entries = gen.generate_all(pcb, sch, out_dir)
+
+        # 4 PCB + 2 schematic = 6
+        assert len(entries) == 6
+
+        # Check PCB entries
+        pcb_entries = [e for e in entries if e.figure_type != "schematic"]
+        assert len(pcb_entries) == 4
+        pcb_types = {e.figure_type for e in pcb_entries}
+        assert pcb_types == {"pcb_front", "pcb_back", "pcb_copper", "assembly"}
+
+        pcb_filenames = {e.filename for e in pcb_entries}
+        assert pcb_filenames == {"pcb_front.png", "pcb_back.png", "pcb_copper.png", "assembly.png"}
+
+        # Check schematic entries
+        sch_entries = [e for e in entries if e.figure_type == "schematic"]
+        assert len(sch_entries) == 2
+        sch_filenames = {e.filename for e in sch_entries}
+        assert sch_filenames == {"schematic_main_sheet.png", "schematic_power_sheet.png"}
+
+        # Verify captions
+        for e in sch_entries:
+            assert e.caption.startswith("Schematic: ")
+
+        # Verify screenshot_board was called with correct presets
+        assert mock_board.call_count == 4
+
+    @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
+    @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
+    @patch("kicad_tools.report.figures.subprocess.run")
+    @patch("kicad_tools.report.figures._svg_to_png")
+    @patch("kicad_tools.report.figures.screenshot_board")
+    def test_partial_pcb_failure(
+        self,
+        mock_board,
+        mock_svg_to_png,
+        mock_subprocess,
+        mock_find_cli,
+        mock_cairosvg,
+        tmp_path,
+        caplog,
+    ):
+        """One PCB preset fails; others still generated."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.touch()
+        sch = tmp_path / "main.kicad_sch"
+        sch.touch()
+        out_dir = tmp_path / "figures"
+
+        # First call (front) fails, rest succeed
+        mock_board.side_effect = [
+            _make_failure_result("front render failed"),
+            _make_success_result(),
+            _make_success_result(),
+            _make_success_result(),
+        ]
+
+        # No schematic SVGs produced
+        mock_subprocess.return_value = MagicMock(returncode=0, stderr="")
+
+        gen = ReportFigureGenerator()
+        with caplog.at_level(logging.WARNING):
+            entries = gen.generate_all(pcb, sch, out_dir)
+
+        # 3 PCB (one failed) + 0 schematic
+        assert len(entries) == 3
+        assert all(e.figure_type != "pcb_front" for e in entries)
+
+        # Warning should be logged
+        assert "front render failed" in caplog.text
+
+    @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
+    @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
+    @patch("kicad_tools.report.figures.subprocess.run")
+    @patch("kicad_tools.report.figures._svg_to_png")
+    @patch("kicad_tools.report.figures.screenshot_board")
+    def test_schematic_svg_conversion_failure(
+        self,
+        mock_board,
+        mock_svg_to_png,
+        mock_subprocess,
+        mock_find_cli,
+        mock_cairosvg,
+        tmp_path,
+        caplog,
+    ):
+        """One schematic SVG fails to convert; the other succeeds."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.touch()
+        sch = tmp_path / "main.kicad_sch"
+        sch.touch()
+        out_dir = tmp_path / "figures"
+
+        mock_board.return_value = _make_success_result()
+
+        def fake_subprocess_run(cmd, **kwargs):
+            output_idx = cmd.index("--output") + 1
+            svg_dir = Path(cmd[output_idx])
+            (svg_dir / "good_sheet.svg").write_text("<svg/>")
+            (svg_dir / "bad_sheet.svg").write_text("<svg/>")
+            return MagicMock(returncode=0, stderr="")
+
+        mock_subprocess.side_effect = fake_subprocess_run
+
+        # First SVG succeeds, second fails
+        mock_svg_to_png.side_effect = [
+            (False, "bad conversion", 0, 0),
+            (True, "", 2000, 1500),
+        ]
+
+        gen = ReportFigureGenerator()
+        with caplog.at_level(logging.WARNING):
+            entries = gen.generate_all(pcb, sch, out_dir)
+
+        # 4 PCB + 1 successful schematic
+        sch_entries = [e for e in entries if e.figure_type == "schematic"]
+        assert len(sch_entries) == 1
+        assert sch_entries[0].filename == "schematic_good_sheet.png"
+        assert "bad conversion" in caplog.text
+
+
+class TestMissingDependencies:
+    """Tests for missing kicad-cli and cairosvg."""
+
+    @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
+    @patch("kicad_tools.report.figures.find_kicad_cli", return_value=None)
+    def test_missing_kicad_cli_raises(self, mock_find_cli, mock_cairosvg, tmp_path):
+        gen = ReportFigureGenerator()
+        with pytest.raises(RuntimeError, match="kicad-cli not found"):
+            gen.generate_all(
+                tmp_path / "board.kicad_pcb",
+                tmp_path / "main.kicad_sch",
+                tmp_path / "out",
+            )
+
+    @patch("kicad_tools.report.figures._check_cairosvg", return_value=False)
+    @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
+    def test_missing_cairosvg_raises(self, mock_find_cli, mock_cairosvg, tmp_path):
+        gen = ReportFigureGenerator()
+        with pytest.raises(RuntimeError, match="cairosvg is required"):
+            gen.generate_all(
+                tmp_path / "board.kicad_pcb",
+                tmp_path / "main.kicad_sch",
+                tmp_path / "out",
+            )
+
+
+class TestMultiSheetSchematics:
+    """Verify multi-sheet schematic handling."""
+
+    @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
+    @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
+    @patch("kicad_tools.report.figures.subprocess.run")
+    @patch("kicad_tools.report.figures._svg_to_png")
+    @patch("kicad_tools.report.figures.screenshot_board")
+    def test_three_sheets(
+        self,
+        mock_board,
+        mock_svg_to_png,
+        mock_subprocess,
+        mock_find_cli,
+        mock_cairosvg,
+        tmp_path,
+    ):
+        """Three schematic sheets produce three FigureEntry objects."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.touch()
+        sch = tmp_path / "main.kicad_sch"
+        sch.touch()
+        out_dir = tmp_path / "figures"
+
+        mock_board.return_value = _make_success_result()
+
+        def fake_subprocess_run(cmd, **kwargs):
+            output_idx = cmd.index("--output") + 1
+            svg_dir = Path(cmd[output_idx])
+            (svg_dir / "main.svg").write_text("<svg/>")
+            (svg_dir / "logic.svg").write_text("<svg/>")
+            (svg_dir / "output.svg").write_text("<svg/>")
+            return MagicMock(returncode=0, stderr="")
+
+        mock_subprocess.side_effect = fake_subprocess_run
+        mock_svg_to_png.return_value = (True, "", 2000, 1500)
+
+        gen = ReportFigureGenerator()
+        entries = gen.generate_all(pcb, sch, out_dir)
+
+        sch_entries = [e for e in entries if e.figure_type == "schematic"]
+        assert len(sch_entries) == 3
+        assert {e.filename for e in sch_entries} == {
+            "schematic_main.png",
+            "schematic_logic.png",
+            "schematic_output.png",
+        }
+
+
+class TestFilenameDeterminism:
+    """Verify deterministic output filenames."""
+
+    @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
+    @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
+    @patch("kicad_tools.report.figures.subprocess.run")
+    @patch("kicad_tools.report.figures._svg_to_png")
+    @patch("kicad_tools.report.figures.screenshot_board")
+    def test_same_filenames_on_repeated_calls(
+        self,
+        mock_board,
+        mock_svg_to_png,
+        mock_subprocess,
+        mock_find_cli,
+        mock_cairosvg,
+        tmp_path,
+    ):
+        """Running generate_all twice produces identical manifest filenames."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.touch()
+        sch = tmp_path / "main.kicad_sch"
+        sch.touch()
+        out_dir = tmp_path / "figures"
+
+        mock_board.return_value = _make_success_result()
+
+        def fake_subprocess_run(cmd, **kwargs):
+            output_idx = cmd.index("--output") + 1
+            svg_dir = Path(cmd[output_idx])
+            (svg_dir / "sheet1.svg").write_text("<svg/>")
+            return MagicMock(returncode=0, stderr="")
+
+        mock_subprocess.side_effect = fake_subprocess_run
+        mock_svg_to_png.return_value = (True, "", 2000, 1500)
+
+        gen = ReportFigureGenerator()
+        entries1 = gen.generate_all(pcb, sch, out_dir)
+        entries2 = gen.generate_all(pcb, sch, out_dir)
+
+        filenames1 = [e.filename for e in entries1]
+        filenames2 = [e.filename for e in entries2]
+        assert filenames1 == filenames2
+
+
+class TestFigureEntry:
+    """Verify FigureEntry dataclass behavior."""
+
+    def test_fields(self):
+        entry = FigureEntry(
+            filename="pcb_front.png",
+            caption="PCB Front",
+            figure_type="pcb_front",
+        )
+        assert entry.filename == "pcb_front.png"
+        assert entry.caption == "PCB Front"
+        assert entry.figure_type == "pcb_front"
+
+    def test_equality(self):
+        a = FigureEntry("f.png", "cap", "pcb_front")
+        b = FigureEntry("f.png", "cap", "pcb_front")
+        assert a == b
+
+    def test_repr(self):
+        entry = FigureEntry("f.png", "cap", "pcb_front")
+        r = repr(entry)
+        assert "f.png" in r
+        assert "pcb_front" in r
+
+
+class TestMaxSizePassedThrough:
+    """Verify max_size_px is forwarded to screenshot_board and _svg_to_png."""
+
+    @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
+    @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
+    @patch("kicad_tools.report.figures.subprocess.run")
+    @patch("kicad_tools.report.figures._svg_to_png")
+    @patch("kicad_tools.report.figures.screenshot_board")
+    def test_custom_max_size_forwarded(
+        self,
+        mock_board,
+        mock_svg_to_png,
+        mock_subprocess,
+        mock_find_cli,
+        mock_cairosvg,
+        tmp_path,
+    ):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.touch()
+        sch = tmp_path / "main.kicad_sch"
+        sch.touch()
+        out_dir = tmp_path / "figures"
+
+        mock_board.return_value = _make_success_result()
+
+        def fake_subprocess_run(cmd, **kwargs):
+            output_idx = cmd.index("--output") + 1
+            svg_dir = Path(cmd[output_idx])
+            (svg_dir / "sheet.svg").write_text("<svg/>")
+            return MagicMock(returncode=0, stderr="")
+
+        mock_subprocess.side_effect = fake_subprocess_run
+        mock_svg_to_png.return_value = (True, "", 2000, 1500)
+
+        gen = ReportFigureGenerator(max_size_px=2400)
+        gen.generate_all(pcb, sch, out_dir)
+
+        # Verify screenshot_board received max_size_px=2400
+        for call in mock_board.call_args_list:
+            assert call.kwargs.get("max_size_px") == 2400 or call[1].get("max_size_px") == 2400
+
+        # Verify _svg_to_png received max_size_px=2400
+        for call in mock_svg_to_png.call_args_list:
+            # Third positional arg is max_size_px
+            assert call[0][2] == 2400
+
+
+class TestOutputDirCreation:
+    """Verify output directory is created if missing."""
+
+    @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
+    @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
+    @patch("kicad_tools.report.figures.subprocess.run")
+    @patch("kicad_tools.report.figures._svg_to_png")
+    @patch("kicad_tools.report.figures.screenshot_board")
+    def test_output_dir_created(
+        self,
+        mock_board,
+        mock_svg_to_png,
+        mock_subprocess,
+        mock_find_cli,
+        mock_cairosvg,
+        tmp_path,
+    ):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.touch()
+        sch = tmp_path / "main.kicad_sch"
+        sch.touch()
+        out_dir = tmp_path / "nested" / "figures"
+
+        mock_board.return_value = _make_success_result()
+        mock_subprocess.return_value = MagicMock(returncode=0, stderr="")
+
+        gen = ReportFigureGenerator()
+        gen.generate_all(pcb, sch, out_dir)
+
+        assert out_dir.exists()
+        assert out_dir.is_dir()
+
+
+class TestReportPackageInit:
+    """Verify the report package re-exports."""
+
+    def test_import_from_package(self):
+        from kicad_tools.report import FigureEntry, ReportFigureGenerator
+
+        assert FigureEntry is not None
+        assert ReportFigureGenerator is not None


### PR DESCRIPTION
## Summary

Add `src/kicad_tools/report/figures.py` with `ReportFigureGenerator` that generates PCB renders (front, back, copper, assembly presets) and per-sheet schematic screenshots for design review reports. Returns a structured manifest of `FigureEntry` dataclass objects.

## Changes

- Create `src/kicad_tools/report/__init__.py` to establish the `report` subpackage, re-exporting `FigureEntry` and `ReportFigureGenerator`
- Create `src/kicad_tools/report/figures.py` with:
  - `FigureEntry` dataclass (filename, caption, figure_type)
  - `ReportFigureGenerator` class with `generate_all(pcb_path, sch_path, output_dir)` method
  - PCB rendering via `screenshot_board` for four presets (front, back, copper, assembly)
  - Multi-sheet schematic rendering via `kicad-cli sch export svg` + `_svg_to_png` for all sheets
  - `REPORT_MAX_SIZE_PX = 3000` (higher than the 1568 px vision-API default)
  - Dependency checks raising `RuntimeError` for missing `kicad-cli` or `cairosvg`
  - Graceful partial failure handling (log warning, exclude failed figure from manifest)
- Create `tests/test_report_figures.py` with 15 unit tests covering:
  - Happy path (all figures generated)
  - Partial PCB failure
  - Schematic SVG conversion failure
  - Missing kicad-cli / missing cairosvg
  - Multi-sheet schematics (3 sheets)
  - Filename determinism across repeated calls
  - FigureEntry dataclass behavior
  - max_size_px pass-through verification
  - Output directory auto-creation
  - Package re-exports

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `src/kicad_tools/report/figures.py` created with `ReportFigureGenerator` | Pass | File exists with class |
| `generate_all(pcb_path, sch_path, output_dir)` generates all five figure types | Pass | `test_generate_all_happy_path` verifies 6 entries (4 PCB + 2 schematic) |
| PCB figures use `screenshot_board` with correct layer presets | Pass | Calls verified in test with mock |
| Schematic figures generate one PNG per sheet (multi-sheet) | Pass | `test_three_sheets` verifies 3 FigureEntry objects |
| Deterministic output filenames | Pass | `test_same_filenames_on_repeated_calls` |
| `generate_all` returns list of FigureEntry (filename, caption, figure_type) | Pass | All tests verify manifest structure |
| Default resolution higher than vision-API cap (3000 px) | Pass | `test_default_max_size` asserts 3000 |
| Missing kicad-cli raises RuntimeError | Pass | `test_missing_kicad_cli_raises` |
| Missing cairosvg raises RuntimeError | Pass | `test_missing_cairosvg_raises` |
| Partial failure handled gracefully | Pass | `test_partial_pcb_failure` and `test_schematic_svg_conversion_failure` |
| `src/kicad_tools/report/__init__.py` created | Pass | File exists, re-exports verified |

## Test Plan

All 15 tests pass:
```
tests/test_report_figures.py - 15 passed in 13.38s
```

Ruff lint and format checks pass on all new files.

Closes #1312