### PR TITLE
fix(audit): prefer base PCB over routed variant when base is newer

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -319,6 +319,7 @@ class ManufacturingAudit:
         quantity: int = 5,
         skip_erc: bool = False,
         no_assembly: bool = False,
+        pcb_override: Path | None = None,
     ):
         """Initialize the audit.
 
@@ -330,6 +331,8 @@ class ManufacturingAudit:
             quantity: Quantity for cost estimate
             skip_erc: Skip ERC check (for PCB-only audits)
             no_assembly: Skip assembly cost calculation
+            pcb_override: Explicit PCB path override (takes precedence over
+                all auto-detection including project.kct)
         """
         self.path = Path(project_or_pcb)
         self.manufacturer = manufacturer
@@ -342,7 +345,14 @@ class ManufacturingAudit:
         # Resolve paths
         if self.path.suffix == ".kicad_pro":
             self.project_path = self.path
-            self.pcb_path = self._resolve_pcb_path()
+            if pcb_override is not None:
+                pcb_override = Path(pcb_override)
+                if not pcb_override.exists():
+                    raise ValueError(f"PCB override file not found: {pcb_override}")
+                logger.info(f"Using PCB override: {pcb_override}")
+                self.pcb_path = pcb_override
+            else:
+                self.pcb_path = self._resolve_pcb_path()
             self.schematic_path = self._resolve_schematic_path()
         elif self.path.suffix == ".kicad_pcb":
             self.project_path = None
@@ -368,8 +378,9 @@ class ManufacturingAudit:
 
         Resolution order:
         1. Check project.kct for artifacts.pcb
