### PR TITLE
fix(report): render action items with priority labels instead of raw dicts

### DIFF
--- a/src/kicad_tools/report/templates/design_report.md.j2
+++ b/src/kicad_tools/report/templates/design_report.md.j2
@@ -107,7 +107,9 @@
 ### Action Items
 
 {% for item in audit.action_items %}
-- {{ item }}
+- **[{{ {1: 'CRITICAL', 2: 'IMPORTANT', 3: 'OPTIONAL'}.get(item.priority, 'INFO') }}]** {{ item.description }}
+{% if item.command %}  `{{ item.command }}`
+{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -63,7 +63,18 @@ def _full_data(**overrides) -> ReportData:
         },
         "audit": {
             "verdict": "ready",
-            "action_items": ["Review silkscreen placement"],
+            "action_items": [
+                {
+                    "priority": 1,
+                    "description": "Complete routing: 3 nets incomplete",
+                    "command": "kct validate connectivity board.kicad_pcb",
+                },
+                {
+                    "priority": 3,
+                    "description": "Review silkscreen placement",
+                    "command": None,
+                },
+            ],
         },
         "net_status": {
             "completion_percent": 95.5,
@@ -414,6 +425,85 @@ class TestReportGenerator:
         content = report_path.read_text(encoding="utf-8")
 
         assert "## Board Summary" not in content
+
+    def test_action_items_render_with_priority_labels(self, tmp_path: Path) -> None:
+        """Action items render with bold priority labels, not raw dict strings."""
+        data = _full_data(
+            audit={
+                "verdict": "not_ready",
+                "action_items": [
+                    {
+                        "priority": 1,
+                        "description": "Complete routing: 5 nets incomplete",
+                        "command": "kct validate connectivity board.kicad_pcb",
+                    },
+                    {
+                        "priority": 2,
+                        "description": "Fix DRC errors before manufacturing",
+                        "command": "kct drc board.kicad_pcb",
+                    },
+                    {
+                        "priority": 3,
+                        "description": "Review silkscreen placement",
+                        "command": None,
+                    },
+                ],
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        # Priority labels must appear as bold Markdown tags
+        assert "**[CRITICAL]** Complete routing: 5 nets incomplete" in content
+        assert "**[IMPORTANT]** Fix DRC errors before manufacturing" in content
+        assert "**[OPTIONAL]** Review silkscreen placement" in content
+
+        # Command must appear as inline code for items that have one
+        assert "`kct validate connectivity board.kicad_pcb`" in content
+        assert "`kct drc board.kicad_pcb`" in content
+
+        # Raw dict syntax must NOT appear
+        assert "{'priority'" not in content
+        assert "'description'" not in content
+
+        # No None literals (command=None must not render)
+        assert "None" not in content
+
+    def test_action_items_unknown_priority_renders_info(self, tmp_path: Path) -> None:
+        """An action item with an unrecognized priority renders as INFO."""
+        data = _full_data(
+            audit={
+                "verdict": "ready",
+                "action_items": [
+                    {
+                        "priority": 99,
+                        "description": "Some informational note",
+                        "command": None,
+                    },
+                ],
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "**[INFO]** Some informational note" in content
+
+    def test_empty_action_items_omits_subsection(self, tmp_path: Path) -> None:
+        """An empty action_items list means no Action Items subsection."""
+        data = _full_data(
+            audit={
+                "verdict": "ready",
+                "action_items": [],
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "## Manufacturing Readiness" in content
+        assert "### Action Items" not in content
 
 
 # ---------------------------------------------------------------------------
@@ -779,7 +869,13 @@ class TestReportCLI:
                 _envelope(
                     {
                         "verdict": "ready",
-                        "action_items": ["Review silkscreen"],
+                        "action_items": [
+                            {
+                                "priority": 3,
+                                "description": "Review silkscreen",
+                                "command": None,
+                            },
+                        ],
                     }
                 )
             )


### PR DESCRIPTION
## Summary

The `design_report.md.j2` template rendered action items as raw Python dict strings (e.g., `{'priority': 1, 'description': '...', 'command': '...'}`) because it used `{{ item }}` instead of accessing individual dict fields. This fix replaces the generic stringification with explicit field access and human-readable priority labels.

## Changes

- **Template fix** (`design_report.md.j2`): Replace `- {{ item }}` with dict-aware rendering that maps `item.priority` to bold labels (`**[CRITICAL]**`, `**[IMPORTANT]**`, `**[OPTIONAL]**`, or `**[INFO]**` for unknown), renders `item.description` as text, and conditionally shows `item.command` as an indented code span
- **Test fixture update** (`test_report_generator.py`): Update `_full_data()` fixture and `test_generate_with_data_dir_envelope` audit JSON to use dict-shaped action items matching the real `AuditResult.to_dict()` serialization format
- **New tests**: Add `test_action_items_render_with_priority_labels` (all three priority levels, command rendering, no raw dict strings, no None literals), `test_action_items_unknown_priority_renders_info` (fallback for unrecognized priority), and `test_empty_action_items_omits_subsection` (empty list omits the Action Items heading)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Template renders using priority, description, command fields | PASS | `test_action_items_render_with_priority_labels` asserts `**[CRITICAL]**`, `**[IMPORTANT]**`, `**[OPTIONAL]**` appear with correct descriptions |
| Priority 1->CRITICAL, 2->IMPORTANT, 3->OPTIONAL, unknown->INFO | PASS | Verified by `test_action_items_render_with_priority_labels` and `test_action_items_unknown_priority_renders_info` |
| Items with command show code span | PASS | Test asserts backtick-wrapped commands appear in output |
| Items without command (None) render no blank command line | PASS | Test asserts `"None" not in content` |
| Test fixture updated to dict-shaped items | PASS | `_full_data()` and envelope test both use `{priority, description, command}` dicts |
| New test asserts priority labels, not raw dict strings | PASS | `test_action_items_render_with_priority_labels` asserts `"{'priority'" not in content` |
| No regression on existing test_full_render | PASS | All 45 tests pass including original `test_full_render` |

## Test Plan

All 45 tests in `tests/test_report_generator.py` pass:
```
45 passed in 0.59s
```

Closes #1333