### PR TITLE
fix(report): show incomplete nets and unconnected pads in routing status

### DIFF
--- a/src/kicad_tools/cli/report_cmd.py
+++ b/src/kicad_tools/cli/report_cmd.py
@@ -327,12 +327,6 @@ def _load_data_dir(data_dir_str: str) -> dict:
     if "bom_groups" in result and isinstance(result["bom_groups"], dict):
         result["bom_groups"] = result["bom_groups"].get("groups", [])
 
-    # net_status: collector writes ``completion_pct`` but the template
-    # reads ``completion_percent``.
-    ns = result.get("net_status")
-    if isinstance(ns, dict) and "completion_pct" in ns:
-        ns["completion_percent"] = ns.pop("completion_pct")
-
     # Load notes from text file
     notes_path = data_dir / "notes.txt"
     if notes_path.exists():

--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -317,6 +317,9 @@ class ReportDataCollector:
             "currency": ce.currency,
         }
 
+    # Maximum number of incomplete net names included in the snapshot.
+    _INCOMPLETE_NET_NAMES_CAP = 50
+
     def collect_net_status(self, pcb: Any) -> dict[str, Any]:
         """Routing completion summary.
 
@@ -324,17 +327,23 @@ class ReportDataCollector:
             pcb: Loaded PCB object.
 
         Returns:
-            Dictionary with net status data including totals and completion
-            percentage.
+            Dictionary with net status data including totals, completion
+            percentage, and names of incomplete/unrouted nets.
         """
         from kicad_tools.analysis.net_status import NetStatusAnalyzer
 
         analyzer = NetStatusAnalyzer(pcb)
         result = analyzer.analyze()
 
-        completion_pct = 0.0
+        completion_percent = 0.0
         if result.total_nets > 0:
-            completion_pct = round(100.0 * result.complete_count / result.total_nets, 1)
+            completion_percent = round(100.0 * result.complete_count / result.total_nets, 1)
+
+        # Collect names of nets that are not fully routed (incomplete or unrouted),
+        # sorted alphabetically and capped to keep JSON snapshots manageable.
+        incomplete_net_names = sorted(n.net_name for n in result.nets if n.status != "complete")[
+            : self._INCOMPLETE_NET_NAMES_CAP
+        ]
 
         return {
             "total_nets": result.total_nets,
@@ -342,7 +351,8 @@ class ReportDataCollector:
             "incomplete_count": result.incomplete_count,
             "unrouted_count": result.unrouted_count,
             "total_unconnected_pads": result.total_unconnected_pads,
-            "completion_pct": completion_pct,
+            "completion_percent": completion_percent,
+            "incomplete_net_names": incomplete_net_names,
         }
 
     def collect_analysis(self, pcb: Any) -> dict[str, Any]:

--- a/src/kicad_tools/report/models.py
+++ b/src/kicad_tools/report/models.py
@@ -38,7 +38,9 @@ class ReportData:
     """Audit results: {verdict, action_items}."""
 
     net_status: dict | None = None
-    """Net completion: {completion_percent, unrouted_count, unrouted_nets}."""
+    """Net completion: {total_nets, complete_count, incomplete_count,
+    unrouted_count, total_unconnected_pads, completion_percent,
+    incomplete_net_names}."""
 
     cost: dict | None = None
     """Cost estimate: {per_unit, batch_qty, batch_total, currency}."""

--- a/src/kicad_tools/report/templates/design_report.md.j2
+++ b/src/kicad_tools/report/templates/design_report.md.j2
@@ -135,12 +135,14 @@
 | Metric | Value |
 |--------|-------|
 | Completion | {{ net_status.completion_percent | default(0) }}% |
-| Unrouted Nets | {{ net_status.unrouted_count | default(0) }} |
+| Complete Nets | {{ net_status.complete_count | default(0) }} / {{ net_status.total_nets | default(0) }} |
+| Incomplete Nets | {{ net_status.incomplete_count | default(0) }} |
+| Unconnected Pads | {{ net_status.total_unconnected_pads | default(0) }} |
 
-{% if net_status.unrouted_nets is defined and net_status.unrouted_nets %}
-### Unrouted Nets
+{% if net_status.incomplete_net_names is defined and net_status.incomplete_net_names %}
+### Incomplete Nets
 
-{% for net in net_status.unrouted_nets %}
+{% for net in net_status.incomplete_net_names %}
 - {{ net }}
 {% endfor %}
 {% endif %}

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -330,7 +330,7 @@ class TestCollectNetStatus:
     """Tests for collect_net_status."""
 
     def test_returns_expected_keys(self):
