### PR TITLE
fix(audit): respect assembly:none setting in cost estimate

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -179,6 +179,7 @@ class CostEstimate:
     total_cost: float = 0.0
     quantity: int = 5
     currency: str = "USD"
+    assembly_mode: str | None = None  # "none" when assembly is excluded
 
     def to_dict(self) -> dict:
         return {
@@ -188,6 +189,7 @@ class CostEstimate:
             "total_cost": self.total_cost,
             "quantity": self.quantity,
             "currency": self.currency,
+            "assembly_mode": self.assembly_mode,
         }
 
 
@@ -314,6 +316,7 @@ class ManufacturingAudit:
         copper_oz: float = 1.0,
         quantity: int = 5,
         skip_erc: bool = False,
+        no_assembly: bool = False,
     ):
         """Initialize the audit.
 
@@ -324,6 +327,7 @@ class ManufacturingAudit:
             copper_oz: Copper weight in oz
             quantity: Quantity for cost estimate
             skip_erc: Skip ERC check (for PCB-only audits)
+            no_assembly: Skip assembly cost calculation
         """
         self.path = Path(project_or_pcb)
         self.manufacturer = manufacturer
@@ -331,6 +335,7 @@ class ManufacturingAudit:
         self.copper_oz = copper_oz
         self.quantity = quantity
         self.skip_erc = skip_erc
+        self.no_assembly = no_assembly
 
         # Resolve paths
         if self.path.suffix == ".kicad_pro":
@@ -344,6 +349,13 @@ class ManufacturingAudit:
             self.skip_erc = True  # Skip ERC for PCB-only
         else:
             raise ValueError(f"Expected .kicad_pro or .kicad_pcb file, got: {self.path}")
+
+        # Read assembly mode from project.kct if not explicitly overridden
+        self._assembly_mode: str | None = None
+        if not self.no_assembly:
+            self._assembly_mode = self._read_assembly_mode()
+            if self._assembly_mode == "none":
+                self.no_assembly = True
 
         # Loaded objects (lazy)
         self._pcb: PCB | None = None
@@ -418,6 +430,35 @@ class ManufacturingAudit:
 
         # 2. Default to <basename>.kicad_sch
         return self.path.with_suffix(".kicad_sch")
+
+    def _read_assembly_mode(self) -> str | None:
+        """Read manufacturing.assembly from project.kct if available.
+
+        Returns the assembly mode string (e.g., "smt", "none") or None
+        if no project.kct exists or the field is not set.
+        """
+        project_dir = self.path.parent
+        kct_path = project_dir / "project.kct"
+        if not kct_path.exists():
+            kct_path = project_dir.parent / "project.kct"
+
+        if kct_path.exists():
+            try:
+                from kicad_tools.spec import load_spec
+
+                spec = load_spec(kct_path)
+                if (
+                    spec.requirements
+                    and spec.requirements.manufacturing
+                    and spec.requirements.manufacturing.assembly
+                ):
+                    mode = spec.requirements.manufacturing.assembly
+                    logger.debug(f"Assembly mode from project.kct: {mode}")
+                    return mode
+            except Exception as e:
+                logger.debug(f"Failed to read assembly mode from project.kct: {e}")
+
+        return None
 
     def _load_pcb(self) -> PCB:
         """Load and cache the PCB."""
@@ -802,8 +843,13 @@ class ManufacturingAudit:
         derives a synthetic BOM from PCB footprints when no schematic BOM is
         available, providing component and assembly cost breakdowns alongside
         PCB fabrication cost.
