### PR TITLE
feat(boards): add LCSC part numbers to bom_entries in all project specs

### DIFF
--- a/boards/00-simple-led/project.kct
+++ b/boards/00-simple-led/project.kct
@@ -46,6 +46,17 @@ requirements:
       purpose: Visual indicator
       footprint: LED_D5.0mm
 
+bom_entries:
+  - ref: J1
+    part: B-2100S02P-A110
+    lcsc: C49257
+  - ref: R1
+    part: 0805W8F3300T5E
+    lcsc: C17630
+  - ref: D1
+    part: C503B-RCN-CW0Z0AA1
+    lcsc: C84256
+
 decisions:
   - topic: Resistor value
     choice: 330 ohm

--- a/boards/01-voltage-divider/project.kct
+++ b/boards/01-voltage-divider/project.kct
@@ -102,6 +102,20 @@ suggestions:
     - "Used for testing the complete kicad-tools pipeline"
     - "Run generate_design.py to regenerate all outputs"
 
+bom_entries:
+  - ref: J1
+    part: B-2100S02P-A110
+    lcsc: C49257
+  - ref: J2
+    part: B-2100S02P-A110
+    lcsc: C49257
+  - ref: R1
+    part: 0805W8F1002T5E
+    lcsc: C17414
+  - ref: R2
+    part: 0805W8F1002T5E
+    lcsc: C17414
+
 decisions:
   - date: 2025-01-09
     phase: concept

--- a/boards/02-charlieplex-led/project.kct
+++ b/boards/02-charlieplex-led/project.kct
@@ -102,6 +102,17 @@ suggestions:
     - "Monte Carlo routing strategy recommended"
     - "Some nets may require manual routing on 2-layer"
 
+bom_entries:
+  - ref: U1
+    part: B-8100S08P-A110
+    lcsc: C57215
+  - ref: R1-R4
+    part: 0805W8F3300T5E
+    lcsc: C17630
+  - ref: D1-D9
+    part: 17-21SURC/S530-A2/TR8
+    lcsc: C72038
+
 decisions:
   - date: 2025-01-08
     phase: concept

--- a/boards/03-usb-joystick/project.kct
+++ b/boards/03-usb-joystick/project.kct
@@ -115,6 +115,26 @@ suggestions:
     preferred_vendors: ["LCSC", "Digikey"]
     cost_target: "$5/board"
 
+bom_entries:
+  - ref: U1
+    part: ATMEGA32U4-AU
+    lcsc: C44854
+  - ref: J1
+    part: TYPE-C-31-M-12
+    lcsc: C165948
+  - ref: J2
+    part: B-5100S05P-A110
+    lcsc: C50950
+  - ref: Y1
+    part: X49SM16MSD2SC
+    lcsc: C13738
+  - ref: SW1-SW4
+    part: TS-1187A-B-A-B
+    lcsc: C318884
+  - ref: C1-C4
+    part: CL21B104KBCNNNC
+    lcsc: C1525
+
 decisions:
   - date: 2025-01-08
     phase: concept

--- a/boards/04-stm32-devboard/project.kct
+++ b/boards/04-stm32-devboard/project.kct
@@ -110,6 +110,38 @@ suggestions:
     - "This is an educational example - MCU not included in generated schematic"
     - "User must add STM32F103C8T6 and connect to generated blocks"
 
+bom_entries:
+  - ref: U1
+    part: AMS1117-3.3
+    lcsc: C6186
+  - ref: C1
+    part: CL21A106KAYNNNE
+    lcsc: C15850
+  - ref: C2
+    part: CL21A106KAYNNNE
+    lcsc: C15850
+  - ref: C3
+    part: CL21B104KBCNNNC
+    lcsc: C1525
+  - ref: Y1
+    part: X49SM8MSD2SC
+    lcsc: C12674
+  - ref: C10
+    part: CL21C200JBANNNC
+    lcsc: C1554
+  - ref: C11
+    part: CL21C200JBANNNC
+    lcsc: C1554
+  - ref: R1
+    part: 0805W8F3300T5E
+    lcsc: C17630
+  - ref: D1
+    part: 17-21SURC/S530-A2/TR8
+    lcsc: C72038
+  - ref: J1
+    part: B-6100S06P-A110
+    lcsc: C40877
+
 decisions:
   - date: 2025-01-08
     phase: concept

