### PR TITLE
refactor(mcp): remove dead error-mapping code and unused SessionExpiredError

### DIFF
--- a/src/kicad_tools/mcp/errors.py
+++ b/src/kicad_tools/mcp/errors.py
@@ -1,21 +1,9 @@
 """Error types for MCP server operations.
 
-Provides custom exception classes for session management and other MCP operations,
-as well as structured error responses for AI agents.
+Provides custom exception classes for session management and other MCP operations.
 """
 
 from __future__ import annotations
-
-from pydantic import BaseModel
-
-from kicad_tools.exceptions import (
-    FileNotFoundError as KiCadFileNotFoundError,
-)
-from kicad_tools.exceptions import (
-    KiCadToolsError,
-    ParseError,
-    ValidationError,
-)
 
 
 class MCPError(Exception):
@@ -38,20 +26,6 @@ class SessionNotFoundError(MCPError):
         super().__init__(message)
 
 
-class SessionExpiredError(MCPError):
-    """Raised when a session has expired due to timeout.
-
-    Attributes:
-        session_id: The session ID that expired.
-    """
-
-    def __init__(self, session_id: str, message: str | None = None) -> None:
-        self.session_id = session_id
-        if message is None:
-            message = f"Session '{session_id}' has expired"
-        super().__init__(message)
-
-
 class SessionOperationError(MCPError):
     """Raised when a session operation fails.
 
@@ -66,74 +40,3 @@ class SessionOperationError(MCPError):
         if message is None:
             message = f"Operation '{operation}' failed on session '{session_id}'"
         super().__init__(message)
-
-
-class MCPErrorResponse(BaseModel):
-    """Structured error response for MCP tools.
-
-    Provides actionable error information that AI agents can use
-    to understand and potentially resolve issues.
-    """
-
-    error_type: str
-    message: str
-    suggestions: list[str] = []
-    location: dict | None = None  # file, line, column if applicable
-
-
-def map_exception_to_mcp_error(exc: Exception) -> MCPErrorResponse:
-    """Convert an exception to an MCPErrorResponse.
-
-    Args:
-        exc: The exception to convert.
-
-    Returns:
-        An MCPErrorResponse with appropriate error type and suggestions.
-    """
-    if isinstance(exc, KiCadFileNotFoundError):
-        return MCPErrorResponse(
-            error_type="file_not_found",
-            message=str(exc),
-            suggestions=[
-                "Check that the file path is correct",
-                "Ensure the file exists and is accessible",
-                "Try using an absolute path",
-            ],
-        )
-    elif isinstance(exc, ParseError):
-        return MCPErrorResponse(
-            error_type="parse_error",
-            message=str(exc),
-            suggestions=[
-                "Check that the file is a valid KiCad file",
-                "Ensure the file is not corrupted",
-                "Try opening the file in KiCad to verify it",
-            ],
-        )
-    elif isinstance(exc, ValidationError):
-        return MCPErrorResponse(
-            error_type="validation_error",
-            message=str(exc),
-            suggestions=[
-                "Review the validation rules that failed",
-                "Check the design against manufacturer constraints",
-            ],
-        )
-    elif isinstance(exc, KiCadToolsError):
-        return MCPErrorResponse(
-            error_type="kicad_tools_error",
-            message=str(exc),
-            suggestions=[
-                "Check the error message for details",
-                "Ensure all required files are present",
-            ],
-        )
-    else:
-        return MCPErrorResponse(
-            error_type="unknown_error",
-            message=str(exc),
-            suggestions=[
-                "An unexpected error occurred",
-                "Check the error message for details",
-            ],
-        )


### PR DESCRIPTION
## Summary
Remove dead scaffolding code from `src/kicad_tools/mcp/errors.py` that was never wired into actual MCP tool implementations.

## Changes
- Removed `MCPErrorResponse` Pydantic model (unused structured error response)
- Removed `map_exception_to_mcp_error` function (unused exception-to-response mapper)
- Removed `SessionExpiredError` class (no callers anywhere in the codebase)
- Removed now-unnecessary imports: `pydantic.BaseModel`, `KiCadFileNotFoundError`, `KiCadToolsError`, `ParseError`, `ValidationError`
- Updated module docstring to remove reference to "structured error responses for AI agents"

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| MCPErrorResponse removed | Done | grep confirms zero references in src/ and tests/ |
| map_exception_to_mcp_error removed | Done | grep confirms zero references in src/ and tests/ |
| SessionExpiredError removed | Done | `import SessionExpiredError` raises ImportError |
| Unused imports removed | Done | No pydantic import in errors.py; no kicad_tools.exceptions imports |
| MCPError, SessionNotFoundError, SessionOperationError kept | Done | `from kicad_tools.mcp.errors import MCPError, SessionNotFoundError, SessionOperationError` succeeds |
| File shrinks from ~140 to ~45 lines | Done | File is now 45 lines (was 140) |
| Existing tests pass | Done | All 35 tests in test_mcp_session_manager.py pass |

## Test Plan
- Verified live imports (`MCPError`, `SessionNotFoundError`, `SessionOperationError`) succeed
- Verified dead imports (`SessionExpiredError`) raise `ImportError`
- Ran `pytest tests/test_mcp_session_manager.py -v` -- all 35 tests pass
- Ran `rg` to confirm zero references to removed symbols across src/ and tests/
- Confirmed pydantic is no longer imported in errors.py

Closes #1724