### PR TITLE
feat(pipeline): use find_schematic for robust schematic discovery

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -176,29 +176,23 @@ def _resolve_pcb_from_project(project_file: Path) -> Path | None:
 def _resolve_schematic(pcb_file: Path, project_file: Path | None = None) -> Path | None:
     """Resolve .kicad_sch path from a project or PCB file.
 
-    Resolution chain:
-        .kicad_pro -> stem.kicad_sch
-        .kicad_pcb -> sibling stem.kicad_sch
+    Delegates to :func:`kicad_tools.report.utils.find_schematic` which
+    implements the full discovery chain: direct stem match, suffix
+    stripping (``_routed``, ``_fixed``, etc.), project file lookup, and
+    single-glob fallback.
 
     Args:
         pcb_file: Path to .kicad_pcb file
-        project_file: Optional path to .kicad_pro file
+        project_file: Optional path to .kicad_pro file (unused; retained
+            for API compatibility -- ``find_schematic`` discovers project
+            files automatically)
 
     Returns:
         Path to the corresponding .kicad_sch if it exists, None otherwise.
     """
-    # Try from project file first
-    if project_file is not None:
-        sch_path = project_file.with_suffix(".kicad_sch")
-        if sch_path.exists():
-            return sch_path
+    from ..report.utils import find_schematic
 
-    # Try from PCB file (sibling with same stem)
-    sch_path = pcb_file.with_suffix(".kicad_sch")
-    if sch_path.exists():
-        return sch_path
-
-    return None
+    return find_schematic(pcb_file)
 
 
 def _run_step_erc(ctx: PipelineContext, console: Console) -> PipelineResult:
@@ -215,7 +209,7 @@ def _run_step_erc(ctx: PipelineContext, console: Console) -> PipelineResult:
         return PipelineResult(
             step=PipelineStep.ERC,
             success=True,
-            message="erc: no .kicad_sch found alongside PCB — skipped",
+            message="erc: no .kicad_sch found alongside PCB — skipped (use --sch to specify)",
             skipped=True,
         )
 
