### PR TITLE
feat(pipeline): partition ERC errors into blocking and non-blocking

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -244,14 +244,26 @@ def _run_step_erc(ctx: PipelineContext, console: Console) -> PipelineResult:
         if result.output_path:
             result.output_path.unlink(missing_ok=True)
 
-    error_count = report.error_count
+    from ..erc import ERC_BLOCKING_TYPES, ERC_NON_BLOCKING_TYPES
+
+    # Partition error-level violations into blocking / non-blocking / unknown.
+    # Unknown types default to blocking (conservative, consistent with auditor).
+    blocking = [v for v in report.errors if v.type in ERC_BLOCKING_TYPES]
+    non_blocking = [v for v in report.errors if v.type in ERC_NON_BLOCKING_TYPES]
+    unknown_errors = [
+        v
+        for v in report.errors
+        if v.type not in ERC_BLOCKING_TYPES and v.type not in ERC_NON_BLOCKING_TYPES
+    ]
+    blocking_error_count = len(blocking) + len(unknown_errors)
+    non_blocking_count = len(non_blocking)
     warning_count = report.warning_count
 
-    # Store error count in context for downstream steps (e.g., FIX_ERC)
-    ctx.erc_error_count = error_count
+    # Store *blocking* error count so FIX_ERC only runs when there are real errors.
+    ctx.erc_error_count = blocking_error_count
 
     # Print per-violation details (unless --quiet)
-    if not ctx.quiet and (error_count > 0 or warning_count > 0):
+    if not ctx.quiet and (blocking_error_count > 0 or non_blocking_count > 0 or warning_count > 0):
         from ..feedback.suggestions import generate_erc_suggestions
 
         for violation in report.violations:
@@ -264,38 +276,50 @@ def _run_step_erc(ctx: PipelineContext, console: Console) -> PipelineResult:
                 console.print(f"          Suggestion: {suggestions[0]}")
 
     # No errors and no warnings -> clean pass
-    if error_count == 0 and warning_count == 0:
+    if blocking_error_count == 0 and non_blocking_count == 0 and warning_count == 0:
         return PipelineResult(
             step=PipelineStep.ERC,
             success=True,
             message="erc: no violations found",
         )
 
-    # Warnings only (no errors) -> pass
-    if error_count == 0:
+    # No blocking errors but non-blocking errors present -> WARN, success=True
+    if blocking_error_count == 0 and non_blocking_count > 0:
+        msg_parts = [f"erc: {non_blocking_count} non-blocking error(s) as warning(s)"]
+        if warning_count > 0:
+            msg_parts.append(f"{warning_count} warning(s)")
+        return PipelineResult(
+            step=PipelineStep.ERC,
+            success=True,
+            message=", ".join(msg_parts),
+        )
+
+    # Warnings only (no errors of any kind) -> pass
+    if blocking_error_count == 0 and non_blocking_count == 0:
         return PipelineResult(
             step=PipelineStep.ERC,
             success=True,
             message=f"erc: {warning_count} warning(s), no errors",
         )
 
-    # Errors found
+    # Blocking errors found
     if ctx.force:
         if not ctx.quiet:
             console.print(
-                f"  [yellow]erc: {error_count} error(s) found — continuing (--force)[/yellow]"
+                f"  [yellow]erc: {blocking_error_count} blocking error(s) found"
+                " — continuing (--force)[/yellow]"
             )
         return PipelineResult(
             step=PipelineStep.ERC,
             success=True,
-            message=f"erc: {error_count} error(s) found — continuing (--force)",
+            message=f"erc: {blocking_error_count} blocking error(s) found — continuing (--force)",
         )
 
     # Halt pipeline
     return PipelineResult(
         step=PipelineStep.ERC,
         success=False,
-        message=f"erc: {error_count} error(s) found (use --force to continue)",
+        message=f"erc: {blocking_error_count} blocking error(s) found (use --force to continue)",
     )
 
 

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -1188,6 +1188,60 @@ ERC_JSON_WARNINGS_ONLY = """{
     ]
 }"""
 
