### PR TITLE
feat(pipeline): auto-detect copper layer count from PCB

### DIFF
--- a/src/kicad_tools/cli/commands/pipeline.py
+++ b/src/kicad_tools/cli/commands/pipeline.py
@@ -22,7 +22,7 @@ def run_pipeline_command(args) -> int:
         sub_argv.extend(["--mfr", args.pipeline_mfr])
 
     # Layers
-    if getattr(args, "pipeline_layers", 2) != 2:
+    if getattr(args, "pipeline_layers", None) is not None:
         sub_argv.extend(["--layers", str(args.pipeline_layers)])
 
     # Flags

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -75,7 +75,7 @@ class PipelineContext:
     pcb_file: Path
     project_file: Path | None = None
     mfr: str = "jlcpcb"
-    layers: int = 2
+    layers: int | None = None
     dry_run: bool = False
     verbose: bool = False
     quiet: bool = False
@@ -538,8 +538,8 @@ Examples:
         "--layers",
         "-l",
         type=int,
-        default=2,
-        help="Number of PCB layers (default: 2)",
+        default=None,
+        help="Number of copper layers (default: auto-detected from board)",
     )
     parser.add_argument(
         "--dry-run",
@@ -601,12 +601,29 @@ Examples:
         )
         return 1
 
+    # Resolve layer count from PCB when not explicitly specified
+    if args.layers is not None:
+        resolved_layers = args.layers
+    else:
+        try:
+            from kicad_tools.schema.pcb import PCB
+
+            pcb = PCB.load(pcb_file)
+            detected = len(pcb.copper_layers)
+            resolved_layers = detected if detected > 0 else 2
+        except Exception:
+            logger.warning(
+                "Could not auto-detect layer count from %s; defaulting to 2",
+                pcb_file.name,
+            )
+            resolved_layers = 2
+
     # Build context
     ctx = PipelineContext(
         pcb_file=pcb_file,
         project_file=project_file,
         mfr=args.mfr,
-        layers=args.layers,
+        layers=resolved_layers,
         dry_run=args.dry_run,
         verbose=args.verbose,
         quiet=args.quiet,

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -430,6 +430,105 @@ class TestPipelineStepOrder:
         assert expected == ALL_STEPS
 
 
+class TestPipelineLayerAutoDetection:
+    """Tests for automatic copper layer count detection in pipeline."""
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_auto_detect_4_layer_board(self, mock_run, four_layer_pcb: Path):
+        """4-layer PCB with no --layers flag passes --layers 4 to fix-vias subprocess."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        main(["--step", "fix-vias", str(four_layer_pcb), "--quiet"])
+
+        cmd_args = mock_run.call_args[0][0]
+        assert "--layers" in cmd_args
+        layers_idx = cmd_args.index("--layers")
+        assert cmd_args[layers_idx + 1] == "4"
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_auto_detect_2_layer_board_no_regression(self, mock_run, routed_pcb: Path):
+        """2-layer PCB with no --layers flag passes --layers 2 (unchanged behavior)."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        main(["--step", "fix-vias", str(routed_pcb), "--quiet"])
+
+        cmd_args = mock_run.call_args[0][0]
+        assert "--layers" in cmd_args
+        layers_idx = cmd_args.index("--layers")
+        assert cmd_args[layers_idx + 1] == "2"
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_explicit_layers_overrides_detection(self, mock_run, four_layer_pcb: Path):
+        """--layers 2 on a 4-layer PCB passes --layers 2 (explicit wins)."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        main(["--step", "fix-vias", "--layers", "2", str(four_layer_pcb), "--quiet"])
+
+        cmd_args = mock_run.call_args[0][0]
+        assert "--layers" in cmd_args
+        layers_idx = cmd_args.index("--layers")
+        assert cmd_args[layers_idx + 1] == "2"
+
+    def test_dry_run_shows_correct_layer_count(self, four_layer_pcb: Path, capsys):
+        """Dry-run on 4-layer board displays 4 layers in output, not 2 layers."""
+        result = main(["--dry-run", str(four_layer_pcb)])
+        assert result == 0
+
+        # The dry-run fix-vias message includes --layers N
+        captured = capsys.readouterr()
+        assert "--layers 4" in captured.out
+
+    def test_help_text_mentions_auto_detection(self, capsys):
+        """kct pipeline --help text includes 'auto-detect'."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--help"])
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "auto-detect" in captured.out.lower()
+
+    def test_commands_shim_passes_none_sentinel(self):
+        """commands/pipeline.py passes --layers when pipeline_layers is not None,
+        does not pass it when None."""
+        from kicad_tools.cli.commands.pipeline import run_pipeline_command
+
+        # When pipeline_layers is None (default), --layers should NOT be forwarded
+        args_none = MagicMock()
+        args_none.pipeline_input = "test.kicad_pcb"
+        args_none.pipeline_step = None
+        args_none.pipeline_mfr = "jlcpcb"
+        args_none.pipeline_layers = None
+        args_none.pipeline_dry_run = False
+        args_none.pipeline_verbose = False
+        args_none.pipeline_force = False
+        args_none.global_quiet = False
+
+        with patch("kicad_tools.cli.pipeline_cmd.main", return_value=0) as mock_main:
+            run_pipeline_command(args_none)
+
+        call_argv = mock_main.call_args[0][0]
+        assert "--layers" not in call_argv
+
+        # When pipeline_layers is set (e.g., 4), --layers should be forwarded
+        args_explicit = MagicMock()
+        args_explicit.pipeline_input = "test.kicad_pcb"
+        args_explicit.pipeline_step = None
+        args_explicit.pipeline_mfr = "jlcpcb"
+        args_explicit.pipeline_layers = 4
+        args_explicit.pipeline_dry_run = False
+        args_explicit.pipeline_verbose = False
+        args_explicit.pipeline_force = False
+        args_explicit.global_quiet = False
+
+        with patch("kicad_tools.cli.pipeline_cmd.main", return_value=0) as mock_main:
+            run_pipeline_command(args_explicit)
+
+        call_argv = mock_main.call_args[0][0]
+        assert "--layers" in call_argv
+        layers_idx = call_argv.index("--layers")
+        assert call_argv[layers_idx + 1] == "4"
+
+
 class TestEdgeCases:
     """Tests for edge cases."""
 


