### PR TITLE
feat(schema): add schematic editing API for programmatic component insertion

### DIFF
--- a/src/kicad_tools/schema/schematic.py
+++ b/src/kicad_tools/schema/schematic.py
@@ -6,6 +6,7 @@ Provides a high-level interface to KiCad schematic files.
 
 from __future__ import annotations
 
+import uuid as uuid_mod
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -15,7 +16,8 @@ from kicad_tools.sexp import SExp
 
 from ..core.sexp_file import load_schematic, save_schematic
 from .label import GlobalLabel, HierarchicalLabel, Label
-from .symbol import SymbolInstance
+from .library import LibrarySymbol
+from .symbol import SymbolInstance, SymbolPin, SymbolProperty
 from .wire import Junction, Wire
 
 if TYPE_CHECKING:
@@ -287,6 +289,328 @@ class Schematic:
                 if sym_name == lib_id:
                     return sym
         return None
+
+    # Editing API
+
+    def _find_insertion_index(self) -> int:
+        """Find the S-expression index where new elements should be inserted.
+
+        Elements are inserted before ``sheet_instances`` and
+        ``symbol_instances`` sections at the end of the file.  If neither
+        exists, elements are appended at the very end.
+        """
+        sentinel_tags = {"sheet_instances", "symbol_instances"}
+        for i, child in enumerate(self._sexp.children):
+            if child.name in sentinel_tags:
+                return i
+        return len(self._sexp.children)
+
+    def add_symbol(
+        self,
+        lib_id: str,
+        reference: str,
+        value: str,
+        footprint: str,
+        position: tuple[float, float],
+        rotation: float = 0,
+        mirror: str = "",
+        unit: int = 1,
+        pin_numbers: list[str] | None = None,
+        datasheet: str = "",
+    ) -> SymbolInstance:
+        """Add a new component symbol to the schematic.
+
+        The symbol's library definition must already exist in the
+        schematic's ``lib_symbols`` section.  Use
+        :meth:`embed_lib_symbol` to add it first if needed.
+
+        Args:
+            lib_id: Library identifier (e.g. ``"Device:R"``).
+            reference: Reference designator (e.g. ``"R1"``).
+            value: Component value (e.g. ``"10k"``).
+            footprint: Footprint name (e.g. ``"Resistor_SMD:R_0402_1005Metric"``).
+            position: ``(x, y)`` placement in schematic coordinates.
+            rotation: Rotation in degrees (default 0).
+            mirror: Mirror mode (``""``, ``"x"``, or ``"y"``).
+            unit: Unit number for multi-unit symbols (default 1).
+            pin_numbers: Optional list of pin numbers.  When *None*, pins
+                are auto-detected from the embedded ``lib_symbols`` entry.
+            datasheet: Optional datasheet URL.
+
+        Returns:
+            The created :class:`SymbolInstance`.
+
+        Raises:
+            ValueError: If ``lib_id`` is not found in ``lib_symbols`` and
+                *pin_numbers* was not supplied.
+        """
+        sym_uuid = str(uuid_mod.uuid4())
+
+        # Build properties
+        props: dict[str, SymbolProperty] = {
+            "Reference": SymbolProperty(
+                name="Reference",
+                value=reference,
+                position=position,
+                rotation=0,
+                visible=True,
+            ),
+            "Value": SymbolProperty(
+                name="Value",
+                value=value,
+                position=(position[0], position[1] + 2.54),
+                rotation=0,
+                visible=True,
+            ),
+            "Footprint": SymbolProperty(
+                name="Footprint",
+                value=footprint,
+                position=position,
+                rotation=0,
+                visible=False,
+            ),
+            "Datasheet": SymbolProperty(
+                name="Datasheet",
+                value=datasheet,
+                position=position,
+                rotation=0,
+                visible=False,
+            ),
+        }
+
+        # Determine pin numbers from lib_symbols when not explicitly given
+        if pin_numbers is None:
+            lib_sym_sexp = self.get_lib_symbol(lib_id)
+            if lib_sym_sexp is not None:
+                lib_sym = LibrarySymbol.from_sexp(lib_sym_sexp)
+                pin_numbers = [p.number for p in lib_sym.pins]
+            else:
+                raise ValueError(
+                    f"lib_id '{lib_id}' not found in schematic lib_symbols. "
+                    "Use embed_lib_symbol() first, or supply pin_numbers explicitly."
+                )
+
+        pins = [SymbolPin(number=num, uuid=str(uuid_mod.uuid4())) for num in pin_numbers]
+
+        instance = SymbolInstance(
+            lib_id=lib_id,
+            uuid=sym_uuid,
+            position=position,
+            rotation=rotation,
+            mirror=mirror,
+            unit=unit,
+            in_bom=True,
+            on_board=True,
+            dnp=False,
+            properties=props,
+            pins=pins,
+        )
+
+        # Insert into S-expression tree before sentinel sections
+        idx = self._find_insertion_index()
+        self._sexp.insert(idx, instance.to_sexp())
+        self.invalidate_cache()
+        return instance
+
+    def add_power(
+        self,
+        name: str,
+        position: tuple[float, float],
+        rotation: float = 0,
+    ) -> SymbolInstance:
+        """Add a power symbol (e.g. GND, +3V3).
+
+        Power symbols have ``in_bom=False`` and ``on_board=False``.
+        The library entry must already exist in ``lib_symbols``.
+
+        Args:
+            name: Power symbol name (e.g. ``"GND"``, ``"+3V3"``).
+            position: ``(x, y)`` placement.
+            rotation: Rotation in degrees (default 0).
+
+        Returns:
+            The created :class:`SymbolInstance`.
+        """
+        lib_id = f"power:{name}"
+        sym_uuid = str(uuid_mod.uuid4())
+
+        # Detect pins from lib_symbols
+        pin_numbers: list[str] = []
+        lib_sym_sexp = self.get_lib_symbol(lib_id)
+        if lib_sym_sexp is not None:
+            lib_sym = LibrarySymbol.from_sexp(lib_sym_sexp)
+            pin_numbers = [p.number for p in lib_sym.pins]
+        else:
+            # Power symbols typically have a single pin "1"
+            pin_numbers = ["1"]
+
+        props: dict[str, SymbolProperty] = {
+            "Reference": SymbolProperty(
+                name="Reference",
+                value=f"#{name}",
+                position=position,
+                rotation=0,
+                visible=False,
+            ),
+            "Value": SymbolProperty(
+                name="Value",
+                value=name,
+                position=(position[0], position[1] + 2.54),
+                rotation=0,
+                visible=True,
+            ),
+            "Footprint": SymbolProperty(
+                name="Footprint",
+                value="",
+                position=position,
+                rotation=0,
+                visible=False,
+            ),
+            "Datasheet": SymbolProperty(
+                name="Datasheet",
+                value="",
+                position=position,
+                rotation=0,
+                visible=False,
+            ),
+        }
+
+        pins = [SymbolPin(number=num, uuid=str(uuid_mod.uuid4())) for num in pin_numbers]
+
+        instance = SymbolInstance(
+            lib_id=lib_id,
+            uuid=sym_uuid,
+            position=position,
+            rotation=rotation,
+            mirror="",
+            unit=1,
+            in_bom=False,
+            on_board=False,
+            dnp=False,
+            properties=props,
+            pins=pins,
+        )
+
+        idx = self._find_insertion_index()
+        self._sexp.insert(idx, instance.to_sexp())
+        self.invalidate_cache()
+        return instance
+
+    def add_wire(
+        self,
+        start: tuple[float, float],
+        end: tuple[float, float],
+    ) -> Wire:
+        """Add a wire segment to the schematic.
+
+        Args:
+            start: ``(x, y)`` start point.
+            end: ``(x, y)`` end point.
+
+        Returns:
+            The created :class:`Wire`.
+        """
+        wire = Wire(
+            start=start,
+            end=end,
+            uuid=str(uuid_mod.uuid4()),
+            stroke_width=0,
+            stroke_type="default",
+        )
+        idx = self._find_insertion_index()
+        self._sexp.insert(idx, wire.to_sexp())
+        self.invalidate_cache()
+        return wire
+
+    def embed_lib_symbol(self, lib_sym: LibrarySymbol) -> None:
+        """Insert a library symbol definition into ``lib_symbols``.
+
+        If a definition with the same name already exists, this is a
+        no-op.
+
+        Args:
+            lib_sym: The :class:`LibrarySymbol` to embed.
+        """
+        lib_syms = self.lib_symbols
+        if lib_syms is None:
+            # Create the lib_symbols section
+            lib_syms = SExp.list("lib_symbols")
+            # Insert it early (after uuid/paper, before symbols)
+            # Find a good insertion point
+            insert_idx = 0
+            for i, child in enumerate(self._sexp.children):
+                if child.name in (
+                    "uuid",
+                    "paper",
+                    "title_block",
+                    "generator",
+                    "generator_version",
+                    "version",
+                ):
+                    insert_idx = i + 1
+            self._sexp.insert(insert_idx, lib_syms)
+
+        # Check if already present
+        for sym in lib_syms.find_all("symbol"):
+            sym_name = sym.get_string(0)
+            if sym_name == lib_sym.name:
+                return  # Already embedded
+
+        lib_syms.append(lib_sym.to_sexp_node())
+
+    @staticmethod
+    def snap_to_grid(
+        value: float,
+        grid: float = 1.27,
+    ) -> float:
+        """Round a coordinate value to the nearest grid point.
+
+        Args:
+            value: Coordinate value in mm.
+            grid: Grid spacing in mm (default 1.27 = 50mil).
+
+        Returns:
+            The snapped value.
+        """
+        return round(value / grid) * grid
+
+    def snap_all_to_grid(self, grid: float = 1.27) -> None:
+        """Snap all symbol and wire positions to the nearest grid point.
+
+        This modifies both the Python dataclass fields *and* the
+        underlying S-expression tree, then invalidates the cache.
+
+        Args:
+            grid: Grid spacing in mm (default 1.27 = 50mil).
+        """
+        snap = self.snap_to_grid
+
+        # Snap symbols
+        for sym_sexp in self._sexp.find_children("symbol"):
+            if at := sym_sexp.find("at"):
+                x = at.get_float(0) or 0
+                y = at.get_float(1) or 0
+                at.set_value(0, snap(x, grid))
+                at.set_value(1, snap(y, grid))
+
+        # Snap wires
+        for wire_sexp in self._sexp.find_all("wire"):
+            if pts := wire_sexp.find("pts"):
+                for xy in pts.find_all("xy"):
+                    x = xy.get_float(0) or 0
+                    y = xy.get_float(1) or 0
+                    xy.set_value(0, snap(x, grid))
+                    xy.set_value(1, snap(y, grid))
+
+        # Snap junctions
+        for junc_sexp in self._sexp.find_all("junction"):
+            if at := junc_sexp.find("at"):
+                x = at.get_float(0) or 0
+                y = at.get_float(1) or 0
+                at.set_value(0, snap(x, grid))
+                at.set_value(1, snap(y, grid))
+
+        self.invalidate_cache()
 
     # Modification helpers
 

