### PR TITLE
fix(report): align BOMGroup.to_dict() keys with Jinja2 template field names

### DIFF
--- a/src/kicad_tools/schema/bom.py
+++ b/src/kicad_tools/schema/bom.py
@@ -108,8 +108,8 @@ class BOMGroup:
         return {
             "value": self.value,
             "footprint": self.footprint,
-            "quantity": self.quantity,
-            "references": self.references,
+            "qty": self.quantity,
+            "refs": self.references,
             "description": self.description,
             "mpn": self.mpn,
             "lcsc": self.lcsc,

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -185,11 +185,11 @@ class TestCollectBOM:
         assert "groups" in bom_data
         assert isinstance(bom_data["groups"], list)
 
-        # Each group should have quantity and lcsc fields
+        # Each group should have qty and lcsc fields
         for group in bom_data["groups"]:
-            assert "quantity" in group
+            assert "qty" in group
             assert "lcsc" in group
-            assert "references" in group
+            assert "refs" in group
             assert "value" in group
             assert "footprint" in group
 
@@ -510,8 +510,8 @@ class TestBOMSerialization:
         group = BOMGroup(value="10k", footprint="R_0402", items=items)
         d = group.to_dict()
 
-        assert d["quantity"] == 2
-        assert "R1" in d["references"]
-        assert "R2" in d["references"]
+        assert d["qty"] == 2
+        assert "R1" in d["refs"]
+        assert "R2" in d["refs"]
         assert d["lcsc"] == "C25744"
         assert len(d["items"]) == 2


### PR DESCRIPTION
## Summary

BOM table in generated reports always showed empty Qty and References columns. The root cause was a key-name mismatch: `BOMGroup.to_dict()` emitted `quantity`/`references` but the Jinja2 template (`design_report.md.j2`) reads `qty`/`refs`. Because Jinja2 silently returns empty strings for undefined attributes (via `| default("", true)`), the mismatch produced a well-formed but empty table with no error.

## Changes

- Rename `BOMGroup.to_dict()` dict keys from `"quantity"` to `"qty"` and `"references"` to `"refs"` in `src/kicad_tools/schema/bom.py`
- Update corresponding test assertions in `tests/test_report_collector.py` (`TestCollectBOM` and `TestBOMSerialization`)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| BOMGroup.to_dict() keys and template variable names are in sync | PASS | `to_dict()` now emits `qty`/`refs` matching `item.qty`/`item.refs` in `design_report.md.j2` line 85 |
| Fix does not break kct bom or other BOMGroup.to_dict() consumers | PASS | `kct bom` uses `bom_cmd.py:group_items()` which builds its own dicts (not `BOMGroup.to_dict()`); no other source consumers reference the old keys |
| All existing report-related tests pass | PASS | `uv run pytest tests/test_report_collector.py tests/test_report_generator.py tests/test_mcp_bom.py` -- 86 passed |
| MPN and LCSC columns render values | PASS | `mpn`/`lcsc` keys were already consistent; the Jinja2 template reads them correctly |
| Existing test_report_cmd.py tests pass (no regression) | PASS | 15 passed, 11 pre-existing failures (all figure-generation related, same on main) |

## Test Plan

- `uv run pytest tests/test_report_collector.py -k bom -v` -- 3 passed
- `uv run pytest tests/test_report_generator.py -k bom -v` -- 1 passed
- `uv run pytest tests/test_report_collector.py tests/test_report_generator.py tests/test_mcp_bom.py -v` -- 86 passed
- `uv run ruff check` and `uv run ruff format --check` on modified files -- clean

Closes #1332