### PR TITLE
fix(cli): wire --output flag through main CLI dispatcher for kct check

### DIFF
--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -212,6 +212,8 @@ def run_check_command(args) -> int:
         sub_argv.extend(["--skip", args.skip_checks])
     if args.verbose:
         sub_argv.append("--verbose")
+    if getattr(args, "output", None):
+        sub_argv.extend(["--output", args.output])
     return check_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -397,6 +397,12 @@ def _add_check_parser(subparsers) -> None:
         help="Skip specific checks (comma-separated)",
     )
     check_parser.add_argument("-v", "--verbose", action="store_true")
+    check_parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Write JSON report to file (implies --format json for file output)",
+    )
 
 
 def _add_sch_parser(subparsers) -> None:


### PR DESCRIPTION
## Summary

- Add `--output`/`-o` argument to check subparser in `parser.py`
- Forward `args.output` in `run_check_command()` in `validation.py`

Regression from #1537 — the `--output` flag was only added to `check_cmd.py`'s internal parser, not the main CLI entry point. This broke all `kct build` verify steps (6/6 boards failing).

Closes #1540

## Test plan
- [x] `kct check board.kicad_pcb --output report.json` works via main CLI
- [x] `kct build` completes 5/5 steps (verify step passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)