### PR TITLE
fix(spec): parse string copper_weight values like '2oz' in ManufacturingRequirements

### DIFF
--- a/src/kicad_tools/spec/schema.py
+++ b/src/kicad_tools/spec/schema.py
@@ -13,11 +13,12 @@ Defines the schema for PCB project specifications including:
 from __future__ import annotations
 
 import datetime
+import re
 from enum import Enum
 from typing import Any
 
 try:
-    from pydantic import BaseModel, Field, field_validator
+    from pydantic import BaseModel, Field, field_validator, model_validator
 except ImportError as e:
     raise ImportError(
         "pydantic is required for the spec module. "
@@ -205,11 +206,43 @@ class EnvironmentalRequirements(BaseModel):
     ip_rating: str | None = Field(default=None, description="IP rating")
 
 
+_COPPER_WEIGHT_RE = re.compile(r"^\s*([\d.]+)\s*(?:oz)?\s*$", re.IGNORECASE)
+
+
+def _parse_copper_weight_oz(value: int | float | str) -> float:
+    """Parse a copper weight value to float oz.
+
+    Accepts:
+      - int or float (returned as-is, e.g. 2 -> 2.0)
+      - str like '2oz', '0.5oz', '2 oz', '2OZ', or bare '2'
+
+    Raises ValueError for unrecognised formats.
+    """
+    if isinstance(value, int | float):
+        return float(value)
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Invalid copper_weight type: {type(value).__name__}. "
+            "Expected a number or string like '2oz', '0.5oz', '1 oz'."
+        )
+    m = _COPPER_WEIGHT_RE.match(value)
+    if m is None:
+        raise ValueError(
+            f"Invalid copper_weight: '{value}'. "
+            "Expected a number or string like '2oz', '0.5oz', '1 oz'."
+        )
+    return float(m.group(1))
+
+
 class ManufacturingRequirements(BaseModel):
     """Manufacturing requirements and constraints."""
 
     layers: dict[str, int] | None = Field(
         default=None, description="Layer count (preferred, min, max)"
+    )
+    copper_weight: float | None = Field(
+        default=None,
+        description="Copper weight in oz/ft^2 (e.g., 1, 2, '2oz', '0.5oz')",
     )
     min_trace: str | None = Field(default=None, description="Minimum trace width")
     min_space: str | None = Field(default=None, description="Minimum spacing")
@@ -222,6 +255,28 @@ class ManufacturingRequirements(BaseModel):
     finish: str | None = Field(default=None, description="Surface finish (HASL, ENIG, etc.)")
     solder_mask: str | None = Field(default=None, description="Solder mask color")
     silkscreen: str | None = Field(default=None, description="Silkscreen color")
+
+    @field_validator("copper_weight", mode="before")
+    @classmethod
+    def validate_copper_weight(cls, v: Any) -> float | None:
+        """Parse copper weight from int, float, or oz-bearing string."""
+        if v is None:
+            return None
+        return _parse_copper_weight_oz(v)
+
+    @model_validator(mode="before")
+    @classmethod
+    def extract_copper_weight_from_layers(cls, data: Any) -> Any:
+        """Promote copper_weight from layers dict to top-level field if nested."""
+        if isinstance(data, dict):
+            layers = data.get("layers")
+            if isinstance(layers, dict) and "copper_weight" in layers:
+                # Only promote if not already set at top level
+                if "copper_weight" not in data or data["copper_weight"] is None:
+                    data["copper_weight"] = layers.pop("copper_weight")
+                else:
+                    layers.pop("copper_weight")
+        return data
 
 
 class Compliance(BaseModel):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -439,3 +439,97 @@ class TestProgress:
         current = spec.get_current_phase_progress()
         assert current is not None
         assert len(current.checklist) == 2
