### PR TITLE
fix(router): cycle all escape strategies and relax success criteria

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -540,12 +540,13 @@ class NegotiatedRouter:
         present_cost_factor: float,
         mark_route_callback: callable,
         strategy_index: int = 0,
-    ) -> tuple[bool, int]:
+    ) -> tuple[bool, int, int]:
         """Try escape strategies when router is stuck oscillating.
 
         When the negotiated router is stuck cycling between states without
         making progress (detected via detect_oscillation), this method
-        tries various strategies to escape the local minimum.
+        tries strategies starting from strategy_index, cycling through all
+        remaining strategies until one succeeds or all are exhausted.
 
         Args:
             overflow_history: List of overflow values from previous iterations
@@ -555,10 +556,11 @@ class NegotiatedRouter:
             net_order: List of net IDs in routing priority order
             present_cost_factor: Current congestion cost factor
             mark_route_callback: Callback to mark routes on the grid
-            strategy_index: Index of strategy to try (cycles through available)
+            strategy_index: Index of strategy to start from (cycles through available)
 
         Returns:
-            Tuple of (success, overflow) where success indicates if overflow improved
+            Tuple of (success, overflow, strategies_tried) where success indicates
+            if overflow improved and strategies_tried is how many were attempted
         """
         strategies = [
             self._escape_shuffle_order,
@@ -566,16 +568,30 @@ class NegotiatedRouter:
             self._escape_random_subset,
         ]
 