--- a/src/kicad_tools/schema/symbol.py
+++ b/src/kicad_tools/schema/symbol.py
@@ -6,6 +6,7 @@ Represents a component instance placed in a schematic.
 
 from __future__ import annotations
 
+import uuid as uuid_mod
 from dataclasses import dataclass, field
 
 from kicad_tools.sexp import SExp
@@ -18,6 +19,14 @@ class SymbolPin:
     number: str
     uuid: str
     name: str | None = None
+
+    def to_sexp(self) -> SExp:
+        """Convert to S-expression.
+
+        Format: ``(pin "1" (uuid "..."))``
+        """
+        pin_uuid = self.uuid or str(uuid_mod.uuid4())
+        return SExp.list("pin", self.number, SExp.list("uuid", pin_uuid))
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> SymbolPin:
@@ -38,6 +47,28 @@ class SymbolProperty:
     position: tuple[float, float] = (0, 0)
     rotation: float = 0
     visible: bool = True
+
+    def to_sexp(self) -> SExp:
+        """Convert to S-expression.
+
+        Format::
+
+            (property "Reference" "R1" (at X Y 0)
+              (effects (font (size 1.27 1.27))))
+
+        Hidden properties include ``(hide yes)`` in the effects block.
+        """
+        effects_children: list[SExp] = [SExp.list("font", SExp.list("size", 1.27, 1.27))]
+        if not self.visible:
+            effects_children.append(SExp.list("hide", "yes"))
+
+        return SExp.list(
+            "property",
+            self.name,
+            self.value,
+            SExp.list("at", self.position[0], self.position[1], self.rotation),
+            SExp(name="effects", children=effects_children),
+        )
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> SymbolProperty:
@@ -108,6 +139,51 @@ class SymbolInstance:
         if "Datasheet" in self.properties:
             return self.properties["Datasheet"].value
         return ""
