### PR TITLE
fix(cli): use exit code 2 for audit/check DRC findings instead of 1

### DIFF
--- a/src/kicad_tools/cli/audit_cmd.py
+++ b/src/kicad_tools/cli/audit_cmd.py
@@ -16,8 +16,8 @@ Usage:
 
 Exit Codes:
     0 - Ready for manufacturing (no errors)
-    1 - Not ready (errors found) or command failure
-    2 - Warnings found (only with --strict)
+    1 - Command failure (file not found, parse error, etc.)
+    2 - Not ready (errors found) or warnings found with --strict
 """
 
 import argparse
@@ -133,9 +133,12 @@ def main(argv: list[str] | None = None) -> int:
         output_table(result, args.verbose)
 
     # Determine exit code
-    if result.verdict == AuditVerdict.NOT_READY:
-        return 1
-    elif result.verdict == AuditVerdict.WARNING and args.strict:
+    # Exit 2 = audit ran successfully but found issues (NOT_READY or WARNING+strict)
+    # Exit 1 = reserved for tool-level failures (file not found, parse error) above
+    # Exit 0 = board is ready for manufacturing
+    if result.verdict == AuditVerdict.NOT_READY or (
+        result.verdict == AuditVerdict.WARNING and args.strict
+    ):
         return 2
     return 0
 

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -12,9 +12,9 @@ Usage:
     kct check board.kicad_pcb --skip silkscreen    # Exclude checks
 
 Exit Codes:
-    0 - No errors (warnings may be present)
-    1 - Errors found or command failure
-    2 - Warnings found (only with --strict)
+    0 - No errors (warnings may be present without --strict)
+    1 - Command failure (file not found, parse error, etc.)
+    2 - Errors found, or warnings found with --strict
 
 Difference from `kct drc`:
     - kct drc: Uses kicad-cli to run DRC (requires KiCad)
@@ -218,12 +218,13 @@ def main(argv: list[str] | None = None) -> int:
         output_table(violations, results, pcb_path, args.mfr, layers, args.verbose)
 
     # Determine exit code
+    # Exit 2 = check ran successfully but found issues (errors, or warnings+strict)
+    # Exit 1 = reserved for tool-level failures (file not found, parse error) above
+    # Exit 0 = no errors (warnings may be present without --strict)
     error_count = sum(1 for v in violations if v.is_error)
     warning_count = len(violations) - error_count
 
-    if error_count > 0:
-        return 1
-    elif warning_count > 0 and args.strict:
+    if error_count > 0 or (warning_count > 0 and args.strict):
         return 2
     return 0
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -511,8 +511,12 @@ class TestAuditExitCodes:
             exit_code = 0
         assert exit_code == 0
 
-    def test_exit_code_one_when_not_ready(self):
-        """Test that CLI returns exit code 1 when verdict is NOT_READY."""
+    def test_exit_code_two_when_not_ready(self):
+        """Test that CLI returns exit code 2 when verdict is NOT_READY.
+
+        Exit code 2 means the audit ran successfully but found issues.
+        Exit code 1 is reserved for tool-level failures (file not found, etc.).
+        """
         result = AuditResult()
         result.erc.error_count = 5
         result.erc.blocking_error_count = 5
@@ -520,10 +524,10 @@ class TestAuditExitCodes:
 
         # Verify the exit code mapping
         if result.verdict == AuditVerdict.NOT_READY:
-            exit_code = 1
+            exit_code = 2
         else:
             exit_code = 0
-        assert exit_code == 1
+        assert exit_code == 2
 
     def test_exit_code_two_when_warning_strict(self):
         """Test that CLI returns exit code 2 for WARNING with --strict."""
@@ -540,6 +544,75 @@ class TestAuditExitCodes:
         else:
             exit_code = 0
         assert exit_code == 2
+
+    def test_exit_code_one_for_file_not_found(self, capsys):
+        """Test that CLI returns exit code 1 for tool-level errors (file not found)."""
+        from kicad_tools.cli.audit_cmd import main
+
+        result = main(["nonexistent_board.kicad_pcb"])
+        assert result == 1
+
+    def test_exit_code_one_for_wrong_extension(self, tmp_path, capsys):
+        """Test that CLI returns exit code 1 for tool-level errors (wrong extension)."""
+        from kicad_tools.cli.audit_cmd import main
+
+        bad_file = tmp_path / "test.txt"
+        bad_file.write_text("not a pcb")
+        result = main([str(bad_file)])
+        assert result == 1
+
+    def test_exit_code_two_when_not_ready_via_main(self, tmp_path, monkeypatch, capsys):
+        """Test that audit main() returns 2 (not 1) when verdict is NOT_READY.
+
+        This confirms the pipeline will see exit code 2 and treat it as
+        'completed with warnings' instead of 'failed'.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.cli.audit_cmd import main
+
+        # Create a dummy PCB file so path validation passes
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb (version 20221018))")
+
+        # Mock ManufacturingAudit to return NOT_READY
+        mock_result = AuditResult()
+        mock_result.drc.blocking_count = 3
+        assert mock_result.verdict == AuditVerdict.NOT_READY
+
+        mock_audit_instance = MagicMock()
+        mock_audit_instance.run.return_value = mock_result
+
+        with patch(
+            "kicad_tools.cli.audit_cmd.ManufacturingAudit",
+            return_value=mock_audit_instance,
+        ):
+            exit_code = main([str(pcb_file)])
+
+        assert exit_code == 2
+
+    def test_exit_code_zero_when_ready_via_main(self, tmp_path, monkeypatch, capsys):
+        """Test that audit main() returns 0 when verdict is READY."""
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.cli.audit_cmd import main
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb (version 20221018))")
+
+        mock_result = AuditResult()
+        assert mock_result.verdict == AuditVerdict.READY
+
+        mock_audit_instance = MagicMock()
+        mock_audit_instance.run.return_value = mock_result
+
+        with patch(
+            "kicad_tools.cli.audit_cmd.ManufacturingAudit",
+            return_value=mock_audit_instance,
+        ):
+            exit_code = main([str(pcb_file)])
+
+        assert exit_code == 0
 
 
 class TestAuditOutputRendering:

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -222,13 +222,24 @@ class TestCheckExitCodes:
         result = main([str(drc_clean_pcb), "--strict"])
         assert result == 0
 
