### PR TITLE
fix(deps): add weasyprint to dev extras for complete report pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ dev = [
     "matplotlib>=3.5",
     "jinja2>=3.1",
     "markdown>=3.5",
+    "weasyprint>=60.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -1838,6 +1838,7 @@ dev = [
     { name = "responses" },
     { name = "rtree" },
     { name = "ruff" },
+    { name = "weasyprint" },
 ]
 drc = [
     { name = "rtree" },
@@ -1939,6 +1940,7 @@ requires-dist = [
     { name = "scikit-build-core", marker = "extra == 'native'", specifier = ">=0.8" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "weasyprint", marker = "extra == 'all'", specifier = ">=60.0" },
+    { name = "weasyprint", marker = "extra == 'dev'", specifier = ">=60.0" },
     { name = "weasyprint", marker = "extra == 'report'", specifier = ">=60.0" },
 ]
 provides-extras = ["drc", "parts", "datasheet", "constraints", "mcp", "native", "cuda", "metal", "visualization", "bayesian", "screenshot", "report", "all", "dev"]


### PR DESCRIPTION
## Summary
Add `weasyprint>=60.0` to the `[dev]` optional-dependencies in `pyproject.toml` so that `uv sync --dev` installs all report-generation dependencies. Previously, `jinja2` and `markdown` were included in dev but `weasyprint` was not, causing PDF generation to silently fail after every `uv sync`.

## Changes
- Added `"weasyprint>=60.0"` to the `dev` extras list in `pyproject.toml`
- Updated `uv.lock` to reflect the new dependency

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `weasyprint>=60.0` added to dev extras in `pyproject.toml` | PASS | Line added after `markdown>=3.5` in the `dev` section |
| `uv sync --dev` installs weasyprint | PASS | Ran `uv sync --extra dev` -- weasyprint==68.1 installed successfully |
| Pipeline report tests pass | PASS | 126 report tests passed (1 pre-existing failure on main unrelated to deps) |

## Test Plan
- Ran `uv sync --extra dev` and confirmed `weasyprint==68.1` was installed
- Ran `uv run pytest tests/ -k "report"` -- 126 passed, 1 skipped, 1 pre-existing failure
- Ran `uv run pytest tests/test_pipeline_cmd.py` -- 111 passed, 1 pre-existing failure
- Verified `ruff check` and `ruff format --check` pass on `pyproject.toml`

Closes #1456