### PR TITLE
fix(router): prevent seg-seg clearance violations from grid quantization

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3166,13 +3166,26 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  Warning: Zone generation failed: {e}")
 
     # Pre-save clearance validation
+    # Issue #1666: Segment-to-segment violations now cause a non-zero exit
+    # code so that CI pipelines and DRC workflows can detect the failure.
+    seg_seg_violation_count = 0
     if stats["nets_routed"] > 0 and not args.dry_run:
         from kicad_tools.router.io import format_clearance_violations, validate_routes
 
         clearance_violations = validate_routes(router)
-        if clearance_violations and not quiet:
-            print("\n--- Pre-save Clearance Validation ---")
-            print(f"  WARNING: {format_clearance_violations(clearance_violations)}")
+        if clearance_violations:
+            seg_seg_violation_count = sum(
+                1 for v in clearance_violations
+                if v.obstacle_type == "segment" and not v.component_inherent
+            )
+            if not quiet:
+                print("\n--- Pre-save Clearance Validation ---")
+                if seg_seg_violation_count > 0:
+                    print(
+                        f"  ERROR: {seg_seg_violation_count} segment-to-segment "
+                        f"clearance violation(s) remain after routing"
+                    )
+                print(f"  {format_clearance_violations(clearance_violations)}")
 
     # Save output
     if args.dry_run:
@@ -3371,7 +3384,10 @@ def main(argv: list[str] | None = None) -> int:
     # 2 = Partial routing — some nets routed, output file exists with traces
     #     (also used for SIGINT partial save, handled earlier in the function)
     # 3 = All nets routed but DRC violations detected
-    if all_nets_routed and drc_passed:
+    # 4 = Seg-seg clearance violations remain after routing (Issue #1666)
+    if seg_seg_violation_count > 0:
+        return 4
+    elif all_nets_routed and drc_passed:
         return 0
     elif not all_nets_routed:
         # Partial routing: some nets were routed — pipeline should continue

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2691,6 +2691,27 @@ class Autorouter:
             if failure_summary:
                 print(failure_summary)
 
+        # Issue #1666: Post-route seg-seg clearance correction pass.
+        # After the negotiated loop converges, validate all routes for
+        # segment-to-segment clearance violations that slipped through
+        # grid-level checks due to quantization.  For each violation,
+        # rip up both offending nets and reroute them with the current
+        # (tightened) blocking radius so they settle into violation-free
+        # positions.
+        if not timed_out and successful_nets > 0:
+            corrected = self._post_route_clearance_correction(
+                net_routes=net_routes,
+                pads_by_net=pads_by_net,
+                present_factor=present_factor,
+                per_net_timeout=per_net_timeout,
+            )
+            if corrected > 0:
+                total_elapsed = time.time() - start_time
+                flush_print(
+                    f"\n  Post-route clearance correction rerouted {corrected} net(s) "
+                    f"({total_elapsed:.1f}s)"
+                )
+
         if progress_callback is not None:
             status = (
                 "converged"
@@ -2755,6 +2776,89 @@ class Autorouter:
         )
         routes.extend(new_routes)
         return routes
+
+    def _post_route_clearance_correction(
+        self,
+        net_routes: dict[int, list[Route]],
+        pads_by_net: dict[int, list[Pad]],
+        present_factor: float,
+        per_net_timeout: float | None = None,
+        max_correction_passes: int = 3,
+    ) -> int:
+        """Rip-up and reroute nets involved in seg-seg clearance violations.
+
+        Issue #1666: After the negotiated loop converges, grid quantization
+        can leave segment-to-segment distances slightly below the required
+        clearance.  This method detects those violations using
+        ``validate_routes()`` from ``io.py`` and selectively rip-up /
+        reroute the offending nets so they settle into positions that
+        satisfy the world-coordinate clearance constraint.
+
+        Args:
+            net_routes: Mapping of net ID to its current routes.
+            pads_by_net: Mapping of net ID to its pad objects.
+            present_factor: Congestion cost factor for rerouting.
+            per_net_timeout: Optional per-net A* timeout.
+            max_correction_passes: Maximum correction iterations (default 3).
+
+        Returns:
+            Total number of nets that were rerouted across all passes.
+        """
+        from .io import validate_routes
+
+        total_corrected = 0
+
+        for pass_idx in range(max_correction_passes):
+            violations = validate_routes(self)
+
+            # Only consider segment-to-segment violations
+            seg_violations = [v for v in violations if v.obstacle_type == "segment"]
+            if not seg_violations:
+                break
+
+            # Collect unique nets involved in violations
+            violating_nets: set[int] = set()
+            for v in seg_violations:
+                violating_nets.add(v.net)
+                violating_nets.add(v.obstacle_net)
+
+            flush_print(
+                f"\n--- Post-route clearance pass {pass_idx + 1}: "
+                f"{len(seg_violations)} seg-seg violation(s) across "
+                f"{len(violating_nets)} net(s) ---"
+            )
+
+            neg_router = NegotiatedRouter(
+                self.grid, self.router, self.rules, self.net_class_map
+            )
+
+            # Rip up all violating nets
+            nets_to_reroute = [n for n in violating_nets if n in net_routes]
+            neg_router.rip_up_nets(nets_to_reroute, net_routes, self.routes)
+
+            # Reroute them
+            rerouted_count = 0
+            for net in nets_to_reroute:
+                routes = self._route_net_negotiated(
+                    net, present_factor, per_net_timeout=per_net_timeout
+                )
+                if routes:
+                    net_routes[net] = routes
+                    rerouted_count += 1
+                    for route in routes:
+                        self.grid.mark_route_usage(route)
+                        self.routes.append(route)
+
+            total_corrected += rerouted_count
+            flush_print(
+                f"  Rerouted {rerouted_count}/{len(nets_to_reroute)} net(s)"
+            )
+
+            if rerouted_count == 0:
+                # No progress -- stop trying
+                break
+
+        return total_corrected
 
     # =========================================================================
     # TWO-PHASE ROUTING (GLOBAL + DETAILED)

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -1172,10 +1172,21 @@ class RoutingGrid:
         """Mark a route's cells as used.
 
         Thread-safe when thread_safe=True.
+
+        Issue #1666: Add a 1-cell safety margin to the blocking radius to
+        prevent seg-seg clearance violations caused by grid quantization.
+        Two parallel traces that each pass grid-level clearance checks can
+        still have world-coordinate centerlines closer than
+        ``trace_width + 2 * trace_clearance`` when grid snap rounds their
+        positions inward.  The extra cell ensures the blocked envelope is
+        always at least as large as the geometric clearance requirement.
         """
         with self._acquire_lock():
             total_clearance = self.rules.trace_width / 2 + self.rules.trace_clearance
             clearance_cells = int(total_clearance / self.resolution) + 1
