### PR TITLE
feat(report): add Jinja2 Markdown report generator with CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,8 +137,9 @@ bayesian = [
 screenshot = [
     "cairosvg>=2.6",
 ]
-# Report rendering (Markdown to HTML/PDF)
+# Report generation (Jinja2 Markdown templates) and rendering (Markdown to HTML/PDF)
 report = [
+    "jinja2>=3.1",
     "markdown>=3.5",
     "weasyprint>=60.0",
 ]
@@ -159,6 +160,7 @@ all = [
     "ax-platform>=0.4.0",
     "botorch>=0.12.0",
     "cairosvg>=2.6",
+    "jinja2>=3.1",
     "markdown>=3.5",
     "weasyprint>=60.0",
 ]
@@ -179,6 +181,7 @@ dev = [
     "fastmcp>=2.0,<3",
     "pydantic>=2.0",
     "matplotlib>=3.5",
+    "jinja2>=3.1",
     "markdown>=3.5",
 ]
 
@@ -284,4 +287,5 @@ warn_return_any = true
 [dependency-groups]
 dev = [
     "pytest-cov>=7.0.0",
+    "jinja2>=3.1",
 ]

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -431,6 +431,9 @@ def _dispatch_command(args) -> int:
     elif args.command == "screenshot":
         return _run_screenshot_command(args)
 
+    elif args.command == "report":
+        return _run_report_command(args)
+
     return 0
 
 
@@ -601,6 +604,32 @@ def _run_screenshot_command(args) -> int:
         sub_argv.extend(["--theme", args.screenshot_theme])
 
     return screenshot_cmd(sub_argv)
+
+
+def _run_report_command(args) -> int:
+    """Run the report command."""
+    from .report_cmd import main as report_cmd
+
+    sub_argv: list[str] = []
+
+    report_command = getattr(args, "report_command", None)
+    if not report_command:
+        return report_cmd(["--help"])
+
+    sub_argv.append(report_command)
+
+    if report_command == "generate":
+        sub_argv.append(args.report_input)
+        if hasattr(args, "report_mfr") and args.report_mfr:
+            sub_argv.extend(["--mfr", args.report_mfr])
+        if hasattr(args, "report_output") and args.report_output:
+            sub_argv.extend(["-o", args.report_output])
+        if hasattr(args, "report_data_dir") and args.report_data_dir:
+            sub_argv.extend(["--data-dir", args.report_data_dir])
+        if hasattr(args, "report_template") and args.report_template:
+            sub_argv.extend(["--template", args.report_template])
+
+    return report_cmd(sub_argv)
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -182,6 +182,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_detect_mistakes_parser(subparsers)
     _add_calibrate_parser(subparsers)
     _add_screenshot_parser(subparsers)
+    _add_report_parser(subparsers)
 
     return parser
 
@@ -3575,4 +3576,44 @@ def _add_screenshot_parser(subparsers) -> None:
         dest="screenshot_theme",
         default=None,
         help="KiCad color theme name",
+    )
+
+
+def _add_report_parser(subparsers) -> None:
+    """Add report subcommand parser."""
+    report_parser = subparsers.add_parser(
+        "report",
+        help="Generate a Markdown design report",
+    )
+    report_sub = report_parser.add_subparsers(dest="report_command")
+
+    gen_parser = report_sub.add_parser("generate", help="Generate a design report")
+    gen_parser.add_argument(
+        "report_input",
+        help="Path to .kicad_pro or .kicad_pcb file",
+    )
+    gen_parser.add_argument(
+        "--mfr",
+        dest="report_mfr",
+        default="unknown",
+        help="Target manufacturer (default: unknown)",
+    )
+    gen_parser.add_argument(
+        "-o",
+        "--output",
+        dest="report_output",
+        default="reports",
+        help="Output directory for versioned reports (default: reports/)",
+    )
+    gen_parser.add_argument(
+        "--data-dir",
+        dest="report_data_dir",
+        default=None,
+        help="Directory containing pre-collected data/ and figures/ snapshots",
+    )
+    gen_parser.add_argument(
+        "--template",
+        dest="report_template",
+        default=None,
+        help="Path to a custom Jinja2 template file",
     )

