### PR TITLE
feat(validate): add solder mask clearance, pad size, and PTH annular ring checks

### DIFF
--- a/src/kicad_tools/manufacturers/base.py
+++ b/src/kicad_tools/manufacturers/base.py
@@ -83,6 +83,9 @@ class DesignRules:
     min_solder_mask_dam_mm: float = 0.1
     min_solder_mask_clearance_mm: float = 0.05
 
+    # Pad constraints
+    min_pad_size_mm: float = 0.25
+
     # Board specifications
     board_thickness_mm: float = 1.6
     outer_copper_oz: float = 1.0
@@ -117,6 +120,8 @@ class DesignRules:
             "min_silkscreen_width_mm": self.min_silkscreen_width_mm,
             "min_silkscreen_height_mm": self.min_silkscreen_height_mm,
             "min_solder_mask_dam_mm": self.min_solder_mask_dam_mm,
+            "min_solder_mask_clearance_mm": self.min_solder_mask_clearance_mm,
+            "min_pad_size_mm": self.min_pad_size_mm,
             "board_thickness_mm": self.board_thickness_mm,
             "outer_copper_oz": self.outer_copper_oz,
             "inner_copper_oz": self.inner_copper_oz,

--- a/src/kicad_tools/manufacturers/data/flashpcb.yaml
+++ b/src/kicad_tools/manufacturers/data/flashpcb.yaml
@@ -22,6 +22,8 @@ design_rules:
     min_silkscreen_width_mm: 0.08   # 3 mil
     min_silkscreen_height_mm: 0.8   # ~32 mil
     min_solder_mask_dam_mm: 0.13    # 5 mil (per FlashPCB instant tier)
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0            # No inner layers
@@ -42,6 +44,8 @@ design_rules:
     min_silkscreen_width_mm: 0.08   # 3 mil
     min_silkscreen_height_mm: 0.8   # ~32 mil
     min_solder_mask_dam_mm: 0.13    # 5 mil (per FlashPCB instant tier)
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.0
@@ -62,6 +66,8 @@ design_rules:
     min_silkscreen_width_mm: 0.08   # 3 mil
     min_silkscreen_height_mm: 0.8   # ~32 mil
     min_solder_mask_dam_mm: 0.13    # 5 mil (per FlashPCB instant tier)
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
@@ -82,6 +88,8 @@ design_rules:
     min_silkscreen_width_mm: 0.08   # 3 mil
     min_silkscreen_height_mm: 0.8   # ~32 mil
     min_solder_mask_dam_mm: 0.13    # 5 mil (per FlashPCB instant tier)
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 1.0

--- a/src/kicad_tools/manufacturers/data/jlcpcb.yaml
+++ b/src/kicad_tools/manufacturers/data/jlcpcb.yaml
@@ -19,6 +19,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
     min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0            # No inner layers
@@ -36,6 +38,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
     min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.0
@@ -53,6 +57,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
     min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
@@ -70,6 +76,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
     min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.5
@@ -87,6 +95,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
     min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5

--- a/src/kicad_tools/manufacturers/data/oshpark.yaml
+++ b/src/kicad_tools/manufacturers/data/oshpark.yaml
@@ -20,6 +20,8 @@ design_rules:
     min_silkscreen_width_mm: 0.127  # 5 mil
     min_silkscreen_height_mm: 0.762 # 30 mil
     min_solder_mask_dam_mm: 0.102   # 4 mil
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0
@@ -38,6 +40,8 @@ design_rules:
     min_silkscreen_width_mm: 0.127
     min_silkscreen_height_mm: 0.762
     min_solder_mask_dam_mm: 0.102
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0
@@ -56,6 +60,8 @@ design_rules:
     min_silkscreen_width_mm: 0.127
     min_silkscreen_height_mm: 0.762
     min_solder_mask_dam_mm: 0.102
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
@@ -74,6 +80,8 @@ design_rules:
     min_silkscreen_width_mm: 0.127
     min_silkscreen_height_mm: 0.762
     min_solder_mask_dam_mm: 0.102
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 0.8         # 0.8mm for Swift
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0
@@ -92,6 +100,8 @@ design_rules:
     min_silkscreen_width_mm: 0.127
     min_silkscreen_height_mm: 0.762
     min_solder_mask_dam_mm: 0.102
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0            # 2oz copper
     inner_copper_oz: 0.0
