### PR TITLE
feat(bom): add spec-aware BOM enrichment from .kct project files

### DIFF
--- a/src/kicad_tools/cli/export_cmd.py
+++ b/src/kicad_tools/cli/export_cmd.py
@@ -84,6 +84,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Disable LCSC auto-matching",
     )
     parser.add_argument(
+        "--no-spec",
+        action="store_true",
+        help="Disable BOM enrichment from .kct project spec",
+    )
+    parser.add_argument(
         "--skip-preflight",
         action="store_true",
         help="Skip all pre-flight validation checks",
@@ -157,6 +162,7 @@ def run_export(args: argparse.Namespace) -> int:
         include_report=not args.no_report,
         include_project_zip=not args.no_project_zip,
         auto_lcsc=auto_lcsc,
+        no_spec=getattr(args, "no_spec", False),
         preflight=preflight_cfg,
     )
 
@@ -223,6 +229,12 @@ def run_export(args: argparse.Namespace) -> int:
                 print(f"  [ok] CPL: {result.assembly_result.pnp_path.name}")
             if result.assembly_result.gerber_path:
                 print(f"  [ok] Gerbers: {result.assembly_result.gerber_path.name}")
+            # Report spec overlay results
+            if result.assembly_result.spec_overlay:
+                overlay = result.assembly_result.spec_overlay
+                print()
+                for line in overlay.summary_lines():
+                    print(f"  {line}")
             # Report LCSC enrichment results
             if result.assembly_result.lcsc_enrichment:
                 enrichment = result.assembly_result.lcsc_enrichment

--- a/src/kicad_tools/export/__init__.py
+++ b/src/kicad_tools/export/__init__.py
@@ -44,6 +44,13 @@ from .bom_enrich import (
     EnrichmentReport,
     enrich_bom_lcsc,
 )
