### PR TITLE
feat(cli): add pcb reannotate command for batch reference renaming

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -11,7 +11,7 @@ def run_pcb_command(args) -> int:
     """Handle PCB subcommands."""
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
-        print("Commands: summary, footprints, nets, traces, stackup, strip")
+        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate")
         return 1
 
     pcb_path = Path(args.pcb)
@@ -22,6 +22,10 @@ def run_pcb_command(args) -> int:
     # Handle strip command separately (doesn't use pcb_query)
     if args.pcb_command == "strip":
         return _run_strip_command(args, pcb_path)
+
+    # Handle reannotate command separately (doesn't use pcb_query)
+    if args.pcb_command == "reannotate":
+        return _run_reannotate_command(args, pcb_path)
 
     from ..pcb_query import main as pcb_main
 
@@ -163,5 +167,300 @@ def _run_strip_command(args, pcb_path: Path) -> int:
         except Exception as e:
             print(f"Error saving PCB: {e}", file=sys.stderr)
             return 1
+
+    return 0
+
+
+def _update_footprint_reference(pcb, old_ref: str, new_ref: str) -> bool:
+    """Update a footprint's reference designator in both parsed data and S-expression tree.
+
+    Handles both KiCad 7 (fp_text) and KiCad 8+ (property) formats.
+
+    Args:
+        pcb: PCB instance.
+        old_ref: Current reference designator.
+        new_ref: New reference designator.
+
+    Returns:
+        True if the reference was found and updated.
+    """
+    # Find the footprint S-expression node
+    fp_sexp = None
+    for candidate in pcb._sexp.find_all("footprint"):
+        ref = pcb._get_footprint_reference(candidate)
+        if ref == old_ref:
+            fp_sexp = candidate
+            break
+
+    if fp_sexp is None:
+        return False
+
+    # Update S-expression: KiCad 7 fp_text format
+    for fp_text in fp_sexp.find_all("fp_text"):
+        if fp_text.get_string(0) == "reference":
+            fp_text.set_atom(1, new_ref)
+            break
+
+    # Update S-expression: KiCad 8+ property format
+    for prop in fp_sexp.find_all("property"):
+        if prop.get_string(0) == "Reference":
+            prop.set_atom(1, new_ref)
+            break
+
+    # Update parsed footprint object
+    for fp in pcb._footprints:
+        if fp.reference == old_ref:
+            fp.reference = new_ref
+            # Also update the FootprintText objects
+            for text in fp.texts:
+                if text.text_type == "reference":
+                    text.text = new_ref
+            break
+
+    return True
+
+
+def _build_rename_plan(
+    mapping: dict[str, str], existing_refs: set[str]
+) -> tuple[list[tuple[str, str, str | None]], list[str], list[str]]:
+    """Build a collision-safe rename plan from a mapping.
+
+    Detects collision chains (where a rename target is also a rename source)
+    and uses temporary intermediate references to resolve them safely.
+
+    Args:
+        mapping: Dict of old_ref -> new_ref.
+        existing_refs: Set of all reference designators currently in the PCB.
+
+    Returns:
+        Tuple of (rename_steps, warnings, errors) where:
+        - rename_steps is a list of (from_ref, to_ref, via_temp) tuples.
+          via_temp is None for direct renames, or the temp ref for chain renames.
+        - warnings is a list of warning messages.
+        - errors is a list of error messages.
+    """
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    # Validate: check that all source refs exist in the PCB
+    for old_ref in mapping:
+        if old_ref not in existing_refs:
+            errors.append(f"Source reference '{old_ref}' not found in PCB")
+
+    # Validate: check that target refs don't collide with existing refs
+    # that are NOT themselves being renamed away
+    mapping_sources = set(mapping.keys())
+    for old_ref, new_ref in mapping.items():
+        if new_ref in existing_refs and new_ref not in mapping_sources:
+            errors.append(
+                f"Target reference '{new_ref}' already exists in PCB "
+                f"and is not being renamed (collision with '{old_ref}' -> '{new_ref}')"
+            )
+
+    if errors:
+        return [], warnings, errors
+
+    # Identify which renames are part of collision chains
+    # A collision chain exists when a target ref is also a source ref
+    sources_set = set(mapping.keys())
+    targets_set = set(mapping.values())
+    conflicting = sources_set & targets_set  # refs that are both source and target
+
+    # Separate direct renames from chain renames
+    direct_renames: list[tuple[str, str, str | None]] = []
+    chain_sources: set[str] = set()
+
+    # Walk chains to find all members
+    for ref in conflicting:
+        # Trace the chain: ref is a target of some other rename
+        chain_sources.add(ref)
+
+    # Also include sources that target a conflicting ref
+    for old_ref, new_ref in mapping.items():
+        if new_ref in conflicting or old_ref in conflicting:
+            chain_sources.add(old_ref)
+
+    # Generate temp refs that don't collide with anything
+    all_refs = existing_refs | targets_set
+    temp_counter = 0
+    temp_map: dict[str, str] = {}  # old_ref -> temp_ref
+    for old_ref in sorted(chain_sources):
+        while f"_TEMP_{temp_counter}" in all_refs:
+            temp_counter += 1
+        temp_ref = f"_TEMP_{temp_counter}"
+        temp_map[old_ref] = temp_ref
+        all_refs.add(temp_ref)
+        temp_counter += 1
+
+    # Build rename steps
+    rename_steps: list[tuple[str, str, str | None]] = []
+
+    # Direct renames (not part of any chain)
+    for old_ref, new_ref in sorted(mapping.items()):
+        if old_ref not in chain_sources:
+            direct_renames.append((old_ref, new_ref, None))
+
+    rename_steps.extend(direct_renames)
+
+    # Chain renames: phase 1 (source -> temp), phase 2 (temp -> final)
+    for old_ref in sorted(chain_sources):
+        rename_steps.append((old_ref, temp_map[old_ref], None))
+
+    for old_ref in sorted(chain_sources):
+        new_ref = mapping[old_ref]
+        rename_steps.append((temp_map[old_ref], new_ref, old_ref))
+
+    return rename_steps, warnings, errors
+
+
+def _run_reannotate_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb reannotate' command."""
+    from kicad_tools.schema.pcb import PCB
+
+    # Load mapping from --map file
+    map_path = getattr(args, "map", None)
+    if not map_path:
+        print("Error: --map is required (path to JSON mapping file)", file=sys.stderr)
+        return 1
+
+    map_file = Path(map_path)
+    if not map_file.exists():
+        print(f"Error: Mapping file not found: {map_file}", file=sys.stderr)
+        return 1
+
+    try:
+        with open(map_file) as f:
+            mapping = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in mapping file: {e}", file=sys.stderr)
+        return 1
+
+    if not isinstance(mapping, dict):
+        print("Error: Mapping file must contain a JSON object (dict)", file=sys.stderr)
+        return 1
+
+    # Validate mapping values are strings
+    for key, value in mapping.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            print("Error: All keys and values in mapping must be strings", file=sys.stderr)
+            return 1
+
+    # Handle empty mapping (no-op)
+    if not mapping:
+        output_format = getattr(args, "format", "text")
+        if output_format == "json":
+            print(json.dumps({"input": str(pcb_path), "renames": [], "status": "no-op"}))
+        else:
+            print("No renames specified in mapping file.")
+        return 0
+
+    # Load PCB
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    # Get all existing references
+    existing_refs = {fp.reference for fp in pcb.footprints}
+
+    # Build collision-safe rename plan
+    rename_steps, warnings, errors = _build_rename_plan(mapping, existing_refs)
+
+    if errors:
+        for err in errors:
+            print(f"Error: {err}", file=sys.stderr)
+        return 1
+
+    dry_run = getattr(args, "dry_run", False)
+    output_format = getattr(args, "format", "text")
+
+    # Build result for reporting
+    result: dict = {
+        "input": str(pcb_path),
+        "dry_run": dry_run,
+        "mapping": mapping,
+        "renames": [],
+        "warnings": warnings,
+    }
+
+    if dry_run:
+        # Report what would be done without modifying
+        for step_from, step_to, via_original in rename_steps:
+            entry: dict[str, str | None] = {"from": step_from, "to": step_to}
+            if via_original is not None:
+                entry["original_source"] = via_original
+            result["renames"].append(entry)
+
+        if output_format == "json":
+            print(json.dumps(result, indent=2))
+        else:
+            print("PCB Reannotate (dry run)")
+            print(f"  Input: {pcb_path}")
+            print()
+            print(f"  Planned renames ({len(mapping)} mappings, {len(rename_steps)} steps):")
+            for step_from, step_to, via_original in rename_steps:
+                if via_original is not None:
+                    print(f"    {step_from} -> {step_to}  (temp for {via_original})")
+                else:
+                    print(f"    {step_from} -> {step_to}")
+            if warnings:
+                print()
+                for w in warnings:
+                    print(f"  Warning: {w}")
+        return 0
+
+    # Execute renames
+    applied: list[dict[str, str | None]] = []
+    for step_from, step_to, via_original in rename_steps:
+        success = _update_footprint_reference(pcb, step_from, step_to)
+        if success:
+            entry = {"from": step_from, "to": step_to}
+            if via_original is not None:
+                entry["original_source"] = via_original
+            applied.append(entry)
+        else:
+            print(
+                f"Error: Failed to rename '{step_from}' -> '{step_to}'",
+                file=sys.stderr,
+            )
+            return 1
+
+    result["renames"] = applied
+
+    # Determine output path
+    output_path = pcb_path
+    if args.output:
+        output_path = Path(args.output)
+
+    result["output"] = str(output_path)
+
+    # Save
+    try:
+        pcb.save(output_path)
+    except Exception as e:
+        print(f"Error saving PCB: {e}", file=sys.stderr)
+        return 1
+
+    if output_format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print("PCB Reannotate")
+        print(f"  Input:  {pcb_path}")
+        print(f"  Output: {output_path}")
+        print()
+        print(f"  Applied {len(mapping)} renames ({len(rename_steps)} steps):")
+        for entry in applied:
+            from_ref = entry["from"]
+            to_ref = entry["to"]
+            orig = entry.get("original_source")
+            if orig is not None:
+                print(f"    {from_ref} -> {to_ref}  (temp for {orig})")
+            else:
+                print(f"    {from_ref} -> {to_ref}")
+        if warnings:
+            print()
+            for w in warnings:
+                print(f"  Warning: {w}")
 
     return 0

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -627,6 +627,38 @@ def _add_pcb_parser(subparsers) -> None:
         help="Show what would be removed without modifying files",
     )
 
