### PR TITLE
feat(router): add automatic strategy retry loop on routing failure

### DIFF
--- a/src/kicad_tools/router/orchestrator.py
+++ b/src/kicad_tools/router/orchestrator.py
@@ -98,6 +98,13 @@ class RoutingOrchestrator:
             When provided, the orchestrator uses this to auto-skip pour nets
             (nets with ``is_pour_net=True``) and return a success result with a
             warning directing users to zone fill instead of trace routing.
+        max_strategy_retries: Maximum number of alternative strategies to try
+            when the primary strategy fails.  When a strategy returns
+            ``success=False`` with a populated ``alternative_strategies`` list,
+            the orchestrator automatically iterates through alternatives (up to
+            this limit) before returning failure.  Set to ``0`` to disable
+            automatic retry and preserve the legacy behaviour of returning
+            immediately on failure.  Default is ``2``.
     """
 
     def __init__(
@@ -110,6 +117,7 @@ class RoutingOrchestrator:
         enable_repair: bool = True,
         enable_via_conflict_resolution: bool = True,
         net_class_map: dict[str, NetClassRouting] | None = None,
+        max_strategy_retries: int = 2,
     ):
         self.pcb = pcb
         self.rules = rules
@@ -119,6 +127,7 @@ class RoutingOrchestrator:
         self.enable_repair = enable_repair
         self.enable_via_conflict_resolution = enable_via_conflict_resolution
         self.net_class_map: dict[str, NetClassRouting] = net_class_map or {}
+        self.max_strategy_retries = max_strategy_retries
 
         # Lazy-initialized routers (created on first use)
         self._global_router: GlobalRouter | None = None
@@ -130,7 +139,8 @@ class RoutingOrchestrator:
 
         logger.info(
             f"RoutingOrchestrator initialized: backend={backend}, "
-            f"corridor_width={corridor_width}mm, density_threshold={density_threshold}"
+            f"corridor_width={corridor_width}mm, density_threshold={density_threshold}, "
+            f"max_strategy_retries={max_strategy_retries}"
         )
 
     def _get_net_class_routing(self, net: str | int) -> NetClassRouting | None:
@@ -196,6 +206,39 @@ class RoutingOrchestrator:
         # Phase 2: Execute routing with selected strategy
         routing_start = time.time()
         result = self._execute_strategy(net, strategy, intent, pads)
+
+        # Phase 2b: Automatic strategy retry on failure
+        if not result.success and result.alternative_strategies and self.max_strategy_retries > 0:
+            retries = result.alternative_strategies[: self.max_strategy_retries]
+            strategies_attempted = [strategy.name]
+
+            for alt in retries:
+                logger.info(
+                    "Retrying net %s with alternative strategy %s (reason: %s, p_success=%.2f)",
+                    net,
+                    alt.strategy.name,
+                    alt.reason,
+                    alt.success_probability,
+                )
+                retry_result = self._execute_strategy(net, alt.strategy, intent, pads)
+                strategies_attempted.append(alt.strategy.name)
+
+                if retry_result.success:
+                    retry_result.warnings.append(
+                        f"Succeeded on retry with {alt.strategy.name} "
+                        f"after {strategies_attempted[0]} failed "
+                        f"(strategies attempted: "
+                        f"{', '.join(strategies_attempted)})"
+                    )
+                    result = retry_result
+                    break
+            else:
+                # All retries exhausted without success — keep the last
+                # failure result but note what was tried
+                result.warnings.append(
+                    f"All strategy retries exhausted (attempted: {', '.join(strategies_attempted)})"
+                )
+
         perf.routing_ms = (time.time() - routing_start) * 1000
 
         # Phase 3: Post-route repair (if enabled and needed)
@@ -283,25 +326,25 @@ class RoutingOrchestrator:
         """
         try:
             if strategy == RoutingStrategy.GLOBAL_WITH_REPAIR:
-                return self._route_global(net, pads)
+                result = self._route_global(net, pads)
 
             elif strategy == RoutingStrategy.ESCAPE_THEN_GLOBAL:
-                return self._route_escape_then_global(net, pads)
+                result = self._route_escape_then_global(net, pads)
 
             elif strategy == RoutingStrategy.HIERARCHICAL_DIFF_PAIR:
-                return self._route_hierarchical(net, intent, pads)
+                result = self._route_hierarchical(net, intent, pads)
 
             elif strategy == RoutingStrategy.SUBGRID_ADAPTIVE:
-                return self._route_subgrid_adaptive(net, pads)
+                result = self._route_subgrid_adaptive(net, pads)
 
             elif strategy == RoutingStrategy.VIA_CONFLICT_RESOLUTION:
-                return self._route_with_via_resolution(net, pads)
+                result = self._route_with_via_resolution(net, pads)
 
             elif strategy == RoutingStrategy.FULL_PIPELINE:
-                return self._route_full_pipeline(net, intent, pads)
+                result = self._route_full_pipeline(net, intent, pads)
 
             elif strategy == RoutingStrategy.MULTI_RESOLUTION:
-                return self._route_multi_resolution(net, pads)
+                result = self._route_multi_resolution(net, pads)
 
             else:
                 error_msg = f"Unknown strategy: {strategy}"
@@ -312,6 +355,13 @@ class RoutingOrchestrator:
                     strategy_used=strategy,
                     error_message=error_msg,
                 )
+
+            # Ensure failed results always carry alternative suggestions so
+            # the retry loop in route_net() has candidates to try.
+            if not result.success and not result.alternative_strategies:
+                result.alternative_strategies = self._suggest_alternatives(strategy)
+
+            return result
 
         except Exception as e:
             logger.exception(f"Strategy execution failed: {e}")

--- a/tests/test_routing_orchestrator.py
+++ b/tests/test_routing_orchestrator.py
@@ -659,3 +659,389 @@ class TestPerformanceStats:
         assert perf.repair_ms == 0.0
         assert perf.gpu_utilized is False
         assert perf.backend_type == "cpu"
