### PR TITLE
feat(placement): add block-aware placement constraints with reduced-dimensionality encoding

### DIFF
--- a/src/kicad_tools/pcb/blocks/base.py
+++ b/src/kicad_tools/pcb/blocks/base.py
@@ -260,6 +260,31 @@ class PCBBlock:
             )
         return result
 
+    def relative_offsets(self) -> list:
+        """Export component positions as :class:`RelativeOffset` instances.
+
+        Returns a list of ``RelativeOffset`` objects describing each component's
+        position relative to the block origin.  Suitable for constructing a
+        ``BlockGroupDef``.
+
+        Returns:
+            List of ``RelativeOffset`` instances (one per component).
+        """
+        from kicad_tools.placement.vector import RelativeOffset
+
+        offsets: list[RelativeOffset] = []
+        for ref, comp in self.components.items():
+            offsets.append(
+                RelativeOffset(
+                    reference=ref,
+                    dx=comp.position.x,
+                    dy=comp.position.y,
+                    rotation=comp.rotation,
+                    side=0,
+                )
+            )
+        return offsets
+
     def __repr__(self):
         placed = f" at ({self.origin.x}, {self.origin.y})" if self.placed else ""
         return f"PCBBlock({self.name}, {len(self.components)} components, {len(self.ports)} ports{placed})"

--- a/src/kicad_tools/pcb/layout.py
+++ b/src/kicad_tools/pcb/layout.py
@@ -5,6 +5,8 @@ This module provides the PCBLayout class for arranging blocks and
 routing between them.
 """
 
+from __future__ import annotations
+
 from .blocks.base import PCBBlock
 from .geometry import Layer
 from .primitives import TraceSegment, Via
@@ -79,6 +81,39 @@ class PCBLayout:
             )
 
         return result
+
+    def to_block_groups(self) -> list:
+        """Extract :class:`BlockGroupDef` instances from registered blocks.
+
+        Each ``PCBBlock`` is converted to a ``BlockGroupDef`` with relative
+        component offsets suitable for the placement optimizer's
+        reduced-dimensionality encoding.
+
+        Returns:
+            List of ``BlockGroupDef`` instances (one per block).
+        """
+        from kicad_tools.placement.vector import BlockGroupDef, RelativeOffset
+
+        groups: list[BlockGroupDef] = []
+        for name, block in self.blocks.items():
+            members: list[RelativeOffset] = []
+            for ref, comp in block.components.items():
+                members.append(
+                    RelativeOffset(
+                        reference=ref,
+                        dx=comp.position.x,
+                        dy=comp.position.y,
+                        rotation=comp.rotation,
+                        side=0,  # default front side
+                    )
+                )
+            groups.append(
+                BlockGroupDef(
+                    block_id=name,
+                    members=tuple(members),
+                )
+            )
+        return groups
 
     def summary(self) -> str:
         """Print layout summary."""

--- a/src/kicad_tools/placement/__init__.py
+++ b/src/kicad_tools/placement/__init__.py
@@ -25,6 +25,11 @@ from .analyzer import DesignRules, PlacementAnalyzer
 with contextlib.suppress(ImportError):
     from .bo_strategy import BayesianOptStrategy
 
+from .cost import (
+    BlockRegion,
+    compute_block_boundary_violation,
+    compute_inter_block_spacing_violation,
+)
 from .cmaes_strategy import CMAESStrategy
 from .collision import (
     CollisionResult,
@@ -66,15 +71,23 @@ from .priors import (
 from .slide_off import SlideOffResult, slide_off_overlaps
 from .strategy import PlacementStrategy, StrategyConfig
 from .vector import (
+    BlockGroupDef,
     ComponentDef,
     PadDef,
     PlacedComponent,
     PlacementBounds,
     PlacementVector,
+    RelativeOffset,
     TransformedPad,
     bounds,
+    bounds_with_blocks,
     decode,
+    decode_with_blocks,
     encode,
+    encode_with_blocks,
+    move_block,
+    rotate_block,
+    swap_blocks,
 )
 from .visualization import (
     IterationRecord,
@@ -94,6 +107,8 @@ from .wirelength import (
 
 __all__ = [
     "AffinityGraph",
+    "BlockGroupDef",
+    "BlockRegion",
     "SlideOffResult",
     "BayesianOptStrategy",
     "CMAESStrategy",
@@ -123,6 +138,7 @@ __all__ = [
     "PlacementStrategy",
     "PlacementValidationResult",
     "PlacementVector",
+    "RelativeOffset",
     "RoutabilityResult",
     "SignalFlowResult",
     "StrategyConfig",
@@ -132,22 +148,30 @@ __all__ = [
     "OptimizationRecorder",
     "ParetoPoint",
     "bounds",
+    "bounds_with_blocks",
     "build_affinity_graph",
+    "compute_block_boundary_violation",
     "compute_hpwl",
     "compute_hpwl_breakdown",
+    "compute_inter_block_spacing_violation",
     "decode",
+    "decode_with_blocks",
     "detect_power_domains",
     "detect_signal_flow",
     "encode",
+    "encode_with_blocks",
     "evaluate_placement_multifidelity",
     "find_clusters",
     "make_adaptive_evaluator",
     "make_fixed_fidelity_evaluator",
+    "move_block",
     "plot_convergence",
     "plot_layout",
     "plot_pareto_front",
     "power_domain_clustering",
     "prior_mean_position",
+    "rotate_block",
     "schematic_proximity_prior",
     "slide_off_overlaps",
+    "swap_blocks",
 ]

--- a/src/kicad_tools/placement/cost.py
+++ b/src/kicad_tools/placement/cost.py
@@ -38,6 +38,8 @@ class PlacementCostConfig:
         boundary_weight: Weight for board boundary violation penalty.
         wirelength_weight: Weight for total wirelength cost.
         area_weight: Weight for bounding-box area cost.
+        block_boundary_weight: Weight for block boundary violation penalty.
+        inter_block_spacing: Minimum spacing between block bounding boxes (mm).
         mode: Scoring mode (weighted_sum or lexicographic).
     """
 
@@ -46,7 +48,28 @@ class PlacementCostConfig:
     boundary_weight: float = 1e5
     wirelength_weight: float = 1.0
     area_weight: float = 0.1
+    block_boundary_weight: float = 1e5
+    inter_block_spacing: float = 1.0
     mode: CostMode = CostMode.WEIGHTED_SUM
+
+
+@dataclass(frozen=True)
+class BlockRegion:
+    """Axis-aligned region assigned to a block.
+
+    Attributes:
+        block_id: Identifier matching a :class:`BlockGroupDef`.
+        min_x: Left edge in mm.
+        min_y: Top edge in mm.
+        max_x: Right edge in mm.
+        max_y: Bottom edge in mm.
+    """
+
+    block_id: str
+    min_x: float
+    min_y: float
+    max_x: float
+    max_y: float
 
 
 @dataclass(frozen=True)
@@ -59,6 +82,8 @@ class CostBreakdown:
         boundary: Raw boundary violation penalty (sum of violation depths, mm).
         drc: Raw DRC violation count.
         area: Raw bounding-box area of all placements (mm^2).
