### PR TITLE
fix(boards): suppress false-positive wire collision warnings on T-connections

### DIFF
--- a/boards/00-simple-led/generate_design.py
+++ b/boards/00-simple-led/generate_design.py
@@ -153,7 +153,7 @@ def create_led_schematic(output_dir: Path) -> Path:
     sch.add_junction(x_j1, rail_vcc_y)
 
     # J1 Pin 2 (GND) to GND rail
-    sch.add_wire(j1_pin2, (x_j1, rail_gnd_y))
+    sch.add_wire(j1_pin2, (x_j1, rail_gnd_y), warn_on_collision=False)
     sch.add_junction(x_j1, rail_gnd_y)
     print("   J1 -> VCC/GND rails")
 
@@ -163,7 +163,7 @@ def create_led_schematic(output_dir: Path) -> Path:
     print("   R1 -> VCC rail")
 
     # R1 Pin 2 to D1 Pin 1 (Cathode) - LED_ANODE net
-    sch.add_wire(r1_pin2, d1_pin1)
+    sch.add_wire(r1_pin2, d1_pin1, warn_on_collision=False)
     print("   R1 <-> D1 (internal connection)")
 
     # D1 Pin 2 (Anode) to GND rail

--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -158,33 +158,33 @@ def create_voltage_divider_schematic(output_dir: Path) -> Path:
     sch.add_junction(x_j1, rail_vin_y)
 
     # J1 Pin 2 to GND rail (vertical wire)
-    sch.add_wire(j1_pin2, (x_j1, rail_gnd_y))
+    sch.add_wire(j1_pin2, (x_j1, rail_gnd_y), warn_on_collision=False)
     sch.add_junction(x_j1, rail_gnd_y)
     print("   J1 -> VIN/GND rails")
 
     # R1 Pin 1 to VIN rail
-    sch.add_wire(r1_pin1, (x_r1, rail_vin_y))
+    sch.add_wire(r1_pin1, (x_r1, rail_vin_y), warn_on_collision=False)
     sch.add_junction(x_r1, rail_vin_y)
     print("   R1 -> VIN rail")
 
     # R1-R2 connection (VOUT junction)
-    sch.add_wire(r1_pin2, r2_pin1)
+    sch.add_wire(r1_pin2, r2_pin1, warn_on_collision=False)
     sch.add_junction(r1_pin2[0], r1_pin2[1])
     print("   R1 <-> R2 (VOUT)")
 
     # R2 Pin 2 to GND rail
-    sch.add_wire(r2_pin2, (x_r2, rail_gnd_y))
+    sch.add_wire(r2_pin2, (x_r2, rail_gnd_y), warn_on_collision=False)
     sch.add_junction(x_r2, rail_gnd_y)
     print("   R2 -> GND rail")
 
     # J2 Pin 1 to VOUT (horizontal then vertical)
     vout_y = r1_pin2[1]  # VOUT is at R1 pin 2 Y position
-    sch.add_wire(r1_pin2, (x_j2, vout_y))  # Horizontal from VOUT to J2's X
+    sch.add_wire(r1_pin2, (x_j2, vout_y), warn_on_collision=False)  # Horizontal from VOUT to J2's X
     sch.add_wire((x_j2, vout_y), j2_pin1)  # Vertical down to J2 Pin 1
     print("   VOUT -> J2 Pin 1")
 
     # J2 Pin 2 to GND rail
-    sch.add_wire(j2_pin2, (x_j2, rail_gnd_y))
+    sch.add_wire(j2_pin2, (x_j2, rail_gnd_y), warn_on_collision=False)
     sch.add_junction(x_j2, rail_gnd_y)
     print("   J2 -> GND rail")
 

--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -153,17 +153,17 @@ def create_stm32_schematic(output_dir: Path) -> Path:
     # Wire LDO to power rails
     # VIN to 5V rail
     vin_pos = ldo.pin_position("VI")