-        """Net status returns total_nets, complete_count, completion_pct."""
+        """Net status returns total_nets, complete_count, completion_percent, etc."""
         pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
         if not pcb_path.exists():
             pytest.skip("test_project.kicad_pcb fixture not found")
@@ -346,9 +346,12 @@ class TestCollectNetStatus:
         assert "incomplete_count" in status
         assert "unrouted_count" in status
         assert "total_unconnected_pads" in status
-        assert "completion_pct" in status
+        assert "completion_percent" in status
+        assert "incomplete_net_names" in status
+        # The old key must not appear
+        assert "completion_pct" not in status
 
-    def test_completion_pct_range(self):
+    def test_completion_percent_range(self):
         """Completion percentage is between 0 and 100."""
         pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
         if not pcb_path.exists():
@@ -360,7 +363,26 @@ class TestCollectNetStatus:
         collector = ReportDataCollector(pcb_path)
         status = collector.collect_net_status(pcb)
 
-        assert 0.0 <= status["completion_pct"] <= 100.0
+        assert 0.0 <= status["completion_percent"] <= 100.0
+
+    def test_incomplete_net_names_is_sorted_list(self):
+        """incomplete_net_names is a sorted list of strings."""
+        pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
+        if not pcb_path.exists():
+            pytest.skip("test_project.kicad_pcb fixture not found")
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(pcb_path)
+        collector = ReportDataCollector(pcb_path)
+        status = collector.collect_net_status(pcb)
+
+        names = status["incomplete_net_names"]
+        assert isinstance(names, list)
+        # All entries are strings
+        assert all(isinstance(n, str) for n in names)
+        # List is sorted
+        assert names == sorted(names)
 
 
 # ---------------------------------------------------------------------------
@@ -612,7 +634,134 @@ class TestEdgeCases:
         status = collector.collect_net_status(pcb)
 
         assert status["total_nets"] >= 0
