### PR TITLE
fix(report): catch OSError from missing native cairo library during figure generation

### DIFF
--- a/src/kicad_tools/cli/report_cmd.py
+++ b/src/kicad_tools/cli/report_cmd.py
@@ -198,9 +198,12 @@ def _generate_figures(
         entries = fig_gen.generate_all(input_path, sch_path, figures_dir)
         data.pcb_figures = _entries_to_pcb_figures(entries)
         data.schematic_sheets = _entries_to_schematic_sheets(entries)
-    except RuntimeError as exc:
+    except (RuntimeError, OSError) as exc:
+        hint = ""
+        if isinstance(exc, OSError) and "cairo" in str(exc).lower():
+            hint = " (hint: on macOS set DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib)"
         print(
-            f"Warning: figure generation skipped — {exc}",
+            f"Warning: figure generation skipped — {exc}{hint}",
             file=sys.stderr,
         )
 

--- a/src/kicad_tools/mcp/tools/screenshot.py
+++ b/src/kicad_tools/mcp/tools/screenshot.py
@@ -37,12 +37,23 @@ KICAD_INSTALL_URL = "https://www.kicad.org/download/"
 
 
 def _check_cairosvg() -> bool:
-    """Check if cairosvg is available."""
-    try:
-        import cairosvg  # noqa: F401
+    """Check if cairosvg is available and the native cairo library is loadable.
 
+    A bare ``import cairosvg`` succeeds even when the underlying C library
+    (``libcairo``) is missing from the dynamic linker's search path.  The
+    ``OSError`` only fires when ``cairosvg`` actually tries to call into the
+    native library.  We therefore do a lightweight probe render to surface
+    that failure early, before any real work begins.
+    """
+    try:
+        import cairosvg
+
+        # Probe: calling svg2png with a trivial SVG document exposes a
+        # missing native cairo library (raises OSError on macOS/Linux when
+        # libcairo is not on the dynamic linker path).
+        cairosvg.svg2png(bytestring=b"<svg xmlns='http://www.w3.org/2000/svg'/>")
         return True
-    except ImportError:
+    except (ImportError, OSError):
         return False
 
 

--- a/tests/test_report_cmd.py
+++ b/tests/test_report_cmd.py
@@ -316,6 +316,67 @@ class TestGracefulDegradation:
         assert "## PCB Layout" not in content
         assert "## Schematic Overview" not in content
 
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_os_error_cairo_missing_prints_warning_with_hint(self, mock_gen_cls, tmp_path, capsys):
+        """When native cairo library is missing (OSError), CLI prints warning
+        with macOS hint and continues without figures."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.side_effect = OSError('no library called "cairo-2" was found')
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                "board.kicad_pcb",
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(output_dir),
+                "--skip-collect",
+            ]
+        )
+
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Warning: figure generation skipped" in captured.err
+        assert 'no library called "cairo-2" was found' in captured.err
+        assert "DYLD_FALLBACK_LIBRARY_PATH" in captured.err
+
+        # Report should still be generated
+        report_path = output_dir / "v1" / "report.md"
+        assert report_path.exists()
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_os_error_non_cairo_prints_warning_without_hint(self, mock_gen_cls, tmp_path, capsys):
+        """When a non-cairo OSError occurs, CLI prints warning without macOS hint."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.side_effect = OSError("disk full")
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                "board.kicad_pcb",
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(output_dir),
+                "--skip-collect",
+            ]
+        )
+
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Warning: figure generation skipped" in captured.err
+        assert "disk full" in captured.err
+        assert "DYLD_FALLBACK_LIBRARY_PATH" not in captured.err
+
+        # Report should still be generated
+        report_path = output_dir / "v1" / "report.md"
+        assert report_path.exists()
+
 
 class TestFiguresInVersionDir:
     """Tests verifying that figures land in the correct versioned directory."""

--- a/tests/test_report_figures.py
+++ b/tests/test_report_figures.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -251,6 +252,46 @@ class TestMissingDependencies:
                 tmp_path / "main.kicad_sch",
                 tmp_path / "out",
             )