-        2. Look for *_routed.kicad_pcb file
-        3. Default to <basename>.kicad_pcb
+        2. When both base and *_routed exist, prefer the most recently modified
+        3. Fall back to *_routed.kicad_pcb if only routed exists
+        4. Default to <basename>.kicad_pcb
         """
         project_dir = self.path.parent
         basename = self.path.stem
@@ -394,10 +405,19 @@ class ManufacturingAudit:
             except Exception as e:
                 logger.debug(f"Failed to load project.kct: {e}")
 
-        # 2. Look for *_routed.kicad_pcb
+        # 2. When both base and routed exist, prefer the most recently modified
+        base_path = project_dir / f"{basename}.kicad_pcb"
         routed_path = project_dir / f"{basename}_routed.kicad_pcb"
-        if routed_path.exists():
-            logger.debug(f"Using routed PCB: {routed_path}")
+
+        if base_path.exists() and routed_path.exists():
+            if base_path.stat().st_mtime >= routed_path.stat().st_mtime:
+                logger.info(f"Using base PCB (newer): {base_path}")
+                return base_path
+            else:
+                logger.info(f"Using routed PCB (newer): {routed_path}")
+                return routed_path
+        elif routed_path.exists():
+            logger.info(f"Using routed PCB: {routed_path}")
             return routed_path
 
         # 3. Default to <basename>.kicad_pcb

--- a/src/kicad_tools/cli/audit_cmd.py
+++ b/src/kicad_tools/cli/audit_cmd.py
@@ -85,6 +85,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Skip assembly cost in estimate (overrides project.kct)",
     )
     parser.add_argument(
+        "--pcb",
+        type=Path,
+        default=None,
+        help="Override auto-detected PCB path (takes precedence over project.kct)",
+    )
+    parser.add_argument(
         "--strict",
         action="store_true",
         help="Exit with code 2 on warnings",
@@ -121,6 +127,7 @@ def main(argv: list[str] | None = None) -> int:
             quantity=args.quantity,
             skip_erc=args.skip_erc,
             no_assembly=args.no_assembly,
+            pcb_override=args.pcb,
         )
         result = audit.run()
     except ValueError as e:

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -460,6 +460,8 @@ def run_audit_command(args) -> int:
         sub_argv.extend(["--quantity", str(args.audit_quantity)])
     if getattr(args, "audit_skip_erc", False):
         sub_argv.append("--skip-erc")
+    if getattr(args, "audit_pcb", None):
+        sub_argv.extend(["--pcb", args.audit_pcb])
     if getattr(args, "audit_strict", False):
         sub_argv.append("--strict")
     if getattr(args, "audit_verbose", False):

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2513,6 +2513,13 @@ def _add_audit_parser(subparsers) -> None:
         help="Skip ERC check (for PCB-only audits)",
     )
     audit_parser.add_argument(
+        "--pcb",
+        dest="audit_pcb",
+        type=str,
+        default=None,
+        help="Override auto-detected PCB path (takes precedence over project.kct)",
+    )
+    audit_parser.add_argument(
         "--strict",
         dest="audit_strict",
         action="store_true",

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -904,20 +904,11 @@ project:
         # Should resolve to the routed PCB from project.kct
         assert audit.pcb_path == routed_pcb
 
-    def test_resolve_pcb_fallback_to_routed_suffix(self, tmp_path: Path):
-        """Test that audit falls back to *_routed.kicad_pcb if no project.kct."""
-        # Create routed PCB
+    def test_resolve_pcb_fallback_to_routed_only(self, tmp_path: Path):
+        """Test that audit uses *_routed.kicad_pcb when only routed exists."""
+        # Create routed PCB only (no base PCB)
         routed_pcb = tmp_path / "test_routed.kicad_pcb"
         routed_pcb.write_text(
-            """(kicad_pcb (version 20221018)
-  (generator pcbnew)
-  (layers (0 "F.Cu" signal))
-)"""
-        )
-
-        # Create unrouted PCB
-        unrouted_pcb = tmp_path / "test.kicad_pcb"
-        unrouted_pcb.write_text(
             """(kicad_pcb (version 20221018)
   (generator pcbnew)
   (layers (0 "F.Cu" signal))
@@ -931,7 +922,7 @@ project:
         # Initialize audit with project file
         audit = ManufacturingAudit(project_file)
 
-        # Should fallback to *_routed.kicad_pcb
+        # Should use routed PCB since it's the only one
         assert audit.pcb_path == routed_pcb
 
     def test_resolve_pcb_default_no_routed(self, tmp_path: Path):
@@ -954,6 +945,114 @@ project:
 
         # Should default to <basename>.kicad_pcb
         assert audit.pcb_path == unrouted_pcb
+
+    def test_resolve_pcb_prefers_newer_base(self, tmp_path: Path):
+        """Test that audit prefers base PCB when it is newer than routed."""
+        import os
+
+        # Create both PCB files
+        base_pcb = tmp_path / "test.kicad_pcb"
+        base_pcb.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        routed_pcb = tmp_path / "test_routed.kicad_pcb"
+        routed_pcb.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+
+        # Set base PCB as newer
+        os.utime(routed_pcb, (1000, 1000))
+        os.utime(base_pcb, (2000, 2000))
+
+        # Create project file (no project.kct)
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        audit = ManufacturingAudit(project_file)
+
+        # Should prefer the newer base PCB
+        assert audit.pcb_path == base_pcb
+
+    def test_resolve_pcb_prefers_newer_routed(self, tmp_path: Path):
+        """Test that audit prefers routed PCB when it is newer than base."""
+        import os
+
+        # Create both PCB files
+        base_pcb = tmp_path / "test.kicad_pcb"
+        base_pcb.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        routed_pcb = tmp_path / "test_routed.kicad_pcb"
+        routed_pcb.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+
+        # Set routed PCB as newer
+        os.utime(base_pcb, (1000, 1000))
+        os.utime(routed_pcb, (2000, 2000))
+
+        # Create project file (no project.kct)
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        audit = ManufacturingAudit(project_file)
+
+        # Should prefer the newer routed PCB
+        assert audit.pcb_path == routed_pcb
+
+    def test_pcb_override_flag(self, tmp_path: Path):
+        """Test that pcb_override takes precedence over auto-detection."""
+        # Create an explicit PCB file
+        override_pcb = tmp_path / "custom.kicad_pcb"
+        override_pcb.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+
+        # Create routed PCB (would normally be selected)
+        routed_pcb = tmp_path / "test_routed.kicad_pcb"
+        routed_pcb.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+
+        # Create project file
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        audit = ManufacturingAudit(project_file, pcb_override=override_pcb)
+
+        # Should use the override path
+        assert audit.pcb_path == override_pcb
+
+    def test_pcb_override_nonexistent(self, tmp_path: Path):
+        """Test that pcb_override raises ValueError for nonexistent file."""
+        import pytest
+
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        with pytest.raises(ValueError, match="PCB override file not found"):
+            ManufacturingAudit(
+                project_file,
+                pcb_override=tmp_path / "nonexistent.kicad_pcb",
+            )
 
 
 class TestAuditJsonSchema:


### PR DESCRIPTION
## Summary
Replace the unconditional routed-file preference in `_resolve_pcb_path()` with a modification-time comparison, so that re-annotated base PCBs are selected over stale routed variants. Also adds a `--pcb` CLI flag for explicit override.

## Changes
- Modified `_resolve_pcb_path()` in `auditor.py` to compare `st_mtime` of base and routed PCBs when both exist, selecting the newer file
- Added `pcb_override` parameter to `ManufacturingAudit.__init__()` that bypasses all auto-detection (including project.kct)
- Added `--pcb` argument to both `audit_cmd.py` (standalone) and `parser.py` (`kct audit` subcommand)
- Threaded `--pcb` through `run_audit_command()` in `validation.py`
- Updated existing test to reflect routed-only fallback scenario
- Added 4 new test cases: newer-base preference, newer-routed preference, pcb_override usage, and nonexistent override error

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Timestamp-based selection when both exist | Pass | `test_resolve_pcb_prefers_newer_base` and `test_resolve_pcb_prefers_newer_routed` pass using `os.utime()` |
| Log which PCB file was selected | Pass | Uses `logger.info()` for all selection paths |
| `--pcb` override flag | Pass | `test_pcb_override_flag` confirms override takes precedence |
| Override nonexistent raises ValueError | Pass | `test_pcb_override_nonexistent` confirms error |
| Routed-only fallback still works | Pass | `test_resolve_pcb_fallback_to_routed_only` passes |
| Base-only default still works | Pass | `test_resolve_pcb_default_no_routed` passes |
| project.kct still takes priority | Pass | `test_resolve_pcb_from_project_kct` passes unchanged |

## Test Plan
All 7 tests in `TestAuditPathResolution` pass: `uv run pytest tests/test_audit.py::TestAuditPathResolution -v`

Closes #1574