### PR TITLE
feat(export): auto-match LCSC part numbers during JLCPCB BOM export

### DIFF
--- a/src/kicad_tools/cli/export_cmd.py
+++ b/src/kicad_tools/cli/export_cmd.py
@@ -72,6 +72,17 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Skip KiCad project ZIP creation",
     )
+    parser.add_argument(
+        "--auto-lcsc",
+        action="store_true",
+        default=True,
+        help="Auto-match LCSC part numbers for JLCPCB BOMs (default: enabled)",
+    )
+    parser.add_argument(
+        "--no-auto-lcsc",
+        action="store_true",
+        help="Disable LCSC auto-matching",
+    )
 
     args = parser.parse_args(argv)
     return run_export(args)
@@ -93,6 +104,7 @@ def run_export(args: argparse.Namespace) -> int:
     output_dir = Path(args.output) if args.output else pcb_path.parent / "manufacturing"
 
     # Build configuration
+    auto_lcsc = args.auto_lcsc and not args.no_auto_lcsc
     config = ManufacturingConfig(
         output_dir=output_dir,
         include_bom=not args.no_bom,
@@ -100,6 +112,7 @@ def run_export(args: argparse.Namespace) -> int:
         include_gerbers=not args.no_gerbers,
         include_report=not args.no_report,
         include_project_zip=not args.no_project_zip,
+        auto_lcsc=auto_lcsc,
     )
 
     pkg = ManufacturingPackage(
@@ -137,6 +150,12 @@ def run_export(args: argparse.Namespace) -> int:
                 print(f"  [ok] CPL: {result.assembly_result.pnp_path.name}")
             if result.assembly_result.gerber_path:
                 print(f"  [ok] Gerbers: {result.assembly_result.gerber_path.name}")
+            # Report LCSC enrichment results
+            if result.assembly_result.lcsc_enrichment:
+                enrichment = result.assembly_result.lcsc_enrichment
+                print()
+                for line in enrichment.summary_lines():
+                    print(f"  {line}")
         if result.report_path:
             print(f"  [ok] Report: {result.report_path.name}")
         if result.project_zip_path:

--- a/src/kicad_tools/export/__init__.py
+++ b/src/kicad_tools/export/__init__.py
@@ -39,10 +39,10 @@ from .assembly import (
     AssemblyPackageResult,
     create_assembly_package,
 )
-from .manufacturing import (
-    ManufacturingConfig,
-    ManufacturingPackage,
-    ManufacturingResult,
+from .bom_enrich import (
+    EnrichmentEntry,
+    EnrichmentReport,
+    enrich_bom_lcsc,
 )
 from .bom_formats import (
     BOM_FORMATTERS,
@@ -62,6 +62,11 @@ from .gerber import (
     ManufacturerPreset,
     export_gerbers,
     find_kicad_cli,
+)
+from .manufacturing import (
+    ManufacturingConfig,
+    ManufacturingPackage,
+    ManufacturingResult,
 )
 from .pnp import (
     PNP_FORMATTERS,
@@ -83,6 +88,10 @@ __all__ = [
     "AssemblyConfig",
     "AssemblyPackageResult",
     "create_assembly_package",
+    # BOM enrichment
+    "enrich_bom_lcsc",
+    "EnrichmentReport",
+    "EnrichmentEntry",
     # Manufacturing package
     "ManufacturingPackage",
     "ManufacturingConfig",

--- a/src/kicad_tools/export/assembly.py
+++ b/src/kicad_tools/export/assembly.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.exceptions import ValidationError
 
+from .bom_enrich import EnrichmentReport, enrich_bom_lcsc
 from .bom_formats import BOMExportConfig, export_bom
 from .gerber import MANUFACTURER_PRESETS, GerberConfig, GerberExporter
 from .pnp import PnPExportConfig, export_pnp
@@ -42,6 +43,11 @@ class AssemblyConfig:
     gerbers_subdir: str = "gerbers"
     gerber_config: GerberConfig | None = None
 
+    # LCSC auto-matching
+    auto_lcsc: bool = True
+    auto_lcsc_prefer_basic: bool = True
+    auto_lcsc_min_stock: int = 100
+
     # Filtering
     exclude_references: list[str] = field(default_factory=list)
 
@@ -54,6 +60,7 @@ class AssemblyPackageResult:
     bom_path: Path | None = None
     pnp_path: Path | None = None
     gerber_path: Path | None = None
+    lcsc_enrichment: EnrichmentReport | None = None
     errors: list[str] = field(default_factory=list)
 
     @property
@@ -191,7 +198,7 @@ class AssemblyPackage:
         # Generate BOM
         if self.config.include_bom:
             try:
-                result.bom_path = self._generate_bom(out_dir)
+                result.bom_path = self._generate_bom(out_dir, result)
             except Exception as e:
                 result.errors.append(f"BOM generation failed: {e}")
                 logger.error(f"BOM generation failed: {e}")
@@ -214,8 +221,21 @@ class AssemblyPackage:
 
         return result
 
-    def _generate_bom(self, output_dir: Path) -> Path:
-        """Generate BOM file."""
+    def _generate_bom(self, output_dir: Path, result: AssemblyPackageResult | None = None) -> Path:
+        """Generate BOM file.
+
+        When ``auto_lcsc`` is enabled (the default) and the target
+        manufacturer is ``jlcpcb``, missing LCSC part numbers are
+        populated automatically via :func:`enrich_bom_lcsc` before
+        the BOM CSV is written.
+
+        Args:
+            output_dir: Directory to write the BOM CSV into.
+            result: Optional result object to attach enrichment report.
+
+        Returns:
+            Path to the written BOM CSV.
+        """
         if not self.schematic_path:
             raise ValidationError(
                 ["Schematic path required for BOM generation"],
@@ -232,6 +252,21 @@ class AssemblyPackage:
         # Filter excluded references
         if self.config.exclude_references:
             items = self._filter_references(items)
+
+        # LCSC auto-matching for JLCPCB exports
+        if self.config.auto_lcsc and self.manufacturer == "jlcpcb":
+            try:
+                enrichment = enrich_bom_lcsc(
+                    items,
+                    prefer_basic=self.config.auto_lcsc_prefer_basic,
+                    min_stock=self.config.auto_lcsc_min_stock,
+                )
+                if result is not None:
+                    result.lcsc_enrichment = enrichment
+                for line in enrichment.summary_lines():
+                    logger.info(line)
+            except Exception as e:
+                logger.warning(f"LCSC auto-matching failed (continuing without): {e}")
 
         # Generate BOM
         bom_config = self.config.bom_config or BOMExportConfig()

--- a/src/kicad_tools/export/bom_enrich.py
+++ b/src/kicad_tools/export/bom_enrich.py
@@ -1,0 +1,212 @@
+"""
+BOM enrichment with LCSC part numbers.
+
+Populates missing LCSC part numbers in BOM items by searching the
+LCSC/JLCPCB parts catalog using component values and footprints.
+
+Uses the existing ``PartSuggester`` engine which handles:
+- Value + footprint search term construction
+- Package-size filtering
+- Basic > Preferred > Extended part ranking
+- Confidence scoring
+- LCSC API rate limiting and caching
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from ..cost.suggest import PartSuggester
+
+if TYPE_CHECKING:
+    from ..schema.bom import BOMItem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EnrichmentEntry:
+    """Record of an LCSC enrichment for a single BOM group."""
+
+    value: str
+    footprint: str
+    references: list[str]
+    lcsc_part: str  # The assigned LCSC part number (empty if unmatched)
+    source: str  # "schematic" | "auto" | "unmatched"
+    confidence: float = 0.0
+    part_type: str = ""  # "Basic" | "Pref" | "Ext" | ""
+    error: str = ""
+
+
+@dataclass
+class EnrichmentReport:
+    """Summary of BOM enrichment results."""
+
+    entries: list[EnrichmentEntry] = field(default_factory=list)
+
+    @property
+    def total_groups(self) -> int:
+        """Total number of component groups processed."""
+        return len(self.entries)
+
+    @property
+    def already_populated(self) -> int:
+        """Groups that already had LCSC numbers from the schematic."""
+        return len([e for e in self.entries if e.source == "schematic"])
+
+    @property
+    def auto_matched(self) -> int:
+        """Groups that were auto-matched via LCSC search."""
+        return len([e for e in self.entries if e.source == "auto"])
+
+    @property
+    def unmatched(self) -> int:
+        """Groups that could not be matched."""
+        return len([e for e in self.entries if e.source == "unmatched"])
+
+    @property
+    def unmatched_entries(self) -> list[EnrichmentEntry]:
+        """Get the entries that could not be matched."""
+        return [e for e in self.entries if e.source == "unmatched"]
+
+    def summary_lines(self) -> list[str]:
+        """Return human-readable summary lines."""
+        lines = [
+            f"LCSC enrichment: {self.auto_matched} auto-matched, "
+            f"{self.already_populated} from schematic, "
+            f"{self.unmatched} unmatched"
+        ]
+        if self.unmatched_entries:
+            lines.append("Unmatched parts:")
+            for entry in self.unmatched_entries:
+                refs = ", ".join(entry.references)
+                reason = f" ({entry.error})" if entry.error else ""
+                lines.append(f"  {entry.value} [{entry.footprint}] ({refs}){reason}")
+        return lines
+
+
+def enrich_bom_lcsc(
+    items: list[BOMItem],
+    *,
+    prefer_basic: bool = True,
+    min_stock: int = 100,
+) -> EnrichmentReport:
+    """
+    Populate missing LCSC part numbers on BOM items in-place.
+
+    For each unique (value, footprint) group that lacks an LCSC number,
+    searches the LCSC catalog using :class:`PartSuggester` and writes
+    the best match back onto every ``BOMItem`` in that group.
+
+    Items that already have an ``lcsc`` value are left untouched.
+
+    Args:
+        items: List of BOM items to enrich (modified in place).
+        prefer_basic: Prefer JLCPCB Basic parts (no extra assembly fee).
+        min_stock: Minimum stock level to consider a part viable.
+
+    Returns:
+        EnrichmentReport summarising what was matched.
+    """
+    report = EnrichmentReport()
+
+    # Group items by (value, footprint) to avoid duplicate searches
+    groups: dict[tuple[str, str], list[BOMItem]] = {}
+    for item in items:
+        if getattr(item, "dnp", False):
+            continue
+        if getattr(item, "is_virtual", False):
+            continue
+        key = (item.value, item.footprint)
+        groups.setdefault(key, []).append(item)
+
+    with PartSuggester(
+        prefer_basic=prefer_basic,
+        min_stock=min_stock,
+    ) as suggester:
+        for (value, footprint), group_items in groups.items():
+            refs = [it.reference for it in group_items]
+
+            # Check if any item in the group already has an LCSC number
+            existing_lcsc = ""
+            for it in group_items:
+                if it.lcsc:
+                    existing_lcsc = it.lcsc
+                    break
+
+            if existing_lcsc:
+                # Propagate existing LCSC to all items in the group
+                for it in group_items:
+                    if not it.lcsc:
+                        it.lcsc = existing_lcsc
+                report.entries.append(
+                    EnrichmentEntry(
+                        value=value,
+                        footprint=footprint,
+                        references=refs,
+                        lcsc_part=existing_lcsc,
+                        source="schematic",
+                    )
+                )
+                continue
+
+            # Use the first reference for type hinting (R1 -> resistor, etc.)
+            first_ref = refs[0] if refs else ""
+
+            suggestion = suggester.suggest_for_component(
+                reference=first_ref,
+                value=value,
+                footprint=footprint,
+                existing_lcsc=None,
+            )
+
+            if suggestion.has_suggestion:
+                best = suggestion.best_suggestion
+                assert best is not None  # guarded by has_suggestion
+                lcsc = best.lcsc_part
+
+                # Write back to all items in the group
+                for it in group_items:
+                    it.lcsc = lcsc
+
+                report.entries.append(
+                    EnrichmentEntry(
+                        value=value,
+                        footprint=footprint,
+                        references=refs,
+                        lcsc_part=lcsc,
+                        source="auto",
+                        confidence=best.confidence,
+                        part_type=best.type_str,
+                    )
+                )
+                logger.info(
+                    "Auto-matched %s [%s] -> %s (%s, confidence=%.2f)",
+                    value,
+                    footprint,
+                    lcsc,
+                    best.type_str,
+                    best.confidence,
+                )
+            else:
+                report.entries.append(
+                    EnrichmentEntry(
+                        value=value,
+                        footprint=footprint,
+                        references=refs,
+                        lcsc_part="",
+                        source="unmatched",
+                        error=suggestion.error or "no matching parts found",
+                    )
+                )
+                logger.warning(
+                    "No LCSC match for %s [%s] (%s): %s",
+                    value,
+                    footprint,
+                    ", ".join(refs),
+                    suggestion.error or "no matching parts found",
+                )
+
+    return report

--- a/tests/test_bom_enrich.py
+++ b/tests/test_bom_enrich.py
@@ -1,0 +1,354 @@
+"""Tests for BOM LCSC auto-enrichment (export.bom_enrich)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from kicad_tools.export.bom_enrich import EnrichmentReport, enrich_bom_lcsc
+from kicad_tools.schema.bom import BOMItem
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(
+    ref: str,
+    value: str,
+    footprint: str,
+    lcsc: str = "",
+    dnp: bool = False,
+) -> BOMItem:
+    """Build a BOMItem with minimal required fields."""
+    return BOMItem(
+        reference=ref,
+        value=value,
+        footprint=footprint,
+        lib_id="Device:R",
+        lcsc=lcsc,
+        dnp=dnp,
+    )
+
+
+def _mock_suggestion(lcsc_part: str, is_basic: bool = True, confidence: float = 0.8):
+    """Return a mock PartSuggestion whose best_suggestion has the given LCSC part."""
+    from kicad_tools.cost.suggest import PartSuggestion, SuggestedPart
+
+    best = SuggestedPart(
+        lcsc_part=lcsc_part,
+        mfr_part="MFR-XXXX",
+        description="Test part",
+        package="0402",
+        stock=5000,
+        is_basic=is_basic,
+        is_preferred=False,
+        unit_price=0.001,
+        confidence=confidence,
+    )
+    return PartSuggestion(
+        reference="R1",
+        value="10k",
+        footprint="Resistor_SMD:R_0402_1005Metric",
+        package="0402",
+        existing_lcsc=None,
+        suggestions=[best],
+        best_suggestion=best,
+    )
+
+
+def _mock_no_match():
+    """Return a mock PartSuggestion with no match."""
+    from kicad_tools.cost.suggest import PartSuggestion
+
+    return PartSuggestion(
+        reference="U1",
+        value="STM32C011F4P6",
+        footprint="Package_SO:TSSOP-20",
+        package="TSSOP-20",
+        existing_lcsc=None,
+        suggestions=[],
+        best_suggestion=None,
+        error="no matching parts found",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichBomLcsc:
+    """Tests for the enrich_bom_lcsc function."""
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_auto_matches_missing_lcsc(self, MockSuggester):
+        """Items without LCSC get populated from PartSuggester."""
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+        mock_instance.suggest_for_component.return_value = _mock_suggestion("C25744")
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            _make_item("R2", "10k", "Resistor_SMD:R_0402_1005Metric"),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        # Both items should now have the LCSC number
+        assert items[0].lcsc == "C25744"
+        assert items[1].lcsc == "C25744"
+
+        # Report should show 1 auto-matched group
+        assert report.auto_matched == 1
+        assert report.unmatched == 0
+        assert report.already_populated == 0
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_preserves_existing_lcsc(self, MockSuggester):
+        """Items with existing LCSC are not searched and are left as-is."""
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric", lcsc="C1525"),
+            _make_item("C2", "100nF", "Capacitor_SMD:C_0402_1005Metric"),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        # Existing LCSC preserved and propagated to group mate
+        assert items[0].lcsc == "C1525"
+        assert items[1].lcsc == "C1525"
+
+        # suggest_for_component should NOT have been called
+        mock_instance.suggest_for_component.assert_not_called()
+
+        assert report.already_populated == 1
+        assert report.auto_matched == 0
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_reports_unmatched(self, MockSuggester):
+        """Unmatched parts appear in the report."""
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+        mock_instance.suggest_for_component.return_value = _mock_no_match()
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("U1", "STM32C011F4P6", "Package_SO:TSSOP-20"),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        assert items[0].lcsc == ""
+        assert report.unmatched == 1
+        assert len(report.unmatched_entries) == 1
+        assert report.unmatched_entries[0].value == "STM32C011F4P6"
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_skips_dnp_items(self, MockSuggester):
+        """DNP items are not searched."""
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric", dnp=True),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        assert items[0].lcsc == ""
+        assert report.total_groups == 0
+        mock_instance.suggest_for_component.assert_not_called()
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_groups_by_value_footprint(self, MockSuggester):
+        """Same value+footprint searched only once, result applied to all."""
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+        mock_instance.suggest_for_component.return_value = _mock_suggestion("C25744")
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            _make_item("R2", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            _make_item("R3", "10k", "Resistor_SMD:R_0402_1005Metric"),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        # All items get the same LCSC
+        for item in items:
+            assert item.lcsc == "C25744"
+
+        # Only one search call for the group
+        mock_instance.suggest_for_component.assert_called_once()
+        assert report.auto_matched == 1
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_different_values_searched_separately(self, MockSuggester):
+        """Different value+footprint combos are searched independently."""
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+
+        # Return different parts for different searches
+        def side_effect(*, reference, value, footprint, existing_lcsc):
+            if value == "10k":
+                return _mock_suggestion("C25744")
+            else:
+                return _mock_suggestion("C1525")
+
+        mock_instance.suggest_for_component.side_effect = side_effect
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric"),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        assert items[0].lcsc == "C25744"
+        assert items[1].lcsc == "C1525"
+        assert report.auto_matched == 2
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_mixed_existing_and_missing(self, MockSuggester):
+        """Mix of items with and without LCSC numbers."""
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+        mock_instance.suggest_for_component.return_value = _mock_suggestion("C25744")
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric", lcsc="C1525"),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        assert items[0].lcsc == "C25744"  # auto-matched
+        assert items[1].lcsc == "C1525"  # preserved
+        assert report.auto_matched == 1
+        assert report.already_populated == 1
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_suggester_exception_handled(self, MockSuggester):
+        """If PartSuggester.suggest_for_component raises, item is unmatched."""
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+        # The suggest_for_component itself doesn't raise; errors are reported
+        # via suggestion.error. But the PartSuggester catches exceptions internally.
+        # Let's test the case where it returns an error suggestion.
+        from kicad_tools.cost.suggest import PartSuggestion
+
+        error_suggestion = PartSuggestion(
+            reference="R1",
+            value="10k",
+            footprint="Resistor_SMD:R_0402_1005Metric",
+            package="0402",
+            existing_lcsc=None,
+            suggestions=[],
+            best_suggestion=None,
+            error="API timeout",
+        )
+        mock_instance.suggest_for_component.return_value = error_suggestion
+        MockSuggester.return_value = mock_instance
+
+        items = [_make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric")]
+        report = enrich_bom_lcsc(items)
+
+        assert items[0].lcsc == ""
+        assert report.unmatched == 1
+        assert report.unmatched_entries[0].error == "API timeout"
+
+
+class TestEnrichmentReport:
+    """Tests for the EnrichmentReport dataclass."""
+
+    def test_summary_lines_all_matched(self):
+        """Summary with only auto-matched entries."""
+        from kicad_tools.export.bom_enrich import EnrichmentEntry
+
+        report = EnrichmentReport(
+            entries=[
+                EnrichmentEntry(
+                    value="10k",
+                    footprint="R_0402",
+                    references=["R1", "R2"],
+                    lcsc_part="C25744",
+                    source="auto",
+                    confidence=0.9,
+                    part_type="Basic",
+                ),
+            ]
+        )
+        lines = report.summary_lines()
+        assert "1 auto-matched" in lines[0]
+        assert "0 unmatched" in lines[0]
+
+    def test_summary_lines_with_unmatched(self):
+        """Summary includes detail lines for unmatched parts."""
+        from kicad_tools.export.bom_enrich import EnrichmentEntry
+
+        report = EnrichmentReport(
+            entries=[
+                EnrichmentEntry(
+                    value="STM32C011F4P6",
+                    footprint="TSSOP-20",
+                    references=["U1"],
+                    lcsc_part="",
+                    source="unmatched",
+                    error="no matching parts found",
+                ),
+            ]
+        )
+        lines = report.summary_lines()
+        assert "1 unmatched" in lines[0]
+        assert len(lines) >= 2
+        assert "STM32C011F4P6" in lines[2]  # after "Unmatched parts:" header
+
+    def test_properties(self):
+        """Test EnrichmentReport property accessors."""
+        from kicad_tools.export.bom_enrich import EnrichmentEntry
+
+        report = EnrichmentReport(
+            entries=[
+                EnrichmentEntry(
+                    value="10k",
+                    footprint="R_0402",
+                    references=["R1"],
+                    lcsc_part="C25744",
+                    source="auto",
+                ),
+                EnrichmentEntry(
+                    value="100nF",
+                    footprint="C_0402",
+                    references=["C1"],
+                    lcsc_part="C1525",
+                    source="schematic",
+                ),
+                EnrichmentEntry(
+                    value="IC1",
+                    footprint="QFN-32",
+                    references=["U1"],
+                    lcsc_part="",
+                    source="unmatched",
+                ),
+            ]
+        )
+        assert report.total_groups == 3
+        assert report.auto_matched == 1
+        assert report.already_populated == 1
+        assert report.unmatched == 1


### PR DESCRIPTION
## Summary

Wire the existing `PartSuggester` into the export/BOM flow so that `kct export` automatically populates missing LCSC part numbers when generating JLCPCB BOMs. Items with existing LCSC numbers from schematic properties are preserved; unmatched parts are reported in the CLI output.

## Changes

- Add `bom_enrich` module (`src/kicad_tools/export/bom_enrich.py`) with `enrich_bom_lcsc()` function that groups BOM items by value+footprint and searches LCSC for missing part numbers via `PartSuggester`
- Integrate enrichment into `AssemblyPackage._generate_bom()` when manufacturer is `jlcpcb` and `auto_lcsc` is enabled (default: on)
- Add `auto_lcsc`, `auto_lcsc_prefer_basic`, `auto_lcsc_min_stock` fields to `AssemblyConfig`
- Add `lcsc_enrichment` field to `AssemblyPackageResult` for downstream reporting
- Add `--auto-lcsc` / `--no-auto-lcsc` CLI flags to `kct export`
- Print enrichment summary (auto-matched, from-schematic, unmatched) in CLI output
- Add 11 tests covering auto-matching, existing LCSC preservation, DNP skipping, grouping, mixed scenarios, error handling, and report properties

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct export` populates LCSC Part # in BOM CSV when symbols lack LCSC properties | Pass | `enrich_bom_lcsc()` modifies BOM items in-place before CSV generation; tested in `test_auto_matches_missing_lcsc` |
| Matching prefers JLCPCB Basic parts over Extended | Pass | `PartSuggester(prefer_basic=True)` is the default; `auto_lcsc_prefer_basic` config flag exposed |
| Matching filters by footprint compatibility | Pass | `PartSuggester` already implements package-size filtering via `extract_package_from_footprint` and confidence scoring |
| Unmatched parts reported in export output | Pass | `EnrichmentReport.summary_lines()` lists unmatched parts with reasons; CLI prints them; tested in `test_reports_unmatched` |
| Cached matches reused on re-export | Pass | `PartSuggester` uses `LCSCClient` which uses `PartsCache` (SQLite with 7-day TTL) |
| `kct parts suggest` continues to work independently | Pass | No changes to `PartSuggester` or `parts_cmd.py` |

## Test Plan

- `uv run pytest tests/test_bom_enrich.py -v` -- all 11 tests pass
- `uv run ruff check` on all changed files -- clean
- `uv run ruff format --check` on all changed files -- clean

Closes #1449