+            # Issue #1666: Add safety margin to prevent grid-quantization
+            # clearance violations between parallel traces.
+            clearance_cells += 1
 
             for seg in route.segments:
                 self._mark_segment(seg, clearance_cells=clearance_cells)

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -3029,3 +3029,54 @@ class TestPerNetTimeout:
             per_net_timeout=10.0,
         )
         assert isinstance(routes, list)
+
+
+class TestPostRouteClearanceCorrection:
+    """Tests for Issue #1666: post-route seg-seg clearance correction pass."""
+
+    def test_post_route_correction_method_exists(self):
+        """The _post_route_clearance_correction method must exist on Autorouter."""
+        router = Autorouter(width=50.0, height=40.0)
+        assert hasattr(router, "_post_route_clearance_correction")
+        assert callable(router._post_route_clearance_correction)
+
+    def test_post_route_correction_no_violations(self):
+        """Correction pass returns 0 when there are no violations."""
+        router = Autorouter(width=50.0, height=40.0)
+
+        # No routes means no violations
+        corrected = router._post_route_clearance_correction(
+            net_routes={},
+            pads_by_net={},
+            present_factor=0.5,
+        )
+        assert corrected == 0
+
+    def test_post_route_correction_with_routes(self):
+        """Correction pass runs without error when routes exist."""
+        rules = DesignRules(
+            grid_resolution=0.1,
+            trace_width=0.2,
+            trace_clearance=0.127,
+        )
+        router = Autorouter(width=50.0, height=40.0, rules=rules)
+
+        # Add two simple nets
+        router.add_component(
+            "R1",
+            [
+                {"number": "1", "x": 5.0, "y": 10.0, "net": 1, "net_name": "NET1"},
+                {"number": "2", "x": 15.0, "y": 10.0, "net": 1, "net_name": "NET1"},
+            ],
+        )
+        router.add_component(
+            "R2",
+            [
+                {"number": "1", "x": 5.0, "y": 20.0, "net": 2, "net_name": "NET2"},
+                {"number": "2", "x": 15.0, "y": 20.0, "net": 2, "net_name": "NET2"},
+            ],
+        )
+
+        # Route with negotiated mode - should invoke the correction pass
+        routes = router.route_all_negotiated(max_iterations=2)
+        assert isinstance(routes, list)

--- a/tests/test_router_grid.py
+++ b/tests/test_router_grid.py
@@ -1574,3 +1574,111 @@ class TestRoutingGrid:
         gx, gy = grid.world_to_grid(100.0, 100.0)
         assert gx == grid.cols - 1
         assert gy == grid.rows - 1