--- a/src/kicad_tools/cli/report_cmd.py
+++ b/src/kicad_tools/cli/report_cmd.py
@@ -1,0 +1,141 @@
+"""report CLI command: generate a Markdown design report from data snapshots.
+
+Usage:
+    kct report generate project.kicad_pro --mfr jlcpcb -o reports/
+    kct report generate board.kicad_pcb --mfr jlcpcb --data-dir data/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the report CLI command."""
+    parser = argparse.ArgumentParser(
+        prog="kct report",
+        description="Generate a Markdown design report.",
+    )
+    sub = parser.add_subparsers(dest="report_subcommand")
+
+    gen_parser = sub.add_parser("generate", help="Generate a design report")
+    gen_parser.add_argument(
+        "input",
+        help="Path to .kicad_pro or .kicad_pcb file",
+    )
+    gen_parser.add_argument(
+        "--mfr",
+        default="unknown",
+        help="Target manufacturer (default: unknown)",
+    )
+    gen_parser.add_argument(
+        "-o",
+        "--output",
+        default="reports",
+        help="Output directory for versioned reports (default: reports/)",
+    )
+    gen_parser.add_argument(
+        "--data-dir",
+        default=None,
+        help="Directory containing pre-collected data/ and figures/ snapshots",
+    )
+    gen_parser.add_argument(
+        "--template",
+        default=None,
+        help="Path to a custom Jinja2 template file",
+    )
+
+    args = parser.parse_args(argv)
+
+    if not args.report_subcommand:
+        parser.print_help()
+        return 0
+
+    if args.report_subcommand == "generate":
+        return _run_generate(args)
+
+    return 0
+
+
+def _run_generate(args: argparse.Namespace) -> int:
+    """Execute the ``generate`` sub-command."""
+    try:
+        from kicad_tools.report import ReportData, ReportGenerator
+    except ImportError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    input_path = Path(args.input)
+    project_name = input_path.stem
+
+    # Build ReportData from data-dir JSON files if available
+    data_kwargs = _load_data_dir(args.data_dir) if args.data_dir else {}
+
+    data = ReportData(
+        project_name=project_name,
+        revision=data_kwargs.pop("revision", "1"),
+        date=data_kwargs.pop(
+            "date",
+            __import__("datetime").date.today().isoformat(),
+        ),
+        manufacturer=args.mfr,
+        **data_kwargs,
+    )
+
+    template_path = Path(args.template) if args.template else None
+    generator = ReportGenerator(template_path=template_path)
+
+    try:
+        report_path = generator.generate(data, Path(args.output))
+    except FileExistsError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Report written to {report_path}")
+    return 0
+
+
+def _load_data_dir(data_dir_str: str) -> dict:
+    """Load JSON files from a data directory into ReportData kwargs."""
+    data_dir = Path(data_dir_str)
+    result: dict = {}
+
+    # Map of JSON file names to ReportData field names
+    mappings = {
+        "board_stats.json": "board_stats",
+        "bom.json": "bom_groups",
+        "drc.json": "drc",
+        "audit.json": "audit",
+        "net_status.json": "net_status",
+        "cost.json": "cost",
+        "schematic_sheets.json": "schematic_sheets",
+        "pcb_figures.json": "pcb_figures",
+    }
+
+    for filename, field_name in mappings.items():
+        json_path = data_dir / filename
+        if json_path.exists():
+            with open(json_path, encoding="utf-8") as f:
+                result[field_name] = json.load(f)
+
+    # Load notes from text file
+    notes_path = data_dir / "notes.txt"
+    if notes_path.exists():
+        result["notes"] = notes_path.read_text(encoding="utf-8").strip()
+
+    # Load metadata fields
+    meta_path = data_dir / "metadata.json"
+    if meta_path.exists():
+        with open(meta_path, encoding="utf-8") as f:
+            meta = json.load(f)
+            if "revision" in meta:
+                result["revision"] = meta["revision"]
+            if "date" in meta:
+                result["date"] = meta["date"]
+            if "git_hash" in meta:
+                result["git_hash"] = meta["git_hash"]
+
+    return result

--- a/src/kicad_tools/report/__init__.py
+++ b/src/kicad_tools/report/__init__.py
@@ -2,11 +2,15 @@
 
 This package provides tools for generating professional design reports
 from KiCad project data, with support for Markdown, HTML, and PDF output formats.
-Includes figure generation (PCB renders, schematic screenshots) and
-structured manifests for design review documents.
+Includes Jinja2-based Markdown generation, figure generation (PCB renders,
+schematic screenshots), and structured manifests for design review documents.
 Also provides data collection for report generation, gathering
 board summary, DRC, BOM, audit, net connectivity, and analysis results
 into JSON snapshots.
