### PR TITLE
fix(boards): rename JOY1 to J2 in USB joystick generators and outputs

### DIFF
--- a/boards/03-usb-joystick/README.md
+++ b/boards/03-usb-joystick/README.md
@@ -44,7 +44,7 @@ kct build boards/03-usb-joystick --dry-run
 |-----------|-------------|-----------|
 | U1 | Microcontroller (ATmega32U4-style) | TQFP-32 7x7mm |
 | J1 | USB Type-C Connector | USB-C Receptacle |
-| JOY1 | 2-axis Analog Joystick | 5-pin module |
+| J2 | 2-axis Analog Joystick | 5-pin module |
 | SW1-SW4 | Tactile Buttons | 6x6mm SMD |
 | Y1 | 16MHz Crystal | HC49 Vertical |
 | C1-C4 | Decoupling Capacitors (100nF) | 0402 SMD |

--- a/boards/03-usb-joystick/generate_design.py
+++ b/boards/03-usb-joystick/generate_design.py
@@ -636,7 +636,7 @@ def create_usb_joystick_pcb(output_dir: Path) -> Path:
     (layer "F.Cu")
     (uuid "{generate_uuid()}")
     (at {x} {y})
-    (fp_text reference "JOY1" (at 0 -3) (layer "F.SilkS") (uuid "{generate_uuid()}")
+    (fp_text reference "J2" (at 0 -3) (layer "F.SilkS") (uuid "{generate_uuid()}")
       (effects (font (size 1 1) (thickness 0.15)))
     )
     (fp_text value "Joystick" (at 0 3) (layer "F.Fab") (uuid "{generate_uuid()}")
@@ -711,7 +711,7 @@ def create_usb_joystick_pcb(output_dir: Path) -> Path:
     print("\n1. Adding footprints...")
     print("   U1 (MCU) at board center")
     print("   J1 (USB-C) at top")
-    print("   JOY1 (Joystick) at left")
+    print("   J2 (Joystick) at left")
     print("   Y1 (Crystal) near MCU")
 
     button_y = BOARD_ORIGIN_Y + 35

--- a/boards/03-usb-joystick/generate_pcb.py
+++ b/boards/03-usb-joystick/generate_pcb.py
@@ -334,7 +334,7 @@ def generate_joystick() -> str:
     (layer "F.Cu")
     (uuid "{generate_uuid()}")
     (at {x} {y})
-    (fp_text reference "JOY1" (at 0 -3) (layer "F.SilkS") (uuid "{generate_uuid()}")
+    (fp_text reference "J2" (at 0 -3) (layer "F.SilkS") (uuid "{generate_uuid()}")
       (effects (font (size 1 1) (thickness 0.15)))
     )
     (fp_text value "Joystick" (at 0 3) (layer "F.Fab") (uuid "{generate_uuid()}")

--- a/boards/03-usb-joystick/output/usb_joystick.kicad_pcb
+++ b/boards/03-usb-joystick/output/usb_joystick.kicad_pcb
@@ -126,7 +126,7 @@
     (layer "F.Cu")
     (uuid "4b31dab1-1edb-437a-b120-414f48e5d96b")
     (at 112.0 122.0)
-    (fp_text reference "JOY1" (at 0 -3) (layer "F.SilkS") (uuid "dfb2b620-62ba-4cba-a091-6e1241fae8c9")
+    (fp_text reference "J2" (at 0 -3) (layer "F.SilkS") (uuid "dfb2b620-62ba-4cba-a091-6e1241fae8c9")
       (effects (font (size 1 1) (thickness 0.15)))
     )
     (fp_text value "Joystick" (at 0 3) (layer "F.Fab") (uuid "eceba65f-5a31-4491-8f4e-08b809a2e6e4")

--- a/boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb
+++ b/boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb
@@ -126,7 +126,7 @@
     (layer "F.Cu")
     (uuid "4b31dab1-1edb-437a-b120-414f48e5d96b")
     (at 112.0 122.0)
-    (fp_text reference "JOY1" (at 0 -3) (layer "F.SilkS") (uuid "dfb2b620-62ba-4cba-a091-6e1241fae8c9")
+    (fp_text reference "J2" (at 0 -3) (layer "F.SilkS") (uuid "dfb2b620-62ba-4cba-a091-6e1241fae8c9")
       (effects (font (size 1 1) (thickness 0.15)))
     )
     (fp_text value "Joystick" (at 0 3) (layer "F.Fab") (uuid "eceba65f-5a31-4491-8f4e-08b809a2e6e4")


### PR DESCRIPTION
## Summary
Fixes the reference designator mismatch in the USB joystick board where the footprint generators used JOY1 for the joystick connector instead of the standard J2 defined in project.kct and the schematic generator. This caused bom_pcb_match and bom_cpl_match preflight failures during kct export.

## Changes
- `generate_pcb.py` line 337: changed footprint reference from "JOY1" to "J2"
- `generate_design.py` line 639: changed footprint reference from "JOY1" to "J2"
- `generate_design.py` line 714: changed print statement from "JOY1" to "J2"
- `README.md` line 47: changed components table entry from JOY1 to J2
- Updated both output PCB files (unrouted and routed) to use J2

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All source generators use J2 for joystick connector | Pass | grep -r "JOY1" on .py/.md/.kct files returns zero matches |
| README components table lists J2 | Pass | Verified edit on line 47 |
| kct export passes bom_pcb_match | Pass | Ran kct export, got [OK] bom_pcb_match |
| kct export passes bom_cpl_match | Pass | Ran kct export, got [OK] bom_cpl_match |
| Output files regenerated with J2 | Pass | Both .kicad_pcb files updated |

## Test Plan
- Ran `kct export` against the routed PCB and confirmed bom_pcb_match and bom_cpl_match both pass with OK status
- Grepped all source and output files to confirm zero remaining JOY1 references

Closes #1525