### PR TITLE
fix(pcb): extend board outline detection to handle gr_rect on Edge.Cuts

### DIFF
--- a/src/kicad_tools/export/preflight.py
+++ b/src/kicad_tools/export/preflight.py
@@ -224,10 +224,23 @@ class PreflightChecker:
 
         outline = self._pcb.get_board_outline()
         if not outline:
+            # Distinguish "no Edge.Cuts content" from "content but not extractable"
+            edge_cuts_count = sum(
+                1
+                for item in self._pcb.graphic_items
+                if hasattr(item, "layer") and item.layer == "Edge.Cuts"
+            )
+            if edge_cuts_count > 0:
+                message = (
+                    f"Edge.Cuts layer has {edge_cuts_count} graphic element(s) "
+                    "but no closed board outline could be extracted"
+                )
+            else:
+                message = "No board outline found on Edge.Cuts layer"
             return PreflightResult(
                 name="board_outline",
                 status="FAIL",
-                message="No board outline found on Edge.Cuts layer",
+                message=message,
                 details="A closed board outline is required for manufacturing",
             )
 

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1591,11 +1591,25 @@ class PCB:
             if graphic.layer == layer:
                 yield graphic
 
+    @staticmethod
+    def _rect_to_segments(
+        start: tuple[float, float], end: tuple[float, float]
+    ) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+        """Decompose a rectangle (start, end corners) into 4 line segments."""
+        x1, y1 = start
+        x2, y2 = end
+        return [
+            ((x1, y1), (x2, y1)),  # top
+            ((x2, y1), (x2, y2)),  # right
+            ((x2, y2), (x1, y2)),  # bottom
+            ((x1, y2), (x1, y1)),  # left
+        ]
+
     def get_board_outline(self) -> list[tuple[float, float]]:
         """Extract board outline polygon from Edge.Cuts layer.
 
         Returns an ordered list of (x, y) points forming the board outline.
-        Only includes line segments on the Edge.Cuts layer.
+        Handles gr_line, gr_arc, and gr_rect elements on the Edge.Cuts layer.
         Arc segments are approximated by their start and end points.
 
         Returns:
@@ -1604,8 +1618,13 @@ class PCB:
         # Collect all Edge.Cuts segments
         edge_lines = [line for line in self._graphic_lines if line.layer == "Edge.Cuts"]
         edge_arcs = [arc for arc in self._graphic_arcs if arc.layer == "Edge.Cuts"]
+        edge_rects = [
+            g
+            for g in self._graphics
+            if g.layer == "Edge.Cuts" and g.graphic_type == "rect"
+        ]
 
-        if not edge_lines and not edge_arcs:
+        if not edge_lines and not edge_arcs and not edge_rects:
             return []
 
         # Build a list of all line segments (including arc endpoints)
@@ -1618,6 +1637,9 @@ class PCB:
             # For arcs, include start->mid and mid->end as approximation
             segments.append((arc.start, arc.mid))
             segments.append((arc.mid, arc.end))
+
+        for rect in edge_rects:
+            segments.extend(self._rect_to_segments(rect.start, rect.end))
 
         if not segments:
             return []
@@ -1669,6 +1691,7 @@ class PCB:
         """Get board outline as a list of line segments.
 
         Returns all Edge.Cuts graphic elements as line segments.
+        Handles gr_line, gr_arc, and gr_rect elements.
         More useful for distance calculations than the polygon.
 
         Returns:
@@ -1685,6 +1708,10 @@ class PCB:
                 # Approximate arc with two segments through midpoint
                 segments.append((arc.start, arc.mid))
                 segments.append((arc.mid, arc.end))
+
+        for graphic in self._graphics:
+            if graphic.layer == "Edge.Cuts" and graphic.graphic_type == "rect":
+                segments.extend(self._rect_to_segments(graphic.start, graphic.end))
 
         return segments
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -172,6 +172,50 @@ class TestPreflightBoardOutline:
         assert outline_result is not None
         assert outline_result.status == "OK"
 
