### PR TITLE
fix(export): auto-detect schematic for _routed.kicad_pcb files

### DIFF
--- a/src/kicad_tools/export/assembly.py
+++ b/src/kicad_tools/export/assembly.py
@@ -150,10 +150,11 @@ class AssemblyPackage:
         if schematic_path:
             self.schematic_path = Path(schematic_path)
         else:
-            # Look for schematic with same name
-            self.schematic_path = self.pcb_path.with_suffix(".kicad_sch")
+            from kicad_tools.report.utils import find_schematic
 
-        if not self.schematic_path.exists():
+            self.schematic_path = find_schematic(self.pcb_path)
+
+        if self.schematic_path is not None and not self.schematic_path.exists():
             logger.warning(f"Schematic not found: {self.schematic_path}")
             self.schematic_path = None
 

--- a/src/kicad_tools/export/preflight.py
+++ b/src/kicad_tools/export/preflight.py
@@ -198,9 +198,11 @@ class PreflightChecker:
     def _check_schematic_exists(self) -> PreflightResult:
         """Check that the schematic file exists (needed for BOM/CPL)."""
         if self.schematic_path is None:
-            # Try auto-detection
-            auto_sch = self.pcb_path.with_suffix(".kicad_sch")
-            if auto_sch.exists():
+            # Try auto-detection using shared find_schematic logic
+            from kicad_tools.report.utils import find_schematic
+
+            auto_sch = find_schematic(self.pcb_path)
+            if auto_sch is not None:
                 self.schematic_path = auto_sch
                 return PreflightResult(
                     name="schematic_file",

--- a/src/kicad_tools/report/utils.py
+++ b/src/kicad_tools/report/utils.py
@@ -41,6 +41,16 @@ def find_schematic(pcb_path: Path) -> Path | None:
     if candidate.exists():
         return candidate
 
+    # Step 1.5: strip known suffixes (_routed, _fixed, etc.) from the PCB stem
+    _STRIP_SUFFIXES = ("_routed", "_fixed", "_v2", "_final")
+    stem = pcb_path.stem
+    for suffix in _STRIP_SUFFIXES:
+        if stem.endswith(suffix):
+            stripped = directory / (stem[: -len(suffix)] + ".kicad_sch")
+            if stripped.exists():
+                return stripped
+            break  # only strip one suffix
+
     # Step 2: project file lookup
     pro_files = list(directory.glob("*.kicad_pro"))
     for pro in pro_files:

--- a/tests/test_find_schematic.py
+++ b/tests/test_find_schematic.py
@@ -59,6 +59,86 @@ class TestDirectStemMatch:
 
 
 # ---------------------------------------------------------------------------
+# Step 1.5: suffix stripping (_routed, _fixed, etc.)
+# ---------------------------------------------------------------------------
+
+
+class TestSuffixStripping:
+    """find_schematic strips known suffixes like _routed from the PCB stem."""
+
+    def test_routed_suffix_finds_base_schematic(self, tmp_path: Path) -> None:
+        """foo_routed.kicad_pcb finds foo.kicad_sch."""
+        pcb = tmp_path / "foo_routed.kicad_pcb"
+        sch = tmp_path / "foo.kicad_sch"
+        pcb.write_text("")
+        sch.write_text("")
+
+        result = find_schematic(pcb)
+        assert result == sch
+
+    def test_fixed_suffix_finds_base_schematic(self, tmp_path: Path) -> None:
+        """board_fixed.kicad_pcb finds board.kicad_sch."""
+        pcb = tmp_path / "board_fixed.kicad_pcb"
+        sch = tmp_path / "board.kicad_sch"
+        pcb.write_text("")
+        sch.write_text("")
+
+        result = find_schematic(pcb)
+        assert result == sch
+
+    def test_direct_match_takes_priority_over_suffix_strip(self, tmp_path: Path) -> None:
+        """foo_routed.kicad_sch wins over foo.kicad_sch when both exist."""
+        pcb = tmp_path / "foo_routed.kicad_pcb"
+        sch_direct = tmp_path / "foo_routed.kicad_sch"
+        sch_base = tmp_path / "foo.kicad_sch"
+        pcb.write_text("")
+        sch_direct.write_text("")
+        sch_base.write_text("")
+
+        result = find_schematic(pcb)
+        assert result == sch_direct
+
+    def test_suffix_strip_no_base_schematic_falls_through(self, tmp_path: Path) -> None:
+        """foo_routed.kicad_pcb with no foo.kicad_sch falls to later steps."""
+        pcb = tmp_path / "foo_routed.kicad_pcb"
+        sch = tmp_path / "other.kicad_sch"
+        pcb.write_text("")
+        sch.write_text("")
+
+        # Should fall through to single-glob fallback and find other.kicad_sch
+        result = find_schematic(pcb)
+        assert result == sch
+
+    def test_suffix_strip_returns_none_when_no_match(self, tmp_path: Path) -> None:
+        """foo_routed.kicad_pcb with no schematics returns None."""
+        pcb = tmp_path / "foo_routed.kicad_pcb"
+        pcb.write_text("")
+
+        result = find_schematic(pcb)
+        assert result is None
+
+    def test_v2_suffix_finds_base_schematic(self, tmp_path: Path) -> None:
+        """board_v2.kicad_pcb finds board.kicad_sch."""
+        pcb = tmp_path / "board_v2.kicad_pcb"
+        sch = tmp_path / "board.kicad_sch"
+        pcb.write_text("")
+        sch.write_text("")
+
+        result = find_schematic(pcb)
+        assert result == sch
+
+    def test_final_suffix_finds_base_schematic(self, tmp_path: Path) -> None:
+        """board_final.kicad_pcb finds board.kicad_sch."""
+        pcb = tmp_path / "board_final.kicad_pcb"
+        sch = tmp_path / "board.kicad_sch"
+        pcb.write_text("")
+        sch.write_text("")
+
+        result = find_schematic(pcb)
+        assert result == sch
+
+
+# ---------------------------------------------------------------------------
 # Step 2: project file lookup
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Schematic auto-detection failed for PCB files with suffixes like `_routed` because the lookup naively replaced `.kicad_pcb` with `.kicad_sch`, preserving the full stem. This consolidates schematic detection in `assembly.py` and `preflight.py` to use the shared `find_schematic()` utility, and adds a suffix-stripping step to handle `_routed`, `_fixed`, `_v2`, and `_final` PCB file names.

## Changes
- Added Step 1.5 to `find_schematic()` in `report/utils.py`: strips known suffixes (`_routed`, `_fixed`, `_v2`, `_final`) from the PCB stem before checking for a matching schematic
- Replaced inline schematic detection in `AssemblyPackage.__init__` (`assembly.py`) with a call to `find_schematic()`
- Replaced inline schematic detection in `PreflightChecker._check_schematic_exists` (`preflight.py`) with a call to `find_schematic()`
- Added 7 new tests in `test_find_schematic.py` covering suffix stripping for all four suffixes, priority ordering, and fallthrough behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `foo_routed.kicad_pcb` auto-detects `foo.kicad_sch` | PASS | New test `test_routed_suffix_finds_base_schematic` passes |
| Explicit `--sch` still takes precedence | PASS | `schematic_path` parameter is checked first in both `assembly.py` and `preflight.py` before calling `find_schematic` |
| Detection consolidated to `find_schematic` | PASS | Both `assembly.py` and `preflight.py` now call `find_schematic()` instead of inline logic |
| All existing tests pass | PASS | All 17 pre-existing tests in `test_find_schematic.py` pass unchanged |
| New tests cover suffix stripping | PASS | 7 new tests added covering `_routed`, `_fixed`, `_v2`, `_final`, priority, fallthrough, and no-match cases |

## Test Plan
- `python3 -m pytest tests/test_find_schematic.py -v -o "addopts="` -- 24/24 passed
- `python3 -m pytest tests/test_export.py tests/test_preflight.py -v -o "addopts="` -- 120/121 passed (1 pre-existing failure unrelated to this change)

Closes #1514