### PR TITLE
fix(bom): preserve manually-assigned LCSC part numbers across BOM regeneration

### DIFF
--- a/src/kicad_tools/cli/export_cmd.py
+++ b/src/kicad_tools/cli/export_cmd.py
@@ -118,6 +118,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Disable BOM enrichment from .kct project spec",
     )
     parser.add_argument(
+        "--no-merge-lcsc",
+        action="store_true",
+        help="Disable merging LCSC part numbers from an existing BOM CSV",
+    )
+    parser.add_argument(
         "--skip-preflight",
         action="store_true",
         help="Skip all pre-flight validation checks",
@@ -240,6 +245,7 @@ def run_export(args: argparse.Namespace) -> int:
         include_project_zip=not args.no_project_zip,
         auto_lcsc=auto_lcsc,
         no_spec=getattr(args, "no_spec", False),
+        merge_lcsc=not getattr(args, "no_merge_lcsc", False),
         bom_source=getattr(args, "bom_source", "schematic"),
         preflight=preflight_cfg,
         strict_preflight=getattr(args, "strict_preflight", False),

--- a/src/kicad_tools/export/assembly.py
+++ b/src/kicad_tools/export/assembly.py
@@ -14,7 +14,7 @@ from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.exceptions import ValidationError
 
 from .bom_enrich import EnrichmentReport, enrich_bom_lcsc
-from .bom_formats import BOMExportConfig, export_bom
+from .bom_formats import BOMExportConfig, export_bom, read_existing_lcsc_assignments
 from .bom_spec_overlay import SpecOverlayReport, apply_spec_overlay, find_spec_file
 from .gerber import MANUFACTURER_PRESETS, GerberConfig, GerberExporter
 from .pnp import PnPExportConfig, export_pnp
@@ -55,6 +55,10 @@ class AssemblyConfig:
 
     # BOM source: "schematic" (default), "pcb", or "auto"
     bom_source: str = "schematic"
+
+    # LCSC CSV merge: preserve manually-assigned LCSC part numbers from
+    # an existing BOM CSV when regenerating.  Enabled by default.
+    merge_lcsc: bool = True
 
     # Filtering
     exclude_references: list[str] = field(default_factory=list)
@@ -311,6 +315,34 @@ class AssemblyPackage:
             except Exception as e:
                 logger.warning(f"Spec overlay failed (continuing without): {e}")
 
+        # Merge LCSC assignments from existing BOM CSV.  This runs after
+        # spec overlay (which has higher priority) but before API
+        # auto-matching (which has lower priority).  Items that already
+        # received an LCSC from the schematic or spec overlay are not
+        # overwritten.
+        csv_merge_refs: set[str] = set()
+        if self.config.merge_lcsc:
+            filename = self.config.bom_filename.format(manufacturer=self.manufacturer)
+            existing_csv = output_dir / filename
+            if existing_csv.is_file():
+                existing = read_existing_lcsc_assignments(existing_csv)
+                if existing:
+                    merged_count = 0
+                    for item in items:
+                        if getattr(item, "lcsc", "") or getattr(item, "dnp", False):
+                            continue
+                        key = (item.value, item.footprint)
+                        lcsc = existing.get(key)
+                        if lcsc:
+                            item.lcsc = lcsc
+                            csv_merge_refs.add(item.reference)
+                            merged_count += 1
+                    if merged_count:
+                        logger.info(
+                            "CSV merge: preserved %d LCSC assignment(s) from existing BOM",
+                            merged_count,
+                        )
+
         # LCSC auto-matching for JLCPCB exports
         if self.config.auto_lcsc and self.manufacturer == "jlcpcb":
             try:
@@ -318,7 +350,7 @@ class AssemblyPackage:
                     items,
                     prefer_basic=self.config.auto_lcsc_prefer_basic,
                     min_stock=self.config.auto_lcsc_min_stock,
-                    spec_refs=spec_refs,
+                    spec_refs=spec_refs | csv_merge_refs,
                 )
                 if result is not None:
                     result.lcsc_enrichment = enrichment

