### PR TITLE
feat(report): add collect_cost sub-collector and normalise field names

### DIFF
--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -1,6 +1,6 @@
 """Data snapshot collection for report generation.
 
-Gathers board summary, DRC, BOM, audit, net connectivity, and analysis
+Gathers board summary, DRC, BOM, audit, cost, net connectivity, and analysis
 results into JSON snapshots. Each sub-collector is fault-tolerant: failures
 produce a warning log and null result rather than propagating exceptions.
 
@@ -76,9 +76,9 @@ class ReportDataCollector:
     def collect_all(self, output_dir: Path) -> dict[str, Path]:
         """Run all collectors, write JSON files, return mapping of name to path.
 
-        Runs ManufacturingAudit once and reuses the result for both DRC and
-        audit snapshots. Each sub-collector is wrapped in try/except so a
-        failure in one does not prevent the others from running.
+        Runs ManufacturingAudit once and reuses the result for DRC, audit,
+        and cost snapshots. Each sub-collector is wrapped in try/except so
+        a failure in one does not prevent the others from running.
 
         Args:
             output_dir: Directory to write JSON snapshot files into.
@@ -109,7 +109,8 @@ class ReportDataCollector:
             audit_result = audit.run()
         except Exception:
             logger.warning(
-                "ManufacturingAudit failed; DRC and audit snapshots will be null", exc_info=True
+                "ManufacturingAudit failed; DRC, audit, and cost snapshots will be null",
+                exc_info=True,
             )
 
         # Board summary
@@ -158,6 +159,14 @@ class ReportDataCollector:
             output_dir,
             files,
             lambda: self.collect_audit(audit_result),
+        )
+
+        # Cost (from audit result, with field names normalised for template)
+        self._safe_collect(
+            "cost",
+            output_dir,
+            files,
+            lambda: self.collect_cost(audit_result),
         )
 
         # Net status
@@ -280,6 +289,33 @@ class ReportDataCollector:
         if audit_result is None:
             return None
         return audit_result.to_dict()
+
+    def collect_cost(self, audit_result: AuditResult | None) -> dict[str, Any] | None:
+        """Extract and normalise cost data from a pre-run AuditResult.
+
+        The template expects keys ``per_unit``, ``batch_qty``,
+        ``batch_total``, and ``currency``.  ``CostEstimate.to_dict()``
+        produces ``pcb_cost``, ``quantity``, ``total_cost``, and
+        ``currency``, so this method maps between the two schemas.
+
+        Args:
+            audit_result: Result from ManufacturingAudit.run(), or None if
+                the audit failed.
+
+        Returns:
+            Normalised cost dictionary for the template, or None if
+            audit_result is None.
+        """
+        if audit_result is None:
+            return None
+        ce = audit_result.cost
+        per_unit = round(ce.total_cost / ce.quantity, 2) if ce.quantity else 0.0
+        return {
+            "per_unit": per_unit,
+            "batch_qty": ce.quantity,
+            "batch_total": round(ce.total_cost, 2),
+            "currency": ce.currency,
+        }
 
     def collect_net_status(self, pcb: Any) -> dict[str, Any]:
         """Routing completion summary.

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -3,6 +3,7 @@
 Tests cover:
 - Board summary collection (layers, footprints, nets, traces, vias, dimensions)
 - DRC collection from AuditResult
+- Cost collection from AuditResult (field normalisation for template)
 - BOM collection from schematic
 - Net status collection
 - Analysis collection (congestion, SI, thermal)
@@ -231,6 +232,64 @@ class TestCollectERC:
 
 
 # ---------------------------------------------------------------------------
+# Unit tests - cost collect
+# ---------------------------------------------------------------------------
+
+
+class TestCollectCost:
+    """Tests for collect_cost."""
+
+    def test_collect_cost_from_audit_result(self):
+        """Cost data has all four template-expected keys with correct values."""
+        audit_result = _make_mock_audit_result()
+        collector = ReportDataCollector(Path("dummy.kicad_pcb"))
+        cost = collector.collect_cost(audit_result)
+
+        assert cost is not None
+        assert set(cost.keys()) == {"per_unit", "batch_qty", "batch_total", "currency"}
+        # mock: total_cost=5.0, quantity=5 => per_unit=1.0
+        assert cost["per_unit"] == 1.0
+        assert cost["batch_qty"] == 5
+        assert cost["batch_total"] == 5.0
+        assert cost["currency"] == "USD"
+
+    def test_collect_cost_returns_none_when_no_audit(self):
+        """collect_cost returns None when audit_result is None."""
+        collector = ReportDataCollector(Path("dummy.kicad_pcb"))
+        assert collector.collect_cost(None) is None
+
+    def test_collect_cost_quantity_zero_no_division_error(self):
+        """quantity=0 produces per_unit=0.0 instead of ZeroDivisionError."""
+        from kicad_tools.audit.auditor import AuditResult, CostEstimate
+
+        audit_result = AuditResult(
+            project_name="test",
+            cost=CostEstimate(pcb_cost=10.0, total_cost=10.0, quantity=0),
+        )
+        collector = ReportDataCollector(Path("dummy.kicad_pcb"))
+        cost = collector.collect_cost(audit_result)
+
+        assert cost is not None
+        assert cost["per_unit"] == 0.0
+        assert cost["batch_qty"] == 0
+        assert cost["batch_total"] == 10.0
+
+    def test_collect_cost_rounds_per_unit(self):
+        """per_unit is rounded to 2 decimal places."""
+        from kicad_tools.audit.auditor import AuditResult, CostEstimate
+
+        audit_result = AuditResult(
+            project_name="test",
+            cost=CostEstimate(pcb_cost=10.0, total_cost=10.0, quantity=3),
+        )
+        collector = ReportDataCollector(Path("dummy.kicad_pcb"))
+        cost = collector.collect_cost(audit_result)
+
+        # 10.0 / 3 = 3.333... -> rounded to 3.33
+        assert cost["per_unit"] == 3.33
+
+
+# ---------------------------------------------------------------------------
 # Unit tests - BOM collect
 # ---------------------------------------------------------------------------
 
@@ -443,6 +502,7 @@ class TestCollectAllIntegration:
             "drc_summary",
             "erc_summary",
             "audit",
+            "cost",
             "net_status",
             "analysis",
         }
@@ -450,6 +510,28 @@ class TestCollectAllIntegration:
         for name in expected_names:
             assert name in files, f"Missing file: {name}"
             assert files[name].exists(), f"File not on disk: {name}"
+
+    def test_cost_json_has_normalised_keys(self, tmp_path):
+        """cost.json contains per_unit, batch_qty, batch_total, currency."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        collector = ReportDataCollector(pcb_path, skip_erc=True)
+        files = collector.collect_all(tmp_path)
+
+        assert "cost" in files, "cost.json not written by collect_all"
+        with open(files["cost"]) as f:
+            envelope = json.load(f)
+
+        cost_data = envelope["data"]
+        # cost_data may be None if the cost estimator returned defaults,
+        # but the dict itself should be present and have the right shape.
+        assert cost_data is not None, "cost data should not be null for a valid audit"
+        assert "per_unit" in cost_data
+        assert "batch_qty" in cost_data
+        assert "batch_total" in cost_data
+        assert "currency" in cost_data
 
     def test_json_validity(self, tmp_path):
         """All written files are valid JSON."""


