### PR TITLE
feat(report): wire ReportFigureGenerator into report generate CLI

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -628,6 +628,10 @@ def _run_report_command(args) -> int:
             sub_argv.extend(["--data-dir", args.report_data_dir])
         if hasattr(args, "report_template") and args.report_template:
             sub_argv.extend(["--template", args.report_template])
+        if hasattr(args, "report_sch") and args.report_sch:
+            sub_argv.extend(["--sch", args.report_sch])
+        if getattr(args, "report_no_figures", False):
+            sub_argv.append("--no-figures")
 
     return report_cmd(sub_argv)
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3617,3 +3617,16 @@ def _add_report_parser(subparsers) -> None:
         default=None,
         help="Path to a custom Jinja2 template file",
     )
+    gen_parser.add_argument(
+        "--sch",
+        dest="report_sch",
+        default=None,
+        help="Path to root .kicad_sch file (inferred from input if omitted)",
+    )
+    gen_parser.add_argument(
+        "--no-figures",
+        dest="report_no_figures",
+        action="store_true",
+        default=False,
+        help="Skip figure generation (useful when kicad-cli/cairosvg are unavailable)",
+    )

--- a/src/kicad_tools/cli/report_cmd.py
+++ b/src/kicad_tools/cli/report_cmd.py
@@ -3,6 +3,8 @@
 Usage:
     kct report generate project.kicad_pro --mfr jlcpcb -o reports/
     kct report generate board.kicad_pcb --mfr jlcpcb --data-dir data/
+    kct report generate board.kicad_pcb --mfr jlcpcb --no-figures
+    kct report generate board.kicad_pcb --mfr jlcpcb --sch path/to/root.kicad_sch
 """
 
 from __future__ import annotations
@@ -11,6 +13,11 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.report.figures import FigureEntry
+    from kicad_tools.report.models import ReportData
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -46,6 +53,17 @@ def main(argv: list[str] | None = None) -> int:
         "--template",
         default=None,
         help="Path to a custom Jinja2 template file",
+    )
+    gen_parser.add_argument(
+        "--sch",
+        default=None,
+        help="Path to root .kicad_sch file (inferred from input if omitted)",
+    )
+    gen_parser.add_argument(
+        "--no-figures",
+        action="store_true",
+        default=False,
+        help="Skip figure generation (useful when kicad-cli/cairosvg are unavailable)",
     )
 
     args = parser.parse_args(argv)
@@ -88,8 +106,17 @@ def _run_generate(args: argparse.Namespace) -> int:
     template_path = Path(args.template) if args.template else None
     generator = ReportGenerator(template_path=template_path)
 
+    # --- Figure generation ---
+    # Only attempt when: no --data-dir (pre-collected data path), no --no-figures,
+    # and the input is a .kicad_pcb file.
+    version_dir: Path | None = None
+    if not args.no_figures and not args.data_dir and input_path.suffix == ".kicad_pcb":
+        version_dir = generator.next_version_dir(Path(args.output))
+        figures_dir = version_dir / "figures"
+        _generate_figures(args, input_path, figures_dir, data)
+
     try:
-        report_path = generator.generate(data, Path(args.output))
+        report_path = generator.generate(data, Path(args.output), version_dir=version_dir)
     except FileExistsError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
@@ -110,6 +137,76 @@ def _unwrap_envelope(payload: dict) -> dict | None:
     if isinstance(payload, dict) and "schema_version" in payload and "data" in payload:
         return payload["data"]
     return payload
+
+
+def _generate_figures(
+    args: argparse.Namespace,
+    input_path: Path,
+    figures_dir: Path,
+    data: ReportData,
+) -> None:
+    """Attempt figure generation, populating *data* in place.
+
+    Handles graceful degradation: prints a warning to stderr and
+    continues without figures if dependencies (kicad-cli / cairosvg)
+    are absent.
+    """
+    try:
+        from kicad_tools.report import ReportFigureGenerator
+    except ImportError as exc:
+        print(
+            f"Warning: figure generation skipped — {exc}",
+            file=sys.stderr,
+        )
+        return
+
+    sch_path = Path(args.sch) if args.sch else input_path.with_suffix(".kicad_sch")
+
+    try:
+        fig_gen = ReportFigureGenerator()
+        print("Generating figures...")
+        entries = fig_gen.generate_all(input_path, sch_path, figures_dir)
+        data.pcb_figures = _entries_to_pcb_figures(entries)
+        data.schematic_sheets = _entries_to_schematic_sheets(entries)
+    except RuntimeError as exc:
+        print(
+            f"Warning: figure generation skipped — {exc}",
+            file=sys.stderr,
+        )
+
+
+def _entries_to_pcb_figures(entries: list[FigureEntry]) -> dict | None:
+    """Convert a list of :class:`FigureEntry` to the dict shape expected by
+    :attr:`ReportData.pcb_figures`.
+
+    Returns ``None`` when no PCB figure entries are present.
+    """
+    type_to_key = {
+        "pcb_front": "front",
+        "pcb_back": "back",
+        "pcb_copper": "copper",
+        "assembly": "assembly",
+    }
+    result: dict[str, str] = {}
+    for entry in entries:
+        key = type_to_key.get(entry.figure_type)
+        if key is not None:
+            result[key] = f"figures/{entry.filename}"
+    return result or None
+
+
+def _entries_to_schematic_sheets(entries: list[FigureEntry]) -> list[dict] | None:
+    """Convert a list of :class:`FigureEntry` to the list shape expected by
+    :attr:`ReportData.schematic_sheets`.
+
+    Returns ``None`` when no schematic entries are present.
+    """
+    sheets = [
+        {"name": entry.caption, "figure_path": f"figures/{entry.filename}"}
+        for entry in entries
+        if entry.figure_type == "schematic"
+    ]
+    return sheets or None
 
 
 def _load_data_dir(data_dir_str: str) -> dict:

--- a/src/kicad_tools/report/generator.py
+++ b/src/kicad_tools/report/generator.py
@@ -49,19 +49,27 @@ class ReportGenerator:
     # Public API
     # ------------------------------------------------------------------
 
-    def generate(self, data: ReportData, output_dir: Path) -> Path:
+    def generate(
+        self,
+        data: ReportData,
+        output_dir: Path,
+        version_dir: Path | None = None,
+    ) -> Path:
         """Render the template and write ``report.md`` into a versioned sub-directory.
 
         Auto-versioning
         ~~~~~~~~~~~~~~~