+
+
+class TestCopperWeight:
+    """Tests for copper_weight parsing on ManufacturingRequirements."""
+
+    def test_copper_weight_int(self):
+        """Test copper_weight accepts plain int (backward compat)."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements(copper_weight=2)
+        assert mfg.copper_weight == 2.0
+
+    def test_copper_weight_float(self):
+        """Test copper_weight accepts plain float."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements(copper_weight=0.5)
+        assert mfg.copper_weight == 0.5
+
+    def test_copper_weight_string_with_oz(self):
+        """Test copper_weight accepts '2oz' string."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements(copper_weight="2oz")
+        assert mfg.copper_weight == 2.0
+
+    def test_copper_weight_fractional_string(self):
+        """Test copper_weight accepts '0.5oz' string."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements(copper_weight="0.5oz")
+        assert mfg.copper_weight == 0.5
+
+    def test_copper_weight_string_with_space(self):
+        """Test copper_weight accepts '2 oz' (space-tolerant)."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements(copper_weight="2 oz")
+        assert mfg.copper_weight == 2.0
+
+    def test_copper_weight_case_insensitive(self):
+        """Test copper_weight accepts '2OZ' (case-insensitive)."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements(copper_weight="2OZ")
+        assert mfg.copper_weight == 2.0
+
+    def test_copper_weight_bare_number_string(self):
+        """Test copper_weight accepts bare number string '2'."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements(copper_weight="2")
+        assert mfg.copper_weight == 2.0
+
+    def test_copper_weight_invalid_unit(self):
+        """Test copper_weight rejects invalid unit like '2lb'."""
+        from pydantic import ValidationError
+
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        with pytest.raises(ValidationError, match="copper_weight"):
+            ManufacturingRequirements(copper_weight="2lb")
+
+    def test_copper_weight_invalid_string(self):
+        """Test copper_weight rejects non-numeric strings."""
+        from pydantic import ValidationError
+
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        with pytest.raises(ValidationError, match="copper_weight"):
+            ManufacturingRequirements(copper_weight="abc")
+
+    def test_copper_weight_default_none(self):
+        """Test copper_weight defaults to None."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements()
+        assert mfg.copper_weight is None
+
+    def test_copper_weight_extracted_from_layers(self):
+        """Test copper_weight is promoted from layers dict to top-level field."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements(layers={"count": 2, "copper_weight": "2oz"})
+        assert mfg.copper_weight == 2.0
+        assert "copper_weight" not in mfg.layers
+
+    def test_layers_without_copper_weight(self):
+        """Test layers dict without copper_weight still works."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements(layers={"count": 2})
+        assert mfg.layers == {"count": 2}
+        assert mfg.copper_weight is None


### PR DESCRIPTION
## Summary
Adds support for string copper weight values (e.g. '2oz', '0.5oz') in .kct files by introducing a dedicated `copper_weight` field on `ManufacturingRequirements` with a field validator that normalizes oz-bearing strings to float.

## Changes
- Added `_parse_copper_weight_oz` helper function with regex-based parsing for int, float, and oz-string formats
- Added `copper_weight: float | None` field to `ManufacturingRequirements`
- Added `@field_validator("copper_weight", mode="before")` to normalize input values
- Added `@model_validator(mode="before")` to extract `copper_weight` from nested `layers` dict
- Added 12 unit tests covering int, float, string with oz, fractional, space-tolerant, case-insensitive, bare number, invalid unit, invalid string, default None, extraction from layers, and layers-without-copper_weight cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `copper_weight: 2` parses to 2.0 (backward compat) | PASS | `test_copper_weight_int` |
| `copper_weight: 0.5` parses to 0.5 (float input) | PASS | `test_copper_weight_float` |
| `copper_weight: "2oz"` parses to 2.0 | PASS | `test_copper_weight_string_with_oz` |
| `copper_weight: "0.5oz"` parses to 0.5 | PASS | `test_copper_weight_fractional_string` |
| `copper_weight: "2 oz"` parses to 2.0 (space-tolerant) | PASS | `test_copper_weight_string_with_space` |
| `copper_weight: "2OZ"` parses to 2.0 (case-insensitive) | PASS | `test_copper_weight_case_insensitive` |
| `copper_weight: "abc"` raises ValidationError | PASS | `test_copper_weight_invalid_string` |
| `copper_weight: "2lb"` raises ValidationError | PASS | `test_copper_weight_invalid_unit` |
| Missing copper_weight defaults to None | PASS | `test_copper_weight_default_none` |
| layers dict with copper_weight promoted to top-level | PASS | `test_copper_weight_extracted_from_layers` |
| layers dict without copper_weight still works | PASS | `test_layers_without_copper_weight` |
| board 05 project.kct loads without error | PASS | Manual verification: `load_spec('boards/05-bldc-motor-controller/project.kct')` returns copper_weight=2.0 |

## Test Plan
- All 12 new tests in `TestCopperWeight` class pass
- All 39 tests in `tests/test_spec.py` pass
- Board 05 `project.kct` with `copper_weight: "2oz"` loads successfully

Closes #1590