### PR TITLE
feat(silkscreen): add ref des visibility and board markings to build pipeline

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -42,6 +42,7 @@ class BuildStep(str, Enum):
     PCB = "pcb"
     OUTLINE = "outline"
     PLACEMENT = "placement"
+    SILKSCREEN = "silkscreen"
     ROUTE = "route"
     VERIFY = "verify"
     EXPORT = "export"
@@ -755,6 +756,92 @@ def _run_step_placement(ctx: BuildContext, console: Console) -> BuildResult:
         )
 
 
+def _run_step_silkscreen(ctx: BuildContext, console: Console) -> BuildResult:
+    """Run silkscreen generation step.
+
+    Ensures footprint reference designators are visible on silkscreen layers
+    and adds board-level markings (project name, revision, date) from the
+    project spec metadata.
+    """
+    if not ctx.pcb_file or not ctx.pcb_file.exists():
+        return BuildResult(
+            step="silkscreen",
+            success=True,
+            message="No PCB file found, skipping silkscreen generation",
+        )
+
+    if ctx.dry_run:
+        return BuildResult(
+            step="silkscreen",
+            success=True,
+            message="[dry-run] Would generate silkscreen content",
+        )
+
+    try:
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(ctx.pcb_file)
+
+        # Step 1: Ensure ref des are visible
+        ref_result = gen.ensure_ref_des_visible()
+
+        # Step 2: Add board markings from spec metadata
+        mark_result = None
+        name = None
+        revision = None
+        date_str = None
+
+        if ctx.spec and ctx.spec.project:
+            name = ctx.spec.project.name
+            revision = ctx.spec.project.revision
+            if ctx.spec.project.created:
+                date_str = str(ctx.spec.project.created)
+
+        if name:
+            mark_result = gen.add_board_markings(
+                name=name,
+                revision=revision,
+                date=date_str,
+            )
+
+        gen.save()
+
+        # Build summary message
+        parts = []
+        if ref_result.refs_unhidden:
+            parts.append(f"{ref_result.refs_unhidden} ref(s) unhidden")
+        if mark_result and mark_result.markings_added:
+            parts.append(f"{mark_result.markings_added} marking(s) added")
+        if mark_result and mark_result.markings_skipped:
+            parts.append(f"{mark_result.markings_skipped} marking(s) already present")
+
+        if parts:
+            message = "Silkscreen: " + ", ".join(parts)
+        else:
+            message = "Silkscreen: no changes needed"
+
+        if not ctx.quiet:
+            for msg in ref_result.messages:
+                console.print(f"    {msg}")
+            if mark_result:
+                for msg in mark_result.messages:
+                    console.print(f"    {msg}")
+
+        return BuildResult(
+            step="silkscreen",
+            success=True,
+            message=message,
+            output_file=ctx.pcb_file,
+        )
+
+    except Exception as e:
+        return BuildResult(
+            step="silkscreen",
+            success=False,
+            message=f"Silkscreen generation failed: {e}",
+        )
+
+
 def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
     """Run autorouting step."""
     # Check if a routed PCB already exists (e.g., from generate_design.py)
@@ -1191,7 +1278,7 @@ Examples:
     parser.add_argument(
         "--step",
         "-s",
-        choices=["schematic", "pcb", "outline", "placement", "route", "verify", "export", "all"],
+        choices=["schematic", "pcb", "outline", "placement", "silkscreen", "route", "verify", "export", "all"],
         default="all",
         help="Run specific step or all (default: all)",
     )
@@ -1328,7 +1415,7 @@ Examples:
 
     # Determine steps to run
     if args.step == "all":
-        steps = [BuildStep.SCHEMATIC, BuildStep.PCB, BuildStep.OUTLINE, BuildStep.PLACEMENT, BuildStep.ROUTE, BuildStep.VERIFY, BuildStep.EXPORT]
+        steps = [BuildStep.SCHEMATIC, BuildStep.PCB, BuildStep.OUTLINE, BuildStep.PLACEMENT, BuildStep.SILKSCREEN, BuildStep.ROUTE, BuildStep.VERIFY, BuildStep.EXPORT]
     else:
         steps = [BuildStep(args.step)]
 
