### PR TITLE
fix(pipeline): enable --local-reroute by default in fix-drc step

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -569,7 +569,7 @@ def _run_step_fix_drc(ctx: PipelineContext, console: Console) -> PipelineResult:
         return PipelineResult(
             step=PipelineStep.FIX_DRC,
             success=True,
-            message=f"[dry-run] Would run: kct fix-drc {ctx.pcb_file.name} --max-passes 3",
+            message=f"[dry-run] Would run: kct fix-drc {ctx.pcb_file.name} --max-passes 3 --local-reroute",
         )
 
     if not ctx.quiet:
@@ -583,6 +583,7 @@ def _run_step_fix_drc(ctx: PipelineContext, console: Console) -> PipelineResult:
         str(ctx.pcb_file),
         "--max-passes",
         "3",
+        "--local-reroute",
     ]
 
     success, message = _run_subprocess_step(cmd, ctx.pcb_file.parent, ctx.verbose)

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -2006,3 +2006,32 @@ class TestZonesDefaultSkip:
         help_text = f.getvalue()
         assert "--zones" in help_text
         assert "data corruption" in help_text.lower() or "corruption" in help_text.lower()
+
+
+class TestFixDrcLocalReroute:
+    """Tests that fix-drc step includes --local-reroute flag."""
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_fix_drc_subprocess_includes_local_reroute(self, mock_run, routed_pcb: Path):
+        """fix-drc subprocess command includes --local-reroute flag."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        main(["--step", "fix-drc", str(routed_pcb), "--quiet"])
+
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "fix-drc" in cmd_args
+        assert "--local-reroute" in cmd_args
+
+    def test_fix_drc_dry_run_mentions_local_reroute(self, routed_pcb: Path):
+        """Dry-run message for fix-drc includes --local-reroute."""
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_fix_drc
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, dry_run=True)
+        console = Console(quiet=True)
+        result = _run_step_fix_drc(ctx, console)
+
+        assert result.success is True
+        assert "--local-reroute" in result.message


### PR DESCRIPTION
## Summary
The pipeline's `fix-drc` step was not forwarding the `--local-reroute` flag introduced in PR #1399. Users running `kct pipeline` never benefited from local A* rerouting even though the feature is stable. This adds the flag to the subprocess command and updates the dry-run message.

## Changes
- Added `"--local-reroute"` to the subprocess command list in `_run_step_fix_drc()` (line ~586 of `pipeline_cmd.py`)
- Updated the dry-run message string to include `--local-reroute` for consistency (line ~572)
- Added `TestFixDrcLocalReroute` test class with two tests:
  - `test_fix_drc_subprocess_includes_local_reroute` -- patches `subprocess.run` and asserts `--local-reroute` is in the captured command args
  - `test_fix_drc_dry_run_mentions_local_reroute` -- calls `_run_step_fix_drc` directly with `dry_run=True` and asserts the message contains the flag

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_run_step_fix_drc()` subprocess command includes `"--local-reroute"` | Pass | Added to cmd list; verified by `test_fix_drc_subprocess_includes_local_reroute` |
| Dry-run message mentions `--local-reroute` | Pass | Updated message string; verified by `test_fix_drc_dry_run_mentions_local_reroute` |
| Existing pipeline tests continue to pass | Pass | 119 existing tests pass (1 pre-existing failure in `TestFixERCStep` unrelated) |
| New unit test confirms `--local-reroute` in subprocess command | Pass | `TestFixDrcLocalReroute` class with 2 tests, both passing |

## Test Plan
- `uv run pytest tests/test_pipeline_cmd.py::TestFixDrcLocalReroute -v` -- 2 passed
- `uv run pytest tests/test_pipeline_cmd.py -v` -- 121 passed, 1 failed (pre-existing)
- `uv run ruff check` and `uv run ruff format --check` on changed files -- all clean

Closes #1400