### PR TITLE
fix(pipeline): default --layers to None so auto-detection runs via CLI

### DIFF
--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2915,8 +2915,8 @@ def _add_pipeline_parser(subparsers) -> None:
         "-l",
         dest="pipeline_layers",
         type=int,
-        default=2,
-        help="Number of PCB layers (default: 2)",
+        default=None,
+        help="Number of copper layers (default: auto-detected from board)",
     )
     pipeline_parser.add_argument(
         "--dry-run",

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -559,6 +559,87 @@ class TestPipelineLayerAutoDetection:
         layers_idx = call_argv.index("--layers")
         assert call_argv[layers_idx + 1] == "4"
 
+    def test_full_cli_parser_defaults_layers_to_none(self):
+        """Full CLI path: _add_pipeline_parser sets pipeline_layers=None by default.
+
+        This is the integration test for issue #1349. The root cause was that
+        parser.py had default=2 for --layers, which meant auto-detection in
+        pipeline_cmd.py was never reached when invoked via 'kct pipeline'.
+        """
+        import argparse
+
+        from kicad_tools.cli.parser import _add_pipeline_parser
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers()
+        _add_pipeline_parser(sub)
+
+        args = parser.parse_args(["pipeline", "board.kicad_pcb", "--dry-run"])
+
+        assert args.pipeline_layers is None, (
+            f"Expected pipeline_layers=None when --layers is omitted, "
+            f"got {args.pipeline_layers!r}. "
+            "parser.py must use default=None so auto-detection runs."
+        )
+
+    def test_full_cli_parser_explicit_layers_preserved(self):
+        """Full CLI path: explicit --layers value is preserved through parser."""
+        import argparse
+
+        from kicad_tools.cli.parser import _add_pipeline_parser
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers()
+        _add_pipeline_parser(sub)
+
+        args = parser.parse_args(["pipeline", "board.kicad_pcb", "--layers", "4"])
+
+        assert args.pipeline_layers == 4, (
+            f"Expected pipeline_layers=4 when --layers 4 is given, got {args.pipeline_layers!r}."
+        )
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_full_cli_path_auto_detects_4_layers(self, mock_run, four_layer_pcb: Path):
+        """Full CLI path: parser args through shim reach pipeline_cmd with auto-detection.
+
+        Exercises the complete chain: parser.parse_args -> run_pipeline_command -> main.
+        """
+        import argparse
+
+        from kicad_tools.cli.commands.pipeline import run_pipeline_command
+        from kicad_tools.cli.parser import _add_pipeline_parser
+
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers()
+        _add_pipeline_parser(sub)
+
+        args = parser.parse_args(
+            [
+                "pipeline",
+                str(four_layer_pcb),
+                "--step",
+                "fix-vias",
+            ]
+        )
+        # --quiet is a global flag on the main parser, not on the pipeline
+        # subparser. Set it directly so the shim passes it through.
+        args.global_quiet = True
+
+        # Verify the parser default is None (not 2)
+        assert args.pipeline_layers is None
+
+        # Run through the real shim
+        run_pipeline_command(args)
+
+        # The shim should NOT have passed --layers (since pipeline_layers is None),
+        # so pipeline_cmd.main auto-detects from the 4-layer PCB file.
+        cmd_args = mock_run.call_args[0][0]
+        assert "--layers" in cmd_args
+        layers_idx = cmd_args.index("--layers")
+        assert cmd_args[layers_idx + 1] == "4"
+
 
 class TestEdgeCases:
     """Tests for edge cases."""


### PR DESCRIPTION
## Summary

The `--layers` argument in `_add_pipeline_parser` still had `default=2` after PR #1343, which prevented the layer auto-detection code in `pipeline_cmd.py` from ever running when invoked via the `kct pipeline` CLI path. This changes the default to `None` so the shim correctly omits `--layers` and auto-detection runs.

## Changes

- Changed `default=2` to `default=None` for the `--layers` argument in `_add_pipeline_parser` (line 2918 of `parser.py`)
- Updated help text from "Number of PCB layers (default: 2)" to "Number of copper layers (default: auto-detected from board)"
- Added `test_full_cli_parser_defaults_layers_to_none` -- verifies parser produces `pipeline_layers=None` when `--layers` is omitted
- Added `test_full_cli_parser_explicit_layers_preserved` -- verifies explicit `--layers 4` is preserved through the parser
- Added `test_full_cli_path_auto_detects_4_layers` -- end-to-end test: parser.parse_args -> run_pipeline_command -> pipeline_cmd.main auto-detects 4 layers from a 4-layer PCB

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Auto-detection runs for 4-layer board via CLI path | Pass | `test_full_cli_path_auto_detects_4_layers` exercises full chain and asserts `--layers 4` |
| 2-layer board still shows 2 layers (no regression) | Pass | Existing `test_auto_detect_2_layer_board_no_regression` still passes |
| Explicit `--layers 2` overrides detection | Pass | Existing `test_explicit_layers_overrides_detection` still passes |
| Integration test via full `run_pipeline_command(args)` path | Pass | `test_full_cli_path_auto_detects_4_layers` constructs args through real parser |

## Test Plan

- `uv run pytest tests/test_pipeline_cmd.py -v --no-cov` -- all 41 tests pass (38 existing + 3 new)
- `uv run ruff check` and `uv run ruff format --check` pass on both changed files

Closes #1349