### PR TITLE
feat(fix-drc): handle clearance_pad_segment and clearance_pad_via violations

### DIFF
--- a/src/kicad_tools/cli/fix_drc_cmd.py
+++ b/src/kicad_tools/cli/fix_drc_cmd.py
@@ -188,6 +188,8 @@ Examples:
             (
                 report.by_type(ViolationType.CLEARANCE)
                 + report.by_type(ViolationType.CLEARANCE_SEGMENT_VIA)
+                + report.by_type(ViolationType.CLEARANCE_PAD_SEGMENT)
+                + report.by_type(ViolationType.CLEARANCE_PAD_VIA)
             )
             if do_clearance
             else []

--- a/src/kicad_tools/drc/repair_clearance.py
+++ b/src/kicad_tools/drc/repair_clearance.py
@@ -172,7 +172,11 @@ class ClearanceRepairer:
 
         clearances = report.by_type(ViolationType.CLEARANCE)
         segment_via_clearances = report.by_type(ViolationType.CLEARANCE_SEGMENT_VIA)
-        all_clearances = clearances + segment_via_clearances
+        pad_segment_clearances = report.by_type(ViolationType.CLEARANCE_PAD_SEGMENT)
+        pad_via_clearances = report.by_type(ViolationType.CLEARANCE_PAD_VIA)
+        all_clearances = (
+            clearances + segment_via_clearances + pad_segment_clearances + pad_via_clearances
+        )
         result.total_violations = len(all_clearances)
 
         # Track violations where nudge was explicitly skipped as infeasible
@@ -192,6 +196,24 @@ class ClearanceRepairer:
             before_infeasible = result.skipped_infeasible
             self._repair_single_violation(
                 violation, result, max_displacement, margin, "move-trace", dry_run
+            )
+            if result.skipped_infeasible > before_infeasible:
+                skipped_violations.append(violation)
+
+        # For pad-segment violations, move the segment (pads are immovable)
+        for violation in pad_segment_clearances:
+            before_infeasible = result.skipped_infeasible
+            self._repair_single_violation(
+                violation, result, max_displacement, margin, "move-trace", dry_run
+            )
+            if result.skipped_infeasible > before_infeasible:
+                skipped_violations.append(violation)
+
+        # For pad-via violations, move the via (pads are immovable)
+        for violation in pad_via_clearances:
+            before_infeasible = result.skipped_infeasible
+            self._repair_single_violation(
+                violation, result, max_displacement, margin, "move-via", dry_run
             )
             if result.skipped_infeasible > before_infeasible:
                 skipped_violations.append(violation)
@@ -498,8 +520,24 @@ class ClearanceRepairer:
             other_seg = obs_obj[0]
             width_node = other_seg.find("width")
             obstacle_radius = float(width_node.get_first_atom()) / 2 if width_node else 0.125
+        elif obs_obj is not None and obs_obj[1] == "pad":
+            obstacle_radius = self._pad_obstacle_radius(obs_obj[0])
 
         return (obs_x, obs_y, obstacle_radius)