+        block_boundary: Raw block boundary violation penalty (mm).
+        inter_block: Raw inter-block spacing violation penalty (mm).
     """
 
     wirelength: float = 0.0
@@ -66,6 +91,8 @@ class CostBreakdown:
     boundary: float = 0.0
     drc: float = 0.0
     area: float = 0.0
+    block_boundary: float = 0.0
+    inter_block: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -353,6 +380,133 @@ def compute_area(
     return width * height
 
 
+def compute_block_boundary_violation(
+    placements: Sequence[ComponentPlacement],
+    block_regions: Sequence[BlockRegion],
+    block_membership: dict[str, str],
+    footprint_sizes: dict[str, tuple[float, float]] | None = None,
+) -> float:
+    """Compute total boundary violation for block member components.
+
+    For each component that belongs to a block, penalizes any portion of
+    its bounding box that extends outside the assigned block region. Uses
+    the same depth-based penalty approach as :func:`compute_boundary_violation`.
+
+    Args:
+        placements: Current component positions.
+        block_regions: Block boundary regions.
+        block_membership: Map from component reference to block_id.
+        footprint_sizes: Map from reference to (width, height) in mm.
+
+    Returns:
+        Sum of boundary violation depths across all block members (mm).
+        Zero means all block members are within their assigned regions.
+    """
+    if not block_regions or not block_membership:
+        return 0.0
+
+    default_size = (1.0, 1.0)
+    region_map = {r.block_id: r for r in block_regions}
+    total = 0.0
+
+    for p in placements:
+        bid = block_membership.get(p.reference)
+        if bid is None:
+            continue
+        region = region_map.get(bid)
+        if region is None:
+            continue
+
+        w, h = (footprint_sizes or {}).get(p.reference, default_size)
+        half_w, half_h = w / 2, h / 2
+
+        left = p.x - half_w
+        right = p.x + half_w
+        top = p.y - half_h
+        bottom = p.y + half_h
+
+        total += max(0.0, region.min_x - left)
+        total += max(0.0, right - region.max_x)
+        total += max(0.0, region.min_y - top)
+        total += max(0.0, bottom - region.max_y)
+
+    return total
+
+
+def compute_inter_block_spacing_violation(
+    placements: Sequence[ComponentPlacement],
+    block_membership: dict[str, str],
+    min_spacing: float,
+    footprint_sizes: dict[str, tuple[float, float]] | None = None,
+) -> float:
+    """Compute penalty for blocks placed closer than minimum spacing.
+
+    Computes the bounding box of each block from its member positions, then
+    checks pairwise edge-to-edge distance. If any pair is closer than
+    *min_spacing*, the shortfall is added to the penalty.
+
+    Args:
+        placements: Current component positions.
+        block_membership: Map from component reference to block_id.
+        min_spacing: Minimum spacing between block bounding boxes (mm).
+        footprint_sizes: Map from reference to (width, height) in mm.
+
+    Returns:
+        Sum of spacing shortfalls across all block pairs (mm).
+        Zero means all blocks are sufficiently spaced.
+    """
+    if not block_membership or min_spacing <= 0:
+        return 0.0
+
+    default_size = (1.0, 1.0)
+
+    # Compute bounding box per block
+    block_boxes: dict[str, list[float]] = {}  # block_id -> [min_x, min_y, max_x, max_y]
+    for p in placements:
+        bid = block_membership.get(p.reference)
+        if bid is None:
+            continue
+        w, h = (footprint_sizes or {}).get(p.reference, default_size)
+        half_w, half_h = w / 2, h / 2
+        left = p.x - half_w
+        right = p.x + half_w
+        top = p.y - half_h
+        bottom = p.y + half_h
+
+        if bid not in block_boxes:
+            block_boxes[bid] = [left, top, right, bottom]
+        else:
+            bb = block_boxes[bid]
+            bb[0] = min(bb[0], left)
+            bb[1] = min(bb[1], top)
+            bb[2] = max(bb[2], right)
+            bb[3] = max(bb[3], bottom)
+
+    # Pairwise spacing check
+    block_ids = list(block_boxes.keys())
+    total = 0.0
+    for i in range(len(block_ids)):
+        for j in range(i + 1, len(block_ids)):
+            a = block_boxes[block_ids[i]]
+            b = block_boxes[block_ids[j]]
+            # Edge-to-edge gap on each axis
+            gap_x = max(a[0], b[0]) - min(a[2], b[2])
+            gap_y = max(a[1], b[1]) - min(a[3], b[3])
+
+            if gap_x <= 0 and gap_y <= 0:
+                # Overlapping -- gap is 0
+                gap = 0.0
+            elif gap_x > 0 and gap_y > 0:
+                gap = (gap_x**2 + gap_y**2) ** 0.5
+            else:
+                gap = max(gap_x, gap_y)
+
+            if gap < min_spacing:
+                total += min_spacing - gap
+
+    return total
+
+
 def evaluate_placement(
     placements: Sequence[ComponentPlacement],
     nets: Sequence[Net],
@@ -360,6 +514,8 @@ def evaluate_placement(
     board: BoardOutline,
     config: PlacementCostConfig | None = None,
     footprint_sizes: dict[str, tuple[float, float]] | None = None,
+    block_regions: Sequence[BlockRegion] | None = None,
+    block_membership: dict[str, str] | None = None,
 ) -> PlacementScore:
     """Evaluate a placement configuration and return a composite score.
 