+
+Jinja2-based report generation requires the ``report`` extra::
+
+    pip install kicad-tools[report]
 """
 
 from __future__ import annotations
@@ -22,3 +26,13 @@ __all__ = [
     "render_html",
     "render_pdf",
 ]
+
+try:
+    import jinja2 as _jinja2  # noqa: F401
+
+    from .generator import ReportGenerator
+    from .models import ReportData
+
+    __all__ += ["ReportData", "ReportGenerator"]
+except ImportError:
+    pass  # jinja2 not installed; Jinja2 report generation unavailable

--- a/src/kicad_tools/report/generator.py
+++ b/src/kicad_tools/report/generator.py
@@ -1,0 +1,137 @@
+"""Jinja2-based Markdown report generator for KiCad design reports."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+from kicad_tools import __version__
+
+from .models import ReportData
+
+__all__ = ["ReportGenerator"]
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+
+class ReportGenerator:
+    """Render a design report from a :class:`ReportData` instance.
+
+    Parameters
+    ----------
+    template_path:
+        Path to a custom Jinja2 template file.  When *None* the bundled
+        ``design_report.md.j2`` template is used.
+    """
+
+    def __init__(self, template_path: Path | None = None) -> None:
+        if template_path is not None:
+            template_dir = template_path.parent
+            template_name = template_path.name
+        else:
+            template_dir = _TEMPLATES_DIR
+            template_name = "design_report.md.j2"
+
+        self._env = Environment(
+            loader=FileSystemLoader(str(template_dir)),
+            keep_trailing_newline=True,
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+        self._template_name = template_name
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def generate(self, data: ReportData, output_dir: Path) -> Path:
+        """Render the template and write ``report.md`` into a versioned sub-directory.
+
+        Auto-versioning
+        ~~~~~~~~~~~~~~~
+        * Scans *output_dir* for existing ``v<N>/`` directories.
+        * Creates the next version directory ``v<N+1>/``.
+        * If the chosen directory already contains ``report.md``,
+          raises :class:`FileExistsError` (immutability guard).
+
+        Returns the path to the written ``report.md``.
+        """
+        version_dir = self._next_version_dir(output_dir)
+        version_dir.mkdir(parents=True, exist_ok=True)
+
+        report_path = version_dir / "report.md"
+        if report_path.exists():
+            raise FileExistsError(
+                f"Report already exists at {report_path}. "
+                "Existing versions must not be overwritten."
+            )
+
+        rendered = self._render(data)
+        report_path.write_text(rendered, encoding="utf-8")
+
+        self._write_metadata(data, version_dir, rendered)
+
+        return report_path
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _render(self, data: ReportData) -> str:
+        """Build the template context and render to a string."""
+        template = self._env.get_template(self._template_name)
+
+        context = {
+            "project_name": data.project_name,
+            "revision": data.revision,
+            "date": data.date,
+            "manufacturer": data.manufacturer,
+            "board_stats": data.board_stats,
+            "bom_groups": data.bom_groups,
+            "drc": data.drc,
+            "audit": data.audit,
+            "net_status": data.net_status,
+            "cost": data.cost,
+            "schematic_sheets": data.schematic_sheets,
+            "pcb_figures": data.pcb_figures,
+            "notes": data.notes,
+            "tool_version": data.tool_version or __version__,
+            "git_hash": data.git_hash,
+        }
+        # Forward any extra context variables
+        context.update(data._extra)
+
+        return template.render(**context)
+
+    @staticmethod
+    def _next_version_dir(output_dir: Path) -> Path:
+        """Determine the next ``vN`` sub-directory under *output_dir*."""
+        output_dir = Path(output_dir)
+        existing = []
+        if output_dir.exists():
+            for child in output_dir.iterdir():
+                if child.is_dir():
+                    match = re.fullmatch(r"v(\d+)", child.name)
+                    if match:
+                        existing.append(int(match.group(1)))
+        next_version = max(existing, default=0) + 1
+        return output_dir / f"v{next_version}"
+
+    def _write_metadata(self, data: ReportData, version_dir: Path, rendered: str) -> None:
+        """Write ``metadata.json`` alongside the report."""
+        template_sha256 = hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+
+        metadata = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "kicad_tools_version": data.tool_version or __version__,
+            "git_hash": data.git_hash,
+            "template_sha256": template_sha256,
+        }
+
+        metadata_path = version_dir / "metadata.json"
+        metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")

