### PR TITLE
feat(schematic): add start_power/end_power params to add_rail()

### DIFF
--- a/src/kicad_tools/schematic/models/wiring_mixin.py
+++ b/src/kicad_tools/schematic/models/wiring_mixin.py
@@ -115,7 +115,14 @@ class SchematicWiringMixin:
                 return  # Only warn once per connection
 
     def add_rail(
-        self, y: float, x_start: float, x_end: float, net_label: str = None, snap: bool = True
+        self,
+        y: float,
+        x_start: float,
+        x_end: float,
+        net_label: str = None,
+        start_power: str = None,
+        end_power: str = None,
+        snap: bool = True,
     ) -> Wire:
         """Add a horizontal power/ground rail as a single wire.
 
@@ -139,11 +146,29 @@ class SchematicWiringMixin:
             sch.add_segmented_rail(y=30, x_points=[25, 50, 100, 150, 175])
             ```
 
+        Power symbols can be placed at rail endpoints to prevent dangling wire
+        validation errors. The symbol connects electrically at the wire endpoint,
+        capping the rail::
+
+            # 3.3V rail with power symbols at both ends
+            sch.add_rail(y=30, x_start=100, x_end=500,
+                         start_power="power:+3V3", end_power="power:+3V3")
+
+            # GND rail with power symbol only at the right end
+            sch.add_rail(y=280, x_start=25, x_end=600,
+                         end_power="power:GND")
+
         Args:
             y: Y coordinate of the rail (snapped to grid)
             x_start: Starting X coordinate (snapped to grid)
             x_end: Ending X coordinate (snapped to grid)
             net_label: Optional net label to add at the start
+            start_power: Optional power symbol lib_id to place at x_start
+                        (e.g., "power:+3V3", "power:GND"). Placed 10 units
+                        above the rail for supply symbols, 10 units below
+                        for ground symbols.
+            end_power: Optional power symbol lib_id to place at x_end.
+                      Same placement rules as start_power.
             snap: Whether to apply grid snapping (default: True)
 
         Returns:
@@ -165,6 +190,18 @@ class SchematicWiringMixin:
         if net_label:
             # Use the actual snapped wire coordinates for the label
             self.add_label(net_label, wire.x1, wire.y1, rotation=0, snap=False)
+
+        # Place power symbols at endpoints to cap the rail
+        for power_lib, px in [
+            (start_power, actual_x_start),
+            (end_power, actual_x_end),
+        ]:
+            if power_lib:
+                # Ground symbols go below the rail; supply symbols go above
+                is_ground = "gnd" in power_lib.lower()
+                py = wire.y1 + (10 if is_ground else -10)
+                self.add_power(power_lib, x=px, y=py, rotation=0, snap=False)
+
         return wire
 
     def add_segmented_rail(

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -923,6 +923,44 @@ class TestSchematicConstruction:
         assert len(sch.labels) == 1
         assert sch.labels[0].text == "VCC"
 
+    def test_add_rail_with_end_power_symbols(self):
+        """add_rail() places power symbols at endpoints when requested."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        wire = sch.add_rail(
+            y=100,
+            x_start=10,
+            x_end=50,
+            net_label="VCC",
+            start_power="power:+3V3",
+            end_power="power:+3V3",
+            snap=False,
+        )
+        assert len(sch.wires) == 1
+        assert len(sch.labels) == 1
+        # Two power symbols placed at endpoints
+        assert len(sch.power_symbols) == 2
+        # Supply symbols should be placed above the rail (y - 10)
+        assert sch.power_symbols[0].y == 90
+        assert sch.power_symbols[1].y == 90
+        # X positions should match wire endpoints
+        xs = sorted([sch.power_symbols[0].x, sch.power_symbols[1].x])
+        assert xs == [10, 50]
+
+    def test_add_rail_with_gnd_power_symbol(self):
+        """add_rail() places GND power symbols below the rail."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        wire = sch.add_rail(
+            y=280,
+            x_start=25,
+            x_end=600,
+            end_power="power:GND",
+            snap=False,
+        )
+        assert len(sch.power_symbols) == 1
+        # GND symbols should be placed below the rail (y + 10)
+        assert sch.power_symbols[0].y == 290
+        assert sch.power_symbols[0].x == 600
+
     def test_add_rail_tracks_continuous_rails(self):
         """add_rail() registers the rail for T-connection warnings."""
         sch = Schematic(title="Test", snap_mode=SnapMode.OFF)


### PR DESCRIPTION
## Summary

- Adds optional `start_power` and `end_power` parameters to `add_rail()` in `wiring_mixin.py` that place power symbols at rail wire endpoints, preventing "Wire endpoint not connected" validation errors
- Supply symbols (e.g., `power:+3V3`) are placed 10 units above the rail; ground symbols (e.g., `power:GND`) are placed 10 units below
- Includes unit tests for both supply and ground power symbol placement

Closes #1635

## Test plan

- [x] Existing `add_rail` tests pass (no regressions)
- [x] New tests verify power symbol placement at endpoints for supply and ground rails
- [x] Pre-existing test failures (test_multiple_leds, test_block_port_coordinates) confirmed on main
- [ ] Manual verification: update local softstart `generate_design.py` to use `end_power` params and confirm zero dangling-endpoint errors

Generated with [Claude Code](https://claude.com/claude-code)