@@ -110,6 +120,8 @@ design_rules:
     min_silkscreen_width_mm: 0.127
     min_silkscreen_height_mm: 0.762
     min_solder_mask_dam_mm: 0.102
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.0

--- a/src/kicad_tools/manufacturers/data/pcbway.yaml
+++ b/src/kicad_tools/manufacturers/data/pcbway.yaml
@@ -18,6 +18,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
     min_solder_mask_dam_mm: 0.1    # 4 mil (per PCBWay specs)
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0
@@ -35,6 +37,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
     min_solder_mask_dam_mm: 0.1    # 4 mil (per PCBWay specs)
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.0
@@ -52,6 +56,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
     min_solder_mask_dam_mm: 0.1    # 4 mil (per PCBWay specs)
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
@@ -69,6 +75,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
     min_solder_mask_dam_mm: 0.1    # 4 mil (per PCBWay specs)
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5

--- a/src/kicad_tools/manufacturers/data/seeed.yaml
+++ b/src/kicad_tools/manufacturers/data/seeed.yaml
@@ -22,6 +22,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15   # 6 mil
     min_silkscreen_height_mm: 0.8   # 32 mil
     min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0
@@ -39,6 +41,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
     min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.0
@@ -56,6 +60,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
     min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
@@ -73,6 +79,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
     min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 1.0
@@ -90,6 +98,8 @@ design_rules:
     min_silkscreen_width_mm: 0.15
     min_silkscreen_height_mm: 0.8
     min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -56,6 +56,7 @@ class Pad:
     net_number: int = 0
     net_name: str = ""
     drill: float = 0.0
+    solder_mask_margin: float | None = None
     uuid: str = ""
 
     @property
@@ -111,6 +112,10 @@ class Pad:
         # Drill
         if drill := sexp.find("drill"):
             pad.drill = drill.get_float(0) or 0.0
+
+        # Solder mask margin (per-pad override)
+        if mask_margin := sexp.find("solder_mask_margin"):
+            pad.solder_mask_margin = mask_margin.get_float(0)
 
         # UUID
         if uuid := sexp.find("uuid"):

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -86,6 +86,7 @@ class DRCChecker:
         results.merge(self.check_dimensions())
         results.merge(self.check_edge_clearances())
         results.merge(self.check_silkscreen())
+        results.merge(self.check_solder_mask_pads())
 
         return results
 
