### PR TITLE
feat(cli): expose --no-cache flag in kct route subcommand

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -217,6 +217,8 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--auto-fix-passes", str(args.auto_fix_passes)])
     if getattr(args, "export_failed_nets", None):
         sub_argv.extend(["--export-failed-nets", args.export_failed_nets])
+    if getattr(args, "no_cache", False):
+        sub_argv.append("--no-cache")
     return route_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1109,6 +1109,11 @@ def _add_route_parser(subparsers) -> None:
             "Useful for scripted workflows or manual completion in KiCad."
         ),
     )
+    route_parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable routing cache (force fresh routing)",
+    )
 
 
 def _add_route_auto_parser(subparsers) -> None:

--- a/tests/test_route_cmd_params.py
+++ b/tests/test_route_cmd_params.py
@@ -669,3 +669,113 @@ class TestEscapeRoutingFlag:
         help_text = help_output.getvalue()
         assert "--escape-routing" in help_text
         assert "--no-escape-routing" in help_text
+
+
+class TestRouteCommandNoCacheFlag:
+    """Tests for --no-cache flag in subcommand parser and dispatch bridge."""
+
+    def test_parser_accepts_no_cache(self):
+        """Centralized parser accepts --no-cache without error."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["route", "test.kicad_pcb", "--no-cache"])
+        assert args.no_cache is True
+
+    def test_parser_no_cache_default_is_false(self):
+        """--no-cache defaults to False when not provided."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["route", "test.kicad_pcb"])
+        assert args.no_cache is False
+
+    def test_no_cache_forwarded(self):
+        """--no-cache is forwarded to route_cmd.main."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = SimpleNamespace(
+            pcb="test.kicad_pcb",
+            output=None,
+            strategy="negotiated",
+            skip_nets=None,
+            grid="0.25",
+            trace_width=0.2,
+            clearance=0.15,
+            via_drill=0.3,
+            via_diameter=0.6,
+            mc_trials=10,
+            iterations=15,
+            verbose=False,
+            dry_run=True,
+            quiet=True,
+            power_nets=None,
+            layers="auto",
+            force=False,
+            no_optimize=False,
+            auto_layers=False,
+            max_layers=6,
+            min_completion=0.95,
+            adaptive_rules=False,
+            min_trace=None,
+            min_clearance_floor=None,
+            manufacturer="jlcpcb",
+            high_performance=False,
+            skip_drc=False,
+            auto_fix=False,
+            auto_fix_passes=None,
+            export_failed_nets=None,
+            no_cache=True,
+        )
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--no-cache" in call_args
+
+    def test_no_cache_not_forwarded_when_false(self):
+        """--no-cache is not forwarded when False."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = SimpleNamespace(
+            pcb="test.kicad_pcb",
+            output=None,
+            strategy="negotiated",
+            skip_nets=None,
+            grid="0.25",
+            trace_width=0.2,
+            clearance=0.15,
+            via_drill=0.3,
+            via_diameter=0.6,
+            mc_trials=10,
+            iterations=15,
+            verbose=False,
+            dry_run=True,
+            quiet=True,
+            power_nets=None,
+            layers="auto",
+            force=False,
+            no_optimize=False,
+            auto_layers=False,
+            max_layers=6,
+            min_completion=0.95,
+            adaptive_rules=False,
+            min_trace=None,
+            min_clearance_floor=None,
+            manufacturer="jlcpcb",
+            high_performance=False,
+            skip_drc=False,
+            auto_fix=False,
+            auto_fix_passes=None,
+            export_failed_nets=None,
+            no_cache=False,
+        )
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--no-cache" not in call_args


### PR DESCRIPTION
## Summary
Expose the existing `--no-cache` routing flag through the `kct route` subcommand so users can force fresh routing without using the standalone `route_cmd.py` entry point.

## Changes
- Add `--no-cache` argument to `_add_route_parser()` in `src/kicad_tools/cli/parser.py`
- Forward the `no_cache` flag in `run_route_command()` dispatch bridge in `src/kicad_tools/cli/commands/routing.py`
- Add tests for parser acceptance, default value, and dispatch forwarding in `tests/test_route_cmd_params.py`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--no-cache` accepted by subcommand parser | PASS | `parse_args(["route", "test.kicad_pcb", "--no-cache"])` sets `no_cache=True` |
| `--no-cache` defaults to False | PASS | `parse_args(["route", "test.kicad_pcb"])` has `no_cache=False` |
| `--no-cache` forwarded to route_cmd.main | PASS | Mock-verified `--no-cache` appears in sub_argv |
| `--no-cache` not forwarded when False | PASS | Mock-verified `--no-cache` absent from sub_argv |

## Test Plan
- All 4 new tests in `TestRouteCommandNoCacheFlag` pass
- Full test suite passes (pre-existing failures in `test_renderers.py`, `test_audit.py`, `test_drc_regression.py` are unrelated)
- Ruff lint passes on all changed files

Closes #1624