### PR TITLE
fix(export): use ReportGenerator class instead of missing generate_report function

### DIFF
--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -332,26 +332,96 @@ class ManufacturingPackage:
     def _generate_report(self, out_dir: Path, result: ManufacturingResult) -> None:
         """Generate a Markdown design report."""
         try:
-            from ..report.generator import generate_report
+            from ..report.collector import ReportDataCollector
+            from ..report.generator import ReportGenerator
+            from ..report.models import ReportData
+        except ImportError:
+            logger.warning(
+                "Report generation skipped: required dependency not installed "
+                "(e.g. jinja2)"
+            )
+            return
 
-            generate_report(
-                input_path=self.pcb_path,
-                output_dir=out_dir,
+        try:
+            # Pre-determine the version directory so collected data and report
+            # land in the same vN/ directory.
+            version_dir = ReportGenerator.next_version_dir(out_dir)
+            data_dir = version_dir / "data"
+
+            # Collect design data snapshots
+            collector = ReportDataCollector(
+                pcb_path=self.pcb_path,
                 manufacturer=self.manufacturer,
             )
-            # The report generator writes to a versioned subdir;
-            # look for the produced .md file.
-            md_files = sorted(out_dir.glob("**/*.md"))
-            if md_files:
-                result.report_path = md_files[0]
-                logger.info(f"Generated report: {result.report_path}")
-            else:
-                result.errors.append("Report generation produced no output")
-        except ImportError:
-            logger.warning("Report generation skipped: report module not available")
+            collector.collect_all(data_dir)
+
+            # Load collected JSON snapshots into ReportData kwargs
+            data_kwargs = self._load_report_data_dir(data_dir)
+
+            project_name = self.pcb_path.stem
+            data = ReportData(
+                project_name=project_name,
+                revision=data_kwargs.pop("revision", "1"),
+                date=data_kwargs.pop(
+                    "date",
+                    datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+                ),
+                manufacturer=self.manufacturer,
+                **data_kwargs,
+            )
+
+            generator = ReportGenerator()
+            report_path = generator.generate(data, out_dir, version_dir=version_dir)
+            result.report_path = report_path
+            logger.info(f"Generated report: {result.report_path}")
         except Exception as e:
             result.errors.append(f"Report generation failed: {e}")
             logger.error(f"Report generation failed: {e}")
+
+    @staticmethod
+    def _load_report_data_dir(data_dir: Path) -> dict:
+        """Load JSON snapshot files from *data_dir* into ReportData kwargs.
+
+        Mirrors the logic in ``cli/report_cmd.py:_load_data_dir`` but is
+        self-contained so the manufacturing exporter has no dependency on the
+        CLI layer.
+        """
+        import json as _json
+
+        mappings = {
+            "board_summary.json": "board_stats",
+            "bom.json": "bom_groups",
+            "drc_summary.json": "drc",
+            "erc_summary.json": "erc",
+            "audit.json": "audit",
+            "net_status.json": "net_status",
+            "cost.json": "cost",
+            "analog_components.json": "analog_components",
+        }
+
+        result: dict = {}
+        for filename, field_name in mappings.items():
+            json_path = data_dir / filename
+            if json_path.exists():
+                with open(json_path, encoding="utf-8") as f:
+                    raw = _json.load(f)
+                # Unwrap the envelope written by ReportDataCollector
+                data = raw.get("data") if isinstance(raw, dict) else raw
+                if data is None:
+                    continue
+                result[field_name] = data
+
+        # BOM: collector nests group list under ``groups`` key;
+        # ReportData.bom_groups expects a plain list[dict].
+        if "bom_groups" in result and isinstance(result["bom_groups"], dict):
+            result["bom_groups"] = result["bom_groups"].get("groups", [])
+
+        # Analog components: collector nests list under ``components``;
+        # ReportData.analog_components expects a plain list[dict].
+        if "analog_components" in result and isinstance(result["analog_components"], dict):
+            result["analog_components"] = result["analog_components"].get("components", [])
+
+        return result
 
     def _generate_project_zip(self, out_dir: Path, result: ManufacturingResult) -> None:
         """Create ZIP of KiCad project files."""

--- a/tests/test_pcb_manufacturing_export.py
+++ b/tests/test_pcb_manufacturing_export.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -239,6 +240,87 @@ class TestExportManufacturing:
             except ExportError as e:
                 # kicad-cli may fail for various reasons
                 pytest.skip(f"kicad-cli export failed: {e}")
+
+
+class TestGenerateReport:
+    """Tests for ManufacturingPackage._generate_report method."""
+
+    def test_generate_report_produces_markdown(self, test_project_pcb):
+        """_generate_report should produce a report.md and set result.report_path."""
+        from kicad_tools.export.manufacturing import (
+            ManufacturingConfig,
+            ManufacturingPackage,
+            ManufacturingResult,
+        )
+
+        pkg = ManufacturingPackage(
+            pcb_path=test_project_pcb,
+            manufacturer="jlcpcb",
+            config=ManufacturingConfig(include_report=True),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir)
+            result = ManufacturingResult(output_dir=out_dir)
+            pkg._generate_report(out_dir, result)
+
+            # report_path should be set to a valid .md file
+            assert result.report_path is not None
+            assert result.report_path.exists()
+            assert result.report_path.suffix == ".md"
+            # No errors should be recorded
+            report_errors = [e for e in result.errors if "Report" in e or "report" in e]
+            assert len(report_errors) == 0
+
+    def test_generate_report_no_import_error(self, test_project_pcb):
+        """_generate_report must not trigger an ImportError for generate_report."""
+        from kicad_tools.export.manufacturing import (
+            ManufacturingPackage,
+            ManufacturingResult,
+        )
+
+        pkg = ManufacturingPackage(
+            pcb_path=test_project_pcb,
+            manufacturer="jlcpcb",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir)
+            result = ManufacturingResult(output_dir=out_dir)
+
+            # Patch logger to capture warnings -- ImportError would produce
+            # "report module not available" warning
+            with patch(
+                "kicad_tools.export.manufacturing.logger"
+            ) as mock_logger:
+                pkg._generate_report(out_dir, result)
+
+                # Verify the old misleading message does NOT appear
+                for call in mock_logger.warning.call_args_list:
+                    msg = call[0][0] if call[0] else ""
+                    assert "report module not available" not in msg
+
+    def test_generate_report_sets_report_path_in_result(self, test_project_pcb):
+        """ManufacturingResult.report_path should point to the generated file."""
+        from kicad_tools.export.manufacturing import (
+            ManufacturingPackage,
+            ManufacturingResult,
+        )
+
+        pkg = ManufacturingPackage(
+            pcb_path=test_project_pcb,
+            manufacturer="jlcpcb",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir)
+            result = ManufacturingResult(output_dir=out_dir)
+            pkg._generate_report(out_dir, result)
+
+            assert result.report_path is not None
+            content = result.report_path.read_text(encoding="utf-8")
+            # Should contain some markdown content
+            assert len(content) > 0
 
 
 # Fixtures


### PR DESCRIPTION
## Summary
Fix ImportError in manufacturing report generation by replacing the broken import of a nonexistent `generate_report` function with proper usage of `ReportGenerator`, `ReportDataCollector`, and `ReportData` classes.

## Changes
- Rewrote `_generate_report()` in `manufacturing.py` to use `ReportDataCollector` for data collection and `ReportGenerator.generate()` for rendering, matching the pattern in `cli/report_cmd.py`
- Added `_load_report_data_dir()` static method to load collected JSON snapshots into `ReportData` kwargs (self-contained, no CLI dependency)
- Updated the `except ImportError` handler to only catch genuinely missing optional dependencies (e.g. jinja2) with a clear log message
- Added 3 tests in `test_pcb_manufacturing_export.py` verifying report generation produces a `.md` file, sets `result.report_path`, and does not trigger ImportError

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct export` with `include_report=True` produces a Markdown report | PASS | Test `test_generate_report_produces_markdown` confirms `.md` file is created |
| `ManufacturingResult.report_path` is correctly set | PASS | Test `test_generate_report_sets_report_path_in_result` verifies path points to readable file |
| No ImportError raised during report generation | PASS | Test `test_generate_report_no_import_error` verifies no "report module not available" warning |
| Misleading log message no longer appears | PASS | Logger mock confirms old message absent |
| `except ImportError` only catches genuinely missing deps | PASS | Handler now only wraps the module imports, not the generation logic |

## Test Plan
- All 3 new tests pass: `pytest tests/test_pcb_manufacturing_export.py::TestGenerateReport -xvs`
- All pre-existing tests in the file still pass (the one pre-existing failure in `TestExportGerbers` is unrelated to this change)

Closes #1516