### PR TITLE
fix(pipeline): use audit step result for summary verdict instead of DRC-only

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -921,13 +921,62 @@ def _print_final_summary(
     else:
         erc_line = erc_result.message
 
+    # --- Audit ---
+    audit_result = next(
+        (r for r in results if r.step == PipelineStep.AUDIT or r.step == PipelineStep.AUDIT.value),
+        None,
+    )
+
     # --- Verdict ---
-    if error_count == 0:
-        verdict = "[green]READY[/green] -- board passes DRC"
-    elif error_count > 0:
-        verdict = f"[red]NOT READY[/red] -- {error_count} DRC error(s) to resolve"
+    # When the AUDIT step ran, its success/failure reflects the full audit
+    # verdict (ERC, DRC, connectivity, manufacturer compatibility).  Use it
+    # as the authoritative source so the pipeline summary matches the audit.
+    if audit_result is not None and not audit_result.skipped:
+        if audit_result.success:
+            # Audit passed -- distinguish READY from WARNING.
+            # Check for DRC/ERC warnings to surface a WARNING verdict.
+            has_drc_warnings = (
+                check_data is not None and check_data.get("summary", {}).get("warnings", 0) > 0
+            )
+            erc_has_warnings = (
+                erc_result is not None
+                and not erc_result.skipped
+                and (
+                    "non-blocking" in erc_result.message.lower()
+                    or (erc_result.warning and erc_result.success)
+                )
+            )
+            if has_drc_warnings or erc_has_warnings:
+                verdict = (
+                    "[yellow]WARNING[/yellow] -- audit passed with warnings (review recommended)"
+                )
+            else:
+                verdict = "[green]READY[/green] -- audit passed"
+        else:
+            # Audit failed -- collect failure reasons from individual steps.
+            reasons: list[str] = []
+            if error_count > 0:
+                reasons.append(f"{error_count} DRC error(s)")
+            if erc_result is not None and not erc_result.skipped and not erc_result.success:
+                reasons.append("ERC errors")
+            if not reasons:
+                reasons.append("see audit output above")
+            verdict = f"[red]NOT READY[/red] -- {', '.join(reasons)}"
     else:
-        verdict = "unknown -- could not determine DRC status"
+        # Audit step did not run -- fall back to DRC + ERC heuristics.
+        erc_failed = erc_result is not None and not erc_result.skipped and not erc_result.success
+        if error_count == 0 and not erc_failed:
+            verdict = "[green]READY[/green] -- board passes DRC"
+        elif error_count > 0 and erc_failed:
+            verdict = (
+                f"[red]NOT READY[/red] -- {error_count} DRC error(s) and ERC errors to resolve"
+            )
+        elif error_count > 0:
+            verdict = f"[red]NOT READY[/red] -- {error_count} DRC error(s) to resolve"
+        elif erc_failed:
+            verdict = "[red]NOT READY[/red] -- ERC errors to resolve"
+        else:
+            verdict = "unknown -- could not determine DRC status"
 
     console.print()
     console.print("[bold]Summary:[/bold]")

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -2739,6 +2739,290 @@ class TestPrintFinalSummary:
         assert "Silkscreen: 0 warnings" in output
 
 
+class TestVerdictMatchesAudit:
+    """Tests that the pipeline verdict uses the audit step result when available.
+
+    Issue #1443: The verdict was derived solely from DRC error count, ignoring
+    ERC, connectivity, and manufacturer compatibility.  When the AUDIT step ran
+    its success/failure should drive the verdict instead.
+    """
+
+    def _make_console(self):
+        from io import StringIO
+
+        from rich.console import Console
+
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=False, no_color=True)
+        return console, buf
+
+    # -- Audit-driven verdicts --
+
+    def test_audit_passed_shows_ready(self, routed_pcb: Path):
+        """When audit step succeeds with no warnings, verdict is READY."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        results = [
+            PipelineResult(step=PipelineStep.ERC, success=True, message="erc: no violations found"),
+            PipelineResult(
+                step=PipelineStep.AUDIT, success=True, message="audit: completed successfully"
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "READY" in output
+        assert "audit passed" in output
+        assert "NOT READY" not in output
+
+    def test_audit_failed_shows_not_ready(self, routed_pcb: Path):
+        """When audit step fails, verdict is NOT READY."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        results = [
+            PipelineResult(step=PipelineStep.ERC, success=True, message="erc: no violations found"),
+            PipelineResult(
+                step=PipelineStep.AUDIT, success=False, message="audit: failed: exit code 1"
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "NOT READY" in output
+
+    def test_audit_failed_with_drc_errors_shows_drc_reason(self, routed_pcb: Path):
+        """When audit fails and DRC has errors, verdict mentions DRC errors."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 3, "warnings": 0, "rules_checked": 5, "passed": False},
+            "violations": [
+                {"type": "clearance", "severity": "error", "message": "v1"},
+                {"type": "clearance", "severity": "error", "message": "v2"},
+                {"type": "clearance", "severity": "error", "message": "v3"},
+            ],
+        }
+        results = [
+            PipelineResult(step=PipelineStep.ERC, success=True, message="erc: no violations found"),
+            PipelineResult(
+                step=PipelineStep.AUDIT, success=False, message="audit: failed: exit code 1"
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "NOT READY" in output
+        assert "3 DRC error(s)" in output
+
+    def test_audit_failed_with_drc_and_erc_errors(self, routed_pcb: Path):
+        """When audit fails with both DRC and ERC errors, both are listed."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 2, "warnings": 0, "rules_checked": 5, "passed": False},
+            "violations": [
+                {"type": "clearance", "severity": "error", "message": "v1"},
+                {"type": "clearance", "severity": "error", "message": "v2"},
+            ],
+        }
+        results = [
+            PipelineResult(
+                step=PipelineStep.ERC,
+                success=False,
+                message="erc: 3 blocking error(s) found",
+            ),
+            PipelineResult(
+                step=PipelineStep.AUDIT, success=False, message="audit: failed: exit code 1"
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "NOT READY" in output
+        assert "2 DRC error(s)" in output
+        assert "ERC errors" in output
+
+    def test_audit_failed_no_drc_or_erc_errors_shows_see_above(self, routed_pcb: Path):
+        """When audit fails but DRC/ERC are fine, verdict says see audit output."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        results = [
+            PipelineResult(step=PipelineStep.ERC, success=True, message="erc: no violations found"),
+            PipelineResult(
+                step=PipelineStep.AUDIT, success=False, message="audit: failed: exit code 1"
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "NOT READY" in output
+        assert "see audit output above" in output
+
+    def test_audit_passed_with_drc_warnings_shows_warning(self, routed_pcb: Path):
+        """When audit passes but DRC has warnings, verdict is WARNING."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 2, "rules_checked": 5, "passed": True},
+            "violations": [
+                {"type": "silk_overlap", "severity": "warning", "message": "s1"},
+                {"type": "clearance", "severity": "warning", "message": "c1"},
+            ],
+        }
+        results = [
+            PipelineResult(step=PipelineStep.ERC, success=True, message="erc: no violations found"),
+            PipelineResult(
+                step=PipelineStep.AUDIT, success=True, message="audit: completed successfully"
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "WARNING" in output
+        assert "audit passed with warnings" in output
+        assert "NOT READY" not in output
+
+    def test_audit_passed_with_erc_warnings_shows_warning(self, routed_pcb: Path):
+        """When audit passes but ERC has non-blocking warnings, verdict is WARNING."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        results = [
+            PipelineResult(
+                step=PipelineStep.ERC,
+                success=True,
+                message="erc: 2 non-blocking error(s) as warning(s)",
+            ),
+            PipelineResult(
+                step=PipelineStep.AUDIT, success=True, message="audit: completed successfully"
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "WARNING" in output
+        assert "audit passed with warnings" in output
+        assert "NOT READY" not in output
+
+    def test_audit_skipped_falls_back_to_drc_only(self, routed_pcb: Path):
+        """When audit step was skipped, verdict falls back to DRC heuristic."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        results = [
+            PipelineResult(step=PipelineStep.ERC, success=True, message="erc: no violations found"),
+            PipelineResult(
+                step=PipelineStep.AUDIT,
+                success=True,
+                message="audit: skipped",
+                skipped=True,
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "READY" in output
+        assert "board passes DRC" in output
+
+    # -- Fallback verdicts (no audit step) --
+
+    def test_no_audit_erc_fail_drc_pass_shows_not_ready(self, routed_pcb: Path):
+        """Without audit, ERC failure alone yields NOT READY (previously READY bug)."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        results = [
+            PipelineResult(
+                step=PipelineStep.ERC,
+                success=False,
+                message="erc: 3 blocking error(s) found",
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "NOT READY" in output
+        assert "ERC errors to resolve" in output
+
+    def test_no_audit_both_drc_and_erc_fail(self, routed_pcb: Path):
+        """Without audit, both DRC and ERC failures are mentioned."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 2, "warnings": 0, "rules_checked": 5, "passed": False},
+            "violations": [
+                {"type": "clearance", "severity": "error", "message": "v1"},
+                {"type": "clearance", "severity": "error", "message": "v2"},
+            ],
+        }
+        results = [
+            PipelineResult(
+                step=PipelineStep.ERC,
+                success=False,
+                message="erc: 3 blocking error(s) found",
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "NOT READY" in output
+        assert "2 DRC error(s) and ERC errors to resolve" in output
+
+    def test_no_audit_drc_pass_erc_skipped_shows_ready(self, routed_pcb: Path):
+        """Without audit, DRC pass and ERC skipped yields READY."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        results = [
+            PipelineResult(
+                step=PipelineStep.ERC,
+                success=True,
+                message="erc: skipped",
+                skipped=True,
+            ),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers=2)
+
+        _print_final_summary(ctx, results, console, check_data=check_data)
+        output = buf.getvalue()
+
+        assert "READY" in output
+        assert "board passes DRC" in output
+
+
 class TestFinalSummaryIntegration:
     """Integration tests for final summary in run_pipeline."""
 


### PR DESCRIPTION
## Summary
The pipeline's `_print_final_summary()` verdict was derived solely from the DRC error count, ignoring ERC status, connectivity, and manufacturer compatibility. This caused the pipeline to show "READY" even when the audit step reported "NOT READY" due to non-DRC failures. Now the AUDIT step's success/failure drives the verdict when it ran, with a fallback to DRC+ERC heuristics when it did not.

## Changes
- Modified verdict logic in `_print_final_summary()` to check for the AUDIT step result first
- When AUDIT ran and succeeded: show READY (or WARNING if DRC/ERC warnings exist)
- When AUDIT ran and failed: show NOT READY with specific failure reasons (DRC errors, ERC errors, or "see audit output above" for connectivity/manufacturer issues)
- When AUDIT did not run: fall back to DRC + ERC heuristics (existing DRC-only behavior plus new ERC failure detection)
- Added 11 new tests covering all verdict paths (audit-driven and fallback)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pipeline verdict matches audit verdict when both run | Pass | `test_audit_passed_shows_ready` and `test_audit_failed_shows_not_ready` verify audit result drives verdict |
| READY shown only when DRC, ERC, connectivity, mfr all pass | Pass | Audit success=True means all checks passed; `test_audit_passed_shows_ready` confirms |
| NOT READY shown when any check fails | Pass | `test_audit_failed_*` tests confirm NOT READY for various failure combos |
| WARNING verdict for non-blocking warnings | Pass | `test_audit_passed_with_drc_warnings_shows_warning` and `test_audit_passed_with_erc_warnings_shows_warning` confirm |
| Verdict text indicates which check(s) failed | Pass | `test_audit_failed_with_drc_and_erc_errors` confirms "2 DRC error(s), ERC errors" |
| Audit skipped falls back to DRC-only | Pass | `test_audit_skipped_falls_back_to_drc_only` confirms existing behavior preserved |
| Fallback also considers ERC failures | Pass | `test_no_audit_erc_fail_drc_pass_shows_not_ready` confirms ERC-only failure caught |

## Test Plan
- Ran `uv run pytest tests/test_pipeline_cmd.py::TestPrintFinalSummary tests/test_pipeline_cmd.py::TestVerdictMatchesAudit tests/test_pipeline_cmd.py::TestFinalSummaryIntegration` -- 28 passed
- Ran `uv run ruff check` and `uv run ruff format --check` on changed files -- clean

Closes #1443