### PR TITLE
fix(boards): conform BLDC motor controller project.kct to ProjectSpec schema

### DIFF
--- a/boards/05-bldc-motor-controller/project.kct
+++ b/boards/05-bldc-motor-controller/project.kct
@@ -24,24 +24,25 @@ intent:
     - "Demonstrate multi-voltage domain power supply design"
 
   interfaces:
-    power_input:
+    - name: power_input
       type: "DC barrel/screw terminal"
       voltage: "12-24V"
-      current: "15A max"
+      current_max: "15A"
 
-    motor_output:
+    - name: motor_output
       type: "3-phase BLDC"
-      phases: ["U", "V", "W"]
-      current: "10A per phase continuous"
+      description: "Phases U, V, W at 10A continuous"
+      pins: ["U", "V", "W"]
 
-    hall_sensors:
+    - name: hall_sensors
       type: "digital"
-      signals: ["HALL_A", "HALL_B", "HALL_C"]
-      voltage: "3.3V logic"
+      description: "Hall sensor inputs at 3.3V logic"
+      pins: ["HALL_A", "HALL_B", "HALL_C"]
+      voltage: "3.3V"
 
-    debug:
+    - name: debug
       type: "SWD"
-      signals: ["SWDIO", "SWCLK", "NRST"]
+      pins: ["SWDIO", "SWCLK", "NRST"]
 
 requirements:
   electrical:
@@ -82,10 +83,11 @@ requirements:
     mounting: "4x M3 corner holes"
 
   manufacturing:
-    layers: 2
-    min_trace: 0.2
-    min_space: 0.2
-    min_drill: 0.3
+    layers:
+      preferred: 2
+    min_trace: "0.2mm"
+    min_space: "0.2mm"
+    min_drill: "0.3mm"
     copper_weight: "2oz"
     unit: "mm"
     notes: "2oz copper recommended for motor phase traces"
@@ -93,55 +95,42 @@ requirements:
 suggestions:
   components:
     gate_driver:
-      part: "DRV8301"
-      package: "QFN-56"
-      notes: "Integrated 3-phase gate driver with current sense amps"
+      preferred: ["DRV8301"]
+      rationale: "Integrated 3-phase gate driver with current sense amps, QFN-56"
 
     mosfets:
-      part: "IRLZ44N"
-      package: "TO-220"
-      notes: "Logic-level N-channel, 55V 47A, Rds(on) 22mΩ"
-      alternative: "IRF3205 for higher current"
+      preferred: ["IRLZ44N"]
+      rationale: "Logic-level N-channel, 55V 47A, Rds(on) 22mOhm, TO-220"
 
     current_sense:
-      part: "Shunt resistor"
-      value: "0.005Ω"
-      package: "2512"
-      power: "1W"
+      preferred: ["Shunt resistor 0.005Ohm 2512"]
+      rationale: "Low-value shunt for current sensing, 1W power rating"
 
     buck_regulator:
-      part: "LM2596"
-      notes: "Simple switcher, 24V→5V @ 3A"
+      preferred: ["LM2596"]
+      rationale: "Simple switcher, 24V to 5V at 3A"
 
     ldo:
-      part: "AMS1117-3.3"
-      notes: "5V→3.3V for MCU"
+      preferred: ["AMS1117-3.3"]
+      rationale: "5V to 3.3V for MCU"
 
     mcu:
-      part: "STM32G431"
-      package: "LQFP-48"
-      notes: "Motor control timers, 170MHz, integrated op-amps"
+      preferred: ["STM32G431"]
+      rationale: "Motor control timers, 170MHz, integrated op-amps, LQFP-48"
 
   layout:
-    power_stage:
-      - "Place MOSFETs in H-bridge configuration near motor connector"
-      - "Use thermal vias under MOSFET tab (min 6 per device)"
-      - "Ground plane on bottom layer for heat spreading"
-      - "Keep gate drive traces short (<10mm)"
-
-    current_sense:
-      - "Use Kelvin connection to shunt resistors"
-      - "Route sense traces away from switching nodes"
-      - "Place sense amplifier close to shunts"
-
-    power_supply:
-      - "Separate motor power from logic power at input"
-      - "Use star-ground topology"
-      - "Bulk capacitors near power input and MOSFETs"
-
-    signal_integrity:
-      - "Keep PWM traces away from sense traces"
-      - "Use ground guard traces around sensitive signals"
+    - "Place MOSFETs in H-bridge configuration near motor connector"
+    - "Use thermal vias under MOSFET tab (min 6 per device)"
+    - "Ground plane on bottom layer for heat spreading"
+    - "Keep gate drive traces short (<10mm)"
+    - "Use Kelvin connection to shunt resistors"
+    - "Route sense traces away from switching nodes"
+    - "Place sense amplifier close to shunts"
+    - "Separate motor power from logic power at input"
+    - "Use star-ground topology"
+    - "Bulk capacitors near power input and MOSFETs"
+    - "Keep PWM traces away from sense traces"
+    - "Use ground guard traces around sensitive signals"
 
 bom_entries:
   - ref: J1
