### PR TITLE
feat(cli): add stitch subcommand to unified kct CLI

### DIFF
--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -132,7 +132,7 @@ class NetStatus:
     def suggested_fix(self) -> str:
         """Suggest fix based on net type."""
         if self.is_plane_net:
-            return f"kicad-pcb-stitch board.kicad_pcb --net {self.net_name}"
+            return f"kct stitch board.kicad_pcb --net {self.net_name}"
         return f"Route traces to connect {self.unconnected_count} pads"
 
     def to_dict(self) -> dict:

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -20,6 +20,7 @@ Provides CLI commands for common KiCad operations via the `kicad-tools` or `kct`
     kicad-tools route <pcb>            - Autoroute a PCB
     kicad-tools route-auto <pcb>       - Orchestrator-based smart routing for a net
     kicad-tools zones <command>        - Add and fill copper pour zones
+    kicad-tools stitch <pcb>           - Auto-add stitching vias for plane connections
     kicad-tools reason <pcb>           - LLM-driven PCB layout reasoning
     kicad-tools placement <command>    - Detect and fix placement conflicts
     kicad-tools optimize-traces <pcb>  - Optimize PCB traces
@@ -306,6 +307,9 @@ def _dispatch_command(args) -> int:
     elif args.command == "zones":
         return run_zones_command(args)
 
+    elif args.command == "stitch":
+        return _run_stitch_command(args)
+
     elif args.command == "route":
         return run_route_command(args)
 
@@ -447,6 +451,37 @@ def _dispatch_command(args) -> int:
         return _run_export_command(args)
 
     return 0
+
+
+def _run_stitch_command(args) -> int:
+    """Run the stitch command."""
+    from .stitch_cmd import main as stitch_cmd
+
+    sub_argv = [args.pcb]
+
+    if hasattr(args, "stitch_nets") and args.stitch_nets:
+        for net in args.stitch_nets:
+            sub_argv.extend(["--net", net])
+    if hasattr(args, "stitch_via_size") and args.stitch_via_size != 0.45:
+        sub_argv.extend(["--via-size", str(args.stitch_via_size)])
+    if hasattr(args, "stitch_drill") and args.stitch_drill != 0.2:
+        sub_argv.extend(["--drill", str(args.stitch_drill)])
+    if hasattr(args, "stitch_clearance") and args.stitch_clearance != 0.2:
+        sub_argv.extend(["--clearance", str(args.stitch_clearance)])
+    if hasattr(args, "stitch_offset") and args.stitch_offset != 0.5:
+        sub_argv.extend(["--offset", str(args.stitch_offset)])
+    if hasattr(args, "stitch_target_layer") and args.stitch_target_layer:
+        sub_argv.extend(["--target-layer", args.stitch_target_layer])
+    if hasattr(args, "stitch_trace_width") and args.stitch_trace_width != 0.2:
+        sub_argv.extend(["--trace-width", str(args.stitch_trace_width)])
+    if hasattr(args, "stitch_dry_run") and args.stitch_dry_run:
+        sub_argv.append("--dry-run")
+    if hasattr(args, "stitch_output") and args.stitch_output:
+        sub_argv.extend(["-o", args.stitch_output])
+    if hasattr(args, "stitch_drc") and args.stitch_drc:
+        sub_argv.append("--drc")
+
+    return stitch_cmd(sub_argv)
 
 
 def _run_explain_command(args) -> int:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -31,6 +31,7 @@ Provides CLI commands for common KiCad operations via the `kicad-tools` or `kct`
     kicad-tools datasheet <command>    - Datasheet search, download, and PDF parsing
     kicad-tools route <pcb>            - Autoroute a PCB
     kicad-tools zones <command>        - Add copper pour zones
+    kicad-tools stitch <pcb>           - Auto-add stitching vias for plane connections
     kicad-tools reason <pcb>           - LLM-driven PCB layout reasoning
     kicad-tools placement <command>    - Detect and fix placement conflicts
     kicad-tools optimize-placement     - Run CMA-ES placement optimization
@@ -144,6 +145,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_footprint_parser(subparsers)
     _add_mfr_parser(subparsers)
     _add_zones_parser(subparsers)