-        * Scans *output_dir* for existing ``v<N>/`` directories.
-        * Creates the next version directory ``v<N+1>/``.
+        * When *version_dir* is ``None`` (default), scans *output_dir*
+          for existing ``v<N>/`` directories and creates the next one.
+        * When *version_dir* is provided, uses that directory directly
+          (useful when figures have already been written there).
         * If the chosen directory already contains ``report.md``,
           raises :class:`FileExistsError` (immutability guard).
 
         Returns the path to the written ``report.md``.
         """
-        version_dir = self._next_version_dir(output_dir)
+        if version_dir is None:
+            version_dir = self.next_version_dir(output_dir)
         version_dir.mkdir(parents=True, exist_ok=True)
 
         report_path = version_dir / "report.md"
@@ -109,7 +117,7 @@ class ReportGenerator:
         return template.render(**context)
 
     @staticmethod
-    def _next_version_dir(output_dir: Path) -> Path:
+    def next_version_dir(output_dir: Path) -> Path:
         """Determine the next ``vN`` sub-directory under *output_dir*."""
         output_dir = Path(output_dir)
         existing = []

--- a/src/kicad_tools/report/templates/design_report.md.j2
+++ b/src/kicad_tools/report/templates/design_report.md.j2
@@ -68,6 +68,12 @@
 ![PCB Copper]({{ pcb_figures.copper }})
 
 {% endif %}
+{% if pcb_figures.assembly is defined and pcb_figures.assembly %}
+### Assembly
+
+![Assembly]({{ pcb_figures.assembly }})
+
+{% endif %}
 {% endif %}
 {% if bom_groups %}
 ## Bill of Materials

--- a/tests/test_report_cmd.py
+++ b/tests/test_report_cmd.py
@@ -1,0 +1,452 @@
+"""Tests for figure generation wiring in report_cmd.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli.report_cmd import (
+    _entries_to_pcb_figures,
+    _entries_to_schematic_sheets,
+)
+from kicad_tools.cli.report_cmd import (
+    main as report_main,
+)
+from kicad_tools.report.figures import FigureEntry
+
+# ---------------------------------------------------------------------------
+# Helper functions for FigureEntry conversion
+# ---------------------------------------------------------------------------
+
+
+class TestEntriesToPcbFigures:
+    """Tests for _entries_to_pcb_figures helper."""
+
+    def test_all_pcb_types(self):
+        entries = [
+            FigureEntry("pcb_front.png", "PCB Front", "pcb_front"),
+            FigureEntry("pcb_back.png", "PCB Back", "pcb_back"),
+            FigureEntry("pcb_copper.png", "PCB Copper Layers", "pcb_copper"),
+            FigureEntry("assembly.png", "Assembly View", "assembly"),
+        ]
+        result = _entries_to_pcb_figures(entries)
+        assert result == {
+            "front": "figures/pcb_front.png",
+            "back": "figures/pcb_back.png",
+            "copper": "figures/pcb_copper.png",
+            "assembly": "figures/assembly.png",
+        }
+
+    def test_partial_pcb_types(self):
+        entries = [
+            FigureEntry("pcb_front.png", "PCB Front", "pcb_front"),
+            FigureEntry("pcb_back.png", "PCB Back", "pcb_back"),
+        ]
+        result = _entries_to_pcb_figures(entries)
+        assert result == {
+            "front": "figures/pcb_front.png",
+            "back": "figures/pcb_back.png",
+        }
+
+    def test_no_pcb_entries_returns_none(self):
+        entries = [
+            FigureEntry("schematic_main.png", "Schematic: main", "schematic"),
+        ]
+        result = _entries_to_pcb_figures(entries)
+        assert result is None
+
+    def test_empty_list_returns_none(self):
+        assert _entries_to_pcb_figures([]) is None
+
+    def test_ignores_schematic_entries(self):
+        entries = [
+            FigureEntry("pcb_front.png", "PCB Front", "pcb_front"),
+            FigureEntry("schematic_main.png", "Schematic: main", "schematic"),
+        ]
+        result = _entries_to_pcb_figures(entries)
+        assert result == {"front": "figures/pcb_front.png"}
+
+
+class TestEntriesToSchematicSheets:
+    """Tests for _entries_to_schematic_sheets helper."""
+
+    def test_schematic_entries(self):
+        entries = [
+            FigureEntry("schematic_main.png", "Schematic: main", "schematic"),
+            FigureEntry("schematic_power.png", "Schematic: power", "schematic"),
+        ]
+        result = _entries_to_schematic_sheets(entries)
+        assert result == [
+            {"name": "Schematic: main", "figure_path": "figures/schematic_main.png"},
+            {"name": "Schematic: power", "figure_path": "figures/schematic_power.png"},
+        ]
+
+    def test_no_schematic_entries_returns_none(self):
+        entries = [
+            FigureEntry("pcb_front.png", "PCB Front", "pcb_front"),
+        ]
+        result = _entries_to_schematic_sheets(entries)
+        assert result is None
+
+    def test_empty_list_returns_none(self):
+        assert _entries_to_schematic_sheets([]) is None
+
+    def test_ignores_pcb_entries(self):
+        entries = [
+            FigureEntry("pcb_front.png", "PCB Front", "pcb_front"),
+            FigureEntry("schematic_main.png", "Schematic: main", "schematic"),
+        ]
+        result = _entries_to_schematic_sheets(entries)
+        assert result == [
+            {"name": "Schematic: main", "figure_path": "figures/schematic_main.png"},
+        ]
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests for figure generation wiring
+# ---------------------------------------------------------------------------
+
+
+def _mock_figure_entries() -> list[FigureEntry]:
+    """Return a synthetic list of FigureEntry objects for testing."""
+    return [
+        FigureEntry("pcb_front.png", "PCB Front", "pcb_front"),
+        FigureEntry("pcb_back.png", "PCB Back", "pcb_back"),
+        FigureEntry("pcb_copper.png", "PCB Copper Layers", "pcb_copper"),
+        FigureEntry("assembly.png", "Assembly View", "assembly"),
+        FigureEntry("schematic_main.png", "Schematic: main", "schematic"),
+    ]
+
+
+class TestFigureGenerationWiring:
+    """Tests for automatic figure generation in the report CLI."""
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_figures_generated_for_kicad_pcb(self, mock_gen_cls, tmp_path):
+        """Calling generate with a .kicad_pcb file triggers figure generation."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.return_value = _mock_figure_entries()
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            ["generate", "board.kicad_pcb", "--mfr", "jlcpcb", "-o", str(output_dir)]
+        )
+        assert result == 0
+
+        # Verify generate_all was called
+        mock_instance.generate_all.assert_called_once()
+        call_args = mock_instance.generate_all.call_args
+        assert call_args[0][0] == Path("board.kicad_pcb")
+        # sch_path should be inferred from pcb path
+        assert call_args[0][1] == Path("board.kicad_sch")
+        # figures_dir should be under version dir
+        figures_dir = call_args[0][2]
+        assert figures_dir.name == "figures"
+        assert "v1" in str(figures_dir)
+
+        # Verify the report contains figure references
+        report_path = output_dir / "v1" / "report.md"
+        assert report_path.exists()
+        content = report_path.read_text(encoding="utf-8")
+        assert "![PCB Front](figures/pcb_front.png)" in content
+        assert "![PCB Back](figures/pcb_back.png)" in content
+        assert "![PCB Copper](figures/pcb_copper.png)" in content
+        assert "![Assembly](figures/assembly.png)" in content
+        assert "![Schematic: main](figures/schematic_main.png)" in content
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_sch_flag_overrides_inferred_path(self, mock_gen_cls, tmp_path):
+        """--sch explicitly sets the schematic path."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.return_value = _mock_figure_entries()
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                "board.kicad_pcb",
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(output_dir),
+                "--sch",
+                "custom/root.kicad_sch",
+            ]
+        )
+        assert result == 0
+
+        call_args = mock_instance.generate_all.call_args
+        assert call_args[0][1] == Path("custom/root.kicad_sch")
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_no_figures_flag_skips_generation(self, mock_gen_cls, tmp_path):
+        """--no-figures prevents figure generation entirely."""
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                "board.kicad_pcb",
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(output_dir),
+                "--no-figures",
+            ]
+        )
+        assert result == 0
+
+        # ReportFigureGenerator should never be instantiated
+        mock_gen_cls.assert_not_called()
+
+        # Report should exist but without figure sections
+        report_path = output_dir / "v1" / "report.md"
+        assert report_path.exists()
+        content = report_path.read_text(encoding="utf-8")
+        assert "## PCB Layout" not in content
+        assert "## Schematic Overview" not in content
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_no_figures_for_kicad_pro_input(self, mock_gen_cls, tmp_path):
+        """Figure generation is skipped for .kicad_pro files."""
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                "project.kicad_pro",
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(output_dir),
+            ]
+        )
+        assert result == 0
+        mock_gen_cls.assert_not_called()
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_data_dir_skips_figure_generation(self, mock_gen_cls, tmp_path):
+        """When --data-dir is provided, figure generation is skipped."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "board_stats.json").write_text(
+            json.dumps({"layer_count": 2, "component_count": 10})
+        )
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                "board.kicad_pcb",
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(output_dir),
+                "--data-dir",
+                str(data_dir),
+            ]
+        )
+        assert result == 0
+        mock_gen_cls.assert_not_called()
+
+
+class TestGracefulDegradation:
+    """Tests for graceful degradation when dependencies are missing."""
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_runtime_error_prints_warning(self, mock_gen_cls, tmp_path, capsys):
+        """When ReportFigureGenerator raises RuntimeError, CLI prints warning
+        and continues without figures."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.side_effect = RuntimeError("kicad-cli not found")
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                "board.kicad_pcb",
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(output_dir),
+            ]
+        )
+
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Warning: figure generation skipped" in captured.err
+        assert "kicad-cli not found" in captured.err
+
+        # Report should still be generated
+        report_path = output_dir / "v1" / "report.md"
+        assert report_path.exists()
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_cairosvg_missing_prints_warning(self, mock_gen_cls, tmp_path, capsys):
+        """When cairosvg is missing, CLI prints warning and continues."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.side_effect = RuntimeError(
+            "cairosvg is required for report figure generation"
+        )
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                "board.kicad_pcb",
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(output_dir),
+            ]
+        )
+
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Warning: figure generation skipped" in captured.err
+        assert "cairosvg is required" in captured.err
+
+        # Report should still be generated without figure sections
+        report_path = output_dir / "v1" / "report.md"
+        assert report_path.exists()
+        content = report_path.read_text(encoding="utf-8")
+        assert "## PCB Layout" not in content
+        assert "## Schematic Overview" not in content
+
+
+class TestFiguresInVersionDir:
+    """Tests verifying that figures land in the correct versioned directory."""
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_figures_dir_in_same_version_as_report(self, mock_gen_cls, tmp_path):
+        """Figures directory must be in the same vN/ directory as report.md."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.return_value = _mock_figure_entries()
+
+        output_dir = tmp_path / "reports"
+        report_main(["generate", "board.kicad_pcb", "--mfr", "jlcpcb", "-o", str(output_dir)])
+
+        # Both report.md and figures/ should be under v1/
+        report_path = output_dir / "v1" / "report.md"
+        assert report_path.exists()
+
+        # generate_all was called with figures_dir under v1
+        call_args = mock_instance.generate_all.call_args
+        figures_dir = call_args[0][2]
+        assert figures_dir == output_dir / "v1" / "figures"
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_second_report_increments_version(self, mock_gen_cls, tmp_path):
+        """Creating a second report puts figures in v2/figures/."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.return_value = _mock_figure_entries()
+
+        output_dir = tmp_path / "reports"
+
+        # First report -> v1
+        report_main(["generate", "board.kicad_pcb", "--mfr", "jlcpcb", "-o", str(output_dir)])
+        assert (output_dir / "v1" / "report.md").exists()
+
+        # Second report -> v2
+        report_main(["generate", "board.kicad_pcb", "--mfr", "jlcpcb", "-o", str(output_dir)])
+        assert (output_dir / "v2" / "report.md").exists()
+
+        # Verify the second call used v2/figures/
+        second_call = mock_instance.generate_all.call_args_list[1]
+        figures_dir = second_call[0][2]
+        assert figures_dir == output_dir / "v2" / "figures"
+
+
+class TestReportContentWithFigures:
+    """Tests verifying report content when figures are generated."""
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_report_has_pcb_layout_section(self, mock_gen_cls, tmp_path):
+        """Report should have PCB Layout section with all figure links."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.return_value = _mock_figure_entries()
+
+        output_dir = tmp_path / "reports"
+        report_main(["generate", "board.kicad_pcb", "--mfr", "jlcpcb", "-o", str(output_dir)])
+
+        content = (output_dir / "v1" / "report.md").read_text(encoding="utf-8")
+        assert "## PCB Layout" in content
+        assert "### Front" in content
+        assert "### Back" in content
+        assert "### Copper" in content
+        assert "### Assembly" in content
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_report_has_schematic_overview(self, mock_gen_cls, tmp_path):
+        """Report should have Schematic Overview section."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.return_value = _mock_figure_entries()
+
+        output_dir = tmp_path / "reports"
+        report_main(["generate", "board.kicad_pcb", "--mfr", "jlcpcb", "-o", str(output_dir)])
+
+        content = (output_dir / "v1" / "report.md").read_text(encoding="utf-8")
+        assert "## Schematic Overview" in content
+        assert "### Schematic: main" in content
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_empty_figure_entries_no_sections(self, mock_gen_cls, tmp_path):
+        """When generate_all returns empty list, no figure sections appear."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.return_value = []
+
+        output_dir = tmp_path / "reports"
+        report_main(["generate", "board.kicad_pcb", "--mfr", "jlcpcb", "-o", str(output_dir)])
+
+        content = (output_dir / "v1" / "report.md").read_text(encoding="utf-8")
+        assert "## PCB Layout" not in content
+        assert "## Schematic Overview" not in content
+
+
+class TestCLIFlags:
+    """Tests for the new CLI flags."""
+
+    def test_help_includes_no_figures(self, capsys):
+        """--no-figures should be in the help output."""
+        with pytest.raises(SystemExit) as exc_info:
+            report_main(["generate", "--help"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "--no-figures" in captured.out
+
+    def test_help_includes_sch(self, capsys):
+        """--sch should be in the help output."""
+        with pytest.raises(SystemExit) as exc_info:
+            report_main(["generate", "--help"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "--sch" in captured.out
+
+    def test_parser_registered_sch_flag(self):
+        """The --sch flag is registered in the main parser."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            ["report", "generate", "board.kicad_pcb", "--sch", "root.kicad_sch"]
+        )
+        assert args.report_sch == "root.kicad_sch"
+
+    def test_parser_registered_no_figures_flag(self):
+        """The --no-figures flag is registered in the main parser."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["report", "generate", "board.kicad_pcb", "--no-figures"])
+        assert args.report_no_figures is True
+
+    def test_parser_no_figures_defaults_false(self):
+        """The --no-figures flag defaults to False."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["report", "generate", "board.kicad_pcb"])
+        assert args.report_no_figures is False

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -208,8 +208,8 @@ class TestReportGenerator:
         path1 = gen.generate(data, tmp_path)
         assert path1.exists()
 
-        # Monkey-patch _next_version_dir to always return v1 (already has report.md)
-        gen._next_version_dir = staticmethod(lambda output_dir: tmp_path / "v1")  # type: ignore[assignment]
+        # Monkey-patch next_version_dir to always return v1 (already has report.md)
+        gen.next_version_dir = staticmethod(lambda output_dir: tmp_path / "v1")  # type: ignore[assignment]
 
         with pytest.raises(FileExistsError, match="must not be overwritten"):
             gen.generate(data, tmp_path)


### PR DESCRIPTION
## Summary

Integrates automatic figure generation into `kct report generate` so PCB renders and schematic screenshots are produced alongside the Markdown report. Adds `--no-figures` and `--sch` CLI flags, converts `FigureEntry` lists to `ReportData`-compatible dicts, and handles graceful degradation when `kicad-cli` or `cairosvg` are absent.

## Changes

- **`src/kicad_tools/cli/report_cmd.py`**: Add `--no-figures` and `--sch` CLI flags; wire `ReportFigureGenerator.generate_all()` into `_run_generate()`; add `_generate_figures()`, `_entries_to_pcb_figures()`, and `_entries_to_schematic_sheets()` helper functions; catch `RuntimeError` from missing dependencies and print warning to stderr
- **`src/kicad_tools/report/generator.py`**: Expose `next_version_dir()` as public API (renamed from `_next_version_dir`); add optional `version_dir` parameter to `generate()` so the CLI can pre-compute the version directory for figure placement
- **`src/kicad_tools/cli/parser.py`**: Register `--sch` and `--no-figures` in the main parser's report subcommand
- **`src/kicad_tools/cli/__init__.py`**: Forward `--sch` and `--no-figures` args from main parser to `report_cmd.main()`
- **`src/kicad_tools/report/templates/design_report.md.j2`**: Add conditional assembly figure rendering section
- **`tests/test_report_generator.py`**: Update monkey-patch reference from `_next_version_dir` to `next_version_dir`
- **`tests/test_report_cmd.py`** (new): 26 tests covering helper functions, figure wiring, CLI flags, graceful degradation, version directory consistency, and report content verification

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct report generate board.kicad_pcb` generates figures in `vN/figures/` | PASS | `test_figures_generated_for_kicad_pcb` and `test_figures_dir_in_same_version_as_report` verify figure generation is called with correct paths and report contains figure references |
| Generated `report.md` contains `![PCB Front](figures/pcb_front.png)` etc. | PASS | `test_report_has_pcb_layout_section` and `test_report_has_schematic_overview` verify all expected image links |
| `--no-figures` skips figure generation entirely | PASS | `test_no_figures_flag_skips_generation` verifies `ReportFigureGenerator` is never instantiated |
| Missing kicad-cli/cairosvg prints warning, continues without crash | PASS | `test_runtime_error_prints_warning` and `test_cairosvg_missing_prints_warning` verify exit code 0 and warning in stderr |
| `--sch path/to/root.kicad_sch` overrides inferred path | PASS | `test_sch_flag_overrides_inferred_path` verifies explicit path is passed to `generate_all()` |
| `--data-dir` path continues to work unchanged | PASS | `test_data_dir_skips_figure_generation` and existing `test_generate_with_data_dir` pass |
| Figure files land in `reports/vN/figures/` (correct version dir) | PASS | `test_figures_dir_in_same_version_as_report` and `test_second_report_increments_version` verify consistency |
| All existing tests continue to pass | PASS | All 17 existing `test_report_generator.py` tests pass |

## Test Plan

- 26 new tests in `tests/test_report_cmd.py` covering all acceptance criteria
- All 17 existing `tests/test_report_generator.py` tests pass
- Ran `uv run ruff check` and `uv run ruff format --check` on all changed files -- no issues

Closes #1323