### PR TITLE
feat(drc): add silkscreen text height auto-fix to SilkscreenRepairer

### DIFF
--- a/src/kicad_tools/cli/fix_silkscreen_cmd.py
+++ b/src/kicad_tools/cli/fix_silkscreen_cmd.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
-"""Fix silkscreen line widths to meet manufacturer specifications.
+"""Fix silkscreen line widths and text heights to meet manufacturer specifications.
 
 Usage:
     kct fix-silkscreen board.kicad_pcb [options]
 
 Examples:
-    # Widen silkscreen lines to meet JLCPCB minimums (default)
+    # Fix silkscreen lines and text to meet JLCPCB minimums (default)
     kct fix-silkscreen board.kicad_pcb --mfr jlcpcb
 
     # Specify minimum width directly
     kct fix-silkscreen board.kicad_pcb --min-width 0.15
+
+    # Specify minimum text height directly
+    kct fix-silkscreen board.kicad_pcb --min-height 1.0
 
     # Preview changes without applying
     kct fix-silkscreen board.kicad_pcb --dry-run
@@ -26,7 +29,11 @@ import sys
 from collections import Counter
 from pathlib import Path
 
-from kicad_tools.drc.repair_silkscreen import SilkscreenRepairer, SilkscreenRepairResult
+from kicad_tools.drc.repair_silkscreen import (
+    SilkscreenRepairer,
+    SilkscreenRepairResult,
+    TextHeightRepairResult,
+)
 from kicad_tools.manufacturers.base import load_design_rules_from_yaml
 
 
