### PR TITLE
fix(cli): add --auto-lcsc and --no-auto-lcsc flags to unified export parser

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -674,6 +674,8 @@ def _run_export_command(args) -> int:
         sub_argv.append("--no-cpl")
     if getattr(args, "export_no_project_zip", False):
         sub_argv.append("--no-project-zip")
+    if getattr(args, "export_no_auto_lcsc", False):
+        sub_argv.append("--no-auto-lcsc")
     if getattr(args, "export_skip_preflight", False):
         sub_argv.append("--skip-preflight")
     if getattr(args, "export_skip_drc", False):

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3858,6 +3858,19 @@ def _add_export_parser(subparsers) -> None:
         help="Skip KiCad project ZIP creation",
     )
     export_parser.add_argument(
+        "--auto-lcsc",
+        dest="export_auto_lcsc",
+        action="store_true",
+        default=True,
+        help="Auto-match LCSC part numbers for JLCPCB BOMs (default: enabled)",
+    )
+    export_parser.add_argument(
+        "--no-auto-lcsc",
+        dest="export_no_auto_lcsc",
+        action="store_true",
+        help="Disable LCSC auto-matching",
+    )
+    export_parser.add_argument(
         "--skip-preflight",
         dest="export_skip_preflight",
         action="store_true",

--- a/tests/test_export_cmd.py
+++ b/tests/test_export_cmd.py
@@ -187,6 +187,8 @@ class TestExportCmdFromMainParser:
         assert args.export_output is None
         assert args.export_dry_run is False
         assert args.export_no_report is False
+        assert args.export_auto_lcsc is True
+        assert args.export_no_auto_lcsc is False
 
     def test_parser_export_all_flags(self):
         from kicad_tools.cli.parser import create_parser
@@ -219,6 +221,50 @@ class TestExportCmdFromMainParser:
         assert args.export_no_bom is True
         assert args.export_no_cpl is True
         assert args.export_no_project_zip is True
+
+    def test_parser_export_no_auto_lcsc_flag(self):
+        """--no-auto-lcsc should set export_no_auto_lcsc to True."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["export", "board.kicad_pcb", "--no-auto-lcsc"])
+        assert args.export_no_auto_lcsc is True
+        # --auto-lcsc default is still True (separate dest)
+        assert args.export_auto_lcsc is True
+
+    def test_parser_export_auto_lcsc_flag(self):
+        """--auto-lcsc should be explicitly recognized."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["export", "board.kicad_pcb", "--auto-lcsc"])
+        assert args.export_auto_lcsc is True
+        assert args.export_no_auto_lcsc is False
+
+    def test_dispatch_forwards_no_auto_lcsc(self, tmp_path, monkeypatch):
+        """--no-auto-lcsc should be forwarded through dispatch to export_cmd."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        captured_argv = {}
+
+        import kicad_tools.cli.export_cmd as export_mod
+
+        original_main = export_mod.main
+
+        def spy_main(argv=None):
+            captured_argv["value"] = argv
+            return original_main(argv)
+
+        monkeypatch.setattr("kicad_tools.cli.export_cmd.main", spy_main)
+
+        from kicad_tools.cli import main as cli_main
+
+        rc = cli_main(
+            ["export", str(pcb), "--no-auto-lcsc", "--dry-run", "-o", str(tmp_path / "out")]
+        )
+        assert rc == 0
+        assert "--no-auto-lcsc" in captured_argv["value"]
 
     def test_dispatch_wiring(self, tmp_path, monkeypatch):
         """Verify that 'kct export ...' dispatches to export_cmd.main."""


### PR DESCRIPTION
## Summary
The unified CLI parser (`parser.py`) was missing `--auto-lcsc` and `--no-auto-lcsc` argument definitions that `export_cmd.py` already had. This meant users running `kct export --no-auto-lcsc` would get an unrecognized argument error -- they could not disable LCSC auto-matching through the unified CLI.

## Changes
- Added `--auto-lcsc` (dest=`export_auto_lcsc`, default=True) and `--no-auto-lcsc` (dest=`export_no_auto_lcsc`) argument definitions to `_add_export_parser()` in `parser.py`
- Added dispatch mapping in `_run_export_command()` in `__init__.py` so `--no-auto-lcsc` is forwarded to `export_cmd.main()`
- Added 4 new tests in `test_export_cmd.py`: default values, explicit flag parsing, and dispatch forwarding

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| --auto-lcsc recognized by unified parser | PASS | `test_parser_export_auto_lcsc_flag` passes; help output shows flag |
| --no-auto-lcsc recognized by unified parser | PASS | `test_parser_export_no_auto_lcsc_flag` passes; help output shows flag |
| Defaults correct (auto_lcsc=True, no_auto_lcsc=False) | PASS | `test_parser_export_defaults` asserts both |
| Dispatch forwards --no-auto-lcsc to export_cmd | PASS | `test_dispatch_forwards_no_auto_lcsc` captures and verifies argv |
| dest names follow export_ prefix convention | PASS | Uses `export_auto_lcsc` and `export_no_auto_lcsc` |

## Test Plan
- All 13 tests in `tests/test_export_cmd.py` pass (4 new + 9 existing)
- Ruff lint and format checks pass on all changed files
- `kct export --help` shows both `--auto-lcsc` and `--no-auto-lcsc` in output

Closes #1483