### PR TITLE
feat(pipeline): add fix-silkscreen step between ERC and fix-vias

### DIFF
--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2891,8 +2891,8 @@ def _add_pipeline_parser(subparsers) -> None:
         help="End-to-end repair pipeline for existing PCBs",
         description=(
             "Orchestrate the full repair pipeline on an existing PCB: "
-            "fix-vias, route (if needed), fix-drc, optimize-traces, zone fill, audit. "
-            "Auto-detects board state to skip unnecessary steps."
+            "erc, fix-silkscreen, fix-vias, route (if needed), fix-drc, optimize-traces, "
+            "zone fill, audit. Auto-detects board state to skip unnecessary steps."
         ),
     )
     pipeline_parser.add_argument(
@@ -2904,7 +2904,16 @@ def _add_pipeline_parser(subparsers) -> None:
         "--step",
         "-s",
         dest="pipeline_step",
-        choices=["erc", "route", "fix-vias", "fix-drc", "optimize", "zones", "audit"],
+        choices=[
+            "erc",
+            "fix-silkscreen",
+            "route",
+            "fix-vias",
+            "fix-drc",
+            "optimize",
+            "zones",
+            "audit",
+        ],
         default=None,
         help="Run only this step (default: run all steps in order)",
     )

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -4,17 +4,19 @@ Pipeline command for end-to-end repair workflow on existing PCBs.
 Orchestrates the full repair pipeline:
 0. ERC check (schematic validation)
 1. Load board state (detect routing status)
-2. Fix vias (manufacturer compliance)
-3. [Optional] Route (if board is unrouted)
-4. Fix DRC violations
-5. Optimize traces
-6. Zone fill (requires kicad-cli)
-7. Audit / check
+2. Fix silkscreen (manufacturer line-width compliance)
+3. Fix vias (manufacturer compliance)
+4. [Optional] Route (if board is unrouted)
+5. Fix DRC violations
+6. Optimize traces
+7. Zone fill (requires kicad-cli)
+8. Audit / check
 
 Usage:
     kct pipeline board.kicad_pcb --mfr jlcpcb
     kct pipeline board.kicad_pcb --dry-run
     kct pipeline board.kicad_pcb --step fix-vias
