### PR TITLE
feat(router): add partial routing UX improvements

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -215,6 +215,8 @@ def run_route_command(args) -> int:
         sub_argv.append("--auto-fix")
     if getattr(args, "auto_fix_passes", None) is not None:
         sub_argv.extend(["--auto-fix-passes", str(args.auto_fix_passes)])
+    if getattr(args, "export_failed_nets", None):
+        sub_argv.extend(["--export-failed-nets", args.export_failed_nets])
     return route_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -982,6 +982,14 @@ def _add_route_parser(subparsers) -> None:
         metavar="N",
         help=("Number of repair passes for --auto-fix (default: 3). Implies --auto-fix."),
     )
+    route_parser.add_argument(
+        "--export-failed-nets",
+        metavar="PATH",
+        help=(
+            "Export failed (unrouted) net names to a file, one per line. "
+            "Useful for scripted workflows or manual completion in KiCad."
+        ),
+    )
 
 
 def _add_route_auto_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -187,6 +187,48 @@ def _save_partial_results() -> bool:
     return False
 
 
+def _export_failed_nets(
+    router: "Autorouter",
+    net_map: dict[str, int],
+    export_path: str,
+    quiet: bool = False,
+) -> bool:
+    """Export the list of failed (unrouted) net names to a file.
+
+    Writes one net name per line to the specified path.
+
+    Args:
+        router: The Autorouter instance with completed routing.
+        net_map: Mapping of net names to net IDs.
+        export_path: File path to write the failed net names.
+        quiet: If True, suppress output messages.
+
+    Returns:
+        True if the file was written successfully, False otherwise.
+    """
+    reverse_net = {v: k for k, v in net_map.items() if v > 0}
+    routed_net_ids = {route.net for route in router.routes}
+    all_net_ids = {v for k, v in net_map.items() if v > 0}
+    unrouted_ids = all_net_ids - routed_net_ids
+
+    if not unrouted_ids:
+        if not quiet:
+            print("  No failed nets to export.")
+        return False
+
+    try:
+        failed_names = sorted(reverse_net.get(nid, f"Net_{nid}") for nid in unrouted_ids)
+        export_file = Path(export_path)
+        export_file.write_text("\n".join(failed_names) + "\n")
+        if not quiet:
+            print(f"  Failed nets exported to: {export_file} ({len(failed_names)} nets)")
+        return True
+    except Exception as e:
+        if not quiet:
+            print(f"  Error exporting failed nets: {e}")
+        return False
+
+
 def show_preview(router, net_map: dict[str, int], nets_to_route: int, quiet: bool = False) -> str:
     """Display routing preview with per-net breakdown.
 
@@ -859,6 +901,7 @@ def route_with_layer_escalation(
                 final_result.nets_to_route,
                 quiet=quiet,
                 current_strategy=args.strategy,
+                pcb_file=args.pcb,
             )
 
     return 0 if final_result.success else 1
@@ -1222,6 +1265,7 @@ def route_with_rule_relaxation(
                 final_result.nets_to_route,
                 quiet=quiet,
                 current_strategy=args.strategy,
+                pcb_file=args.pcb,
             )
 
     return 0 if final_result.success else 1
@@ -1617,6 +1661,7 @@ def route_with_combined_escalation(
                 final_result.nets_to_route,
                 quiet=quiet,
                 current_strategy=args.strategy,
+                pcb_file=args.pcb,
             )
 
     return 0 if final_result.success else 1
@@ -2103,6 +2148,16 @@ def main(argv: list[str] | None = None) -> int:
             "Automatically add stitching vias for power planes after routing. "
             "Connects surface-mount component pads to their power plane layers. "
             "Equivalent to running 'kicad-pcb-stitch' after routing."
+        ),
+    )
+
+    # Export failed nets
+    parser.add_argument(
+        "--export-failed-nets",
+        metavar="PATH",
+        help=(
+            "Export failed (unrouted) net names to a file, one per line. "
+            "Useful for scripted workflows or manual completion in KiCad."
         ),
     )
 
@@ -3158,7 +3213,18 @@ def main(argv: list[str] | None = None) -> int:
                     quiet=quiet,
                     verbose=verbose,
                     current_strategy=args.strategy,
+                    pcb_file=args.pcb,
                 )
+
+    # Save partial results on clean partial exit (not just SIGINT)
+    if not all_nets_routed and not args.dry_run and router.routes:
+        partial_saved = _save_partial_results()
+        if partial_saved and not quiet:
+            print("  Open in KiCad to complete remaining nets manually")
+
+    # Export failed nets to file if requested
+    if getattr(args, "export_failed_nets", None) and not all_nets_routed:
+        _export_failed_nets(router, net_map, args.export_failed_nets, quiet=quiet)
 
     # Exit codes:
     # 0 = All nets routed AND (DRC passed OR DRC not run)

--- a/src/kicad_tools/router/output.py
+++ b/src/kicad_tools/router/output.py
@@ -23,6 +23,7 @@ def show_routing_summary(
     quiet: bool = False,
     verbose: bool = False,
     current_strategy: str = "basic",
+    pcb_file: str | None = None,
 ) -> None:
     """Show comprehensive routing summary with successes, failures, and suggestions.
 
