### PR TITLE
feat(pcb): add update_footprint_reference and update_footprint_value methods

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1866,6 +1866,118 @@ class PCB:
 
         return False
 
+    def update_footprint_reference(
+        self,
+        old_reference: str,
+        new_reference: str,
+    ) -> bool:
+        """
+        Update a footprint's reference designator.
+
+        Renames the reference designator in both the parsed footprint object
+        and the underlying S-expression tree. Handles both KiCad 7 (fp_text)
+        and KiCad 8+ (property) formats.
+
+        Args:
+            old_reference: Current reference designator (e.g., "R1")
+            new_reference: New reference designator (e.g., "R100")
+
+        Returns:
+            True if footprint was found and updated, False if the old
+            reference was not found or the new reference already exists.
+        """
+        # Check that the old reference exists
+        fp = self.get_footprint(old_reference)
+        if not fp:
+            return False
+
+        # Check for collision with existing reference
+        if old_reference != new_reference and self.get_footprint(new_reference):
+            return False
+
+        # Update the S-expression tree
+        for child in self._sexp.iter_children():
+            if child.tag != "footprint":
+                continue
+
+            fp_ref = self._get_footprint_reference(child)
+            if fp_ref != old_reference:
+                continue
+
+            # Update KiCad 7 format: fp_text with type "reference"
+            for fp_text in child.find_all("fp_text"):
+                if fp_text.get_string(0) == "reference":
+                    fp_text.set_value(1, new_reference)
+
+            # Update KiCad 8+ format: property with name "Reference"
+            for prop in child.find_all("property"):
+                if prop.get_string(0) == "Reference":
+                    prop.set_value(1, new_reference)
+
+            # Update parsed footprint object
+            fp.reference = new_reference
+            for text in fp.texts:
+                if text.text_type == "reference":
+                    text.text = new_reference
+
+            return True
+
+        return False
+
+    def update_footprint_value(
+        self,
+        reference: str,
+        new_value: str,
+    ) -> bool:
+        """
+        Update a footprint's value field.
+
+        Updates the value in both the parsed footprint object and the
+        underlying S-expression tree. Handles both KiCad 7 (fp_text)
+        and KiCad 8+ (property) formats.
+
+        Args:
+            reference: Reference designator of the footprint (e.g., "R1")
+            new_value: New value string (e.g., "4.7k")
+
+        Returns:
+            True if footprint was found and updated, False if the
+            reference was not found.
+        """
+        # Check that the reference exists
+        fp = self.get_footprint(reference)
+        if not fp:
+            return False
+
+        # Update the S-expression tree
+        for child in self._sexp.iter_children():
+            if child.tag != "footprint":
+                continue
+
+            fp_ref = self._get_footprint_reference(child)
+            if fp_ref != reference:
+                continue
+
+            # Update KiCad 7 format: fp_text with type "value"
+            for fp_text in child.find_all("fp_text"):
+                if fp_text.get_string(0) == "value":
+                    fp_text.set_value(1, new_value)
+
+            # Update KiCad 8+ format: property with name "Value"
+            for prop in child.find_all("property"):
+                if prop.get_string(0) == "Value":
+                    prop.set_value(1, new_value)
+
+            # Update parsed footprint object
+            fp.value = new_value
+            for text in fp.texts:
+                if text.text_type == "value":
+                    text.text = new_value
+
+            return True
+
+        return False
+
     # Silkscreen management methods
 
     def set_reference_visibility(

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -651,6 +651,240 @@ class TestUpdateFootprintPosition:
         assert result is False
 
 
+class TestUpdateFootprintReference:
+    """Tests for PCB.update_footprint_reference method."""
+
+    def test_rename_reference_kicad8(self, minimal_pcb, tmp_path):
+        """Test renaming a reference designator in KiCad 8+ format (property)."""
+        doc = load_pcb(str(minimal_pcb))
+        pcb = PCB(doc)
+
+        # Verify footprint exists
+        fp = pcb.get_footprint("R1")
+        assert fp is not None
+
+        # Rename R1 -> R100
+        result = pcb.update_footprint_reference("R1", "R100")
+        assert result is True
+
+        # Verify in memory
+        assert pcb.get_footprint("R1") is None
+        fp = pcb.get_footprint("R100")
+        assert fp is not None
+        assert fp.reference == "R100"
+
+        # Verify FootprintText also updated
+        ref_texts = [t for t in fp.texts if t.text_type == "reference"]
+        assert len(ref_texts) > 0
+        assert ref_texts[0].text == "R100"
+
+        # Save and reload
+        output_path = tmp_path / "output.kicad_pcb"
+        pcb.save(output_path)
+
+        doc2 = load_pcb(str(output_path))
+        pcb2 = PCB(doc2)
+
+        # Verify persisted
+        assert pcb2.get_footprint("R1") is None
+        fp2 = pcb2.get_footprint("R100")
+        assert fp2 is not None
+        assert fp2.reference == "R100"
+
+    def test_rename_reference_kicad7(self, routing_test_pcb, tmp_path):
+        """Test renaming a reference designator in KiCad 7 format (fp_text)."""
+        doc = load_pcb(str(routing_test_pcb))
+        pcb = PCB(doc)
+
+        # Rename R1 -> R50
+        result = pcb.update_footprint_reference("R1", "R50")
+        assert result is True
+
+        # Verify in memory
+        assert pcb.get_footprint("R1") is None
+        fp = pcb.get_footprint("R50")
+        assert fp is not None
+        assert fp.reference == "R50"
+
+        # Save and reload
+        output_path = tmp_path / "output.kicad_pcb"
+        pcb.save(output_path)
+
+        doc2 = load_pcb(str(output_path))
+        pcb2 = PCB(doc2)
+
+        assert pcb2.get_footprint("R1") is None
+        fp2 = pcb2.get_footprint("R50")
+        assert fp2 is not None
+        assert fp2.reference == "R50"
+
+    def test_rename_reference_collision(self, routing_test_pcb):
+        """Test that renaming to an existing reference returns False."""
+        doc = load_pcb(str(routing_test_pcb))
+        pcb = PCB(doc)
+
+        # U1 and R1 both exist -- renaming R1 to U1 should fail
+        result = pcb.update_footprint_reference("R1", "U1")
+        assert result is False
+
+        # Original should be unchanged
+        assert pcb.get_footprint("R1") is not None
+        assert pcb.get_footprint("R1").reference == "R1"
+
+    def test_rename_reference_nonexistent(self, routing_test_pcb):
+        """Test that renaming a nonexistent reference returns False."""
+        doc = load_pcb(str(routing_test_pcb))
+        pcb = PCB(doc)
+
+        result = pcb.update_footprint_reference("NONEXISTENT", "R99")
+        assert result is False
+
+    def test_rename_reference_same_name(self, routing_test_pcb):
+        """Test renaming to the same name succeeds (no-op)."""
+        doc = load_pcb(str(routing_test_pcb))
+        pcb = PCB(doc)
+
+        result = pcb.update_footprint_reference("R1", "R1")
+        assert result is True
+        assert pcb.get_footprint("R1") is not None
+
+
+class TestUpdateFootprintValue:
+    """Tests for PCB.update_footprint_value method."""
+
+    def test_update_value_kicad8(self, minimal_pcb, tmp_path):
+        """Test updating value in KiCad 8+ format (property)."""
+        doc = load_pcb(str(minimal_pcb))
+        pcb = PCB(doc)
+
+        # The minimal_pcb has R1 with value "10k"
+        fp = pcb.get_footprint("R1")
+        assert fp is not None
+        assert fp.value == "10k"
+
+        # Update value
+        result = pcb.update_footprint_value("R1", "4.7k")
+        assert result is True
+
+        # Verify in memory
+        fp = pcb.get_footprint("R1")
+        assert fp.value == "4.7k"
+
+        # Verify FootprintText also updated
+        val_texts = [t for t in fp.texts if t.text_type == "value"]
+        assert len(val_texts) > 0
+        assert val_texts[0].text == "4.7k"
+
+        # Save and reload
+        output_path = tmp_path / "output.kicad_pcb"
+        pcb.save(output_path)
+
+        doc2 = load_pcb(str(output_path))
+        pcb2 = PCB(doc2)
+
+        fp2 = pcb2.get_footprint("R1")
+        assert fp2 is not None
+        assert fp2.value == "4.7k"
+
+    def test_update_value_kicad7(self, tmp_path):
+        """Test updating value in KiCad 7 format (fp_text)."""
+        # Create a KiCad 7-style PCB with fp_text value entries
+        pcb_content = """(kicad_pcb
+  (version 20171130)
+  (generator "test")
+  (general
+    (thickness 1.6)
+  )
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (gr_rect (start 100 100) (end 150 140)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000001")
+    (at 120 120)
+    (fp_text reference "R1" (at 0 -1.5) (layer "F.SilkS"))
+    (fp_text value "10k" (at 0 1.5) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 0 ""))
+  )
+)
+"""
+        pcb_file = tmp_path / "kicad7.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        doc = load_pcb(str(pcb_file))
+        pcb = PCB(doc)
+
+        fp = pcb.get_footprint("R1")
+        assert fp is not None
+        assert fp.value == "10k"
+
+        # Update value
+        result = pcb.update_footprint_value("R1", "4.7k")
+        assert result is True
+
+        # Verify in memory
+        fp = pcb.get_footprint("R1")
+        assert fp.value == "4.7k"
+
+        # Save and reload
+        output_path = tmp_path / "output.kicad_pcb"
+        pcb.save(output_path)
+
+        doc2 = load_pcb(str(output_path))
+        pcb2 = PCB(doc2)
+
+        fp2 = pcb2.get_footprint("R1")
+        assert fp2 is not None
+        assert fp2.value == "4.7k"
+
+    def test_update_value_nonexistent(self, routing_test_pcb):
+        """Test that updating value of nonexistent reference returns False."""
+        doc = load_pcb(str(routing_test_pcb))
+        pcb = PCB(doc)
+
+        result = pcb.update_footprint_value("NONEXISTENT", "4.7k")
+        assert result is False
+
+    def test_update_value_round_trip(self, minimal_pcb, tmp_path):
+        """Test that updating value does not corrupt other footprint fields."""
+        doc = load_pcb(str(minimal_pcb))
+        pcb = PCB(doc)
+
+        # Record original state
+        fp = pcb.get_footprint("R1")
+        original_pos = fp.position
+        original_ref = fp.reference
+
+        # Update value
+        pcb.update_footprint_value("R1", "100k")
+
+        # Save and reload
+        output_path = tmp_path / "output.kicad_pcb"
+        pcb.save(output_path)
+
+        doc2 = load_pcb(str(output_path))
+        pcb2 = PCB(doc2)
+
+        fp2 = pcb2.get_footprint("R1")
+        assert fp2.value == "100k"
+        assert fp2.position == pytest.approx(original_pos)
+        assert fp2.reference == original_ref
+
+
 class TestAddFootprint:
     """Tests for PCB.add_footprint and add_footprint_from_file methods."""
 


### PR DESCRIPTION
## Summary

Add two new mutation methods to the PCB class for renaming reference designators and updating footprint value fields. Both methods handle KiCad 7 (fp_text) and KiCad 8+ (property) S-expression formats, maintain consistency between parsed objects and the underlying S-expression tree, and support save/reload round-trips.

## Changes

- Add `update_footprint_reference(old_reference, new_reference)` method to PCB class with collision detection
- Add `update_footprint_value(reference, new_value)` method to PCB class
- Both methods update the S-expression tree and parsed `Footprint`/`FootprintText` objects
- Add `TestUpdateFootprintReference` test class with 5 tests (KiCad 7, KiCad 8+, collision, nonexistent, same-name)
- Add `TestUpdateFootprintValue` test class with 4 tests (KiCad 7, KiCad 8+, nonexistent, round-trip integrity)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Rename existing reference and verify in-memory + save/reload | Done | test_rename_reference_kicad8, test_rename_reference_kicad7 |
| Rename to already-existing reference returns False | Done | test_rename_reference_collision |
| Rename nonexistent reference returns False | Done | test_rename_reference_nonexistent |
| Update value and verify in-memory + save/reload | Done | test_update_value_kicad8, test_update_value_kicad7 |
| Update value of nonexistent reference returns False | Done | test_update_value_nonexistent |
| KiCad 7 (fp_text) format handled | Done | test_rename_reference_kicad7, test_update_value_kicad7 |
| KiCad 8+ (property) format handled | Done | test_rename_reference_kicad8, test_update_value_kicad8 |
| Round-trip integrity (no field corruption) | Done | test_update_value_round_trip |

## Test Plan

All 131 tests in test_pcb.py pass, including 9 new tests for the two methods.

Closes #1565