@@ -67,32 +74,74 @@ def _get_min_width(
     return 0.15
 
 
+def _get_min_height(
+    mfr: str | None,
+    layers: int,
+    copper: float,
+    explicit_height: float | None,
+) -> float:
+    """Resolve the target minimum silkscreen text height.
+
+    If *explicit_height* is given it takes precedence.  Otherwise the value is
+    loaded from the manufacturer YAML profile.
+    """
+    if explicit_height is not None:
+        return explicit_height
+
+    if mfr:
+        try:
+            rules_dict = load_design_rules_from_yaml(mfr)
+            key = f"{layers}layer_{int(copper)}oz"
+            if key in rules_dict:
+                return rules_dict[key].min_silkscreen_height_mm
+            # Try without copper weight
+            key = f"{layers}layer_1oz"
+            if key in rules_dict:
+                return rules_dict[key].min_silkscreen_height_mm
+            # Fall back to first available
+            first = next(iter(rules_dict.values()))
+            return first.min_silkscreen_height_mm
+        except FileNotFoundError:
+            print(
+                f"Warning: No configuration found for manufacturer '{mfr}'",
+                file=sys.stderr,
+            )
+
+    # Sensible default matching JLCPCB minimum
+    return 1.0
+
+
 def _print_results(
-    result: SilkscreenRepairResult,
+    line_result: SilkscreenRepairResult,
+    text_result: TextHeightRepairResult,
     output_format: str,
     dry_run: bool,
     mfr: str | None,
 ) -> None:
     """Print repair results in the requested format."""
     if output_format == "json":
-        _print_json(result, dry_run, mfr)
+        _print_json(line_result, text_result, dry_run, mfr)
     elif output_format == "summary":
-        _print_summary(result, dry_run, mfr)
+        _print_summary(line_result, text_result, dry_run, mfr)
     else:
-        _print_text(result, dry_run, mfr)
+        _print_text(line_result, text_result, dry_run, mfr)
 
 
 def _print_json(
-    result: SilkscreenRepairResult,
+    line_result: SilkscreenRepairResult,
+    text_result: TextHeightRepairResult,
     dry_run: bool,
     mfr: str | None,
 ) -> None:
     data = {
-        "min_width_mm": result.min_width_mm,
+        "min_width_mm": line_result.min_width_mm,
+        "min_height_mm": text_result.min_height_mm,
         "manufacturer": mfr,
         "dry_run": dry_run,
-        "total_fixed": result.total_fixed,
-        "fixes": [
+        "total_line_width_fixed": line_result.total_fixed,
+        "total_text_height_fixed": text_result.total_fixed,
+        "total_fixed": line_result.total_fixed + text_result.total_fixed,
+        "line_width_fixes": [
             {
                 "element_type": f.element_type,
                 "layer": f.layer,
@@ -100,66 +149,119 @@ def _print_json(
                 "old_width_mm": f.old_width,
                 "new_width_mm": f.new_width,
             }
-            for f in result.fixes
+            for f in line_result.fixes
+        ],
+        "text_height_fixes": [
+            {
+                "element_type": f.element_type,
+                "layer": f.layer,
+                "footprint_ref": f.footprint_ref,
+                "old_height_mm": f.old_height,
+                "new_height_mm": f.new_height,
+                "old_width_mm": f.old_width,
+                "new_width_mm": f.new_width,
+            }
+            for f in text_result.fixes
         ],
     }
     print(json.dumps(data, indent=2))
 
 
 def _print_summary(
-    result: SilkscreenRepairResult,
+    line_result: SilkscreenRepairResult,
+    text_result: TextHeightRepairResult,
     dry_run: bool,
     mfr: str | None,
 ) -> None:
     action = "Would fix" if dry_run else "Fixed"
     source = f" to {mfr.upper()} minimum" if mfr else ""
-    print(
-        f"{action} {result.total_fixed} silkscreen line width violation(s)"
-        f"{source} (min: {result.min_width_mm}mm)"
-    )
+    total = line_result.total_fixed + text_result.total_fixed
+    parts = []
+    if line_result.total_fixed > 0:
+        parts.append(
+            f"{line_result.total_fixed} line width violation(s)"
+            f" (min: {line_result.min_width_mm}mm)"
+        )
+    if text_result.total_fixed > 0:
+        parts.append(
+            f"{text_result.total_fixed} text height violation(s)"
+            f" (min: {text_result.min_height_mm}mm)"
+        )
+    if not parts:
+        parts.append("0 silkscreen violation(s)")
+    print(f"{action} {total} silkscreen violation(s){source}: {'; '.join(parts)}")
 
 
 def _print_text(
-    result: SilkscreenRepairResult,
+    line_result: SilkscreenRepairResult,
+    text_result: TextHeightRepairResult,
     dry_run: bool,
     mfr: str | None,
 ) -> None:
-    if result.total_fixed == 0:
-        print("No silkscreen lines needed widening.")
+    has_line_fixes = line_result.total_fixed > 0
+    has_text_fixes = text_result.total_fixed > 0
+
+    if not has_line_fixes and not has_text_fixes:
+        print("No silkscreen violations found.")
         return
 
-    action = "Would widen" if dry_run else "Widened"
     source = f" to {mfr.upper()} minimum" if mfr else ""
-    print(
-        f"{action} {result.total_fixed} silkscreen line(s){source} (min: {result.min_width_mm}mm):"
-    )
 
-    # Group by footprint for readable output
-    by_fp: Counter[str] = Counter()
-    width_examples: dict[str, tuple[float, float]] = {}
-    for fix in result.fixes:
-        key = fix.footprint_ref or "(board-level)"
-        by_fp[key] += 1
-        if key not in width_examples:
-            width_examples[key] = (fix.old_width, fix.new_width)
+    # Line width fixes
+    if has_line_fixes:
+        action = "Would widen" if dry_run else "Widened"
+        print(
+            f"{action} {line_result.total_fixed} silkscreen line(s){source}"
+            f" (min: {line_result.min_width_mm}mm):"
+        )
+        by_fp: Counter[str] = Counter()
+        width_examples: dict[str, tuple[float, float]] = {}
+        for fix in line_result.fixes:
+            key = fix.footprint_ref or "(board-level)"
+            by_fp[key] += 1
+            if key not in width_examples:
+                width_examples[key] = (fix.old_width, fix.new_width)
+        for fp_ref, count in by_fp.most_common():
+            old_w, new_w = width_examples[fp_ref]
+            print(f"  {fp_ref}: {count} line(s) widened ({old_w:.2f}mm -> {new_w:.2f}mm)")
 
-    for fp_ref, count in by_fp.most_common():
-        old_w, new_w = width_examples[fp_ref]
-        print(f"  {fp_ref}: {count} line(s) widened ({old_w:.2f}mm -> {new_w:.2f}mm)")
+    # Text height fixes
+    if has_text_fixes:
+        action = "Would scale" if dry_run else "Scaled"
+        print(
+            f"{action} {text_result.total_fixed} silkscreen text element(s){source}"
+            f" (min height: {text_result.min_height_mm}mm):"
+        )
+        by_fp_text: Counter[str] = Counter()
+        height_examples: dict[str, tuple[float, float]] = {}
+        for fix in text_result.fixes:
+            key = fix.footprint_ref or "(board-level)"
+            by_fp_text[key] += 1
+            if key not in height_examples:
+                height_examples[key] = (fix.old_height, fix.new_height)
+        for fp_ref, count in by_fp_text.most_common():
+            old_h, new_h = height_examples[fp_ref]
+            print(
+                f"  {fp_ref}: {count} text element(s) scaled"
+                f" ({old_h:.2f}mm -> {new_h:.2f}mm)"
+            )
 
 
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for fix-silkscreen command."""
     parser = argparse.ArgumentParser(
-        description="Fix silkscreen line widths to meet manufacturer specifications",
+        description="Fix silkscreen line widths and text heights to meet manufacturer specifications",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    # Widen silkscreen lines to meet JLCPCB minimums
+    # Fix silkscreen lines and text to meet JLCPCB minimums
     kct fix-silkscreen board.kicad_pcb --mfr jlcpcb
 
     # Specify minimum width directly
     kct fix-silkscreen board.kicad_pcb --min-width 0.15
+
+    # Specify minimum text height directly
+    kct fix-silkscreen board.kicad_pcb --min-height 1.0
 
     # Preview changes without applying
     kct fix-silkscreen board.kicad_pcb --dry-run
@@ -188,6 +290,11 @@ Examples:
         "--min-width",
         type=float,
         help="Minimum silkscreen line width in mm (overrides manufacturer rules)",
+    )
+    parser.add_argument(
+        "--min-height",
+        type=float,
+        help="Minimum silkscreen text height in mm (overrides manufacturer rules)",
     )
     parser.add_argument(
         "-o",
@@ -224,8 +331,9 @@ Examples:
         print(f"Error: Expected .kicad_pcb file, got: {pcb_path.suffix}", file=sys.stderr)
         return 1
 
-    # Resolve minimum width
+    # Resolve minimums
     min_width = _get_min_width(args.mfr, args.layers, args.copper, args.min_width)
+    min_height = _get_min_height(args.mfr, args.layers, args.copper, args.min_height)
 
     # Parse and repair
     try:
@@ -234,14 +342,23 @@ Examples:
         print(f"Error parsing PCB file: {e}", file=sys.stderr)
         return 1
 
-    result = repairer.repair_line_widths(min_width, dry_run=args.dry_run)
+    line_result = repairer.repair_line_widths(min_width, dry_run=args.dry_run)
+    text_result = repairer.repair_text_heights(min_height, dry_run=args.dry_run)
+
+    total_fixed = line_result.total_fixed + text_result.total_fixed
 
     # Print results
     if not args.quiet:
-        _print_results(result, output_format=args.format, dry_run=args.dry_run, mfr=args.mfr)
+        _print_results(
+            line_result,
+            text_result,
+            output_format=args.format,
+            dry_run=args.dry_run,
+            mfr=args.mfr,
+        )
 
     # Save if not dry run and there were fixes
-    if result.total_fixed > 0 and not args.dry_run:
+    if total_fixed > 0 and not args.dry_run:
         output_path = Path(args.output) if args.output else pcb_path
         try:
             repairer.save(output_path)

--- a/src/kicad_tools/drc/repair_silkscreen.py
+++ b/src/kicad_tools/drc/repair_silkscreen.py
@@ -1,8 +1,12 @@
-"""Silkscreen line width repair.
+"""Silkscreen repair: line widths and text heights.
 
 Walks the raw SExp tree to find silkscreen graphic elements (fp_line, fp_rect,
 fp_circle, fp_arc, gr_line, gr_rect, gr_circle, gr_arc) whose stroke width is
 below the manufacturer minimum, and sets the width to the minimum.
+
+Also walks text elements (fp_text, property, gr_text) on silkscreen layers and
+scales undersized font heights (and proportionally widths/thickness) up to the
+manufacturer minimum.
 
 This operates on the raw SExp tree (not the read-only schema dataclasses) so
 that modifications can be written back to disk, following the same pattern as
@@ -44,6 +48,40 @@ class SilkscreenRepairResult:
 
     min_width_mm: float = 0.0
     fixes: list[SilkscreenFix] = field(default_factory=list)
+
+    @property
+    def total_fixed(self) -> int:
+        return len(self.fixes)
+
+
+# Text element types inside footprints.
+FP_TEXT_TYPES = ("fp_text", "property")
+
+# Text element types at board level.
+GR_TEXT_TYPES = ("gr_text",)
+
+
+@dataclass
+class TextHeightFix:
+    """Record of a single text element that was (or would be) fixed."""
+
+    element_type: str  # e.g. "fp_text", "property", "gr_text"
+    layer: str
+    old_height: float
+    new_height: float
+    old_width: float
+    new_width: float
+    old_thickness: float | None
+    new_thickness: float | None
+    footprint_ref: str  # empty string for board-level text
+
+
+@dataclass
+class TextHeightRepairResult:
+    """Aggregate result of a text height repair pass."""
+
+    min_height_mm: float = 0.0
+    fixes: list[TextHeightFix] = field(default_factory=list)
 
     @property
     def total_fixed(self) -> int:
@@ -106,6 +144,53 @@ class SilkscreenRepairer:
                     element_type=gtype,
                     footprint_ref="",
                     min_width_mm=min_width_mm,
+                    dry_run=dry_run,
+                    result=result,
+                )
+
+        return result
+
+    def repair_text_heights(
+        self,
+        min_height_mm: float,
+        dry_run: bool = False,
+    ) -> TextHeightRepairResult:
+        """Scale up silkscreen text whose font height is below *min_height_mm*.
+
+        Font width and thickness are scaled proportionally to preserve the
+        original aspect ratio.
+
+        Args:
+            min_height_mm: The minimum acceptable font height in mm.
+            dry_run: If ``True``, collect fixes but do not mutate the tree.
+
+        Returns:
+            A :class:`TextHeightRepairResult` with every fix recorded.
+        """
+        result = TextHeightRepairResult(min_height_mm=min_height_mm)
+
+        # --- Footprint-level text ---
+        for fp_node in self.doc.find_all("footprint"):
+            fp_ref = self._footprint_reference(fp_node)
+            for ttype in FP_TEXT_TYPES:
+                for text_node in fp_node.find_all(ttype):
+                    self._maybe_fix_text(
+                        text_node,
+                        element_type=ttype,
+                        footprint_ref=fp_ref,
+                        min_height_mm=min_height_mm,
+                        dry_run=dry_run,
+                        result=result,
+                    )
+
+        # --- Board-level text ---
+        for ttype in GR_TEXT_TYPES:
+            for text_node in self.doc.find_all(ttype):
+                self._maybe_fix_text(
+                    text_node,
+                    element_type=ttype,
+                    footprint_ref="",
+                    min_height_mm=min_height_mm,
                     dry_run=dry_run,
                     result=result,
                 )
@@ -202,3 +287,140 @@ class SilkscreenRepairer:
             width_node = stroke_node.find("width")
             assert width_node is not None
             width_node.set_atom(0, min_width_mm)
+
+    @staticmethod
+    def _is_hidden(text_node: SExp) -> bool:
+        """Return True if a text node is hidden.
+
+        KiCad uses several conventions:
+        - ``(hide yes)`` sub-node on the text or property node
+        - A bare ``hide`` atom inside the ``effects`` node
+        - A ``(hide)`` sub-node inside ``effects``
+        """
+        # Check for (hide yes) sub-node directly on text node
+        hide_node = text_node.find("hide")
+        if hide_node is not None:
+            atom = hide_node.get_first_atom()
+            if atom is not None and str(atom) == "yes":
+                return True
+            # (hide) with no atoms is also considered hidden
+            if atom is None:
+                return True
+        # Check for bare "hide" atom among direct children
+        for child in text_node.children:
+            if child.is_atom and str(child.value) == "hide":
+                return True
+        # Check inside (effects ...) for bare "hide" atom or (hide) sub-node
+        effects = text_node.find("effects")
+        if effects is not None:
+            for child in effects.children:
+                if child.is_atom and str(child.value) == "hide":
+                    return True
+            hide_in_effects = effects.find("hide")
+            if hide_in_effects is not None:
+                return True
+        return False
+
+    @staticmethod
+    def _get_font_size(text_node: SExp) -> tuple[float, float] | None:
+        """Return (width, height) from a text node's font size, or None."""
+        effects = text_node.find("effects")
+        if effects is None:
+            return None
+        font = effects.find("font")
+        if font is None:
+            return None
+        size = font.find("size")
+        if size is None:
+            return None
+        atoms = size.get_atoms()
+        if len(atoms) < 2:
+            return None
+        return (float(atoms[0]), float(atoms[1]))
+
+    @staticmethod
+    def _get_font_thickness(text_node: SExp) -> float | None:
+        """Return the font thickness from a text node, or None."""
+        effects = text_node.find("effects")
+        if effects is None:
+            return None
+        font = effects.find("font")
+        if font is None:
+            return None
+        thickness = font.find("thickness")
+        if thickness is None:
+            return None
+        val = thickness.get_first_atom()
+        return float(val) if val is not None else None
+
+    def _maybe_fix_text(
+        self,
+        text_node: SExp,
+        *,
+        element_type: str,
+        footprint_ref: str,
+        min_height_mm: float,
+        dry_run: bool,
+        result: TextHeightRepairResult,
+    ) -> None:
+        """Check one text node and fix it if font height is below minimum."""
+        if not self._is_silkscreen(text_node):
+            return
+
+        if self._is_hidden(text_node):
+            return
+
+        font_size = self._get_font_size(text_node)
+        if font_size is None:
+            return
+
+        font_width, font_height = font_size
+
+        # Zero-height text is a special marker; skip it.
+        if font_height == 0:
+            return
+
+        if font_height >= min_height_mm:
+            return
+
+        # Compute proportional scale factor.
+        scale = min_height_mm / font_height
+        new_height = min_height_mm
+        new_width = font_width * scale
+
+        # Round to avoid floating-point noise in the output.
+        new_width = round(new_width, 6)
+        new_height = round(new_height, 6)
+
+        old_thickness = self._get_font_thickness(text_node)
+        new_thickness: float | None = None
+        if old_thickness is not None and old_thickness > 0:
+            new_thickness = round(old_thickness * scale, 6)
+
+        result.fixes.append(
+            TextHeightFix(
+                element_type=element_type,
+                layer=str(text_node.find("layer").get_first_atom()),  # type: ignore[union-attr]
+                old_height=font_height,
+                new_height=new_height,
+                old_width=font_width,
+                new_width=new_width,
+                old_thickness=old_thickness,
+                new_thickness=new_thickness,
+                footprint_ref=footprint_ref,
+            )
+        )
+
+        if not dry_run:
+            effects = text_node.find("effects")
+            assert effects is not None
+            font = effects.find("font")
+            assert font is not None
+            size_node = font.find("size")
+            assert size_node is not None
+            size_node.set_atom(0, new_width)
+            size_node.set_atom(1, new_height)
+            if new_thickness is not None:
+                thickness_node = font.find("thickness")
+                assert thickness_node is not None
+                thickness_node.set_atom(0, new_thickness)

--- a/tests/test_fix_silkscreen.py
+++ b/tests/test_fix_silkscreen.py
@@ -4,12 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from kicad_tools.cli.fix_silkscreen_cmd import _get_min_width, main
+from kicad_tools.cli.fix_silkscreen_cmd import _get_min_height, _get_min_width, main
 from kicad_tools.drc.repair_silkscreen import SilkscreenRepairer
 from kicad_tools.sexp.parser import parse_file
 
 # --------------------------------------------------------------------------
-# Fixtures: synthetic PCB content
+# Fixtures: synthetic PCB content -- line width tests
 # --------------------------------------------------------------------------
 
 # PCB with undersized silkscreen lines in footprints (0.12mm < 0.15mm JLCPCB min).
@@ -154,6 +154,297 @@ PCB_WITH_OK_SILK = """\
 )
 """
 
+# --------------------------------------------------------------------------
+# Fixtures: synthetic PCB content -- text height tests
+# --------------------------------------------------------------------------
+
+# PCB with undersized silkscreen text in footprints.
+PCB_WITH_UNDERSIZED_TEXT = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (36 "B.SilkS" user "B.Silkscreen")
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (at 100 100)
+    (fp_text reference "R1"
+      (at 0 -1.5)
+      (effects (font (size 0.5 0.5) (thickness 0.075)))
+      (layer "F.SilkS"))
+    (fp_text value "10k"
+      (at 0 1.5)
+      (effects (font (size 0.5 0.5) (thickness 0.075)))
+      (layer "F.SilkS"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (at 110 100)
+    (fp_text reference "C1"
+      (at 0 -1.5)
+      (effects (font (size 0.8 0.8) (thickness 0.12)))
+      (layer "F.SilkS"))
+  )
+)
+"""
+
+# PCB with KiCad 8+ property nodes instead of fp_text.
+PCB_WITH_UNDERSIZED_PROPERTY_TEXT = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (footprint "Test:KiCad8"
+    (layer "F.Cu")
+    (at 0 0)
+    (property "Reference" "U1"
+      (at 0 -2)
+      (effects (font (size 0.6 0.6) (thickness 0.09)))
+      (layer "F.SilkS"))
+    (property "Value" "IC1"
+      (at 0 2)
+      (effects (font (size 0.6 0.6) (thickness 0.09)))
+      (layer "F.SilkS"))
+  )
+)
+"""
+
+# PCB with board-level gr_text on silkscreen.
+PCB_WITH_BOARD_LEVEL_TEXT = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (36 "B.SilkS" user "B.Silkscreen")
+    (37 "F.SilkS" user "F.Silkscreen")
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (gr_text "Rev A"
+    (at 10 10)
+    (effects (font (size 0.5 0.5) (thickness 0.075)))
+    (layer "F.SilkS"))
+  (gr_text "Board v1"
+    (at 20 20)
+    (effects (font (size 0.8 0.8) (thickness 0.12)))
+    (layer "B.SilkS"))
+)
+"""
+
+# PCB with hidden text (should NOT be modified).
+PCB_WITH_HIDDEN_TEXT = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (footprint "Test:Hidden"
+    (layer "F.Cu")
+    (at 0 0)
+    (fp_text reference "U1"
+      (at 0 -1.5)
+      (effects (font (size 0.5 0.5) (thickness 0.075)))
+      (layer "F.SilkS"))
+    (fp_text value "IC"
+      (at 0 1.5)
+      (effects (font (size 0.5 0.5) (thickness 0.075)) hide)
+      (layer "F.SilkS"))
+  )
+)
+"""
+
+# PCB with hidden text using (hide yes) syntax.
+PCB_WITH_HIDDEN_TEXT_YES = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (footprint "Test:HiddenYes"
+    (layer "F.Cu")
+    (at 0 0)
+    (fp_text value "IC"
+      (at 0 1.5)
+      (effects (font (size 0.5 0.5) (thickness 0.075)))
+      (layer "F.SilkS")
+      (hide yes))
+  )
+)
+"""
+
+# PCB with zero-height text (should NOT be modified).
+PCB_WITH_ZERO_HEIGHT_TEXT = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (footprint "Test:ZeroHeight"
+    (layer "F.Cu")
+    (at 0 0)
+    (fp_text reference "U1"
+      (at 0 -1.5)
+      (effects (font (size 0 0) (thickness 0)))
+      (layer "F.SilkS"))
+  )
+)
+"""
+
+# PCB with non-1:1 aspect ratio text.
+PCB_WITH_NONSTANDARD_ASPECT = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (footprint "Test:Aspect"
+    (layer "F.Cu")
+    (at 0 0)
+    (fp_text reference "U1"
+      (at 0 -1.5)
+      (effects (font (size 0.4 0.5) (thickness 0.075)))
+      (layer "F.SilkS"))
+  )
+)
+"""
+
+# PCB with text on non-silkscreen layers (should NOT be modified).
+PCB_WITH_NON_SILK_TEXT = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (38 "B.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (footprint "Test:NonSilk"
+    (layer "F.Cu")
+    (at 0 0)
+    (fp_text reference "U1"
+      (at 0 -1.5)
+      (effects (font (size 0.5 0.5) (thickness 0.075)))
+      (layer "F.Cu"))
+    (fp_text value "IC"
+      (at 0 1.5)
+      (effects (font (size 0.5 0.5) (thickness 0.075)))
+      (layer "B.Fab"))
+  )
+)
+"""
+
+# PCB with text already meeting minimum height.
+PCB_WITH_OK_TEXT = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (footprint "Test:OkText"
+    (layer "F.Cu")
+    (at 0 0)
+    (fp_text reference "U1"
+      (at 0 -1.5)
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (layer "F.SilkS"))
+    (fp_text value "IC"
+      (at 0 1.5)
+      (effects (font (size 1.2 1.2) (thickness 0.18)))
+      (layer "F.SilkS"))
+  )
+)
+"""
+
+# PCB with both undersized lines AND undersized text.
+PCB_WITH_UNDERSIZED_BOTH = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (footprint "Test:Both"
+    (layer "F.Cu")
+    (at 0 0)
+    (property "Reference" "U1")
+    (fp_text reference "U1"
+      (at 0 -1.5)
+      (effects (font (size 0.5 0.5) (thickness 0.075)))
+      (layer "F.SilkS"))
+    (fp_line (start 0 0) (end 5 0)
+      (stroke (width 0.10) (type solid)) (layer "F.SilkS"))
+  )
+)
+"""
+
 
 # --------------------------------------------------------------------------
 # Pytest fixtures
