### PR TITLE
fix(cli): resolve .kicad_pro to .kicad_pcb in validate --connectivity and report generate

### DIFF
--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -287,8 +287,18 @@ def run_validate_connectivity_command(args) -> int:
                 pcb_path = f
                 break
             elif f.lower().endswith(".kicad_pro"):
-                # Project file - just pass it through
-                pcb_path = f
+                # Resolve .kicad_pro to .kicad_pcb by stem matching so the
+                # S-expression parser receives a PCB file, not JSON.
+                from pathlib import Path
+
+                pro_path = Path(f)
+                resolved = pro_path.with_suffix(".kicad_pcb")
+                if not resolved.exists():
+                    print(
+                        f"Error: PCB file not found: {resolved}"
+                    )
+                    return 1
+                pcb_path = str(resolved)
                 break
 
     if not pcb_path:

--- a/src/kicad_tools/cli/report_cmd.py
+++ b/src/kicad_tools/cli/report_cmd.py
@@ -105,6 +105,18 @@ def _run_generate(args: argparse.Namespace) -> int:
     input_path = Path(args.input)
     project_name = input_path.stem
 
+    # Resolve .kicad_pro to .kicad_pcb by stem matching so the S-expression
+    # parser receives a PCB file rather than JSON project metadata.
+    if input_path.suffix == ".kicad_pro":
+        pcb_path = input_path.with_suffix(".kicad_pcb")
+        if not pcb_path.exists():
+            print(
+                f"Error: PCB file not found: {pcb_path}",
+                file=sys.stderr,
+            )
+            return 1
+        input_path = pcb_path
+
     # Determine data source: explicit --data-dir, auto-collection, or skeleton
     version_dir: Path | None = None
     if args.data_dir:

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -616,3 +616,55 @@ class TestConnectivityCLI:
         assert exit_code == 1
         captured = capsys.readouterr()
         assert "Error" in captured.err or "not found" in captured.err
+
+
+class TestConnectivityProResolution:
+    """Tests for .kicad_pro -> .kicad_pcb resolution in validate --connectivity."""
+
+    def test_kicad_pro_resolves_to_pcb(self, tmp_path: Path):
+        """run_validate_connectivity_command resolves .kicad_pro to .kicad_pcb."""
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.validation import run_validate_connectivity_command
+
+        # Create a .kicad_pro and corresponding .kicad_pcb
+        pro_file = tmp_path / "board.kicad_pro"
+        pro_file.write_text("{}")
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(FULLY_CONNECTED_PCB)
+
+        args = SimpleNamespace(
+            connectivity=True,
+            validate_files=[str(pro_file)],
+            validate_pcb=None,
+            validate_format="table",
+            validate_errors_only=False,
+            validate_strict=False,
+            validate_verbose=False,
+        )
+        exit_code = run_validate_connectivity_command(args)
+        assert exit_code == 0
+
+    def test_kicad_pro_missing_pcb_returns_error(self, tmp_path: Path, capsys):
+        """run_validate_connectivity_command errors when .kicad_pcb is missing."""
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.validation import run_validate_connectivity_command
+
+        pro_file = tmp_path / "board.kicad_pro"
+        pro_file.write_text("{}")
+        # Do NOT create .kicad_pcb
+
+        args = SimpleNamespace(
+            connectivity=True,
+            validate_files=[str(pro_file)],
+            validate_pcb=None,
+            validate_format="table",
+            validate_errors_only=False,
+            validate_strict=False,
+            validate_verbose=False,
+        )
+        exit_code = run_validate_connectivity_command(args)
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "PCB file not found" in captured.out

--- a/tests/test_report_cmd.py
+++ b/tests/test_report_cmd.py
@@ -209,21 +209,36 @@ class TestFigureGenerationWiring:
         assert "## Schematic Overview" not in content
 
     @patch("kicad_tools.report.ReportFigureGenerator")
-    def test_no_figures_for_kicad_pro_input(self, mock_gen_cls, tmp_path):
-        """Figure generation is skipped for .kicad_pro files."""
+    def test_kicad_pro_resolves_to_kicad_pcb(self, mock_gen_cls, tmp_path):
+        """A .kicad_pro input is resolved to .kicad_pcb and triggers figures."""
+        mock_instance = mock_gen_cls.return_value
+        mock_instance.generate_all.return_value = _mock_figure_entries()
+
+        # Create project, PCB, and schematic files so resolution succeeds
+        pro_file = tmp_path / "project.kicad_pro"
+        pro_file.write_text("{}")
+        pcb_file = tmp_path / "project.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+        sch_file = tmp_path / "project.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+
         output_dir = tmp_path / "reports"
         result = report_main(
             [
                 "generate",
-                "project.kicad_pro",
+                str(pro_file),
                 "--mfr",
                 "jlcpcb",
                 "-o",
                 str(output_dir),
+                "--skip-collect",
             ]
         )
         assert result == 0
