### PR TITLE
fix(schematic): add resistor_ref parameter to LEDIndicator to prevent ref collisions

### DIFF
--- a/src/kicad_tools/schematic/blocks/indicators.py
+++ b/src/kicad_tools/schematic/blocks/indicators.py
@@ -35,6 +35,7 @@ class LEDIndicator(CircuitBlock):
         vertical: bool = True,
         led_footprint: str = "",
         resistor_footprint: str = "",
+        resistor_ref: str = "",
     ):
         """
         Create an LED indicator.
@@ -51,13 +52,18 @@ class LEDIndicator(CircuitBlock):
             vertical: If True, LED is vertical (rotated 90°)
             led_footprint: Footprint for LED (e.g., "LED_SMD:LED_0805_2012Metric")
             resistor_footprint: Footprint for resistor (e.g., "Resistor_SMD:R_0805_2012Metric")
+            resistor_ref: Explicit resistor reference (e.g., "R12"). If empty,
+                derived from ref_prefix digit (e.g., "D2" -> "R2").
         """
         super().__init__(sch, x, y)
 
         # Parse reference prefix
         d_ref = ref_prefix if ref_prefix[-1].isdigit() else ref_prefix
-        r_num = ref_prefix[-1] if ref_prefix[-1].isdigit() else "1"
-        r_ref = f"R{r_num}"
+        if resistor_ref:
+            r_ref = resistor_ref
+        else:
+            r_num = ref_prefix[-1] if ref_prefix[-1].isdigit() else "1"
+            r_ref = f"R{r_num}"
 
         # Component spacing
         led_resistor_spacing = 15  # mm between LED and resistor centers

--- a/tests/test_schematic_blocks.py
+++ b/tests/test_schematic_blocks.py
@@ -176,6 +176,16 @@ class TestLEDIndicatorMocked:
         # Should add junctions
         assert mock_schematic.add_junction.called
 
+    def test_led_explicit_resistor_ref(self, mock_schematic):
+        """LED indicator uses explicit resistor_ref when provided."""
+        LEDIndicator(mock_schematic, x=100, y=100, ref_prefix="D2", resistor_ref="R12")
+
+        # The resistor add_symbol call should use "R12", not the auto-derived "R2"
+        add_calls = mock_schematic.add_symbol.call_args_list
+        # Second add_symbol call is the resistor
+        resistor_call_args = add_calls[1]
+        assert resistor_call_args[0][3] == "R12"
+
 
 class TestDecouplingCapsMocked:
     """Tests for DecouplingCaps with mocked schematic."""


### PR DESCRIPTION
## Summary
The `LEDIndicator` block auto-derived its resistor reference from the LED digit (e.g., `ref_prefix="D2"` produced `R2`), which collided with the `VoltageDividerSense` block's R1/R2 refs in the softstart board design. This adds an explicit `resistor_ref` parameter so callers can control the resistor reference designator.

## Changes
- Added optional `resistor_ref` parameter to `LEDIndicator.__init__` in `indicators.py`
- When `resistor_ref` is provided, it overrides the auto-derived value; existing behavior is preserved when omitted
- Updated the (gitignored) `boards/external/softstart/generate_design.py` to pass `resistor_ref="R12"` to the status LED
- Added test for the new `resistor_ref` parameter

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct build` produces no "Duplicate reference" errors | Pass | Ran `kct build boards/external/softstart/project.kct --force --step schematic -v` -- zero duplicate reference errors in output |
| All component references are unique | Pass | Voltage divider uses R1-R2, explicit resistors R3-R11, LED resistor now R12 |
| No functional changes to the circuit | Pass | Same components and values, only the resistor ref designator changed from R2 to R12 |

## Test Plan
- Ran `kct build boards/external/softstart/project.kct --force --step schematic -v` and confirmed zero "Duplicate reference" errors
- Added unit test `test_led_explicit_resistor_ref` verifying the parameter is used
- All 250 tests pass (3 pre-existing failures in `TestBlockIntegration` unrelated to this change)

Closes #1634