### PR TITLE
feat(report): add analog component detection with advisory audit action item

### DIFF
--- a/src/kicad_tools/analysis/__init__.py
+++ b/src/kicad_tools/analysis/__init__.py
@@ -8,8 +8,13 @@ This module provides analysis tools for PCB designs:
 - Trace length analysis for timing-critical nets
 - Signal integrity analysis (crosstalk and impedance discontinuities)
 - Thermal analysis and hotspot detection
+- Analog component detection for layout-sensitive parts
 """
 
+from .analog_detect import (
+    AnalogComponent,
+    detect_analog_components,
+)
 from .complexity import (
     Bottleneck,
     ComplexityAnalyzer,
@@ -44,6 +49,7 @@ from .trace_length import (
 )
 
 __all__ = [
+    "AnalogComponent",
     "Bottleneck",
     "ComplexityAnalyzer",
     "ComplexityRating",
@@ -68,4 +74,5 @@ __all__ = [
     "ThermalSource",
     "TraceLengthAnalyzer",
     "TraceLengthReport",
+    "detect_analog_components",
 ]

--- a/src/kicad_tools/analysis/analog_detect.py
+++ b/src/kicad_tools/analysis/analog_detect.py
@@ -1,0 +1,198 @@
+"""Analog component detection for PCB designs.
+
+Identifies components that are sensitive to layout quality (analog DACs/ADCs,
+op-amps, precision voltage references, audio-frequency crystals, analog
+switches) by matching footprint library IDs and component values against
+known patterns.  The results are advisory only -- they do not block export.
+
+Example::
+
+    >>> from kicad_tools.analysis.analog_detect import detect_analog_components
+    >>> components = detect_analog_components(pcb)
+    >>> for c in components:
+    ...     print(f"{c['reference']}: {c['reason']}")
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import PCB
+
+__all__ = [
+    "AnalogComponent",
+    "detect_analog_components",
+]
+
+
+@dataclass
+class AnalogComponent:
+    """A detected analog-sensitive component."""
+
+    reference: str
+    value: str
+    footprint: str
+    reason: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "reference": self.reference,
+            "value": self.value,
+            "footprint": self.footprint,
+            "reason": self.reason,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Detection patterns
+# ---------------------------------------------------------------------------
+
+# Library ID / footprint name patterns (case-insensitive).
+# Each tuple is (compiled regex, human-readable reason).
+_LIBRARY_ID_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Audio DACs
+    (re.compile(r"PCM5\d{3}", re.IGNORECASE), "audio DAC (PCM51xx family)"),
+    (re.compile(r"CS43\d{2}", re.IGNORECASE), "audio DAC (Cirrus Logic CS43xx)"),
+    (re.compile(r"ES90\d{2}", re.IGNORECASE), "audio DAC (ESS Sabre ES90xx)"),
+    (re.compile(r"AK4\d{3}", re.IGNORECASE), "audio DAC/ADC (AKM AK4xxx)"),
+    (re.compile(r"WM89\d{2}", re.IGNORECASE), "audio codec (Wolfson WM89xx)"),
+    (re.compile(r"TLV320", re.IGNORECASE), "audio codec (TI TLV320)"),
+    (re.compile(r"SGTL5000", re.IGNORECASE), "audio codec (NXP SGTL5000)"),
+    # Audio ADCs
+    (re.compile(r"PCM18\d{2}", re.IGNORECASE), "audio ADC (PCM18xx family)"),
+    (re.compile(r"CS53\d{2}", re.IGNORECASE), "audio ADC (Cirrus Logic CS53xx)"),
+    # Audio amplifiers
+    (re.compile(r"TPA\d{4}", re.IGNORECASE), "audio amplifier (TI TPA)"),
+    (re.compile(r"LM48\d{2}", re.IGNORECASE), "audio amplifier (LM48xx)"),
+    (re.compile(r"MAX98\d{3}", re.IGNORECASE), "audio amplifier (MAX98xxx)"),
+    (re.compile(r"SSM\d{4}", re.IGNORECASE), "audio amplifier (Analog Devices SSM)"),
+    # Op-amps: specific families before the general OPA pattern
+    (re.compile(r"OPA16\d{2}", re.IGNORECASE), "audio op-amp (OPA16xx)"),
+    (re.compile(r"LME49\d{3}", re.IGNORECASE), "audio op-amp (LME49xxx)"),
+    (re.compile(r"OPA\d{3,4}", re.IGNORECASE), "op-amp (TI OPA)"),
+    (re.compile(r"AD8\d{2,3}", re.IGNORECASE), "op-amp (Analog Devices AD8xx)"),
+    (re.compile(r"LM358", re.IGNORECASE), "op-amp (LM358)"),
+    (re.compile(r"LM324", re.IGNORECASE), "op-amp (LM324)"),
+    (re.compile(r"NE5532", re.IGNORECASE), "op-amp (NE5532)"),
+    (re.compile(r"TL07\d", re.IGNORECASE), "op-amp (TL07x)"),
+    (re.compile(r"TL08\d", re.IGNORECASE), "op-amp (TL08x)"),
+    # Precision voltage references
+    (re.compile(r"REF\d{2,4}", re.IGNORECASE), "precision voltage reference"),
+    (re.compile(r"LM4040", re.IGNORECASE), "precision voltage reference (LM4040)"),
+    (re.compile(r"ADR\d{3}", re.IGNORECASE), "precision voltage reference (ADR)"),
+    (re.compile(r"LT1009", re.IGNORECASE), "precision voltage reference (LT1009)"),
+    (re.compile(r"MCP1541", re.IGNORECASE), "precision voltage reference (MCP1541)"),
+    # Analog switches / multiplexers
+    (re.compile(r"ADG\d{3,4}", re.IGNORECASE), "analog switch (Analog Devices ADG)"),
+    (re.compile(r"DG4\d{2}", re.IGNORECASE), "analog switch (DG4xx)"),
+    (re.compile(r"TS5A\d{4}", re.IGNORECASE), "analog switch (TI TS5A)"),
+    (re.compile(r"CD4066", re.IGNORECASE), "analog switch (CD4066)"),
+    (re.compile(r"MAX4\d{3}", re.IGNORECASE), "analog switch/mux (MAX4xxx)"),
+    # Instrumentation amplifiers
+    (re.compile(r"INA\d{3}", re.IGNORECASE), "instrumentation amplifier (TI INA)"),
+    (re.compile(r"AD620", re.IGNORECASE), "instrumentation amplifier (AD620)"),
+    (re.compile(r"AD623", re.IGNORECASE), "instrumentation amplifier (AD623)"),
+]
+
+# Audio-frequency crystal oscillator values (Hz).
+# These are standard audio master clock frequencies.
+_AUDIO_CRYSTAL_FREQUENCIES_MHZ: set[str] = {
+    "11.2896",
+    "12.288",
+    "24.576",
+    "22.5792",
+    "45.1584",
+    "16.9344",
+    "33.8688",
+}
+
+# Regex to extract a numeric MHz value from a component value string.
+_MHZ_RE = re.compile(r"(\d+(?:\.\d+)?)\s*[Mm][Hh][Zz]")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def detect_analog_components(pcb: PCB) -> list[AnalogComponent]:
+    """Scan all footprints on a PCB and return analog-sensitive components.
+
+    Detection is based on:
+    1. Footprint library ID / name matching against known analog part families.
+    2. Component value matching for audio-frequency crystal oscillators.
+
+    The function never raises; components that cannot be inspected are skipped.
+
+    Parameters
+    ----------
+    pcb:
+        A loaded PCB object from :mod:`kicad_tools.schema.pcb`.
+
+    Returns
+    -------
+    list[AnalogComponent]
+        Detected analog-sensitive components, sorted by reference designator.
+    """
+    results: list[AnalogComponent] = []
+    seen_refs: set[str] = set()
+
+    for fp in pcb.footprints:
+        ref = fp.reference or ""
+        if not ref or ref in seen_refs:
+            continue
+
+        # Fields available for matching
+        name = fp.name or ""
+        value = fp.value or ""
+
+        reason = _match_library_id(name, value)
+        if reason is None:
+            reason = _match_crystal_value(value)
+
+        if reason is not None:
+            seen_refs.add(ref)
+            results.append(
+                AnalogComponent(
+                    reference=ref,
+                    value=value,
+                    footprint=name,
+                    reason=reason,
+                )
+            )
+
+    results.sort(key=lambda c: c.reference)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _match_library_id(name: str, value: str) -> str | None:
+    """Check footprint name and value against known analog part patterns.
+
+    Returns a human-readable reason string on match, or ``None``.
+    """
+    for pattern, reason in _LIBRARY_ID_PATTERNS:
+        if pattern.search(name) or pattern.search(value):
+            return reason
+    return None
+
+
+def _match_crystal_value(value: str) -> str | None:
+    """Check whether a component value indicates an audio-frequency crystal.
+
+    Returns a reason string on match, or ``None``.
+    """
+    m = _MHZ_RE.search(value)
+    if m is None:
+        return None
+    freq = m.group(1)
+    if freq in _AUDIO_CRYSTAL_FREQUENCIES_MHZ:
+        return f"audio-frequency crystal ({freq} MHz)"
+    return None

