### PR TITLE
docs: fix incorrect Schematic import path and constructor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,13 +188,13 @@ See `docs/mcp/` for complete documentation.
 Build schematics using reusable, tested circuit blocks:
 
 ```python
-from kicad_tools.schematic import Schematic
+from kicad_tools.schematic.models import Schematic
 from kicad_tools.schematic.blocks import (
     MCUBlock, CrystalOscillator, LDOBlock, USBConnector,
     DebugHeader, I2CPullups, ResetButton
 )
 
-sch = Schematic.create("project.kicad_sch")
+sch = Schematic("My STM32 Design")
 
 # Add an MCU with bypass capacitors
 mcu = MCUBlock(sch, x=150, y=100,


### PR DESCRIPTION
## Summary
Fix the Circuit Blocks example in the README which documented a non-existent API, making the schematic module appear completely broken to new users.

## Changes
- Fixed import path from `kicad_tools.schematic` to `kicad_tools.schematic.models` (the `__init__.py` at `kicad_tools.schematic` only exports symbol generation tools, not the `Schematic` class)
- Fixed constructor from `Schematic.create("project.kicad_sch")` to `Schematic("My STM32 Design")` (no `create()` class method exists; the actual API is `Schematic(title)`)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Import path matches actual module structure | Pass | `kicad_tools.schematic.models.__init__.py` exports `Schematic` in its `__all__` |
| Constructor matches actual API | Pass | `Schematic.__init__` takes `title` as first positional arg, no `create()` classmethod exists |
| No other incorrect references remain | Pass | Grep for `Schematic.create` and old import path returns zero matches |

## Test Plan
- Verified `Schematic` is exported from `kicad_tools.schematic.models` (confirmed in `__init__.py` `__all__`)
- Verified `Schematic.__init__` signature accepts `title` as first argument
- Verified no `create()` classmethod exists on `Schematic`
- Grepped README for any remaining incorrect references

Closes #1500