### PR TITLE
fix(router): tighten grid selection to prevent DRC clearance violations

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -483,9 +483,11 @@ def _get_routing_params(
         if via_diameter is None:
             via_diameter = 0.6
 
-    # Auto-calculate grid: must be ≤ clearance / 2 for DRC compliance
-    # Round DOWN to a clean value (0.05mm increments) to ensure compliance
-    grid = clearance / 2
+    # Auto-calculate grid: use clearance / 3 so that worst-case quantisation
+    # error (up to resolution/sqrt(2) for two grid-snapped objects) stays
+    # well within the DRC clearance margin.
+    # Round DOWN to a clean value (0.05mm increments) to ensure compliance.
+    grid = clearance / 3
     grid = max(0.05, math.floor(grid / 0.05) * 0.05)  # Round DOWN to 0.05mm, min 0.05mm
 
     return grid, clearance, trace_width, via_drill, via_diameter

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -541,8 +541,9 @@ def auto_select_grid_resolution(
     # Calculate minimum resolution for DRC compliance
     min_resolution = clearance / 2
 
-    # Filter candidates: must be DRC-compliant
-    valid_candidates = [c for c in candidates if c <= clearance]
+    # Filter candidates: must be DRC-compliant (grid <= clearance/2 so that
+    # worst-case grid-quantisation error never exceeds half the clearance)
+    valid_candidates = [c for c in candidates if c <= clearance / 2]
 
     if not valid_candidates:
         # All candidates are too coarse, use minimum DRC-compliant resolution

--- a/tests/test_build_routing_params.py
+++ b/tests/test_build_routing_params.py
@@ -237,6 +237,6 @@ class TestGetRoutingParamsWithSpec:
 
         assert clearance == pytest.approx(0.2), "Should use 0.2mm from spec"
         assert trace_width == pytest.approx(0.3), "Should use 0.3mm from spec"
-        # Grid for 0.2mm clearance: 0.2/2 = 0.1mm, rounded down to 0.1mm
-        assert grid == pytest.approx(0.1), "Grid should be 0.1mm for 0.2mm clearance"
+        # Grid for 0.2mm clearance: 0.2/3 = 0.0667mm, rounded down to 0.05mm
+        assert grid == pytest.approx(0.05), "Grid should be 0.05mm for 0.2mm clearance"
         assert grid <= clearance / 2, "Grid should be DRC-compatible"

--- a/tests/test_grid_auto_selection.py
+++ b/tests/test_grid_auto_selection.py
@@ -114,8 +114,8 @@ class TestAutoSelectGridResolution:
         """Test that selected resolution respects DRC clearance."""
         pads = [PadPosition(x=0.0, y=0.0)]
         result = auto_select_grid_resolution(pads, clearance=0.15)
-        # Resolution must be <= clearance for DRC compliance
-        assert result.resolution <= 0.15
+        # Resolution must be <= clearance/2 for DRC compliance
+        assert result.resolution <= 0.15 / 2
 
     def test_prefers_coarser_when_equal(self):
         """Test that coarser resolution is preferred when off-grid counts are equal."""
@@ -162,12 +162,13 @@ class TestAutoSelectGridResolution:
     def test_tssop_pitch_alignment_with_default_candidates(self):
         """Test that default candidates include TSSOP-friendly 0.065mm."""
         # TSSOP pitch is 0.65mm, which divides evenly by 0.065mm
+        # Use clearance=0.15 so that 0.065 <= 0.15/2 = 0.075 passes the filter
         pads = [
             PadPosition(x=0.0, y=0.0),
             PadPosition(x=0.65, y=0.0),  # TSSOP pitch
             PadPosition(x=1.30, y=0.0),  # 2x TSSOP pitch
         ]
-        result = auto_select_grid_resolution(pads, clearance=0.1)
+        result = auto_select_grid_resolution(pads, clearance=0.15)
         # Should include 0.065mm in candidates tried
         resolutions_tried = [c[0] for c in result.candidates_tried]
         assert 0.065 in resolutions_tried
@@ -175,18 +176,46 @@ class TestAutoSelectGridResolution:
     def test_selects_0065_for_tssop_pads(self):
         """Test that 0.065mm is selected for pure TSSOP placement."""
         # All pads on 0.65mm grid
+        # Use clearance=0.15 so that 0.065 <= 0.075 passes the filter
         pads = [
             PadPosition(x=0.0, y=0.0),
             PadPosition(x=0.65, y=0.0),
             PadPosition(x=1.30, y=0.0),
             PadPosition(x=1.95, y=0.0),
         ]
-        result = auto_select_grid_resolution(pads, clearance=0.1)
+        result = auto_select_grid_resolution(pads, clearance=0.15)
         # 0.065mm should have zero off-grid pads (0.65 / 0.065 = 10 exact)
         # So should 0.05mm (0.65 / 0.05 = 13 exact)
         # Function prefers coarser when equal, so 0.065mm should be selected
         assert result.off_grid_pads == 0
         assert result.resolution in [0.065, 0.05]  # Either is valid
+
+
+    def test_no_candidate_exceeds_half_clearance(self):
+        """With clearance=0.15, no selected candidate should exceed 0.075."""
+        pads = [PadPosition(x=0.0, y=0.0), PadPosition(x=1.0, y=0.0)]
+        result = auto_select_grid_resolution(pads, clearance=0.15)
+        assert result.resolution <= 0.15 / 2
+        # Also verify all *tried* candidates respect the threshold
+        for res, _off in result.candidates_tried:
+            assert res <= 0.15 / 2
+
+    def test_tight_clearance_floor(self):
+        """With very tight clearance (0.1mm), grid must not go below 0.05mm floor."""
+        pads = [PadPosition(x=0.0, y=0.0)]
+        result = auto_select_grid_resolution(pads, clearance=0.1)
+        # clearance/2 = 0.05, only candidate that fits is 0.05
+        assert result.resolution == 0.05
+
+    def test_board05_clearance_selects_fine_grid(self):
+        """Board 05 scenario: clearance=0.2mm should select grid <= 0.1mm."""
+        pads = [
+            PadPosition(x=0.0, y=0.0),
+            PadPosition(x=1.27, y=0.0),
+            PadPosition(x=2.54, y=1.27),
+        ]
+        result = auto_select_grid_resolution(pads, clearance=0.2)
+        assert result.resolution <= 0.2 / 2  # Must be <= 0.1mm
 
 
 class TestGridAutoSelectionSummary:


### PR DESCRIPTION
## Summary
Fix two bugs in grid resolution selection that caused persistent DRC clearance violations on board 05 (and potentially other boards with tight clearances).

## Changes
- Fix `auto_select_grid_resolution` candidate filter in `io.py` from `c <= clearance` to `c <= clearance / 2`, ensuring the auto-selected grid is always fine enough for DRC compliance
- Change grid formula in `_get_routing_params` (`build_cmd.py`) from `clearance / 2` to `clearance / 3`, providing sufficient margin against worst-case grid-quantization error
- Update existing test expectation in `test_build_routing_params.py` for the new clearance/3 formula
- Add three new tests in `test_grid_auto_selection.py`: half-clearance filter verification, tight clearance floor check, and board 05 scenario test

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| auto_select_grid_resolution filters with c <= clearance/2 | Pass | Verified in io.py line 546; test_no_candidate_exceeds_half_clearance passes |
| build_cmd grid uses clearance/3 | Pass | Verified in build_cmd.py line 490; test_voltage_divider_project_values updated and passes |
| No candidate > clearance/2 selected by auto grid | Pass | New test test_no_candidate_exceeds_half_clearance asserts all tried candidates <= clearance/2 |
| Board 05 clearance=0.2mm selects grid <= 0.1mm | Pass | New test test_board05_clearance_selects_fine_grid passes |
| Tight clearance floor at 0.05mm | Pass | New test test_tight_clearance_floor passes |
| All 58 tests pass | Pass | pytest runs 58 passed, 0 failed |

## Test Plan
- Ran `uv run pytest tests/test_grid_auto_selection.py tests/test_build_routing_params.py -v` -- all 58 tests pass
- Manual board 05 build verification deferred to CI (requires KiCad installation)

Closes #1591