@@ -1428,6 +1422,13 @@ Examples:
         ),
     )
     parser.add_argument(
+        "--sch",
+        "--schematic",
+        dest="sch",
+        default=None,
+        help="Path to root .kicad_sch file (overrides auto-discovery)",
+    )
+    parser.add_argument(
         "--zones",
         action="store_true",
         default=False,
@@ -1494,7 +1495,14 @@ Examples:
             resolved_layers = "2"
 
     # Resolve schematic file for ERC step
-    schematic_file = _resolve_schematic(pcb_file, project_file)
+    if args.sch is not None:
+        sch_path = Path(args.sch).resolve()
+        if not sch_path.exists():
+            print(f"Error: Schematic file not found: {sch_path}", file=sys.stderr)
+            return 1
+        schematic_file = sch_path
+    else:
+        schematic_file = _resolve_schematic(pcb_file, project_file)
 
     # Build context
     ctx = PipelineContext(

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -1612,7 +1612,7 @@ def pcb_without_schematic(tmp_path: Path) -> Path:
 
 
 class TestResolveSchematic:
-    """Tests for _resolve_schematic helper."""
+    """Tests for _resolve_schematic helper (delegates to find_schematic)."""
 
     def test_finds_schematic_from_pcb(self, pcb_with_schematic):
         """Resolves .kicad_sch from .kicad_pcb with same stem."""
@@ -1636,6 +1636,72 @@ class TestResolveSchematic:
         result = _resolve_schematic(pcb_without_schematic)
         assert result is None
 
+    def test_finds_schematic_with_routed_suffix(self, tmp_path: Path):
+        """Resolves .kicad_sch when PCB has _routed suffix."""
+        pcb_file = tmp_path / "board_routed.kicad_pcb"
+        pcb_file.write_text(ROUTED_PCB)
+        sch_file = tmp_path / "board.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+        result = _resolve_schematic(pcb_file)
+        assert result == sch_file
+
+    def test_finds_schematic_via_project_file_lookup(self, tmp_path: Path):
+        """Resolves .kicad_sch via .kicad_pro when PCB stem differs."""
+        pcb_file = tmp_path / "board_routed.kicad_pcb"
+        pcb_file.write_text(ROUTED_PCB)
+        pro_file = tmp_path / "design.kicad_pro"
+        pro_file.write_text('{"meta": {"filename": "design.kicad_pro"}}')
+        sch_file = tmp_path / "design.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+        # _resolve_schematic now auto-discovers the project file
+        result = _resolve_schematic(pcb_file)
+        assert result == sch_file
+
+    def test_finds_schematic_via_single_glob_fallback(self, tmp_path: Path):
+        """Resolves .kicad_sch when exactly one exists in directory."""
+        pcb_file = tmp_path / "mismatched.kicad_pcb"
+        pcb_file.write_text(ROUTED_PCB)
+        sch_file = tmp_path / "only_one.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+        result = _resolve_schematic(pcb_file)
+        assert result == sch_file
+
+
+class TestSchematicFlag:
+    """Tests for --sch / --schematic CLI flag."""
+
+    def test_sch_flag_overrides_autodiscovery(self, tmp_path: Path):
+        """--sch flag uses the specified schematic, bypassing auto-discovery."""
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(ROUTED_PCB)
+        # Create a schematic with a different name than the PCB
+        sch_file = tmp_path / "other.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+
+        # dry-run so we don't need kicad-cli
+        result = main(["--step", "erc", "--dry-run", "--sch", str(sch_file), str(pcb_file)])
+        assert result == 0
+
+    def test_sch_flag_nonexistent_file_errors(self, tmp_path: Path):
+        """--sch flag with nonexistent file produces error."""
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(ROUTED_PCB)
+
+        result = main(["--dry-run", "--sch", str(tmp_path / "missing.kicad_sch"), str(pcb_file)])
+        assert result == 1
+
+    def test_schematic_long_form_alias(self, tmp_path: Path):
+        """--schematic long-form alias works the same as --sch."""
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(ROUTED_PCB)
+        sch_file = tmp_path / "other.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+
+        result = main(
+            ["--step", "erc", "--dry-run", "--schematic", str(sch_file), str(pcb_file)]
+        )
+        assert result == 0
+
 
 class TestERCStep:
     """Tests for ERC pipeline step."""
@@ -1651,6 +1717,7 @@ class TestERCStep:
         assert result.success is True
         assert result.skipped is True
         assert "no .kicad_sch" in result.message
+        assert "--sch" in result.message
 
     @patch("kicad_tools.cli.runner.find_kicad_cli", return_value=None)
     def test_erc_skip_when_no_kicad_cli(self, mock_find, pcb_with_schematic):


### PR DESCRIPTION
## Summary

Replace the pipeline's naive `_resolve_schematic()` (stem-match only) with a delegation to the existing `report.utils.find_schematic()`, which supports suffix stripping, project file lookup, and single-glob fallback. Also add a `--sch` / `--schematic` CLI flag for explicit override.

## Changes

- Replaced `_resolve_schematic()` body in `pipeline_cmd.py` with a call to `find_schematic()` from `report/utils.py`
- Added `--sch` / `--schematic` argument to the pipeline CLI parser
- Added validation for explicit `--sch` path (errors if file does not exist)
- Updated ERC skip message to hint about `--sch` when no schematic is found
- Added tests for suffix stripping (`_routed`), project file lookup, single-glob fallback, and the `--sch` flag

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| PCB with `_routed` suffix finds schematic via suffix stripping | Pass | `test_finds_schematic_with_routed_suffix` passes |
| PCB with mismatched stem finds schematic via project file | Pass | `test_finds_schematic_via_project_file_lookup` passes |
| Single `.kicad_sch` in directory found via glob fallback | Pass | `test_finds_schematic_via_single_glob_fallback` passes |
| `--sch` flag overrides auto-discovery | Pass | `test_sch_flag_overrides_autodiscovery` passes |
| `--sch` with missing file returns error | Pass | `test_sch_flag_nonexistent_file_errors` passes |
| `--schematic` long-form alias works | Pass | `test_schematic_long_form_alias` passes |
| ERC skip message includes `--sch` hint | Pass | `test_erc_skip_when_no_schematic` updated and passes |

## Test Plan

- All 10 tests in `TestResolveSchematic`, `TestSchematicFlag`, and the ERC skip test pass
- Full pipeline test suite passes (143/143 pass; 1 pre-existing failure in `TestExportStep::test_export_runs_after_audit_failure` unrelated to this change)
- `test_find_schematic.py` (24 tests) continues to pass

Closes #1556