+
+
+class TestCheckCairosvgProbe:
+    """Tests for _check_cairosvg() native library probe."""
+
+    def test_returns_false_when_svg2png_raises_os_error(self):
+        """_check_cairosvg() returns False when cairosvg.svg2png raises OSError
+        (native cairo library missing)."""
+        import types
+
+        fake_cairosvg = types.ModuleType("cairosvg")
+
+        def _raise_os_error(**kwargs):
+            raise OSError('no library called "cairo-2" was found')
+
+        fake_cairosvg.svg2png = _raise_os_error
+
+        with patch.dict(sys.modules, {"cairosvg": fake_cairosvg}):
+            from kicad_tools.mcp.tools.screenshot import _check_cairosvg
+
+            assert _check_cairosvg() is False
+
+    def test_returns_false_when_import_fails(self):
+        """_check_cairosvg() returns False when cairosvg cannot be imported."""
+        with patch.dict(sys.modules, {"cairosvg": None}):
+            from kicad_tools.mcp.tools.screenshot import _check_cairosvg
+
+            assert _check_cairosvg() is False
+
+    def test_returns_true_when_probe_succeeds(self):
+        """_check_cairosvg() returns True when cairosvg.svg2png succeeds."""
+        import types
+
+        fake_cairosvg = types.ModuleType("cairosvg")
+        fake_cairosvg.svg2png = lambda **kwargs: b"\x89PNG"
+
+        with patch.dict(sys.modules, {"cairosvg": fake_cairosvg}):
+            from kicad_tools.mcp.tools.screenshot import _check_cairosvg
+
+            assert _check_cairosvg() is True
 
 
 class TestMultiSheetSchematics:


### PR DESCRIPTION
## Summary
When cairosvg is installed but the native libcairo C library is missing from the dynamic linker path, `cairosvg.svg2png()` raises an `OSError` that was not caught, crashing the CLI. This PR adds defence-in-depth: a probe render in `_check_cairosvg()` catches the failure early, and `_generate_figures()` now catches `OSError` alongside `RuntimeError` so the report CLI degrades gracefully with a warning.

## Changes
- **`src/kicad_tools/mcp/tools/screenshot.py`**: Extended `_check_cairosvg()` to call `cairosvg.svg2png()` with a minimal SVG, catching `OSError` alongside `ImportError` so a missing native library is detected at probe time.
- **`src/kicad_tools/cli/report_cmd.py`**: Widened the except clause in `_generate_figures()` from `RuntimeError` to `(RuntimeError, OSError)`. When the OSError message contains "cairo", an actionable macOS hint about `DYLD_FALLBACK_LIBRARY_PATH` is appended.
- **`tests/test_report_cmd.py`**: Added two tests to `TestGracefulDegradation` -- one verifying `OSError` with a cairo message shows the macOS hint, one verifying a non-cairo `OSError` omits the hint. Both verify exit code 0 and report file generation.
- **`tests/test_report_figures.py`**: Added `TestCheckCairosvgProbe` class with three tests -- `svg2png` raising `OSError` returns `False`, import failure returns `False`, successful probe returns `True`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| CLI exits 0 when native cairo missing | Pass | `test_os_error_cairo_missing_prints_warning_with_hint` asserts `result == 0` |
| Warning printed to stderr | Pass | Test asserts "Warning: figure generation skipped" in stderr |
| Report file still generated | Pass | Test asserts `report.md` exists after OSError |
| `--no-figures` unchanged | Pass | Pre-existing `test_no_figures_flag_skips_generation` still passes |
| No regression in existing TestGracefulDegradation | Pass | Pre-existing tests unchanged; new tests added alongside |
| macOS hint in warning when error contains "cairo" | Pass | `test_os_error_cairo_missing_prints_warning_with_hint` asserts `DYLD_FALLBACK_LIBRARY_PATH` in stderr |
| No hint for non-cairo OSError | Pass | `test_os_error_non_cairo_prints_warning_without_hint` asserts `DYLD_FALLBACK_LIBRARY_PATH` not in stderr |
| `_check_cairosvg()` returns False on OSError | Pass | `test_returns_false_when_svg2png_raises_os_error` |

## Test Plan
- All 5 new tests pass: `uv run pytest tests/test_report_cmd.py::TestGracefulDegradation::test_os_error_cairo_missing_prints_warning_with_hint tests/test_report_cmd.py::TestGracefulDegradation::test_os_error_non_cairo_prints_warning_without_hint tests/test_report_figures.py::TestCheckCairosvgProbe --no-cov -v`
- All 18 tests in `test_report_figures.py` pass (15 pre-existing + 3 new)
- All 17 passing tests in `test_report_cmd.py` pass (15 pre-existing + 2 new); 11 pre-existing failures are unrelated (auto-collect path missing `--skip-collect`)
- Ruff lint and format checks pass on all changed files

Closes #1335