--- a/src/kicad_tools/report/models.py
+++ b/src/kicad_tools/report/models.py
@@ -1,0 +1,54 @@
+"""Data models for design report generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ReportData:
+    """Typed input data for the design report template.
+
+    All optional sections default to ``None`` so the template can
+    conditionally omit them when data is unavailable.
+    """
+
+    # --- required header fields ---
+    project_name: str
+    revision: str
+    date: str  # ISO-8601 date string
+    manufacturer: str
+
+    # --- optional section data ---
+    board_stats: dict | None = None
+    """Layer count, component count, board area, net count, etc."""
+
+    bom_groups: list[dict] | None = None
+    """List of dicts: {value, footprint, qty, refs, mpn, lcsc}."""
+
+    drc: dict | None = None
+    """DRC summary: {error_count, warning_count, blocking_count, passed}."""
+
+    audit: dict | None = None
+    """Audit results: {verdict, action_items}."""
+
+    net_status: dict | None = None
+    """Net completion: {completion_percent, unrouted_count, unrouted_nets}."""
+
+    cost: dict | None = None
+    """Cost estimate: {per_unit, batch_qty, batch_total, currency}."""
+
+    schematic_sheets: list[dict] | None = None
+    """List of dicts: {name, figure_path}."""
+
+    pcb_figures: dict | None = None
+    """PCB renders: {front: path, back: path, copper: path}."""
+
+    notes: str = ""
+    """Free-form notes section content."""
+
+    # --- metadata ---
+    tool_version: str = ""
+    git_hash: str = ""
+    _extra: dict = field(default_factory=dict)
+    """Extra key-value pairs forwarded to the template context."""

--- a/src/kicad_tools/report/templates/design_report.md.j2
+++ b/src/kicad_tools/report/templates/design_report.md.j2
@@ -1,0 +1,146 @@
+# {{ project_name }} - Design Report
+
+| Field | Value |
+|-------|-------|
+| **Project** | {{ project_name }} |
+| **Revision** | {{ revision }} |
+| **Date** | {{ date }} |
+| **Manufacturer** | {{ manufacturer }} |
+| **Tool Version** | {{ tool_version }} |
+{% if git_hash %}
+| **Git Hash** | {{ git_hash }} |
+{% endif %}
+
+---
+
+{% if board_stats %}
+## Design Summary
+
+| Metric | Value |
+|--------|-------|
+{% if board_stats.layer_count is defined and board_stats.layer_count is not none %}
+| Layers | {{ board_stats.layer_count }} |
+{% endif %}
+{% if board_stats.component_count is defined and board_stats.component_count is not none %}
+| Components | {{ board_stats.component_count }} |
+{% endif %}
+{% if board_stats.net_count is defined and board_stats.net_count is not none %}
+| Nets | {{ board_stats.net_count }} |
+{% endif %}
+{% if board_stats.board_area is defined and board_stats.board_area is not none %}
+| Board Area | {{ board_stats.board_area }} |
+{% endif %}
+{% for key, value in board_stats.items() %}
+{% if key not in ("layer_count", "component_count", "net_count", "board_area") %}
+| {{ key | replace("_", " ") | title }} | {{ value }} |
+{% endif %}
+{% endfor %}
+
+{% endif %}
+{% if schematic_sheets %}
+## Schematic Overview
+
+{% for sheet in schematic_sheets %}
+### {{ sheet.name }}
+
+![{{ sheet.name }}]({{ sheet.figure_path }})
+
+{% endfor %}
+{% endif %}
+{% if pcb_figures %}
+## PCB Layout
+
+{% if pcb_figures.front is defined and pcb_figures.front %}
+### Front
+
+![PCB Front]({{ pcb_figures.front }})
+
+{% endif %}
+{% if pcb_figures.back is defined and pcb_figures.back %}
+### Back
+
+![PCB Back]({{ pcb_figures.back }})
+
+{% endif %}
+{% if pcb_figures.copper is defined and pcb_figures.copper %}
+### Copper
+
+![PCB Copper]({{ pcb_figures.copper }})
+
+{% endif %}
+{% endif %}
+{% if bom_groups %}
+## Bill of Materials
+
+| Value | Footprint | Qty | References | MPN | LCSC |
+|-------|-----------|-----|------------|-----|------|
+{% for item in bom_groups %}
+| {{ item.value | default("", true) }} | {{ item.footprint | default("", true) }} | {{ item.qty | default("", true) }} | {{ item.refs | default("", true) }} | {{ item.mpn | default("", true) }} | {{ item.lcsc | default("", true) }} |
+{% endfor %}
+
+{% endif %}
+{% if drc %}
+## DRC Status
+
+| Metric | Count |
+|--------|-------|
+| Errors | {{ drc.error_count | default(0) }} |
+| Warnings | {{ drc.warning_count | default(0) }} |
+| Blocking | {{ drc.blocking_count | default(0) }} |
+
+**Status**: {% if drc.passed | default(false) %}PASS{% else %}FAIL{% endif %}
+
+{% endif %}
+{% if audit %}
+## Manufacturing Readiness
+
+**Verdict**: {{ audit.verdict | default("unknown") | upper }}
+
+{% if audit.action_items is defined and audit.action_items %}
+### Action Items
+
+{% for item in audit.action_items %}
+- {{ item }}
+{% endfor %}
+{% endif %}
+
+{% endif %}
+{% if net_status %}
+## Routing Status
+
+| Metric | Value |
+|--------|-------|
+| Completion | {{ net_status.completion_percent | default(0) }}% |
+| Unrouted Nets | {{ net_status.unrouted_count | default(0) }} |
+
+{% if net_status.unrouted_nets is defined and net_status.unrouted_nets %}
+### Unrouted Nets
+
+{% for net in net_status.unrouted_nets %}
+- {{ net }}
+{% endfor %}
+{% endif %}
+
+{% endif %}
+{% if cost %}
+## Cost Estimate
+
+| Metric | Value |
+|--------|-------|
+{% if cost.per_unit is defined and cost.per_unit is not none %}
+| Per Unit | {{ cost.per_unit }} {{ cost.currency | default("USD") }} |
+{% endif %}
+{% if cost.batch_qty is defined and cost.batch_qty is not none %}
+| Batch Quantity | {{ cost.batch_qty }} |
+{% endif %}
+{% if cost.batch_total is defined and cost.batch_total is not none %}
+| Batch Total | {{ cost.batch_total }} {{ cost.currency | default("USD") }} |
+{% endif %}
+
+{% endif %}
+{% if notes %}
+## Notes
+
+{{ notes }}
+
+{% endif %}

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,0 +1,435 @@
+"""Tests for the report generation module."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from kicad_tools.report.generator import ReportGenerator
+from kicad_tools.report.models import ReportData
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _full_data(**overrides) -> ReportData:
+    """Return a fully-populated ``ReportData`` instance."""
+    defaults: dict = {
+        "project_name": "TestBoard",
+        "revision": "A",
+        "date": "2026-04-12",
+        "manufacturer": "jlcpcb",
+        "board_stats": {
+            "layer_count": 4,
+            "component_count": 42,
+            "net_count": 80,
+            "board_area": "50x30 mm",
+        },
+        "bom_groups": [
+            {
+                "value": "100nF",
+                "footprint": "0402",
+                "qty": 10,
+                "refs": "C1-C10",
+                "mpn": "CL05B104KO5NNNC",
+                "lcsc": "C1525",
+            },
+            {
+                "value": "10k",
+                "footprint": "0402",
+                "qty": 5,
+                "refs": "R1-R5",
+                "mpn": "RC0402FR-0710KL",
+                "lcsc": "C25744",
+            },
+        ],
+        "drc": {
+            "error_count": 0,
+            "warning_count": 2,
+            "blocking_count": 0,
+            "passed": True,
+        },
+        "audit": {
+            "verdict": "ready",
+            "action_items": ["Review silkscreen placement"],
+        },
+        "net_status": {
+            "completion_percent": 95.5,
+            "unrouted_count": 3,
+            "unrouted_nets": ["GND", "VCC", "SDA"],
+        },
+        "cost": {
+            "per_unit": 2.50,
+            "batch_qty": 100,
+            "batch_total": 250.00,
+            "currency": "USD",
+        },
+        "schematic_sheets": [
+            {"name": "Main Sheet", "figure_path": "figures/main_sheet.png"},
+            {"name": "Power", "figure_path": "figures/power.png"},
+        ],
+        "pcb_figures": {
+            "front": "figures/pcb_front.png",
+            "back": "figures/pcb_back.png",
+            "copper": "figures/pcb_copper.png",
+        },
+        "notes": "This is a prototype build.",
+        "tool_version": "0.11.0",
+        "git_hash": "abc1234",
+    }
+    defaults.update(overrides)
+    return ReportData(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# TestReportData
+# ---------------------------------------------------------------------------
+
+
+class TestReportData:
+    """Test the ReportData dataclass."""
+
+    def test_full_instantiation(self) -> None:
+        data = _full_data()
+        assert data.project_name == "TestBoard"
+        assert data.revision == "A"
+        assert data.date == "2026-04-12"
+        assert data.manufacturer == "jlcpcb"
+        assert data.board_stats is not None
+        assert data.bom_groups is not None
+        assert data.drc is not None
+        assert data.audit is not None
+        assert data.net_status is not None
+        assert data.cost is not None
+        assert data.schematic_sheets is not None
+        assert data.pcb_figures is not None
+        assert data.notes == "This is a prototype build."
+        assert data.tool_version == "0.11.0"
+        assert data.git_hash == "abc1234"
+
+    def test_defaults(self) -> None:
+        data = ReportData(
+            project_name="Minimal",
+            revision="1",
+            date="2026-01-01",
+            manufacturer="pcbway",
+        )
+        assert data.board_stats is None
+        assert data.bom_groups is None
+        assert data.notes == ""
+        assert data.tool_version == ""
+        assert data.git_hash == ""
+
+
+# ---------------------------------------------------------------------------
+# TestReportGenerator
+# ---------------------------------------------------------------------------
+
+
+class TestReportGenerator:
+    """Test the ReportGenerator class."""
+
+    def test_full_render(self, tmp_path: Path) -> None:
+        data = _full_data()
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+
+        assert report_path.exists()
+        content = report_path.read_text(encoding="utf-8")
+
+        # All 10 section headings must appear
+        assert "# TestBoard - Design Report" in content
+        assert "## Design Summary" in content
+        assert "## Schematic Overview" in content
+        assert "## PCB Layout" in content
+        assert "## Bill of Materials" in content
+        assert "## DRC Status" in content
+        assert "## Manufacturing Readiness" in content
+        assert "## Routing Status" in content
+        assert "## Cost Estimate" in content
+        assert "## Notes" in content
+
+        # No None literals
+        assert "None" not in content
+
+        # Verify some data rendered
+        assert "jlcpcb" in content
+        assert "100nF" in content
+        assert "PASS" in content
+        assert "READY" in content
+        assert "95.5%" in content
+        assert "abc1234" in content
+
+    def test_partial_data_omits_sections(self, tmp_path: Path) -> None:
+        data = ReportData(
+            project_name="Sparse",
+            revision="1",
+            date="2026-01-01",
+            manufacturer="pcbway",
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+
+        content = report_path.read_text(encoding="utf-8")
+
+        # Header is always present
+        assert "# Sparse - Design Report" in content
+
+        # Optional sections must be absent
+        assert "## Design Summary" not in content
+        assert "## Schematic Overview" not in content
+        assert "## PCB Layout" not in content
+        assert "## Bill of Materials" not in content
+        assert "## DRC Status" not in content
+        assert "## Manufacturing Readiness" not in content
+        assert "## Routing Status" not in content
+        assert "## Cost Estimate" not in content
+        assert "## Notes" not in content
+
+        # No None literals
+        assert "None" not in content
+
+    def test_immutability_guard(self, tmp_path: Path) -> None:
+        """If the computed next version directory already contains report.md,
+        generate() must raise FileExistsError.
+
+        Simulates a race condition by monkey-patching the version scanner
+        to return a directory that already holds a report.
+        """
+        data = _full_data()
+        gen = ReportGenerator()
+
+        # Generate v1 normally
+        path1 = gen.generate(data, tmp_path)
+        assert path1.exists()
+
+        # Monkey-patch _next_version_dir to always return v1 (already has report.md)
+        gen._next_version_dir = staticmethod(lambda output_dir: tmp_path / "v1")  # type: ignore[assignment]
+
+        with pytest.raises(FileExistsError, match="must not be overwritten"):
+            gen.generate(data, tmp_path)
+
+    def test_metadata_written(self, tmp_path: Path) -> None:
+        data = _full_data()
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+
+        metadata_path = report_path.parent / "metadata.json"
+        assert metadata_path.exists()
+
+        meta = json.loads(metadata_path.read_text(encoding="utf-8"))
+        assert "timestamp" in meta
+        assert "kicad_tools_version" in meta
+        assert "git_hash" in meta
+        assert "template_sha256" in meta
+
+        # template_sha256 must be a valid hex string
+        sha = meta["template_sha256"]
+        assert len(sha) == 64
+        assert all(c in "0123456789abcdef" for c in sha)
+
+        # Version and hash from data
+        assert meta["kicad_tools_version"] == "0.11.0"
+        assert meta["git_hash"] == "abc1234"
+
+    def test_auto_version_increment(self, tmp_path: Path) -> None:
+        data = _full_data()
+        gen = ReportGenerator()
+
+        p1 = gen.generate(data, tmp_path)
+        p2 = gen.generate(data, tmp_path)
+        p3 = gen.generate(data, tmp_path)
+
+        assert p1.parent.name == "v1"
+        assert p2.parent.name == "v2"
+        assert p3.parent.name == "v3"
+
+    def test_custom_template(self, tmp_path: Path) -> None:
+        template_dir = tmp_path / "custom_templates"
+        template_dir.mkdir()
+        custom_template = template_dir / "custom.md.j2"
+        custom_template.write_text("# {{ project_name }} custom report\n")
+
+        data = _full_data()
+        output_dir = tmp_path / "output"
+        gen = ReportGenerator(template_path=custom_template)
+        report_path = gen.generate(data, output_dir)
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "# TestBoard custom report" in content
+
+    def test_figure_paths_not_validated(self, tmp_path: Path) -> None:
+        """Figure paths are strings in the output, not validated on disk."""
+        data = _full_data(
+            pcb_figures={
+                "front": "figures/nonexistent.png",
+                "back": "figures/also_missing.png",
+            },
+            schematic_sheets=[
+                {"name": "Ghost", "figure_path": "figures/ghost.png"},
+            ],
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "figures/nonexistent.png" in content
+        assert "figures/ghost.png" in content
+
+    def test_empty_notes_omitted(self, tmp_path: Path) -> None:
+        """Empty notes string means no Notes section."""
+        data = _full_data(notes="")
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "## Notes" not in content
+
+    def test_nonempty_notes_included(self, tmp_path: Path) -> None:
+        data = _full_data(notes="Ship by Friday.")
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "## Notes" in content
+        assert "Ship by Friday." in content
+
+    def test_drc_fail_status(self, tmp_path: Path) -> None:
+        data = _full_data(
+            drc={
+                "error_count": 3,
+                "warning_count": 1,
+                "blocking_count": 2,
+                "passed": False,
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "FAIL" in content
+
+
+# ---------------------------------------------------------------------------
+# TestImportError
+# ---------------------------------------------------------------------------
+
+
+class TestReportImportError:
+    """Test graceful degradation when jinja2 is absent."""
+
+    def test_import_error_message(self) -> None:
+        """Verify that when jinja2 is absent the module still imports but
+        ReportData and ReportGenerator are not exported."""
+        # Save and remove the real jinja2 module
+        saved = {}
+        for key in list(sys.modules.keys()):
+            if key == "jinja2" or key.startswith("jinja2."):
+                saved[key] = sys.modules.pop(key)
+
+        # Also remove cached report modules so they re-import
+        for key in list(sys.modules.keys()):
+            if "kicad_tools.report" in key:
+                saved[key] = sys.modules.pop(key)
+
+        try:
+            with mock.patch.dict(sys.modules, {"jinja2": None}):
+                import importlib
+
+                mod = importlib.import_module("kicad_tools.report")
+                # Core figure/render exports must always be available
+                assert hasattr(mod, "FigureEntry")
+                assert hasattr(mod, "ReportFigureGenerator")
+                assert hasattr(mod, "render_html")
+                assert hasattr(mod, "render_pdf")
+                # Jinja2-dependent exports must be absent
+                assert not hasattr(mod, "ReportData")
+                assert not hasattr(mod, "ReportGenerator")
+        finally:
+            # Restore all saved modules
+            sys.modules.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# TestReportCLI
+# ---------------------------------------------------------------------------
+
+
+class TestReportCLI:
+    """Test the CLI entry point."""
+
+    def test_help(self) -> None:
+        """kct report generate --help must exit 0."""
+        from kicad_tools.cli.report_cmd import main as report_main
+
+        with pytest.raises(SystemExit) as exc_info:
+            report_main(["generate", "--help"])
+        assert exc_info.value.code == 0
+
+    def test_report_parser_registered(self) -> None:
+        """The report subcommand must be recognized by the main parser."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["report", "generate", "test.kicad_pro", "--mfr", "jlcpcb"])
+        assert args.command == "report"
+        assert args.report_command == "generate"
+        assert args.report_input == "test.kicad_pro"
+        assert args.report_mfr == "jlcpcb"
+
+    def test_generate_skeleton(self, tmp_path: Path) -> None:
+        """Calling generate without a data-dir should produce a skeleton report."""
+        from kicad_tools.cli.report_cmd import main as report_main
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            ["generate", "test.kicad_pro", "--mfr", "testmfr", "-o", str(output_dir)]
+        )
+        assert result == 0
+
+        report_path = output_dir / "v1" / "report.md"
+        assert report_path.exists()
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "# test - Design Report" in content
+        assert "testmfr" in content
+
+    def test_generate_with_data_dir(self, tmp_path: Path) -> None:
+        """Calling generate with --data-dir loads JSON files."""
+        from kicad_tools.cli.report_cmd import main as report_main
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        # Write a board_stats JSON file
+        (data_dir / "board_stats.json").write_text(
+            json.dumps({"layer_count": 2, "component_count": 10})
+        )
+        (data_dir / "drc.json").write_text(
+            json.dumps({"error_count": 0, "warning_count": 0, "blocking_count": 0, "passed": True})
+        )
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                "board.kicad_pcb",
+                "--mfr",
+                "pcbway",
+                "-o",
+                str(output_dir),
+                "--data-dir",
+                str(data_dir),
+            ]
+        )
+        assert result == 0
+
+        content = (output_dir / "v1" / "report.md").read_text(encoding="utf-8")
+        assert "## Design Summary" in content
+        assert "## DRC Status" in content
+        assert "PASS" in content

--- a/uv.lock
+++ b/uv.lock
@@ -1787,6 +1787,7 @@ all = [
     { name = "cairosvg" },
     { name = "cupy-cuda12x" },
     { name = "fastmcp" },
+    { name = "jinja2" },
     { name = "markdown" },
     { name = "markitdown" },
     { name = "matplotlib" },
@@ -1820,6 +1821,7 @@ datasheet = [
 ]
 dev = [
     { name = "fastmcp" },
+    { name = "jinja2" },
     { name = "markdown" },
     { name = "matplotlib" },
     { name = "mypy" },
@@ -1857,6 +1859,7 @@ parts = [
     { name = "requests" },
 ]
 report = [
+    { name = "jinja2" },
     { name = "markdown" },
     { name = "weasyprint" },
 ]
@@ -1869,6 +1872,7 @@ visualization = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "jinja2" },
     { name = "pytest-cov" },
 ]
 
@@ -1887,6 +1891,9 @@ requires-dist = [
     { name = "fastmcp", marker = "extra == 'all'", specifier = ">=2.0,<3" },
     { name = "fastmcp", marker = "extra == 'dev'", specifier = ">=2.0,<3" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0,<3" },
+    { name = "jinja2", marker = "extra == 'all'", specifier = ">=3.1" },
+    { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.1" },
+    { name = "jinja2", marker = "extra == 'report'", specifier = ">=3.1" },
     { name = "markdown", marker = "extra == 'all'", specifier = ">=3.5" },
     { name = "markdown", marker = "extra == 'dev'", specifier = ">=3.5" },
     { name = "markdown", marker = "extra == 'report'", specifier = ">=3.5" },
@@ -1937,7 +1944,10 @@ requires-dist = [
 provides-extras = ["drc", "parts", "datasheet", "constraints", "mcp", "native", "cuda", "metal", "visualization", "bayesian", "screenshot", "report", "all", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest-cov", specifier = ">=7.0.0" }]
+dev = [
+    { name = "jinja2", specifier = ">=3.1" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+]
 
 [[package]]
 name = "kiwisolver"


### PR DESCRIPTION
## Summary

Add a new `report` module that renders Markdown design reports from structured data using Jinja2 templates. The module includes auto-versioned output directories, an immutability guard, and a CLI entry point (`kct report generate`).

## Changes

- Create `src/kicad_tools/report/` package with `__init__.py`, `models.py`, `generator.py`, and `templates/design_report.md.j2`
- Create `src/kicad_tools/cli/report_cmd.py` with `kct report generate` CLI command
- Register report subcommand in `parser.py` and `__init__.py`
- Add `report = ["jinja2>=3.1"]` to `pyproject.toml` optional dependencies
- Add `jinja2>=3.1` to `all` extra and `dev` dependency groups
- Create 17 unit/integration tests in `tests/test_report_generator.py`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `src/kicad_tools/report/` package with __init__, generator, models, template | Pass | Created all four files |
| `ReportGenerator.generate()` renders all 10 spine sections | Pass | `test_full_render` verifies all section headings present |
| Sections with None/empty data omitted gracefully | Pass | `test_partial_data_omits_sections` confirms no optional sections in sparse data |
| Duplicate generate raises FileExistsError | Pass | `test_immutability_guard` verifies the guard |
| metadata.json with timestamp, version, git_hash, template_sha256 | Pass | `test_metadata_written` parses and validates all keys |
| ImportError with pip install message when jinja2 absent | Pass | `test_import_error_message` mocks jinja2 absence |
| `kct report generate --help` works | Pass | `test_help` and `test_report_parser_registered` both pass |
| pyproject.toml has `report = ["jinja2>=3.1"]` | Pass | Added to optional-dependencies |
| Passes ruff check and format | Pass | `ruff check` and `ruff format --check` both pass |
| Passes mypy | Pass | `mypy src/kicad_tools/report/` reports no errors |
| >=80% line coverage on report module | Pass | 100% on __init__.py and models.py, 96.88% on generator.py |

## Test Plan

All 17 tests pass: `uv run pytest tests/test_report_generator.py -v`

- ReportData round-trip (2 tests)
- Full render with all 10 sections (1 test)
- Partial data omits sections (1 test)
- Immutability guard (1 test)
- metadata.json validation (1 test)
- Auto-version increment v1/v2/v3 (1 test)
- Custom template (1 test)
- Figure paths as strings, not validated (1 test)
- Empty/non-empty notes (2 tests)
- DRC FAIL status (1 test)
- Import error message (1 test)
- CLI help and parser registration (2 tests)
- CLI skeleton and data-dir generation (2 tests)

Closes #1313