### PR TITLE
feat(router): use per-net-class clearance in pre-save validation

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
 from .core import Autorouter
 from .layers import Layer, LayerDefinition, LayerStack, LayerType
-from .rules import DEFAULT_NET_CLASS_MAP, DesignRules
+from .rules import DEFAULT_NET_CLASS_MAP, DesignRules, NetClassRouting
 
 # =============================================================================
 # DRC COMPLIANCE TYPES AND FUNCTIONS
@@ -754,6 +754,30 @@ def extract_pad_positions(pcb_path_or_text: str | Path) -> list[PadPosition]:
     return positions
 
 
+def _get_pair_clearance(
+    net_a: int,
+    net_b: int,
+    default_clearance: float,
+    net_names: dict[int, str],
+    net_class_map: dict[str, NetClassRouting] | None,
+) -> float:
+    """Resolve the effective clearance between two nets.
+
+    Uses the KiCad rule: ``max(net_a_class.clearance, net_b_class.clearance)``.
+    Falls back to *default_clearance* when the net class map is unavailable or
+    a net is not found in it.
+    """
+    if net_class_map is None:
+        return default_clearance
+    name_a = net_names.get(net_a, "")
+    name_b = net_names.get(net_b, "")
+    class_a = net_class_map.get(name_a)
+    class_b = net_class_map.get(name_b)
+    clearance_a = class_a.clearance if class_a else default_clearance
+    clearance_b = class_b.clearance if class_b else default_clearance
+    return max(clearance_a, clearance_b)
+
+
 def validate_routes(
     router: Autorouter,
     rules: DesignRules | None = None,
@@ -781,6 +805,9 @@ def validate_routes(
     clearance = rules.trace_clearance
     via_clear = rules.via_clearance
     net_names = getattr(router, "net_names", {})
+
+    # Resolve per-net-class clearance map (if available on the router)
+    ncm: dict[str, NetClassRouting] | None = getattr(router, "net_class_map", None)
 
     def _resolve_net_name(net_id: int) -> str:
         return net_names.get(net_id, f"Net {net_id}")
@@ -817,7 +844,11 @@ def validate_routes(
                 pad_radius = max(pad.width, pad.height) / 2
                 effective_dist = dist - pad_radius - seg_half_width
 
-                if effective_dist < clearance:
+                pair_clear = _get_pair_clearance(
+                    route_net, pad.net, clearance, net_names, ncm
+                )
+
+                if effective_dist < pair_clear:
                     # Detect component-inherent violations: obstacle pad is
                     # on the same component as a pad in the route's net.
                     is_component_inherent = ref in route_component_refs
@@ -833,7 +864,7 @@ def validate_routes(
                             obstacle_type="pad",
                             obstacle_net=pad.net,
                             distance=effective_dist,
-                            required=clearance,
+                            required=pair_clear,
                             net_name=_resolve_net_name(route_net),
                             obstacle_net_name=_resolve_net_name(pad.net),
                             location=(pad.x, pad.y),
@@ -868,7 +899,11 @@ def validate_routes(
                     other_half_width = other_seg.width / 2
                     effective_dist = dist - seg_half_width - other_half_width
 
-                    if effective_dist < clearance:
+                    pair_clear = _get_pair_clearance(
+                        route_net, other_route.net, clearance, net_names, ncm
+                    )
+
+                    if effective_dist < pair_clear:
                         # Approximate violation location at midpoint of closest approach
                         loc_x = (segment.x1 + segment.x2 + other_seg.x1 + other_seg.x2) / 4
                         loc_y = (segment.y1 + segment.y2 + other_seg.y1 + other_seg.y2) / 4
@@ -883,7 +918,7 @@ def validate_routes(
                                 obstacle_type="segment",
                                 obstacle_net=other_route.net,
                                 distance=effective_dist,
-                                required=clearance,
+                                required=pair_clear,
                                 net_name=_resolve_net_name(route_net),
                                 obstacle_net_name=_resolve_net_name(other_route.net),
                                 location=(loc_x, loc_y),

--- a/tests/test_router_io.py
+++ b/tests/test_router_io.py
@@ -1527,6 +1527,194 @@ class TestValidateRoutes:
         assert len(via_violations) >= 1
         assert via_violations[0].required == 0.5  # Should use via_clearance
 
+    # --- Per-net-class clearance tests ---
+
+    def test_same_class_pair_uses_class_clearance(self):
+        """Two nets both in Default class (clearance 0.25). Segment at 0.22mm should violate."""
+        ncm = {
+            "NET1": NetClassRouting(name="Default", clearance=0.25),
+            "NET2": NetClassRouting(name="Default", clearance=0.25),
+        }
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,  # global default is smaller
+            grid_resolution=0.1,
+        )
+        router = Autorouter(width=50, height=50, rules=rules, net_class_map=ncm)
+
+        # Two parallel segments on different nets, edge-to-edge 0.22mm apart
+        # center-to-center = 0.22 + 0.1 + 0.1 = 0.42mm
+        seg1 = Segment(x1=10, y1=10, x2=20, y2=10, layer=Layer.F_CU, width=0.2)
+        route1 = Route(net=1, net_name="NET1", segments=[seg1], vias=[])
+
+        seg2 = Segment(x1=10, y1=10.42, x2=20, y2=10.42, layer=Layer.F_CU, width=0.2)
+        route2 = Route(net=2, net_name="NET2", segments=[seg2], vias=[])
+
+        router.routes.extend([route1, route2])
+        router.net_names = {1: "NET1", 2: "NET2"}
+
+        violations = validate_routes(router)
+
+        seg_violations = [v for v in violations if v.obstacle_type == "segment"]
+        # 0.22mm edge-to-edge < 0.25mm class clearance => violation
+        assert len(seg_violations) >= 1
+        assert seg_violations[0].required == pytest.approx(0.25)
+
+    def test_mixed_class_pair_uses_max_clearance(self):
+        """Power (0.3) vs HighSpeed (0.15): effective clearance should be max(0.3, 0.15)=0.3."""
+        ncm = {
+            "VCC": NetClassRouting(name="Power", clearance=0.3),
+            "CLK": NetClassRouting(name="HighSpeed", clearance=0.15),
+        }
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            grid_resolution=0.1,
+        )
+        router = Autorouter(width=50, height=50, rules=rules, net_class_map=ncm)
+
+        # Edge-to-edge 0.25mm apart -- violates 0.3 but not 0.2
+        # center-to-center = 0.25 + 0.1 + 0.1 = 0.45mm
+        seg1 = Segment(x1=10, y1=10, x2=20, y2=10, layer=Layer.F_CU, width=0.2)
+        route1 = Route(net=1, net_name="VCC", segments=[seg1], vias=[])
+
+        seg2 = Segment(x1=10, y1=10.45, x2=20, y2=10.45, layer=Layer.F_CU, width=0.2)
+        route2 = Route(net=2, net_name="CLK", segments=[seg2], vias=[])
+
+        router.routes.extend([route1, route2])
+        router.net_names = {1: "VCC", 2: "CLK"}
+
+        violations = validate_routes(router)
+
+        seg_violations = [v for v in violations if v.obstacle_type == "segment"]
+        assert len(seg_violations) >= 1
+        assert seg_violations[0].required == pytest.approx(0.3)
+
+    def test_mixed_class_no_violation_when_clearance_met(self):
+        """Power (0.3) vs HighSpeed (0.15): at 0.32mm apart, no violation."""
+        ncm = {
+            "VCC": NetClassRouting(name="Power", clearance=0.3),
+            "CLK": NetClassRouting(name="HighSpeed", clearance=0.15),
+        }
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            grid_resolution=0.1,
+        )
+        router = Autorouter(width=50, height=50, rules=rules, net_class_map=ncm)
+
+        # Edge-to-edge 0.32mm apart -- meets 0.3 clearance
+        # center-to-center = 0.32 + 0.1 + 0.1 = 0.52mm
+        seg1 = Segment(x1=10, y1=10, x2=20, y2=10, layer=Layer.F_CU, width=0.2)
+        route1 = Route(net=1, net_name="VCC", segments=[seg1], vias=[])
+
+        seg2 = Segment(x1=10, y1=10.52, x2=20, y2=10.52, layer=Layer.F_CU, width=0.2)
+        route2 = Route(net=2, net_name="CLK", segments=[seg2], vias=[])
+
+        router.routes.extend([route1, route2])
+        router.net_names = {1: "VCC", 2: "CLK"}
+
+        violations = validate_routes(router)
+
+        seg_violations = [v for v in violations if v.obstacle_type == "segment"]
+        assert len(seg_violations) == 0
+
+    def test_fallback_when_no_net_class_map(self):
+        """Router with no net_class_map uses rules.trace_clearance for all checks."""
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            grid_resolution=0.1,
+        )
+        # Bare Autorouter -- default net_class_map won't have these net names
+        router = Autorouter(width=50, height=50, rules=rules)
+
+        # Edge-to-edge overlap (violation for 0.2mm clearance)
+        seg1 = Segment(x1=10, y1=10, x2=20, y2=10, layer=Layer.F_CU, width=0.2)
+        route1 = Route(net=1, net_name="NET1", segments=[seg1], vias=[])
+
+        seg2 = Segment(x1=10, y1=10.1, x2=20, y2=10.1, layer=Layer.F_CU, width=0.2)
+        route2 = Route(net=2, net_name="NET2", segments=[seg2], vias=[])
+
+        router.routes.extend([route1, route2])
+        router.net_names = {1: "NET1", 2: "NET2"}
+
+        violations = validate_routes(router)
+
+        seg_violations = [v for v in violations if v.obstacle_type == "segment"]
+        assert len(seg_violations) >= 1
+        # Should use the global default
+        assert seg_violations[0].required == pytest.approx(0.2)
+
+    def test_unknown_net_falls_back_to_default(self):
+        """A net not in any class falls back to rules.trace_clearance for its side."""
+        ncm = {
+            "VCC": NetClassRouting(name="Power", clearance=0.3),
+            # "UNKNOWN" is not in the map
+        }
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            grid_resolution=0.1,
+        )
+        router = Autorouter(width=50, height=50, rules=rules, net_class_map=ncm)
+
+        # Edge-to-edge 0.25mm: max(0.3, 0.2) = 0.3 => violation
+        # center-to-center = 0.25 + 0.1 + 0.1 = 0.45mm
+        seg1 = Segment(x1=10, y1=10, x2=20, y2=10, layer=Layer.F_CU, width=0.2)
+        route1 = Route(net=1, net_name="VCC", segments=[seg1], vias=[])
+
+        seg2 = Segment(x1=10, y1=10.45, x2=20, y2=10.45, layer=Layer.F_CU, width=0.2)
+        route2 = Route(net=2, net_name="UNKNOWN", segments=[seg2], vias=[])
+
+        router.routes.extend([route1, route2])
+        router.net_names = {1: "VCC", 2: "UNKNOWN"}
+
+        violations = validate_routes(router)
+
+        seg_violations = [v for v in violations if v.obstacle_type == "segment"]
+        assert len(seg_violations) >= 1
+        # VCC class has 0.3, UNKNOWN falls back to 0.2 => max is 0.3
+        assert seg_violations[0].required == pytest.approx(0.3)
+
+    def test_per_class_clearance_seg_to_pad(self):
+        """Seg-to-pad check uses per-net-class clearance."""
+        ncm = {
+            "NET1": NetClassRouting(name="Power", clearance=0.3),
+            "NET2": NetClassRouting(name="Default", clearance=0.2),
+        }
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.15,  # global is smaller than both classes
+            grid_resolution=0.1,
+        )
+        router = Autorouter(width=50, height=50, rules=rules, net_class_map=ncm)
+
+        # Pad on net 2 at (20, 10) with radius 0.5
+        router.add_component(
+            "U1",
+            [
+                {"number": "1", "x": 10, "y": 10, "width": 1.0, "height": 1.0, "net": 1},
+                {"number": "2", "x": 20, "y": 10, "width": 1.0, "height": 1.0, "net": 2},
+            ],
+        )
+
+        # Segment on net 1 ending 0.25mm edge-to-edge from pad 2
+        # Pad radius = 0.5, seg half-width = 0.1
+        # dist from seg end to pad center = 0.25 + 0.5 + 0.1 = 0.85
+        # So segment endpoint at 20 - 0.85 = 19.15
+        segment = Segment(x1=10, y1=10, x2=19.15, y2=10, layer=Layer.F_CU, width=0.2)
+        route = Route(net=1, net_name="NET1", segments=[segment], vias=[])
+        router.routes.append(route)
+        router.net_names = {1: "NET1", 2: "NET2"}
+
+        violations = validate_routes(router)
+
+        pad_violations = [v for v in violations if v.obstacle_type == "pad"]
+        # 0.25mm < max(0.3, 0.2) = 0.3 => violation
+        assert len(pad_violations) >= 1
+        assert pad_violations[0].required == pytest.approx(0.3)
+
 
 class TestLoadPcbForRoutingDrcCompliance:
     """Tests for DRC compliance features in load_pcb_for_routing."""


### PR DESCRIPTION
## Summary

- Add `_get_pair_clearance()` helper that resolves effective clearance between two nets using `max(class_a.clearance, class_b.clearance)`, matching KiCad's per-net-class rule
- Update `validate_routes()` segment-to-pad and segment-to-segment checks to use per-net-class clearance instead of the single global `rules.trace_clearance`
- Falls back to `rules.trace_clearance` when net class map is unavailable or a net is not in any class (backward compatible)

Closes #1655

## Test plan

- [x] Same-class pair: both nets in Default class trigger violation at correct class clearance
- [x] Mixed-class pair: Power (0.3) vs HighSpeed (0.15) uses max(0.3, 0.15) = 0.3
- [x] Mixed-class pair: no violation when clearance is met
- [x] Fallback: bare router without explicit net class map uses global default
- [x] Unknown net: net not in any class falls back to rules.trace_clearance for its side
- [x] Seg-to-pad: per-net-class clearance applied to segment-to-pad checks
- [x] All 23 existing TestValidateRoutes tests continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)