### PR TITLE
fix(export): proceed with export when preflight checks fail

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -678,6 +678,8 @@ def _run_export_command(args) -> int:
         sub_argv.append("--no-auto-lcsc")
     if getattr(args, "export_skip_preflight", False):
         sub_argv.append("--skip-preflight")
+    if getattr(args, "export_strict_preflight", False):
+        sub_argv.append("--strict-preflight")
     if getattr(args, "export_skip_drc", False):
         sub_argv.append("--skip-drc")
     if getattr(args, "export_skip_erc", False):

--- a/src/kicad_tools/cli/export_cmd.py
+++ b/src/kicad_tools/cli/export_cmd.py
@@ -89,6 +89,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Skip all pre-flight validation checks",
     )
     parser.add_argument(
+        "--strict-preflight",
+        action="store_true",
+        help="Block export when preflight checks fail (for CI; default: export proceeds with warnings)",
+    )
+    parser.add_argument(
         "--skip-drc",
         action="store_true",
         help="Skip DRC check in pre-flight validation",
@@ -158,6 +163,7 @@ def run_export(args: argparse.Namespace) -> int:
         include_project_zip=not args.no_project_zip,
         auto_lcsc=auto_lcsc,
         preflight=preflight_cfg,
+        strict_preflight=getattr(args, "strict_preflight", False),
     )
 
     pkg = ManufacturingPackage(
@@ -202,6 +208,13 @@ def run_export(args: argparse.Namespace) -> int:
                 print(f"         {pr.details}")
         print()
 
+    # Display preflight warnings (non-blocking failures) in text mode
+    if result.warnings and output_format == "text" and not quiet:
+        print(f"Preflight warnings ({len(result.warnings)}):")
+        for warn in result.warnings:
+            print(f"  - {warn}")
+        print()
+
     # JSON output mode
     if output_format == "json":
         json_result: dict = {
@@ -210,6 +223,8 @@ def run_export(args: argparse.Namespace) -> int:
             "files": [str(f) for f in result.all_files],
             "errors": result.errors,
         }
+        if result.warnings:
+            json_result["warnings"] = result.warnings
         if result.preflight_results:
             json_result["preflight"] = [pr.to_dict() for pr in result.preflight_results]
         print(json.dumps(json_result, indent=2))

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3877,6 +3877,12 @@ def _add_export_parser(subparsers) -> None:
         help="Skip all pre-flight validation checks",
     )
     export_parser.add_argument(
+        "--strict-preflight",
+        dest="export_strict_preflight",
+        action="store_true",
+        help="Block export when preflight checks fail (for CI; default: export proceeds with warnings)",
+    )
+    export_parser.add_argument(
         "--skip-drc",
         dest="export_skip_drc",
         action="store_true",

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -41,6 +41,11 @@ class ManufacturingConfig(AssemblyConfig):
     # Pre-flight validation settings
     preflight: PreflightConfig | None = None
 
+    # When True, preflight FAIL results block export (early return, no files).
+    # When False (default), preflight failures are recorded as warnings but
+    # export proceeds to generate output files.
+    strict_preflight: bool = False
+
 
 @dataclass
 class ManufacturingResult:
@@ -52,6 +57,7 @@ class ManufacturingResult:
     project_zip_path: Path | None = None
     manifest_path: Path | None = None
     preflight_results: list[PreflightResult] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
     @property
@@ -227,14 +233,20 @@ class ManufacturingPackage:
             result.preflight_results = preflight_results
 
             if PreflightChecker.has_failures(preflight_results):
-                # Collect failure messages into errors
+                # Collect failure messages
                 for pr in preflight_results:
                     if pr.status == "FAIL":
                         msg = f"Preflight FAIL [{pr.name}]: {pr.message}"
                         if pr.details:
                             msg += f" ({pr.details})"
-                        result.errors.append(msg)
-                return result
+                        if self.config.strict_preflight:
+                            result.errors.append(msg)
+                        else:
+                            result.warnings.append(msg)
+
+                # In strict mode, block export on preflight failures
+                if self.config.strict_preflight:
+                    return result
 
         out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_export_cmd.py
+++ b/tests/test_export_cmd.py
@@ -266,6 +266,47 @@ class TestExportCmdFromMainParser:
         assert rc == 0
         assert "--no-auto-lcsc" in captured_argv["value"]
 
+    def test_parser_strict_preflight_flag(self):
+        """--strict-preflight should be parsed correctly."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["export", "board.kicad_pcb", "--strict-preflight"])
+        assert args.export_strict_preflight is True
+
+    def test_parser_strict_preflight_default_false(self):
+        """--strict-preflight should default to False."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["export", "board.kicad_pcb"])
+        assert args.export_strict_preflight is False
+
+    def test_dispatch_forwards_strict_preflight(self, tmp_path, monkeypatch):
+        """--strict-preflight should be forwarded through dispatch to export_cmd."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        captured_argv = {}
+
+        import kicad_tools.cli.export_cmd as export_mod
+
+        original_main = export_mod.main
+
+        def spy_main(argv=None):
+            captured_argv["value"] = argv
+            return original_main(argv)
+
+        monkeypatch.setattr("kicad_tools.cli.export_cmd.main", spy_main)
+
+        from kicad_tools.cli import main as cli_main
+
+        rc = cli_main(
+            ["export", str(pcb), "--strict-preflight", "--dry-run", "-o", str(tmp_path / "out")]
+        )
+        assert rc == 0
+        assert "--strict-preflight" in captured_argv["value"]
+
     def test_dispatch_wiring(self, tmp_path, monkeypatch):
         """Verify that 'kct export ...' dispatches to export_cmd.main."""
         pcb = tmp_path / "board.kicad_pcb"
@@ -275,4 +316,17 @@ class TestExportCmdFromMainParser:
 
         # Just test dry-run to avoid needing kicad-cli
         rc = cli_main(["export", str(pcb), "--dry-run", "-o", str(tmp_path / "out")])
+        assert rc == 0
+
+
+class TestExportCmdStrictPreflight:
+    """Tests for --strict-preflight flag behavior."""
+
+    def test_strict_preflight_parsed(self, tmp_path):
+        """--strict-preflight flag should be parsed by export_cmd."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        # dry-run to avoid needing kicad-cli
+        rc = export_main([str(pcb), "--strict-preflight", "--dry-run", "-o", str(tmp_path / "out")])
         assert rc == 0

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -14,7 +14,7 @@ from kicad_tools.export.manufacturing import (
     _create_project_zip,
     _sha256_file,
 )
-from kicad_tools.export.preflight import PreflightConfig
+from kicad_tools.export.preflight import PreflightChecker, PreflightConfig, PreflightResult
 
 
 class TestSha256File:
@@ -385,3 +385,116 @@ class TestManufacturingPackageExport:
         result = pkg.export(tmp_path / "out")
 
         assert result.report_path is None
+
+    def test_preflight_failure_proceeds_by_default(self, tmp_path, monkeypatch):
+        """Preflight FAIL should NOT block export when strict_preflight is False (default)."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        from kicad_tools.export import assembly
+
+        assembly_called = {"value": False}
+
+        def fake_assembly_export(self, output_dir=None):
+            assembly_called["value"] = True
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            bom_path = od / "bom_jlcpcb.csv"
+            bom_path.write_text("Comment,Designator,Footprint,LCSC Part #\n")
+            return assembly.AssemblyPackageResult(
+                output_dir=od,
+                bom_path=bom_path,
+            )
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        # Mock preflight to return a FAIL result
+        fail_results = [
+            PreflightResult(name="board_outline", status="FAIL", message="No board outline found"),
+            PreflightResult(name="bom_pcb_match", status="OK", message="All BOM components placed"),
+        ]
+        monkeypatch.setattr(
+            PreflightChecker, "run_all", lambda self: fail_results
+        )
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            # strict_preflight defaults to False
+        )
+        pkg = ManufacturingPackage(
+            pcb_path=pcb,
+            manufacturer="jlcpcb",
+            config=config,
+        )
+        result = pkg.export(tmp_path / "out")
+
+        # Export should have proceeded
+        assert assembly_called["value"], "Assembly generation should have been called"
+        assert result.assembly_result is not None
+        assert result.assembly_result.bom_path is not None
+
+        # Preflight failures should appear as warnings, not errors
+        assert len(result.warnings) == 1
+        assert "board_outline" in result.warnings[0]
+        assert result.success, f"Unexpected errors: {result.errors}"
+
+        # Preflight results should still be recorded
+        assert len(result.preflight_results) == 2
+
+    def test_strict_preflight_blocks_export(self, tmp_path, monkeypatch):
+        """Preflight FAIL should block export when strict_preflight is True."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        from kicad_tools.export import assembly
+
+        assembly_called = {"value": False}
+
+        def fake_assembly_export(self, output_dir=None):
+            assembly_called["value"] = True
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        # Mock preflight to return a FAIL result
+        fail_results = [
+            PreflightResult(
+                name="board_outline",
+                status="FAIL",
+                message="No board outline found",
+                details="Expected Edge.Cuts layer",
+            ),
+        ]
+        monkeypatch.setattr(
+            PreflightChecker, "run_all", lambda self: fail_results
+        )
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            strict_preflight=True,
+        )
+        pkg = ManufacturingPackage(
+            pcb_path=pcb,
+            manufacturer="jlcpcb",
+            config=config,
+        )
+        out_dir = tmp_path / "out"
+        result = pkg.export(out_dir)
+
+        # Export should NOT have proceeded
+        assert not assembly_called["value"], "Assembly generation should NOT have been called"
+        assert not result.success
+        assert len(result.errors) == 1
+        assert "board_outline" in result.errors[0]
+        assert "Expected Edge.Cuts layer" in result.errors[0]
+
+        # Output directory should not exist
+        assert not out_dir.exists()


