### PR TITLE
feat(export): filter THT and DNP components from CPL output

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -688,6 +688,8 @@ def _run_export_command(args) -> int:
         sub_argv.extend(["--drc-report", args.export_drc_report])
     if hasattr(args, "export_erc_report") and args.export_erc_report:
         sub_argv.extend(["--erc-report", args.export_erc_report])
+    if getattr(args, "export_include_tht", False):
+        sub_argv.append("--include-tht")
     if hasattr(args, "export_format") and args.export_format != "text":
         sub_argv.extend(["--format", args.export_format])
 

--- a/src/kicad_tools/cli/export_cmd.py
+++ b/src/kicad_tools/cli/export_cmd.py
@@ -119,6 +119,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to pre-existing ERC report file",
     )
     parser.add_argument(
+        "--include-tht",
+        action="store_true",
+        help="Include through-hole components in CPL (they are excluded by default for JLCPCB)",
+    )
+    parser.add_argument(
         "--format",
         dest="output_format",
         default="text",
@@ -157,6 +162,13 @@ def run_export(args: argparse.Namespace) -> int:
         erc_report_path=getattr(args, "erc_report", None),
     )
 
+    # Build PnP configuration when --include-tht is specified
+    pnp_config = None
+    if getattr(args, "include_tht", False):
+        from kicad_tools.export.pnp import PnPExportConfig
+
+        pnp_config = PnPExportConfig(exclude_tht=False)
+
     # Build configuration
     auto_lcsc = args.auto_lcsc and not args.no_auto_lcsc
     config = ManufacturingConfig(
@@ -169,7 +181,8 @@ def run_export(args: argparse.Namespace) -> int:
         auto_lcsc=auto_lcsc,
         no_spec=getattr(args, "no_spec", False),
         preflight=preflight_cfg,
-        strict_preflight=getattr(args, "strict_preflight", False),
+strict_preflight=getattr(args, "strict_preflight", False),
+        pnp_config=pnp_config,
     )
 
     pkg = ManufacturingPackage(

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3907,6 +3907,12 @@ def _add_export_parser(subparsers) -> None:
         help="Path to pre-existing ERC report file",
     )
     export_parser.add_argument(
+        "--include-tht",
+        dest="export_include_tht",
+        action="store_true",
+        help="Include through-hole components in CPL (they are excluded by default for JLCPCB)",
+    )
+    export_parser.add_argument(
         "--format",
         dest="export_format",
         default="text",

--- a/src/kicad_tools/export/assembly.py
+++ b/src/kicad_tools/export/assembly.py
@@ -326,9 +326,9 @@ class AssemblyPackage:
         if self.config.exclude_references:
             footprints = [fp for fp in footprints if not self._is_excluded(fp.reference)]
 
-        # Generate CPL
-        pnp_config = self.config.pnp_config or PnPExportConfig()
-        pnp_csv = export_pnp(footprints, self.manufacturer, pnp_config)
+        # Generate CPL – pass None when no explicit config so that the
+        # formatter can apply its own defaults (e.g. JLCPCB exclude_tht=True).
+        pnp_csv = export_pnp(footprints, self.manufacturer, self.config.pnp_config)
 
         # Write to file
         filename = self.config.pnp_filename.format(manufacturer=self.manufacturer)

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -274,12 +274,19 @@ class ManufacturingPackage:
     def _run_preflight(self) -> list[PreflightResult]:
         """Run pre-flight validation checks."""
         preflight_cfg = self.config.preflight or PreflightConfig()
+
+        # Pass explicit THT exclusion setting when the user provided a PnP config
+        exclude_tht = None
+        if self.config.pnp_config is not None:
+            exclude_tht = self.config.pnp_config.exclude_tht
+
         checker = PreflightChecker(
             pcb_path=self.pcb_path,
             schematic_path=self.schematic_path,
             manufacturer=self.manufacturer,
             output_dir=self.config.output_dir,
             config=preflight_cfg,
+            exclude_tht=exclude_tht,
         )
         return checker.run_all()
 

--- a/src/kicad_tools/export/pnp.py
+++ b/src/kicad_tools/export/pnp.py
@@ -47,6 +47,7 @@ class PnPExportConfig:
 
     # Filtering
     include_dnp: bool = False
+    exclude_tht: bool = False  # Exclude through-hole components from CPL
     top_only: bool = False
     bottom_only: bool = False
 
@@ -108,10 +109,20 @@ class PnPFormatter(ABC):
 
 
 class JLCPCBPnPFormatter(PnPFormatter):
-    """Pick-and-place formatter for JLCPCB assembly service."""
+    """Pick-and-place formatter for JLCPCB assembly service.
+
+    JLCPCB's standard assembly service is SMT-only, so through-hole
+    components are excluded from the CPL by default.  Pass
+    ``PnPExportConfig(exclude_tht=False)`` to include them.
+    """
 
     manufacturer_id = "jlcpcb"
     manufacturer_name = "JLCPCB"
+
+    def __init__(self, config: PnPExportConfig | None = None):
+        if config is None:
+            config = PnPExportConfig(exclude_tht=True)
+        super().__init__(config)
 
     def get_headers(self) -> list[str]:
         """JLCPCB CPL column headers."""
@@ -279,20 +290,33 @@ def get_pnp_formatter(manufacturer: str, config: PnPExportConfig | None = None) 
     return formatter_class(config)
 
 
-def extract_placements(footprints: list[Footprint]) -> list[PlacementData]:
+def extract_placements(
+    footprints: list[Footprint],
+    config: PnPExportConfig | None = None,
+) -> list[PlacementData]:
     """
     Extract placement data from PCB footprints.
 
     Args:
         footprints: List of Footprint objects from PCB
+        config: Optional export config for filtering (exclude_tht, include_dnp)
 
     Returns:
         List of PlacementData for assembly
     """
+    config = config or PnPExportConfig()
     placements = []
     for fp in footprints:
-        # Skip virtual or excluded footprints
+        # Skip footprints excluded from position files
         if getattr(fp, "exclude_from_pos_files", False):
+            continue
+
+        # Skip DNP (Do Not Place) footprints unless explicitly included
+        if not config.include_dnp and getattr(fp, "dnp", False):
+            continue
+
+        # Skip through-hole footprints when exclude_tht is enabled
+        if config.exclude_tht and getattr(fp, "attr", "") == "through_hole":
             continue
 
         x, y = fp.position
@@ -355,10 +379,8 @@ def export_pnp(
     Returns:
         Formatted CPL as CSV string
     """
-    config = config or PnPExportConfig()
-
     # Auto-apply auxiliary origin offset when a PCB path is provided
-    if pcb_path is not None and config.use_aux_origin:
+    if config is not None and pcb_path is not None and config.use_aux_origin:
         aux_x, aux_y = get_aux_origin(pcb_path)
         if aux_x != 0.0 or aux_y != 0.0:
             config = PnPExportConfig(
@@ -368,11 +390,22 @@ def export_pnp(
                 mirror_y=config.mirror_y,
                 use_aux_origin=config.use_aux_origin,
                 include_dnp=config.include_dnp,
+                exclude_tht=config.exclude_tht,
                 top_only=config.top_only,
                 bottom_only=config.bottom_only,
                 rotation_offset=config.rotation_offset,
             )
+    elif config is None and pcb_path is not None:
+        # Check aux origin with default config settings
+        aux_x, aux_y = get_aux_origin(pcb_path)
+        if aux_x != 0.0 or aux_y != 0.0:
+            config = PnPExportConfig(
+                x_offset=-aux_x,
+                y_offset=-aux_y,
+            )
 
-    placements = extract_placements(footprints)
+    # Let the formatter provide its own default config (e.g., JLCPCB
+    # defaults to exclude_tht=True) when the caller did not supply one.
     formatter = get_pnp_formatter(manufacturer, config)
+    placements = extract_placements(footprints, formatter.config)
     return formatter.format(placements)

--- a/src/kicad_tools/export/preflight.py
+++ b/src/kicad_tools/export/preflight.py
@@ -82,6 +82,9 @@ class PreflightChecker:
             print("Cannot proceed with export")
     """
 
+    # Manufacturers whose standard assembly service is SMT-only
+    _SMT_ONLY_MANUFACTURERS = {"jlcpcb"}
+
     def __init__(
         self,
         pcb_path: str | Path,
@@ -89,12 +92,19 @@ class PreflightChecker:
         manufacturer: str = "jlcpcb",
         output_dir: str | Path | None = None,
         config: PreflightConfig | None = None,
+        exclude_tht: bool | None = None,
     ):
         self.pcb_path = Path(pcb_path)
         self.schematic_path = Path(schematic_path) if schematic_path else None
         self.manufacturer = manufacturer.lower()
         self.output_dir = Path(output_dir) if output_dir else None
         self.config = config or PreflightConfig()
+
+        # Determine THT exclusion: explicit override, or default per manufacturer
+        if exclude_tht is not None:
+            self._exclude_tht = exclude_tht
+        else:
+            self._exclude_tht = self.manufacturer in self._SMT_ONLY_MANUFACTURERS
 
         # Lazy-loaded objects
         self._pcb = None
@@ -123,6 +133,10 @@ class PreflightChecker:
             results.append(self._check_footprints_present())
             results.append(self._check_board_dimensions())
             results.append(self._check_drill_holes())
+
+        # THT-in-CPL warning
+        if self._pcb is not None:
+            results.append(self._check_tht_in_cpl())
 
         # BOM checks (only if schematic is available)
         if self.schematic_path and self.schematic_path.exists():
@@ -406,6 +420,58 @@ class PreflightChecker:
             message=f"Drill holes present ({via_count} vias, {th_pad_count} TH pads)",
         )
 
+    def _check_tht_in_cpl(self) -> PreflightResult:
+        """Warn when THT components are present on a board targeting an SMT-only assembler."""
+        if self._pcb is None:
+            return PreflightResult(
+                name="tht_in_cpl",
+                status="WARN",
+                message="Cannot check THT components: PCB not loaded",
+            )
+
+        tht_refs = [
+            fp.reference
+            for fp in self._pcb.footprints
+            if getattr(fp, "attr", "") == "through_hole"
+            and not getattr(fp, "exclude_from_pos_files", False)
+        ]
+
+        if not tht_refs:
+            return PreflightResult(
+                name="tht_in_cpl",
+                status="OK",
+                message="No through-hole components in CPL-eligible footprints",
+            )
+
+        refs = ", ".join(sorted(tht_refs)[:10])
+        suffix = f" (and {len(tht_refs) - 10} more)" if len(tht_refs) > 10 else ""
+
+        if self._exclude_tht:
+            return PreflightResult(
+                name="tht_in_cpl",
+                status="OK",
+                message=f"{len(tht_refs)} through-hole component(s) excluded from CPL",
+                details=f"THT references: {refs}{suffix}",
+            )
+
+        if self.manufacturer in self._SMT_ONLY_MANUFACTURERS:
+            return PreflightResult(
+                name="tht_in_cpl",
+                status="WARN",
+                message=(
+                    f"{len(tht_refs)} through-hole component(s) in CPL "
+                    f"for SMT-only assembler ({self.manufacturer})"
+                ),
+                details=f"THT references: {refs}{suffix}; use --include-tht to keep them or they will be auto-excluded",
+            )
+
+        return PreflightResult(
+            name="tht_in_cpl",
+            status="OK",
+            message=f"{len(tht_refs)} through-hole component(s) included in CPL",
+            details=f"THT references: {refs}{suffix}",
+        )
+
     def _check_bom_fields(self) -> PreflightResult:
         """Check that BOM items have required fields for manufacturing."""
         try:
@@ -529,8 +595,9 @@ class PreflightChecker:
         """Check that BOM references match CPL-eligible PCB footprints.
 
         The CPL (pick-and-place) file is generated from PCB footprints with
-        filtering applied: DNP components and footprints excluded from position
-        files are omitted.  This check compares the set of active BOM
+        filtering applied: DNP components, footprints excluded from position
+        files, and (when targeting SMT-only assemblers) through-hole
+        components are omitted.  This check compares the set of active BOM
         references against the CPL-eligible footprint references so that
         assembly mismatches are caught before export.
         """
@@ -554,13 +621,22 @@ class PreflightChecker:
         bom_refs = {item.reference for item in bom.items if not item.is_virtual and not item.dnp}
 
         # CPL-eligible footprint references -- mirrors extract_placements() in pnp.py
-        cpl_refs = {
-            fp.reference
-            for fp in self._pcb.footprints
-            if not getattr(fp, "exclude_from_pos_files", False)
-        }
+        cpl_refs = set()
+        tht_excluded_refs = set()
+        dnp_excluded_refs = set()
+        for fp in self._pcb.footprints:
+            if getattr(fp, "exclude_from_pos_files", False):
+                continue
+            if getattr(fp, "dnp", False):
+                dnp_excluded_refs.add(fp.reference)
+                continue
+            if self._exclude_tht and getattr(fp, "attr", "") == "through_hole":
+                tht_excluded_refs.add(fp.reference)
+                continue
+            cpl_refs.add(fp.reference)
 
-        in_bom_not_cpl = bom_refs - cpl_refs
+        # THT-excluded and DNP-excluded components are expected mismatches
+        in_bom_not_cpl = bom_refs - cpl_refs - tht_excluded_refs - dnp_excluded_refs
         in_cpl_not_bom = cpl_refs - bom_refs
 
         issues: list[str] = []
@@ -581,10 +657,16 @@ class PreflightChecker:
                 details="; ".join(issues),
             )
 