+    # pcb reannotate
+    pcb_reannotate = pcb_subparsers.add_parser(
+        "reannotate",
+        help="Batch rename reference designators",
+        description="Rename reference designators in a PCB using a JSON mapping file. "
+        "Handles collision chains (e.g., C6->C10 while C10->C15) safely using "
+        "temporary intermediate references.",
+    )
+    pcb_reannotate.add_argument("pcb", help="Path to .kicad_pcb file")
+    pcb_reannotate.add_argument(
+        "--map",
+        required=True,
+        help='Path to JSON mapping file (e.g., {"C1": "C10", "C10": "C15"})',
+    )
+    pcb_reannotate.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        help="Output file path (default: overwrite input)",
+    )
+    pcb_reannotate.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for results",
+    )
+    pcb_reannotate.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview renames without modifying the PCB file",
+    )
+
 
 def _add_lib_parser(subparsers) -> None:
     """Add library subcommand parser with its subcommands."""

--- a/tests/test_cli_pcb.py
+++ b/tests/test_cli_pcb.py
@@ -526,6 +526,7 @@ class TestPcbStrip:
 
         # Verify the output file has no traces
         from kicad_tools.schema.pcb import PCB
+
         stripped_pcb = PCB.load(output_file)
         assert len(stripped_pcb.segments) == 0
 