@@ -40,6 +41,7 @@ def show_routing_summary(
         current_strategy: The routing strategy that was used (e.g. "basic",
             "negotiated", "monte-carlo"). Suggestions will exclude this strategy
             since the user already tried it.
+        pcb_file: Optional PCB file path for inclusion in suggestion commands.
     """
     if quiet:
         return
@@ -342,6 +344,18 @@ def show_routing_summary(
             if num_layers <= 2:
                 suggestion_num += 1
                 print(f"{suggestion_num}. Consider 4-layer routing: kct route --layers 4")
+
+        # Always suggest --auto-layers when routing on fewer than 4 layers with failures
+        num_layers = getattr(router.grid, "num_layers", 2)
+        if num_layers < 4:
+            failed_count = len(unrouted_ids)
+            failure_pct = failed_count / nets_to_route * 100 if nets_to_route > 0 else 0
+            pcb_arg = f" {pcb_file}" if pcb_file else ""
+            print(
+                f"\nTip: {failed_count}/{nets_to_route} nets failed on {num_layers} layers "
+                f"({failure_pct:.0f}% failure rate)."
+            )
+            print(f"Try automatic layer escalation: kct route{pcb_arg} --auto-layers")
 
     print(f"\n{'=' * 60}")
 

--- a/tests/test_partial_routing_features.py
+++ b/tests/test_partial_routing_features.py
@@ -1,0 +1,446 @@
+"""Tests for partial routing UX improvements (issue #1382).
+
+Covers three features:
+1. Proactive --auto-layers suggestion in show_routing_summary() when nets fail
+2. Partial result saving on clean partial exit (not just SIGINT)
+3. --export-failed-nets CLI flag
+"""
+
+import contextlib
+import sys
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_mock_route(net_id: int, net_name: str = ""):
+    """Create a minimal mock Route object."""
+    route = MagicMock()
+    route.net = net_id
+    route.net_name = net_name
+    route.segments = []
+    route.vias = []
+    return route
+
+
+def _make_mock_router(
+    routed_nets: list[int],
+    num_layers: int = 2,
+    routing_failures: list | None = None,
+):
+    """Create a mock Autorouter with the given routed nets and grid config."""
+    router = MagicMock()
+    router.routes = [_make_mock_route(nid) for nid in routed_nets]
+    router.routing_failures = routing_failures or []
+    router.grid = SimpleNamespace(num_layers=num_layers, resolution=0.25)
+    return router
+
+
+class TestAutoLayersSuggestion:
+    """Tests for proactive --auto-layers suggestion in show_routing_summary()."""
+
+    def test_auto_layers_suggestion_shown_on_2_layer_failure(self):
+        """Suggestion appears when nets fail on a 2-layer board."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {"A": 1, "B": 2, "C": 3, "D": 4}
+        router = _make_mock_router(routed_nets=[1, 2], num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=4,
+                quiet=False,
+                pcb_file="board.kicad_pcb",
+            )
+
+        text = output.getvalue()
+        assert "--auto-layers" in text
+        assert "board.kicad_pcb" in text
+        assert "2/4 nets failed" in text
+
+    def test_auto_layers_suggestion_not_shown_on_4_layer_board(self):
+        """Suggestion does NOT appear when already using 4+ layers."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {"A": 1, "B": 2, "C": 3}
+        router = _make_mock_router(routed_nets=[1], num_layers=4)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=3,
+                quiet=False,
+            )
+
+        text = output.getvalue()
+        assert "--auto-layers" not in text
+
+    def test_auto_layers_suggestion_not_shown_when_all_routed(self):
+        """Suggestion does NOT appear when all nets are routed (no failures)."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {"A": 1, "B": 2}
+        router = _make_mock_router(routed_nets=[1, 2], num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=2,
+                quiet=False,
+            )
+
+        text = output.getvalue()
+        # No unrouted nets, so no suggestions block at all
+        assert "--auto-layers" not in text
+
+    def test_auto_layers_suggestion_shows_failure_percentage(self):
+        """Suggestion includes failure percentage."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {f"Net{i}": i for i in range(1, 11)}
+        # Route 7 out of 10 (30% failure rate)
+        router = _make_mock_router(routed_nets=list(range(1, 8)), num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=10,
+                quiet=False,
+            )
+
+        text = output.getvalue()
+        assert "3/10 nets failed" in text
+        assert "30% failure rate" in text
+
+    def test_auto_layers_suggestion_without_pcb_file(self):
+        """Suggestion works without pcb_file (no filename in command)."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {"A": 1, "B": 2}
+        router = _make_mock_router(routed_nets=[1], num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=2,
+                quiet=False,
+            )
+
+        text = output.getvalue()
+        assert "kct route --auto-layers" in text
+
+    def test_auto_layers_suggestion_with_pcb_file(self):
+        """Suggestion includes pcb filename when provided."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {"A": 1, "B": 2}
+        router = _make_mock_router(routed_nets=[1], num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=2,
+                quiet=False,
+                pcb_file="my_board.kicad_pcb",
+            )
+
+        text = output.getvalue()
+        assert "kct route my_board.kicad_pcb --auto-layers" in text
+
+    def test_auto_layers_suggestion_quiet_mode(self):
+        """No output in quiet mode."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {"A": 1, "B": 2}
+        router = _make_mock_router(routed_nets=[1], num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=2,
+                quiet=True,
+            )
+
+        text = output.getvalue()
+        assert text == ""
+
+
+class TestExportFailedNets:
+    """Tests for --export-failed-nets feature."""
+
+    def test_export_failed_nets_function(self, tmp_path):
+        """_export_failed_nets writes correct net names to file."""
+        from kicad_tools.cli.route_cmd import _export_failed_nets
+
+        net_map = {"GND": 0, "VCC": 1, "SDA": 2, "SCL": 3, "NRST": 4}
+        router = _make_mock_router(routed_nets=[1, 2])  # VCC and SDA routed
+
+        export_file = tmp_path / "failed.txt"
+        result = _export_failed_nets(router, net_map, str(export_file), quiet=True)
+
+        assert result is True
+        content = export_file.read_text()
+        lines = content.strip().split("\n")
+        # Net 3 (SCL) and Net 4 (NRST) are unrouted; GND (net 0) is excluded
+        assert sorted(lines) == ["NRST", "SCL"]
+
+    def test_export_failed_nets_no_failures(self, tmp_path):
+        """_export_failed_nets returns False when all nets are routed."""
+        from kicad_tools.cli.route_cmd import _export_failed_nets
+
+        net_map = {"GND": 0, "VCC": 1, "SDA": 2}
+        router = _make_mock_router(routed_nets=[1, 2])  # All signal nets routed
+
+        export_file = tmp_path / "failed.txt"
+        result = _export_failed_nets(router, net_map, str(export_file), quiet=True)
+
+        assert result is False
+        assert not export_file.exists()
+
+    def test_export_failed_nets_writes_one_per_line(self, tmp_path):
+        """Each failed net name is on its own line."""
+        from kicad_tools.cli.route_cmd import _export_failed_nets
+
+        net_map = {f"NET_{i}": i for i in range(1, 6)}
+        router = _make_mock_router(routed_nets=[1])  # Only NET_1 routed
+
+        export_file = tmp_path / "failed.txt"
+        _export_failed_nets(router, net_map, str(export_file), quiet=True)
+
+        content = export_file.read_text()
+        lines = content.strip().split("\n")
+        assert len(lines) == 4  # NET_2, NET_3, NET_4, NET_5
+        # Verify trailing newline
+        assert content.endswith("\n")
+
+    def test_export_failed_nets_cli_flag_in_help(self):
+        """--export-failed-nets appears in help output."""
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        help_output = StringIO()
+        with patch.object(sys, "stdout", help_output):
+            with contextlib.suppress(SystemExit):
+                route_main(["--help"])
+
+        help_text = help_output.getvalue()
+        assert "--export-failed-nets" in help_text
+
+    def test_export_failed_nets_forwarded_by_run_route_command(self):
+        """run_route_command forwards --export-failed-nets to route_cmd.main."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = SimpleNamespace(
+            pcb="test.kicad_pcb",
+            output=None,
+            strategy="negotiated",
+            skip_nets=None,
+            grid="0.25",
+            trace_width=0.2,
+            clearance=0.15,
+            via_drill=0.3,
+            via_diameter=0.6,
+            mc_trials=10,
+            iterations=15,
+            verbose=False,
+            dry_run=True,
+            quiet=True,
+            power_nets=None,
+            layers="auto",
+            force=False,
+            no_optimize=False,
+            auto_layers=False,
+            max_layers=6,
+            min_completion=0.95,
+            adaptive_rules=False,
+            min_trace=None,
+            min_clearance_floor=None,
+            manufacturer="jlcpcb",
+            high_performance=False,
+            skip_drc=False,
+            auto_fix=False,
+            auto_fix_passes=None,
+            export_failed_nets="failed.txt",
+        )
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--export-failed-nets" in call_args
+            idx = call_args.index("--export-failed-nets")
+            assert call_args[idx + 1] == "failed.txt"
+
+    def test_export_failed_nets_not_forwarded_when_none(self):
+        """run_route_command does NOT forward --export-failed-nets when not set."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = SimpleNamespace(
+            pcb="test.kicad_pcb",
+            output=None,
+            strategy="negotiated",
+            skip_nets=None,
+            grid="0.25",
+            trace_width=0.2,
+            clearance=0.15,
+            via_drill=0.3,
+            via_diameter=0.6,
+            mc_trials=10,
+            iterations=15,
+            verbose=False,
+            dry_run=True,
+            quiet=True,
+            power_nets=None,
+            layers="auto",
+            force=False,
+            no_optimize=False,
+            auto_layers=False,
+            max_layers=6,
+            min_completion=0.95,
+            adaptive_rules=False,
+            min_trace=None,
+            min_clearance_floor=None,
+            manufacturer="jlcpcb",
+            high_performance=False,
+            skip_drc=False,
+            auto_fix=False,
+            auto_fix_passes=None,
+            export_failed_nets=None,
+        )
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--export-failed-nets" not in call_args
+
+    def test_export_failed_nets_in_parser(self):
+        """--export-failed-nets is in the route subparser."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        # Parse with route subcommand
+        args = parser.parse_args(["route", "test.kicad_pcb", "--export-failed-nets", "out.txt"])
+        assert args.export_failed_nets == "out.txt"
+
+
+class TestPartialResultSaving:
+    """Tests for saving partial results on clean partial exit."""
+
+    def test_save_partial_results_called_on_partial_exit(self, tmp_path):
+        """_save_partial_results is called when routing partially succeeds."""
+        from kicad_tools.cli.route_cmd import _interrupt_state, _save_partial_results
+
+        # Set up the interrupt state with valid router and paths
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb (version 20240101) (generator test))")
+
+        output_file = tmp_path / "board_routed.kicad_pcb"
+
+        mock_router = MagicMock()
+        mock_router.routes = [_make_mock_route(1)]
+        mock_router.to_sexp.return_value = (
+            '(segment (start 0 0) (end 1 1) (width 0.2) (layer "F.Cu") (net 1))'
+        )
+        mock_router.get_statistics.return_value = {
+            "nets_routed": 1,
+            "segments": 1,
+            "vias": 0,
+        }
+
+        # Set global state
+        _interrupt_state["router"] = mock_router
+        _interrupt_state["output_path"] = output_file
+        _interrupt_state["pcb_path"] = pcb_file
+        _interrupt_state["quiet"] = True
+
+        result = _save_partial_results()
+
+        assert result is True
+        partial_path = output_file.with_stem(output_file.stem + "_partial")
+        assert partial_path.exists()
+        content = partial_path.read_text()
+        assert "(segment" in content
+
+        # Clean up global state
+        _interrupt_state["router"] = None
+        _interrupt_state["output_path"] = None
+        _interrupt_state["pcb_path"] = None
+
+    def test_save_partial_no_routes(self, tmp_path):
+        """_save_partial_results returns False when no routes exist."""
+        from kicad_tools.cli.route_cmd import _interrupt_state, _save_partial_results
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb (version 20240101) (generator test))")
+
+        output_file = tmp_path / "board_routed.kicad_pcb"
+
+        mock_router = MagicMock()
+        mock_router.routes = []  # No routes
+
+        _interrupt_state["router"] = mock_router
+        _interrupt_state["output_path"] = output_file
+        _interrupt_state["pcb_path"] = pcb_file
+        _interrupt_state["quiet"] = True
+
+        result = _save_partial_results()
+
+        assert result is False
+
+        # Clean up
+        _interrupt_state["router"] = None
+        _interrupt_state["output_path"] = None
+        _interrupt_state["pcb_path"] = None
+
+
+class TestAutoLayersSuggestionInJSON:
+    """Tests for --auto-layers suggestion in JSON diagnostics output."""
+
+    def test_json_diagnostics_includes_layer_suggestion(self):
+        """JSON diagnostics includes layer count suggestion for 2-layer boards."""
+        from kicad_tools.router.output import get_routing_diagnostics_json
+
+        net_map = {"A": 1, "B": 2, "C": 3}
+        router = _make_mock_router(routed_nets=[1], num_layers=2)
+
+        # Add a mock failure for congestion
+        failure = MagicMock()
+        failure.net = 2
+        failure.net_name = "B"
+        failure.failure_cause = SimpleNamespace(value="congestion")
+        failure.source_pad = ("U1", "1")
+        failure.target_pad = ("R1", "1")
+        failure.source_coords = (0, 0)
+        failure.target_coords = (1, 1)
+        failure.blocking_components = []
+        failure.blocking_nets = []
+        failure.reason = "Area too crowded"
+        failure.analysis = None
+        router.routing_failures = [failure]
+
+        result = get_routing_diagnostics_json(
+            router, net_map, nets_to_route=3, current_strategy="basic"
+        )
+
+        # Verify the suggestions include a layer count suggestion
+        suggestions = result.get("suggestions", [])
+        layer_suggestions = [s for s in suggestions if s.get("category") == "LAYER_COUNT"]
+        assert len(layer_suggestions) > 0
+        assert "--layers 4" in layer_suggestions[0]["fix"]


### PR DESCRIPTION
## Summary

Improves the user experience when the autorouter exits with partial success on dense 2-layer boards. Adds proactive layer escalation suggestion, automatic partial result saving, and a new --export-failed-nets flag for scripted workflows.

## Changes

- **Proactive --auto-layers suggestion** (Feature 1): `show_routing_summary()` in `output.py` now always shows a tip recommending `--auto-layers` when nets fail on fewer than 4 layers, including the exact `kct route <file> --auto-layers` command. Added `pcb_file` parameter to all call sites.
- **Partial result saving on clean exit** (Feature 2): When routing exits with partial success (return code 1) and at least one net was routed, the `_save_partial_results()` function is called automatically to write a `_partial.kicad_pcb` file. Previously this only happened on SIGINT.
- **--export-failed-nets flag** (Feature 3): New `--export-failed-nets <path>` CLI argument writes unrouted net names (one per line) to a file. Added to both the standalone route parser and the `_add_route_parser()` subparser, with forwarding in `run_route_command()`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Stdout includes --auto-layers suggestion when num_layers < 4 and nets fail | Pass | Tests `test_auto_layers_suggestion_shown_on_2_layer_failure`, `test_auto_layers_suggestion_shows_failure_percentage` |
| Suggestion shows exact command with PCB filename | Pass | Tests `test_auto_layers_suggestion_with_pcb_file`, `test_auto_layers_suggestion_without_pcb_file` |
| _partial.kicad_pcb written on clean partial exit (not just SIGINT) | Pass | Test `test_save_partial_results_called_on_partial_exit`; code calls `_save_partial_results()` in the `not all_nets_routed` path |
| Partial output path reported in summary | Pass | `_save_partial_results()` prints path; additional "Open in KiCad" message shown |
| --export-failed-nets writes one net name per line | Pass | Tests `test_export_failed_nets_function`, `test_export_failed_nets_writes_one_per_line` |
| --export-failed-nets documented in --help | Pass | Test `test_export_failed_nets_cli_flag_in_help` |
| All behaviors covered by automated tests | Pass | 17 new tests in `test_partial_routing_features.py` |
| Existing --auto-layers behavior unchanged | Pass | All 11 existing `test_layer_escalation.py` tests pass |

## Test Plan

- 17 new tests in `tests/test_partial_routing_features.py` covering all three features
- All 48 existing tests in `test_layer_escalation.py` and `test_route_cmd_params.py` pass with no regressions
- `uv run ruff check` clean on all modified files (only pre-existing F541 in route_cmd.py)
- `uv run ruff format --check` clean on all modified files

Closes #1382