### PR TITLE
feat(audit): classify non-electrical ERC violations as warnings

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -34,6 +34,7 @@ class ERCStatus:
 
     error_count: int = 0
     warning_count: int = 0
+    blocking_error_count: int = 0  # Only electrical errors that block readiness
     passed: bool = True
     details: str = ""
     report_path: Path | None = None
@@ -42,6 +43,7 @@ class ERCStatus:
         return {
             "error_count": self.error_count,
             "warning_count": self.warning_count,
+            "blocking_error_count": self.blocking_error_count,
             "passed": self.passed,
             "details": self.details,
         }
@@ -224,7 +226,7 @@ class AuditResult:
     def verdict(self) -> AuditVerdict:
         """Determine overall verdict based on check results."""
         # Critical failures
-        if self.erc.error_count > 0:
+        if self.erc.blocking_error_count > 0:
             return AuditVerdict.NOT_READY
         if self.drc.blocking_count > 0:
             return AuditVerdict.NOT_READY
@@ -484,16 +486,38 @@ class ManufacturingAudit:
 
                 if report_path.exists():
                     from kicad_tools.erc import ERCReport
+                    from kicad_tools.erc.violation import (
+                        ERC_BLOCKING_TYPES,
+                        ERC_NON_BLOCKING_TYPES,
+                    )
 
                     report = ERCReport.load(report_path)
-                    status.error_count = report.error_count
-                    status.warning_count = report.warning_count
-                    status.passed = report.error_count == 0
-                    if report.error_count > 0:
-                        # Get first few error types
+                    status.error_count = report.error_count  # raw total for reporting
+
+                    # Split errors by blocking vs non-blocking type
+                    blocking = [v for v in report.errors if v.type in ERC_BLOCKING_TYPES]
+                    non_blocking = [v for v in report.errors if v.type in ERC_NON_BLOCKING_TYPES]
+                    unknown_errors = [
+                        v
+                        for v in report.errors
+                        if v.type not in ERC_BLOCKING_TYPES and v.type not in ERC_NON_BLOCKING_TYPES
+                    ]
+
+                    # Unknown error types default to blocking (conservative)
+                    status.blocking_error_count = len(blocking) + len(unknown_errors)
+                    # Demote non-blocking errors to warnings
+                    status.warning_count = report.warning_count + len(non_blocking)
+                    status.passed = status.blocking_error_count == 0
+
+                    if status.blocking_error_count > 0:
+                        # Get first few blocking error types for the details string
                         by_type = report.violations_by_type()
-                        types = list(by_type.keys())[:3]
-                        status.details = ", ".join(t.value for t in types)
+                        blocking_types = [
+                            t
+                            for t in by_type
+                            if t in ERC_BLOCKING_TYPES or t not in ERC_NON_BLOCKING_TYPES
+                        ][:3]
+                        status.details = ", ".join(t.value for t in blocking_types)
                     status.report_path = report_path
             except FileNotFoundError:
                 # kicad-cli not installed
@@ -701,13 +725,24 @@ class ManufacturingAudit:
         """Generate prioritized action items from results."""
         items: list[ActionItem] = []
 
-        # ERC errors
-        if result.erc.error_count > 0:
+        # Blocking ERC errors (electrical issues)
+        if result.erc.blocking_error_count > 0:
             items.append(
                 ActionItem(
                     priority=1,
-                    description=f"Fix {result.erc.error_count} ERC errors in schematic"
+                    description=f"Fix {result.erc.blocking_error_count} blocking ERC errors in schematic"
                     + (f" ({result.erc.details})" if result.erc.details else ""),
+                    command=f"kicad-cli sch erc {self.schematic_path}",
+                )
+            )
+
+        # Non-blocking ERC errors (demoted to warnings)
+        non_blocking_count = result.erc.error_count - result.erc.blocking_error_count
+        if non_blocking_count > 0:
+            items.append(
+                ActionItem(
+                    priority=3,
+                    description=f"Review {non_blocking_count} non-blocking ERC warnings (library/footprint checks)",
                     command=f"kicad-cli sch erc {self.schematic_path}",
                 )
             )