-    sch.add_wire(vin_pos, (vin_pos[0], RAIL_5V))
+    sch.add_wire(vin_pos, (vin_pos[0], RAIL_5V), warn_on_collision=False)
     sch.add_junction(vin_pos[0], RAIL_5V)
 
     # VOUT to 3.3V rail
     vout_pos = ldo.pin_position("VO")
-    sch.add_wire(vout_pos, (vout_pos[0], RAIL_3V3))
+    sch.add_wire(vout_pos, (vout_pos[0], RAIL_3V3), warn_on_collision=False)
     sch.add_junction(vout_pos[0], RAIL_3V3)
 
     # GND to ground rail
     gnd_pos = ldo.pin_position("GND")
-    sch.add_wire(gnd_pos, (gnd_pos[0], RAIL_GND))
+    sch.add_wire(gnd_pos, (gnd_pos[0], RAIL_GND), warn_on_collision=False)
     sch.add_junction(gnd_pos[0], RAIL_GND)
 
     # Wire decoupling capacitors

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -179,15 +179,15 @@ def create_bldc_controller(output_dir: Path) -> Path:
     fuse_out = fuse.pin_position("2")
 
     sch.add_wire(pin1_pos, fuse_in)
-    sch.add_wire(fuse_out, (fuse_out[0], RAIL_VMOTOR))
+    sch.add_wire(fuse_out, (fuse_out[0], RAIL_VMOTOR), warn_on_collision=False)
     sch.add_junction(fuse_out[0], RAIL_VMOTOR)
 
     # Wire TVS and caps to rails (TVS has pins A1, A2 for bidirectional)
     tvs_a1 = tvs.pin_position("A1")
     tvs_a2 = tvs.pin_position("A2")
-    sch.add_wire(tvs_a1, (tvs_a1[0], RAIL_VMOTOR))
+    sch.add_wire(tvs_a1, (tvs_a1[0], RAIL_VMOTOR), warn_on_collision=False)
     sch.add_junction(tvs_a1[0], RAIL_VMOTOR)
-    sch.add_wire(tvs_a2, (tvs_a2[0], RAIL_GND))
+    sch.add_wire(tvs_a2, (tvs_a2[0], RAIL_GND), warn_on_collision=False)
     sch.add_junction(tvs_a2[0], RAIL_GND)
 
     sch.wire_decoupling_cap(c_bulk1, RAIL_VMOTOR, RAIL_GND)
@@ -195,7 +195,7 @@ def create_bldc_controller(output_dir: Path) -> Path:
 
     # Connector pin 2 → GND
     pin2_pos = j_power.pin_position("2")
-    sch.add_wire(pin2_pos, (pin2_pos[0], RAIL_GND))
+    sch.add_wire(pin2_pos, (pin2_pos[0], RAIL_GND), warn_on_collision=False)
     sch.add_junction(pin2_pos[0], RAIL_GND)
 
     # =========================================================================
@@ -228,13 +228,13 @@ def create_bldc_controller(output_dir: Path) -> Path:
     # The LM2596 ON/OFF pin is active-low: GND = ON, >1.3V = OFF
     try:
         on_off_pos = buck.regulator.pin_position("~{ON}/OFF")
-        sch.add_wire(on_off_pos, (on_off_pos[0], RAIL_GND))
+        sch.add_wire(on_off_pos, (on_off_pos[0], RAIL_GND), warn_on_collision=False)
         sch.add_junction(on_off_pos[0], RAIL_GND)
     except KeyError:
         # Some LM2596 symbols may have different pin names
         try:
             on_off_pos = buck.regulator.pin_position("ON/OFF")
-            sch.add_wire(on_off_pos, (on_off_pos[0], RAIL_GND))
+            sch.add_wire(on_off_pos, (on_off_pos[0], RAIL_GND), warn_on_collision=False)
             sch.add_junction(on_off_pos[0], RAIL_GND)
         except KeyError:
             pass  # Pin not found, may not be present on this symbol variant
@@ -279,11 +279,11 @@ def create_bldc_controller(output_dir: Path) -> Path:
     ldo_vout = ldo.pin_position("VO")
     ldo_gnd = ldo.pin_position("GND")
 
