### PR TITLE
fix(export): walk up parent directories to find .kct spec file

### DIFF
--- a/src/kicad_tools/export/bom_spec_overlay.py
+++ b/src/kicad_tools/export/bom_spec_overlay.py
@@ -122,19 +122,19 @@ class SpecOverlayReport:
 # ---------------------------------------------------------------------------
 
 
-def find_spec_file(project_dir: Path) -> Path | None:
-    """Locate a ``.kct`` spec file in *project_dir*.
+def _find_spec_in_dir(directory: Path) -> Path | None:
+    """Check a single directory for a ``.kct`` spec file.
 
     Prefers ``project.kct``; falls back to the first ``.kct`` found.
     Warns if multiple ``.kct`` files exist and none is named ``project.kct``.
 
-    Returns ``None`` when no spec file is found.
+    Returns ``None`` when no spec file is found in *directory*.
     """
-    project_kct = project_dir / "project.kct"
+    project_kct = directory / "project.kct"
     if project_kct.is_file():
         return project_kct
 
-    kct_files = sorted(project_dir.glob("*.kct"))
+    kct_files = sorted(directory.glob("*.kct"))
     if not kct_files:
         return None
 
@@ -142,11 +142,47 @@ def find_spec_file(project_dir: Path) -> Path | None:
         logger.warning(
             "Multiple .kct files found in %s; using %s. "
             "Rename the primary spec to 'project.kct' to suppress this warning.",
-            project_dir,
+            directory,
             kct_files[0].name,
         )
 
     return kct_files[0]
+
+
+def find_spec_file(project_dir: Path) -> Path | None:
+    """Locate a ``.kct`` spec file in *project_dir* or its ancestors.
+
+    Searches *project_dir* first, then walks up parent directories until a
+    ``.kct`` file is found, the filesystem root is reached, or a ``.git``
+    directory is encountered (to avoid escaping the repository).
+
+    Within each directory, ``project.kct`` is preferred over other ``.kct``
+    files.
+
+    Returns ``None`` when no spec file is found.
+    """
+    current = project_dir.resolve()
+
+    while True:
+        result = _find_spec_in_dir(current)
+        if result is not None:
+            if current != project_dir.resolve():
+                logger.info(
+                    "Auto-detected spec file in parent directory: %s",
+                    result,
+                )
+            return result
+
+        # Stop if we hit a .git boundary (don't escape the repo)
+        if (current / ".git").exists():
+            return None
+
+        parent = current.parent
+        # Stop at filesystem root
+        if parent == current:
+            return None
+
+        current = parent
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bom_spec_overlay.py
+++ b/tests/test_bom_spec_overlay.py
@@ -219,6 +219,62 @@ class TestFindSpecFile:
             assert result is not None
             mock_logger.warning.assert_called_once()
 
+    def test_find_spec_file_in_parent_dir(self, tmp_path: Path):
+        """A .kct in the parent directory is found when PCB is in a subdirectory."""
+        (tmp_path / "project.kct").write_text("kct_version: '1.0'")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = find_spec_file(output_dir)
+        assert result is not None
+        assert result.name == "project.kct"
+        assert result.parent == tmp_path
+
+    def test_find_spec_file_stops_at_git_boundary(self, tmp_path: Path):
+        """Walk-up should not cross a .git boundary."""
+        # Place .kct above a directory that contains .git
+        (tmp_path / "project.kct").write_text("kct_version: '1.0'")
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()  # simulates a git repo root
+        output_dir = repo_dir / "output"
+        output_dir.mkdir()
+
+        result = find_spec_file(output_dir)
+        # Should stop at repo_dir (which has .git) and NOT find the .kct above
+        assert result is None
+
+    def test_find_spec_file_stops_at_root(self, tmp_path: Path):
+        """No infinite loop when no .kct exists anywhere."""
+        deep_dir = tmp_path / "a" / "b" / "c"
+        deep_dir.mkdir(parents=True)
+
+        result = find_spec_file(deep_dir)
+        assert result is None
+
+    def test_find_spec_file_prefers_same_dir(self, tmp_path: Path):
+        """If .kct exists in both current and parent, use current."""
+        (tmp_path / "project.kct").write_text("kct_version: '1.0'")
+        child = tmp_path / "child"
+        child.mkdir()
+        (child / "project.kct").write_text("kct_version: '1.0'")
+
+        result = find_spec_file(child)
+        assert result is not None
+        assert result.parent == child
+
+    def test_find_spec_file_parent_logs_info(self, tmp_path: Path):
+        """An INFO log is emitted when the spec is found in a parent directory."""
+        (tmp_path / "project.kct").write_text("kct_version: '1.0'")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        with patch("kicad_tools.export.bom_spec_overlay.logger") as mock_logger:
+            result = find_spec_file(output_dir)
+            assert result is not None
+            mock_logger.info.assert_called_once()
+            assert "parent" in mock_logger.info.call_args[0][0].lower()
+
 
 # ---------------------------------------------------------------------------
 # Integration: spec source in enrichment report


### PR DESCRIPTION
## Summary
When a PCB file lives in a subdirectory (e.g. `boards/01-voltage-divider/output/`), `find_spec_file()` was only searching that exact directory for a `.kct` file. Since `project.kct` lives in the parent project directory, auto-detection failed silently. This fix makes `find_spec_file()` walk up parent directories until a `.kct` is found, a `.git` boundary is hit, or the filesystem root is reached.

## Changes
- Extract single-directory search into `_find_spec_in_dir()` helper
- Modify `find_spec_file()` to iterate up parent directories with `.git` and root stop conditions
- Emit an INFO log when a spec file is found in a parent directory
- Add 5 new tests covering parent discovery, `.git` boundary, root stop, same-dir preference, and INFO logging

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Auto-detect .kct in parent when PCB is in subdirectory | PASS | `test_find_spec_file_in_parent_dir` passes |
| Same-directory behavior unchanged (no regression) | PASS | All existing `TestFindSpecFile` tests pass |
| `--no-spec` skips walking | PASS | No change to `no_spec` logic in assembly.py; walk only runs when `no_spec=False` and `spec_path` is None |
| Explicit `--spec` path skips walk-up | PASS | `spec_path` is checked before `find_spec_file` is called (line 267 of assembly.py) |
| Walk-up stops at `.git` boundary | PASS | `test_find_spec_file_stops_at_git_boundary` passes |
| Walk-up stops at filesystem root | PASS | `test_find_spec_file_stops_at_root` passes |
| INFO log emitted for parent directory match | PASS | `test_find_spec_file_parent_logs_info` passes |

## Test Plan
- All 31 tests in `tests/test_bom_spec_overlay.py` pass (26 existing + 5 new)

Closes #1515