+
+
+class TestStrategyRetry:
+    """Test automatic strategy retry when primary strategy fails."""
+
+    def test_retry_succeeds_on_alternative_strategy(self, mock_pcb, design_rules):
+        """Verify orchestrator retries with alternative strategy on failure.
+
+        When the primary strategy (GLOBAL_WITH_REPAIR) fails with populated
+        alternative_strategies, the orchestrator should iterate through
+        alternatives until one succeeds.
+        """
+        orch = RoutingOrchestrator(
+            pcb=mock_pcb,
+            rules=design_rules,
+            backend="cpu",
+            max_strategy_retries=2,
+        )
+
+        pads = [
+            _pad(x=5.0, y=5.0, pin="1"),
+            _pad(x=15.0, y=5.0, pin="2"),
+        ]
+
+        # Track how many times _execute_strategy is called
+        call_count = 0
+
+        def mock_execute(net, strategy, intent, pads_arg):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call (primary strategy) fails
+                return RoutingResult(
+                    success=False,
+                    net=net,
+                    strategy_used=strategy,
+                    error_message="Global router failed to find corridor assignment",
+                    alternative_strategies=[
+                        AlternativeStrategy(
+                            strategy=RoutingStrategy.MULTI_RESOLUTION,
+                            reason="Fine-grid retry may resolve",
+                            estimated_cost=1.5,
+                            success_probability=0.65,
+                        ),
+                        AlternativeStrategy(
+                            strategy=RoutingStrategy.FULL_PIPELINE,
+                            reason="Complete pipeline applies all techniques",
+                            estimated_cost=2.0,
+                            success_probability=0.7,
+                        ),
+                    ],
+                )
+            elif call_count == 2:
+                # Second call (first retry: MULTI_RESOLUTION) also fails
+                return RoutingResult(
+                    success=False,
+                    net=net,
+                    strategy_used=strategy,
+                    error_message="Multi-resolution also failed",
+                )
+            else:
+                # Third call (second retry: FULL_PIPELINE) succeeds
+                return RoutingResult(
+                    success=True,
+                    net=net,
+                    strategy_used=strategy,
+                    metrics=RoutingMetrics(total_length_mm=12.0, via_count=1),
+                )
+
+        orch._execute_strategy = mock_execute
+
+        result = orch.route_net("NET1", pads=pads)
+
+        assert result.success is True
+        assert call_count == 3
+        # Should note the retry path in warnings
+        assert any("retry" in w.lower() for w in result.warnings)
+        assert any("FULL_PIPELINE" in w for w in result.warnings)
+
+    def test_retry_all_alternatives_fail(self, mock_pcb, design_rules):
+        """Verify all-failed retries are noted in warnings."""
+        orch = RoutingOrchestrator(
+            pcb=mock_pcb,
+            rules=design_rules,
+            backend="cpu",
+            max_strategy_retries=2,
+        )
+
+        pads = [
+            _pad(x=5.0, y=5.0, pin="1"),
+            _pad(x=15.0, y=5.0, pin="2"),
+        ]
+
+        def always_fail(net, strategy, intent, pads_arg):
+            return RoutingResult(
+                success=False,
+                net=net,
+                strategy_used=strategy,
+                error_message=f"{strategy.name} failed",
+                alternative_strategies=[
+                    AlternativeStrategy(
+                        strategy=RoutingStrategy.MULTI_RESOLUTION,
+                        reason="Try finer grid",
+                        estimated_cost=1.5,
+                        success_probability=0.65,
+                    ),
+                    AlternativeStrategy(
+                        strategy=RoutingStrategy.FULL_PIPELINE,
+                        reason="Try complete pipeline",
+                        estimated_cost=2.0,
+                        success_probability=0.7,
+                    ),
+                ],
+            )
+
+        orch._execute_strategy = always_fail
+
+        result = orch.route_net("NET1", pads=pads)
+
+        assert result.success is False
+        assert any("retries exhausted" in w.lower() for w in result.warnings)
+        assert any("GLOBAL_WITH_REPAIR" in w for w in result.warnings)
+
+    def test_retry_disabled_with_zero_max(self, mock_pcb, design_rules):
+        """Verify max_strategy_retries=0 disables automatic retry."""
+        orch = RoutingOrchestrator(
+            pcb=mock_pcb,
+            rules=design_rules,
+            backend="cpu",
+            max_strategy_retries=0,
+        )
+
+        pads = [
+            _pad(x=5.0, y=5.0, pin="1"),
+            _pad(x=15.0, y=5.0, pin="2"),
+        ]
+
+        call_count = 0
+
+        def fail_once(net, strategy, intent, pads_arg):
+            nonlocal call_count
+            call_count += 1
+            return RoutingResult(
+                success=False,
+                net=net,
+                strategy_used=strategy,
+                error_message="Failed",
+                alternative_strategies=[
+                    AlternativeStrategy(
+                        strategy=RoutingStrategy.FULL_PIPELINE,
+                        reason="Try complete pipeline",
+                        estimated_cost=2.0,
+                        success_probability=0.7,
+                    ),
+                ],
+            )
+
+        orch._execute_strategy = fail_once
+
+        result = orch.route_net("NET1", pads=pads)
+
+        assert result.success is False
+        # Should only call once (no retry)
+        assert call_count == 1
+        # Should NOT have retry warnings
+        assert not any("retries exhausted" in w.lower() for w in result.warnings)
+
+    def test_retry_respects_budget_limit(self, mock_pcb, design_rules):
+        """Verify retry loop stops at max_strategy_retries even with more alternatives."""
+        orch = RoutingOrchestrator(
+            pcb=mock_pcb,
+            rules=design_rules,
+            backend="cpu",
+            max_strategy_retries=1,  # Only try 1 alternative
+        )
+
+        pads = [
+            _pad(x=5.0, y=5.0, pin="1"),
+            _pad(x=15.0, y=5.0, pin="2"),
+        ]
+
+        call_count = 0
+
+        def fail_always(net, strategy, intent, pads_arg):
+            nonlocal call_count
+            call_count += 1
+            return RoutingResult(
+                success=False,
+                net=net,
+                strategy_used=strategy,
+                error_message="Failed",
+                alternative_strategies=[
+                    AlternativeStrategy(
+                        strategy=RoutingStrategy.MULTI_RESOLUTION,
+                        reason="Try finer grid",
+                        estimated_cost=1.5,
+                        success_probability=0.65,
+                    ),
+                    AlternativeStrategy(
+                        strategy=RoutingStrategy.FULL_PIPELINE,
+                        reason="Try complete pipeline",
+                        estimated_cost=2.0,
+                        success_probability=0.7,
+                    ),
+                    AlternativeStrategy(
+                        strategy=RoutingStrategy.HIERARCHICAL_DIFF_PAIR,
+                        reason="Try hierarchical",
+                        estimated_cost=1.5,
+                        success_probability=0.6,
+                    ),
+                ],
+            )
+
+        orch._execute_strategy = fail_always
+
+        result = orch.route_net("NET1", pads=pads)
+
+        assert result.success is False
+        # Should call twice: original + 1 retry (budget=1)
+        assert call_count == 2
+
+    def test_retry_first_alternative_succeeds(self, mock_pcb, design_rules):
+        """Verify retry stops on first successful alternative."""
+        orch = RoutingOrchestrator(
+            pcb=mock_pcb,
+            rules=design_rules,
+            backend="cpu",
+            max_strategy_retries=2,
+        )
+
+        pads = [
+            _pad(x=5.0, y=5.0, pin="1"),
+            _pad(x=15.0, y=5.0, pin="2"),
+        ]
+
+        call_count = 0
+
+        def succeed_on_second(net, strategy, intent, pads_arg):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return RoutingResult(
+                    success=False,
+                    net=net,
+                    strategy_used=strategy,
+                    error_message="Primary failed",
+                    alternative_strategies=[
+                        AlternativeStrategy(
+                            strategy=RoutingStrategy.MULTI_RESOLUTION,
+                            reason="Try finer grid",
+                            estimated_cost=1.5,
+                            success_probability=0.65,
+                        ),
+                        AlternativeStrategy(
+                            strategy=RoutingStrategy.FULL_PIPELINE,
+                            reason="Try complete pipeline",
+                            estimated_cost=2.0,
+                            success_probability=0.7,
+                        ),
+                    ],
+                )
+            else:
+                return RoutingResult(
+                    success=True,
+                    net=net,
+                    strategy_used=strategy,
+                    metrics=RoutingMetrics(total_length_mm=10.0),
+                )
+
+        orch._execute_strategy = succeed_on_second
+
+        result = orch.route_net("NET1", pads=pads)
+
+        assert result.success is True
+        # Should call twice: original + first retry succeeds
+        assert call_count == 2
+        # Should NOT try the second alternative
+        assert any("MULTI_RESOLUTION" in w for w in result.warnings)
+
+    def test_no_retry_when_no_alternatives(self, mock_pcb, design_rules):
+        """Verify no retry when result has empty alternative_strategies."""
+        orch = RoutingOrchestrator(
+            pcb=mock_pcb,
+            rules=design_rules,
+            backend="cpu",
+            max_strategy_retries=2,
+        )
+
+        pads = [
+            _pad(x=5.0, y=5.0, pin="1"),
+            _pad(x=15.0, y=5.0, pin="2"),
+        ]
+
+        call_count = 0
+
+        def fail_no_alternatives(net, strategy, intent, pads_arg):
+            nonlocal call_count
+            call_count += 1
+            return RoutingResult(
+                success=False,
+                net=net,
+                strategy_used=strategy,
+                error_message="Failed with no alternatives",
+                alternative_strategies=[],
+            )
+
+        orch._execute_strategy = fail_no_alternatives
+
+        result = orch.route_net("NET1", pads=pads)
+
+        assert result.success is False
+        assert call_count == 1
+
+    def test_execute_strategy_populates_alternatives_on_failure(self, mock_pcb, design_rules):
+        """Verify _execute_strategy always populates alternatives on failure.
+
+        Strategies like _route_escape_then_global may not populate
+        alternative_strategies on their own. _execute_strategy should
+        fill them in so the retry loop has candidates.
+        """
+        orch = RoutingOrchestrator(
+            pcb=mock_pcb,
+            rules=design_rules,
+            backend="cpu",
+        )
+
+        pads = [
+            _pad(x=5.0, y=5.0, pin="1"),
+        ]  # Only one pad -> will fail
+
+        result = orch._execute_strategy(
+            "NET1",
+            RoutingStrategy.ESCAPE_THEN_GLOBAL,
+            intent=None,
+            pads=pads,
+        )
+
+        assert result.success is False
+        # Should have alternatives populated even though
+        # _route_escape_then_global does not populate them itself
+        assert len(result.alternative_strategies) > 0
+        assert any(
+            alt.strategy == RoutingStrategy.FULL_PIPELINE for alt in result.alternative_strategies
+        )
+
+    def test_default_max_strategy_retries(self, mock_pcb, design_rules):
+        """Verify default max_strategy_retries is 2."""
+        orch = RoutingOrchestrator(
+            pcb=mock_pcb,
+            rules=design_rules,
+            backend="cpu",
+        )
+        assert orch.max_strategy_retries == 2
+
+    def test_successful_primary_strategy_skips_retry(self, mock_pcb, design_rules):
+        """Verify no retry when primary strategy succeeds."""
+        orch = RoutingOrchestrator(
+            pcb=mock_pcb,
+            rules=design_rules,
+            backend="cpu",
+            max_strategy_retries=2,
+        )
+
+        pads = [
+            _pad(x=5.0, y=5.0, pin="1"),
+            _pad(x=15.0, y=5.0, pin="2"),
+        ]
+
+        call_count = 0
+
+        def counting_execute(net, strategy, intent, pads_arg):
+            nonlocal call_count
+            call_count += 1
+            return RoutingResult(
+                success=True,
+                net=net,
+                strategy_used=strategy,
+                metrics=RoutingMetrics(total_length_mm=10.0),
+            )
+
+        orch._execute_strategy = counting_execute
+
+        result = orch.route_net("NET1", pads=pads)
+
+        assert result.success is True
+        assert call_count == 1  # Only primary call, no retry


