### PR TITLE
fix(boards): accept partial routing in USB joystick route_demo.py

### DIFF
--- a/boards/03-usb-joystick/route_demo.py
+++ b/boards/03-usb-joystick/route_demo.py
@@ -134,7 +134,10 @@ def main():
     )
 
     # Skip power/ground planes (assume these are routed as pours)
-    skip_nets = ["VCC", "GND", "VBUS"]
+    # Skip USB_CC1/USB_CC2 - CC configuration channel nets between USB-C
+    # connector and MCU that cannot be autorouted on 2 layers due to
+    # USB-C connector pad density exceeding 2-layer routing capacity
+    skip_nets = ["VCC", "GND", "VBUS", "USB_CC1", "USB_CC2"]
 
     print("\n--- Loading PCB ---")
     print(f"  Grid resolution: {rules.grid_resolution}mm")
@@ -265,8 +268,10 @@ def main():
         show_routing_summary(router, net_map, total_nets)
     print("=" * 60)
 
-    # Return success only if all nets routed AND DRC passed
-    return 0 if all_nets_routed and drc_passed else 1
+    # Partial routing is acceptable for this board; the USB-C connector
+    # pad density exceeds what a 2-layer autorouter can fully handle.
+    # Match the approach used by generate_design.py: success if DRC passes.
+    return 0 if drc_passed else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
USB joystick `route_demo.py` fails with exit code 1 because the autorouter cannot fully route all nets on a 2-layer board due to USB-C connector pad density. This aligns the exit logic with `generate_design.py`'s existing approach of accepting partial routing.

## Changes
- Changed exit logic in `route_demo.py` to return success when DRC passes, regardless of routing completeness (matching `generate_design.py` pattern)
- Added `USB_CC1` and `USB_CC2` to `skip_nets` since these CC configuration channel nets cannot be autorouted between the dense USB-C connector pads on 2 layers

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `route_demo.py` exits 0 when DRC passes, even with partial routing | PASS | Exit logic changed from `all_nets_routed and drc_passed` to `drc_passed` |
| Routing summary clearly reports routed vs skipped/failed nets | PASS | Existing summary logic preserved -- PARTIAL message and `show_routing_summary()` still display when not all nets routed |
| `generate_design.py` continues to work correctly | PASS | No changes made to `generate_design.py` |
| No changes to autorouter core logic | PASS | Only `route_demo.py` modified |

## Test Plan
- `tests/test_partial_routing_features.py` -- 17/17 tests pass
- Python syntax validation passes
- Change is consistent with the pattern established in commit 8cafd00 which decoupled route_success from exit code in `generate_design.py` files

Closes #1532