+# Sample ERC JSON report with only non-blocking errors (pin_to_pin)
+ERC_JSON_WITH_NON_BLOCKING_ERRORS = """{
+    "source": "test.kicad_sch",
+    "kicad_version": "8.0.0",
+    "coordinate_units": "mm",
+    "sheets": [
+        {
+            "path": "/",
+            "uuid_path": "test-uuid",
+            "violations": [
+                {
+                    "type": "pin_to_pin",
+                    "severity": "error",
+                    "description": "Pin-to-pin connection between U1/OUT and U2/OUT",
+                    "pos": {"x": 110, "y": 55},
+                    "items": [{"description": "U1 pin OUT"}, {"description": "U2 pin OUT"}],
+                    "excluded": false
+                }
+            ]
+        }
+    ]
+}"""
+
+# Sample ERC JSON report with mixed blocking + non-blocking errors
+ERC_JSON_WITH_MIXED_ERRORS = """{
+    "source": "test.kicad_sch",
+    "kicad_version": "8.0.0",
+    "coordinate_units": "mm",
+    "sheets": [
+        {
+            "path": "/",
+            "uuid_path": "test-uuid",
+            "violations": [
+                {
+                    "type": "pin_to_pin",
+                    "severity": "error",
+                    "description": "Pin-to-pin connection between U1/OUT and U2/OUT",
+                    "pos": {"x": 110, "y": 55},
+                    "items": [{"description": "U1 pin OUT"}, {"description": "U2 pin OUT"}],
+                    "excluded": false
+                },
+                {
+                    "type": "pin_not_connected",
+                    "severity": "error",
+                    "description": "Pin 3 of U3 is not connected",
+                    "pos": {"x": 130, "y": 70},
+                    "items": [{"description": "Pin 3 of U3"}],
+                    "excluded": false
+                }
+            ]
+        }
+    ]
+}"""
+
 
 @pytest.fixture
 def pcb_with_schematic(tmp_path: Path) -> tuple[Path, Path]:
@@ -1299,7 +1353,7 @@ class TestERCStep:
         result = _run_step_erc(ctx, console)
 
         assert result.success is False
-        assert "2 error(s) found" in result.message
+        assert "2 blocking error(s) found" in result.message
         assert "--force" in result.message
 
     @patch("kicad_tools.cli.runner.find_kicad_cli")
@@ -1323,7 +1377,7 @@ class TestERCStep:
         assert result.success is True
         assert result.skipped is False
         assert "--force" in result.message
-        assert "2 error(s)" in result.message
+        assert "2 blocking error(s)" in result.message
 
     @patch("kicad_tools.cli.runner.find_kicad_cli")
     @patch("kicad_tools.cli.runner.run_erc")
@@ -1492,6 +1546,103 @@ class TestERCStep:
         assert ALL_STEPS[0] == PipelineStep.ERC
         assert ALL_STEPS[1] == PipelineStep.FIX_ERC
         assert ALL_STEPS[2] == PipelineStep.FIX_SILKSCREEN
+
+    @patch("kicad_tools.cli.runner.find_kicad_cli")
+    @patch("kicad_tools.cli.runner.run_erc")
+    def test_erc_non_blocking_errors_pass(
+        self, mock_run_erc, mock_find_cli, pcb_with_schematic, tmp_path
+    ):
+        """Non-blocking errors (e.g. pin_to_pin) pass the pipeline with WARN."""
+        pcb_file, sch_file = pcb_with_schematic
+
+        erc_report_file = tmp_path / "erc_report.json"
+        erc_report_file.write_text(ERC_JSON_WITH_NON_BLOCKING_ERRORS)
+
+        mock_find_cli.return_value = Path("/usr/bin/kicad-cli")
+        mock_run_erc.return_value = MagicMock(success=True, output_path=erc_report_file, stderr="")
+
+        from rich.console import Console
+
+        ctx = PipelineContext(pcb_file=pcb_file, schematic_file=sch_file, quiet=True)
+        console = Console(quiet=True)
+        result = _run_step_erc(ctx, console)
+
+        assert result.success is True
+        assert result.skipped is False
+        assert "non-blocking" in result.message
+        assert "1 non-blocking error(s)" in result.message
+
+    @patch("kicad_tools.cli.runner.find_kicad_cli")
+    @patch("kicad_tools.cli.runner.run_erc")
+    def test_erc_non_blocking_sets_zero_error_count(
+        self, mock_run_erc, mock_find_cli, pcb_with_schematic, tmp_path
+    ):
+        """ctx.erc_error_count is 0 when only non-blocking errors are present."""
+        pcb_file, sch_file = pcb_with_schematic
+
+        erc_report_file = tmp_path / "erc_report.json"
+        erc_report_file.write_text(ERC_JSON_WITH_NON_BLOCKING_ERRORS)
+
+        mock_find_cli.return_value = Path("/usr/bin/kicad-cli")
+        mock_run_erc.return_value = MagicMock(success=True, output_path=erc_report_file, stderr="")
+
+        from rich.console import Console
+
+        ctx = PipelineContext(pcb_file=pcb_file, schematic_file=sch_file, quiet=True)
+        console = Console(quiet=True)
+        _run_step_erc(ctx, console)
+
+        # Only blocking errors count — non-blocking should not trigger fix-erc
+        assert ctx.erc_error_count == 0
+
+    @patch("kicad_tools.cli.runner.find_kicad_cli")
+    @patch("kicad_tools.cli.runner.run_erc")
+    def test_erc_mixed_blocking_and_non_blocking_halts(
+        self, mock_run_erc, mock_find_cli, pcb_with_schematic, tmp_path
+    ):
+        """Mixed blocking + non-blocking errors halts with blocking count only."""
+        pcb_file, sch_file = pcb_with_schematic
+
+        erc_report_file = tmp_path / "erc_report.json"
+        erc_report_file.write_text(ERC_JSON_WITH_MIXED_ERRORS)
+
+        mock_find_cli.return_value = Path("/usr/bin/kicad-cli")
+        mock_run_erc.return_value = MagicMock(success=True, output_path=erc_report_file, stderr="")
+
+        from rich.console import Console
+
+        ctx = PipelineContext(pcb_file=pcb_file, schematic_file=sch_file, quiet=True)
+        console = Console(quiet=True)
+        result = _run_step_erc(ctx, console)
+
+        # Should fail because of the 1 blocking error (pin_not_connected)
+        assert result.success is False
+        assert "1 blocking error(s) found" in result.message
+        # Should NOT report total count (2), only blocking count (1)
+        assert "2 blocking" not in result.message
+
+    @patch("kicad_tools.cli.runner.find_kicad_cli")
+    @patch("kicad_tools.cli.runner.run_erc")
+    def test_erc_mixed_errors_sets_blocking_count(
+        self, mock_run_erc, mock_find_cli, pcb_with_schematic, tmp_path
+    ):
+        """ctx.erc_error_count reflects only blocking errors in mixed scenario."""
+        pcb_file, sch_file = pcb_with_schematic
+
+        erc_report_file = tmp_path / "erc_report.json"
+        erc_report_file.write_text(ERC_JSON_WITH_MIXED_ERRORS)
+
+        mock_find_cli.return_value = Path("/usr/bin/kicad-cli")
+        mock_run_erc.return_value = MagicMock(success=True, output_path=erc_report_file, stderr="")
+
+        from rich.console import Console
+
+        ctx = PipelineContext(pcb_file=pcb_file, schematic_file=sch_file, quiet=True, force=True)
+        console = Console(quiet=True)
+        _run_step_erc(ctx, console)
+
+        # pin_not_connected is blocking, pin_to_pin is non-blocking
+        assert ctx.erc_error_count == 1
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

