### PR TITLE
fix(report): prevent double-nesting of figures path in _embed_images

### DIFF
--- a/src/kicad_tools/report/renderers.py
+++ b/src/kicad_tools/report/renderers.py
@@ -16,7 +16,7 @@ _TEMPLATES_DIR = Path(__file__).parent / "templates"
 
 def render_html(
     markdown_content: str,
-    figures_dir: Path | None = None,
+    figures_dir: Path | str | None = None,
 ) -> str:
     """Convert Markdown report to a self-contained HTML document.
 
@@ -27,6 +27,7 @@ def render_html(
     Args:
         markdown_content: Markdown source text (e.g. from ReportGenerator).
         figures_dir: Directory containing PNG figures referenced in the Markdown.
+            Accepts both :class:`~pathlib.Path` objects and plain strings.
             If None, image ``src`` attributes are left unchanged.
 
     Returns:
@@ -48,6 +49,7 @@ def render_html(
     css = _load_css()
 
     if figures_dir is not None:
+        figures_dir = Path(figures_dir)
         html_body = _embed_images(html_body, figures_dir)
 
     # Wrap tables in a scrollable div for responsive layout
@@ -116,8 +118,9 @@ def _embed_images(html: str, figures_dir: Path) -> str:
 
     def _replacer(match: re.Match) -> str:
         src = match.group(1)
-        # Handle both bare filenames and relative paths
-        img_path = figures_dir / src
+        # Use only the filename to avoid double-nesting when src already
+        # contains a directory prefix like "figures/" from template rendering.
+        img_path = figures_dir / Path(src).name
         if img_path.exists() and img_path.suffix.lower() == ".png":
             data = base64.b64encode(img_path.read_bytes()).decode("ascii")
             return match.group(0).replace(

--- a/tests/report/test_renderers.py
+++ b/tests/report/test_renderers.py
@@ -200,6 +200,28 @@ class TestRenderHtml:
         assert "<link " not in result
         assert 'rel="stylesheet"' not in result
 
+    def test_figures_dir_as_string(
+        self,
+        markdown_with_image: str,
+        figures_dir: Path,
+    ) -> None:
+        """render_html accepts figures_dir as a plain str without raising."""
+        from kicad_tools.report.renderers import render_html
+
+        result = render_html(markdown_with_image, figures_dir=str(figures_dir))
+        assert "data:image/png;base64," in result
+        assert 'src="front_copper.png"' not in result
+
+    def test_embeds_figures_with_prefixed_src(self, figures_dir: Path) -> None:
+        """Images with a 'figures/' prefix in src are embedded correctly."""
+        from kicad_tools.report.renderers import render_html
+
+        # This mirrors the real template output where src="figures/front.png"
+        md = "# Board\n\n![Front](figures/front.png)\n\nDescription.\n"
+        result = render_html(md, figures_dir=figures_dir)
+        assert "data:image/png;base64," in result
+        assert 'src="figures/front.png"' not in result
+
     def test_cover_block_in_html_output(self) -> None:
         """Cover block div passes through Markdown-to-HTML conversion."""
         from kicad_tools.report.renderers import render_html
@@ -451,6 +473,32 @@ class TestEmbedImages:
         from kicad_tools.report.renderers import _embed_images
 
         html = "<p>No images here</p>"
+        result = _embed_images(html, figures_dir)
+        assert result == html
+
+    def test_strips_figures_prefix_from_src(self, figures_dir: Path) -> None:
+        """src with a 'figures/' prefix does not double-nest the path."""
+        from kicad_tools.report.renderers import _embed_images
+
+        html = '<img alt="Front" src="figures/front.png" />'
+        result = _embed_images(html, figures_dir)
+        assert "data:image/png;base64," in result
+        assert 'src="figures/front.png"' not in result
+
+    def test_deeply_nested_prefix_left_unchanged(self, figures_dir: Path) -> None:
+        """A deeply nested prefix like 'assets/figures/file.png' uses only the filename."""
+        from kicad_tools.report.renderers import _embed_images
+
+        # front.png exists in figures_dir, so using .name extracts it correctly
+        html = '<img alt="Front" src="assets/figures/front.png" />'
+        result = _embed_images(html, figures_dir)
+        assert "data:image/png;base64," in result
+
+    def test_non_png_with_figures_prefix_not_embedded(self, figures_dir: Path) -> None:
+        """Non-PNG files with a figures/ prefix are left unchanged."""
+        from kicad_tools.report.renderers import _embed_images
+
+        html = '<img alt="Diagram" src="figures/diagram.svg" />'
         result = _embed_images(html, figures_dir)
         assert result == html
 


### PR DESCRIPTION
## Summary
Fix two bugs in `_embed_images` that caused zero images to be embedded in real usage: (1) image `src` attributes containing a `figures/` prefix were double-nested when joined with `figures_dir`, and (2) passing `figures_dir` as a string caused an `AttributeError`.

## Changes
- Use `Path(src).name` in `_embed_images._replacer` to strip any directory prefix from the image `src` before joining with `figures_dir`, preventing double-nesting like `figures/figures/pcb_front.png`
- Add `figures_dir = Path(figures_dir)` coercion in `render_html` before passing to `_embed_images`, matching the pattern already used by `render_pdf`
- Update type annotation to `Path | str | None` for accuracy
- Add regression tests: prefixed src embedding, string figures_dir, deeply nested prefix, non-PNG with prefix

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `render_html(md, figures_dir="...")` does not raise AttributeError (str coercion) | PASS | `test_figures_dir_as_string` passes |
| `![alt](figures/pcb_front.png)` with `figures_dir` pointing to figures/ embeds correctly | PASS | `test_embeds_figures_with_prefixed_src` passes |
| `![alt](pcb_front.png)` (bare filename) still embeds correctly | PASS | `test_embeds_figures_as_base64` and `test_replaces_existing_png` pass |
| Missing images left unchanged | PASS | `test_preserves_missing_images` and `test_embeds_multiple_figures` pass |
| All existing test_renderers.py tests pass | PASS | 42/42 tests pass |

## Test Plan
- All 42 tests in `tests/report/test_renderers.py` pass
- New tests cover: prefixed src (`figures/front.png`), string figures_dir, deeply nested prefix (`assets/figures/front.png`), non-PNG with prefix
- `ruff check` and `ruff format --check` pass on both changed files

Closes #1383