### PR TITLE
fix(router): allow sub-grid escape through neighbor clearance zones

### DIFF
--- a/src/kicad_tools/router/subgrid.py
+++ b/src/kicad_tools/router/subgrid.py
@@ -223,13 +223,20 @@ class SubGridRouter:
         grid: RoutingGrid,
         rules: DesignRules,
         grid_tolerance: float | None = None,
-        escape_search_radius: int = 3,
+        escape_search_radius: int | None = None,
         clearance_weight: float = 2.5,
     ):
         self.grid = grid
         self.rules = rules
         self.grid_tolerance = grid_tolerance if grid_tolerance is not None else grid.resolution / 4
-        self.escape_search_radius = escape_search_radius
+        # Adaptive search radius: at fine grids (< 0.1mm), 3 cells may not
+        # reach past neighboring clearance zones for fine-pitch packages.
+        # Scale the radius so the physical search distance is at least 0.3mm.
+        if escape_search_radius is not None:
+            self.escape_search_radius = escape_search_radius
+        else:
+            min_search_mm = 0.3  # minimum physical search distance
+            self.escape_search_radius = max(3, math.ceil(min_search_mm / grid.resolution))
         self.clearance_weight = clearance_weight
 
     def analyze_pads(
@@ -387,17 +394,30 @@ class SubGridRouter:
             for layer_idx in layer_indices:
                 if 0 <= gx < self.grid.cols and 0 <= gy < self.grid.rows:
                     cell = self.grid.grid[layer_idx][gy][gx]
-                    # Only unblock if the cell belongs to our net or is unassigned
-                    if cell.net == pad.net or cell.net == 0:
-                        if cell.blocked and not cell.pad_blocked:
-                            # This is a clearance zone cell, not actual pad copper.
-                            # Unblock it so the router can reach this grid point.
-                            cell.blocked = False
-                            cell.net = pad.net
-                            unblocked += 1
-                        elif not cell.blocked:
-                            # Already unblocked, just ensure net assignment
-                            cell.net = pad.net
+                    # Unblock clearance-zone cells so the router can reach
+                    # this grid point.  Clearance-zone cells (blocked but NOT
+                    # pad_blocked) may belong to a neighboring pad's net at
+                    # fine pitch (e.g. 0.65mm on 0.05mm grid).  The escape
+                    # segment was already validated by
+                    # validate_segment_clearance() in generate_escape_segments,
+                    # so overriding the net assignment here is safe.  Actual
+                    # copper (pad_blocked=True) is never unblocked.
+                    if cell.blocked and not cell.pad_blocked:
+                        # Clearance-zone cell -- safe to claim for our net
+                        prev_net = cell.net
+                        cell.blocked = False
+                        cell.net = pad.net
+                        unblocked += 1
+                        if prev_net != pad.net and prev_net != 0:
+                            logger.debug(
+                                "Overriding clearance cell (%d,%d) net %d -> "
+                                "%d for %s.%s escape",
+                                gx, gy, prev_net, pad.net,
+                                pad.ref, pad.pin,
+                            )
+                    elif not cell.blocked:
+                        # Already unblocked, just ensure net assignment
+                        cell.net = pad.net
 
         result.unblocked_count = unblocked
         logger.info("Sub-grid escape: unblocked %d grid cells", unblocked)
@@ -536,24 +556,32 @@ class SubGridRouter:
                 # Distance from pad center to this grid point
                 dist = math.sqrt((pad.x - snap_x) ** 2 + (pad.y - snap_y) ** 2)
 
-                # Check if this grid point is accessible on any valid layer
+                # Check if this grid point is a valid escape target on any
+                # valid layer.  The escape target must be a cell that
+                # apply_escape_segments() can make routable:
+                #   - Already unblocked (free cell -- no action needed)
+                #   - Clearance-zone cell of ANY net (blocked, not
+                #     pad_blocked) -- apply_escape_segments will unblock it
+                # Cells that are the pad's own copper (pad_blocked, same net)
+                # are NOT useful targets: they are already blocked and
+                # cannot be unblocked (they ARE the pad).  The router needs
+                # an entry point OUTSIDE the pad copper.
+                # Cells that are another net's copper (pad_blocked, different
+                # net) are also rejected -- cannot unblock real copper.
                 accessible = False
                 for layer_idx in check_layers:
                     cell = self.grid.grid[layer_idx][gy][gx]
-                    # Accept cells that are:
-                    # - Unblocked
-                    # - Same-net (our pad's clearance zone)
-                    # - Clearance-only (not actual pad copper from other net)
                     if not cell.blocked:
+                        # Free cell -- router can already reach it
                         accessible = True
                         break
-                    elif cell.net == pad.net:
+                    elif not cell.pad_blocked:
+                        # Clearance-zone cell (any net) -- can be unblocked
+                        # by apply_escape_segments; validate_segment_clearance
+                        # will do the precise DRC check later.
                         accessible = True
                         break
-                    elif not cell.pad_blocked and cell.original_net == pad.net:
-                        # Clearance zone of our own pad
-                        accessible = True
-                        break
+                    # pad_blocked cells (own or other net copper) are skipped
 
                 if not accessible:
                     continue

--- a/src/kicad_tools/router/subgrid.py
+++ b/src/kicad_tools/router/subgrid.py
@@ -215,7 +215,8 @@ class SubGridRouter:
             Default is resolution/4, which catches pads that are more than
             25% of a grid cell away from the nearest grid point.
         escape_search_radius: Number of grid cells to search for a valid
-            escape endpoint. Default is 3 cells.
+            escape endpoint. Default adapts to grid resolution
+            (minimum 3 cells, scaled so search covers at least 0.3mm).
     """
 
     def __init__(

--- a/tests/test_subgrid.py
+++ b/tests/test_subgrid.py
@@ -1179,3 +1179,245 @@ class TestClearanceWeightedSelection:
                 escape.segment, exclude_net=escape.pad.net,
             )
             assert is_valid
+
+
+class TestFineGridClearanceZoneUnblocking:
+    """Tests for Issue #1703: sub-grid escape at 0.05mm grid with SSOP/QFP pads.
+
+    At fine grids (0.05mm), neighboring pads' clearance zones overlap the
+    nearest grid point to an off-grid pad.  The escape system must:
+    1. Allow escape candidates in clearance-zone cells of other nets.
+    2. Unblock those cells in apply_escape_segments even when the cell's
+       net differs from the pad's net.
+    3. Never unblock actual copper (pad_blocked=True).
+    """
+
+    def test_ssop28_at_005mm_grid(self):
+        """SSOP-28 at 0.65mm pitch on 0.05mm grid should produce escape
+        segments that unblock grid cells.
+
+        This is the primary regression test for the '0 cells unblocked'
+        failure reported in Issue #1703.  The component is placed at an
+        off-grid position (base_y=3.023mm) so that pads fall between
+        grid points -- matching real-world placement where SSOP pads
+        are off-grid by 0.02-0.08mm.
+        """
+        grid, rules = make_grid_and_rules(
+            width=20.0,
+            height=20.0,
+            resolution=0.05,
+            trace_width=0.2,
+            trace_clearance=0.15,
+        )
+        subgrid = SubGridRouter(grid, rules)
+
+        # Create SSOP-28: 14 pads per side, 0.65mm pitch
+        # Place component at an off-grid position so pads don't snap to grid
+        pads = []
+        base_x = 5.023
+        base_y = 3.017
+
+        # Left side pads (pin 1-14)
+        for i in range(14):
+            pads.append(make_pad(
+                x=base_x,
+                y=base_y + i * 0.65,
+                net=i + 1,
+                ref="U1",
+                pin=str(i + 1),
+                width=0.3,
+                height=0.45,
+            ))
+
+        # Right side pads (pin 15-28)
+        for i in range(14):
+            pads.append(make_pad(
+                x=base_x + 6.0,
+                y=base_y + i * 0.65,
+                net=i + 15,
+                ref="U1",
+                pin=str(i + 15),
+                width=0.3,
+                height=0.45,
+            ))
+
+        for p in pads:
+            grid.add_pad(p)
+
+        analysis = subgrid.analyze_pads(pads)
+        # Most pads should be off-grid (0.65 / 0.05 = 13, but base_y offset
+        # means many pads land between grid points)
+        assert analysis.has_off_grid_pads
+        assert analysis.off_grid_count > 0
+
+        result = subgrid.generate_escape_segments(analysis)
+        unblocked = subgrid.apply_escape_segments(result)
+
+        # Key assertion: cells must actually be unblocked (was 0 before fix)
+        assert unblocked > 0, (
+            f"Expected >0 cells unblocked, got {unblocked}. "
+            f"{result.success_count}/{result.total_attempted} escapes generated."
+        )
+        # At least half the off-grid pads should escape successfully
+        assert result.success_count >= analysis.off_grid_count * 0.5, (
+            f"Only {result.success_count}/{analysis.off_grid_count} pads escaped"
+        )
+
+    def test_adjacent_pad_clearance_zone_unblocking(self):
+        """Escape endpoint in a different-net clearance zone should be
+        unblocked by apply_escape_segments.
+
+        Two adjacent pads (different nets) at 0.65mm spacing on 0.05mm grid,
+        placed at off-grid positions: the escape endpoint for pad A may land
+        in pad B's clearance zone.  The fix should unblock it since it is
+        clearance-only (not copper).
+        """
+        grid, rules = make_grid_and_rules(
+            width=10.0,
+            height=10.0,
+            resolution=0.05,
+            trace_width=0.15,
+            trace_clearance=0.1,
+        )
+        subgrid = SubGridRouter(grid, rules)
+
+        # Two adjacent pads at 0.65mm apart on different nets, off-grid
+        pad_a = make_pad(
+            x=5.023, y=5.017, net=1, ref="U1", pin="1",
+            width=0.3, height=0.45, net_name="NET_A",
+        )
+        pad_b = make_pad(
+            x=5.023, y=5.667, net=2, ref="U1", pin="2",
+            width=0.3, height=0.45, net_name="NET_B",
+        )
+        # Third pad for component center calculation
+        pad_c = make_pad(
+            x=5.023, y=6.317, net=3, ref="U1", pin="3",
+            width=0.3, height=0.45, net_name="NET_C",
+        )
+
+        for p in [pad_a, pad_b, pad_c]:
+            grid.add_pad(p)
+
+        result = subgrid.route_with_subgrid([pad_a, pad_b, pad_c])
+
+        # Should have unblocked at least some cells
+        assert result.unblocked_count > 0, (
+            f"Expected >0 cells unblocked for adjacent pad clearance-zone "
+            f"test, got {result.unblocked_count}"
+        )
+
+    def test_pad_blocked_cell_never_unblocked(self):
+        """apply_escape_segments must never unblock a cell that is actual
+        copper (pad_blocked=True) from another net."""
+        grid, rules = make_grid_and_rules(
+            width=10.0,
+            height=10.0,
+            resolution=0.05,
+            trace_width=0.15,
+            trace_clearance=0.1,
+        )
+        subgrid = SubGridRouter(grid, rules)
+
+        # Place a pad at an off-grid position
+        pad = make_pad(
+            x=5.023, y=5.017, net=1, ref="U1", pin="1",
+            width=0.3, height=0.45,
+        )
+        # Another pad on a different net nearby (its copper will be pad_blocked)
+        other_pad = make_pad(
+            x=5.023, y=5.667, net=2, ref="U1", pin="2",
+            width=0.3, height=0.45,
+        )
+
+        for p in [pad, other_pad]:
+            grid.add_pad(p)
+
+        # Find the grid cell for the other pad's center -- it should be pad_blocked
+        ogx, ogy = grid.world_to_grid(other_pad.x, other_pad.y)
+        layer_idx = grid.layer_to_index(Layer.F_CU.value)
+        center_cell = grid.grid[layer_idx][ogy][ogx]
+
+        # Verify the other pad's copper cell is pad_blocked before escape
+        assert center_cell.pad_blocked, (
+            "Test setup error: other pad's center cell should be pad_blocked"
+        )
+        was_blocked = center_cell.blocked
+
+        # Run escape routing
+        result = subgrid.route_with_subgrid([pad, other_pad])
+
+        # After escape routing, the other pad's copper must still be blocked
+        center_cell_after = grid.grid[layer_idx][ogy][ogx]
+        assert center_cell_after.pad_blocked, (
+            "pad_blocked cell should remain pad_blocked after escape routing"
+        )
+        # The cell should remain blocked (actual copper must never be unblocked)
+        assert center_cell_after.blocked == was_blocked, (
+            "pad_blocked cell should not be unblocked by escape routing"
+        )
+
+    def test_adaptive_search_radius_fine_grid(self):
+        """SubGridRouter should use a larger search radius on fine grids."""
+        grid_fine, rules_fine = make_grid_and_rules(resolution=0.05)
+        grid_coarse, rules_coarse = make_grid_and_rules(resolution=0.1)
+
+        subgrid_fine = SubGridRouter(grid_fine, rules_fine)
+        subgrid_coarse = SubGridRouter(grid_coarse, rules_coarse)
+
+        # Fine grid (0.05mm) should have radius >= 6 (0.3mm / 0.05mm)
+        assert subgrid_fine.escape_search_radius >= 6, (
+            f"Fine grid radius {subgrid_fine.escape_search_radius} too small"
+        )
+        # Coarse grid (0.1mm) should have radius >= 3 (0.3mm / 0.1mm)
+        assert subgrid_coarse.escape_search_radius >= 3
+
+    def test_explicit_search_radius_overrides_adaptive(self):
+        """Explicit escape_search_radius should override the adaptive default."""
+        grid, rules = make_grid_and_rules(resolution=0.05)
+        subgrid = SubGridRouter(grid, rules, escape_search_radius=2)
+        assert subgrid.escape_search_radius == 2
+
+    def test_escape_segments_valid_clearance_at_005mm(self):
+        """All escape segments generated at 0.05mm grid must pass clearance
+        validation -- no DRC violations from escape routing itself."""
+        grid, rules = make_grid_and_rules(
+            width=15.0,
+            height=15.0,
+            resolution=0.05,
+            trace_width=0.15,
+            trace_clearance=0.1,
+        )
+        subgrid = SubGridRouter(grid, rules)
+
+        # Row of 6 pads at 0.65mm pitch, off-grid placement
+        pads = []
+        for i in range(6):
+            pads.append(make_pad(
+                x=5.023,
+                y=5.017 + i * 0.65,
+                net=i + 1,
+                ref="U1",
+                pin=str(i + 1),
+                width=0.3,
+                height=0.45,
+            ))
+
+        for p in pads:
+            grid.add_pad(p)
+
+        analysis = subgrid.analyze_pads(pads)
+        result = subgrid.generate_escape_segments(analysis)
+
+        component_pitches = grid.compute_component_pitches()
+        for escape in result.escapes:
+            is_valid, clearance, violation_loc = grid.validate_segment_clearance(
+                escape.segment,
+                exclude_net=escape.pad.net,
+                component_pitches=component_pitches,
+            )
+            assert is_valid, (
+                f"Escape for {escape.pad.ref}.{escape.pad.pin} (net "
+                f"{escape.pad.net}) violates clearance={clearance:.4f}mm "
+                f"at {violation_loc}"
+            )

--- a/tests/test_subgrid_integration.py
+++ b/tests/test_subgrid_integration.py
@@ -122,7 +122,7 @@ class TestSubgridPrepass:
         # with very short length connecting off-grid pad to grid point)
         escape_segments = [
             r for r in routes
-            if len(r.segments) == 1 and ((r.segments[0].x2 - r.segments[0].x1) ** 2 + (r.segments[0].y2 - r.segments[0].y1) ** 2) ** 0.5 < 0.2
+            if len(r.segments) == 1 and ((r.segments[0].x2 - r.segments[0].x1) ** 2 + (r.segments[0].y2 - r.segments[0].y1) ** 2) ** 0.5 < 0.5
         ]
         # We should have at least some escape segments for the off-grid pads
         # (10.65 and 11.30 are off-grid on 0.1mm grid)
@@ -164,7 +164,7 @@ class TestSubgridPrepass:
         # Check that escape routes are in self.routes
         escape_routes_in_self = [
             r for r in router.routes
-            if len(r.segments) == 1 and ((r.segments[0].x2 - r.segments[0].x1) ** 2 + (r.segments[0].y2 - r.segments[0].y1) ** 2) ** 0.5 < 0.2
+            if len(r.segments) == 1 and ((r.segments[0].x2 - r.segments[0].x1) ** 2 + (r.segments[0].y2 - r.segments[0].y1) ** 2) ** 0.5 < 0.5
         ]
         assert len(escape_routes_in_self) >= 1
 


### PR DESCRIPTION
## Summary
Fixes sub-grid escape routing for fine-pitch SSOP/QFP pads at 0.05mm grid, where escape segments were generated but 0 grid cells were unblocked due to three interacting defects in the clearance-zone handling.

## Changes
- **apply_escape_segments**: Removed net-ownership guard that rejected clearance-zone cells belonging to a different net. Any clearance-zone cell (blocked, not pad_blocked) can now be unblocked regardless of which net owns it, since the escape segment was already validated by validate_segment_clearance().
- **_find_escape_for_pad**: Changed accessibility check to skip pad's own copper cells (pad_blocked + same net) as escape targets, since they cannot be unblocked. Only free cells and clearance-zone cells are now considered valid targets.
- **Adaptive escape_search_radius**: Default search radius now scales with grid resolution (minimum 0.3mm physical distance), giving radius=6 at 0.05mm grid instead of 3.
- **Integration test threshold**: Updated escape segment length filter from 0.2mm to 0.5mm to accommodate escape segments that now correctly target cells outside pad copper.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Sub-grid escape generates functional escape routes that unblock grid cells | PASS | New test_ssop28_at_005mm_grid verifies >0 cells unblocked at 0.05mm grid with 28 off-grid pads |
| No DRC violations from escape routing itself | PASS | test_escape_segments_valid_clearance_at_005mm validates all escape segments against validate_segment_clearance |
| Escape routing works without reducing clearance below manufacturer minimums | PASS | Tests use standard 0.1-0.15mm clearance; no clearance reduction needed |
| pad_blocked cells never unblocked | PASS | test_pad_blocked_cell_never_unblocked confirms copper cells remain blocked |
| Existing SSOP-20 test at 0.1mm grid still passes | PASS | All 41 original unit tests pass, all 16 integration tests pass |

## Test Plan
- 47 unit tests pass (41 existing + 6 new in TestFineGridClearanceZoneUnblocking)
- 16 integration tests pass (test_subgrid_integration.py)
- New tests cover: SSOP-28 at 0.05mm grid, adjacent pad clearance-zone unblocking, pad_blocked rejection, adaptive search radius, explicit radius override, clearance validation at 0.05mm
- Pre-existing failure in tests/report/test_renderers.py is unrelated (fails on main without changes)

Closes #1703