### PR TITLE
feat(router): apply per-net-class trace widths during segment creation

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -1284,9 +1284,12 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # Configure design rules (from project.kct spec)
     # min_trace: 0.2mm signal, min_space: 0.2mm, min_drill: 0.3mm
     # Grid resolution must be <= clearance/2 for reliable DRC compliance
+    # Issue #1543: Increased trace_width from 0.15mm to 0.2mm for reliable
+    # signal routing on a motor controller board. Power nets get wider traces
+    # (0.5mm+) via the net-class system automatically.
     rules = DesignRules(
         grid_resolution=0.05,
-        trace_width=0.15,
+        trace_width=0.2,
         trace_clearance=0.3,
         via_drill=0.3,
         via_diameter=0.6,

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -432,7 +432,9 @@ class Autorouter:
             grid = RoutingGrid(
                 width, height, self.rules, origin_x, origin_y, layer_stack=self.layer_stack
             )
-        router = create_hybrid_router(grid, self.rules, force_python=self._force_python)
+        router = create_hybrid_router(
+            grid, self.rules, force_python=self._force_python, net_class_map=self.net_class_map
+        )
         zone_manager = ZoneManager(grid, self.rules)
         return grid, router, zone_manager
 
@@ -633,7 +635,7 @@ class Autorouter:
         self, net: int, pads: list[tuple[str, str]]
     ) -> tuple[list[Route], set[int]]:
         """Create direct routes for same-IC pins on the same net."""
-        return create_intra_ic_routes(net, pads, self.pads, self.rules)
+        return create_intra_ic_routes(net, pads, self.pads, self.rules, self.net_class_map)
 
     def _get_unrouted_pads(self, exclude_net: int | None = None) -> list[Pad]:
         """Get list of pads that haven't been routed yet.
@@ -3190,7 +3192,9 @@ class Autorouter:
     def _escape(self) -> EscapeRouter:
         """Lazy-initialize escape router."""
         if self._escape_router is None:
-            self._escape_router = EscapeRouter(self.grid, self.rules)
+            self._escape_router = EscapeRouter(
+                self.grid, self.rules, net_class_map=self.net_class_map
+            )
         return self._escape_router
 
     def detect_dense_packages(self) -> list[PackageInfo]:
@@ -3747,7 +3751,9 @@ class Autorouter:
                     fine_grid.add_pad(pad)
 
         # Create a fine-grid router
-        fine_router = create_hybrid_router(fine_grid, fine_rules, force_python=self._force_python)
+        fine_router = create_hybrid_router(
+            fine_grid, fine_rules, force_python=self._force_python, net_class_map=self.net_class_map
+        )
 
         fine_grid_nets_count = 0
         fine_grid_deadline: float | None = None
@@ -3981,7 +3987,8 @@ class Autorouter:
 
             # Create a relaxed router for these nets
             relaxed_router = create_hybrid_router(
-                self.grid, relaxed_rules, force_python=self._force_python
+                self.grid, relaxed_rules, force_python=self._force_python,
+                net_class_map=self.net_class_map,
             )
 
             # Try to route each failed net with relaxed clearance

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -273,9 +273,13 @@ class CppPathfinder:
         grid: CppGrid,
         rules: DesignRules,
         diagonal_routing: bool = True,
+        net_class_map: dict[str, NetClassRouting] | None = None,
     ):
         if not _CPP_AVAILABLE:
             raise RuntimeError("C++ router backend not available")
+
+        # Net class map for per-net trace width lookup
+        self._net_class_map = net_class_map or {}
 
         # Convert Python rules to C++ DesignRules
         cpp_rules = router_cpp.DesignRules()
@@ -398,6 +402,12 @@ class CppPathfinder:
         # Convert C++ result to Python Route
         route = Route(net=start.net, net_name=start.net_name)
 
+        # Issue #1543: Apply net-class-aware trace width to segments.
+        # The C++ backend uses the global rules.trace_width for all segments,
+        # so we override with the per-net width when converting to Python.
+        net_class = self._net_class_map.get(start.net_name)
+        trace_width = net_class.trace_width if net_class else None
+
         for cpp_seg in result.segments:
             # Convert grid index to Layer enum value
             layer_enum_value = self._grid.index_to_layer(cpp_seg.layer)
@@ -406,7 +416,7 @@ class CppPathfinder:
                 y1=cpp_seg.y1,
                 x2=cpp_seg.x2,
                 y2=cpp_seg.y2,
-                width=cpp_seg.width,
+                width=trace_width if trace_width is not None else cpp_seg.width,
                 layer=Layer(layer_enum_value),
                 net=cpp_seg.net,
                 net_name=start.net_name,
@@ -528,6 +538,7 @@ def create_hybrid_router(
     rules: DesignRules,
     diagonal_routing: bool = True,
     force_python: bool = False,
+    net_class_map: dict[str, NetClassRouting] | None = None,
 ):
     """Create a router, preferring C++ backend if available.
 
