### PR TITLE
fix(report): render ERC as SKIPPED when not actually run

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -36,6 +36,7 @@ class ERCStatus:
     warning_count: int = 0
     blocking_error_count: int = 0  # Only electrical errors that block readiness
     passed: bool = True
+    skipped: bool = False
     details: str = ""
     report_path: Path | None = None
 
@@ -45,6 +46,7 @@ class ERCStatus:
             "warning_count": self.warning_count,
             "blocking_error_count": self.blocking_error_count,
             "passed": self.passed,
+            "skipped": self.skipped,
             "details": self.details,
         }
 
@@ -450,6 +452,12 @@ class ManufacturingAudit:
         # Run checks
         if not self.skip_erc and self.schematic_path.exists():
             result.erc = self._check_erc()
+        else:
+            result.erc.skipped = True
+            if self.skip_erc:
+                result.erc.details = "ERC skipped by user request"
+            else:
+                result.erc.details = "ERC skipped (no schematic provided)"
 
         if self.pcb_path.exists():
             pcb = self._load_pcb()

--- a/src/kicad_tools/report/models.py
+++ b/src/kicad_tools/report/models.py
@@ -32,7 +32,9 @@ class ReportData:
     """DRC summary: {error_count, warning_count, blocking_count, passed}."""
 
     erc: dict | None = None
-    """ERC summary: {error_count, warning_count, passed, details}."""
+    """ERC summary: {error_count, warning_count, passed, skipped, details}.
+    When ``skipped`` is true the ERC check was not executed (e.g. no
+    schematic provided or ``--skip-erc`` flag used)."""
 
     audit: dict | None = None
     """Audit results: {verdict, action_items}."""

--- a/src/kicad_tools/report/templates/design_report.md.j2
+++ b/src/kicad_tools/report/templates/design_report.md.j2
@@ -41,7 +41,7 @@
 | Errors | {{ erc.error_count | default(0) }} |
 | Warnings | {{ erc.warning_count | default(0) }} |
 
-**Status**: {% if erc.passed | default(true) %}PASS{% else %}FAIL{% endif %}
+**Status**: {% if erc.skipped | default(false) %}SKIPPED{% elif erc.passed | default(true) %}PASS{% else %}FAIL{% endif %}
 
 {% if erc.details %}
 **Details**: {{ erc.details }}

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -14,6 +14,33 @@ from kicad_tools.audit.auditor import (
 )
 
 
+class TestERCStatusSkipped:
+    """Tests for ERCStatus.skipped field."""
+
+    def test_default_skipped_is_false(self):
+        """ERCStatus defaults to skipped=False."""
+        status = ERCStatus()
+        assert status.skipped is False
+
+    def test_skipped_true(self):
+        """ERCStatus can be constructed with skipped=True."""
+        status = ERCStatus(skipped=True)
+        assert status.skipped is True
+
+    def test_to_dict_includes_skipped(self):
+        """ERCStatus.to_dict() includes skipped key."""
+        status = ERCStatus(skipped=True)
+        d = status.to_dict()
+        assert "skipped" in d
+        assert d["skipped"] is True
+
+    def test_to_dict_skipped_false_by_default(self):
+        """ERCStatus.to_dict() includes skipped=False by default."""
+        status = ERCStatus()
+        d = status.to_dict()
+        assert d["skipped"] is False
+
+
 class TestAuditResult:
     """Tests for AuditResult class."""
 
@@ -470,9 +497,17 @@ class TestManufacturingAudit:
         audit = ManufacturingAudit(drc_clean_pcb, skip_erc=True)
         result = audit.run()
 
-        # ERC should be skipped - check that we have default empty status
-        # (Either no errors or note about being skipped)
-        assert result.erc.error_count == 0 or result.erc.details
+        assert result.erc.skipped is True
+        assert result.erc.error_count == 0
+        assert "skipped" in result.erc.details.lower()
+
+    def test_pcb_only_audit_sets_erc_skipped(self, drc_clean_pcb: Path):
+        """PCB-only audit (no schematic) marks ERC as skipped."""
+        audit = ManufacturingAudit(drc_clean_pcb)
+        assert audit.skip_erc is True
+        result = audit.run()
+        assert result.erc.skipped is True
+        assert result.erc.passed is True  # default, not a real pass
 
 
 class TestAuditCLI:

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -565,6 +565,62 @@ class TestReportGenerator:
         assert "FAIL" in content
         assert "pin_not_connected (2x), power_pin_not_driven (1x)" in content
 