@@ -1359,6 +1446,9 @@ Examples:
 
             elif step == BuildStep.PLACEMENT:
                 result = _run_step_placement(ctx, console)
+
+            elif step == BuildStep.SILKSCREEN:
+                result = _run_step_silkscreen(ctx, console)
 
             elif step == BuildStep.ROUTE:
                 result = _run_step_route(ctx, console)

--- a/src/kicad_tools/pcb/editor.py
+++ b/src/kicad_tools/pcb/editor.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 # Import SExp parsing and builders
 from kicad_tools.sexp import SExp, parse_file
-from kicad_tools.sexp.builders import fmt, gr_line_node, segment_node, via_node, zone_node
+from kicad_tools.sexp.builders import fmt, gr_line_node, gr_text_node, segment_node, via_node, zone_node
 
 
 @dataclass
@@ -546,6 +546,41 @@ class PCBEditor:
                 self.doc.append(node)
 
         return nodes
+
+    def add_silkscreen_text(
+        self,
+        text: str,
+        x: float,
+        y: float,
+        layer: str = "F.SilkS",
+        font_size: float = 1.0,
+        font_thickness: float = 0.15,
+    ) -> SExp:
+        """Add board-level silkscreen text (gr_text) to the PCB.
+
+        Args:
+            text: Text content to display
+            x, y: Position coordinates in mm
+            layer: Silkscreen layer (default "F.SilkS")
+            font_size: Font size in mm (default 1.0)
+            font_thickness: Font stroke thickness in mm (default 0.15)
+
+        Returns:
+            The created gr_text SExp node.
+
+        Raises:
+            ValueError: If no PCB document is loaded.
+        """
+        if not self.doc:
+            raise ValueError("No PCB document loaded")
+
+        node = gr_text_node(
+            text, x, y, layer=layer, font_size=font_size,
+            font_thickness=font_thickness,
+            uuid_str=str(uuid_module.uuid4()),
+        )
+        self.doc.append(node)
+        return node
 
     def get_zones(self) -> list[dict]:
         """Get all zones from the PCB.

--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -418,6 +418,54 @@ def gr_line_node(
     )
 
 
+def gr_text_node(
+    text: str,
+    x: float,
+    y: float,
+    layer: str = "F.SilkS",
+    font_size: float = 1.0,
+    font_thickness: float = 0.15,
+    uuid_str: str = "",
+) -> SExp:
+    """Build a PCB board-level text S-expression (gr_text).
+
+    Used for board markings such as project name, revision, and date
+    on silkscreen layers.
+
+    Args:
+        text: Text content to display
+        x, y: Position coordinates in mm
+        layer: Layer name (default "F.SilkS")
+        font_size: Font height and width in mm (default 1.0)
+        font_thickness: Stroke thickness of font in mm (default 0.15)
+        uuid_str: Unique identifier
+
+    Example output:
+        (gr_text "Board v1.0"
+            (at 105 118)
+            (layer "F.SilkS")
+            (uuid "...")
+            (effects (font (size 1 1) (thickness 0.15)))
+        )
+    """
+    effects_node = SExp.list(
+        "effects",
+        SExp.list(
+            "font",
+            SExp.list("size", fmt(font_size), fmt(font_size)),
+            SExp.list("thickness", fmt(font_thickness)),
+        ),
+    )
+    return SExp.list(
+        "gr_text",
+        text,
+        SExp.list("at", fmt(x), fmt(y)),
+        SExp.list("layer", layer),
+        uuid_node(uuid_str),
+        effects_node,
+    )
+
+
 def zone_node(
     net: int,
     net_name: str,

--- a/src/kicad_tools/silkscreen/__init__.py
+++ b/src/kicad_tools/silkscreen/__init__.py
@@ -1,0 +1,1 @@
+"""Silkscreen generation for KiCad PCBs."""

--- a/src/kicad_tools/silkscreen/generator.py
+++ b/src/kicad_tools/silkscreen/generator.py
@@ -1,0 +1,326 @@
+"""Silkscreen generator: ensure ref des visibility and add board markings.
+
+Operates on the raw SExp tree so that modifications can be written back to
+disk, following the same pattern as ``repair_silkscreen.py``.
+
+First-pass scope:
+- Ensure every footprint reference designator on F.SilkS/B.SilkS is visible
+  (unhide hidden references).
+- Add board-level ``gr_text`` elements for project name, revision, and date
+  sourced from the project spec metadata.
+
+Deferred to follow-up issues:
+- Polarity marks (IC pin 1, diode cathode)
+- Intelligent auto-placement with pad/copper collision avoidance
+"""
+
+from __future__ import annotations
+
+import uuid as uuid_module
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from kicad_tools.core.sexp_file import save_pcb
+from kicad_tools.sexp.builders import gr_text_node
+from kicad_tools.sexp.parser import SExp, parse_file
+
+# Silkscreen layer names recognised by KiCad (pre-8.0 and 8.0+).
+SILKSCREEN_LAYERS = frozenset(("F.SilkS", "B.SilkS", "F.Silkscreen", "B.Silkscreen"))
+
+# Board-level gr_text marker attribute used for idempotency detection.
+_MARKING_PREFIX = "kct:"
+
+
+@dataclass
+class SilkscreenResult:
+    """Result of a silkscreen generation pass."""
+
+    refs_unhidden: int = 0
+    markings_added: int = 0
+    markings_skipped: int = 0
+    messages: list[str] = field(default_factory=list)
+
+    @property
+    def total_changes(self) -> int:
+        return self.refs_unhidden + self.markings_added
+
+
+class SilkscreenGenerator:
+    """Generate silkscreen content for a KiCad PCB.
+
+    Usage::
+
+        gen = SilkscreenGenerator(Path("board.kicad_pcb"))
+        result = gen.ensure_ref_des_visible()
+        result += gen.add_board_markings(name="MyBoard", revision="A")
+        gen.save()
+    """
+
+    def __init__(self, pcb_path: Path):
+        self.path = pcb_path
+        self.doc: SExp = parse_file(pcb_path)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def ensure_ref_des_visible(self) -> SilkscreenResult:
+        """Unhide footprint reference designators on silkscreen layers.
+
+        Walks every footprint and checks its reference text node (either
+        ``fp_text reference`` for KiCad 7 or ``property "Reference"`` for
+        KiCad 8+). If the text is on a silkscreen layer and hidden, it is
+        unhidden.
+
+        Returns:
+            SilkscreenResult with the count of references unhidden.
+        """
+        result = SilkscreenResult()
+
+        for fp_node in self.doc.find_all("footprint"):
+            ref_text = self._find_ref_text(fp_node)
+            if ref_text is None:
+                continue
+
+            if not self._is_silkscreen(ref_text):
+                continue
+
+            if self._is_hidden(ref_text):
+                self._unhide(ref_text)
+                ref_name = self._extract_ref_name(fp_node)
+                result.refs_unhidden += 1
+                result.messages.append(f"Unhid reference {ref_name}")
+
+        return result
+
+    def add_board_markings(
+        self,
+        name: str | None = None,
+        revision: str | None = None,
+        date: str | None = None,
+        layer: str = "F.SilkS",
+        font_size: float = 1.0,
+        font_thickness: float = 0.15,
+    ) -> SilkscreenResult:
+        """Add board-level text markings (project name, revision, date).
+
+        Places ``gr_text`` elements near the bottom-left of the board
+        outline (or at a default position if no outline exists).
+
+        This method is idempotent: it will not add duplicate markings if
+        they already exist.
+
+        Args:
+            name: Project name (e.g. "LED Driver")
+            revision: Revision string (e.g. "A", "1.0")
+            date: Date string (e.g. "2026-04-19")
+            layer: Silkscreen layer for markings
+            font_size: Font size in mm
+            font_thickness: Font stroke thickness in mm
+
+        Returns:
+            SilkscreenResult with counts of markings added/skipped.
+        """
+        result = SilkscreenResult()
+
+        # Find board extents from Edge.Cuts outline for positioning
+        base_x, base_y = self._get_marking_position()
+
+        markings: list[tuple[str, str]] = []
+        if name:
+            label = f"{name} Rev {revision}" if revision else name
+            markings.append(("name", label))
+        if date:
+            markings.append(("date", date))
+
+        y_offset = 0.0
+        for tag, text in markings:
+            marker = f"{_MARKING_PREFIX}{tag}"
+            if self._has_marking(marker):
+                result.markings_skipped += 1
+                result.messages.append(f"Marking '{tag}' already exists, skipped")
+                continue
+
+            # Embed the marker tag as a second line so we can detect duplicates
+            # later; KiCad renders multi-line gr_text fine.
+            node = gr_text_node(
+                text,
+                base_x,
+                base_y + y_offset,
+                layer=layer,
+                font_size=font_size,
+                font_thickness=font_thickness,
+                uuid_str=str(uuid_module.uuid4()),
+            )
+
+            # Store the idempotency marker as a custom child node so that
+            # re-running the generator can detect existing markings without
+            # relying on fragile text matching.
+            node.append(SExp.list("kct_marking", marker))
+
+            self.doc.append(node)
+            result.markings_added += 1
+            result.messages.append(f"Added marking '{tag}': {text}")
+            y_offset += font_size + 0.5  # spacing between lines
+
+        return result
+
+    def save(self, output_path: Path | None = None) -> None:
+        """Write the (possibly modified) SExp tree to disk."""
+        save_pcb(self.doc, output_path or self.path)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _find_ref_text(fp_node: SExp) -> SExp | None:
+        """Find the reference text node in a footprint.
+
+        Handles both KiCad 7 (fp_text reference) and KiCad 8+ (property
+        "Reference") formats.
+        """
+        # KiCad 7: (fp_text reference "R1" ...)
+        for child in fp_node.children:
+            if not child.is_atom and child.name == "fp_text":
+                atoms = child.get_atoms()
+                if atoms and str(atoms[0]) == "reference":
+                    return child
+        # KiCad 8+: (property "Reference" "R1" ...)
+        for child in fp_node.children:
+            if not child.is_atom and child.name == "property":
+                atoms = child.get_atoms()
+                if atoms and str(atoms[0]) == "Reference":
+                    return child
+        return None
+
+    @staticmethod
+    def _extract_ref_name(fp_node: SExp) -> str:
+        """Extract the reference designator string from a footprint."""
+        for child in fp_node.children:
+            if not child.is_atom and child.name == "fp_text":
+                atoms = child.get_atoms()
+                if atoms and str(atoms[0]) == "reference" and len(atoms) >= 2:
+                    return str(atoms[1])
+        for child in fp_node.children:
+            if not child.is_atom and child.name == "property":
+                atoms = child.get_atoms()
+                if atoms and str(atoms[0]) == "Reference" and len(atoms) >= 2:
+                    return str(atoms[1])
+        return "?"
+
+    @staticmethod
+    def _is_silkscreen(text_node: SExp) -> bool:
+        """Return True if *text_node* is on a silkscreen layer."""
+        layer_node = text_node.find("layer")
+        if layer_node is None:
+            return False
+        layer_name = layer_node.get_first_atom()
+        return str(layer_name) in SILKSCREEN_LAYERS if layer_name is not None else False
+
+    @staticmethod
+    def _is_hidden(text_node: SExp) -> bool:
+        """Return True if a text node is hidden.
+
+        KiCad uses several conventions:
+        - ``(hide yes)`` sub-node on the text or property node
+        - A bare ``hide`` atom inside the ``effects`` node
+        - A ``(hide)`` sub-node inside ``effects``
+        """
+        # Check for (hide yes) directly on text node
+        hide_node = text_node.find("hide")
+        if hide_node is not None:
+            atom = hide_node.get_first_atom()
+            if atom is not None and str(atom) == "yes":
+                return True
+            if atom is None:
+                return True
+        # Bare "hide" atom among direct children
+        for child in text_node.children:
+            if child.is_atom and str(child.value) == "hide":
+                return True
+        # Inside (effects ...) node
+        effects = text_node.find("effects")
+        if effects is not None:
+            for child in effects.children:
+                if child.is_atom and str(child.value) == "hide":
+                    return True
+            hide_in_effects = effects.find("hide")
+            if hide_in_effects is not None:
+                return True
+        return False
+
+    @staticmethod
+    def _unhide(text_node: SExp) -> None:
+        """Remove all hide directives from a text node."""
+        # Remove (hide yes) or (hide) from the text node
+        hide_node = text_node.find("hide")
+        if hide_node is not None:
+            text_node.remove(hide_node)
+        # Remove bare "hide" atoms from direct children
+        text_node.children = [
+            c for c in text_node.children
+            if not (c.is_atom and str(c.value) == "hide")
+        ]
+        # Remove from effects node
+        effects = text_node.find("effects")
+        if effects is not None:
+            effects.children = [
+                c for c in effects.children
+                if not (c.is_atom and str(c.value) == "hide")
+            ]
+            hide_in_effects = effects.find("hide")
+            if hide_in_effects is not None:
+                effects.remove(hide_in_effects)
+
+    def _get_marking_position(self) -> tuple[float, float]:
+        """Determine a suitable position for board markings.
+
+        Tries to place markings just below the board outline on Edge.Cuts.
+        Falls back to a default position if no outline exists.
+
+        Returns:
+            (x, y) position in mm for the first marking line.
+        """
+        min_x = None
+        max_y = None
+
+        for tag in ("gr_line", "gr_rect", "gr_arc"):
+            for node in self.doc.find_all(tag):
+                layer = node.find("layer")
+                if not layer:
+                    continue
+                layer_name = layer.get_first_atom()
+                if layer_name is None or str(layer_name) != "Edge.Cuts":
+                    continue
+
+                # Extract coordinates from start/end nodes
+                for pos_tag in ("start", "end"):
+                    pos = node.find(pos_tag)
+                    if pos is None:
+                        continue
+                    atoms = pos.get_atoms()
+                    if len(atoms) >= 2:
+                        x_val = float(atoms[0])
+                        y_val = float(atoms[1])
+                        if min_x is None or x_val < min_x:
+                            min_x = x_val
+                        if max_y is None or y_val > max_y:
+                            max_y = y_val
+
+        if min_x is not None and max_y is not None:
+            # Place markings 1.5mm below the bottom-left of the board
+            return min_x, max_y + 1.5
+
+        # Fallback: default KiCad origin area
+        return 100.0, 115.0
+
+    def _has_marking(self, marker: str) -> bool:
+        """Check if a marking with the given idempotency tag already exists."""
+        for gr_text in self.doc.find_all("gr_text"):
+            kct_node = gr_text.find("kct_marking")
+            if kct_node is not None:
+                atom = kct_node.get_first_atom()
+                if atom is not None and str(atom) == marker:
+                    return True
+        return False

--- a/tests/test_silkscreen_generator.py
+++ b/tests/test_silkscreen_generator.py
@@ -1,0 +1,363 @@
+"""Tests for silkscreen generation (ref des visibility + board markings)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.sexp.builders import gr_text_node
+from kicad_tools.sexp.parser import SExp, parse_string
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_pcb(extra: str = "") -> str:
+    """Return a minimal KiCad PCB string with optional extra content."""
+    return textwrap.dedent(f"""\
+        (kicad_pcb (version 20240108) (generator "test")
+          (general (thickness 1.6) (legacy_teardrops no))
+          (layers (0 "F.Cu" signal))
+          {extra}
+        )
+    """)
+
+
+def _write_pcb(tmp_path: Path, content: str) -> Path:
+    pcb_path = tmp_path / "test.kicad_pcb"
+    pcb_path.write_text(content)
+    return pcb_path
+
+
+# ---------------------------------------------------------------------------
+# gr_text_node builder tests
+# ---------------------------------------------------------------------------
+
+
+class TestGrTextNode:
+    def test_basic_structure(self):
+        node = gr_text_node("Hello", 10.0, 20.0, uuid_str="test-uuid")
+        s = node.to_string()
+        assert "(gr_text" in s
+        assert '"Hello"' in s or "Hello" in s
+        assert "(at 10 20)" in s
+        assert '(layer "F.SilkS")' in s
+        assert '(uuid "test-uuid")' in s
+        assert "(effects" in s
+        assert "(font" in s
+        assert "(thickness" in s
+
+    def test_custom_layer(self):
+        node = gr_text_node("Back", 5.0, 5.0, layer="B.SilkS", uuid_str="u")
+        s = node.to_string()
+        assert '(layer "B.SilkS")' in s
+
+    def test_custom_font_size(self):
+        node = gr_text_node("Big", 0.0, 0.0, font_size=2.0, uuid_str="u")
+        s = node.to_string()
+        assert "(size 2 2)" in s
+
+    def test_roundtrip(self):
+        """gr_text_node output should be re-parseable."""
+        node = gr_text_node("Test", 100.0, 200.0, uuid_str="rt-uuid")
+        reparsed = parse_string(node.to_string())
+        assert reparsed.name == "gr_text"
+
+
+# ---------------------------------------------------------------------------
+# SilkscreenGenerator tests
+# ---------------------------------------------------------------------------
+
+
+class TestRefDesVisibility:
+    """Test ensure_ref_des_visible()."""
+
+    def test_unhides_hidden_fp_text_reference(self, tmp_path):
+        """A hidden fp_text reference on F.SilkS should be unhidden."""
+        pcb = _minimal_pcb("""
+          (footprint "Package_SO:SOIC-8" (at 100 100) (layer "F.Cu")
+            (fp_text reference "U1" (at 0 -2) (layer "F.SilkS")
+              (hide yes)
+              (effects (font (size 1 1) (thickness 0.15)))
+            )
+          )
+        """)
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        result = gen.ensure_ref_des_visible()
+
+        assert result.refs_unhidden == 1
+        assert "U1" in result.messages[0]
+
+        # Verify the hide node was removed
+        fp = gen.doc.find_all("footprint")[0]
+        ref_text = None
+        for child in fp.children:
+            if not child.is_atom and child.name == "fp_text":
+                atoms = child.get_atoms()
+                if atoms and str(atoms[0]) == "reference":
+                    ref_text = child
+                    break
+        assert ref_text is not None
+        assert ref_text.find("hide") is None
+
+    def test_already_visible_noop(self, tmp_path):
+        """A visible fp_text reference should not be modified."""
+        pcb = _minimal_pcb("""
+          (footprint "R:0805" (at 110 100) (layer "F.Cu")
+            (fp_text reference "R1" (at 0 -2) (layer "F.SilkS")
+              (effects (font (size 1 1) (thickness 0.15)))
+            )
+          )
+        """)
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        result = gen.ensure_ref_des_visible()
+
+        assert result.refs_unhidden == 0
+
+    def test_hidden_via_bare_hide_atom(self, tmp_path):
+        """A ref hidden via bare 'hide' atom should be unhidden."""
+        pcb = _minimal_pcb("""
+          (footprint "C:0402" (at 120 100) (layer "F.Cu")
+            (fp_text reference "C1" (at 0 -2) (layer "F.SilkS") hide
+              (effects (font (size 1 1) (thickness 0.15)))
+            )
+          )
+        """)
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        result = gen.ensure_ref_des_visible()
+
+        assert result.refs_unhidden == 1
+
+    def test_hidden_via_effects_hide(self, tmp_path):
+        """A ref hidden via hide inside effects should be unhidden."""
+        pcb = _minimal_pcb("""
+          (footprint "C:0402" (at 120 100) (layer "F.Cu")
+            (fp_text reference "C2" (at 0 -2) (layer "F.SilkS")
+              (effects (font (size 1 1) (thickness 0.15)) hide)
+            )
+          )
+        """)
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        result = gen.ensure_ref_des_visible()
+
+        assert result.refs_unhidden == 1
+
+    def test_kicad8_property_reference(self, tmp_path):
+        """KiCad 8+ property Reference format should also be handled."""
+        pcb = _minimal_pcb("""
+          (footprint "R:0805" (at 110 100) (layer "F.Cu")
+            (property "Reference" "R2" (at 0 -2) (layer "F.SilkS")
+              (hide yes)
+              (effects (font (size 1 1) (thickness 0.15)))
+            )
+          )
+        """)
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        result = gen.ensure_ref_des_visible()
+
+        assert result.refs_unhidden == 1
+
+    def test_non_silkscreen_layer_ignored(self, tmp_path):
+        """Hidden ref on non-silkscreen layer should NOT be unhidden."""
+        pcb = _minimal_pcb("""
+          (footprint "R:0805" (at 110 100) (layer "F.Cu")
+            (fp_text reference "R3" (at 0 -2) (layer "F.Fab")
+              (hide yes)
+              (effects (font (size 1 1) (thickness 0.15)))
+            )
+          )
+        """)
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        result = gen.ensure_ref_des_visible()
+
+        assert result.refs_unhidden == 0
+
+
+class TestBoardMarkings:
+    """Test add_board_markings()."""
+
+    def test_adds_name_and_date(self, tmp_path):
+        """Board markings should be added with name and date."""
+        pcb = _minimal_pcb("""
+          (gr_line (start 100 100) (end 150 100) (stroke (width 0.1) (type default))
+            (layer "Edge.Cuts") (uuid "e1"))
+          (gr_line (start 150 100) (end 150 120) (stroke (width 0.1) (type default))
+            (layer "Edge.Cuts") (uuid "e2"))
+          (gr_line (start 150 120) (end 100 120) (stroke (width 0.1) (type default))
+            (layer "Edge.Cuts") (uuid "e3"))
+          (gr_line (start 100 120) (end 100 100) (stroke (width 0.1) (type default))
+            (layer "Edge.Cuts") (uuid "e4"))
+        """)
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        result = gen.add_board_markings(name="TestBoard", revision="B", date="2026-04-19")
+
+        assert result.markings_added == 2  # name+revision combined, date
+        assert result.markings_skipped == 0
+
+        # Check gr_text nodes were added
+        gr_texts = [n for n in gen.doc.find_all("gr_text")]
+        marking_texts = [n for n in gr_texts if n.find("kct_marking") is not None]
+        assert len(marking_texts) == 2
+
+    def test_idempotent(self, tmp_path):
+        """Running add_board_markings twice should not duplicate."""
+        pcb = _minimal_pcb()
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        result1 = gen.add_board_markings(name="MyBoard", revision="A")
+        assert result1.markings_added == 1
+
+        result2 = gen.add_board_markings(name="MyBoard", revision="A")
+        assert result2.markings_added == 0
+        assert result2.markings_skipped == 1
+
+    def test_no_metadata_no_markings(self, tmp_path):
+        """Calling with no metadata should add nothing."""
+        pcb = _minimal_pcb()
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        result = gen.add_board_markings()
+
+        assert result.markings_added == 0
+
+    def test_position_near_outline(self, tmp_path):
+        """Markings should be positioned near the board outline."""
+        pcb = _minimal_pcb("""
+          (gr_line (start 100 100) (end 150 100) (stroke (width 0.1) (type default))
+            (layer "Edge.Cuts") (uuid "e1"))
+          (gr_line (start 150 100) (end 150 130) (stroke (width 0.1) (type default))
+            (layer "Edge.Cuts") (uuid "e2"))
+          (gr_line (start 150 130) (end 100 130) (stroke (width 0.1) (type default))
+            (layer "Edge.Cuts") (uuid "e3"))
+          (gr_line (start 100 130) (end 100 100) (stroke (width 0.1) (type default))
+            (layer "Edge.Cuts") (uuid "e4"))
+        """)
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        gen.add_board_markings(name="PosTest", revision="A")
+
+        marking_texts = [n for n in gen.doc.find_all("gr_text") if n.find("kct_marking")]
+        assert len(marking_texts) == 1
+
+        at_node = marking_texts[0].find("at")
+        assert at_node is not None
+        atoms = at_node.get_atoms()
+        y = float(atoms[1])
+        # Should be below the board bottom edge (130) + 1.5mm offset
+        assert y == pytest.approx(131.5, abs=0.5)
+
+    def test_fallback_position_no_outline(self, tmp_path):
+        """Without Edge.Cuts, markings should use fallback position."""
+        pcb = _minimal_pcb()
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        gen.add_board_markings(name="Fallback")
+
+        marking_texts = [n for n in gen.doc.find_all("gr_text") if n.find("kct_marking")]
+        assert len(marking_texts) == 1
+
+        at_node = marking_texts[0].find("at")
+        atoms = at_node.get_atoms()
+        # Fallback position
+        assert float(atoms[0]) == pytest.approx(100.0)
+        assert float(atoms[1]) == pytest.approx(115.0)
+
+
+class TestSaveAndReload:
+    """Test save/reload roundtrip."""
+
+    def test_save_and_reload(self, tmp_path):
+        """Changes should persist after save and reload."""
+        pcb = _minimal_pcb("""
+          (footprint "R:0805" (at 110 100) (layer "F.Cu")
+            (fp_text reference "R1" (at 0 -2) (layer "F.SilkS")
+              (hide yes)
+              (effects (font (size 1 1) (thickness 0.15)))
+            )
+          )
+        """)
+        pcb_path = _write_pcb(tmp_path, pcb)
+
+        from kicad_tools.silkscreen.generator import SilkscreenGenerator
+
+        gen = SilkscreenGenerator(pcb_path)
+        gen.ensure_ref_des_visible()
+        gen.add_board_markings(name="SaveTest", revision="C", date="2026-01-01")
+        gen.save()
+
+        # Reload and verify
+        gen2 = SilkscreenGenerator(pcb_path)
+
+        # Ref should still be visible
+        ref_result = gen2.ensure_ref_des_visible()
+        assert ref_result.refs_unhidden == 0
+
+        # Markings should already exist (idempotent)
+        mark_result = gen2.add_board_markings(name="SaveTest", revision="C", date="2026-01-01")
+        assert mark_result.markings_added == 0
+        assert mark_result.markings_skipped == 2  # name and date
+
+
+class TestBuildStepEnum:
+    """Verify SILKSCREEN is registered in the build pipeline."""
+
+    def test_silkscreen_in_build_steps(self):
+        from kicad_tools.cli.build_cmd import BuildStep
+
+        assert hasattr(BuildStep, "SILKSCREEN")
+        assert BuildStep.SILKSCREEN.value == "silkscreen"
+
+    def test_silkscreen_step_order(self):
+        """SILKSCREEN should come after OUTLINE and before ROUTE."""
+        from kicad_tools.cli.build_cmd import BuildStep
+
+        members = list(BuildStep)
+        outline_idx = members.index(BuildStep.OUTLINE)
+        silk_idx = members.index(BuildStep.SILKSCREEN)
+        route_idx = members.index(BuildStep.ROUTE)
+
+        assert outline_idx < silk_idx < route_idx


