### PR TITLE
fix(report): accept str paths in render_pdf to prevent AttributeError

### DIFF
--- a/src/kicad_tools/report/renderers.py
+++ b/src/kicad_tools/report/renderers.py
@@ -56,17 +56,19 @@ def render_html(
     return _wrap_html(html_body, css)
 
 
-def render_pdf(html_content: str, output_path: Path) -> None:
+def render_pdf(html_content: str, output_path: Path | str) -> None:
     """Render an HTML document to PDF via weasyprint.
 
     Args:
         html_content: Complete HTML document string (from ``render_html``).
-        output_path: Destination path for the PDF file.
+        output_path: Destination path for the PDF file. Accepts both
+            :class:`~pathlib.Path` objects and plain strings.
 
     Raises:
         ImportError: If weasyprint is not installed, with an actionable
             message directing the user to install it.
     """
+    output_path = Path(output_path)
     if not _weasyprint_available():
         raise ImportError(
             "PDF output requires weasyprint. Install with: pip install 'kicad-tools[report]'"

--- a/tests/report/test_renderers.py
+++ b/tests/report/test_renderers.py
@@ -264,6 +264,41 @@ class TestRenderPdf:
         finally:
             del sys.modules["weasyprint"]
 
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        """render_pdf accepts a plain str path without raising AttributeError."""
+        import sys
+
+        from kicad_tools.report.renderers import render_pdf
+
+        output = tmp_path / "str_test" / "report.pdf"
+        # Pass the path as a plain string, not a Path object
+        output_str = str(output)
+
+        # Create a fake weasyprint module with a mock HTML class
+        mock_html_cls = type(
+            "MockHTML",
+            (),
+            {
+                "__init__": lambda self, string: None,
+                "write_pdf": lambda self, path: Path(path).write_bytes(b"%PDF-mock"),
+            },
+        )
+
+        fake_weasyprint = type(sys)("weasyprint")
+        fake_weasyprint.HTML = mock_html_cls
+        sys.modules["weasyprint"] = fake_weasyprint
+
+        try:
+            with patch(
+                "kicad_tools.report.renderers._weasyprint_available",
+                return_value=True,
+            ):
+                render_pdf("<html></html>", output_str)
+                assert output.parent.exists()
+                assert output.exists()
+        finally:
+            del sys.modules["weasyprint"]
+
 
 # ---------------------------------------------------------------------------
 # CSS tests


### PR DESCRIPTION
## Summary
`render_pdf` crashed with `AttributeError: 'str' object has no attribute 'parent'` when callers passed a plain string path. This widens the type annotation and coerces the argument to `Path` at function entry.

## Changes
- Updated `render_pdf` signature from `output_path: Path` to `output_path: Path | str`
- Added `output_path = Path(output_path)` as first line of function body (before the weasyprint check)
- Updated docstring to document that both `Path` and `str` are accepted
- Added `test_accepts_string_path` to `TestRenderPdf` verifying a str argument works end-to-end

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `render_pdf(html, "/tmp/report.pdf")` (string path) does not raise `AttributeError` | Pass | New test `test_accepts_string_path` passes a `str` and asserts no error |
| `render_pdf(html, Path("/tmp/report.pdf"))` (Path object) continues to work | Pass | Existing `test_creates_parent_directories` still passes with `Path` arg |
| Type annotation updated to `Path \| str` | Pass | Signature reads `output_path: Path \| str` |
| Automated test passes a string path and asserts completion | Pass | `test_accepts_string_path` asserts parent dir exists and PDF file is written |

## Test Plan
- `uv run pytest tests/report/test_renderers.py::TestRenderPdf -v` -- all 4 tests pass (3 existing + 1 new)
- `uv run ruff check` and `uv run ruff format --check` pass on both changed files
- Pre-existing `TestRenderHtml` failures are due to missing `markdown` package in minimal venv (unrelated)

Closes #1360