### PR TITLE
fix(blocks): add footprint parameters to CrystalOscillator, DebugHeader, and LEDIndicator

### DIFF
--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -190,6 +190,8 @@ def create_stm32_schematic(output_dir: Path) -> Path:
         load_caps="20pF",
         ref_prefix="Y",
         cap_ref_start=10,
+        crystal_footprint="Crystal:Crystal_HC49-4H_Vertical",
+        cap_footprint="Capacitor_SMD:C_0805_2012Metric",
     )
     print(f"   Crystal: {xtal.crystal.reference} with C10, C11")
 
@@ -220,6 +222,7 @@ def create_stm32_schematic(output_dir: Path) -> Path:
         pins=6,
         series_resistors=False,
         ref="J1",
+        header_footprint="Connector_PinHeader_2.54mm:PinHeader_1x06_P2.54mm_Vertical",
     )
     print(f"   Debug header: {debug.header.reference} (SWD-6)")
 
@@ -239,6 +242,8 @@ def create_stm32_schematic(output_dir: Path) -> Path:
         ref_prefix="D1",
         label="USER",
         resistor_value="330R",
+        led_footprint="LED_SMD:LED_0805_2012Metric",
+        resistor_footprint="Resistor_SMD:R_0805_2012Metric",
     )
     print(f"   LED: {led.led.reference} with current-limiting resistor")
 

--- a/src/kicad_tools/schematic/blocks/indicators.py
+++ b/src/kicad_tools/schematic/blocks/indicators.py
@@ -33,6 +33,8 @@ class LEDIndicator(CircuitBlock):
         led_symbol: str = "Device:LED",
         resistor_symbol: str = "Device:R",
         vertical: bool = True,
+        led_footprint: str = "",
+        resistor_footprint: str = "",
     ):
         """
         Create an LED indicator.
@@ -47,6 +49,8 @@ class LEDIndicator(CircuitBlock):
             led_symbol: KiCad symbol for LED
             resistor_symbol: KiCad symbol for resistor
             vertical: If True, LED is vertical (rotated 90°)
+            led_footprint: Footprint for LED (e.g., "LED_SMD:LED_0805_2012Metric")
+            resistor_footprint: Footprint for resistor (e.g., "Resistor_SMD:R_0805_2012Metric")
         """
         super().__init__(sch, x, y)
 
@@ -60,14 +64,14 @@ class LEDIndicator(CircuitBlock):
 
         # Place LED
         rotation = 90 if vertical else 0
-        self.led = sch.add_symbol(led_symbol, x, y, d_ref, label, rotation=rotation)
+        self.led = sch.add_symbol(led_symbol, x, y, d_ref, label, rotation=rotation, footprint=led_footprint)
 
         # Place resistor below LED (if vertical)
         if vertical:
             r_y = y + led_resistor_spacing
         else:
             r_y = y
-        self.resistor = sch.add_symbol(resistor_symbol, x, r_y, r_ref, resistor_value)
+        self.resistor = sch.add_symbol(resistor_symbol, x, r_y, r_ref, resistor_value, footprint=resistor_footprint)
 
         self.components = {"LED": self.led, "R": self.resistor}
 

--- a/src/kicad_tools/schematic/blocks/interface/debug.py
+++ b/src/kicad_tools/schematic/blocks/interface/debug.py
@@ -114,6 +114,7 @@ class DebugHeader(CircuitBlock):
         resistor_ref_start: int = 1,
         header_symbol: str | None = None,
         resistor_symbol: str = "Device:R",
+        header_footprint: str = "",
     ):
         """
         Create a debug header block.
@@ -130,6 +131,7 @@ class DebugHeader(CircuitBlock):
             resistor_ref_start: Starting reference number for resistors
             header_symbol: KiCad symbol for header (auto-selected if None)
             resistor_symbol: KiCad symbol for resistors
+            header_footprint: Footprint for header (e.g., "Connector_PinHeader_2.54mm:PinHeader_1x06_P2.54mm_Vertical")
         """
         super().__init__(sch, x, y)
         self.interface = interface.lower()
@@ -148,7 +150,7 @@ class DebugHeader(CircuitBlock):
 
         # Place header
         value = self._get_value_label()
-        self.header = sch.add_symbol(header_symbol, x, y, ref, value)
+        self.header = sch.add_symbol(header_symbol, x, y, ref, value, footprint=header_footprint)
         self.components = {"HEADER": self.header}
 
         # Get signals that need resistors (data lines, not power/ground)

