### PR TITLE
fix(cli): correct --trials to --mc-trials in route suggestion message

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3254,7 +3254,7 @@ def main(argv: list[str] | None = None) -> int:
             print()
             print("Suggestions:")
             print(f"  - Auto-repair DRC violations: kct fix-drc {output_path} --max-passes 20")
-            print("  - Try Monte Carlo routing: kct route --trials 10")
+            print(f"  - Try Monte Carlo routing: kct route {args.pcb} --strategy monte-carlo --mc-trials 10")
             print("  - Increase board area")
             print("  - Reduce component density")
             print("  - Try 4-layer routing: kct route --layers 4")


### PR DESCRIPTION
## Summary
Fixes wrong flag name in the DRC violation suggestion message. The suggestion printed `--trials` which does not exist; the correct flag is `--mc-trials`. The suggestion also now includes the required `--strategy monte-carlo` flag and the board path to make it directly copy-pasteable.

## Changes
- Changed suggestion at route_cmd.py:3257 from `kct route --trials 10` to `kct route <board> --strategy monte-carlo --mc-trials 10`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Suggestion message shows correct flags | Done | Verified `--strategy monte-carlo --mc-trials N` in source |
| No other `--trials` (without `mc-` prefix) in user-facing messages | Done | Grepped entire src/ directory, no other occurrences |
| `--strategy` flag exposed in kct route | Done | Already wired in parser.py:970-987 (confirmed by curator) |
| `--mc-trials` flag exposed in kct route | Done | Already wired in parser.py:970-987 (confirmed by curator) |

## Test Plan
- Grepped `src/` for any remaining `--trials` without `mc-` prefix: none found
- `uv run pytest tests/ -x -q`: 1 pre-existing failure in test_renderers.py (unrelated to this change), 21 passed
- `uv run ruff check`: 1 pre-existing lint issue on line 2852 (unrelated f-string), no new issues

Closes #1645