+
+        When ``self.no_assembly`` is True (from ``--no-assembly`` CLI flag or
+        ``manufacturing.assembly: "none"`` in project.kct), assembly cost is
+        excluded from the estimate.
         """
-        estimate = CostEstimate(quantity=self.quantity)
+        assembly_mode = "none" if self.no_assembly else self._assembly_mode
+        estimate = CostEstimate(quantity=self.quantity, assembly_mode=assembly_mode)
 
         try:
             from kicad_tools.cost import ManufacturingCostEstimator
@@ -819,8 +865,16 @@ class ManufacturingAudit:
 
             estimate.pcb_cost = full_result.pcb.total_cost
             estimate.component_cost = full_result.component_cost_per_unit * full_result.quantity
-            estimate.assembly_cost = full_result.assembly.total_cost
-            estimate.total_cost = full_result.total_for_quantity
+
+            if self.no_assembly:
+                estimate.assembly_cost = 0.0
+                # Total excludes assembly cost
+                estimate.total_cost = (
+                    full_result.total_for_quantity - full_result.assembly.total_cost
+                )
+            else:
+                estimate.assembly_cost = full_result.assembly.total_cost
+                estimate.total_cost = full_result.total_for_quantity
 
         except Exception as e:
             logger.warning(f"Cost estimation failed: {e}")

--- a/src/kicad_tools/cli/audit_cmd.py
+++ b/src/kicad_tools/cli/audit_cmd.py
@@ -80,6 +80,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Skip ERC check (for PCB-only audits)",
     )
     parser.add_argument(
+        "--no-assembly",
+        action="store_true",
+        help="Skip assembly cost in estimate (overrides project.kct)",
+    )
+    parser.add_argument(
         "--strict",
         action="store_true",
         help="Exit with code 2 on warnings",
@@ -115,6 +120,7 @@ def main(argv: list[str] | None = None) -> int:
             copper_oz=args.copper,
             quantity=args.quantity,
             skip_erc=args.skip_erc,
+            no_assembly=args.no_assembly,
         )
         result = audit.run()
     except ValueError as e:
@@ -267,7 +273,9 @@ def output_table(result: AuditResult, verbose: bool = False) -> None:
         print(f"    PCB cost: ${result.cost.pcb_cost:.2f}")
         if result.cost.component_cost:
             print(f"    Components: ${result.cost.component_cost:.2f}")
-        if result.cost.assembly_cost:
+        if result.cost.assembly_mode == "none":
+            print("    Assembly: excluded (assembly: none)")
+        elif result.cost.assembly_cost:
             print(f"    Assembly: ${result.cost.assembly_cost:.2f}")
         print(f"    Total: ${result.cost.total_cost:.2f} {result.cost.currency}")
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -8,6 +8,7 @@ import pytest
 from kicad_tools.audit import AuditResult, AuditVerdict, ManufacturingAudit
 from kicad_tools.audit.auditor import (
     ConnectivityStatus,
+    CostEstimate,
     DRCStatus,
     ERCStatus,
     ManufacturerCompatibility,
@@ -1954,3 +1955,157 @@ class TestOrphanedFootprints:
         assert len(items) == 1
         assert "15 orphaned footprint(s)" in items[0].description
         assert "(and 5 more)" in items[0].description
+
+
+# ---------------------------------------------------------------------------
+# Test: assembly mode / --no-assembly flag
+# ---------------------------------------------------------------------------
+
+
+class TestAssemblyMode:
+    """Tests for assembly cost exclusion via project.kct and --no-assembly flag."""
+
+    def test_cost_estimate_assembly_mode_field(self):
+        """CostEstimate dataclass has assembly_mode field included in to_dict."""
+        est = CostEstimate(assembly_mode="none")
+        d = est.to_dict()
+        assert "assembly_mode" in d
+        assert d["assembly_mode"] == "none"
+
+    def test_cost_estimate_assembly_mode_default_none(self):
+        """CostEstimate.assembly_mode defaults to None."""
+        est = CostEstimate()
+        assert est.assembly_mode is None
+        assert est.to_dict()["assembly_mode"] is None
+
+    def test_no_assembly_flag_skips_assembly_cost(self, drc_clean_pcb: Path):
+        """ManufacturingAudit with no_assembly=True zeros assembly cost."""
+        audit = ManufacturingAudit(drc_clean_pcb, no_assembly=True)
+        result = audit.run()
+
+        assert result.cost.assembly_cost == 0.0
+        assert result.cost.assembly_mode == "none"
+        # Total should not include assembly
+        # (just verify assembly is excluded from total)
+        assert result.cost.total_cost >= 0.0
+
+    def test_default_includes_assembly_cost(self, drc_clean_pcb: Path):
+        """Default audit (no flags) includes assembly cost as before."""
+        audit = ManufacturingAudit(drc_clean_pcb)
+        result = audit.run()
+
+        # assembly_mode should be None when not explicitly set to "none"
+        assert result.cost.assembly_mode is None
+
+    def test_assembly_none_from_project_kct(self, tmp_path: Path):
+        """When project.kct has assembly: none, assembly cost is excluded."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("")
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        # Write project.kct with assembly: none
+        kct_path = tmp_path / "project.kct"
+        kct_path.write_text(
+            """kct_version: "1.0"
+project:
+  name: test
+  board: test
+requirements:
+  manufacturing:
+    assembly: "none"
+"""
+        )
+
+        audit = ManufacturingAudit(project_file)
+        assert audit.no_assembly is True
+        assert audit._assembly_mode == "none"
+
+    def test_assembly_smt_from_project_kct(self, tmp_path: Path):
+        """When project.kct has assembly: smt, assembly cost is included."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("")
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        kct_path = tmp_path / "project.kct"
+        kct_path.write_text(
+            """kct_version: "1.0"
+project:
+  name: test
+  board: test
+requirements:
+  manufacturing:
+    assembly: "smt"
+"""
+        )
+
+        audit = ManufacturingAudit(project_file)
+        assert audit.no_assembly is False
+        assert audit._assembly_mode == "smt"
+
+    def test_no_assembly_flag_overrides_project_kct(self, tmp_path: Path):
+        """--no-assembly CLI flag overrides project.kct assembly: smt."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("")
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        kct_path = tmp_path / "project.kct"
+        kct_path.write_text(
+            """kct_version: "1.0"
+project:
+  name: test
+  board: test
+requirements:
+  manufacturing:
+    assembly: "smt"
+"""
+        )
+
+        # no_assembly=True should override the smt setting
+        audit = ManufacturingAudit(project_file, no_assembly=True)
+        assert audit.no_assembly is True
+
+    def test_cli_no_assembly_flag(self, drc_clean_pcb: Path, capsys):
+        """CLI --no-assembly flag produces assembly_mode: none in JSON."""
+        from kicad_tools.cli.audit_cmd import main
+
+        result = main([str(drc_clean_pcb), "--no-assembly", "--format", "json"])
+        assert result in [0, 1, 2]
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["cost"]["assembly_mode"] == "none"
+        assert data["cost"]["assembly_cost"] == 0.0
+
+    def test_cli_no_assembly_table_output(self, drc_clean_pcb: Path, capsys):
+        """CLI --no-assembly shows 'Assembly: excluded' in table output."""
+        from kicad_tools.cli.audit_cmd import main
+
+        result = main([str(drc_clean_pcb), "--no-assembly"])
+        assert result in [0, 1, 2]
+
+        captured = capsys.readouterr()
+        assert "Assembly: excluded" in captured.out


