### PR TITLE
feat(pipeline): add --max-displacement pass-through to fix-drc step

### DIFF
--- a/src/kicad_tools/cli/commands/pipeline.py
+++ b/src/kicad_tools/cli/commands/pipeline.py
@@ -39,6 +39,11 @@ def run_pipeline_command(args) -> int:
     if getattr(args, "pipeline_commit", False):
         sub_argv.append("--commit")
 
+    # Max displacement for fix-drc step
+    max_disp = getattr(args, "pipeline_max_displacement", None)
+    if max_disp is not None and max_disp != 0.5:
+        sub_argv.extend(["--max-displacement", str(max_disp)])
+
     # Zones opt-in
     if getattr(args, "pipeline_zones", False):
         sub_argv.append("--zones")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2994,6 +2994,17 @@ def _add_pipeline_parser(subparsers) -> None:
         help="Create a git commit with modified files after a successful pipeline run",
     )
     pipeline_parser.add_argument(
+        "--max-displacement",
+        dest="pipeline_max_displacement",
+        type=float,
+        default=0.5,
+        help=(
+            "Maximum nudge/slide distance in mm for fix-drc step (default: 0.5). "
+            "Increase when enlarged vias cause segment-to-via violations that "
+            "exceed the displacement budget."
+        ),
+    )
+    pipeline_parser.add_argument(
         "--zones",
         dest="pipeline_zones",
         action="store_true",

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -97,6 +97,7 @@ class PipelineContext:
     force: bool = False
     is_project: bool = False
     commit: bool = False
+    max_displacement: float = 0.5
     erc_error_count: int = 0
 
 
@@ -593,7 +594,10 @@ def _run_step_fix_drc(ctx: PipelineContext, console: Console) -> PipelineResult:
         return PipelineResult(
             step=PipelineStep.FIX_DRC,
             success=True,
-            message=f"[dry-run] Would run: kct fix-drc {ctx.pcb_file.name} --max-passes 3 --local-reroute",
+            message=(
+                f"[dry-run] Would run: kct fix-drc {ctx.pcb_file.name} "
+                f"--max-passes 3 --local-reroute --max-displacement {ctx.max_displacement}"
+            ),
         )
 
     if not ctx.quiet:
@@ -608,6 +612,8 @@ def _run_step_fix_drc(ctx: PipelineContext, console: Console) -> PipelineResult:
         "--max-passes",
         "3",
         "--local-reroute",
+        "--max-displacement",
+        str(ctx.max_displacement),
     ]
 
     success, message = _run_subprocess_step(cmd, ctx.pcb_file.parent, ctx.verbose)
@@ -1132,6 +1138,16 @@ Examples:
         help="Create a git commit with the modified PCB file after a successful pipeline run",
     )
     parser.add_argument(
+        "--max-displacement",
+        type=float,
+        default=0.5,
+        help=(
+            "Maximum nudge/slide distance in mm for fix-drc step (default: 0.5). "
+            "Increase when enlarged vias cause segment-to-via violations that "
+            "exceed the displacement budget."
+        ),
+    )
+    parser.add_argument(
         "--zones",
         action="store_true",
         default=False,
@@ -1210,6 +1226,7 @@ Examples:
         force=args.force,
         is_project=is_project,
         commit=args.commit,
+        max_displacement=args.max_displacement,
     )
 
     # Determine steps to run

--- a/tests/test_fix_drc_cmd.py
+++ b/tests/test_fix_drc_cmd.py
@@ -253,6 +253,48 @@ DRC_REPORT_EMPTY = """\
 ** End of Report **
 """
 
+# PCB with a segment overlapping an enlarged via (post fix-vias enlargement).
+# Via enlarged from 0.6 to 0.8 mm; the trace that formerly had 0.1 mm clearance
+# now has negative clearance (overlap).  The required nudge exceeds the old
+# 0.25 mm default but is well within the new 0.5 mm pipeline default.
+PCB_ENLARGED_VIA = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (segment (start 100 100.05) (end 110 100.05) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-ev-1"))
+  (via (at 105 100) (size 0.8) (drill 0.4) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-ev-1"))
+)
+"""
+
+# DRC report for the enlarged-via scenario: required 0.2 mm, actual -0.07 mm.
+# delta = 0.27 mm; with 0.01 mm margin the required displacement is 0.28 mm.
+# This exceeds the old 0.25 mm cap but is within the new 0.5 mm pipeline default.
+DRC_REPORT_ENLARGED_VIA = """\
+** Drc report for test.kicad_pcb **
+** Created on 2025-12-28T21:29:34-08:00 **
+
+** Found 1 DRC violations **
+[clearance_segment_via]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual -0.0700 mm)
+    Rule: netclass 'Default'; error
+    @(105.0000 mm, 100.0500 mm): Track [+3.3V] on F.Cu
+    @(105.0000 mm, 100.0000 mm): Via [GND] on F.Cu - B.Cu
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+
 
 # ── Fixtures ────────────────────────────────────────────────────────
 
