### PR TITLE
fix(cli): flush progress output during long routing runs

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -604,7 +604,7 @@ def route_with_layer_escalation(
     Returns:
         Exit code (0 = success, 1 = failure)
     """
-    from kicad_tools.cli.progress import spinner
+    from kicad_tools.cli.progress import flush_print, spinner
     from kicad_tools.router import (
         DesignRules,
         LayerStack,
@@ -653,26 +653,26 @@ def route_with_layer_escalation(
     layer_configs = [(n, s) for n, s in layer_configs if n <= args.max_layers]
 
     if not quiet:
-        print("=" * 60)
-        print("KiCad PCB Autorouter - Layer Escalation Mode")
-        print("=" * 60)
-        print(f"Input:          {pcb_path}")
-        print(f"Output:         {output_path}")
-        print(f"Strategy:       {args.strategy}")
-        print(f"Max layers:     {args.max_layers}")
-        print(f"Min completion: {args.min_completion * 100:.0f}%")
+        flush_print("=" * 60)
+        flush_print("KiCad PCB Autorouter - Layer Escalation Mode")
+        flush_print("=" * 60)
+        flush_print(f"Input:          {pcb_path}")
+        flush_print(f"Output:         {output_path}")
+        flush_print(f"Strategy:       {args.strategy}")
+        flush_print(f"Max layers:     {args.max_layers}")
+        flush_print(f"Min completion: {args.min_completion * 100:.0f}%")
         if skip_nets:
-            print(f"Skip:           {', '.join(skip_nets)}")
-        print()
+            flush_print(f"Skip:           {', '.join(skip_nets)}")
+        flush_print()
 
     best_result: LayerEscalationResult | None = None
     successful_result: LayerEscalationResult | None = None
 
     for attempt_num, (layer_count, layer_stack) in enumerate(layer_configs, 1):
         if not quiet:
-            print("=" * 60)
-            print(f"Attempt {attempt_num}: {layer_count} layers")
-            print("=" * 60)
+            flush_print("=" * 60)
+            flush_print(f"Attempt {attempt_num}: {layer_count} layers")
+            flush_print("=" * 60)
 
         # Load PCB with this layer stack
         try:
@@ -699,12 +699,12 @@ def route_with_layer_escalation(
         nets_to_route = len(multi_pad_nets)
 
         if not quiet:
-            print(f"  Board size: {router.grid.width}mm x {router.grid.height}mm")
-            print(f"  Nets to route: {nets_to_route}")
+            flush_print(f"  Board size: {router.grid.width}mm x {router.grid.height}mm")
+            flush_print(f"  Nets to route: {nets_to_route}")
 
         # Route
         if not quiet:
-            print(f"\n  Routing ({args.strategy})...")
+            flush_print(f"\n  Routing ({args.strategy})...")
 
         escape_flag = _resolve_escape_routing_flag(args)
 
@@ -765,8 +765,8 @@ def route_with_layer_escalation(
         # Report attempt result
         status = "SUCCESS" if result.success else "INSUFFICIENT - escalating"
         if not quiet:
-            print(f"\n  Routed: {nets_routed}/{nets_to_route} nets ({completion * 100:.0f}%)")
-            print(f"  Status: {status}")
+            flush_print(f"\n  Routed: {nets_routed}/{nets_to_route} nets ({completion * 100:.0f}%)")
+            flush_print(f"  Status: {status}")
 
         # Check for success
         if result.success:
@@ -945,7 +945,7 @@ def route_with_rule_relaxation(
     Returns:
         Exit code (0 = success, 1 = failure)
     """
-    from kicad_tools.cli.progress import spinner
+    from kicad_tools.cli.progress import flush_print, spinner
     from kicad_tools.router import (
         DesignRules,
         LayerStack,
@@ -1001,28 +1001,28 @@ def route_with_rule_relaxation(
         layer_stack = layer_stack_map[args.layers]
 
     if not quiet:
-        print("=" * 60)
-        print("KiCad PCB Autorouter - Adaptive Rules Mode")
-        print("=" * 60)
-        print(f"Input:          {pcb_path}")
-        print(f"Output:         {output_path}")
-        print(f"Strategy:       {args.strategy}")
-        print(f"Manufacturer:   {args.manufacturer}")
-        print(f"Min completion: {args.min_completion * 100:.0f}%")
-        print(f"Relaxation tiers: {len(tiers)}")
+        flush_print("=" * 60)
+        flush_print("KiCad PCB Autorouter - Adaptive Rules Mode")
+        flush_print("=" * 60)
+        flush_print(f"Input:          {pcb_path}")
+        flush_print(f"Output:         {output_path}")
+        flush_print(f"Strategy:       {args.strategy}")
+        flush_print(f"Manufacturer:   {args.manufacturer}")
+        flush_print(f"Min completion: {args.min_completion * 100:.0f}%")
+        flush_print(f"Relaxation tiers: {len(tiers)}")
         if skip_nets:
-            print(f"Skip:           {', '.join(skip_nets)}")
-        print()
+            flush_print(f"Skip:           {', '.join(skip_nets)}")
+        flush_print()
 
     best_result: RuleRelaxationResult | None = None
     successful_result: RuleRelaxationResult | None = None
 
     for tier in tiers:
         if not quiet:
-            print("=" * 60)
-            print(f"Attempt {tier.tier + 1}: {tier.description}")
-            print(f"  trace={tier.trace_width:.3f}mm, clearance={tier.clearance:.3f}mm")
-            print("=" * 60)
+            flush_print("=" * 60)
+            flush_print(f"Attempt {tier.tier + 1}: {tier.description}")
+            flush_print(f"  trace={tier.trace_width:.3f}mm, clearance={tier.clearance:.3f}mm")
+            flush_print("=" * 60)
 
         # Configure design rules for this tier
         rules = DesignRules(
@@ -1058,12 +1058,12 @@ def route_with_rule_relaxation(
         nets_to_route = len(multi_pad_nets)
 
         if not quiet:
-            print(f"  Board size: {router.grid.width}mm x {router.grid.height}mm")
-            print(f"  Nets to route: {nets_to_route}")
+            flush_print(f"  Board size: {router.grid.width}mm x {router.grid.height}mm")
+            flush_print(f"  Nets to route: {nets_to_route}")
 
         # Route
         if not quiet:
-            print(f"\n  Routing ({args.strategy})...")
+            flush_print(f"\n  Routing ({args.strategy})...")
 
         escape_flag = _resolve_escape_routing_flag(args)
 
@@ -1129,8 +1129,8 @@ def route_with_rule_relaxation(
         # Report attempt result
         status = "SUCCESS" if result.success else "INSUFFICIENT - relaxing rules"
         if not quiet:
-            print(f"\n  Routed: {nets_routed}/{nets_to_route} nets ({completion * 100:.0f}%)")
-            print(f"  Status: {status}")
+            flush_print(f"\n  Routed: {nets_routed}/{nets_to_route} nets ({completion * 100:.0f}%)")
+            flush_print(f"  Status: {status}")
 
         # Check for success
         if result.success:
@@ -1322,7 +1322,7 @@ def route_with_combined_escalation(
     Returns:
         Exit code (0 = success, 1 = failure)
     """
-    from kicad_tools.cli.progress import spinner
+    from kicad_tools.cli.progress import flush_print, spinner
     from kicad_tools.router import (
         DesignRules,
         LayerStack,
@@ -1374,25 +1374,25 @@ def route_with_combined_escalation(
     layer_configs = [(n, s) for n, s in layer_configs if n <= args.max_layers]
 
     if not quiet:
-        print("=" * 60)
-        print("KiCad PCB Autorouter - Combined Escalation Mode")
-        print("=" * 60)
-        print(f"Input:          {pcb_path}")
-        print(f"Output:         {output_path}")
-        print(f"Strategy:       {args.strategy}")
-        print(f"Manufacturer:   {args.manufacturer}")
-        print(f"Max layers:     {args.max_layers}")
-        print(f"Min completion: {args.min_completion * 100:.0f}%")
-        print(f"Rule tiers:     {len(tiers)}")
-        print(f"Layer configs:  {[n for n, _ in layer_configs]}")
+        flush_print("=" * 60)
+        flush_print("KiCad PCB Autorouter - Combined Escalation Mode")
+        flush_print("=" * 60)
+        flush_print(f"Input:          {pcb_path}")
+        flush_print(f"Output:         {output_path}")
+        flush_print(f"Strategy:       {args.strategy}")
+        flush_print(f"Manufacturer:   {args.manufacturer}")
+        flush_print(f"Max layers:     {args.max_layers}")
+        flush_print(f"Min completion: {args.min_completion * 100:.0f}%")
+        flush_print(f"Rule tiers:     {len(tiers)}")
+        flush_print(f"Layer configs:  {[n for n, _ in layer_configs]}")
         if skip_nets:
-            print(f"Skip:           {', '.join(skip_nets)}")
-        print()
-        print("Search matrix:")
-        print("         ", end="")
+            flush_print(f"Skip:           {', '.join(skip_nets)}")
+        flush_print()
+        flush_print("Search matrix:")
+        flush_print("         ", end="")
         for n, _ in layer_configs:
-            print(f" {n}L    ", end="")
-        print()
+            flush_print(f" {n}L    ", end="")
+        flush_print()
 
     best_result: RuleRelaxationResult | None = None
     successful_result: RuleRelaxationResult | None = None
@@ -1402,7 +1402,7 @@ def route_with_combined_escalation(
     for layer_count, layer_stack in layer_configs:
         for tier in tiers:
             if not quiet:
-                print(
+                flush_print(
                     f"\nTrying: {layer_count} layers, tier {tier.tier} "
                     f"(trace={tier.trace_width:.2f}mm, clearance={tier.clearance:.2f}mm)"
                 )
@@ -1485,7 +1485,7 @@ def route_with_combined_escalation(
             results_matrix[(tier.tier, layer_count)] = completion
 
             if not quiet:
-                print(f"  Routed: {nets_routed}/{nets_to_route} ({completion * 100:.0f}%)")
+                flush_print(f"  Routed: {nets_routed}/{nets_to_route} ({completion * 100:.0f}%)")
 
             # Create result
             result = RuleRelaxationResult(
@@ -2592,18 +2592,18 @@ def main(argv: list[str] | None = None) -> int:
     power_nets_skipped = len(skip_nets)
 
     if not quiet:
-        print(f"  Board size: {router.grid.width}mm x {router.grid.height}mm")
+        flush_print(f"  Board size: {router.grid.width}mm x {router.grid.height}mm")
         backend_info = router.backend_info
         grid_cells = router.grid.cols * router.grid.rows * router.grid.num_layers
         from kicad_tools.router.cpp_backend import format_backend_status
 
         backend_status = format_backend_status(backend_info, grid_cells)
-        print(f"  Backend:    {backend_status}")
-        print(
+        flush_print(f"  Backend:    {backend_status}")
+        flush_print(
             f"  Grid:       {router.grid.cols}x{router.grid.rows}x{router.grid.num_layers} = {grid_cells:,} cells"
         )
-        print(f"  Total nets: {len(net_map)}")
-        print(f"  Nets to route: {nets_to_route} (multi-pad signal nets)")
+        flush_print(f"  Total nets: {len(net_map)}")
+        flush_print(f"  Nets to route: {nets_to_route} (multi-pad signal nets)")
 
         if args.verbose:
             print("\n  Net breakdown:")
@@ -2625,7 +2625,7 @@ def main(argv: list[str] | None = None) -> int:
             clearance=args.clearance,
         )
         if fine_pitch_report.has_warnings:
-            print("\n--- Fine-Pitch Component Analysis ---")
+            flush_print("\n--- Fine-Pitch Component Analysis ---")
             show_fine_pitch_warnings(fine_pitch_report, quiet=quiet, verbose=args.verbose)
 
     # Analyze routability if requested
@@ -3032,12 +3032,12 @@ def main(argv: list[str] | None = None) -> int:
     stats = router.get_statistics()
 
     if not quiet:
-        print("\n--- Results ---")
-        print(f"  Routes created:  {stats['routes']}")
-        print(f"  Segments:        {stats['segments']}")
-        print(f"  Vias:            {stats['vias']}")
-        print(f"  Total length:    {stats['total_length_mm']:.2f}mm")
-        print(f"  Nets routed:     {stats['nets_routed']}/{nets_to_route}")
+        flush_print("\n--- Results ---")
+        flush_print(f"  Routes created:  {stats['routes']}")
+        flush_print(f"  Segments:        {stats['segments']}")
+        flush_print(f"  Vias:            {stats['vias']}")
+        flush_print(f"  Total length:    {stats['total_length_mm']:.2f}mm")
+        flush_print(f"  Nets routed:     {stats['nets_routed']}/{nets_to_route}")
 
     # Report differential pair length mismatch warnings
     if diffpair_warnings and not quiet:

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -274,14 +274,14 @@ class TwoPhaseRouter:
         # Initial routing pass
         for i, net in enumerate(net_order):
             if check_timeout():
-                print(
+                flush_print(
                     f"  ⚠ Timeout during detailed routing at net {i}/{total_nets} ({elapsed_str()})"
                 )
                 break
 
             net_name = self.net_names.get(net, f"Net {net}")
             pct = (i / total_nets * 100) if total_nets > 0 else 0
-            print(f"  [{pct:5.1f}%] Routing {net_name}... ({elapsed_str()})")
+            flush_print(f"  [{pct:5.1f}%] Routing {net_name}... ({elapsed_str()})")
 
             routes = self._route_net_with_corridor(net, present_factor)
             if routes:
@@ -291,7 +291,7 @@ class TwoPhaseRouter:
                     self.routes.append(route)
 
         overflow = self.grid.get_total_overflow()
-        print(f"  Initial pass: {len(net_routes)}/{total_nets} nets, overflow: {overflow}")
+        flush_print(f"  Initial pass: {len(net_routes)}/{total_nets} nets, overflow: {overflow}")
 
         # Rip-up and reroute iterations if needed
         if overflow > 0:
@@ -301,7 +301,7 @@ class TwoPhaseRouter:
 
             for iteration in range(1, max_iterations + 1):
                 if check_timeout():
-                    print(f"  ⚠ Timeout at iteration {iteration} ({elapsed_str()})")
+                    flush_print(f"  ⚠ Timeout at iteration {iteration} ({elapsed_str()})")
                     break
 
                 if progress_callback is not None:
@@ -316,7 +316,7 @@ class TwoPhaseRouter:
 
                 overused = self.grid.find_overused_cells()
                 nets_to_reroute = neg_router.find_nets_through_overused_cells(net_routes, overused)
-                print(
+                flush_print(
                     f"  Iteration {iteration}: ripping up {len(nets_to_reroute)} nets ({elapsed_str()})"
                 )
 
@@ -333,10 +333,10 @@ class TwoPhaseRouter:
                             self.routes.append(route)
 
                 overflow = self.grid.get_total_overflow()
-                print(f"  Iteration {iteration} complete: overflow={overflow}")
+                flush_print(f"  Iteration {iteration} complete: overflow={overflow}")
 
                 if overflow == 0:
-                    print(f"  Converged at iteration {iteration}!")
+                    flush_print(f"  Converged at iteration {iteration}!")
                     break
 
         return list(self.routes)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2033,15 +2033,15 @@ class Autorouter:
             layer_count=self.grid.num_layers,
         )
 
-        print("  Board characteristics:")
-        print(f"    Pads: {characteristics.total_pads}")
-        print(f"    Nets: {characteristics.total_nets}")
-        print(f"    Pin density: {characteristics.pin_density:.4f} pads/mm²")
-        print(f"    Avg net span: {characteristics.avg_net_span:.1f}mm")
+        flush_print("  Board characteristics:")
+        flush_print(f"    Pads: {characteristics.total_pads}")
+        flush_print(f"    Nets: {characteristics.total_nets}")
+        flush_print(f"    Pin density: {characteristics.pin_density:.4f} pads/mm²")
+        flush_print(f"    Avg net span: {characteristics.avg_net_span:.1f}mm")
 
         if method == "adaptive":
             # Use adaptive routing with dynamic cost adjustment
-            print(f"  Method: Adaptive (max {max_iterations} iterations)")
+            flush_print(f"  Method: Adaptive (max {max_iterations} iterations)")
             adaptive_router = create_adaptive_router(
                 self,
                 max_iterations=max_iterations,
@@ -2050,41 +2050,41 @@ class Autorouter:
         elif method == "quick":
             # Fast heuristic tuning
             params = quick_tune(characteristics)
-            print("  Method: Quick heuristic tuning")
-            print("  Tuned parameters:")
-            print(f"    Via cost: {params.via:.1f}")
-            print(f"    Turn cost: {params.turn:.1f}")
-            print(f"    Congestion cost: {params.congestion:.1f}")
+            flush_print("  Method: Quick heuristic tuning")
+            flush_print("  Tuned parameters:")
+            flush_print(f"    Via cost: {params.via:.1f}")
+            flush_print(f"    Turn cost: {params.turn:.1f}")
+            flush_print(f"    Congestion cost: {params.congestion:.1f}")
 
             self.rules = params.apply_to_rules(self.rules)
             routes = self.route_all(progress_callback=progress_callback)
         else:
             # Full optimization
-            print(f"  Method: {method} optimization (max {max_iterations} iterations)")
+            flush_print(f"  Method: {method} optimization (max {max_iterations} iterations)")
             result = tune_parameters(
                 self,
                 max_iterations=max_iterations,
                 method=method,
             )
 
-            print(f"  Tuning completed in {result.tuning_time_ms:.0f}ms")
-            print("  Best parameters:")
-            print(f"    Via cost: {result.params.via:.1f}")
-            print(f"    Turn cost: {result.params.turn:.1f}")
-            print(f"    Congestion cost: {result.params.congestion:.1f}")
+            flush_print(f"  Tuning completed in {result.tuning_time_ms:.0f}ms")
+            flush_print("  Best parameters:")
+            flush_print(f"    Via cost: {result.params.via:.1f}")
+            flush_print(f"    Turn cost: {result.params.turn:.1f}")
+            flush_print(f"    Congestion cost: {result.params.congestion:.1f}")
 
             if result.quality:
-                print(f"  Quality score: {result.quality.score:.1f}")
-                print(f"    Completion: {result.quality.completion_rate * 100:.1f}%")
-                print(f"    Total vias: {result.quality.total_vias}")
+                flush_print(f"  Quality score: {result.quality.score:.1f}")
+                flush_print(f"    Completion: {result.quality.completion_rate * 100:.1f}%")
+                flush_print(f"    Total vias: {result.quality.total_vias}")
 
             self.rules = result.params.apply_to_rules(self.rules)
             routes = self.route_all(progress_callback=progress_callback)
 
-        print("\n=== Tuned Routing Complete ===")
-        print(f"  Routes: {len(routes)}")
-        print(f"  Segments: {sum(len(r.segments) for r in routes)}")
-        print(f"  Vias: {sum(len(r.vias) for r in routes)}")
+        flush_print("\n=== Tuned Routing Complete ===")
+        flush_print(f"  Routes: {len(routes)}")
+        flush_print(f"  Segments: {sum(len(r.segments) for r in routes)}")
+        flush_print(f"  Vias: {sum(len(r.vias) for r in routes)}")
 
         return routes
 


### PR DESCRIPTION
## Summary

Convert progress-critical `print()` calls to `flush_print()` across the route command pipeline so that output is visible incrementally when stdout is buffered (e.g., when piped through `cat` or `tee`). Previously, all progress output was invisible until routing completed.

## Changes

- **`src/kicad_tools/router/algorithms/two_phase.py`**: Convert 7 `print()` calls to `flush_print()` in the negotiated routing iteration loop (per-net progress, initial pass summary, iteration rip-up/overflow/convergence, timeout warnings)
- **`src/kicad_tools/cli/route_cmd.py`**: Convert ~35 `print()` calls to `flush_print()` covering grid setup info, fine-pitch analysis header, final results summary, layer escalation mode header/per-attempt progress, adaptive rules mode header/per-attempt progress, and combined escalation mode header/per-attempt progress. Added `flush_print` to local imports in layer escalation, adaptive rules, and combined escalation functions.
- **`src/kicad_tools/router/core.py`**: Convert ~15 `print()` calls to `flush_print()` in the tuning output section (board characteristics, method selection, tuned parameters, quality scores, completion message)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Progress messages visible during routing (not only after completion) | Pass | All progress `print()` calls in the routing hot path now use `flush_print()` which calls `sys.stdout.flush()` after each print |
| Grid setup, per-iteration overflow, and final results flush incrementally | Pass | Converted all three categories: grid setup (route_cmd.py lines 2595-2606), per-iteration overflow (two_phase.py lines 319-339), and final results (route_cmd.py lines 3035-3040) |

## Test Plan

- Ran `uv run pytest tests/test_router_algorithms.py tests/test_reroute_progress_output.py` -- 18 tests passed
- Pre-existing test failures in `test_renderers.py` (ImportError) and `test_audit.py` (AssertionError) are unrelated to this change and reproduce on main
- Manual verification: `kct route ... 2>&1 | cat` should now show progress lines incrementally

Closes #1644