+    def test_gr_rect_outline_ok(self, tmp_path):
+        """Board outline defined via gr_rect on Edge.Cuts should pass."""
+        pcb_content = """(kicad_pcb (version 20231014) (generator "pcbnew")
+  (general
+    (thickness 1.6)
+    (legacy_teardrops no)
+  )
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (gr_rect (start 0 0) (end 50 50)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+)
+"""
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text(pcb_content)
+        checker = PreflightChecker(
+            pcb_path=pcb_path,
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        results = checker.run_all()
+        outline_result = _find_result(results, "board_outline")
+        assert outline_result is not None
+        assert outline_result.status == "OK"
+
+    def test_no_outline_error_message_empty(self, tmp_path):
+        """When Edge.Cuts has no content, message says 'No board outline found'."""
+        pcb = _create_minimal_pcb(tmp_path, include_outline=False)
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        results = checker.run_all()
+        outline_result = _find_result(results, "board_outline")
+        assert outline_result is not None
+        assert "No board outline found" in outline_result.message
+
 
 # ---------------------------------------------------------------------------
 # PreflightChecker -- board dimensions checks

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1098,6 +1098,61 @@ class TestBoardOutline:
 
         assert outline == []
 
+    def test_get_board_outline_gr_rect(self, tmp_path: Path):
+        """Test extracting board outline from a gr_rect on Edge.Cuts."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (layers (0 "F.Cu" signal) (44 "Edge.Cuts" user))
+          (net 0 "")
+          (gr_rect (start 0 0) (end 50 30)
+            (stroke (width 0.1) (type default))
+            (fill none)
+            (layer "Edge.Cuts")
+            (uuid "12345678-1234-1234-1234-123456789abc"))
+        )"""
+        pcb_file = tmp_path / "rect_outline.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        pcb = PCB.load(str(pcb_file))
+        outline = pcb.get_board_outline()
+
+        # gr_rect decomposes to 4 segments -> 5 points (closed rectangle)
+        assert len(outline) == 5
+        # First and last point should be close (closed polygon)
+        assert pcb._points_close(outline[0], outline[-1])
+
+    def test_get_board_outline_segments_gr_rect(self, tmp_path: Path):
+        """Test getting board outline segments from a gr_rect on Edge.Cuts."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (layers (0 "F.Cu" signal) (44 "Edge.Cuts" user))
+          (net 0 "")
+          (gr_rect (start 10 20) (end 60 70)
+            (stroke (width 0.1) (type default))
+            (fill none)
+            (layer "Edge.Cuts")
+            (uuid "12345678-1234-1234-1234-123456789abc"))
+        )"""
+        pcb_file = tmp_path / "rect_segments.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        pcb = PCB.load(str(pcb_file))
+        segments = pcb.get_board_outline_segments()
+
+        # gr_rect should produce 4 segments
+        assert len(segments) == 4
+        for seg_start, seg_end in segments:
+            assert isinstance(seg_start, tuple)
+            assert isinstance(seg_end, tuple)
+            assert len(seg_start) == 2
+            assert len(seg_end) == 2
+
 
 class TestEdgeClearanceRule:
     """Tests for EdgeClearanceRule."""


### PR DESCRIPTION
## Summary

Board outline detection failed for PCBs using `gr_rect` on Edge.Cuts because `get_board_outline()` and `get_board_outline_segments()` only searched `_graphic_lines` and `_graphic_arcs`, never `_graphics` where `gr_rect` elements are stored. This caused contradictory audit output (board size reported correctly via `graphic_items` but outline check failed).

## Changes

- Added `_rect_to_segments()` static method to decompose a rectangle into 4 line segments
- Extended `get_board_outline()` to collect `gr_rect` elements from `_graphics` on Edge.Cuts and decompose them into segments
- Extended `get_board_outline_segments()` with the same `gr_rect` handling
- Improved `_check_board_outline_closed()` error messaging to distinguish "no Edge.Cuts content" from "Edge.Cuts has content but no closed outline could be extracted"

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `get_board_outline()` returns valid polygon for gr_rect on Edge.Cuts | PASS | New test `test_get_board_outline_gr_rect` confirms 5 points (closed rectangle) |
| `get_board_outline_segments()` returns segments for gr_rect on Edge.Cuts | PASS | New test `test_get_board_outline_segments_gr_rect` confirms 4 segments |
| Preflight `_check_board_outline_closed()` reports OK for gr_rect outlines | PASS | New test `test_gr_rect_outline_ok` confirms OK status |
| Improved error message when Edge.Cuts has non-closeable content | PASS | New test `test_no_outline_error_message_empty` and code inspection |
| Existing tests for gr_line-based outlines continue to pass | PASS | All 134 tests in test_validate.py and test_preflight.py pass |

## Test Plan

- Ran `tests/test_validate.py::TestBoardOutline` (5 tests) -- all pass
- Ran `tests/test_preflight.py::TestPreflightBoardOutline` (4 tests) -- all pass
- Ran full `tests/test_validate.py` and `tests/test_preflight.py` -- 134 passed, 5 skipped
- Pre-existing failure in `tests/report/test_renderers.py` (missing `markdown` package) is unrelated

Closes #1492