### PR TITLE
feat(route): make all copper layers routable including PLANE-type layers

### DIFF
--- a/src/kicad_tools/router/layers.py
+++ b/src/kicad_tools/router/layers.py
@@ -21,9 +21,9 @@ from kicad_tools.exceptions import RoutingError
 class LayerType(Enum):
     """Layer function type."""
 
-    SIGNAL = "signal"  # Routable signal layer
-    PLANE = "plane"  # Power/ground plane (no routing, only antipads)
-    MIXED = "mixed"  # Plane with limited routing (split planes)
+    SIGNAL = "signal"  # Primary signal routing layer
+    PLANE = "plane"  # Power/ground plane (routable; zones flow around traces)
+    MIXED = "mixed"  # Plane with signal routing (split planes)
 
 
 @dataclass
@@ -55,8 +55,15 @@ class LayerDefinition:
 
     @property
     def is_routable(self) -> bool:
-        """Check if signals can be routed on this layer."""
-        return self.layer_type in (LayerType.SIGNAL, LayerType.MIXED)
+        """Check if signals can be routed on this layer.
+
+        All copper layers are routable -- even layers designated as PLANE.
+        In KiCad, zone fills on plane layers naturally flow around traces,
+        so routing on a ground/power plane layer produces correct copper
+        when zones are refilled.  The LayerType designation is metadata
+        describing the layer's *primary* function, not a routing constraint.
+        """
+        return True
 
 
 @dataclass

--- a/tests/test_router_grid.py
+++ b/tests/test_router_grid.py
@@ -585,8 +585,8 @@ class TestLayerStackPresets:
         """Test 4-layer SIG-GND-PWR-SIG stack."""
         stack = LayerStack.four_layer_sig_gnd_pwr_sig()
         assert stack.num_layers == 4
-        assert len(stack.signal_layers) == 2  # F.Cu and B.Cu
-        assert len(stack.plane_layers) == 2  # In1.Cu and In2.Cu
+        assert len(stack.signal_layers) == 4  # All layers routable
+        assert len(stack.plane_layers) == 2  # Plane metadata preserved
 
     def test_four_layer_sig_sig_gnd_pwr(self):
         """Test 4-layer SIG-SIG-GND-PWR stack."""
@@ -597,8 +597,8 @@ class TestLayerStackPresets:
         """Test 6-layer stack creation."""
         stack = LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig()
         assert stack.num_layers == 6
-        assert len(stack.signal_layers) == 4
-        assert len(stack.plane_layers) == 2
+        assert len(stack.signal_layers) == 6  # All layers routable
+        assert len(stack.plane_layers) == 2  # Plane metadata preserved
 
     def test_outer_layers(self):
         """Test outer layers property."""

--- a/tests/test_router_layers.py
+++ b/tests/test_router_layers.py
@@ -310,13 +310,13 @@ class TestLayerDefinition:
         assert layer_def.layer_enum == Layer.F_CU
 
     def test_layer_definition_is_routable(self):
-        """Test routable check."""
+        """Test routable check -- all layer types are routable."""
         signal = LayerDefinition("F.Cu", 0, LayerType.SIGNAL)
         plane = LayerDefinition("In1.Cu", 1, LayerType.PLANE)
         mixed = LayerDefinition("B.Cu", 3, LayerType.MIXED)
 
         assert signal.is_routable is True
-        assert plane.is_routable is False
+        assert plane.is_routable is True
         assert mixed.is_routable is True
 
 
@@ -333,8 +333,8 @@ class TestLayerStack:
         """Test 4-layer stack preset."""
         stack = LayerStack.four_layer_sig_gnd_pwr_sig()
         assert stack.num_layers == 4
-        assert len(stack.signal_layers) == 2
-        assert len(stack.plane_layers) == 2
+        assert len(stack.signal_layers) == 4  # All layers routable
+        assert len(stack.plane_layers) == 2  # Plane metadata preserved
 
     def test_four_layer_all_signal_stack(self):
         """Test 4-layer all-signal stack preset."""
@@ -348,7 +348,7 @@ class TestLayerStack:
         """Test 6-layer stack preset."""
         stack = LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig()
         assert stack.num_layers == 6
-        assert len(stack.signal_layers) == 4
+        assert len(stack.signal_layers) == 6  # All layers routable
 
     def test_layer_stack_validation(self):
         """Test layer stack validation."""
@@ -390,12 +390,10 @@ class TestLayerStack:
         assert layer == Layer.F_CU
 
     def test_get_routable_indices(self):
