### PR TITLE
fix(router): mark same-component pad-to-pad violations as component-inherent

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -181,6 +181,7 @@ class ClearanceViolation:
     net_name: str = ""  # Human-readable net name
     obstacle_net_name: str = ""  # Human-readable obstacle net name
     location: tuple[float, float] | None = None  # Approximate violation location (x, y)
+    component_inherent: bool = False  # True if both pads are on the same component
 
 
 def parse_pcb_design_rules(pcb_text: str) -> PCBDesignRules:
@@ -781,6 +782,12 @@ def validate_routes(
             seg_half_width = segment.width / 2
 
             # --- Segment-to-pad checks ---
+            # Build set of component refs that this route's net connects to
+            route_component_refs: set[str] = set()
+            if route_net in router.nets:
+                for r, _p in router.nets[route_net]:
+                    route_component_refs.add(r)
+
             for (ref, num), pad in router.pads.items():
                 # Skip pads on the same net
                 if pad.net == route_net:
@@ -796,6 +803,10 @@ def validate_routes(
                 effective_dist = dist - pad_radius - seg_half_width
 
                 if effective_dist < clearance:
+                    # Detect component-inherent violations: obstacle pad is
+                    # on the same component as a pad in the route's net.
+                    is_component_inherent = ref in route_component_refs
+
                     violations.append(
                         ClearanceViolation(
                             segment_index=seg_idx,
@@ -811,6 +822,7 @@ def validate_routes(
                             net_name=_resolve_net_name(route_net),
                             obstacle_net_name=_resolve_net_name(pad.net),
                             location=(pad.x, pad.y),
+                            component_inherent=is_component_inherent,
                         )
                     )
 
@@ -906,6 +918,9 @@ def validate_routes(
 def format_clearance_violations(violations: list[ClearanceViolation]) -> str:
     """Format clearance violations as a human-readable summary.
 
+    Separates routing-caused violations (reported as warnings) from
+    component-inherent pad spacings (reported as informational).
+
     Args:
         violations: List of ClearanceViolation objects from validate_routes()
 
@@ -915,32 +930,43 @@ def format_clearance_violations(violations: list[ClearanceViolation]) -> str:
     if not violations:
         return ""
 
-    lines = []
-    lines.append(f"Found {len(violations)} clearance violation(s):")
+    # Separate routing violations from component-inherent pad spacings
+    routing_violations = [v for v in violations if not v.component_inherent]
+    inherent_violations = [v for v in violations if v.component_inherent]
 
-    # Group by obstacle type for summary
-    by_type: dict[str, int] = {}
-    for v in violations:
-        by_type[v.obstacle_type] = by_type.get(v.obstacle_type, 0) + 1
+    lines: list[str] = []
 
-    for obs_type, count in sorted(by_type.items()):
-        lines.append(f"  {obs_type}: {count}")
+    if routing_violations:
+        lines.append(f"Found {len(routing_violations)} clearance violation(s):")
 
-    # Show individual violations (limit to first 20 to avoid flooding output)
-    max_detail = 20
-    for i, v in enumerate(violations[:max_detail]):
-        net_label = v.net_name or f"Net {v.net}"
-        obs_label = v.obstacle_net_name or f"Net {v.obstacle_net}"
-        loc_str = ""
-        if v.location:
-            loc_str = f" at ({v.location[0]:.2f}, {v.location[1]:.2f})"
+        # Group by obstacle type for summary
+        by_type: dict[str, int] = {}
+        for v in routing_violations:
+            by_type[v.obstacle_type] = by_type.get(v.obstacle_type, 0) + 1
+
+        for obs_type, count in sorted(by_type.items()):
+            lines.append(f"  {obs_type}: {count}")
+
+        # Show individual violations (limit to first 20 to avoid flooding output)
+        max_detail = 20
+        for i, v in enumerate(routing_violations[:max_detail]):
+            net_label = v.net_name or f"Net {v.net}"
+            obs_label = v.obstacle_net_name or f"Net {v.obstacle_net}"
+            loc_str = ""
+            if v.location:
+                loc_str = f" at ({v.location[0]:.2f}, {v.location[1]:.2f})"
+            lines.append(
+                f"  [{v.obstacle_type}] {net_label} vs {obs_label}{loc_str}: "
+                f"{v.distance:.3f}mm (required {v.required:.3f}mm)"
+            )
+
+        if len(routing_violations) > max_detail:
+            lines.append(f"  ... and {len(routing_violations) - max_detail} more")
+
+    if inherent_violations:
         lines.append(
-            f"  [{v.obstacle_type}] {net_label} vs {obs_label}{loc_str}: "
-            f"{v.distance:.3f}mm (required {v.required:.3f}mm)"
+            f"Info: {len(inherent_violations)} component-inherent pad spacing(s) excluded"
         )
-
-    if len(violations) > max_detail:
-        lines.append(f"  ... and {len(violations) - max_detail} more")
 
     return "\n".join(lines)
 

--- a/tests/test_router_io.py
+++ b/tests/test_router_io.py
@@ -1146,6 +1146,131 @@ class TestValidateRoutes:
         assert "GND" in result
         assert "15.00" in result
 
+    def test_same_component_pad_marked_component_inherent(self):
+        """Test that pad violations within the same component are marked component_inherent."""
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.15,
+            grid_resolution=0.1,
+        )
+        router = Autorouter(width=50, height=50, rules=rules)
+
+        # Add two pads on the same component (U1) but different nets,
+        # at fine-pitch spacing (0.65mm apart, like SSOP-28)
+        router.add_component(
+            "U1",
+            [
+                {"number": "1", "x": 10, "y": 10, "width": 0.4, "height": 1.2, "net": 1},
+                {"number": "2", "x": 10.65, "y": 10, "width": 0.4, "height": 1.2, "net": 2},
+            ],
+        )
+
+        # Route a segment to pad 1 that passes near pad 2
+        segment = Segment(x1=5, y1=10, x2=10, y2=10, layer=Layer.F_CU, width=0.2)
+        route = Route(net=1, net_name="SPI_SCK", segments=[segment], vias=[])
+        router.routes.append(route)
+
+        violations = validate_routes(router)
+
+        # The pad-to-pad violation should be marked as component_inherent
+        pad_violations = [v for v in violations if v.obstacle_type == "pad"]
+        assert len(pad_violations) >= 1
+        for v in pad_violations:
+            assert v.component_inherent is True
+
+    def test_cross_component_pad_not_marked_component_inherent(self):
+        """Test that pad violations between different components are NOT component_inherent."""
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.15,
+            grid_resolution=0.1,
+        )
+        router = Autorouter(width=50, height=50, rules=rules)
+
+        # Pad on U1 (net 1) and pad on R1 (net 2), placed close together
+        router.add_component(
+            "U1",
+            [{"number": "1", "x": 10, "y": 10, "width": 0.4, "height": 1.2, "net": 1}],
+        )
+        router.add_component(
+            "R1",
+            [{"number": "1", "x": 10.65, "y": 10, "width": 0.4, "height": 1.2, "net": 2}],
+        )
+
+        # Route to U1 pad that passes near R1 pad
+        segment = Segment(x1=5, y1=10, x2=10, y2=10, layer=Layer.F_CU, width=0.2)
+        route = Route(net=1, net_name="VCC", segments=[segment], vias=[])
+        router.routes.append(route)
+
+        violations = validate_routes(router)
+
+        pad_violations = [v for v in violations if v.obstacle_type == "pad"]
+        assert len(pad_violations) >= 1
+        for v in pad_violations:
+            assert v.component_inherent is False
+
+    def test_format_separates_component_inherent_violations(self):
+        """Test format_clearance_violations separates component-inherent from routing."""
+        from kicad_tools.router.io import ClearanceViolation
+
+        violations = [
+            # A routing violation
+            ClearanceViolation(
+                segment_index=0,
+                x1=10, y1=10, x2=20, y2=10,
+                net=1, obstacle_type="pad", obstacle_net=2,
+                distance=-0.05, required=0.15,
+                net_name="VCC", obstacle_net_name="GND",
+                location=(15.0, 10.0),
+                component_inherent=False,
+            ),
+            # A component-inherent violation
+            ClearanceViolation(
+                segment_index=0,
+                x1=10, y1=10, x2=20, y2=10,
+                net=1, obstacle_type="pad", obstacle_net=3,
+                distance=-0.10, required=0.15,
+                net_name="SPI_SCK", obstacle_net_name="SPI_MISO",
+                location=(10.65, 10.0),
+                component_inherent=True,
+            ),
+        ]
+
+        result = format_clearance_violations(violations)
+
+        # Should report 1 routing violation (not 2)
+        assert "1 clearance violation" in result
+        # Should mention the component-inherent count separately
+        assert "1 component-inherent pad spacing(s) excluded" in result
+        # The routing violation details should be present
+        assert "VCC" in result
+        assert "GND" in result
+        # The component-inherent violation details should NOT be in the warnings
+        assert "[pad] SPI_SCK vs SPI_MISO" not in result
+
+    def test_format_only_component_inherent_no_routing_violations(self):
+        """Test format output when all violations are component-inherent."""
+        from kicad_tools.router.io import ClearanceViolation
+
+        violations = [
+            ClearanceViolation(
+                segment_index=0,
+                x1=10, y1=10, x2=20, y2=10,
+                net=1, obstacle_type="pad", obstacle_net=2,
+                distance=-0.10, required=0.15,
+                net_name="SPI_SCK", obstacle_net_name="SPI_MISO",
+                location=(10.65, 10.0),
+                component_inherent=True,
+            ),
+        ]
+
+        result = format_clearance_violations(violations)
+
+        # Should NOT say "0 clearance violation(s)"
+        assert "clearance violation" not in result
+        # Should report the component-inherent count
+        assert "1 component-inherent pad spacing(s) excluded" in result
+
 
 class TestLoadPcbForRoutingDrcCompliance:
     """Tests for DRC compliance features in load_pcb_for_routing."""


### PR DESCRIPTION
## Summary
Pre-save clearance validation now distinguishes component-inherent pad spacings (e.g., adjacent pins on fine-pitch ICs) from actual routing violations, eliminating false-positive warnings.

## Changes
- Added `component_inherent: bool = False` field to `ClearanceViolation` dataclass
- In `validate_routes()`, build a set of component references for each route's net and mark pad violations on those same components as `component_inherent=True`
- Updated `format_clearance_violations()` to report component-inherent pad spacings separately as informational, not as warnings
- Added 4 new tests covering same-component detection, cross-component detection, and format output separation

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pad-to-pad violations within the same footprint are categorized separately | Done | `test_same_component_pad_marked_component_inherent` passes |
| Only routing-caused violations are reported as warnings | Done | `test_format_separates_component_inherent_violations` confirms component-inherent are excluded from warning output |
| Output clearly distinguishes component-inherent spacing from routing errors | Done | `test_format_only_component_inherent_no_routing_violations` and `test_format_separates_component_inherent_violations` verify separate info line |

## Test Plan
- `uv run pytest tests/test_router_io.py::TestValidateRoutes -x -q` -- all 15 tests pass
- Pre-existing ruff lint warnings (lines 233, 246 in io.py) are unrelated to this change

Closes #1625