+
+    def _pad_obstacle_radius(self, pad_node: SExp) -> float:
+        """Estimate the effective radius of a pad for obstacle avoidance.
+
+        Uses the larger of the pad's width and height divided by 2.
+        Falls back to 0.5 mm if the size cannot be determined.
+        """
+        size_node = pad_node.find("size")
+        if size_node:
+            atoms = size_node.get_atoms()
+            w = float(atoms[0]) if atoms else 1.0
+            h = float(atoms[1]) if len(atoms) > 1 else w
+            return max(w, h) / 2
+        return 0.5
 
     def _attempt_local_reroute_with_extras(
         self,
@@ -554,6 +592,8 @@ class ClearanceRepairer:
             other_seg = obs_obj[0]
             width_node = other_seg.find("width")
             obstacle_radius = float(width_node.get_first_atom()) / 2 if width_node else 0.125
+        elif obs_obj is not None and obs_obj[1] == "pad":
+            obstacle_radius = self._pad_obstacle_radius(obs_obj[0])
 
         width_node = seg_node.find("width")
         trace_width = float(width_node.get_first_atom()) if width_node else 0.25
@@ -640,6 +680,8 @@ class ClearanceRepairer:
             other_seg = obs_obj[0]
             width_node = other_seg.find("width")
             obstacle_radius = float(width_node.get_first_atom()) / 2 if width_node else 0.125
+        elif obs_obj is not None and obs_obj[1] == "pad":
+            obstacle_radius = self._pad_obstacle_radius(obs_obj[0])
 
         # Get trace parameters
         width_node = seg_node.find("width")
@@ -898,7 +940,12 @@ class ClearanceRepairer:
         if vias:
             return vias[0]
 
-        # Check pads (pads are not movable, so return None to skip)
+        # Check pads (pads are immovable, but we return them so
+        # _choose_target() can select the *other* object to move)
+        pads = self._find_pads_near(x, y, search_radius, layer, nets)
+        if pads:
+            return pads[0]
+
         return None
 
     def _find_segments_near(
@@ -1002,6 +1049,86 @@ class ClearanceRepairer:
 
         return results
 
+    def _find_pads_near(
+        self,
+        x: float,
+        y: float,
+        radius: float,
+        layer: str | None,
+        nets: list[str] | None,
+    ) -> list[tuple[SExp, str, float, float, str, str]]:
+        """Find pads near a point.
+
+        Pads are nested inside footprint nodes in the s-expression tree.
+        Their positions are in footprint-local coordinates and must be
+        transformed to board coordinates using the footprint's position
+        and rotation.
+
+        Returns list of (pad_node, "pad", abs_x, abs_y, pad_layer, net_name).
+        """
+        results = []
+
+        for fp_node in self.doc.find_all("footprint"):
+            # Get footprint position and rotation
+            fp_at = fp_node.find("at")
+            if not fp_at:
+                continue
+            fp_atoms = fp_at.get_atoms()
+            fp_x = float(fp_atoms[0]) if fp_atoms else 0.0
+            fp_y = float(fp_atoms[1]) if len(fp_atoms) > 1 else 0.0
+            fp_rot = float(fp_atoms[2]) if len(fp_atoms) > 2 else 0.0
+
+            angle_rad = math.radians(fp_rot)
+            cos_a = math.cos(angle_rad)
+            sin_a = math.sin(angle_rad)
+
+            for pad_node in fp_node.find_all("pad"):
+                pad_at = pad_node.find("at")
+                if not pad_at:
+                    continue
+                pad_atoms = pad_at.get_atoms()
+                local_x = float(pad_atoms[0]) if pad_atoms else 0.0
+                local_y = float(pad_atoms[1]) if len(pad_atoms) > 1 else 0.0
+
+                # Transform from footprint-local to board coordinates
+                abs_x = fp_x + local_x * cos_a - local_y * sin_a
+                abs_y = fp_y + local_x * sin_a + local_y * cos_a
+
+                dist = math.sqrt((abs_x - x) ** 2 + (abs_y - y) ** 2)
+                if dist > radius:
+                    continue
+
+                # Check layer match
+                pad_layers_node = pad_node.find("layers")
+                pad_layers: list[str] = []
+                if pad_layers_node:
+                    pad_layers = [str(a) for a in pad_layers_node.get_atoms()]
+
+                if layer:
+                    # Pad matches if it's on the specified layer or on all copper layers
+                    if layer not in pad_layers and "*.Cu" not in pad_layers:
+                        continue
+
+                # Check net match
+                pad_net_node = pad_node.find("net")
+                pad_net_num = 0
+                if pad_net_node:
+                    first_atom = pad_net_node.get_first_atom()
+                    if first_atom is not None:
+                        try:
+                            pad_net_num = int(first_atom)
+                        except (ValueError, TypeError):
+                            pad_net_num = 0
+                pad_net_name = self.nets.get(pad_net_num, "")
+
+                if nets and pad_net_name not in nets:
+                    continue
+
+                pad_layer = pad_layers[0] if pad_layers else ""
+                results.append((pad_node, "pad", abs_x, abs_y, pad_layer, pad_net_name))
+
+        return results
+
     def _choose_target(
         self,
         obj1: tuple[SExp, str, float, float, str, str] | None,
@@ -1027,6 +1154,15 @@ class ClearanceRepairer:
 
         _, type1, _, _, _, _ = obj1
         _, type2, _, _, _, _ = obj2
+
+        # Pads are immovable -- always move the other object.
+        # If both are pads, neither can be moved.
+        if type1 == "pad" and type2 == "pad":
+            return None
+        if type1 == "pad":
+            return obj2
+        if type2 == "pad":
+            return obj1
 
         if prefer == "move-trace":
             if type1 == "segment":

--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -17,6 +17,8 @@ class ViolationType(Enum):
     # Clearance violations
     CLEARANCE = "clearance"
     CLEARANCE_SEGMENT_VIA = "clearance_segment_via"
+    CLEARANCE_PAD_SEGMENT = "clearance_pad_segment"
+    CLEARANCE_PAD_VIA = "clearance_pad_via"
     COPPER_EDGE_CLEARANCE = "copper_edge_clearance"
     COURTYARD_OVERLAP = "courtyard_overlap"
 
@@ -75,6 +77,10 @@ class ViolationType(Enum):
                 return cls.COPPER_EDGE_CLEARANCE
             if "segment" in s_lower and "via" in s_lower:
                 return cls.CLEARANCE_SEGMENT_VIA
+            if "pad" in s_lower and "segment" in s_lower:
+                return cls.CLEARANCE_PAD_SEGMENT
+            if "pad" in s_lower and "via" in s_lower:
+                return cls.CLEARANCE_PAD_VIA
             return cls.CLEARANCE
         if "unconnected" in s_lower:
             return cls.UNCONNECTED_ITEMS
@@ -187,6 +193,8 @@ class DRCViolation:
         return self.type in (
             ViolationType.CLEARANCE,
             ViolationType.CLEARANCE_SEGMENT_VIA,
+            ViolationType.CLEARANCE_PAD_SEGMENT,
+            ViolationType.CLEARANCE_PAD_VIA,
             ViolationType.COPPER_EDGE_CLEARANCE,
         )
 

--- a/tests/test_repair_clearance.py
+++ b/tests/test_repair_clearance.py
@@ -1642,3 +1642,386 @@ class TestClusterRerouteIntegration:
         # Same x,y -> grouped together (spatial only)
         assert len(clusters) == 1
         assert len(clusters[0]) == 2
+
+
+# ── Pad-clearance repair tests ─────────────────────────────────────────────
+
+# PCB with a footprint containing a pad (pad "1" at footprint-local (0, 0))
+# and a segment that runs too close to it.
+# Footprint at (105, 100) with 0 rotation, so pad absolute position is (105, 100).
+# Segment runs from (100, 100.12) to (110, 100.12) on F.Cu, net "+3.3V".
+# The pad is on net "GND".
+PCB_WITH_PAD_SEGMENT_VIOLATION = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "TestLib:R0402"
+    (layer "F.Cu")
+    (at 105 100)
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "pad-1"))
+    (pad "2" smd roundrect (at 1.0 0) (size 0.6 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "+3.3V") (uuid "pad-2"))
+  )
+  (segment (start 100 100.12) (end 110 100.12) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-pad-1"))
+)
+"""
+
+# PCB with a footprint at (105, 100) rotated 90 degrees.
+# Pad "1" local offset is (0.5, 0), so after 90deg rotation:
+#   abs_x = 105 + 0.5*cos(90) - 0*sin(90) = 105 + 0 - 0 = 105
+#   abs_y = 100 + 0.5*sin(90) + 0*cos(90) = 100 + 0.5 + 0 = 100.5
+# A via at (105, 100.35) is too close to the pad.
+PCB_WITH_ROTATED_PAD_VIA_VIOLATION = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "TestLib:R0402"
+    (layer "F.Cu")
+    (at 105 100 90)
+    (pad "1" smd roundrect (at 0.5 0) (size 0.6 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "pad-rot-1"))
+  )
+  (via (at 105 100.35) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 2) (uuid "via-pad-1"))
+)
+"""
+
+# PCB with two pads close together (both immovable -- should be skipped)
+PCB_WITH_PAD_PAD_VIOLATION = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "TestLib:C0402"
+    (layer "F.Cu")
+    (at 105 100)
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "pad-pp-1"))
+  )
+  (footprint "TestLib:C0402"
+    (layer "F.Cu")
+    (at 105.5 100)
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "+3.3V") (uuid "pad-pp-2"))
+  )
+)
+"""
+
+
+class TestPadClearanceRepair:
+    """Tests for pad-segment and pad-via clearance repair."""
+
+    def test_violation_type_from_string_pad_segment(self):
+        """ViolationType.from_string should parse clearance_pad_segment."""
+        assert (
+            ViolationType.from_string("clearance_pad_segment")
+            == ViolationType.CLEARANCE_PAD_SEGMENT
+        )
+
+    def test_violation_type_from_string_pad_via(self):
+        """ViolationType.from_string should parse clearance_pad_via."""
+        assert ViolationType.from_string("clearance_pad_via") == ViolationType.CLEARANCE_PAD_VIA
+
+    def test_pad_clearance_types_are_clearance(self):
+        """PAD_SEGMENT and PAD_VIA violations should count as clearance."""
+        v1 = DRCViolation(
+            type=ViolationType.CLEARANCE_PAD_SEGMENT,
+            type_str="clearance_pad_segment",
+            severity=Severity.ERROR,
+            message="test",
+        )
+        v2 = DRCViolation(
+            type=ViolationType.CLEARANCE_PAD_VIA,
+            type_str="clearance_pad_via",
+            severity=Severity.ERROR,
+            message="test",
+        )
+        assert v1.is_clearance
+        assert v2.is_clearance
+
+    def test_pad_segment_repair_moves_segment(self, tmp_path: Path):
+        """Pad-segment repair should move the segment, never the pad."""
+        pcb_file = tmp_path / "pad_seg.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_PAD_SEGMENT_VIOLATION)
+
+        repairer = ClearanceRepairer(pcb_file)
+
+        report = DRCReport(
+            source_file="test",
+            created_at=None,
+            pcb_name="test",
+            violations=[
+                DRCViolation(
+                    type=ViolationType.CLEARANCE_PAD_SEGMENT,
+                    type_str="clearance_pad_segment",
+                    severity=Severity.ERROR,
+                    message="Clearance violation (0.12mm < 0.20mm)",
+                    locations=[
+                        Location(x_mm=105.0, y_mm=100.0, layer="F.Cu"),
+                        Location(x_mm=105.0, y_mm=100.12, layer="F.Cu"),
+                    ],
+                    nets=["GND", "+3.3V"],
+                    required_value_mm=0.2,
+                    actual_value_mm=0.12,
+                ),
+            ],
+        )
+
+        result = repairer.repair_from_report(
+            report,
+            max_displacement=0.5,
+            dry_run=True,
+        )
+
+        assert result.total_violations == 1
+        assert result.repaired == 1
+        # Must have moved the segment, not the pad
+        assert len(result.nudges) == 1
+        assert result.nudges[0].object_type == "segment"
+
+    def test_pad_segment_repair_applies_changes(self, tmp_path: Path):
+        """Pad-segment repair should modify PCB when not dry run."""
+        pcb_file = tmp_path / "pad_seg.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_PAD_SEGMENT_VIOLATION)
+
+        repairer = ClearanceRepairer(pcb_file)
+
+        report = DRCReport(
+            source_file="test",
+            created_at=None,
+            pcb_name="test",
+            violations=[
+                DRCViolation(
+                    type=ViolationType.CLEARANCE_PAD_SEGMENT,
+                    type_str="clearance_pad_segment",
+                    severity=Severity.ERROR,
+                    message="Clearance violation (0.12mm < 0.20mm)",
+                    locations=[
+                        Location(x_mm=105.0, y_mm=100.0, layer="F.Cu"),
+                        Location(x_mm=105.0, y_mm=100.12, layer="F.Cu"),
+                    ],
+                    nets=["GND", "+3.3V"],
+                    required_value_mm=0.2,
+                    actual_value_mm=0.12,
+                ),
+            ],
+        )
+
+        result = repairer.repair_from_report(
+            report,
+            max_displacement=0.5,
+            dry_run=False,
+        )
+
+        assert result.repaired == 1
+        assert repairer.modified
+
+    def test_pad_via_repair_moves_via(self, tmp_path: Path):
+        """Pad-via repair should relocate the via, never the pad."""
+        pcb_file = tmp_path / "pad_via.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_ROTATED_PAD_VIA_VIOLATION)
+
+        repairer = ClearanceRepairer(pcb_file)
+
+        # Pad "1" at footprint (105, 100) rotated 90deg with local offset (0.5, 0)
+        # -> absolute (105, 100.5).  Via at (105, 100.35).
+        report = DRCReport(
+            source_file="test",
+            created_at=None,
+            pcb_name="test",
+            violations=[
+                DRCViolation(
+                    type=ViolationType.CLEARANCE_PAD_VIA,
+                    type_str="clearance_pad_via",
+                    severity=Severity.ERROR,
+                    message="Clearance violation (0.10mm < 0.20mm)",
+                    locations=[
+                        Location(x_mm=105.0, y_mm=100.5, layer="F.Cu"),
+                        Location(x_mm=105.0, y_mm=100.35, layer="F.Cu"),
+                    ],
+                    nets=["GND", "+3.3V"],
+                    required_value_mm=0.2,
+                    actual_value_mm=0.10,
+                ),
+            ],
+        )
+
+        result = repairer.repair_from_report(
+            report,
+            max_displacement=0.5,
+            dry_run=True,
+        )
+
+        assert result.total_violations == 1
+        assert result.repaired == 1
+        # Must have moved the via, not the pad
+        assert len(result.nudges) == 1
+        assert result.nudges[0].object_type == "via"
+
+    def test_pad_pad_violation_skipped(self, tmp_path: Path):
+        """Pad-to-pad violation should be skipped (neither is movable)."""
+        pcb_file = tmp_path / "pad_pad.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_PAD_PAD_VIOLATION)
+
+        repairer = ClearanceRepairer(pcb_file)
+
+        report = DRCReport(
+            source_file="test",
+            created_at=None,
+            pcb_name="test",
+            violations=[
+                DRCViolation(
+                    type=ViolationType.CLEARANCE,
+                    type_str="clearance",
+                    severity=Severity.ERROR,
+                    message="Clearance violation (0.10mm < 0.20mm)",
+                    locations=[
+                        Location(x_mm=105.0, y_mm=100.0, layer="F.Cu"),
+                        Location(x_mm=105.5, y_mm=100.0, layer="F.Cu"),
+                    ],
+                    nets=["GND", "+3.3V"],
+                    required_value_mm=0.2,
+                    actual_value_mm=0.10,
+                ),
+            ],
+        )
+
+        result = repairer.repair_from_report(
+            report,
+            max_displacement=0.5,
+            dry_run=True,
+        )
+
+        # Both objects are pads -- neither is movable
+        assert result.repaired == 0
+        assert result.skipped_infeasible == 1
+
+    def test_find_pads_near(self, tmp_path: Path):
+        """_find_pads_near should locate pads with correct board coordinates."""
+        pcb_file = tmp_path / "pad_near.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_PAD_SEGMENT_VIOLATION)
+
+        repairer = ClearanceRepairer(pcb_file)
+
+        # Footprint at (105, 100), pad "1" at local (0, 0) -> board (105, 100)
+        pads = repairer._find_pads_near(105.0, 100.0, 0.5, "F.Cu", ["GND"])
+        assert len(pads) >= 1
+        pad_info = pads[0]
+        assert pad_info[1] == "pad"
+        assert abs(pad_info[2] - 105.0) < 0.01
+        assert abs(pad_info[3] - 100.0) < 0.01
+
+    def test_find_pads_near_rotated_footprint(self, tmp_path: Path):
+        """_find_pads_near should account for footprint rotation."""
+        pcb_file = tmp_path / "pad_rot.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_ROTATED_PAD_VIA_VIOLATION)
+
+        repairer = ClearanceRepairer(pcb_file)
+
+        # Footprint at (105, 100) rotated 90deg, pad local (0.5, 0)
+        # After rotation: abs = (105, 100.5)
+        pads = repairer._find_pads_near(105.0, 100.5, 0.5, "F.Cu", ["GND"])
+        assert len(pads) >= 1
+        pad_info = pads[0]
+        assert pad_info[1] == "pad"
+        assert abs(pad_info[2] - 105.0) < 0.01
+        assert abs(pad_info[3] - 100.5) < 0.01
+
+    def test_choose_target_never_moves_pad(self, tmp_path: Path):
+        """_choose_target should always return the non-pad object."""
+        pcb_file = tmp_path / "choose.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_PAD_SEGMENT_VIOLATION)
+
+        repairer = ClearanceRepairer(pcb_file)
+
+        from kicad_tools.sexp import SExp
+
+        # Create mock objects
+        mock_pad = (SExp("pad"), "pad", 105.0, 100.0, "F.Cu", "GND")
+        mock_seg = (SExp("segment"), "segment", 105.0, 100.12, "F.Cu", "+3.3V")
+        mock_via = (SExp("via"), "via", 105.0, 100.35, "F.Cu", "+3.3V")
+
+        # Pad + segment -> always returns segment
+        target = repairer._choose_target(mock_pad, mock_seg, "move-trace")
+        assert target[1] == "segment"
+
+        target = repairer._choose_target(mock_seg, mock_pad, "move-trace")
+        assert target[1] == "segment"
+
+        # Pad + via -> always returns via
+        target = repairer._choose_target(mock_pad, mock_via, "move-via")
+        assert target[1] == "via"
+
+        target = repairer._choose_target(mock_via, mock_pad, "move-via")
+        assert target[1] == "via"
+
+        # Pad + pad -> returns None (neither movable)
+        mock_pad2 = (SExp("pad"), "pad", 105.5, 100.0, "F.Cu", "+3.3V")
+        target = repairer._choose_target(mock_pad, mock_pad2, "move-trace")
+        assert target is None
+
+    def test_pad_segment_included_in_fix_drc_count(self, tmp_path: Path):
+        """fix-drc should count pad-segment and pad-via violations."""
+        pcb_file = tmp_path / "pad_seg_drc.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_PAD_SEGMENT_VIOLATION)
+
+        # Create a DRC report containing pad-segment violations
+        report_content = """\
+** Drc report for test.kicad_pcb **
+** Created on 2025-12-28T21:29:34-08:00 **
+
+** Found 1 DRC violations **
+[clearance_pad_segment]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.1200 mm)
+    Rule: netclass 'Default'; error
+    @(105.0000 mm, 100.0000 mm): Pad [GND] on F.Cu
+    @(105.0000 mm, 100.1200 mm): Track [+3.3V] on F.Cu
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+        report_file = tmp_path / "test-drc.rpt"
+        report_file.write_text(report_content)
+
+        from kicad_tools.cli.fix_drc_cmd import main as fix_drc_main
+
+        result = fix_drc_main(
+            [
+                str(pcb_file),
+                "--drc-report",
+                str(report_file),
+                "--dry-run",
+                "--format",
+                "json",
+                "--quiet",
+            ]
+        )
+
+        # Should not crash; any return code acceptable in dry-run
+        assert result in (0, 1, 2)


