### PR TITLE
fix(router): default grid selection too coarse after imperial grid PR

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -164,7 +164,7 @@ def run_route_command(args) -> int:
     if args.skip_nets:
         sub_argv.extend(["--skip-nets", args.skip_nets])
     grid_val = str(args.grid)
-    if grid_val.lower() == "auto" or grid_val != "0.25":
+    if grid_val.lower() != "auto":
         sub_argv.extend(["--grid", grid_val])
     if args.trace_width != 0.2:
         sub_argv.extend(["--trace-width", str(args.trace_width)])

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -977,8 +977,8 @@ def _add_route_parser(subparsers) -> None:
     route_parser.add_argument(
         "--grid",
         type=str,
-        default="0.25",
-        help="Grid resolution in mm or 'auto' for automatic selection (default: 0.25)",
+        default="auto",
+        help="Grid resolution in mm or 'auto' for automatic selection (default: auto)",
     )
     route_parser.add_argument("--trace-width", type=float, default=0.2, help="Trace width in mm")
     route_parser.add_argument("--clearance", type=float, default=0.15, help="Clearance in mm")

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1868,10 +1868,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--grid",
         type=str,
-        default="0.25",
+        default="auto",
         help=(
             "Grid resolution in mm or 'auto' for automatic selection "
-            "(default: 0.25, use 0.1 for dense QFP, or 'auto' to analyze pads)"
+            "(default: auto, analyzes pad positions and clearance; "
+            "use explicit value like 0.1 for dense QFP)"
         ),
     )
     parser.add_argument(

--- a/tests/test_route_cmd_params.py
+++ b/tests/test_route_cmd_params.py
@@ -12,7 +12,7 @@ class TestRouteCommandGridParameter:
     """Tests for --grid parameter handling in route command."""
 
     def test_grid_parameter_passed_when_not_default(self):
-        """Grid parameter is passed when different from default 0.25."""
+        """Grid parameter is passed when different from default 'auto'."""
         from kicad_tools.cli.commands.routing import run_route_command
 
         # Create args simulating --grid 0.1 (non-default)
@@ -45,16 +45,16 @@ class TestRouteCommandGridParameter:
             assert call_args[grid_idx + 1] == "0.1"
 
     def test_grid_parameter_not_duplicated_when_default(self):
-        """Grid parameter is not passed when equal to default 0.25."""
+        """Grid parameter is not passed when equal to default 'auto'."""
         from kicad_tools.cli.commands.routing import run_route_command
 
-        # Create args simulating default --grid 0.25
+        # Create args simulating default --grid auto
         args = SimpleNamespace(
             pcb="test.kicad_pcb",
             output=None,
             strategy="negotiated",
             skip_nets=None,
-            grid="0.25",  # Default value (string) - should not be passed
+            grid="auto",  # Default value (string) - should not be passed
             trace_width=0.2,
             clearance=0.15,
             via_drill=0.3,
@@ -75,8 +75,8 @@ class TestRouteCommandGridParameter:
             call_args = mock_main.call_args[0][0]
             assert "--grid" not in call_args
 
-    def test_grid_auto_passed_through(self):
-        """Grid 'auto' value is always passed through to route_cmd."""
+    def test_grid_auto_not_forwarded_as_default(self):
+        """Grid 'auto' is the default and should not be forwarded to route_cmd."""
         from kicad_tools.cli.commands.routing import run_route_command
 
         args = SimpleNamespace(
@@ -84,7 +84,7 @@ class TestRouteCommandGridParameter:
             output=None,
             strategy="negotiated",
             skip_nets=None,
-            grid="auto",  # Auto mode
+            grid="auto",  # Default value
             trace_width=0.2,
             clearance=0.15,
             via_drill=0.3,
@@ -101,13 +101,12 @@ class TestRouteCommandGridParameter:
             mock_main.return_value = 0
             run_route_command(args)
 
+            # auto is the default in route_cmd too, so it should not be forwarded
             call_args = mock_main.call_args[0][0]
-            assert "--grid" in call_args
-            grid_idx = call_args.index("--grid")
-            assert call_args[grid_idx + 1] == "auto"
+            assert "--grid" not in call_args
 
-    def test_grid_auto_uppercase_passed_through(self):
-        """Grid 'AUTO' (uppercase) value is passed through to route_cmd."""
+    def test_grid_auto_uppercase_not_forwarded(self):
+        """Grid 'AUTO' (uppercase) is also treated as default and not forwarded."""
         from kicad_tools.cli.commands.routing import run_route_command
 
         args = SimpleNamespace(
@@ -132,10 +131,40 @@ class TestRouteCommandGridParameter:
             mock_main.return_value = 0
             run_route_command(args)
 
+            # AUTO (case-insensitive) is the default, so should not be forwarded
+            call_args = mock_main.call_args[0][0]
+            assert "--grid" not in call_args
+
+    def test_grid_explicit_025_forwarded(self):
+        """Explicit --grid 0.25 is forwarded since it's no longer the default."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = SimpleNamespace(
+            pcb="test.kicad_pcb",
+            output=None,
+            strategy="negotiated",
+            skip_nets=None,
+            grid="0.25",  # Explicit non-default value
+            trace_width=0.2,
+            clearance=0.15,
+            via_drill=0.3,
+            via_diameter=0.6,
+            mc_trials=10,
+            iterations=15,
+            verbose=False,
+            dry_run=True,
+            quiet=True,
+            power_nets=None,
+        )
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
             call_args = mock_main.call_args[0][0]
             assert "--grid" in call_args
             grid_idx = call_args.index("--grid")
-            assert call_args[grid_idx + 1] == "AUTO"
+            assert call_args[grid_idx + 1] == "0.25"
 
 
 class TestRouteCommandClearanceParameter:
@@ -221,7 +250,7 @@ class TestRouteCommandDefaultConsistency:
         args = parser.parse_args(["route", "test.kicad_pcb", "--dry-run"])
 
         # These should match the checks in routing.py
-        assert args.grid == "0.25", "Grid default should be '0.25'"
+        assert args.grid == "auto", "Grid default should be 'auto'"
         assert args.clearance == 0.15, "Clearance default should be 0.15"
         assert args.trace_width == 0.2, "Trace width default should be 0.2"
         assert args.via_drill == 0.3, "Via drill default should be 0.3"
@@ -264,7 +293,7 @@ class TestRouteCommandDefaultConsistency:
         help_text = help_output.getvalue()
 
         # Verify the defaults in help text
-        assert "default: 0.25" in help_text, "route_cmd --grid default should be 0.25"
+        assert "default: auto" in help_text, "route_cmd --grid default should be auto"
         assert "default: 0.15" in help_text, "route_cmd --clearance default should be 0.15"
 
 


### PR DESCRIPTION
## Summary

- Change `--grid` default from `"0.25"` to `"auto"` in both `route_cmd.py` and the centralized `parser.py`, so that `kct route` auto-selects a DRC-compliant grid based on pad positions and clearance
- Update the dispatch bridge in `routing.py` to treat `"auto"` as the new default (not forwarded redundantly)
- Update existing tests to reflect the new default and add a test for explicit `--grid 0.25` forwarding

Closes #1669

## Test plan

- [x] All 42 tests in `test_route_cmd_params.py` pass
- [x] All 62 tests in `test_grid_auto_selection.py` and `test_build_routing_params.py` pass
- [ ] Manual: `kct route <pcb>` with 0.15mm clearance no longer errors without `--grid`
- [ ] Manual: `kct route <pcb> --grid 0.25 --clearance 0.3` still works (explicit grid within clearance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)