### PR DESCRIPTION
## Summary
The audit cost estimator unconditionally computed assembly costs even when `project.kct` specified `manufacturing.assembly: "none"`. This fix reads the assembly mode from `project.kct` and skips assembly cost when set to `"none"`, and adds a `--no-assembly` CLI flag as a manual override.

## Changes
- Add `assembly_mode` field to `CostEstimate` dataclass (included in JSON output)
- Add `no_assembly` parameter to `ManufacturingAudit.__init__`
- Add `_read_assembly_mode()` method to read `manufacturing.assembly` from `project.kct`
- Update `_estimate_cost()` to zero assembly cost and exclude it from total when assembly is disabled
- Add `--no-assembly` CLI flag to `audit_cmd.py`
- Update table display to show "Assembly: excluded (assembly: none)" when skipped

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| project.kct assembly: none shows $0.00 for assembly | Done | Test `test_assembly_none_from_project_kct` + `test_no_assembly_flag_skips_assembly_cost` |
| Table output displays "Assembly: excluded" when disabled | Done | Test `test_cli_no_assembly_table_output` |
| --no-assembly CLI flag available | Done | Test `test_cli_no_assembly_flag` |
| --no-assembly overrides project.kct settings | Done | Test `test_no_assembly_flag_overrides_project_kct` |
| JSON output has assembly_cost: 0.0 and assembly_mode: none | Done | Test `test_cli_no_assembly_flag` |
| total_cost correctly excludes assembly when disabled | Done | Verified in `_estimate_cost` logic |
| Default behavior preserved when assembly is not "none" | Done | Tests `test_default_includes_assembly_cost` + `test_assembly_smt_from_project_kct` |

## Test Plan
- 9 new tests in `TestAssemblyMode` class, all passing
- Full audit test suite (90 tests) passes with no regressions

Closes #1495