### PR TITLE
fix(schematic): add missing junction markers and remove unnecessary collision suppression

### DIFF
--- a/src/kicad_tools/schematic/blocks/indicators.py
+++ b/src/kicad_tools/schematic/blocks/indicators.py
@@ -84,7 +84,7 @@ class LEDIndicator(CircuitBlock):
         # Wire LED cathode to resistor
         led_cathode = self.led.pin_position("K")
         r_pin1 = self.resistor.pin_position("1")
-        sch.add_wire(led_cathode, r_pin1, warn_on_collision=False)
+        sch.add_wire(led_cathode, r_pin1)
 
         # Define ports
         led_anode = self.led.pin_position("A")

--- a/src/kicad_tools/schematic/blocks/mcu.py
+++ b/src/kicad_tools/schematic/blocks/mcu.py
@@ -197,6 +197,11 @@ class MCUBlock(CircuitBlock):
                 sch.add_wire(prev_gnd, (cap_gnd[0], gnd_y), warn_on_collision=False)
                 sch.add_wire((cap_gnd[0], gnd_y), cap_gnd, warn_on_collision=False)
 
+                # Add junctions at intermediate cap pins where bus segments meet
+                if i > 1:
+                    sch.add_junction(prev_vdd[0], prev_vdd[1])
+                    sch.add_junction(prev_gnd[0], prev_gnd[1])
+
     def _build_ports(self):
         """Build ports dict exposing all MCU pins."""
         # Add VDD port (use first VDD pin position, or first cap's VDD)
@@ -453,6 +458,7 @@ class ResetButton(CircuitBlock):
         # For active-high, this would be VCC
         sch.add_wire(sw_pin2, (c_pin2[0], sw_pin2[1]), warn_on_collision=False)  # Horizontal
         sch.add_wire((c_pin2[0], sw_pin2[1]), c_pin2, warn_on_collision=False)  # Vertical
+        sch.add_junction(sw_pin2[0], sw_pin2[1])
 
         # Add TVS diode if requested
         self.tvs: SymbolInstance | None = None
@@ -469,6 +475,7 @@ class ResetButton(CircuitBlock):
             # Wire TVS anode to reset node
             sch.add_wire((c_pin1[0], sw_pin1[1]), (tvs_anode[0], sw_pin1[1]), warn_on_collision=False)
             sch.add_wire((tvs_anode[0], sw_pin1[1]), tvs_anode, warn_on_collision=False)
+            sch.add_junction(c_pin1[0], sw_pin1[1])
 
             # TVS cathode goes to ground (will be wired in connect_to_rails)
             # Store for later
@@ -853,6 +860,9 @@ class BootModeSelector(CircuitBlock):
                 # Button connects boot pin to VCC when pressed
                 # Button is above the boot pin
                 sch.add_wire(sw_pin2, (boot_junction_x, boot_junction_y), warn_on_collision=False)
+
+            # Mark the T-junction where button wire meets resistor-to-boot-pin wire
+            sch.add_junction(boot_junction_x, boot_junction_y)
 
             # Store button rail pin for connect_to_rails
             if self.default_high:

--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -347,7 +347,7 @@ class ThreePhaseInverter(CircuitBlock):
             phase_pos = hb.port("VOUT")
             label_x = phase_pos[0] + 10
             # Add wire from phase output to label position
-            sch.add_wire(phase_pos, (label_x, phase_pos[1]), warn_on_collision=False)
+            sch.add_wire(phase_pos, (label_x, phase_pos[1]))
             sch.add_label(f"PHASE_{label}", label_x, phase_pos[1], rotation=0)
 
         # Store all components

--- a/src/kicad_tools/schematic/blocks/timing.py
+++ b/src/kicad_tools/schematic/blocks/timing.py
@@ -252,7 +252,7 @@ class CrystalOscillator(CircuitBlock):
         sch.add_wire((c2_pin1[0], xtal_pin2[1]), c2_pin1)  # Vertical down to cap
 
         # Wire cap bottoms together (ground bus)
-        sch.add_wire(c1_pin2, c2_pin2, warn_on_collision=False)
+        sch.add_wire(c1_pin2, c2_pin2)
 
         # Add junctions at crystal-to-cap connection points
         sch.add_junction(c1_pin1[0], xtal_pin1[1])


### PR DESCRIPTION
## Summary
Adds missing `add_junction()` calls at 6 wire intersection points in `mcu.py` where `warn_on_collision=False` was suppressing collision warnings without an explicit junction marker. Also removes unnecessary `warn_on_collision=False` from 3 point-to-point wires in other files.

## Changes
- **mcu.py `_wire_bypass_caps`**: Add junctions at intermediate cap pin positions where daisy-chained VDD/GND bus segments meet (lines 193-198)
- **mcu.py `ResetButton.__init__`**: Add junction at sw_pin2 for switch-to-cap GND L-route (lines 454-455)
- **mcu.py `ResetButton.__init__`**: Add junction at cap-top branch point where TVS anode wire diverges (lines 470-471)
- **mcu.py `BootModeSelector.__init__`**: Add junction at boot_junction point where button wire meets resistor-to-boot-pin wire (lines 851, 855)
- **motor.py**: Remove `warn_on_collision=False` from phase-output-to-label wire (no collision risk)
- **timing.py**: Remove `warn_on_collision=False` from cap-bottom ground bus wire (no collision risk)
- **indicators.py**: Remove `warn_on_collision=False` from LED-cathode-to-resistor wire (no collision risk)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 6 suspicious mcu.py instances have junction markers added | Pass | Added `add_junction()` at all 6 identified intersection points |
| 3 low-priority instances have suppression removed | Pass | Removed `warn_on_collision=False` from motor.py, timing.py, indicators.py |
| All existing tests pass | Pass | `uv run pytest tests/test_schematic_blocks.py -x -q` -- 253 passed |

## Test Plan
- Ran `uv run pytest tests/test_schematic_blocks.py -x -q` -- all 253 tests passed in 24.97s

Closes #1653