+
+    def to_sexp(self) -> SExp:
+        """Convert to S-expression for insertion into a schematic.
+
+        Produces the standard KiCad 8 symbol instance format::
+
+            (symbol
+              (lib_id "Device:R")
+              (at X Y ROT)
+              (mirror x)          ; only if mirror is set
+              (unit 1)
+              (in_bom yes)
+              (on_board yes)
+              (dnp no)
+              (uuid "...")
+              (property "Reference" "R1" ...)
+              (property "Value" "10k" ...)
+              (pin "1" (uuid "..."))
+              (pin "2" (uuid "..."))
+              (instances ...)
+            )
+        """
+        sym = SExp.list("symbol")
+        sym.append(SExp.list("lib_id", self.lib_id))
+        if self.rotation != 0:
+            sym.append(SExp.list("at", self.position[0], self.position[1], self.rotation))
+        else:
+            sym.append(SExp.list("at", self.position[0], self.position[1], 0))
+        if self.mirror:
+            sym.append(SExp.list("mirror", self.mirror))
+        sym.append(SExp.list("unit", self.unit))
+        sym.append(SExp.list("in_bom", "yes" if self.in_bom else "no"))
+        sym.append(SExp.list("on_board", "yes" if self.on_board else "no"))
+        sym.append(SExp.list("dnp", "yes" if self.dnp else "no"))
+        sym.append(SExp.list("uuid", self.uuid))
+
+        # Properties
+        for prop in self.properties.values():
+            sym.append(prop.to_sexp())
+
+        # Pins
+        for pin in self.pins:
+            sym.append(pin.to_sexp())
+
+        return sym
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> SymbolInstance:

--- a/src/kicad_tools/schema/wire.py
+++ b/src/kicad_tools/schema/wire.py
@@ -6,6 +6,7 @@ Represents electrical connections in a schematic.
 
 from __future__ import annotations
 
+import uuid as uuid_mod
 from dataclasses import dataclass
 
 from kicad_tools.sexp import SExp
@@ -24,6 +25,30 @@ class Wire:
     uuid: str = ""
     stroke_width: float = 0
     stroke_type: str = "default"
+
+    def to_sexp(self) -> SExp:
+        """Convert to S-expression.
+
+        Format::
+
+            (wire
+              (pts (xy X1 Y1) (xy X2 Y2))
+              (stroke (width 0) (type default))
+              (uuid "...")
+            )
+        """
+        wire_uuid = self.uuid or str(uuid_mod.uuid4())
+        pts = SExp.list(
+            "pts",
+            SExp.list("xy", self.start[0], self.start[1]),
+            SExp.list("xy", self.end[0], self.end[1]),
+        )
+        stroke = SExp.list(
+            "stroke",
+            SExp.list("width", self.stroke_width),
+            SExp.list("type", self.stroke_type),
+        )
+        return SExp.list("wire", pts, stroke, SExp.list("uuid", wire_uuid))
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> Wire:
@@ -101,6 +126,22 @@ class Junction:
     position: tuple[float, float]
     uuid: str = ""
     diameter: float = 0
+
+    def to_sexp(self) -> SExp:
+        """Convert to S-expression.
+
+        Format::
+
+            (junction (at X Y) (diameter D) (color 0 0 0 0) (uuid "..."))
+        """
+        junc_uuid = self.uuid or str(uuid_mod.uuid4())
+        return SExp.list(
+            "junction",
+            SExp.list("at", self.position[0], self.position[1]),
+            SExp.list("diameter", self.diameter),
+            SExp.list("color", 0, 0, 0, 0),
+            SExp.list("uuid", junc_uuid),
+        )
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> Junction:

