### PR TITLE
feat(placement): add C++ AABB cost evaluation with nanobind bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Root CMakeLists.txt for building C++ router extension
+# Root CMakeLists.txt for building C++ native extensions
 # This is used by scikit-build-core for pip install with native support
 #
 # Usage:
@@ -9,9 +9,13 @@
 #   cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
 #   cmake --build build
 #   cp build/router_cpp.*.so src/kicad_tools/router/
+#   cp build/placement_cpp.*.so src/kicad_tools/placement/
 
 cmake_minimum_required(VERSION 3.15...3.27)
 project(kicad_tools_native LANGUAGES CXX)
 
 # Include the router C++ module
 add_subdirectory(src/kicad_tools/router/cpp)
+
+# Include the placement C++ module
+add_subdirectory(src/kicad_tools/placement/cpp)

--- a/src/kicad_tools/placement/cpp/CMakeLists.txt
+++ b/src/kicad_tools/placement/cpp/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.15...3.27)
+set(PROJECT_NAME placement_cpp)
+
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+# Python and nanobind setup
+if(SKBUILD)
+    set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+    set(Python_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}")
+    set(Python_LIBRARY "${PYTHON_LIBRARY}")
+endif()
+
+if(CMAKE_VERSION VERSION_LESS 3.18)
+    set(DEV_MODULE Development)
+else()
+    set(DEV_MODULE Development.Module)
+endif()
+
+find_package(Python COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+message(STATUS "Python_EXECUTABLE: ${Python_EXECUTABLE}")
+message(STATUS "nanobind_ROOT: ${nanobind_ROOT}")
+
+# Build type
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# C++ standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Compiler flags
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20 /Zc:__cplusplus /O2")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+endif()
+
+# Source files
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+file(GLOB_RECURSE SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+
+# Build nanobind module
+nanobind_add_module(${PROJECT_NAME} ${SOURCE_FILES})
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION kicad_tools/placement)
+
+message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")

--- a/src/kicad_tools/placement/cpp/include/aabb.hpp
+++ b/src/kicad_tools/placement/cpp/include/aabb.hpp
@@ -1,0 +1,114 @@
+/*
+ * Placement C++ Core - AABB overlap/clearance operations
+ *
+ * Provides high-performance pairwise AABB computations for placement
+ * cost evaluation. These functions mirror the pure Python implementations
+ * in cost.py and must produce numerically identical results.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace placement {
+
+/// Axis-Aligned Bounding Box represented as (min_x, min_y, max_x, max_y).
+struct AABB {
+    double min_x;
+    double min_y;
+    double max_x;
+    double max_y;
+};
+
+/// Compute total pairwise overlap area between AABBs.
+///
+/// Mirrors cost.py:compute_overlap(). For each pair (i, j) where i < j,
+/// computes the intersection area of the two AABBs and sums them.
+///
+/// @param boxes  Vector of AABBs (min_x, min_y, max_x, max_y).
+/// @return Sum of pairwise overlap areas (mm^2). Zero means no overlaps.
+inline double compute_overlap(const std::vector<AABB>& boxes) {
+    double total = 0.0;
+    const size_t n = boxes.size();
+    for (size_t i = 0; i < n; ++i) {
+        for (size_t j = i + 1; j < n; ++j) {
+            double x_overlap = std::max(
+                0.0,
+                std::min(boxes[i].max_x, boxes[j].max_x) -
+                    std::max(boxes[i].min_x, boxes[j].min_x));
+            double y_overlap = std::max(
+                0.0,
+                std::min(boxes[i].max_y, boxes[j].max_y) -
+                    std::max(boxes[i].min_y, boxes[j].min_y));
+            total += x_overlap * y_overlap;
+        }
+    }
+    return total;
+}
+
+/// Compute total boundary violation depth.
+///
+/// Mirrors cost.py:compute_boundary_violation(). For each box that extends
+/// beyond the board outline, sums the depth of violation on each edge.
+///
+/// @param boxes   Vector of component AABBs.
+/// @param board   Board outline AABB.
+/// @return Sum of boundary violation depths across all components (mm).
+inline double compute_boundary_violation(
+    const std::vector<AABB>& boxes,
+    const AABB& board) {
+    double total = 0.0;
+    for (const auto& box : boxes) {
+        total += std::max(0.0, board.min_x - box.min_x);
+        total += std::max(0.0, box.max_x - board.max_x);
+        total += std::max(0.0, board.min_y - box.min_y);
+        total += std::max(0.0, box.max_y - board.max_y);
+    }
+    return total;
+}
+
+/// Compute count of DRC clearance violations.
+///
+/// Mirrors cost.py:compute_drc_violations(). Checks pairwise clearance
+/// between component bounding boxes against the minimum clearance rule.
+///
+/// @param boxes    Vector of component AABBs.
+/// @param min_gap  Minimum clearance distance (mm).
+/// @return Number of pairwise clearance violations.
+inline double compute_drc_violations(
+    const std::vector<AABB>& boxes,
+    double min_gap) {
+    double violations = 0.0;
+    const size_t n = boxes.size();
+    for (size_t i = 0; i < n; ++i) {
+        for (size_t j = i + 1; j < n; ++j) {
+            // Edge-to-edge gap (negative means overlap)
+            double gap_x = std::max(boxes[i].min_x, boxes[j].min_x) -
+                           std::min(boxes[i].max_x, boxes[j].max_x);
+            double gap_y = std::max(boxes[i].min_y, boxes[j].min_y) -
+                           std::min(boxes[i].max_y, boxes[j].max_y);
+
+            double gap;
+            if (gap_x <= 0 && gap_y <= 0) {
+                // Overlapping on both axes
+                gap = 0.0;
+            } else if (gap_x > 0 && gap_y > 0) {
+                // Corner-to-corner distance
+                gap = std::sqrt(gap_x * gap_x + gap_y * gap_y);
+            } else {
+                // Edge-to-edge on one axis
+                gap = std::max(gap_x, gap_y);
+            }
+
+            if (gap < min_gap) {
+                violations += 1.0;
+            }
+        }
+    }
+    return violations;
+}
+
+}  // namespace placement

--- a/src/kicad_tools/placement/cpp/include/cost_evaluator.hpp
+++ b/src/kicad_tools/placement/cpp/include/cost_evaluator.hpp
@@ -1,0 +1,143 @@
+/*
+ * Placement C++ Core - Batch cost evaluator
+ *
+ * Accepts flat arrays of component positions and sizes for efficient
+ * batch evaluation without per-object marshaling overhead.
+ */
+
+#pragma once
+
+#include "aabb.hpp"
+#include <cstddef>
+#include <vector>
+
+namespace placement {
+
+/// Result of a batch cost evaluation.
+struct CostResult {
+    double overlap;
+    double boundary;
+    double drc;
+};
+
+/// Batch cost evaluator for placement optimization.
+///
+/// Accepts flat arrays of positions (x, y) and sizes (w, h) and evaluates
+/// overlap, boundary violation, and DRC violations in a single pass.
+/// The flat-array interface avoids per-object marshaling overhead when
+/// called from Python via nanobind.
+class BatchCostEvaluator {
+public:
+    /// Construct evaluator with board outline and design rule clearance.
+    ///
+    /// @param board_min_x  Left edge of board (mm).
+    /// @param board_min_y  Top edge of board (mm).
+    /// @param board_max_x  Right edge of board (mm).
+    /// @param board_max_y  Bottom edge of board (mm).
+    /// @param min_clearance  Minimum copper-to-copper clearance (mm).
+    BatchCostEvaluator(
+        double board_min_x,
+        double board_min_y,
+        double board_max_x,
+        double board_max_y,
+        double min_clearance)
+        : board_{board_min_x, board_min_y, board_max_x, board_max_y},
+          min_clearance_(min_clearance) {}
+
+    /// Evaluate all cost components for a set of components.
+    ///
+    /// @param xs      X positions of components (mm).
+    /// @param ys      Y positions of components (mm).
+    /// @param widths  Widths of components (mm).
+    /// @param heights Heights of components (mm).
+    /// @return CostResult with overlap, boundary, and drc fields.
+    CostResult evaluate(
+        const std::vector<double>& xs,
+        const std::vector<double>& ys,
+        const std::vector<double>& widths,
+        const std::vector<double>& heights) const {
+
+        const size_t n = xs.size();
+
+        // Build AABBs from positions and sizes
+        std::vector<AABB> boxes;
+        boxes.reserve(n);
+        for (size_t i = 0; i < n; ++i) {
+            double half_w = widths[i] / 2.0;
+            double half_h = heights[i] / 2.0;
+            boxes.push_back({
+                xs[i] - half_w,
+                ys[i] - half_h,
+                xs[i] + half_w,
+                ys[i] + half_h,
+            });
+        }
+
+        CostResult result;
+        result.overlap = compute_overlap(boxes);
+        result.boundary = compute_boundary_violation(boxes, board_);
+        result.drc = compute_drc_violations(boxes, min_clearance_);
+        return result;
+    }
+
+    /// Compute only pairwise overlap area.
+    double evaluate_overlap(
+        const std::vector<double>& xs,
+        const std::vector<double>& ys,
+        const std::vector<double>& widths,
+        const std::vector<double>& heights) const {
+
+        auto boxes = build_boxes(xs, ys, widths, heights);
+        return compute_overlap(boxes);
+    }
+
+    /// Compute only boundary violations.
+    double evaluate_boundary(
+        const std::vector<double>& xs,
+        const std::vector<double>& ys,
+        const std::vector<double>& widths,
+        const std::vector<double>& heights) const {
+
+        auto boxes = build_boxes(xs, ys, widths, heights);
+        return compute_boundary_violation(boxes, board_);
+    }
+
+    /// Compute only DRC violations.
+    double evaluate_drc(
+        const std::vector<double>& xs,
+        const std::vector<double>& ys,
+        const std::vector<double>& widths,
+        const std::vector<double>& heights) const {
+
+        auto boxes = build_boxes(xs, ys, widths, heights);
+        return compute_drc_violations(boxes, min_clearance_);
+    }
+
+private:
+    AABB board_;
+    double min_clearance_;
+
+    std::vector<AABB> build_boxes(
+        const std::vector<double>& xs,
+        const std::vector<double>& ys,
+        const std::vector<double>& widths,
+        const std::vector<double>& heights) const {
+
+        const size_t n = xs.size();
+        std::vector<AABB> boxes;
+        boxes.reserve(n);
+        for (size_t i = 0; i < n; ++i) {
+            double half_w = widths[i] / 2.0;
+            double half_h = heights[i] / 2.0;
+            boxes.push_back({
+                xs[i] - half_w,
+                ys[i] - half_h,
+                xs[i] + half_w,
+                ys[i] + half_h,
+            });
+        }
+        return boxes;
+    }
+};
+
+}  // namespace placement

--- a/src/kicad_tools/placement/cpp/src/bindings.cpp
+++ b/src/kicad_tools/placement/cpp/src/bindings.cpp
@@ -1,0 +1,71 @@
+/*
+ * Placement C++ Core - nanobind Python bindings
+ *
+ * Exposes AABB overlap/clearance operations and the BatchCostEvaluator
+ * for high-performance placement cost evaluation.
+ */
+
+#include "aabb.hpp"
+#include "cost_evaluator.hpp"
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace placement;
+
+NB_MODULE(placement_cpp, m) {
+    m.doc() = "C++ placement core for high-performance AABB cost evaluation";
+
+    // AABB struct
+    nb::class_<AABB>(m, "AABB")
+        .def(nb::init<double, double, double, double>(),
+             "min_x"_a, "min_y"_a, "max_x"_a, "max_y"_a)
+        .def_rw("min_x", &AABB::min_x)
+        .def_rw("min_y", &AABB::min_y)
+        .def_rw("max_x", &AABB::max_x)
+        .def_rw("max_y", &AABB::max_y);
+
+    // CostResult struct
+    nb::class_<CostResult>(m, "CostResult")
+        .def(nb::init<>())
+        .def_rw("overlap", &CostResult::overlap)
+        .def_rw("boundary", &CostResult::boundary)
+        .def_rw("drc", &CostResult::drc);
+
+    // Free functions matching cost.py signatures
+    m.def("compute_overlap", &compute_overlap,
+          "boxes"_a,
+          "Compute total pairwise overlap area between AABBs.");
+
+    m.def("compute_boundary_violation", &compute_boundary_violation,
+          "boxes"_a, "board"_a,
+          "Compute total boundary violation depth.");
+
+    m.def("compute_drc_violations", &compute_drc_violations,
+          "boxes"_a, "min_gap"_a,
+          "Compute count of DRC clearance violations.");
+
+    // BatchCostEvaluator class
+    nb::class_<BatchCostEvaluator>(m, "BatchCostEvaluator")
+        .def(nb::init<double, double, double, double, double>(),
+             "board_min_x"_a, "board_min_y"_a,
+             "board_max_x"_a, "board_max_y"_a,
+             "min_clearance"_a)
+        .def("evaluate", &BatchCostEvaluator::evaluate,
+             "xs"_a, "ys"_a, "widths"_a, "heights"_a,
+             "Evaluate all cost components (overlap, boundary, drc).")
+        .def("evaluate_overlap", &BatchCostEvaluator::evaluate_overlap,
+             "xs"_a, "ys"_a, "widths"_a, "heights"_a,
+             "Compute only pairwise overlap area.")
+        .def("evaluate_boundary", &BatchCostEvaluator::evaluate_boundary,
+             "xs"_a, "ys"_a, "widths"_a, "heights"_a,
+             "Compute only boundary violations.")
+        .def("evaluate_drc", &BatchCostEvaluator::evaluate_drc,
+             "xs"_a, "ys"_a, "widths"_a, "heights"_a,
+             "Compute only DRC violations.");
+
+    // Version info
+    m.def("version", []() { return "1.0.0"; });
+    m.def("is_available", []() { return true; });
+}

--- a/src/kicad_tools/placement/cpp_backend.py
+++ b/src/kicad_tools/placement/cpp_backend.py
@@ -1,0 +1,413 @@
+"""
+C++ placement backend with Python fallback.
+
+This module provides a unified interface to the placement AABB cost
+functions that automatically uses the C++ implementation when available,
+falling back to pure Python.
+
+The C++ backend provides significant speedup for the O(N^2) pairwise
+AABB loops in compute_overlap, compute_drc_violations, and
+compute_boundary_violation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+if TYPE_CHECKING:
+    from .cost import BoardOutline, ComponentPlacement, DesignRuleSet
+
+# Try to import C++ module with detailed error tracking
+_CPP_IMPORT_ERROR: str | None = None
+try:
+    from . import placement_cpp
+
+    _CPP_AVAILABLE = True
+except ImportError as e:
+    _CPP_AVAILABLE = False
+    _CPP_IMPORT_ERROR = str(e)
+    placement_cpp = None  # type: ignore
+
+
+def is_cpp_available() -> bool:
+    """Check if the C++ placement backend is available."""
+    return _CPP_AVAILABLE
+
+
+def get_cpp_unavailable_reason() -> str | None:
+    """Get the reason why C++ backend is unavailable.
+
+    Returns:
+        Error message if C++ backend failed to load, None if available.
+    """
+    if _CPP_AVAILABLE:
+        return None
+    return _CPP_IMPORT_ERROR
+
+
+def get_backend_info() -> dict:
+    """Get information about the active backend.
+
+    Returns a dictionary with:
+        - backend: "cpp" or "python"
+        - version: version string
+        - available: True if C++ backend is available
+        - unavailable_reason: Error message if C++ unavailable
+        - platform: Current platform info (for diagnostics)
+    """
+    import platform
+    import sys
+
+    platform_info = {
+        "system": platform.system(),
+        "machine": platform.machine(),
+        "python_version": sys.version.split()[0],
+    }
+
+    if _CPP_AVAILABLE:
+        return {
+            "backend": "cpp",
+            "version": placement_cpp.version(),
+            "available": True,
+            "platform": platform_info,
+        }
+
+    reason = _CPP_IMPORT_ERROR or "Unknown error"
+
+    build_hint = (
+        "Build the C++ extension for faster placement evaluation:\n"
+        "  kct build-native\n"
+        "Or install with native support:\n"
+        "  pip install kicad-tools[native]"
+    )
+
+    diagnostic_hint = None
+    if "arm64" in platform.machine().lower() or "aarch64" in platform.machine().lower():
+        if "darwin" in platform.system().lower():
+            diagnostic_hint = (
+                "On Apple Silicon, the C++ extension must be built locally. "
+                "Run 'kct build-native' to build (requires Xcode Command Line Tools)."
+            )
+    elif "cannot open shared object" in reason.lower() or "dll" in reason.lower():
+        diagnostic_hint = (
+            "The compiled C++ extension was not found for this platform. "
+            "Run 'kct build-native' to build from source."
+        )
+
+    result = {
+        "backend": "python",
+        "version": "pure-python",
+        "available": False,
+        "unavailable_reason": reason,
+        "build_hint": build_hint,
+        "platform": platform_info,
+    }
+
+    if diagnostic_hint:
+        result["diagnostic_hint"] = diagnostic_hint
+
+    return result
+
+
+def _build_boxes_from_placements(
+    placements: Sequence[ComponentPlacement],
+    footprint_sizes: dict[str, tuple[float, float]] | None = None,
+) -> tuple[list[float], list[float], list[float], list[float]]:
+    """Convert placements + footprint_sizes to flat arrays.
+
+    Returns:
+        Tuple of (xs, ys, widths, heights) lists.
+    """
+    default_size = (1.0, 1.0)
+    xs: list[float] = []
+    ys: list[float] = []
+    widths: list[float] = []
+    heights: list[float] = []
+
+    for p in placements:
+        w, h = (footprint_sizes or {}).get(p.reference, default_size)
+        xs.append(p.x)
+        ys.append(p.y)
+        widths.append(w)
+        heights.append(h)
+
+    return xs, ys, widths, heights
+
+
+def compute_overlap_cpp(
+    placements: Sequence[ComponentPlacement],
+    footprint_sizes: dict[str, tuple[float, float]] | None = None,
+) -> float:
+    """Compute overlap using C++ backend.
+
+    Args:
+        placements: Current component positions.
+        footprint_sizes: Map from reference to (width, height) in mm.
+
+    Returns:
+        Sum of pairwise overlap areas (mm^2).
+
+    Raises:
+        RuntimeError: If C++ backend is not available.
+    """
+    if not _CPP_AVAILABLE:
+        raise RuntimeError("C++ placement backend not available")
+
+    xs, ys, widths, heights = _build_boxes_from_placements(
+        placements, footprint_sizes
+    )
+
+    # Build AABB list for the C++ free function
+    boxes = []
+    for i in range(len(xs)):
+        half_w = widths[i] / 2.0
+        half_h = heights[i] / 2.0
+        boxes.append(
+            placement_cpp.AABB(
+                xs[i] - half_w,
+                ys[i] - half_h,
+                xs[i] + half_w,
+                ys[i] + half_h,
+            )
+        )
+    return placement_cpp.compute_overlap(boxes)
+
+
+def compute_boundary_violation_cpp(
+    placements: Sequence[ComponentPlacement],
+    board: BoardOutline,
+    footprint_sizes: dict[str, tuple[float, float]] | None = None,
+) -> float:
+    """Compute boundary violation using C++ backend.
+
+    Args:
+        placements: Current component positions.
+        board: Board outline.
+        footprint_sizes: Map from reference to (width, height) in mm.
+
+    Returns:
+        Sum of boundary violation depths (mm).
+
+    Raises:
+        RuntimeError: If C++ backend is not available.
+    """
+    if not _CPP_AVAILABLE:
+        raise RuntimeError("C++ placement backend not available")
+
+    xs, ys, widths, heights = _build_boxes_from_placements(
+        placements, footprint_sizes
+    )
+
+    boxes = []
+    for i in range(len(xs)):
+        half_w = widths[i] / 2.0
+        half_h = heights[i] / 2.0
+        boxes.append(
+            placement_cpp.AABB(
+                xs[i] - half_w,
+                ys[i] - half_h,
+                xs[i] + half_w,
+                ys[i] + half_h,
+            )
+        )
+
+    board_aabb = placement_cpp.AABB(board.min_x, board.min_y, board.max_x, board.max_y)
+    return placement_cpp.compute_boundary_violation(boxes, board_aabb)
+
+
+def compute_drc_violations_cpp(
+    placements: Sequence[ComponentPlacement],
+    rules: DesignRuleSet,
+    footprint_sizes: dict[str, tuple[float, float]] | None = None,
+) -> float:
+    """Compute DRC violations using C++ backend.
+
+    Args:
+        placements: Current component positions.
+        rules: Design rules with clearance constraints.
+        footprint_sizes: Map from reference to (width, height) in mm.
+
+    Returns:
+        Number of pairwise clearance violations.
+
+    Raises:
+        RuntimeError: If C++ backend is not available.
+    """
+    if not _CPP_AVAILABLE:
+        raise RuntimeError("C++ placement backend not available")
+
+    xs, ys, widths, heights = _build_boxes_from_placements(
+        placements, footprint_sizes
+    )
+
+    boxes = []
+    for i in range(len(xs)):
+        half_w = widths[i] / 2.0
+        half_h = heights[i] / 2.0
+        boxes.append(
+            placement_cpp.AABB(
+                xs[i] - half_w,
+                ys[i] - half_h,
+                xs[i] + half_w,
+                ys[i] + half_h,
+            )
+        )
+    return placement_cpp.compute_drc_violations(boxes, rules.min_clearance)
+
+
+def create_batch_evaluator(
+    board: BoardOutline,
+    rules: DesignRuleSet,
+) -> BatchCostEvaluatorWrapper:
+    """Create a batch cost evaluator, preferring C++ if available.
+
+    Args:
+        board: Board outline.
+        rules: Design rules with clearance constraints.
+
+    Returns:
+        BatchCostEvaluatorWrapper that uses C++ when available.
+    """
+    return BatchCostEvaluatorWrapper(board, rules)
+
+
+class BatchCostEvaluatorWrapper:
+    """Wrapper that delegates to C++ BatchCostEvaluator or Python fallback.
+
+    This class provides a unified interface for batch cost evaluation.
+    When the C++ backend is available, it delegates to the C++
+    BatchCostEvaluator. Otherwise, it falls back to the pure Python
+    implementations in cost.py.
+    """
+
+    def __init__(
+        self,
+        board: BoardOutline,
+        rules: DesignRuleSet,
+        force_python: bool = False,
+    ):
+        self._board = board
+        self._rules = rules
+        self._use_cpp = _CPP_AVAILABLE and not force_python
+
+        if self._use_cpp:
+            self._cpp_evaluator = placement_cpp.BatchCostEvaluator(
+                board.min_x, board.min_y, board.max_x, board.max_y,
+                rules.min_clearance,
+            )
+        else:
+            self._cpp_evaluator = None
+
+    @property
+    def backend(self) -> str:
+        """Return which backend is active: 'cpp' or 'python'."""
+        return "cpp" if self._use_cpp else "python"
+
+    def evaluate(
+        self,
+        placements: Sequence[ComponentPlacement],
+        footprint_sizes: dict[str, tuple[float, float]] | None = None,
+    ) -> tuple[float, float, float]:
+        """Evaluate overlap, boundary, and DRC costs.
+
+        Args:
+            placements: Current component positions.
+            footprint_sizes: Map from reference to (width, height) in mm.
+
+        Returns:
+            Tuple of (overlap, boundary, drc) costs.
+        """
+        if self._use_cpp and self._cpp_evaluator is not None:
+            xs, ys, widths, heights = _build_boxes_from_placements(
+                placements, footprint_sizes
+            )
+            result = self._cpp_evaluator.evaluate(xs, ys, widths, heights)
+            return result.overlap, result.boundary, result.drc
+
+        # Python fallback
+        from .cost import (
+            compute_boundary_violation,
+            compute_drc_violations,
+            compute_overlap,
+        )
+
+        overlap = compute_overlap(placements, footprint_sizes)
+        boundary = compute_boundary_violation(
+            placements, self._board, footprint_sizes
+        )
+        drc = compute_drc_violations(placements, self._rules, footprint_sizes)
+        return overlap, boundary, drc
+
+    def evaluate_overlap(
+        self,
+        placements: Sequence[ComponentPlacement],
+        footprint_sizes: dict[str, tuple[float, float]] | None = None,
+    ) -> float:
+        """Compute only pairwise overlap area.
+
+        Args:
+            placements: Current component positions.
+            footprint_sizes: Map from reference to (width, height) in mm.
+
+        Returns:
+            Sum of pairwise overlap areas (mm^2).
+        """
+        if self._use_cpp and self._cpp_evaluator is not None:
+            xs, ys, widths, heights = _build_boxes_from_placements(
+                placements, footprint_sizes
+            )
+            return self._cpp_evaluator.evaluate_overlap(xs, ys, widths, heights)
+
+        from .cost import compute_overlap
+
+        return compute_overlap(placements, footprint_sizes)
+
+    def evaluate_boundary(
+        self,
+        placements: Sequence[ComponentPlacement],
+        footprint_sizes: dict[str, tuple[float, float]] | None = None,
+    ) -> float:
+        """Compute only boundary violations.
+
+        Args:
+            placements: Current component positions.
+            footprint_sizes: Map from reference to (width, height) in mm.
+
+        Returns:
+            Sum of boundary violation depths (mm).
+        """
+        if self._use_cpp and self._cpp_evaluator is not None:
+            xs, ys, widths, heights = _build_boxes_from_placements(
+                placements, footprint_sizes
+            )
+            return self._cpp_evaluator.evaluate_boundary(xs, ys, widths, heights)
+
+        from .cost import compute_boundary_violation
+
+        return compute_boundary_violation(
+            placements, self._board, footprint_sizes
+        )
+
+    def evaluate_drc(
+        self,
+        placements: Sequence[ComponentPlacement],
+        footprint_sizes: dict[str, tuple[float, float]] | None = None,
+    ) -> float:
+        """Compute only DRC violations.
+
+        Args:
+            placements: Current component positions.
+            footprint_sizes: Map from reference to (width, height) in mm.
+
+        Returns:
+            Number of pairwise clearance violations.
+        """
+        if self._use_cpp and self._cpp_evaluator is not None:
+            xs, ys, widths, heights = _build_boxes_from_placements(
+                placements, footprint_sizes
+            )
+            return self._cpp_evaluator.evaluate_drc(xs, ys, widths, heights)
+
+        from .cost import compute_drc_violations
+
+        return compute_drc_violations(placements, self._rules, footprint_sizes)

--- a/tests/test_placement_cpp_backend.py
+++ b/tests/test_placement_cpp_backend.py
@@ -1,0 +1,608 @@
+"""Cross-check tests for C++ placement backend vs pure Python.
+
+These tests verify that the C++ implementations produce numerically
+identical results to the Python implementations for all AABB cost
+functions (compute_overlap, compute_boundary_violation,
+compute_drc_violations) and the BatchCostEvaluator.
+
+Tests run against both backends and compare results. If the C++ backend
+is not available, the cross-check tests are skipped but the Python
+fallback tests still run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.placement.cost import (
+    BoardOutline,
+    ComponentPlacement,
+    DesignRuleSet,
+    compute_boundary_violation,
+    compute_drc_violations,
+    compute_overlap,
+)
+from kicad_tools.placement.cpp_backend import (
+    BatchCostEvaluatorWrapper,
+    _build_boxes_from_placements,
+    get_backend_info,
+    is_cpp_available,
+)
+
+# Tolerance for floating point comparison
+TOLERANCE = 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_placements(positions: list[tuple[str, float, float]]) -> list[ComponentPlacement]:
+    """Create ComponentPlacement objects from (ref, x, y) tuples."""
+    return [ComponentPlacement(reference=ref, x=x, y=y) for ref, x, y in positions]
+
+
+def _make_footprint_sizes(
+    refs: list[str],
+    sizes: list[tuple[float, float]],
+) -> dict[str, tuple[float, float]]:
+    """Create footprint_sizes dict from parallel lists."""
+    return dict(zip(refs, sizes))
+
+
+# ---------------------------------------------------------------------------
+# Backend info tests (always run)
+# ---------------------------------------------------------------------------
+
+
+class TestBackendInfo:
+    """Test backend info and availability reporting."""
+
+    def test_get_backend_info_returns_dict(self):
+        info = get_backend_info()
+        assert isinstance(info, dict)
+        assert "backend" in info
+        assert "version" in info
+        assert "available" in info
+        assert "platform" in info
+
+    def test_backend_info_has_platform_details(self):
+        info = get_backend_info()
+        plat = info["platform"]
+        assert "system" in plat
+        assert "machine" in plat
+        assert "python_version" in plat
+
+    def test_is_cpp_available_returns_bool(self):
+        assert isinstance(is_cpp_available(), bool)
+
+    def test_backend_info_consistency(self):
+        info = get_backend_info()
+        if is_cpp_available():
+            assert info["backend"] == "cpp"
+            assert info["available"] is True
+        else:
+            assert info["backend"] == "python"
+            assert info["available"] is False
+            assert "unavailable_reason" in info
+
+
+# ---------------------------------------------------------------------------
+# Python fallback tests (always run, no C++ required)
+# ---------------------------------------------------------------------------
+
+
+class TestPythonFallback:
+    """Verify all functions work correctly with pure Python fallback."""
+
+    def test_batch_evaluator_python_fallback(self):
+        """BatchCostEvaluatorWrapper works with force_python=True."""
+        board = BoardOutline(min_x=0, min_y=0, max_x=50, max_y=50)
+        rules = DesignRuleSet(min_clearance=0.2)
+        evaluator = BatchCostEvaluatorWrapper(board, rules, force_python=True)
+
+        assert evaluator.backend == "python"
+
+        placements = _make_placements([
+            ("U1", 10, 10),
+            ("U2", 12, 10),
+        ])
+        sizes = {"U1": (5.0, 5.0), "U2": (5.0, 5.0)}
+
+        overlap, boundary, drc = evaluator.evaluate(placements, sizes)
+        # These two boxes overlap (centers 2mm apart, each 5mm wide)
+        assert overlap > 0
+        assert boundary == 0.0
+        assert drc > 0
+
+    def test_batch_evaluator_no_components(self):
+        """Batch evaluator handles empty placement list."""
+        board = BoardOutline(min_x=0, min_y=0, max_x=50, max_y=50)
+        rules = DesignRuleSet(min_clearance=0.2)
+        evaluator = BatchCostEvaluatorWrapper(board, rules, force_python=True)
+
+        placements: list[ComponentPlacement] = []
+        overlap, boundary, drc = evaluator.evaluate(placements)
+        assert overlap == 0.0
+        assert boundary == 0.0
+        assert drc == 0.0
+
+    def test_batch_evaluator_single_component(self):
+        """Single component: no pairwise comparisons, check boundary only."""
+        board = BoardOutline(min_x=0, min_y=0, max_x=50, max_y=50)
+        rules = DesignRuleSet(min_clearance=0.2)
+        evaluator = BatchCostEvaluatorWrapper(board, rules, force_python=True)
+
+        placements = _make_placements([("U1", 25, 25)])
+        sizes = {"U1": (5.0, 5.0)}
+
+        overlap, boundary, drc = evaluator.evaluate(placements, sizes)
+        assert overlap == 0.0
+        assert boundary == 0.0
+        assert drc == 0.0
+
+    def test_batch_evaluator_boundary_violation(self):
+        """Component extending beyond board edge."""
+        board = BoardOutline(min_x=0, min_y=0, max_x=50, max_y=50)
+        rules = DesignRuleSet(min_clearance=0.2)
+        evaluator = BatchCostEvaluatorWrapper(board, rules, force_python=True)
+
+        # Place component at left edge so it extends beyond
+        placements = _make_placements([("U1", 1, 25)])
+        sizes = {"U1": (5.0, 5.0)}
+
+        overlap, boundary, drc = evaluator.evaluate(placements, sizes)
+        assert overlap == 0.0
+        assert boundary > 0.0  # Left edge violation: 0 - (1 - 2.5) = 1.5
+        assert drc == 0.0
+
+    def test_individual_methods_python_fallback(self):
+        """Individual evaluate_* methods work via Python fallback."""
+        board = BoardOutline(min_x=0, min_y=0, max_x=50, max_y=50)
+        rules = DesignRuleSet(min_clearance=0.2)
+        evaluator = BatchCostEvaluatorWrapper(board, rules, force_python=True)
+
+        placements = _make_placements([
+            ("U1", 10, 10),
+            ("U2", 12, 10),
+        ])
+        sizes = {"U1": (5.0, 5.0), "U2": (5.0, 5.0)}
+
+        overlap = evaluator.evaluate_overlap(placements, sizes)
+        boundary = evaluator.evaluate_boundary(placements, sizes)
+        drc = evaluator.evaluate_drc(placements, sizes)
+
+        assert overlap > 0
+        assert boundary == 0.0
+        assert drc > 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-check tests (require C++ backend)
+# ---------------------------------------------------------------------------
+
+cpp_required = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ placement backend not available",
+)
+
+
+@cpp_required
+class TestCrossCheckOverlap:
+    """Cross-check compute_overlap: C++ vs Python."""
+
+    def test_no_overlap(self):
+        """Non-overlapping boxes produce identical zero results."""
+        placements = _make_placements([
+            ("U1", 0, 0),
+            ("U2", 20, 0),
+            ("U3", 0, 20),
+        ])
+        sizes = {"U1": (5, 5), "U2": (5, 5), "U3": (5, 5)}
+
+        py_result = compute_overlap(placements, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            BoardOutline(0, 0, 100, 100),
+            DesignRuleSet(min_clearance=0.2),
+            force_python=False,
+        )
+        cpp_result = cpp_evaluator.evaluate_overlap(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+        assert py_result == 0.0
+
+    def test_full_overlap(self):
+        """Identical positions produce identical overlap areas."""
+        placements = _make_placements([
+            ("U1", 10, 10),
+            ("U2", 10, 10),
+        ])
+        sizes = {"U1": (4, 6), "U2": (4, 6)}
+
+        py_result = compute_overlap(placements, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            BoardOutline(0, 0, 100, 100),
+            DesignRuleSet(min_clearance=0.2),
+            force_python=False,
+        )
+        cpp_result = cpp_evaluator.evaluate_overlap(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+        # Full overlap of 4x6 box
+        assert abs(py_result - 24.0) < TOLERANCE
+
+    def test_partial_overlap(self):
+        """Partially overlapping boxes produce identical results."""
+        placements = _make_placements([
+            ("U1", 10, 10),
+            ("U2", 12, 11),
+        ])
+        sizes = {"U1": (6, 6), "U2": (6, 6)}
+
+        py_result = compute_overlap(placements, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            BoardOutline(0, 0, 100, 100),
+            DesignRuleSet(min_clearance=0.2),
+            force_python=False,
+        )
+        cpp_result = cpp_evaluator.evaluate_overlap(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+        assert py_result > 0
+
+    def test_many_components(self):
+        """50 components in a grid produce identical overlap results."""
+        import random
+
+        random.seed(42)
+        refs = [f"C{i}" for i in range(50)]
+        positions = [(ref, random.uniform(0, 30), random.uniform(0, 30)) for ref in refs]
+        placements = _make_placements(positions)
+        sizes = {ref: (2.0, 1.0) for ref in refs}
+
+        py_result = compute_overlap(placements, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            BoardOutline(0, 0, 100, 100),
+            DesignRuleSet(min_clearance=0.2),
+            force_python=False,
+        )
+        cpp_result = cpp_evaluator.evaluate_overlap(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+
+    def test_default_sizes(self):
+        """Default 1x1mm sizes when footprint_sizes is None."""
+        placements = _make_placements([
+            ("U1", 10, 10),
+            ("U2", 10.5, 10),
+        ])
+
+        py_result = compute_overlap(placements, None)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            BoardOutline(0, 0, 100, 100),
+            DesignRuleSet(min_clearance=0.2),
+            force_python=False,
+        )
+        cpp_result = cpp_evaluator.evaluate_overlap(placements, None)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+
+
+@cpp_required
+class TestCrossCheckBoundary:
+    """Cross-check compute_boundary_violation: C++ vs Python."""
+
+    def test_all_inside(self):
+        """Components inside board produce zero violation."""
+        board = BoardOutline(0, 0, 100, 100)
+        placements = _make_placements([
+            ("U1", 50, 50),
+            ("U2", 25, 75),
+        ])
+        sizes = {"U1": (10, 10), "U2": (10, 10)}
+
+        py_result = compute_boundary_violation(placements, board, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            board, DesignRuleSet(min_clearance=0.2), force_python=False
+        )
+        cpp_result = cpp_evaluator.evaluate_boundary(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+        assert py_result == 0.0
+
+    def test_left_edge_violation(self):
+        """Component extending past left edge."""
+        board = BoardOutline(0, 0, 100, 100)
+        placements = _make_placements([("U1", 2, 50)])
+        sizes = {"U1": (10, 10)}
+
+        py_result = compute_boundary_violation(placements, board, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            board, DesignRuleSet(min_clearance=0.2), force_python=False
+        )
+        cpp_result = cpp_evaluator.evaluate_boundary(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+        # Left edge: board.min_x (0) - (2 - 5) = 3.0
+        assert abs(py_result - 3.0) < TOLERANCE
+
+    def test_multiple_edge_violations(self):
+        """Component extending past multiple edges."""
+        board = BoardOutline(10, 10, 40, 40)
+        placements = _make_placements([("U1", 8, 42)])
+        sizes = {"U1": (6, 6)}
+
+        py_result = compute_boundary_violation(placements, board, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            board, DesignRuleSet(min_clearance=0.2), force_python=False
+        )
+        cpp_result = cpp_evaluator.evaluate_boundary(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+        assert py_result > 0
+
+    def test_many_components_boundary(self):
+        """50 components with some outside board."""
+        import random
+
+        random.seed(123)
+        board = BoardOutline(0, 0, 50, 50)
+        refs = [f"R{i}" for i in range(50)]
+        # Some positions deliberately outside
+        positions = [(ref, random.uniform(-5, 55), random.uniform(-5, 55)) for ref in refs]
+        placements = _make_placements(positions)
+        sizes = {ref: (3.0, 2.0) for ref in refs}
+
+        py_result = compute_boundary_violation(placements, board, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            board, DesignRuleSet(min_clearance=0.2), force_python=False
+        )
+        cpp_result = cpp_evaluator.evaluate_boundary(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+
+
+@cpp_required
+class TestCrossCheckDRC:
+    """Cross-check compute_drc_violations: C++ vs Python."""
+
+    def test_well_spaced(self):
+        """Well-spaced components produce zero violations."""
+        placements = _make_placements([
+            ("U1", 0, 0),
+            ("U2", 20, 0),
+        ])
+        sizes = {"U1": (5, 5), "U2": (5, 5)}
+        rules = DesignRuleSet(min_clearance=0.2)
+
+        py_result = compute_drc_violations(placements, rules, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            BoardOutline(0, 0, 100, 100), rules, force_python=False
+        )
+        cpp_result = cpp_evaluator.evaluate_drc(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+        assert py_result == 0.0
+
+    def test_overlapping_boxes(self):
+        """Overlapping boxes are always DRC violations."""
+        placements = _make_placements([
+            ("U1", 10, 10),
+            ("U2", 10, 10),
+        ])
+        sizes = {"U1": (5, 5), "U2": (5, 5)}
+        rules = DesignRuleSet(min_clearance=0.2)
+
+        py_result = compute_drc_violations(placements, rules, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            BoardOutline(0, 0, 100, 100), rules, force_python=False
+        )
+        cpp_result = cpp_evaluator.evaluate_drc(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+        assert py_result == 1.0
+
+    def test_corner_to_corner(self):
+        """Corner-to-corner distance uses Euclidean calculation."""
+        # Boxes separated on both axes, corner-to-corner < min_clearance
+        placements = _make_placements([
+            ("U1", 0, 0),
+            ("U2", 5.1, 5.1),
+        ])
+        sizes = {"U1": (5, 5), "U2": (5, 5)}
+        # gap_x = 0.1, gap_y = 0.1, corner distance = sqrt(0.01+0.01) ~ 0.1414
+        rules = DesignRuleSet(min_clearance=0.2)
+
+        py_result = compute_drc_violations(placements, rules, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            BoardOutline(0, 0, 100, 100), rules, force_python=False
+        )
+        cpp_result = cpp_evaluator.evaluate_drc(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+        assert py_result == 1.0  # 0.1414 < 0.2 clearance
+
+    def test_edge_to_edge(self):
+        """Edge-to-edge gap on one axis."""
+        # Boxes separated on X axis but overlapping on Y axis
+        placements = _make_placements([
+            ("U1", 0, 0),
+            ("U2", 5.1, 0),
+        ])
+        sizes = {"U1": (5, 5), "U2": (5, 5)}
+        rules = DesignRuleSet(min_clearance=0.2)
+
+        py_result = compute_drc_violations(placements, rules, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            BoardOutline(0, 0, 100, 100), rules, force_python=False
+        )
+        cpp_result = cpp_evaluator.evaluate_drc(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+        # gap = 0.1 < 0.2 -> violation
+        assert py_result == 1.0
+
+    def test_many_components_drc(self):
+        """50 components in tight space produce identical violation counts."""
+        import random
+
+        random.seed(99)
+        refs = [f"Q{i}" for i in range(50)]
+        positions = [(ref, random.uniform(0, 20), random.uniform(0, 20)) for ref in refs]
+        placements = _make_placements(positions)
+        sizes = {ref: (2.0, 2.0) for ref in refs}
+        rules = DesignRuleSet(min_clearance=0.5)
+
+        py_result = compute_drc_violations(placements, rules, sizes)
+        cpp_evaluator = BatchCostEvaluatorWrapper(
+            BoardOutline(0, 0, 100, 100), rules, force_python=False
+        )
+        cpp_result = cpp_evaluator.evaluate_drc(placements, sizes)
+
+        assert abs(py_result - cpp_result) < TOLERANCE
+
+
+@cpp_required
+class TestCrossCheckBatch:
+    """Cross-check BatchCostEvaluator: C++ vs Python."""
+
+    def test_batch_evaluate_matches_individual(self):
+        """Batch evaluate matches individual Python function results."""
+        board = BoardOutline(0, 0, 50, 50)
+        rules = DesignRuleSet(min_clearance=0.3)
+
+        placements = _make_placements([
+            ("U1", 5, 5),
+            ("U2", 7, 5),
+            ("U3", 48, 48),
+        ])
+        sizes = {"U1": (4, 4), "U2": (4, 4), "U3": (6, 6)}
+
+        # Python reference
+        py_overlap = compute_overlap(placements, sizes)
+        py_boundary = compute_boundary_violation(placements, board, sizes)
+        py_drc = compute_drc_violations(placements, rules, sizes)
+
+        # C++ batch
+        evaluator = BatchCostEvaluatorWrapper(board, rules, force_python=False)
+        cpp_overlap, cpp_boundary, cpp_drc = evaluator.evaluate(placements, sizes)
+
+        assert abs(py_overlap - cpp_overlap) < TOLERANCE
+        assert abs(py_boundary - cpp_boundary) < TOLERANCE
+        assert abs(py_drc - cpp_drc) < TOLERANCE
+
+    def test_batch_vs_python_fallback(self):
+        """C++ batch evaluator matches Python fallback evaluator."""
+        board = BoardOutline(0, 0, 100, 100)
+        rules = DesignRuleSet(min_clearance=0.2)
+
+        import random
+
+        random.seed(7)
+        refs = [f"D{i}" for i in range(30)]
+        positions = [(ref, random.uniform(5, 95), random.uniform(5, 95)) for ref in refs]
+        placements = _make_placements(positions)
+        sizes = {ref: (random.uniform(1, 5), random.uniform(1, 5)) for ref in refs}
+
+        cpp_eval = BatchCostEvaluatorWrapper(board, rules, force_python=False)
+        py_eval = BatchCostEvaluatorWrapper(board, rules, force_python=True)
+
+        cpp_overlap, cpp_boundary, cpp_drc = cpp_eval.evaluate(placements, sizes)
+        py_overlap, py_boundary, py_drc = py_eval.evaluate(placements, sizes)
+
+        assert abs(py_overlap - cpp_overlap) < TOLERANCE
+        assert abs(py_boundary - cpp_boundary) < TOLERANCE
+        assert abs(py_drc - cpp_drc) < TOLERANCE
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests (always run via Python, cross-check if C++ available)
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases that should work identically on both backends."""
+
+    def test_zero_components(self):
+        """Empty list produces all-zero costs."""
+        board = BoardOutline(0, 0, 50, 50)
+        rules = DesignRuleSet(min_clearance=0.2)
+
+        py_eval = BatchCostEvaluatorWrapper(board, rules, force_python=True)
+        py_result = py_eval.evaluate([], None)
+        assert py_result == (0.0, 0.0, 0.0)
+
+        if is_cpp_available():
+            cpp_eval = BatchCostEvaluatorWrapper(board, rules, force_python=False)
+            cpp_result = cpp_eval.evaluate([], None)
+            assert cpp_result == (0.0, 0.0, 0.0)
+
+    def test_single_component_no_pairwise(self):
+        """Single component produces zero overlap and DRC."""
+        board = BoardOutline(0, 0, 50, 50)
+        rules = DesignRuleSet(min_clearance=0.2)
+        placements = _make_placements([("U1", 25, 25)])
+        sizes = {"U1": (5, 5)}
+
+        py_eval = BatchCostEvaluatorWrapper(board, rules, force_python=True)
+        py_overlap, py_boundary, py_drc = py_eval.evaluate(placements, sizes)
+        assert py_overlap == 0.0
+        assert py_drc == 0.0
+
+        if is_cpp_available():
+            cpp_eval = BatchCostEvaluatorWrapper(board, rules, force_python=False)
+            cpp_overlap, cpp_boundary, cpp_drc = cpp_eval.evaluate(placements, sizes)
+            assert abs(py_overlap - cpp_overlap) < TOLERANCE
+            assert abs(py_boundary - cpp_boundary) < TOLERANCE
+            assert abs(py_drc - cpp_drc) < TOLERANCE
+
+    def test_asymmetric_sizes(self):
+        """Components with different widths and heights."""
+        board = BoardOutline(0, 0, 100, 100)
+        rules = DesignRuleSet(min_clearance=0.2)
+        placements = _make_placements([
+            ("U1", 10, 10),
+            ("U2", 12, 10),
+        ])
+        sizes = {"U1": (8, 2), "U2": (2, 8)}
+
+        py_eval = BatchCostEvaluatorWrapper(board, rules, force_python=True)
+        py_result = py_eval.evaluate(placements, sizes)
+
+        if is_cpp_available():
+            cpp_eval = BatchCostEvaluatorWrapper(board, rules, force_python=False)
+            cpp_result = cpp_eval.evaluate(placements, sizes)
+            for py_val, cpp_val in zip(py_result, cpp_result):
+                assert abs(py_val - cpp_val) < TOLERANCE
+
+
+class TestBuildBoxesHelper:
+    """Test the _build_boxes_from_placements helper function."""
+
+    def test_basic_conversion(self):
+        placements = _make_placements([
+            ("U1", 10, 20),
+            ("U2", 30, 40),
+        ])
+        sizes = {"U1": (5.0, 3.0), "U2": (2.0, 4.0)}
+
+        xs, ys, widths, heights = _build_boxes_from_placements(placements, sizes)
+
+        assert xs == [10, 30]
+        assert ys == [20, 40]
+        assert widths == [5.0, 2.0]
+        assert heights == [3.0, 4.0]
+
+    def test_default_sizes(self):
+        placements = _make_placements([("U1", 5, 5)])
+
+        xs, ys, widths, heights = _build_boxes_from_placements(placements, None)
+
+        assert widths == [1.0]
+        assert heights == [1.0]
+
+    def test_empty_placements(self):
+        xs, ys, widths, heights = _build_boxes_from_placements([], None)
+        assert xs == []
+        assert ys == []


### PR DESCRIPTION
## Summary
Add C++ acceleration for placement cost AABB evaluation (Phase 1). Creates the placement/cpp/ directory with nanobind bindings for compute_overlap, compute_boundary_violation, and compute_drc_violations, following the existing router/cpp/ pattern. Includes a Python fallback wrapper and comprehensive cross-check tests.

## Changes
- Create `src/kicad_tools/placement/cpp/CMakeLists.txt` mirroring the router/cpp/ build configuration
- Create `src/kicad_tools/placement/cpp/include/aabb.hpp` with AABB overlap, boundary, and DRC functions
- Create `src/kicad_tools/placement/cpp/include/cost_evaluator.hpp` with BatchCostEvaluator class accepting flat arrays
- Create `src/kicad_tools/placement/cpp/src/bindings.cpp` with nanobind placement_cpp module
- Create `src/kicad_tools/placement/cpp_backend.py` with BatchCostEvaluatorWrapper (auto C++/Python fallback)
- Update root `CMakeLists.txt` to add placement_cpp as a build target
- Add `tests/test_placement_cpp_backend.py` with 31 tests (15 always-run Python tests, 16 C++ cross-check tests)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Create src/kicad_tools/placement/cpp/ directory | Done | Files created at cpp/CMakeLists.txt, cpp/include/aabb.hpp, cpp/include/cost_evaluator.hpp, cpp/src/bindings.cpp |
| Follow existing router/cpp/ pattern | Done | Identical CMake structure, nanobind setup, C++20 standard, SKBUILD detection |
| nanobind bindings for AABB overlap/clearance | Done | bindings.cpp exposes AABB struct, compute_overlap, compute_boundary_violation, compute_drc_violations, BatchCostEvaluator |
| placement/cpp_backend.py with Python fallback | Done | BatchCostEvaluatorWrapper with force_python parameter, try/except import pattern |
| Cross-check tests C++ vs Python identical results | Done | 16 cross-check tests comparing results within 1e-9 tolerance |
| Edge cases (0 components, 1 component, corner distance) | Done | Tests for zero, single, asymmetric sizes, corner-to-corner Euclidean distance |

## Test Plan
- 31 tests: 15 pass (Python fallback), 16 skip (C++ not built in test environment)
- Cross-check tests validate numerical identity between C++ and Python for all three cost functions
- Edge case coverage: empty list, single component, overlapping, separated, corner-to-corner distance
- Existing placement tests (46) continue to pass

Closes #1713