### PR DESCRIPTION
## Summary

`ReportDataCollector.collect_all()` never extracted cost data from the shared `AuditResult` into a separate `cost.json` snapshot, leaving `ReportData.cost` always `None` and the template's Cost Estimate section permanently hidden. Additionally, `CostEstimate.to_dict()` field names (`pcb_cost`, `quantity`, `total_cost`) did not match the template's expected keys (`per_unit`, `batch_qty`, `batch_total`).

## Changes

- Added `collect_cost(audit_result)` method to `ReportDataCollector` that extracts cost data from `AuditResult.cost` and normalises field names to match the template schema
- Wired `_safe_collect("cost", ...)` into `collect_all()` after the audit collection, following the existing fault-tolerant pattern
- Handles `quantity=0` edge case (returns `per_unit=0.0` instead of raising `ZeroDivisionError`)
- Updated docstrings and log messages to mention cost alongside DRC and audit

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `collect_all()` writes a `cost.json` file alongside `audit.json` | Pass | `test_writes_expected_files` now asserts `"cost" in files`; `test_cost_json_has_normalised_keys` reads the file |
| `cost.json` contains keys `per_unit`, `batch_qty`, `batch_total`, and `currency` | Pass | `test_collect_cost_from_audit_result` checks exact key set; `test_cost_json_has_normalised_keys` checks integration |
| When `ManufacturingAudit` fails, `cost.json` is written with `data: null` | Pass | Uses `_safe_collect` pattern which writes `data: null` on failure |
| No regression: `test_full_render` continues to assert `## Cost Estimate` in content | Pass | Ran `test_full_render` -- passes |

## Test Plan

- `TestCollectCost::test_collect_cost_from_audit_result` -- verifies all four keys with correct values
- `TestCollectCost::test_collect_cost_returns_none_when_no_audit` -- verifies None when audit_result is None
- `TestCollectCost::test_collect_cost_quantity_zero_no_division_error` -- edge case for zero quantity
- `TestCollectCost::test_collect_cost_rounds_per_unit` -- verifies rounding to 2 decimal places
- `TestCollectAllIntegration::test_writes_expected_files` -- updated to include "cost" in expected set
- `TestCollectAllIntegration::test_cost_json_has_normalised_keys` -- new integration test for cost.json content
- All 25 tests in `test_report_collector.py` pass; `test_full_render` in `test_report_generator.py` passes

Closes #1338