### PR TITLE
fix(optimizer): wire GridCollisionChecker into TraceOptimizer in route pipeline

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -804,7 +804,11 @@ def route_with_layer_escalation(
 
     # Optimize traces
     if not args.no_optimize and final_result.router.routes:
-        from kicad_tools.router.optimizer import OptimizationConfig, TraceOptimizer
+        from kicad_tools.router.optimizer import (
+            GridCollisionChecker,
+            OptimizationConfig,
+            TraceOptimizer,
+        )
 
         if not quiet:
             print("\n--- Optimizing traces ---")
@@ -817,7 +821,8 @@ def route_with_layer_escalation(
             corner_chamfer_size=0.5,
             minimize_vias=True,
         )
-        optimizer = TraceOptimizer(config=opt_config)
+        collision_checker = GridCollisionChecker(final_result.router.grid)
+        optimizer = TraceOptimizer(config=opt_config, collision_checker=collision_checker)
 
         with spinner("Optimizing traces...", quiet=quiet):
             optimized_routes = []
@@ -1180,7 +1185,11 @@ def route_with_rule_relaxation(
 
     # Optimize traces
     if not args.no_optimize and final_result.router.routes:
-        from kicad_tools.router.optimizer import OptimizationConfig, TraceOptimizer
+        from kicad_tools.router.optimizer import (
+            GridCollisionChecker,
+            OptimizationConfig,
+            TraceOptimizer,
+        )
 
         if not quiet:
             print("\n--- Optimizing traces ---")
@@ -1193,7 +1202,8 @@ def route_with_rule_relaxation(
             corner_chamfer_size=0.5,
             minimize_vias=True,
         )
-        optimizer = TraceOptimizer(config=opt_config)
+        collision_checker = GridCollisionChecker(final_result.router.grid)
+        optimizer = TraceOptimizer(config=opt_config, collision_checker=collision_checker)
 
         with spinner("Optimizing traces...", quiet=quiet):
             optimized_routes = []
@@ -1574,7 +1584,11 @@ def route_with_combined_escalation(
 
     # Optimize traces
     if not args.no_optimize and final_result.router.routes:
-        from kicad_tools.router.optimizer import OptimizationConfig, TraceOptimizer
+        from kicad_tools.router.optimizer import (
+            GridCollisionChecker,
+            OptimizationConfig,
+            TraceOptimizer,
+        )
 
         if not quiet:
             print("\n--- Optimizing traces ---")
@@ -1587,7 +1601,8 @@ def route_with_combined_escalation(
             corner_chamfer_size=0.5,
             minimize_vias=True,
         )
-        optimizer = TraceOptimizer(config=opt_config)
+        collision_checker = GridCollisionChecker(final_result.router.grid)
+        optimizer = TraceOptimizer(config=opt_config, collision_checker=collision_checker)
 
         with spinner("Optimizing traces...", quiet=quiet):
             optimized_routes = []
@@ -2968,7 +2983,11 @@ def main(argv: list[str] | None = None) -> int:
 
     # Optimize traces (unless --no-optimize/--raw flag is set)
     if not args.no_optimize and router.routes:
-        from kicad_tools.router.optimizer import OptimizationConfig, TraceOptimizer
+        from kicad_tools.router.optimizer import (
+            GridCollisionChecker,
+            OptimizationConfig,
+            TraceOptimizer,
+        )
 
         if not quiet:
             print("\n--- Optimizing traces ---")
@@ -2986,7 +3005,8 @@ def main(argv: list[str] | None = None) -> int:
             corner_chamfer_size=0.5,
             minimize_vias=True,
         )
-        optimizer = TraceOptimizer(config=opt_config)
+        collision_checker = GridCollisionChecker(router.grid)
+        optimizer = TraceOptimizer(config=opt_config, collision_checker=collision_checker)
 
         with spinner("Optimizing traces...", quiet=quiet):
             optimized_routes = []


### PR DESCRIPTION
## Summary
Wire up `GridCollisionChecker` in all `TraceOptimizer` construction sites so that trace optimization validates clearance before accepting moves, making optimization DRC-safe by construction.

## Changes
- Import `GridCollisionChecker` from `kicad_tools.router.optimizer` at all 4 optimization sites in `route_cmd.py`
- Instantiate `GridCollisionChecker` with the router's grid before creating each `TraceOptimizer`
- Pass the collision checker to `TraceOptimizer(config=opt_config, collision_checker=collision_checker)`
- Covers: `main()`, `route_with_layer_escalation()`, `route_with_rule_relaxation()`, `route_with_combined_escalation()`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| TraceOptimizer created with GridCollisionChecker backed by router.grid | PASS | All 4 construction sites updated with `GridCollisionChecker(router.grid)` or `GridCollisionChecker(final_result.router.grid)` |
| ViaOptimizer also receives collision checker | PASS | Automatic via TraceOptimizer constructor forwarding (trace.py:88) |
| No regression in optimizer tests | PASS | All 62 tests in test_trace_optimizer.py pass |
| No new lint errors introduced | PASS | ruff check shows only pre-existing F541 warning |

## Test Plan
- Ran `uv run pytest tests/test_trace_optimizer.py -x -q` -- all 62 tests pass
- Ran `uv run pytest tests/ -x -q --ignore=tests/report` -- 315 pass, 1 pre-existing failure in test_audit.py (unrelated)
- Verified `ruff check` on route_cmd.py -- only pre-existing F541 remains
- Verified `py_compile` succeeds on route_cmd.py

Closes #1620