### PR TITLE
fix(parts): add circuit breaker for JLCPCB API 403 Forbidden responses

### DIFF
--- a/src/kicad_tools/cost/suggest.py
+++ b/src/kicad_tools/cost/suggest.py
@@ -560,6 +560,13 @@ class PartSuggester:
                 suggestion.best_suggestion = suggestion.suggestions[0]
 
         except Exception as e:
+            # Re-raise LCSCForbiddenError so callers can detect API-wide
+            # unavailability and short-circuit remaining lookups.
+            from ..parts.lcsc import LCSCForbiddenError
+
+            if isinstance(e, LCSCForbiddenError):
+                raise
+
             logger.warning(f"Search failed for {reference}: {e}")
             suggestion.error = str(e)
 

--- a/src/kicad_tools/export/bom_enrich.py
+++ b/src/kicad_tools/export/bom_enrich.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ..cost.suggest import PartSuggester
+from ..parts.lcsc import LCSCForbiddenError
 
 if TYPE_CHECKING:
     from ..schema.bom import BOMItem
@@ -122,6 +123,9 @@ def enrich_bom_lcsc(
         key = (item.value, item.footprint)
         groups.setdefault(key, []).append(item)
 
+    api_forbidden = False
+    forbidden_error = "JLCPCB API unavailable (403)"
+
     with PartSuggester(
         prefer_basic=prefer_basic,
         min_stock=min_stock,
@@ -152,15 +156,50 @@ def enrich_bom_lcsc(
                 )
                 continue
 
+            # If the API is known to be forbidden, skip without calling
+            if api_forbidden:
+                report.entries.append(
+                    EnrichmentEntry(
+                        value=value,
+                        footprint=footprint,
+                        references=refs,
+                        lcsc_part="",
+                        source="unmatched",
+                        error=forbidden_error,
+                    )
+                )
+                continue
+
             # Use the first reference for type hinting (R1 -> resistor, etc.)
             first_ref = refs[0] if refs else ""
 
-            suggestion = suggester.suggest_for_component(
-                reference=first_ref,
-                value=value,
-                footprint=footprint,
-                existing_lcsc=None,
-            )
+            try:
+                suggestion = suggester.suggest_for_component(
+                    reference=first_ref,
+                    value=value,
+                    footprint=footprint,
+                    existing_lcsc=None,
+                )
+            except LCSCForbiddenError:
+                # API is globally unavailable -- emit a single warning and
+                # mark this and all remaining groups as unmatched.
+                api_forbidden = True
+                logger.warning(
+                    "JLCPCB API returned 403 Forbidden -- "
+                    "skipping remaining LCSC auto-matching. "
+                    "Use --no-auto-lcsc to suppress."
+                )
+                report.entries.append(
+                    EnrichmentEntry(
+                        value=value,
+                        footprint=footprint,
+                        references=refs,
+                        lcsc_part="",
+                        source="unmatched",
+                        error=forbidden_error,
+                    )
+                )
+                continue
 
             if suggestion.has_suggestion:
                 best = suggestion.best_suggestion

--- a/src/kicad_tools/parts/__init__.py
+++ b/src/kicad_tools/parts/__init__.py
@@ -58,7 +58,7 @@ from .importer import (
     LayoutStyle,
     PartImporter,
 )
-from .lcsc import LCSCClient, RateLimiter
+from .lcsc import LCSCClient, LCSCForbiddenError, RateLimiter
 from .models import (
     BOMAvailability,
     PackageType,
@@ -72,6 +72,7 @@ from .models import (
 __all__ = [
     # Client
     "LCSCClient",
+    "LCSCForbiddenError",
     "RateLimiter",
     # Importer
     "PartImporter",

--- a/src/kicad_tools/parts/lcsc.py
+++ b/src/kicad_tools/parts/lcsc.py
@@ -34,6 +34,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class LCSCForbiddenError(Exception):
+    """Raised when the JLCPCB API returns 403 Forbidden.
+
+    This indicates the API is globally unavailable (e.g. authentication
+    required, geo-blocking) and further requests should not be attempted.
+    """
+
+
 class RateLimiter:
     """
     Thread-safe rate limiter that enforces a minimum interval between requests.
@@ -254,6 +262,7 @@ class LCSCClient:
         self._rate_limiter = RateLimiter(rate_limit) if rate_limit > 0 else None
         self._max_retries = max_retries
         self._base_retry_delay = base_retry_delay
+        self._api_forbidden = False
 
     def _get_session(self):
         """Get or create requests session."""
@@ -274,8 +283,17 @@ class LCSCClient:
 
         Returns:
             Response JSON data, or None if the request fails after all retries
+
+        Raises:
+            LCSCForbiddenError: If the API returns 403 Forbidden (circuit breaker).
         """
         import requests
+
+        # Circuit breaker: if a previous request got 403, skip immediately
+        if self._api_forbidden:
+            raise LCSCForbiddenError(
+                "JLCPCB API returned 403 Forbidden -- skipping request (circuit breaker active)"
+            )
 
         session = self._get_session()
 
@@ -293,8 +311,16 @@ class LCSCClient:
             except requests.HTTPError as e:
                 status_code = e.response.status_code if e.response is not None else 0
 
+                # 403 is not transient -- trip the circuit breaker and raise
+                if status_code == 403:
+                    self._api_forbidden = True
+                    raise LCSCForbiddenError(
+                        "JLCPCB API returned 403 Forbidden -- "
+                        "API may require authentication or be geo-blocked"
+                    ) from e
+
                 # Only retry on rate limit and server errors
-                if status_code not in (403, 429, 500, 502, 503, 504):
+                if status_code not in (429, 500, 502, 503, 504):
                     raise
 
                 last_exception = e

--- a/tests/test_bom_enrich.py
+++ b/tests/test_bom_enrich.py
@@ -274,6 +274,114 @@ class TestEnrichBomLcsc:
         assert report.unmatched_entries[0].error == "API timeout"
 
 
+class TestEnrichBomLcscCircuitBreaker:
+    """Tests for enrichment loop short-circuit on 403 Forbidden."""
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_403_stops_remaining_lookups(self, MockSuggester):
+        """After a 403, remaining groups are marked unmatched without API calls."""
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+
+        # First call raises LCSCForbiddenError
+        mock_instance.suggest_for_component.side_effect = LCSCForbiddenError(
+            "403 Forbidden"
+        )
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric"),
+            _make_item("L1", "4.7uH", "Inductor_SMD:L_0603_1608Metric"),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        # suggest_for_component should only be called once (for the first group)
+        assert mock_instance.suggest_for_component.call_count == 1
+
+        # All three groups should be unmatched with the 403 error
+        assert report.unmatched == 3
+        for entry in report.entries:
+            assert entry.source == "unmatched"
+            assert "403" in entry.error
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_403_preserves_existing_lcsc_in_remaining_groups(self, MockSuggester):
+        """Groups with existing LCSC are still handled after 403."""
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+
+        # The first group that needs a lookup will get 403
+        mock_instance.suggest_for_component.side_effect = LCSCForbiddenError(
+            "403 Forbidden"
+        )
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            # Group 1: has existing LCSC -- processed before any API call
+            _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric", lcsc="C1525"),
+            # Group 2: needs lookup -- will trigger 403
+            _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            # Group 3: needs lookup -- should be skipped
+            _make_item("L1", "4.7uH", "Inductor_SMD:L_0603_1608Metric"),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        # Group 1 should still be from schematic
+        assert report.already_populated == 1
+        assert items[0].lcsc == "C1525"
+
+        # Groups 2 and 3 should be unmatched with 403
+        assert report.unmatched == 2
+        assert mock_instance.suggest_for_component.call_count == 1
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_successful_before_403(self, MockSuggester):
+        """Groups matched before the 403 keep their results."""
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        mock_instance = MagicMock()
+        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+        mock_instance.__exit__ = MagicMock(return_value=False)
+
+        call_count = [0]
+
+        def side_effect(*, reference, value, footprint, existing_lcsc):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return _mock_suggestion("C25744")
+            raise LCSCForbiddenError("403 Forbidden")
+
+        mock_instance.suggest_for_component.side_effect = side_effect
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric"),
+            _make_item("L1", "4.7uH", "Inductor_SMD:L_0603_1608Metric"),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        # First group was successfully matched
+        assert items[0].lcsc == "C25744"
+        assert report.auto_matched == 1
+
+        # Remaining groups unmatched with 403
+        assert report.unmatched == 2
+
+        # Only 2 API calls made (first success, second 403, third skipped)
+        assert mock_instance.suggest_for_component.call_count == 2
+
+
 class TestEnrichmentReport:
     """Tests for the EnrichmentReport dataclass."""
 

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1379,3 +1379,122 @@ class TestCategorizationEdgeCases:
         # Note: "Light Emitting Diode" matches "diode" first in the check order
         result = _categorize_part("Light Emitting Diode", "0603")
         assert result in (PartCategory.DIODE, PartCategory.LED)
+
+
+@pytest.mark.skipif(not HAS_REQUESTS, reason="requests not installed")
+class TestLCSCClientCircuitBreaker:
+    """Tests for LCSCClient circuit-breaker on 403 Forbidden."""
+
+    def test_403_raises_forbidden_error_no_retry(self, tmp_path):
+        """A 403 response raises LCSCForbiddenError immediately with no retry."""
+        import requests
+
+        from kicad_tools.parts import LCSCClient, PartsCache
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        cache = PartsCache(db_path=tmp_path / "cache.db")
+        client = LCSCClient(cache=cache, rate_limit=0)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.raise_for_status.side_effect = requests.HTTPError(
+            response=mock_response
+        )
+
+        with patch("kicad_tools.parts.lcsc.LCSCClient._get_session") as mock_session:
+            mock_session.return_value.post.return_value = mock_response
+
+            with pytest.raises(LCSCForbiddenError):
+                client._make_request("https://example.com/api", {"key": "val"})
+
+            # Should have been called exactly once (no retries)
+            assert mock_session.return_value.post.call_count == 1
+
+    def test_circuit_breaker_flag_set_after_403(self, tmp_path):
+        """After a 403, the _api_forbidden flag is set."""
+        import requests
+
+        from kicad_tools.parts import LCSCClient, PartsCache
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        cache = PartsCache(db_path=tmp_path / "cache.db")
+        client = LCSCClient(cache=cache, rate_limit=0)
+
+        assert client._api_forbidden is False
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.raise_for_status.side_effect = requests.HTTPError(
+            response=mock_response
+        )
+
+        with patch("kicad_tools.parts.lcsc.LCSCClient._get_session") as mock_session:
+            mock_session.return_value.post.return_value = mock_response
+
+            with pytest.raises(LCSCForbiddenError):
+                client._make_request("https://example.com/api", {})
+
+        assert client._api_forbidden is True
+
+    def test_circuit_breaker_prevents_subsequent_requests(self, tmp_path):
+        """Once circuit breaker is tripped, subsequent calls raise without HTTP."""
+        from kicad_tools.parts import LCSCClient, PartsCache
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        cache = PartsCache(db_path=tmp_path / "cache.db")
+        client = LCSCClient(cache=cache, rate_limit=0)
+        client._api_forbidden = True  # Pre-trip the breaker
+
+        with patch("kicad_tools.parts.lcsc.LCSCClient._get_session") as mock_session:
+            with pytest.raises(LCSCForbiddenError):
+                client._make_request("https://example.com/api", {})
+
+            # No HTTP request should have been made
+            mock_session.return_value.post.assert_not_called()
+
+    def test_429_still_retries(self, tmp_path):
+        """429 responses still trigger retries (not affected by 403 change)."""
+        import requests
+
+        from kicad_tools.parts import LCSCClient, PartsCache
+
+        cache = PartsCache(db_path=tmp_path / "cache.db")
+        client = LCSCClient(
+            cache=cache, rate_limit=0, max_retries=2, base_retry_delay=0.01
+        )
+
+        mock_response_429 = MagicMock()
+        mock_response_429.status_code = 429
+        mock_response_429.raise_for_status.side_effect = requests.HTTPError(
+            response=mock_response_429
+        )
+
+        mock_response_ok = MagicMock()
+        mock_response_ok.raise_for_status = MagicMock()
+        mock_response_ok.json.return_value = {"code": 200, "data": {}}
+
+        with patch("kicad_tools.parts.lcsc.LCSCClient._get_session") as mock_session:
+            # First call: 429, second call: success
+            mock_session.return_value.post.side_effect = [
+                mock_response_429,
+                mock_response_ok,
+            ]
+
+            result = client._make_request("https://example.com/api", {})
+
+            assert result == {"code": 200, "data": {}}
+            assert mock_session.return_value.post.call_count == 2
+            assert client._api_forbidden is False
+
+    def test_search_raises_forbidden_on_403(self, tmp_path):
+        """LCSCClient.search propagates LCSCForbiddenError from _make_request."""
+        from kicad_tools.parts import LCSCClient, PartsCache
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        cache = PartsCache(db_path=tmp_path / "cache.db")
+        client = LCSCClient(cache=cache, rate_limit=0)
+        client._api_forbidden = True  # Pre-trip
+
+        # search() catches requests.RequestException but not LCSCForbiddenError
+        with pytest.raises(LCSCForbiddenError):
+            client.search("100nF 0402")


### PR DESCRIPTION
## Summary
Add a circuit-breaker pattern to `LCSCClient` so that a single 403 Forbidden from the JLCPCB API stops all subsequent requests, preventing minutes of wasted retries during BOM enrichment.

## Changes
- Add `LCSCForbiddenError` exception class to `lcsc.py`
- Remove 403 from the retryable status set in `_make_request()`; a 403 now immediately trips an `_api_forbidden` flag and raises `LCSCForbiddenError`
- Subsequent `_make_request()` calls short-circuit without HTTP when the flag is set
- Re-raise `LCSCForbiddenError` in `PartSuggester.suggest_for_component()` instead of swallowing it
- Catch `LCSCForbiddenError` in `enrich_bom_lcsc()`, emit a single warning, and mark all remaining groups as unmatched with error "JLCPCB API unavailable (403)"
- Export `LCSCForbiddenError` from `kicad_tools.parts`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Single 403 stops all further LCSC lookups | Pass | `test_403_stops_remaining_lookups` -- only 1 API call for 3 groups |
| Single-line warning emitted on 403 | Pass | `enrich_bom_lcsc` logs one warning then skips via flag |
| `_make_request()` does not retry on 403 | Pass | `test_403_raises_forbidden_error_no_retry` -- post called once |
| 429 and 5xx still retry with backoff | Pass | `test_429_still_retries` -- 429 retried, then succeeds |
| Circuit-breaker items reported as unmatched with "JLCPCB API unavailable (403)" | Pass | All 403-skipped entries have `error="JLCPCB API unavailable (403)"` |
| Existing tests pass; new tests cover circuit-breaker | Pass | 115 tests pass |

## Test Plan
- `python3 -m pytest tests/test_parts.py tests/test_bom_enrich.py -v` -- all 115 tests pass
- New test classes: `TestLCSCClientCircuitBreaker` (5 tests) and `TestEnrichBomLcscCircuitBreaker` (3 tests)

Closes #1491