### PR TITLE
feat(drc): add C++ accelerated pad-to-pad clearance checking

### DIFF
--- a/src/kicad_tools/drc/cpp/CMakeLists.txt
+++ b/src/kicad_tools/drc/cpp/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.15...3.27)
+set(PROJECT_NAME drc_cpp)
+
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+# Python and nanobind setup
+if(SKBUILD)
+    set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+    set(Python_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}")
+    set(Python_LIBRARY "${PYTHON_LIBRARY}")
+endif()
+
+if(CMAKE_VERSION VERSION_LESS 3.18)
+    set(DEV_MODULE Development)
+else()
+    set(DEV_MODULE Development.Module)
+endif()
+
+find_package(Python COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+message(STATUS "Python_EXECUTABLE: ${Python_EXECUTABLE}")
+message(STATUS "nanobind_ROOT: ${nanobind_ROOT}")
+
+# Build type
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# C++ standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Compiler flags
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20 /Zc:__cplusplus /O2")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+endif()
+
+# Source files
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+file(GLOB_RECURSE SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+
+# Build nanobind module
+nanobind_add_module(${PROJECT_NAME} ${SOURCE_FILES})
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION kicad_tools/drc)
+
+message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")

--- a/src/kicad_tools/drc/cpp/include/drc_clearance.hpp
+++ b/src/kicad_tools/drc/cpp/include/drc_clearance.hpp
@@ -1,0 +1,75 @@
+/*
+ * DRC Clearance C++ Core - pad-to-pad clearance computation
+ * Part of kicad-tools DRC performance optimization (Phase 4)
+ *
+ * Uses struct-of-arrays layout and squared-distance optimization
+ * to accelerate the O(P1 x P2) inner loop.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+namespace drc {
+
+/// Result of a batch pad-to-pad clearance check.
+struct ClearanceResult {
+    float min_clearance = std::numeric_limits<float>::infinity();
+    float location_x = 0.0f;
+    float location_y = 0.0f;
+    int pad1_index = -1;
+    int pad2_index = -1;
+    bool has_result = false;
+};
+
+/// Batch pad-to-pad clearance check using struct-of-arrays layout.
+///
+/// All pad data is passed as flat arrays to minimize marshaling overhead.
+/// Trig is computed once per footprint. The inner loop uses squared-distance
+/// comparison and only computes sqrt for the minimum-distance pair.
+///
+/// @param pad1_local_x   Component 1 pad local X coordinates
+/// @param pad1_local_y   Component 1 pad local Y coordinates
+/// @param pad1_radius    Component 1 pad radii (max(w,h)/2)
+/// @param pad1_net       Component 1 pad net numbers
+/// @param n_pads1        Number of pads in component 1
+/// @param fp1_x          Component 1 footprint X position (board coords)
+/// @param fp1_y          Component 1 footprint Y position (board coords)
+/// @param fp1_rotation_rad Component 1 footprint rotation in radians
+/// @param pad2_local_x   Component 2 pad local X coordinates
+/// @param pad2_local_y   Component 2 pad local Y coordinates
+/// @param pad2_radius    Component 2 pad radii (max(w,h)/2)
+/// @param pad2_net       Component 2 pad net numbers
+/// @param n_pads2        Number of pads in component 2
+/// @param fp2_x          Component 2 footprint X position (board coords)
+/// @param fp2_y          Component 2 footprint Y position (board coords)
+/// @param fp2_rotation_rad Component 2 footprint rotation in radians
+/// @return ClearanceResult with minimum clearance and location
+ClearanceResult check_pair_clearance(
+    const float* pad1_local_x, const float* pad1_local_y,
+    const float* pad1_radius, const int* pad1_net,
+    int n_pads1,
+    float fp1_x, float fp1_y, float fp1_rotation_rad,
+    const float* pad2_local_x, const float* pad2_local_y,
+    const float* pad2_radius, const int* pad2_net,
+    int n_pads2,
+    float fp2_x, float fp2_y, float fp2_rotation_rad
+);
+
+/// Vector-based wrapper for Python bindings (copies data from vectors).
+ClearanceResult check_pair_clearance_vec(
+    const std::vector<float>& pad1_local_x,
+    const std::vector<float>& pad1_local_y,
+    const std::vector<float>& pad1_radius,
+    const std::vector<int>& pad1_net,
+    float fp1_x, float fp1_y, float fp1_rotation_rad,
+    const std::vector<float>& pad2_local_x,
+    const std::vector<float>& pad2_local_y,
+    const std::vector<float>& pad2_radius,
+    const std::vector<int>& pad2_net,
+    float fp2_x, float fp2_y, float fp2_rotation_rad
+);
+
+} // namespace drc

--- a/src/kicad_tools/drc/cpp/src/bindings.cpp
+++ b/src/kicad_tools/drc/cpp/src/bindings.cpp
@@ -1,0 +1,61 @@
+/*
+ * DRC C++ Core - nanobind Python bindings
+ * Part of kicad-tools DRC performance optimization (Phase 4)
+ */
+
+#include "drc_clearance.hpp"
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace drc;
+
+NB_MODULE(drc_cpp, m) {
+    m.doc() = "C++ DRC core for high-performance pad-to-pad clearance checking";
+
+    // ClearanceResult struct
+    nb::class_<ClearanceResult>(m, "ClearanceResult")
+        .def(nb::init<>())
+        .def_ro("min_clearance", &ClearanceResult::min_clearance)
+        .def_ro("location_x", &ClearanceResult::location_x)
+        .def_ro("location_y", &ClearanceResult::location_y)
+        .def_ro("pad1_index", &ClearanceResult::pad1_index)
+        .def_ro("pad2_index", &ClearanceResult::pad2_index)
+        .def_ro("has_result", &ClearanceResult::has_result);
+
+    // Batch clearance check (vector-based for Python interop)
+    m.def("check_pair_clearance", &check_pair_clearance_vec,
+        "pad1_local_x"_a, "pad1_local_y"_a,
+        "pad1_radius"_a, "pad1_net"_a,
+        "fp1_x"_a, "fp1_y"_a, "fp1_rotation_rad"_a,
+        "pad2_local_x"_a, "pad2_local_y"_a,
+        "pad2_radius"_a, "pad2_net"_a,
+        "fp2_x"_a, "fp2_y"_a, "fp2_rotation_rad"_a,
+        "Batch pad-to-pad clearance check.\n\n"
+        "Checks all pads of component 1 against all pads of component 2.\n"
+        "Uses squared-distance optimization to minimize sqrt calls.\n"
+        "Pad data is passed as flat arrays (struct-of-arrays layout).\n\n"
+        "Args:\n"
+        "    pad1_local_x: Component 1 pad local X coordinates\n"
+        "    pad1_local_y: Component 1 pad local Y coordinates\n"
+        "    pad1_radius: Component 1 pad radii (max(w,h)/2)\n"
+        "    pad1_net: Component 1 pad net numbers\n"
+        "    fp1_x: Component 1 footprint X position\n"
+        "    fp1_y: Component 1 footprint Y position\n"
+        "    fp1_rotation_rad: Component 1 rotation in radians\n"
+        "    pad2_local_x: Component 2 pad local X coordinates\n"
+        "    pad2_local_y: Component 2 pad local Y coordinates\n"
+        "    pad2_radius: Component 2 pad radii (max(w,h)/2)\n"
+        "    pad2_net: Component 2 pad net numbers\n"
+        "    fp2_x: Component 2 footprint X position\n"
+        "    fp2_y: Component 2 footprint Y position\n"
+        "    fp2_rotation_rad: Component 2 rotation in radians\n\n"
+        "Returns:\n"
+        "    ClearanceResult with minimum clearance and violation location"
+    );
+
+    // Version info
+    m.def("version", []() { return "1.0.0"; });
+    m.def("is_available", []() { return true; });
+}

--- a/src/kicad_tools/drc/cpp/src/drc_clearance.cpp
+++ b/src/kicad_tools/drc/cpp/src/drc_clearance.cpp
@@ -1,0 +1,157 @@
+/*
+ * DRC Clearance C++ Core - pad-to-pad clearance computation
+ *
+ * Key optimizations vs the Python version:
+ * 1. Trig computed once per footprint (cos/sin), not per pad
+ * 2. Inner loop uses squared-distance to avoid sqrt until the end
+ * 3. Struct-of-arrays layout for contiguous memory access
+ * 4. No Python interpreter overhead per iteration
+ */
+
+#include "drc_clearance.hpp"
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace drc {
+
+ClearanceResult check_pair_clearance(
+    const float* pad1_local_x, const float* pad1_local_y,
+    const float* pad1_radius, const int* pad1_net,
+    int n_pads1,
+    float fp1_x, float fp1_y, float fp1_rotation_rad,
+    const float* pad2_local_x, const float* pad2_local_y,
+    const float* pad2_radius, const int* pad2_net,
+    int n_pads2,
+    float fp2_x, float fp2_y, float fp2_rotation_rad
+) {
+    ClearanceResult result;
+
+    if (n_pads1 <= 0 || n_pads2 <= 0) {
+        return result;
+    }
+
+    // Precompute trig for each footprint (once, not per pad)
+    const float cos1 = std::cos(fp1_rotation_rad);
+    const float sin1 = std::sin(fp1_rotation_rad);
+    const float cos2 = std::cos(fp2_rotation_rad);
+    const float sin2 = std::sin(fp2_rotation_rad);
+
+    // Precompute absolute pad positions for component 1
+    // This avoids recomputing the rotation for every inner iteration
+    std::vector<float> abs_x1(n_pads1), abs_y1(n_pads1);
+    for (int i = 0; i < n_pads1; ++i) {
+        float lx = pad1_local_x[i];
+        float ly = pad1_local_y[i];
+        abs_x1[i] = fp1_x + lx * cos1 - ly * sin1;
+        abs_y1[i] = fp1_y + lx * sin1 + ly * cos1;
+    }
+
+    // Precompute absolute pad positions for component 2
+    std::vector<float> abs_x2(n_pads2), abs_y2(n_pads2);
+    for (int j = 0; j < n_pads2; ++j) {
+        float lx = pad2_local_x[j];
+        float ly = pad2_local_y[j];
+        abs_x2[j] = fp2_x + lx * cos2 - ly * sin2;
+        abs_y2[j] = fp2_y + lx * sin2 + ly * cos2;
+    }
+
+    // Track minimum using squared distance to avoid sqrt in the inner loop.
+    // We track the best (min_clearance_sq_adjusted) which represents
+    // (distance - r1 - r2)^2 effectively, but since we need the actual
+    // clearance = dist - r1 - r2 and comparison is non-trivial with the
+    // radius terms, we track the actual clearance value and defer sqrt
+    // only to when we find a new minimum candidate.
+    //
+    // Optimization: we use a "best squared distance" threshold to skip
+    // pairs where the center-to-center distance alone (ignoring radii)
+    // already exceeds the current best clearance + max possible radii sum.
+    float best_clearance = std::numeric_limits<float>::infinity();
+    int best_i = -1, best_j = -1;
+
+    // Find max radius sum to establish a tighter skip threshold
+    float max_r1 = 0.0f, max_r2 = 0.0f;
+    for (int i = 0; i < n_pads1; ++i) {
+        if (pad1_radius[i] > max_r1) max_r1 = pad1_radius[i];
+    }
+    for (int j = 0; j < n_pads2; ++j) {
+        if (pad2_radius[j] > max_r2) max_r2 = pad2_radius[j];
+    }
+
+    for (int i = 0; i < n_pads1; ++i) {
+        const float ax1 = abs_x1[i];
+        const float ay1 = abs_y1[i];
+        const float r1 = pad1_radius[i];
+        const int net1 = pad1_net[i];
+
+        for (int j = 0; j < n_pads2; ++j) {
+            // Skip same-net pads (same net can touch), but not unconnected (net 0)
+            if (net1 == pad2_net[j] && net1 != 0) {
+                continue;
+            }
+
+            const float dx = abs_x2[j] - ax1;
+            const float dy = abs_y2[j] - ay1;
+            const float dist_sq = dx * dx + dy * dy;
+
+            // Early skip: if center-to-center distance squared is already
+            // larger than (best_clearance + r1 + r2)^2, this pair cannot
+            // produce a smaller clearance. This avoids sqrt for most pairs.
+            const float r_sum = r1 + pad2_radius[j];
+            const float threshold = best_clearance + r_sum;
+            if (dist_sq > threshold * threshold) {
+                continue;
+            }
+
+            // Only compute sqrt for candidates that pass the threshold
+            const float dist = std::sqrt(dist_sq);
+            const float clearance = dist - r_sum;
+
+            if (clearance < best_clearance) {
+                best_clearance = clearance;
+                best_i = i;
+                best_j = j;
+            }
+        }
+    }
+
+    if (best_i >= 0) {
+        result.min_clearance = best_clearance;
+        result.location_x = (abs_x1[best_i] + abs_x2[best_j]) / 2.0f;
+        result.location_y = (abs_y1[best_i] + abs_y2[best_j]) / 2.0f;
+        result.pad1_index = best_i;
+        result.pad2_index = best_j;
+        result.has_result = true;
+    }
+
+    return result;
+}
+
+ClearanceResult check_pair_clearance_vec(
+    const std::vector<float>& pad1_local_x,
+    const std::vector<float>& pad1_local_y,
+    const std::vector<float>& pad1_radius,
+    const std::vector<int>& pad1_net,
+    float fp1_x, float fp1_y, float fp1_rotation_rad,
+    const std::vector<float>& pad2_local_x,
+    const std::vector<float>& pad2_local_y,
+    const std::vector<float>& pad2_radius,
+    const std::vector<int>& pad2_net,
+    float fp2_x, float fp2_y, float fp2_rotation_rad
+) {
+    int n1 = static_cast<int>(pad1_local_x.size());
+    int n2 = static_cast<int>(pad2_local_x.size());
+
+    return check_pair_clearance(
+        pad1_local_x.data(), pad1_local_y.data(),
+        pad1_radius.data(), pad1_net.data(),
+        n1,
+        fp1_x, fp1_y, fp1_rotation_rad,
+        pad2_local_x.data(), pad2_local_y.data(),
+        pad2_radius.data(), pad2_net.data(),
+        n2,
+        fp2_x, fp2_y, fp2_rotation_rad
+    );
+}
+
+} // namespace drc

--- a/src/kicad_tools/drc/cpp_backend.py
+++ b/src/kicad_tools/drc/cpp_backend.py
@@ -1,0 +1,184 @@
+"""
+C++ DRC backend with Python fallback.
+
+This module provides a unified interface for pad-to-pad clearance checking
+that automatically uses the C++ implementation when available, falling back
+to pure Python.
+
+The C++ backend provides significant speedup for the O(P1 x P2) inner loop
+in pad-to-pad clearance computation by using:
+- Squared-distance optimization (avoids sqrt for non-minimum pairs)
+- Struct-of-arrays memory layout for contiguous access
+- Single trig computation per footprint
+- No Python interpreter overhead per iteration
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import Footprint
+
+# Try to import C++ module with detailed error tracking
+_CPP_IMPORT_ERROR: str | None = None
+try:
+    from . import drc_cpp
+
+    _CPP_AVAILABLE = True
+except ImportError as e:
+    _CPP_AVAILABLE = False
+    _CPP_IMPORT_ERROR = str(e)
+    drc_cpp = None  # type: ignore[assignment]
+
+
+def is_cpp_available() -> bool:
+    """Check if the C++ DRC backend is available."""
+    return _CPP_AVAILABLE
+
+
+def get_cpp_unavailable_reason() -> str | None:
+    """Get the reason why C++ backend is unavailable.
+
+    Returns:
+        Error message if C++ backend failed to load, None if available.
+    """
+    if _CPP_AVAILABLE:
+        return None
+    return _CPP_IMPORT_ERROR
+
+
+def get_backend_info() -> dict:
+    """Get information about the active DRC backend.
+
+    Returns a dictionary with:
+        - backend: "cpp" or "python"
+        - version: version string
+        - available: True if C++ backend is available
+        - unavailable_reason: Error message if C++ unavailable
+    """
+    import platform
+    import sys
+
+    platform_info = {
+        "system": platform.system(),
+        "machine": platform.machine(),
+        "python_version": sys.version.split()[0],
+    }
+
+    if _CPP_AVAILABLE:
+        return {
+            "backend": "cpp",
+            "version": drc_cpp.version(),
+            "available": True,
+            "platform": platform_info,
+        }
+
+    reason = _CPP_IMPORT_ERROR or "Unknown error"
+    build_hint = (
+        "Build the C++ extension for faster DRC clearance checking:\n"
+        "  kct build-native\n"
+        "Or install with native support:\n"
+        "  pip install kicad-tools[native]"
+    )
+
+    return {
+        "backend": "python",
+        "version": "pure-python",
+        "available": False,
+        "unavailable_reason": reason,
+        "build_hint": build_hint,
+        "platform": platform_info,
+    }
+
+
+def _extract_pad_arrays(
+    fp: Footprint,
+) -> tuple[list[float], list[float], list[float], list[int], list[str]]:
+    """Extract pad data into struct-of-arrays format.
+
+    Returns:
+        Tuple of (local_x, local_y, radius, net_numbers, pad_numbers)
+        where pad_numbers are the pad identifier strings (e.g. "1", "2").
+    """
+    local_x: list[float] = []
+    local_y: list[float] = []
+    radius: list[float] = []
+    net_nums: list[int] = []
+    pad_ids: list[str] = []
+
+    for pad in fp.pads:
+        local_x.append(pad.position[0])
+        local_y.append(pad.position[1])
+        radius.append(max(pad.size[0], pad.size[1]) / 2.0)
+        net_nums.append(pad.net_number)
+        pad_ids.append(pad.number)
+
+    return local_x, local_y, radius, net_nums, pad_ids
+
+
+def check_pair_clearance_cpp(
+    fp1: Footprint,
+    fp2: Footprint,
+    ref1: str,
+    ref2: str,
+    fp1_position: tuple[float, float] | None = None,
+) -> tuple[float, tuple[float, float], tuple[str, ...], tuple[str, ...]] | None:
+    """Check pad-to-pad clearance using C++ backend.
+
+    Args:
+        fp1: First footprint
+        fp2: Second footprint
+        ref1: Reference designator for fp1
+        ref2: Reference designator for fp2
+        fp1_position: Override position for fp1 (for moved component checks).
+            If None, uses fp1.position.
+
+    Returns:
+        Tuple of (min_clearance, location, items, nets) or None if no pads.
+        - min_clearance: Minimum edge-to-edge clearance in mm
+        - location: (x, y) midpoint of closest pad pair
+        - items: ("ref1-pad1", "ref2-pad2") identifiers
+        - nets: (net_name1, net_name2) net names
+    """
+    if not _CPP_AVAILABLE:
+        raise RuntimeError("C++ DRC backend not available")
+
+    lx1, ly1, r1, nets1, pids1 = _extract_pad_arrays(fp1)
+    lx2, ly2, r2, nets2, pids2 = _extract_pad_arrays(fp2)
+
+    if not lx1 or not lx2:
+        return None
+
+    pos1 = fp1_position if fp1_position is not None else fp1.position
+    rot1_rad = math.radians(fp1.rotation)
+    rot2_rad = math.radians(fp2.rotation)
+
+    result = drc_cpp.check_pair_clearance(
+        lx1,
+        ly1,
+        r1,
+        nets1,
+        pos1[0],
+        pos1[1],
+        rot1_rad,
+        lx2,
+        ly2,
+        r2,
+        nets2,
+        fp2.position[0],
+        fp2.position[1],
+        rot2_rad,
+    )
+
+    if not result.has_result:
+        return None
+
+    i = result.pad1_index
+    j = result.pad2_index
+
+    items = (f"{ref1}-{pids1[i]}", f"{ref2}-{pids2[j]}")
+    net_names = (fp1.pads[i].net_name, fp2.pads[j].net_name)
+
+    return (result.min_clearance, (result.location_x, result.location_y), items, net_names)

--- a/src/kicad_tools/drc/incremental.py
+++ b/src/kicad_tools/drc/incremental.py
@@ -43,6 +43,14 @@ if TYPE_CHECKING:
     from kicad_tools.manufacturers.base import DesignRules
     from kicad_tools.schema.pcb import PCB, Footprint
 
+# Try to import C++ DRC backend for accelerated clearance checking
+from kicad_tools.drc.cpp_backend import (
+    check_pair_clearance_cpp,
+)
+from kicad_tools.drc.cpp_backend import (
+    is_cpp_available as _is_drc_cpp_available,
+)
+
 # Try to import rtree, gracefully handle missing dependency
 try:
     from rtree import index as rtree_index
@@ -658,18 +666,66 @@ class IncrementalDRC:
         return violations
 
     def _check_pair_clearance(self, ref1: str, ref2: str) -> Violation | None:
-        """Check clearance between two components."""
+        """Check clearance between two components.
+
+        Dispatches to C++ backend when available for accelerated computation.
+        Falls back to pure Python implementation otherwise.
+        """
         fp1 = self.pcb.get_footprint(ref1)
         fp2 = self.pcb.get_footprint(ref2)
 
         if fp1 is None or fp2 is None:
             return None
 
+        if _is_drc_cpp_available():
+            return self._check_pair_clearance_cpp(fp1, fp2, ref1, ref2)
+        return self._check_pair_clearance_python(fp1, fp2, ref1, ref2)
+
+    def _check_pair_clearance_cpp(
+        self,
+        fp1: Footprint,
+        fp2: Footprint,
+        ref1: str,
+        ref2: str,
+        fp1_position: tuple[float, float] | None = None,
+    ) -> Violation | None:
+        """Check clearance using C++ backend."""
+        result = check_pair_clearance_cpp(fp1, fp2, ref1, ref2, fp1_position)
+        if result is None:
+            return None
+
+        min_clearance, min_location, min_items, min_nets = result
+
+        if min_clearance < self.rules.min_clearance_mm:
+            return Violation(
+                rule_id="clearance",
+                message=f"Clearance {min_clearance:.3f}mm < minimum {self.rules.min_clearance_mm:.3f}mm",
+                severity="error",
+                location=min_location,
+                items=min_items,
+                nets=min_nets,
+                actual_value=min_clearance,
+                required_value=self.rules.min_clearance_mm,
+            )
+
+        return None
+
+    def _check_pair_clearance_python(
+        self,
+        fp1: Footprint,
+        fp2: Footprint,
+        ref1: str,
+        ref2: str,
+        fp1_position: tuple[float, float] | None = None,
+    ) -> Violation | None:
+        """Check clearance using pure Python (fallback)."""
         # Check pad-to-pad clearances
         min_clearance = float("inf")
         min_location = (0.0, 0.0)
         min_items: tuple[str, ...] = ()
         min_nets: tuple[str, ...] = ()
+
+        pos1 = fp1_position if fp1_position is not None else fp1.position
 
         cos1 = math.cos(math.radians(fp1.rotation))
         sin1 = math.sin(math.radians(fp1.rotation))
@@ -681,8 +737,8 @@ class IncrementalDRC:
             local_x1, local_y1 = pad1.position
             rotated_x1 = local_x1 * cos1 - local_y1 * sin1
             rotated_y1 = local_x1 * sin1 + local_y1 * cos1
-            abs_x1 = fp1.position[0] + rotated_x1
-            abs_y1 = fp1.position[1] + rotated_y1
+            abs_x1 = pos1[0] + rotated_x1
+            abs_y1 = pos1[1] + rotated_y1
             r1 = max(pad1.size[0], pad1.size[1]) / 2
 
             for pad2 in fp2.pads:
@@ -726,7 +782,11 @@ class IncrementalDRC:
     def _check_component_clearances(
         self, ref: str, bounds: Rectangle, nearby_refs: list[str]
     ) -> list[Violation]:
-        """Check clearances for a single component against nearby components."""
+        """Check clearances for a single component against nearby components.
+
+        Dispatches to C++ backend when available for accelerated computation.
+        Falls back to pure Python implementation otherwise.
+        """
         violations: list[Violation] = []
 
         fp = self.pcb.get_footprint(ref)
@@ -744,8 +804,7 @@ class IncrementalDRC:
         # Create a modified position tuple
         new_position = (fp.position[0] + dx, fp.position[1] + dy)
 
-        cos1 = math.cos(math.radians(fp.rotation))
-        sin1 = math.sin(math.radians(fp.rotation))
+        use_cpp = _is_drc_cpp_available()
 
         for other_ref in nearby_refs:
             if other_ref == ref:
@@ -755,59 +814,17 @@ class IncrementalDRC:
             if fp2 is None:
                 continue
 
-            cos2 = math.cos(math.radians(fp2.rotation))
-            sin2 = math.sin(math.radians(fp2.rotation))
-
-            # Check pad clearances
-            min_clearance = float("inf")
-            min_location = (0.0, 0.0)
-            min_items: tuple[str, ...] = ()
-            min_nets: tuple[str, ...] = ()
-
-            for pad1 in fp.pads:
-                # Transform pad1 using NEW position
-                local_x1, local_y1 = pad1.position
-                rotated_x1 = local_x1 * cos1 - local_y1 * sin1
-                rotated_y1 = local_x1 * sin1 + local_y1 * cos1
-                abs_x1 = new_position[0] + rotated_x1
-                abs_y1 = new_position[1] + rotated_y1
-                r1 = max(pad1.size[0], pad1.size[1]) / 2
-
-                for pad2 in fp2.pads:
-                    # Skip if same net
-                    if pad1.net_number == pad2.net_number and pad1.net_number != 0:
-                        continue
-
-                    # Transform pad2 using original position
-                    local_x2, local_y2 = pad2.position
-                    rotated_x2 = local_x2 * cos2 - local_y2 * sin2
-                    rotated_y2 = local_x2 * sin2 + local_y2 * cos2
-                    abs_x2 = fp2.position[0] + rotated_x2
-                    abs_y2 = fp2.position[1] + rotated_y2
-                    r2 = max(pad2.size[0], pad2.size[1]) / 2
-
-                    dist = math.sqrt((abs_x2 - abs_x1) ** 2 + (abs_y2 - abs_y1) ** 2)
-                    clearance = dist - r1 - r2
-
-                    if clearance < min_clearance:
-                        min_clearance = clearance
-                        min_location = ((abs_x1 + abs_x2) / 2, (abs_y1 + abs_y2) / 2)
-                        min_items = (f"{ref}-{pad1.number}", f"{other_ref}-{pad2.number}")
-                        min_nets = (pad1.net_name, pad2.net_name)
-
-            if min_clearance < self.rules.min_clearance_mm:
-                violations.append(
-                    Violation(
-                        rule_id="clearance",
-                        message=f"Clearance {min_clearance:.3f}mm < minimum {self.rules.min_clearance_mm:.3f}mm",
-                        severity="error",
-                        location=min_location,
-                        items=min_items,
-                        nets=min_nets,
-                        actual_value=min_clearance,
-                        required_value=self.rules.min_clearance_mm,
-                    )
+            if use_cpp:
+                violation = self._check_pair_clearance_cpp(
+                    fp, fp2, ref, other_ref, fp1_position=new_position
                 )
+            else:
+                violation = self._check_pair_clearance_python(
+                    fp, fp2, ref, other_ref, fp1_position=new_position
+                )
+
+            if violation:
+                violations.append(violation)
 
         return violations
 

--- a/tests/test_drc_cpp_backend.py
+++ b/tests/test_drc_cpp_backend.py
@@ -1,0 +1,572 @@
+"""Tests for C++ DRC backend wrapper and Python/C++ parity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.drc.cpp_backend import (
+    get_backend_info,
+    get_cpp_unavailable_reason,
+    is_cpp_available,
+)
+from kicad_tools.drc.incremental import (
+    IncrementalDRC,
+)
+from kicad_tools.manufacturers.base import DesignRules
+from kicad_tools.schema.pcb import PCB
+
+# ----- Test Fixtures -----
+
+# PCB with two close components (clearance violation expected)
+PCB_CLOSE_COMPONENTS = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "SIG1")
+  (net 3 "SIG2")
+  (gr_rect (start 100 100) (end 200 200)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 120 120)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "SIG1"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (at 121.2 120)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000021"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000022"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 3 "SIG2"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+)
+"""
+
+# PCB with same-net pads close together (should NOT trigger violation)
+PCB_SAME_NET = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (gr_rect (start 100 100) (end 200 200)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 120 120)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (at 121.2 120)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000021"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000022"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+)
+"""
+
+# PCB with well-spaced components (no violations)
+PCB_WELL_SPACED = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (gr_rect (start 100 100) (end 200 200)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 120 120)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (at 140 140)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000021"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000022"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+)
+"""
+
+# PCB with a rotated component
+PCB_ROTATED = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "SIG1")
+  (net 3 "SIG2")
+  (gr_rect (start 100 100) (end 200 200)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 120 120 90)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "SIG1"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (at 121.2 120)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000021"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000022"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 3 "SIG2"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+)
+"""
+
+# PCB with no pads (edge case)
+PCB_NO_PADS = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (gr_rect (start 100 100) (end 200 200)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "TestLib:NoPads"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 120 120)
+    (property "Reference" "J1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "CONN" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+  )
+  (footprint "TestLib:NoPads"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (at 121 120)
+    (property "Reference" "J2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000021"))
+    (property "Value" "CONN" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000022"))
+  )
+)
+"""
+
+# PCB with single pad per component
+PCB_SINGLE_PAD = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "SIG1")
+  (gr_rect (start 100 100) (end 200 200)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "TestLib:SinglePad"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 120 120)
+    (property "Reference" "TP1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "TP" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (pad "1" smd circle (at 0 0) (size 1.0 1.0) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND"))
+  )
+  (footprint "TestLib:SinglePad"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (at 121.5 120)
+    (property "Reference" "TP2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000021"))
+    (property "Value" "TP" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000022"))
+    (pad "1" smd circle (at 0 0) (size 1.0 1.0) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "SIG1"))
+  )
+)
+"""
+
+
+def _load_pcb(tmp_path: Path, content: str, name: str = "test.kicad_pcb") -> PCB:
+    """Helper to load a PCB from string content."""
+    pcb_file = tmp_path / name
+    pcb_file.write_text(content)
+    return PCB.load(str(pcb_file))
+
+
+@pytest.fixture
+def default_rules() -> DesignRules:
+    """Standard design rules for testing."""
+    return DesignRules(
+        min_trace_width_mm=0.1,
+        min_clearance_mm=0.15,
+        min_via_drill_mm=0.3,
+        min_via_diameter_mm=0.6,
+        min_annular_ring_mm=0.15,
+    )
+
+
+# ----- Backend availability tests -----
+
+
+class TestCppBackendAvailability:
+    """Tests for C++ backend availability detection and fallback."""
+
+    def test_is_cpp_available_returns_bool(self):
+        """is_cpp_available returns a boolean."""
+        result = is_cpp_available()
+        assert isinstance(result, bool)
+
+    def test_get_backend_info_structure(self):
+        """get_backend_info returns well-formed dict."""
+        info = get_backend_info()
+        assert "backend" in info
+        assert info["backend"] in ("cpp", "python")
+        assert "available" in info
+        assert "platform" in info
+
+    def test_get_backend_info_cpp_available(self):
+        """When C++ is available, backend info reflects that."""
+        info = get_backend_info()
+        if info["available"]:
+            assert info["backend"] == "cpp"
+            assert "version" in info
+        else:
+            assert info["backend"] == "python"
+            assert "unavailable_reason" in info
+
+    def test_fallback_on_import_error(self):
+        """Backend gracefully falls back when C++ module is missing."""
+        # This test verifies that the import failure path is handled.
+        # Even if C++ is available in this environment, we test the
+        # fallback logic by checking the module structure.
+        reason = get_cpp_unavailable_reason()
+        if is_cpp_available():
+            assert reason is None
+        else:
+            assert isinstance(reason, str)
+            assert len(reason) > 0
+
+
+# ----- Python fallback parity tests -----
+
+
+class TestPythonFallbackParity:
+    """Tests ensuring Python fallback produces correct results.
+
+    These tests run with forced Python mode by patching the availability
+    check, ensuring the Python path is always exercised regardless of
+    whether C++ is actually available.
+    """
+
+    def test_python_detects_violation(self, tmp_path: Path, default_rules: DesignRules):
+        """Python fallback detects clearance violations."""
+        pcb = _load_pcb(tmp_path, PCB_CLOSE_COMPONENTS)
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc = IncrementalDRC(pcb, default_rules)
+            violations = drc.full_check()
+        assert len(violations) > 0
+        assert all(v.rule_id == "clearance" for v in violations)
+
+    def test_python_clean_board(self, tmp_path: Path, default_rules: DesignRules):
+        """Python fallback returns no violations for clean board."""
+        pcb = _load_pcb(tmp_path, PCB_WELL_SPACED)
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc = IncrementalDRC(pcb, default_rules)
+            violations = drc.full_check()
+        assert len(violations) == 0
+
+    def test_python_same_net_skip(self, tmp_path: Path, default_rules: DesignRules):
+        """Python fallback correctly skips same-net pad pairs."""
+        pcb = _load_pcb(tmp_path, PCB_SAME_NET)
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc = IncrementalDRC(pcb, default_rules)
+            violations = drc.full_check()
+        # All pads on same net -- no violations even though components are close
+        assert len(violations) == 0
+
+    def test_python_no_pads(self, tmp_path: Path, default_rules: DesignRules):
+        """Python fallback handles components with no pads."""
+        pcb = _load_pcb(tmp_path, PCB_NO_PADS)
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc = IncrementalDRC(pcb, default_rules)
+            violations = drc.full_check()
+        assert len(violations) == 0
+
+    def test_python_single_pad(self, tmp_path: Path, default_rules: DesignRules):
+        """Python fallback handles single-pad components."""
+        pcb = _load_pcb(tmp_path, PCB_SINGLE_PAD)
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc = IncrementalDRC(pcb, default_rules)
+            violations = drc.full_check()
+        # Single pad components 1.5mm apart, pad radius 0.5mm each
+        # clearance = 1.5 - 0.5 - 0.5 = 0.5mm > 0.15mm min, so no violation
+        assert len(violations) == 0
+
+    def test_python_rotated_component(self, tmp_path: Path, default_rules: DesignRules):
+        """Python fallback correctly handles rotated components."""
+        pcb = _load_pcb(tmp_path, PCB_ROTATED)
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc = IncrementalDRC(pcb, default_rules)
+            violations = drc.full_check()
+        # Should still detect violations (R1 rotated 90 degrees but still close to R2)
+        # The rotation may change which pads are closest
+        assert isinstance(violations, list)
+
+    def test_python_check_move(self, tmp_path: Path, default_rules: DesignRules):
+        """Python fallback correctly handles check_move with position offset."""
+        pcb = _load_pcb(tmp_path, PCB_CLOSE_COMPONENTS)
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc = IncrementalDRC(pcb, default_rules)
+            drc.full_check()
+            # Get R2's internal bounds center to move R1 right next to it
+            r2_center_x = drc.state.component_bounds["R2"].center_x
+            r2_center_y = drc.state.component_bounds["R2"].center_y
+            # Move R1 to overlap with R2 (same center = maximum overlap)
+            delta = drc.check_move("R1", r2_center_x, r2_center_y)
+        # R1 overlapping R2 should produce violations (different-net pads overlap)
+        assert len(delta.new_violations) > 0
+
+
+# ----- C++ / Python parity tests (only run if C++ is available) -----
+
+
+class TestCppPythonParity:
+    """Tests comparing C++ and Python backends for identical results.
+
+    These tests verify that both backends produce the same violation
+    results for identical inputs, ensuring the C++ optimization does
+    not change behavior.
+    """
+
+    @pytest.mark.skipif(not is_cpp_available(), reason="C++ DRC backend not built")
+    def test_parity_violation_detection(self, tmp_path: Path, default_rules: DesignRules):
+        """C++ and Python backends detect the same violations."""
+        pcb = _load_pcb(tmp_path, PCB_CLOSE_COMPONENTS)
+
+        # Run with C++ backend
+        drc_cpp_run = IncrementalDRC(pcb, default_rules)
+        violations_cpp = drc_cpp_run.full_check()
+
+        # Run with Python backend
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc_py = IncrementalDRC(pcb, default_rules)
+            violations_py = drc_py.full_check()
+
+        assert len(violations_cpp) == len(violations_py)
+
+        # Compare violation details
+        for v_cpp, v_py in zip(
+            sorted(violations_cpp, key=lambda v: v.items),
+            sorted(violations_py, key=lambda v: v.items),
+            strict=False,
+        ):
+            assert v_cpp.rule_id == v_py.rule_id
+            assert v_cpp.items == v_py.items
+            assert v_cpp.nets == v_py.nets
+            # Clearance values should match within float32 tolerance
+            assert abs(v_cpp.actual_value - v_py.actual_value) < 1e-3
+
+    @pytest.mark.skipif(not is_cpp_available(), reason="C++ DRC backend not built")
+    def test_parity_clean_board(self, tmp_path: Path, default_rules: DesignRules):
+        """Both backends agree on clean board."""
+        pcb = _load_pcb(tmp_path, PCB_WELL_SPACED)
+
+        drc_cpp_run = IncrementalDRC(pcb, default_rules)
+        violations_cpp = drc_cpp_run.full_check()
+
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc_py = IncrementalDRC(pcb, default_rules)
+            violations_py = drc_py.full_check()
+
+        assert len(violations_cpp) == 0
+        assert len(violations_py) == 0
+
+    @pytest.mark.skipif(not is_cpp_available(), reason="C++ DRC backend not built")
+    def test_parity_same_net_skip(self, tmp_path: Path, default_rules: DesignRules):
+        """Both backends correctly skip same-net pairs."""
+        pcb = _load_pcb(tmp_path, PCB_SAME_NET)
+
+        drc_cpp_run = IncrementalDRC(pcb, default_rules)
+        violations_cpp = drc_cpp_run.full_check()
+
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc_py = IncrementalDRC(pcb, default_rules)
+            violations_py = drc_py.full_check()
+
+        assert len(violations_cpp) == 0
+        assert len(violations_py) == 0
+
+    @pytest.mark.skipif(not is_cpp_available(), reason="C++ DRC backend not built")
+    def test_parity_rotated(self, tmp_path: Path, default_rules: DesignRules):
+        """Both backends agree on rotated component results."""
+        pcb = _load_pcb(tmp_path, PCB_ROTATED)
+
+        drc_cpp_run = IncrementalDRC(pcb, default_rules)
+        violations_cpp = drc_cpp_run.full_check()
+
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc_py = IncrementalDRC(pcb, default_rules)
+            violations_py = drc_py.full_check()
+
+        assert len(violations_cpp) == len(violations_py)
+
+    @pytest.mark.skipif(not is_cpp_available(), reason="C++ DRC backend not built")
+    def test_parity_numerical_precision(self, tmp_path: Path, default_rules: DesignRules):
+        """C++ and Python clearance values match within float32 tolerance."""
+        pcb = _load_pcb(tmp_path, PCB_CLOSE_COMPONENTS)
+
+        drc_cpp_run = IncrementalDRC(pcb, default_rules)
+        violations_cpp = drc_cpp_run.full_check()
+
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc_py = IncrementalDRC(pcb, default_rules)
+            violations_py = drc_py.full_check()
+
+        for v_cpp, v_py in zip(
+            sorted(violations_cpp, key=lambda v: v.items),
+            sorted(violations_py, key=lambda v: v.items),
+            strict=False,
+        ):
+            # float32 vs float64 can differ by ~1e-6 in the worst case,
+            # but pad geometry values are small so 1e-3 is conservative
+            assert abs(v_cpp.actual_value - v_py.actual_value) < 1e-3, (
+                f"Clearance mismatch: C++={v_cpp.actual_value:.6f} "
+                f"vs Python={v_py.actual_value:.6f}"
+            )
+
+    @pytest.mark.skipif(not is_cpp_available(), reason="C++ DRC backend not built")
+    def test_parity_check_move(self, tmp_path: Path, default_rules: DesignRules):
+        """Both backends agree on check_move results with position offset."""
+        pcb = _load_pcb(tmp_path, PCB_CLOSE_COMPONENTS)
+
+        # C++ path
+        drc_cpp_run = IncrementalDRC(pcb, default_rules)
+        drc_cpp_run.full_check()
+        r2_cx = drc_cpp_run.state.component_bounds["R2"].center_x
+        r2_cy = drc_cpp_run.state.component_bounds["R2"].center_y
+        delta_cpp = drc_cpp_run.check_move("R1", r2_cx, r2_cy)
+
+        # Python path
+        with patch("kicad_tools.drc.incremental._is_drc_cpp_available", return_value=False):
+            drc_py = IncrementalDRC(pcb, default_rules)
+            drc_py.full_check()
+            delta_py = drc_py.check_move("R1", r2_cx, r2_cy)
+
+        assert len(delta_cpp.new_violations) == len(delta_py.new_violations)
+
+
+# ----- Edge case tests -----
+
+
+class TestEdgeCases:
+    """Edge case tests that run on whichever backend is available."""
+
+    def test_zero_pads_no_crash(self, tmp_path: Path, default_rules: DesignRules):
+        """Components with zero pads do not crash."""
+        pcb = _load_pcb(tmp_path, PCB_NO_PADS)
+        drc = IncrementalDRC(pcb, default_rules)
+        violations = drc.full_check()
+        assert len(violations) == 0
+
+    def test_single_pad_components(self, tmp_path: Path, default_rules: DesignRules):
+        """Single-pad components work correctly (1x1 trivial case)."""
+        pcb = _load_pcb(tmp_path, PCB_SINGLE_PAD)
+        drc = IncrementalDRC(pcb, default_rules)
+        violations = drc.full_check()
+        # 1.5mm center-to-center, 0.5mm radius each = 0.5mm clearance > 0.15mm
+        assert len(violations) == 0
+
+    def test_net_zero_not_skipped(self, tmp_path: Path, default_rules: DesignRules):
+        """Pads with net_number=0 (unconnected) are not skipped."""
+        # Unconnected pads (net 0) should still be checked against each other
+        # because net_number == 0 is not a real net connection
+        pcb_content = PCB_CLOSE_COMPONENTS.replace('(net 2 "SIG1")', '(net 0 "")')
+        pcb_content = pcb_content.replace('(net 3 "SIG2")', '(net 0 "")')
+        # Replace pad net assignments
+        pcb_content = pcb_content.replace('(net 2 "SIG1"))', '(net 0 ""))')
+        pcb_content = pcb_content.replace('(net 3 "SIG2"))', '(net 0 ""))')
+        pcb = _load_pcb(tmp_path, pcb_content)
+        drc = IncrementalDRC(pcb, default_rules)
+        violations = drc.full_check()
+        # Should still detect violations because net 0 pairs are not skipped
+        assert len(violations) > 0