--- a/src/kicad_tools/erc/__init__.py
+++ b/src/kicad_tools/erc/__init__.py
@@ -17,7 +17,9 @@ from .report import (
     parse_text_report,
 )
 from .violation import (
+    ERC_BLOCKING_TYPES,
     ERC_CATEGORIES,
+    ERC_NON_BLOCKING_TYPES,
     ERC_TYPE_DESCRIPTIONS,
     ERCViolation,
     ERCViolationType,
@@ -31,6 +33,8 @@ __all__ = [
     "Severity",
     "ERC_TYPE_DESCRIPTIONS",
     "ERC_CATEGORIES",
+    "ERC_BLOCKING_TYPES",
+    "ERC_NON_BLOCKING_TYPES",
     # Report parsing
     "ERCReport",
     "parse_json_report",

--- a/src/kicad_tools/erc/violation.py
+++ b/src/kicad_tools/erc/violation.py
@@ -53,6 +53,13 @@ class ERCViolationType(Enum):
     UNSPECIFIED = "unspecified"
     WIRE_DANGLING = "wire_dangling"
 
+    # Library/footprint checks (non-electrical)
+    LIB_SYMBOL_MISMATCH = "lib_symbol_mismatch"
+    FOOTPRINT_LINK_ISSUES = "footprint_link_issues"
+    SINGLE_GLOBAL_LABEL = "single_global_label"
+    ISOLATED_PIN_LABEL = "isolated_pin_label"
+    PIN_TO_PIN = "pin_to_pin"
+
     # Unknown
     UNKNOWN = "unknown"
 
@@ -107,6 +114,12 @@ ERC_TYPE_DESCRIPTIONS = {
     "unannotated": "Symbol not annotated",
     "unspecified": "Unspecified error",
     "wire_dangling": "Wire not connected at both ends",
+    # Library/footprint checks (non-electrical)
+    "lib_symbol_mismatch": "Library symbol does not match schematic symbol",
+    "footprint_link_issues": "Footprint link issues",
+    "single_global_label": "Only one global label for a net",
+    "isolated_pin_label": "Pin connected only by label (no wire)",
+    "pin_to_pin": "Pin-to-pin connection issue",
     # Unknown
     "unknown": "Unknown violation type",
 }
@@ -146,6 +159,7 @@ ERC_CATEGORIES = {
     "Symbols": [
         "extra_units",
         "lib_symbol_issues",
+        "lib_symbol_mismatch",
         "missing_bidi_pin",
         "missing_input_pin",
         "missing_power_pin",
@@ -153,8 +167,47 @@ ERC_CATEGORIES = {
         "simulation_model",
         "unannotated",
     ],
-    "Other": ["unresolved_variable", "unspecified", "unknown"],
+    "Other": [
+        "footprint_link_issues",
+        "isolated_pin_label",
+        "pin_to_pin",
+        "single_global_label",
+        "unresolved_variable",
+        "unspecified",
+        "unknown",
+    ],
 }
+
+
+# Violation types that indicate genuine electrical problems.
+# These block manufacturing readiness (verdict = NOT_READY).
+ERC_BLOCKING_TYPES: frozenset[ERCViolationType] = frozenset(
+    {
+        ERCViolationType.POWER_PIN_NOT_DRIVEN,
+        ERCViolationType.PIN_NOT_CONNECTED,
+        ERCViolationType.PIN_NOT_DRIVEN,
+        ERCViolationType.DIFFERENT_UNIT_NET,
+        ERCViolationType.DUPLICATE_REFERENCE,
+        ERCViolationType.MISSING_POWER_PIN,
+        ERCViolationType.HIER_LABEL_MISMATCH,
+        ERCViolationType.BUS_TO_NET_CONFLICT,
+        ERCViolationType.BUS_TO_BUS_CONFLICT,
+    }
+)
+
+# Violation types that are non-electrical and should not block manufacturing
+# readiness.  These are demoted to warnings in the audit verdict.
+ERC_NON_BLOCKING_TYPES: frozenset[ERCViolationType] = frozenset(
+    {
+        ERCViolationType.LIB_SYMBOL_MISMATCH,
+        ERCViolationType.FOOTPRINT_LINK_ISSUES,
+        ERCViolationType.SINGLE_GLOBAL_LABEL,
+        ERCViolationType.ISOLATED_PIN_LABEL,
+        ERCViolationType.PIN_TO_PIN,
+        ERCViolationType.ENDPOINT_OFF_GRID,
+        ERCViolationType.SIMILAR_LABELS,
+    }
+)
 
 
 @dataclass

--- a/tests/fixtures/sample_erc_non_blocking.json
+++ b/tests/fixtures/sample_erc_non_blocking.json
@@ -1,0 +1,43 @@
+{
+    "source": "test-non-blocking.kicad_sch",
+    "kicad_version": "8.0.0",
+    "coordinate_units": "mm",
+    "sheets": [
+        {
+            "path": "/",
+            "uuid_path": "00000000-0000-0000-0000-000000000000",
+            "violations": [
+                {
+                    "type": "lib_symbol_mismatch",
+                    "severity": "error",
+                    "description": "Symbol 'R_0402' in library has been modified",
+                    "pos": {"x": 100.0, "y": 50.0},
+                    "items": [
+                        {"description": "Symbol R1 (R_0402)"}
+                    ],
+                    "excluded": false
+                },
+                {
+                    "type": "footprint_link_issues",
+                    "severity": "error",
+                    "description": "Footprint not found in library",
+                    "pos": {"x": 120.0, "y": 60.0},
+                    "items": [
+                        {"description": "Symbol U1 footprint Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"}
+                    ],
+                    "excluded": false
+                },
+                {
+                    "type": "single_global_label",
+                    "severity": "warning",
+                    "description": "Only one global label for net 'RESET'",
+                    "pos": {"x": 140.0, "y": 70.0},
+                    "items": [
+                        {"description": "Global label 'RESET'"}
+                    ],
+                    "excluded": false
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -24,9 +24,10 @@ class TestAuditResult:
         assert result.is_ready is True
 
     def test_verdict_not_ready_with_erc_errors(self):
-        """Test that verdict is NOT_READY with ERC errors."""
+        """Test that verdict is NOT_READY with blocking ERC errors."""
         result = AuditResult()
         result.erc.error_count = 1
+        result.erc.blocking_error_count = 1
         assert result.verdict == AuditVerdict.NOT_READY
         assert result.is_ready is False
 
@@ -156,9 +157,10 @@ class TestAuditResult:
         When only one gate fails and all others pass, verdict must be NOT_READY.
         This confirms no gate is redundant and all four are independently checked.
         """
-        # Gate 1: Only ERC errors block
+        # Gate 1: Only ERC blocking errors block
         result = AuditResult()
         result.erc.error_count = 3
+        result.erc.blocking_error_count = 3
         result.drc.blocking_count = 0
         result.connectivity.passed = True
         result.compatibility.passed = True
@@ -513,6 +515,7 @@ class TestAuditExitCodes:
         """Test that CLI returns exit code 1 when verdict is NOT_READY."""
         result = AuditResult()
         result.erc.error_count = 5
+        result.erc.blocking_error_count = 5
         assert result.verdict == AuditVerdict.NOT_READY
 
         # Verify the exit code mapping
@@ -561,11 +564,12 @@ class TestAuditOutputRendering:
         assert "[OK] READY FOR MANUFACTURING" in captured.out
 
     def test_output_table_shows_not_ready_when_erc_fails(self, capsys):
-        """Test that output_table prints NOT READY when ERC has errors."""
+        """Test that output_table prints NOT READY when ERC has blocking errors."""
         from kicad_tools.cli.audit_cmd import output_table
 
         result = AuditResult(project_name="test_failing_board")
         result.erc.error_count = 3
+        result.erc.blocking_error_count = 3
         assert result.verdict == AuditVerdict.NOT_READY
 
         output_table(result)

--- a/tests/test_erc_violation_classification.py
+++ b/tests/test_erc_violation_classification.py
@@ -1,0 +1,251 @@
+"""Tests for ERC violation classification (blocking vs non-blocking).
+
+Tests the ERC_BLOCKING_TYPES and ERC_NON_BLOCKING_TYPES frozensets,
+the ERCStatus.blocking_error_count field, and the verdict gate that
+uses blocking_error_count instead of raw error_count.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.audit import AuditResult, AuditVerdict
+from kicad_tools.audit.auditor import ERCStatus
+from kicad_tools.erc import ERCReport, ERCViolationType
+from kicad_tools.erc.violation import (
+    ERC_BLOCKING_TYPES,
+    ERC_NON_BLOCKING_TYPES,
+)
+
+
+class TestERCBlockingAndNonBlockingSets:
+    """Tests for ERC_BLOCKING_TYPES and ERC_NON_BLOCKING_TYPES frozensets."""
+
+    def test_blocking_types_is_frozenset(self):
+        """ERC_BLOCKING_TYPES must be a frozenset."""
+        assert isinstance(ERC_BLOCKING_TYPES, frozenset)
+
+    def test_non_blocking_types_is_frozenset(self):
+        """ERC_NON_BLOCKING_TYPES must be a frozenset."""
+        assert isinstance(ERC_NON_BLOCKING_TYPES, frozenset)
+
+    def test_blocking_and_non_blocking_are_disjoint(self):
+        """Blocking and non-blocking sets must not overlap."""
+        overlap = ERC_BLOCKING_TYPES & ERC_NON_BLOCKING_TYPES
+        assert overlap == frozenset(), f"Overlap found: {overlap}"
+
+    def test_blocking_types_contain_expected_electrical_errors(self):
+        """Blocking types should include core electrical errors."""
+        expected = {
+            ERCViolationType.POWER_PIN_NOT_DRIVEN,
+            ERCViolationType.PIN_NOT_CONNECTED,
+            ERCViolationType.PIN_NOT_DRIVEN,
+            ERCViolationType.DIFFERENT_UNIT_NET,
+            ERCViolationType.DUPLICATE_REFERENCE,
+            ERCViolationType.MISSING_POWER_PIN,
+            ERCViolationType.HIER_LABEL_MISMATCH,
+            ERCViolationType.BUS_TO_NET_CONFLICT,
+            ERCViolationType.BUS_TO_BUS_CONFLICT,
+        }
+        assert expected == ERC_BLOCKING_TYPES
+
+    def test_non_blocking_types_contain_expected_library_checks(self):
+        """Non-blocking types should include library/footprint checks."""
+        assert ERCViolationType.LIB_SYMBOL_MISMATCH in ERC_NON_BLOCKING_TYPES
+        assert ERCViolationType.FOOTPRINT_LINK_ISSUES in ERC_NON_BLOCKING_TYPES
+        assert ERCViolationType.SINGLE_GLOBAL_LABEL in ERC_NON_BLOCKING_TYPES
+        assert ERCViolationType.ISOLATED_PIN_LABEL in ERC_NON_BLOCKING_TYPES
+        assert ERCViolationType.PIN_TO_PIN in ERC_NON_BLOCKING_TYPES
+        assert ERCViolationType.ENDPOINT_OFF_GRID in ERC_NON_BLOCKING_TYPES
+        assert ERCViolationType.SIMILAR_LABELS in ERC_NON_BLOCKING_TYPES
+
+    def test_all_set_members_are_valid_enum_values(self):
+        """Every member of both sets must be a valid ERCViolationType value."""
+        for t in ERC_BLOCKING_TYPES:
+            assert isinstance(t, ERCViolationType), f"{t} is not ERCViolationType"
+        for t in ERC_NON_BLOCKING_TYPES:
+            assert isinstance(t, ERCViolationType), f"{t} is not ERCViolationType"
+
+    def test_unknown_type_is_not_in_either_set(self):
+        """UNKNOWN type should not be in either set (defaults to blocking behavior)."""
+        assert ERCViolationType.UNKNOWN not in ERC_BLOCKING_TYPES
+        assert ERCViolationType.UNKNOWN not in ERC_NON_BLOCKING_TYPES
+
+
+class TestNewERCViolationTypes:
+    """Tests for newly added ERCViolationType enum values."""
+
+    def test_lib_symbol_mismatch_parses(self):
+        """lib_symbol_mismatch should parse to LIB_SYMBOL_MISMATCH, not UNKNOWN."""
+        assert (
+            ERCViolationType.from_string("lib_symbol_mismatch")
+            == ERCViolationType.LIB_SYMBOL_MISMATCH
+        )
+
+    def test_footprint_link_issues_parses(self):
+        """footprint_link_issues should parse to FOOTPRINT_LINK_ISSUES, not UNKNOWN."""
+        assert (
+            ERCViolationType.from_string("footprint_link_issues")
+            == ERCViolationType.FOOTPRINT_LINK_ISSUES
+        )
+
+    def test_single_global_label_parses(self):
+        """single_global_label should parse to SINGLE_GLOBAL_LABEL, not UNKNOWN."""
+        assert (
+            ERCViolationType.from_string("single_global_label")
+            == ERCViolationType.SINGLE_GLOBAL_LABEL
+        )
+
+    def test_isolated_pin_label_parses(self):
+        """isolated_pin_label should parse to ISOLATED_PIN_LABEL, not UNKNOWN."""
+        assert (
+            ERCViolationType.from_string("isolated_pin_label")
+            == ERCViolationType.ISOLATED_PIN_LABEL
+        )
+
+    def test_pin_to_pin_parses(self):
+        """pin_to_pin should parse to PIN_TO_PIN, not UNKNOWN."""
+        assert ERCViolationType.from_string("pin_to_pin") == ERCViolationType.PIN_TO_PIN
+
+
+class TestNonBlockingERCFixture:
+    """Tests using the non-blocking ERC fixture file."""
+
+    @pytest.fixture
+    def non_blocking_report(self, fixtures_dir: Path) -> ERCReport:
+        """Load the non-blocking ERC fixture."""
+        return ERCReport.load(fixtures_dir / "sample_erc_non_blocking.json")
+
+    def test_non_blocking_fixture_loads(self, non_blocking_report: ERCReport):
+        """Fixture should load without errors."""
+        assert non_blocking_report.source_file == "test-non-blocking.kicad_sch"
+
+    def test_non_blocking_fixture_has_errors(self, non_blocking_report: ERCReport):
+        """Fixture should have error-severity violations."""
+        assert non_blocking_report.error_count == 2  # lib_symbol_mismatch + footprint_link_issues
+
+    def test_lib_symbol_mismatch_parsed_correctly(self, non_blocking_report: ERCReport):
+        """lib_symbol_mismatch violations should parse to the correct type."""
+        by_type = non_blocking_report.violations_by_type()
+        assert ERCViolationType.LIB_SYMBOL_MISMATCH in by_type
+        assert len(by_type[ERCViolationType.LIB_SYMBOL_MISMATCH]) == 1
+
+    def test_footprint_link_issues_parsed_correctly(self, non_blocking_report: ERCReport):
+        """footprint_link_issues violations should parse to the correct type."""
+        by_type = non_blocking_report.violations_by_type()
+        assert ERCViolationType.FOOTPRINT_LINK_ISSUES in by_type
+        assert len(by_type[ERCViolationType.FOOTPRINT_LINK_ISSUES]) == 1
+
+    def test_all_errors_are_non_blocking(self, non_blocking_report: ERCReport):
+        """All error-level violations in the fixture should be non-blocking."""
+        for v in non_blocking_report.errors:
+            assert v.type in ERC_NON_BLOCKING_TYPES, (
+                f"Error type {v.type} is not in ERC_NON_BLOCKING_TYPES"
+            )
+
+
+class TestERCStatusBlockingErrorCount:
+    """Tests for ERCStatus.blocking_error_count field."""
+
+    def test_default_blocking_error_count_is_zero(self):
+        """ERCStatus should default blocking_error_count to 0."""
+        status = ERCStatus()
+        assert status.blocking_error_count == 0
+
+    def test_blocking_error_count_in_to_dict(self):
+        """blocking_error_count should appear in to_dict output."""
+        status = ERCStatus(error_count=5, blocking_error_count=3)
+        d = status.to_dict()
+        assert "blocking_error_count" in d
+        assert d["blocking_error_count"] == 3
+
+    def test_error_count_preserved_raw(self):
+        """error_count should remain the raw total, not affected by blocking split."""
+        status = ERCStatus(error_count=5, blocking_error_count=2, warning_count=3)
+        assert status.error_count == 5
+        assert status.blocking_error_count == 2
+
+
+class TestVerdictWithBlockingClassification:
+    """Tests for AuditResult.verdict using the blocking_error_count gate."""
+
+    def test_non_blocking_erc_error_does_not_block_ready(self):
+        """A design with only non-blocking ERC errors should produce READY."""
+        result = AuditResult()
+        result.erc = ERCStatus(
+            error_count=2,  # 2 raw errors (e.g., lib_symbol_mismatch)
+            blocking_error_count=0,  # none are blocking
+            warning_count=2,  # non-blocking errors demoted to warnings
+            passed=True,
+        )
+        # Non-blocking errors are demoted to warnings, so verdict is WARNING
+        assert result.verdict == AuditVerdict.WARNING
+
+    def test_non_blocking_erc_only_with_zero_warnings_is_ready(self):
+        """A design with non-blocking ERC errors but zero total warnings."""
+        result = AuditResult()
+        result.erc = ERCStatus(
+            error_count=2,
+            blocking_error_count=0,
+            warning_count=0,  # non-blocking errors not counted as warnings here
+            passed=True,
+        )
+        assert result.verdict == AuditVerdict.READY
+
+    def test_blocking_erc_error_blocks_ready(self):
+        """A design with blocking ERC errors should produce NOT_READY."""
+        result = AuditResult()
+        result.erc = ERCStatus(
+            error_count=1,
+            blocking_error_count=1,  # power_pin_not_driven
+            warning_count=0,
+            passed=False,
+        )
+        assert result.verdict == AuditVerdict.NOT_READY
+
+    def test_unknown_erc_type_blocks_ready(self):
+        """Unknown ERC violation types should block READY (conservative default)."""
+        result = AuditResult()
+        # Simulates the case where an unknown error type is treated as blocking
+        result.erc = ERCStatus(
+            error_count=1,
+            blocking_error_count=1,  # unknown type defaults to blocking
+            warning_count=0,
+            passed=False,
+        )
+        assert result.verdict == AuditVerdict.NOT_READY
+
+    def test_non_blocking_erc_errors_demoted_to_warnings(self):
+        """Non-blocking errors should appear in warning_count."""
+        result = AuditResult()
+        result.erc = ERCStatus(
+            error_count=3,
+            blocking_error_count=0,
+            warning_count=3,  # 3 non-blocking errors demoted to warnings
+            passed=True,
+        )
+        # No blocking errors, but warnings present -> WARNING verdict
+        assert result.verdict == AuditVerdict.WARNING
+        assert result.is_ready is False
+
+    def test_mix_of_blocking_and_non_blocking(self):
+        """A mix of blocking + non-blocking errors should produce NOT_READY."""
+        result = AuditResult()
+        result.erc = ERCStatus(
+            error_count=5,  # 2 blocking + 3 non-blocking
+            blocking_error_count=2,
+            warning_count=3,  # 3 non-blocking demoted
+            passed=False,
+        )
+        assert result.verdict == AuditVerdict.NOT_READY
+
+    def test_raw_error_count_does_not_affect_verdict(self):
+        """error_count alone should NOT cause NOT_READY; only blocking_error_count matters."""
+        result = AuditResult()
+        result.erc = ERCStatus(
+            error_count=100,  # lots of raw errors
+            blocking_error_count=0,  # but none are blocking
+            warning_count=0,
+            passed=True,
+        )
+        assert result.verdict == AuditVerdict.READY


### PR DESCRIPTION
## Summary

Non-electrical ERC violations (library symbol mismatch, footprint link issues, etc.) were incorrectly blocking manufacturing readiness by being counted as errors in the verdict gate. This PR adds blocking vs non-blocking classification so only genuine electrical errors block the READY verdict, while non-electrical violations are demoted to warnings.

## Changes

- Added 5 new `ERCViolationType` enum values: `LIB_SYMBOL_MISMATCH`, `FOOTPRINT_LINK_ISSUES`, `SINGLE_GLOBAL_LABEL`, `ISOLATED_PIN_LABEL`, `PIN_TO_PIN` (previously parsed as `UNKNOWN`)
- Added `ERC_BLOCKING_TYPES` and `ERC_NON_BLOCKING_TYPES` frozensets in `violation.py`
- Added `ERCStatus.blocking_error_count` field (only electrical errors that block readiness)
- Changed `AuditResult.verdict` gate from `self.erc.error_count > 0` to `self.erc.blocking_error_count > 0`
- Updated `_check_erc()` to split violations into blocking, non-blocking, and unknown categories
- Updated `_generate_action_items()` to use `blocking_error_count` for priority-1 items and separately report non-blocking violations at priority-3
- Updated `ERC_TYPE_DESCRIPTIONS` and `ERC_CATEGORIES` for all new types
- Exported new constants from `kicad_tools.erc.__init__`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `lib_symbol_mismatch`, `footprint_link_issues`, `single_global_label`, `isolated_pin_label`, `pin_to_pin` recognized as `ERCViolationType` values | Pass | `test_lib_symbol_mismatch_parses`, `test_footprint_link_issues_parses`, etc. all pass |
| `ERC_BLOCKING_TYPES` and `ERC_NON_BLOCKING_TYPES` frozensets exist | Pass | `test_blocking_types_is_frozenset`, `test_non_blocking_types_is_frozenset` |
| `ERCStatus` has `blocking_error_count` field | Pass | `test_default_blocking_error_count_is_zero`, `test_blocking_error_count_in_to_dict` |
| Design with only `lib_symbol_mismatch` errors (0 blocking) does not produce NOT_READY | Pass | `test_non_blocking_erc_error_does_not_block_ready`, `test_raw_error_count_does_not_affect_verdict` |
| Non-blocking errors surface as warnings (not silently ignored) | Pass | `test_non_blocking_erc_errors_demoted_to_warnings` |
| `power_pin_not_driven` still produces NOT_READY | Pass | `test_blocking_erc_error_blocks_ready` |
| Unknown ERC types continue to block READY | Pass | `test_unknown_erc_type_blocks_ready`, `test_unknown_type_is_not_in_either_set` |
| `ERCStatus.error_count` unchanged in meaning | Pass | `test_error_count_preserved_raw` |
| All existing audit tests continue to pass | Pass | 45/45 existing audit tests pass |
| Blocking and non-blocking sets are disjoint | Pass | `test_blocking_and_non_blocking_are_disjoint` |

## Test Plan

- 102 tests pass across `test_audit.py` (45), `test_erc.py` (30), `test_erc_violation_classification.py` (27)
- New test fixture `tests/fixtures/sample_erc_non_blocking.json` with `lib_symbol_mismatch` and `footprint_link_issues` violations
- All changed files pass `ruff check` and `ruff format`

Closes #1381