### PR TITLE
fix(drc): parse kct-check JSON format in DRC report reader

### DIFF
--- a/src/kicad_tools/drc/report.py
+++ b/src/kicad_tools/drc/report.py
@@ -240,12 +240,104 @@ def parse_text_report(content: str, source_file: str = "") -> DRCReport:
 
 
 def parse_json_report(content: str, source_file: str = "") -> DRCReport:
-    """Parse KiCad JSON-format DRC report.
+    """Parse JSON-format DRC report (KiCad-cli or kct-check format).
 
-    KiCad 8+ can output DRC reports in JSON format with --format json.
+    Supports two JSON schemas:
+    - KiCad-cli format: has "source", "date", violations with "type"/"description"
+      and dict items with "description"/"pos"/"net" keys.
+    - kct-check format: has "summary", "manufacturer", violations with "rule_id"/
+      "message" and string items (e.g., ["Pad 1", "Pad 2"]).
     """
     data = json.loads(content)
 
+    # Detect kct-check format by presence of "summary" or "manufacturer" keys
+    if "summary" in data or "manufacturer" in data:
+        return _parse_kct_check_json(data, source_file)
+
+    return _parse_kicad_cli_json(data, source_file)
+
+
+def _parse_kct_check_json(data: dict, source_file: str = "") -> DRCReport:
+    """Parse kct-check JSON format written by ``kct check --output``.
+
+    Expected schema::
+
+        {
+            "file": "/path/to/board.kicad_pcb",
+            "manufacturer": "jlcpcb",
+            "layers": 2,
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 4, "passed": true},
+            "violations": [
+                {
+                    "rule_id": "clearance_pad_pad",
+                    "severity": "warning",
+                    "message": "...",
+                    "location": [x, y],
+                    "layer": "F.Cu",
+                    "actual_value": 0.15,
+                    "required_value": 0.2,
+                    "items": ["Pad 1", "Pad 2"]
+                }
+            ]
+        }
+    """
+    pcb_name = data.get("file", "")
+
+    violations: list[DRCViolation] = []
+
+    for item in data.get("violations", []):
+        type_str = item.get("rule_id", "unknown")
+        message = item.get("message", "")
+        severity = Severity.from_string(item.get("severity", "error"))
+
+        locations: list[Location] = []
+
+        # Parse location from [x, y] tuple
+        loc = item.get("location")
+        if loc and isinstance(loc, (list, tuple)) and len(loc) >= 2:
+            layer = item.get("layer", "")
+            locations.append(Location(x_mm=loc[0], y_mm=loc[1], layer=layer))
+
+        # Items are plain strings in kct-check format
+        raw_items = item.get("items", [])
+        items = [str(i) for i in raw_items]
+
+        raw_type = ViolationType.from_string(type_str)
+        refined_type = _infer_segment_via_type(raw_type, items)
+
+        violation = DRCViolation(
+            type=refined_type,
+            type_str=type_str,
+            severity=severity,
+            message=message,
+            rule=type_str,
+            locations=locations,
+            items=items,
+            nets=[],
+            required_value_mm=item.get("required_value"),
+            actual_value_mm=item.get("actual_value"),
+        )
+        _extract_values(violation.__dict__, message)
+        # Generate fix suggestions
+        from kicad_tools.feedback import generate_drc_suggestions
+
+        violation.suggestions = generate_drc_suggestions(violation)
+        violations.append(violation)
+
+    return DRCReport(
+        source_file=source_file,
+        created_at=None,
+        pcb_name=pcb_name,
+        violations=violations,
+        footprint_errors=0,
+    )
+
+
+def _parse_kicad_cli_json(data: dict, source_file: str = "") -> DRCReport:
+    """Parse KiCad-cli JSON-format DRC report.
+
+    KiCad 8+ can output DRC reports in JSON format with --format json.
+    """
     # Extract metadata
     pcb_name = data.get("source", "")
     created_at = None

--- a/tests/test_drc_report_formats.py
+++ b/tests/test_drc_report_formats.py
@@ -1,0 +1,224 @@
+"""Tests for DRC report JSON format parsing (KiCad-cli and kct-check formats)."""
+
+import json
+
+from kicad_tools.drc.report import parse_json_report
+from kicad_tools.drc.violation import Severity, ViolationType
+
+
+class TestKctCheckJsonFormat:
+    """Tests for parsing kct-check JSON format written by ``kct check --output``."""
+
+    def test_parse_empty_violations(self):
+        """Parse kct-check report with no violations (DRC passed)."""
+        data = {
+            "file": "/path/to/board.kicad_pcb",
+            "manufacturer": "jlcpcb",
+            "layers": 2,
+            "summary": {
+                "errors": 0,
+                "warnings": 0,
+                "rules_checked": 4,
+                "passed": True,
+            },
+            "violations": [],
+        }
+        report = parse_json_report(json.dumps(data), source_file="test.json")
+        assert report.pcb_name == "/path/to/board.kicad_pcb"
+        assert report.violation_count == 0
+        assert report.error_count == 0
+        assert report.warning_count == 0
+
+    def test_parse_with_violations(self):
+        """Parse kct-check report with both errors and warnings."""
+        data = {
+            "file": "/path/to/board.kicad_pcb",
+            "manufacturer": "jlcpcb",
+            "layers": 2,
+            "summary": {
+                "errors": 1,
+                "warnings": 1,
+                "rules_checked": 4,
+                "passed": False,
+            },
+            "violations": [
+                {
+                    "rule_id": "clearance_pad_pad",
+                    "severity": "warning",
+                    "message": "Pad-to-pad clearance 0.15 mm below minimum 0.20 mm",
+                    "location": [100.5, 200.3],
+                    "layer": "F.Cu",
+                    "actual_value": 0.15,
+                    "required_value": 0.20,
+                    "items": ["Pad 1 of U1", "Pad 2 of C3"],
+                },
+                {
+                    "rule_id": "track_width",
+                    "severity": "error",
+                    "message": "Track width too narrow",
+                    "location": [50.0, 75.0],
+                    "layer": "B.Cu",
+                    "actual_value": 0.1,
+                    "required_value": 0.15,
+                    "items": ["Track on B.Cu"],
+                },
+            ],
+        }
+        report = parse_json_report(json.dumps(data), source_file="test.json")
+        assert report.violation_count == 2
+        assert report.error_count == 1
+        assert report.warning_count == 1
+
+        # Check warning violation
+        warning = report.warnings[0]
+        assert warning.type_str == "clearance_pad_pad"
+        assert warning.severity == Severity.WARNING
+        assert warning.message == "Pad-to-pad clearance 0.15 mm below minimum 0.20 mm"
+        assert len(warning.locations) == 1
+        assert warning.locations[0].x_mm == 100.5
+        assert warning.locations[0].y_mm == 200.3
+        assert warning.locations[0].layer == "F.Cu"
+        assert warning.items == ["Pad 1 of U1", "Pad 2 of C3"]
+        assert warning.actual_value_mm == 0.15
+        assert warning.required_value_mm == 0.20
+
+        # Check error violation
+        error = report.errors[0]
+        assert error.type_str == "track_width"
+        assert error.severity == Severity.ERROR
+        assert error.type == ViolationType.TRACK_WIDTH
+
+    def test_parse_no_location(self):
+        """Parse kct-check violation without location field."""
+        data = {
+            "file": "board.kicad_pcb",
+            "summary": {"errors": 1, "warnings": 0, "rules_checked": 1, "passed": False},
+            "violations": [
+                {
+                    "rule_id": "unconnected_items",
+                    "severity": "error",
+                    "message": "Unconnected net",
+                    "items": ["Net VCC"],
+                },
+            ],
+        }
+        report = parse_json_report(json.dumps(data))
+        assert report.violation_count == 1
+        v = report.violations[0]
+        assert len(v.locations) == 0
+        assert v.items == ["Net VCC"]
+
+    def test_parse_empty_items(self):
+        """Parse kct-check violation with empty items list."""
+        data = {
+            "file": "board.kicad_pcb",
+            "manufacturer": "jlcpcb",
+            "summary": {"errors": 1, "warnings": 0, "rules_checked": 1, "passed": False},
+            "violations": [
+                {
+                    "rule_id": "unknown_rule",
+                    "severity": "error",
+                    "message": "Some error",
+                    "items": [],
+                },
+            ],
+        }
+        report = parse_json_report(json.dumps(data))
+        assert report.violation_count == 1
+        assert report.violations[0].items == []
+
+    def test_format_detection_with_manufacturer_only(self):
+        """Detect kct-check format when only 'manufacturer' key is present."""
+        data = {
+            "file": "board.kicad_pcb",
+            "manufacturer": "pcbway",
+            "layers": 4,
+            "violations": [],
+        }
+        report = parse_json_report(json.dumps(data))
+        assert report.pcb_name == "board.kicad_pcb"
+        assert report.violation_count == 0
+
+    def test_format_detection_with_summary_only(self):
+        """Detect kct-check format when only 'summary' key is present."""
+        data = {
+            "file": "board.kicad_pcb",
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 2, "passed": True},
+            "violations": [],
+        }
+        report = parse_json_report(json.dumps(data))
+        assert report.pcb_name == "board.kicad_pcb"
+        assert report.violation_count == 0
+
+
+class TestKicadCliJsonFormat:
+    """Tests for parsing KiCad-cli JSON format (regression tests)."""
+
+    def test_parse_empty_violations(self):
+        """Parse KiCad-cli report with no violations."""
+        data = {
+            "source": "board.kicad_pcb",
+            "date": "2025-12-28T21:29:34",
+            "violations": [],
+        }
+        report = parse_json_report(json.dumps(data))
+        assert report.pcb_name == "board.kicad_pcb"
+        assert report.violation_count == 0
+        assert report.created_at is not None
+        assert report.created_at.year == 2025
+
+    def test_parse_with_violations(self):
+        """Parse KiCad-cli report with dict-style items."""
+        data = {
+            "source": "board.kicad_pcb",
+            "date": "2025-12-28T21:29:34",
+            "violations": [
+                {
+                    "type": "clearance",
+                    "description": "Clearance violation (0.20 mm required, actual 0.15 mm)",
+                    "severity": "error",
+                    "pos": {"x": 162.45, "y": 100.32},
+                    "items": [
+                        {
+                            "description": "Pad 6 [VCC] of U3 on F.Cu",
+                            "pos": {"x": 162.45, "y": 100.32},
+                            "net": "VCC",
+                        },
+                        {
+                            "description": "Via [SPI_NSS] on F.Cu - B.Cu",
+                            "pos": {"x": 161.6, "y": 100.9},
+                            "net": "SPI_NSS",
+                        },
+                    ],
+                },
+            ],
+        }
+        report = parse_json_report(json.dumps(data))
+        assert report.violation_count == 1
+        v = report.violations[0]
+        assert v.type_str == "clearance"
+        assert v.severity == Severity.ERROR
+        assert len(v.items) == 2
+        assert "Pad 6 [VCC] of U3 on F.Cu" in v.items
+        assert len(v.nets) == 2
+        assert "VCC" in v.nets
+        assert "SPI_NSS" in v.nets
+        # 3 locations: one from violation pos + two from items
+        assert len(v.locations) == 3
+
+    def test_parse_with_no_items_key(self):
+        """Parse KiCad-cli violation without items."""
+        data = {
+            "source": "board.kicad_pcb",
+            "date": "2025-01-01T00:00:00",
+            "violations": [
+                {
+                    "type": "footprint",
+                    "description": "Footprint error",
+                    "severity": "warning",
+                },
+            ],
+        }
+        report = parse_json_report(json.dumps(data))
+        assert report.violation_count == 1
+        assert report.violations[0].items == []


### PR DESCRIPTION
## Summary

`parse_json_report()` crashed with `'str' object has no attribute 'get'` when reading DRC reports written by `kct check --output`, because it only understood the KiCad-cli JSON schema (dict-style items) and not the kct-check schema (string items). This fix adds format detection and a dedicated parser for the kct-check format.

## Changes

- Add format detection in `parse_json_report()` that checks for `"summary"` or `"manufacturer"` keys (kct-check indicators) vs `"source"`/`"date"` (KiCad-cli indicators)
- Extract existing KiCad-cli parsing logic into `_parse_kicad_cli_json()` (no behavioral changes)
- Add new `_parse_kct_check_json()` helper that correctly maps `rule_id` to `type_str`, `message` to `message`, `location` tuples to `Location` objects, and string `items` to the items list
- Add 9 new tests covering both formats in `tests/test_drc_report_formats.py`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `parse_json_report()` handles both KiCad-cli and kct-check JSON formats | PASS | 9 new tests cover both formats with violations, empty violations, missing fields |
| kct-check violations are correctly reported as errors/warnings | PASS | Tests verify severity mapping for both error and warning violations |
| Existing KiCad-cli DRC report parsing is not broken | PASS | All 77 existing `test_drc.py` tests pass without changes |
| String items in kct-check format do not cause crash | PASS | Tests use string items (e.g., `["Pad 1 of U1", "Pad 2 of C3"]`) and parse correctly |

## Test Plan

- Ran `tests/test_drc_report_formats.py` (9 tests) -- all pass
- Ran `tests/test_drc.py` (77 tests) -- all pass, no regressions

Closes #1549