### PR TITLE
feat(pipeline): increase default --max-passes from 3 to 20

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -602,7 +602,7 @@ def _run_step_fix_drc(ctx: PipelineContext, console: Console) -> PipelineResult:
             success=True,
             message=(
                 f"[dry-run] Would run: kct fix-drc {ctx.pcb_file.name} "
-                f"--max-passes 3 --local-reroute --max-displacement {ctx.max_displacement}"
+                f"--max-passes 20 --local-reroute --max-displacement {ctx.max_displacement}"
             ),
         )
 
@@ -616,7 +616,7 @@ def _run_step_fix_drc(ctx: PipelineContext, console: Console) -> PipelineResult:
         "fix-drc",
         str(ctx.pcb_file),
         "--max-passes",
-        "3",
+        "20",
         "--local-reroute",
         "--max-displacement",
         str(ctx.max_displacement),

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3201,7 +3201,7 @@ def main(argv: list[str] | None = None) -> int:
             print("This board cannot be manufactured without fixing DRC errors.")
             print()
             print("Suggestions:")
-            print(f"  - Auto-repair DRC violations: kct fix-drc {output_path} --max-passes 3")
+            print(f"  - Auto-repair DRC violations: kct fix-drc {output_path} --max-passes 20")
             print("  - Try Monte Carlo routing: kct route --trials 10")
             print("  - Increase board area")
             print("  - Reduce component density")

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -2330,6 +2330,39 @@ class TestFixDrcLocalReroute:
         assert result.success is True
         assert "--local-reroute" in result.message
 
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_fix_drc_subprocess_includes_max_passes_20(self, mock_run, routed_pcb: Path):
+        """fix-drc subprocess command passes --max-passes 20."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_fix_drc
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True)
+        console = Console(quiet=True)
+        result = _run_step_fix_drc(ctx, console)
+
+        assert result.success is True
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "--max-passes" in cmd_args
+        passes_idx = cmd_args.index("--max-passes")
+        assert cmd_args[passes_idx + 1] == "20"
+
+    def test_fix_drc_dry_run_shows_max_passes_20(self, routed_pcb: Path):
+        """Dry-run message for fix-drc includes --max-passes 20."""
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_fix_drc
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, dry_run=True)
+        console = Console(quiet=True)
+        result = _run_step_fix_drc(ctx, console)
+
+        assert result.success is True
+        assert "--max-passes 20" in result.message
+
 
 class TestMaxDisplacementPassThrough:
     """Tests for --max-displacement pipeline option forwarded to fix-drc step."""


### PR DESCRIPTION
## Summary

Raises the default `--max-passes` value in the pipeline `fix-drc` step from 3 to 20. With `--max-displacement 2.0mm` (the current default since PR #1429), boards may need up to 8 passes to reach zero DRC errors. The fix-drc command already exits early when no violations remain, so the higher ceiling has negligible cost on fast-converging boards.

## Changes

- `pipeline_cmd.py` line 605: dry-run message string changed from `--max-passes 3` to `--max-passes 20`
- `pipeline_cmd.py` line 619: subprocess `cmd` list changed from `"3"` to `"20"`
- `route_cmd.py` line 3204: user-facing suggestion string changed from `--max-passes 3` to `--max-passes 20`
- `test_pipeline_cmd.py`: added `test_fix_drc_subprocess_includes_max_passes_20` and `test_fix_drc_dry_run_shows_max_passes_20` in `TestFixDrcLocalReroute`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_run_step_fix_drc()` passes `--max-passes 20` to subprocess | PASS | `test_fix_drc_subprocess_includes_max_passes_20` asserts `cmd_args[passes_idx + 1] == "20"` |
| Dry-run message mentions `--max-passes 20` | PASS | `test_fix_drc_dry_run_shows_max_passes_20` asserts `"--max-passes 20" in result.message` |
| Suggestion string in `route_cmd.py` recommends `--max-passes 20` | PASS | Verified via diff |
| No new `PipelineContext` fields required | PASS | Only literal string values changed |
| Existing tests pass without modification | PASS | All 8 fix_drc tests pass (`uv run pytest tests/test_pipeline_cmd.py -k fix_drc`) |

## Test Plan

- Ran `uv run pytest tests/test_pipeline_cmd.py -k fix_drc -v` -- all 8 tests pass (6 existing + 2 new)
- Verified formatting with `uv run ruff format --check` on all changed files
- Pre-existing lint error in `route_cmd.py:2818` (unrelated f-string) left untouched per scope discipline

Closes #1433