@@ -540,6 +551,7 @@ def create_hybrid_router(
         rules: Design rules
         diagonal_routing: Enable 45-degree diagonal routing
         force_python: Force use of Python backend (for testing)
+        net_class_map: Optional net class map for per-net trace widths
 
     Returns:
         Either CppPathfinder or Python Router instance
@@ -547,7 +559,7 @@ def create_hybrid_router(
     if _CPP_AVAILABLE and not force_python:
         try:
             cpp_grid = CppGrid.from_routing_grid(grid)
-            return CppPathfinder(cpp_grid, rules, diagonal_routing)
+            return CppPathfinder(cpp_grid, rules, diagonal_routing, net_class_map=net_class_map)
         except Exception:
             # Fall back to Python if C++ initialization fails
             pass
@@ -555,4 +567,4 @@ def create_hybrid_router(
     # Fall back to Python implementation
     from .pathfinder import Router
 
-    return Router(grid, rules, diagonal_routing=diagonal_routing)
+    return Router(grid, rules, net_class_map=net_class_map, diagonal_routing=diagonal_routing)

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .core import Autorouter
     from .grid import RoutingGrid
-    from .rules import DesignRules
+    from .rules import DesignRules, NetClassRouting
 
 from .diffpair import (
     DifferentialPair,
@@ -116,6 +116,7 @@ class CoupledPathfinder:
         grid: RoutingGrid,
         rules: DesignRules,
         target_spacing_cells: int,
+        net_class_map: dict[str, NetClassRouting] | None = None,
     ):
         """Initialize coupled pathfinder.
 
@@ -123,10 +124,12 @@ class CoupledPathfinder:
             grid: The routing grid
             rules: Design rules for routing
             target_spacing_cells: Target spacing between P/N in grid cells
+            net_class_map: Optional net class map for per-net trace widths
         """
         self.grid = grid
         self.rules = rules
         self.target_spacing_cells = target_spacing_cells
+        self.net_class_map = net_class_map or {}
 
         # Pre-calculate trace clearance radius
         self._trace_half_width_cells = max(
@@ -412,6 +415,19 @@ class CoupledPathfinder:
 
         return p_route, n_route
 
+    def _get_trace_width_for_net(self, net_name: str) -> float:
+        """Get the trace width for a net based on its net class.
+
+        Args:
+            net_name: Name of the net
+
+        Returns:
+            Trace width in mm
+        """
+        if self.net_class_map and net_name in self.net_class_map:
+            return self.net_class_map[net_name].trace_width
+        return self.rules.trace_width
+
     def _build_route_from_path(
         self,
         route: Route,
@@ -423,6 +439,8 @@ class CoupledPathfinder:
         if len(path) < 2:
             return
 
+        # Issue #1543: Use net-class-aware trace width
+        trace_width = self._get_trace_width_for_net(start_pad.net_name)
         current_x, current_y = start_pad.x, start_pad.y
         current_layer_idx = self.grid.layer_to_index(start_pad.layer.value)
 
@@ -451,7 +469,7 @@ class CoupledPathfinder:
                         y1=current_y,
                         x2=wx,
                         y2=wy,
-                        width=self.rules.trace_width,
+                        width=trace_width,
                         layer=Layer(self.grid.index_to_layer(layer_idx)),
                         net=start_pad.net,
                         net_name=start_pad.net_name,
@@ -467,7 +485,7 @@ class CoupledPathfinder:
                 y1=current_y,
                 x2=end_pad.x,
                 y2=end_pad.y,
-                width=self.rules.trace_width,
+                width=trace_width,
                 layer=Layer(self.grid.index_to_layer(current_layer_idx)),
                 net=start_pad.net,
                 net_name=start_pad.net_name,
@@ -777,6 +795,7 @@ class DiffPairRouter:
             self.autorouter.grid,
             self.autorouter.rules,
             spacing_cells,
+            net_class_map=self.autorouter.net_class_map,
         )
 
         routes: list[Route] = []

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .grid import RoutingGrid
-    from .rules import DesignRules
+    from .rules import DesignRules, NetClassRouting
 
 from .layers import Layer
 from .primitives import Pad, Route, Segment, Via
@@ -545,6 +545,7 @@ class EscapeRouter:
         rules: DesignRules,
         via_spacing: float | None = None,
         escape_clearance: float | None = None,
+        net_class_map: dict[str, NetClassRouting] | None = None,
     ):
         """Initialize the escape router.
 
@@ -553,11 +554,26 @@ class EscapeRouter:
             rules: Design rules for dimensions
             via_spacing: Minimum via-to-via spacing (defaults to via_diameter + clearance)
             escape_clearance: Clearance from package edge (defaults to trace_clearance * 2)
+            net_class_map: Optional net class map for per-net trace widths
         """
         self.grid = grid
         self.rules = rules
         self.via_spacing = via_spacing or (rules.via_diameter + rules.via_clearance)
         self.escape_clearance = escape_clearance or (rules.trace_clearance * 2)
+        self.net_class_map = net_class_map or {}
+
+    def _get_trace_width_for_net(self, net_name: str) -> float:
+        """Get the trace width for a net based on its net class.
+
+        Args:
+            net_name: Name of the net
+
+        Returns:
+            Trace width in mm
+        """
+        if self.net_class_map and net_name in self.net_class_map:
+            return self.net_class_map[net_name].trace_width
+        return self.rules.trace_width
 
     def analyze_package(self, pads: list[Pad]) -> PackageInfo:
         """Analyze a package to determine escape routing needs.
@@ -758,7 +774,7 @@ class EscapeRouter:
                     y1=pad.y,
                     x2=via_x,
                     y2=via_y,
-                    width=self.rules.trace_width,
+                    width=self._get_trace_width_for_net(pad.net_name),
                     layer=pad.layer,
                     net=pad.net,
                     net_name=pad.net_name,
@@ -783,7 +799,7 @@ class EscapeRouter:
                     y1=via_y,
                     x2=escape_x,
                     y2=escape_y,
-                    width=self.rules.trace_width,
+                    width=self._get_trace_width_for_net(pad.net_name),
                     layer=escape_layer,
                     net=pad.net,
                     net_name=pad.net_name,
@@ -797,7 +813,7 @@ class EscapeRouter:
                     y1=pad.y,
                     x2=escape_x,
                     y2=escape_y,
-                    width=self.rules.trace_width,
+                    width=self._get_trace_width_for_net(pad.net_name),
                     layer=pad.layer,
                     net=pad.net,
                     net_name=pad.net_name,
@@ -912,7 +928,7 @@ class EscapeRouter:
             y1=pad.y,
             x2=escape_x,
             y2=escape_y,
-            width=self.rules.trace_width,
+            width=self._get_trace_width_for_net(pad.net_name),
             layer=pad.layer,
             net=pad.net,
             net_name=pad.net_name,
@@ -1088,7 +1104,7 @@ class EscapeRouter:
                         y1=pad.y,
                         x2=via_x,
                         y2=via_y,
-                        width=self.rules.trace_width,
+                        width=self._get_trace_width_for_net(pad.net_name),
                         layer=pad.layer,
                         net=pad.net,
                         net_name=pad.net_name,
@@ -1113,7 +1129,7 @@ class EscapeRouter:
                         y1=via_y,
                         x2=escape_x,
                         y2=escape_y,
-                        width=self.rules.trace_width,
+                        width=self._get_trace_width_for_net(pad.net_name),
                         layer=escape_layer,
                         net=pad.net,
                         net_name=pad.net_name,
@@ -1145,7 +1161,7 @@ class EscapeRouter:
                     y1=pad.y,
                     x2=escape_x,
                     y2=escape_y,
-                    width=self.rules.trace_width,
+                    width=self._get_trace_width_for_net(pad.net_name),
                     layer=pad.layer,
                     net=pad.net,
                     net_name=pad.net_name,
@@ -1315,7 +1331,7 @@ class EscapeRouter:
                     y1=pad.y,
                     x2=via_x,
                     y2=via_y,
-                    width=self.rules.trace_width,
+                    width=self._get_trace_width_for_net(pad.net_name),
                     layer=pad.layer,
                     net=pad.net,
                     net_name=pad.net_name,
@@ -1340,7 +1356,7 @@ class EscapeRouter:
                     y1=via_y,
                     x2=escape_x,
                     y2=escape_y,
-                    width=self.rules.trace_width,
+                    width=self._get_trace_width_for_net(pad.net_name),
                     layer=escape_layer,
                     net=pad.net,
                     net_name=pad.net_name,
@@ -1389,7 +1405,7 @@ class EscapeRouter:
                 y1=pad.y,
                 x2=escape_x,
                 y2=escape_y,
-                width=self.rules.trace_width,
+                width=self._get_trace_width_for_net(pad.net_name),
                 layer=pad.layer,
                 net=pad.net,
                 net_name=pad.net_name,

--- a/src/kicad_tools/router/orchestrator.py
+++ b/src/kicad_tools/router/orchestrator.py
@@ -560,7 +560,7 @@ class RoutingOrchestrator:
         if self._escape is None:
             grid = getattr(self.pcb, "grid", None)
             if grid is not None:
-                self._escape = EscapeRouter(grid=grid, rules=self.rules)
+                self._escape = EscapeRouter(grid=grid, rules=self.rules, net_class_map=self.net_class_map)
 
         if self._escape is not None:
             package_info = self._escape.analyze_package(pads)
@@ -1175,7 +1175,7 @@ class RoutingOrchestrator:
         if self._escape is None:
             grid = getattr(self.pcb, "grid", None)
             if grid is not None:
-                self._escape = EscapeRouter(grid=grid, rules=self.rules)
+                self._escape = EscapeRouter(grid=grid, rules=self.rules, net_class_map=self.net_class_map)
         return self._escape
 
     @property

--- a/src/kicad_tools/router/path.py
+++ b/src/kicad_tools/router/path.py
@@ -13,8 +13,29 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .primitives import Pad, Route
+    from .rules import NetClassRouting
 
 from .primitives import Route, Segment
+
+
+def _get_trace_width_for_net(
+    net_name: str,
+    rules,
+    net_class_map: dict[str, NetClassRouting] | None = None,
+) -> float:
+    """Get the trace width for a net based on its net class.
+
+    Args:
+        net_name: Name of the net
+        rules: Design rules with trace_width default
+        net_class_map: Optional mapping of net names to NetClassRouting
+
+    Returns:
+        Trace width in mm
+    """
+    if net_class_map and net_name in net_class_map:
+        return net_class_map[net_name].trace_width
+    return rules.trace_width
 
 
 def create_intra_ic_routes(
@@ -22,6 +43,7 @@ def create_intra_ic_routes(
     pads: list[tuple[str, str]],
     pad_lookup: dict[tuple[str, str], Pad],
     rules,
+    net_class_map: dict[str, NetClassRouting] | None = None,
 ) -> tuple[list[Route], set[int]]:
     """Create direct routes for same-IC pins on the same net.
 
@@ -34,6 +56,7 @@ def create_intra_ic_routes(
         pads: List of (ref, pin) tuples for this net
         pad_lookup: Dictionary mapping (ref, pin) to Pad objects
         rules: Design rules with trace_width
+        net_class_map: Optional net class map for per-net trace widths
 
     Returns:
         Tuple of (routes created, set of pad indices that were connected)
@@ -74,13 +97,15 @@ def create_intra_ic_routes(
                 continue  # Too far apart, let normal router handle it
 
             # Create route with single segment
+            # Issue #1543: Use net-class-aware trace width
+            trace_width = _get_trace_width_for_net(net_name, rules, net_class_map)
             route = Route(net=net, net_name=net_name)
             seg = Segment(
                 x1=pad1.x,
                 y1=pad1.y,
                 x2=pad2.x,
                 y2=pad2.y,
-                width=rules.trace_width,
+                width=trace_width,
                 layer=pad1.layer,  # Use pad layer (typically F.Cu for SMD)
                 net=net,
                 net_name=net_name,

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -470,6 +470,24 @@ class Router:
         """Get the net class for a net name."""
         return self.net_class_map.get(net_name)
 
+    def _get_trace_width_for_net(self, net_name: str) -> float:
+        """Get the trace width for a net based on its net class.
+
+        Looks up the net's class in the net_class_map and returns the
+        class-specific trace width. Falls back to rules.trace_width if
+        the net has no class mapping.
+
+        Args:
+            net_name: Name of the net
+
+        Returns:
+            Trace width in mm
+        """
+        net_class = self._get_net_class(net_name)
+        if net_class is not None:
+            return net_class.trace_width
+        return self.rules.trace_width
+
     def _get_pad_metal_bounds(self, pad: Pad) -> tuple[int, int, int, int]:
         """Calculate the grid coordinate bounds of a pad's metal area.
 
@@ -1567,6 +1585,11 @@ class Router:
         start_needs_neckdown = self.rules.should_apply_neck_down(start_pad.ref, start_pitch)
         end_needs_neckdown = self.rules.should_apply_neck_down(end_pad.ref, end_pitch)
 
+        # Issue #1543: Use net-class-aware trace width as the base width.
+        # Look up the net class for this net and use its trace_width if defined,
+        # falling back to the global rules.trace_width for unclassified nets.
+        base_trace_width = self._get_trace_width_for_net(start_pad.net_name)
+
         def _normalize_direction(dx: float, dy: float) -> tuple[float, float] | None:
             """Normalize direction vector, return None if no movement."""
             length = (dx * dx + dy * dy) ** 0.5
@@ -1586,19 +1609,22 @@ class Router:
             return math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
 
         def _calculate_segment_width(x1: float, y1: float, x2: float, y2: float) -> float:
-            """Calculate trace width for a segment based on distance to pads.
+            """Calculate trace width for a segment based on net class and distance to pads.
+
+            Issue #1543: Uses net-class-aware base width (e.g., POWER=0.5mm)
+            instead of the global rules.trace_width.
 
             Issue #1018: For segments near fine-pitch pads, the width tapers
-            from normal trace width to minimum trace width. The width is
+            from the base trace width to minimum trace width. The width is
             determined by the minimum distance from the segment endpoints
             to either pad that needs neck-down.
             """
-            # If no neck-down needed at either end, use normal width
+            # If no neck-down needed at either end, use net-class base width
             if not start_needs_neckdown and not end_needs_neckdown:
-                return self.rules.trace_width
+                return base_trace_width
 
             # Calculate distances from segment endpoints to pads
-            min_width = self.rules.trace_width
+            min_width = base_trace_width
 
             # Check start pad influence
             if start_needs_neckdown:

--- a/src/kicad_tools/router/sparse.py
+++ b/src/kicad_tools/router/sparse.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 from .layers import Layer
 from .primitives import Route, Segment, Via
-from .rules import DesignRules
+from .rules import DesignRules, NetClassRouting
 
 
 @dataclass
@@ -205,6 +205,7 @@ class SparseRoutingGraph:
         num_layers: int = 2,
         contour_samples: int = 8,
         sparse_grid_spacing: float = 2.0,
+        net_class_map: dict[str, NetClassRouting] | None = None,
     ):
         """Initialize sparse routing graph.
 
@@ -215,6 +216,7 @@ class SparseRoutingGraph:
             num_layers: Number of routing layers
             contour_samples: Number of waypoints per obstacle contour (8 = octagon)
             sparse_grid_spacing: Spacing for sparse interior grid points (mm)
+            net_class_map: Optional net class map for per-net trace widths
         """
         self.width = width
         self.height = height
@@ -224,6 +226,7 @@ class SparseRoutingGraph:
         self.num_layers = num_layers
         self.contour_samples = contour_samples
         self.sparse_grid_spacing = sparse_grid_spacing
+        self.net_class_map = net_class_map or {}
 
         # Clearance buffer: distance from obstacle edge to valid routing
         self.clearance_buffer = rules.trace_clearance + rules.trace_width / 2
@@ -436,6 +439,19 @@ class SparseRoutingGraph:
 
         return True
 
+    def _get_trace_width_for_net(self, net_name: str) -> float:
+        """Get the trace width for a net based on its net class.
+
+        Args:
+            net_name: Name of the net
+
+        Returns:
+            Trace width in mm
+        """
+        if self.net_class_map and net_name in self.net_class_map:
+            return self.net_class_map[net_name].trace_width
+        return self.rules.trace_width
+
     def route(
         self,
         start_pad: Pad,
@@ -597,6 +613,8 @@ class SparseRoutingGraph:
             return route
 
         # Convert to segments and vias
+        # Issue #1543: Use net-class-aware trace width
+        trace_width = self._get_trace_width_for_net(start_pad.net_name)
         current_x, current_y = start_pad.x, start_pad.y
         current_layer = path[0][0].layer
 
@@ -622,7 +640,7 @@ class SparseRoutingGraph:
                         y1=current_y,
                         x2=wp.x,
                         y2=wp.y,
-                        width=self.rules.trace_width,
+                        width=trace_width,
                         layer=Layer(current_layer),
                         net=start_pad.net,
                         net_name=start_pad.net_name,
@@ -637,7 +655,7 @@ class SparseRoutingGraph:
                 y1=current_y,
                 x2=end_pad.x,
                 y2=end_pad.y,
-                width=self.rules.trace_width,
+                width=trace_width,
                 layer=Layer(current_layer),
                 net=start_pad.net,
                 net_name=start_pad.net_name,
@@ -884,6 +902,7 @@ class SparseRouter:
         origin_x: float = 0,
         origin_y: float = 0,
         num_layers: int = 2,
+        net_class_map: dict[str, NetClassRouting] | None = None,
     ):
         """Initialize sparse router.
 
@@ -892,6 +911,7 @@ class SparseRouter:
             rules: Design rules
             origin_x, origin_y: Board origin
             num_layers: Number of copper layers
+            net_class_map: Optional net class map for per-net trace widths
         """
         self.graph = SparseRoutingGraph(
             width=width,
@@ -902,6 +922,7 @@ class SparseRouter:
             num_layers=num_layers,
             contour_samples=8,  # Octagonal contours
             sparse_grid_spacing=max(2.0, rules.trace_clearance * 10),
+            net_class_map=net_class_map,
         )
         self.rules = rules
         self.pads: dict[str, Pad] = {}

--- a/tests/test_net_class_trace_width.py
+++ b/tests/test_net_class_trace_width.py
@@ -1,0 +1,185 @@
+"""Tests for net-class-aware trace widths in segment creation.
+
+Issue #1543: Verifies that the autorouter uses per-net-class trace widths
+when creating segments, rather than always using the global rules.trace_width.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.path import _get_trace_width_for_net, create_intra_ic_routes
+from kicad_tools.router.pathfinder import Router
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import (
+    NET_CLASS_DIGITAL,
+    NET_CLASS_POWER,
+    DesignRules,
+    NetClassRouting,
+)
+
+
+class TestGetTraceWidthForNet:
+    """Test the helper function for net-class trace width lookup."""
+
+    def test_power_net_gets_wide_trace(self):
+        rules = DesignRules(trace_width=0.2)
+        net_class_map = {"+5V": NET_CLASS_POWER}
+        width = _get_trace_width_for_net("+5V", rules, net_class_map)
+        assert width == NET_CLASS_POWER.trace_width
+        assert width == 0.5
+
+    def test_digital_net_gets_standard_trace(self):
+        rules = DesignRules(trace_width=0.2)
+        net_class_map = {"SIG1": NET_CLASS_DIGITAL}
+        width = _get_trace_width_for_net("SIG1", rules, net_class_map)
+        assert width == NET_CLASS_DIGITAL.trace_width
+        assert width == 0.2
+
+    def test_unknown_net_falls_back_to_rules(self):
+        rules = DesignRules(trace_width=0.15)
+        net_class_map = {"+5V": NET_CLASS_POWER}
+        width = _get_trace_width_for_net("UNKNOWN_NET", rules, net_class_map)
+        assert width == 0.15
+
+    def test_none_net_class_map_falls_back(self):
+        rules = DesignRules(trace_width=0.25)
+        width = _get_trace_width_for_net("ANY_NET", rules, None)
+        assert width == 0.25
+
+    def test_empty_net_class_map_falls_back(self):
+        rules = DesignRules(trace_width=0.18)
+        width = _get_trace_width_for_net("ANY_NET", rules, {})
+        assert width == 0.18
+
+
+class TestRouterNetClassWidth:
+    """Test that Router._get_trace_width_for_net uses the net class map."""
+
+    def test_router_uses_net_class_width(self):
+        rules = DesignRules(trace_width=0.2)
+        net_class_map = {"+5V": NET_CLASS_POWER, "GND": NET_CLASS_POWER}
+        grid = RoutingGrid(10, 10, rules)
+        router = Router(grid, rules, net_class_map=net_class_map)
+
+        assert router._get_trace_width_for_net("+5V") == 0.5
+        assert router._get_trace_width_for_net("GND") == 0.5
+        assert router._get_trace_width_for_net("SIG1") == 0.2  # fallback
+
+    def test_router_routes_with_net_class_width(self):
+        """Integration test: route a power net and verify segment widths."""
+        rules = DesignRules(trace_width=0.2, grid_resolution=0.5)
+        net_class_map = {"+5V": NET_CLASS_POWER}
+        grid = RoutingGrid(20, 20, rules)
+        router = Router(grid, rules, net_class_map=net_class_map)
+
+        # Create two pads on the +5V net
+        pad1 = Pad(
+            ref="C1", pin="1", x=2.0, y=5.0, width=1.0, height=1.0,
+            layer=Layer.F_CU, net=1, net_name="+5V",
+        )
+        pad2 = Pad(
+            ref="C2", pin="1", x=8.0, y=5.0, width=1.0, height=1.0,
+            layer=Layer.F_CU, net=1, net_name="+5V",
+        )
+
+        grid.add_pad(pad1)
+        grid.add_pad(pad2)
+
+        route = router.route(pad1, pad2)
+        assert route is not None, "Routing should succeed"
+        assert len(route.segments) > 0, "Route should have segments"
+
+        # All segments should use the POWER net class width (0.5mm),
+        # not the default rules width (0.2mm)
+        for seg in route.segments:
+            assert seg.width == 0.5, (
+                f"Segment width should be 0.5mm (POWER class), got {seg.width}mm"
+            )
+
+    def test_router_signal_net_uses_default_width(self):
+        """Verify that signal nets (not in net_class_map) use rules.trace_width."""
+        rules = DesignRules(trace_width=0.2, grid_resolution=0.5)
+        net_class_map = {"+5V": NET_CLASS_POWER}
+        grid = RoutingGrid(20, 20, rules)
+        router = Router(grid, rules, net_class_map=net_class_map)
+
+        # Create two pads on a signal net (not in net_class_map)
+        pad1 = Pad(
+            ref="U1", pin="1", x=2.0, y=5.0, width=1.0, height=1.0,
+            layer=Layer.F_CU, net=2, net_name="DATA",
+        )
+        pad2 = Pad(
+            ref="U2", pin="1", x=8.0, y=5.0, width=1.0, height=1.0,
+            layer=Layer.F_CU, net=2, net_name="DATA",
+        )
+
+        grid.add_pad(pad1)
+        grid.add_pad(pad2)
+
+        route = router.route(pad1, pad2)
+        assert route is not None, "Routing should succeed"
+        assert len(route.segments) > 0, "Route should have segments"
+
+        # All segments should use the default trace width (0.2mm)
+        for seg in route.segments:
+            assert seg.width == 0.2, (
+                f"Segment width should be 0.2mm (default), got {seg.width}mm"
+            )
+
+
+class TestIntraIcNetClassWidth:
+    """Test that intra-IC routes use net-class-aware trace widths."""
+
+    def test_intra_ic_uses_net_class_width(self):
+        """Intra-IC routes for power nets should use the power trace width."""
+        rules = DesignRules(trace_width=0.2)
+        net_class_map = {"+5V": NET_CLASS_POWER}
+
+        # Create two pads on the same IC, same power net
+        pad1 = Pad(
+            ref="U1", pin="1", x=1.0, y=1.0, width=0.5, height=0.5,
+            layer=Layer.F_CU, net=1, net_name="+5V",
+        )
+        pad2 = Pad(
+            ref="U1", pin="2", x=1.5, y=1.0, width=0.5, height=0.5,
+            layer=Layer.F_CU, net=1, net_name="+5V",
+        )
+
+        pad_lookup = {("U1", "1"): pad1, ("U1", "2"): pad2}
+        pads = [("U1", "1"), ("U1", "2")]
+
+        routes, connected = create_intra_ic_routes(
+            net=1, pads=pads, pad_lookup=pad_lookup, rules=rules,
+            net_class_map=net_class_map,
+        )
+
+        assert len(routes) == 1
+        assert routes[0].segments[0].width == 0.5  # POWER class width
+
+    def test_intra_ic_signal_uses_default_width(self):
+        """Intra-IC routes for signal nets should use default width."""
+        rules = DesignRules(trace_width=0.2)
+        net_class_map = {"+5V": NET_CLASS_POWER}
+
+        pad1 = Pad(
+            ref="U1", pin="3", x=1.0, y=2.0, width=0.5, height=0.5,
+            layer=Layer.F_CU, net=2, net_name="SIG",
+        )
+        pad2 = Pad(
+            ref="U1", pin="4", x=1.5, y=2.0, width=0.5, height=0.5,
+            layer=Layer.F_CU, net=2, net_name="SIG",
+        )
+
+        pad_lookup = {("U1", "3"): pad1, ("U1", "4"): pad2}
+        pads = [("U1", "3"), ("U1", "4")]
+
+        routes, connected = create_intra_ic_routes(
+            net=2, pads=pads, pad_lookup=pad_lookup, rules=rules,
+            net_class_map=net_class_map,
+        )
+
+        assert len(routes) == 1
+        assert routes[0].segments[0].width == 0.2  # default width


### PR DESCRIPTION
## Summary

Bridge the gap between the existing net-class classification system and actual segment creation. Previously, all segment-creation code used the global `rules.trace_width` regardless of net class (e.g., POWER nets got the same 0.15mm traces as signals). Now each routing path looks up the net's class and uses its `NetClassRouting.trace_width` when creating Segments.

## Changes

- **pathfinder.py**: Added `_get_trace_width_for_net()` helper; updated `_calculate_segment_width()` to use net-class base width instead of `self.rules.trace_width`
- **path.py**: Added `_get_trace_width_for_net()` helper; `create_intra_ic_routes()` now accepts and uses `net_class_map` parameter
- **escape.py**: Added `net_class_map` parameter to `EscapeRouter`; all 10 segment-creation sites now use `_get_trace_width_for_net(pad.net_name)`
- **sparse.py**: Added `net_class_map` to both `SparseRoutingGraph` and `SparseRouter`; segment creation uses per-net width
- **diffpair_routing.py**: Added `net_class_map` to `CoupledPathfinder`; `_build_route_from_path()` uses per-net width
- **cpp_backend.py**: Added `net_class_map` to `CppPathfinder` and `create_hybrid_router()`; overrides C++ segment widths with net-class width during Python conversion
- **core.py**: Passes `net_class_map` through to all sub-routers (escape, hybrid router creation, intra-IC routing)
- **orchestrator.py**: Passes `net_class_map` to `EscapeRouter` instantiation
- **design.py** (Board 05): Increased default `trace_width` from 0.15mm to 0.2mm for signal nets

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Autorouter applies per-net-class trace widths when creating segments | PASS | New test `test_router_routes_with_net_class_width` verifies POWER nets get 0.5mm segments |
| Board 05 design.py uses at least 0.2mm default trace_width | PASS | Changed from 0.15 to 0.2 in design.py line 1289 |
| NetClassRouting.trace_width is respected during segment creation | PASS | All 6 segment-creation modules updated with net-class lookup |
| Gate driver nets routed with at least 0.2mm traces | PASS | Default trace_width is now 0.2mm; classified nets get their class width |
| Existing board builds continue without regression | PASS | 794 router tests pass, 234 core router tests pass |

## Test Plan

- Added `tests/test_net_class_trace_width.py` with 10 tests covering:
  - Helper function `_get_trace_width_for_net` (5 tests: power, digital, unknown, None map, empty map)
  - Router integration (3 tests: net class lookup, power net routing with 0.5mm segments, signal net fallback to 0.2mm)
  - Intra-IC routing (2 tests: power net uses class width, signal uses default)
- All 10 new tests pass
- All 794 existing router-related tests pass (0 regressions)

Closes #1543