### PR DESCRIPTION
## Summary

Add a `drc/cpp/` C++ module with nanobind bindings for batch pad-to-pad clearance computation, accelerating the O(P1*P2) inner loop in `IncrementalDRC._check_pair_clearance()` and `_check_component_clearances()`. The existing Python implementation is preserved as a fallback.

## Changes

- **New `src/kicad_tools/drc/cpp/`**: C++ nanobind module (`drc_cpp`) with `check_pair_clearance()` function
  - `include/drc_clearance.hpp`: Header with `ClearanceResult` struct and function declarations
  - `src/drc_clearance.cpp`: Core computation with squared-distance optimization, precomputed trig, and struct-of-arrays layout
  - `src/bindings.cpp`: nanobind Python bindings
  - `CMakeLists.txt`: Build configuration following `router/cpp/` pattern
- **New `src/kicad_tools/drc/cpp_backend.py`**: Python wrapper with availability detection, pad array extraction, and graceful fallback (mirrors `router/cpp_backend.py` pattern)
- **Modified `src/kicad_tools/drc/incremental.py`**: Refactored `_check_pair_clearance()` and `_check_component_clearances()` to dispatch to C++ when available; extracted Python fallback into `_check_pair_clearance_python()` with `fp1_position` parameter for moved-component checks
- **New `tests/test_drc_cpp_backend.py`**: 20 tests covering backend availability, Python fallback correctness, C++/Python parity (skipped when C++ not built), and edge cases (zero pads, single pad, same-net skip, net-0 handling, rotated components)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| C++ module under `drc/cpp/` (not `placement/cpp/`) | PASS | Created at `src/kicad_tools/drc/cpp/` |
| Squared-distance optimization | PASS | Inner loop uses `dist_sq > threshold * threshold` to skip sqrt |
| Struct-of-arrays layout | PASS | Flat arrays for pad positions, radii, nets |
| nanobind bindings following router/cpp/ pattern | PASS | Same CMakeLists.txt structure, NB_MODULE pattern |
| `drc/cpp_backend.py` with Python fallback | PASS | `is_cpp_available()`, `check_pair_clearance_cpp()`, graceful ImportError |
| Same-net skip preserved | PASS | `net1 == pad2_net[j] && net1 != 0` in C++, tested |
| Net-0 not incorrectly skipped | PASS | Explicit test `test_net_zero_not_skipped` passes |
| Existing tests pass unchanged | PASS | All 31 tests in `test_incremental_drc.py` pass |
| New tests for C++/Python parity | PASS | 20 tests in `test_drc_cpp_backend.py` (14 pass, 6 skipped pending C++ build) |

## Test Plan

```
python3 -m pytest tests/test_incremental_drc.py tests/test_drc_cpp_backend.py -v -o "addopts="
# Result: 45 passed, 6 skipped (C++ parity tests skip when native module not built)
```

Closes #1716