### PR TITLE
feat(screenshot): auto-detect Homebrew libcairo on macOS via ctypes preload

### DIFF
--- a/src/kicad_tools/cli/report_cmd.py
+++ b/src/kicad_tools/cli/report_cmd.py
@@ -214,7 +214,11 @@ def _generate_figures(
     except (RuntimeError, OSError) as exc:
         hint = ""
         if isinstance(exc, OSError) and "cairo" in str(exc).lower():
-            hint = " (hint: on macOS set DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib)"
+            hint = (
+                " (hint: auto-detection of Homebrew libcairo was attempted"
+                " but failed — try: DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib"
+                " kct report generate ...)"
+            )
         print(
             f"Warning: figure generation skipped — {exc}{hint}",
             file=sys.stderr,

--- a/src/kicad_tools/mcp/tools/screenshot.py
+++ b/src/kicad_tools/mcp/tools/screenshot.py
@@ -8,8 +8,11 @@ images suitable for vision API consumption.
 from __future__ import annotations
 
 import base64
+import ctypes
 import logging
+import os
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -42,6 +45,71 @@ _FALLBACK_RENDER_PX = 4096
 KICAD_INSTALL_URL = "https://www.kicad.org/download/"
 
 
+def _macos_cairo_lib_dirs() -> list[str]:
+    """Return candidate directories for ``libcairo.dylib`` on macOS.
+
+    Checks ``HOMEBREW_PREFIX`` first, then the well-known Homebrew
+    library paths for Apple Silicon and Intel Macs.  Only directories
+    that actually exist on disk are returned.
+    """
+    candidates: list[str] = []
+    homebrew_prefix = os.environ.get("HOMEBREW_PREFIX")
+    if homebrew_prefix:
+        candidates.append(f"{homebrew_prefix}/lib")
+    candidates.extend(
+        [
+            "/opt/homebrew/lib",  # Apple Silicon
+            "/usr/local/lib",  # Intel
+        ]
+    )
+    # De-duplicate while preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for c in candidates:
+        if c not in seen and Path(c).is_dir():
+            seen.add(c)
+            unique.append(c)
+    return unique
+
+
+def _try_preload_cairo_macos() -> bool:
+    """Attempt to pre-load ``libcairo`` from Homebrew paths on macOS.
+
+    Uses :func:`ctypes.cdll.LoadLibrary` to explicitly load the shared
+    library before ``cairosvg`` tries to find it via the default dynamic
+    linker search.  This is more reliable than setting
+    ``DYLD_FALLBACK_LIBRARY_PATH`` because the env var may not take
+    effect for already-initialised ``dlopen`` state.
+
+    Returns ``True`` if a subsequent cairosvg probe render succeeds
+    after pre-loading the library; ``False`` otherwise.
+    """
+    import cairosvg  # already known importable at this point
+
+    probe_svg = b"<svg xmlns='http://www.w3.org/2000/svg' width='1' height='1'/>"
+
+    for lib_dir in _macos_cairo_lib_dirs():
+        cairo_path = Path(lib_dir) / "libcairo.dylib"
+        if not cairo_path.exists():
+            continue
+        try:
+            ctypes.cdll.LoadLibrary(str(cairo_path))
+            logger.debug("Pre-loaded libcairo from %s", cairo_path)
+        except OSError:
+            logger.debug("Failed to load libcairo from %s", cairo_path)
+            continue
+
+        # Re-attempt the probe render now that the library is loaded.
+        try:
+            cairosvg.svg2png(bytestring=probe_svg)
+            logger.info("Auto-detected cairo library at %s", lib_dir)
+            return True
+        except (OSError, ValueError):
+            continue
+
+    return False
+
+
 def _check_cairosvg() -> bool:
     """Check if cairosvg is available and the native cairo library is loadable.
 
@@ -50,6 +118,11 @@ def _check_cairosvg() -> bool:
     ``OSError`` only fires when ``cairosvg`` actually tries to call into the
     native library.  We therefore do a lightweight probe render to surface
     that failure early, before any real work begins.
+
+    On macOS, if the initial probe fails with ``OSError``, this function
+    attempts to pre-load ``libcairo.dylib`` from common Homebrew
+    installation paths (``/opt/homebrew/lib`` for Apple Silicon,
+    ``/usr/local/lib`` for Intel) before retrying.
     """
     try:
         import cairosvg
@@ -65,7 +138,12 @@ def _check_cairosvg() -> bool:
             bytestring=b"<svg xmlns='http://www.w3.org/2000/svg' width='1' height='1'/>"
         )
         return True
-    except (ImportError, OSError, ValueError):
+    except ImportError:
+        return False
+    except (OSError, ValueError):
+        # On macOS, try pre-loading libcairo from Homebrew paths.
+        if sys.platform == "darwin":
+            return _try_preload_cairo_macos()
         return False
 
 

--- a/tests/test_mcp_screenshot.py
+++ b/tests/test_mcp_screenshot.py
@@ -19,9 +19,11 @@ from kicad_tools.mcp.tools.screenshot import (
     DEFAULT_LAYERS,
     LAYER_PRESETS,
     _check_cairosvg,
+    _macos_cairo_lib_dirs,
     _png_dimensions,
     _resolve_layers,
     _svg_to_png,
+    _try_preload_cairo_macos,
     screenshot_board,
     screenshot_schematic,
 )
@@ -701,3 +703,308 @@ class TestScreenshotSchematicIntegration:
         assert output.exists()
         assert output.stat().st_size > 0
         assert result["output_path"] == str(output)
+
+
+# ---------------------------------------------------------------------------
+# macOS cairo auto-detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestMacosCairoLibDirs:
+    """Tests for _macos_cairo_lib_dirs helper."""
+
+    def test_homebrew_prefix_respected(self, tmp_path):
+        """HOMEBREW_PREFIX env var is included first in candidates."""
+        fake_lib = tmp_path / "lib"
+        fake_lib.mkdir()
+
+        with patch.dict("os.environ", {"HOMEBREW_PREFIX": str(tmp_path)}, clear=False):
+            dirs = _macos_cairo_lib_dirs()
+
+        assert str(fake_lib) in dirs
+        # HOMEBREW_PREFIX entry should be first
+        assert dirs[0] == str(fake_lib)
+
+    def test_deduplicates_when_homebrew_prefix_matches_default(self, tmp_path):
+        """If HOMEBREW_PREFIX/lib matches a default path, no duplicates."""
+        # Use /opt/homebrew as HOMEBREW_PREFIX so its /lib overlaps
+        with patch.dict("os.environ", {"HOMEBREW_PREFIX": "/opt/homebrew"}, clear=False):
+            dirs = _macos_cairo_lib_dirs()
+
+        # /opt/homebrew/lib should appear at most once
+        assert dirs.count("/opt/homebrew/lib") <= 1
+
+    def test_only_existing_dirs_returned(self):
+        """Directories that do not exist on disk are excluded."""
+        with patch.dict("os.environ", {}, clear=False):
+            # Remove HOMEBREW_PREFIX to avoid interference
+            import os
+
+            env = os.environ.copy()
+            env.pop("HOMEBREW_PREFIX", None)
+            with patch.dict("os.environ", env, clear=True):
+                dirs = _macos_cairo_lib_dirs()
+                for d in dirs:
+                    assert Path(d).is_dir()
+
+    def test_returns_empty_when_no_dirs_exist(self):
+        """Returns empty list when none of the candidate dirs exist."""
+        with patch.dict("os.environ", {}, clear=True):
+            with patch("kicad_tools.mcp.tools.screenshot.Path.is_dir", return_value=False):
+                dirs = _macos_cairo_lib_dirs()
+                assert dirs == []
+
+
+class TestTryPreloadCairoMacos:
+    """Tests for _try_preload_cairo_macos helper."""
+
+    def test_succeeds_when_lib_exists_and_probe_passes(self, tmp_path):
+        """Pre-loading from a valid path makes the probe succeed."""
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        dylib_path = lib_dir / "libcairo.dylib"
+        dylib_path.write_bytes(b"fake dylib")
+
+        fake_cairosvg = types.ModuleType("cairosvg")
+        # First call (in _check_cairosvg) raises OSError; after preload succeeds
+        call_count = [0]
+
+        def fake_svg2png(**kwargs):
+            call_count[0] += 1
+            return b"\x89PNG"
+
+        fake_cairosvg.svg2png = fake_svg2png
+
+        with (
+            patch.dict(sys.modules, {"cairosvg": fake_cairosvg}),
+            patch(
+                "kicad_tools.mcp.tools.screenshot._macos_cairo_lib_dirs",
+                return_value=[str(lib_dir)],
+            ),
+            patch("kicad_tools.mcp.tools.screenshot.ctypes.cdll") as mock_cdll,
+        ):
+            mock_cdll.LoadLibrary.return_value = None
+            result = _try_preload_cairo_macos()
+
+        assert result is True
+        mock_cdll.LoadLibrary.assert_called_once_with(str(dylib_path))
+
+    def test_returns_false_when_no_dylib_exists(self, tmp_path):
+        """Returns False when no libcairo.dylib is found in any candidate dir."""
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        # No libcairo.dylib created
+
+        fake_cairosvg = types.ModuleType("cairosvg")
+        fake_cairosvg.svg2png = lambda **kwargs: b"\x89PNG"
+
+        with (
+            patch.dict(sys.modules, {"cairosvg": fake_cairosvg}),
+            patch(
+                "kicad_tools.mcp.tools.screenshot._macos_cairo_lib_dirs",
+                return_value=[str(lib_dir)],
+            ),
+        ):
+            result = _try_preload_cairo_macos()
+
+        assert result is False
+
+    def test_returns_false_when_load_library_fails(self, tmp_path):
+        """Returns False when ctypes.cdll.LoadLibrary raises OSError."""
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        (lib_dir / "libcairo.dylib").write_bytes(b"fake")
+
+        fake_cairosvg = types.ModuleType("cairosvg")
+        fake_cairosvg.svg2png = lambda **kwargs: (_ for _ in ()).throw(OSError("cannot load"))
+
+        with (
+            patch.dict(sys.modules, {"cairosvg": fake_cairosvg}),
+            patch(
+                "kicad_tools.mcp.tools.screenshot._macos_cairo_lib_dirs",
+                return_value=[str(lib_dir)],
+            ),
+            patch("kicad_tools.mcp.tools.screenshot.ctypes.cdll") as mock_cdll,
+        ):
+            mock_cdll.LoadLibrary.side_effect = OSError("bad library")
+            result = _try_preload_cairo_macos()
+
+        assert result is False
+
+    def test_tries_multiple_dirs_on_failure(self, tmp_path):
+        """Tries next directory when first one fails."""
+        dir1 = tmp_path / "dir1"
+        dir1.mkdir()
+        (dir1 / "libcairo.dylib").write_bytes(b"fake")
+
+        dir2 = tmp_path / "dir2"
+        dir2.mkdir()
+        (dir2 / "libcairo.dylib").write_bytes(b"fake")
+
+        fake_cairosvg = types.ModuleType("cairosvg")
+        probe_calls = [0]
+
+        def fake_svg2png(**kwargs):
+            probe_calls[0] += 1
+            if probe_calls[0] == 1:
+                raise OSError("still broken")
+            return b"\x89PNG"
+
+        fake_cairosvg.svg2png = fake_svg2png
+
+        with (
+            patch.dict(sys.modules, {"cairosvg": fake_cairosvg}),
+            patch(
+                "kicad_tools.mcp.tools.screenshot._macos_cairo_lib_dirs",
+                return_value=[str(dir1), str(dir2)],
+            ),
+            patch("kicad_tools.mcp.tools.screenshot.ctypes.cdll") as mock_cdll,
+        ):
+            mock_cdll.LoadLibrary.return_value = None
+            result = _try_preload_cairo_macos()
+
+        assert result is True
+        assert mock_cdll.LoadLibrary.call_count == 2
+
+    def test_returns_false_when_no_candidates(self):
+        """Returns False when _macos_cairo_lib_dirs returns empty list."""
+        fake_cairosvg = types.ModuleType("cairosvg")
+        fake_cairosvg.svg2png = lambda **kwargs: b"\x89PNG"
+
+        with (
+            patch.dict(sys.modules, {"cairosvg": fake_cairosvg}),
+            patch(
+                "kicad_tools.mcp.tools.screenshot._macos_cairo_lib_dirs",
+                return_value=[],
+            ),
+        ):
+            result = _try_preload_cairo_macos()
+
+        assert result is False
+
+
+class TestCheckCairosvgMacosAutoDetect:
+    """Tests for _check_cairosvg macOS auto-detection integration."""
+
+    def test_oserror_on_darwin_triggers_preload(self):
+        """On macOS, OSError from probe triggers _try_preload_cairo_macos."""
+        fake_cairosvg = types.ModuleType("cairosvg")
+        call_count = [0]
+
+        def fake_svg2png(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise OSError("no library called 'cairo-2' was found")
+            return b"\x89PNG"
+
+        fake_cairosvg.svg2png = fake_svg2png
+
+        with (
+            patch.dict(sys.modules, {"cairosvg": fake_cairosvg}),
+            patch("kicad_tools.mcp.tools.screenshot.sys") as mock_sys,
+            patch(
+                "kicad_tools.mcp.tools.screenshot._try_preload_cairo_macos",
+                return_value=True,
+            ) as mock_preload,
+        ):
+            mock_sys.platform = "darwin"
+            result = _check_cairosvg()
+
+        assert result is True
+        mock_preload.assert_called_once()
+
+    def test_oserror_on_linux_does_not_trigger_preload(self):
+        """On Linux, OSError from probe returns False without attempting preload."""
+        fake_cairosvg = types.ModuleType("cairosvg")
+
+        def raise_os_error(**kwargs):
+            raise OSError("no library called 'cairo-2' was found")
+
+        fake_cairosvg.svg2png = raise_os_error
+
+        with (
+            patch.dict(sys.modules, {"cairosvg": fake_cairosvg}),
+            patch("kicad_tools.mcp.tools.screenshot.sys") as mock_sys,
+            patch(
+                "kicad_tools.mcp.tools.screenshot._try_preload_cairo_macos",
+            ) as mock_preload,
+        ):
+            mock_sys.platform = "linux"
+            result = _check_cairosvg()
+
+        assert result is False
+        mock_preload.assert_not_called()
+
+    def test_import_error_returns_false_without_preload(self):
+        """ImportError returns False without any macOS preload attempt."""
+        with (
+            patch.dict(sys.modules, {"cairosvg": None}),
+            patch(
+                "kicad_tools.mcp.tools.screenshot._try_preload_cairo_macos",
+            ) as mock_preload,
+        ):
+            result = _check_cairosvg()
+
+        assert result is False
+        mock_preload.assert_not_called()
+
+    def test_successful_probe_does_not_trigger_preload(self):
+        """When probe succeeds initially, no preload is attempted."""
+        fake_cairosvg = types.ModuleType("cairosvg")
+        fake_cairosvg.svg2png = lambda **kwargs: b"\x89PNG"
+
+        with (
+            patch.dict(sys.modules, {"cairosvg": fake_cairosvg}),
+            patch(
+                "kicad_tools.mcp.tools.screenshot._try_preload_cairo_macos",
+            ) as mock_preload,
+        ):
+            result = _check_cairosvg()
+
+        assert result is True
+        mock_preload.assert_not_called()
+
+    def test_value_error_on_darwin_triggers_preload(self):
+        """On macOS, ValueError from probe also triggers auto-detection."""
+        fake_cairosvg = types.ModuleType("cairosvg")
+
+        def raise_value_error(**kwargs):
+            raise ValueError("The SVG size is undefined")
+
+        fake_cairosvg.svg2png = raise_value_error
+
+        with (
+            patch.dict(sys.modules, {"cairosvg": fake_cairosvg}),
+            patch("kicad_tools.mcp.tools.screenshot.sys") as mock_sys,
+            patch(
+                "kicad_tools.mcp.tools.screenshot._try_preload_cairo_macos",
+                return_value=False,
+            ) as mock_preload,
+        ):
+            mock_sys.platform = "darwin"
+            result = _check_cairosvg()
+
+        assert result is False
+        mock_preload.assert_called_once()
+
+    def test_preload_failure_returns_false(self):
+        """When preload attempt fails, _check_cairosvg returns False."""
+        fake_cairosvg = types.ModuleType("cairosvg")
+
+        def raise_os_error(**kwargs):
+            raise OSError("no library called 'cairo-2' was found")
+
+        fake_cairosvg.svg2png = raise_os_error
+
+        with (
+            patch.dict(sys.modules, {"cairosvg": fake_cairosvg}),
+            patch("kicad_tools.mcp.tools.screenshot.sys") as mock_sys,
+            patch(
+                "kicad_tools.mcp.tools.screenshot._try_preload_cairo_macos",
+                return_value=False,
+            ),
+        ):
+            mock_sys.platform = "darwin"
+            result = _check_cairosvg()
+
+        assert result is False


### PR DESCRIPTION
## Summary
On macOS with Homebrew-installed cairo, `_check_cairosvg()` fails silently because `libcairo.dylib` is not on the default dynamic linker search path. This PR adds automatic detection and pre-loading of the library from known Homebrew paths using `ctypes.cdll.LoadLibrary()`, eliminating the need for users to manually set `DYLD_FALLBACK_LIBRARY_PATH`.

## Changes
- Add `_macos_cairo_lib_dirs()` helper that returns existing Homebrew library directories, respecting `HOMEBREW_PREFIX` and supporting both Apple Silicon (`/opt/homebrew/lib`) and Intel (`/usr/local/lib`) paths
- Add `_try_preload_cairo_macos()` which uses `ctypes.cdll.LoadLibrary()` to explicitly load `libcairo.dylib` before retrying the cairosvg probe render
- Modify `_check_cairosvg()` to call `_try_preload_cairo_macos()` on `OSError`/`ValueError` when `sys.platform == "darwin"`, leaving non-macOS behavior unchanged
- Update the hint message in `report_cmd.py` to note that auto-detection was attempted but failed
- Add 16 new unit tests covering all helper functions, edge cases, and platform-specific behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| On macOS with Homebrew cairo, `_check_cairosvg()` auto-detects and loads the native library | PASS | `_try_preload_cairo_macos()` uses `ctypes.cdll.LoadLibrary()` to pre-load from Homebrew paths before retrying probe |
| Both Apple Silicon and Intel paths are tried | PASS | `_macos_cairo_lib_dirs()` includes `/opt/homebrew/lib` and `/usr/local/lib` |
| `HOMEBREW_PREFIX` env var is respected if set | PASS | `_macos_cairo_lib_dirs()` checks `HOMEBREW_PREFIX` first and includes it at highest priority |
| On non-macOS platforms, behavior is unchanged | PASS | `sys.platform == "darwin"` guard; tested with `test_oserror_on_linux_does_not_trigger_preload` |
| If auto-detection fails, hint message is still shown | PASS | Updated hint in `report_cmd.py` now notes auto-detection was attempted |
| Log message emitted when auto-detection succeeds | PASS | `logger.info("Auto-detected cairo library at %s", lib_dir)` in `_try_preload_cairo_macos()` |

## Test Plan
- 63 tests pass across `test_mcp_screenshot.py` and `test_report_figures.py` (11 integration tests skipped for missing kicad-cli)
- 16 new tests added covering: `_macos_cairo_lib_dirs` (4 tests), `_try_preload_cairo_macos` (5 tests), `_check_cairosvg` macOS integration (6 tests)
- Pre-existing failures in `test_report_cmd.py` confirmed unrelated (same failures on main)

Closes #1457