### PR TITLE
fix(zones): restore per-element net assignments after zone fill

### DIFF
--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -83,15 +83,27 @@ class NetStatus:
 
     @property
     def connection_percentage(self) -> float:
-        """Percentage of pads connected (0-100)."""
+        """Percentage of pads connected (0-100).
+
+        Returns 0.0 when total_pads is 0 to avoid masking data corruption
+        where all pad net assignments have been stripped.
+        """
         if self.total_pads == 0:
-            return 100.0
+            return 0.0
         return (self.connected_count / self.total_pads) * 100
 
     @property
     def status(self) -> str:
-        """Net status: 'complete', 'incomplete', or 'unrouted'."""
-        if self.total_pads <= 1:
+        """Net status: 'complete', 'incomplete', or 'unrouted'.
+
+        A net with 0 pads is reported as 'unrouted' rather than 'complete'
+        to avoid masking corruption where pad net assignments were stripped.
+        A net with exactly 1 pad is genuinely complete (single-pad nets are
+        valid in KiCad).
+        """
+        if self.total_pads == 0:
+            return "unrouted"
+        if self.total_pads == 1:
             return "complete"
         if self.unconnected_count == 0:
             return "complete"

--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -572,10 +572,42 @@ class ManufacturingAudit:
         return status
 
     def _check_connectivity(self, pcb: PCB) -> ConnectivityStatus:
-        """Check net connectivity."""
+        """Check net connectivity.
+
+        Includes a corruption guard: if the board has footprints but every
+        pad is assigned to net 0 (unconnected), this indicates that inline
+        net assignments were stripped (e.g. by kicad-cli).  In that case
+        the check is marked as failed with a corruption diagnostic.
+        """
         status = ConnectivityStatus()
 
         try:
+            # Corruption guard: detect boards where all pad net assignments
+            # have been zeroed out.  A board with footprints must have at
+            # least some pads with non-zero net numbers.
+            if pcb.footprint_count > 0:
+                total_pads = 0
+                pads_with_net = 0
+                for fp in pcb.footprints:
+                    for pad in fp.pads:
+                        total_pads += 1
+                        if pad.net_number != 0:
+                            pads_with_net += 1
+
+                if total_pads > 0 and pads_with_net == 0:
+                    logger.warning(
+                        "Data corruption detected: %d pads on %d footprints "
+                        "but all pads assigned to net 0",
+                        total_pads,
+                        pcb.footprint_count,
+                    )
+                    status.passed = False
+                    status.details = (
+                        f"Possible data corruption: {total_pads} pads across "
+                        f"{pcb.footprint_count} footprints all assigned to net 0"
+                    )
+                    return status
+
             from kicad_tools.validate import ConnectivityValidator
 
             validator = ConnectivityValidator(pcb)

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -417,59 +417,166 @@ def _snapshot_net_declarations(pcb_path: Path) -> list:
     return [child for child in sexp.children if child.name == "net"]
 
 
-def _restore_net_declarations(target_pcb: Path, net_nodes: list) -> None:
-    """Restore net declarations in *target_pcb* from a snapshot.
+def _snapshot_element_nets(pcb_path: Path) -> dict[str, list]:
+    """Snapshot per-element inline ``(net N ...)`` assignments from a PCB.
 
-    kicad-cli may strip ``(net N "name")`` header declarations when
-    re-serializing a PCB that was not originally written by KiCad itself.
-    This function replaces the output file's net declarations with those
-    captured before the DRC run, preserving all other content (including
-    filled zone polygons).
+    Captures the ``(net ...)`` child S-expression for every pad, segment,
+    and via, keyed by a stable identifier:
 