--- a/boards/05-bldc-motor-controller/project.kct
+++ b/boards/05-bldc-motor-controller/project.kct
@@ -143,6 +143,72 @@ suggestions:
       - "Keep PWM traces away from sense traces"
       - "Use ground guard traces around sensitive signals"
 
+bom_entries:
+  - ref: J1
+    part: WJ15EDGRC-3.81-2P
+    lcsc: C8465
+  - ref: F1
+    part: 0685P9150-01
+    lcsc: C89657
+  - ref: D1
+    part: SMDJ24A
+    lcsc: C35208
+  - ref: C1
+    part: 470uF/35V
+    lcsc: C134742
+  - ref: C2
+    part: CL21B104KBCNNNC
+    lcsc: C1525
+  - ref: U1
+    part: LM2596S-5.0
+    lcsc: C29781
+  - ref: U2
+    part: AMS1117-3.3
+    lcsc: C6186
+  - ref: C5
+    part: CL21A106KAYNNNE
+    lcsc: C15850
+  - ref: C6
+    part: CL21B104KBCNNNC
+    lcsc: C1525
+  - ref: C7-C8
+    part: CL21B104KBCNNNC
+    lcsc: C1525
+  - ref: C9
+    part: CL21A475KAQNNNE
+    lcsc: C1779
+  - ref: Y1
+    part: X49SM8MSD2SC
+    lcsc: C12674
+  - ref: C10-C11
+    part: CL21C200JBANNNC
+    lcsc: C1554
+  - ref: U3
+    part: DRV8301DCAR
+    lcsc: C129292
+  - ref: Q1-Q6
+    part: IRLZ44NPBF
+    lcsc: C2537
+  - ref: R10-R12
+    part: CS2512-0R005-J-T
+    source: LCSC
+    lcsc: C76662
+  - ref: J2
+    part: WJ15EDGRC-3.81-3P
+    lcsc: C8390
+  - ref: J3
+    part: B-5100S05P-A110
+    lcsc: C50950
+  - ref: J4
+    part: B-6100S06P-A110
+    lcsc: C40877
+  - ref: D3
+    part: 17-21SUGC/S530-A2/TR8
+    lcsc: C72043
+  - ref: D4
+    part: 17-21SURC/S530-A2/TR8
+    lcsc: C72038
+
 decisions:
   - id: "discrete-mosfets"
     description: "Use discrete MOSFETs instead of integrated driver"


### PR DESCRIPTION
## Summary

Populates the `bom_entries` field (introduced in PR #1510) across all six board
projects in `boards/` with JLCPCB-compatible LCSC part numbers and manufacturer
part numbers for every reference designator.

## Changes

- **boards/00-simple-led/project.kct** -- 3 entries (J1, R1, D1)
- **boards/01-voltage-divider/project.kct** -- 4 entries (J1, J2, R1, R2)
- **boards/02-charlieplex-led/project.kct** -- 3 entries using ranges (U1, R1-R4, D1-D9)
- **boards/03-usb-joystick/project.kct** -- 6 entries (U1, J1, J2, Y1, SW1-SW4, C1-C4)
- **boards/04-stm32-devboard/project.kct** -- 10 entries (U1, C1-C3, Y1, C10-C11, R1, D1, J1)
- **boards/05-bldc-motor-controller/project.kct** -- 21 entries covering power, gate driver, MOSFETs, passives, connectors, and LEDs

Uses well-known JLCPCB basic/preferred parts for common passives (e.g., C17630 for 330R 0805,
C1525 for 100nF 0805, C15850 for 10uF 0805) and appropriate LCSC numbers for ICs,
connectors, and specialty components.

## Test Plan

- All 6 project.kct files parse as valid YAML
- Boards 00 through 04 validate successfully against the Pydantic `ProjectSpec` schema
  (board 05 has pre-existing schema mismatches in non-bom fields)
- 366 existing tests pass; 0 new failures introduced