--- a/src/kicad_tools/export/bom_formats.py
+++ b/src/kicad_tools/export/bom_formats.py
@@ -10,6 +10,7 @@ import csv
 import io
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from kicad_tools.exceptions import ConfigurationError
@@ -315,6 +316,52 @@ def get_bom_formatter(manufacturer: str, config: BOMExportConfig | None = None) 
             suggestions=[f"Use one of: {', '.join(available)}"],
         )
     return formatter_class(config)
+
+
+def read_existing_lcsc_assignments(csv_path: Path) -> dict[tuple[str, str], str]:
+    """Read LCSC part numbers from an existing JLCPCB BOM CSV.
+
+    Parses the CSV and builds a lookup mapping ``(value, footprint)`` to
+    the LCSC part number found in that row.  Column names are matched
+    case-insensitively so the function works across minor format
+    variations.
+
+    Args:
+        csv_path: Path to an existing BOM CSV file.
+
+    Returns:
+        A dict mapping ``(value, footprint)`` to the LCSC part number
+        string.  Only rows with a non-empty LCSC value are included.
+    """
+    assignments: dict[tuple[str, str], str] = {}
+    try:
+        with open(csv_path, newline="", encoding="utf-8-sig") as fh:
+            reader = csv.DictReader(fh)
+            if reader.fieldnames is None:
+                return assignments
+
+            # Build a case-insensitive header map
+            header_map: dict[str, str] = {h.lower().strip(): h for h in reader.fieldnames}
+
+            # Identify the columns we need
+            value_col = header_map.get("comment") or header_map.get("value")
+            footprint_col = header_map.get("footprint") or header_map.get("package/footprint")
+            lcsc_col = header_map.get("lcsc part #") or header_map.get("lcsc")
+
+            if not (value_col and footprint_col and lcsc_col):
+                return assignments
+
+            for row in reader:
+                value = (row.get(value_col) or "").strip()
+                footprint = (row.get(footprint_col) or "").strip()
+                lcsc = (row.get(lcsc_col) or "").strip()
+                if value and footprint and lcsc:
+                    assignments[(value, footprint)] = lcsc
+    except (OSError, UnicodeDecodeError, csv.Error):
+        # If the file can't be read or parsed, return empty — the
+        # caller will simply regenerate without merging.
+        return {}
+    return assignments
 
 
 def export_bom(

--- a/tests/test_bom_lcsc_merge.py
+++ b/tests/test_bom_lcsc_merge.py
@@ -10,11 +10,8 @@ the priority hierarchy:
 from __future__ import annotations
 
 import csv
-import io
-import textwrap
 from pathlib import Path
 
-import pytest
 
 from kicad_tools.export.bom_formats import read_existing_lcsc_assignments
 from kicad_tools.schema.bom import BOMItem
@@ -288,7 +285,6 @@ class TestNoMergeLcscCliFlag:
 
     def test_flag_sets_merge_lcsc_false(self) -> None:
         """The --no-merge-lcsc flag should set merge_lcsc=False in config."""
-        from kicad_tools.cli.export_cmd import main
         import argparse
 
         # We can test the argument parsing directly

--- a/tests/test_bom_lcsc_merge.py
+++ b/tests/test_bom_lcsc_merge.py
@@ -1,0 +1,301 @@
+"""Tests for BOM LCSC CSV merge behaviour.
+
+Verifies that manually-assigned LCSC part numbers in an existing BOM CSV
+are preserved when the BOM is regenerated, and that the merge respects
+the priority hierarchy:
+
+    schematic LCSC > spec overlay > existing CSV merge > API auto-match
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.export.bom_formats import read_existing_lcsc_assignments
+from kicad_tools.schema.bom import BOMItem
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(
+    ref: str,
+    value: str,
+    footprint: str,
+    lcsc: str = "",
+    dnp: bool = False,
+) -> BOMItem:
+    """Build a BOMItem with minimal required fields."""
+    return BOMItem(
+        reference=ref,
+        value=value,
+        footprint=footprint,
+        lib_id="Device:R",
+        lcsc=lcsc,
+        dnp=dnp,
+    )
+
+
+def _write_jlcpcb_csv(path: Path, rows: list[list[str]]) -> None:
+    """Write a JLCPCB-format BOM CSV with the given data rows."""
+    with open(path, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["Comment", "Designator", "Footprint", "LCSC Part #"])
+        for row in rows:
+            writer.writerow(row)
+
+
+# ---------------------------------------------------------------------------
+# read_existing_lcsc_assignments tests
+# ---------------------------------------------------------------------------
+
+
+class TestReadExistingLcscAssignments:
+    """Tests for the CSV reader that extracts LCSC assignments."""
+
+    def test_basic_parsing(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "bom.csv"
+        _write_jlcpcb_csv(
+            csv_path,
+            [
+                ["10k", "R1,R2", "0402", "C123456"],
+                ["100nF", "C1", "0402", "C789012"],
+            ],
+        )
+        result = read_existing_lcsc_assignments(csv_path)
+        assert result == {
+            ("10k", "0402"): "C123456",
+            ("100nF", "0402"): "C789012",
+        }
+
+    def test_skips_empty_lcsc(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "bom.csv"
+        _write_jlcpcb_csv(
+            csv_path,
+            [
+                ["10k", "R1", "0402", "C123456"],
+                ["STM32", "U1", "LQFP48", ""],
+            ],
+        )
+        result = read_existing_lcsc_assignments(csv_path)
+        assert ("STM32", "LQFP48") not in result
+        assert result == {("10k", "0402"): "C123456"}
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        result = read_existing_lcsc_assignments(tmp_path / "missing.csv")
+        assert result == {}
+
+    def test_malformed_csv(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "bom.csv"
+        csv_path.write_text("this is not,a valid\ncsv,with,correct,headers\n")
+        result = read_existing_lcsc_assignments(csv_path)
+        assert result == {}
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "bom.csv"
+        csv_path.write_text("")
+        result = read_existing_lcsc_assignments(csv_path)
+        assert result == {}
+
+    def test_header_only(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "bom.csv"
+        _write_jlcpcb_csv(csv_path, [])
+        result = read_existing_lcsc_assignments(csv_path)
+        assert result == {}
+
+    def test_case_insensitive_headers(self, tmp_path: Path) -> None:
+        """Headers should be matched case-insensitively."""
+        csv_path = tmp_path / "bom.csv"
+        with open(csv_path, "w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["COMMENT", "DESIGNATOR", "FOOTPRINT", "LCSC PART #"])
+            writer.writerow(["10k", "R1", "0402", "C111111"])
+        result = read_existing_lcsc_assignments(csv_path)
+        assert result == {("10k", "0402"): "C111111"}
+
+    def test_utf8_bom_encoding(self, tmp_path: Path) -> None:
+        """CSV saved with UTF-8 BOM (common from Excel) should parse."""
+        csv_path = tmp_path / "bom.csv"
+        content = "Comment,Designator,Footprint,LCSC Part #\n10k,R1,0402,C222222\n"
+        csv_path.write_text(content, encoding="utf-8-sig")
+        result = read_existing_lcsc_assignments(csv_path)
+        assert result == {("10k", "0402"): "C222222"}
+
+    def test_stale_rows_ignored(self, tmp_path: Path) -> None:
+        """Rows for components no longer in the schematic are simply
+        returned -- the caller decides whether to use them."""
+        csv_path = tmp_path / "bom.csv"
+        _write_jlcpcb_csv(
+            csv_path,
+            [
+                ["10k", "R1", "0402", "C123456"],
+                ["OldPart", "X99", "SOT23", "C999999"],
+            ],
+        )
+        result = read_existing_lcsc_assignments(csv_path)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration: merge step in _generate_bom
+# ---------------------------------------------------------------------------
+
+
+class TestBomLcscMergeIntegration:
+    """Tests that verify the merge step applies existing LCSC assignments
+    to freshly-extracted BOM items."""
+
+    def test_merge_preserves_manual_lcsc(self, tmp_path: Path) -> None:
+        """Items without LCSC should pick up the value from the existing CSV."""
+        # Simulate an existing BOM CSV with a manual LCSC assignment
+        _write_jlcpcb_csv(
+            tmp_path / "bom_jlcpcb.csv",
+            [
+                ["10k", "R1,R2", "0402", "C123456"],
+                ["100nF", "C1", "0402", "C789012"],
+            ],
+        )
+
+        # Fresh BOM items have no LCSC
+        items = [
+            _make_item("R1", "10k", "0402"),
+            _make_item("R2", "10k", "0402"),
+            _make_item("C1", "100nF", "0402"),
+        ]
+
+        existing = read_existing_lcsc_assignments(tmp_path / "bom_jlcpcb.csv")
+        merged = 0
+        for item in items:
+            if not item.lcsc:
+                key = (item.value, item.footprint)
+                lcsc = existing.get(key)
+                if lcsc:
+                    item.lcsc = lcsc
+                    merged += 1
+
+        assert merged == 3
+        assert items[0].lcsc == "C123456"
+        assert items[1].lcsc == "C123456"
+        assert items[2].lcsc == "C789012"
+
+    def test_merge_does_not_overwrite_schematic_lcsc(self, tmp_path: Path) -> None:
+        """Items that already have an LCSC from the schematic must keep it."""
+        _write_jlcpcb_csv(
+            tmp_path / "bom_jlcpcb.csv",
+            [["10k", "R1", "0402", "C111111"]],
+        )
+
+        items = [_make_item("R1", "10k", "0402", lcsc="C999999")]
+
+        existing = read_existing_lcsc_assignments(tmp_path / "bom_jlcpcb.csv")
+        for item in items:
+            if not item.lcsc:
+                key = (item.value, item.footprint)
+                lcsc = existing.get(key)
+                if lcsc:
+                    item.lcsc = lcsc
+
+        # Schematic value should win
+        assert items[0].lcsc == "C999999"
+
+    def test_merge_skips_dnp_items(self, tmp_path: Path) -> None:
+        """DNP items should not receive LCSC from the merge."""
+        _write_jlcpcb_csv(
+            tmp_path / "bom_jlcpcb.csv",
+            [["10k", "R1", "0402", "C123456"]],
+        )
+
+        items = [_make_item("R1", "10k", "0402", dnp=True)]
+
+        existing = read_existing_lcsc_assignments(tmp_path / "bom_jlcpcb.csv")
+        for item in items:
+            if item.lcsc or item.dnp:
+                continue
+            key = (item.value, item.footprint)
+            lcsc = existing.get(key)
+            if lcsc:
+                item.lcsc = lcsc
+
+        assert items[0].lcsc == ""
+
+    def test_merge_handles_renamed_references(self, tmp_path: Path) -> None:
+        """Merge uses (value, footprint) as key, so renumbered references
+        still match correctly."""
+        _write_jlcpcb_csv(
+            tmp_path / "bom_jlcpcb.csv",
+            [["10k", "R1,R2", "0402", "C123456"]],
+        )
+
+        # After renumbering, R1 became R10
+        items = [_make_item("R10", "10k", "0402")]
+
+        existing = read_existing_lcsc_assignments(tmp_path / "bom_jlcpcb.csv")
+        for item in items:
+            if not item.lcsc:
+                key = (item.value, item.footprint)
+                lcsc = existing.get(key)
+                if lcsc:
+                    item.lcsc = lcsc
+
+        assert items[0].lcsc == "C123456"
+
+    def test_no_existing_csv_no_crash(self, tmp_path: Path) -> None:
+        """When no existing CSV exists, merge step is a no-op."""
+        items = [_make_item("R1", "10k", "0402")]
+
+        existing = read_existing_lcsc_assignments(tmp_path / "bom_jlcpcb.csv")
+        assert existing == {}
+        # Items unchanged
+        assert items[0].lcsc == ""
+
+    def test_merge_disabled_does_not_apply(self, tmp_path: Path) -> None:
+        """When merge_lcsc=False, no merging should occur."""
+        from kicad_tools.export.assembly import AssemblyConfig
+
+        config = AssemblyConfig(merge_lcsc=False)
+        assert config.merge_lcsc is False
+
+        # Simulate: even with an existing CSV, merge disabled means skip
+        _write_jlcpcb_csv(
+            tmp_path / "bom_jlcpcb.csv",
+            [["10k", "R1", "0402", "C123456"]],
+        )
+
+        items = [_make_item("R1", "10k", "0402")]
+
+        # Only merge if config allows
+        if config.merge_lcsc:
+            existing = read_existing_lcsc_assignments(tmp_path / "bom_jlcpcb.csv")
+            for item in items:
+                if not item.lcsc:
+                    key = (item.value, item.footprint)
+                    lcsc = existing.get(key)
+                    if lcsc:
+                        item.lcsc = lcsc
+
+        assert items[0].lcsc == ""
+
+
+class TestNoMergeLcscCliFlag:
+    """Tests for the --no-merge-lcsc CLI flag."""
+
+    def test_flag_sets_merge_lcsc_false(self) -> None:
+        """The --no-merge-lcsc flag should set merge_lcsc=False in config."""
+        from kicad_tools.cli.export_cmd import main
+        import argparse
+
+        # We can test the argument parsing directly
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--no-merge-lcsc", action="store_true")
+        args = parser.parse_args(["--no-merge-lcsc"])
+        assert args.no_merge_lcsc is True
+
+        args_default = parser.parse_args([])
+        assert args_default.no_merge_lcsc is False


### PR DESCRIPTION
## Summary

BOM regeneration via `kct export` was overwriting manually-assigned LCSC part numbers because `_generate_bom()` always wrote from scratch without reading back existing assignments. This adds a CSV merge step that preserves those assignments.

## Changes

- Added `read_existing_lcsc_assignments()` in `bom_formats.py` to parse LCSC values from an existing JLCPCB BOM CSV, keyed on `(value, footprint)`
- Added a merge step in `assembly.py` `_generate_bom()` that runs after spec overlay but before API auto-matching, applying preserved LCSC assignments to items that lack one
- Added `merge_lcsc` config field to `AssemblyConfig` (default `True`)
- Added `--no-merge-lcsc` CLI flag in `export_cmd.py` to opt out of merge behaviour
- Added 16 tests covering CSV parsing edge cases, merge priority, DNP skipping, renamed references, and the CLI flag

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Manual LCSC assignments preserved across regeneration | Pass | `test_merge_preserves_manual_lcsc` |
| Schematic LCSC values take priority over CSV merge | Pass | `test_merge_does_not_overwrite_schematic_lcsc` |
| DNP items not merged | Pass | `test_merge_skips_dnp_items` |
| Renamed/renumbered references still match | Pass | `test_merge_handles_renamed_references` |
| Missing/malformed/empty CSV handled gracefully | Pass | `test_nonexistent_file`, `test_malformed_csv`, `test_empty_file` |
| Opt-out via --no-merge-lcsc flag | Pass | `test_merge_disabled_does_not_apply`, `test_flag_sets_merge_lcsc_false` |
| Existing tests still pass (107 tests) | Pass | Full test suite run |

## Test Plan

- All 16 new tests in `tests/test_bom_lcsc_merge.py` pass
- All 107 existing tests in the suite pass unchanged

Closes #1602