--- a/tests/test_schematic_editing.py
+++ b/tests/test_schematic_editing.py
@@ -1,0 +1,420 @@
+"""Tests for the schematic editing API.
+
+Covers add_symbol(), add_power(), add_wire(), embed_lib_symbol(),
+snap_to_grid(), snap_all_to_grid(), and round-trip serialization.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.schema import Schematic
+from kicad_tools.schema.library import LibrarySymbol
+from kicad_tools.schema.symbol import SymbolInstance, SymbolPin, SymbolProperty
+from kicad_tools.schema.wire import Junction, Wire
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A minimal schematic with a lib_symbols section containing Device:R
+SCHEMATIC_WITH_LIB = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (property "Reference" "R" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "R" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (symbol "Device:R_0_1"
+        (polyline (pts (xy -1.016 -2.54) (xy -1.016 2.54)) (stroke (width 0) (type default)) (fill (type none)))
+      )
+      (symbol "Device:R_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+        (pin passive line (at 0 -3.81 90) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+      )
+    )
+    (symbol "power:GND"
+      (property "Reference" "#PWR" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "GND" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:GND_0_1"
+        (polyline (pts (xy 0 0) (xy 0 -1.27)) (stroke (width 0) (type default)) (fill (type none)))
+      )
+      (symbol "power:GND_1_1"
+        (pin power_in line (at 0 0 0) (length 0) (name "GND" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+def _write_schematic(tmp_path: Path, content: str = SCHEMATIC_WITH_LIB) -> Path:
+    p = tmp_path / "edit_test.kicad_sch"
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# SymbolProperty.to_sexp round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolPropertyToSexp:
+    def test_visible_property_round_trip(self):
+        prop = SymbolProperty(
+            name="Reference", value="R1", position=(10, 20), rotation=0, visible=True
+        )
+        sexp = prop.to_sexp()
+        parsed = SymbolProperty.from_sexp(sexp)
+        assert parsed.name == "Reference"
+        assert parsed.value == "R1"
+        assert parsed.visible is True
+
+    def test_hidden_property_round_trip(self):
+        prop = SymbolProperty(
+            name="Footprint", value="SMD:R_0402", position=(5, 5), rotation=0, visible=False
+        )
+        sexp = prop.to_sexp()
+        parsed = SymbolProperty.from_sexp(sexp)
+        assert parsed.name == "Footprint"
+        assert parsed.value == "SMD:R_0402"
+        assert parsed.visible is False
+
+
+# ---------------------------------------------------------------------------
+# SymbolPin.to_sexp round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolPinToSexp:
+    def test_round_trip(self):
+        pin = SymbolPin(number="1", uuid="aaaa-bbbb", name=None)
+        sexp = pin.to_sexp()
+        parsed = SymbolPin.from_sexp(sexp)
+        assert parsed.number == "1"
+        assert parsed.uuid == "aaaa-bbbb"
+
+
+# ---------------------------------------------------------------------------
+# Wire.to_sexp round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestWireToSexp:
+    def test_round_trip(self):
+        wire = Wire(start=(10, 20), end=(30, 40), uuid="wire-uuid-1")
+        sexp = wire.to_sexp()
+        parsed = Wire.from_sexp(sexp)
+        assert parsed.start == (10, 20)
+        assert parsed.end == (30, 40)
+        assert parsed.uuid == "wire-uuid-1"
+
+
+# ---------------------------------------------------------------------------
+# Junction.to_sexp round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestJunctionToSexp:
+    def test_round_trip(self):
+        junc = Junction(position=(15, 25), uuid="junc-uuid-1", diameter=0)
+        sexp = junc.to_sexp()
+        parsed = Junction.from_sexp(sexp)
+        assert parsed.position == (15, 25)
+        assert parsed.uuid == "junc-uuid-1"
+
+
+# ---------------------------------------------------------------------------
+# SymbolInstance.to_sexp round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolInstanceToSexp:
+    def test_round_trip(self):
+        props = {
+            "Reference": SymbolProperty("Reference", "C1", (50, 60), 0, True),
+            "Value": SymbolProperty("Value", "100nF", (50, 62), 0, True),
+            "Footprint": SymbolProperty("Footprint", "SMD:C_0402", (50, 60), 0, False),
+            "Datasheet": SymbolProperty("Datasheet", "", (50, 60), 0, False),
+        }
+        pins = [
+            SymbolPin("1", "pin-uuid-1"),
+            SymbolPin("2", "pin-uuid-2"),
+        ]
+        inst = SymbolInstance(
+            lib_id="Device:C",
+            uuid="sym-uuid-1",
+            position=(50, 60),
+            rotation=90,
+            mirror="x",
+            unit=1,
+            in_bom=True,
+            on_board=True,
+            properties=props,
+            pins=pins,
+        )
+        sexp = inst.to_sexp()
+        parsed = SymbolInstance.from_sexp(sexp)
+
+        assert parsed.lib_id == "Device:C"
+        assert parsed.uuid == "sym-uuid-1"
+        assert parsed.position == (50, 60)
+        assert parsed.rotation == 90
+        assert parsed.mirror == "x"
+        assert parsed.in_bom is True
+        assert parsed.on_board is True
+        assert parsed.reference == "C1"
+        assert parsed.value == "100nF"
+        assert parsed.footprint == "SMD:C_0402"
+        assert len(parsed.pins) == 2
+
+
+# ---------------------------------------------------------------------------
+# Schematic.add_symbol
+# ---------------------------------------------------------------------------
+
+
+class TestAddSymbol:
+    def test_add_symbol_basic(self, tmp_path: Path):
+        sch = Schematic.load(_write_schematic(tmp_path))
+        assert len(sch.symbols) == 0
+
+        sym = sch.add_symbol(
+            lib_id="Device:R",
+            reference="R1",
+            value="10k",
+            footprint="Resistor_SMD:R_0402",
+            position=(100, 100),
+        )
+
+        assert isinstance(sym, SymbolInstance)
+        assert sym.reference == "R1"
+        assert sym.value == "10k"
+        assert sym.lib_id == "Device:R"
+        assert sym.position == (100, 100)
+        assert len(sym.pins) == 2  # auto-detected from lib_symbols
+        assert sym.in_bom is True
+        assert sym.on_board is True
+
+        # Cache should reflect the new symbol
+        assert len(sch.symbols) == 1
+        assert sch.symbols[0].reference == "R1"
+
+    def test_add_symbol_with_rotation(self, tmp_path: Path):
+        sch = Schematic.load(_write_schematic(tmp_path))
+        sym = sch.add_symbol(
+            lib_id="Device:R",
+            reference="R2",
+            value="4.7k",
+            footprint="Resistor_SMD:R_0402",
+            position=(120, 80),
+            rotation=90,
+            mirror="x",
+        )
+        assert sym.rotation == 90
+        assert sym.mirror == "x"
+
+    def test_add_symbol_missing_lib_raises(self, tmp_path: Path):
+        sch = Schematic.load(_write_schematic(tmp_path))
+        with pytest.raises(ValueError, match="not found in schematic lib_symbols"):
+            sch.add_symbol(
+                lib_id="Device:C",
+                reference="C1",
+                value="100nF",
+                footprint="SMD:C_0402",
+                position=(50, 50),
+            )
+
+    def test_add_symbol_explicit_pins(self, tmp_path: Path):
+        """When pin_numbers is given, lib_symbols lookup is not required."""
+        sch = Schematic.load(_write_schematic(tmp_path))
+        sym = sch.add_symbol(
+            lib_id="Device:C",
+            reference="C1",
+            value="100nF",
+            footprint="SMD:C_0402",
+            position=(50, 50),
+            pin_numbers=["1", "2"],
+        )
+        assert len(sym.pins) == 2
+
+    def test_add_multiple_symbols(self, tmp_path: Path):
+        sch = Schematic.load(_write_schematic(tmp_path))
+        sch.add_symbol("Device:R", "R1", "10k", "SMD:R_0402", (100, 100))
+        sch.add_symbol("Device:R", "R2", "4.7k", "SMD:R_0402", (120, 100))
+        assert len(sch.symbols) == 2
+
+    def test_insertion_before_sheet_instances(self, tmp_path: Path):
+        """New symbols must be inserted before sheet_instances."""
+        sch = Schematic.load(_write_schematic(tmp_path))
+        sch.add_symbol("Device:R", "R1", "10k", "SMD:R_0402", (100, 100))
+
+        # Verify sheet_instances is still the last named section
+        last_named = None
+        for child in sch.sexp.children:
+            if child.name:
+                last_named = child.name
+        assert last_named == "sheet_instances"
+
+
+# ---------------------------------------------------------------------------
+# Schematic.add_power
+# ---------------------------------------------------------------------------
+
+
+class TestAddPower:
+    def test_add_power_gnd(self, tmp_path: Path):
+        sch = Schematic.load(_write_schematic(tmp_path))
+        sym = sch.add_power("GND", (100, 110))
+
+        assert sym.lib_id == "power:GND"
+        assert sym.in_bom is False
+        assert sym.on_board is False
+        assert sym.position == (100, 110)
+        assert len(sym.pins) == 1  # auto-detected from lib_symbols
+        assert len(sch.symbols) == 1
+
+
+# ---------------------------------------------------------------------------
+# Schematic.add_wire
+# ---------------------------------------------------------------------------
+
+
+class TestAddWire:
+    def test_add_wire(self, tmp_path: Path):
+        sch = Schematic.load(_write_schematic(tmp_path))
+        assert len(sch.wires) == 0
+
+        wire = sch.add_wire((90, 100), (110, 100))
+        assert isinstance(wire, Wire)
+        assert wire.start == (90, 100)
+        assert wire.end == (110, 100)
+        assert wire.uuid  # UUID was generated
+        assert len(sch.wires) == 1
+
+
+# ---------------------------------------------------------------------------
+# Schematic.embed_lib_symbol
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedLibSymbol:
+    def test_embed_new_symbol(self, tmp_path: Path):
+        sch = Schematic.load(_write_schematic(tmp_path))
+        # Device:R already exists -- a new one should not duplicate
+        lib_sym_r = LibrarySymbol(name="Device:R")
+        sch.embed_lib_symbol(lib_sym_r)
+        # Count how many Device:R entries there are
+        count = sum(1 for s in sch.lib_symbols.find_all("symbol") if s.get_string(0) == "Device:R")
+        assert count == 1  # not duplicated
+
+    def test_embed_completely_new_symbol(self, tmp_path: Path):
+        sch = Schematic.load(_write_schematic(tmp_path))
+        lib_sym = LibrarySymbol(name="Device:C")
+        lib_sym.add_pin("1", "~", "passive", (0, 3.81), 270, 1.27)
+        lib_sym.add_pin("2", "~", "passive", (0, -3.81), 90, 1.27)
+        sch.embed_lib_symbol(lib_sym)
+
+        assert sch.get_lib_symbol("Device:C") is not None
+
+
+# ---------------------------------------------------------------------------
+# snap_to_grid
+# ---------------------------------------------------------------------------
+
+
+class TestSnapToGrid:
+    def test_snap_to_1_27(self):
+        assert Schematic.snap_to_grid(88.91, 1.27) == pytest.approx(88.9)
+
+    def test_snap_exact(self):
+        assert Schematic.snap_to_grid(2.54, 1.27) == pytest.approx(2.54)
+
+    def test_snap_to_2_54(self):
+        assert Schematic.snap_to_grid(3.0, 2.54) == pytest.approx(2.54)
+
+
+class TestSnapAllToGrid:
+    def test_snap_symbols_and_wires(self, tmp_path: Path):
+        sch = Schematic.load(_write_schematic(tmp_path))
+        # Add elements at off-grid positions
+        sch.add_symbol(
+            "Device:R",
+            "R1",
+            "10k",
+            "SMD:R_0402",
+            position=(88.91, 101.5),
+            pin_numbers=["1", "2"],
+        )
+        sch.add_wire((88.91, 101.5), (92.0, 101.5))
+
+        sch.snap_all_to_grid(1.27)
+
+        # Reload from sexp to check underlying values
+        sym = sch.symbols[0]
+        assert sym.position[0] == pytest.approx(88.9)
+        assert sym.position[1] == pytest.approx(101.6)
+
+        wire = sch.wires[0]
+        assert wire.start[0] == pytest.approx(88.9)
+        assert wire.end[0] == pytest.approx(91.44)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: save then reload
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_add_and_save_reload(self, tmp_path: Path):
+        """load -> add_symbol -> add_wire -> save -> load preserves new elements."""
+        path = _write_schematic(tmp_path)
+        sch = Schematic.load(path)
+
+        sch.add_symbol("Device:R", "R1", "10k", "SMD:R_0402", (100, 100))
+        sch.add_wire((90, 100), (100, 100))
+
+        out_path = tmp_path / "output.kicad_sch"
+        sch.save(out_path)
+
+        sch2 = Schematic.load(out_path)
+        assert len(sch2.symbols) == 1
+        assert sch2.symbols[0].reference == "R1"
+        assert len(sch2.wires) == 1
+        assert sch2.wires[0].start == (90, 100)
+        assert sch2.wires[0].end == (100, 100)
+
+    def test_preserves_existing_content(self, minimal_schematic: Path):
+        """Adding elements to a real schematic preserves existing content."""
+        sch = Schematic.load(minimal_schematic)
+        original_sym_count = len(sch.symbols)
+        original_wire_count = len(sch.wires)
+        original_label_count = len(sch.labels)
+
+        # Add a symbol with explicit pins (lib_symbols may be empty in minimal)
+        sch.add_symbol(
+            "Device:R",
+            "R99",
+            "1M",
+            "SMD:R_0402",
+            position=(150, 150),
+            pin_numbers=["1", "2"],
+        )
+        sch.add_wire((140, 150), (150, 150))
+
+        out = minimal_schematic.parent / "round_trip.kicad_sch"
+        sch.save(out)
+
+        sch2 = Schematic.load(out)
+        assert len(sch2.symbols) == original_sym_count + 1
+        assert len(sch2.wires) == original_wire_count + 1
+        assert len(sch2.labels) == original_label_count


### PR DESCRIPTION
## Summary

Add a schematic editing API that enables programmatic insertion of symbols, power symbols, and wires into KiCad schematic files. This mirrors the existing PCB editing API pattern (add_segment/add_via) for the schematic domain.

## Changes

- Add `to_sexp()` serialization methods to `SymbolInstance`, `SymbolProperty`, `SymbolPin`, `Wire`, and `Junction` dataclasses
- Add `Schematic.add_symbol()` for inserting component symbols with auto-detected pins from lib_symbols
- Add `Schematic.add_power()` for inserting power symbols (GND, +3V3, etc.) with `in_bom=False`, `on_board=False`
- Add `Schematic.add_wire()` for inserting wire segments
- Add `Schematic.embed_lib_symbol()` for adding library definitions to the schematic's lib_symbols section
- Add `Schematic.snap_to_grid()` (static) and `Schematic.snap_all_to_grid()` for grid-snapping coordinates
- New elements are inserted before `sheet_instances` section to maintain valid S-expression ordering
- Add comprehensive test suite (22 tests) covering round-trips, insertion, error cases, and grid snapping

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| add_symbol() creates component with correct UUIDs and properties | Pass | TestAddSymbol::test_add_symbol_basic verifies reference, value, lib_id, position, pins, flags |
| add_power() creates power symbols with in_bom=no, on_board=no | Pass | TestAddPower::test_add_power_gnd verifies flags and pin auto-detection |
| add_wire() creates wire segments with proper S-expression structure | Pass | TestAddWire::test_add_wire and TestWireToSexp::test_round_trip |
| Pin numbers auto-detected from lib_symbols | Pass | TestAddSymbol::test_add_symbol_basic shows 2 pins auto-detected from Device:R |
| snap_to_grid() rounds coordinates to specified grid | Pass | TestSnapToGrid tests with 1.27mm and 2.54mm grids |
| Round-trip load->add->save->load preserves all content | Pass | TestRoundTrip::test_add_and_save_reload and test_preserves_existing_content |
| New elements inserted before sheet_instances | Pass | TestAddSymbol::test_insertion_before_sheet_instances |
| Missing lib_symbol raises clear error | Pass | TestAddSymbol::test_add_symbol_missing_lib_raises |
| embed_lib_symbol() inserts library definitions without duplicating | Pass | TestEmbedLibSymbol tests |

## Test Plan

All 22 new tests pass. All 382 existing schematic-related tests pass with no regressions.

Closes #1577