### PR TITLE
fix(router): validate via-to-via clearance during route placement

### DIFF
--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -1075,6 +1075,65 @@ class RoutingGrid:
         is_valid = not has_violation
         return is_valid, min_actual_clearance, violation_loc
 
+    def validate_via_to_via_clearance(
+        self,
+        via: "Via",
+        exclude_net: int,
+        min_clearance: float | None = None,
+    ) -> tuple[bool, float, tuple[float, float] | None]:
+        """Validate geometric clearance of a via against all other-net vias.
+
+        Issue #1693: Complements validate_via_clearance() by checking vias
+        against other-net vias. Without this, two vias from different nets can
+        be placed too close together, creating a DRC violation that grid-based
+        checking misses because the grid marking radius is tuned for trace
+        avoidance, not via-to-via proximity.
+
+        Uses simple center-to-center Euclidean distance minus both via radii
+        to compute edge-to-edge clearance. No layer filtering is needed since
+        vias are through-hole.
+
+        Args:
+            via: The via to validate
+            exclude_net: Net ID to exclude (same-net vias don't violate clearance)
+            min_clearance: Minimum required clearance (default: rules.via_clearance)
+
+        Returns:
+            Tuple of (is_valid, actual_clearance, violation_location)
+            - is_valid: True if via meets clearance requirements
+            - actual_clearance: Minimum clearance found (negative if overlapping)
+            - violation_location: (x, y) of worst violation, or None if valid
+        """
+        import math
+
+        if min_clearance is None:
+            min_clearance = self.rules.via_clearance
+
+        via_radius = via.diameter / 2
+        min_actual_clearance = float("inf")
+        violation_loc: tuple[float, float] | None = None
+        has_violation = False
+
+        for route in self.routes:
+            if route.net == exclude_net:
+                continue
+
+            for existing_via in route.vias:
+                distance = math.sqrt(
+                    (via.x - existing_via.x) ** 2 + (via.y - existing_via.y) ** 2
+                )
+                existing_via_radius = existing_via.diameter / 2
+                clearance = distance - via_radius - existing_via_radius
+
+                if clearance < min_actual_clearance:
+                    min_actual_clearance = clearance
+                if clearance < min_clearance:
+                    has_violation = True
+                    violation_loc = (via.x, via.y)
+
+        is_valid = not has_violation
+        return is_valid, min_actual_clearance, violation_loc
+
     def _point_to_segment_distance(
         self,
         px: float,

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -1849,6 +1849,14 @@ class Router:
             if not is_valid:
                 return False
 
+        # Issue #1693: Validate vias against other-net vias
+        for via in route.vias:
+            is_valid, _clearance, _location = self.grid.validate_via_to_via_clearance(
+                via, exclude_net=exclude_net
+            )
+            if not is_valid:
+                return False
+
         return True
 
     def _reconstruct_route(self, end_node: AStarNode, start_pad: Pad, end_pad: Pad) -> Route | None:

--- a/tests/test_router_grid.py
+++ b/tests/test_router_grid.py
@@ -1376,6 +1376,186 @@ class TestViaClearanceValidation:
         assert clearance < grid.rules.via_clearance
 
 
+class TestViaToViaClearanceValidation:
+    """Tests for validate_via_to_via_clearance() -- Issue #1693.
+
+    Verifies that vias are checked against other-net vias for clearance
+    violations. This catches via-to-via violations that grid-based checking
+    misses because the grid marking radius is tuned for trace avoidance,
+    not via-to-via proximity.
+    """
+
+    @pytest.fixture
+    def grid(self):
+        """Create a routing grid for via-to-via clearance testing."""
+        rules = DesignRules(
+            grid_resolution=0.1,
+            trace_width=0.2,
+            trace_clearance=0.127,
+            via_drill=0.35,
+            via_diameter=0.7,
+            via_clearance=0.2,
+        )
+        return RoutingGrid(width=20.0, height=20.0, rules=rules)
+
+    def test_via_to_via_far_apart(self, grid):
+        """Test via far from other-net via passes validation."""
+        other_route = Route(net=1, net_name="NET1")
+        other_route.vias.append(
+            Via(x=5.0, y=5.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(other_route)
+
+        # Place a via far away (at 15.0, 15.0)
+        via = Via(
+            x=15.0, y=15.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="NET2",
+        )
+
+        is_valid, clearance, location = grid.validate_via_to_via_clearance(via, exclude_net=2)
+
+        assert is_valid is True
+        # Distance = sqrt(200) ~ 14.14, edge clearance = 14.14 - 0.35 - 0.35 = 13.44
+        assert clearance > grid.rules.via_clearance
+        assert location is None
+
+    def test_via_to_via_too_close(self, grid):
+        """Test via too close to other-net via is detected as violation."""
+        other_route = Route(net=1, net_name="NET1")
+        other_route.vias.append(
+            Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(other_route)
+
+        # Place a via very close: center distance = 0.8
+        # Edge clearance = 0.8 - 0.35 - 0.35 = 0.1, required = 0.2 => violation
+        via = Via(
+            x=10.8, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="NET2",
+        )
+
+        is_valid, clearance, location = grid.validate_via_to_via_clearance(via, exclude_net=2)
+
+        assert is_valid is False
+        assert clearance < grid.rules.via_clearance
+        assert location is not None
+        assert location == (10.8, 10.0)
+
+    def test_via_to_via_same_net_ignored(self, grid):
+        """Test that same-net vias are ignored in clearance check."""
+        same_net_route = Route(net=2, net_name="NET2")
+        same_net_route.vias.append(
+            Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="NET2")
+        )
+        grid.routes.append(same_net_route)
+
+        # Place a via overlapping the same-net via
+        via = Via(
+            x=10.0, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="NET2",
+        )
+
+        is_valid, clearance, location = grid.validate_via_to_via_clearance(via, exclude_net=2)
+
+        assert is_valid is True
+
+    def test_via_to_via_at_exact_boundary(self, grid):
+        """Test via exactly at clearance boundary passes validation."""
+        other_route = Route(net=1, net_name="NET1")
+        other_route.vias.append(
+            Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(other_route)
+
+        # Edge-to-edge clearance == required_clearance should pass
+        # Required clearance = 0.2, via radius = 0.35 each
+        # Need: distance - 0.35 - 0.35 = 0.2 => distance = 0.9
+        via = Via(
+            x=10.9, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="NET2",
+        )
+
+        is_valid, clearance, location = grid.validate_via_to_via_clearance(via, exclude_net=2)
+
+        assert is_valid is True
+        assert abs(clearance - 0.2) < 0.01
+
+    def test_via_to_via_just_below_boundary(self, grid):
+        """Test via 0.001mm below clearance boundary is detected as violation."""
+        other_route = Route(net=1, net_name="NET1")
+        other_route.vias.append(
+            Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(other_route)
+
+        # Edge clearance = 0.899 - 0.35 - 0.35 = 0.199, just below 0.2
+        via = Via(
+            x=10.899, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="NET2",
+        )
+
+        is_valid, clearance, location = grid.validate_via_to_via_clearance(via, exclude_net=2)
+
+        assert is_valid is False
+        assert clearance < grid.rules.via_clearance
+
+    def test_via_to_via_different_diameters(self, grid):
+        """Test via-to-via clearance with different via diameters."""
+        other_route = Route(net=1, net_name="NET1")
+        # Larger via with diameter 1.0
+        other_route.vias.append(
+            Via(x=10.0, y=10.0, drill=0.5, diameter=1.0,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(other_route)
+
+        # Standard via (diameter 0.7) placed too close
+        # Center distance = 0.9, edge clearance = 0.9 - 0.5 - 0.35 = 0.05 < 0.2
+        via = Via(
+            x=10.9, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="NET2",
+        )
+
+        is_valid, clearance, location = grid.validate_via_to_via_clearance(via, exclude_net=2)
+
+        assert is_valid is False
+        assert clearance < grid.rules.via_clearance
+
+    def test_via_to_via_multiple_existing_vias(self, grid):
+        """Test via checked against multiple existing vias from different nets."""
+        # Add vias on two different nets
+        route1 = Route(net=1, net_name="NET1")
+        route1.vias.append(
+            Via(x=5.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(route1)
+
+        route3 = Route(net=3, net_name="NET3")
+        route3.vias.append(
+            Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=3, net_name="NET3")
+        )
+        grid.routes.append(route3)
+
+        # Place via close to NET3's via but far from NET1's via
+        # Distance to NET3 via = 0.8, edge clearance = 0.8 - 0.35 - 0.35 = 0.1 < 0.2
+        via = Via(
+            x=10.8, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="NET2",
+        )
+
+        is_valid, clearance, location = grid.validate_via_to_via_clearance(via, exclude_net=2)
+
+        assert is_valid is False
+        assert clearance < grid.rules.via_clearance
+
+
 class TestHeuristics:
     """Tests for heuristic classes."""
 


### PR DESCRIPTION
## Summary
Add via-to-via geometric clearance validation to the router's A* search loop. Previously, via-to-via clearance was only checked in post-save validation (io.py), meaning violations were already baked into the routed PCB. Now the pathfinder rejects candidate routes with via-to-via violations during search, causing it to try alternative via positions.

## Changes
- Add `validate_via_to_via_clearance()` method to `Grid` class in `grid.py` -- checks a candidate via against all existing other-net vias using edge-to-edge Euclidean distance
- Call the new method from `_validate_route_clearance()` in `pathfinder.py` for each via in the candidate route
- Add `TestViaToViaClearanceValidation` test class with 7 tests covering: valid placement, violation detection, same-net exclusion, exact boundary, sub-boundary violation, different diameters, and multiple existing vias

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New `validate_via_to_via_clearance()` method added to Grid | Pass | Method added at grid.py after `validate_via_clearance()` |
| `_validate_route_clearance()` calls the new method | Pass | Loop added in pathfinder.py after existing via-to-segment check |
| No regression in existing router tests | Pass | All 353 tests pass across test_router_grid.py, test_router_io.py, test_router_primitives.py |

## Test Plan
- 7 new unit tests all pass covering: far apart (valid), too close (violation), same-net ignored, exact boundary (valid), 0.001mm below boundary (violation), different diameters, multiple existing vias from different nets
- Full regression: `pytest tests/test_router_grid.py tests/test_router_io.py tests/test_router_primitives.py` -- 353 passed in 0.78s

Closes #1693