### PR TITLE
feat(schema): add graphical shape primitives to LibrarySymbol

### DIFF
--- a/src/kicad_tools/schema/library.py
+++ b/src/kicad_tools/schema/library.py
@@ -31,6 +31,298 @@ VALID_PIN_TYPES = frozenset(
     }
 )
 
+# Valid fill types for graphical shapes
+VALID_FILL_TYPES = frozenset({"none", "outline", "background"})
+
+# Valid stroke types for graphical shapes
+VALID_STROKE_TYPES = frozenset({"default", "dash", "dot", "dash_dot", "dash_dot_dot", "solid"})
+
+# Union type for all graphical shape dataclasses
+SymbolGraphic = "SymbolPolyline | SymbolCircle | SymbolArc | SymbolRectangle"
+
+
+def _validate_fill_type(fill_type: str) -> None:
+    """Validate that a fill type is a recognized KiCad value."""
+    if fill_type not in VALID_FILL_TYPES:
+        raise ValueError(
+            f"Invalid fill_type '{fill_type}'. Must be one of: {sorted(VALID_FILL_TYPES)}"
+        )
+
+
+def _validate_stroke_type(stroke_type: str) -> None:
+    """Validate that a stroke type is a recognized KiCad value."""
+    if stroke_type not in VALID_STROKE_TYPES:
+        raise ValueError(
+            f"Invalid stroke_type '{stroke_type}'. Must be one of: {sorted(VALID_STROKE_TYPES)}"
+        )
+
+
+def _stroke_sexp(width: float, stroke_type: str) -> SExp:
+    """Build a (stroke (width N) (type T)) S-expression node."""
+    return SExp.list(
+        "stroke",
+        SExp.list("width", width),
+        SExp.list("type", stroke_type),
+    )
+
+
+def _fill_sexp(fill_type: str) -> SExp:
+    """Build a (fill (type T)) S-expression node."""
+    return SExp.list("fill", SExp.list("type", fill_type))
+
+
+@dataclass
+class SymbolPolyline:
+    """A polyline graphical element in a symbol.
+
+    For closed polygons, repeat the first point as the last point.
+    """
+
+    points: list[tuple[float, float]]
+    stroke_width: float = 0.0
+    stroke_type: str = "default"
+    fill_type: str = "none"
+
+    def __post_init__(self) -> None:
+        if len(self.points) < 2:
+            raise ValueError("A polyline requires at least 2 points")
+        _validate_fill_type(self.fill_type)
+        _validate_stroke_type(self.stroke_type)
+
+    def to_sexp_node(self) -> SExp:
+        """Generate ``(polyline (pts ...) (stroke ...) (fill ...))``."""
+        pts_children: list[SExp] = []
+        for x, y in self.points:
+            pts_children.append(SExp.list("xy", x, y))
+        pts_node = SExp(name="pts", children=pts_children)
+
+        return SExp(
+            name="polyline",
+            children=[
+                pts_node,
+                _stroke_sexp(self.stroke_width, self.stroke_type),
+                _fill_sexp(self.fill_type),
+            ],
+        )
+
+    @classmethod
+    def from_sexp(cls, sexp: SExp) -> SymbolPolyline:
+        """Parse a ``(polyline ...)`` S-expression node."""
+        points: list[tuple[float, float]] = []
+        if pts_node := sexp.find("pts"):
+            for xy in pts_node.find_all("xy"):
+                x = xy.get_float(0) or 0.0
+                y = xy.get_float(1) or 0.0
+                points.append((x, y))
+
+        stroke_width = 0.0
+        stroke_type = "default"
+        if stroke := sexp.find("stroke"):
+            if w := stroke.find("width"):
+                stroke_width = w.get_float(0) or 0.0
+            if t := stroke.find("type"):
+                stroke_type = t.get_string(0) or "default"
+
+        fill_type = "none"
+        if fill := sexp.find("fill"):
+            if t := fill.find("type"):
+                fill_type = t.get_string(0) or "none"
+
+        return cls(
+            points=points,
+            stroke_width=stroke_width,
+            stroke_type=stroke_type,
+            fill_type=fill_type,
+        )
+
+
+@dataclass
+class SymbolCircle:
+    """A circle graphical element in a symbol."""
+
+    center: tuple[float, float]
+    radius: float
+    stroke_width: float = 0.0
+    stroke_type: str = "default"
+    fill_type: str = "none"
+
+    def __post_init__(self) -> None:
+        if self.radius <= 0:
+            raise ValueError("Circle radius must be positive")
+        _validate_fill_type(self.fill_type)
+        _validate_stroke_type(self.stroke_type)
+
+    def to_sexp_node(self) -> SExp:
+        """Generate ``(circle (center ...) (radius ...) (stroke ...) (fill ...))``."""
+        return SExp(
+            name="circle",
+            children=[
+                SExp.list("center", self.center[0], self.center[1]),
+                SExp.list("radius", self.radius),
+                _stroke_sexp(self.stroke_width, self.stroke_type),
+                _fill_sexp(self.fill_type),
+            ],
+        )
+
+    @classmethod
+    def from_sexp(cls, sexp: SExp) -> SymbolCircle:
+        """Parse a ``(circle ...)`` S-expression node."""
+        center = (0.0, 0.0)
+        if c := sexp.find("center"):
+            center = (c.get_float(0) or 0.0, c.get_float(1) or 0.0)
+
+        radius = 0.0
+        if r := sexp.find("radius"):
+            radius = r.get_float(0) or 0.0
+
+        stroke_width = 0.0
+        stroke_type = "default"
+        if stroke := sexp.find("stroke"):
+            if w := stroke.find("width"):
+                stroke_width = w.get_float(0) or 0.0
+            if t := stroke.find("type"):
+                stroke_type = t.get_string(0) or "default"
+
+        fill_type = "none"
+        if fill := sexp.find("fill"):
+            if t := fill.find("type"):
+                fill_type = t.get_string(0) or "none"
+
+        return cls(
+            center=center,
+            radius=radius,
+            stroke_width=stroke_width,
+            stroke_type=stroke_type,
+            fill_type=fill_type,
+        )
+
+
+@dataclass
+class SymbolArc:
+    """An arc graphical element in a symbol.
+
+    KiCad arcs are defined by start, mid (midpoint on the arc), and end points.
+    """
+
+    start: tuple[float, float]
+    mid: tuple[float, float]
+    end: tuple[float, float]
+    stroke_width: float = 0.0
+    stroke_type: str = "default"
+    fill_type: str = "none"
+
+    def __post_init__(self) -> None:
+        _validate_fill_type(self.fill_type)
+        _validate_stroke_type(self.stroke_type)
+
+    def to_sexp_node(self) -> SExp:
+        """Generate ``(arc (start ...) (mid ...) (end ...) (stroke ...) (fill ...))``."""
+        return SExp(
+            name="arc",
+            children=[
+                SExp.list("start", self.start[0], self.start[1]),
+                SExp.list("mid", self.mid[0], self.mid[1]),
+                SExp.list("end", self.end[0], self.end[1]),
+                _stroke_sexp(self.stroke_width, self.stroke_type),
+                _fill_sexp(self.fill_type),
+            ],
+        )
+
+    @classmethod
+    def from_sexp(cls, sexp: SExp) -> SymbolArc:
+        """Parse an ``(arc ...)`` S-expression node."""
+        start = (0.0, 0.0)
+        mid = (0.0, 0.0)
+        end = (0.0, 0.0)
+
+        if s := sexp.find("start"):
+            start = (s.get_float(0) or 0.0, s.get_float(1) or 0.0)
+        if m := sexp.find("mid"):
+            mid = (m.get_float(0) or 0.0, m.get_float(1) or 0.0)
+        if e := sexp.find("end"):
+            end = (e.get_float(0) or 0.0, e.get_float(1) or 0.0)
+
+        stroke_width = 0.0
+        stroke_type = "default"
+        if stroke := sexp.find("stroke"):
+            if w := stroke.find("width"):
+                stroke_width = w.get_float(0) or 0.0
+            if t := stroke.find("type"):
+                stroke_type = t.get_string(0) or "default"
+
+        fill_type = "none"
+        if fill := sexp.find("fill"):
+            if t := fill.find("type"):
+                fill_type = t.get_string(0) or "none"
+
+        return cls(
+            start=start,
+            mid=mid,
+            end=end,
+            stroke_width=stroke_width,
+            stroke_type=stroke_type,
+            fill_type=fill_type,
+        )
+
+
+@dataclass
+class SymbolRectangle:
+    """A rectangle graphical element in a symbol."""
+
+    start: tuple[float, float]
+    end: tuple[float, float]
+    stroke_width: float = 0.0
+    stroke_type: str = "default"
+    fill_type: str = "none"
+
+    def __post_init__(self) -> None:
+        _validate_fill_type(self.fill_type)
+        _validate_stroke_type(self.stroke_type)
+
+    def to_sexp_node(self) -> SExp:
+        """Generate ``(rectangle (start ...) (end ...) (stroke ...) (fill ...))``."""
+        return SExp(
+            name="rectangle",
+            children=[
+                SExp.list("start", self.start[0], self.start[1]),
+                SExp.list("end", self.end[0], self.end[1]),
+                _stroke_sexp(self.stroke_width, self.stroke_type),
+                _fill_sexp(self.fill_type),
+            ],
+        )
+
+    @classmethod
+    def from_sexp(cls, sexp: SExp) -> SymbolRectangle:
+        """Parse a ``(rectangle ...)`` S-expression node."""
+        start = (0.0, 0.0)
+        end = (0.0, 0.0)
+
+        if s := sexp.find("start"):
+            start = (s.get_float(0) or 0.0, s.get_float(1) or 0.0)
+        if e := sexp.find("end"):
+            end = (e.get_float(0) or 0.0, e.get_float(1) or 0.0)
+
+        stroke_width = 0.0
+        stroke_type = "default"
+        if stroke := sexp.find("stroke"):
+            if w := stroke.find("width"):
+                stroke_width = w.get_float(0) or 0.0
+            if t := stroke.find("type"):
+                stroke_type = t.get_string(0) or "default"
+
+        fill_type = "none"
+        if fill := sexp.find("fill"):
+            if t := fill.find("type"):
+                fill_type = t.get_string(0) or "none"
+
+        return cls(
+            start=start,
+            end=end,
+            stroke_width=stroke_width,
+            stroke_type=stroke_type,
+            fill_type=fill_type,
+        )
+
 
 @dataclass
 class LibraryPin:
@@ -138,6 +430,9 @@ class LibrarySymbol:
     name: str
     properties: dict[str, str] = field(default_factory=dict)
     pins: list[LibraryPin] = field(default_factory=list)
+    graphics: list[SymbolPolyline | SymbolCircle | SymbolArc | SymbolRectangle] = field(
+        default_factory=list
+    )
     units: int = 1
 
     @property
@@ -229,8 +524,9 @@ class LibrarySymbol:
             if prop_name:
                 properties[prop_name] = prop_value or ""
 
-        # Parse pins from unit symbols
-        pins = []
+        # Parse pins and graphics from unit symbols
+        pins: list[LibraryPin] = []
+        graphics: list[SymbolPolyline | SymbolCircle | SymbolArc | SymbolRectangle] = []
         for unit_sym in sexp.find_all("symbol"):
             _unit_name = unit_sym.get_string(0) or ""  # noqa: F841
             # Unit symbols have names like "TPA3116D2_1_1"
@@ -238,10 +534,21 @@ class LibrarySymbol:
             for pin_sexp in unit_sym.find_all("pin"):
                 pins.append(LibraryPin.from_sexp(pin_sexp))
 
+            # Parse graphical primitives
+            for polyline_sexp in unit_sym.find_all("polyline"):
+                graphics.append(SymbolPolyline.from_sexp(polyline_sexp))
+            for circle_sexp in unit_sym.find_all("circle"):
+                graphics.append(SymbolCircle.from_sexp(circle_sexp))
+            for arc_sexp in unit_sym.find_all("arc"):
+                graphics.append(SymbolArc.from_sexp(arc_sexp))
+            for rect_sexp in unit_sym.find_all("rectangle"):
+                graphics.append(SymbolRectangle.from_sexp(rect_sexp))
+
         return cls(
             name=name,
             properties=properties,
             pins=pins,
+            graphics=graphics,
         )
 
     def add_pin(
@@ -309,6 +616,166 @@ class LibrarySymbol:
         """
         self.properties[name] = value
 
+    # -- Graphical shape methods -----------------------------------------------
+
+    def add_polyline(
+        self,
+        points: list[tuple[float, float]],
+        *,
+        stroke_width: float = 0.0,
+        stroke_type: str = "default",
+        fill_type: str = "none",
+    ) -> SymbolPolyline:
+        """Add a polyline (open line strip) to the symbol body.
+
+        Args:
+            points: Ordered list of (x, y) vertices (minimum 2).
+            stroke_width: Line width in mm (0 = KiCad default).
+            stroke_type: Stroke style (``default``, ``dash``, ``dot``, ...).
+            fill_type: Fill mode (``none``, ``outline``, ``background``).
+
+        Returns:
+            The created ``SymbolPolyline``.
+        """
+        shape = SymbolPolyline(
+            points=list(points),
+            stroke_width=stroke_width,
+            stroke_type=stroke_type,
+            fill_type=fill_type,
+        )
+        self.graphics.append(shape)
+        return shape
+
+    def add_polygon(
+        self,
+        points: list[tuple[float, float]],
+        *,
+        stroke_width: float = 0.0,
+        stroke_type: str = "default",
+        fill_type: str = "outline",
+    ) -> SymbolPolyline:
+        """Add a closed polygon to the symbol body.
+
+        If the last point does not equal the first, it is automatically
+        appended to close the polygon.
+
+        Args:
+            points: Ordered list of (x, y) vertices (minimum 3 unique).
+            stroke_width: Line width in mm (0 = KiCad default).
+            stroke_type: Stroke style.
+            fill_type: Fill mode (defaults to ``outline`` for filled polygon).
+
+        Returns:
+            The created ``SymbolPolyline`` (closed).
+        """
+        if len(points) < 3:
+            raise ValueError("A polygon requires at least 3 points")
+        pts = list(points)
+        if pts[0] != pts[-1]:
+            pts.append(pts[0])
+        return self.add_polyline(
+            pts,
+            stroke_width=stroke_width,
+            stroke_type=stroke_type,
+            fill_type=fill_type,
+        )
+
+    def add_circle(
+        self,
+        center: tuple[float, float],
+        radius: float,
+        *,
+        stroke_width: float = 0.0,
+        stroke_type: str = "default",
+        fill_type: str = "none",
+    ) -> SymbolCircle:
+        """Add a circle to the symbol body.
+
+        Args:
+            center: (x, y) center coordinate.
+            radius: Radius in mm (must be positive).
+            stroke_width: Line width in mm.
+            stroke_type: Stroke style.
+            fill_type: Fill mode.
+
+        Returns:
+            The created ``SymbolCircle``.
+        """
+        shape = SymbolCircle(
+            center=center,
+            radius=radius,
+            stroke_width=stroke_width,
+            stroke_type=stroke_type,
+            fill_type=fill_type,
+        )
+        self.graphics.append(shape)
+        return shape
+
+    def add_arc(
+        self,
+        start: tuple[float, float],
+        mid: tuple[float, float],
+        end: tuple[float, float],
+        *,
+        stroke_width: float = 0.0,
+        stroke_type: str = "default",
+        fill_type: str = "none",
+    ) -> SymbolArc:
+        """Add an arc to the symbol body.
+
+        Args:
+            start: (x, y) start point.
+            mid: (x, y) midpoint on the arc.
+            end: (x, y) end point.
+            stroke_width: Line width in mm.
+            stroke_type: Stroke style.
+            fill_type: Fill mode.
+
+        Returns:
+            The created ``SymbolArc``.
+        """
+        shape = SymbolArc(
+            start=start,
+            mid=mid,
+            end=end,
+            stroke_width=stroke_width,
+            stroke_type=stroke_type,
+            fill_type=fill_type,
+        )
+        self.graphics.append(shape)
+        return shape
+
+    def add_rectangle(
+        self,
+        start: tuple[float, float],
+        end: tuple[float, float],
+        *,
+        stroke_width: float = 0.0,
+        stroke_type: str = "default",
+        fill_type: str = "none",
+    ) -> SymbolRectangle:
+        """Add a rectangle to the symbol body.
+
+        Args:
+            start: (x, y) of one corner.
+            end: (x, y) of the opposite corner.
+            stroke_width: Line width in mm.
+            stroke_type: Stroke style.
+            fill_type: Fill mode.
+
+        Returns:
+            The created ``SymbolRectangle``.
+        """
+        shape = SymbolRectangle(
+            start=start,
+            end=end,
+            stroke_width=stroke_width,
+            stroke_type=stroke_type,
+            fill_type=fill_type,
+        )
+        self.graphics.append(shape)
+        return shape
+
     def get_pins_for_unit(self, unit: int) -> list[LibraryPin]:
         """Get all pins belonging to a specific unit.
 
@@ -328,11 +795,19 @@ class LibrarySymbol:
               (property "Reference" "U" (at 0 0 0) (effects ...))
               (property "Value" "<name>" (at 0 0 0) (effects ...))
               ...
+              (symbol "<name>_0_1"
+                (polyline ...)
+                (circle ...)
+                ...
+              )
               (symbol "<name>_1_1"
                 (pin ...)
                 (pin ...)
               )
             )