@@ -345,6 +387,20 @@ def report_no_net_via(tmp_path: Path) -> Path:
 def report_empty(tmp_path: Path) -> Path:
     f = tmp_path / "empty-drc.rpt"
     f.write_text(DRC_REPORT_EMPTY)
+    return f
+
+
+@pytest.fixture
+def pcb_enlarged_via(tmp_path: Path) -> Path:
+    f = tmp_path / "enlarged_via.kicad_pcb"
+    f.write_text(PCB_ENLARGED_VIA)
+    return f
+
+
+@pytest.fixture
+def report_enlarged_via(tmp_path: Path) -> Path:
+    f = tmp_path / "enlarged-via-drc.rpt"
+    f.write_text(DRC_REPORT_ENLARGED_VIA)
     return f
 
 
@@ -1485,3 +1541,103 @@ class TestMultiPassIteration:
         data = json.loads(captured.out)
         assert data["total_repaired"] >= 1
         assert result == 0
+
+
+# ── Enlarged-via displacement threshold tests ──────────────────────
+
+
+class TestEnlargedViaDisplacement:
+    """Verify that segment-to-via violations near enlarged vias are
+    skipped at the old 0.25 mm cap but repaired at 0.5 mm.
+
+    This exercises the core scenario from issue #1401: after fix-vias
+    enlarges a via, the induced clearance violation requires a nudge
+    larger than the old default but within the new pipeline default.
+    """
+
+    def test_skipped_at_old_default(
+        self, pcb_enlarged_via: Path, report_enlarged_via: Path, capsys
+    ):
+        """Violation is skipped when max-displacement is the old 0.25 mm default."""
+        main(
+            [
+                str(pcb_enlarged_via),
+                "--drc-report",
+                str(report_enlarged_via),
+                "--max-displacement",
+                "0.25",
+                "--dry-run",
+                "--format",
+                "json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["clearance"]["repaired"] == 0
+        assert data["clearance"]["skipped"]["exceeds_max"] >= 1
+
+    def test_repaired_at_new_default(
+        self, pcb_enlarged_via: Path, report_enlarged_via: Path, capsys
+    ):
+        """Violation is repaired when max-displacement is raised to 0.5 mm."""
+        main(
+            [
+                str(pcb_enlarged_via),
+                "--drc-report",
+                str(report_enlarged_via),
+                "--max-displacement",
+                "0.5",
+                "--dry-run",
+                "--format",
+                "json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["clearance"]["repaired"] >= 1
+        assert data["clearance"]["skipped"]["exceeds_max"] == 0
+
+    @pytest.mark.parametrize(
+        "max_disp,expect_repaired",
+        [
+            (0.25, False),
+            (0.27, False),  # 0.27 + 0.01 margin = 0.28, still exceeds 0.27
+            (0.30, True),  # 0.28 < 0.30
+            (0.50, True),
+            (1.00, True),
+        ],
+    )
+    def test_displacement_threshold_boundary(
+        self,
+        pcb_enlarged_via: Path,
+        report_enlarged_via: Path,
+        capsys,
+        max_disp: float,
+        expect_repaired: bool,
+    ):
+        """Parametrized boundary test across displacement thresholds."""
+        main(
+            [
+                str(pcb_enlarged_via),
+                "--drc-report",
+                str(report_enlarged_via),
+                "--max-displacement",
+                str(max_disp),
+                "--dry-run",
+                "--format",
+                "json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        if expect_repaired:
+            assert data["clearance"]["repaired"] >= 1, (
+                f"Expected repair at max_displacement={max_disp}"
+            )
+        else:
+            assert data["clearance"]["repaired"] == 0, (
+                f"Expected skip at max_displacement={max_disp}"
+            )

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -2244,3 +2244,96 @@ class TestFixDrcLocalReroute:
 
         assert result.success is True
         assert "--local-reroute" in result.message
+
+
+class TestMaxDisplacementPassThrough:
+    """Tests for --max-displacement pipeline option forwarded to fix-drc step."""
+
+    def test_fix_drc_dry_run_shows_max_displacement(self, routed_pcb: Path):
+        """Dry-run message for fix-drc reflects the configured max-displacement."""
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_fix_drc
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, dry_run=True)
+        console = Console(quiet=True)
+        result = _run_step_fix_drc(ctx, console)
+
+        assert result.success is True
+        assert "--max-displacement 0.5" in result.message
+
+    def test_fix_drc_dry_run_shows_custom_max_displacement(self, routed_pcb: Path):
+        """Dry-run message reflects a user-specified max-displacement value."""
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_fix_drc
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, dry_run=True, max_displacement=0.75)
+        console = Console(quiet=True)
+        result = _run_step_fix_drc(ctx, console)
+
+        assert result.success is True
+        assert "--max-displacement 0.75" in result.message
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_fix_drc_subprocess_receives_max_displacement(self, mock_run, routed_pcb: Path):
+        """fix-drc subprocess command includes --max-displacement from context."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_fix_drc
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, max_displacement=0.5)
+        console = Console(quiet=True)
+        result = _run_step_fix_drc(ctx, console)
+
+        assert result.success is True
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "--max-displacement" in cmd_args
+        disp_idx = cmd_args.index("--max-displacement")
+        assert cmd_args[disp_idx + 1] == "0.5"
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_fix_drc_subprocess_receives_custom_max_displacement(self, mock_run, routed_pcb: Path):
+        """fix-drc subprocess command uses a non-default max-displacement."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_fix_drc
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, max_displacement=1.0)
+        console = Console(quiet=True)
+        result = _run_step_fix_drc(ctx, console)
+
+        assert result.success is True
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "--max-displacement" in cmd_args
+        disp_idx = cmd_args.index("--max-displacement")
+        assert cmd_args[disp_idx + 1] == "1.0"
+
+    def test_pipeline_default_max_displacement_is_0_5(self):
+        """PipelineContext defaults to 0.5 mm max-displacement."""
+        from pathlib import Path
+
+        ctx = PipelineContext(pcb_file=Path("dummy.kicad_pcb"))
+        assert ctx.max_displacement == 0.5
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_cli_max_displacement_forwarded_to_pipeline(self, mock_run, routed_pcb: Path):
+        """CLI --max-displacement argument is forwarded to the fix-drc subprocess."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        result = main(
+            [str(routed_pcb), "--step", "fix-drc", "--max-displacement", "0.75", "--quiet"]
+        )
+        assert result == 0
+
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "--max-displacement" in cmd_args
+        disp_idx = cmd_args.index("--max-displacement")
+        assert cmd_args[disp_idx + 1] == "0.75"


### PR DESCRIPTION
## Summary
Add `--max-displacement` CLI argument to the pipeline command and raise the default from 0.25 mm to 0.5 mm. This resolves the issue where segment-to-via clearance violations induced by `fix-vias` enlargement are skipped as "Exceeds max displacement" during the `fix-drc` step.

## Changes
- Add `max_displacement` field (default 0.5) to `PipelineContext` dataclass
- Pass `--max-displacement` from context to `fix-drc` subprocess in `_run_step_fix_drc`
- Add `--max-displacement` argument to `pipeline` CLI (both `pipeline_cmd.py` and `parser.py`)
- Forward `--max-displacement` through the command dispatcher in `commands/pipeline.py`
- Update dry-run message to reflect the actual max-displacement value being used
- Add 13 new tests covering the displacement threshold behavior and pipeline pass-through

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pipeline after via enlargement leaves 0 `skipped_exceeds_max` within 0.5 mm | Pass | Parametrized test `TestEnlargedViaDisplacement::test_repaired_at_new_default` confirms repaired=1, exceeds_max=0 at 0.5 mm |
| `kct fix-drc --max-displacement 0.5` repairs previously-skipped violations | Pass | `test_repaired_at_new_default` and boundary tests at 0.30/0.50/1.00 all repair the violation |
| Existing tests continue to pass | Pass | 187 tests pass (64 fix-drc + 123 pipeline); 1 pre-existing failure (`test_fix_erc_step_skipped_no_errors`) unrelated |
| Dry-run message reflects actual `--max-displacement` value | Pass | `test_fix_drc_dry_run_shows_max_displacement` and `test_fix_drc_dry_run_shows_custom_max_displacement` |
| No regression in segment-to-segment or drill-clearance repair | Pass | All existing `TestDrillClearanceRepairer` and clearance tests pass unchanged |

## Test Plan
- `uv run pytest tests/test_fix_drc_cmd.py -x` -- 64 passed
- `uv run pytest tests/test_pipeline_cmd.py -k "not test_fix_erc_step_skipped_no_errors"` -- 123 passed
- `uv run ruff check` and `uv run ruff format --check` on all modified files -- clean

Closes #1401