### PR TITLE
feat(fix-vias): add selective via skip and layer auto-detection

### DIFF
--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -67,7 +67,7 @@ def run_fix_vias_command(args) -> int:
     sub_argv = [args.pcb]
     if args.mfr != "jlcpcb":
         sub_argv.extend(["--mfr", args.mfr])
-    if args.layers != 2:
+    if args.layers is not None:
         sub_argv.extend(["--layers", str(args.layers)])
     if args.copper != 1.0:
         sub_argv.extend(["--copper", str(args.copper)])
@@ -84,6 +84,8 @@ def run_fix_vias_command(args) -> int:
     # Use global quiet flag
     if getattr(args, "global_quiet", False):
         sub_argv.append("--quiet")
+    if getattr(args, "skip_if_clearance_violation", False):
+        sub_argv.append("--skip-if-clearance-violation")
     return fix_vias_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/fix_vias_cmd.py
+++ b/src/kicad_tools/cli/fix_vias_cmd.py
@@ -56,6 +56,20 @@ class ViaClearanceWarning:
     clearance_mm: float
 
 
+@dataclass
+class ViaSkip:
+    """Record of a via that was skipped because resizing would violate clearance."""
+
+    x: float
+    y: float
+    net: int
+    current_drill: float
+    current_diameter: float
+    would_be_diameter: float
+    reason: str
+    uuid: str
+
+
 def get_design_rules(
     mfr: str | None, layers: int, copper: float, drill: float | None, diameter: float | None
 ) -> tuple[float, float, float, float]:
@@ -252,7 +266,8 @@ def fix_vias(
     min_clearance: float = 0.2,
     dry_run: bool = False,
     min_annular_ring: float = 0.0,
-) -> tuple[list[ViaFix], list[ViaClearanceWarning]]:
+    skip_on_clearance: bool = False,
+) -> tuple[list[ViaFix], list[ViaClearanceWarning], list[ViaSkip]]:
     """Fix undersized vias in the PCB.
 
     Args:
@@ -265,12 +280,17 @@ def fix_vias(
             When set, each via's diameter is also checked against
             its own drill size to ensure the annular ring is met:
             required_diameter = drill + 2 * min_annular_ring.
+        skip_on_clearance: If True, skip resizing vias that would
+            cause clearance violations after enlargement.  The skipped
+            vias are returned in the third element of the tuple.
 
     Returns:
-        Tuple of (fixes, warnings)
+        Tuple of (fixes, warnings, skips).  ``skips`` is empty when
+        *skip_on_clearance* is False.
     """
     fixes = []
     warnings = []
+    skips: list[ViaSkip] = []
 
     vias = find_all_vias(doc)
 