@@ -374,6 +530,8 @@ def evaluate_placement(
         config: Cost function configuration. Uses defaults if None.
         footprint_sizes: Optional map from reference to (width, height) in mm.
             Used by overlap, boundary, and DRC sub-functions.
+        block_regions: Optional block boundary regions for block-aware scoring.
+        block_membership: Optional map from component reference to block_id.
 
     Returns:
         PlacementScore with total score, per-component breakdown, and
@@ -389,15 +547,33 @@ def evaluate_placement(
     drc = compute_drc_violations(placements, rules, footprint_sizes)
     area = compute_area(placements)
 
+    # Block-aware cost components
+    block_boundary = 0.0
+    inter_block = 0.0
+    if block_regions and block_membership:
+        block_boundary = compute_block_boundary_violation(
+            placements, block_regions, block_membership, footprint_sizes
+        )
+        inter_block = compute_inter_block_spacing_violation(
+            placements, block_membership, config.inter_block_spacing, footprint_sizes
+        )
+
     breakdown = CostBreakdown(
         wirelength=wirelength,
         overlap=overlap,
         boundary=boundary,
         drc=drc,
         area=area,
+        block_boundary=block_boundary,
+        inter_block=inter_block,
     )
 
-    is_feasible = overlap == 0.0 and drc == 0.0 and boundary == 0.0
+    is_feasible = (
+        overlap == 0.0
+        and drc == 0.0
+        and boundary == 0.0
+        and block_boundary == 0.0
+    )
 
     if config.mode == CostMode.LEXICOGRAPHIC:
         total = _lexicographic_score(breakdown, config, is_feasible)
@@ -419,6 +595,8 @@ def _weighted_sum_score(breakdown: CostBreakdown, config: PlacementCostConfig) -
         + config.boundary_weight * breakdown.boundary
         + config.wirelength_weight * breakdown.wirelength
         + config.area_weight * breakdown.area
+        + config.block_boundary_weight * breakdown.block_boundary
+        + config.block_boundary_weight * breakdown.inter_block
     )
 
 

--- a/src/kicad_tools/placement/vector.py
+++ b/src/kicad_tools/placement/vector.py
@@ -9,15 +9,28 @@ where:
     rot    -- discrete rotation index {0, 1, 2, 3} => {0, 90, 180, 270} degrees
     side   -- binary {0, 1} => {front, back}
 
+Block-aware encoding
+--------------------
+When ``block_groups`` are provided, components belonging to a block share a
+single ``[bx, by, brot]`` triple in the vector instead of individual
+``[x, y, rot, side]`` entries.  This reduces the search-space dimensionality
+from ``4*N`` to ``4*N_free + 3*N_blocks`` and lets the optimizer move
+blocks as rigid units.
+
 Usage:
     vector = encode(placements)
     placements = decode(vector, component_defs)
     bnd = bounds(board, component_defs)
+
+    # Block-aware:
+    vector = encode_with_blocks(placements, block_groups)
+    placements = decode_with_blocks(vector, component_defs, block_groups)
+    bnd = bounds_with_blocks(board, component_defs, block_groups)
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Sequence
 
 import numpy as np
@@ -78,6 +91,51 @@ class ComponentDef:
     pads: tuple[PadDef, ...] = ()
     width: float = 1.0
     height: float = 1.0
+
+
+@dataclass(frozen=True)
+class RelativeOffset:
+    """Position of a component relative to its block origin.
+
+    Attributes:
+        reference: Component reference designator.
+        dx: X offset from block origin in mm.
+        dy: Y offset from block origin in mm.
+        rotation: Component rotation relative to block rotation in degrees.
+        side: Board side (0=front, 1=back).
+    """
+
+    reference: str
+    dx: float
+    dy: float
+    rotation: float = 0.0
+    side: int = 0
+
+
+@dataclass(frozen=True)
+class BlockGroupDef:
+    """Definition of a block group for reduced-dimensionality encoding.
+
+    Maps a block identifier to its member components and their relative
+    offsets from the block origin. During encoding the block is represented
+    as 3 fields ``[bx, by, brot]`` instead of ``4*M`` fields for *M* members.
+
+    Attributes:
+        block_id: Unique identifier for the block.
+        members: Relative offsets for each member component.
+    """
+
+    block_id: str
+    members: tuple[RelativeOffset, ...] = field(default_factory=tuple)
+
+    @property
+    def member_refs(self) -> frozenset[str]:
+        """Set of component reference designators in this block."""
+        return frozenset(m.reference for m in self.members)
+
+
+FIELDS_PER_BLOCK = 3
+"""Number of fields per block in the flat vector: bx, by, brot."""
 
 
 @dataclass(frozen=True)
@@ -395,3 +453,395 @@ def bounds(
         discrete_mask[base + 3] = True
 
     return PlacementBounds(lower=lower, upper=upper, discrete_mask=discrete_mask)
+
+
+# ---------------------------------------------------------------------------
+# Block-aware helpers
+# ---------------------------------------------------------------------------
+
+
+def _rotate_offset(dx: float, dy: float, rot_deg: float) -> tuple[float, float]:
+    """Rotate an offset vector by *rot_deg* degrees counter-clockwise."""
+    rot_idx = int(round(rot_deg / 90.0)) % 4
+    if rot_idx == 0:
+        return dx, dy
+    elif rot_idx == 1:
+        return -dy, dx
+    elif rot_idx == 2:
+        return -dx, -dy
+    else:
+        return dy, -dx
+
+
+def _block_member_refs(block_groups: Sequence[BlockGroupDef]) -> frozenset[str]:
+    """Return the set of all component references that belong to any block."""
+    refs: set[str] = set()
+    for bg in block_groups:
+        for m in bg.members:
+            refs.add(m.reference)
+    return frozenset(refs)
+
+
+def _split_free_and_block(
+    components: Sequence[ComponentDef],
+    block_groups: Sequence[BlockGroupDef],
+) -> tuple[list[int], dict[str, int]]:
+    """Return (free_indices, ref_to_comp_index) for the given components.
+
+    ``free_indices`` lists component-array indices that are NOT in any block.
+    ``ref_to_comp_index`` maps every component reference to its index in *components*.
+    """
+    ref_to_idx = {c.reference: i for i, c in enumerate(components)}
+    blocked = _block_member_refs(block_groups)
+    free_indices = [i for i, c in enumerate(components) if c.reference not in blocked]
+    return free_indices, ref_to_idx
+
+
+# ---------------------------------------------------------------------------
+# Block-aware encode / decode
+# ---------------------------------------------------------------------------
+
+
+def encode_with_blocks(
+    placements: Sequence[PlacedComponent],
+    block_groups: Sequence[BlockGroupDef],
+) -> PlacementVector:
+    """Encode placements using reduced-dimensionality block representation.
+
+    Free components get 4 fields each ``[x, y, rot, side]``.
+    Each block gets 3 fields ``[bx, by, brot]``.
+
+    The vector layout is::
+
+        [free0_x, free0_y, free0_rot, free0_side,
+         ...
+         block0_bx, block0_by, block0_brot,
+         block1_bx, block1_by, block1_brot,
+         ...]
+
+    Block origin and rotation are inferred from the first member's position
+    and the block's relative offsets.
+
+    Args:
+        placements: Ordered sequence of placed components (all components,
+            both free and block members).
+        block_groups: Block group definitions.
+
+    Returns:
+        A reduced-dimensionality :class:`PlacementVector`.
+    """
+    pos_map: dict[str, PlacedComponent] = {p.reference: p for p in placements}
+    blocked_refs = _block_member_refs(block_groups)
+
+    # Free components in the order they appear in placements
+    free = [p for p in placements if p.reference not in blocked_refs]
+    n_free = len(free)
+    n_blocks = len(block_groups)
+    total = n_free * FIELDS_PER_COMPONENT + n_blocks * FIELDS_PER_BLOCK
+
+    data = np.empty(total, dtype=np.float64)
+
+    # Encode free components
+    for i, p in enumerate(free):
+        base = i * FIELDS_PER_COMPONENT
+        rot_idx = int(round(p.rotation / 90.0)) % 4
+        data[base] = p.x
+        data[base + 1] = p.y
+        data[base + 2] = float(rot_idx)
+        data[base + 3] = float(p.side)
+
+    # Encode blocks: infer block origin from first member
+    block_offset = n_free * FIELDS_PER_COMPONENT
+    for bi, bg in enumerate(block_groups):
+        if not bg.members:
+            data[block_offset] = 0.0
+            data[block_offset + 1] = 0.0
+            data[block_offset + 2] = 0.0
+            block_offset += FIELDS_PER_BLOCK
+            continue
+
+        first = bg.members[0]
+        placed = pos_map.get(first.reference)
+        if placed is None:
+            data[block_offset] = 0.0
+            data[block_offset + 1] = 0.0
+            data[block_offset + 2] = 0.0
+            block_offset += FIELDS_PER_BLOCK
+            continue
+
+        # Infer block rotation from the first member
+        block_rot_deg = (placed.rotation - first.rotation) % 360
+        block_rot_idx = int(round(block_rot_deg / 90.0)) % 4
+        block_rot = ROTATION_STEPS[block_rot_idx]
+
+        # Infer block origin: placed_pos = origin + rotate(offset, block_rot)
+        rdx, rdy = _rotate_offset(first.dx, first.dy, block_rot)
+        bx = placed.x - rdx
+        by = placed.y - rdy
+
+        data[block_offset] = bx
+        data[block_offset + 1] = by
+        data[block_offset + 2] = float(block_rot_idx)
+        block_offset += FIELDS_PER_BLOCK
+
+    return PlacementVector(data=data)
+
+
+def decode_with_blocks(
+    vector: PlacementVector,
+    components: Sequence[ComponentDef],
+    block_groups: Sequence[BlockGroupDef],
+) -> list[PlacedComponent]:
+    """Decode a block-aware placement vector to placed components.
+
+    Returns one :class:`PlacedComponent` per entry in *components*, in the
+    same order. Free-component positions come from the vector directly; block
+    member positions are derived from the block origin/rotation and relative
+    offsets.
+
+    Args:
+        vector: Reduced-dimensionality placement vector.
+        components: Component definitions (all components, both free and block).
+        block_groups: Block group definitions matching those used for encoding.
+
+    Returns:
+        List of :class:`PlacedComponent` with the same length and order as
+        *components*.
+
+    Raises:
+        ValueError: If vector length does not match expected dimensionality.
+    """
+    blocked_refs = _block_member_refs(block_groups)
+    free_indices, ref_to_idx = _split_free_and_block(components, block_groups)
+    n_free = len(free_indices)
+    n_blocks = len(block_groups)
+
+    expected_len = n_free * FIELDS_PER_COMPONENT + n_blocks * FIELDS_PER_BLOCK
+    if len(vector.data) != expected_len:
+        raise ValueError(
+            f"Vector length {len(vector.data)} does not match expected "
+            f"{expected_len} (free={n_free}, blocks={n_blocks})"
+        )
+
+    comp_map = {c.reference: c for c in components}
+    result_map: dict[str, PlacedComponent] = {}
+
+    # Decode free components
+    for fi, comp_idx in enumerate(free_indices):
+        base = fi * FIELDS_PER_COMPONENT
+        vals = vector.data[base : base + FIELDS_PER_COMPONENT]
+        x = float(vals[0])
+        y = float(vals[1])
+        rot_idx = int(round(float(vals[2]))) % 4
+        side = int(round(float(vals[3])))
+        rotation_deg = ROTATION_STEPS[rot_idx]
+
+        comp_def = components[comp_idx]
+        transformed_pads = tuple(
+            _transform_pad(pad, x, y, rotation_deg, side) for pad in comp_def.pads
+        )
+        result_map[comp_def.reference] = PlacedComponent(
+            reference=comp_def.reference,
+            x=x,
+            y=y,
+            rotation=rotation_deg,
+            side=side,
+            pads=transformed_pads,
+        )
+
+    # Decode block members
+    block_offset = n_free * FIELDS_PER_COMPONENT
+    for bg in block_groups:
+        bx = float(vector.data[block_offset])
+        by = float(vector.data[block_offset + 1])
+        brot_idx = int(round(float(vector.data[block_offset + 2]))) % 4
+        brot_deg = ROTATION_STEPS[brot_idx]
+        block_offset += FIELDS_PER_BLOCK
+
+        for m in bg.members:
+            rdx, rdy = _rotate_offset(m.dx, m.dy, brot_deg)
+            cx = bx + rdx
+            cy = by + rdy
+            crot = (brot_deg + m.rotation) % 360
+            side = m.side
+
+            comp_def = comp_map.get(m.reference)
+            pads: tuple[TransformedPad, ...] = ()
+            if comp_def is not None:
+                pads = tuple(
+                    _transform_pad(pad, cx, cy, crot, side) for pad in comp_def.pads
+                )
+
+            result_map[m.reference] = PlacedComponent(
+                reference=m.reference,
+                x=cx,
+                y=cy,
+                rotation=crot,
+                side=side,
+                pads=pads,
+            )
+
+    # Return in the same order as components
+    return [result_map[c.reference] for c in components]
+
+
+def bounds_with_blocks(
+    board: BoardOutline,
+    components: Sequence[ComponentDef],
+    block_groups: Sequence[BlockGroupDef],
+) -> PlacementBounds:
+    """Compute per-dimension bounds for a block-aware placement vector.
+
+    Free components get the same bounds as :func:`bounds`. Each block gets
+    bounds ensuring that all its members stay within the board outline for
+    any rotation.
+
+    Args:
+        board: Board outline.
+        components: All component definitions.
+        block_groups: Block group definitions.
+
+    Returns:
+        :class:`PlacementBounds` for the reduced-dimensionality vector.
+    """
+    blocked_refs = _block_member_refs(block_groups)
+    free_indices, ref_to_idx = _split_free_and_block(components, block_groups)
+    n_free = len(free_indices)
+    n_blocks = len(block_groups)
+    total = n_free * FIELDS_PER_COMPONENT + n_blocks * FIELDS_PER_BLOCK
+
+    lower = np.empty(total, dtype=np.float64)
+    upper = np.empty(total, dtype=np.float64)
+    discrete_mask = np.zeros(total, dtype=np.bool_)
+
+    # Free component bounds (same logic as bounds())
+    for fi, comp_idx in enumerate(free_indices):
+        comp = components[comp_idx]
+        base = fi * FIELDS_PER_COMPONENT
+        half_w = comp.width / 2.0
+        half_h = comp.height / 2.0
+
+        lower[base] = board.min_x + half_w
+        upper[base] = board.max_x - half_w
+        lower[base + 1] = board.min_y + half_h
+        upper[base + 1] = board.max_y - half_h
+        lower[base + 2] = 0.0
+        upper[base + 2] = 3.0
+        discrete_mask[base + 2] = True
+        lower[base + 3] = 0.0
+        upper[base + 3] = 1.0
+        discrete_mask[base + 3] = True
+
+    # Block bounds: block origin must keep all members within board for any rotation
+    comp_map = {c.reference: c for c in components}
+    block_base = n_free * FIELDS_PER_COMPONENT
+    for bg in block_groups:
+        # Compute worst-case radius: maximum distance any member corner can be
+        # from the block origin across all 4 rotations
+        max_reach = 0.0
+        for m in bg.members:
+            cdef = comp_map.get(m.reference)
+            half_w = (cdef.width / 2.0) if cdef else 0.5
+            half_h = (cdef.height / 2.0) if cdef else 0.5
+            # For each rotation, member offset rotates; add component half-size
+            for rot in ROTATION_STEPS:
+                rdx, rdy = _rotate_offset(m.dx, m.dy, rot)
+                reach_x = abs(rdx) + half_w
+                reach_y = abs(rdy) + half_h
+                max_reach = max(max_reach, reach_x, reach_y)
+
+        lower[block_base] = board.min_x + max_reach
+        upper[block_base] = board.max_x - max_reach
+        lower[block_base + 1] = board.min_y + max_reach
+        upper[block_base + 1] = board.max_y - max_reach
+        lower[block_base + 2] = 0.0
+        upper[block_base + 2] = 3.0
+        discrete_mask[block_base + 2] = True
+        block_base += FIELDS_PER_BLOCK
+
+    return PlacementBounds(lower=lower, upper=upper, discrete_mask=discrete_mask)
+
+
+# ---------------------------------------------------------------------------
+# Block manipulation utilities
+# ---------------------------------------------------------------------------
+
+
+def move_block(
+    vector: PlacementVector,
+    block_index: int,
+    dx: float,
+    dy: float,
+    n_free: int,
+) -> PlacementVector:
+    """Translate a block by (dx, dy) in a block-aware placement vector.
+
+    Args:
+        vector: Block-aware placement vector.
+        block_index: Zero-based index of the block in the block_groups list.
+        dx: Translation in X (mm).
+        dy: Translation in Y (mm).
+        n_free: Number of free (non-block) components.
+
+    Returns:
+        New :class:`PlacementVector` with the block moved.
+    """
+    new_data = vector.data.copy()
+    base = n_free * FIELDS_PER_COMPONENT + block_index * FIELDS_PER_BLOCK
+    new_data[base] += dx
+    new_data[base + 1] += dy
+    return PlacementVector(data=new_data)
+
+
+def rotate_block(
+    vector: PlacementVector,
+    block_index: int,
+    rotation_steps: int,
+    n_free: int,
+) -> PlacementVector:
+    """Rotate a block by a number of 90-degree steps.
+
+    Args:
+        vector: Block-aware placement vector.
+        block_index: Zero-based index of the block.
+        rotation_steps: Number of 90-degree CCW steps to add (can be negative).
+        n_free: Number of free (non-block) components.
+
+    Returns:
+        New :class:`PlacementVector` with the block rotated.
+    """
+    new_data = vector.data.copy()
+    base = n_free * FIELDS_PER_COMPONENT + block_index * FIELDS_PER_BLOCK
+    current = int(round(new_data[base + 2]))
+    new_data[base + 2] = float((current + rotation_steps) % 4)
+    return PlacementVector(data=new_data)
+
+
+def swap_blocks(
+    vector: PlacementVector,
+    block_a: int,
+    block_b: int,
+    n_free: int,
+) -> PlacementVector:
+    """Swap the positions of two blocks (keeping their rotations).
+
+    Args:
+        vector: Block-aware placement vector.
+        block_a: Zero-based index of the first block.
+        block_b: Zero-based index of the second block.
+        n_free: Number of free (non-block) components.
+
+    Returns:
+        New :class:`PlacementVector` with the two blocks' positions swapped.
+    """
+    new_data = vector.data.copy()
+    base_a = n_free * FIELDS_PER_COMPONENT + block_a * FIELDS_PER_BLOCK
+    base_b = n_free * FIELDS_PER_COMPONENT + block_b * FIELDS_PER_BLOCK
+
+    # Swap x and y only (keep rotation)
+    new_data[base_a], new_data[base_b] = new_data[base_b].copy(), new_data[base_a].copy()
+    new_data[base_a + 1], new_data[base_b + 1] = (
+        new_data[base_b + 1].copy(),
+        new_data[base_a + 1].copy(),
+    )
+    return PlacementVector(data=new_data)

--- a/tests/test_placement_block_constraints.py
+++ b/tests/test_placement_block_constraints.py
@@ -1,0 +1,614 @@
+"""Tests for block-aware placement constraints.
+
+Covers:
+- BlockGroupDef dataclass and properties
+- Block-aware vector encoding: reduced dimensionality
+- Block-aware vector decoding: relative positions maintained
+- Block rotation at 90/180/270 degrees
+- Block boundary violation cost
+- Inter-block spacing violation cost
+- Block move/rotate/swap utility functions
+- Mixed optimization: free + block components
+- Regression: no blocks => identical to standard behavior
+- Edge case: single-component block
+- Edge case: all components in blocks
+- PCBLayout.to_block_groups() bridge
+- PCBBlock.relative_offsets() helper
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from kicad_tools.placement.cost import (
+    BlockRegion,
+    BoardOutline,
+    ComponentPlacement,
+    DesignRuleSet,
+    Net,
+    PlacementCostConfig,
+    compute_block_boundary_violation,
+    compute_inter_block_spacing_violation,
+    evaluate_placement,
+)
+from kicad_tools.placement.vector import (
+    FIELDS_PER_BLOCK,
+    FIELDS_PER_COMPONENT,
+    ROTATION_STEPS,
+    BlockGroupDef,
+    ComponentDef,
+    PadDef,
+    PlacedComponent,
+    PlacementVector,
+    RelativeOffset,
+    bounds,
+    bounds_with_blocks,
+    decode,
+    decode_with_blocks,
+    encode,
+    encode_with_blocks,
+    move_block,
+    rotate_block,
+    swap_blocks,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _close(a: float, b: float, tol: float = 1e-6) -> bool:
+    return abs(a - b) < tol
+
+
+def _make_board(w: float = 100.0, h: float = 100.0) -> BoardOutline:
+    return BoardOutline(min_x=0.0, min_y=0.0, max_x=w, max_y=h)
+
+
+def _make_comp(ref: str, w: float = 2.0, h: float = 2.0) -> ComponentDef:
+    return ComponentDef(reference=ref, width=w, height=h)
+
+
+def _make_block_with_3_members() -> BlockGroupDef:
+    """A block with U1 at origin, C1 at (3,0), C2 at (0,3)."""
+    return BlockGroupDef(
+        block_id="mcu_block",
+        members=(
+            RelativeOffset(reference="U1", dx=0.0, dy=0.0, rotation=0.0),
+            RelativeOffset(reference="C1", dx=3.0, dy=0.0, rotation=0.0),
+            RelativeOffset(reference="C2", dx=0.0, dy=3.0, rotation=0.0),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# BlockGroupDef dataclass tests
+# ---------------------------------------------------------------------------
+
+class TestBlockGroupDef:
+    def test_member_refs(self):
+        bg = _make_block_with_3_members()
+        assert bg.member_refs == frozenset({"U1", "C1", "C2"})
+
+    def test_empty_block(self):
+        bg = BlockGroupDef(block_id="empty")
+        assert bg.member_refs == frozenset()
+        assert len(bg.members) == 0
+
+
+# ---------------------------------------------------------------------------
+# Block vector encoding tests
+# ---------------------------------------------------------------------------
+
+class TestBlockVectorEncoding:
+    def test_vector_length_reduced(self):
+        """2 blocks (3 each) + 2 free => 4*2 + 3*2 = 14, not 4*8=32."""
+        block1 = _make_block_with_3_members()
+        block2 = BlockGroupDef(
+            block_id="power_block",
+            members=(
+                RelativeOffset(reference="U2", dx=0.0, dy=0.0),
+                RelativeOffset(reference="C3", dx=2.0, dy=0.0),
+                RelativeOffset(reference="C4", dx=0.0, dy=2.0),
+            ),
+        )
+        # Place all 8 components
+        placements = [
+            # Free components
+            PlacedComponent(reference="R1", x=10.0, y=10.0, rotation=0.0, side=0),
+            PlacedComponent(reference="R2", x=20.0, y=20.0, rotation=90.0, side=0),
+            # Block 1 members at block origin (50, 50), rotation 0
+            PlacedComponent(reference="U1", x=50.0, y=50.0, rotation=0.0, side=0),
+            PlacedComponent(reference="C1", x=53.0, y=50.0, rotation=0.0, side=0),
+            PlacedComponent(reference="C2", x=50.0, y=53.0, rotation=0.0, side=0),
+            # Block 2 members at block origin (70, 70), rotation 0
+            PlacedComponent(reference="U2", x=70.0, y=70.0, rotation=0.0, side=0),
+            PlacedComponent(reference="C3", x=72.0, y=70.0, rotation=0.0, side=0),
+            PlacedComponent(reference="C4", x=70.0, y=72.0, rotation=0.0, side=0),
+        ]
+
+        vec = encode_with_blocks(placements, [block1, block2])
+        expected_len = 2 * FIELDS_PER_COMPONENT + 2 * FIELDS_PER_BLOCK  # 8 + 6 = 14
+        assert len(vec.data) == expected_len
+
+    def test_encode_decode_roundtrip(self):
+        """Encode then decode should recover original positions."""
+        block = _make_block_with_3_members()
+        placements = [
+            PlacedComponent(reference="R1", x=10.0, y=15.0, rotation=0.0, side=0),
+            PlacedComponent(reference="U1", x=50.0, y=50.0, rotation=0.0, side=0),
+            PlacedComponent(reference="C1", x=53.0, y=50.0, rotation=0.0, side=0),
+            PlacedComponent(reference="C2", x=50.0, y=53.0, rotation=0.0, side=0),
+        ]
+        components = [
+            _make_comp("R1"),
+            _make_comp("U1", 4.0, 4.0),
+            _make_comp("C1"),
+            _make_comp("C2"),
+        ]
+
+        vec = encode_with_blocks(placements, [block])
+        decoded = decode_with_blocks(vec, components, [block])
+
+        assert len(decoded) == 4
+        for orig, dec in zip(placements, decoded):
+            assert orig.reference == dec.reference
+            assert _close(orig.x, dec.x), f"{orig.reference}: x {orig.x} != {dec.x}"
+            assert _close(orig.y, dec.y), f"{orig.reference}: y {orig.y} != {dec.y}"
+
+    def test_decode_wrong_length_raises(self):
+        """Decode with wrong vector length should raise ValueError."""
+        block = _make_block_with_3_members()
+        components = [_make_comp("R1"), _make_comp("U1"), _make_comp("C1"), _make_comp("C2")]
+        # 1 free (4) + 1 block (3) = 7; give 10 instead
+        bad_vec = PlacementVector(data=np.zeros(10, dtype=np.float64))
+        with pytest.raises(ValueError, match="Vector length"):
+            decode_with_blocks(bad_vec, components, [block])
+
+
+# ---------------------------------------------------------------------------
+# Block rotation tests
+# ---------------------------------------------------------------------------
+
+class TestBlockRotation:
+    @pytest.mark.parametrize("rot_deg,rot_idx", [(0, 0), (90, 1), (180, 2), (270, 3)])
+    def test_block_rotation_maintains_relative_positions(self, rot_deg, rot_idx):
+        """Rotating a block should maintain relative distances between members."""
+        block = BlockGroupDef(
+            block_id="test_block",
+            members=(
+                RelativeOffset(reference="U1", dx=0.0, dy=0.0),
+                RelativeOffset(reference="C1", dx=5.0, dy=0.0),
+            ),
+        )
+        components = [_make_comp("U1", 4.0, 4.0), _make_comp("C1")]
+
+        # Create vector: 0 free + 1 block
+        # block at (50, 50) with given rotation
+        data = np.array([50.0, 50.0, float(rot_idx)], dtype=np.float64)
+        vec = PlacementVector(data=data)
+
+        decoded = decode_with_blocks(vec, components, [block])
+        u1 = decoded[0]
+        c1 = decoded[1]
+
+        # Distance between U1 and C1 should always be 5.0
+        dist = ((u1.x - c1.x) ** 2 + (u1.y - c1.y) ** 2) ** 0.5
+        assert _close(dist, 5.0), f"Distance {dist} != 5.0 at rotation {rot_deg}"
+
+    def test_90_degree_rotation_specifics(self):
+        """At 90 deg CCW, offset (5,0) becomes (0,5)."""
+        block = BlockGroupDef(
+            block_id="b",
+            members=(
+                RelativeOffset(reference="U1", dx=0.0, dy=0.0),
+                RelativeOffset(reference="C1", dx=5.0, dy=0.0),
+            ),
+        )
+        components = [_make_comp("U1"), _make_comp("C1")]
+
+        # Block at origin (10, 10), rotation index 1 (90 deg)
+        data = np.array([10.0, 10.0, 1.0], dtype=np.float64)
+        vec = PlacementVector(data=data)
+        decoded = decode_with_blocks(vec, components, [block])
+
+        u1 = decoded[0]
+        c1 = decoded[1]
+        # U1 at (10, 10), C1 should be at (10-0, 10+5) = (10, 15)
+        # _rotate_offset(5, 0, 90) = (-0, 5) = (0, 5)
+        assert _close(u1.x, 10.0)
+        assert _close(u1.y, 10.0)
+        assert _close(c1.x, 10.0), f"C1.x = {c1.x}"
+        assert _close(c1.y, 15.0), f"C1.y = {c1.y}"
+
+
+# ---------------------------------------------------------------------------
+# Block boundary violation tests
+# ---------------------------------------------------------------------------
+
+class TestBlockBoundaryViolation:
+    def test_no_violation_when_inside(self):
+        """Components inside their block region should have zero penalty."""
+        placements = [
+            ComponentPlacement(reference="U1", x=5.0, y=5.0),
+            ComponentPlacement(reference="C1", x=7.0, y=5.0),
+        ]
+        regions = [BlockRegion(block_id="b1", min_x=0.0, min_y=0.0, max_x=10.0, max_y=10.0)]
+        membership = {"U1": "b1", "C1": "b1"}
+
+        result = compute_block_boundary_violation(placements, regions, membership)
+        assert result == 0.0
+
+    def test_violation_outside_region(self):
+        """Component partially outside should produce positive penalty."""
+        placements = [
+            ComponentPlacement(reference="U1", x=0.0, y=5.0),  # left edge at -0.5
+        ]
+        regions = [BlockRegion(block_id="b1", min_x=0.0, min_y=0.0, max_x=10.0, max_y=10.0)]
+        membership = {"U1": "b1"}
+
+        result = compute_block_boundary_violation(placements, regions, membership)
+        assert result > 0.0
+
+    def test_no_regions_returns_zero(self):
+        placements = [ComponentPlacement(reference="U1", x=5.0, y=5.0)]
+        assert compute_block_boundary_violation(placements, [], {}) == 0.0
+
+    def test_free_component_ignored(self):
+        """Components not in block_membership should not contribute."""
+        placements = [
+            ComponentPlacement(reference="R1", x=-10.0, y=-10.0),  # far outside
+        ]
+        regions = [BlockRegion(block_id="b1", min_x=0.0, min_y=0.0, max_x=10.0, max_y=10.0)]
+        membership = {}  # R1 not in any block
+
+        result = compute_block_boundary_violation(placements, regions, membership)
+        assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Inter-block spacing violation tests
+# ---------------------------------------------------------------------------
+
+class TestInterBlockSpacingViolation:
+    def test_no_violation_when_far_apart(self):
+        placements = [
+            ComponentPlacement(reference="U1", x=5.0, y=5.0),
+            ComponentPlacement(reference="U2", x=50.0, y=50.0),
+        ]
+        membership = {"U1": "b1", "U2": "b2"}
+        result = compute_inter_block_spacing_violation(placements, membership, min_spacing=2.0)
+        assert result == 0.0
+
+    def test_violation_when_too_close(self):
+        placements = [
+            ComponentPlacement(reference="U1", x=5.0, y=5.0),
+            ComponentPlacement(reference="U2", x=6.5, y=5.0),
+        ]
+        membership = {"U1": "b1", "U2": "b2"}
+        # With default 1x1 sizes, blocks are 0.5mm apart (edge-to-edge)
+        result = compute_inter_block_spacing_violation(placements, membership, min_spacing=2.0)
+        assert result > 0.0
+
+    def test_no_membership_returns_zero(self):
+        placements = [ComponentPlacement(reference="U1", x=5.0, y=5.0)]
+        result = compute_inter_block_spacing_violation(placements, {}, min_spacing=2.0)
+        assert result == 0.0
+
+    def test_zero_spacing_returns_zero(self):
+        placements = [
+            ComponentPlacement(reference="U1", x=5.0, y=5.0),
+            ComponentPlacement(reference="U2", x=5.0, y=5.0),  # overlapping
+        ]
+        membership = {"U1": "b1", "U2": "b2"}
+        result = compute_inter_block_spacing_violation(placements, membership, min_spacing=0.0)
+        assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Block move/rotate/swap utility tests
+# ---------------------------------------------------------------------------
+
+class TestBlockMoveOperations:
+    def _make_simple_vec(self):
+        """1 free component + 2 blocks => 4 + 3 + 3 = 10 fields."""
+        data = np.array([
+            # Free: R1 at (10, 20, rot=0, side=0)
+            10.0, 20.0, 0.0, 0.0,
+            # Block 0 at (30, 40, rot=0)
+            30.0, 40.0, 0.0,
+            # Block 1 at (60, 70, rot=1)
+            60.0, 70.0, 1.0,
+        ], dtype=np.float64)
+        return PlacementVector(data=data)
+
+    def test_move_block(self):
+        vec = self._make_simple_vec()
+        moved = move_block(vec, block_index=0, dx=5.0, dy=-3.0, n_free=1)
+        assert _close(moved.data[4], 35.0)  # bx
+        assert _close(moved.data[5], 37.0)  # by
+        # Block 1 unchanged
+        assert _close(moved.data[7], 60.0)
+        assert _close(moved.data[8], 70.0)
+
+    def test_rotate_block(self):
+        vec = self._make_simple_vec()
+        rotated = rotate_block(vec, block_index=1, rotation_steps=2, n_free=1)
+        # Block 1 rotation was 1, +2 = 3
+        assert _close(rotated.data[9], 3.0)
+        # Block 0 rotation unchanged
+        assert _close(rotated.data[6], 0.0)
+
+    def test_rotate_block_wraps(self):
+        vec = self._make_simple_vec()
+        rotated = rotate_block(vec, block_index=1, rotation_steps=3, n_free=1)
+        # 1 + 3 = 4 => 0 (mod 4)
+        assert _close(rotated.data[9], 0.0)
+
+    def test_swap_blocks(self):
+        vec = self._make_simple_vec()
+        swapped = swap_blocks(vec, block_a=0, block_b=1, n_free=1)
+        # Block 0 now has Block 1's position
+        assert _close(swapped.data[4], 60.0)
+        assert _close(swapped.data[5], 70.0)
+        # Block 1 now has Block 0's position
+        assert _close(swapped.data[7], 30.0)
+        assert _close(swapped.data[8], 40.0)
+        # Rotations preserved
+        assert _close(swapped.data[6], 0.0)  # Block 0 keeps its rotation
+        assert _close(swapped.data[9], 1.0)  # Block 1 keeps its rotation
+
+
+# ---------------------------------------------------------------------------
+# Regression: no blocks => identical behavior
+# ---------------------------------------------------------------------------
+
+class TestNoBlocksRegression:
+    def test_encode_no_blocks_matches_standard(self):
+        """With no block groups, encode_with_blocks should match encode."""
+        placements = [
+            PlacedComponent(reference="R1", x=10.0, y=20.0, rotation=0.0, side=0),
+            PlacedComponent(reference="R2", x=30.0, y=40.0, rotation=90.0, side=1),
+        ]
+        vec_standard = encode(placements)
+        vec_block = encode_with_blocks(placements, [])
+        np.testing.assert_array_almost_equal(vec_standard.data, vec_block.data)
+
+    def test_decode_no_blocks_matches_standard(self):
+        components = [_make_comp("R1"), _make_comp("R2")]
+        placements = [
+            PlacedComponent(reference="R1", x=10.0, y=20.0, rotation=0.0, side=0),
+            PlacedComponent(reference="R2", x=30.0, y=40.0, rotation=90.0, side=1),
+        ]
+        vec = encode(placements)
+        dec_standard = decode(vec, components)
+        dec_block = decode_with_blocks(vec, components, [])
+
+        for s, b in zip(dec_standard, dec_block):
+            assert s.reference == b.reference
+            assert _close(s.x, b.x)
+            assert _close(s.y, b.y)
+
+    def test_evaluate_placement_no_blocks(self):
+        """evaluate_placement with no block args should behave identically."""
+        placements = [
+            ComponentPlacement(reference="R1", x=10.0, y=10.0),
+            ComponentPlacement(reference="R2", x=20.0, y=20.0),
+        ]
+        nets = [Net(name="N1", pins=[("R1", "1"), ("R2", "1")])]
+        rules = DesignRuleSet()
+        board = _make_board()
+        config = PlacementCostConfig()
+
+        score_no_blocks = evaluate_placement(placements, nets, rules, board, config)
+        score_with_none = evaluate_placement(
+            placements, nets, rules, board, config,
+            block_regions=None, block_membership=None,
+        )
+        assert _close(score_no_blocks.total, score_with_none.total)
+        assert score_no_blocks.breakdown.block_boundary == 0.0
+        assert score_no_blocks.breakdown.inter_block == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_single_component_block(self):
+        """A block with one component should behave like a free component."""
+        block = BlockGroupDef(
+            block_id="single",
+            members=(RelativeOffset(reference="U1", dx=0.0, dy=0.0),),
+        )
+        components = [_make_comp("U1"), _make_comp("R1")]
+        placements = [
+            PlacedComponent(reference="U1", x=20.0, y=30.0, rotation=0.0, side=0),
+            PlacedComponent(reference="R1", x=50.0, y=60.0, rotation=0.0, side=0),
+        ]
+
+        vec = encode_with_blocks(placements, [block])
+        # 1 free (R1) * 4 + 1 block * 3 = 7
+        assert len(vec.data) == 7
+
+        decoded = decode_with_blocks(vec, components, [block])
+        u1 = next(d for d in decoded if d.reference == "U1")
+        r1 = next(d for d in decoded if d.reference == "R1")
+        assert _close(u1.x, 20.0)
+        assert _close(u1.y, 30.0)
+        assert _close(r1.x, 50.0)
+        assert _close(r1.y, 60.0)
+
+    def test_all_components_in_blocks(self):
+        """No free components: entire board in blocks."""
+        block = BlockGroupDef(
+            block_id="all",
+            members=(
+                RelativeOffset(reference="U1", dx=0.0, dy=0.0),
+                RelativeOffset(reference="C1", dx=3.0, dy=0.0),
+            ),
+        )
+        components = [_make_comp("U1"), _make_comp("C1")]
+        placements = [
+            PlacedComponent(reference="U1", x=40.0, y=40.0, rotation=0.0, side=0),
+            PlacedComponent(reference="C1", x=43.0, y=40.0, rotation=0.0, side=0),
+        ]
+
+        vec = encode_with_blocks(placements, [block])
+        # 0 free + 1 block * 3 = 3
+        assert len(vec.data) == 3
+
+        decoded = decode_with_blocks(vec, components, [block])
+        assert len(decoded) == 2
+        u1 = next(d for d in decoded if d.reference == "U1")
+        c1 = next(d for d in decoded if d.reference == "C1")
+        assert _close(u1.x, 40.0)
+        assert _close(c1.x, 43.0)
+
+    def test_empty_block_group(self):
+        """A block with no members should not cause errors."""
+        block = BlockGroupDef(block_id="empty")
+        components = [_make_comp("R1")]
+        placements = [
+            PlacedComponent(reference="R1", x=10.0, y=10.0, rotation=0.0, side=0),
+        ]
+
+        vec = encode_with_blocks(placements, [block])
+        # 1 free * 4 + 1 empty block * 3 = 7
+        assert len(vec.data) == 7
+
+        decoded = decode_with_blocks(vec, components, [block])
+        assert len(decoded) == 1
+        assert decoded[0].reference == "R1"
+
+
+# ---------------------------------------------------------------------------
+# Bounds tests
+# ---------------------------------------------------------------------------
+
+class TestBoundsWithBlocks:
+    def test_bounds_length(self):
+        board = _make_board()
+        block = _make_block_with_3_members()
+        components = [_make_comp("R1"), _make_comp("U1"), _make_comp("C1"), _make_comp("C2")]
+        b = bounds_with_blocks(board, components, [block])
+        # 1 free (R1) * 4 + 1 block * 3 = 7
+        assert len(b.lower) == 7
+        assert len(b.upper) == 7
+        assert len(b.discrete_mask) == 7
+
+    def test_block_rotation_is_discrete(self):
+        board = _make_board()
+        block = _make_block_with_3_members()
+        components = [_make_comp("R1"), _make_comp("U1"), _make_comp("C1"), _make_comp("C2")]
+        b = bounds_with_blocks(board, components, [block])
+        # Block rotation at index 6 (4 free fields + 2 block xy fields)
+        assert b.discrete_mask[6] == True  # noqa: E712
+
+    def test_no_blocks_matches_standard(self):
+        board = _make_board()
+        components = [_make_comp("R1"), _make_comp("R2")]
+        b_standard = bounds(board, components)
+        b_block = bounds_with_blocks(board, components, [])
+        np.testing.assert_array_almost_equal(b_standard.lower, b_block.lower)
+        np.testing.assert_array_almost_equal(b_standard.upper, b_block.upper)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_placement with block arguments
+# ---------------------------------------------------------------------------
+
+class TestEvaluatePlacementWithBlocks:
+    def test_block_boundary_violation_in_score(self):
+        """Block boundary violation should be reflected in the total score."""
+        placements = [
+            ComponentPlacement(reference="U1", x=-5.0, y=5.0),  # outside region
+        ]
+        regions = [BlockRegion(block_id="b1", min_x=0.0, min_y=0.0, max_x=10.0, max_y=10.0)]
+        membership = {"U1": "b1"}
+        board = _make_board()
+        nets: list[Net] = []
+        rules = DesignRuleSet()
+
+        score = evaluate_placement(
+            placements, nets, rules, board,
+            block_regions=regions, block_membership=membership,
+        )
+        assert score.breakdown.block_boundary > 0.0
+        assert not score.is_feasible
+
+    def test_feasible_with_blocks(self):
+        """All components inside regions => feasible."""
+        placements = [
+            ComponentPlacement(reference="U1", x=5.0, y=5.0),
+            ComponentPlacement(reference="R1", x=50.0, y=50.0),
+        ]
+        regions = [BlockRegion(block_id="b1", min_x=0.0, min_y=0.0, max_x=10.0, max_y=10.0)]
+        membership = {"U1": "b1"}
+        board = _make_board()
+        nets: list[Net] = []
+        rules = DesignRuleSet()
+
+        score = evaluate_placement(
+            placements, nets, rules, board,
+            block_regions=regions, block_membership=membership,
+        )
+        assert score.breakdown.block_boundary == 0.0
+        assert score.is_feasible
+
+
+# ---------------------------------------------------------------------------
+# PCBLayout.to_block_groups() bridge test
+# ---------------------------------------------------------------------------
+
+class TestPCBLayoutBridge:
+    def test_to_block_groups(self):
+        from kicad_tools.pcb.layout import PCBLayout
+        from kicad_tools.pcb.blocks.base import PCBBlock
+
+        layout = PCBLayout("test")
+        block = PCBBlock("mcu")
+        block.add_component("U1", "QFP-48", 0.0, 0.0)
+        block.add_component("C1", "C_0805", 3.0, 0.0)
+        layout.add_block(block, "mcu")
+
+        groups = layout.to_block_groups()
+        assert len(groups) == 1
+        bg = groups[0]
+        assert bg.block_id == "mcu"
+        assert len(bg.members) == 2
+        refs = {m.reference for m in bg.members}
+        assert refs == {"U1", "C1"}
+
+    def test_to_block_groups_empty_layout(self):
+        from kicad_tools.pcb.layout import PCBLayout
+
+        layout = PCBLayout("empty")
+        groups = layout.to_block_groups()
+        assert groups == []
+
+
+# ---------------------------------------------------------------------------
+# PCBBlock.relative_offsets() helper test
+# ---------------------------------------------------------------------------
+
+class TestPCBBlockRelativeOffsets:
+    def test_relative_offsets(self):
+        from kicad_tools.pcb.blocks.base import PCBBlock
+
+        block = PCBBlock("test")
+        block.add_component("U1", "QFP-48", 0.0, 0.0, rotation=0.0)
+        block.add_component("C1", "C_0805", 3.0, 1.5, rotation=90.0)
+
+        offsets = block.relative_offsets()
+        assert len(offsets) == 2
+
+        u1_offset = next(o for o in offsets if o.reference == "U1")
+        c1_offset = next(o for o in offsets if o.reference == "C1")
+
+        assert _close(u1_offset.dx, 0.0)
+        assert _close(u1_offset.dy, 0.0)
+        assert _close(c1_offset.dx, 3.0)
+        assert _close(c1_offset.dy, 1.5)
+        assert _close(c1_offset.rotation, 90.0)


### PR DESCRIPTION
## Summary
Add block-aware placement constraints so the optimizer can move PCB blocks as rigid units with reduced search-space dimensionality, block boundary violation penalties, and inter-block spacing enforcement.

## Changes
- Add `BlockGroupDef`, `RelativeOffset` dataclasses and `encode_with_blocks()`, `decode_with_blocks()`, `bounds_with_blocks()` to `vector.py` for reduced-dimensionality block encoding (3 fields per block vs 4 per component)
- Add `move_block()`, `rotate_block()`, `swap_blocks()` utility functions for block-level manipulation
- Add `BlockRegion`, `compute_block_boundary_violation()`, `compute_inter_block_spacing_violation()` to `cost.py` with block boundary/spacing cost terms wired into `evaluate_placement()`
- Add `block_boundary_weight` and `inter_block_spacing` to `PlacementCostConfig`
- Add `PCBLayout.to_block_groups()` bridge method to extract `BlockGroupDef` from registered blocks
- Add `PCBBlock.relative_offsets()` helper for exporting component offsets
- Export new types and functions from `placement/__init__.py`
- Add comprehensive test suite (36 tests) covering encoding, decoding, rotation, cost functions, utilities, regression, and edge cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| BlockGroupDef in vector.py with encode/decode/bounds | Pass | Unit tests verify vector length (14 vs 32), roundtrip encode/decode, bounds dimensions |
| Block boundary cost in cost.py | Pass | Tests for zero penalty inside region, positive penalty outside |
| Inter-block spacing cost | Pass | Tests for zero when far apart, positive when too close |
| Block move/rotate/swap utilities | Pass | Tests for move, rotate (with wrapping), swap operations |
| PCBLayout bridge to optimizer | Pass | Test extracts BlockGroupDef from PCBLayout with correct members |
| PCBBlock.relative_offsets() helper | Pass | Test exports RelativeOffset with correct dx/dy/rotation |
| No regression without blocks | Pass | encode/decode/evaluate with no blocks matches standard behavior |
| Edge cases (single-component, all-in-blocks, empty) | Pass | Dedicated edge case tests all pass |

## Test Plan
- `pytest tests/test_placement_block_constraints.py` - 36 tests pass
- `pytest tests/test_placement_vector.py tests/test_placement.py` - 84 existing tests pass (no regressions)

Closes #1588