+    _add_stitch_parser(subparsers)
     _add_route_parser(subparsers)
     _add_route_auto_parser(subparsers)
     _add_reason_parser(subparsers)
@@ -881,6 +883,82 @@ def _add_zones_parser(subparsers) -> None:
     zones_fill.add_argument("-v", "--verbose", action="store_true")
     zones_fill.add_argument(
         "--dry-run", action="store_true", help="Show what would be done, no output"
+    )
+
+
+def _add_stitch_parser(subparsers) -> None:
+    """Add stitch subcommand parser for stitching vias."""
+    stitch_parser = subparsers.add_parser(
+        "stitch", help="Auto-add stitching vias for plane connections"
+    )
+    stitch_parser.add_argument("pcb", help="Path to .kicad_pcb file")
+    stitch_parser.add_argument(
+        "--net",
+        "-n",
+        action="append",
+        dest="stitch_nets",
+        help="Net name to add vias for (can be repeated). "
+        "If not specified, auto-detects all power plane nets from zones.",
+    )
+    stitch_parser.add_argument(
+        "--via-size",
+        type=float,
+        default=0.45,
+        dest="stitch_via_size",
+        help="Via pad diameter in mm (default: 0.45)",
+    )
+    stitch_parser.add_argument(
+        "--drill",
+        type=float,
+        default=0.2,
+        dest="stitch_drill",
+        help="Via drill size in mm (default: 0.2)",
+    )
+    stitch_parser.add_argument(
+        "--clearance",
+        type=float,
+        default=0.2,
+        dest="stitch_clearance",
+        help="Minimum clearance from existing copper in mm (default: 0.2)",
+    )
+    stitch_parser.add_argument(
+        "--offset",
+        type=float,
+        default=0.5,
+        dest="stitch_offset",
+        help="Max distance from pad center for via placement in mm (default: 0.5)",
+    )
+    stitch_parser.add_argument(
+        "--target-layer",
+        "-t",
+        dest="stitch_target_layer",
+        help="Target plane layer (e.g., In1.Cu). Default: auto-detect",
+    )
+    stitch_parser.add_argument(
+        "--trace-width",
+        type=float,
+        default=0.2,
+        dest="stitch_trace_width",
+        help="Width of pad-to-via trace segments in mm (default: 0.2)",
+    )
+    stitch_parser.add_argument(
+        "--dry-run",
+        "-d",
+        action="store_true",
+        dest="stitch_dry_run",
+        help="Show changes without applying",
+    )
+    stitch_parser.add_argument(
+        "-o",
+        "--output",
+        dest="stitch_output",
+        help="Output file (default: modify in place)",
+    )
+    stitch_parser.add_argument(
+        "--drc",
+        action="store_true",
+        dest="stitch_drc",
+        help="Run DRC after stitching (fills zones automatically via kicad-cli)",
     )
 
 


### PR DESCRIPTION
## Summary
Integrates the existing `kicad-pcb-stitch` standalone tool into the unified `kct` CLI as `kct stitch`. Updates the net-status suggested fix to reference `kct stitch` instead of `kicad-pcb-stitch`.

## Changes
- Added `_add_stitch_parser()` to `parser.py` with all stitch_cmd.py arguments
- Added `_run_stitch_command()` dispatch in `__init__.py`
- Updated CLI docstring/help to list `kct stitch`
- Updated `net_status.py` `suggested_fix` from `kicad-pcb-stitch` to `kct stitch`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct stitch` subcommand added to parser.py | Pass | Parser test shows correct args namespace |
| Wired to existing stitch_cmd.py implementation | Pass | Dispatch builds sub_argv and calls stitch_cmd.main() |
| net-status suggests `kct stitch` instead of `kicad-pcb-stitch` | Pass | Updated line 135 of net_status.py |

## Test Plan
- All 116 existing stitch tests pass (`tests/test_stitch_cmd.py`)
- All 36 net-status tests pass (`tests/test_net_status.py`)
- Parser correctly parses `kct stitch board.kicad_pcb --net GND --dry-run`

Closes #1600