-        mock_gen_cls.assert_not_called()
+        # Figure generation should be triggered since resolved path is .kicad_pcb
+        mock_instance.generate_all.assert_called_once()
+        call_args = mock_instance.generate_all.call_args
+        assert call_args[0][0] == pcb_file
 
     @patch("kicad_tools.report.ReportFigureGenerator")
     def test_data_dir_skips_figure_generation(self, mock_gen_cls, tmp_path):
@@ -511,3 +526,54 @@ class TestCLIFlags:
         parser = create_parser()
         args = parser.parse_args(["report", "generate", "board.kicad_pcb"])
         assert args.report_no_figures is False
+
+
+class TestKicadProResolution:
+    """Tests for .kicad_pro -> .kicad_pcb resolution in report generate."""
+
+    def test_missing_pcb_for_kicad_pro_returns_error(self, tmp_path, capsys):
+        """When .kicad_pro is given but .kicad_pcb does not exist, return error."""
+        pro_file = tmp_path / "project.kicad_pro"
+        pro_file.write_text("{}")
+        # Do NOT create the .kicad_pcb file
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                str(pro_file),
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(output_dir),
+            ]
+        )
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "Error: PCB file not found" in captured.err
+        assert "project.kicad_pcb" in captured.err
+
+    @patch("kicad_tools.report.ReportFigureGenerator")
+    def test_kicad_pro_no_figures_flag_skips_figures(self, mock_gen_cls, tmp_path):
+        """.kicad_pro with --no-figures resolves to .kicad_pcb but skips figures."""
+        pro_file = tmp_path / "project.kicad_pro"
+        pro_file.write_text("{}")
+        pcb_file = tmp_path / "project.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+
+        output_dir = tmp_path / "reports"
+        result = report_main(
+            [
+                "generate",
+                str(pro_file),
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(output_dir),
+                "--no-figures",
+                "--skip-collect",
+            ]
+        )
+        assert result == 0
+        mock_gen_cls.assert_not_called()


### PR DESCRIPTION
## Summary
Two CLI code paths (`report generate` and `validate --connectivity`) passed `.kicad_pro` file paths directly to the S-expression parser, which expects `(kicad_pcb ...)` format but receives JSON, causing `ParseError: Unexpected content at position 4`. This adds stem-matching resolution at both CLI entry points.

## Changes
- `src/kicad_tools/cli/report_cmd.py`: Add `.kicad_pro` -> `.kicad_pcb` resolution in `_run_generate()` before `_auto_collect()` and figure generation
- `src/kicad_tools/cli/commands/validation.py`: Resolve `.kicad_pro` to `.kicad_pcb` in `run_validate_connectivity_command()` instead of passing it through
- `tests/test_report_cmd.py`: Update existing `.kicad_pro` test to verify resolution; add tests for missing PCB error and `--no-figures` with `.kicad_pro`
- `tests/test_connectivity.py`: Add tests for `.kicad_pro` resolution and missing PCB error in connectivity validation

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `validate --connectivity project.kicad_pro` resolves to `.kicad_pcb` | PASS | New test `test_kicad_pro_resolves_to_pcb` passes with real PCB content |
| `report generate project.kicad_pro --mfr jlcpcb --no-figures` resolves to `.kicad_pcb` | PASS | New test `test_kicad_pro_no_figures_flag_skips_figures` passes |
| `report generate project.kicad_pro --mfr jlcpcb` (with figures) works | PASS | Test `test_kicad_pro_resolves_to_kicad_pcb` verifies figure generation triggers |
| Clear error when `.kicad_pcb` does not exist | PASS | Tests `test_missing_pcb_for_kicad_pro_returns_error` and `test_kicad_pro_missing_pcb_returns_error` verify error messages |
| All existing tests continue to pass | PASS | All pre-existing passing tests still pass; pre-existing failures on main are unchanged |

## Test Plan
- `python3 -m pytest tests/test_connectivity.py -o addopts=""` -- 30/30 pass
- `python3 -m pytest tests/test_report_cmd.py -o addopts="" -k "KicadPro or test_kicad_pro_resolves"` -- 4/4 pass (new + updated tests)

Closes #1493