@@ -144,6 +145,22 @@ class DRCChecker:
             DRCResults containing silkscreen violations
         """
         return check_all_silkscreen(self.pcb, self.design_rules)
+
+    def check_solder_mask_pads(self) -> DRCResults:
+        """Check solder mask and pad dimension rules.
+
+        Validates:
+        - Solder mask expansion meets manufacturer minimum clearance
+        - Minimum pad size for manufacturability
+        - PTH pad annular ring
+
+        Returns:
+            DRCResults containing solder mask and pad violations
+        """
+        from .rules.solder_mask import SolderMaskPadRules
+
+        rule = SolderMaskPadRules()
+        return rule.check(self.pcb, self.design_rules)
 
     def __repr__(self) -> str:
         return (

--- a/src/kicad_tools/validate/rules/__init__.py
+++ b/src/kicad_tools/validate/rules/__init__.py
@@ -9,6 +9,7 @@ from .clearance import ClearanceRule
 from .dimensions import DimensionRules
 from .edge import EdgeClearanceRule
 from .impedance import ImpedanceRule, NetImpedanceSpec
+from .solder_mask import SolderMaskPadRules
 from .silkscreen import (
     check_all_silkscreen,
     check_silkscreen_line_width,
@@ -23,6 +24,7 @@ __all__ = [
     "EdgeClearanceRule",
     "ImpedanceRule",
     "NetImpedanceSpec",
+    "SolderMaskPadRules",
     "check_all_silkscreen",
     "check_silkscreen_line_width",
     "check_silkscreen_over_pads",

--- a/src/kicad_tools/validate/rules/solder_mask.py
+++ b/src/kicad_tools/validate/rules/solder_mask.py
@@ -1,0 +1,225 @@
+"""Solder mask and pad dimension DRC rules.
+
+This module implements validation rules for:
+- Solder mask expansion/clearance (per-pad and board-level)
+- Minimum pad size for manufacturability
+- PTH pad annular ring (pad copper ring around drill hole)
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from ..violations import DRCResults, DRCViolation
+from .base import DRCRule
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers import DesignRules
+    from kicad_tools.schema.pcb import PCB
+
+
+class SolderMaskPadRules(DRCRule):
+    """Check solder mask and pad dimension rules.
+
+    Validates:
+    - Solder mask expansion meets manufacturer minimum clearance
+    - SMD pad dimensions meet minimum pad size
+    - PTH pad annular ring (pad size - drill) / 2
+    """
+
+    rule_id = "solder_mask_pad"
+    name = "Solder Mask & Pad Rules"
+    description = (
+        "Check solder mask clearance, minimum pad size, "
+        "and PTH pad annular ring"
+    )
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Check all solder mask and pad rules.
+
+        Args:
+            pcb: The PCB to check
+            design_rules: Design rules from the manufacturer profile
+
+        Returns:
+            DRCResults containing violations found
+        """
+        results = DRCResults()
+
+        self._check_solder_mask_clearance(pcb, design_rules, results)
+        self._check_min_pad_size(pcb, design_rules, results)
+        self._check_pth_annular_ring(pcb, design_rules, results)
+
+        # 3 rule categories checked
+        results.rules_checked = 3
+
+        return results
+
+    def _check_solder_mask_clearance(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+        results: DRCResults,
+    ) -> None:
+        """Check that solder mask expansion meets manufacturer minimum.
+
+        The solder mask clearance (expansion) is the gap between the pad
+        copper and the edge of the solder mask opening. If this is too
+        small, the mask may not register properly and could cover part
+        of the pad.
+
+        Uses per-pad solder_mask_margin when available, otherwise falls
+        back to the board-level pad_to_mask_clearance from PCB setup.
+        """
+        min_clearance = design_rules.min_solder_mask_clearance_mm
+
+        # Board-level default mask clearance from PCB setup
+        board_mask_clearance = getattr(
+            getattr(pcb, "setup", None), "pad_to_mask_clearance", 0.0
+        )
+
+        for fp in pcb.footprints:
+            for pad in fp.pads:
+                # Only check pads that have mask layers
+                has_mask = any(
+                    layer.endswith(".Mask") for layer in pad.layers
+                )
+                if not has_mask:
+                    continue
+
+                # Determine effective mask clearance for this pad
+                if pad.solder_mask_margin is not None:
+                    effective_clearance = pad.solder_mask_margin
+                else:
+                    effective_clearance = board_mask_clearance
+
+                # A clearance of 0 means the mask opening exactly matches
+                # the pad -- this is common and acceptable if the manufacturer
+                # allows it.  Only flag when the effective clearance is
+                # explicitly set to a value below the manufacturer minimum
+                # AND is non-zero (a zero value is KiCad's default meaning
+                # "use global/manufacturer default" and should not be flagged).
+                if effective_clearance != 0.0 and effective_clearance < min_clearance:
+                    abs_x = fp.position[0] + pad.position[0]
+                    abs_y = fp.position[1] + pad.position[1]
+
+                    results.add(
+                        DRCViolation(
+                            rule_id="solder_mask_clearance",
+                            severity="warning",
+                            message=(
+                                f"Solder mask clearance {effective_clearance:.3f}mm "
+                                f"< minimum {min_clearance:.3f}mm"
+                            ),
+                            location=(abs_x, abs_y),
+                            layer=None,
+                            actual_value=effective_clearance,
+                            required_value=min_clearance,
+                            items=(f"{fp.reference}-{pad.number}",),
+                        )
+                    )
+
+    def _check_min_pad_size(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+        results: DRCResults,
+    ) -> None:
+        """Check that pad dimensions meet manufacturer minimum.
+
+        Both width and height of the pad must meet the minimum pad size.
+        This applies to SMD pads primarily, as PTH pads are typically
+        larger.
+        """
+        min_size = design_rules.min_pad_size_mm
+
+        for fp in pcb.footprints:
+            for pad in fp.pads:
+                # Skip non-plated through-holes (mounting holes)
+                if pad.type == "np_thru_hole":
+                    continue
+
+                pad_w, pad_h = pad.size
+                min_dim = min(pad_w, pad_h)
+
+                if min_dim > 0 and min_dim < min_size:
+                    abs_x = fp.position[0] + pad.position[0]
+                    abs_y = fp.position[1] + pad.position[1]
+
+                    results.add(
+                        DRCViolation(
+                            rule_id="min_pad_size",
+                            severity="error",
+                            message=(
+                                f"Pad size {pad_w:.3f}x{pad_h:.3f}mm: "
+                                f"smallest dimension {min_dim:.3f}mm "
+                                f"< minimum {min_size:.3f}mm"
+                            ),
+                            location=(abs_x, abs_y),
+                            layer=fp.layer,
+                            actual_value=min_dim,
+                            required_value=min_size,
+                            items=(f"{fp.reference}-{pad.number}",),
+                        )
+                    )
+
+    def _check_pth_annular_ring(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+        results: DRCResults,
+    ) -> None:
+        """Check PTH pad annular ring.
+
+        For through-hole pads, the annular ring is the copper ring
+        around the drill hole: (min(pad_width, pad_height) - drill) / 2.
+        This must meet the manufacturer's minimum annular ring.
+
+        Note: This reuses min_annular_ring_mm from the design rules,
+        which is the same constraint used for vias. Manufacturers
+        typically apply the same minimum to both.
+        """
+        min_annular = design_rules.min_annular_ring_mm
+
+        for fp in pcb.footprints:
+            for pad in fp.pads:
+                if pad.type != "thru_hole":
+                    continue
+                if pad.drill <= 0:
+                    continue
+
+                pad_w, pad_h = pad.size
+                min_pad_dim = min(pad_w, pad_h)
+
+                # Annular ring = (pad dimension - drill) / 2
+                annular_ring = (min_pad_dim - pad.drill) / 2
+
+                if annular_ring < min_annular:
+                    abs_x = fp.position[0] + pad.position[0]
+                    abs_y = fp.position[1] + pad.position[1]
+                    net_name = pad.net_name or f"net:{pad.net_number}"
+
+                    results.add(
+                        DRCViolation(
+                            rule_id="pth_annular_ring",
+                            severity="error",
+                            message=(
+                                f"PTH annular ring {annular_ring:.3f}mm "
+                                f"< minimum {min_annular:.3f}mm "
+                                f"(pad {min_pad_dim:.3f}mm, drill {pad.drill:.3f}mm)"
+                            ),
+                            location=(abs_x, abs_y),
+                            layer=None,
+                            actual_value=annular_ring,
+                            required_value=min_annular,
+                            items=(
+                                f"{fp.reference}-{pad.number}",
+                                net_name,
+                            ),
+                        )
+                    )

--- a/tests/test_validate_solder_mask.py
+++ b/tests/test_validate_solder_mask.py
@@ -1,0 +1,554 @@
+"""Tests for solder mask and pad dimension DRC rules."""
+
+import pytest
+
+from kicad_tools.validate.rules.solder_mask import SolderMaskPadRules
+
+
+# -- Mock classes ----------------------------------------------------------
+
+
+class MockSetup:
+    """Mock PCB setup with board-level mask clearance."""
+
+    def __init__(self, pad_to_mask_clearance: float = 0.0):
+        self.pad_to_mask_clearance = pad_to_mask_clearance
+
+
+class MockDesignRules:
+    """Mock design rules for testing."""
+
+    def __init__(
+        self,
+        min_solder_mask_clearance_mm: float = 0.05,
+        min_pad_size_mm: float = 0.25,
+        min_annular_ring_mm: float = 0.15,
+    ):
+        self.min_solder_mask_clearance_mm = min_solder_mask_clearance_mm
+        self.min_pad_size_mm = min_pad_size_mm
+        self.min_annular_ring_mm = min_annular_ring_mm
+
+
+class MockPad:
+    """Mock pad for testing."""
+
+    def __init__(
+        self,
+        number: str = "1",
+        type: str = "smd",
+        position: tuple[float, float] = (0.0, 0.0),
+        size: tuple[float, float] = (1.0, 1.0),
+        layers: list[str] | None = None,
+        drill: float = 0.0,
+        net_name: str = "",
+        net_number: int = 0,
+        solder_mask_margin: float | None = None,
+    ):
+        self.number = number
+        self.type = type
+        self.position = position
+        self.size = size
+        self.layers = layers or ["F.Cu", "F.Paste", "F.Mask"]
+        self.drill = drill
+        self.net_name = net_name
+        self.net_number = net_number
+        self.solder_mask_margin = solder_mask_margin
+
+
+class MockFootprint:
+    """Mock footprint for testing."""
+
+    def __init__(
+        self,
+        reference: str = "U1",
+        position: tuple[float, float] = (10.0, 20.0),
+        layer: str = "F.Cu",
+        pads: list[MockPad] | None = None,
+    ):
+        self.reference = reference
+        self.position = position
+        self.layer = layer
+        self.pads = pads or []
+
+
+class MockPCB:
+    """Mock PCB for testing solder mask rules."""
+
+    def __init__(
+        self,
+        footprints: list[MockFootprint] | None = None,
+        setup: MockSetup | None = None,
+    ):
+        self.footprints = footprints or []
+        self.setup = setup or MockSetup()
+
+
+# -- Solder Mask Clearance Tests -------------------------------------------
+
+
+class TestSolderMaskClearance:
+    """Tests for solder mask clearance validation."""
+
+    def test_no_violation_with_zero_clearance(self):
+        """Zero mask clearance (KiCad default) should not be flagged."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(solder_mask_margin=None),
+                ]),
+            ],
+            setup=MockSetup(pad_to_mask_clearance=0.0),
+        )
+        rules = MockDesignRules(min_solder_mask_clearance_mm=0.05)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        mask_violations = [v for v in results.violations if v.rule_id == "solder_mask_clearance"]
+        assert len(mask_violations) == 0
+
+    def test_violation_with_small_per_pad_clearance(self):
+        """Per-pad mask clearance below minimum should be flagged."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(solder_mask_margin=0.02),
+                ]),
+            ],
+        )
+        rules = MockDesignRules(min_solder_mask_clearance_mm=0.05)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        mask_violations = [v for v in results.violations if v.rule_id == "solder_mask_clearance"]
+        assert len(mask_violations) == 1
+        assert mask_violations[0].severity == "warning"
+        assert mask_violations[0].actual_value == pytest.approx(0.02)
+        assert mask_violations[0].required_value == pytest.approx(0.05)
+
+    def test_violation_with_small_board_level_clearance(self):
+        """Board-level mask clearance below minimum should be flagged."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(solder_mask_margin=None),
+                ]),
+            ],
+            setup=MockSetup(pad_to_mask_clearance=0.03),
+        )
+        rules = MockDesignRules(min_solder_mask_clearance_mm=0.05)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        mask_violations = [v for v in results.violations if v.rule_id == "solder_mask_clearance"]
+        assert len(mask_violations) == 1
+
+    def test_no_violation_with_adequate_clearance(self):
+        """Clearance at or above minimum should pass."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(solder_mask_margin=0.05),
+                ]),
+            ],
+        )
+        rules = MockDesignRules(min_solder_mask_clearance_mm=0.05)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        mask_violations = [v for v in results.violations if v.rule_id == "solder_mask_clearance"]
+        assert len(mask_violations) == 0
+
+    def test_pads_without_mask_layer_skipped(self):
+        """Pads without mask layers should not be checked."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(
+                        solder_mask_margin=0.01,
+                        layers=["F.Cu"],  # No mask layer
+                    ),
+                ]),
+            ],
+        )
+        rules = MockDesignRules(min_solder_mask_clearance_mm=0.05)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        mask_violations = [v for v in results.violations if v.rule_id == "solder_mask_clearance"]
+        assert len(mask_violations) == 0
+
+    def test_per_pad_overrides_board_level(self):
+        """Per-pad margin should override board-level setting."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(solder_mask_margin=0.06),  # Above min
+                ]),
+            ],
+            setup=MockSetup(pad_to_mask_clearance=0.01),  # Below min
+        )
+        rules = MockDesignRules(min_solder_mask_clearance_mm=0.05)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        mask_violations = [v for v in results.violations if v.rule_id == "solder_mask_clearance"]
+        assert len(mask_violations) == 0
+
+
+# -- Minimum Pad Size Tests ------------------------------------------------
+
+
+class TestMinPadSize:
+    """Tests for minimum pad size validation."""
+
+    def test_adequate_pad_size_passes(self):
+        """Pads at or above minimum should pass."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(size=(0.5, 0.8)),
+                ]),
+            ],
+        )
+        rules = MockDesignRules(min_pad_size_mm=0.25)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pad_violations = [v for v in results.violations if v.rule_id == "min_pad_size"]
+        assert len(pad_violations) == 0
+
+    def test_undersized_pad_detected(self):
+        """Pad with smallest dimension below minimum should be flagged."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(size=(0.2, 0.5)),  # Width 0.2 < 0.25
+                ]),
+            ],
+        )
+        rules = MockDesignRules(min_pad_size_mm=0.25)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pad_violations = [v for v in results.violations if v.rule_id == "min_pad_size"]
+        assert len(pad_violations) == 1
+        assert pad_violations[0].severity == "error"
+        assert pad_violations[0].actual_value == pytest.approx(0.2)
+        assert pad_violations[0].required_value == pytest.approx(0.25)
+        assert "U1-1" in pad_violations[0].items
+
+    def test_npth_pads_skipped(self):
+        """Non-plated through holes should not be checked for size."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(
+                        type="np_thru_hole",
+                        size=(0.1, 0.1),
+                        drill=0.1,
+                        layers=["*.Cu"],
+                    ),
+                ]),
+            ],
+        )
+        rules = MockDesignRules(min_pad_size_mm=0.25)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pad_violations = [v for v in results.violations if v.rule_id == "min_pad_size"]
+        assert len(pad_violations) == 0
+
+    def test_multiple_undersized_pads(self):
+        """Multiple undersized pads should all be reported."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(
+                    reference="C1",
+                    pads=[
+                        MockPad(number="1", size=(0.15, 0.3)),
+                        MockPad(number="2", size=(0.15, 0.3)),
+                    ],
+                ),
+            ],
+        )
+        rules = MockDesignRules(min_pad_size_mm=0.25)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pad_violations = [v for v in results.violations if v.rule_id == "min_pad_size"]
+        assert len(pad_violations) == 2
+
+    def test_violation_location_is_absolute(self):
+        """Violation location should be absolute (footprint + pad position)."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(
+                    position=(100.0, 200.0),
+                    pads=[
+                        MockPad(position=(5.0, 3.0), size=(0.1, 0.1)),
+                    ],
+                ),
+            ],
+        )
+        rules = MockDesignRules(min_pad_size_mm=0.25)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pad_violations = [v for v in results.violations if v.rule_id == "min_pad_size"]
+        assert len(pad_violations) == 1
+        assert pad_violations[0].location == pytest.approx((105.0, 203.0))
+
+
+# -- PTH Annular Ring Tests ------------------------------------------------
+
+
+class TestPTHAnnularRing:
+    """Tests for PTH pad annular ring validation."""
+
+    def test_adequate_annular_ring_passes(self):
+        """Through-hole pad with adequate ring should pass."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(
+                        type="thru_hole",
+                        size=(1.8, 1.8),
+                        drill=1.0,
+                        layers=["*.Cu", "*.Mask"],
+                        net_name="VCC",
+                    ),
+                ]),
+            ],
+        )
+        # annular_ring = (1.8 - 1.0) / 2 = 0.4mm > 0.15mm
+        rules = MockDesignRules(min_annular_ring_mm=0.15)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pth_violations = [v for v in results.violations if v.rule_id == "pth_annular_ring"]
+        assert len(pth_violations) == 0
+
+    def test_undersized_annular_ring_detected(self):
+        """Through-hole pad with thin ring should be flagged."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(
+                    reference="R1",
+                    pads=[
+                        MockPad(
+                            type="thru_hole",
+                            size=(1.1, 1.1),
+                            drill=1.0,
+                            layers=["*.Cu", "*.Mask"],
+                            net_name="GND",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        # annular_ring = (1.1 - 1.0) / 2 = 0.05mm < 0.15mm
+        rules = MockDesignRules(min_annular_ring_mm=0.15)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pth_violations = [v for v in results.violations if v.rule_id == "pth_annular_ring"]
+        assert len(pth_violations) == 1
+        assert pth_violations[0].severity == "error"
+        assert pth_violations[0].actual_value == pytest.approx(0.05)
+        assert pth_violations[0].required_value == pytest.approx(0.15)
+        assert "R1-1" in pth_violations[0].items
+        assert "GND" in pth_violations[0].items
+
+    def test_smd_pads_not_checked_for_annular_ring(self):
+        """SMD pads should not be checked for annular ring."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(type="smd", size=(0.5, 0.5)),
+                ]),
+            ],
+        )
+        rules = MockDesignRules(min_annular_ring_mm=0.15)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pth_violations = [v for v in results.violations if v.rule_id == "pth_annular_ring"]
+        assert len(pth_violations) == 0
+
+    def test_oval_pad_uses_smallest_dimension(self):
+        """Oval pad should use smallest dimension for annular ring."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(
+                    reference="J1",
+                    pads=[
+                        MockPad(
+                            type="thru_hole",
+                            size=(2.0, 1.2),  # Oval pad
+                            drill=1.0,
+                            layers=["*.Cu", "*.Mask"],
+                            net_name="SIG",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        # annular_ring = (min(2.0, 1.2) - 1.0) / 2 = (1.2 - 1.0) / 2 = 0.1mm
+        rules = MockDesignRules(min_annular_ring_mm=0.15)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pth_violations = [v for v in results.violations if v.rule_id == "pth_annular_ring"]
+        assert len(pth_violations) == 1
+        assert pth_violations[0].actual_value == pytest.approx(0.1)
+
+    def test_no_drill_skipped(self):
+        """Through-hole pad with no drill should be skipped."""
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(pads=[
+                    MockPad(type="thru_hole", size=(1.0, 1.0), drill=0.0),
+                ]),
+            ],
+        )
+        rules = MockDesignRules(min_annular_ring_mm=0.15)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pth_violations = [v for v in results.violations if v.rule_id == "pth_annular_ring"]
+        assert len(pth_violations) == 0
+
+
+# -- Rules Metadata Tests --------------------------------------------------
+
+
+class TestSolderMaskPadRulesMetadata:
+    """Test SolderMaskPadRules class metadata."""
+
+    def test_rule_id(self):
+        rule = SolderMaskPadRules()
+        assert rule.rule_id == "solder_mask_pad"
+
+    def test_rule_name(self):
+        rule = SolderMaskPadRules()
+        assert rule.name == "Solder Mask & Pad Rules"
+
+    def test_rules_checked_count(self):
+        """Should report 3 rule categories."""
+        pcb = MockPCB()
+        rules = MockDesignRules()
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+        assert results.rules_checked == 3
+
+    def test_empty_pcb_no_violations(self):
+        """Empty PCB should produce no violations."""
+        pcb = MockPCB()
+        rules = MockDesignRules()
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+        assert len(results.violations) == 0
+
+
+# -- Integration Test -------------------------------------------------------
+
+
+class TestSolderMaskPadIntegration:
+    """Integration test with DRCChecker."""
+
+    def test_check_all_includes_solder_mask_rules(self):
+        """Verify check_all() includes solder mask/pad rules in results."""
+        from kicad_tools.schema.pcb import PCB, Footprint, Pad
+        from kicad_tools.sexp import SExp
+        from kicad_tools.validate import DRCChecker
+
+        sexp = SExp(name="kicad_pcb")
+        pcb = PCB(sexp)
+
+        # Add a footprint with an undersized pad
+        fp = Footprint(
+            name="TestFP",
+            layer="F.Cu",
+            position=(10.0, 20.0),
+            rotation=0.0,
+            reference="C1",
+            value="100nF",
+            pads=[
+                Pad(
+                    number="1",
+                    type="smd",
+                    shape="roundrect",
+                    position=(0.0, 0.0),
+                    size=(0.15, 0.3),  # Width below 0.25mm min
+                    layers=["F.Cu", "F.Paste", "F.Mask"],
+                ),
+            ],
+        )
+        pcb._footprints.append(fp)
+
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+        results = checker.check_all()
+
+        # Should find the undersized pad
+        pad_violations = [v for v in results.violations if v.rule_id == "min_pad_size"]
+        assert len(pad_violations) == 1
+
+        # rules_checked should include solder_mask_pad (3 rules)
+        assert results.rules_checked >= 3
+
+    def test_check_solder_mask_pads_method(self):
+        """Verify DRCChecker.check_solder_mask_pads() works standalone."""
+        from kicad_tools.schema.pcb import PCB, Footprint, Pad
+        from kicad_tools.sexp import SExp
+        from kicad_tools.validate import DRCChecker
+
+        sexp = SExp(name="kicad_pcb")
+        pcb = PCB(sexp)
+
+        fp = Footprint(
+            name="TestFP",
+            layer="F.Cu",
+            position=(0.0, 0.0),
+            rotation=0.0,
+            reference="R1",
+            value="10k",
+            pads=[
+                Pad(
+                    number="1",
+                    type="thru_hole",
+                    shape="circle",
+                    position=(0.0, 0.0),
+                    size=(1.1, 1.1),
+                    layers=["*.Cu", "*.Mask"],
+                    drill=1.0,
+                    net_name="NET1",
+                ),
+            ],
+        )
+        pcb._footprints.append(fp)
+
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+        results = checker.check_solder_mask_pads()
+
+        # PTH annular ring = (1.1 - 1.0) / 2 = 0.05 < 0.15
+        pth_violations = [v for v in results.violations if v.rule_id == "pth_annular_ring"]
+        assert len(pth_violations) == 1
+        assert results.rules_checked == 3


### PR DESCRIPTION
## Summary

Adds three new Priority 1 (blocking for fab) DRC rule checks to the pure Python validator (`kct check`): solder mask clearance, minimum pad size, and PTH pad annular ring. This is Sub-issue A of #1675.

## Changes

- **New rule module** `src/kicad_tools/validate/rules/solder_mask.py` implementing `SolderMaskPadRules` with three checks:
  - Solder mask expansion/clearance against manufacturer minimum (per-pad and board-level)
  - Minimum pad size (smallest dimension vs manufacturer threshold)
  - PTH pad annular ring ((pad_size - drill) / 2 vs min_annular_ring)
- **Pad schema**: Parse per-pad `solder_mask_margin` from KiCad S-expression in `Pad.from_sexp()`
- **DesignRules**: Add `min_pad_size_mm` field; add `min_solder_mask_clearance_mm` and `min_pad_size_mm` to `to_dict()` serialization
- **Manufacturer configs**: Add `min_solder_mask_clearance_mm` and `min_pad_size_mm` to all 5 YAML configs (jlcpcb, oshpark, pcbway, seeed, flashpcb)
- **Checker integration**: Wire `SolderMaskPadRules` into `DRCChecker.check_all()` and expose via `check_solder_mask_pads()`
- **22 unit tests** covering all three rule categories, edge cases, and integration

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Solder mask expansion/clearance check | Done | `solder_mask_clearance` rule checks per-pad and board-level mask margin |
| Minimum pad size per manufacturer | Done | `min_pad_size` rule flags pads below `min_pad_size_mm` |
| PTH pad annular ring | Done | `pth_annular_ring` rule checks (pad - drill) / 2 |
| `min_solder_mask_clearance_mm` in all YAMLs and `to_dict()` | Done | All 5 YAML configs updated, verified programmatically |
| Per-pad `solder_mask_margin` parsed in `Pad.from_sexp()` | Done | New field with S-expression parsing |
| Existing tests pass (no regressions) | Done | 130 passed, 5 skipped |
| Each new rule has unit tests | Done | 22 tests total |

## Test Plan

- `uv run pytest tests/test_validate_solder_mask.py -x -q` -- 22 passed
- `uv run pytest tests/test_validate.py tests/test_validate_dimensions.py tests/test_validate_solder_mask.py -x -q` -- 130 passed, 5 skipped

Closes #1675