### PR DESCRIPTION
## Summary

Add an automatic strategy retry loop in `RoutingOrchestrator.route_net()` so that when the primary routing strategy fails and `result.alternative_strategies` is populated, the orchestrator iterates through alternatives before returning failure. This leverages existing infrastructure from PRs #1252-#1254 (crossing-aware A*, R-tree indexing, multi-resolution routing) which are already available as fallback targets but were never automatically tried.

## Changes

- Add `max_strategy_retries` parameter to `RoutingOrchestrator.__init__()` (default: 2) controlling how many alternative strategies to attempt on failure
- Add Phase 2b retry loop in `route_net()`: after `_execute_strategy()` fails, iterate through `alternative_strategies[:max_strategy_retries]` and retry with each until one succeeds
- Ensure `_execute_strategy()` always populates `alternative_strategies` on failure, even for strategies (like `ESCAPE_THEN_GLOBAL`) that do not set them internally -- this guarantees the retry loop always has candidates
- Add retry path metadata in warnings: on success, notes which strategy succeeded and what was attempted; on exhaustion, notes all strategies tried

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `route_net()` automatically retries with alternative strategies on failure | Done | `test_retry_succeeds_on_alternative_strategy` -- primary fails, first retry fails, second retry (FULL_PIPELINE) succeeds; 3 calls verified |
| No regression on existing tests | Done | All 32 pre-existing tests in `test_routing_orchestrator.py` pass unchanged |
| Retry respects configurable budget | Done | `test_retry_respects_budget_limit` -- max_strategy_retries=1 limits to exactly 1 retry |
| Retry disabled with max_strategy_retries=0 | Done | `test_retry_disabled_with_zero_max` -- only 1 call, no retry attempted |
| Failed results always carry alternatives | Done | `test_execute_strategy_populates_alternatives_on_failure` -- ESCAPE_THEN_GLOBAL failure now has FULL_PIPELINE in alternatives |
| Successful primary skips retry | Done | `test_successful_primary_strategy_skips_retry` -- only 1 call when primary succeeds |
| All retries exhausted noted in warnings | Done | `test_retry_all_alternatives_fail` -- "retries exhausted" warning present |
| First successful retry stops loop | Done | `test_retry_first_alternative_succeeds` -- 2 calls total, MULTI_RESOLUTION noted in warning |
| No retry when alternatives list is empty | Done | `test_no_retry_when_no_alternatives` -- 1 call, no retry |

## Test Plan

- 9 new unit tests in `TestStrategyRetry` class covering all retry paths
- All 41 tests pass (32 existing + 9 new)
- `ruff check` and `ruff format` clean on changed files

Closes #1357