### PR TITLE
fix(cli): list all candidate scripts in 'no generator found' error messages

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -100,15 +100,14 @@ def _find_spec_file(directory: Path) -> Path | None:
     return None
 
 
-def _find_generator_script(directory: Path, script_type: str) -> Path | None:
-    """Find a generator script in the project directory.
+def _generator_candidates(script_type: str) -> list[str]:
+    """Return the list of candidate filenames for a generator script type.
 
     Args:
-        directory: Project directory to search
         script_type: Type of script ('schematic', 'pcb', 'design')
 
     Returns:
-        Path to the generator script if found
+        List of candidate filenames in search order
     """
     candidates = [
         f"generate_{script_type}.py",
@@ -121,12 +120,46 @@ def _find_generator_script(directory: Path, script_type: str) -> Path | None:
         candidates.append("generate_design.py")
         candidates.append("design.py")
 
-    for candidate in candidates:
+    return candidates
+
+
+def _find_generator_script(directory: Path, script_type: str) -> Path | None:
+    """Find a generator script in the project directory.
+
+    Args:
+        directory: Project directory to search
+        script_type: Type of script ('schematic', 'pcb', 'design')
+
+    Returns:
+        Path to the generator script if found
+    """
+    for candidate in _generator_candidates(script_type):
         script_path = directory / candidate
         if script_path.exists():
             return script_path
 
     return None
+
+
+def _format_no_generator_message(script_type: str, directory: Path) -> str:
+    """Format an informative error message when no generator script is found.
+
+    Args:
+        script_type: Type of script ('schematic' or 'pcb')
+        directory: The project directory that was searched
+
+    Returns:
+        Multi-line error message with candidate list and guidance
+    """
+    candidates = _generator_candidates(script_type)
+    candidate_list = "\n".join(f"  - {c}" for c in candidates)
+    return (
+        f"No {script_type} generator found in {directory}\n"
+        f"Searched for:\n"
+        f"{candidate_list}\n"
+        f"Hint: create one of these files, or use a combined generator "
+        f"(see boards/00-simple-led/generate_design.py for an example)"
+    )
 
 
 def _get_expected_pcb_artifact(ctx: BuildContext) -> str | None:
@@ -252,7 +285,7 @@ def _run_step_schematic(ctx: BuildContext, console: Console) -> BuildResult:
         return BuildResult(
             step="schematic",
             success=False,
-            message="No schematic generator found (generate_schematic.py)",
+            message=_format_no_generator_message("schematic", ctx.project_dir),
         )
 
     if ctx.dry_run:
@@ -297,7 +330,7 @@ def _run_step_pcb(ctx: BuildContext, console: Console) -> BuildResult:
         return BuildResult(
             step="pcb",
             success=False,
-            message="No PCB generator found (generate_pcb.py)",
+            message=_format_no_generator_message("pcb", ctx.project_dir),
         )
 
     # Skip if this script was already executed (e.g., generate_design.py ran in schematic step)

--- a/tests/test_build_cmd_errors.py
+++ b/tests/test_build_cmd_errors.py
@@ -1,0 +1,152 @@
+"""Tests for improved error messages in build_cmd when no generator script is found."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.build_cmd import (
+    BuildContext,
+    _format_no_generator_message,
+    _generator_candidates,
+    _run_step_pcb,
+    _run_step_schematic,
+)
+
+
+class TestGeneratorCandidates:
+    """Tests for _generator_candidates helper."""
+
+    def test_schematic_candidates_include_type_specific_and_combined(self) -> None:
+        candidates = _generator_candidates("schematic")
+        assert "generate_schematic.py" in candidates
+        assert "gen_schematic.py" in candidates
+        assert "schematic_gen.py" in candidates
+        assert "generate_design.py" in candidates
+        assert "design.py" in candidates
+
+    def test_pcb_candidates_include_type_specific_and_combined(self) -> None:
+        candidates = _generator_candidates("pcb")
+        assert "generate_pcb.py" in candidates
+        assert "gen_pcb.py" in candidates
+        assert "pcb_gen.py" in candidates
+        assert "generate_design.py" in candidates
+        assert "design.py" in candidates
+
+    def test_design_candidates_no_combined_extras(self) -> None:
+        candidates = _generator_candidates("design")
+        assert "generate_design.py" in candidates
+        assert "gen_design.py" in candidates
+        assert "design_gen.py" in candidates
+        # 'design' type should NOT add itself again as a combined candidate
+        assert len(candidates) == 3
+
+
+class TestFormatNoGeneratorMessage:
+    """Tests for _format_no_generator_message helper."""
+
+    def test_message_contains_all_candidate_filenames(self) -> None:
+        msg = _format_no_generator_message("schematic", Path("/some/project"))
+        for candidate in _generator_candidates("schematic"):
+            assert candidate in msg, f"Expected '{candidate}' in error message"
+
+    def test_message_contains_searched_directory(self) -> None:
+        directory = Path("/my/project/dir")
+        msg = _format_no_generator_message("schematic", directory)
+        assert str(directory) in msg
+
+    def test_message_contains_example_reference(self) -> None:
+        msg = _format_no_generator_message("pcb", Path("/tmp"))
+        assert "boards/00-simple-led/generate_design.py" in msg
+
+    def test_message_contains_hint(self) -> None:
+        msg = _format_no_generator_message("schematic", Path("/tmp"))
+        assert "Hint" in msg or "hint" in msg.lower()
+
+    def test_pcb_message_contains_pcb_candidates(self) -> None:
+        msg = _format_no_generator_message("pcb", Path("/tmp"))
+        for candidate in _generator_candidates("pcb"):
+            assert candidate in msg, f"Expected '{candidate}' in PCB error message"
+
+
+class TestRunStepSchematicError:
+    """Tests for _run_step_schematic error path."""
+
+    def test_error_message_lists_candidates(self, tmp_path: Path) -> None:
+        """When no generator exists and no schematic file exists, the error
+        message must list all candidate filenames."""
+        ctx = BuildContext(
+            project_dir=tmp_path,
+            spec_file=None,
+            schematic_file=None,
+            pcb_file=None,
+        )
+        from rich.console import Console
+
+        console = Console(quiet=True)
+        result = _run_step_schematic(ctx, console)
+
+        assert not result.success
+        for candidate in _generator_candidates("schematic"):
+            assert candidate in result.message
+        assert str(tmp_path) in result.message
+        assert "boards/00-simple-led/generate_design.py" in result.message
+
+    def test_existing_schematic_skips_without_error(self, tmp_path: Path) -> None:
+        """When schematic already exists, return success even with no generator."""
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.touch()
+        ctx = BuildContext(
+            project_dir=tmp_path,
+            spec_file=None,
+            schematic_file=sch_file,
+            pcb_file=None,
+        )
+        from rich.console import Console
+
+        console = Console(quiet=True)
+        result = _run_step_schematic(ctx, console)
+        assert result.success
+        assert "already exists" in result.message
+
+
+class TestRunStepPcbError:
+    """Tests for _run_step_pcb error path."""
+
+    def test_error_message_lists_candidates(self, tmp_path: Path) -> None:
+        """When no generator exists and no PCB file exists, the error
+        message must list all candidate filenames."""
+        ctx = BuildContext(
+            project_dir=tmp_path,
+            spec_file=None,
+            schematic_file=None,
+            pcb_file=None,
+        )
+        from rich.console import Console
+
+        console = Console(quiet=True)
+        result = _run_step_pcb(ctx, console)
+
+        assert not result.success
+        for candidate in _generator_candidates("pcb"):
+            assert candidate in result.message
+        assert str(tmp_path) in result.message
+        assert "boards/00-simple-led/generate_design.py" in result.message
+
+    def test_existing_pcb_skips_without_error(self, tmp_path: Path) -> None:
+        """When PCB already exists, return success even with no generator."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.touch()
+        ctx = BuildContext(
+            project_dir=tmp_path,
+            spec_file=None,
+            schematic_file=None,
+            pcb_file=pcb_file,
+        )
+        from rich.console import Console
+
+        console = Console(quiet=True)
+        result = _run_step_pcb(ctx, console)
+        assert result.success
+        assert "already exists" in result.message


### PR DESCRIPTION
## Summary
When no schematic or PCB generator script is found, the error message now lists
every candidate filename that was searched, the directory that was searched, and
a reference to the example board at boards/00-simple-led/generate_design.py.

## Changes
- Extract `_generator_candidates(script_type)` helper that returns the list of candidate filenames
- Extract `_format_no_generator_message(script_type, directory)` helper that builds an informative multi-line error message
- Update `_run_step_schematic()` and `_run_step_pcb()` to use the new message formatter instead of hard-coded single-candidate strings
- Add `tests/test_build_cmd_errors.py` with 12 tests covering candidate lists, message content, and both schematic/PCB error paths

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Error message lists all candidate filenames | Pass | Tests assert every candidate from _generator_candidates() appears in the message |
| Error message shows searched directory | Pass | Tests assert str(directory) appears in message |
| Error message references example board | Pass | Tests assert "boards/00-simple-led/generate_design.py" appears |
| Both schematic and PCB steps use improved message | Pass | Both _run_step_schematic and _run_step_pcb tested |
| No regression when generator IS found | Pass | Existing test_build_routing_params.py (25 tests) all pass |

## Test Plan
- `uv run python -m pytest tests/test_build_cmd_errors.py -v` -- all 12 tests pass
- `uv run python -m pytest tests/test_build_routing_params.py -v` -- all 25 existing tests pass (no regression)

Closes #1592