### PR TITLE
feat(fix-drc): add post-pass connectivity check with automatic rollback

### DIFF
--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -162,6 +162,8 @@ def run_fix_drc_command(args) -> int:
         sub_argv.extend(["--max-passes", str(args.max_passes)])
     if getattr(args, "local_reroute", False):
         sub_argv.append("--local-reroute")
+    if getattr(args, "no_connectivity_check", False):
+        sub_argv.append("--no-connectivity-check")
     if args.format != "text":
         sub_argv.extend(["--format", args.format])
     # Use command-level quiet or global quiet

--- a/src/kicad_tools/cli/fix_drc_cmd.py
+++ b/src/kicad_tools/cli/fix_drc_cmd.py
@@ -37,6 +37,9 @@ class PassResult:
     repaired: int
     clearance_result: RepairResult
     drill_result: DrillRepairResult
+    connectivity_before: int | None = None
+    connectivity_after: int | None = None
+    connectivity_rolled_back: bool = False
 
     @property
     def violations_after(self) -> int:
@@ -130,6 +133,14 @@ Examples:
         help="Output format (default: text)",
     )
     parser.add_argument(
+        "--no-connectivity-check",
+        action="store_true",
+        help=(
+            "Skip post-pass connectivity check and rollback. "
+            "Use for boards with no footprints where connectivity is meaningless."
+        ),
+    )
+    parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
@@ -165,6 +176,8 @@ Examples:
     output_path = Path(args.output) if args.output else pcb_path
 
     pass_results: list[PassResult] = []
+    do_connectivity_check = not args.dry_run and not args.no_connectivity_check
+    connectivity_rollback_occurred = False
 
     for pass_num in range(1, effective_max_passes + 1):
         # Classify violations from current report
@@ -207,6 +220,15 @@ Examples:
             if drill_violations:
                 print(f"  Drill clearance: {len(drill_violations)}")
 
+        # Snapshot and baseline connectivity before the repair pass
+        snapshot: bytes | None = None
+        baseline_conn: int | None = None
+        if do_connectivity_check:
+            load_for_snapshot = output_path if pass_num > 1 else pcb_path
+            if load_for_snapshot.exists():
+                snapshot = load_for_snapshot.read_bytes()
+                baseline_conn = _count_connected_nets(load_for_snapshot)
+
         # Run single-pass repairs
         clearance_result, drill_result = _run_single_pass(
             report=report,
@@ -223,6 +245,30 @@ Examples:
 
         repaired_this_pass = clearance_result.repaired + drill_result.repaired
 
+        # Post-pass connectivity check and rollback
+        after_conn: int | None = None
+        rolled_back = False
+        if (
+            snapshot is not None
+            and baseline_conn is not None
+            and baseline_conn >= 0
+            and not args.dry_run
+            and repaired_this_pass > 0
+            and output_path.exists()
+        ):
+            after_conn = _count_connected_nets(output_path)
+            if after_conn >= 0 and after_conn < baseline_conn:
+                # Connectivity decreased -- rollback
+                output_path.write_bytes(snapshot)
+                rolled_back = True
+                connectivity_rollback_occurred = True
+                repaired_this_pass = 0
+                print(
+                    f"Warning: pass {pass_num} decreased connectivity "
+                    f"({baseline_conn} -> {after_conn} nets); rolled back.",
+                    file=sys.stderr,
+                )
+
         pass_results.append(
             PassResult(
                 pass_number=pass_num,
@@ -230,8 +276,15 @@ Examples:
                 repaired=repaired_this_pass,
                 clearance_result=clearance_result,
                 drill_result=drill_result,
+                connectivity_before=baseline_conn,
+                connectivity_after=after_conn,
+                connectivity_rolled_back=rolled_back,
             )
         )
+
+        # Stop if rolled back -- no point continuing
+        if rolled_back:
+            break
 
         # Stop if no progress
         if repaired_this_pass == 0:
@@ -253,7 +306,10 @@ Examples:
             args.max_passes,
         )
 