@@ -670,3 +671,599 @@ class TestPcbStrip:
         # Check that the stripped file was created with the suffix
         expected_output = minimal_pcb.with_stem(f"{minimal_pcb.stem}-stripped")
         assert expected_output.exists()
+
+
+# PCB with multiple footprints for reannotation testing
+MULTI_FOOTPRINT_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000001")
+    (at 100 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000101"))
+    (property "Value" "100nF" (at 0 1.5 0) (layer "F.Fab")
+      (uuid "00000000-0000-0000-0000-000000000102"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (at 110 100)
+    (property "Reference" "C2" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000201"))
+    (property "Value" "100nF" (at 0 1.5 0) (layer "F.Fab")
+      (uuid "00000000-0000-0000-0000-000000000202"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000003")
+    (at 120 100)
+    (property "Reference" "C3" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000301"))
+    (property "Value" "100nF" (at 0 1.5 0) (layer "F.Fab")
+      (uuid "00000000-0000-0000-0000-000000000302"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000004")
+    (at 130 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000401"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab")
+      (uuid "00000000-0000-0000-0000-000000000402"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000005")
+    (at 140 100)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000501"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab")
+      (uuid "00000000-0000-0000-0000-000000000502"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+)
+"""
+
+
+# KiCad 7 format PCB with fp_text instead of property
+KICAD7_MULTI_FOOTPRINT_PCB = """(kicad_pcb
+  (version 20230101)
+  (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 100 100)
+    (fp_text reference "R1" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15))))
+    (fp_text value "10k" (at 0 1.5 0) (layer "F.Fab")
+      (effects (font (size 1.0 1.0) (thickness 0.15))))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (at 110 100)
+    (fp_text reference "R2" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15))))
+    (fp_text value "22k" (at 0 1.5 0) (layer "F.Fab")
+      (effects (font (size 1.0 1.0) (thickness 0.15))))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+)
+"""
+
+
+@pytest.fixture
+def multi_fp_pcb(tmp_path: Path) -> Path:
+    """Create a PCB with multiple footprints for reannotation testing."""
+    pcb_file = tmp_path / "multi.kicad_pcb"
+    pcb_file.write_text(MULTI_FOOTPRINT_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def kicad7_multi_fp_pcb(tmp_path: Path) -> Path:
+    """Create a KiCad 7 format PCB with multiple footprints."""
+    pcb_file = tmp_path / "kicad7_multi.kicad_pcb"
+    pcb_file.write_text(KICAD7_MULTI_FOOTPRINT_PCB)
+    return pcb_file
+
+
+class TestPcbReannotate:
+    """Tests for pcb reannotate command."""
+
+    def test_simple_rename(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test simple non-conflicting rename (A->B where B does not exist)."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        # Create mapping file
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"C1": "C10", "R1": "R10"}))
+
+        output_file = tmp_path / "output.kicad_pcb"
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=str(output_file),
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+        # Verify renames applied
+        pcb = PCB.load(output_file)
+        refs = {fp.reference for fp in pcb.footprints}
+        assert "C10" in refs
+        assert "R10" in refs
+        assert "C1" not in refs
+        assert "R1" not in refs
+        # Unchanged refs still present
+        assert "C2" in refs
+        assert "C3" in refs
+        assert "R2" in refs
+
+    def test_collision_chain(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test collision chain: A->B, B->C where B is both source and target."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        # C1->C2, C2->C3, C3->C10 (chain)
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"C1": "C2", "C2": "C3", "C3": "C10"}))
+
+        output_file = tmp_path / "output.kicad_pcb"
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=str(output_file),
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+        # Verify: original C1 should now be C2, original C2 should be C3,
+        # original C3 should be C10
+        pcb = PCB.load(output_file)
+        refs = {fp.reference for fp in pcb.footprints}
+        assert "C2" in refs
+        assert "C3" in refs
+        assert "C10" in refs
+        assert "C1" not in refs
+
+    def test_cyclic_rename(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test cyclic rename: A->B, B->A (swap)."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"C1": "C2", "C2": "C1"}))
+
+        output_file = tmp_path / "output.kicad_pcb"
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=str(output_file),
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+        # Load and check: both C1 and C2 should still exist (swapped)
+        pcb = PCB.load(output_file)
+        refs = {fp.reference for fp in pcb.footprints}
+        assert "C1" in refs
+        assert "C2" in refs
+
+    def test_three_way_cycle(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test 3-way cyclic rename: A->B, B->C, C->A."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"C1": "C2", "C2": "C3", "C3": "C1"}))
+
+        output_file = tmp_path / "output.kicad_pcb"
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=str(output_file),
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+        pcb = PCB.load(output_file)
+        refs = {fp.reference for fp in pcb.footprints}
+        # All three should still exist after the cycle
+        assert "C1" in refs
+        assert "C2" in refs
+        assert "C3" in refs
+
+    def test_dry_run_no_modification(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test --dry-run produces output without modifying the file."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"C1": "C10"}))
+
+        # Read original content
+        original_content = multi_fp_pcb.read_text()
+
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=None,
+            format="text",
+            dry_run=True,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+        # File should be unchanged
+        assert multi_fp_pcb.read_text() == original_content
+
+        captured = capsys.readouterr()
+        assert "dry run" in captured.out.lower()
+        assert "C1" in captured.out
+        assert "C10" in captured.out
+
+    def test_dry_run_json_format(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test --dry-run with JSON output format."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"C1": "C10", "C2": "C20"}))
+
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=None,
+            format="json",
+            dry_run=True,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["dry_run"] is True
+        assert len(data["renames"]) > 0
+        assert data["mapping"] == {"C1": "C10", "C2": "C20"}
+
+    def test_json_output_format(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test JSON output format for actual renames."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"C1": "C10"}))
+
+        output_file = tmp_path / "output.kicad_pcb"
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=str(output_file),
+            format="json",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["dry_run"] is False
+        assert data["output"] == str(output_file)
+        assert len(data["renames"]) == 1
+
+    def test_missing_source_ref_error(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test error when source reference does not exist in PCB."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"NONEXISTENT": "C10"}))
+
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=None,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "NONEXISTENT" in captured.err
+        assert "not found" in captured.err.lower()
+
+    def test_target_collides_with_existing_non_mapped_ref(
+        self, multi_fp_pcb: Path, tmp_path, capsys
+    ):
+        """Test error when target collides with existing ref not in the mapping."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        # C1 -> R1, but R1 exists and is NOT being renamed
+        # Actually R1 is in the PCB. Map C1 to R2 (R2 also exists and is not mapped).
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"C1": "R2"}))
+
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=None,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "R2" in captured.err
+        assert "already exists" in captured.err.lower()
+
+    def test_empty_mapping(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test empty mapping file is a no-op."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text("{}")
+
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=None,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+    def test_empty_mapping_json_format(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test empty mapping with JSON output."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text("{}")
+
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=None,
+            format="json",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["status"] == "no-op"
+
+    def test_invalid_json_mapping(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test error on invalid JSON mapping file."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text("not json at all")
+
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=None,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "invalid json" in captured.err.lower()
+
+    def test_mapping_file_not_found(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test error when mapping file does not exist."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(tmp_path / "nonexistent.json"),
+            output=None,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "not found" in captured.err.lower()
+
+    def test_overwrite_input_when_no_output(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test that without -o, the input file is overwritten."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"C1": "C10"}))
+
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=None,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+        # Verify input file was modified
+        pcb = PCB.load(multi_fp_pcb)
+        refs = {fp.reference for fp in pcb.footprints}
+        assert "C10" in refs
+        assert "C1" not in refs
+
+    def test_kicad7_format_rename(self, kicad7_multi_fp_pcb: Path, tmp_path, capsys):
+        """Test rename with KiCad 7 fp_text format."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text(json.dumps({"R1": "R10", "R2": "R20"}))
+
+        output_file = tmp_path / "output.kicad_pcb"
+        args = Namespace(
+            pcb=str(kicad7_multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=str(output_file),
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 0
+
+        pcb = PCB.load(output_file)
+        refs = {fp.reference for fp in pcb.footprints}
+        assert "R10" in refs
+        assert "R20" in refs
+        assert "R1" not in refs
+        assert "R2" not in refs
+
+    def test_mapping_not_a_dict(self, multi_fp_pcb: Path, tmp_path, capsys):
+        """Test error when mapping file contains a non-dict JSON value."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        map_file = tmp_path / "map.json"
+        map_file.write_text('["C1", "C2"]')
+
+        args = Namespace(
+            pcb=str(multi_fp_pcb),
+            pcb_command="reannotate",
+            map=str(map_file),
+            output=None,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "object" in captured.err.lower() or "dict" in captured.err.lower()


### PR DESCRIPTION
## Summary
Adds a new `kct pcb reannotate` subcommand that batch-renames reference designators in a PCB file using a JSON mapping. The rename engine safely handles collision chains (e.g., C6->C10 while C10->C15) and cyclic renames (e.g., C1->C2, C2->C1) via temporary intermediate references.

## Changes
- Add `_run_reannotate_command()` handler in `commands/pcb.py` with collision-safe rename engine
- Add `_update_footprint_reference()` helper supporting both KiCad 7 (fp_text) and KiCad 8+ (property) formats
- Add `_build_rename_plan()` that detects chains/cycles and generates safe two-phase rename steps
- Add `pcb reannotate` subparser in `parser.py` with `--map`, `--dry-run`, `--format`, `-o` arguments
- Add 16 tests in `test_cli_pcb.py` covering simple renames, collision chains, cycles, dry-run, JSON output, error cases, empty mappings, KiCad 7 format, and input validation

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Simple non-conflicting renames work | PASS | test_simple_rename |
| Collision chain detection and resolution | PASS | test_collision_chain |
| Cyclic renames (A->B, B->A) | PASS | test_cyclic_rename |
| 3-way cyclic renames | PASS | test_three_way_cycle |
| --dry-run preview without modification | PASS | test_dry_run_no_modification |
| JSON output format | PASS | test_json_output_format, test_dry_run_json_format |
| Missing source ref produces error | PASS | test_missing_source_ref_error |
| Target collision with non-mapped ref errors | PASS | test_target_collides_with_existing_non_mapped_ref |
| Empty mapping is no-op | PASS | test_empty_mapping |
| KiCad 7 fp_text format support | PASS | test_kicad7_format_rename |
| Invalid JSON / missing file errors | PASS | test_invalid_json_mapping, test_mapping_file_not_found |

## Test Plan
All 54 tests in `test_cli_pcb.py` pass (16 new + 38 existing), with no regressions.

Closes #1564