@@ -195,6 +486,76 @@ def pcb_ok(tmp_path: Path) -> Path:
     return pcb_file
 
 
+@pytest.fixture
+def pcb_undersized_text(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "undersized_text.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_UNDERSIZED_TEXT)
+    return pcb_file
+
+
+@pytest.fixture
+def pcb_undersized_property(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "undersized_property.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_UNDERSIZED_PROPERTY_TEXT)
+    return pcb_file
+
+
+@pytest.fixture
+def pcb_board_level_text(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "board_level_text.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_BOARD_LEVEL_TEXT)
+    return pcb_file
+
+
+@pytest.fixture
+def pcb_hidden_text(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "hidden_text.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_HIDDEN_TEXT)
+    return pcb_file
+
+
+@pytest.fixture
+def pcb_hidden_text_yes(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "hidden_text_yes.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_HIDDEN_TEXT_YES)
+    return pcb_file
+
+
+@pytest.fixture
+def pcb_zero_height_text(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "zero_height_text.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_ZERO_HEIGHT_TEXT)
+    return pcb_file
+
+
+@pytest.fixture
+def pcb_nonstandard_aspect(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "nonstandard_aspect.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_NONSTANDARD_ASPECT)
+    return pcb_file
+
+
+@pytest.fixture
+def pcb_non_silk_text(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "non_silk_text.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_NON_SILK_TEXT)
+    return pcb_file
+
+
+@pytest.fixture
+def pcb_ok_text(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "ok_text.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_OK_TEXT)
+    return pcb_file
+
+
+@pytest.fixture
+def pcb_undersized_both(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "undersized_both.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_UNDERSIZED_BOTH)
+    return pcb_file
+
+
 # --------------------------------------------------------------------------
 # Tests: _get_min_width
 # --------------------------------------------------------------------------
@@ -217,12 +578,33 @@ class TestGetMinWidth:
 
 
 # --------------------------------------------------------------------------
-# Tests: SilkscreenRepairer
+# Tests: _get_min_height
+# --------------------------------------------------------------------------
+
+
+class TestGetMinHeight:
+    """Tests for the _get_min_height helper."""
+
+    def test_explicit_height_overrides(self):
+        """Explicit --min-height takes precedence over manufacturer."""
+        assert _get_min_height("jlcpcb", 2, 1.0, 1.5) == 1.5
+
+    def test_jlcpcb_default(self):
+        """JLCPCB 2-layer 1oz returns 1.0mm."""
+        assert _get_min_height("jlcpcb", 2, 1.0, None) == 1.0
+
+    def test_no_mfr_fallback(self):
+        """No manufacturer returns sensible default."""
+        assert _get_min_height(None, 2, 1.0, None) == 1.0
+
+
+# --------------------------------------------------------------------------
+# Tests: SilkscreenRepairer -- line widths
 # --------------------------------------------------------------------------
 
 
 class TestSilkscreenRepairer:
-    """Tests for the core repair logic."""
+    """Tests for the core line width repair logic."""
 
     def test_fixes_undersized_fp_lines(self, pcb_undersized: Path):
         """Undersized fp_line and fp_rect strokes are widened."""
@@ -336,6 +718,148 @@ class TestSilkscreenRepairer:
 
 
 # --------------------------------------------------------------------------
+# Tests: SilkscreenRepairer -- text heights
+# --------------------------------------------------------------------------
+
+
+class TestSilkscreenRepairerTextHeight:
+    """Tests for the text height repair logic."""
+
+    def test_fixes_undersized_text_height(self, pcb_undersized_text: Path):
+        """fp_text with height < min is scaled up."""
+        repairer = SilkscreenRepairer(pcb_undersized_text)
+        result = repairer.repair_text_heights(min_height_mm=1.0)
+
+        # R1 has 2 undersized fp_text (0.5mm), C1 has 1 (0.8mm) = 3 total
+        assert result.total_fixed == 3
+
+        for fix in result.fixes:
+            assert fix.new_height == 1.0
+            assert fix.old_height < 1.0
+
+    def test_text_height_preserves_aspect_ratio(self, pcb_nonstandard_aspect: Path):
+        """Width scales proportionally with height."""
+        repairer = SilkscreenRepairer(pcb_nonstandard_aspect)
+        result = repairer.repair_text_heights(min_height_mm=1.0)
+
+        assert result.total_fixed == 1
+        fix = result.fixes[0]
+        # Original: W=0.4, H=0.5, ratio W/H = 0.8
+        # New: H=1.0, so W should be 0.4 * (1.0/0.5) = 0.8
+        assert fix.old_width == 0.4
+        assert fix.old_height == 0.5
+        assert fix.new_height == 1.0
+        assert fix.new_width == pytest.approx(0.8, abs=1e-6)
+
+        # Thickness should also scale proportionally
+        assert fix.old_thickness == 0.075
+        assert fix.new_thickness == pytest.approx(0.15, abs=1e-6)
+
+    def test_text_height_mutates_tree(self, pcb_undersized_text: Path):
+        """Without dry_run, the SExp tree is actually modified."""
+        repairer = SilkscreenRepairer(pcb_undersized_text)
+        repairer.repair_text_heights(min_height_mm=1.0)
+
+        # Verify the tree was mutated -- check the first footprint's first fp_text
+        fp = repairer.doc.find_all("footprint")[0]
+        fp_text = fp.find_all("fp_text")[0]
+        effects = fp_text.find("effects")
+        font = effects.find("font")
+        size = font.find("size")
+        atoms = size.get_atoms()
+        assert float(atoms[0]) == 1.0  # width scaled from 0.5 to 1.0
+        assert float(atoms[1]) == 1.0  # height scaled from 0.5 to 1.0
+
+        # Also check thickness was scaled
+        thickness = font.find("thickness")
+        assert float(thickness.get_first_atom()) == pytest.approx(0.15, abs=1e-6)
+
+    def test_hidden_text_skipped(self, pcb_hidden_text: Path):
+        """Hidden fp_text is not modified."""
+        repairer = SilkscreenRepairer(pcb_hidden_text)
+        result = repairer.repair_text_heights(min_height_mm=1.0)
+
+        # Only the visible reference text should be fixed, not the hidden value
+        assert result.total_fixed == 1
+        assert result.fixes[0].element_type == "fp_text"
+
+    def test_hidden_text_yes_skipped(self, pcb_hidden_text_yes: Path):
+        """Hidden fp_text with (hide yes) syntax is not modified."""
+        repairer = SilkscreenRepairer(pcb_hidden_text_yes)
+        result = repairer.repair_text_heights(min_height_mm=1.0)
+
+        assert result.total_fixed == 0
+
+    def test_zero_height_text_skipped(self, pcb_zero_height_text: Path):
+        """Zero-height text is not modified."""
+        repairer = SilkscreenRepairer(pcb_zero_height_text)
+        result = repairer.repair_text_heights(min_height_mm=1.0)
+
+        assert result.total_fixed == 0
+
+    def test_board_level_text_height(self, pcb_board_level_text: Path):
+        """gr_text on silk layers is fixed."""
+        repairer = SilkscreenRepairer(pcb_board_level_text)
+        result = repairer.repair_text_heights(min_height_mm=1.0)
+
+        # Both gr_text elements are undersized (0.5 and 0.8)
+        assert result.total_fixed == 2
+        for fix in result.fixes:
+            assert fix.element_type == "gr_text"
+            assert fix.footprint_ref == ""
+
+    def test_property_nodes_handled(self, pcb_undersized_property: Path):
+        """KiCad 8 property nodes on silkscreen are fixed."""
+        repairer = SilkscreenRepairer(pcb_undersized_property)
+        result = repairer.repair_text_heights(min_height_mm=1.0)
+
+        assert result.total_fixed == 2
+        for fix in result.fixes:
+            assert fix.element_type == "property"
+            assert fix.new_height == 1.0
+
+    def test_non_silk_text_untouched(self, pcb_non_silk_text: Path):
+        """Text on non-silkscreen layers is not modified."""
+        repairer = SilkscreenRepairer(pcb_non_silk_text)
+        result = repairer.repair_text_heights(min_height_mm=1.0)
+
+        assert result.total_fixed == 0
+
+    def test_already_ok_text_no_fixes(self, pcb_ok_text: Path):
+        """Text already meeting minimum height is not modified."""
+        repairer = SilkscreenRepairer(pcb_ok_text)
+        result = repairer.repair_text_heights(min_height_mm=1.0)
+
+        assert result.total_fixed == 0
+
+    def test_text_height_dry_run(self, pcb_undersized_text: Path):
+        """dry run collects fixes without mutation."""
+        repairer = SilkscreenRepairer(pcb_undersized_text)
+        result = repairer.repair_text_heights(min_height_mm=1.0, dry_run=True)
+
+        assert result.total_fixed == 3
+
+        # Verify the tree was NOT mutated
+        fp = repairer.doc.find_all("footprint")[0]
+        fp_text = fp.find_all("fp_text")[0]
+        effects = fp_text.find("effects")
+        font = effects.find("font")
+        size = font.find("size")
+        atoms = size.get_atoms()
+        assert float(atoms[1]) == 0.5  # still original height
+
+    def test_text_height_idempotent(self, pcb_undersized_text: Path):
+        """Running twice produces same result."""
+        repairer = SilkscreenRepairer(pcb_undersized_text)
+        result1 = repairer.repair_text_heights(min_height_mm=1.0)
+        assert result1.total_fixed == 3
+
+        # Run again on the same (already-mutated) tree
+        result2 = repairer.repair_text_heights(min_height_mm=1.0)
+        assert result2.total_fixed == 0
+
+
+# --------------------------------------------------------------------------
 # Tests: CLI main()
 # --------------------------------------------------------------------------
 
@@ -382,6 +906,7 @@ class TestCLI:
         data = json.loads(captured.out)
         assert data["total_fixed"] == 4
         assert data["dry_run"] is True
+        assert "text_height_fixes" in data
 
     def test_summary_output(self, pcb_undersized: Path, capsys):
         """--format summary produces compact output."""
@@ -413,9 +938,42 @@ class TestCLI:
         exit_code = main([str(pcb_undersized), "--min-width", "0.20", "--dry-run"])
         assert exit_code == 0
 
+    def test_min_height_override(self, pcb_undersized_text: Path):
+        """--min-height overrides manufacturer defaults."""
+        exit_code = main([str(pcb_undersized_text), "--min-height", "0.8", "--dry-run"])
+        assert exit_code == 0
+
     def test_quiet_flag(self, pcb_undersized: Path, capsys):
         """--quiet suppresses output."""
         exit_code = main([str(pcb_undersized), "--dry-run", "--quiet"])
         assert exit_code == 0
         captured = capsys.readouterr()
         assert captured.out == ""
+
+    def test_text_height_fix_applied(self, pcb_undersized_text: Path):
+        """CLI integrates text height repair."""
+        exit_code = main([str(pcb_undersized_text)])
+        assert exit_code == 0
+
+        # Verify text heights were fixed
+        doc = parse_file(pcb_undersized_text)
+        fp = doc.find_all("footprint")[0]
+        fp_text = fp.find_all("fp_text")[0]
+        effects = fp_text.find("effects")
+        font = effects.find("font")
+        size = font.find("size")
+        atoms = size.get_atoms()
+        assert float(atoms[1]) >= 1.0  # height was scaled up
+
+    def test_both_line_and_text_fixes(self, pcb_undersized_both: Path, capsys):
+        """CLI fixes both line widths and text heights in a single run."""
+        exit_code = main([str(pcb_undersized_both), "--dry-run", "--format", "json"])
+        assert exit_code == 0
+
+        import json
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["total_line_width_fixed"] == 1
+        assert data["total_text_height_fixed"] == 1
+        assert data["total_fixed"] == 2


### PR DESCRIPTION
## Summary
Add text height repair capability to the silkscreen fix pipeline. The existing `kct fix-silkscreen` command only repaired line widths; this extends it to also auto-fix undersized text heights on silkscreen layers, scaling font width and thickness proportionally to preserve aspect ratio.

## Changes
- Add `TextHeightFix` dataclass and `TextHeightRepairResult` to `repair_silkscreen.py`
- Add `repair_text_heights()` method to `SilkscreenRepairer` that walks `fp_text`, `property`, and `gr_text` nodes
- Add `_is_hidden()`, `_get_font_size()`, `_get_font_thickness()`, and `_maybe_fix_text()` helpers
- Add `_get_min_height()` helper to `fix_silkscreen_cmd.py` that reads `min_silkscreen_height_mm` from manufacturer YAML profiles
- Add `--min-height` CLI flag for explicit override
- Update CLI `main()` to call both `repair_line_widths()` and `repair_text_heights()`
- Update all output formatters (text, JSON, summary) to report both line width and text height fixes
- Add 15 new test cases covering: undersized fp_text, KiCad 8 property nodes, board-level gr_text, hidden text skipping (both `hide` atom and `(hide yes)` syntax), zero-height skipping, aspect ratio preservation, dry-run, idempotency, CLI integration, and combined line+text fixes

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `repair_text_heights(min_height_mm)` method exists | Pass | Method added to `SilkscreenRepairer` class |
| Both fp_text/property and gr_text handled | Pass | Tests `test_property_nodes_handled` and `test_board_level_text_height` pass |
| Hidden text elements skipped | Pass | Tests `test_hidden_text_skipped` and `test_hidden_text_yes_skipped` pass |
| Zero-height text elements skipped | Pass | Test `test_zero_height_text_skipped` passes |
| Font width and thickness scaled proportionally | Pass | Test `test_text_height_preserves_aspect_ratio` verifies W/H ratio preserved |
| CLI resolves min_silkscreen_height_mm from YAML | Pass | `_get_min_height` reads from manufacturer profiles; `test_jlcpcb_default` returns 1.0mm |
| Fix is idempotent | Pass | Test `test_text_height_idempotent` runs twice, second pass finds 0 fixes |
| --dry-run reports without mutating | Pass | Test `test_text_height_dry_run` verifies tree unchanged after dry run |

## Test Plan
- All 40 tests in `test_fix_silkscreen.py` pass (9 existing line-width tests + 3 _get_min helpers + 15 new text-height tests + 13 CLI tests)
- All 189 tests across `test_fix_silkscreen.py`, `test_drc.py`, and `test_sexp_parser.py` pass

Closes #1518