+from .bom_spec_overlay import (
+    SpecOverlayEntry,
+    SpecOverlayReport,
+    apply_spec_overlay,
+    expand_ref_range,
+    find_spec_file,
+)
 from .bom_formats import (
     BOM_FORMATTERS,
     BOMExportConfig,
@@ -97,6 +104,12 @@ __all__ = [
     "enrich_bom_lcsc",
     "EnrichmentReport",
     "EnrichmentEntry",
+    # BOM spec overlay
+    "apply_spec_overlay",
+    "SpecOverlayReport",
+    "SpecOverlayEntry",
+    "expand_ref_range",
+    "find_spec_file",
     # Manufacturing package
     "ManufacturingPackage",
     "ManufacturingConfig",

--- a/src/kicad_tools/export/assembly.py
+++ b/src/kicad_tools/export/assembly.py
@@ -15,6 +15,7 @@ from kicad_tools.exceptions import ValidationError
 
 from .bom_enrich import EnrichmentReport, enrich_bom_lcsc
 from .bom_formats import BOMExportConfig, export_bom
+from .bom_spec_overlay import SpecOverlayReport, apply_spec_overlay, find_spec_file
 from .gerber import MANUFACTURER_PRESETS, GerberConfig, GerberExporter
 from .pnp import PnPExportConfig, export_pnp
 
@@ -48,6 +49,10 @@ class AssemblyConfig:
     auto_lcsc_prefer_basic: bool = True
     auto_lcsc_min_stock: int = 100
 
+    # Spec overlay
+    no_spec: bool = False
+    spec_path: Path | None = None
+
     # Filtering
     exclude_references: list[str] = field(default_factory=list)
 
@@ -60,6 +65,7 @@ class AssemblyPackageResult:
     bom_path: Path | None = None
     pnp_path: Path | None = None
     gerber_path: Path | None = None
+    spec_overlay: SpecOverlayReport | None = None
     lcsc_enrichment: EnrichmentReport | None = None
     errors: list[str] = field(default_factory=list)
 
@@ -253,6 +259,33 @@ class AssemblyPackage:
         if self.config.exclude_references:
             items = self._filter_references(items)
 
+        # Spec overlay: apply MPN/LCSC from .kct before auto-enrichment
+        spec_refs: set[str] = set()
+        if not self.config.no_spec:
+            try:
+                spec_file = self.config.spec_path
+                if spec_file is None:
+                    # Auto-detect from schematic/PCB directory
+                    spec_file = find_spec_file(self.pcb_path.parent)
+                if spec_file is not None:
+                    from ..spec.parser import load_spec
+
+                    spec = load_spec(spec_file)
+                    if spec.bom_entries:
+                        overlay_report = apply_spec_overlay(items, spec.bom_entries)
+                        if result is not None:
+                            result.spec_overlay = overlay_report
+                        for line in overlay_report.summary_lines():
+                            logger.info(line)
+                        # Collect refs that got an LCSC from spec
+                        spec_refs = {
+                            e.reference
+                            for e in overlay_report.entries
+                            if e.matched and e.lcsc
+                        }
+            except Exception as e:
+                logger.warning(f"Spec overlay failed (continuing without): {e}")
+
         # LCSC auto-matching for JLCPCB exports
         if self.config.auto_lcsc and self.manufacturer == "jlcpcb":
             try:
@@ -260,6 +293,7 @@ class AssemblyPackage:
                     items,
                     prefer_basic=self.config.auto_lcsc_prefer_basic,
                     min_stock=self.config.auto_lcsc_min_stock,
+                    spec_refs=spec_refs,
                 )
                 if result is not None:
                     result.lcsc_enrichment = enrichment

--- a/src/kicad_tools/export/bom_enrich.py
+++ b/src/kicad_tools/export/bom_enrich.py
@@ -57,6 +57,11 @@ class EnrichmentReport:
         return len([e for e in self.entries if e.source == "schematic"])
 
     @property
+    def spec_populated(self) -> int:
+        """Groups that already had LCSC numbers from the project spec."""
+        return len([e for e in self.entries if e.source == "spec"])
+
+    @property
     def auto_matched(self) -> int:
         """Groups that were auto-matched via LCSC search."""
         return len([e for e in self.entries if e.source == "auto"])
@@ -73,11 +78,12 @@ class EnrichmentReport:
 
     def summary_lines(self) -> list[str]:
         """Return human-readable summary lines."""
-        lines = [
-            f"LCSC enrichment: {self.auto_matched} auto-matched, "
-            f"{self.already_populated} from schematic, "
-            f"{self.unmatched} unmatched"
-        ]
+        parts = [f"{self.auto_matched} auto-matched"]
+        if self.spec_populated:
+            parts.append(f"{self.spec_populated} from spec")
+        parts.append(f"{self.already_populated} from schematic")
+        parts.append(f"{self.unmatched} unmatched")
+        lines = [f"LCSC enrichment: {', '.join(parts)}"]
         if self.unmatched_entries:
             lines.append("Unmatched parts:")
             for entry in self.unmatched_entries:
@@ -92,6 +98,7 @@ def enrich_bom_lcsc(
     *,
     prefer_basic: bool = True,
     min_stock: int = 100,
+    spec_refs: set[str] | None = None,
 ) -> EnrichmentReport:
     """
     Populate missing LCSC part numbers on BOM items in-place.
@@ -106,6 +113,9 @@ def enrich_bom_lcsc(
         items: List of BOM items to enrich (modified in place).
         prefer_basic: Prefer JLCPCB Basic parts (no extra assembly fee).
         min_stock: Minimum stock level to consider a part viable.
+        spec_refs: Set of reference designators whose LCSC was populated
+            by the project spec overlay.  These are reported with
+            ``source="spec"`` instead of ``"schematic"``.
 
     Returns:
         EnrichmentReport summarising what was matched.
@@ -141,13 +151,22 @@ def enrich_bom_lcsc(
                 for it in group_items:
                     if not it.lcsc:
                         it.lcsc = existing_lcsc
+
+                # Determine source: if any ref in the group was set by spec,
+                # report as "spec"; otherwise "schematic".
+                _spec_refs = spec_refs or set()
+                source = (
+                    "spec"
+                    if any(r in _spec_refs for r in refs)
+                    else "schematic"
+                )
                 report.entries.append(
                     EnrichmentEntry(
                         value=value,
                         footprint=footprint,
                         references=refs,
                         lcsc_part=existing_lcsc,
-                        source="schematic",
+                        source=source,
                     )
                 )
                 continue

--- a/src/kicad_tools/export/bom_spec_overlay.py
+++ b/src/kicad_tools/export/bom_spec_overlay.py
@@ -1,0 +1,222 @@
+"""
+Overlay BOM fields from a .kct project spec onto BOM items.
+
+Reads ``bom_entries`` from a :class:`~kicad_tools.spec.schema.ProjectSpec`
+and writes MPN / LCSC fields onto matching :class:`~kicad_tools.schema.bom.BOMItem`
+instances **in place**.  Items that match a spec entry are tagged with
+``source="spec"`` in the returned :class:`SpecOverlayReport` so that
+downstream enrichment (e.g. LCSC auto-match) can skip them.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..schema.bom import BOMItem
+    from ..spec.schema import BOMEntry
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Reference-range expansion
+# ---------------------------------------------------------------------------
+
+_REF_RE = re.compile(r"^([A-Za-z]+)(\d+)$")
+
+
+def expand_ref_range(ref_spec: str) -> list[str]:
+    """Expand a reference designator or dash-separated range.
+
+    Examples::
+
+        expand_ref_range("U1")        -> ["U1"]
+        expand_ref_range("Q1-Q4")     -> ["Q1", "Q2", "Q3", "Q4"]
+        expand_ref_range("R10-R12")   -> ["R10", "R11", "R12"]
+
+    If the string cannot be parsed as a range it is returned as-is in a
+    single-element list.
+    """
+    if "-" not in ref_spec:
+        return [ref_spec.strip()]
+
+    parts = ref_spec.split("-", 1)
+    start_match = _REF_RE.match(parts[0].strip())
+    end_match = _REF_RE.match(parts[1].strip())
+
+    if not start_match or not end_match:
+        # Not a valid range -- return the raw string
+        return [ref_spec.strip()]
+
+    prefix_start = start_match.group(1)
+    prefix_end = end_match.group(1)
+
+    if prefix_start != prefix_end:
+        # Different prefixes (e.g. "R1-C4") -- not a valid range
+        return [ref_spec.strip()]
+
+    num_start = int(start_match.group(2))
+    num_end = int(end_match.group(2))
+
+    if num_start > num_end:
+        return [ref_spec.strip()]
+
+    return [f"{prefix_start}{n}" for n in range(num_start, num_end + 1)]
+
+
+# ---------------------------------------------------------------------------
+# Overlay report
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SpecOverlayEntry:
+    """Record of a single spec-to-BOM overlay application."""
+
+    reference: str
+    mpn: str
+    lcsc: str
+    matched: bool  # True if a BOM item with this reference was found
+
+
+@dataclass
+class SpecOverlayReport:
+    """Summary of spec overlay results."""
+
+    entries: list[SpecOverlayEntry] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.entries)
+
+    @property
+    def matched(self) -> int:
+        return len([e for e in self.entries if e.matched])
+
+    @property
+    def unmatched(self) -> int:
+        return len([e for e in self.entries if not e.matched])
+
+    @property
+    def unmatched_refs(self) -> list[str]:
+        return [e.reference for e in self.entries if not e.matched]
+
+    def summary_lines(self) -> list[str]:
+        lines = [
+            f"Spec overlay: {self.matched} applied, {self.unmatched} unmatched"
+        ]
+        if self.unmatched_refs:
+            lines.append(
+                f"  Unmatched spec refs: {', '.join(self.unmatched_refs)}"
+            )
+        return lines
+
+
+# ---------------------------------------------------------------------------
+# Spec auto-detection
+# ---------------------------------------------------------------------------
+
+
+def find_spec_file(project_dir: Path) -> Path | None:
+    """Locate a ``.kct`` spec file in *project_dir*.
+
+    Prefers ``project.kct``; falls back to the first ``.kct`` found.
+    Warns if multiple ``.kct`` files exist and none is named ``project.kct``.
+
+    Returns ``None`` when no spec file is found.
+    """
+    project_kct = project_dir / "project.kct"
+    if project_kct.is_file():
+        return project_kct
+
+    kct_files = sorted(project_dir.glob("*.kct"))
+    if not kct_files:
+        return None
+
+    if len(kct_files) > 1:
+        logger.warning(
+            "Multiple .kct files found in %s; using %s. "
+            "Rename the primary spec to 'project.kct' to suppress this warning.",
+            project_dir,
+            kct_files[0].name,
+        )
+
+    return kct_files[0]
+
+
+# ---------------------------------------------------------------------------
+# Core overlay function
+# ---------------------------------------------------------------------------
+
+
+def apply_spec_overlay(
+    items: list[BOMItem],
+    bom_entries: list[BOMEntry],
+) -> SpecOverlayReport:
+    """Apply spec BOM entries onto *items* in place.
+
+    For each :class:`BOMEntry`, the function expands reference ranges and
+    looks for a ``BOMItem`` with a matching ``reference``.  When found the
+    item's ``mpn`` and ``lcsc`` fields are overwritten with the spec values
+    (if the spec value is non-empty / non-None).
+
+    Args:
+        items: BOM items to mutate.
+        bom_entries: Entries from the project spec.
+
+    Returns:
+        A :class:`SpecOverlayReport` summarising what was applied.
+    """
+    report = SpecOverlayReport()
+
+    # Build lookup: reference -> BOMItem
+    ref_to_item: dict[str, BOMItem] = {item.reference: item for item in items}
+
+    for entry in bom_entries:
+        refs = expand_ref_range(entry.ref)
+        for ref in refs:
+            item = ref_to_item.get(ref)
+            if item is None:
+                logger.warning(
+                    "Spec BOM entry ref '%s' does not match any schematic component",
+                    ref,
+                )
+                report.entries.append(
+                    SpecOverlayEntry(
+                        reference=ref,
+                        mpn=entry.part,
+                        lcsc=entry.lcsc or "",
+                        matched=False,
+                    )
+                )
+                continue
+
+            # Overlay MPN
+            if entry.part:
+                item.mpn = entry.part
+
+            # Overlay LCSC
+            if entry.lcsc:
+                item.lcsc = entry.lcsc
+
+            report.entries.append(
+                SpecOverlayEntry(
+                    reference=ref,
+                    mpn=entry.part,
+                    lcsc=entry.lcsc or "",
+                    matched=True,
+                )
+            )
+            logger.info(
+                "Spec overlay: %s -> mpn=%s lcsc=%s",
+                ref,
+                entry.part,
+                entry.lcsc or "(none)",
+            )
+
+    return report