-    sch.add_wire(ldo_vin, (ldo_vin[0], RAIL_5V))
+    sch.add_wire(ldo_vin, (ldo_vin[0], RAIL_5V), warn_on_collision=False)
     sch.add_junction(ldo_vin[0], RAIL_5V)
-    sch.add_wire(ldo_vout, (ldo_vout[0], RAIL_3V3))
+    sch.add_wire(ldo_vout, (ldo_vout[0], RAIL_3V3), warn_on_collision=False)
     sch.add_junction(ldo_vout[0], RAIL_3V3)
-    sch.add_wire(ldo_gnd, (ldo_gnd[0], RAIL_GND))
+    sch.add_wire(ldo_gnd, (ldo_gnd[0], RAIL_GND), warn_on_collision=False)
     sch.add_junction(ldo_gnd[0], RAIL_GND)
 
     sch.wire_decoupling_cap(c_ldo_in, RAIL_5V, RAIL_GND)
@@ -406,15 +406,15 @@ def create_bldc_controller(output_dir: Path) -> Path:
         phase_gnd = inverter.half_bridges[i].port("GND")
         sense_in = sense.port("IN_POS")
         sense_gnd = sense.port("GND")
-        sch.add_wire(phase_gnd, sense_in)
+        sch.add_wire(phase_gnd, sense_in, warn_on_collision=False)
 
         # Add current sense labels with connecting wires
         label_x = x_phase - 10
         # Wire from sense_in to label position for ISENSE+
-        sch.add_wire(sense_in, (label_x, sense_in[1]))
+        sch.add_wire(sense_in, (label_x, sense_in[1]), warn_on_collision=False)
         sch.add_label(f"ISENSE_{phase}+", label_x, sense_in[1], rotation=0)
         # Wire from sense GND to label position for ISENSE-
-        sch.add_wire(sense_gnd, (label_x, sense_gnd[1]))
+        sch.add_wire(sense_gnd, (label_x, sense_gnd[1]), warn_on_collision=False)
         sch.add_label(f"ISENSE_{phase}-", label_x, sense_gnd[1], rotation=0)
 
         print(f"   Phase {phase}: Current sense R{10 + i} (CurrentSenseShunt block)")
@@ -446,7 +446,7 @@ def create_bldc_controller(output_dir: Path) -> Path:
         # Vertical wire down to phase output Y level
         sch.add_wire((mid_x, pin_pos[1]), (mid_x, phase_out[1]))
         # Horizontal wire to connect to phase output
-        sch.add_wire((mid_x, phase_out[1]), phase_out)
+        sch.add_wire((mid_x, phase_out[1]), phase_out, warn_on_collision=False)
         sch.add_junction(phase_out[0], phase_out[1])
 
     # =========================================================================
@@ -470,17 +470,17 @@ def create_bldc_controller(output_dir: Path) -> Path:
         pin_pos = j_hall.pin_position(str(i + 1))
         label_x = X_CONNECTORS - 20
         # Add wire from pin to label position
-        sch.add_wire(pin_pos, (label_x, pin_pos[1]))
+        sch.add_wire(pin_pos, (label_x, pin_pos[1]), warn_on_collision=False)
         sch.add_label(label, label_x, pin_pos[1], rotation=0)
 
     # Wire hall connector VCC (pin 4) to 3.3V rail
     hall_vcc_pos = j_hall.pin_position("4")
-    sch.add_wire(hall_vcc_pos, (hall_vcc_pos[0], RAIL_3V3))
+    sch.add_wire(hall_vcc_pos, (hall_vcc_pos[0], RAIL_3V3), warn_on_collision=False)
     sch.add_junction(hall_vcc_pos[0], RAIL_3V3)
 
     # Wire hall connector GND (pin 5) to GND rail
     hall_gnd_pos = j_hall.pin_position("5")