The ERC pipeline step now partitions error-level violations into blocking vs non-blocking
using the existing `ERC_BLOCKING_TYPES` and `ERC_NON_BLOCKING_TYPES` sets from
`erc/violation.py`. Non-blocking errors (e.g. `pin_to_pin`) produce a WARN result with
`success=True` instead of halting the pipeline. Unknown error types default to blocking
(conservative, consistent with the auditor).

## Changes

- In `_run_step_erc()`, replace raw `report.error_count` with a three-way partition of
  `report.errors` into blocking, non-blocking, and unknown lists
- `ctx.erc_error_count` now stores only blocking error count, so `_run_step_fix_erc()`
  correctly skips when only non-blocking errors are present
- Add new result branch: non-blocking-only yields `success=True` with message
  `"erc: N non-blocking error(s) as warning(s)"`
- Update blocking/force/halt messages to say "blocking error(s)" for clarity

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Non-blocking errors (pin_to_pin) pass pipeline with WARN | PASS | `test_erc_non_blocking_errors_pass` asserts `success=True`, `"non-blocking"` in message |
| ctx.erc_error_count is 0 for non-blocking-only | PASS | `test_erc_non_blocking_sets_zero_error_count` asserts `ctx.erc_error_count == 0` |
| Mixed blocking + non-blocking halts with blocking count only | PASS | `test_erc_mixed_blocking_and_non_blocking_halts` asserts `success=False`, message shows 1 not 2 |
| ctx.erc_error_count reflects blocking count in mixed case | PASS | `test_erc_mixed_errors_sets_blocking_count` asserts `ctx.erc_error_count == 1` |
| Existing blocking-error tests still fail pipeline | PASS | `test_erc_halts_pipeline_on_errors` still passes (both violations are blocking) |
| Unknown types default to blocking (conservative) | PASS | Implemented in code, consistent with auditor pattern |

## Test Plan

- Added `ERC_JSON_WITH_NON_BLOCKING_ERRORS` fixture (single `pin_to_pin` error)
- Added `ERC_JSON_WITH_MIXED_ERRORS` fixture (one `pin_to_pin` + one `pin_not_connected`)
- Added 4 new tests in `TestERCStep`: non-blocking pass, zero error count, mixed halt, mixed count
- Updated 2 existing test assertions to match new "blocking error(s)" wording
- All 121 pipeline tests pass (1 pre-existing failure unrelated to this change)

Closes #1404