### PR DESCRIPTION
## Summary

Add pad-aware repair to the clearance repair pipeline so that `clearance_pad_segment` and `clearance_pad_via` DRC violations are detected and fixed by nudging segments or vias away from immovable pads.

## Changes

- Add `CLEARANCE_PAD_SEGMENT` and `CLEARANCE_PAD_VIA` enum values to `ViolationType` with `from_string()` parsing
- Add `_find_pads_near()` method that transforms footprint-local pad coordinates to board coordinates (handling rotation via standard 2D rotation matrix)
- Update `_find_object_at()` to return pad objects instead of `None`
- Update `_choose_target()` to never select pads for movement (pads are immovable); pad-to-pad violations are correctly skipped as infeasible
- Wire new violation types into `repair_from_report()` (pad-segment uses "move-trace", pad-via uses "move-via") and `fix_drc_cmd.py`
- Add pad obstacle radius extraction (`_pad_obstacle_radius()`) for the local reroute phases
- Add `is_clearance` property coverage for the new types
- Add 11 tests covering pad-segment repair, pad-via repair, pad-pad skip, rotated footprint pad detection, `_choose_target` pad handling, and fix-drc CLI integration

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `clearance_pad_segment` violations are repaired by nudging the segment away from the pad | PASS | `test_pad_segment_repair_moves_segment` and `test_pad_segment_repair_applies_changes` both pass |
| `clearance_pad_via` violations are repaired by relocating the via away from the pad | PASS | `test_pad_via_repair_moves_via` passes -- nudge targets the via, not the pad |
| Pads are never moved (only segments and vias are displaced) | PASS | `test_choose_target_never_moves_pad` verifies pad+segment, pad+via, pad+pad combinations |
| No regressions in existing clearance repair behavior | PASS | All 48 pre-existing tests pass alongside the 11 new tests (59 total) |
| Pad-to-pad violations are skipped (neither is movable) | PASS | `test_pad_pad_violation_skipped` confirms `skipped_infeasible == 1` |

## Test Plan

- All 59 tests in `tests/test_repair_clearance.py` pass (48 existing + 11 new)
- Broader DRC/clearance test suite (911 tests) passes with 0 failures
- Lint and format checks pass on all modified files

Closes #1453