### PR TITLE
feat(report): add ReportDataCollector for JSON data snapshots

### DIFF
--- a/src/kicad_tools/report/__init__.py
+++ b/src/kicad_tools/report/__init__.py
@@ -4,11 +4,21 @@ This package provides tools for generating professional design reports
 from KiCad project data, with support for Markdown, HTML, and PDF output formats.
 Includes figure generation (PCB renders, schematic screenshots) and
 structured manifests for design review documents.
+Also provides data collection for report generation, gathering
+board summary, DRC, BOM, audit, net connectivity, and analysis results
+into JSON snapshots.
 """
 
 from __future__ import annotations
 
+from kicad_tools.report.collector import ReportDataCollector
 from kicad_tools.report.figures import FigureEntry, ReportFigureGenerator
 from kicad_tools.report.renderers import render_html, render_pdf
 
-__all__ = ["FigureEntry", "ReportFigureGenerator", "render_html", "render_pdf"]
+__all__ = [
+    "FigureEntry",
+    "ReportDataCollector",
+    "ReportFigureGenerator",
+    "render_html",
+    "render_pdf",
+]

--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -1,0 +1,400 @@
+"""Data snapshot collection for report generation.
+
+Gathers board summary, DRC, BOM, audit, net connectivity, and analysis
+results into JSON snapshots. Each sub-collector is fault-tolerant: failures
+produce a warning log and null result rather than propagating exceptions.
+
+Example:
+    >>> from kicad_tools.report import ReportDataCollector
+    >>> collector = ReportDataCollector(Path("board.kicad_pcb"))
+    >>> files = collector.collect_all(Path("output/data"))
+    >>> for name, path in files.items():
+    ...     print(f"{name}: {path}")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+
+def _make_envelope(data: dict[str, Any] | None, pcb_path: Path) -> dict[str, Any]:
+    """Wrap data in a standard envelope with schema version and timestamp."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "pcb_path": str(pcb_path),
+        "data": data,
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write a JSON file with consistent formatting."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(payload, f, indent=2)
+
+
+class ReportDataCollector:
+    """Collects data snapshots for report generation.
+
+    Orchestrates calls to existing analysis APIs and serializes their
+    results as JSON files. ManufacturingAudit is run once and its results
+    are distributed to both the DRC and audit snapshots.
+
+    Args:
+        pcb_path: Path to .kicad_pcb file.
+        manufacturer: Target manufacturer ID (default: "jlcpcb").
+        quantity: Quantity for cost estimation (default: 5).
+        skip_erc: Skip ERC check (default: False).
+    """
+
+    def __init__(
+        self,
+        pcb_path: Path,
+        manufacturer: str = "jlcpcb",
+        quantity: int = 5,
+        skip_erc: bool = False,
+    ) -> None:
+        self.pcb_path = Path(pcb_path)
+        self.manufacturer = manufacturer
+        self.quantity = quantity
+        self.skip_erc = skip_erc
+
+    def collect_all(self, output_dir: Path) -> dict[str, Path]:
+        """Run all collectors, write JSON files, return mapping of name to path.
+
+        Runs ManufacturingAudit once and reuses the result for both DRC and
+        audit snapshots. Each sub-collector is wrapped in try/except so a
+        failure in one does not prevent the others from running.
+
+        Args:
+            output_dir: Directory to write JSON snapshot files into.
+
+        Returns:
+            Mapping of snapshot name to file path for each successfully
+            written file.
+        """
+        from kicad_tools.schema.pcb import PCB
+
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        files: dict[str, Path] = {}
+        pcb = PCB.load(self.pcb_path)
+
+        # Run ManufacturingAudit once and reuse for DRC + audit snapshots.
+        audit_result = None
+        try:
+            from kicad_tools.audit.auditor import ManufacturingAudit
+
+            audit = ManufacturingAudit(
+                self.pcb_path,
+                manufacturer=self.manufacturer,
+                quantity=self.quantity,
+                skip_erc=self.skip_erc,
+            )
+            audit_result = audit.run()
+        except Exception:
+            logger.warning(
+                "ManufacturingAudit failed; DRC and audit snapshots will be null", exc_info=True
+            )
+
+        # Board summary
+        self._safe_collect(
+            "board_summary",
+            output_dir,
+            files,
+            lambda: self.collect_board_summary(pcb),
+        )
+
+        # DRC summary (from audit result)
+        self._safe_collect(
+            "drc_summary",
+            output_dir,
+            files,
+            lambda: self.collect_drc(audit_result),
+        )
+
+        # BOM
+        sch_path = self.pcb_path.with_suffix(".kicad_sch")
+        if sch_path.exists():
+            self._safe_collect(
+                "bom",
+                output_dir,
+                files,
+                lambda: self.collect_bom(sch_path),
+            )
+        else:
+            logger.warning("No schematic found at %s; skipping BOM collection", sch_path)
+
+        # Audit
+        self._safe_collect(
+            "audit",
+            output_dir,
+            files,
+            lambda: self.collect_audit(audit_result),
+        )
+
+        # Net status
+        self._safe_collect(
+            "net_status",
+            output_dir,
+            files,
+            lambda: self.collect_net_status(pcb),
+        )
+
+        # Analysis (congestion + SI + thermal)
+        self._safe_collect(
+            "analysis",
+            output_dir,
+            files,
+            lambda: self.collect_analysis(pcb),
+        )
+
+        return files
+
+    # ------------------------------------------------------------------
+    # Individual sub-collectors
+    # ------------------------------------------------------------------
+
+    def collect_board_summary(self, pcb: Any) -> dict[str, Any]:
+        """Collect board summary: layers, footprints, nets, traces, vias, dimensions.
+
+        Args:
+            pcb: Loaded PCB object.
+
+        Returns:
+            Dictionary with board summary data.
+        """
+        # Layer info
+        copper_layers = pcb.copper_layers
+        layer_names = [layer.name for layer in copper_layers]
+
+        # Footprint breakdown
+        total_fp = len(pcb.footprints)
+        smd_count = sum(1 for fp in pcb.footprints if fp.attr == "smd")
+        tht_count = sum(1 for fp in pcb.footprints if fp.attr == "through_hole")
+        other_count = total_fp - smd_count - tht_count
+
+        # Board dimensions via Edge.Cuts parsing (same pattern as ManufacturingAudit)
+        board_width, board_height = self._get_board_dimensions(pcb)
+
+        return {
+            "layer_count": len(copper_layers),
+            "layer_names": layer_names,
+            "footprint_count": total_fp,
+            "footprint_smd": smd_count,
+            "footprint_tht": tht_count,
+            "footprint_other": other_count,
+            "net_count": len(pcb.nets),
+            "segment_count": len(pcb.segments),
+            "via_count": len(pcb.vias),
+            "board_width_mm": round(board_width, 2),
+            "board_height_mm": round(board_height, 2),
+        }
+
+    def collect_drc(self, audit_result: Any | None) -> dict[str, Any] | None:
+        """Extract DRC sub-section from a pre-run AuditResult.
+
+        Args:
+            audit_result: Result from ManufacturingAudit.run(), or None if
+                the audit failed.
+
+        Returns:
+            DRC data dictionary, or None if audit_result is None.
+        """
+        if audit_result is None:
+            return None
+        return audit_result.drc.to_dict()
+
+    def collect_bom(self, sch_path: Path) -> dict[str, Any]:
+        """Collect BOM grouped by value+footprint with LCSC numbers.
+
+        Args:
+            sch_path: Path to .kicad_sch file.
+
+        Returns:
+            Dictionary with BOM data.
+        """
+        from kicad_tools.schema.bom import extract_bom
+
+        bom = extract_bom(str(sch_path))
+        groups = bom.grouped()
+
+        return {
+            "total_components": bom.total_components,
+            "unique_parts": bom.unique_parts,
+            "dnp_count": bom.dnp_count,
+            "groups": [g.to_dict() for g in groups],
+        }
+
+    def collect_audit(self, audit_result: Any | None) -> dict[str, Any] | None:
+        """Full manufacturing audit snapshot.
+
+        Args:
+            audit_result: Result from ManufacturingAudit.run(), or None if
+                the audit failed.
+
+        Returns:
+            Audit data dictionary, or None if audit_result is None.
+        """
+        if audit_result is None:
+            return None
+        return audit_result.to_dict()
+
+    def collect_net_status(self, pcb: Any) -> dict[str, Any]:
+        """Routing completion summary.
+
+        Args:
+            pcb: Loaded PCB object.
+
+        Returns:
+            Dictionary with net status data including totals and completion
+            percentage.
+        """
+        from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+        analyzer = NetStatusAnalyzer(pcb)
+        result = analyzer.analyze()
+
+        completion_pct = 0.0
+        if result.total_nets > 0:
+            completion_pct = round(100.0 * result.complete_count / result.total_nets, 1)
+
+        return {
+            "total_nets": result.total_nets,
+            "complete_count": result.complete_count,
+            "incomplete_count": result.incomplete_count,
+            "unrouted_count": result.unrouted_count,
+            "total_unconnected_pads": result.total_unconnected_pads,
+            "completion_pct": completion_pct,
+        }
+
+    def collect_analysis(self, pcb: Any) -> dict[str, Any]:
+        """Combined congestion, signal integrity, and thermal snapshots.
+
+        Each section is collected independently. If any analyzer raises,
+        that section is set to None with a warning log.
+
+        Args:
+            pcb: Loaded PCB object.
+
+        Returns:
+            Dictionary with congestion, signal_integrity, and thermal
+            sections. Each section may be None on error.
+        """
+        result: dict[str, Any] = {
+            "congestion": None,
+            "signal_integrity": None,
+            "thermal": None,
+        }
+
+        # Congestion
+        try:
+            from kicad_tools.analysis.congestion import CongestionAnalyzer
+
+            reports = CongestionAnalyzer().analyze(pcb)
+            result["congestion"] = {
+                "hotspot_count": len(reports),
+                "severity_breakdown": self._severity_breakdown(reports),
+                "hotspots": [r.to_dict() for r in reports],
+            }
+        except Exception:
+            logger.warning("Congestion analysis failed", exc_info=True)
+
+        # Signal integrity
+        try:
+            from kicad_tools.analysis.signal_integrity import SignalIntegrityAnalyzer
+
+            si = SignalIntegrityAnalyzer()
+            crosstalk = si.analyze_crosstalk(pcb)
+            impedance = si.analyze_impedance(pcb)
+            result["signal_integrity"] = {
+                "crosstalk_risk_count": len(crosstalk),
+                "impedance_discontinuity_count": len(impedance),
+                "crosstalk_risks": [r.to_dict() for r in crosstalk],
+                "impedance_discontinuities": [d.to_dict() for d in impedance],
+            }
+        except Exception:
+            logger.warning("Signal integrity analysis failed", exc_info=True)
+
+        # Thermal
+        try:
+            from kicad_tools.analysis.thermal import ThermalAnalyzer
+
+            hotspots = ThermalAnalyzer().analyze(pcb)
+            result["thermal"] = {
+                "hotspot_count": len(hotspots),
+                "hotspots": [h.to_dict() for h in hotspots],
+            }
+        except Exception:
+            logger.warning("Thermal analysis failed", exc_info=True)
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _safe_collect(
+        self,
+        name: str,
+        output_dir: Path,
+        files: dict[str, Path],
+        collector_fn: Any,
+    ) -> None:
+        """Run a collector function, wrap in envelope, and write JSON.
+
+        If the collector raises, the file is still written with
+        ``data: null`` so downstream consumers can distinguish between
+        'not collected' (file absent) and 'collection failed' (data null).
+        """
+        try:
+            data = collector_fn()
+        except Exception:
+            logger.warning("Collector '%s' failed", name, exc_info=True)
+            data = None
+
+        path = output_dir / f"{name}.json"
+        _write_json(path, _make_envelope(data, self.pcb_path))
+        files[name] = path
+
+    def _get_board_dimensions(self, pcb: Any) -> tuple[float, float]:
+        """Get board dimensions (width, height) in mm from Edge.Cuts."""
+        min_x = min_y = float("inf")
+        max_x = max_y = float("-inf")
+
+        for item in pcb.graphic_items:
+            if item.layer == "Edge.Cuts":
+                if hasattr(item, "start"):
+                    min_x = min(min_x, item.start[0])
+                    min_y = min(min_y, item.start[1])
+                    max_x = max(max_x, item.start[0])
+                    max_y = max(max_y, item.start[1])
+                if hasattr(item, "end"):
+                    min_x = min(min_x, item.end[0])
+                    min_y = min(min_y, item.end[1])
+                    max_x = max(max_x, item.end[0])
+                    max_y = max(max_y, item.end[1])
+
+        if min_x != float("inf"):
+            return (max_x - min_x, max_y - min_y)
+
+        return (0.0, 0.0)
+
+    @staticmethod
+    def _severity_breakdown(reports: list[Any]) -> dict[str, int]:
+        """Count congestion reports by severity level."""
+        breakdown: dict[str, int] = {}
+        for r in reports:
+            key = r.severity.value
+            breakdown[key] = breakdown.get(key, 0) + 1
+        return breakdown

--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -18,7 +18,10 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from kicad_tools.audit.auditor import AuditResult
 
 logger = logging.getLogger(__name__)
 
@@ -201,7 +204,7 @@ class ReportDataCollector:
             "board_height_mm": round(board_height, 2),
         }
 
-    def collect_drc(self, audit_result: Any | None) -> dict[str, Any] | None:
+    def collect_drc(self, audit_result: AuditResult | None) -> dict[str, Any] | None:
         """Extract DRC sub-section from a pre-run AuditResult.
 
         Args:
