### PR TITLE
feat(router): wire RegionGraph corridor costs into inter-block routing

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3052,6 +3052,7 @@ class Autorouter:
             List of Route objects (block-internal + inter-block).
         """
         from .block_router import BlockRouter, BlockRoutingResult
+        from .global_router import GlobalRouter
         from .region_graph import RegionGraph
 
         # Determine which blocks to route
@@ -3170,6 +3171,40 @@ class Autorouter:
                 f"{len(all_inter_block_nets)}"
             )
 
+        # Issue #1654: Wire RegionGraph corridor costs into inter-block routing.
+        # Use GlobalRouter to assign corridors for inter-block nets so that
+        # detailed routing prefers paths through low-utilization regions
+        # (corridors between blocks) rather than block interiors.
+        corridor_width = 2.0 * self.rules.trace_clearance
+        global_router = GlobalRouter(
+            region_graph=region_graph,
+            corridor_width=corridor_width,
+            default_layer=0,
+        )
+        corridor_penalty = 5.0
+        corridor_assigned_nets: set[int] = set()
+
+        inter_block_to_route = all_inter_block_nets & set(nets_to_route)
+        for net in inter_block_to_route:
+            pad_keys = self.nets.get(net, [])
+            pad_positions = []
+            for pk in pad_keys:
+                pad_obj = self.pads.get(pk)
+                if pad_obj is not None:
+                    pad_positions.append((pad_obj.x, pad_obj.y))
+            assignment = global_router.route_net(net, pad_positions)
+            if assignment is not None:
+                self.grid.set_corridor_preference(
+                    assignment.corridor, net, corridor_penalty
+                )
+                corridor_assigned_nets.add(net)
+
+        if corridor_assigned_nets:
+            flush_print(
+                f"    Corridor assignments: {len(corridor_assigned_nets)}/"
+                f"{len(inter_block_to_route)} inter-block nets"
+            )
+
         # Issue #1603: Sub-grid escape pre-pass for off-grid pads
         escape_routes = self._run_subgrid_prepass()
         all_routes.extend(escape_routes)
@@ -3201,6 +3236,10 @@ class Autorouter:
                     f"  Net {net}: {len(routes)} routes, "
                     f"{sum(len(r.segments) for r in routes)} segments"
                 )
+
+        # Clear corridor preferences after Phase B routing (Issue #1654)
+        if corridor_assigned_nets:
+            self.grid.clear_all_corridor_preferences()
 
         if progress_callback is not None:
             routed_count = len({r.net for r in all_routes})

--- a/tests/test_block_router.py
+++ b/tests/test_block_router.py
@@ -686,3 +686,199 @@ class TestBlockOccupancyIntegration:
 
         routes = router.route_all_block_aware()
         assert len(routes) > 0
+
+
+# ===========================================================================
+# Issue #1654: RegionGraph corridor costs wired into inter-block routing
+# ===========================================================================
+
+class TestCorridorCostsInterBlockRouting:
+    """Verify that route_all_block_aware sets corridor preferences for inter-block nets."""
+
+    def _setup_two_block_board(self):
+        """Create a board with 2 blocks and a shared inter-block signal net."""
+        rules = DesignRules()
+        router = Autorouter(80, 60, force_python=True, rules=rules)
+
+        # Block A at (15, 30)
+        block_a = PCBBlock(name="block_a", block_id="block_a")
+        block_a.add_component("U1A", "SOT-23", 0, 0,
+                              pads={"1": (-1, 0), "2": (1, 0)})
+        block_a.add_component("C1A", "C_0805", 3, 0,
+                              pads={"1": (2.5, 0), "2": (3.5, 0)})
+        block_a.add_port("VIN_A", -4, 0, direction="in")
+        block_a.add_port("VOUT_A", 6, 0, direction="out")
+        block_a.place(15, 30)
+
+        # Block B at (50, 30)
+        block_b = PCBBlock(name="block_b", block_id="block_b")
+        block_b.add_component("U1B", "SOT-23", 0, 0,
+                              pads={"1": (-1, 0), "2": (1, 0)})
+        block_b.add_component("C1B", "C_0805", 3, 0,
+                              pads={"1": (2.5, 0), "2": (3.5, 0)})
+        block_b.add_port("VIN_B", -4, 0, direction="in")
+        block_b.add_port("VOUT_B", 6, 0, direction="out")
+        block_b.place(50, 30)
+
+        # Block A pads
+        router.add_component("U1A", [
+            {"number": "1", "x": 14.0, "y": 30.0, "net": 1, "net_name": "NET_A1",
+             "width": 0.5, "height": 0.5},
+            {"number": "2", "x": 16.0, "y": 30.0, "net": 2, "net_name": "NET_A2",
+             "width": 0.5, "height": 0.5},
+        ])
+        router.add_component("C1A", [
+            {"number": "1", "x": 17.5, "y": 30.0, "net": 2, "net_name": "NET_A2",
+             "width": 0.5, "height": 0.5},
+            {"number": "2", "x": 18.5, "y": 30.0, "net": 3, "net_name": "INTER_AB",
+             "width": 0.5, "height": 0.5},
+        ])
+        # Block B pads
+        router.add_component("U1B", [
+            {"number": "1", "x": 49.0, "y": 30.0, "net": 4, "net_name": "NET_B1",
+             "width": 0.5, "height": 0.5},
+            {"number": "2", "x": 51.0, "y": 30.0, "net": 5, "net_name": "NET_B2",
+             "width": 0.5, "height": 0.5},
+        ])
+        router.add_component("C1B", [
+            {"number": "1", "x": 52.5, "y": 30.0, "net": 5, "net_name": "NET_B2",
+             "width": 0.5, "height": 0.5},
+            {"number": "2", "x": 53.5, "y": 30.0, "net": 3, "net_name": "INTER_AB",
+             "width": 0.5, "height": 0.5},
+        ])
+
+        router.register_block(block_a)
+        router.register_block(block_b)
+        return router
+
+    def test_corridor_preferences_set_for_inter_block_nets(self):
+        """set_corridor_preference is called for inter-block nets during Phase B."""
+        from unittest.mock import patch
+
+        router = self._setup_two_block_board()
+
+        calls = []
+        original_set = router.grid.set_corridor_preference
+
+        def tracking_set(corridor, net, penalty):
+            calls.append((net, penalty))
+            return original_set(corridor, net, penalty)
+
+        with patch.object(router.grid, "set_corridor_preference", side_effect=tracking_set):
+            routes = router.route_all_block_aware()
+
+        # INTER_AB (net 3) is the inter-block net shared between block_a and block_b.
+        # It should have received a corridor assignment.
+        assigned_nets = {net for net, _ in calls}
+        assert 3 in assigned_nets, (
+            f"Inter-block INTER_AB net should receive corridor preference, "
+            f"but only these nets were assigned: {assigned_nets}"
+        )
+        # Penalty should match the expected value (5.0)
+        for net, penalty in calls:
+            assert penalty == 5.0, f"Corridor penalty should be 5.0, got {penalty}"
+
+        assert len(routes) > 0, "Should produce routes"
+
+    def test_corridor_preferences_cleared_after_routing(self):
+        """clear_all_corridor_preferences is called after Phase B routing."""
+        from unittest.mock import patch
+
+        router = self._setup_two_block_board()
+
+        clear_calls = []
+        original_clear = router.grid.clear_all_corridor_preferences
+
+        def tracking_clear():
+            clear_calls.append(True)
+            return original_clear()
+
+        with patch.object(router.grid, "clear_all_corridor_preferences", side_effect=tracking_clear):
+            router.route_all_block_aware()
+
+        assert len(clear_calls) > 0, (
+            "clear_all_corridor_preferences should be called after Phase B"
+        )
+
+    def test_no_corridor_for_non_inter_block_nets(self):
+        """Block-internal-only nets should not receive corridor preferences."""
+        from unittest.mock import patch
+
+        router = self._setup_two_block_board()
+
+        assigned_nets = []
+        original_set = router.grid.set_corridor_preference
+
+        def tracking_set(corridor, net, penalty):
+            assigned_nets.append(net)
+            return original_set(corridor, net, penalty)
+
+        with patch.object(router.grid, "set_corridor_preference", side_effect=tracking_set):
+            router.route_all_block_aware()
+
+        # Nets 1, 2 are block_a internal; nets 4, 5 are block_b internal.
+        # They should NOT receive corridor assignments.
+        for internal_net in [1, 2, 4, 5]:
+            assert internal_net not in assigned_nets, (
+                f"Block-internal net {internal_net} should not receive corridor preference"
+            )
+
+    def test_global_router_fallback_routes_without_corridor(self):
+        """If GlobalRouter returns None for a net, it still routes without corridor."""
+        from unittest.mock import patch
+
+        router = self._setup_two_block_board()
+
+        # Patch GlobalRouter.route_net to always return None
+        with patch(
+            "kicad_tools.router.global_router.GlobalRouter.route_net",
+            return_value=None,
+        ):
+            routes = router.route_all_block_aware()
+
+        # Routing should still succeed (fallback to no corridor guidance)
+        assert len(routes) > 0, "Should produce routes even without corridor assignments"
+
+    def test_single_block_no_corridor_assignments(self):
+        """Single-block design has no inter-block nets, so no corridors are assigned."""
+        from unittest.mock import patch
+
+        rules = DesignRules()
+        router = Autorouter(60, 40, force_python=True, rules=rules)
+
+        block = PCBBlock(name="only_block", block_id="only_block")
+        block.add_component("U1", "SOT-23", 0, 0,
+                            pads={"1": (-1, 0), "2": (1, 0)})
+        block.add_component("C1", "C_0805", 3, 0,
+                            pads={"1": (2.5, 0), "2": (3.5, 0)})
+        block.place(20, 20)
+
+        router.add_component("U1", [
+            {"number": "1", "x": 19.0, "y": 20.0, "net": 1, "net_name": "VIN",
+             "width": 0.5, "height": 0.5},
+            {"number": "2", "x": 21.0, "y": 20.0, "net": 2, "net_name": "VOUT",
+             "width": 0.5, "height": 0.5},
+        ])
+        router.add_component("C1", [
+            {"number": "1", "x": 22.5, "y": 20.0, "net": 2, "net_name": "VOUT",
+             "width": 0.5, "height": 0.5},
+            {"number": "2", "x": 23.5, "y": 20.0, "net": 3, "net_name": "GND",
+             "width": 0.5, "height": 0.5},
+        ])
+
+        router.register_block(block)
+
+        calls = []
+        original_set = router.grid.set_corridor_preference
+
+        def tracking_set(corridor, net, penalty):
+            calls.append(net)
+            return original_set(corridor, net, penalty)
+
+        with patch.object(router.grid, "set_corridor_preference", side_effect=tracking_set):
+            routes = router.route_all_block_aware()
+
+        # No inter-block nets means no corridor assignments
+        assert len(calls) == 0, (
+            f"Single-block board should have no corridor assignments, got {calls}"
+        )


### PR DESCRIPTION
## Summary

- Wire `RegionGraph` corridor costs into `route_all_block_aware()` Phase B by instantiating a `GlobalRouter` with the populated region graph, assigning corridors for inter-block nets, and setting corridor preferences on the grid before detailed routing
- Inter-block nets now prefer routing through low-utilization regions (corridors between blocks) rather than through block interiors, matching the pattern used by the hierarchical router
- Corridor preferences are cleared after Phase B routing to avoid leaking state

Closes #1654

## Test plan

- [x] New `TestCorridorCostsInterBlockRouting` class with 5 tests:
  - `test_corridor_preferences_set_for_inter_block_nets` -- verifies `set_corridor_preference` is called for inter-block nets with penalty 5.0
  - `test_corridor_preferences_cleared_after_routing` -- verifies cleanup via `clear_all_corridor_preferences`
  - `test_no_corridor_for_non_inter_block_nets` -- verifies block-internal nets do not receive corridor assignments
  - `test_global_router_fallback_routes_without_corridor` -- verifies routing still succeeds when `GlobalRouter.route_net()` returns None
  - `test_single_block_no_corridor_assignments` -- verifies single-block designs have no corridor assignments
- [x] All 30 tests in `test_block_router.py` pass
- [x] All 170 tests in `test_router_core.py` and `test_global_router.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)