### PR TITLE
feat(router): add clearance-weighted scoring to escape grid snap selection

### DIFF
--- a/src/kicad_tools/router/subgrid.py
+++ b/src/kicad_tools/router/subgrid.py
@@ -224,11 +224,13 @@ class SubGridRouter:
         rules: DesignRules,
         grid_tolerance: float | None = None,
         escape_search_radius: int = 3,
+        clearance_weight: float = 2.5,
     ):
         self.grid = grid
         self.rules = rules
         self.grid_tolerance = grid_tolerance if grid_tolerance is not None else grid.resolution / 4
         self.escape_search_radius = escape_search_radius
+        self.clearance_weight = clearance_weight
 
     def analyze_pads(
         self,
@@ -429,6 +431,53 @@ class SubGridRouter:
 
         return result
 
+    def _min_clearance_to_neighbors(
+        self,
+        x: float,
+        y: float,
+        half_width: float,
+        net: int,
+        layer_idx: int,
+    ) -> float:
+        """Compute minimum edge-to-edge distance from a candidate point to any different-net pad.
+
+        Used for clearance-weighted scoring of escape candidates (Issue #1642).
+        For each pad on the board that belongs to a different net and overlaps
+        the candidate's layer, computes the edge-to-edge distance (center-to-center
+        minus the candidate's half-width minus the pad's effective radius).
+
+        Args:
+            x: Candidate snap point X coordinate (world units, mm)
+            y: Candidate snap point Y coordinate (world units, mm)
+            half_width: Half the trace width of the escape segment
+            net: Net ID of the pad being escaped (neighbors on this net are skipped)
+            layer_idx: Grid layer index to check (SMD pads on other layers are skipped)
+
+        Returns:
+            Minimum edge-to-edge distance in mm. Returns ``float('inf')`` when
+            there are no different-net pads on the relevant layer.
+        """
+        min_dist = float("inf")
+        for pad in self.grid._pads:
+            if pad.net == net:
+                continue
+            # Layer filtering: through-hole pads appear on all layers,
+            # SMD pads only on their own layer.
+            if not pad.through_hole:
+                try:
+                    pad_li = self.grid.layer_to_index(pad.layer.value)
+                except Exception:
+                    continue
+                if pad_li != layer_idx:
+                    continue
+            pad_radius = max(pad.width, pad.height) / 2
+            dx = x - pad.x
+            dy = y - pad.y
+            dist = math.sqrt(dx * dx + dy * dy) - half_width - pad_radius
+            if dist < min_dist:
+                min_dist = dist
+        return min_dist
+
     def _find_escape_for_pad(self, sgp: SubGridPad) -> SubGridEscape | None:
         """Find the best escape point for a single off-grid pad.
 
@@ -454,6 +503,20 @@ class SubGridRouter:
             check_layers = list(range(self.grid.num_layers))
         else:
             check_layers = [self.grid.layer_to_index(pad.layer.value)]
+
+        # Determine trace width for escape segment (needed for clearance scoring)
+        layer = pad.layer
+        width = self.rules.trace_width
+
+        # Apply neck-down if configured for fine-pitch
+        if self.rules.min_trace_width is not None:
+            ref = pad.ref
+            pin_pitch = None
+            if ref:
+                pitches = self.grid.compute_component_pitches()
+                pin_pitch = pitches.get(ref)
+            if self.rules.should_apply_neck_down(ref, pin_pitch):
+                width = self.rules.min_trace_width
 
         # Collect all accessible candidates with their scores
         candidates: list[tuple[float, int, int, float, float]] = []
@@ -516,6 +579,24 @@ class SubGridRouter:
                 if dist > self.grid.resolution * radius:
                     score += dist * 2
 
+                # Clearance-aware scoring (Phase 2, Issue #1642)
+                # Penalize candidates that are close to different-net pads.
+                # This re-orders candidates so that high-clearance points are
+                # preferred, reducing DRC violations on tightly-packed ICs.
+                if self.clearance_weight > 0:
+                    required_clearance = self.rules.trace_clearance
+                    neighbor_clearance = self._min_clearance_to_neighbors(
+                        snap_x, snap_y, width / 2, pad.net, check_layers[0],
+                    )
+                    # Only penalize when clearance margin is tight
+                    # (below 2x required clearance)
+                    threshold = required_clearance * 2
+                    if neighbor_clearance < threshold:
+                        clearance_penalty = (
+                            (threshold - neighbor_clearance) * self.clearance_weight
+                        )
+                        score += clearance_penalty
+
                 candidates.append((score, gx, gy, snap_x, snap_y))
 
         if not candidates:
@@ -523,20 +604,6 @@ class SubGridRouter:
 
         # Sort candidates by score (lowest = best)
         candidates.sort(key=lambda c: c[0])
-
-        # Determine trace width for escape segment
-        layer = pad.layer
-        width = self.rules.trace_width
-
-        # Apply neck-down if configured for fine-pitch
-        if self.rules.min_trace_width is not None:
-            ref = pad.ref
-            pin_pitch = None
-            if ref:
-                pitches = self.grid.compute_component_pitches()
-                pin_pitch = pitches.get(ref)
-            if self.rules.should_apply_neck_down(ref, pin_pitch):
-                width = self.rules.min_trace_width
 
         # Compute component pitches once for clearance validation
         component_pitches = self.grid.compute_component_pitches()

--- a/tests/test_subgrid.py
+++ b/tests/test_subgrid.py
@@ -932,3 +932,250 @@ class TestEscapeClearanceValidation:
                 escape.segment, exclude_net=escape.pad.net,
             )
             assert is_valid
+
+
+class TestClearanceWeightedSelection:
+    """Tests for clearance-aware grid snap selection (Issue #1642).
+
+    Verifies that _find_escape_for_pad() uses clearance-weighted scoring
+    to prefer grid points farther from different-net neighbors, reducing
+    DRC violations on tightly-packed fine-pitch components.
+    """
+
+    def test_prefers_high_clearance_candidate(self):
+        """When two candidates are equidistant, the one farther from a
+        different-net neighbor should be selected."""
+        grid, rules = make_grid_and_rules(
+            width=20.0,
+            height=20.0,
+            resolution=0.1,
+            trace_width=0.15,
+            trace_clearance=0.127,
+        )
+        subgrid = SubGridRouter(grid, rules, clearance_weight=2.5)
+
+        # Off-grid pad at y=5.05 (between grid points 5.0 and 5.1)
+        off_grid_pad = make_pad(
+            x=5.0, y=5.05, net=1, ref="U1", pin="1",
+            width=0.3, height=0.3,
+        )
+
+        # Neighbor pad of different net close to grid point y=5.0 (below),
+        # making y=5.0 a worse escape target than y=5.1
+        neighbor_below = make_pad(
+            x=5.0, y=4.6, net=2, ref="U2", pin="1",
+            width=0.3, height=0.3,
+        )
+
+        # Component center pad (for escape direction calculation)
+        center_pad = make_pad(
+            x=5.0, y=7.0, net=3, ref="U1", pin="2",
+            width=0.3, height=0.3,
+        )
+
+        all_pads = [off_grid_pad, neighbor_below, center_pad]
+        for p in all_pads:
+            grid.add_pad(p)
+
+        analysis = subgrid.analyze_pads(all_pads)
+        result = subgrid.generate_escape_segments(analysis)
+
+        # The escape for net 1 should exist and prefer the candidate
+        # farther from the neighbor (y=5.1 rather than y=5.0)
+        net1_escapes = [e for e in result.escapes if e.pad.net == 1]
+        assert len(net1_escapes) == 1
+        escape = net1_escapes[0]
+        # The snap point Y should be >= 5.05 (away from the neighbor at 4.6)
+        assert escape.snap_point[1] >= 5.05 - 0.001, (
+            f"Expected escape toward y>=5.05 (away from neighbor), "
+            f"got snap_y={escape.snap_point[1]:.3f}"
+        )
+        # Must also pass binary clearance validation
+        is_valid, _clearance, _loc = grid.validate_segment_clearance(
+            escape.segment, exclude_net=1,
+        )
+        assert is_valid
+
+    def test_fallback_when_no_neighbors(self):
+        """When no different-net neighbors exist, clearance scoring should
+        not change the selection (nearest/best-direction still wins)."""
+        grid, rules = make_grid_and_rules(
+            width=20.0,
+            height=20.0,
+            resolution=0.1,
+            trace_width=0.15,
+            trace_clearance=0.127,
+        )
+
+        # Run with clearance_weight=0 and clearance_weight=2.5 and compare
+        subgrid_no_weight = SubGridRouter(grid, rules, clearance_weight=0.0)
+        subgrid_weighted = SubGridRouter(grid, rules, clearance_weight=2.5)
+
+        # Isolated off-grid pad -- no different-net neighbors nearby
+        off_grid_pad = make_pad(
+            x=10.05, y=10.0, net=1, ref="U1", pin="1",
+            width=0.3, height=0.3,
+        )
+        center_pad = make_pad(
+            x=10.05, y=12.0, net=2, ref="U1", pin="2",
+            width=0.3, height=0.3,
+        )
+
+        all_pads = [off_grid_pad, center_pad]
+        for p in all_pads:
+            grid.add_pad(p)
+
+        analysis = subgrid_no_weight.analyze_pads(all_pads)
+        result_no = subgrid_no_weight.generate_escape_segments(analysis)
+
+        analysis2 = subgrid_weighted.analyze_pads(all_pads)
+        result_w = subgrid_weighted.generate_escape_segments(analysis2)
+
+        # Both should produce escapes for the same pad
+        net1_no = [e for e in result_no.escapes if e.pad.net == 1]
+        net1_w = [e for e in result_w.escapes if e.pad.net == 1]
+
+        assert len(net1_no) >= 1
+        assert len(net1_w) >= 1
+
+        # The selected snap points should be the same (no neighbor influence)
+        assert abs(net1_no[0].snap_point[0] - net1_w[0].snap_point[0]) < 0.001
+        assert abs(net1_no[0].snap_point[1] - net1_w[0].snap_point[1]) < 0.001
+
+    def test_min_clearance_to_neighbors_basic(self):
+        """_min_clearance_to_neighbors should compute correct edge-to-edge distance."""
+        grid, rules = make_grid_and_rules(
+            width=20.0,
+            height=20.0,
+            resolution=0.1,
+            trace_width=0.15,
+            trace_clearance=0.1,
+        )
+        subgrid = SubGridRouter(grid, rules)
+
+        # Place a pad at (5.0, 5.0) with width=0.4, height=0.4 -> radius=0.2
+        neighbor = make_pad(
+            x=5.0, y=5.0, net=2, ref="U2", pin="1",
+            width=0.4, height=0.4,
+        )
+        grid.add_pad(neighbor)
+
+        # Query from (5.5, 5.0) with half_width=0.075 for net=1
+        # Center-to-center = 0.5mm, edge-to-edge = 0.5 - 0.075 - 0.2 = 0.225
+        layer_idx = grid.layer_to_index(Layer.F_CU.value)
+        dist = subgrid._min_clearance_to_neighbors(
+            5.5, 5.0, 0.075, net=1, layer_idx=layer_idx,
+        )
+        expected = 0.5 - 0.075 - 0.2
+        assert abs(dist - expected) < 0.001, f"Expected {expected}, got {dist}"
+
+    def test_min_clearance_to_neighbors_skips_same_net(self):
+        """_min_clearance_to_neighbors should skip pads on the same net."""
+        grid, rules = make_grid_and_rules(
+            width=20.0,
+            height=20.0,
+            resolution=0.1,
+            trace_width=0.15,
+            trace_clearance=0.1,
+        )
+        subgrid = SubGridRouter(grid, rules)
+
+        # Pad on net=1 -- should be skipped when querying for net=1
+        same_net_pad = make_pad(
+            x=5.0, y=5.0, net=1, ref="U1", pin="1",
+            width=0.4, height=0.4,
+        )
+        grid.add_pad(same_net_pad)
+
+        layer_idx = grid.layer_to_index(Layer.F_CU.value)
+        dist = subgrid._min_clearance_to_neighbors(
+            5.5, 5.0, 0.075, net=1, layer_idx=layer_idx,
+        )
+        assert dist == float("inf"), "Same-net pad should be ignored"
+
+    def test_min_clearance_to_neighbors_layer_filtering(self):
+        """_min_clearance_to_neighbors should skip SMD pads on other layers."""
+        grid, rules = make_grid_and_rules(
+            width=20.0,
+            height=20.0,
+            resolution=0.1,
+            trace_width=0.15,
+            trace_clearance=0.1,
+        )
+        subgrid = SubGridRouter(grid, rules)
+
+        # Pad on B.Cu -- should be skipped when querying F.Cu layer
+        back_pad = make_pad(
+            x=5.0, y=5.0, net=2, ref="U2", pin="1",
+            width=0.4, height=0.4,
+            layer=Layer.B_CU,
+        )
+        grid.add_pad(back_pad)
+
+        f_cu_idx = grid.layer_to_index(Layer.F_CU.value)
+        dist = subgrid._min_clearance_to_neighbors(
+            5.5, 5.0, 0.075, net=1, layer_idx=f_cu_idx,
+        )
+        assert dist == float("inf"), "Pad on B.Cu should be skipped for F.Cu query"
+
+    def test_min_clearance_to_neighbors_through_hole_not_skipped(self):
+        """_min_clearance_to_neighbors should include through-hole pads on any layer."""
+        grid, rules = make_grid_and_rules(
+            width=20.0,
+            height=20.0,
+            resolution=0.1,
+            trace_width=0.15,
+            trace_clearance=0.1,
+        )
+        subgrid = SubGridRouter(grid, rules)
+
+        # Through-hole pad should be visible on all layers
+        th_pad = make_pad(
+            x=5.0, y=5.0, net=2, ref="J1", pin="1",
+            width=1.7, height=1.7,
+            through_hole=True,
+        )
+        grid.add_pad(th_pad)
+
+        f_cu_idx = grid.layer_to_index(Layer.F_CU.value)
+        dist = subgrid._min_clearance_to_neighbors(
+            5.5, 5.0, 0.075, net=1, layer_idx=f_cu_idx,
+        )
+        # Through-hole pad radius = 1.7/2 = 0.85
+        # Distance = 0.5 - 0.075 - 0.85 = -0.425 (overlapping)
+        expected = 0.5 - 0.075 - 0.85
+        assert abs(dist - expected) < 0.001, f"Expected {expected}, got {dist}"
+
+    def test_clearance_weight_zero_disables_scoring(self):
+        """With clearance_weight=0, scoring should match pre-Phase-2 behavior."""
+        grid, rules = make_grid_and_rules(
+            width=20.0,
+            height=20.0,
+            resolution=0.1,
+            trace_width=0.15,
+            trace_clearance=0.127,
+        )
+        subgrid = SubGridRouter(grid, rules, clearance_weight=0.0)
+
+        off_grid_pad = make_pad(
+            x=5.05, y=5.0, net=1, ref="U1", pin="1",
+            width=0.3, height=0.3,
+        )
+        center_pad = make_pad(
+            x=5.05, y=7.0, net=2, ref="U1", pin="2",
+            width=0.3, height=0.3,
+        )
+
+        all_pads = [off_grid_pad, center_pad]
+        for p in all_pads:
+            grid.add_pad(p)
+
+        analysis = subgrid.analyze_pads(all_pads)
+        result = subgrid.generate_escape_segments(analysis)
+
+        # Should still produce valid escapes (binary check is defense-in-depth)
+        for escape in result.escapes:
+            is_valid, _clearance, _loc = grid.validate_segment_clearance(
+                escape.segment, exclude_net=escape.pad.net,
+            )
+            assert is_valid


### PR DESCRIPTION
## Summary

Adds clearance-aware grid snap selection (Phase 2) to the sub-grid escape router. Instead of always snapping off-grid pads to the nearest grid point, candidate grid points are now scored with a clearance penalty that favors points farther from different-net obstacles. This reduces DRC violations on tightly-packed fine-pitch components (SSOP-28, SSOP-20).

## Changes

- Added `_min_clearance_to_neighbors()` helper to `SubGridRouter` that computes minimum edge-to-edge distance from a candidate snap point to any different-net pad, with proper layer filtering for SMD vs through-hole pads
- Moved trace width computation before the candidate scoring loop so clearance scoring has access to the half-width
- Integrated clearance-weighted penalty into candidate scoring: when neighbor clearance is below 2x required clearance, a penalty proportional to `clearance_weight` is added to the score
- Added `clearance_weight` parameter to `SubGridRouter.__init__()` (default 2.5)
- Retained Phase 1 binary `validate_segment_clearance()` check as defense-in-depth
- Added 7 new tests in `TestClearanceWeightedSelection` class covering:
  - High-clearance candidate preference
  - Fallback behavior with no neighbors
  - `_min_clearance_to_neighbors` edge-to-edge distance correctness
  - Same-net pad skipping
  - Layer filtering (SMD pads on other layers)
  - Through-hole pad visibility on all layers
  - clearance_weight=0 disabling the feature

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Grid snap selection considers clearance to neighboring nets | Pass | `_min_clearance_to_neighbors()` computes per-candidate clearance; penalty integrated into scoring loop |
| No regression on boards with on-grid pads | Pass | All 41 existing tests pass; fallback test confirms identical selection when no neighbors present |

## Test Plan

- `uv run pytest tests/test_subgrid.py -x -q` -- all 41 tests pass (34 existing + 7 new)
- Lint check: zero new issues (5 pre-existing issues unchanged)

Closes #1642