--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -967,6 +967,27 @@ class ManufacturingAudit:
                 )
             )
 
+        # Analog component advisory
+        try:
+            pcb = self._load_pcb()
+            from kicad_tools.analysis.analog_detect import detect_analog_components
+
+            analog = detect_analog_components(pcb)
+            if analog:
+                count = len(analog)
+                items.append(
+                    ActionItem(
+                        priority=3,
+                        description=(
+                            f"{count} analog-sensitive component{'s' if count != 1 else ''}"
+                            " detected — manual layout review recommended"
+                        ),
+                        command=None,
+                    )
+                )
+        except Exception:
+            logger.debug("Analog component detection skipped", exc_info=True)
+
         return sorted(items, key=lambda x: x.priority)
 
     # Helper methods for extracting PCB metrics

--- a/src/kicad_tools/cli/report_cmd.py
+++ b/src/kicad_tools/cli/report_cmd.py
@@ -311,6 +311,7 @@ def _load_data_dir(data_dir_str: str) -> dict:
         "cost.json": "cost",
         "schematic_sheets.json": "schematic_sheets",
         "pcb_figures.json": "pcb_figures",
+        "analog_components.json": "analog_components",
     }
 
     for filename, field_name in mappings.items():
@@ -330,6 +331,11 @@ def _load_data_dir(data_dir_str: str) -> dict:
     # ReportData.bom_groups expects a plain list[dict].
     if "bom_groups" in result and isinstance(result["bom_groups"], dict):
         result["bom_groups"] = result["bom_groups"].get("groups", [])
