### PR TITLE
feat(check): add --output flag to persist DRC reports for export preflight

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -792,6 +792,9 @@ def _run_step_verify(ctx: BuildContext, console: Console) -> BuildResult:
 
     # Run DRC check
     try:
+        # Write DRC report next to the PCB file so kct export preflight can find it
+        drc_report_path = pcb_to_verify.parent / "drc_report.json"
+
         cmd = [
             sys.executable,
             "-m",
@@ -800,6 +803,8 @@ def _run_step_verify(ctx: BuildContext, console: Console) -> BuildResult:
             str(pcb_to_verify),
             "--mfr",
             ctx.mfr,
+            "--output",
+            str(drc_report_path),
         ]
 
         result = subprocess.run(

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -120,6 +120,12 @@ def main(argv: list[str] | None = None) -> int:
         help=f"Skip specific checks (comma-separated: {', '.join(CHECK_CATEGORIES)})",
     )
     parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Write JSON report to file (implies --format json for file output)",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -216,6 +222,12 @@ def main(argv: list[str] | None = None) -> int:
         output_summary(violations, results, pcb_path)
     else:
         output_table(violations, results, pcb_path, args.mfr, layers, args.verbose)
+
+    # Write JSON report to file if --output specified
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        write_json_report(violations, results, pcb_path, args.mfr, layers, output_path)
 
     # Determine exit code
     # Exit 2 = check ran successfully but found issues (errors, or warnings+strict)
@@ -379,6 +391,33 @@ def output_json(
         "violations": [v.to_dict() for v in violations],
     }
     print(json.dumps(data, indent=2))
+
+
+def write_json_report(
+    violations: list[DRCViolation],
+    results: DRCResults,
+    pcb_path: Path,
+    mfr: str,
+    layers: int,
+    output_path: Path,
+) -> None:
+    """Write DRC results as a JSON report file."""
+    error_count = sum(1 for v in violations if v.is_error)
+    warning_count = len(violations) - error_count
+
+    data = {
+        "file": str(pcb_path),
+        "manufacturer": mfr,
+        "layers": layers,
+        "summary": {
+            "errors": error_count,
+            "warnings": warning_count,
+            "rules_checked": results.rules_checked,
+            "passed": error_count == 0,
+        },
+        "violations": [v.to_dict() for v in violations],
+    }
+    output_path.write_text(json.dumps(data, indent=2) + "\n")
 
 
 def output_summary(

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -158,6 +158,79 @@ class TestCheckCommand:
         assert "Pure Python DRC" in captured.out or "kct check" in captured.out
 
 
+class TestCheckOutputFlag:
+    """Tests for the --output flag that writes JSON report to file."""
+
+    def test_output_writes_json_file(self, drc_clean_pcb: Path, tmp_path: Path):
+        """Test that --output writes a valid JSON report file."""
+        from kicad_tools.cli.check_cmd import main
+
+        output_file = tmp_path / "drc_report.json"
+        result = main([str(drc_clean_pcb), "--output", str(output_file)])
+        assert result == 0
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        assert "file" in data
+        assert "summary" in data
+        assert "violations" in data
+        assert data["summary"]["passed"] is True
+
+    def test_output_with_table_format(self, drc_clean_pcb: Path, tmp_path: Path, capsys):
+        """Test that --output writes JSON file even with table format (default)."""
+        from kicad_tools.cli.check_cmd import main
+
+        output_file = tmp_path / "drc_report.json"
+        result = main([str(drc_clean_pcb), "--output", str(output_file)])
+        assert result == 0
+
+        # Table output should still go to stdout
+        captured = capsys.readouterr()
+        assert "PURE PYTHON DRC CHECK" in captured.out
+
+        # JSON file should also be written
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        assert data["summary"]["passed"] is True
+
+    def test_output_creates_parent_directories(self, drc_clean_pcb: Path, tmp_path: Path):
+        """Test that --output creates parent directories if needed."""
+        from kicad_tools.cli.check_cmd import main
+
+        output_file = tmp_path / "subdir" / "nested" / "drc_report.json"
+        result = main([str(drc_clean_pcb), "--output", str(output_file)])
+        assert result == 0
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        assert "summary" in data
+
+    def test_output_without_flag_no_file(self, drc_clean_pcb: Path, tmp_path: Path, capsys):
+        """Test that no file is written when --output is not specified."""
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(drc_clean_pcb)])
+        assert result == 0
+
+        # No drc_report.json should exist in the PCB directory
+        report = drc_clean_pcb.parent / "drc_report.json"
+        assert not report.exists()
+
+    def test_output_with_violations(self, minimal_pcb: Path, tmp_path: Path):
+        """Test that --output captures violations in the report file."""
+        from kicad_tools.cli.check_cmd import main
+
+        output_file = tmp_path / "drc_report.json"
+        result = main([str(minimal_pcb), "--output", str(output_file)])
+        assert result == 2  # Violations found
+
+        assert output_file.exists()
+        data = json.loads(output_file.read_text())
+        assert data["summary"]["passed"] is False
+        assert data["summary"]["errors"] > 0
+        assert len(data["violations"]) > 0
+
+
 class TestCheckCommandIntegration:
     """Integration tests for check command via main CLI."""
 


### PR DESCRIPTION
## Summary

Adds an `--output`/`-o` flag to `kct check` that writes DRC results as a JSON report file. Wires `kct build`'s verify step to use this flag, persisting `drc_report.json` next to the PCB file so that `kct export` preflight can find it.

## Changes

- Added `--output`/`-o` argument to `kct check` CLI command
- Added `write_json_report()` function to write JSON report to file (reuses same schema as `output_json()`)
- Modified `_run_step_verify()` in `build_cmd.py` to pass `--output <pcb_dir>/drc_report.json` when invoking `kct check`
- Added 5 tests for the `--output` flag covering: file creation, table+file dual output, parent directory creation, no-file-without-flag, and violations in report

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct check board.kicad_pcb --output report.json` writes JSON DRC report | PASS | 5 new tests all pass, including `test_output_writes_json_file` and `test_output_with_violations` |
| `kct build` verify step writes `drc_report.json` next to verified PCB | PASS | `_run_step_verify()` now passes `--output <pcb_dir>/drc_report.json` |
| `kct export` preflight no longer warns "No DRC report found" after build | PASS | `preflight.py` already auto-discovers `drc_report.json` next to PCB -- no changes needed |
| Existing `kct check` stdout behavior unchanged without `--output` | PASS | `test_output_without_flag_no_file` confirms no file created; all existing tests pass |
| ERC report persistence | N/A | ERC requires `kicad-cli` and is not part of the verify step; documented as known limitation |

## Test Plan

- All 34 tests in `tests/test_cli_check.py` pass (29 existing + 5 new)
- All 25 tests in `tests/test_build_routing_params.py` pass (existing, no regressions)

Closes #1535