-        assert status["completion_pct"] >= 0.0
+        assert status["completion_percent"] >= 0.0
+        assert status["incomplete_net_names"] == []
+
+
+# ---------------------------------------------------------------------------
+# Net status scenarios (mocked NetStatusAnalyzer)
+# ---------------------------------------------------------------------------
+
+
+def _make_net_status_result(complete_names, incomplete_names, unrouted_names):
+    """Build a mock NetStatusResult with the given net name lists."""
+    from kicad_tools.analysis.net_status import NetStatus, NetStatusResult
+
+    nets = []
+    for name in complete_names:
+        ns = NetStatus(net_number=len(nets) + 1, net_name=name, total_pads=2)
+        ns.connected_pads = [object(), object()]  # two connected pads
+        nets.append(ns)
+    for name in incomplete_names:
+        ns = NetStatus(net_number=len(nets) + 1, net_name=name, total_pads=3)
+        ns.connected_pads = [object()]  # one connected
+        ns.unconnected_pads = [object(), object()]  # two unconnected
+        nets.append(ns)
+    for name in unrouted_names:
+        ns = NetStatus(net_number=len(nets) + 1, net_name=name, total_pads=2)
+        # No connected pads, two unconnected
+        ns.unconnected_pads = [object(), object()]
+        nets.append(ns)
+
+    result = NetStatusResult(nets=nets, total_nets=len(nets))
+    return result
+
+
+class TestCollectNetStatusScenarios:
+    """Tests for collect_net_status with controlled scenarios."""
+
+    def test_incomplete_only_scenario(self, tmp_path):
+        """Board with incomplete nets and 0 unrouted shows correct counts."""
+        mock_result = _make_net_status_result(
+            complete_names=["GND", "VCC"],
+            incomplete_names=["SDA", "SCL", "MOSI"],
+            unrouted_names=[],
+        )
+        pcb_path = tmp_path / "dummy.kicad_pcb"
+        pcb_path.touch()
+        collector = ReportDataCollector(pcb_path)
+
+        with patch(
+            "kicad_tools.analysis.net_status.NetStatusAnalyzer.analyze",
+            return_value=mock_result,
+        ):
+            status = collector.collect_net_status(None)
+
+        assert status["incomplete_count"] == 3
+        assert status["unrouted_count"] == 0
+        assert status["complete_count"] == 2
+        assert status["total_nets"] == 5
+        assert status["completion_percent"] == 40.0  # 2/5 = 40%
+        assert status["incomplete_net_names"] == ["MOSI", "SCL", "SDA"]
+
+    def test_mixed_incomplete_and_unrouted(self, tmp_path):
+        """Board with both incomplete and unrouted nets."""
+        mock_result = _make_net_status_result(
+            complete_names=["GND"],
+            incomplete_names=["SDA", "SCL"],
+            unrouted_names=["RESET"],
+        )
+        pcb_path = tmp_path / "dummy.kicad_pcb"
+        pcb_path.touch()
+        collector = ReportDataCollector(pcb_path)
+
+        with patch(
+            "kicad_tools.analysis.net_status.NetStatusAnalyzer.analyze",
+            return_value=mock_result,
+        ):
+            status = collector.collect_net_status(None)
+
+        assert status["incomplete_count"] == 2
+        assert status["unrouted_count"] == 1
+        assert status["complete_count"] == 1
+        # incomplete_net_names includes both incomplete and unrouted
+        assert status["incomplete_net_names"] == ["RESET", "SCL", "SDA"]
+
+    def test_fully_routed_scenario(self, tmp_path):
+        """Board with all nets complete produces empty incomplete_net_names."""
+        mock_result = _make_net_status_result(
+            complete_names=["GND", "VCC", "+3V3"],
+            incomplete_names=[],
+            unrouted_names=[],
+        )
+        pcb_path = tmp_path / "dummy.kicad_pcb"
+        pcb_path.touch()
+        collector = ReportDataCollector(pcb_path)
+
+        with patch(
+            "kicad_tools.analysis.net_status.NetStatusAnalyzer.analyze",
+            return_value=mock_result,
+        ):
+            status = collector.collect_net_status(None)
+
+        assert status["incomplete_count"] == 0
+        assert status["unrouted_count"] == 0
+        assert status["complete_count"] == 3
+        assert status["completion_percent"] == 100.0
+        assert status["incomplete_net_names"] == []
+
+    def test_incomplete_net_names_capped(self, tmp_path):
+        """incomplete_net_names is capped at _INCOMPLETE_NET_NAMES_CAP."""
+        # Create more incomplete nets than the cap
+        incomplete_names = [f"NET_{i:03d}" for i in range(70)]
+        mock_result = _make_net_status_result(
+            complete_names=[],
+            incomplete_names=incomplete_names,
+            unrouted_names=[],
+        )
+        pcb_path = tmp_path / "dummy.kicad_pcb"
+        pcb_path.touch()
+        collector = ReportDataCollector(pcb_path)
+
+        with patch(
+            "kicad_tools.analysis.net_status.NetStatusAnalyzer.analyze",
+            return_value=mock_result,
+        ):
+            status = collector.collect_net_status(None)
+
+        assert len(status["incomplete_net_names"]) == 50
+        # Should be the first 50 when sorted alphabetically
+        assert status["incomplete_net_names"] == sorted(incomplete_names)[:50]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -83,9 +83,13 @@ def _full_data(**overrides) -> ReportData:
             ],
         },
         "net_status": {
+            "total_nets": 61,
+            "complete_count": 58,
             "completion_percent": 95.5,
-            "unrouted_count": 3,
-            "unrouted_nets": ["GND", "VCC", "SDA"],
+            "incomplete_count": 3,
+            "unrouted_count": 0,
+            "total_unconnected_pads": 5,
+            "incomplete_net_names": ["GND", "SDA", "VCC"],
         },
         "cost": {
             "per_unit": 2.50,
@@ -719,18 +723,17 @@ class TestLoadDataDir:
         assert isinstance(result["bom_groups"], list)
         assert result["bom_groups"][0]["value"] == "10k"
 
-    def test_completion_pct_renamed(self, tmp_path: Path) -> None:
-        """completion_pct is renamed to completion_percent."""
+    def test_completion_percent_passed_through(self, tmp_path: Path) -> None:
+        """completion_percent emitted by the collector is passed through as-is."""
         from kicad_tools.cli.report_cmd import _load_data_dir
 
         (tmp_path / "net_status.json").write_text(
-            json.dumps({"completion_pct": 95.0, "unrouted_count": 2})
+            json.dumps({"completion_percent": 95.0, "incomplete_count": 2})
         )
         result = _load_data_dir(str(tmp_path))
         ns = result["net_status"]
         assert "completion_percent" in ns
         assert ns["completion_percent"] == 95.0
-        assert "completion_pct" not in ns
 
     def test_envelope_unwrapping(self, tmp_path: Path) -> None:
         """Enveloped JSON files are unwrapped to their data payload."""
@@ -873,13 +876,12 @@ class TestReportCLI:
         Writes JSON files using the same envelope format the collector
         produces (``{schema_version, generated_at, pcb_path, data: {...}}``),
         verifies that every section renders with the correct values, and
-        exercises all five bug fixes from issue #1321:
+        exercises the data-dir loading bug fixes from issue #1321:
 
         1. Envelope unwrapping (all sections)
         2. Filename mapping (board_summary.json -> board_stats,
            drc_summary.json -> drc)
         3. BOM groups extraction (data.groups -> bom_groups list)
-        4. completion_pct -> completion_percent rename
         """
         from kicad_tools.cli.report_cmd import main as report_main
 
@@ -966,7 +968,7 @@ class TestReportCLI:
             )
         )
 
-        # Bug 4: net_status with completion_pct (not completion_percent)
+        # net_status: collector now emits completion_percent directly
         (data_dir / "net_status.json").write_text(
             json.dumps(
                 _envelope(
@@ -976,7 +978,8 @@ class TestReportCLI:
                         "incomplete_count": 4,
                         "unrouted_count": 2,
                         "total_unconnected_pads": 5,
-                        "completion_pct": 95.0,
+                        "completion_percent": 95.0,
+                        "incomplete_net_names": ["CLK", "MISO", "MOSI", "RST"],
                     }
                 )
             )
@@ -1024,8 +1027,16 @@ class TestReportCLI:
         assert "READY" in content
         assert "Review silkscreen" in content
 
-        # Bug 4: completion_percent renders (renamed from completion_pct)
+        # Routing status: completion_percent renders directly from collector
         assert "95.0%" in content
+        # New rows in the routing status table
+        assert "| Complete Nets | 76 / 80 |" in content
+        assert "| Incomplete Nets | 4 |" in content
+        assert "| Unconnected Pads | 5 |" in content
+        # Incomplete net names list rendered
+        assert "### Incomplete Nets" in content
+        assert "- CLK" in content
+        assert "- MOSI" in content
 
     def test_generate_with_data_dir_null_envelope(self, tmp_path: Path) -> None:
         """An envelope with ``data: null`` (collector failure) omits the section."""


### PR DESCRIPTION
## Summary

Fix the Routing Status section in the design report which showed a misleading "Unrouted Nets: 0" even when nets were partially routed. The collector now emits the correct key names and includes incomplete net names, and the template renders all relevant routing metrics.

## Changes

- **collector.py**: Rename `completion_pct` to `completion_percent` at source; add `incomplete_net_names` list (sorted alphabetically, capped at 50 entries)
- **design_report.md.j2**: Replace single "Unrouted Nets" row with "Complete Nets (x/y)", "Incomplete Nets", and "Unconnected Pads" rows; render incomplete net names list under "### Incomplete Nets" heading
- **models.py**: Update `net_status` docstring to document all seven keys emitted by the collector
- **report_cmd.py**: Remove the `completion_pct -> completion_percent` rename workaround (no longer needed since collector emits the correct key)
- **test_report_collector.py**: Add `TestCollectNetStatusScenarios` class with four mocked tests (incomplete-only, mixed incomplete+unrouted, fully-routed, cap-exceeded); update existing assertions for renamed key
- **test_report_generator.py**: Update fixture data and integration test assertions to match new template output

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board with 39 incomplete / 0 unrouted shows Incomplete Nets: 39 | PASS | `test_incomplete_only_scenario` asserts `incomplete_count == 3`, `unrouted_count == 0`, names list populated |
| Routing Status table renders: Completion %, Complete Nets (x/y), Incomplete Nets, Unconnected Pads | PASS | Integration test asserts `Complete Nets \| 76 / 80`, `Incomplete Nets \| 4`, `Unconnected Pads \| 5` |
| Incomplete Nets names list populated when incomplete nets exist | PASS | Integration test asserts `### Incomplete Nets`, `- CLK`, `- MOSI` present in rendered output |
| complete_count shown as ratio (e.g., 22 / 61) | PASS | Template renders `{{ complete_count }} / {{ total_nets }}`; verified in integration test |
| `completion_pct` key no longer used; collector emits `completion_percent` | PASS | `test_returns_expected_keys` asserts `completion_percent in status` and `completion_pct not in status` |
| `report_cmd.py` rename workaround removed | PASS | Lines 313-317 deleted; `test_completion_percent_passed_through` verifies passthrough |
| `ReportData.net_status` docstring matches actual keys | PASS | Docstring updated to list all 7 keys |
| Tests cover incomplete-only, mixed, fully-routed scenarios | PASS | `TestCollectNetStatusScenarios` has 4 tests; 67 tests pass total |

## Test Plan

All 67 tests in `test_report_collector.py` and `test_report_generator.py` pass. The 11 failures in `test_report_cmd.py` are pre-existing on main (unrelated auto-collect from non-existent PCB file).

```
uv run pytest tests/test_report_collector.py tests/test_report_generator.py -v
# 67 passed in 13.53s
```

Closes #1334