+
+        The ``_0_1`` sub-symbol holds graphical decoration (body shapes).
+        The ``_N_1`` sub-symbols hold pins for each unit.
         """
         children: list[SExp] = [SExp(value=self.name)]
 
@@ -354,6 +829,14 @@ class LibrarySymbol:
             )
             children.append(prop_node)
             prop_y_offset += 2.54
+
+        # Add _0_1 sub-symbol for graphical shapes (body decoration)
+        if self.graphics:
+            gfx_name = f"{self.name}_0_1"
+            gfx_children: list[SExp] = [SExp(value=gfx_name)]
+            for graphic in self.graphics:
+                gfx_children.append(graphic.to_sexp_node())
+            children.append(SExp(name="symbol", children=gfx_children))
 
         # Add unit symbols with their pins
         for unit_idx in range(1, self.units + 1):

--- a/src/kicad_tools/schematic/symbol_generator.py
+++ b/src/kicad_tools/schematic/symbol_generator.py
@@ -52,6 +52,12 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
+from kicad_tools.schema.library import (
+    SymbolArc,
+    SymbolCircle,
+    SymbolPolyline,
+    SymbolRectangle,
+)
 from kicad_tools.utils import ensure_parent_dir
 
 
@@ -149,6 +155,9 @@ class SymbolDef:
     pin_length: float = 2.54  # mm
     pin_spacing: float = 2.54  # mm (100 mil)
     min_width: float = 10.16  # mm (400 mil)
+
+    # Custom graphical shapes for the symbol body (emitted inside _0_1 block)
+    graphics: list[SymbolPolyline | SymbolCircle | SymbolArc | SymbolRectangle] | None = None
 
     def __post_init__(self):
         if not self.value:
@@ -486,6 +495,29 @@ def generate_symbol_sexp(sym: SymbolDef) -> str:
 
     pins_sexp = "\n".join(pin_lines)
 
+    # Build the _0_1 graphical body block
+    if sym.graphics:
+        # Use custom graphics supplied by the caller
+        from kicad_tools.sexp import serialize_sexp as _ser
+
+        gfx_lines = []
+        for g in sym.graphics:
+            gfx_lines.append("\t\t\t" + _ser(g.to_sexp_node()))
+        gfx_block = "\n".join(gfx_lines)
+    else:
+        # Default: a background-filled rectangle around the pins
+        gfx_block = f"""\t\t\t(rectangle
+\t\t\t\t(start {-half_w:.2f} {half_h:.2f})
+\t\t\t\t(end {half_w:.2f} {-half_h:.2f})
+\t\t\t\t(stroke
+\t\t\t\t\t(width 0.254)
+\t\t\t\t\t(type default)
+\t\t\t\t)
+\t\t\t\t(fill
+\t\t\t\t\t(type background)
+\t\t\t\t)
+\t\t\t)"""
+
     # Build complete symbol
     sexp = f'''(kicad_symbol_lib
 \t(version 20231120)
@@ -548,17 +580,7 @@ def generate_symbol_sexp(sym: SymbolDef) -> str:
 \t\t\t)
 \t\t)
 \t\t(symbol "{sym.name}_0_1"
-\t\t\t(rectangle
-\t\t\t\t(start {-half_w:.2f} {half_h:.2f})
-\t\t\t\t(end {half_w:.2f} {-half_h:.2f})
-\t\t\t\t(stroke
-\t\t\t\t\t(width 0.254)
-\t\t\t\t\t(type default)
-\t\t\t\t)
-\t\t\t\t(fill
-\t\t\t\t\t(type background)
-\t\t\t\t)
-\t\t\t)
+{gfx_block}
 \t\t)
 \t\t(symbol "{sym.name}_1_1"
 {pins_sexp}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,7 +8,16 @@ from kicad_tools.schema.bom import BOM, BOMGroup, BOMItem
 from kicad_tools.schema.hierarchy import HierarchyNode, SheetPin
 from kicad_tools.schema.hierarchy import SheetInstance as HierarchySheetInstance
 from kicad_tools.schema.label import GlobalLabel, HierarchicalLabel, Label, PowerSymbol
-from kicad_tools.schema.library import LibraryManager, LibraryPin, LibrarySymbol, SymbolLibrary
+from kicad_tools.schema.library import (
+    LibraryManager,
+    LibraryPin,
+    LibrarySymbol,
+    SymbolArc,
+    SymbolCircle,
+    SymbolLibrary,
+    SymbolPolyline,
+    SymbolRectangle,
+)
 from kicad_tools.schema.schematic import Schematic, SheetInstance, TitleBlock
 from kicad_tools.schema.wire import Bus, Junction, Wire
 from kicad_tools.sexp import parse_sexp
@@ -1530,3 +1539,353 @@ class TestSymbolLibraryLoad:
 
         with pytest.raises(ValueError, match="Not a KiCad symbol library"):
             SymbolLibrary.load(str(invalid_file))
+
+
+# =============================================================================
+# Symbol Graphics Tests
+# =============================================================================
+
+
+class TestLibrarySymbolGraphics:
+    """Tests for graphical shape support in LibrarySymbol."""
+
+    # -- SymbolPolyline -------------------------------------------------------
+
+    def test_add_polyline(self):
+        """Test adding a polyline to a symbol."""
+        sym = LibrarySymbol(name="Test")
+        pl = sym.add_polyline([(0, 0), (5.08, 0), (5.08, 5.08)])
+        assert len(sym.graphics) == 1
+        assert isinstance(pl, SymbolPolyline)
+        assert pl.points == [(0, 0), (5.08, 0), (5.08, 5.08)]
+        assert pl.stroke_width == 0.0
+        assert pl.stroke_type == "default"
+        assert pl.fill_type == "none"
+
+    def test_polyline_to_sexp(self):
+        """Test SymbolPolyline S-expression output."""
+        pl = SymbolPolyline(
+            points=[(0, 0), (2.54, -1.27)],
+            stroke_width=0.254,
+            stroke_type="dash",
+            fill_type="none",
+        )
+        sexp = pl.to_sexp_node()
+        assert sexp.name == "polyline"
+        s = sexp.to_string()
+        assert "(pts" in s
+        assert "(xy 0" in s
+        assert "(xy 2.54 -1.27)" in s
+        assert "(stroke" in s
+        assert "(width 0.254)" in s
+        assert '(type "dash")' in s or "(type dash)" in s
+        assert "(fill" in s
+
+    def test_polyline_from_sexp_round_trip(self):
+        """Test SymbolPolyline round-trips through S-expression."""
+        original = SymbolPolyline(
+            points=[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)],
+            stroke_width=0.5,
+            stroke_type="default",
+            fill_type="outline",
+        )
+        sexp = original.to_sexp_node()
+        restored = SymbolPolyline.from_sexp(sexp)
+        assert restored.points == original.points
+        assert restored.stroke_width == original.stroke_width
+        assert restored.stroke_type == original.stroke_type
+        assert restored.fill_type == original.fill_type
+
+    def test_polyline_requires_at_least_2_points(self):
+        """Test that a polyline with fewer than 2 points raises ValueError."""
+        with pytest.raises(ValueError, match="at least 2 points"):
+            SymbolPolyline(points=[(0, 0)])
+
+    def test_polyline_empty_points_raises(self):
+        """Test that empty points list raises ValueError."""
+        with pytest.raises(ValueError, match="at least 2 points"):
+            SymbolPolyline(points=[])
+
+    # -- SymbolCircle ---------------------------------------------------------
+
+    def test_add_circle(self):
+        """Test adding a circle to a symbol."""
+        sym = LibrarySymbol(name="Test")
+        c = sym.add_circle((0, 0), 2.54)
+        assert len(sym.graphics) == 1
+        assert isinstance(c, SymbolCircle)
+        assert c.center == (0, 0)
+        assert c.radius == 2.54
+
+    def test_circle_to_sexp(self):
+        """Test SymbolCircle S-expression output."""
+        c = SymbolCircle(center=(1.27, -1.27), radius=5.08)
+        sexp = c.to_sexp_node()
+        assert sexp.name == "circle"
+        s = sexp.to_string()
+        assert "(center" in s
+        assert "(radius" in s
+
+    def test_circle_from_sexp_round_trip(self):
+        """Test SymbolCircle round-trips through S-expression."""
+        original = SymbolCircle(
+            center=(2.54, 3.81),
+            radius=5.08,
+            stroke_width=0.25,
+            fill_type="background",
+        )
+        sexp = original.to_sexp_node()
+        restored = SymbolCircle.from_sexp(sexp)
+        assert restored.center == original.center
+        assert restored.radius == original.radius
+        assert restored.stroke_width == original.stroke_width
+        assert restored.fill_type == original.fill_type
+
+    def test_circle_zero_radius_raises(self):
+        """Test that a circle with zero radius raises ValueError."""
+        with pytest.raises(ValueError, match="radius must be positive"):
+            SymbolCircle(center=(0, 0), radius=0)
+
+    def test_circle_negative_radius_raises(self):
+        """Test that a circle with negative radius raises ValueError."""
+        with pytest.raises(ValueError, match="radius must be positive"):
+            SymbolCircle(center=(0, 0), radius=-1)
+
+    # -- SymbolArc ------------------------------------------------------------
+
+    def test_add_arc(self):
+        """Test adding an arc to a symbol."""
+        sym = LibrarySymbol(name="Test")
+        a = sym.add_arc((0, 0), (1.27, 1.27), (2.54, 0))
+        assert len(sym.graphics) == 1
+        assert isinstance(a, SymbolArc)
+        assert a.start == (0, 0)
+        assert a.mid == (1.27, 1.27)
+        assert a.end == (2.54, 0)
+
+    def test_arc_to_sexp(self):
+        """Test SymbolArc S-expression output."""
+        a = SymbolArc(start=(0, 0), mid=(1.27, 1.27), end=(2.54, 0))
+        sexp = a.to_sexp_node()
+        assert sexp.name == "arc"
+        s = sexp.to_string()
+        assert "(start" in s
+        assert "(mid" in s
+        assert "(end" in s
+        assert "(stroke" in s
+        assert "(fill" in s
+
+    def test_arc_from_sexp_round_trip(self):
+        """Test SymbolArc round-trips through S-expression."""
+        original = SymbolArc(
+            start=(0, 0),
+            mid=(1.27, 2.54),
+            end=(2.54, 0),
+            stroke_width=0.1,
+            fill_type="outline",
+        )
+        sexp = original.to_sexp_node()
+        restored = SymbolArc.from_sexp(sexp)
+        assert restored.start == original.start
+        assert restored.mid == original.mid
+        assert restored.end == original.end
+        assert restored.stroke_width == original.stroke_width
+        assert restored.fill_type == original.fill_type
+
+    # -- SymbolRectangle ------------------------------------------------------
+
+    def test_add_rectangle(self):
+        """Test adding a rectangle to a symbol."""
+        sym = LibrarySymbol(name="Test")
+        r = sym.add_rectangle((-5.08, 5.08), (5.08, -5.08), fill_type="background")
+        assert len(sym.graphics) == 1
+        assert isinstance(r, SymbolRectangle)
+        assert r.start == (-5.08, 5.08)
+        assert r.end == (5.08, -5.08)
+        assert r.fill_type == "background"
+
+    def test_rectangle_to_sexp(self):
+        """Test SymbolRectangle S-expression output."""
+        r = SymbolRectangle(start=(-5.08, 5.08), end=(5.08, -5.08))
+        sexp = r.to_sexp_node()
+        assert sexp.name == "rectangle"
+        s = sexp.to_string()
+        assert "(start" in s
+        assert "(end" in s
+
+    def test_rectangle_from_sexp_round_trip(self):
+        """Test SymbolRectangle round-trips through S-expression."""
+        original = SymbolRectangle(
+            start=(-5.08, 5.08),
+            end=(5.08, -5.08),
+            stroke_width=0.254,
+            stroke_type="solid",
+            fill_type="background",
+        )
+        sexp = original.to_sexp_node()
+        restored = SymbolRectangle.from_sexp(sexp)
+        assert restored.start == original.start
+        assert restored.end == original.end
+        assert restored.stroke_width == original.stroke_width
+        assert restored.stroke_type == original.stroke_type
+        assert restored.fill_type == original.fill_type
+
+    # -- Polygon convenience method -------------------------------------------
+
+    def test_add_polygon(self):
+        """Test add_polygon auto-closes the shape."""
+        sym = LibrarySymbol(name="Test")
+        pl = sym.add_polygon([(0, 0), (2.54, -1.27), (0, -2.54)])
+        assert len(sym.graphics) == 1
+        assert isinstance(pl, SymbolPolyline)
+        # Should be auto-closed
+        assert pl.points[0] == pl.points[-1]
+        assert len(pl.points) == 4
+
+    def test_add_polygon_already_closed(self):
+        """Test add_polygon with an already-closed polygon."""
+        sym = LibrarySymbol(name="Test")
+        pl = sym.add_polygon([(0, 0), (2.54, -1.27), (0, -2.54), (0, 0)])
+        # Should NOT double-close
+        assert len(pl.points) == 4
+        assert pl.points[0] == pl.points[-1]
+
+    def test_add_polygon_fewer_than_3_raises(self):
+        """Test that add_polygon with fewer than 3 points raises ValueError."""
+        sym = LibrarySymbol(name="Test")
+        with pytest.raises(ValueError, match="at least 3 points"):
+            sym.add_polygon([(0, 0), (1, 1)])
+
+    def test_add_polygon_default_fill(self):
+        """Test that polygon defaults to outline fill."""
+        sym = LibrarySymbol(name="Test")
+        pl = sym.add_polygon([(0, 0), (2.54, 0), (1.27, 2.54)])
+        assert pl.fill_type == "outline"
+
+    # -- Validation -----------------------------------------------------------
+
+    def test_invalid_fill_type_raises(self):
+        """Test that invalid fill type raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid fill_type"):
+            SymbolPolyline(points=[(0, 0), (1, 1)], fill_type="invalid")
+
+    def test_invalid_stroke_type_raises(self):
+        """Test that invalid stroke type raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid stroke_type"):
+            SymbolCircle(center=(0, 0), radius=1.0, stroke_type="zigzag")
+
+    # -- to_sexp_node integration (LibrarySymbol) -----------------------------
+
+    def test_to_sexp_node_emits_graphics_in_0_1(self):
+        """Test that to_sexp_node() emits graphics inside a _0_1 sub-symbol."""
+        sym = LibrarySymbol(name="TriBody")
+        sym.add_polygon([(0, 0), (2.54, -1.27), (0, -2.54)])
+        sym.add_pin("1", "B", "input", (-5.08, -1.27), rotation=0)
+
+        sexp = sym.to_sexp_node()
+        sexp_str = sexp.to_string()
+
+        # _0_1 block should exist and contain polyline
+        assert "TriBody_0_1" in sexp_str
+        assert "(polyline" in sexp_str
+
+        # _1_1 block should still contain pin
+        assert "TriBody_1_1" in sexp_str
+        assert "(pin" in sexp_str
+
+    def test_to_sexp_node_no_graphics_no_0_1(self):
+        """Test that _0_1 sub-symbol is omitted when there are no graphics."""
+        sym = LibrarySymbol(name="PinOnly")
+        sym.add_pin("1", "A", "input", (0, 0))
+
+        sexp = sym.to_sexp_node()
+        sexp_str = sexp.to_string()
+        assert "PinOnly_0_1" not in sexp_str
+        assert "PinOnly_1_1" in sexp_str
+
+    def test_to_sexp_node_multiple_shape_types(self):
+        """Test emitting several different shape types."""
+        sym = LibrarySymbol(name="Mixed")
+        sym.add_polyline([(0, 0), (5, 0)])
+        sym.add_circle((0, 0), 2.0)
+        sym.add_arc((0, 0), (1, 1), (2, 0))
+        sym.add_rectangle((-3, 3), (3, -3))
+
+        sexp = sym.to_sexp_node()
+        s = sexp.to_string()
+        assert "(polyline" in s
+        assert "(circle" in s
+        assert "(arc" in s
+        assert "(rectangle" in s
+
+    # -- from_sexp round-trip (full LibrarySymbol) ----------------------------
+
+    def test_from_sexp_parses_graphics(self):
+        """Test that from_sexp round-trips graphical shapes."""
+        sym = LibrarySymbol(name="RoundTrip")
+        sym.add_polygon([(0, 0), (2.54, -1.27), (0, -2.54)])
+        sym.add_circle((0, 0), 1.27, fill_type="background")
+        sym.add_rectangle((-5, 5), (5, -5), stroke_width=0.254)
+        sym.add_pin("1", "A", "input", (-5.08, 0))
+
+        sexp = sym.to_sexp_node()
+        restored = LibrarySymbol.from_sexp(sexp)
+
+        # Pins preserved
+        assert len(restored.pins) == 1
+
+        # Graphics preserved
+        assert len(restored.graphics) == 3
+        types = {type(g).__name__ for g in restored.graphics}
+        assert "SymbolPolyline" in types
+        assert "SymbolCircle" in types
+        assert "SymbolRectangle" in types
+
+    def test_save_and_load_with_graphics(self, tmp_path: Path):
+        """Test that a library with graphics survives save/load."""
+        lib = SymbolLibrary(path=str(tmp_path / "gfx.kicad_sym"), symbols={})
+        sym = lib.create_symbol("GfxPart")
+        sym.add_property("Reference", "U")
+        sym.add_property("Value", "GfxPart")
+        sym.add_polygon([(0, 0), (5.08, -2.54), (0, -5.08)])
+        sym.add_pin("1", "IN", "input", (-5.08, 0))
+
+        lib.save()
+
+        lib2 = SymbolLibrary.load(str(tmp_path / "gfx.kicad_sym"))
+        sym2 = lib2.symbols["GfxPart"]
+        assert len(sym2.pins) == 1
+        assert len(sym2.graphics) == 1
+        assert isinstance(sym2.graphics[0], SymbolPolyline)
+        assert sym2.graphics[0].fill_type == "outline"
+
+    def test_triangular_body_api(self):
+        """Test that a user can build a triangular body entirely through the API."""
+        lib = SymbolLibrary(path="triangle.kicad_sym", symbols={})
+        sym = lib.create_symbol("OpAmpBody")
+        sym.add_property("Reference", "U")
+        sym.add_property("Value", "OpAmpBody")
+
+        # Draw a triangle body
+        sym.add_polygon(
+            [(0, 2.54), (5.08, 0), (0, -2.54)],
+            stroke_width=0.254,
+            fill_type="background",
+        )
+
+        # Add pins
+        sym.add_pin("1", "+", "input", (-2.54, 1.27), rotation=0)
+        sym.add_pin("2", "-", "input", (-2.54, -1.27), rotation=0)
+        sym.add_pin("3", "OUT", "output", (7.62, 0), rotation=180)
+
+        sexp = sym.to_sexp_node()
+        s = sexp.to_string()
+
+        # Verify the polyline is present with closed triangle
+        assert "(polyline" in s
+        # Verify all three pins are present
+        assert s.count("(pin") == 3
+        # Verify no raw S-expression strings were needed
+        assert len(sym.graphics) == 1
+        assert isinstance(sym.graphics[0], SymbolPolyline)
+        assert sym.graphics[0].points[0] == sym.graphics[0].points[-1]

--- a/tests/test_symbol_generator.py
+++ b/tests/test_symbol_generator.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from kicad_tools.schema.library import SymbolPolyline, SymbolRectangle
 from kicad_tools.schematic.symbol_generator import (
     PACKAGE_TEMPLATES,
     PinDef,
@@ -751,3 +752,74 @@ class TestSymbolGeneratorIntegration:
         assert "(kicad_symbol_lib" in sexp
         assert 'symbol "Amplifier"' in sexp
         assert len(sym.pins) == 8
+
+
+# =============================================================================
+# Custom Graphics Tests
+# =============================================================================
+
+
+class TestGenerateSymbolSexpGraphics:
+    """Tests for custom graphics in generate_symbol_sexp()."""
+
+    def test_default_rectangle_when_no_graphics(self):
+        """Test that the default rectangle is emitted when no graphics are set."""
+        pins = [PinDef(number="1", name="IN", pin_type=PinType.INPUT, side=PinSide.LEFT)]
+        sym = SymbolDef(name="PlainIC", pins=pins)
+        sexp = generate_symbol_sexp(sym)
+
+        assert "(rectangle" in sexp
+        assert 'symbol "PlainIC_0_1"' in sexp
+
+    def test_custom_polygon_replaces_default_rect(self):
+        """Test that custom graphics replace the default rectangle."""
+        pins = [PinDef(number="1", name="IN", pin_type=PinType.INPUT, side=PinSide.LEFT)]
+        triangle = SymbolPolyline(
+            points=[(0, 0), (2.54, -1.27), (0, -2.54), (0, 0)],
+            fill_type="outline",
+        )
+        sym = SymbolDef(name="TriSym", pins=pins, graphics=[triangle])
+        sexp = generate_symbol_sexp(sym)
+
+        # Custom polygon should be present
+        assert "(polyline" in sexp
+        assert 'symbol "TriSym_0_1"' in sexp
+
+    def test_custom_graphics_multiple_shapes(self):
+        """Test emitting multiple custom shapes."""
+        pins = [PinDef(number="1", name="A", pin_type=PinType.PASSIVE, side=PinSide.LEFT)]
+        shapes = [
+            SymbolPolyline(points=[(0, 0), (5, 0), (5, 5)], fill_type="none"),
+            SymbolRectangle(start=(-2, 2), end=(2, -2), fill_type="background"),
+        ]
+        sym = SymbolDef(name="Multi", pins=pins, graphics=shapes)
+        sexp = generate_symbol_sexp(sym)
+
+        assert "(polyline" in sexp
+        assert "(rectangle" in sexp
+        assert 'symbol "Multi_0_1"' in sexp
+
+    def test_graphics_field_defaults_to_none(self):
+        """Test that SymbolDef.graphics defaults to None."""
+        sym = SymbolDef(name="Default", pins=[])
+        assert sym.graphics is None
+
+    def test_pins_still_emitted_with_custom_graphics(self):
+        """Test that pins are still present when custom graphics are used."""
+        pins = [
+            PinDef(number="1", name="IN", pin_type=PinType.INPUT, side=PinSide.LEFT),
+            PinDef(number="2", name="OUT", pin_type=PinType.OUTPUT, side=PinSide.RIGHT),
+        ]
+        triangle = SymbolPolyline(
+            points=[(0, 2.54), (5.08, 0), (0, -2.54), (0, 2.54)],
+            fill_type="outline",
+        )
+        sym = SymbolDef(name="WithPins", pins=pins, graphics=[triangle])
+        sexp = generate_symbol_sexp(sym)
+
+        # Both _0_1 (graphics) and _1_1 (pins) blocks should be present
+        assert 'symbol "WithPins_0_1"' in sexp
+        assert 'symbol "WithPins_1_1"' in sexp
+        assert "(polyline" in sexp
+        assert "(pin input" in sexp
+        assert "(pin output" in sexp


### PR DESCRIPTION
## Summary
Add polygon, polyline, circle, arc, and rectangle graphical shape support to `LibrarySymbol`, enabling custom symbol body drawing through a typed Python API instead of raw S-expression strings.

## Changes
- Add `SymbolPolyline`, `SymbolCircle`, `SymbolArc`, `SymbolRectangle` dataclasses in `schema/library.py` with `to_sexp_node()` and `from_sexp()` methods
- Add `graphics` field to `LibrarySymbol` with convenience methods: `add_polyline()`, `add_polygon()`, `add_circle()`, `add_arc()`, `add_rectangle()`
- Update `LibrarySymbol.to_sexp_node()` to emit graphics inside the `_0_1` sub-symbol block
- Update `LibrarySymbol.from_sexp()` to parse graphical primitives from existing `.kicad_sym` files
- Add `graphics` field to `SymbolDef` in `symbol_generator.py`; custom shapes replace the default rectangle in `generate_symbol_sexp()`
- Add validation for `fill_type` and `stroke_type` parameters
- 28 new tests in `TestLibrarySymbolGraphics` (test_schema.py) covering creation, S-expression output, round-trip, edge cases, and save/load
- 5 new tests in `TestGenerateSymbolSexpGraphics` (test_symbol_generator.py) covering the string-template generator path

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `add_polygon`, `add_polyline`, `add_circle`, `add_arc`, `add_rectangle` methods with optional kwargs | Done | Methods added with `stroke_width`, `stroke_type`, `fill_type` kwargs |
| Shapes emit valid KiCad S-expression | Done | `to_sexp_node()` produces `(polyline (pts ...) (stroke ...) (fill ...))` etc. per KiCad 7/8 spec |
| `from_sexp()` round-trips graphics | Done | Tests verify parse-serialize-parse preserves all fields |
| Default rectangle preserved in `generate_symbol_sexp()` | Done | Default rect emitted when `graphics` is None/empty |
| `SymbolDef` accepts `graphics` field | Done | Field added, serialized into `_0_1` block |
| Triangular body via Python API only | Done | `test_triangular_body_api` builds a 3-point closed polyline without raw S-expression strings |

## Test Plan
- 33 new automated tests all pass (224 total in the two test files, 0 failures)
- `uv run ruff check` passes on all changed files
- `uv run ruff format --check` passes on all changed files

Closes #1418