### PR TITLE
fix(boards): skip pour nets and decouple route_success from exit code

### DIFF
--- a/boards/00-simple-led/generate_design.py
+++ b/boards/00-simple-led/generate_design.py
@@ -448,7 +448,7 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # Load the PCB
     router, net_map = load_pcb_for_routing(
         str(input_path),
-        skip_nets=[],
+        skip_nets=["GND"],  # GND is a pour net, not routed as traces
         rules=rules,
     )
 
@@ -669,7 +669,8 @@ def main() -> int:
         print("  - D1: LED indicator")
         print("  - 5V input -> ~10mA LED current")
 
-        return 0 if erc_success and route_success and drc_success else 1
+        # Partial routing is acceptable; success if ERC and DRC pass
+        return 0 if erc_success and drc_success else 1
 
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)

--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -453,7 +453,7 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # Load the PCB
     router, net_map = load_pcb_for_routing(
         str(input_path),
-        skip_nets=[],  # Route all nets
+        skip_nets=["GND"],  # GND is a pour net, not routed as traces
         rules=rules,
     )
 
@@ -702,7 +702,8 @@ def main() -> int:
         print("  - J2: 2-pin output connector (VOUT, GND)")
         print("  - 5V input -> 2.5V output")
 
-        return 0 if erc_success and route_success and drc_success else 1
+        # Partial routing is acceptable; success if ERC and DRC pass
+        return 0 if erc_success and drc_success else 1
 
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)

--- a/boards/02-charlieplex-led/generate_design.py
+++ b/boards/02-charlieplex-led/generate_design.py
@@ -670,7 +670,8 @@ def main() -> int:
         for led_conn in LED_CONNECTIONS:
             print(f"  {led_conn.ref}    {led_conn.anode_node}  {led_conn.cathode_node}")
 
-        return 0 if erc_success and route_success and drc_success else 1
+        # Partial routing is acceptable; success if ERC and DRC pass
+        return 0 if erc_success and drc_success else 1
 
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary
Boards 00-02 generate_design.py scripts incorrectly treated partial routing (due to pour-net skip) as build failure. This fix adds GND to skip_nets for boards 00 and 01, and removes the route_success gate from the exit code in all three affected boards, matching the pattern already used by boards 03-05.

## Changes
- `boards/00-simple-led/generate_design.py`: Changed skip_nets from `[]` to `["GND"]`; removed `route_success` from exit code gate
- `boards/01-voltage-divider/generate_design.py`: Changed skip_nets from `[]` to `["GND"]`; removed `route_success` from exit code gate
- `boards/02-charlieplex-led/generate_design.py`: Removed `route_success` from exit code gate (skip_nets was already correct)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board 00 returns exit 0 when ERC/DRC pass regardless of GND routing | Done | GND skipped from routing; exit gate only checks erc_success and drc_success |
| Board 01 returns exit 0 when ERC/DRC pass regardless of GND routing | Done | GND skipped from routing; exit gate only checks erc_success and drc_success |
| Board 02 returns exit 0 when ERC/DRC pass consistent with boards 03-05 | Done | Exit gate now matches boards 03-05 pattern |
| GND/pour nets skipped from routing or excluded from success calc | Done | Boards 00-01 now skip GND; board 02 already skipped VCC/GND |
| No regression in boards 03-05 | Done | No files in boards 03-05 were modified |

## Test Plan
- Verified all three changed files have correct skip_nets and exit code patterns
- Confirmed boards 03, 04, 05 already use the same exit code pattern and were not modified

Closes #1524