### PR TITLE
fix(cli): use exit code 2 for fix-vias warnings instead of 1

### DIFF
--- a/src/kicad_tools/cli/fix_vias_cmd.py
+++ b/src/kicad_tools/cli/fix_vias_cmd.py
@@ -567,8 +567,10 @@ Examples:
             print(f"Error saving PCB file: {e}", file=sys.stderr)
             return 1
 
-    # Return non-zero if there were warnings (like DRC might fail)
-    return 1 if warnings else 0
+    # Return exit code 2 for success-with-warnings (pipeline treats this as
+    # "completed with warnings" and continues).  Exit code 1 is reserved for
+    # actual errors (file not found, parse failure, save failure).
+    return 2 if warnings else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_fix_vias.py
+++ b/tests/test_fix_vias.py
@@ -746,3 +746,122 @@ class TestManufacturerClearance:
         # With JLCPCB 0.127mm clearance, no warnings expected
         assert len(data["warnings"]) == 0
         assert result == 0
+
+
+class TestExitCodeWarnings:
+    """Tests for exit code semantics: 0=success, 1=error, 2=success-with-warnings."""
+
+    def test_exit_code_0_no_fixes_needed(self, tmp_path: Path):
+        """Exit code 0 when all vias are already compliant (no fixes, no warnings)."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "compliant.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        result = main([str(pcb_file), "--mfr", "jlcpcb", "--dry-run"])
+        assert result == 0
+
+    def test_exit_code_0_fixes_no_warnings(self, tmp_path: Path):
+        """Exit code 0 when vias are resized but no clearance warnings are detected."""
+        # Via far from any other items -- no clearance issue after resize
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "isolated.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        output_file = tmp_path / "fixed.kicad_pcb"
+
+        result = main([str(pcb_file), "--mfr", "jlcpcb", "-o", str(output_file)])
+        assert result == 0
+
+    def test_exit_code_2_fixes_with_warnings(self, tmp_path: Path):
+        """Exit code 2 when vias are resized and clearance warnings are detected."""
+        # Via very close to a trace on a different net -- clearance warning expected
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (net 2 "+3.3V")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+          (segment (start 95 100.5) (end 105 100.5) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-1"))
+        )
+        """
+        pcb_file = tmp_path / "crowded.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        output_file = tmp_path / "fixed.kicad_pcb"
+
+        result = main([str(pcb_file), "--mfr", "jlcpcb", "-o", str(output_file)])
+        assert result == 2
+
+    def test_exit_code_1_file_not_found(self, tmp_path: Path):
+        """Exit code 1 for actual errors (file not found)."""
+        result = main([str(tmp_path / "nonexistent.kicad_pcb")])
+        assert result == 1
+
+    def test_exit_code_1_bad_extension(self, tmp_path: Path):
+        """Exit code 1 for unsupported file extension."""
+        bad_file = tmp_path / "board.txt"
+        bad_file.write_text("not a pcb")
+        result = main([str(bad_file)])
+        assert result == 1
+
+    def test_dry_run_exit_code_0_no_warnings(self, tmp_path: Path):
+        """Dry-run exit code is 0 when there are fixes but no clearance warnings."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "isolated_dry.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        result = main([str(pcb_file), "--mfr", "jlcpcb", "--dry-run"])
+        assert result == 0
+
+    def test_dry_run_exit_code_2_with_warnings(self, tmp_path: Path):
+        """Dry-run still returns exit code 2 when clearance warnings exist."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (net 2 "+3.3V")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+          (segment (start 95 100.5) (end 105 100.5) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-1"))
+        )
+        """
+        pcb_file = tmp_path / "crowded_dry.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        result = main([str(pcb_file), "--mfr", "jlcpcb", "--dry-run"])
+        assert result == 2

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -311,6 +311,37 @@ class TestExitCodes:
         result = main(["--step", "fix-vias", str(routed_pcb), "--quiet"])
         assert result == 0
 
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_fix_vias_exit_code_2_treated_as_success(self, mock_run, routed_pcb: Path):
+        """Pipeline treats fix-vias exit code 2 (warnings) as success, not failure."""
+        mock_run.return_value = MagicMock(returncode=2, stderr="", stdout="")
+
+        result = main(["--step", "fix-vias", str(routed_pcb), "--quiet"])
+        assert result == 0
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_pipeline_continues_past_fix_vias_warnings(self, mock_run, routed_pcb: Path):
+        """Pipeline continues to subsequent steps when fix-vias returns exit code 2."""
+
+        def side_effect(cmd, **kwargs):
+            # fix-vias returns exit code 2 (success with warnings)
+            if "fix-vias" in cmd:
+                return MagicMock(returncode=2, stderr="", stdout="")
+            # All other steps succeed normally
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        mock_run.side_effect = side_effect
+
+        # Run fix-vias and fix-drc steps together
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True)
+        results = run_pipeline(ctx, [PipelineStep.FIX_VIAS, PipelineStep.FIX_DRC])
+
+        # Both steps should have run and succeeded
+        assert len(results) == 2
+        assert results[0].success is True
+        assert "warnings" in results[0].message
+        assert results[1].success is True
+
 
 class TestProjectInput:
     """Tests for .kicad_pro input support."""


### PR DESCRIPTION
## Summary
Change `fix-vias` to return exit code 2 (not 1) when clearance warnings are detected after resizing vias. The pipeline's `_run_subprocess_step` already treats exit code 2 as "completed with warnings" and continues, so this single-line fix aligns fix-vias with the established convention and unblocks the pipeline.

## Changes
- `src/kicad_tools/cli/fix_vias_cmd.py`: Change `return 1 if warnings else 0` to `return 2 if warnings else 0` (line 571)
- `tests/test_fix_vias.py`: Add `TestExitCodeWarnings` class with 7 tests covering exit codes 0, 1, and 2 for various scenarios including dry-run
- `tests/test_pipeline_cmd.py`: Add 2 tests verifying pipeline treats fix-vias exit code 2 as success and continues to subsequent steps

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Exit code 0 when vias already compliant | Pass | `test_exit_code_0_no_fixes_needed` |
| Exit code 0 when vias resized with no warnings | Pass | `test_exit_code_0_fixes_no_warnings` |
| Exit code 2 when vias resized with clearance warnings | Pass | `test_exit_code_2_fixes_with_warnings` |
| Exit code 1 for actual errors (file not found, bad ext) | Pass | `test_exit_code_1_file_not_found`, `test_exit_code_1_bad_extension` |
| Pipeline continues past fix-vias when warnings exist | Pass | `test_pipeline_continues_past_fix_vias_warnings` |
| Pipeline treats exit code 2 as success | Pass | `test_fix_vias_exit_code_2_treated_as_success` |
| Dry-run unaffected (returns 0 or 2 based on warnings) | Pass | `test_dry_run_exit_code_0_no_warnings`, `test_dry_run_exit_code_2_with_warnings` |

## Test Plan
- 42 fix-vias tests pass (`uv run pytest tests/test_fix_vias.py` -- 42 passed)
- 32 pipeline tests pass (`uv run pytest tests/test_pipeline_cmd.py` -- 32 passed)
- Ruff lint and format checks pass on all changed files

Closes #1331