+    def test_erc_skipped_status(self, tmp_path: Path) -> None:
+        """ERC section renders SKIPPED when skipped is True."""
+        data = _full_data(
+            erc={
+                "error_count": 0,
+                "warning_count": 0,
+                "passed": True,
+                "skipped": True,
+                "details": "ERC skipped by user request",
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "## ERC Status" in content
+        assert "SKIPPED" in content
+        assert "PASS" not in content.split("## ERC Status")[1].split("##")[0]
+
+    def test_erc_pass_not_affected_by_skipped_false(self, tmp_path: Path) -> None:
+        """ERC renders PASS when skipped is False (explicit)."""
+        data = _full_data(
+            erc={
+                "error_count": 0,
+                "warning_count": 0,
+                "passed": True,
+                "skipped": False,
+                "details": "",
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+
+        content = report_path.read_text(encoding="utf-8")
+        erc_section = content.split("## ERC Status")[1].split("##")[0]
+        assert "PASS" in erc_section
+        assert "SKIPPED" not in erc_section
+
+    def test_erc_pass_when_skipped_key_absent(self, tmp_path: Path) -> None:
+        """ERC renders PASS when skipped key is absent (backward compat)."""
+        data = _full_data(
+            erc={
+                "error_count": 0,
+                "warning_count": 0,
+                "passed": True,
+                "details": "",
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+
+        content = report_path.read_text(encoding="utf-8")
+        erc_section = content.split("## ERC Status")[1].split("##")[0]
+        assert "PASS" in erc_section
+        assert "SKIPPED" not in erc_section
+
     def test_erc_omitted_when_none(self, tmp_path: Path) -> None:
         """ERC section is absent when erc is None."""
         data = _full_data(erc=None)


### PR DESCRIPTION
## Summary
When ERC is skipped (via `--skip-erc` or when a `.kicad_pcb` is passed directly), the report incorrectly showed "PASS" because the default `ERCStatus` was indistinguishable from a genuine clean ERC run. This adds a `skipped` field so the report renders "SKIPPED" instead.

## Changes
- Added `skipped: bool = False` field to `ERCStatus` dataclass in `auditor.py`
- Included `skipped` key in `ERCStatus.to_dict()` output
- Set `skipped=True` with explanatory details in `ManufacturingAudit.run()` when ERC is not executed
- Updated `design_report.md.j2` template to render "SKIPPED" when `erc.skipped` is true (with `| default(false)` for backward compatibility)
- Updated `ReportData.erc` docstring in `models.py` to document the `skipped` field

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--skip-erc` shows SKIPPED | Done | `test_skip_erc_flag` verifies `skipped=True` and details contain "skipped" |
| PCB-only input shows SKIPPED | Done | `test_pcb_only_audit_sets_erc_skipped` verifies `skipped=True` |
| Real ERC pass still shows PASS | Done | `test_erc_pass_status` and `test_erc_pass_not_affected_by_skipped_false` |
| Real ERC fail still shows FAIL | Done | `test_erc_fail_status` |
| `to_dict()` includes `skipped` key | Done | `test_to_dict_includes_skipped` and `test_to_dict_skipped_false_by_default` |
| Backward compat (no skipped key) | Done | `test_erc_pass_when_skipped_key_absent` uses `| default(false)` |

## Test Plan
- 86 audit tests pass, 70 report generator tests pass, 35 report collector tests pass
- New tests: `TestERCStatusSkipped` (4 tests), updated `test_skip_erc_flag`, new `test_pcb_only_audit_sets_erc_skipped`, new template tests for SKIPPED rendering and backward compatibility

Closes #1496