-        """Test getting routable layer indices."""
+        """Test getting routable layer indices -- all layers are routable."""
         stack = LayerStack.four_layer_sig_gnd_pwr_sig()
         indices = stack.get_routable_indices()
-        assert 0 in indices  # F.Cu
-        assert 3 in indices  # B.Cu
-        assert 1 not in indices  # GND plane
+        assert indices == [0, 1, 2, 3]  # All layers routable including planes
 
     def test_is_plane_layer(self):
         """Test plane layer check."""
@@ -457,9 +455,9 @@ class TestDetectLayerStack:
         stack = detect_layer_stack(pcb_text)
         assert stack.num_layers == 4
         assert "4-Layer" in stack.name
-        # Inner layers should be planes
+        # Inner layers should be planes (metadata preserved)
         assert len(stack.plane_layers) == 2
-        assert len(stack.signal_layers) == 2
+        assert len(stack.signal_layers) == 4  # All layers routable
 
     def test_detect_4_layer_board_no_zones(self):
         """Test detecting a 4-layer board without zones."""
@@ -657,13 +655,20 @@ class TestFourLayerAllSignal:
         assert rules.through_via.spans_layer(3, stack.num_layers)
 
     def test_differs_from_sig_gnd_pwr_sig(self):
-        """4-all must have more routable layers than standard 4-layer."""
+        """4-all differs from standard 4-layer in layer types, not routability.
+
+        Both stacks have 4 routable layers since all copper layers are now
+        routable.  The difference is that 4-all has no PLANE designations,
+        while the standard stack preserves GND/PWR plane metadata.
+        """
         standard = LayerStack.four_layer_sig_gnd_pwr_sig()
         all_sig = LayerStack.four_layer_all_signal()
-        assert len(all_sig.get_routable_indices()) > len(standard.get_routable_indices())
-        # Standard has 2 routable layers, all-sig has 4
-        assert standard.get_routable_indices() == [0, 3]
+        # Both now have identical routable indices
+        assert standard.get_routable_indices() == [0, 1, 2, 3]
         assert all_sig.get_routable_indices() == [0, 1, 2, 3]
+        # But standard has plane metadata, all-sig does not
+        assert len(standard.plane_layers) == 2
+        assert len(all_sig.plane_layers) == 0
 
     def test_stack_name_and_description(self):
         """Verify name and description are set."""


### PR DESCRIPTION
## Summary

Makes `LayerDefinition.is_routable` return `True` unconditionally so that PLANE-type layers (e.g., GND and PWR inner layers in a standard 4-layer stack) participate in routing. The 3D routing grid and A* pathfinder already supported multi-layer via transitions -- the only thing preventing routing on inner plane layers was this single property gate.

## Changes

- `src/kicad_tools/router/layers.py`: Changed `is_routable` to return `True` for all layer types; updated `LayerType` enum docstrings to reflect that PLANE layers are routable
- `tests/test_router_layers.py`: Updated assertions for `is_routable`, `signal_layers` counts, `get_routable_indices`, and the 4-all vs standard 4-layer comparison test
- `tests/test_router_grid.py`: Updated `signal_layers` count assertions for 4-layer and 6-layer stacks

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `is_routable` returns `True` for all `LayerType` values including `PLANE` | PASS | `test_layer_definition_is_routable` updated and passes |
| `--layers 4` (SIG-GND-PWR-SIG) produces `get_routable_indices() == [0, 1, 2, 3]` | PASS | `test_get_routable_indices` asserts exactly `[0, 1, 2, 3]` |
| `--layers 6` produces `get_routable_indices() == [0, 1, 2, 3, 4, 5]` | PASS | 6-layer `signal_layers` count is now 6 (all layers) |
| `plane_net` and `reference_plane` metadata is preserved | PASS | No changes to `LayerDefinition` fields; `plane_layers` property unchanged |
| `LayerStack.plane_layers` and `is_plane_layer()` continue to work | PASS | These use `layer_type == LayerType.PLANE` directly, unaffected by `is_routable` |
| Layer preference logic still functions correctly | PASS | `get_layers_adjacent_to_plane` and `get_layers_with_reference_plane` still work |
| No regressions in existing 2-layer routing behavior | PASS | 2-layer stack has no PLANE layers; all 325 tests pass |

## Test Plan

- All 73 `test_router_layers.py` tests pass
- All 113 `test_router_grid.py` tests pass
- All 139 `test_router_io.py` tests pass

Closes #1460