+    kct pipeline board.kicad_pcb --step fix-silkscreen
     kct pipeline board.kicad_pcb --step erc
     kct pipeline project.kicad_pro --mfr jlcpcb --layers 4
 """
@@ -42,6 +44,7 @@ class PipelineStep(str, Enum):
     """Pipeline step identifiers."""
 
     ERC = "erc"
+    FIX_SILKSCREEN = "fix-silkscreen"
     ROUTE = "route"
     FIX_VIAS = "fix-vias"
     FIX_DRC = "fix-drc"
@@ -53,6 +56,7 @@ class PipelineStep(str, Enum):
 # Ordered list of all pipeline steps
 ALL_STEPS = [
     PipelineStep.ERC,
+    PipelineStep.FIX_SILKSCREEN,
     PipelineStep.FIX_VIAS,
     PipelineStep.ROUTE,
     PipelineStep.FIX_DRC,
@@ -281,6 +285,40 @@ def _run_step_erc(ctx: PipelineContext, console: Console) -> PipelineResult:
         step=PipelineStep.ERC,
         success=False,
         message=f"erc: {error_count} error(s) found (use --force to continue)",
+    )
+
+
+def _run_step_fix_silkscreen(ctx: PipelineContext, console: Console) -> PipelineResult:
+    """Run silkscreen line-width repair step.
+
+    Fixes silkscreen line widths to meet manufacturer minimum specifications.
+    This is safe to run unconditionally and is idempotent.
+    """
+    if ctx.dry_run:
+        return PipelineResult(
+            step=PipelineStep.FIX_SILKSCREEN,
+            success=True,
+            message=f"[dry-run] Would run: kct fix-silkscreen {ctx.pcb_file.name} --mfr {ctx.mfr}",
+        )
+
+    if not ctx.quiet:
+        console.print(f"  Fixing silkscreen widths for {ctx.mfr}...")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "fix-silkscreen",
+        str(ctx.pcb_file),
+        "--mfr",
+        ctx.mfr,
+    ]
+
+    success, message = _run_subprocess_step(cmd, ctx.pcb_file.parent, ctx.verbose)
+    return PipelineResult(
+        step=PipelineStep.FIX_SILKSCREEN,
+        success=success,
+        message=f"fix-silkscreen: {message}",
     )
 
 
@@ -748,6 +786,7 @@ def _git_commit_result(
 # Map of step name to runner function
 STEP_RUNNERS = {
     PipelineStep.ERC: _run_step_erc,
+    PipelineStep.FIX_SILKSCREEN: _run_step_fix_silkscreen,
     PipelineStep.ROUTE: _run_step_route,
     PipelineStep.FIX_VIAS: _run_step_fix_vias,
     PipelineStep.FIX_DRC: _run_step_fix_drc,

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -210,6 +210,62 @@ class TestDryRun:
         assert result == 0
 
 
+class TestFixSilkscreenStep:
+    """Tests for the fix-silkscreen pipeline step."""
+
+    def test_dry_run_fix_silkscreen_message(self, routed_pcb: Path):
+        """Dry-run fix-silkscreen reports the command that would be executed."""
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_fix_silkscreen
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, dry_run=True, mfr="pcbway")
+        console = Console(quiet=True)
+        result = _run_step_fix_silkscreen(ctx, console)
+
+        assert result.success is True
+        assert "fix-silkscreen" in result.message
+        assert "pcbway" in result.message
+        assert result.step == PipelineStep.FIX_SILKSCREEN
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_fix_silkscreen_calls_subprocess(self, mock_run, routed_pcb: Path):
+        """fix-silkscreen step invokes the correct subprocess command."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_fix_silkscreen
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, mfr="jlcpcb")
+        console = Console(quiet=True)
+        result = _run_step_fix_silkscreen(ctx, console)
+
+        assert result.success is True
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "fix-silkscreen" in cmd_args
+        assert "--mfr" in cmd_args
+        mfr_idx = cmd_args.index("--mfr")
+        assert cmd_args[mfr_idx + 1] == "jlcpcb"
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_fix_silkscreen_failure_propagates(self, mock_run, routed_pcb: Path):
+        """fix-silkscreen step reports failure when subprocess fails."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="parse error", stdout="")
+
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_fix_silkscreen
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, mfr="jlcpcb")
+        console = Console(quiet=True)
+        result = _run_step_fix_silkscreen(ctx, console)
+
+        assert result.success is False
+        assert "fix-silkscreen" in result.message
+
+
 class TestRoutingSkip:
     """Tests for automatic routing detection and skip."""
 
@@ -258,6 +314,18 @@ class TestSingleStep:
         mock_run.assert_called_once()
         cmd_args = mock_run.call_args[0][0]
         assert "fix-vias" in cmd_args
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_single_step_fix_silkscreen(self, mock_run, routed_pcb: Path):
+        """--step fix-silkscreen runs only that step."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        result = main(["--step", "fix-silkscreen", str(routed_pcb), "--quiet"])
+
+        assert result == 0
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "fix-silkscreen" in cmd_args
 
     @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
     def test_single_step_audit(self, mock_run, routed_pcb: Path):
@@ -403,6 +471,18 @@ class TestMfrAndLayersForwarding:
     """Tests that --mfr and --layers flags are forwarded correctly."""
 
     @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_mfr_forwarded_to_fix_silkscreen(self, mock_run, routed_pcb: Path):