@@ -210,8 +199,8 @@ bom_entries:
     lcsc: C72038
 
 decisions:
-  - id: "discrete-mosfets"
-    description: "Use discrete MOSFETs instead of integrated driver"
+  - topic: "Discrete MOSFETs vs Integrated Driver"
+    choice: "Discrete TO-220 MOSFETs (IRLZ44N)"
     rationale: |
       Discrete MOSFETs provide better thermal visibility for testing
       ThermalAnalyzer. TO-220 package has well-characterized thermal
@@ -220,8 +209,8 @@ decisions:
       - "Integrated half-bridge ICs (e.g., IR2184 + dual MOSFET)"
       - "Smart power modules"
 
-  - id: "2-layer-board"
-    description: "Use 2-layer PCB instead of 4-layer"
+  - topic: "PCB Layer Count"
+    choice: "2-layer PCB"
     rationale: |
       Tests routing capability on constrained layer count.
       Requires careful copper pour management for power delivery.
@@ -229,8 +218,8 @@ decisions:
     alternatives:
       - "4-layer with dedicated power planes"
 
-  - id: "through-hole-power"
-    description: "Use through-hole for power components"
+  - topic: "Power Component Package"
+    choice: "Through-hole for power components"
     rationale: |
       TO-220 MOSFETs and through-hole screw terminals are
       common in motor control. Tests mixed SMD/THT routing.


### PR DESCRIPTION
## Summary

Fix 6 schema validation errors in the BLDC motor controller project.kct file so it conforms to the ProjectSpec Pydantic schema. This is a data-only YAML fix with no code changes.

## Changes

- `intent.interfaces`: Convert from dict-of-dicts to list[Interface] with `name` fields
- `requirements.manufacturing.layers`: Convert from bare int (`2`) to dict (`{preferred: 2}`)
- `requirements.manufacturing.min_trace/min_space/min_drill`: Convert from float to string with unit suffix (e.g., `"0.2mm"`)
- `suggestions.components`: Convert ad-hoc fields (`part`, `package`, `notes`) to ComponentSuggestion schema (`preferred`, `rationale`)
- `suggestions.layout`: Flatten from dict-of-lists to flat `list[str]`
- `decisions[]`: Replace `id`/`description` fields with `topic`/`choice` fields

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `load_spec()` succeeds without validation errors | Pass | `uv run python -c "from kicad_tools.spec.parser import load_spec; s = load_spec('boards/05-bldc-motor-controller/project.kct'); print(f'OK: {s.project.name}')"` prints `OK: BLDC Motor Controller` |
| All bom_entries unchanged | Pass | `git diff` confirms zero changes to lines 146-210 (bom_entries section) |
| interfaces is list[Interface] with name fields | Pass | Verified in diff and via load_spec validation |
| manufacturing.layers is `{preferred: 2}` | Pass | Verified in diff |
| min_trace/min_space/min_drill are strings with unit suffix | Pass | Verified in diff |
| suggestions.layout is flat list[str] | Pass | Verified in diff |
| suggestions.components values conform to ComponentSuggestion | Pass | Verified in diff and via load_spec validation |
| decisions use topic/choice fields | Pass | Verified in diff |
| No other sections altered beyond schema conformance | Pass | Only 1 file changed, all edits scoped to the 6 non-conforming sections |
| Test suite passes | Pass | 264 tests passed (2 pre-existing failures in unrelated modules excluded) |

## Test Plan

- Ran `uv run python -c "from kicad_tools.spec.parser import load_spec; s = load_spec('boards/05-bldc-motor-controller/project.kct'); print(f'OK: {s.project.name}')"` -- prints OK
- Ran `uv run pytest tests/test_spec.py tests/test_schema.py tests/test_export.py tests/test_export_cmd.py -q` -- 264 passed
- Used board 04 (STM32 devboard) as canonical reference for correct formatting

Closes #1526