### PR TITLE
feat(route): enhance partial routing output with actionable suggestions

### DIFF
--- a/src/kicad_tools/router/output.py
+++ b/src/kicad_tools/router/output.py
@@ -333,9 +333,10 @@ def show_routing_summary(
         if suggestions_shown == 0:
             num_layers = getattr(router.grid, "num_layers", 2)
             suggestion_num = 0
+            pcb_arg = f" {pcb_file}" if pcb_file else ""
             all_strategies = {
-                "negotiated": "Try negotiated routing: kct route --strategy negotiated",
-                "monte-carlo": "Try Monte Carlo routing: kct route --strategy monte-carlo --mc-trials 20",
+                "negotiated": f"Try negotiated routing: kct route{pcb_arg} --strategy negotiated",
+                "monte-carlo": f"Try Monte Carlo routing: kct route{pcb_arg} --strategy monte-carlo --mc-trials 20",
             }
             for strategy_name, suggestion_text in all_strategies.items():
                 if strategy_name != current_strategy:
@@ -343,19 +344,37 @@ def show_routing_summary(
                     print(f"{suggestion_num}. {suggestion_text}")
             if num_layers <= 2:
                 suggestion_num += 1
-                print(f"{suggestion_num}. Consider 4-layer routing: kct route --layers 4-all")
+                print(f"{suggestion_num}. Consider 4-layer routing: kct route{pcb_arg} --layers 4-all")
 
-        # Always suggest --auto-layers when routing on fewer than 4 layers with failures
+        # Layer escalation recommendation with percentage-based threshold
         num_layers = getattr(router.grid, "num_layers", 2)
-        if num_layers < 4:
-            failed_count = len(unrouted_ids)
-            failure_pct = failed_count / nets_to_route * 100 if nets_to_route > 0 else 0
-            pcb_arg = f" {pcb_file}" if pcb_file else ""
+        failed_count = len(unrouted_ids)
+        failure_pct = failed_count / nets_to_route * 100 if nets_to_route > 0 else 0
+        pcb_arg = f" {pcb_file}" if pcb_file else ""
+
+        if num_layers < 4 and failure_pct > 20:
+            print(f"\n{'=' * 60}")
+            print(
+                f"RECOMMENDATION: {failed_count}/{nets_to_route} nets "
+                f"({failure_pct:.0f}%) failed on {num_layers} layers."
+            )
+            print(f"  Try: kct route{pcb_arg} --auto-layers")
+            print(f"  Or:  kct route{pcb_arg} --layers 4")
+        elif num_layers < 4:
             print(
                 f"\nTip: {failed_count}/{nets_to_route} nets failed on {num_layers} layers "
                 f"({failure_pct:.0f}% failure rate)."
             )
             print(f"Try automatic layer escalation: kct route{pcb_arg} --auto-layers")
+
+        # Strategy suggestion: surface monte-carlo when using negotiated
+        if current_strategy == "negotiated":
+            print("\nTip: Try randomized net ordering for better results:")
+            print(f"  kct route{pcb_arg} --strategy monte-carlo --mc-trials 20")
+
+        # Export failed nets suggestion
+        print("\nTip: Export failed net names for manual routing in KiCad:")
+        print(f"  kct route{pcb_arg} --export-failed-nets failed_nets.txt")
 
     print(f"\n{'=' * 60}")
 
@@ -538,6 +557,43 @@ def get_routing_diagnostics_json(
         for strategy_name, suggestion in all_strategy_suggestions.items():
             if strategy_name != current_strategy:
                 suggestions.append(suggestion)
+
+    # Layer escalation recommendation when >20% failure on < 4 layers
+    failure_pct = len(unrouted_ids) / nets_to_route * 100 if nets_to_route > 0 else 0
+    if num_layers < 4 and failure_pct > 20:
+        suggestions.append(
+            {
+                "category": "LAYER_ESCALATION",
+                "description": (
+                    f"{len(unrouted_ids)}/{nets_to_route} nets ({failure_pct:.0f}%) "
+                    f"failed on {num_layers} layers"
+                ),
+                "fix": "--auto-layers",
+            }
+        )
+
+    # Surface monte-carlo suggestion when using negotiated strategy
+    if current_strategy == "negotiated":
+        # Only add if not already suggested via cause-specific logic
+        mc_already_suggested = any("monte-carlo" in s.get("fix", "") for s in suggestions)
+        if not mc_already_suggested:
+            suggestions.append(
+                {
+                    "category": "STRATEGY",
+                    "description": "Try randomized net ordering for better results",
+                    "fix": "--strategy monte-carlo --mc-trials 20",
+                }
+            )
+
+    # Always suggest --export-failed-nets when there are unrouted nets
+    if unrouted_ids:
+        suggestions.append(
+            {
+                "category": "EXPORT",
+                "description": "Export failed net names for manual routing in KiCad",
+                "fix": "--export-failed-nets failed_nets.txt",
+            }
+        )
 
     return {
         "summary": {

--- a/tests/test_partial_routing_features.py
+++ b/tests/test_partial_routing_features.py
@@ -59,7 +59,8 @@ class TestAutoLayersSuggestion:
         text = output.getvalue()
         assert "--auto-layers" in text
         assert "board.kicad_pcb" in text
-        assert "2/4 nets failed" in text
+        assert "2/4 nets" in text
+        assert "failed on 2 layers" in text
 
     def test_auto_layers_suggestion_not_shown_on_4_layer_board(self):
         """Suggestion does NOT appear when already using 4+ layers."""
@@ -118,8 +119,9 @@ class TestAutoLayersSuggestion:
             )
 
         text = output.getvalue()
-        assert "3/10 nets failed" in text
-        assert "30% failure rate" in text
+        assert "3/10 nets" in text
+        assert "30%" in text
+        assert "failed on 2 layers" in text
 
     def test_auto_layers_suggestion_without_pcb_file(self):
         """Suggestion works without pcb_file (no filename in command)."""

--- a/tests/test_route_exit_codes.py
+++ b/tests/test_route_exit_codes.py
@@ -1,4 +1,4 @@
-"""Tests for route command exit codes (issue #1301, #1413).
+"""Tests for route command exit codes (issue #1301, #1413, #1454).
 
 Exit code semantics:
   0 = All nets routed AND (DRC passed OR DRC not run)
@@ -7,6 +7,10 @@ Exit code semantics:
       (also used for SIGINT partial save)
   3 = All nets routed but DRC violations detected
 """
+
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -245,3 +249,236 @@ class TestRouteExitCodeDocumentation:
                             f"DRC-only failure should return 3, found: {lines[j].strip()}"
                         )
                         break
+
+
+# ---------------------------------------------------------------------------
+# Partial routing output suggestions (issue #1454)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_route(net_id: int):
+    """Create a minimal mock Route object for output tests."""
+    route = MagicMock()
+    route.net = net_id
+    route.segments = []
+    route.vias = []
+    return route
+
+
+def _make_mock_router(routed_nets, num_layers=2, routing_failures=None):
+    """Create a mock Autorouter for output tests."""
+    router = MagicMock()
+    router.routes = [_make_mock_route(nid) for nid in routed_nets]
+    router.routing_failures = routing_failures or []
+    router.grid = SimpleNamespace(num_layers=num_layers, resolution=0.25)
+    return router
+
+
+class TestPartialRoutingSuggestions:
+    """Tests that partial routing output surfaces existing capabilities (issue #1454).
+
+    When routing completes partially (exit code 2), the output should include:
+    - Percentage-based layer escalation recommendation with exact commands
+    - Mention of --export-failed-nets option
+    - Suggestion of --strategy monte-carlo when current strategy is negotiated
+    - --auto-layers suggestion when on 2 layers with >20% failure rate
+    - Copy-pasteable commands with the current PCB file path
+    """
+
+    def test_auto_layers_recommendation_above_20_pct_failure(self):
+        """When >20% of nets fail on 2 layers, output includes RECOMMENDATION block."""
+        from kicad_tools.router.output import show_routing_summary
+
+        # 16/58 nets failed = 28% failure rate (mirrors the softstart scenario)
+        net_map = {f"Net{i}": i for i in range(1, 59)}
+        router = _make_mock_router(routed_nets=list(range(1, 43)), num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=58,
+                quiet=False,
+                pcb_file="softstart.kicad_pcb",
+            )
+
+        text = output.getvalue()
+        assert "RECOMMENDATION" in text
+        assert "16/58" in text
+        assert "28%" in text
+        assert "kct route softstart.kicad_pcb --auto-layers" in text
+        assert "kct route softstart.kicad_pcb --layers 4" in text
+
+    def test_auto_layers_tip_below_20_pct_failure(self):
+        """When <=20% of nets fail on 2 layers, output shows Tip instead of RECOMMENDATION."""
+        from kicad_tools.router.output import show_routing_summary
+
+        # 1/10 nets failed = 10% failure rate
+        net_map = {f"Net{i}": i for i in range(1, 11)}
+        router = _make_mock_router(routed_nets=list(range(1, 10)), num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=10,
+                quiet=False,
+                pcb_file="board.kicad_pcb",
+            )
+
+        text = output.getvalue()
+        assert "RECOMMENDATION" not in text
+        assert "Tip:" in text
+        assert "--auto-layers" in text
+
+    def test_export_failed_nets_mentioned_in_partial_output(self):
+        """Partial routing output mentions --export-failed-nets option."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {"A": 1, "B": 2, "C": 3}
+        router = _make_mock_router(routed_nets=[1], num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=3,
+                quiet=False,
+                pcb_file="board.kicad_pcb",
+            )
+
+        text = output.getvalue()
+        assert "--export-failed-nets" in text
+        assert "kct route board.kicad_pcb --export-failed-nets" in text
+
+    def test_monte_carlo_suggested_when_negotiated(self):
+        """When current strategy is negotiated, output suggests monte-carlo."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {"A": 1, "B": 2, "C": 3}
+        router = _make_mock_router(routed_nets=[1], num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=3,
+                quiet=False,
+                current_strategy="negotiated",
+                pcb_file="board.kicad_pcb",
+            )
+
+        text = output.getvalue()
+        assert "--strategy monte-carlo --mc-trials 20" in text
+        assert "kct route board.kicad_pcb --strategy monte-carlo" in text
+
+    def test_no_escalation_recommendation_when_all_routed(self):
+        """Full routing success (exit code 0) does NOT show escalation recommendations."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {"A": 1, "B": 2}
+        router = _make_mock_router(routed_nets=[1, 2], num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=2,
+                quiet=False,
+            )
+
+        text = output.getvalue()
+        assert "RECOMMENDATION" not in text
+        assert "--auto-layers" not in text
+        assert "--export-failed-nets" not in text
+
+    def test_suggestions_include_pcb_file_path(self):
+        """All copy-pasteable commands include the PCB file path."""
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {"A": 1, "B": 2, "C": 3, "D": 4}
+        router = _make_mock_router(routed_nets=[1], num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=4,
+                quiet=False,
+                pcb_file="my_board.kicad_pcb",
+            )
+
+        text = output.getvalue()
+        # Check that command suggestions include the PCB file path
+        assert "kct route my_board.kicad_pcb --auto-layers" in text
+        assert "kct route my_board.kicad_pcb --export-failed-nets" in text
+
+    def test_json_diagnostics_includes_layer_escalation(self):
+        """JSON diagnostics includes LAYER_ESCALATION when >20% failure on 2 layers."""
+        from kicad_tools.router.output import get_routing_diagnostics_json
+
+        # 3/4 nets failed = 75% failure rate
+        net_map = {"A": 1, "B": 2, "C": 3, "D": 4}
+        router = _make_mock_router(routed_nets=[1], num_layers=2)
+
+        result = get_routing_diagnostics_json(
+            router, net_map, nets_to_route=4, current_strategy="basic"
+        )
+
+        suggestions = result.get("suggestions", [])
+        escalation = [s for s in suggestions if s.get("category") == "LAYER_ESCALATION"]
+        assert len(escalation) == 1
+        assert "--auto-layers" in escalation[0]["fix"]
+        assert "75%" in escalation[0]["description"]
+
+    def test_json_diagnostics_includes_export_suggestion(self):
+        """JSON diagnostics includes EXPORT suggestion when nets fail."""
+        from kicad_tools.router.output import get_routing_diagnostics_json
+
+        net_map = {"A": 1, "B": 2}
+        router = _make_mock_router(routed_nets=[1], num_layers=2)
+
+        result = get_routing_diagnostics_json(
+            router, net_map, nets_to_route=2, current_strategy="basic"
+        )
+
+        suggestions = result.get("suggestions", [])
+        export_suggestions = [s for s in suggestions if s.get("category") == "EXPORT"]
+        assert len(export_suggestions) == 1
+        assert "--export-failed-nets" in export_suggestions[0]["fix"]
+
+    def test_json_diagnostics_no_export_when_all_routed(self):
+        """JSON diagnostics does NOT include EXPORT suggestion when all nets routed."""
+        from kicad_tools.router.output import get_routing_diagnostics_json
+
+        net_map = {"A": 1, "B": 2}
+        router = _make_mock_router(routed_nets=[1, 2], num_layers=2)
+
+        result = get_routing_diagnostics_json(
+            router, net_map, nets_to_route=2, current_strategy="basic"
+        )
+
+        suggestions = result.get("suggestions", [])
+        export_suggestions = [s for s in suggestions if s.get("category") == "EXPORT"]
+        assert len(export_suggestions) == 0
+
+    def test_json_monte_carlo_surfaced_when_negotiated(self):
+        """JSON diagnostics surfaces monte-carlo when current strategy is negotiated."""
+        from kicad_tools.router.output import get_routing_diagnostics_json
+
+        net_map = {"A": 1, "B": 2}
+        router = _make_mock_router(routed_nets=[1], num_layers=2)
+
+        result = get_routing_diagnostics_json(
+            router, net_map, nets_to_route=2, current_strategy="negotiated"
+        )
+
+        suggestions = result.get("suggestions", [])
+        mc_suggestions = [s for s in suggestions if "monte-carlo" in s.get("fix", "")]
+        assert len(mc_suggestions) >= 1


### PR DESCRIPTION
## Summary
Enhance partial routing output to surface existing capabilities more prominently. When routing completes partially (exit code 2), the output now includes percentage-based layer escalation recommendations, mentions `--export-failed-nets`, and suggests `--strategy monte-carlo` -- all with copy-pasteable commands including the PCB file path.

## Changes
- Add RECOMMENDATION block when >20% of nets fail on 2 layers (vs. generic Tip for lower failure rates)
- Add `--export-failed-nets` suggestion in all partial routing text output
- Surface `--strategy monte-carlo --mc-trials 20` when current strategy is `negotiated`
- Include PCB file path in all copy-pasteable command suggestions
- Add LAYER_ESCALATION, EXPORT, and STRATEGY suggestions to JSON diagnostics output
- Add 10 new tests covering all acceptance criteria
- Update 2 existing tests to match the enhanced output format

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Partial routing output includes percentage-based layer escalation recommendation with exact commands | Pass | `test_auto_layers_recommendation_above_20_pct_failure` verifies RECOMMENDATION block with 16/58 (28%) scenario |
| Partial routing output mentions `--export-failed-nets` | Pass | `test_export_failed_nets_mentioned_in_partial_output` verifies presence |
| Partial routing output suggests `--strategy monte-carlo` when current strategy is `negotiated` | Pass | `test_monte_carlo_suggested_when_negotiated` verifies |
| Partial routing output suggests `--auto-layers` when on 2 layers with >20% failure rate | Pass | `test_auto_layers_recommendation_above_20_pct_failure` verifies RECOMMENDATION format; `test_auto_layers_tip_below_20_pct_failure` verifies Tip format for lower rates |
| All suggestions include copy-pasteable commands with the current PCB file path | Pass | `test_suggestions_include_pcb_file_path` verifies |
| Full routing success does NOT show escalation recommendations | Pass | `test_no_escalation_recommendation_when_all_routed` verifies |
| JSON diagnostics includes LAYER_ESCALATION, EXPORT, and monte-carlo suggestions | Pass | `test_json_diagnostics_includes_layer_escalation`, `test_json_diagnostics_includes_export_suggestion`, `test_json_monte_carlo_surfaced_when_negotiated` |

## Test Plan
- All 64 tests in `test_route_exit_codes.py`, `test_routing_output.py`, and `test_partial_routing_features.py` pass
- 10 new tests added to `TestPartialRoutingSuggestions` class in `test_route_exit_codes.py`
- 2 existing tests updated in `test_partial_routing_features.py` to match enhanced output format
- Ruff lint and format checks pass on all changed files

Closes #1454