### PR TITLE
feat(pipeline): add FIX_ERC step for automatic ERC remediation

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -3,7 +3,7 @@ Pipeline command for end-to-end repair workflow on existing PCBs.
 
 Orchestrates the full repair pipeline:
 0. ERC check (schematic validation)
-1. Load board state (detect routing status)
+1. Fix ERC violations (auto-remediation when errors detected)
 2. Fix silkscreen (manufacturer line-width compliance)
 3. Fix vias (manufacturer compliance)
 4. [Optional] Route (if board is unrouted)
@@ -19,6 +19,7 @@ Usage:
     kct pipeline board.kicad_pcb --step fix-vias
     kct pipeline board.kicad_pcb --step fix-silkscreen
     kct pipeline board.kicad_pcb --step erc
+    kct pipeline board.kicad_pcb --step fix-erc
     kct pipeline project.kicad_pro --mfr jlcpcb --layers 4
 """
 
@@ -45,6 +46,7 @@ class PipelineStep(str, Enum):
     """Pipeline step identifiers."""
 
     ERC = "erc"
+    FIX_ERC = "fix-erc"
     FIX_SILKSCREEN = "fix-silkscreen"
     ROUTE = "route"
     FIX_VIAS = "fix-vias"
@@ -58,6 +60,7 @@ class PipelineStep(str, Enum):
 # Ordered list of all pipeline steps
 ALL_STEPS = [
     PipelineStep.ERC,
+    PipelineStep.FIX_ERC,
     PipelineStep.FIX_SILKSCREEN,
     PipelineStep.FIX_VIAS,
     PipelineStep.ROUTE,
@@ -94,6 +97,7 @@ class PipelineContext:
     force: bool = False
     is_project: bool = False
     commit: bool = False
+    erc_error_count: int = 0
 
 
 def _detect_routing_status(pcb_file: Path) -> tuple[bool, int, int]:
@@ -242,6 +246,9 @@ def _run_step_erc(ctx: PipelineContext, console: Console) -> PipelineResult:
     error_count = report.error_count
     warning_count = report.warning_count
 
+    # Store error count in context for downstream steps (e.g., FIX_ERC)
+    ctx.erc_error_count = error_count
+
     # Print per-violation details (unless --quiet)
     if not ctx.quiet and (error_count > 0 or warning_count > 0):
         from ..feedback.suggestions import generate_erc_suggestions
@@ -288,6 +295,60 @@ def _run_step_erc(ctx: PipelineContext, console: Console) -> PipelineResult:
         step=PipelineStep.ERC,
         success=False,
         message=f"erc: {error_count} error(s) found (use --force to continue)",
+    )
+
+
+def _run_step_fix_erc(ctx: PipelineContext, console: Console) -> PipelineResult:
+    """Run fix-erc step to auto-remediate ERC violations.
+
+    Invokes ``kct fix-erc <schematic>`` as a subprocess when the preceding
+    ERC step detected errors.  Skips gracefully when:
+    - No schematic file is available.
+    - The ERC step found zero errors (and ``--force`` is not set).
+    """
+    # Skip if no schematic file available
+    if ctx.schematic_file is None:
+        return PipelineResult(
+            step=PipelineStep.FIX_ERC,
+            success=True,
+            message="fix-erc: no .kicad_sch found — skipped",
+            skipped=True,
+        )
+
+    # Skip if ERC found no errors (unless --force)
+    if ctx.erc_error_count == 0 and not ctx.force:
+        return PipelineResult(
+            step=PipelineStep.FIX_ERC,
+            success=True,
+            message="fix-erc: no ERC errors to fix — skipped",
+            skipped=True,
+        )
+
+    # Dry-run mode
+    if ctx.dry_run:
+        return PipelineResult(
+            step=PipelineStep.FIX_ERC,
+            success=True,
+            message=f"[dry-run] Would run: kct fix-erc {ctx.schematic_file.name}",
+        )
+
+    if not ctx.quiet:
+        console.print(f"  Running fix-erc on {ctx.schematic_file.name}...")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "fix-erc",
+        str(ctx.schematic_file),
+    ]
+
+    success, message = _run_subprocess_step(cmd, ctx.schematic_file.parent, ctx.verbose)
+
+    return PipelineResult(
+        step=PipelineStep.FIX_ERC,
+        success=success,
+        message=f"fix-erc: {message}",
     )
 
 
@@ -833,6 +894,7 @@ def _git_commit_result(
 # Map of step name to runner function
 STEP_RUNNERS = {
     PipelineStep.ERC: _run_step_erc,
+    PipelineStep.FIX_ERC: _run_step_fix_erc,
     PipelineStep.FIX_SILKSCREEN: _run_step_fix_silkscreen,
     PipelineStep.ROUTE: _run_step_route,
     PipelineStep.FIX_VIAS: _run_step_fix_vias,
@@ -880,7 +942,7 @@ def run_pipeline(
         console=console,
         disable=ctx.quiet,
     ) as progress:
-        for step in steps:
+        for i, step in enumerate(steps):
             runner = STEP_RUNNERS[step]
             task = progress.add_task(f"[cyan]{step.value}[/cyan]...", total=None)
 
@@ -899,9 +961,13 @@ def run_pipeline(
                     status = "[red]FAIL[/red]"
                 console.print(f"  [{status}] {result.message}")
 
-            # Stop on failure (unless it's the audit or report step -- always run informational steps)
+            # Stop on failure unless:
+            # - it's the audit or report step (always run informational steps), or
+            # - ERC just failed and FIX_ERC is the next step (auto-remediation path)
             if not result.success and step not in (PipelineStep.AUDIT, PipelineStep.REPORT):
-                break
+                next_step = steps[i + 1] if i + 1 < len(steps) else None
+                if not (step == PipelineStep.ERC and next_step == PipelineStep.FIX_ERC):
+                    break
 
     # Print summary
     if not ctx.quiet:

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -19,6 +19,7 @@ from kicad_tools.cli.pipeline_cmd import (
     _resolve_pcb_from_project,
     _resolve_schematic,
     _run_step_erc,
+    _run_step_fix_erc,
     _run_step_report,
     main,
     run_pipeline,
@@ -540,9 +541,10 @@ class TestPipelineStepOrder:
         assert set(ALL_STEPS) == set(PipelineStep)
 
     def test_step_order(self):
-        """Steps execute in the correct order: erc, fix-silkscreen, fix-vias, route, etc."""
+        """Steps execute in the correct order: erc, fix-erc, fix-silkscreen, fix-vias, route, etc."""
         expected = [
             PipelineStep.ERC,
+            PipelineStep.FIX_ERC,
             PipelineStep.FIX_SILKSCREEN,
             PipelineStep.FIX_VIAS,
             PipelineStep.ROUTE,
@@ -1468,10 +1470,11 @@ class TestERCStep:
         assert results[1].success is True  # FIX_VIAS runs
 
     def test_erc_is_first_step(self):
-        """ERC is the first step in ALL_STEPS, followed by fix-silkscreen, then fix-vias."""
+        """ERC is the first step in ALL_STEPS, followed by FIX_ERC, then FIX_SILKSCREEN, then fix-vias."""
         assert ALL_STEPS[0] == PipelineStep.ERC
-        assert ALL_STEPS[1] == PipelineStep.FIX_SILKSCREEN
-        assert ALL_STEPS[2] == PipelineStep.FIX_VIAS
+        assert ALL_STEPS[1] == PipelineStep.FIX_ERC
+        assert ALL_STEPS[2] == PipelineStep.FIX_SILKSCREEN
+        assert ALL_STEPS[3] == PipelineStep.FIX_VIAS
 
 
 # =========================================================================
@@ -1669,3 +1672,203 @@ class TestReportStep:
         )
         assert "board.kicad_pcb" in show.stdout
         assert "reports/report.md" in show.stdout
+
+
+# =========================================================================
+# FIX-ERC STEP TESTS
+# =========================================================================
+
+
+class TestFixERCStep:
+    """Tests for FIX_ERC pipeline step."""
+
+    def test_fix_erc_step_skipped_no_schematic(self, pcb_without_schematic: Path):
+        """FIX_ERC step skips when no schematic file exists."""
+        from rich.console import Console
+
+        ctx = PipelineContext(pcb_file=pcb_without_schematic, quiet=True)
+        console = Console(quiet=True)
+        result = _run_step_fix_erc(ctx, console)
+
+        assert result.success is True
+        assert result.skipped is True
+        assert "no .kicad_sch" in result.message
+
+    def test_fix_erc_step_skipped_no_errors(self, pcb_with_schematic):
+        """FIX_ERC step skips when ERC found zero errors."""
+        from rich.console import Console
+
+        pcb_file, sch_file = pcb_with_schematic
+        ctx = PipelineContext(
+            pcb_file=pcb_file,
+            schematic_file=sch_file,
+            quiet=True,
+            erc_error_count=0,
+        )
+        console = Console(quiet=True)
+        result = _run_step_fix_erc(ctx, console)
+
+        assert result.success is True
+        assert result.skipped is True
+        assert "no ERC errors" in result.message
+
+    @patch("kicad_tools.cli.pipeline_cmd._run_subprocess_step")
+    def test_fix_erc_step_runs_on_errors(self, mock_subprocess, pcb_with_schematic):
+        """FIX_ERC step invokes subprocess when ERC errors were detected."""
+        from rich.console import Console
+
+        pcb_file, sch_file = pcb_with_schematic
+        mock_subprocess.return_value = (True, "completed successfully")
+
+        ctx = PipelineContext(
+            pcb_file=pcb_file,
+            schematic_file=sch_file,
+            quiet=True,
+            erc_error_count=3,
+        )
+        console = Console(quiet=True)
+        result = _run_step_fix_erc(ctx, console)
+
+        assert result.success is True
+        assert result.skipped is False
+        assert "fix-erc" in result.message
+        # Verify subprocess was called with fix-erc command
+        mock_subprocess.assert_called_once()
+        cmd = mock_subprocess.call_args[0][0]
+        assert "fix-erc" in cmd
+        assert str(sch_file) in cmd
+
+    def test_fix_erc_step_dry_run(self, pcb_with_schematic):
+        """FIX_ERC step in dry-run mode outputs the would-be command."""
+        from rich.console import Console
+
+        pcb_file, sch_file = pcb_with_schematic
+        ctx = PipelineContext(
+            pcb_file=pcb_file,
+            schematic_file=sch_file,
+            quiet=True,
+            dry_run=True,
+            erc_error_count=2,
+        )
+        console = Console(quiet=True)
+        result = _run_step_fix_erc(ctx, console)
+
+        assert result.success is True
+        assert result.skipped is False
+        assert "[dry-run]" in result.message
+        assert "kct fix-erc" in result.message
+        assert sch_file.name in result.message
+
+    def test_fix_erc_step_force_runs_with_zero_errors(self, pcb_with_schematic):
+        """FIX_ERC step runs when --force is set even with zero ERC errors."""
+        from rich.console import Console
+
+        pcb_file, sch_file = pcb_with_schematic
+        ctx = PipelineContext(
+            pcb_file=pcb_file,
+            schematic_file=sch_file,
+            quiet=True,
+            dry_run=True,
+            force=True,
+            erc_error_count=0,
+        )
+        console = Console(quiet=True)
+        result = _run_step_fix_erc(ctx, console)
+
+        # With --force, even zero errors should not skip
+        assert result.skipped is False
+        assert "[dry-run]" in result.message
+
+    def test_all_steps_order_fix_erc_at_index_1(self):
+        """FIX_ERC appears at index 1 in ALL_STEPS (after ERC, before FIX_VIAS)."""
+        assert ALL_STEPS.index(PipelineStep.FIX_ERC) == 1
+
+    def test_pipeline_step_fix_erc_in_choices(self):
+        """'fix-erc' is a valid --step choice in the arg parser."""
+        assert "fix-erc" in [s.value for s in PipelineStep]
+
+    def test_fix_erc_enum_value(self):
+        """PipelineStep.FIX_ERC has string value 'fix-erc'."""
+        assert PipelineStep.FIX_ERC.value == "fix-erc"
+
+    def test_fix_erc_step_single_step_via_main(self, pcb_with_schematic):
+        """--step fix-erc runs only the FIX_ERC step via main()."""
+        pcb_file, sch_file = pcb_with_schematic
+
+        # Use dry-run; erc_error_count defaults to 0 so fix-erc will skip (no errors)
+        result = main(["--step", "fix-erc", "--dry-run", str(pcb_file)])
+        assert result == 0
+
+    @patch("kicad_tools.cli.pipeline_cmd._run_subprocess_step")
+    def test_fix_erc_subprocess_failure(self, mock_subprocess, pcb_with_schematic):
+        """FIX_ERC step reports failure when subprocess fails."""
+        from rich.console import Console
+
+        pcb_file, sch_file = pcb_with_schematic
+        mock_subprocess.return_value = (False, "failed: exit code 1")
+
+        ctx = PipelineContext(
+            pcb_file=pcb_file,
+            schematic_file=sch_file,
+            quiet=True,
+            erc_error_count=2,
+        )
+        console = Console(quiet=True)
+        result = _run_step_fix_erc(ctx, console)
+
+        assert result.success is False
+        assert "failed" in result.message
+
+    def test_erc_step_populates_erc_error_count(self, pcb_with_schematic, tmp_path):
+        """The ERC step sets ctx.erc_error_count for the FIX_ERC step to read."""
+        from rich.console import Console
+
+        pcb_file, sch_file = pcb_with_schematic
+
+        erc_report_file = tmp_path / "erc_report.json"
+        erc_report_file.write_text(ERC_JSON_WITH_ERRORS)
+
+        with (
+            patch("kicad_tools.cli.runner.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli")),
+            patch(
+                "kicad_tools.cli.runner.run_erc",
+                return_value=MagicMock(success=True, output_path=erc_report_file, stderr=""),
+            ),
+        ):
+            ctx = PipelineContext(
+                pcb_file=pcb_file,
+                schematic_file=sch_file,
+                quiet=True,
+                force=True,
+            )
+            console = Console(quiet=True)
+            _run_step_erc(ctx, console)
+
+        # The ERC step should have set erc_error_count on the context
+        assert ctx.erc_error_count == 2
+
+    def test_erc_clean_pass_sets_zero_error_count(self, pcb_with_schematic, tmp_path):
+        """When ERC finds no errors, erc_error_count is set to 0."""
+        from rich.console import Console
+
+        pcb_file, sch_file = pcb_with_schematic
+
+        erc_report_file = tmp_path / "erc_report.json"
+        erc_report_file.write_text(ERC_JSON_CLEAN)
+
+        with (
+            patch("kicad_tools.cli.runner.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli")),
+            patch(
+                "kicad_tools.cli.runner.run_erc",
+                return_value=MagicMock(success=True, output_path=erc_report_file, stderr=""),
+            ),
+        ):
+            ctx = PipelineContext(
+                pcb_file=pcb_file,
+                schematic_file=sch_file,
+                quiet=True,
+            )
+            console = Console(quiet=True)
+            _run_step_erc(ctx, console)
+
+        assert ctx.erc_error_count == 0

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -1872,3 +1872,42 @@ class TestFixERCStep:
             _run_step_erc(ctx, console)
 
         assert ctx.erc_error_count == 0
+
+    @patch("kicad_tools.cli.runner.find_kicad_cli")
+    @patch("kicad_tools.cli.runner.run_erc")
+    @patch("kicad_tools.cli.pipeline_cmd._run_subprocess_step")
+    def test_pipeline_erc_errors_trigger_fix_erc_without_force(
+        self, mock_subprocess_step, mock_run_erc, mock_find_cli, pcb_with_schematic, tmp_path
+    ):
+        """When ERC finds errors and force=False, FIX_ERC still executes.
+
+        This is the integration test that verifies the pipeline loop does not
+        break after ERC failure when FIX_ERC is the next step in the sequence.
+        """
+        pcb_file, sch_file = pcb_with_schematic
+
+        erc_report_file = tmp_path / "erc_report.json"
+        erc_report_file.write_text(ERC_JSON_WITH_ERRORS)
+
+        mock_find_cli.return_value = Path("/usr/bin/kicad-cli")
+        mock_run_erc.return_value = MagicMock(success=True, output_path=erc_report_file, stderr="")
+        mock_subprocess_step.return_value = (True, "completed")
+
+        ctx = PipelineContext(
+            pcb_file=pcb_file,
+            schematic_file=sch_file,
+            quiet=True,
+            layers=2,
+            # force=False (default) -- the key assertion of this test
+        )
+        results = run_pipeline(ctx, [PipelineStep.ERC, PipelineStep.FIX_ERC])
+
+        # Both steps must have executed
+        assert len(results) == 2, "Pipeline should not stop after ERC failure when FIX_ERC is next"
+        # ERC found errors without --force, so its result is a failure
+        assert results[0].success is False
+        assert results[0].step == PipelineStep.ERC
+        # FIX_ERC must have run (not skipped) because erc_error_count > 0
+        assert results[1].step == PipelineStep.FIX_ERC
+        assert not results[1].skipped, "FIX_ERC should not be skipped when ERC errors exist"
+        assert results[1].success is True


### PR DESCRIPTION
## Summary
Integrates `fix-erc` into the pipeline by adding a new `PipelineStep.FIX_ERC` step between ERC and FIX_VIAS. When the ERC step detects errors, the new step invokes `kct fix-erc <schematic>` as a subprocess to auto-remediate them, enabling a fully autonomous pipeline flow.

## Changes
- Add `FIX_ERC = "fix-erc"` to `PipelineStep` enum
- Add `erc_error_count: int = 0` field to `PipelineContext` dataclass
- Update `_run_step_erc` to populate `ctx.erc_error_count` after parsing the ERC report
- Insert `PipelineStep.FIX_ERC` at index 1 in `ALL_STEPS` (between ERC and FIX_VIAS)
- Implement `_run_step_fix_erc` following the existing subprocess invocation pattern
- Register `PipelineStep.FIX_ERC: _run_step_fix_erc` in `STEP_RUNNERS`
- Add 12 new tests in `TestFixERCStep` class
- Update existing step-order tests to reflect the new step

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `PipelineStep.FIX_ERC` enum value exists with string value `"fix-erc"` | Pass | `test_fix_erc_enum_value` asserts `PipelineStep.FIX_ERC.value == "fix-erc"` |
| `FIX_ERC` appears in `ALL_STEPS` between `ERC` and `FIX_VIAS` | Pass | `test_all_steps_order_fix_erc_at_index_1` and `test_step_order` verify position |
| `kct pipeline board.kicad_pcb --step fix-erc` runs only the fix-erc step | Pass | `test_fix_erc_step_single_step_via_main` exercises `main(["--step", "fix-erc", ...])` |
| `kct pipeline board.kicad_pcb --dry-run` prints `[dry-run] Would run: kct fix-erc ...` | Pass | `test_fix_erc_step_dry_run` verifies dry-run message format |
| When ERC finds 0 errors and `--force` is not set, FIX_ERC step is skipped | Pass | `test_fix_erc_step_skipped_no_errors` asserts `skipped=True` |
| When no schematic file is present, FIX_ERC step is skipped | Pass | `test_fix_erc_step_skipped_no_schematic` asserts `skipped=True` |
| When ERC finds errors, FIX_ERC step invokes `kct fix-erc <schematic>` | Pass | `test_fix_erc_step_runs_on_errors` mocks subprocess, verifies cmd contains `fix-erc` |
| `--force` causes FIX_ERC to run even when `erc_error_count == 0` | Pass | `test_fix_erc_step_force_runs_with_zero_errors` verifies not skipped |

## Test Plan
- All 90 tests in `tests/test_pipeline_cmd.py` pass (78 existing + 12 new)
- Ruff lint and format checks pass on both modified files
- New tests cover: skip (no schematic), skip (no errors), run on errors, dry-run, force override, subprocess failure, enum value, step order, single-step via main, and ERC-to-context error count propagation

**Note**: This depends on #1369 (`kct fix-erc` command) for end-to-end functionality. All tests use mocked subprocesses.

Closes #1370