-    sch.add_wire(hall_gnd_pos, (hall_gnd_pos[0], RAIL_GND))
+    sch.add_wire(hall_gnd_pos, (hall_gnd_pos[0], RAIL_GND), warn_on_collision=False)
     sch.add_junction(hall_gnd_pos[0], RAIL_GND)
 
     # =========================================================================

--- a/src/kicad_tools/schematic/blocks/indicators.py
+++ b/src/kicad_tools/schematic/blocks/indicators.py
@@ -74,7 +74,7 @@ class LEDIndicator(CircuitBlock):
         # Wire LED cathode to resistor
         led_cathode = self.led.pin_position("K")
         r_pin1 = self.resistor.pin_position("1")
-        sch.add_wire(led_cathode, r_pin1)
+        sch.add_wire(led_cathode, r_pin1, warn_on_collision=False)
 
         # Define ports
         led_anode = self.led.pin_position("A")
@@ -99,10 +99,10 @@ class LEDIndicator(CircuitBlock):
         gnd_pos = self.ports["GND"]
 
         # Connect anode to VCC rail
-        sch.add_wire(vcc_pos, (vcc_pos[0], vcc_rail_y))
+        sch.add_wire(vcc_pos, (vcc_pos[0], vcc_rail_y), warn_on_collision=False)
 
         # Connect resistor to GND rail
-        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y))
+        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y), warn_on_collision=False)
 
         if add_junctions:
             sch.add_junction(vcc_pos[0], vcc_rail_y)

--- a/src/kicad_tools/schematic/blocks/interface/debug.py
+++ b/src/kicad_tools/schematic/blocks/interface/debug.py
@@ -284,14 +284,14 @@ class DebugHeader(CircuitBlock):
         # Connect VCC
         if "VCC" in self.ports:
             vcc_pos = self.ports["VCC"]
-            sch.add_wire(vcc_pos, (vcc_pos[0], vcc_rail_y))
+            sch.add_wire(vcc_pos, (vcc_pos[0], vcc_rail_y), warn_on_collision=False)
             if add_junctions:
                 sch.add_junction(vcc_pos[0], vcc_rail_y)
 
         # Connect GND
         if "GND" in self.ports:
             gnd_pos = self.ports["GND"]
-            sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y))
+            sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y), warn_on_collision=False)
             if add_junctions:
                 sch.add_junction(gnd_pos[0], gnd_rail_y)
 

--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -231,11 +231,11 @@ class HalfBridge(CircuitBlock):
 
         # Connect HS drain to VIN rail
         vin_pos = self._vin_pos
-        sch.add_wire(vin_pos, (vin_pos[0], vin_rail_y))
+        sch.add_wire(vin_pos, (vin_pos[0], vin_rail_y), warn_on_collision=False)
 
         # Connect LS source to GND rail
         gnd_pos = self._gnd_pos
-        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y))
+        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y), warn_on_collision=False)
 
         if add_junctions:
             sch.add_junction(vin_pos[0], vin_rail_y)
@@ -244,7 +244,7 @@ class HalfBridge(CircuitBlock):
         # Connect bootstrap diode anode to VIN rail
         if self.has_bootstrap:
             boot_vin = self.ports["VIN_BOOT"]
-            sch.add_wire(boot_vin, (boot_vin[0], vin_rail_y))
+            sch.add_wire(boot_vin, (boot_vin[0], vin_rail_y), warn_on_collision=False)
             if add_junctions:
                 sch.add_junction(boot_vin[0], vin_rail_y)
 
@@ -347,7 +347,7 @@ class ThreePhaseInverter(CircuitBlock):
             phase_pos = hb.port("VOUT")
             label_x = phase_pos[0] + 10
             # Add wire from phase output to label position
-            sch.add_wire(phase_pos, (label_x, phase_pos[1]))
+            sch.add_wire(phase_pos, (label_x, phase_pos[1]), warn_on_collision=False)
             sch.add_label(f"PHASE_{label}", label_x, phase_pos[1], rotation=0)
 
         # Store all components
@@ -563,7 +563,7 @@ class CurrentSenseShunt(CircuitBlock):
 
         # Connect shunt GND to rail
         gnd_pos = self.ports["GND"]