-    def test_exit_code_1_with_violations(self, minimal_pcb: Path):
-        """Test exit code 1 when DRC violations are found."""
+    def test_exit_code_2_with_violations(self, minimal_pcb: Path):
+        """Test exit code 2 when DRC violations are found.
+
+        Exit code 2 means the check ran successfully but found errors.
+        Exit code 1 is reserved for tool-level failures (file not found, etc.).
+        """
         from kicad_tools.cli.check_cmd import main
 
         # minimal_pcb has a trace overlapping a pad, causing a clearance violation
         result = main([str(minimal_pcb)])
-        assert result == 1  # Errors found
+        assert result == 2  # Errors found (tool ran OK, board has issues)
+
+    def test_exit_code_1_for_tool_error(self, capsys):
+        """Test exit code 1 for tool-level errors (file not found)."""
+        from kicad_tools.cli.check_cmd import main
+
+        result = main(["nonexistent_board.kicad_pcb"])
+        assert result == 1  # Tool error
 
 
 class TestCheckJsonSchema:

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -394,12 +394,26 @@ class TestExitCodes:
     """Tests for pipeline exit codes."""
 
     @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
-    def test_exit_code_on_drc_failure(self, mock_run, routed_pcb: Path):
-        """Pipeline returns exit code 1 when final audit fails."""
-        mock_run.return_value = MagicMock(returncode=1, stderr="DRC violations found", stdout="")
+    def test_exit_code_on_audit_tool_error(self, mock_run, routed_pcb: Path):
+        """Pipeline returns exit code 1 when audit subprocess has a tool error (exit 1)."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="file not found", stdout="")
 
         result = main(["--step", "audit", str(routed_pcb), "--quiet"])
         assert result == 1
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_audit_exit_code_2_treated_as_success(self, mock_run, routed_pcb: Path):
+        """Pipeline treats audit exit code 2 (DRC violations found) as success with warnings.
+
+        This is the core behavioral change: audit now exits 2 (not 1) when DRC
+        violations are found. The pipeline already treats exit code 2 as
+        'completed with warnings', so the pipeline now reports success instead
+        of failure for boards with DRC violations.
+        """
+        mock_run.return_value = MagicMock(returncode=2, stderr="", stdout="")
+
+        result = main(["--step", "audit", str(routed_pcb), "--quiet"])
+        assert result == 0
 
     @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
     def test_exit_code_zero_on_success(self, mock_run, routed_pcb: Path):
@@ -439,6 +453,50 @@ class TestExitCodes:
         assert results[0].success is True
         assert "warnings" in results[0].message
         assert results[1].success is True
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_pipeline_audit_exit_2_reports_success_with_warnings(self, mock_run, routed_pcb: Path):
+        """Pipeline reports audit step as 'completed with warnings' when exit code is 2.
+
+        Audit now exits 2 for NOT_READY (DRC violations found). The pipeline
+        already treats exit code 2 as a soft warning, so multi-step pipelines
+        that include audit should report all steps succeeded.
+        """
+
+        def side_effect(cmd, **kwargs):
+            # Detect audit/check subcommands by looking at the argv list
+            if "audit" in cmd or "check" in cmd:
+                return MagicMock(returncode=2, stderr="", stdout="")
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        mock_run.side_effect = side_effect
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True)
+        results = run_pipeline(ctx, [PipelineStep.FIX_VIAS, PipelineStep.AUDIT])
+
+        assert len(results) == 2
+        assert results[0].success is True
+        assert results[1].success is True
+        assert "warnings" in results[1].message
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_pipeline_audit_exit_1_is_tool_failure(self, mock_run, routed_pcb: Path):
+        """Pipeline reports audit step as failed when exit code is 1 (tool error).
+
+        Exit code 1 from audit now means a tool-level error (file not found,
+        parse failure), not DRC violations. The pipeline should still treat
+        this as a failure.
+        """
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error: parse failed", stdout="")
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True)
+        results = run_pipeline(ctx, [PipelineStep.AUDIT])
+
+        assert len(results) == 1
+        # Audit step failures don't stop the pipeline (informational), but
+        # the step itself is marked as failed
+        assert results[0].success is False
+        assert "failed" in results[0].message
 
 
 class TestProjectInput:


### PR DESCRIPTION
## Summary
Change `kct audit` and `kct check` to exit with code 2 (not 1) when DRC violations or errors are found. Exit code 1 is now reserved for tool-level failures (file not found, parse errors). This aligns with the pipeline's existing convention where exit code 2 means "completed with warnings", so the pipeline now correctly reports success instead of failure when audit finds DRC violations.

## Changes
- `audit_cmd.py`: `AuditVerdict.NOT_READY` now returns exit code 2 instead of 1; `WARNING` with `--strict` still returns 2; docstring updated
- `check_cmd.py`: `error_count > 0` now returns exit code 2 instead of 1; `warnings + --strict` still returns 2; docstring updated
- `test_audit.py`: Updated `test_exit_code_two_when_not_ready` (was `test_exit_code_one_when_not_ready`); added tests for tool-error exit code 1, NOT_READY exit code 2 via main(), READY exit code 0 via main()
- `test_cli_check.py`: Updated `test_exit_code_2_with_violations` (was `test_exit_code_1_with_violations`); added `test_exit_code_1_for_tool_error`
- `test_pipeline_cmd.py`: Updated `test_exit_code_on_audit_tool_error` (was `test_exit_code_on_drc_failure`); added `test_audit_exit_code_2_treated_as_success`, `test_pipeline_audit_exit_2_reports_success_with_warnings`, `test_pipeline_audit_exit_1_is_tool_failure`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct audit` exits 2 (not 1) when NOT_READY | PASS | `test_exit_code_two_when_not_ready_via_main` mocks NOT_READY verdict, asserts exit 2 |
| `kct check` exits 2 (not 1) when errors found | PASS | `test_exit_code_2_with_violations` runs check on minimal_pcb with violations, asserts exit 2 |
| `kct audit`/`kct check` exits 1 on tool-level errors | PASS | `test_exit_code_one_for_file_not_found`, `test_exit_code_1_for_tool_error` confirm exit 1 for missing files |
| `kct audit`/`kct check` exits 0 when READY | PASS | `test_exit_code_zero_when_ready_via_main` mocks READY verdict, asserts exit 0 |
| Pipeline treats audit exit 2 as success with warnings | PASS | `test_audit_exit_code_2_treated_as_success` and `test_pipeline_audit_exit_2_reports_success_with_warnings` |
| Pipeline treats audit exit 1 as tool failure | PASS | `test_pipeline_audit_exit_1_is_tool_failure` |
| `--strict` mode behavior preserved | PASS | `test_exit_code_two_when_warning_strict` unchanged, still asserts exit 2 |

## Test Plan
- Ran `uv run pytest tests/test_audit.py` -- 52 passed
- Ran `uv run pytest tests/test_cli_check.py` -- 29 passed
- Ran `uv run pytest tests/test_pipeline_cmd.py` -- 120 passed, 1 pre-existing failure (unrelated `test_fix_erc_step_skipped_no_errors`)
- Ran `uv run ruff check` on all changed files -- all checks passed
- Ran `uv run ruff format --check` on all changed files -- all formatted

Closes #1403