### PR TITLE
fix(pipeline): reorder ALL_STEPS to run optimize-traces before fix-drc

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -7,8 +7,8 @@ Orchestrates the full repair pipeline:
 2. Fix silkscreen (manufacturer line-width compliance)
 3. Fix vias (manufacturer compliance)
 4. [Optional] Route (if board is unrouted)
-5. Fix DRC violations
-6. Optimize traces
+5. Optimize traces
+6. Fix DRC violations
 7. Zone fill (requires kicad-cli)
 8. Audit / check
 9. Report generation (manufacturing report)
@@ -64,8 +64,8 @@ ALL_STEPS = [
     PipelineStep.FIX_SILKSCREEN,
     PipelineStep.FIX_VIAS,
     PipelineStep.ROUTE,
-    PipelineStep.FIX_DRC,
     PipelineStep.OPTIMIZE,
+    PipelineStep.FIX_DRC,
     PipelineStep.ZONES,
     PipelineStep.AUDIT,
     PipelineStep.REPORT,

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -506,7 +506,7 @@ class TestRouteExitCode2Pipeline:
 
     Issue #1413: When route exits with code 2 (partial routing), the pipeline
     should treat it as success-with-warnings and continue to downstream steps
-    (fix-drc, optimize-traces, audit, report).
+    (optimize-traces, fix-drc, audit, report).
 
     Uses unrouted_pcb fixture so the route step does not skip due to
     detecting existing traces in the board.
@@ -709,8 +709,8 @@ class TestPipelineStepOrder:
             PipelineStep.FIX_SILKSCREEN,
             PipelineStep.FIX_VIAS,
             PipelineStep.ROUTE,
-            PipelineStep.FIX_DRC,
             PipelineStep.OPTIMIZE,
+            PipelineStep.FIX_DRC,
             PipelineStep.ZONES,
             PipelineStep.AUDIT,
             PipelineStep.REPORT,


### PR DESCRIPTION
## Summary
Reorders `ALL_STEPS` in the pipeline to run `optimize-traces` before `fix-drc`. This reduces redundant segment geometry before DRC repair, improving error reduction from 38% to 81% on the chorus-test-revA benchmark.

## Changes
- Swapped `PipelineStep.OPTIMIZE` and `PipelineStep.FIX_DRC` in `ALL_STEPS` list (pipeline_cmd.py lines 67-68)
- Updated module docstring step numbering to reflect the new order
- Updated `TestPipelineStepOrder.test_step_order` expected list to match
- Updated `TestRouteExitCode2Pipeline` class docstring to reflect new step order

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `ALL_STEPS` orders `OPTIMIZE` before `FIX_DRC` | PASS | Direct code inspection confirms swap |
| `TestPipelineStepOrder.test_step_order` updated | PASS | Test passes with new order |
| All other step-order assertion tests updated | PASS | All 4 `TestPipelineStepOrder` tests pass |
| Existing pipeline integration tests continue to pass | PASS | 159 passed, 1 pre-existing failure unrelated to change |
| No regression to partial-routing continuation path | PASS | `TestRouteExitCode2Pipeline` tests all pass (use explicit step lists, not `ALL_STEPS`) |

## Test Plan
- `uv run pytest tests/test_pipeline_cmd.py::TestPipelineStepOrder -v` -- all 4 tests pass
- `uv run pytest tests/test_pipeline_cmd.py -v` -- 159 passed, 1 pre-existing failure (`TestFixERCStep::test_fix_erc_step_skipped_no_errors`, confirmed on main)

Closes #1421