### PR DESCRIPTION
## Summary

The pipeline command hardcoded `--layers 2` as the default, silently applying 2-layer manufacturer rules to multi-layer boards. This changes the default to `None` and auto-detects the layer count from `pcb.copper_layers`, matching the pattern already used in `check_cmd.py`.

## Changes

- Change `--layers` parser default from `2` to `None` in `pipeline_cmd.py`
- Update `PipelineContext.layers` type from `int` to `int | None`
- Add auto-detection block that reads `pcb.copper_layers` before constructing `PipelineContext`, with try/except fallback to 2
- Update help text to mention auto-detection
- Fix dispatch shim in `commands/pipeline.py`: change sentinel comparison from `!= 2` to `is not None` so explicit `--layers 2` is forwarded correctly

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 4-layer PCB auto-detects 4 layers | PASS | `test_auto_detect_4_layer_board` passes --layers 4 to fix-vias |
| 2-layer PCB still defaults to 2 layers | PASS | `test_auto_detect_2_layer_board_no_regression` |
| Explicit --layers overrides detection | PASS | `test_explicit_layers_overrides_detection` |
| Dry-run shows correct layer count | PASS | `test_dry_run_shows_correct_layer_count` |
| Help text mentions auto-detection | PASS | `test_help_text_mentions_auto_detection` |
| Commands shim uses None sentinel | PASS | `test_commands_shim_passes_none_sentinel` |
| All existing tests pass | PASS | 30 existing tests + 6 new = 36 total, all pass |

## Test Plan

All 36 tests pass (`uv run pytest tests/test_pipeline_cmd.py`):
- 30 existing tests: no regressions
- 6 new tests in `TestPipelineLayerAutoDetection` class

Closes #1330