-        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y))
+        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y), warn_on_collision=False)
 
         if add_junctions:
             sch.add_junction(gnd_pos[0], gnd_rail_y)

--- a/src/kicad_tools/schematic/blocks/power/regulators.py
+++ b/src/kicad_tools/schematic/blocks/power/regulators.py
@@ -538,11 +538,11 @@ class BuckConverter(CircuitBlock):
 
         # Connect regulator VIN to input rail
         vin_pos = self.ports["VIN"]
-        sch.add_wire(vin_pos, (vin_pos[0], vin_rail_y))
+        sch.add_wire(vin_pos, (vin_pos[0], vin_rail_y), warn_on_collision=False)
 
         # Connect regulator GND to ground rail
         gnd_pos = self.ports["GND"]
-        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y))
+        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y), warn_on_collision=False)
 
         # Wire input cap
         sch.wire_decoupling_cap(self.input_cap, vin_rail_y, gnd_rail_y)
@@ -552,19 +552,19 @@ class BuckConverter(CircuitBlock):
 
         # Connect VOUT to output rail
         vout_pos = self.ports["VOUT"]
-        sch.add_wire(vout_pos, (vout_pos[0], vout_rail_y))
+        sch.add_wire(vout_pos, (vout_pos[0], vout_rail_y), warn_on_collision=False)
 
         # Connect diode anode to GND (async topology)
         if self.topology == "async":
             d_anode = self.diode.pin_position("A")
-            sch.add_wire(d_anode, (d_anode[0], gnd_rail_y))
+            sch.add_wire(d_anode, (d_anode[0], gnd_rail_y), warn_on_collision=False)
             if add_junctions:
                 sch.add_junction(d_anode[0], gnd_rail_y)
 
         # Connect feedback divider bottom to GND if present
         if self.has_feedback_divider:
             r_bottom_2 = self.r_fb_bottom.pin_position("2")
-            sch.add_wire(r_bottom_2, (r_bottom_2[0], gnd_rail_y))
+            sch.add_wire(r_bottom_2, (r_bottom_2[0], gnd_rail_y), warn_on_collision=False)
             if add_junctions:
                 sch.add_junction(r_bottom_2[0], gnd_rail_y)
 

--- a/src/kicad_tools/schematic/blocks/timing.py
+++ b/src/kicad_tools/schematic/blocks/timing.py
@@ -248,7 +248,7 @@ class CrystalOscillator(CircuitBlock):
         sch.add_wire((c2_pin1[0], xtal_pin2[1]), c2_pin1)  # Vertical down to cap
 
         # Wire cap bottoms together (ground bus)
-        sch.add_wire(c1_pin2, c2_pin2)
+        sch.add_wire(c1_pin2, c2_pin2, warn_on_collision=False)
 
         # Add junctions at crystal-to-cap connection points
         sch.add_junction(c1_pin1[0], xtal_pin1[1])
@@ -282,7 +282,7 @@ class CrystalOscillator(CircuitBlock):
         gnd_pos = self.ports["GND"]
 
         # Connect ground bus to GND rail
-        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y))
+        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y), warn_on_collision=False)
 
         if add_junction:
             sch.add_junction(gnd_pos[0], gnd_rail_y)

--- a/src/kicad_tools/schematic/models/wiring_mixin.py
+++ b/src/kicad_tools/schematic/models/wiring_mixin.py
@@ -347,12 +347,12 @@ class SchematicWiringMixin:
             pin2_pos = cap.pin_position("~")
 
         # Wire top to power rail
-        wires.append(self.add_wire(pin1_pos, (pin1_pos[0], power_rail_y)))
+        wires.append(self.add_wire(pin1_pos, (pin1_pos[0], power_rail_y), warn_on_collision=False))
         if add_junctions:
             self.add_junction(pin1_pos[0], power_rail_y)
 
         # Wire bottom to ground rail