-    # Exit code: 0 = all repaired, 1 = no violations found/no progress, 2 = partial repair
+    # Exit code: 0 = all repaired, 1 = no violations found/no progress,
+    #            2 = partial repair, 3 = connectivity rollback
+    if connectivity_rollback_occurred:
+        return 3
     final_pass = pass_results[-1] if pass_results else None
     if final_pass is None:
         return 0
@@ -320,6 +376,24 @@ def _run_single_pass(
             print(f"Error during drill clearance repair: {e}", file=sys.stderr)
 
     return clearance_result, drill_result
+
+
+def _count_connected_nets(pcb_path: Path) -> int:
+    """Return the number of fully connected nets, or -1 on error.
+
+    Uses :class:`~kicad_tools.validate.connectivity.ConnectivityValidator`
+    to perform the check.  Returns ``-1`` when the validator cannot be
+    imported or raises an exception so that callers can treat the result
+    as "unknown" and skip rollback logic.
+    """
+    try:
+        from kicad_tools.validate.connectivity import ConnectivityValidator
+
+        validator = ConnectivityValidator(pcb_path)
+        result = validator.validate()
+        return result.connected_nets
+    except Exception:
+        return -1
 
 
 def _get_drc_report(drc_report_path: str | None, pcb_path: Path) -> DRCReport | None:
@@ -516,6 +590,24 @@ def _print_json(
         },
     }
 
+    # Add connectivity_check section when any pass has connectivity data
+    has_connectivity_data = any(
+        p.connectivity_before is not None or p.connectivity_after is not None for p in pass_results
+    )
+    if has_connectivity_data:
+        data["connectivity_check"] = {
+            "passes": [
+                {
+                    "pass": p.pass_number,
+                    "connected_nets_before": p.connectivity_before,
+                    "connected_nets_after": p.connectivity_after,
+                    "rolled_back": p.connectivity_rolled_back,
+                }
+                for p in pass_results
+                if p.connectivity_before is not None or p.connectivity_after is not None
+            ],
+        }
+
     # Add passes array only when the user requested multi-pass mode
     if max_passes > 1:
         data["passes"] = [
@@ -524,6 +616,11 @@ def _print_json(
                 "violations_before": p.violations_before,
                 "repaired": p.repaired,
                 "violations_after": p.violations_after,
+                **(
+                    {"connectivity_rolled_back": p.connectivity_rolled_back}
+                    if p.connectivity_before is not None
+                    else {}
+                ),
             }
             for p in pass_results
         ]

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1412,6 +1412,14 @@ def _add_fix_drc_parser(subparsers) -> None:
         ),
     )
     fix_drc_parser.add_argument(
+        "--no-connectivity-check",
+        action="store_true",
+        help=(
+            "Skip post-pass connectivity check and rollback. "
+            "Use for boards with no footprints where connectivity is meaningless."
+        ),
+    )
+    fix_drc_parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",

--- a/tests/test_fix_drc_cmd.py
+++ b/tests/test_fix_drc_cmd.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import pytest
 
-from kicad_tools.cli.fix_drc_cmd import main
+from kicad_tools.cli.fix_drc_cmd import PassResult, main
+from kicad_tools.drc.repair_clearance import RepairResult
 from kicad_tools.drc.repair_drill_clearance import (
     DrillClearanceRepairer,
     DrillRepairResult,
@@ -1701,3 +1702,388 @@ class TestLocalRerouteViaCentralizedCLI:
             ["fix-drc", str(pcb_file), "--max-displacement", "0.5", "--dry-run", "--quiet"]
         )
         assert result != 2