+        """--mfr flag is forwarded to fix-silkscreen step."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        main(["--step", "fix-silkscreen", "--mfr", "pcbway", str(routed_pcb), "--quiet"])
+
+        cmd_args = mock_run.call_args[0][0]
+        assert "--mfr" in cmd_args
+        mfr_idx = cmd_args.index("--mfr")
+        assert cmd_args[mfr_idx + 1] == "pcbway"
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
     def test_mfr_forwarded_to_fix_vias(self, mock_run, routed_pcb: Path):
         """--mfr flag is forwarded to fix-vias step."""
         mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
@@ -459,9 +539,10 @@ class TestPipelineStepOrder:
         assert set(ALL_STEPS) == set(PipelineStep)
 
     def test_step_order(self):
-        """Steps execute in the correct order: erc first, then fix-vias before route."""
+        """Steps execute in the correct order: erc, fix-silkscreen, fix-vias, route, etc."""
         expected = [
             PipelineStep.ERC,
+            PipelineStep.FIX_SILKSCREEN,
             PipelineStep.FIX_VIAS,
             PipelineStep.ROUTE,
             PipelineStep.FIX_DRC,
@@ -470,6 +551,17 @@ class TestPipelineStepOrder:
             PipelineStep.AUDIT,
         ]
         assert expected == ALL_STEPS
+
+    def test_fix_silkscreen_between_erc_and_fix_vias(self):
+        """FIX_SILKSCREEN is positioned after ERC and before FIX_VIAS in ALL_STEPS."""
+        erc_idx = ALL_STEPS.index(PipelineStep.ERC)
+        silkscreen_idx = ALL_STEPS.index(PipelineStep.FIX_SILKSCREEN)
+        vias_idx = ALL_STEPS.index(PipelineStep.FIX_VIAS)
+        assert erc_idx < silkscreen_idx < vias_idx
+
+    def test_fix_silkscreen_in_all_steps(self):
+        """PipelineStep.FIX_SILKSCREEN is present in ALL_STEPS."""
+        assert PipelineStep.FIX_SILKSCREEN in ALL_STEPS
 
 
 class TestPipelineLayerAutoDetection:
@@ -1374,6 +1466,7 @@ class TestERCStep:
         assert results[1].success is True  # FIX_VIAS runs
 
     def test_erc_is_first_step(self):
-        """ERC is the first step in ALL_STEPS, before fix-vias."""
+        """ERC is the first step in ALL_STEPS, followed by fix-silkscreen, then fix-vias."""
         assert ALL_STEPS[0] == PipelineStep.ERC
-        assert ALL_STEPS[1] == PipelineStep.FIX_VIAS
+        assert ALL_STEPS[1] == PipelineStep.FIX_SILKSCREEN
+        assert ALL_STEPS[2] == PipelineStep.FIX_VIAS


### PR DESCRIPTION
## Summary

Add `PipelineStep.FIX_SILKSCREEN` to the pipeline, positioned after ERC and before fix-vias. The new step calls `kct fix-silkscreen` with the `--mfr` flag from the pipeline context. Running silkscreen repair early (before routing) reduces the workload for downstream `fix-drc` and `audit` steps, since silkscreen line-width violations are the most common DRC issue class.

## Changes

- Add `FIX_SILKSCREEN = "fix-silkscreen"` to `PipelineStep` enum in `pipeline_cmd.py`
- Insert `PipelineStep.FIX_SILKSCREEN` into `ALL_STEPS` between ERC and FIX_VIAS
- Add `_run_step_fix_silkscreen()` runner function (modeled on `_run_step_fix_vias`)
- Register the new step in `STEP_RUNNERS` dict
- Update module docstring to reflect the new step numbering
- Add `"fix-silkscreen"` to `--step` choices in `parser.py`
- Update parser description string to mention fix-silkscreen
- Update `test_step_order` and `test_erc_is_first_step` tests for new ordering
- Add `TestFixSilkscreenStep` test class (dry-run, subprocess, failure propagation)
- Add `test_single_step_fix_silkscreen` and `test_mfr_forwarded_to_fix_silkscreen` tests
- Add `test_fix_silkscreen_between_erc_and_fix_vias` and `test_fix_silkscreen_in_all_steps` tests

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `PipelineStep.FIX_SILKSCREEN = "fix-silkscreen"` exists in the enum | Pass | Added to `PipelineStep` class |
| `ALL_STEPS` contains `FIX_SILKSCREEN` between ERC and FIX_VIAS | Pass | `test_fix_silkscreen_between_erc_and_fix_vias` passes |
| `STEP_RUNNERS` maps `FIX_SILKSCREEN` to a runner function | Pass | Mapped to `_run_step_fix_silkscreen` |
| `kct pipeline board.kicad_pcb --dry-run` includes fix-silkscreen | Pass | `test_dry_run_fix_silkscreen_message` passes |
| `kct pipeline board.kicad_pcb --step fix-silkscreen` runs only that step | Pass | `test_single_step_fix_silkscreen` passes |
| `fix-silkscreen` listed as valid --step choice | Pass | Added to parser choices in `parser.py` |
| `set(ALL_STEPS) == set(PipelineStep)` still passes | Pass | `test_all_steps_defined` passes |
| `test_step_order` updated with FIX_SILKSCREEN | Pass | Updated expected list, test passes |
| Module docstring and parser description reflect updated step list | Pass | Both updated |

## Test Plan

All 85 tests in `tests/test_pipeline_cmd.py` pass. New tests added:
- `TestFixSilkscreenStep::test_dry_run_fix_silkscreen_message`
- `TestFixSilkscreenStep::test_fix_silkscreen_calls_subprocess`
- `TestFixSilkscreenStep::test_fix_silkscreen_failure_propagates`
- `TestSingleStep::test_single_step_fix_silkscreen`
- `TestMfrAndLayersForwarding::test_mfr_forwarded_to_fix_silkscreen`
- `TestPipelineStepOrder::test_fix_silkscreen_between_erc_and_fix_vias`
- `TestPipelineStepOrder::test_fix_silkscreen_in_all_steps`

Closes #1372