### PR TITLE
fix(pipeline): add route: prefix to routing skip message and test --force bypass

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -474,7 +474,7 @@ def _run_step_route(ctx: PipelineContext, console: Console) -> PipelineResult:
         return PipelineResult(
             step=PipelineStep.ROUTE,
             success=True,
-            message=f"Board already routed ({trace_count} traces, {net_count} nets) - skipped",
+            message=f"route: Board already routed ({trace_count} traces, {net_count} nets) - skipped",
             skipped=True,
         )
 

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -280,6 +280,8 @@ class TestRoutingSkip:
         assert results[0].success is True
         assert results[0].skipped is True
         assert "already routed" in results[0].message
+        # Verify message uses "route: " prefix convention
+        assert results[0].message.startswith("route: ")
 
     @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
     def test_routing_invoked_when_unrouted(self, mock_run, unrouted_pcb: Path):
@@ -300,6 +302,22 @@ class TestRoutingSkip:
         assert "--grid" in cmd_args
         assert "--manufacturer" in cmd_args
         assert "--auto-fix" in cmd_args
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_force_bypasses_routing_skip(self, mock_run, routed_pcb: Path):
+        """--force on a routed board invokes the router instead of skipping."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, force=True)
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert results[0].skipped is False
+        # Verify subprocess was actually called (not skipped)
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "route" in cmd_args
 
 
 class TestSingleStep:


### PR DESCRIPTION
## Summary
Fixes the route step skip message to follow the "stepname: ..." prefix convention used by all other pipeline steps, and adds a missing test for the --force bypass path.

## Changes
- Changed skip message from `"Board already routed (...) - skipped"` to `"route: Board already routed (...) - skipped"` in `_run_step_route()`
- Added assertion in existing `test_routing_skipped_when_routed` to verify the "route: " prefix
- Added new `test_force_bypasses_routing_skip` test that sets `ctx.force=True` on a routed board and verifies the router subprocess is invoked (not skipped)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Skip message uses "route: ..." prefix | Done | Changed line 477; verified by `test_routing_skipped_when_routed` assertion on `startswith("route: ")` |
| Running pipeline on routed board produces skip with exit 0 | Done | `test_routing_skipped_when_routed` asserts `success=True`, `skipped=True`, message contains "already routed" and starts with "route: " |
| Running pipeline with --force invokes router (does not skip) | Done | New `test_force_bypasses_routing_skip` asserts `skipped=False` and `mock_run.assert_called_once()` |
| `skipped=True` set on PipelineResult for skip path | Done | Pre-existing and verified by `test_routing_skipped_when_routed` |

## Test Plan
- `uv run pytest tests/test_pipeline_cmd.py::TestRoutingSkip -v` -- all 3 tests pass
- `uv run pytest tests/test_pipeline_cmd.py -v` -- 117 passed, 1 pre-existing failure (TestFixERCStep::test_fix_erc_step_skipped_no_errors, confirmed pre-existing on main)
- `uv run ruff check` and `uv run ruff format --check` pass on both changed files

Closes #1396