### PR TITLE
feat(export): add --latest-only flag for flat report directory

### DIFF
--- a/src/kicad_tools/cli/export_cmd.py
+++ b/src/kicad_tools/cli/export_cmd.py
@@ -102,6 +102,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Skip KiCad project ZIP creation",
     )
     parser.add_argument(
+        "--latest-only",
+        action="store_true",
+        help="Include only the latest report version in a flat report/ directory (removes vN/ dirs)",
+    )
+    parser.add_argument(
         "--auto-lcsc",
         action="store_true",
         default=True,
@@ -250,6 +255,7 @@ def run_export(args: argparse.Namespace) -> int:
         preflight=preflight_cfg,
         strict_preflight=getattr(args, "strict_preflight", False),
         pnp_config=pnp_config,
+        latest_report_only=getattr(args, "latest_only", False),
     )
 
     pkg = ManufacturingPackage(

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
+import shutil
 import zipfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -45,6 +47,11 @@ class ManufacturingConfig(AssemblyConfig):
     # When False (default), preflight failures are recorded as warnings but
     # export proceeds to generate output files.
     strict_preflight: bool = False
+
+    # When True, flatten the latest vN/ report directory into a ``report/``
+    # subdirectory and remove all vN/ directories from the output.
+    # When False (default), versioned directories are preserved as-is.
+    latest_report_only: bool = False
 
 
 @dataclass
@@ -257,6 +264,10 @@ class ManufacturingPackage:
         if self.config.include_report:
             self._generate_report(out_dir, result)
 
+        # Step 2.5: Flatten report into report/ when latest_report_only is set
+        if self.config.latest_report_only:
+            self._flatten_latest_report(out_dir, result)
+
         # Step 3: KiCad project ZIP (optional)
         if self.config.include_project_zip:
             self._generate_project_zip(out_dir, result)
@@ -423,6 +434,40 @@ class ManufacturingPackage:
             result["analog_components"] = result["analog_components"].get("components", [])
 
         return result
+
+    def _flatten_latest_report(self, out_dir: Path, result: ManufacturingResult) -> None:
+        """Copy the latest ``vN/`` contents into ``report/`` and remove version dirs.
+
+        When ``config.latest_report_only`` is ``True``, this post-processing
+        step replaces versioned directories with a single flat ``report/``
+        subdirectory containing only the latest version's contents.
+        """
+        try:
+            from ..report.generator import ReportGenerator
+        except ImportError:
+            return
+
+        latest = ReportGenerator.latest_version_dir(out_dir)
+        if latest is None:
+            # No versioned directories (e.g. --no-report was also set)
+            return
+
+        report_dest = out_dir / "report"
+        if report_dest.exists():
+            shutil.rmtree(report_dest)
+        shutil.copytree(latest, report_dest)
+
+        # Remove all vN/ directories from the output
+        for child in list(out_dir.iterdir()):
+            if child.is_dir() and re.fullmatch(r"v\d+", child.name):
+                shutil.rmtree(child)
+
+        # Update result.report_path to point to the flattened location
+        flat_report = report_dest / "report.md"
+        if flat_report.exists():
+            result.report_path = flat_report
+
+        logger.info(f"Flattened latest report into {report_dest}")
 
     def _generate_project_zip(self, out_dir: Path, result: ManufacturingResult) -> None:
         """Create ZIP of KiCad project files."""

--- a/src/kicad_tools/report/generator.py
+++ b/src/kicad_tools/report/generator.py
@@ -173,6 +173,24 @@ class ReportGenerator:
         next_version = max(existing, default=0) + 1
         return output_dir / f"v{next_version}"
 
+    @staticmethod
+    def latest_version_dir(output_dir: Path) -> Path | None:
+        """Return the highest-numbered ``vN`` sub-directory under *output_dir*.
+
+        Returns ``None`` when no versioned directories exist.
+        """
+        output_dir = Path(output_dir)
+        existing: list[int] = []
+        if output_dir.exists():
+            for child in output_dir.iterdir():
+                if child.is_dir():
+                    match = re.fullmatch(r"v(\d+)", child.name)
+                    if match:
+                        existing.append(int(match.group(1)))
+        if not existing:
+            return None
+        return output_dir / f"v{max(existing)}"
+
     def _write_metadata(self, data: ReportData, version_dir: Path, rendered: str) -> None:
         """Write ``metadata.json`` alongside the report."""
         template_sha256 = hashlib.sha256(rendered.encode("utf-8")).hexdigest()

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -498,3 +498,195 @@ class TestManufacturingPackageExport:
 
         # Output directory should not exist
         assert not out_dir.exists()
+
+
+class TestLatestReportOnly:
+    """Tests for the latest_report_only flattening feature."""
+
+    def _setup_project(self, tmp_path):
+        """Create a minimal project directory and return pcb path."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        sch = project_dir / "board.kicad_sch"
+        sch.write_text("(kicad_sch)")
+        return pcb
+
+    def _fake_report_generate(self, out_dir, version_num):
+        """Simulate report generation by creating a vN/ directory with report.md."""
+        version_dir = out_dir / f"v{version_num}"
+        version_dir.mkdir(parents=True, exist_ok=True)
+        data_dir = version_dir / "data"
+        data_dir.mkdir(exist_ok=True)
+        (data_dir / "board_summary.json").write_text('{"layer_count": 2}')
+        (version_dir / "report.md").write_text(f"# Report v{version_num}\n")
+        (version_dir / "metadata.json").write_text('{"version": ' + str(version_num) + "}\n")
+        return version_dir / "report.md"
+
+    def test_flatten_latest_report(self, tmp_path, monkeypatch):
+        """With latest_report_only=True, output has report/ instead of vN/ dirs."""
+        pcb = self._setup_project(tmp_path)
+        out_dir = tmp_path / "output"
+
+        from kicad_tools.export import assembly
+
+        def fake_assembly_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        # Pre-create versioned directories to simulate prior exports
+        out_dir.mkdir(parents=True, exist_ok=True)
+        self._fake_report_generate(out_dir, 1)
+        self._fake_report_generate(out_dir, 2)
+
+        # Mock _generate_report to create v3 (the latest)
+        def fake_generate_report(self_pkg, od, result):
+            report_path = self._fake_report_generate(od, 3)
+            result.report_path = report_path
+
+        monkeypatch.setattr(ManufacturingPackage, "_generate_report", fake_generate_report)
+
+        config = ManufacturingConfig(
+            include_report=True,
+            include_project_zip=False,
+            include_manifest=False,
+            latest_report_only=True,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        result = pkg.export(out_dir)
+
+        # Flattened report/ directory should exist
+        report_dir = out_dir / "report"
+        assert report_dir.exists()
+        assert (report_dir / "report.md").exists()
+        assert "v3" in (report_dir / "report.md").read_text()
+
+        # Data subdirectory should also be copied
+        assert (report_dir / "data" / "board_summary.json").exists()
+
+        # No vN/ directories should remain
+        import re
+        for child in out_dir.iterdir():
+            if child.is_dir():
+                assert not re.fullmatch(r"v\d+", child.name), (
+                    f"Version directory {child.name} should have been removed"
+                )
+
+        # result.report_path should point to the flattened location
+        assert result.report_path == report_dir / "report.md"
+
+    def test_latest_only_false_preserves_version_dirs(self, tmp_path, monkeypatch):
+        """With latest_report_only=False (default), vN/ directories are preserved."""
+        pcb = self._setup_project(tmp_path)
+        out_dir = tmp_path / "output"
+
+        from kicad_tools.export import assembly
+
+        def fake_assembly_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        self._fake_report_generate(out_dir, 1)
+
+        def fake_generate_report(self_pkg, od, result):
+            report_path = self._fake_report_generate(od, 2)
+            result.report_path = report_path
+
+        monkeypatch.setattr(ManufacturingPackage, "_generate_report", fake_generate_report)
+
+        config = ManufacturingConfig(
+            include_report=True,
+            include_project_zip=False,
+            include_manifest=False,
+            latest_report_only=False,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        result = pkg.export(out_dir)
+
+        # Version directories should remain
+        assert (out_dir / "v1").exists()
+        assert (out_dir / "v2").exists()
+
+        # No report/ directory should have been created
+        assert not (out_dir / "report").exists()
+
+    def test_latest_only_with_no_report(self, tmp_path, monkeypatch):
+        """latest_report_only=True with include_report=False should not fail."""
+        pcb = self._setup_project(tmp_path)
+        out_dir = tmp_path / "output"
+
+        from kicad_tools.export import assembly
+
+        def fake_assembly_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            include_manifest=False,
+            latest_report_only=True,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        result = pkg.export(out_dir)
+
+        # Should succeed without errors
+        assert result.success
+        # No report/ or vN/ directories
+        assert not (out_dir / "report").exists()
+
+    def test_latest_only_fresh_project_single_version(self, tmp_path, monkeypatch):
+        """On a fresh project, latest_report_only flattens the single v1/ into report/."""
+        pcb = self._setup_project(tmp_path)
+        out_dir = tmp_path / "output"
+
+        from kicad_tools.export import assembly
+
+        def fake_assembly_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        def fake_generate_report(self_pkg, od, result):
+            report_path = self._fake_report_generate(od, 1)
+            result.report_path = report_path
+
+        monkeypatch.setattr(ManufacturingPackage, "_generate_report", fake_generate_report)
+
+        config = ManufacturingConfig(
+            include_report=True,
+            include_project_zip=False,
+            include_manifest=False,
+            latest_report_only=True,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        result = pkg.export(out_dir)
+
+        # report/ directory should exist with v1 content
+        assert (out_dir / "report" / "report.md").exists()
+        assert "v1" in (out_dir / "report" / "report.md").read_text()
+
+        # v1/ should be removed
+        assert not (out_dir / "v1").exists()
+
+    def test_config_default_latest_report_only(self):
+        """latest_report_only defaults to False."""
+        config = ManufacturingConfig()
+        assert config.latest_report_only is False

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -351,6 +351,38 @@ class TestReportGenerator:
         assert p2.parent.name == "v2"
         assert p3.parent.name == "v3"
 
+    def test_latest_version_dir_no_versions(self, tmp_path: Path) -> None:
+        """Returns None when no vN/ directories exist."""
+        assert ReportGenerator.latest_version_dir(tmp_path) is None
+
+    def test_latest_version_dir_nonexistent_dir(self) -> None:
+        """Returns None when the output directory does not exist."""
+        assert ReportGenerator.latest_version_dir(Path("/nonexistent/dir")) is None
+
+    def test_latest_version_dir_single_version(self, tmp_path: Path) -> None:
+        """Returns the only vN/ directory when there is one."""
+        (tmp_path / "v1").mkdir()
+        result = ReportGenerator.latest_version_dir(tmp_path)
+        assert result is not None
+        assert result.name == "v1"
+
+    def test_latest_version_dir_multiple_versions(self, tmp_path: Path) -> None:
+        """Returns the highest-numbered vN/ directory."""
+        for i in (1, 2, 5, 3):
+            (tmp_path / f"v{i}").mkdir()
+        result = ReportGenerator.latest_version_dir(tmp_path)
+        assert result is not None
+        assert result.name == "v5"
+
+    def test_latest_version_dir_ignores_non_version_dirs(self, tmp_path: Path) -> None:
+        """Non-vN directories are ignored."""
+        (tmp_path / "v1").mkdir()
+        (tmp_path / "report").mkdir()
+        (tmp_path / "data").mkdir()
+        result = ReportGenerator.latest_version_dir(tmp_path)
+        assert result is not None
+        assert result.name == "v1"
+
     def test_custom_template(self, tmp_path: Path) -> None:
         template_dir = tmp_path / "custom_templates"
         template_dir.mkdir()


### PR DESCRIPTION
## Summary

- Adds `--latest-only` CLI flag to `kct export` that flattens the latest versioned report directory (`vN/`) into a single `report/` subdirectory and removes all `vN/` directories from the output
- Adds `ReportGenerator.latest_version_dir()` static method for finding the highest-numbered version directory
- Adds `ManufacturingConfig.latest_report_only` field (default `False`) to preserve backward compatibility

Closes #1671

## Test plan

- [x] Unit tests for `ReportGenerator.latest_version_dir()` with 0, 1, and multiple `vN/` directories (5 tests)
- [x] Integration tests for `ManufacturingPackage.export()` with `latest_report_only=True` confirming flattened output structure (3 tests)
- [x] Edge case: `--latest-only --no-report` does not fail
- [x] Edge case: fresh project with single v1 produces `report/` with v1 content
- [x] Backward compatibility: `latest_report_only=False` preserves versioned directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)