--- a/src/kicad_tools/spec/schema.py
+++ b/src/kicad_tools/spec/schema.py
@@ -43,6 +43,7 @@ __all__ = [
     "Compliance",
     "Suggestions",
     "ComponentSuggestion",
+    "BOMEntry",
     "Decision",
     "Progress",
     "PhaseProgress",
@@ -272,6 +273,23 @@ class BOMSuggestions(BaseModel):
     cost_target: str | None = Field(default=None, description="Target BOM cost")
 
 
+class BOMEntry(BaseModel):
+    """Per-reference BOM mapping for explicit part assignment.
+
+    Allows the project spec to declare exact MPN and LCSC part numbers
+    for specific reference designators, overriding whatever the schematic
+    symbol properties may (or may not) contain.
+
+    The ``ref`` field accepts single references (``"U1"``) or dash-separated
+    ranges (``"Q1-Q4"``) which are expanded into individual designators.
+    """
+
+    ref: str = Field(..., description="Reference designator or range (e.g. 'U1' or 'Q1-Q4')")
+    part: str = Field(..., description="Manufacturer Part Number (MPN)")
+    source: str = Field(default="LCSC", description="Supplier name (e.g. 'LCSC', 'Digikey')")
+    lcsc: str | None = Field(default=None, description="Explicit LCSC part number if known")
+
+
 class Suggestions(BaseModel):
     """Design suggestions and preferences (SHOULD, not MUST)."""
 
@@ -355,6 +373,10 @@ class ProjectSpec(BaseModel):
     intent: DesignIntent | None = Field(default=None, description="Design intent")
     requirements: Requirements | None = Field(default=None, description="Requirements")
     suggestions: Suggestions | None = Field(default=None, description="Suggestions")
+    bom_entries: list[BOMEntry] | None = Field(
+        default=None,
+        description="Per-reference BOM part mappings (MPN, LCSC)",
+    )
     decisions: list[Decision] | None = Field(default=None, description="Design decisions")
     progress: Progress | None = Field(default=None, description="Progress tracking")
     validation: Validation | None = Field(default=None, description="Validation results")

--- a/tests/test_bom_spec_overlay.py
+++ b/tests/test_bom_spec_overlay.py
@@ -1,0 +1,315 @@
+"""Tests for BOM spec overlay (export.bom_spec_overlay)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.export.bom_spec_overlay import (
+    SpecOverlayReport,
+    apply_spec_overlay,
+    expand_ref_range,
+    find_spec_file,
+)
+from kicad_tools.schema.bom import BOMItem
+from kicad_tools.spec.schema import BOMEntry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(
+    ref: str,
+    value: str = "10k",
+    footprint: str = "R_0402",
+    mpn: str = "",
+    lcsc: str = "",
+) -> BOMItem:
+    return BOMItem(
+        reference=ref,
+        value=value,
+        footprint=footprint,
+        lib_id="Device:R",
+        mpn=mpn,
+        lcsc=lcsc,
+    )
+
+
+# ---------------------------------------------------------------------------
+# expand_ref_range
+# ---------------------------------------------------------------------------
+
+
+class TestExpandRefRange:
+    def test_single_ref(self):
+        assert expand_ref_range("U1") == ["U1"]
+
+    def test_range(self):
+        assert expand_ref_range("Q1-Q4") == ["Q1", "Q2", "Q3", "Q4"]
+
+    def test_range_with_higher_numbers(self):
+        assert expand_ref_range("R10-R12") == ["R10", "R11", "R12"]
+
+    def test_single_element_range(self):
+        assert expand_ref_range("R5-R5") == ["R5"]
+
+    def test_reversed_range(self):
+        # Invalid range returns as-is
+        assert expand_ref_range("R5-R3") == ["R5-R3"]
+
+    def test_mixed_prefix_range(self):
+        # Different prefixes -- not a valid range
+        assert expand_ref_range("R1-C4") == ["R1-C4"]
+
+    def test_non_numeric_ref(self):
+        # No digits -- returned as-is
+        assert expand_ref_range("TP_A-TP_B") == ["TP_A-TP_B"]
+
+    def test_whitespace_stripped(self):
+        assert expand_ref_range(" R1 - R3 ") == ["R1", "R2", "R3"]
+
+
+# ---------------------------------------------------------------------------
+# apply_spec_overlay
+# ---------------------------------------------------------------------------
+
+
+class TestApplySpecOverlay:
+    def test_single_ref_mpn_and_lcsc(self):
+        items = [_make_item("U1", value="STM32")]
+        entries = [BOMEntry(ref="U1", part="STM32G031F6P6", lcsc="C529330")]
+
+        report = apply_spec_overlay(items, entries)
+
+        assert items[0].mpn == "STM32G031F6P6"
+        assert items[0].lcsc == "C529330"
+        assert report.matched == 1
+        assert report.unmatched == 0
+
+    def test_range_expansion(self):
+        items = [
+            _make_item("Q1"),
+            _make_item("Q2"),
+            _make_item("Q3"),
+            _make_item("Q4"),
+        ]
+        entries = [BOMEntry(ref="Q1-Q4", part="2N7002", lcsc="C8545")]
+
+        report = apply_spec_overlay(items, entries)
+
+        for item in items:
+            assert item.mpn == "2N7002"
+            assert item.lcsc == "C8545"
+        assert report.matched == 4
+
+    def test_missing_ref_warns_not_errors(self):
+        items = [_make_item("R1")]
+        entries = [BOMEntry(ref="U99", part="MISSING_PART")]
+
+        report = apply_spec_overlay(items, entries)
+
+        # R1 unchanged
+        assert items[0].mpn == ""
+        assert report.unmatched == 1
+        assert "U99" in report.unmatched_refs
+
+    def test_no_entries(self):
+        items = [_make_item("R1")]
+        report = apply_spec_overlay(items, [])
+        assert report.total == 0
+        assert items[0].mpn == ""
+
+    def test_lcsc_only_no_mpn_change(self):
+        """When part is empty string, mpn should still be set (but to empty)."""
+        items = [_make_item("C1", mpn="existing")]
+        entries = [BOMEntry(ref="C1", part="", lcsc="C1525")]
+
+        apply_spec_overlay(items, entries)
+        # part="" is falsy so mpn is not overwritten
+        assert items[0].mpn == "existing"
+        assert items[0].lcsc == "C1525"
+
+    def test_mpn_only_no_lcsc(self):
+        items = [_make_item("U1")]
+        entries = [BOMEntry(ref="U1", part="ATmega328P")]
+
+        apply_spec_overlay(items, entries)
+        assert items[0].mpn == "ATmega328P"
+        assert items[0].lcsc == ""  # no LCSC set
+
+    def test_multiple_entries(self):
+        items = [_make_item("U1"), _make_item("R1"), _make_item("C1")]
+        entries = [
+            BOMEntry(ref="U1", part="STM32G031F6P6", lcsc="C529330"),
+            BOMEntry(ref="C1", part="GRM155R71C104K", lcsc="C1525"),
+        ]
+
+        report = apply_spec_overlay(items, entries)
+
+        assert items[0].mpn == "STM32G031F6P6"
+        assert items[2].lcsc == "C1525"
+        # R1 untouched
+        assert items[1].mpn == ""
+        assert report.matched == 2
+
+
+# ---------------------------------------------------------------------------
+# SpecOverlayReport
+# ---------------------------------------------------------------------------
+
+
+class TestSpecOverlayReport:
+    def test_summary_all_matched(self):
+        from kicad_tools.export.bom_spec_overlay import SpecOverlayEntry
+
+        report = SpecOverlayReport(
+            entries=[
+                SpecOverlayEntry(reference="U1", mpn="X", lcsc="C123", matched=True),
+            ]
+        )
+        lines = report.summary_lines()
+        assert "1 applied" in lines[0]
+        assert "0 unmatched" in lines[0]
+
+    def test_summary_with_unmatched(self):
+        from kicad_tools.export.bom_spec_overlay import SpecOverlayEntry
+
+        report = SpecOverlayReport(
+            entries=[
+                SpecOverlayEntry(reference="U99", mpn="X", lcsc="", matched=False),
+            ]
+        )
+        lines = report.summary_lines()
+        assert "1 unmatched" in lines[0]
+        assert "U99" in lines[1]
+
+
+# ---------------------------------------------------------------------------
+# find_spec_file
+# ---------------------------------------------------------------------------
+
+
+class TestFindSpecFile:
+    def test_no_kct_files(self, tmp_path: Path):
+        assert find_spec_file(tmp_path) is None
+
+    def test_project_kct_preferred(self, tmp_path: Path):
+        (tmp_path / "project.kct").write_text("kct_version: '1.0'")
+        (tmp_path / "other.kct").write_text("kct_version: '1.0'")
+        result = find_spec_file(tmp_path)
+        assert result is not None
+        assert result.name == "project.kct"
+
+    def test_single_kct(self, tmp_path: Path):
+        (tmp_path / "myboard.kct").write_text("kct_version: '1.0'")
+        result = find_spec_file(tmp_path)
+        assert result is not None
+        assert result.name == "myboard.kct"
+
+    def test_multiple_kct_warns(self, tmp_path: Path):
+        (tmp_path / "a.kct").write_text("kct_version: '1.0'")
+        (tmp_path / "b.kct").write_text("kct_version: '1.0'")
+        with patch("kicad_tools.export.bom_spec_overlay.logger") as mock_logger:
+            result = find_spec_file(tmp_path)
+            assert result is not None
+            mock_logger.warning.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Integration: spec source in enrichment report
+# ---------------------------------------------------------------------------
+
+
+class TestSpecSourceInEnrichment:
+    """Verify that enrich_bom_lcsc reports 'spec' source for spec-populated refs."""
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_spec_source_reported(self, MockSuggester):
+        from kicad_tools.export.bom_enrich import enrich_bom_lcsc
+
+        mock_instance = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock()
+        mock_instance.__enter__ = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock(
+            return_value=mock_instance
+        )
+        mock_instance.__exit__ = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock(
+            return_value=False
+        )
+        MockSuggester.return_value = mock_instance
+
+        items = [_make_item("U1", lcsc="C529330")]
+        report = enrich_bom_lcsc(items, spec_refs={"U1"})
+
+        assert report.entries[0].source == "spec"
+        assert report.spec_populated == 1
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_schematic_source_without_spec_refs(self, MockSuggester):
+        from kicad_tools.export.bom_enrich import enrich_bom_lcsc
+
+        mock_instance = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock()
+        mock_instance.__enter__ = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock(
+            return_value=mock_instance
+        )
+        mock_instance.__exit__ = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock(
+            return_value=False
+        )
+        MockSuggester.return_value = mock_instance
+
+        items = [_make_item("U1", lcsc="C529330")]
+        report = enrich_bom_lcsc(items)
+
+        assert report.entries[0].source == "schematic"
+        assert report.spec_populated == 0
+
+
+# ---------------------------------------------------------------------------
+# Schema: BOMEntry in ProjectSpec
+# ---------------------------------------------------------------------------
+
+
+class TestBOMEntrySchema:
+    def test_bom_entries_parsed(self):
+        from kicad_tools.spec.schema import ProjectMetadata, ProjectSpec
+
+        spec = ProjectSpec(
+            project=ProjectMetadata(name="test"),
+            bom_entries=[
+                BOMEntry(ref="U1", part="STM32G031F6P6", lcsc="C529330"),
+                BOMEntry(ref="Q1-Q4", part="2N7002"),
+            ],
+        )
+        assert spec.bom_entries is not None
+        assert len(spec.bom_entries) == 2
+        assert spec.bom_entries[0].lcsc == "C529330"
+        assert spec.bom_entries[1].lcsc is None
+
+    def test_bom_entries_optional(self):
+        from kicad_tools.spec.schema import ProjectMetadata, ProjectSpec
+
+        spec = ProjectSpec(project=ProjectMetadata(name="test"))
+        assert spec.bom_entries is None
+
+    def test_bom_entries_roundtrip_yaml(self, tmp_path: Path):
+        """Verify bom_entries survive save/load cycle."""
+        from kicad_tools.spec.parser import load_spec, save_spec
+        from kicad_tools.spec.schema import ProjectMetadata, ProjectSpec
+
+        spec = ProjectSpec(
+            project=ProjectMetadata(name="test"),
+            bom_entries=[
+                BOMEntry(ref="U1", part="STM32G031F6P6", lcsc="C529330"),
+            ],
+        )
+        path = tmp_path / "test.kct"
+        save_spec(spec, path)
+        loaded = load_spec(path)
+        assert loaded.bom_entries is not None
+        assert len(loaded.bom_entries) == 1
+        assert loaded.bom_entries[0].ref == "U1"
+        assert loaded.bom_entries[0].part == "STM32G031F6P6"
+        assert loaded.bom_entries[0].lcsc == "C529330"


### PR DESCRIPTION
## Summary
The BOM pipeline previously read MPN/LCSC exclusively from KiCad schematic symbol properties, completely ignoring part selections in the `.kct` project spec. This adds a spec overlay pass that applies `bom_entries` from the `.kct` file onto BOM items before LCSC auto-enrichment runs, so the user's deliberate part choices flow through to the generated JLCPCB BOM CSV.

## Changes
- Add `BOMEntry` model to `spec/schema.py` with ref, part (MPN), source, and optional LCSC fields
- Add `bom_entries` list field to `ProjectSpec`
- Create `export/bom_spec_overlay.py` with reference range expansion (`"Q1-Q4"` -> Q1, Q2, Q3, Q4), spec file auto-detection, and overlay logic
- Wire spec overlay into `AssemblyPackage._generate_bom()` before `enrich_bom_lcsc()` so spec-provided LCSC numbers prevent redundant auto-matching
- Pass `spec_refs` set to `enrich_bom_lcsc()` so spec-sourced items are reported as `source: "spec"` (not `"schematic"`)
- Add `spec_populated` property and updated summary line to `EnrichmentReport`
- Add `--no-spec` CLI flag to `kct export` to disable spec overlay
- Add `spec_overlay` field to `AssemblyPackageResult` and display in CLI output
- Export new types from `export/__init__.py`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| .kct schema supports per-reference part mappings with MPN and optional LCSC | PASS | `BOMEntry` model added; YAML roundtrip test passes |
| `kct export` reads project spec and populates MPN/LCSC before LCSC auto-enrichment | PASS | Overlay wired into `_generate_bom()` before `enrich_bom_lcsc()` |
| Reference ranges expanded correctly | PASS | 8 tests for `expand_ref_range` covering single, range, reversed, mixed prefix |
| Spec-provided LCSC reported as source: "spec" | PASS | `spec_refs` parameter flows through; dedicated test confirms source="spec" |
| Components without spec entry fall through to existing auto-match | PASS | Only matched refs get overlay; enrichment runs normally on remaining items |
| Generated JLCPCB BOM CSV includes populated LCSC Part # for spec-mapped components | PASS | Overlay sets `item.lcsc` in-place before CSV export |
| `--no-spec` flag disables spec overlay | PASS | Flag added to CLI, sets `config.no_spec=True`, skips overlay block |

## Test Plan
- 26 new tests in `tests/test_bom_spec_overlay.py` covering:
  - Reference range expansion (single, range, reversed, mixed prefix, whitespace)
  - Overlay application (single ref, range, missing ref warning, MPN-only, LCSC-only, multiple entries)
  - Report summary formatting
  - Spec file auto-detection (none, project.kct preferred, single .kct, multiple warns)
  - Spec source attribution in enrichment report
  - Schema parsing and YAML roundtrip
- All 99 existing related tests pass (bom_enrich, assembly_validation, spec)

Closes #1494