### PR TITLE
feat(export): accept directory paths with PCB auto-discovery

### DIFF
--- a/src/kicad_tools/cli/export_cmd.py
+++ b/src/kicad_tools/cli/export_cmd.py
@@ -14,6 +14,35 @@ import sys
 from pathlib import Path
 
 
+def _find_pcb_for_export(directory: Path) -> Path | None:
+    """Find a .kicad_pcb file in the given directory for export.
+
+    Searches recursively and prefers routed files (*_routed.kicad_pcb)
+    since those are the manufacturing-ready artifacts. Falls back to the
+    primary (non-backup) PCB file if no routed version exists.
+
+    Args:
+        directory: Directory to search
+
+    Returns:
+        Path to PCB file if found, None otherwise
+    """
+    pcb_files = list(directory.glob("**/*.kicad_pcb"))
+    # Filter out backup files
+    pcb_files = [f for f in pcb_files if not f.name.endswith("-bak.kicad_pcb")]
+
+    if not pcb_files:
+        return None
+
+    # Prefer routed files (manufacturing-ready)
+    routed = [f for f in pcb_files if f.name.endswith("_routed.kicad_pcb")]
+    if routed:
+        return routed[0]
+
+    # Fall back to non-routed PCB files
+    return pcb_files[0]
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the kct export command."""
     parser = argparse.ArgumentParser(
@@ -22,7 +51,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "pcb",
-        help="Path to .kicad_pcb file",
+        help="Path to .kicad_pcb file or directory containing one",
     )
     parser.add_argument(
         "--mfr",
@@ -145,10 +174,31 @@ def run_export(args: argparse.Namespace) -> int:
     )
     from kicad_tools.export.preflight import PreflightConfig
 
-    pcb_path = Path(args.pcb)
-    if not pcb_path.exists():
-        print(f"Error: PCB file not found: {pcb_path}", file=sys.stderr)
+    input_path = Path(args.pcb).resolve()
+
+    if not input_path.exists():
+        print(f"Error: Path not found: {input_path}", file=sys.stderr)
         return 1
+
+    if input_path.is_dir():
+        # Auto-discover PCB file in directory (consistent with kct build/check)
+        pcb_path = _find_pcb_for_export(input_path)
+        if pcb_path is None:
+            print(
+                f"Error: No .kicad_pcb file found in directory: {input_path}",
+                file=sys.stderr,
+            )
+            print(
+                "Hint: Specify a .kicad_pcb file directly, or ensure the directory contains one.",
+                file=sys.stderr,
+            )
+            return 1
+    elif input_path.suffix != ".kicad_pcb":
+        print(f"Error: Expected .kicad_pcb file, got: {input_path.name}", file=sys.stderr)
+        print("Hint: Provide a .kicad_pcb file or a directory containing one.", file=sys.stderr)
+        return 1
+    else:
+        pcb_path = input_path
 
     # Determine output directory
     output_dir = Path(args.output) if args.output else pcb_path.parent / "manufacturing"

--- a/tests/test_export_cmd.py
+++ b/tests/test_export_cmd.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from kicad_tools.cli.export_cmd import main as export_main
+from kicad_tools.cli.export_cmd import _find_pcb_for_export, main as export_main
 
 
 class TestExportCmdParsing:
@@ -422,4 +422,125 @@ class TestExportCmdIncludeTHT:
         )
         assert rc == 0
         assert captured_config["pnp_config"] is None
+
+
+class TestFindPcbForExport:
+    """Tests for the _find_pcb_for_export helper function."""
+
+    def test_prefers_routed_file(self, tmp_path):
+        """When both routed and unrouted PCB files exist, prefer the routed one."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        unrouted = tmp_path / "board.kicad_pcb"
+        unrouted.write_text("(kicad_pcb)")
+        routed = output_dir / "board_routed.kicad_pcb"
+        routed.write_text("(kicad_pcb)")
+
+        result = _find_pcb_for_export(tmp_path)
+        assert result == routed
+
+    def test_falls_back_to_unrouted(self, tmp_path):
+        """When only an unrouted PCB file exists, use it."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        result = _find_pcb_for_export(tmp_path)
+        assert result == pcb
+
+    def test_returns_none_for_empty_directory(self, tmp_path):
+        """Empty directory should return None."""
+        result = _find_pcb_for_export(tmp_path)
+        assert result is None
+
+    def test_ignores_backup_files(self, tmp_path):
+        """Backup files (*-bak.kicad_pcb) should be excluded."""
+        bak = tmp_path / "board-bak.kicad_pcb"
+        bak.write_text("(kicad_pcb)")
+
+        result = _find_pcb_for_export(tmp_path)
+        assert result is None
+
+    def test_only_backup_files_returns_none(self, tmp_path):
+        """Directory with only backup files should return None."""
+        (tmp_path / "board-bak.kicad_pcb").write_text("(kicad_pcb)")
+        (tmp_path / "other-bak.kicad_pcb").write_text("(kicad_pcb)")
+
+        result = _find_pcb_for_export(tmp_path)
+        assert result is None
+
+    def test_searches_subdirectories(self, tmp_path):
+        """Should find PCB files in nested subdirectories."""
+        sub = tmp_path / "output"
+        sub.mkdir()
+        pcb = sub / "board_routed.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        result = _find_pcb_for_export(tmp_path)
+        assert result == pcb
+
+
+class TestExportCmdDirectoryInput:
+    """Tests for directory path input to kct export."""
+
+    def test_directory_with_routed_pcb_dry_run(self, tmp_path):
+        """Directory containing a routed PCB should work with --dry-run."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        routed = output_dir / "board_routed.kicad_pcb"
+        routed.write_text("(kicad_pcb)")
+
+        rc = export_main([str(tmp_path), "--dry-run", "-o", str(tmp_path / "mfg")])
+        assert rc == 0
+
+    def test_directory_with_only_unrouted_pcb_dry_run(self, tmp_path):
+        """Directory with only unrouted PCB should work."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        rc = export_main([str(tmp_path), "--dry-run", "-o", str(tmp_path / "mfg")])
+        assert rc == 0
+
+    def test_directory_with_no_pcb_returns_error(self, tmp_path, capsys):
+        """Empty directory should return exit code 1 with helpful message."""
+        rc = export_main([str(tmp_path)])
+        assert rc == 1
+
+        captured = capsys.readouterr()
+        assert "No .kicad_pcb file found" in captured.err
+        assert "Hint:" in captured.err
+
+    def test_explicit_pcb_path_still_works(self, tmp_path):
+        """Direct file path should behave as before (regression check)."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        rc = export_main([str(pcb), "--dry-run", "-o", str(tmp_path / "mfg")])
+        assert rc == 0
+
+    def test_wrong_file_extension_returns_error(self, tmp_path, capsys):
+        """Non-.kicad_pcb file should return exit code 1."""
+        wrong = tmp_path / "board.txt"
+        wrong.write_text("not a pcb")
+
+        rc = export_main([str(wrong)])
+        assert rc == 1
+
+        captured = capsys.readouterr()
+        assert "Expected .kicad_pcb file" in captured.err
+
+    def test_directory_prefers_routed_over_unrouted(self, tmp_path, capsys):
+        """When both routed and unrouted exist, routed is selected for export."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        (tmp_path / "board.kicad_pcb").write_text("(kicad_pcb)")
+        routed = output_dir / "board_routed.kicad_pcb"
+        routed.write_text("(kicad_pcb)")
+
+        rc = export_main([str(tmp_path), "--dry-run", "-o", str(tmp_path / "mfg")])
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        # The dry-run output should reference the output directory,
+        # confirming we got past the directory resolution step
+        assert "Dry run" in captured.out
 


### PR DESCRIPTION
## Summary
Makes `kct export` accept directory paths (like `kct build` and `kct check` already do), auto-discovering PCB files within the directory. Routed files (`*_routed.kicad_pcb`) are preferred since they are the manufacturing-ready artifacts.

## Changes
- Add `_find_pcb_for_export()` helper in `export_cmd.py` that searches directories recursively, prefers routed PCB files, excludes backup files
- Add directory-to-file resolution in `run_export()` with clear error messages for missing/wrong files
- Update help text for the `pcb` argument to indicate directories are accepted
- Add 12 new tests covering the helper function and CLI directory input behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct export boards/00-simple-led --mfr jlcpcb --dry-run` succeeds | Pass | Directory input resolves to PCB file via dry-run test |
| Routed version selected when both exist | Pass | `test_prefers_routed_file` and `test_directory_prefers_routed_over_unrouted` |
| Unrouted fallback when no routed version | Pass | `test_falls_back_to_unrouted` and `test_directory_with_only_unrouted_pcb_dry_run` |
| Clear error when no PCB in directory | Pass | `test_directory_with_no_pcb_returns_error` |
| Help text updated | Pass | Argument help reads "Path to .kicad_pcb file or directory containing one" |
| Explicit file paths still work | Pass | `test_explicit_pcb_path_still_works` and all pre-existing tests pass |
| Consistent with kct build/check | Pass | Same pattern as `check_cmd._find_pcb_file()` with inverted routed preference |

## Test Plan
All 32 tests pass (20 pre-existing + 12 new).

Closes #1548