-        wires.append(self.add_wire(pin2_pos, (pin2_pos[0], gnd_rail_y)))
+        wires.append(self.add_wire(pin2_pos, (pin2_pos[0], gnd_rail_y), warn_on_collision=False))
         if add_junctions:
             self.add_junction(pin2_pos[0], gnd_rail_y)
 

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -2274,6 +2274,43 @@ class TestWireCollisionDetection:
         assert (50, 100) in endpoints
         assert (150, 100) in endpoints
 
+    def test_t_connection_no_warn_with_suppression(self):
+        """Intentional T-connections don't warn when warn_on_collision=False."""
+        import warnings
+
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+
+        # Create a horizontal rail (simulating add_rail)
+        sch.add_wire((0, 100), (200, 100), snap=False, warn_on_collision=False)
+
+        # Create multiple vertical T-connections to the rail with suppression
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            sch.add_wire((50, 50), (50, 100), snap=False, warn_on_collision=False)
+            sch.add_wire((100, 50), (100, 100), snap=False, warn_on_collision=False)
+            sch.add_wire((150, 50), (150, 100), snap=False, warn_on_collision=False)
+
+            collision_warnings = [x for x in w if "lands on existing wire" in str(x.message)]
+            assert len(collision_warnings) == 0
+
+    def test_t_connection_still_warns_without_suppression(self):
+        """T-connections still warn when warn_on_collision is True (default)."""
+        import warnings
+
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+
+        # Create a horizontal rail
+        sch.add_wire((0, 100), (200, 100), snap=False, warn_on_collision=False)
+
+        # Create a vertical T-connection WITHOUT suppression
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            sch.add_wire((50, 50), (50, 100), snap=False, warn_on_collision=True)
+
+            collision_warnings = [x for x in w if "lands on existing wire" in str(x.message)]
+            assert len(collision_warnings) == 1
+            assert "(50, 100)" in str(collision_warnings[0].message)
+
     def test_wire_collision_str(self):
         """WireCollision has a useful string representation."""
         from kicad_tools.schematic.models import Wire, WireCollision


### PR DESCRIPTION
## Summary
Adds `warn_on_collision=False` to all `add_wire()` calls that create intentional T-connections to power/ground rails in board scripts and library block `connect_to_rails()` methods. This eliminates dozens of spurious `UserWarning` messages emitted during board generation while preserving collision detection for genuinely accidental wire intersections.

## Changes
- Board scripts: Added `warn_on_collision=False` to `add_wire()` calls connecting component pins to rails in boards 00, 01, 04, and 05
- `wiring_mixin.py`: Suppressed warnings in `wire_decoupling_cap()` since it always creates intentional rail connections
- `timing.py`: Suppressed warnings in oscillator ground bus wiring and `connect_to_rails()`
- `indicators.py`: Suppressed warnings in LED internal wiring and `connect_to_rails()`
- `motor.py`: Suppressed warnings in half-bridge `connect_to_rails()`, phase output wiring, and current sense `connect_to_rails()`
- `regulators.py`: Suppressed warnings in buck converter `connect_to_rails()` for VIN, VOUT, GND, diode, and feedback connections
- `debug.py`: Suppressed warnings in debug header `connect_to_rails()`
- Added 2 new test cases verifying T-connection suppression behavior and that unsuppressed T-connections still warn

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Zero UserWarning messages on valid T-connections | PASS | Ran all board scripts with `python -W all` and confirmed 0 collision warnings |
| Genuine cross-wire collision warnings NOT suppressed | PASS | `test_t_connection_still_warns_without_suppression` confirms warnings fire when `warn_on_collision=True` |
| All existing TestWireCollisionDetection tests pass | PASS | All 10 original + 2 new tests pass (12 total) |
| Full test suite passes | PASS | 201 passed, 0 failures |

## Test Plan
- Verified each board script (00-05) produces zero false-positive collision warnings
- Added `test_t_connection_no_warn_with_suppression` to verify multiple T-connections with suppression emit no warnings
- Added `test_t_connection_still_warns_without_suppression` as regression guard ensuring genuine collisions still warn
- Full test suite: 201 passed

Closes #1527