+
+    def test_centralized_cli_no_connectivity_check(self, tmp_path):
+        """kct fix-drc ... --no-connectivity-check parses without error."""
+        from kicad_tools.cli import main as cli_main
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_CLEARANCE)
+
+        result = cli_main(
+            ["fix-drc", str(pcb_file), "--no-connectivity-check", "--dry-run", "--quiet"]
+        )
+        assert result != 2
+
+
+# ── Connectivity check and rollback tests ────────────────────────────
+
+
+class TestConnectivityCheckRollback:
+    """Tests for the post-pass connectivity check and rollback logic."""
+
+    def test_connectivity_decrease_triggers_rollback(
+        self, pcb_same_net_vias: Path, report_same_net_drill: Path, tmp_path, capsys, monkeypatch
+    ):
+        """When connected_nets decreases after a pass, the file is rolled back."""
+        output_file = tmp_path / "output.kicad_pcb"
+        original_content = pcb_same_net_vias.read_bytes()
+
+        # Simulate connectivity decrease: baseline=10, after=8
+        call_count = 0
+
+        def mock_count_connected_nets(pcb_path):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return 10  # baseline
+            return 8  # after pass -- decreased
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            mock_count_connected_nets,
+        )
+
+        result = main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "-o",
+                str(output_file),
+                "--format",
+                "json",
+            ]
+        )
+
+        # Exit code 3 = connectivity rollback
+        assert result == 3
+
+        # The output file should be restored to the original content
+        assert output_file.read_bytes() == original_content
+
+        # Warning should be printed to stderr
+        captured = capsys.readouterr()
+        assert "decreased connectivity" in captured.err
+        assert "rolled back" in captured.err
+
+        # JSON output should include connectivity_check section
+        data = json.loads(captured.out)
+        assert "connectivity_check" in data
+        passes = data["connectivity_check"]["passes"]
+        assert len(passes) >= 1
+        assert passes[0]["connected_nets_before"] == 10
+        assert passes[0]["connected_nets_after"] == 8
+        assert passes[0]["rolled_back"] is True
+
+    def test_connectivity_stable_allows_pass(
+        self, pcb_same_net_vias: Path, report_same_net_drill: Path, tmp_path, capsys, monkeypatch
+    ):
+        """When connected_nets stays the same or increases, no rollback occurs."""
+        output_file = tmp_path / "output.kicad_pcb"
+
+        call_count = 0
+
+        def mock_count_connected_nets(pcb_path):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return 10  # baseline
+            return 10  # after pass -- same
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            mock_count_connected_nets,
+        )
+
+        result = main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "-o",
+                str(output_file),
+                "--format",
+                "json",
+            ]
+        )
+
+        # Should succeed (exit code 0 since all violations repaired)
+        assert result == 0
+
+        # No rollback warning
+        captured = capsys.readouterr()
+        assert "rolled back" not in captured.err
+
+        # JSON should have connectivity_check with no rollback
+        data = json.loads(captured.out)
+        assert "connectivity_check" in data
+        passes = data["connectivity_check"]["passes"]
+        assert passes[0]["rolled_back"] is False
+
+    def test_connectivity_increase_allowed(
+        self, pcb_same_net_vias: Path, report_same_net_drill: Path, tmp_path, monkeypatch
+    ):
+        """When connected_nets increases after a pass, no rollback occurs."""
+        output_file = tmp_path / "output.kicad_pcb"
+
+        call_count = 0
+
+        def mock_count_connected_nets(pcb_path):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return 5  # baseline
+            return 7  # after pass -- increased
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            mock_count_connected_nets,
+        )
+
+        result = main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "-o",
+                str(output_file),
+            ]
+        )
+
+        # Not a rollback exit code
+        assert result != 3
+
+    def test_no_connectivity_check_flag_skips_check(
+        self, pcb_same_net_vias: Path, report_same_net_drill: Path, tmp_path, capsys, monkeypatch
+    ):
+        """--no-connectivity-check skips the connectivity check entirely."""
+        output_file = tmp_path / "output.kicad_pcb"
+
+        # This mock would trigger rollback, but the flag should prevent it
+        def mock_count_connected_nets(pcb_path):
+            raise AssertionError("Should not be called when --no-connectivity-check is set")
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            mock_count_connected_nets,
+        )
+
+        result = main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "-o",
+                str(output_file),
+                "--no-connectivity-check",
+                "--format",
+                "json",
+            ]
+        )
+
+        # Should succeed without calling the mock
+        assert result == 0
+
+        # No connectivity_check in JSON output
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "connectivity_check" not in data
+
+    def test_dry_run_skips_connectivity_check(
+        self, pcb_same_net_vias: Path, report_same_net_drill: Path, capsys, monkeypatch
+    ):
+        """--dry-run should not perform connectivity checks."""
+
+        def mock_count_connected_nets(pcb_path):
+            raise AssertionError("Should not be called during --dry-run")
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            mock_count_connected_nets,
+        )
+
+        result = main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "--dry-run",
+                "--format",
+                "json",
+            ]
+        )
+
+        # Should succeed without calling the mock
+        assert result in (0, 1, 2)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "connectivity_check" not in data
+
+    def test_connectivity_error_returns_minus_one_skips_rollback(
+        self, pcb_same_net_vias: Path, report_same_net_drill: Path, tmp_path, capsys, monkeypatch
+    ):
+        """When _count_connected_nets returns -1, rollback is skipped."""
+        output_file = tmp_path / "output.kicad_pcb"
+
+        def mock_count_connected_nets(pcb_path):
+            return -1  # Error / unknown
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            mock_count_connected_nets,
+        )
+
+        result = main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "-o",
+                str(output_file),
+            ]
+        )
+
+        # Should not rollback -- exit code should NOT be 3
+        assert result != 3
+
+    def test_json_connectivity_check_per_pass(
+        self, pcb_same_net_vias: Path, report_same_net_drill: Path, tmp_path, capsys, monkeypatch
+    ):
+        """JSON output should show connectivity data per pass when enabled."""
+        output_file = tmp_path / "output.kicad_pcb"
+
+        call_count = 0
+
+        def mock_count_connected_nets(pcb_path):
+            nonlocal call_count
+            call_count += 1
+            return 15  # stable connectivity
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            mock_count_connected_nets,
+        )
+
+        main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "-o",
+                str(output_file),
+                "--format",
+                "json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        assert "connectivity_check" in data
+        passes = data["connectivity_check"]["passes"]
+        assert len(passes) >= 1
+        for p in passes:
+            assert "pass" in p
+            assert "connected_nets_before" in p
+            assert "connected_nets_after" in p
+            assert "rolled_back" in p
+
+    def test_no_repairs_skips_connectivity_check(
+        self, pcb_clearance: Path, report_clearance: Path, capsys, monkeypatch
+    ):
+        """When max-displacement is 0 (no repairs made), connectivity check is skipped."""
+
+        call_count = 0
+
+        def mock_count_connected_nets(pcb_path):
+            nonlocal call_count
+            call_count += 1
+            return 10
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            mock_count_connected_nets,
+        )
+
+        main(
+            [
+                str(pcb_clearance),
+                "--drc-report",
+                str(report_clearance),
+                "--max-displacement",
+                "0",
+                "--format",
+                "json",
+            ]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # The baseline is taken but after_conn is never measured since
+        # repaired_this_pass == 0, so no after value
+        if "connectivity_check" in data:
+            # If present, no rollback should have occurred
+            for p in data["connectivity_check"]["passes"]:
+                assert p["rolled_back"] is False
+
+    def test_pass_result_dataclass_fields(self):
+        """PassResult should have connectivity fields."""
+        pr = PassResult(
+            pass_number=1,
+            violations_before=5,
+            repaired=3,
+            clearance_result=RepairResult(),
+            drill_result=DrillRepairResult(),
+            connectivity_before=10,
+            connectivity_after=8,
+            connectivity_rolled_back=True,
+        )
+        assert pr.connectivity_before == 10
+        assert pr.connectivity_after == 8
+        assert pr.connectivity_rolled_back is True
+
+    def test_pass_result_connectivity_defaults(self):
+        """PassResult connectivity fields default to None/False."""
+        pr = PassResult(
+            pass_number=1,
+            violations_before=5,
+            repaired=3,
+            clearance_result=RepairResult(),
+            drill_result=DrillRepairResult(),
+        )
+        assert pr.connectivity_before is None
+        assert pr.connectivity_after is None
+        assert pr.connectivity_rolled_back is False
+
+
+class TestCountConnectedNets:
+    """Tests for the _count_connected_nets helper."""
+
+    def test_returns_count_for_valid_pcb(self, tmp_path):
+        """Should return a non-negative count for a valid PCB."""
+        from kicad_tools.cli.fix_drc_cmd import _count_connected_nets
+
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_SAME_NET_VIAS)
+
+        result = _count_connected_nets(pcb_file)
+        assert result >= 0
+
+    def test_returns_minus_one_for_invalid_file(self, tmp_path):
+        """Should return -1 for an invalid/unparseable file."""
+        from kicad_tools.cli.fix_drc_cmd import _count_connected_nets
+
+        bad_file = tmp_path / "bad.kicad_pcb"
+        bad_file.write_text("this is not a valid pcb file")
+
+        result = _count_connected_nets(bad_file)
+        assert result == -1
+
+    def test_returns_minus_one_for_nonexistent_file(self, tmp_path):
+        """Should return -1 for a file that does not exist."""
+        from kicad_tools.cli.fix_drc_cmd import _count_connected_nets
+
+        result = _count_connected_nets(tmp_path / "nonexistent.kicad_pcb")
+        assert result == -1