+
+    # Analog components: the collector nests the list under ``components``;
+    # ReportData.analog_components expects a plain list[dict].
+    if "analog_components" in result and isinstance(result["analog_components"], dict):
+        result["analog_components"] = result["analog_components"].get("components", [])
 
     # Load notes from text file
     notes_path = data_dir / "notes.txt"

--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -185,6 +185,14 @@ class ReportDataCollector:
             lambda: self.collect_analysis(pcb),
         )
 
+        # Analog components
+        self._safe_collect(
+            "analog_components",
+            output_dir,
+            files,
+            lambda: self.collect_analog_components(pcb),
+        )
+
         return files
 
     # ------------------------------------------------------------------
@@ -434,6 +442,28 @@ class ReportDataCollector:
             logger.warning("Thermal analysis failed", exc_info=True)
 
         return result
+
+    def collect_analog_components(self, pcb: Any) -> dict[str, Any] | None:
+        """Detect analog-sensitive components on the board.
+
+        Returns a dictionary with count and component details, or None
+        if no analog components are detected.
+
+        Args:
+            pcb: Loaded PCB object.
+
+        Returns:
+            Dictionary with analog component data, or None if none found.
+        """
+        from kicad_tools.analysis.analog_detect import detect_analog_components
+
+        components = detect_analog_components(pcb)
+        if not components:
+            return None
+        return {
+            "count": len(components),
+            "components": [c.to_dict() for c in components],
+        }
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/kicad_tools/report/generator.py
+++ b/src/kicad_tools/report/generator.py
@@ -149,6 +149,7 @@ class ReportGenerator:
             "cost": data.cost,
             "schematic_sheets": data.schematic_sheets,
             "pcb_figures": data.pcb_figures,
+            "analog_components": data.analog_components,
             "notes": data.notes,
             "tool_version": data.tool_version or __version__,
             "git_hash": data.git_hash,

--- a/src/kicad_tools/report/models.py
+++ b/src/kicad_tools/report/models.py
@@ -53,6 +53,9 @@ class ReportData:
     pcb_figures: dict | None = None
     """PCB renders: {front: path, back: path, copper: path}."""
 
+    analog_components: list[dict] | None = None
+    """Analog-sensitive components: [{reference, value, footprint, reason}]."""
+
     notes: str = ""
     """Free-form notes section content."""
 

--- a/src/kicad_tools/report/templates/design_report.md.j2
+++ b/src/kicad_tools/report/templates/design_report.md.j2
@@ -131,6 +131,18 @@
 {% endif %}
 
 {% endif %}
