### PR TITLE
fix(cli): add --local-reroute and --quiet to centralized fix-drc parser

### DIFF
--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -160,10 +160,12 @@ def run_fix_drc_command(args) -> int:
         sub_argv.append("--dry-run")
     if getattr(args, "max_passes", 1) != 1:
         sub_argv.extend(["--max-passes", str(args.max_passes)])
+    if getattr(args, "local_reroute", False):
+        sub_argv.append("--local-reroute")
     if args.format != "text":
         sub_argv.extend(["--format", args.format])
-    # Use global quiet flag
-    if getattr(args, "global_quiet", False):
+    # Use command-level quiet or global quiet
+    if getattr(args, "quiet", False) or getattr(args, "global_quiet", False):
         sub_argv.append("--quiet")
     return fix_drc_main(sub_argv)
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1404,6 +1404,20 @@ def _add_fix_drc_parser(subparsers) -> None:
         ),
     )
     fix_drc_parser.add_argument(
+        "--local-reroute",
+        action="store_true",
+        help=(
+            "Attempt local A* rerouting for infeasible violations "
+            "(segments with both endpoints at vias). Off by default."
+        ),
+    )
+    fix_drc_parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress progress output (for scripting)",
+    )
+    fix_drc_parser.add_argument(
         "--format",
         choices=["text", "json", "summary"],
         default="text",

--- a/tests/test_fix_drc_cmd.py
+++ b/tests/test_fix_drc_cmd.py
@@ -1641,3 +1641,63 @@ class TestEnlargedViaDisplacement:
             assert data["clearance"]["repaired"] == 0, (
                 f"Expected skip at max_displacement={max_disp}"
             )
+
+
+# ── Centralized CLI forwarding tests ────────────────────────────────
+
+
+class TestLocalRerouteViaCentralizedCLI:
+    """Tests that --local-reroute and --quiet work via kct fix-drc (centralized CLI)."""
+
+    def test_centralized_cli_local_reroute_dry_run(self, tmp_path):
+        """kct fix-drc ... --local-reroute --dry-run parses without 'unrecognized arguments'."""
+        from kicad_tools.cli import main as cli_main
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_CLEARANCE)
+
+        result = cli_main(["fix-drc", str(pcb_file), "--local-reroute", "--dry-run", "--quiet"])
+        # Should not fail with unrecognized arguments (exit code 2 = argparse error)
+        assert result != 2
+
+    def test_centralized_cli_quiet_dry_run(self, tmp_path):
+        """kct fix-drc ... --quiet --dry-run parses without 'unrecognized arguments'."""
+        from kicad_tools.cli import main as cli_main
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_CLEARANCE)
+
+        result = cli_main(["fix-drc", str(pcb_file), "--quiet", "--dry-run"])
+        assert result != 2
+
+    def test_centralized_cli_quiet_short_flag_dry_run(self, tmp_path):
+        """kct fix-drc ... -q --dry-run parses the short -q flag."""
+        from kicad_tools.cli import main as cli_main
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_CLEARANCE)
+
+        result = cli_main(["fix-drc", str(pcb_file), "-q", "--dry-run"])
+        assert result != 2
+
+    def test_centralized_cli_local_reroute_quiet_combined(self, tmp_path):
+        """kct fix-drc ... --local-reroute --quiet --dry-run combines without conflict."""
+        from kicad_tools.cli import main as cli_main
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_CLEARANCE)
+
+        result = cli_main(["fix-drc", str(pcb_file), "--local-reroute", "--quiet", "--dry-run"])
+        assert result != 2
+
+    def test_centralized_cli_max_displacement_still_works(self, tmp_path):
+        """kct fix-drc ... --max-displacement 0.5 --dry-run still works (regression check)."""
+        from kicad_tools.cli import main as cli_main
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_CLEARANCE)
+
+        result = cli_main(
+            ["fix-drc", str(pcb_file), "--max-displacement", "0.5", "--dry-run", "--quiet"]
+        )
+        assert result != 2


### PR DESCRIPTION
## Summary
Add missing `--local-reroute` and `-q`/`--quiet` arguments to the centralized CLI parser for `fix-drc`, and forward `local_reroute` in the command dispatcher. Without this, `kct fix-drc --local-reroute` fails with "unrecognized arguments".

## Changes
- Add `--local-reroute` argument to `_add_fix_drc_parser()` in `parser.py` (matching standalone `fix_drc_cmd.py`)
- Add `-q`/`--quiet` argument to `_add_fix_drc_parser()` in `parser.py` (matching standalone `fix_drc_cmd.py`)
- Forward `local_reroute` flag in `run_fix_drc_command()` in `commands/validation.py`
- Update quiet forwarding to check both command-level `--quiet` and `global_quiet` (matching pattern from `commands/routing.py`)
- Add 5 tests in `TestLocalRerouteViaCentralizedCLI` class covering all new flags and combinations

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--local-reroute` registered in centralized parser | Pass | Added to `_add_fix_drc_parser()`, test `test_centralized_cli_local_reroute_dry_run` passes |
| `-q`/`--quiet` registered in centralized parser | Pass | Added to `_add_fix_drc_parser()`, tests for `--quiet` and `-q` both pass |
| `local_reroute` forwarded to standalone `main()` | Pass | Added forwarding in `run_fix_drc_command()` |
| Combined flags work without conflict | Pass | `test_centralized_cli_local_reroute_quiet_combined` passes |
| Existing flags not broken | Pass | `test_centralized_cli_max_displacement_still_works` passes; all 69 tests in test_fix_drc_cmd.py pass |

## Test Plan
- All 5 new tests pass: `uv run pytest tests/test_fix_drc_cmd.py::TestLocalRerouteViaCentralizedCLI -v`
- All 69 tests in `test_fix_drc_cmd.py` pass (no regressions)
- Ruff lint and format checks pass on all changed files

Closes #1420