### PR TITLE
fix(schematic): correct XC6206 LDO symbol from SOT-23-5 to SOT-23-3

### DIFF
--- a/src/kicad_tools/pcb/footprints.py
+++ b/src/kicad_tools/pcb/footprints.py
@@ -232,7 +232,7 @@ COMMON_FOOTPRINTS = {
     # Voltage Regulators
     # -------------------------------------------------------------------------
     "Package_TO_SOT_SMD:SOT-23-5": {
-        # Typical LDO pinout (e.g., XC6206, AP2112):
+        # Typical 5-pin LDO pinout (e.g., AP2204K, AP2112):
         # Pin 1: VIN (left, bottom)
         # Pin 2: GND (left, middle)
         # Pin 3: EN (left, top)

--- a/src/kicad_tools/schematic/blocks/power/regulators.py
+++ b/src/kicad_tools/schematic/blocks/power/regulators.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from ..base import CircuitBlock
+from ...exceptions import PinNotFoundError
 from ..interfaces import PowerPort
 
 if TYPE_CHECKING:
@@ -40,7 +41,7 @@ class LDOBlock(CircuitBlock):
         y: float,
         ref: str = "U1",
         value: str = "LDO",
-        ldo_symbol: str = "Regulator_Linear:AP2204K-1.5",
+        ldo_symbol: str = "Regulator_Linear:XC6206PxxxMR",
         input_cap: str = "10uF",
         output_caps: list[str] = None,
         cap_ref_start: int = 1,
@@ -111,15 +112,21 @@ class LDOBlock(CircuitBlock):
         vin_pos = self.ldo.pin_position("VIN")
         vout_pos = self.ldo.pin_position("VOUT")
         gnd_pos = self.ldo.pin_position("GND")
-        en_pos = self.ldo.pin_position("EN")
+
+        # EN pin is optional -- 3-pin LDOs (e.g., XC6206PxxxMR) lack it
+        try:
+            en_pos = self.ldo.pin_position("EN")
+        except PinNotFoundError:
+            en_pos = None
 
         # Define ports
         self.ports = {
             "VIN": vin_pos,
             "VOUT": vout_pos,
             "GND": gnd_pos,
-            "EN": en_pos,
         }
+        if en_pos is not None:
+            self.ports["EN"] = en_pos
 
         # Register typed ports with power interface metadata
         self.typed_ports = {
@@ -145,8 +152,8 @@ class LDOBlock(CircuitBlock):
             ),
         }
 
-        # Tie EN to VIN if requested
-        if en_tied_to_vin:
+        # Tie EN to VIN if requested and EN pin exists
+        if en_tied_to_vin and en_pos is not None:
             # Connect EN to VIN (vertical wire)
             sch.add_wire(en_pos, (en_pos[0], vin_pos[1]))
 
@@ -643,7 +650,7 @@ def create_3v3_ldo(
         y,
         ref=ref,
         value="XC6206-3.3V",
-        ldo_symbol="Regulator_Linear:AP2204K-1.5",
+        ldo_symbol="Regulator_Linear:XC6206PxxxMR",
         input_cap="10uF",
         output_caps=["10uF", "100nF"],
         cap_ref_start=cap_ref_start,

--- a/src/kicad_tools/schematic/registry.py
+++ b/src/kicad_tools/schematic/registry.py
@@ -241,7 +241,7 @@ class SymbolRegistry:
         self._opl_mapping = {
             # Regulators
             "XC6206P332MR-G": "Regulator_Linear:XC6206PxxxMR",
-            "XC6206-3.3V": "Regulator_Linear:AP2204K-1.5",  # Compatible pinout
+            "XC6206-3.3V": "Regulator_Linear:XC6206PxxxMR",  # SOT-23-3 (3-pin)
             # Passive components
             "470R_FB": "Device:FerriteBead_Small",
             # Discretes

--- a/tests/test_schematic_blocks.py
+++ b/tests/test_schematic_blocks.py
@@ -582,15 +582,30 @@ class TestLDOBlockMocked:
         sch = Mock()
 
         def create_mock_component(symbol, x, y, ref, *args, **kwargs):
+            from kicad_tools.schematic.exceptions import PinNotFoundError
+
             comp = Mock()
-            # LDO pins
+            # LDO pins -- XC6206PxxxMR is SOT-23-3 (no EN pin)
             if "LDO" in str(symbol) or "Regulator" in str(symbol) or "AP2204" in str(symbol):
-                comp.pin_position.side_effect = lambda name: {
+                has_en = "XC6206" not in str(symbol)
+                pin_map = {
                     "VIN": (x - 10, y),
                     "VOUT": (x + 10, y),
                     "GND": (x, y + 10),
-                    "EN": (x - 5, y + 5),
-                }.get(name, (0, 0))
+                }
+                if has_en:
+                    pin_map["EN"] = (x - 5, y + 5)
+
+                def _pin_position(name, _pin_map=pin_map, _symbol=symbol):
+                    if name in _pin_map:
+                        return _pin_map[name]
+                    raise PinNotFoundError(
+                        pin_name=name,
+                        symbol_name=str(_symbol),
+                        available_pins=[],
+                    )
+
+                comp.pin_position.side_effect = _pin_position
             else:
                 # Capacitor pins
                 comp.pin_position.side_effect = lambda name: {"1": (x, y - 5), "2": (x, y + 5)}.get(
@@ -606,10 +621,26 @@ class TestLDOBlockMocked:
         return sch
 
     def test_ldo_block_creation(self, mock_schematic):
-        """Create LDO block."""
+        """Create LDO block with default XC6206 (3-pin, no EN)."""
         ldo = LDOBlock(mock_schematic, x=100, y=100, ref="U1", value="3.3V")
 
         assert ldo.schematic == mock_schematic
+        assert "VIN" in ldo.ports
+        assert "VOUT" in ldo.ports
+        assert "GND" in ldo.ports
+        assert "EN" not in ldo.ports  # XC6206PxxxMR has no EN pin
+
+    def test_ldo_block_creation_with_en(self, mock_schematic):
+        """Create LDO block with 5-pin symbol that has EN."""
+        ldo = LDOBlock(
+            mock_schematic,
+            x=100,
+            y=100,
+            ref="U1",
+            value="3.3V",
+            ldo_symbol="Regulator_Linear:AP2204K-1.5",
+        )
+
         assert "VIN" in ldo.ports
         assert "VOUT" in ldo.ports
         assert "GND" in ldo.ports
@@ -625,11 +656,25 @@ class TestLDOBlockMocked:
         assert "C_OUT2" in ldo.components
 
     def test_ldo_en_tied_to_vin(self, mock_schematic):
-        """EN pin tied to VIN when requested."""
-        LDOBlock(mock_schematic, x=100, y=100, ref="U1", en_tied_to_vin=True)
+        """EN pin tied to VIN when symbol has EN."""
+        LDOBlock(
+            mock_schematic,
+            x=100,
+            y=100,
+            ref="U1",
+            en_tied_to_vin=True,
+            ldo_symbol="Regulator_Linear:AP2204K-1.5",
+        )
 
         # Should add wire connecting EN to VIN level
         assert mock_schematic.add_wire.called
+
+    def test_ldo_no_en_wire_for_3pin(self, mock_schematic):
+        """No EN wire added for 3-pin LDO without EN pin."""
+        LDOBlock(mock_schematic, x=100, y=100, ref="U1", en_tied_to_vin=True)
+
+        # XC6206PxxxMR has no EN pin, so no wire should be added for EN
+        assert not mock_schematic.add_wire.called
 
     def test_ldo_connect_to_rails(self, mock_schematic):
         """Connect LDO to power rails."""

--- a/tests/test_typed_ports.py
+++ b/tests/test_typed_ports.py
@@ -512,16 +512,29 @@ class TestLDOBlockTypedPorts:
         sch = Mock()
 
         def make_mock_symbol(symbol, x, y, ref, *args, **kwargs):
+            from kicad_tools.schematic.exceptions import PinNotFoundError
+
             mock = Mock()
+            # XC6206PxxxMR is SOT-23-3: no EN pin
+            has_en = "XC6206" not in str(symbol)
             pin_map = {
                 "VIN": (x - 10, y),
                 "VOUT": (x + 10, y),
                 "GND": (x, y + 10),
-                "EN": (x - 5, y + 5),
                 "1": (x, y - 5),
                 "2": (x, y + 5),
             }
-            mock.pin_position.side_effect = lambda name: pin_map.get(name, (0, 0))
+            if has_en:
+                pin_map["EN"] = (x - 5, y + 5)
+
+            def _pin_pos(name, _pm=pin_map, _sym=symbol):
+                if name in _pm:
+                    return _pm[name]
+                raise PinNotFoundError(
+                    pin_name=name, symbol_name=str(_sym), available_pins=[]
+                )
+
+            mock.pin_position.side_effect = _pin_pos
             return mock
 
         sch.add_symbol = Mock(side_effect=make_mock_symbol)


### PR DESCRIPTION
## Summary
Fixes incorrect symbol and footprint mapping for the XC6206 3.3V LDO regulator. The XC6206 is a 3-pin SOT-23-3 device but was mapped to the 5-pin AP2204K-1.5 symbol (SOT-23-5), which has incompatible pinouts that would cause hardware damage if fabricated.

## Changes
- Fix `registry.py` OPL mapping: `"XC6206-3.3V"` now maps to `"Regulator_Linear:XC6206PxxxMR"` instead of `"Regulator_Linear:AP2204K-1.5"`
- Fix `regulators.py` `create_3v3_ldo()` factory: uses correct `XC6206PxxxMR` symbol
- Update `LDOBlock` default symbol from `AP2204K-1.5` to `XC6206PxxxMR`
- Make `LDOBlock` EN pin handling graceful: catches `PinNotFoundError` for 3-pin LDOs that lack an enable pin, skipping the EN-to-VIN wire
- Fix misleading comment in `footprints.py` that incorrectly listed XC6206 as a SOT-23-5 example

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `registry.py` mapping corrected for XC6206-3.3V | PASS | Line 244 now maps to `Regulator_Linear:XC6206PxxxMR` |
| `regulators.py` `create_3v3_ldo()` uses correct symbol | PASS | Line 647 now uses `Regulator_Linear:XC6206PxxxMR` |
| LDOBlock handles missing EN pin for 3-pin symbols | PASS | try/except PinNotFoundError; EN excluded from ports when absent |
| Tests pass | PASS | 591 tests pass (2 pre-existing failures unrelated to this change) |

## Test Plan
- Ran `TestLDOBlockMocked` (15 tests) -- all pass, including new tests for 3-pin LDO behavior
- Ran `test_typed_ports.py` (48 tests) -- all pass with updated mock
- Ran full relevant test suite (591 pass, 2 pre-existing failures in unrelated TestBlockIntegration)
- New tests added: `test_ldo_block_creation_with_en`, `test_ldo_no_en_wire_for_3pin`

Closes #1572