### PR DESCRIPTION
## Summary

Preflight failures no longer block file generation by default. The early `return result` in `ManufacturingPackage.export()` that exited before creating the output directory or generating any files has been replaced with a warnings-based approach. A new `--strict-preflight` opt-in flag preserves the old blocking behavior for CI pipelines.

## Changes

- Remove early return on preflight failure in `ManufacturingPackage.export()` -- failures are now recorded as warnings and export proceeds
- Add `strict_preflight` field to `ManufacturingConfig` (default `False`) that restores the old blocking behavior when enabled
- Add `warnings` field to `ManufacturingResult` for non-blocking preflight messages
- Add `--strict-preflight` CLI flag to `export_cmd.py`, `parser.py`, and the dispatch layer in `__init__.py`
- Display preflight warnings in both text and JSON output modes
- Add tests for both default (non-blocking) and strict (blocking) preflight behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Export produces output files even when preflight checks report FAIL | PASS | `test_preflight_failure_proceeds_by_default` verifies assembly is called, BOM is generated, and `result.success` is True |
| Preflight failures are still printed/included in output | PASS | Warnings list populated, JSON output includes `warnings` key, text mode prints warnings |
| `--skip-preflight` bypasses all preflight checks | PASS | Existing tests confirm skip_all behavior unchanged |
| `--strict-preflight` restores blocking behavior | PASS | `test_strict_preflight_blocks_export` verifies early return, no assembly call, output dir not created |
| Exit code reflects actual export errors, not preflight advisories | PASS | Default mode returns exit 0 when files generated despite preflight FAIL |
| JSON output includes preflight results regardless of pass/fail | PASS | JSON output includes `preflight` and `warnings` keys |

## Test Plan

All 39 tests pass across `test_manufacturing_package.py` and `test_export_cmd.py`:
- `test_preflight_failure_proceeds_by_default` -- verifies export continues past FAIL, warnings populated, no errors
- `test_strict_preflight_blocks_export` -- verifies early return, errors populated, output dir not created
- `test_parser_strict_preflight_flag` -- flag parsed correctly in main parser
- `test_parser_strict_preflight_default_false` -- default is False
- `test_dispatch_forwards_strict_preflight` -- flag forwarded through dispatch layer
- `test_strict_preflight_parsed` -- flag accepted by export_cmd parser

Closes #1490