-    The function is a no-op when the output already has at least as many
-    net declarations as the snapshot (i.e. kicad-cli kept them intact).
+    - **Pads**: keyed by ``"fp:<footprint_uuid>:pad:<pad_number>"`` since
+      pads in KiCad files do not have their own UUIDs.
+    - **Segments/Vias**: keyed by their UUID string.
+
+    Returns a dict mapping key strings to a list ``[net_sexp_node]``
+    containing the original ``(net ...)`` S-expression.  An empty dict
+    is returned if the file cannot be read.
+    """
+    from kicad_tools.core.sexp_file import load_pcb
+
+    try:
+        sexp = load_pcb(str(pcb_path))
+    except Exception:
+        return {}
+
+    snapshot: dict[str, list] = {}
+
+    # Snapshot pads inside footprints, keyed by footprint UUID + pad number
+    for fp_node in (c for c in sexp.children if c.name == "footprint"):
+        fp_uuid_node = fp_node.get("uuid")
+        if fp_uuid_node is None:
+            continue
+        fp_uuid = fp_uuid_node.get_string(0) or ""
+        if not fp_uuid:
+            continue
+
+        for pad_node in (c for c in fp_node.children if c.name == "pad"):
+            net_node = pad_node.get("net")
+            if net_node is None:
+                continue
+            net_num = net_node.get_int(0)
+            if net_num is None or net_num == 0:
+                continue
+            # Use the pad's first atom (its number) as sub-key
+            pad_number = pad_node.get_first_atom()
+            if pad_number is None:
+                continue
+            key = f"fp:{fp_uuid}:pad:{pad_number}"
+            snapshot[key] = [net_node]
+
+    # Snapshot segments and vias at the top level, keyed by UUID
+    for child in sexp.children:
+        if child.name in ("segment", "via"):
+            uuid_node = child.get("uuid")
+            net_node = child.get("net")
+            if uuid_node is not None and net_node is not None:
+                uuid_val = uuid_node.get_string(0)
+                net_num = net_node.get_int(0)
+                if uuid_val and net_num is not None and net_num != 0:
+                    snapshot[uuid_val] = [net_node]
+
+    return snapshot
+
+
+def _restore_net_declarations(
+    target_pcb: Path,
+    net_nodes: list,
+    element_nets: dict[str, list] | None = None,
+) -> None:
+    """Restore net declarations and per-element net assignments in *target_pcb*.
+
+    kicad-cli may strip ``(net N "name")`` header declarations and/or
+    inline ``(net N)`` assignments inside pads, segments, and vias when
+    re-serializing a PCB.  This function restores both from snapshots
+    captured before the DRC run.
+
+    The net table restoration is a no-op when the output already has at
+    least as many net declarations as the snapshot.
+
+    The per-element restoration is a no-op when no element_nets snapshot
+    was provided or when no elements had their nets zeroed out.
     """
     from kicad_tools.core.sexp_file import load_pcb, save_pcb
 
     output_sexp = load_pcb(str(target_pcb))
 
-    # Count existing nets in the output
+    modified = False
+
+    # --- Restore net table headers ---
     output_net_nodes = [child for child in output_sexp.children if child.name == "net"]
 
-    if len(output_net_nodes) >= len(net_nodes):
-        # Net table was not stripped — nothing to do.
-        return
+    if len(output_net_nodes) < len(net_nodes):
+        # Remove whatever net declarations remain in the output.
+        for node in output_net_nodes:
+            output_sexp.children.remove(node)
 
-    # Remove whatever net declarations remain in the output.
-    for node in output_net_nodes:
-        output_sexp.children.remove(node)
+        # Find insertion point: nets go after ``setup`` / ``title_block`` and
+        # before ``footprint`` / ``segment`` / ``via`` / ``zone`` / ``gr_*``.
+        insert_index = len(output_sexp.children)
+        content_tags = {
+            "footprint",
+            "segment",
+            "via",
+            "zone",
+            "gr_line",
+            "gr_arc",
+            "gr_text",
+            "gr_rect",
+            "gr_circle",
+            "gr_poly",
+        }
+        for i, child in enumerate(output_sexp.children):
+            if child.name in content_tags:
+                insert_index = i
+                break
 
-    # Find insertion point: nets go after ``setup`` / ``title_block`` and
-    # before ``footprint`` / ``segment`` / ``via`` / ``zone`` / ``gr_*``.
-    # Walk backward from the first content element to find the right spot.
-    insert_index = len(output_sexp.children)
-    content_tags = {
-        "footprint",
-        "segment",
-        "via",
-        "zone",
-        "gr_line",
-        "gr_arc",
-        "gr_text",
-        "gr_rect",
-        "gr_circle",
-        "gr_poly",
-    }
-    for i, child in enumerate(output_sexp.children):
-        if child.name in content_tags:
-            insert_index = i
-            break
+        for offset, net_node in enumerate(net_nodes):
+            output_sexp.children.insert(insert_index + offset, net_node)
+        modified = True
 
-    # Insert the snapshotted net declarations at the computed position.
-    for offset, net_node in enumerate(net_nodes):
-        output_sexp.children.insert(insert_index + offset, net_node)
+    # --- Restore per-element inline net assignments ---
+    if element_nets:
+        # Restore pad nets inside footprints (keyed by fp_uuid:pad_number)
+        for fp_node in (c for c in output_sexp.children if c.name == "footprint"):
+            fp_uuid_node = fp_node.get("uuid")
+            if fp_uuid_node is None:
+                continue
+            fp_uuid = fp_uuid_node.get_string(0) or ""
+            if not fp_uuid:
+                continue
 
-    save_pcb(output_sexp, target_pcb)
+            for pad_node in (c for c in fp_node.children if c.name == "pad"):
+                pad_number = pad_node.get_first_atom()
+                if pad_number is None:
+                    continue
+                key = f"fp:{fp_uuid}:pad:{pad_number}"
+                if key not in element_nets:
+                    continue
+                current_net = pad_node.get("net")
+                current_num = current_net.get_int(0) if current_net else None
+                if current_num == 0 or current_net is None:
+                    if current_net is not None:
+                        pad_node.remove(current_net)
+                    pad_node.append(element_nets[key][0])
+                    modified = True
+
+        # Restore segment and via nets at the top level (keyed by UUID)
+        for child in output_sexp.children:
+            if child.name in ("segment", "via"):
+                uuid_node = child.get("uuid")
+                if uuid_node is None:
+                    continue
+                uuid_val = uuid_node.get_string(0)
+                if uuid_val and uuid_val in element_nets:
+                    current_net = child.get("net")
+                    current_num = current_net.get_int(0) if current_net else None
+                    if current_num == 0 or current_net is None:
+                        if current_net is not None:
+                            child.remove(current_net)
+                        child.append(element_nets[uuid_val][0])
+                        modified = True
+
+    if modified:
+        save_pcb(output_sexp, target_pcb)
 
 
 def _run_fill_zones_via_drc(
@@ -494,9 +601,11 @@ def _run_fill_zones_via_drc(
     """
     import os
 