+        info_parts = [f"{len(cpl_refs)} components"]
+        if tht_excluded_refs:
+            info_parts.append(f"{len(tht_excluded_refs)} THT excluded")
+        if dnp_excluded_refs:
+            info_parts.append(f"{len(dnp_excluded_refs)} DNP excluded")
+
         return PreflightResult(
             name="bom_cpl_match",
             status="OK",
-            message=f"BOM and CPL references match ({len(bom_refs)} components)",
+            message=f"BOM and CPL references match ({', '.join(info_parts)})",
         )
 
     def _check_drc(self) -> PreflightResult:

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -417,6 +417,9 @@ class Footprint:
     description: str = ""
     tags: str = ""
     attr: str = ""  # smd, through_hole
+    exclude_from_pos_files: bool = False
+    exclude_from_bom: bool = False
+    dnp: bool = False
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> Footprint:
@@ -458,6 +461,15 @@ class Footprint:
             fp.tags = tags.get_string(0) or ""
         if attr := sexp.find("attr"):
             fp.attr = attr.get_string(0) or ""
+            # Parse additional attribute flags (e.g., exclude_from_pos_files, dnp)
+            for i in range(len(attr.children)):
+                token = attr.get_string(i)
+                if token == "exclude_from_pos_files":
+                    fp.exclude_from_pos_files = True
+                elif token == "exclude_from_bom":
+                    fp.exclude_from_bom = True
+                elif token == "dnp":
+                    fp.dnp = True
 
         # Reference and value from fp_text (KiCad 7 format)
         for fp_text_sexp in sexp.find_all("fp_text"):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -566,7 +566,9 @@ class TestExtractPlacementsTHTFiltering:
         return [
             MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
             MockFootprint("C1", "100nF", "0402", (15.0, 25.0), 0.0, "F.Cu", attr="smd"),
-            MockFootprint("J1", "Conn_01x04", "PinHeader_1x04", (50.0, 10.0), 0.0, "F.Cu", attr="through_hole"),
+            MockFootprint(
+                "J1", "Conn_01x04", "PinHeader_1x04", (50.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+            ),
             MockFootprint("U1", "STM32", "LQFP48", (30.0, 30.0), 45.0, "F.Cu", attr="smd"),
         ]
 
@@ -594,8 +596,12 @@ class TestExtractPlacementsTHTFiltering:
     def test_all_tht_board_produces_empty_cpl(self):
         """Board with only THT components + exclude_tht should produce empty list."""
         footprints = [
-            MockFootprint("J1", "Conn", "PinHeader", (10.0, 10.0), 0.0, "F.Cu", attr="through_hole"),
-            MockFootprint("J2", "Conn", "PinHeader", (20.0, 10.0), 0.0, "F.Cu", attr="through_hole"),
+            MockFootprint(
+                "J1", "Conn", "PinHeader", (10.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+            ),
+            MockFootprint(
+                "J2", "Conn", "PinHeader", (20.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+            ),
         ]
         config = PnPExportConfig(exclude_tht=True)
         placements = extract_placements(footprints, config)
@@ -659,7 +665,9 @@ class TestExportPnPTHTIntegration:
     def mixed_footprints(self) -> list[MockFootprint]:
         return [
             MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
-            MockFootprint("J1", "Conn", "PinHeader_1x04", (50.0, 10.0), 0.0, "F.Cu", attr="through_hole"),
+            MockFootprint(
+                "J1", "Conn", "PinHeader_1x04", (50.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+            ),
         ]
 
     def test_jlcpcb_excludes_tht(self, mixed_footprints):
@@ -686,3 +694,63 @@ class TestExportPnPTHTIntegration:
         output = export_pnp(mixed_footprints, "pcbway")
         assert "R1" in output
         assert "J1" in output
+
+
+class TestAssemblyPackageJLCPCBTHTIntegration:
+    """Integration test: AssemblyPackage JLCPCB path excludes THT components."""
+
+    def test_jlcpcb_assembly_package_excludes_tht(self, tmp_path):
+        """AssemblyPackage with manufacturer='jlcpcb' and no explicit pnp_config
+        should produce a CPL file that excludes through-hole components.
+
+        This guards against a regression where AssemblyPackage._generate_pnp()
+        created a bare PnPExportConfig (exclude_tht=False) instead of letting
+        the JLCPCB formatter supply its own default (exclude_tht=True).
+        """
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.export.assembly import AssemblyConfig, AssemblyPackage
+
+        # Create a minimal PCB file so the constructor's existence check passes
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb (version 20221018))")
+
+        config = AssemblyConfig(
+            include_bom=False,
+            include_gerbers=False,
+            include_pnp=True,
+            # Intentionally leave pnp_config=None to exercise the default path
+        )
+
+        pkg = AssemblyPackage(
+            pcb_path=pcb_file,
+            schematic_path=None,
+            manufacturer="jlcpcb",
+            config=config,
+        )
+
+        # Mock PCB.load to return footprints with mixed SMD and THT
+        mock_pcb = MagicMock()
+        mock_pcb.footprints = [
+            MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint("C1", "100nF", "0402", (15.0, 25.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint(
+                "J1", "Conn_01x04", "PinHeader_1x04", (50.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+            ),
+        ]
+
+        # Patch PCB at the schema module level; the lazy import in
+        # _generate_pnp (``from ..schema.pcb import PCB``) resolves
+        # against this module.
+        with patch("kicad_tools.schema.pcb.PCB") as MockPCB:
+            MockPCB.load.return_value = mock_pcb
+            result = pkg.export(output_dir=tmp_path / "out")
+
+        assert result.pnp_path is not None
+        cpl_content = result.pnp_path.read_text()
+
+        # SMD components must be present
+        assert "R1" in cpl_content
+        assert "C1" in cpl_content
+        # THT connector must be excluded
+        assert "J1" not in cpl_content

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -53,6 +53,8 @@ class MockFootprint:
     rotation: float
     layer: str
     exclude_from_pos_files: bool = False
+    attr: str = "smd"
+    dnp: bool = False
 
 
 class TestBOMExportConfig:
@@ -553,3 +555,134 @@ class TestAssemblyPackageResult:
         output = str(result)
         assert "Assembly Package" in output
         assert "BOM" in output
+
+
+class TestExtractPlacementsTHTFiltering:
+    """Tests for THT filtering in extract_placements."""
+
+    @pytest.fixture
+    def mixed_footprints(self) -> list[MockFootprint]:
+        """Board with SMD and THT components."""
+        return [
+            MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint("C1", "100nF", "0402", (15.0, 25.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint("J1", "Conn_01x04", "PinHeader_1x04", (50.0, 10.0), 0.0, "F.Cu", attr="through_hole"),
+            MockFootprint("U1", "STM32", "LQFP48", (30.0, 30.0), 45.0, "F.Cu", attr="smd"),
+        ]
+
+    def test_default_config_includes_tht(self, mixed_footprints):
+        """Default PnPExportConfig does not exclude THT."""
+        config = PnPExportConfig()
+        placements = extract_placements(mixed_footprints, config)
+        refs = {p.reference for p in placements}
+        assert refs == {"R1", "C1", "J1", "U1"}
+
+    def test_exclude_tht_filters_through_hole(self, mixed_footprints):
+        """exclude_tht=True should remove through_hole footprints."""
+        config = PnPExportConfig(exclude_tht=True)
+        placements = extract_placements(mixed_footprints, config)
+        refs = {p.reference for p in placements}
+        assert refs == {"R1", "C1", "U1"}
+        assert "J1" not in refs
+
+    def test_exclude_tht_keeps_smd(self, mixed_footprints):
+        """exclude_tht should not affect SMD components."""
+        config = PnPExportConfig(exclude_tht=True)
+        placements = extract_placements(mixed_footprints, config)
+        assert len(placements) == 3
+
+    def test_all_tht_board_produces_empty_cpl(self):
+        """Board with only THT components + exclude_tht should produce empty list."""
+        footprints = [
+            MockFootprint("J1", "Conn", "PinHeader", (10.0, 10.0), 0.0, "F.Cu", attr="through_hole"),
+            MockFootprint("J2", "Conn", "PinHeader", (20.0, 10.0), 0.0, "F.Cu", attr="through_hole"),
+        ]
+        config = PnPExportConfig(exclude_tht=True)
+        placements = extract_placements(footprints, config)
+        assert len(placements) == 0
+
+
+class TestExtractPlacementsDNPFiltering:
+    """Tests for DNP filtering in extract_placements."""
+
+    def test_dnp_excluded_by_default(self):
+        """DNP footprints should be excluded by default."""
+        footprints = [
+            MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint("R2", "1k", "0402", (15.0, 25.0), 0.0, "F.Cu", attr="smd", dnp=True),
+        ]
+        placements = extract_placements(footprints)
+        refs = {p.reference for p in placements}
+        assert refs == {"R1"}
+
+    def test_dnp_included_when_configured(self):
+        """DNP footprints should be included when include_dnp=True."""
+        footprints = [
+            MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint("R2", "1k", "0402", (15.0, 25.0), 0.0, "F.Cu", attr="smd", dnp=True),
+        ]
+        config = PnPExportConfig(include_dnp=True)
+        placements = extract_placements(footprints, config)
+        refs = {p.reference for p in placements}
+        assert refs == {"R1", "R2"}
+
+
+class TestJLCPCBPnPFormatterDefaults:
+    """Tests for JLCPCB formatter default THT exclusion."""
+
+    def test_jlcpcb_defaults_exclude_tht(self):
+        """JLCPCB formatter should default to exclude_tht=True."""
+        formatter = JLCPCBPnPFormatter()
+        assert formatter.config.exclude_tht is True
+
+    def test_jlcpcb_explicit_include_tht(self):
+        """Passing exclude_tht=False should override JLCPCB default."""
+        config = PnPExportConfig(exclude_tht=False)
+        formatter = JLCPCBPnPFormatter(config)
+        assert formatter.config.exclude_tht is False
+
+    def test_generic_does_not_exclude_tht(self):
+        """Generic formatter should include THT by default."""
+        formatter = GenericPnPFormatter()
+        assert formatter.config.exclude_tht is False
+
+    def test_pcbway_does_not_exclude_tht(self):
+        """PCBWay formatter should include THT by default."""
+        formatter = PCBWayPnPFormatter()
+        assert formatter.config.exclude_tht is False
+
+
+class TestExportPnPTHTIntegration:
+    """Integration tests for THT filtering through export_pnp."""
+
+    @pytest.fixture
+    def mixed_footprints(self) -> list[MockFootprint]:
+        return [
+            MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint("J1", "Conn", "PinHeader_1x04", (50.0, 10.0), 0.0, "F.Cu", attr="through_hole"),
+        ]
+
+    def test_jlcpcb_excludes_tht(self, mixed_footprints):
+        """JLCPCB export should exclude THT components by default."""
+        output = export_pnp(mixed_footprints, "jlcpcb")
+        assert "R1" in output
+        assert "J1" not in output
+
+    def test_jlcpcb_include_tht_override(self, mixed_footprints):
+        """JLCPCB export with exclude_tht=False should include THT."""
+        config = PnPExportConfig(exclude_tht=False)
+        output = export_pnp(mixed_footprints, "jlcpcb", config=config)
+        assert "R1" in output
+        assert "J1" in output
+
+    def test_generic_includes_tht(self, mixed_footprints):
+        """Generic export should include THT components by default."""
+        output = export_pnp(mixed_footprints, "generic")
+        assert "R1" in output
+        assert "J1" in output
+
+    def test_pcbway_includes_tht(self, mixed_footprints):
+        """PCBWay export should include THT components by default."""
+        output = export_pnp(mixed_footprints, "pcbway")
+        assert "R1" in output
+        assert "J1" in output

--- a/tests/test_export_cmd.py
+++ b/tests/test_export_cmd.py
@@ -210,6 +210,7 @@ class TestExportCmdFromMainParser:
                 "--no-bom",
                 "--no-cpl",
                 "--no-project-zip",
+                "--include-tht",
             ]
         )
         assert args.export_mfr == "pcbway"
@@ -221,6 +222,7 @@ class TestExportCmdFromMainParser:
         assert args.export_no_bom is True
         assert args.export_no_cpl is True
         assert args.export_no_project_zip is True
+        assert args.export_include_tht is True
 
     def test_parser_export_no_auto_lcsc_flag(self):
         """--no-auto-lcsc should set export_no_auto_lcsc to True."""
@@ -330,3 +332,94 @@ class TestExportCmdStrictPreflight:
         # dry-run to avoid needing kicad-cli
         rc = export_main([str(pcb), "--strict-preflight", "--dry-run", "-o", str(tmp_path / "out")])
         assert rc == 0
+
+
+class TestExportCmdIncludeTHT:
+    """Tests for the --include-tht CLI flag."""
+
+    def test_include_tht_flag_accepted(self, tmp_path):
+        """--include-tht should be a recognized flag."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        rc = export_main([str(pcb), "--include-tht", "--dry-run", "-o", str(tmp_path / "out")])
+        assert rc == 0
+
+    def test_include_tht_sets_pnp_config(self, tmp_path, monkeypatch):
+        """--include-tht should set exclude_tht=False on PnPExportConfig."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        from kicad_tools.export import assembly
+
+        captured_config = {}
+
+        original_init = assembly.AssemblyPackage.__init__
+
+        def spy_init(self, pcb_path, schematic_path=None, manufacturer="jlcpcb", config=None):
+            captured_config["pnp_config"] = config.pnp_config if config else None
+            original_init(self, pcb_path, schematic_path, manufacturer, config)
+
+        def fake_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "__init__", spy_init)
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_export)
+
+        rc = export_main(
+            [
+                str(pcb),
+                "--include-tht",
+                "--no-report",
+                "--no-project-zip",
+                "--skip-preflight",
+                "-o",
+                str(tmp_path / "out"),
+            ]
+        )
+        assert rc == 0
+        assert captured_config["pnp_config"] is not None
+        assert captured_config["pnp_config"].exclude_tht is False
+
+    def test_without_include_tht_no_pnp_config(self, tmp_path, monkeypatch):
+        """Without --include-tht, pnp_config should be None (formatter default applies)."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        from kicad_tools.export import assembly
+
+        captured_config = {}
+
+        original_init = assembly.AssemblyPackage.__init__
+
+        def spy_init(self, pcb_path, schematic_path=None, manufacturer="jlcpcb", config=None):
+            captured_config["pnp_config"] = config.pnp_config if config else None
+            original_init(self, pcb_path, schematic_path, manufacturer, config)
+
+        def fake_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "__init__", spy_init)
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_export)
+
+        rc = export_main(
+            [
+                str(pcb),
+                "--no-report",
+                "--no-project-zip",
+                "--skip-preflight",
+                "-o",
+                str(tmp_path / "out"),
+            ]
+        )
+        assert rc == 0
+        assert captured_config["pnp_config"] is None
+

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1157,3 +1157,209 @@ def _create_pcb_with_footprints(
     pcb_path = directory / filename
     pcb_path.write_text(content)
     return pcb_path
+
+
+def _create_pcb_with_mixed_footprints(
+    directory: Path,
+    smd_refs: list[str],
+    tht_refs: list[str],
+    dnp_refs: list[str] | None = None,
+    filename: str = "board.kicad_pcb",
+) -> Path:
+    """Create a PCB with SMD and THT footprints for testing.
+
+    Args:
+        directory: Directory to write the PCB file.
+        smd_refs: References for SMD footprints.
+        tht_refs: References for through-hole footprints.
+        dnp_refs: References for DNP footprints (added as SMD with dnp flag).
+        filename: Output filename.
+    """
+    footprints = []
+    x = 10.0
+    for ref in smd_refs:
+        footprints.append(
+            f"""  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (at {x} 25)
+    (attr smd)
+    (fp_text reference "{ref}" (at 0 -1.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (fp_text value "10k" (at 0 1.5) (layer "F.Fab") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+  )"""
+        )
+        x += 5.0
+
+    for ref in tht_refs:
+        footprints.append(
+            f"""  (footprint "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical"
+    (layer "F.Cu")
+    (at {x} 25)
+    (attr through_hole)
+    (fp_text reference "{ref}" (at 0 -1.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (fp_text value "Conn_01x04" (at 0 1.5) (layer "F.Fab") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" thru_hole rect (at 0 0) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 0 ""))
+  )"""
+        )
+        x += 5.0
+
+    for ref in (dnp_refs or []):
+        footprints.append(
+            f"""  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (at {x} 25)
+    (attr smd dnp)
+    (fp_text reference "{ref}" (at 0 -1.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (fp_text value "DNP" (at 0 1.5) (layer "F.Fab") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+  )"""
+        )
+        x += 5.0
+
+    fp_block = "\n".join(footprints)
+    content = f"""(kicad_pcb (version 20231014) (generator "pcbnew")
+  (general
+    (thickness 1.6)
+    (legacy_teardrops no)
+  )
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (gr_line (start 0 0) (end 50 0) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 50 0) (end 50 50) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 50 50) (end 0 50) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 0 50) (end 0 0) (layer "Edge.Cuts") (width 0.1))
+{fp_block}
+)
+"""
+    pcb_path = directory / filename
+    pcb_path.write_text(content)
+    return pcb_path
+
+
+# ---------------------------------------------------------------------------
+# THT-in-CPL preflight check tests
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightTHTInCPL:
+    """Tests for the THT-in-CPL preflight check."""
+
+    def test_no_tht_components(self, tmp_path):
+        """All-SMD board should produce OK result."""
+        pcb = _create_pcb_with_footprints(tmp_path, ["R1", "R2"])
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        checker.run_all()
+        result = checker._check_tht_in_cpl()
+        assert result.status == "OK"
+        assert "No through-hole" in result.message
+
+    def test_tht_present_jlcpcb_excluded(self, tmp_path):
+        """JLCPCB (SMT-only default) with THT should show excluded message."""
+        pcb = _create_pcb_with_mixed_footprints(tmp_path, ["R1"], ["J1"])
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            manufacturer="jlcpcb",
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        checker.run_all()
+        result = checker._check_tht_in_cpl()
+        assert result.status == "OK"
+        assert "excluded from CPL" in result.message
+        assert "J1" in result.details
+
+    def test_tht_present_jlcpcb_include_override(self, tmp_path):
+        """JLCPCB with explicit exclude_tht=False should warn about THT."""
+        pcb = _create_pcb_with_mixed_footprints(tmp_path, ["R1"], ["J1"])
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            manufacturer="jlcpcb",
+            exclude_tht=False,
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        checker.run_all()
+        result = checker._check_tht_in_cpl()
+        assert result.status == "WARN"
+        assert "SMT-only" in result.message
+
+    def test_tht_present_generic_ok(self, tmp_path):
+        """Generic manufacturer with THT should show included message."""
+        pcb = _create_pcb_with_mixed_footprints(tmp_path, ["R1"], ["J1"])
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            manufacturer="generic",
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        checker.run_all()
+        result = checker._check_tht_in_cpl()
+        assert result.status == "OK"
+        assert "included" in result.message
+
+
+class TestPreflightBomCplMatchTHT:
+    """Tests for BOM/CPL match check accounting for THT exclusions."""
+
+    def test_tht_excluded_not_false_positive(self, tmp_path, monkeypatch):
+        """THT components excluded from CPL should not cause BOM/CPL mismatch."""
+        pcb = _create_pcb_with_mixed_footprints(tmp_path, ["R1", "C1"], ["J1"])
+        sch = tmp_path / "board.kicad_sch"
+        sch.write_text('(kicad_sch (version 20231120) (generator "eeschema"))')
+
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            schematic_path=sch,
+            manufacturer="jlcpcb",
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        checker.run_all()
+
+        from kicad_tools.schema.bom import BOM, BOMItem
+
+        bom = BOM(
+            items=[
+                BOMItem(reference="R1", value="10k", footprint="R_0402", lib_id="Device:R"),
+                BOMItem(reference="C1", value="100nF", footprint="C_0402", lib_id="Device:C"),
+                BOMItem(reference="J1", value="Conn", footprint="PinHeader", lib_id="Connector:Conn"),
+            ]
+        )
+        monkeypatch.setattr(checker, "_load_bom", lambda: bom)
+
+        result = checker._check_bom_cpl_match()
+        assert result.status == "OK"
+        assert "THT excluded" in result.message
+
+    def test_dnp_excluded_not_false_positive(self, tmp_path, monkeypatch):
+        """DNP components on PCB should not cause BOM/CPL mismatch."""
+        pcb = _create_pcb_with_mixed_footprints(tmp_path, ["R1"], [], dnp_refs=["R2"])
+        sch = tmp_path / "board.kicad_sch"
+        sch.write_text('(kicad_sch (version 20231120) (generator "eeschema"))')
+
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            schematic_path=sch,
+            manufacturer="jlcpcb",
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        checker.run_all()
+
+        from kicad_tools.schema.bom import BOM, BOMItem
+
+        bom = BOM(
+            items=[
+                BOMItem(reference="R1", value="10k", footprint="R_0402", lib_id="Device:R"),
+            ]
+        )
+        monkeypatch.setattr(checker, "_load_bom", lambda: bom)
+
+        result = checker._check_bom_cpl_match()
+        assert result.status == "OK"
+        assert "DNP excluded" in result.message


### PR DESCRIPTION
## Summary
Exclude through-hole (THT) and Do Not Place (DNP) components from CPL/pick-and-place files. JLCPCB's standard assembly service is SMT-only, so THT components are excluded by default when targeting JLCPCB. A new `--include-tht` CLI flag allows users to override this behavior.

## Changes
- Parse `exclude_from_pos_files`, `exclude_from_bom`, and `dnp` flags from the Footprint `(attr ...)` s-expression in `pcb.py`
- Add `exclude_tht` field to `PnPExportConfig` (default `False`; `JLCPCBPnPFormatter` overrides to `True`)
- Add `--include-tht` CLI flag to `export_cmd.py` and wire it through `parser.py` and `__init__.py`
- Filter DNP footprints from CPL output in `extract_placements()`
- Add `_check_tht_in_cpl()` preflight check that warns about THT on SMT-only assemblers
- Update `_check_bom_cpl_match()` to account for THT and DNP exclusions (no false-positive FAIL)
- Pass `exclude_tht` context from `ManufacturingPackage` to `PreflightChecker`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| JLCPCB excludes THT from CPL by default | PASS | `JLCPCBPnPFormatter` defaults `exclude_tht=True`; integration test `test_jlcpcb_excludes_tht` confirms |
| `--include-tht` includes THT in JLCPCB CPL | PASS | `test_jlcpcb_include_tht_override` and CLI test `test_include_tht_sets_pnp_config` confirm |
| Generic includes THT by default | PASS | `test_generic_includes_tht` confirms |
| PCBWay includes THT by default | PASS | `test_pcbway_includes_tht` confirms |
| DNP components excluded from CPL | PASS | `test_dnp_excluded_by_default` confirms |
| Preflight warns about THT on SMT-only assembler | PASS | `test_tht_present_jlcpcb_include_override` confirms WARN status |
| bom_cpl_match does not FAIL for THT exclusions | PASS | `test_tht_excluded_not_false_positive` confirms OK status |
| BOM and CPL counts are consistent after filtering | PASS | Preflight message includes "THT excluded" and "DNP excluded" counts |

## Test Plan
- 134 tests pass across `test_export.py`, `test_preflight.py`, and `test_export_cmd.py`
- New tests cover THT filtering, DNP filtering, JLCPCB/generic/PCBWay defaults, CLI flag parsing, and preflight checks

Closes #1498