-        strategy = strategies[strategy_index % len(strategies)]
-        return strategy(
-            overflow_history=overflow_history,
-            net_routes=net_routes,
-            routes_list=routes_list,
-            pads_by_net=pads_by_net,
-            net_order=net_order,
-            present_cost_factor=present_cost_factor,
-            mark_route_callback=mark_route_callback,
-        )
+        num_strategies = len(strategies)
+        strategies_tried = 0
+
+        for i in range(num_strategies):
+            idx = (strategy_index + i) % num_strategies
+            strategy = strategies[idx]
+            strategies_tried += 1
+
+            success, new_overflow = strategy(
+                overflow_history=overflow_history,
+                net_routes=net_routes,
+                routes_list=routes_list,
+                pads_by_net=pads_by_net,
+                net_order=net_order,
+                present_cost_factor=present_cost_factor,
+                mark_route_callback=mark_route_callback,
+            )
+
+            if success:
+                return True, new_overflow, strategies_tried
+
+        # All strategies exhausted without success
+        current_overflow = overflow_history[-1] if overflow_history else 0
+        return False, current_overflow, strategies_tried
 
     def _escape_shuffle_order(
         self,
@@ -626,10 +642,10 @@ class NegotiatedRouter:
         new_overflow = self.grid.get_total_overflow()
         best_overflow = min(overflow_history) if overflow_history else float("inf")
 
-        # Only consider escape successful if ALL nets were re-routed AND overflow improved
-        # (Issue #762: escape was incorrectly reporting success when nets failed to re-route)
-        all_rerouted = rerouted_count == expected_count
-        return all_rerouted and new_overflow < best_overflow, new_overflow
+        # Accept escape if overflow improved and at least some nets survived
+        # (Issue #762: require rerouted_count > 0 to avoid false success on total loss)
+        # (Issue #1638: relaxed from requiring ALL nets to allow partial progress)
+        return rerouted_count > 0 and new_overflow < best_overflow, new_overflow
 
     def _escape_reverse_order(
         self,
@@ -678,10 +694,10 @@ class NegotiatedRouter:
         new_overflow = self.grid.get_total_overflow()
         best_overflow = min(overflow_history) if overflow_history else float("inf")
 
-        # Only consider escape successful if ALL nets were re-routed AND overflow improved
-        # (Issue #762: escape was incorrectly reporting success when nets failed to re-route)
-        all_rerouted = rerouted_count == expected_count
-        return all_rerouted and new_overflow < best_overflow, new_overflow
+        # Accept escape if overflow improved and at least some nets survived
+        # (Issue #762: require rerouted_count > 0 to avoid false success on total loss)
+        # (Issue #1638: relaxed from requiring ALL nets to allow partial progress)
+        return rerouted_count > 0 and new_overflow < best_overflow, new_overflow
 
     def _escape_random_subset(
         self,
@@ -731,7 +747,7 @@ class NegotiatedRouter:
         new_overflow = self.grid.get_total_overflow()
         best_overflow = min(overflow_history) if overflow_history else float("inf")
 
-        # Only consider escape successful if ALL nets were re-routed AND overflow improved
-        # (Issue #762: escape was incorrectly reporting success when nets failed to re-route)
-        all_rerouted = rerouted_count == expected_count
-        return all_rerouted and new_overflow < best_overflow, new_overflow
+        # Accept escape if overflow improved and at least some nets survived
+        # (Issue #762: require rerouted_count > 0 to avoid false success on total loss)
+        # (Issue #1638: relaxed from requiring ALL nets to allow partial progress)
+        return rerouted_count > 0 and new_overflow < best_overflow, new_overflow

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2541,12 +2541,12 @@ class Autorouter:
                     # Adaptive oscillation detection for targeted mode (Issue #633)
                     if adaptive and detect_oscillation(overflow_history):
                         print(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
-                        print(f"    Attempting escape strategy {escape_strategy_index + 1}...")
+                        print(f"    Attempting escape strategies starting from {escape_strategy_index + 1}...")
 
                         def mark_route_targeted(route: Route) -> None:
                             self._mark_route(route)
 
-                        success, new_overflow = neg_router.escape_local_minimum(
+                        success, new_overflow, tried = neg_router.escape_local_minimum(
                             overflow_history=overflow_history,
                             net_routes=net_routes,
                             routes_list=self.routes,
@@ -2556,7 +2556,7 @@ class Autorouter:
                             mark_route_callback=mark_route_targeted,
                             strategy_index=escape_strategy_index,
                         )
-                        escape_strategy_index += 1
+                        escape_strategy_index += tried
 
                         if success:
                             print(f"    Escape successful! Overflow: {overflow} → {new_overflow}")
@@ -2564,7 +2564,7 @@ class Autorouter:
                             overflow_history[-1] = new_overflow
                             overused = self.grid.find_overused_cells()
                         else:
-                            print("    Escape attempt did not improve overflow")
+                            print(f"    All {tried} escape strategies exhausted without improvement")
 
                     # Skip common code since targeted ripup handles everything
                     # (convergence and oscillation already checked above)
@@ -2649,12 +2649,12 @@ class Autorouter:
                 # Adaptive oscillation detection and escape (Issue #633)
                 if adaptive and detect_oscillation(overflow_history):
                     print(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
-                    print(f"    Attempting escape strategy {escape_strategy_index + 1}...")
+                    print(f"    Attempting escape strategies starting from {escape_strategy_index + 1}...")
 
                     def mark_route(route: Route) -> None:
                         self._mark_route(route)
 
-                    success, new_overflow = neg_router.escape_local_minimum(
+                    success, new_overflow, tried = neg_router.escape_local_minimum(
                         overflow_history=overflow_history,
                         net_routes=net_routes,
                         routes_list=self.routes,
@@ -2664,7 +2664,7 @@ class Autorouter:
                         mark_route_callback=mark_route,
                         strategy_index=escape_strategy_index,
                     )
-                    escape_strategy_index += 1
+                    escape_strategy_index += tried
 
                     if success:
                         print(f"    Escape successful! Overflow: {overflow} → {new_overflow}")
@@ -2672,7 +2672,7 @@ class Autorouter:
                         overflow_history[-1] = new_overflow  # Update last entry
                         overused = self.grid.find_overused_cells()
                     else:
-                        print("    Escape attempt did not improve overflow")
+                        print(f"    All {tried} escape strategies exhausted without improvement")
                         # Continue to next iteration with different parameters
 
         successful_nets = sum(1 for routes in net_routes.values() if routes)

--- a/tests/test_negotiated_adaptive.py
+++ b/tests/test_negotiated_adaptive.py
@@ -215,6 +215,109 @@ class TestIsMonotonicallyDiverging:
         assert _is_monotonically_diverging([90, 96, 88, 130, 148, 155], window=3) is True
 
 
+class TestEscapeStrategyCycling:
+    """Tests for escape_local_minimum trying all strategies (Issue #1638)."""
+
+    def test_escape_tries_all_strategies_on_failure(self):
+        """escape_local_minimum should cycle through all 3 strategies before giving up."""
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        mock_grid = MagicMock()
+        mock_router = MagicMock()
+        neg = NegotiatedRouter(mock_grid, mock_router, MagicMock(), {})
+
+        # Make all strategies fail
+        neg._escape_shuffle_order = MagicMock(return_value=(False, 10))
+        neg._escape_reverse_order = MagicMock(return_value=(False, 10))
+        neg._escape_random_subset = MagicMock(return_value=(False, 10))
+
+        success, overflow, tried = neg.escape_local_minimum(
+            overflow_history=[10, 10, 10, 10],
+            net_routes={},
+            routes_list=[],
+            pads_by_net={},
+            net_order=[],
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+            strategy_index=0,
+        )
+
+        assert success is False
+        assert tried == 3
+        assert neg._escape_shuffle_order.call_count == 1
+        assert neg._escape_reverse_order.call_count == 1
+        assert neg._escape_random_subset.call_count == 1
+
+    def test_escape_stops_on_first_success(self):
+        """escape_local_minimum should stop as soon as one strategy succeeds."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        mock_grid = MagicMock()
+        mock_router = MagicMock()
+        neg = NegotiatedRouter(mock_grid, mock_router, MagicMock(), {})
+
+        # First fails, second succeeds
+        neg._escape_shuffle_order = MagicMock(return_value=(False, 10))
+        neg._escape_reverse_order = MagicMock(return_value=(True, 5))
+        neg._escape_random_subset = MagicMock(return_value=(False, 10))
+
+        success, overflow, tried = neg.escape_local_minimum(
+            overflow_history=[10, 10, 10, 10],
+            net_routes={},
+            routes_list=[],
+            pads_by_net={},
+            net_order=[],
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+            strategy_index=0,
+        )
+
+        assert success is True
+        assert overflow == 5
+        assert tried == 2
+        assert neg._escape_shuffle_order.call_count == 1
+        assert neg._escape_reverse_order.call_count == 1
+        assert neg._escape_random_subset.call_count == 0  # Not tried
+
+    def test_escape_wraps_around_strategy_index(self):
+        """escape_local_minimum should wrap strategy index modulo num strategies."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        mock_grid = MagicMock()
+        mock_router = MagicMock()
+        neg = NegotiatedRouter(mock_grid, mock_router, MagicMock(), {})
+
+        # All fail
+        neg._escape_shuffle_order = MagicMock(return_value=(False, 10))
+        neg._escape_reverse_order = MagicMock(return_value=(False, 10))
+        neg._escape_random_subset = MagicMock(return_value=(False, 10))
+
+        # Start from index 1 (reverse), should try reverse -> random -> shuffle
+        success, overflow, tried = neg.escape_local_minimum(
+            overflow_history=[10, 10, 10, 10],
+            net_routes={},
+            routes_list=[],
+            pads_by_net={},
+            net_order=[],
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+            strategy_index=1,
+        )
+
+        assert success is False
+        assert tried == 3
+        # All three should be called exactly once
+        assert neg._escape_shuffle_order.call_count == 1
+        assert neg._escape_reverse_order.call_count == 1
+        assert neg._escape_random_subset.call_count == 1
+
+
 class TestCalculatePresentCost:
     """Tests for calculate_present_cost function."""
 


### PR DESCRIPTION
## Summary

Fixes two issues in the negotiated congestion router's oscillation escape mechanism that prevented resolution of congestion on the softstart board:

1. **Escape now tries all 3 strategies before giving up** -- previously only one strategy was tried per oscillation detection, and early termination could fire before remaining strategies were attempted
2. **Relaxed escape success criteria** -- previously required ALL nets to re-route AND overflow to improve; now accepts if overflow improved and at least one net re-routed (guards against total net loss per Issue #762)

## Changes

- Modified `escape_local_minimum()` in `negotiated.py` to loop through all 3 strategies (shuffle, reverse, random subset) before reporting failure, returning a 3-tuple `(success, overflow, strategies_tried)`
- Relaxed success check in all 3 escape strategy methods from `all_rerouted and new_overflow < best_overflow` to `rerouted_count > 0 and new_overflow < best_overflow`
- Updated both call sites in `core.py` (targeted and full rip-up modes) to handle the new return value and increment `escape_strategy_index` by the number of strategies tried
- Added 3 unit tests for the strategy cycling behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Router tries multiple escape strategies before giving up | PASS | `escape_local_minimum` now loops through all 3 strategies; verified by unit tests |
| No regression on existing routing test cases | PASS | All 37 negotiated/oscillation tests pass |

## Test Plan

- `uv run pytest tests/test_negotiated_adaptive.py -x -q -v` -- 37/37 pass including 3 new tests for strategy cycling
- New tests verify: all strategies tried on failure, stops on first success, wraps around strategy index correctly

Closes #1638