+
+
+class TestGridQuantizationClearance:
+    """Tests for Issue #1666: grid-quantization seg-seg clearance safety margin.
+
+    The blocking radius in ``mark_route()`` must be large enough that two
+    routes placed on adjacent grid cells cannot violate the world-coordinate
+    segment-to-segment clearance requirement.
+    """
+
+    @pytest.fixture
+    def tight_grid(self):
+        """Create a grid where resolution ~= clearance (worst-case quantization)."""
+        rules = DesignRules(
+            grid_resolution=0.1,
+            trace_width=0.2,
+            trace_clearance=0.102,  # Just above one grid cell
+        )
+        return RoutingGrid(width=20.0, height=20.0, rules=rules)
+
+    def test_parallel_segments_one_grid_cell_apart_blocked(self, tight_grid):
+        """Two parallel segments placed 1 grid cell apart must be detected.
+
+        Before the fix, the blocking radius allowed two traces whose
+        centerlines were ``(clearance_cells * resolution)`` apart,
+        which could be less than ``trace_width + 2 * trace_clearance``
+        due to truncation.  The safety margin prevents this.
+        """
+        # Route 1 at x=5.0
+        seg1 = Segment(
+            x1=5.0, y1=0.0, x2=5.0, y2=10.0,
+            width=0.2, layer=Layer.F_CU, net=1, net_name="NET1",
+        )
+        route1 = Route(net=1, net_name="NET1", segments=[seg1], vias=[])
+        tight_grid.mark_route(route1)
+
+        # Route 2 at x=5.3 -- only 0.3mm apart (center-to-center).
+        # Edge-to-edge clearance = 0.3 - 0.1 - 0.1 = 0.1mm < 0.102mm required.
+        seg2 = Segment(
+            x1=5.3, y1=0.0, x2=5.3, y2=10.0,
+            width=0.2, layer=Layer.F_CU, net=2, net_name="NET2",
+        )
+
+        is_valid, clearance, _ = tight_grid.validate_segment_clearance(
+            seg2, exclude_net=2
+        )
+        assert is_valid is False, (
+            f"Parallel segments 0.3mm apart should violate 0.102mm clearance "
+            f"(actual clearance={clearance:.4f}mm)"
+        )
+
+    def test_mark_route_safety_margin_blocks_adjacent_cell(self, tight_grid):
+        """After mark_route, the grid cell adjacent to a route must be blocked.
+
+        The +1 safety margin ensures that grid cells immediately next to the
+        calculated clearance radius are also marked as blocked, preventing
+        a second route from being placed there.
+        """
+        seg = Segment(
+            x1=5.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=1, net_name="NET1",
+        )
+        route = Route(net=1, net_name="NET1", segments=[seg], vias=[])
+        tight_grid.mark_route(route)
+
+        # Check that cells within the blocking radius + safety margin are blocked
+        center_gx, center_gy = tight_grid.world_to_grid(7.0, 5.0)
+        layer_idx = tight_grid.layer_to_index(Layer.F_CU.value)
+
+        # The required blocking radius without safety margin
+        total_clearance = tight_grid.rules.trace_width / 2 + tight_grid.rules.trace_clearance
+        base_cells = int(total_clearance / tight_grid.resolution) + 1
+        # With safety margin: base_cells + 1
+        safe_cells = base_cells + 1
+
+        # A cell at exactly base_cells offset should now be blocked
+        # (it would NOT have been blocked without the safety margin)
+        check_gy = center_gy + safe_cells
+        if 0 <= check_gy < tight_grid.rows:
+            cell = tight_grid.grid[layer_idx][check_gy][center_gx]
+            assert cell.blocked is True, (
+                f"Cell at offset {safe_cells} from route centerline should be "
+                f"blocked by the safety margin"
+            )
+
+    def test_sufficient_spacing_still_valid(self, tight_grid):
+        """Segments with clearly sufficient spacing must still pass validation."""
+        seg1 = Segment(
+            x1=5.0, y1=0.0, x2=5.0, y2=10.0,
+            width=0.2, layer=Layer.F_CU, net=1, net_name="NET1",
+        )
+        route1 = Route(net=1, net_name="NET1", segments=[seg1], vias=[])
+        tight_grid.mark_route(route1)
+
+        # Route 2 at x=5.6 -- center-to-center 0.6mm.
+        # Edge-to-edge = 0.6 - 0.1 - 0.1 = 0.4mm >> 0.102mm.
+        seg2 = Segment(
+            x1=5.6, y1=0.0, x2=5.6, y2=10.0,
+            width=0.2, layer=Layer.F_CU, net=2, net_name="NET2",
+        )
+
+        is_valid, clearance, _ = tight_grid.validate_segment_clearance(
+            seg2, exclude_net=2
+        )
+        assert is_valid is True, (
+            f"Segments 0.6mm apart should pass clearance validation "
+            f"(clearance={clearance:.4f}mm)"
+        )


### PR DESCRIPTION
## Summary

- Add a 1-cell safety margin to the grid blocking radius in `mark_route()` to prevent two parallel traces from violating world-coordinate clearance due to grid snap rounding
- Add a post-route clearance correction pass in `route_all_negotiated()` that detects remaining seg-seg violations and selectively rip-up/reroutes offending nets
- Upgrade pre-save validation in `route_cmd.py` from warn-only to exit code 4 when seg-seg violations persist

Closes #1666

## Test plan

- [x] 3 new unit tests in `tests/test_router_grid.py` for grid-quantization edge cases (parallel segments 1 cell apart, safety margin blocking, sufficient spacing still valid)
- [x] 3 new unit tests in `tests/test_router_core.py` for the post-route clearance correction pass (method exists, no-op with no routes, runs with actual routes)
- [x] All 116 existing grid tests pass (`tests/test_router_grid.py`)
- [x] All 123 existing core tests pass (`tests/test_router_core.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)