--- a/src/kicad_tools/schematic/blocks/timing.py
+++ b/src/kicad_tools/schematic/blocks/timing.py
@@ -172,6 +172,8 @@ class CrystalOscillator(CircuitBlock):
         cap_ref_start: int = 1,
         crystal_symbol: str = "Device:Crystal",
         cap_symbol: str = "Device:C",
+        crystal_footprint: str = "",
+        cap_footprint: str = "",
     ):
         """
         Create a crystal oscillator with load capacitors.
@@ -188,6 +190,8 @@ class CrystalOscillator(CircuitBlock):
             cap_ref_start: Starting reference number for capacitors
             crystal_symbol: KiCad symbol for crystal
             cap_symbol: KiCad symbol for capacitors
+            crystal_footprint: Footprint for crystal (e.g., "Crystal:Crystal_HC49-4H_Vertical")
+            cap_footprint: Footprint for load capacitors (e.g., "Capacitor_SMD:C_0805_2012Metric")
         """
         super().__init__(sch, x, y)
 
@@ -209,7 +213,7 @@ class CrystalOscillator(CircuitBlock):
         cap_x_spacing = 15  # mm between caps (crystal is centered)
 
         # Place crystal
-        self.crystal = sch.add_symbol(crystal_symbol, x, y, y_ref, frequency)
+        self.crystal = sch.add_symbol(crystal_symbol, x, y, y_ref, frequency, footprint=crystal_footprint)
 
         # Place load capacitors below crystal
         c1_x = x - cap_x_spacing / 2
@@ -219,8 +223,8 @@ class CrystalOscillator(CircuitBlock):
         c1_ref = f"C{cap_ref_start}"
         c2_ref = f"C{cap_ref_start + 1}"
 
-        self.cap1 = sch.add_symbol(cap_symbol, c1_x, cap_y, c1_ref, cap1_value)
-        self.cap2 = sch.add_symbol(cap_symbol, c2_x, cap_y, c2_ref, cap2_value)
+        self.cap1 = sch.add_symbol(cap_symbol, c1_x, cap_y, c1_ref, cap1_value, footprint=cap_footprint)
+        self.cap2 = sch.add_symbol(cap_symbol, c2_x, cap_y, c2_ref, cap2_value, footprint=cap_footprint)
 
         self.components = {
             "XTAL": self.crystal,


### PR DESCRIPTION
## Summary

Add optional footprint parameters to three circuit block constructors so that callers can propagate footprint metadata to schematic symbols. Update board 04's generate_design.py to pass the correct footprint values, eliminating BOM preflight "missing footprint" warnings for Y1, C10, C11, J1, and D1.

## Changes

- `src/kicad_tools/schematic/blocks/timing.py` -- Add `crystal_footprint` and `cap_footprint` params to `CrystalOscillator.__init__()`; pass them through to `add_symbol()` calls
- `src/kicad_tools/schematic/blocks/interface/debug.py` -- Add `header_footprint` param to `DebugHeader.__init__()`; pass it through to `add_symbol()` call
- `src/kicad_tools/schematic/blocks/indicators.py` -- Add `led_footprint` and `resistor_footprint` params to `LEDIndicator.__init__()`; pass them through to `add_symbol()` calls
- `boards/04-stm32-devboard/generate_design.py` -- Pass footprint strings when instantiating CrystalOscillator, DebugHeader, and LEDIndicator

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Y1, C10, C11, J1, D1 have populated Footprint fields | Pass | Confirmed via grep on generated .kicad_sch -- all 5 symbols have non-empty Footprint properties |
| BOM preflight no longer reports "missing footprint" | Pass | `kct export --mfr jlcpcb` shows no missing footprint warning (only LCSC part number warning remains) |
| Block classes accept optional footprint parameters | Pass | All three classes have new params defaulting to "" |
| Backward compatible (defaults to empty string) | Pass | All new params default to `""`, existing callers unaffected |
| Correct footprint values match PCB | Pass | Y1=Crystal:Crystal_HC49-4H_Vertical, C10/C11=Capacitor_SMD:C_0805_2012Metric, J1=Connector_PinHeader_2.54mm:PinHeader_1x06_P2.54mm_Vertical, D1=LED_SMD:LED_0805_2012Metric |
| Full board 04 build passes | Pass | generate_design.py + kct export complete successfully |

## Test Plan

- Ran `python3 generate_design.py` for board 04 -- ERC passes, DRC passes
- Ran `kct export ... --mfr jlcpcb` -- no "missing footprint" BOM warnings
- Ran pytest (excluding pre-existing failures in test_renderers and test_audit) -- all block-related tests pass with no regressions

Closes #1550