### PR DESCRIPTION
## Summary

After each non-dry-run repair pass in `fix-drc`, run `ConnectivityValidator` on the output file and compare `connected_nets` against the pre-pass baseline. If connectivity decreased (indicating trace endpoints were pushed off pads by aggressive nudging), restore the file from the pre-pass snapshot, warn on stderr, and exit with code 3. This prevents `fix-drc` from silently breaking net connectivity while repairing DRC clearance violations.

## Changes

- Extended `PassResult` dataclass with `connectivity_before`, `connectivity_after`, and `connectivity_rolled_back` fields
- Added `_count_connected_nets()` helper that wraps `ConnectivityValidator` with error handling (returns -1 on failure)
- Added snapshot/rollback logic in the `main()` pass loop: snapshot file bytes before each pass, check connectivity after, rollback if decreased
- Added `--no-connectivity-check` CLI flag to opt out (for boards with no footprints where connectivity is meaningless)
- Added `connectivity_check` section to JSON output showing per-pass before/after net counts and rollback status
- New exit code 3 for connectivity rollback (distinct from 0=all repaired, 1=no progress, 2=partial)
- Updated centralized CLI parser (`parser.py`) and command forwarding (`validation.py`) to support the new flag
- Added 13 new test cases covering: rollback on decrease, stable connectivity, increase allowed, `--no-connectivity-check` bypass, `--dry-run` skip, error handling (-1 return), JSON output format, PassResult dataclass fields, `_count_connected_nets` helper

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| After each non-dry-run pass, ConnectivityValidator runs on output | Pass | Implemented in main loop with `_count_connected_nets()` |
| If connected_nets decreases, file restored and warning printed | Pass | `test_connectivity_decrease_triggers_rollback` verifies rollback, file restore, and stderr warning |
| Rollback exits with non-zero code | Pass | Exit code 3 verified in test |
| `--no-connectivity-check` disables check | Pass | `test_no_connectivity_check_flag_skips_check` uses AssertionError mock to verify function is never called |
| `--dry-run` unaffected | Pass | `test_dry_run_skips_connectivity_check` uses AssertionError mock |
| JSON output includes connectivity_check section | Pass | `test_json_connectivity_check_per_pass` verifies structure |
| Existing test suite passes | Pass | All 83 tests in test_fix_drc_cmd.py pass |
| New tests cover rollback, stable, and bypass scenarios | Pass | 13 new tests added in `TestConnectivityCheckRollback` and `TestCountConnectedNets` classes |

## Test Plan

All 83 tests pass:
```
uv run pytest tests/test_fix_drc_cmd.py -v
============================= 83 passed in 20.04s ==============================
```

Closes #1436