+{% if analog_components %}
+## Analog Components
+
+{{ analog_components | length }} analog-sensitive component{{ 's' if analog_components | length != 1 else '' }} detected — manual layout review recommended.
+
+| Reference | Value | Reason |
+|-----------|-------|--------|
+{% for comp in analog_components %}
+| {{ comp.reference | default("", true) }} | {{ comp.value | default("", true) }} | {{ comp.reason | default("", true) }} |
+{% endfor %}
+
+{% endif %}
 {% if net_status %}
 ## Routing Status
 

--- a/tests/test_analog_detect.py
+++ b/tests/test_analog_detect.py
@@ -1,0 +1,435 @@
+"""Tests for analog component detection.
+
+Verifies that the detection logic correctly identifies analog-sensitive
+components (audio DACs/ADCs, op-amps, precision references, audio crystals,
+analog switches) and produces no false positives for standard digital parts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from kicad_tools.analysis.analog_detect import (
+    AnalogComponent,
+    detect_analog_components,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal mock objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockPad:
+    net_number: int = 0
+    layers: list[str] = field(default_factory=lambda: ["F.Cu"])
+    size: tuple[float, float] = (1.0, 1.0)
+
+
+@dataclass
+class MockFootprint:
+    name: str = ""
+    layer: str = "F.Cu"
+    position: tuple[float, float] = (0.0, 0.0)
+    rotation: float = 0.0
+    reference: str = ""
+    value: str = ""
+    pads: list[MockPad] = field(default_factory=list)
+    texts: list[Any] = field(default_factory=list)
+    graphics: list[Any] = field(default_factory=list)
+    uuid: str = ""
+    description: str = ""
+    tags: str = ""
+    attr: str = "smd"
+
+
+@dataclass
+class MockPCB:
+    """Minimal PCB mock supporting footprint iteration."""
+
+    footprints: list[MockFootprint] = field(default_factory=list)
+
+
+def _make_pcb(*footprints: MockFootprint) -> MockPCB:
+    return MockPCB(footprints=list(footprints))
+
+
+def _fp(ref: str, value: str, name: str = "") -> MockFootprint:
+    """Shorthand to build a mock footprint."""
+    return MockFootprint(reference=ref, value=value, name=name)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Audio DAC detection
+# ---------------------------------------------------------------------------
+
+
+class TestAudioDACDetection:
+    """Detection of audio DAC/ADC ICs."""
+
+    def test_pcm5122_by_name(self) -> None:
+        pcb = _make_pcb(_fp("U1", "PCM5122", name="Package_SO:TSSOP-20_PCM5122"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert result[0].reference == "U1"
+        assert "audio DAC" in result[0].reason
+
+    def test_pcm5102_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U2", "PCM5102A"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "PCM51xx" in result[0].reason
+
+    def test_cs4344_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "CS4344"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "Cirrus Logic CS43xx" in result[0].reason
+
+    def test_es9038_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "ES9038PRO"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "ESS Sabre" in result[0].reason
+
+    def test_ak4490_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "AK4490"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "AKM" in result[0].reason
+
+    def test_wm8960_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "WM8960"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "Wolfson" in result[0].reason
+
+    def test_tlv320_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "TLV320AIC3104"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "TLV320" in result[0].reason
+
+    def test_sgtl5000_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "SGTL5000"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "SGTL5000" in result[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Tests: Op-amp detection
+# ---------------------------------------------------------------------------
+
+
+class TestOpAmpDetection:
+    """Detection of operational amplifiers."""
+
+    def test_opa2134_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U3", "OPA2134"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "op-amp" in result[0].reason
+
+    def test_ad8421_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "AD8421"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "AD8xx" in result[0].reason
+
+    def test_ne5532_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "NE5532"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "NE5532" in result[0].reason
+
+    def test_tl072_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "TL072"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "TL07x" in result[0].reason
+
+    def test_lm358_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "LM358"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "LM358" in result[0].reason
+
+    def test_opa1612_by_name(self) -> None:
+        pcb = _make_pcb(_fp("U1", "OPA1612", name="Amplifier:OPA1612"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "audio op-amp" in result[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Tests: Precision reference detection
+# ---------------------------------------------------------------------------
+
+
+class TestPrecisionReferenceDetection:
+    """Detection of precision voltage references."""
+
+    def test_ref5050_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "REF5050"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "precision voltage reference" in result[0].reason
+
+    def test_lm4040_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "LM4040"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "LM4040" in result[0].reason
+
+    def test_adr4550_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "ADR4550"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "ADR" in result[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Tests: Audio crystal detection
+# ---------------------------------------------------------------------------
+
+
+class TestAudioCrystalDetection:
+    """Detection of audio-frequency crystal oscillators."""
+
+    def test_11_2896mhz(self) -> None:
+        pcb = _make_pcb(_fp("Y1", "11.2896MHz"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "audio-frequency crystal" in result[0].reason
+        assert "11.2896" in result[0].reason
+
+    def test_12_288mhz(self) -> None:
+        pcb = _make_pcb(_fp("Y1", "12.288 MHz"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "12.288" in result[0].reason
+
+    def test_24_576mhz(self) -> None:
+        pcb = _make_pcb(_fp("Y1", "24.576MHz"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "24.576" in result[0].reason
+
+    def test_non_audio_crystal_not_detected(self) -> None:
+        """Standard digital crystals should not be flagged."""
+        pcb = _make_pcb(_fp("Y1", "8MHz"), _fp("Y2", "25MHz"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 0
+
+    def test_16mhz_not_detected(self) -> None:
+        """Common MCU crystal should not be flagged."""
+        pcb = _make_pcb(_fp("Y1", "16.000MHz"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: Analog switch detection
+# ---------------------------------------------------------------------------
+
+
+class TestAnalogSwitchDetection:
+    """Detection of analog switches and multiplexers."""
+
+    def test_adg708_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "ADG708"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "analog switch" in result[0].reason
+
+    def test_ts5a3159_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "TS5A3159"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "analog switch" in result[0].reason
+
+    def test_cd4066_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "CD4066"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "CD4066" in result[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Tests: Instrumentation amplifier detection
+# ---------------------------------------------------------------------------
+
+
+class TestInstrumentationAmpDetection:
+    """Detection of instrumentation amplifiers."""
+
+    def test_ina128_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "INA128"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "instrumentation amplifier" in result[0].reason
+
+    def test_ad620_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "AD620"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "AD620" in result[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Tests: Audio amplifier detection
+# ---------------------------------------------------------------------------
+
+
+class TestAudioAmplifierDetection:
+    """Detection of audio power amplifiers."""
+
+    def test_tpa3116_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "TPA3116"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "audio amplifier" in result[0].reason
+
+    def test_max98357_by_value(self) -> None:
+        pcb = _make_pcb(_fp("U1", "MAX98357"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "audio amplifier" in result[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Tests: No false positives
+# ---------------------------------------------------------------------------
+
+
+class TestNoFalsePositives:
+    """Standard digital components should not be detected."""
+
+    def test_mcu_not_detected(self) -> None:
+        pcb = _make_pcb(
+            _fp("U1", "STM32F411CEU6"),
+            _fp("U2", "ESP32-WROOM-32"),
+        )
+        assert detect_analog_components(pcb) == []
+
+    def test_passives_not_detected(self) -> None:
+        pcb = _make_pcb(
+            _fp("R1", "10k"),
+            _fp("C1", "100nF"),
+            _fp("L1", "10uH"),
+        )
+        assert detect_analog_components(pcb) == []
+
+    def test_digital_ic_not_detected(self) -> None:
+        pcb = _make_pcb(
+            _fp("U1", "74HC595"),
+            _fp("U2", "SN74LVC1G04"),
+        )
+        assert detect_analog_components(pcb) == []
+
+    def test_voltage_regulator_not_detected(self) -> None:
+        pcb = _make_pcb(
+            _fp("U1", "AMS1117-3.3"),
+            _fp("U2", "LM7805"),
+        )
+        assert detect_analog_components(pcb) == []
+
+    def test_empty_pcb(self) -> None:
+        pcb = _make_pcb()
+        assert detect_analog_components(pcb) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: Mixed board
+# ---------------------------------------------------------------------------
+
+
+class TestMixedBoard:
+    """Boards with both analog and digital components."""
+
+    def test_mixed_board_detects_only_analog(self) -> None:
+        pcb = _make_pcb(
+            _fp("U1", "STM32F411CEU6"),  # digital MCU
+            _fp("U2", "PCM5122"),  # audio DAC
+            _fp("R1", "10k"),  # passive
+            _fp("Y1", "12.288MHz"),  # audio crystal
+            _fp("U3", "OPA2134"),  # op-amp
+            _fp("C1", "100nF"),  # passive
+        )
+        result = detect_analog_components(pcb)
+        refs = {c.reference for c in result}
+        assert refs == {"U2", "Y1", "U3"}
+
+    def test_results_sorted_by_reference(self) -> None:
+        pcb = _make_pcb(
+            _fp("U5", "OPA2134"),
+            _fp("U1", "PCM5122"),
+            _fp("U3", "AD8421"),
+        )
+        result = detect_analog_components(pcb)
+        refs = [c.reference for c in result]
+        assert refs == ["U1", "U3", "U5"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: AnalogComponent dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestAnalogComponentDataclass:
+    """Tests for the AnalogComponent dataclass and to_dict."""
+
+    def test_to_dict(self) -> None:
+        comp = AnalogComponent(
+            reference="U1",
+            value="PCM5122",
+            footprint="Package_SO:TSSOP-20",
+            reason="audio DAC (PCM51xx family)",
+        )
+        d = comp.to_dict()
+        assert d == {
+            "reference": "U1",
+            "value": "PCM5122",
+            "footprint": "Package_SO:TSSOP-20",
+            "reason": "audio DAC (PCM51xx family)",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Tests: Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases and robustness."""
+
+    def test_empty_reference_skipped(self) -> None:
+        """Footprints without a reference are skipped."""
+        pcb = _make_pcb(_fp("", "PCM5122"))
+        assert detect_analog_components(pcb) == []
+
+    def test_duplicate_reference_only_counted_once(self) -> None:
+        """If two footprints share a reference, only the first is counted."""
+        pcb = _make_pcb(
+            _fp("U1", "PCM5122"),
+            _fp("U1", "PCM5122"),
+        )
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+
+    def test_case_insensitive_matching(self) -> None:
+        """Pattern matching is case-insensitive."""
+        pcb = _make_pcb(_fp("U1", "pcm5122"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+
+    def test_name_matching_takes_precedence_over_crystal(self) -> None:
+        """Library ID match is returned even if crystal match would also hit."""
+        # A component whose name matches a library pattern and whose value
+        # could be interpreted as a crystal frequency -- library match wins.
+        pcb = _make_pcb(_fp("U1", "12.288MHz", name="AudioCodec:PCM5122"))
+        result = detect_analog_components(pcb)
+        assert len(result) == 1
+        assert "audio DAC" in result[0].reason


### PR DESCRIPTION
## Summary

Add detection logic for layout-sensitive analog components (audio DACs/ADCs, op-amps, precision references, audio-frequency crystals, analog switches). Results appear as an advisory section in the design report and as a priority-3 action item in the manufacturing audit. Advisory only -- does not block export.

## Changes

- **New module**: `src/kicad_tools/analysis/analog_detect.py` -- detection engine with regex-based library ID and value matching against known analog part families
- **ReportData model**: Added `analog_components` field (`list[dict] | None`)
- **Report collector**: Added `collect_analog_components()` sub-collector writing `analog_components.json`
- **Report generator**: Forward `analog_components` to Jinja2 template context
- **Report template**: Conditional "Analog Components" section with count, table of references/values/reasons
- **Auditor**: Added advisory ActionItem (priority=3) in `_generate_action_items()` when analog components detected
- **CLI report_cmd**: Added `analog_components.json` to data-dir loading with post-load transformation
- **Exports**: `AnalogComponent` and `detect_analog_components` exported from `kicad_tools.analysis`
- **Tests**: 41 tests covering audio DACs, op-amps, precision references, audio crystals, analog switches, instrumentation amps, audio amplifiers, false-positive rejection, mixed boards, edge cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Detection logic matching library IDs and values against analog patterns | Done | 41 tests covering PCM5122, CS4344, OPA2134, AD8421, REF5050, 12.288MHz crystals, ADG708, INA128, TPA3116, etc. |
| `analog_components` field added to ReportData | Done | Field added to `report/models.py` |
| Integration as advisory ActionItem (priority-3) in audit | Done | Added in `_generate_action_items()` with "N analog-sensitive components detected -- manual layout review recommended" |
| Report section: "N analog-sensitive components detected -- manual layout review recommended" | Done | Template section with count and component table |
| Advisory only -- does not block export | Done | Priority-3 action item; no effect on audit verdict |
| No false positives for standard digital components | Done | Tests verify MCUs, passives, digital ICs, voltage regulators not detected |

## Test Plan

- `uv run pytest tests/test_analog_detect.py -v` -- 41 tests, all passing
- `uv run pytest tests/test_audit.py` -- 74 existing tests, all passing (no regressions)
- `uv run ruff check` on all changed files -- clean
- `uv run ruff format --check` on all changed files -- clean

Closes #1481