### PR TITLE
feat(pipeline): increase default --max-displacement from 0.5mm to 2.0mm

### DIFF
--- a/src/kicad_tools/cli/commands/pipeline.py
+++ b/src/kicad_tools/cli/commands/pipeline.py
@@ -41,7 +41,7 @@ def run_pipeline_command(args) -> int:
 
     # Max displacement for fix-drc step
     max_disp = getattr(args, "pipeline_max_displacement", None)
-    if max_disp is not None and max_disp != 0.5:
+    if max_disp is not None and max_disp != 2.0:
         sub_argv.extend(["--max-displacement", str(max_disp)])
 
     # Zones opt-in

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3020,9 +3020,9 @@ def _add_pipeline_parser(subparsers) -> None:
         "--max-displacement",
         dest="pipeline_max_displacement",
         type=float,
-        default=0.5,
+        default=2.0,
         help=(
-            "Maximum nudge/slide distance in mm for fix-drc step (default: 0.5). "
+            "Maximum nudge/slide distance in mm for fix-drc step (default: 2.0). "
             "Increase when enlarged vias cause segment-to-via violations that "
             "exceed the displacement budget."
         ),

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -1266,9 +1266,9 @@ Examples:
     parser.add_argument(
         "--max-displacement",
         type=float,
-        default=0.5,
+        default=2.0,
         help=(
-            "Maximum nudge/slide distance in mm for fix-drc step (default: 0.5). "
+            "Maximum nudge/slide distance in mm for fix-drc step (default: 2.0). "
             "Increase when enlarged vias cause segment-to-via violations that "
             "exceed the displacement budget."
         ),

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -98,7 +98,7 @@ class PipelineContext:
     force: bool = False
     is_project: bool = False
     commit: bool = False
-    max_displacement: float = 0.5
+    max_displacement: float = 2.0
     erc_error_count: int = 0
     _check_data: dict | None = None  # cached kct check --format json result
 

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -2345,7 +2345,7 @@ class TestMaxDisplacementPassThrough:
         result = _run_step_fix_drc(ctx, console)
 
         assert result.success is True
-        assert "--max-displacement 0.5" in result.message
+        assert "--max-displacement 2.0" in result.message
 
     def test_fix_drc_dry_run_shows_custom_max_displacement(self, routed_pcb: Path):
         """Dry-run message reflects a user-specified max-displacement value."""
@@ -2400,12 +2400,12 @@ class TestMaxDisplacementPassThrough:
         disp_idx = cmd_args.index("--max-displacement")
         assert cmd_args[disp_idx + 1] == "1.0"
 
-    def test_pipeline_default_max_displacement_is_0_5(self):
-        """PipelineContext defaults to 0.5 mm max-displacement."""
+    def test_pipeline_default_max_displacement_is_2_0(self):
+        """PipelineContext defaults to 2.0 mm max-displacement."""
         from pathlib import Path
 
         ctx = PipelineContext(pcb_file=Path("dummy.kicad_pcb"))
-        assert ctx.max_displacement == 0.5
+        assert ctx.max_displacement == 2.0
 
     @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
     def test_cli_max_displacement_forwarded_to_pipeline(self, mock_run, routed_pcb: Path):


### PR DESCRIPTION
## Summary
Increase the default `--max-displacement` budget from 0.5mm to 2.0mm so the fix-drc pipeline step can resolve violations where segments must move more than 0.5mm to clear. Testing on chorus-test-revA demonstrated that 2.0mm resolves all DRC violations without disconnecting nets.

## Changes
- `src/kicad_tools/cli/pipeline_cmd.py`: Change `PipelineContext.max_displacement` default from 0.5 to 2.0
- `src/kicad_tools/cli/parser.py`: Update CLI argument default and help text from 0.5 to 2.0
- `src/kicad_tools/cli/commands/pipeline.py`: Update default-suppression guard from 0.5 to 2.0
- `tests/test_pipeline_cmd.py`: Update two tests that assert the default value (dry-run message and dataclass default)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `PipelineContext().max_displacement` equals 2.0 | Pass | Test `test_pipeline_default_max_displacement_is_2_0` passes |
| Default invocation uses `--max-displacement 2.0` | Pass | Test `test_fix_drc_dry_run_shows_max_displacement` asserts `"--max-displacement 2.0"` in dry-run message |
| `--max-displacement 0.5` override still works | Pass | Test `test_fix_drc_subprocess_receives_max_displacement` explicitly passes 0.5 and verifies pass-through |
| `kct pipeline --help` shows `(default: 2.0)` | Pass | Verified via `kct pipeline --help` output |
| All `TestMaxDisplacementPassThrough` tests pass | Pass | All 6 tests pass |

## Test Plan
- Ran `uv run pytest tests/test_pipeline_cmd.py::TestMaxDisplacementPassThrough -v` -- all 6 tests pass
- Ran `uv run ruff check` and `uv run ruff format --check` on all changed files -- clean
- Verified `kct pipeline --help` shows `(default: 2.0)` for `--max-displacement`

Closes #1427