@@ -236,7 +239,7 @@ class ReportDataCollector:
             "groups": [g.to_dict() for g in groups],
         }
 
-    def collect_audit(self, audit_result: Any | None) -> dict[str, Any] | None:
+    def collect_audit(self, audit_result: AuditResult | None) -> dict[str, Any] | None:
         """Full manufacturing audit snapshot.
 
         Args:

--- a/src/kicad_tools/schema/bom.py
+++ b/src/kicad_tools/schema/bom.py
@@ -41,6 +41,19 @@ class BOMItem:
         """Check if this is a virtual component (not placed on PCB)."""
         return not self.in_bom or self.is_power_symbol
 
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "reference": self.reference,
+            "value": self.value,
+            "footprint": self.footprint,
+            "description": self.description,
+            "manufacturer": self.manufacturer,
+            "mpn": self.mpn,
+            "lcsc": self.lcsc,
+            "dnp": self.dnp,
+        }
+
 
 @dataclass
 class BOMGroup:
@@ -89,6 +102,19 @@ class BOMGroup:
             if item.description:
                 return item.description
         return ""
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "value": self.value,
+            "footprint": self.footprint,
+            "quantity": self.quantity,
+            "references": self.references,
+            "description": self.description,
+            "mpn": self.mpn,
+            "lcsc": self.lcsc,
+            "items": [item.to_dict() for item in self.items],
+        }
 
 
 @dataclass

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -1,0 +1,516 @@
+"""Tests for report data collector.
+
+Tests cover:
+- Board summary collection (layers, footprints, nets, traces, vias, dimensions)
+- DRC collection from AuditResult
+- BOM collection from schematic
+- Net status collection
+- Analysis collection (congestion, SI, thermal)
+- Fault tolerance (sub-collector failures produce null, not exceptions)
+- Schema versioning (schema_version + generated_at in every JSON file)
+- Integration: collect_all writes files and produces valid JSON
+- PCB-only mode (no schematic): BOM skipped gracefully
+- Empty PCB produces valid zeroed snapshots
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.report.collector import SCHEMA_VERSION, ReportDataCollector
+
+FIXTURES = Path(__file__).parent / "fixtures"
+PROJECT_FIXTURES = FIXTURES / "projects"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_audit_result():
+    """Create a mock AuditResult with known DRC counts."""
+    from kicad_tools.audit.auditor import (
+        ActionItem,
+        AuditResult,
+        ConnectivityStatus,
+        CostEstimate,
+        DRCStatus,
+        ERCStatus,
+        LayerUtilization,
+        ManufacturerCompatibility,
+    )
+
+    return AuditResult(
+        project_name="test",
+        drc=DRCStatus(
+            error_count=2,
+            warning_count=3,
+            blocking_count=1,
+            passed=False,
+            details="clearance (2)",
+        ),
+        erc=ERCStatus(error_count=0, warning_count=1, passed=True),
+        connectivity=ConnectivityStatus(
+            total_nets=10,
+            connected_nets=8,
+            incomplete_nets=2,
+            completion_percent=80.0,
+            unconnected_pads=4,
+            passed=False,
+        ),
+        compatibility=ManufacturerCompatibility(manufacturer="JLCPCB", passed=True),
+        layers=LayerUtilization(layer_count=2),
+        cost=CostEstimate(pcb_cost=5.0, total_cost=5.0, quantity=5),
+        action_items=[ActionItem(priority=1, description="Fix clearance")],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - board summary
+# ---------------------------------------------------------------------------
+
+
+class TestCollectBoardSummary:
+    """Tests for collect_board_summary."""
+
+    def test_returns_expected_keys(self):
+        """Board summary contains all required fields."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(pcb_path)
+        collector = ReportDataCollector(pcb_path)
+        summary = collector.collect_board_summary(pcb)
+
+        expected_keys = {
+            "layer_count",
+            "layer_names",
+            "footprint_count",
+            "footprint_smd",
+            "footprint_tht",
+            "footprint_other",
+            "net_count",
+            "segment_count",
+            "via_count",
+            "board_width_mm",
+            "board_height_mm",
+        }
+        assert expected_keys == set(summary.keys())
+
+    def test_layer_count_is_positive(self):
+        """Board must have at least one copper layer."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(pcb_path)
+        collector = ReportDataCollector(pcb_path)
+        summary = collector.collect_board_summary(pcb)
+
+        assert summary["layer_count"] >= 1
+        assert len(summary["layer_names"]) == summary["layer_count"]
+
+    def test_footprint_breakdown_sums(self):
+        """SMD + THT + other should equal total."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(pcb_path)
+        collector = ReportDataCollector(pcb_path)
+        summary = collector.collect_board_summary(pcb)
+
+        total = summary["footprint_smd"] + summary["footprint_tht"] + summary["footprint_other"]
+        assert total == summary["footprint_count"]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - DRC collect
+# ---------------------------------------------------------------------------
+
+
+class TestCollectDRC:
+    """Tests for collect_drc."""
+
+    def test_extracts_drc_from_audit_result(self):
+        """DRC data matches the AuditResult's DRC fields."""
+        audit_result = _make_mock_audit_result()
+        collector = ReportDataCollector(Path("dummy.kicad_pcb"))
+        drc = collector.collect_drc(audit_result)
+
+        assert drc is not None
+        assert drc["error_count"] == 2
+        assert drc["warning_count"] == 3
+        assert drc["blocking_count"] == 1
+        assert drc["passed"] is False
+
+    def test_returns_none_when_no_audit(self):
+        """collect_drc returns None when audit_result is None."""
+        collector = ReportDataCollector(Path("dummy.kicad_pcb"))
+        assert collector.collect_drc(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - BOM collect
+# ---------------------------------------------------------------------------
+
+
+class TestCollectBOM:
+    """Tests for collect_bom."""
+
+    def test_collects_bom_from_schematic(self):
+        """BOM returns grouped items with quantity and lcsc fields."""
+        sch_path = PROJECT_FIXTURES / "test_project.kicad_sch"
+        if not sch_path.exists():
+            pytest.skip("test_project.kicad_sch fixture not found")
+
+        collector = ReportDataCollector(Path("dummy.kicad_pcb"))
+        bom_data = collector.collect_bom(sch_path)
+
+        assert "total_components" in bom_data
+        assert "unique_parts" in bom_data
+        assert "dnp_count" in bom_data
+        assert "groups" in bom_data
+        assert isinstance(bom_data["groups"], list)
+
+        # Each group should have quantity and lcsc fields
+        for group in bom_data["groups"]:
+            assert "quantity" in group
+            assert "lcsc" in group
+            assert "references" in group
+            assert "value" in group
+            assert "footprint" in group
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - net status collect
+# ---------------------------------------------------------------------------
+
+
+class TestCollectNetStatus:
+    """Tests for collect_net_status."""
+
+    def test_returns_expected_keys(self):
+        """Net status returns total_nets, complete_count, completion_pct."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(pcb_path)
+        collector = ReportDataCollector(pcb_path)
+        status = collector.collect_net_status(pcb)
+
+        assert "total_nets" in status
+        assert "complete_count" in status
+        assert "incomplete_count" in status
+        assert "unrouted_count" in status
+        assert "total_unconnected_pads" in status
+        assert "completion_pct" in status
+
+    def test_completion_pct_range(self):
+        """Completion percentage is between 0 and 100."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(pcb_path)
+        collector = ReportDataCollector(pcb_path)
+        status = collector.collect_net_status(pcb)
+
+        assert 0.0 <= status["completion_pct"] <= 100.0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - fault tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestFaultTolerance:
+    """Tests for fault tolerance in collect_all and collect_analysis."""
+
+    def test_congestion_failure_produces_null(self):
+        """If CongestionAnalyzer.analyze raises, congestion is None."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(pcb_path)
+        collector = ReportDataCollector(pcb_path)
+
+        with patch(
+            "kicad_tools.analysis.congestion.CongestionAnalyzer.analyze",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = collector.collect_analysis(pcb)
+
+        assert result["congestion"] is None
+        # Other sections should still be populated
+        assert result["signal_integrity"] is not None or result["thermal"] is not None or True
+
+    def test_si_failure_produces_null(self):
+        """If SignalIntegrityAnalyzer.analyze_crosstalk raises, SI is None."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(pcb_path)
+        collector = ReportDataCollector(pcb_path)
+
+        with patch(
+            "kicad_tools.analysis.signal_integrity.SignalIntegrityAnalyzer.analyze_crosstalk",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = collector.collect_analysis(pcb)
+
+        assert result["signal_integrity"] is None
+
+    def test_thermal_failure_produces_null(self):
+        """If ThermalAnalyzer.analyze raises, thermal is None."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(pcb_path)
+        collector = ReportDataCollector(pcb_path)
+
+        with patch(
+            "kicad_tools.analysis.thermal.ThermalAnalyzer.analyze",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = collector.collect_analysis(pcb)
+
+        assert result["thermal"] is None
+
+    def test_collect_all_survives_sub_collector_failure(self, tmp_path):
+        """collect_all completes even when one sub-collector raises."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        collector = ReportDataCollector(pcb_path, skip_erc=True)
+
+        with patch(
+            "kicad_tools.analysis.congestion.CongestionAnalyzer.analyze",
+            side_effect=RuntimeError("boom"),
+        ):
+            files = collector.collect_all(tmp_path)
+
+        # Should still produce files for all categories
+        assert "board_summary" in files
+        assert "analysis" in files
+
+        # analysis.json should exist but congestion inside should be null
+        with open(files["analysis"]) as f:
+            data = json.load(f)
+        assert data["data"]["congestion"] is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - schema versioning
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersioning:
+    """Tests for schema version and timestamp in every JSON file."""
+
+    def test_all_files_have_schema_version(self, tmp_path):
+        """Every written JSON file has schema_version and generated_at."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        collector = ReportDataCollector(pcb_path, skip_erc=True)
+        files = collector.collect_all(tmp_path)
+
+        for name, fpath in files.items():
+            with open(fpath) as f:
+                data = json.load(f)
+            assert data["schema_version"] == SCHEMA_VERSION, f"{name} missing schema_version"
+            assert "generated_at" in data, f"{name} missing generated_at"
+            assert "pcb_path" in data, f"{name} missing pcb_path"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectAllIntegration:
+    """Integration tests for collect_all."""
+
+    def test_writes_expected_files(self, tmp_path):
+        """collect_all writes all expected JSON files to output dir."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        collector = ReportDataCollector(pcb_path, skip_erc=True)
+        files = collector.collect_all(tmp_path)
+
+        expected_names = {"board_summary", "drc_summary", "audit", "net_status", "analysis"}
+        # BOM is optional (depends on schematic existing)
+        for name in expected_names:
+            assert name in files, f"Missing file: {name}"
+            assert files[name].exists(), f"File not on disk: {name}"
+
+    def test_json_validity(self, tmp_path):
+        """All written files are valid JSON."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        collector = ReportDataCollector(pcb_path, skip_erc=True)
+        files = collector.collect_all(tmp_path)
+
+        for name, fpath in files.items():
+            with open(fpath) as f:
+                data = json.load(f)  # Should not raise
+            assert isinstance(data, dict), f"{name} is not a dict"
+
+    def test_pcb_only_no_schematic(self, tmp_path):
+        """collect_all with no schematic skips BOM gracefully."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        # Use a PCB path where no schematic exists alongside it
+        # Create a temp PCB by copying
+        import shutil
+
+        isolated_pcb = tmp_path / "isolated" / "board.kicad_pcb"
+        isolated_pcb.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(pcb_path, isolated_pcb)
+
+        output_dir = tmp_path / "output"
+        collector = ReportDataCollector(isolated_pcb, skip_erc=True)
+        files = collector.collect_all(output_dir)
+
+        # BOM should be absent (no schematic)
+        assert "bom" not in files
+
+        # Other files should exist
+        assert "board_summary" in files
+        assert "net_status" in files
+        assert "analysis" in files
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge case tests."""
+
+    def test_empty_pcb_produces_valid_snapshots(self, tmp_path):
+        """A PCB with no footprints or nets produces valid zeroed snapshots."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=50.0, height=50.0, layers=2)
+
+        # Save PCB to disk so the collector can reference it
+        pcb_path = tmp_path / "empty.kicad_pcb"
+        pcb.save(str(pcb_path))
+
+        collector = ReportDataCollector(pcb_path, skip_erc=True)
+        summary = collector.collect_board_summary(pcb)
+
+        assert summary["footprint_count"] == 0
+        assert summary["net_count"] >= 0
+        assert summary["segment_count"] == 0
+        assert summary["via_count"] == 0
+
+    def test_empty_pcb_net_status(self, tmp_path):
+        """Net status on empty PCB produces valid output."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=50.0, height=50.0, layers=2)
+        pcb_path = tmp_path / "empty.kicad_pcb"
+        pcb.save(str(pcb_path))
+
+        collector = ReportDataCollector(pcb_path, skip_erc=True)
+        status = collector.collect_net_status(pcb)
+
+        assert status["total_nets"] >= 0
+        assert status["completion_pct"] >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# BOMItem / BOMGroup to_dict tests
+# ---------------------------------------------------------------------------
+
+
+class TestBOMSerialization:
+    """Tests for BOMItem.to_dict and BOMGroup.to_dict."""
+
+    def test_bom_item_to_dict(self):
+        """BOMItem.to_dict returns expected keys."""
+        from kicad_tools.schema.bom import BOMItem
+
+        item = BOMItem(
+            reference="R1",
+            value="10k",
+            footprint="Resistor_SMD:R_0402_1005Metric",
+            lib_id="Device:R",
+            description="Resistor",
+            manufacturer="Yageo",
+            mpn="RC0402FR-0710KL",
+            lcsc="C25744",
+        )
+        d = item.to_dict()
+        assert d["reference"] == "R1"
+        assert d["value"] == "10k"
+        assert d["lcsc"] == "C25744"
+        assert d["mpn"] == "RC0402FR-0710KL"
+        assert d["dnp"] is False
+
+    def test_bom_group_to_dict(self):
+        """BOMGroup.to_dict returns quantity, references, lcsc."""
+        from kicad_tools.schema.bom import BOMGroup, BOMItem
+
+        items = [
+            BOMItem(
+                reference="R1",
+                value="10k",
+                footprint="R_0402",
+                lib_id="Device:R",
+                lcsc="C25744",
+            ),
+            BOMItem(
+                reference="R2",
+                value="10k",
+                footprint="R_0402",
+                lib_id="Device:R",
+                lcsc="C25744",
+            ),
+        ]
+        group = BOMGroup(value="10k", footprint="R_0402", items=items)
+        d = group.to_dict()
+
+        assert d["quantity"] == 2
+        assert "R1" in d["references"]
+        assert "R2" in d["references"]
+        assert d["lcsc"] == "C25744"
+        assert len(d["items"]) == 2

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -263,7 +263,8 @@ class TestFaultTolerance:
 
         assert result["congestion"] is None
         # Other sections should still be populated
-        assert result["signal_integrity"] is not None or result["thermal"] is not None or True
+        assert result["signal_integrity"] is not None
+        assert result["thermal"] is not None
 
     def test_si_failure_produces_null(self):
         """If SignalIntegrityAnalyzer.analyze_crosstalk raises, SI is None."""


### PR DESCRIPTION
## Summary

Add a new `report` module with `ReportDataCollector` that gathers board summary, DRC, BOM, manufacturing audit, net connectivity, and analysis results into versioned JSON snapshot files. This is the data-gathering foundation for the report generation epic (#1310).

## Changes

- Create `src/kicad_tools/report/__init__.py` exporting `ReportDataCollector`
- Create `src/kicad_tools/report/collector.py` implementing the full collector with six sub-collectors: board_summary, drc_summary, bom, audit, net_status, analysis (congestion + SI + thermal)
- Add `to_dict()` methods to `BOMItem` and `BOMGroup` in `src/kicad_tools/schema/bom.py`
- Create `tests/test_report_collector.py` with 20 tests covering unit, integration, fault tolerance, schema versioning, and edge cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `report/__init__.py` exists and exports `ReportDataCollector` | PASS | File created with proper import |
| `collector.py` implements `ReportDataCollector` with `collect_all()` | PASS | Returns `dict[str, Path]` of written files |
| `collect_all()` runs ManufacturingAudit once, reuses for DRC + audit | PASS | Single `audit.run()` call, result passed to both sub-collectors |
| Each sub-collector individually callable | PASS | `collect_board_summary`, `collect_drc`, `collect_bom`, `collect_audit`, `collect_net_status`, `collect_analysis` are all public methods |
| JSON files contain `schema_version: 1` and `generated_at` ISO timestamp | PASS | `_make_envelope` wraps every file; verified by `TestSchemaVersioning` |
| Sub-collector failures produce warning + null, not exception | PASS | `_safe_collect` wraps each; `collect_analysis` uses per-section try/except; verified by `TestFaultTolerance` (4 tests) |
| BOM includes grouped components with quantity, references, LCSC | PASS | Uses `BOMGroup.to_dict()` with all fields; verified by `TestCollectBOM` |
| Board summary includes layers, footprints (SMD/THT), nets, traces, vias, dimensions | PASS | All fields present; verified by `TestCollectBoardSummary` (3 tests) |
| Net status includes totals, completion percentage | PASS | Verified by `TestCollectNetStatus` (2 tests) |
| Analysis includes congestion/SI/thermal; each null on error | PASS | Verified by fault tolerance tests |
| Missing schematic handled gracefully | PASS | Verified by `test_pcb_only_no_schematic` |
| `BOMGroup` and `BOMItem` gain `to_dict()` methods | PASS | Added to `schema/bom.py`; verified by `TestBOMSerialization` (2 tests) |

## Test Plan

20 tests, all passing:
- Board summary: 3 unit tests (expected keys, positive layer count, footprint breakdown)
- DRC: 2 unit tests (extraction from AuditResult, None handling)
- BOM: 1 unit test (grouped items with quantity/lcsc)
- Net status: 2 unit tests (expected keys, completion range)
- Fault tolerance: 4 tests (congestion/SI/thermal failures, collect_all resilience)
- Schema versioning: 1 test (all files have version + timestamp)
- Integration: 3 tests (file writing, JSON validity, PCB-only mode)
- Edge cases: 2 tests (empty PCB board summary, empty PCB net status)
- BOM serialization: 2 tests (BOMItem.to_dict, BOMGroup.to_dict)

Closes #1311