-    # Snapshot input net declarations *before* DRC runs — the DRC
-    # may modify the file in-place when no output_path is given.
+    # Snapshot input net declarations and per-element net assignments
+    # *before* DRC runs — the DRC may modify the file in-place when
+    # no output_path is given.
     input_net_nodes = _snapshot_net_declarations(pcb_path)
+    input_element_nets = _snapshot_element_nets(pcb_path)
 
     # DRC modifies the input file in-place.  If the caller requested a
     # separate output file, copy the source first and run DRC on the copy.
@@ -534,8 +643,9 @@ def _run_fill_zones_via_drc(
         # are still filled.  We treat it as success when the DRC report
         # was actually produced (meaning the command ran to completion).
         if drc_report.exists() and drc_report.stat().st_size > 0:
-            # Restore net declarations if kicad-cli stripped them.
-            _restore_net_declarations(target_pcb, input_net_nodes)
+            # Restore net declarations and per-element net assignments
+            # if kicad-cli stripped them.
+            _restore_net_declarations(target_pcb, input_net_nodes, input_element_nets)
 
             return KiCadCLIResult(
                 success=True,

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -252,9 +252,21 @@ class ConnectivityValidator:
         result.total_nets = len(nets)
         connected_count = 0
 
+        # Determine whether the board has footprints.  If it does but a
+        # named net has zero pads, the net assignments may have been
+        # corrupted (all pads zeroed to net 0).  In that case the net
+        # should NOT be counted as connected.
+        has_footprints = len(self.pcb.footprints) > 0
+
         for net_number, net in nets.items():
             # Get all pads on this net
             pads = self._get_net_pads(net_number)
+
+            if len(pads) == 0 and has_footprints:
+                # A named net with no pads on a board that has footprints
+                # is suspicious -- pad net assignments may have been
+                # stripped.  Do NOT count as connected.
+                continue
 
             if len(pads) < 2:
                 # Single-pad nets are always "connected"

--- a/tests/test_analysis_net_status.py
+++ b/tests/test_analysis_net_status.py
@@ -274,7 +274,7 @@ class TestNetStatus:
     def test_connection_percentage_empty(self):
         """Test connection_percentage with no pads."""
         status = NetStatus(net_number=1, net_name="VCC", total_pads=0)
-        assert status.connection_percentage == 100.0
+        assert status.connection_percentage == 0.0
 
     def test_status_complete(self):
         """Test status is 'complete' when all pads connected."""

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -744,3 +744,111 @@ class TestAuditJsonSchema:
         # CI-friendly check: counts are integers
         assert isinstance(data["erc"]["error_count"], int)
         assert isinstance(data["drc"]["error_count"], int)
+
+
+# ---------------------------------------------------------------------------
+# Test: corruption guard in auditor
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptionGuard:
+    """Tests for the data corruption guard in ManufacturingAudit._check_connectivity."""
+
+    # A board with footprints where all pads have net 0 (corrupted)
+    CORRUPTED_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3V3")
+  (gr_rect (start 0 0) (end 100 100) (stroke (width 0.15) (type default)) (fill none) (layer "Edge.Cuts") (uuid "edge"))
+  (footprint "R_0402"
+    (layer "F.Cu")
+    (uuid "fp1")
+    (at 50 50)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref1"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "val1"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.6 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 0 ""))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.6 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 0 ""))
+  )
+)
+"""
+
+    # A board with proper net assignments
+    NORMAL_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3V3")
+  (gr_rect (start 0 0) (end 100 100) (stroke (width 0.15) (type default)) (fill none) (layer "Edge.Cuts") (uuid "edge"))
+  (footprint "R_0402"
+    (layer "F.Cu")
+    (uuid "fp1")
+    (at 50 50)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref1"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "val1"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.6 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.6 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3V3"))
+  )
+)
+"""
+
+    def test_all_pads_net_zero_triggers_not_ready(self, tmp_path):
+        """Board with footprints where all pads have net 0 should be NOT_READY."""
+        pcb_path = tmp_path / "corrupted.kicad_pcb"
+        pcb_path.write_text(self.CORRUPTED_PCB)
+
+        audit = ManufacturingAudit(pcb_path)
+        result = audit.run()
+
+        assert result.connectivity.passed is False
+        assert "corruption" in result.connectivity.details.lower()
+        assert result.verdict == AuditVerdict.NOT_READY
+
+    def test_normal_board_does_not_trigger_guard(self, tmp_path):
+        """Board with proper pad net assignments should not trigger guard."""
+        pcb_path = tmp_path / "normal.kicad_pcb"
+        pcb_path.write_text(self.NORMAL_PCB)
+
+        audit = ManufacturingAudit(pcb_path)
+        result = audit.run()
+
+        # Should NOT have corruption message
+        assert "corruption" not in result.connectivity.details.lower()
+
+    def test_no_footprints_does_not_trigger_guard(self, tmp_path):
+        """Board with no footprints should not trigger the corruption guard."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=100, height=100)
+        pcb_path = tmp_path / "empty.kicad_pcb"
+        pcb.save(str(pcb_path))
+
+        audit = ManufacturingAudit(pcb_path)
+        result = audit.run()
+
+        # Should not have corruption details
+        assert "corruption" not in result.connectivity.details.lower()

--- a/tests/test_net_status.py
+++ b/tests/test_net_status.py
@@ -796,3 +796,104 @@ class TestNetStatusIntegration:
         parsed = json.loads(json_str)
         assert parsed["total_nets"] == result.total_nets
         assert len(parsed["nets"]) == len(result.nets)
+
+
+# ---------------------------------------------------------------------------
+# Tests for corruption defense in NetStatus
+# ---------------------------------------------------------------------------
+
+
+class TestNetStatusCorruptionDefense:
+    """Tests for NetStatus behavior when pad net assignments are corrupted."""
+
+    def test_zero_pads_returns_zero_percentage(self):
+        """connection_percentage returns 0.0 when total_pads is 0."""
+        ns = NetStatus(net_number=1, net_name="GND", total_pads=0)
+        assert ns.connection_percentage == 0.0
+
+    def test_zero_pads_status_is_unrouted(self):
+        """A net with 0 pads is reported as 'unrouted', not 'complete'."""
+        ns = NetStatus(net_number=1, net_name="GND", total_pads=0)
+        assert ns.status == "unrouted"
+
+    def test_single_pad_status_is_complete(self):
+        """A net with exactly 1 pad is genuinely complete."""
+        pad = PadInfo(
+            reference="U1",
+            pad_number="1",
+            position=(0.0, 0.0),
+            is_connected=True,
+        )
+        ns = NetStatus(
+            net_number=1,
+            net_name="VCC",
+            total_pads=1,
+            connected_pads=[pad],
+        )
+        assert ns.status == "complete"
+        assert ns.connection_percentage == 100.0
+
+    def test_two_pads_all_connected(self):
+        """A net with 2 pads all connected is complete."""
+        pad1 = PadInfo(
+            reference="R1",
+            pad_number="1",
+            position=(0.0, 0.0),
+            is_connected=True,
+        )
+        pad2 = PadInfo(
+            reference="R2",
+            pad_number="1",
+            position=(10.0, 0.0),
+            is_connected=True,
+        )
+        ns = NetStatus(
+            net_number=1,
+            net_name="GND",
+            total_pads=2,
+            connected_pads=[pad1, pad2],
+        )
+        assert ns.status == "complete"
+        assert ns.connection_percentage == 100.0
+
+    def test_corrupted_board_analyzer_reports_unrouted(self, tmp_path):
+        """NetStatusAnalyzer on a board where all pads are net 0 reports unrouted."""
+        # A board with nets declared but all pads at net 0
+        corrupted_pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3V3")
+  (footprint "R_0402"
+    (layer "F.Cu")
+    (uuid "fp1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref1"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 0 ""))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 0 ""))
+  )
+)
+"""
+        pcb_path = tmp_path / "corrupted.kicad_pcb"
+        pcb_path.write_text(corrupted_pcb_content)
+
+        analyzer = NetStatusAnalyzer(pcb_path)
+        result = analyzer.analyze()
+
+        # Both declared nets should have 0 pads and be unrouted
+        for net_status in result.nets:
+            assert net_status.total_pads == 0
+            assert net_status.status == "unrouted"
+            assert net_status.connection_percentage == 0.0

--- a/tests/test_zones_cmd.py
+++ b/tests/test_zones_cmd.py
@@ -639,6 +639,181 @@ class TestRunFillZonesDRCFallback:
 
 
 # ---------------------------------------------------------------------------
+# Test: per-element net assignment preservation through zone fill
+# ---------------------------------------------------------------------------
+
+
+class TestPadNetPreservation:
+    """Tests for per-element (pad, segment, via) net assignment preservation."""
+
+    def test_drc_fallback_preserves_pad_nets(self, tmp_pcb, tmp_path):
+        """Pad net assignments are restored when kicad-cli zeroes them out."""
+        from kicad_tools.cli.runner import run_fill_zones
+        from kicad_tools.schema.pcb import PCB
+
+        input_pcb = PCB.load(str(tmp_pcb))
+        # Collect original pad net assignments
+        input_pad_nets = {}
+        for fp in input_pcb.footprints:
+            for pad in fp.pads:
+                if pad.net_number != 0:
+                    input_pad_nets[f"{fp.reference}.{pad.number}"] = pad.net_number
+        assert len(input_pad_nets) > 0, "Fixture must have pads with net assignments"
+
+        def fake_run_strips_pad_nets(cmd, **kwargs):
+            """Simulate kicad-cli zeroing out inline (net N) on pads."""
+            import re
+
+            report_path = cmd[cmd.index("--output") + 1]
+            Path(report_path).write_text('{"violations": []}')
+
+            target = Path(cmd[-1])
+            content = target.read_text()
+            # Zero out inline (net N "name") inside pads to (net 0 "")
+            content = re.sub(r'\(net \d+ "[^"]*"\)', '(net 0 "")', content)
+            target.write_text(content)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        out = tmp_path / "filled.kicad_pcb"
+
+        with (
+            patch(_HAS_FILL_ZONES, return_value=False),
+            patch(_DRC_SUPPORTS_REFILL, return_value=False),
+            patch(_SUBPROCESS_RUN, side_effect=fake_run_strips_pad_nets),
+        ):
+            result = run_fill_zones(tmp_pcb, output_path=out, kicad_cli=Path("/usr/bin/kicad-cli"))
+
+        assert result.success is True
+        output_pcb = PCB.load(str(out))
+
+        # Verify pad net assignments were restored
+        output_pad_nets = {}
+        for fp in output_pcb.footprints:
+            for pad in fp.pads:
+                if pad.net_number != 0:
+                    output_pad_nets[f"{fp.reference}.{pad.number}"] = pad.net_number
+        assert output_pad_nets == input_pad_nets
+
+    def test_drc_fallback_preserves_segment_nets(self, tmp_pcb, tmp_path):
+        """Segment net assignments are restored when kicad-cli zeroes them."""
+        from kicad_tools.cli.runner import run_fill_zones
+        from kicad_tools.schema.pcb import PCB
+
+        input_pcb = PCB.load(str(tmp_pcb))
+        input_seg_nets = {
+            seg.uuid: seg.net_number for seg in input_pcb.segments if seg.net_number != 0
+        }
+        assert len(input_seg_nets) > 0, "Fixture must have segments with nets"
+
+        def fake_run_strips_element_nets(cmd, **kwargs):
+            """Simulate kicad-cli zeroing out (net N) on segments."""
+            import re
+
+            report_path = cmd[cmd.index("--output") + 1]
+            Path(report_path).write_text('{"violations": []}')
+
+            target = Path(cmd[-1])
+            content = target.read_text()
+            # Zero out all inline net references: (net N) -> (net 0)
+            # and (net N "name") -> (net 0 "")
+            content = re.sub(r'\(net \d+ "[^"]*"\)', '(net 0 "")', content)
+            content = re.sub(r"\(net \d+\)", "(net 0)", content)
+            target.write_text(content)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        out = tmp_path / "filled.kicad_pcb"
+
+        with (
+            patch(_HAS_FILL_ZONES, return_value=False),
+            patch(_DRC_SUPPORTS_REFILL, return_value=False),
+            patch(_SUBPROCESS_RUN, side_effect=fake_run_strips_element_nets),
+        ):
+            result = run_fill_zones(tmp_pcb, output_path=out, kicad_cli=Path("/usr/bin/kicad-cli"))
+
+        assert result.success is True
+        output_pcb = PCB.load(str(out))
+
+        output_seg_nets = {
+            seg.uuid: seg.net_number for seg in output_pcb.segments if seg.net_number != 0
+        }
+        assert output_seg_nets == input_seg_nets
+
+    def test_drc_fallback_preserves_via_nets(self, tmp_pcb, tmp_path):
+        """Via net assignments are restored when kicad-cli zeroes them."""
+        from kicad_tools.cli.runner import run_fill_zones
+        from kicad_tools.schema.pcb import PCB
+
+        input_pcb = PCB.load(str(tmp_pcb))
+        input_via_nets = {via.uuid: via.net_number for via in input_pcb.vias if via.net_number != 0}
+        assert len(input_via_nets) > 0, "Fixture must have vias with nets"
+
+        def fake_run_strips_element_nets(cmd, **kwargs):
+            """Simulate kicad-cli zeroing out (net N) on vias."""
+            import re
+
+            report_path = cmd[cmd.index("--output") + 1]
+            Path(report_path).write_text('{"violations": []}')
+
+            target = Path(cmd[-1])
+            content = target.read_text()
+            content = re.sub(r'\(net \d+ "[^"]*"\)', '(net 0 "")', content)
+            content = re.sub(r"\(net \d+\)", "(net 0)", content)
+            target.write_text(content)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        out = tmp_path / "filled.kicad_pcb"
+
+        with (
+            patch(_HAS_FILL_ZONES, return_value=False),
+            patch(_DRC_SUPPORTS_REFILL, return_value=False),
+            patch(_SUBPROCESS_RUN, side_effect=fake_run_strips_element_nets),
+        ):
+            result = run_fill_zones(tmp_pcb, output_path=out, kicad_cli=Path("/usr/bin/kicad-cli"))
+
+        assert result.success is True
+        output_pcb = PCB.load(str(out))
+
+        output_via_nets = {
+            via.uuid: via.net_number for via in output_pcb.vias if via.net_number != 0
+        }
+        assert output_via_nets == input_via_nets
+
+    def test_drc_fallback_noop_when_element_nets_intact(self, tmp_pcb, tmp_path):
+        """Element net restoration is a no-op when nets are not stripped."""
+        from kicad_tools.cli.runner import run_fill_zones
+        from kicad_tools.schema.pcb import PCB
+
+        input_pcb = PCB.load(str(tmp_pcb))
+        input_pad_nets = {}
+        for fp in input_pcb.footprints:
+            for pad in fp.pads:
+                input_pad_nets[f"{fp.reference}.{pad.number}"] = pad.net_number
+
+        def fake_run_keeps_nets(cmd, **kwargs):
+            report_path = cmd[cmd.index("--output") + 1]
+            Path(report_path).write_text('{"violations": []}')
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        out = tmp_path / "filled.kicad_pcb"
+
+        with (
+            patch(_HAS_FILL_ZONES, return_value=False),
+            patch(_DRC_SUPPORTS_REFILL, return_value=False),
+            patch(_SUBPROCESS_RUN, side_effect=fake_run_keeps_nets),
+        ):
+            result = run_fill_zones(tmp_pcb, output_path=out, kicad_cli=Path("/usr/bin/kicad-cli"))
+
+        assert result.success is True
+        output_pcb = PCB.load(str(out))
+
+        output_pad_nets = {}
+        for fp in output_pcb.footprints:
+            for pad in fp.pads:
+                output_pad_nets[f"{fp.reference}.{pad.number}"] = pad.net_number
+        assert output_pad_nets == input_pad_nets
+
+
+# ---------------------------------------------------------------------------
 # Integration test: requires kicad-cli
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Zone fill via kicad-cli DRC strips inline `(net N)` assignments from pads, segments, and vias -- not just the top-level net table headers that PR #1297 already restores. This causes all pads to read as net 0, making the board appear 100% connected when it is actually corrupted. This PR fixes the root cause and adds defense-in-depth to catch future corruption.

## Changes

- **runner.py**: Add `_snapshot_element_nets()` to capture per-pad (keyed by `fp_uuid:pad_number`), per-segment, and per-via (keyed by UUID) inline net assignments before zone fill. Extend `_restore_net_declarations()` to restore zeroed-out inline net assignments from the snapshot after DRC completes.
- **auditor.py**: Add corruption guard in `_check_connectivity()` -- if the board has footprints but every pad is assigned to net 0, return `NOT_READY` with a "possible data corruption" diagnostic instead of silently passing.
- **net_status.py**: Fix `connection_percentage` to return `0.0` (not `100.0`) when `total_pads == 0`. Fix `status` to return `"unrouted"` (not `"complete"`) for nets with 0 pads.
- **connectivity.py**: Fix `validate()` to not count 0-pad nets as connected when the board has footprints, preventing false "fully routed" verdicts on corrupted data.
- **Tests**: 12 new tests covering pad/segment/via net preservation through zone fill, corruption guard triggering, and net_status corruption defense.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pads retain net numbers after zone fill | Pass | `test_drc_fallback_preserves_pad_nets` verifies all pad net assignments survive kicad-cli zeroing |
| Segments retain net numbers after zone fill | Pass | `test_drc_fallback_preserves_segment_nets` verifies segment nets restored |
| Vias retain net numbers after zone fill | Pass | `test_drc_fallback_preserves_via_nets` verifies via nets restored |
| Audit returns NOT_READY on corrupted board | Pass | `test_all_pads_net_zero_triggers_not_ready` verifies corruption guard |
| Normal board does not trigger guard | Pass | `test_normal_board_does_not_trigger_guard` |
| No-footprint board does not trigger guard | Pass | `test_no_footprints_does_not_trigger_guard` |
| NetStatus returns 0% for 0-pad nets | Pass | `test_zero_pads_returns_zero_percentage` |
| NetStatus returns "unrouted" for 0-pad nets | Pass | `test_zero_pads_status_is_unrouted` |
| Existing zone fill tests pass | Pass | All 28 pre-existing unit tests in test_zones_cmd.py pass |

## Test Plan

- All 137 tests across the 4 affected test files pass (137 passed, 5 integration tests deselected)
- Ruff lint and format checks pass on all changed files
- Pre-existing integration test failure (requires kicad-cli binary) is unchanged

Closes #1388