@@ -291,6 +311,50 @@ def fix_vias(
 
         new_diameter = max(current_diameter, target_diameter, annular_ring_diameter)
 
+        # Check for potential clearance issues
+        size_increase = new_diameter - current_diameter
+        via_warnings: list[ViaClearanceWarning] = []
+        if size_increase > 0:
+            check_radius = new_diameter / 2 + min_clearance * 2
+            nearby = find_nearby_items(doc, x, y, check_radius)
+            for item_type, ix, iy, item_width in nearby:
+                dist = ((ix - x) ** 2 + (iy - y) ** 2) ** 0.5
+                # Edge-to-edge clearance: subtract both the via radius and
+                # half the width/size of the nearby item
+                clearance = dist - new_diameter / 2 - item_width / 2
+                if clearance < min_clearance:
+                    via_warnings.append(
+                        ViaClearanceWarning(
+                            x=x,
+                            y=y,
+                            new_diameter=new_diameter,
+                            nearby_item=f"{item_type} at ({ix:.2f}, {iy:.2f})",
+                            clearance_mm=clearance,
+                        )
+                    )
+
+        # When skip_on_clearance is enabled, do not resize vias that would
+        # cause clearance violations -- keep the original size instead.
+        if skip_on_clearance and via_warnings:
+            reasons = [
+                f"{w.clearance_mm:.3f}mm to {w.nearby_item}" for w in via_warnings
+            ]
+            skips.append(
+                ViaSkip(
+                    x=x,
+                    y=y,
+                    net=net,
+                    current_drill=current_drill,
+                    current_diameter=current_diameter,
+                    would_be_diameter=new_diameter,
+                    reason="; ".join(reasons),
+                    uuid=uuid,
+                )
+            )
+            continue
+
+        warnings.extend(via_warnings)
+
         # Record the fix
         fixes.append(
             ViaFix(
@@ -305,27 +369,6 @@ def fix_vias(
             )
         )
 
-        # Check for potential clearance issues
-        size_increase = new_diameter - current_diameter
-        if size_increase > 0:
-            check_radius = new_diameter / 2 + min_clearance * 2
-            nearby = find_nearby_items(doc, x, y, check_radius)
-            for item_type, ix, iy, item_width in nearby:
-                dist = ((ix - x) ** 2 + (iy - y) ** 2) ** 0.5
-                # Edge-to-edge clearance: subtract both the via radius and
-                # half the width/size of the nearby item
-                clearance = dist - new_diameter / 2 - item_width / 2
-                if clearance < min_clearance:
-                    warnings.append(
-                        ViaClearanceWarning(
-                            x=x,
-                            y=y,
-                            new_diameter=new_diameter,
-                            nearby_item=f"{item_type} at ({ix:.2f}, {iy:.2f})",
-                            clearance_mm=clearance,
-                        )
-                    )
-
         # Apply the fix if not dry run
         if not dry_run:
             drill_node = via_node.find("drill")
@@ -337,7 +380,7 @@ def fix_vias(
             if size_node and need_diameter_fix:
                 size_node.set_value(0, new_diameter)
 
-    return fixes, warnings
+    return fixes, warnings, skips
 
 
 def print_fix_results(
@@ -348,6 +391,7 @@ def print_fix_results(
     target_drill: float = 0,
     target_diameter: float = 0,
     mfr: str | None = None,
+    skips: list[ViaSkip] | None = None,
 ) -> None:
     """Print the results of via fixes.
 
@@ -359,7 +403,10 @@ def print_fix_results(
         target_drill: Target drill size used
         target_diameter: Target diameter used
         mfr: Manufacturer name (for display)
+        skips: List of vias skipped due to clearance violations
     """
+    skips = skips or []
+
     if output_format == "json":
         data = {
             "target_drill_mm": target_drill,
@@ -389,6 +436,19 @@ def print_fix_results(
                 }
                 for w in warnings
             ],
+            "skipped": [
+                {
+                    "x": s.x,
+                    "y": s.y,
+                    "net": s.net,
+                    "current_drill_mm": s.current_drill,
+                    "current_diameter_mm": s.current_diameter,
+                    "would_be_diameter_mm": s.would_be_diameter,
+                    "reason": s.reason,
+                    "uuid": s.uuid,
+                }
+                for s in skips
+            ],
         }
         print(json.dumps(data, indent=2))
         return
@@ -398,12 +458,14 @@ def print_fix_results(
         source = f" to {mfr.upper()} minimums" if mfr else ""
         print(f"{action} vias{source} (drill: {target_drill}mm, diameter: {target_diameter}mm):")
         print(f"  {len(fixes)} vias {'would be ' if dry_run else ''}updated")
+        if skips:
+            print(f"  {len(skips)} vias skipped (clearance violation)")
         if warnings:
             print(f"  {len(warnings)} potential clearance violations")
         return
 
     # Text output
-    if not fixes:
+    if not fixes and not skips:
         print("No vias needed resizing.")
         return
 
@@ -430,6 +492,17 @@ def print_fix_results(
                 f"diameter {f.old_diameter:.3f}→{f.new_diameter:.3f}mm"
             )
         print(f"    ... and {len(fixes) - 3} more")
+
+    if skips:
+        print(f"\n  Skipped {len(skips)} via(s) (would violate clearance):")
+        for s in skips[:5]:
+            print(
+                f"    Via at ({s.x:.2f}, {s.y:.2f}): "
+                f"kept at {s.current_diameter:.3f}mm "
+                f"(enlarging to {s.would_be_diameter:.3f}mm would violate clearance: {s.reason})"
+            )
+        if len(skips) > 5:
+            print(f"    ... and {len(skips) - 5} more")
 
     if warnings:
         print(f"\nWarning: {len(warnings)} via(s) may cause DRC violations after resize:")
@@ -468,8 +541,8 @@ Examples:
     parser.add_argument(
         "--layers",
         type=int,
-        default=2,
-        help="Number of PCB layers (default: 2)",
+        default=None,
+        help="Number of PCB layers (auto-detected from board if not specified)",
     )
     parser.add_argument(
         "--copper",
@@ -509,6 +582,15 @@ Examples:
         action="store_true",
         help="Suppress progress output (for scripting)",
     )
+    parser.add_argument(
+        "--skip-if-clearance-violation",
+        action="store_true",
+        help=(
+            "Skip resizing vias that would cause clearance violations. "
+            "Keeps the original via size when enlargement would violate "
+            "minimum clearance to nearby tracks, pads, or other vias."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -522,9 +604,22 @@ Examples:
         print(f"Error: Expected .kicad_pcb file, got: {pcb_path.suffix}", file=sys.stderr)
         return 1
 
+    # Auto-detect layer count from PCB if not explicitly provided
+    if args.layers is not None:
+        resolved_layers = args.layers
+    else:
+        try:
+            from kicad_tools.schema.pcb import PCB
+
+            pcb = PCB.load(pcb_path)
+            detected = len(pcb.copper_layers)
+            resolved_layers = detected if detected > 0 else 2
+        except Exception:
+            resolved_layers = 2
+
     # Get target dimensions
     target_drill, target_diameter, min_annular_ring, min_clearance = get_design_rules(
-        args.mfr, args.layers, args.copper, args.drill, args.diameter
+        args.mfr, resolved_layers, args.copper, args.drill, args.diameter
     )
 
     # Parse PCB
@@ -535,13 +630,14 @@ Examples:
         return 1
 
     # Fix vias
-    fixes, warnings = fix_vias(
+    fixes, warnings, skips = fix_vias(
         doc,
         target_drill,
         target_diameter,
         min_clearance=min_clearance,
         dry_run=args.dry_run,
         min_annular_ring=min_annular_ring,
+        skip_on_clearance=args.skip_if_clearance_violation,
     )
 
     # Print results
@@ -554,6 +650,7 @@ Examples:
             target_drill=target_drill,
             target_diameter=target_diameter,
             mfr=args.mfr,
+            skips=skips,
         )
 
     # Save if not dry run and there were fixes

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1212,8 +1212,8 @@ def _add_fix_vias_parser(subparsers) -> None:
     fix_vias_parser.add_argument(
         "--layers",
         type=int,
-        default=2,
-        help="Number of PCB layers (default: 2)",
+        default=None,
+        help="Number of PCB layers (auto-detected from board if not specified)",
     )
     fix_vias_parser.add_argument(
         "--copper",
@@ -1246,6 +1246,15 @@ def _add_fix_vias_parser(subparsers) -> None:
         choices=["text", "json", "summary"],
         default="text",
         help="Output format (default: text)",
+    )
+    fix_vias_parser.add_argument(
+        "--skip-if-clearance-violation",
+        action="store_true",
+        help=(
+            "Skip resizing vias that would cause clearance violations. "
+            "Keeps the original via size when enlargement would violate "
+            "minimum clearance to nearby tracks, pads, or other vias."
+        ),
     )
 
 

--- a/tests/test_fix_vias.py
+++ b/tests/test_fix_vias.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from kicad_tools.cli.fix_vias_cmd import (
+    ViaSkip,
     _closest_point_on_segment,
     find_all_vias,
     find_nearby_items,
@@ -122,7 +123,7 @@ class TestFixVias:
         """Should fix only undersized vias."""
         doc = parse_file(pcb_with_undersized_vias)
 
-        fixes, warnings = fix_vias(doc, target_drill=0.3, target_diameter=0.6, dry_run=True)
+        fixes, warnings, _skips = fix_vias(doc, target_drill=0.3, target_diameter=0.6, dry_run=True)
 
         # Should fix 2 vias (via-1 and via-2), not via-3 which is already compliant
         assert len(fixes) == 2
@@ -182,7 +183,7 @@ class TestFixVias:
         pcb_file.write_text(pcb_content)
 
         doc = parse_file(pcb_file)
-        fixes, warnings = fix_vias(doc, target_drill=0.3, target_diameter=0.6)
+        fixes, warnings, _skips = fix_vias(doc, target_drill=0.3, target_diameter=0.6)
 
         assert len(fixes) == 0
 
@@ -211,7 +212,7 @@ class TestFixVias:
 
         doc = parse_file(pcb_file)
         # target_diameter=0.45 (JLCPCB 4-layer min), but with annular ring check
-        fixes, warnings = fix_vias(
+        fixes, warnings, _skips = fix_vias(
             doc,
             target_drill=0.2,
             target_diameter=0.45,
@@ -241,7 +242,7 @@ class TestFixVias:
         pcb_file.write_text(pcb_content)
 
         doc = parse_file(pcb_file)
-        fixes, warnings = fix_vias(
+        fixes, warnings, _skips = fix_vias(
             doc,
             target_drill=0.2,
             target_diameter=0.45,
@@ -270,7 +271,7 @@ class TestFixVias:
         doc = parse_file(pcb_file)
         # Drill will be resized from 0.15 to 0.2, so annular ring needs
         # 0.2 + 2*0.15 = 0.50mm diameter
-        fixes, warnings = fix_vias(
+        fixes, warnings, _skips = fix_vias(
             doc,
             target_drill=0.2,
             target_diameter=0.45,
@@ -619,7 +620,7 @@ class TestClearanceWithTraceWidth:
         pcb_file.write_text(pcb_content)
         doc = parse_file(pcb_file)
 
-        fixes, warnings = fix_vias(
+        fixes, warnings, _skips = fix_vias(
             doc, target_drill=0.3, target_diameter=0.6, min_clearance=0.127, dry_run=True
         )
 
@@ -652,7 +653,7 @@ class TestClearanceWithTraceWidth:
         pcb_file.write_text(pcb_content)
         doc = parse_file(pcb_file)
 
-        fixes, warnings = fix_vias(
+        fixes, warnings, _skips = fix_vias(
             doc, target_drill=0.3, target_diameter=0.6, min_clearance=0.127, dry_run=True
         )
 
@@ -693,7 +694,7 @@ class TestManufacturerClearance:
 
         # With JLCPCB clearance (0.127mm), the trace at 0.6mm distance should NOT warn
         # gap = 0.6 - 0.3 - 0.125 = 0.175 > 0.127 => no warning
-        fixes, warnings = fix_vias(
+        fixes, warnings, _skips = fix_vias(
             doc, target_drill=0.3, target_diameter=0.6, min_clearance=0.127, dry_run=True
         )
         assert len(fixes) == 1
@@ -702,7 +703,7 @@ class TestManufacturerClearance:
         # With old hardcoded clearance (0.2mm), the same trace would warn
         # gap = 0.175 < 0.2 => warning
         doc2 = parse_file(pcb_file)
-        fixes2, warnings2 = fix_vias(
+        fixes2, warnings2, _skips2 = fix_vias(
             doc2, target_drill=0.3, target_diameter=0.6, min_clearance=0.2, dry_run=True
         )
         assert len(fixes2) == 1
@@ -865,3 +866,374 @@ class TestExitCodeWarnings:
 
         result = main([str(pcb_file), "--mfr", "jlcpcb", "--dry-run"])
         assert result == 2
+
+
+class TestSelectiveViaSkip:
+    """Tests for --skip-if-clearance-violation feature (Option B)."""
+
+    def test_skip_via_with_clearance_violation(self, tmp_path: Path):
+        """Via near a trace should be skipped when skip_on_clearance is True."""
+        # Via at (100, 100) would be resized from 0.45mm to 0.6mm.
+        # Trace at y=100.5, width=0.25 => clearance after resize:
+        # dist=0.5, gap = 0.5 - 0.3 - 0.125 = 0.075 < 0.127 => violation
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (net 2 "+3.3V")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+          (segment (start 95 100.5) (end 105 100.5) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-1"))
+        )
+        """
+        pcb_file = tmp_path / "skip_via.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings, skips = fix_vias(
+            doc,
+            target_drill=0.3,
+            target_diameter=0.6,
+            min_clearance=0.127,
+            dry_run=True,
+            skip_on_clearance=True,
+        )
+
+        assert len(fixes) == 0
+        assert len(warnings) == 0
+        assert len(skips) == 1
+        assert skips[0].uuid == "via-1"
+        assert skips[0].current_diameter == 0.45
+        assert skips[0].would_be_diameter == 0.6
+        assert "track" in skips[0].reason
+
+    def test_skip_does_not_affect_uncrowded_vias(self, tmp_path: Path):
+        """Isolated via should still be resized even with skip_on_clearance=True."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "isolated_skip.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings, skips = fix_vias(
+            doc,
+            target_drill=0.3,
+            target_diameter=0.6,
+            min_clearance=0.127,
+            dry_run=True,
+            skip_on_clearance=True,
+        )
+
+        assert len(fixes) == 1
+        assert len(skips) == 0
+        assert fixes[0].new_diameter == 0.6
+
+    def test_mixed_skip_and_resize(self, tmp_path: Path):
+        """Board with two vias: one crowded (skip), one isolated (resize)."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (net 2 "+3.3V")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-crowded"))
+          (via (at 200 200) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-isolated"))
+          (segment (start 95 100.5) (end 105 100.5) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-1"))
+        )
+        """
+        pcb_file = tmp_path / "mixed.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings, skips = fix_vias(
+            doc,
+            target_drill=0.3,
+            target_diameter=0.6,
+            min_clearance=0.127,
+            dry_run=True,
+            skip_on_clearance=True,
+        )
+
+        assert len(fixes) == 1
+        assert len(skips) == 1
+        assert fixes[0].uuid == "via-isolated"
+        assert skips[0].uuid == "via-crowded"
+
+    def test_skip_keeps_original_size_on_disk(self, tmp_path: Path):
+        """When skip_on_clearance skips a via, the file should retain original size."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (net 2 "+3.3V")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+          (segment (start 95 100.5) (end 105 100.5) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-1"))
+        )
+        """
+        pcb_file = tmp_path / "skip_disk.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings, skips = fix_vias(
+            doc,
+            target_drill=0.3,
+            target_diameter=0.6,
+            min_clearance=0.127,
+            dry_run=False,
+            skip_on_clearance=True,
+        )
+
+        # No fixes applied (the only via was skipped)
+        assert len(fixes) == 0
+        assert len(skips) == 1
+
+        # Verify the via retains its original size in the document
+        vias = find_all_vias(doc)
+        _, _, _, drill, diameter, _, _ = vias[0]
+        assert drill == 0.2
+        assert diameter == 0.45
+
+    def test_skip_without_flag_still_warns(self, tmp_path: Path):
+        """Without skip_on_clearance, crowded vias produce warnings, not skips."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (net 2 "+3.3V")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+          (segment (start 95 100.5) (end 105 100.5) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-1"))
+        )
+        """
+        pcb_file = tmp_path / "no_skip.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings, skips = fix_vias(
+            doc,
+            target_drill=0.3,
+            target_diameter=0.6,
+            min_clearance=0.127,
+            dry_run=True,
+            skip_on_clearance=False,
+        )
+
+        assert len(fixes) == 1
+        assert len(warnings) == 1
+        assert len(skips) == 0
+
+    def test_cli_skip_flag(self, tmp_path: Path, capsys):
+        """CLI --skip-if-clearance-violation flag works correctly."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (net 2 "+3.3V")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+          (segment (start 95 100.5) (end 105 100.5) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-1"))
+        )
+        """
+        pcb_file = tmp_path / "cli_skip.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        result = main([
+            str(pcb_file),
+            "--mfr", "jlcpcb",
+            "--dry-run",
+            "--format", "json",
+            "--skip-if-clearance-violation",
+        ])
+
+        assert result == 0  # No warnings (via was skipped, not warned)
+
+        import json
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data["fixes"]) == 0
+        assert len(data["warnings"]) == 0
+        assert len(data["skipped"]) == 1
+        assert data["skipped"][0]["uuid"] == "via-1"
+
+    def test_cli_skip_json_output_includes_skipped_key(self, tmp_path: Path, capsys):
+        """JSON output includes the 'skipped' key even when empty."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "json_skipped.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        main([str(pcb_file), "--dry-run", "--format", "json"])
+
+        import json
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "skipped" in data
+        assert len(data["skipped"]) == 0
+
+
+class TestLayerAutoDetection:
+    """Tests for auto-detecting layer count from PCB file."""
+
+    def test_4layer_pcb_auto_detects(self, tmp_path: Path, capsys):
+        """A 4-layer PCB file should auto-detect 4 layers and use 4-layer rules."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (1 "In1.Cu" signal)
+            (2 "In2.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "4layer_auto.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        # Without --layers, should auto-detect 4 layers from PCB.
+        # For 4-layer JLCPCB: min_via_drill=0.2, min_via_diameter=0.45,
+        # annular ring requires 0.2 + 2*0.15 = 0.50.
+        # The via at 0.45mm diameter should be flagged for resize to 0.50.
+        result = main([
+            str(pcb_file),
+            "--mfr", "jlcpcb",
+            "--dry-run",
+            "--format", "json",
+        ])
+
+        assert result == 0
+        import json
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data["fixes"]) == 1
+        # 4-layer rules: target_diameter should be 0.5 (annular ring constrained)
+        assert data["target_diameter_mm"] == 0.5
+        assert data["target_drill_mm"] == 0.2
+        assert data["fixes"][0]["new_diameter_mm"] == 0.5
+
+    def test_2layer_pcb_auto_detects(self, tmp_path: Path, capsys):
+        """A 2-layer PCB file should auto-detect 2 layers and use 2-layer rules."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "2layer_auto.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        result = main([
+            str(pcb_file),
+            "--mfr", "jlcpcb",
+            "--dry-run",
+            "--format", "json",
+        ])
+
+        assert result == 0
+        import json
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # 2-layer rules: min_via_drill=0.3, min_via_diameter=0.6
+        assert data["target_diameter_mm"] == 0.6
+        assert data["target_drill_mm"] == 0.3
+
+    def test_explicit_layers_overrides_auto(self, tmp_path: Path, capsys):
+        """Explicit --layers flag should override auto-detection."""
+        # 4-layer PCB file, but we force --layers 2
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (1 "In1.Cu" signal)
+            (2 "In2.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 100 100) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "override.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        result = main([
+            str(pcb_file),
+            "--mfr", "jlcpcb",
+            "--layers", "2",
+            "--dry-run",
+            "--format", "json",
+        ])
+
+        assert result == 0
+        import json
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # 2-layer rules forced despite 4-layer PCB
+        assert data["target_diameter_mm"] == 0.6
+        assert data["target_drill_mm"] == 0.3
+
+    def test_layers_4_selects_4layer_1oz_rules(self):
+        """--layers 4 should select 4layer_1oz rules from JLCPCB."""
+        drill, diameter, annular, clearance = get_design_rules("jlcpcb", 4, 1.0, None, None)
+        assert drill == 0.2
+        # min_via_diameter is 0.45, but annular ring requires 0.2 + 2*0.15 = 0.50
+        assert diameter == 0.5
+        assert annular == 0.15
+        assert clearance == 0.1016
+
+    def test_layers_2_still_enlarges_to_0_6mm(self):
+        """--layers 2 should still require 0.6mm diameter for 2-layer JLCPCB."""
+        drill, diameter, annular, clearance = get_design_rules("jlcpcb", 2, 1.0, None, None)
+        assert drill == 0.3
+        assert diameter == 0.6
+        assert clearance == 0.127


### PR DESCRIPTION
## Summary
Add `--skip-if-clearance-violation` flag to `fix-vias` that prevents enlarging vias when the new diameter would violate minimum clearance to nearby items. Also auto-detect the PCB layer count instead of defaulting to 2-layer rules, matching the pattern already used by `check` and `pipeline` commands.

## Changes
- Add `ViaSkip` dataclass for recording vias that were skipped due to clearance violations
- Add `skip_on_clearance` parameter to `fix_vias()` function -- when enabled, vias that would cause clearance violations after enlargement are left at their original size instead of being resized with a warning
- Add `--skip-if-clearance-violation` CLI flag to `fix-vias` command (in both `fix_vias_cmd.py` and `parser.py`)
- Change `--layers` default from `2` to `None` (auto-detected from PCB file copper layers), matching `check_cmd` and `pipeline_cmd` patterns
- Update `print_fix_results()` to display skipped via information in text, JSON, and summary output formats
- Update `commands/validation.py` to pass through the new flag and handle `None` layers correctly
- Add 12 new tests covering selective skip logic, JSON output, CLI flag, layer auto-detection, and explicit override

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `fix-vias` with `--layers 4` uses `4layer_1oz` rules | PASS | `test_layers_4_selects_4layer_1oz_rules` verifies drill=0.2, diameter=0.5, clearance=0.1016 |
| Vias with insufficient clearance for enlargement remain at original size when flag is set | PASS | `test_skip_via_with_clearance_violation` and `test_skip_keeps_original_size_on_disk` |
| Warning emitted for skipped vias | PASS | `test_cli_skip_flag` verifies JSON `skipped` array populated with reason |
| All existing test_fix_vias.py tests pass | PASS | 42 original tests pass unchanged (3-tuple unpacking updated) |
| 0 regressions in test_repair_clearance.py | PASS | 48 tests pass |
| Auto-detect layers from 4-layer PCB | PASS | `test_4layer_pcb_auto_detects` verifies target_diameter_mm=0.5 |
| Auto-detect layers from 2-layer PCB | PASS | `test_2layer_pcb_auto_detects` verifies target_diameter_mm=0.6 |
| Explicit --layers overrides auto-detection | PASS | `test_explicit_layers_overrides_auto` |

## Test Plan
- `uv run pytest tests/test_fix_vias.py -v` -- 54 tests pass (42 existing + 12 new)
- `uv run pytest tests/test_repair_clearance.py -v` -- 48 tests pass (no regressions)
- `uv run pytest tests/test_pipeline_cmd.py -k "fix_vias or layer" -v` -- 19 tests pass

Closes #1410