### PR DESCRIPTION
## Summary

Add a SILKSCREEN step to the build pipeline that ensures footprint reference designators are visible on silkscreen layers and adds board-level text markings (project name, revision, date) from the project spec metadata. This is the first-pass scope recommended by the curator, deferring polarity marks and intelligent auto-placement to follow-up issues.

## Changes

- Add `gr_text_node()` builder in `sexp/builders.py` for PCB board-level text elements
- Add `add_silkscreen_text()` method to `PCBEditor` for inserting gr_text nodes
- Create `silkscreen/generator.py` with `SilkscreenGenerator` class that:
  - Unhides hidden footprint ref des text on silkscreen layers (KiCad 7 and 8+ formats)
  - Adds board-level `gr_text` markings positioned near the board outline (with fallback)
  - Uses idempotency markers to prevent duplicate markings on re-runs
- Register `SILKSCREEN` build step in the pipeline enum between OUTLINE and ROUTE
- Add step dispatch in `_run_step_silkscreen()` that reads metadata from `ctx.spec.project`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Ref des text on F.SilkS is unhidden | PASS | Tests verify all 3 hide conventions (hide yes, bare hide, effects hide) |
| Board markings added from spec metadata | PASS | Tests verify name+revision and date gr_text creation |
| Idempotent (running twice does not duplicate) | PASS | Dedicated idempotency test confirms no duplicates |
| SILKSCREEN step between OUTLINE and ROUTE | PASS | Enum ordering test confirms correct position |
| KiCad 7 and 8+ format support | PASS | Tests cover both fp_text reference and property Reference |
| Save/reload roundtrip | PASS | Test saves, reloads, verifies visibility and markings persist |

## Test Plan

18 tests in `tests/test_silkscreen_generator.py`:
- `TestGrTextNode`: basic structure, custom layer, custom font, roundtrip parsing
- `TestRefDesVisibility`: hidden fp_text, already visible, bare hide atom, effects hide, KiCad 8+ property, non-silkscreen ignored
- `TestBoardMarkings`: name+date, idempotent, no metadata, position near outline, fallback position
- `TestSaveAndReload`: full roundtrip persistence
- `TestBuildStepEnum`: step exists, correct ordering

All 18 tests pass. Related tests (sexp_builders, board_outline, fix_silkscreen, build_cmd_errors) also pass.

Closes #1676