### PR TITLE
fix(deps): move cmaes from core to optional placement extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
     "pyyaml>=6.0",
     "numpy>=1.24",
     "pydantic>=2.0",
-    "cmaes>=0.12.0",
 ]
 
 [project.urls]
@@ -100,9 +99,9 @@ datasheet = [
     "pdfplumber>=0.10.0",
     "PyMuPDF>=1.23.0",
 ]
-# YAML constraint manifest support
-constraints = [
-    "pyyaml>=6.0",
+# CMA-ES placement optimization strategy
+placement = [
+    "cmaes>=0.12.0",
 ]
 # MCP server for AI agent integration
 mcp = [
@@ -159,6 +158,7 @@ all = [
     "matplotlib>=3.5",
     "ax-platform>=0.4.0",
     "botorch>=0.12.0",
+    "cmaes>=0.12.0",
     "cairosvg>=2.6",
     "jinja2>=3.1",
     "markdown>=3.5",
@@ -180,6 +180,7 @@ dev = [
     "pyyaml>=6.0",
     "fastmcp>=2.0,<3",
     "pydantic>=2.0",
+    "cmaes>=0.12.0",
     "matplotlib>=3.5",
     "jinja2>=3.1",
     "markdown>=3.5",

--- a/src/kicad_tools/placement/__init__.py
+++ b/src/kicad_tools/placement/__init__.py
@@ -30,7 +30,8 @@ from .cost import (
     compute_block_boundary_violation,
     compute_inter_block_spacing_violation,
 )
-from .cmaes_strategy import CMAESStrategy
+with contextlib.suppress(ImportError):
+    from .cmaes_strategy import CMAESStrategy
 from .collision import (
     CollisionResult,
     DRCResult,

--- a/uv.lock
+++ b/uv.lock
@@ -1769,7 +1769,6 @@ name = "kicad-tools"
 version = "0.12.0"
 source = { editable = "." }
 dependencies = [
-    { name = "cmaes" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
@@ -1785,6 +1784,7 @@ all = [
     { name = "botorch", version = "0.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "botorch", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "cairosvg" },
+    { name = "cmaes" },
     { name = "cupy-cuda12x" },
     { name = "fastmcp" },
     { name = "jinja2" },
@@ -1808,9 +1808,6 @@ bayesian = [
     { name = "botorch", version = "0.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "botorch", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-constraints = [
-    { name = "pyyaml" },
-]
 cuda = [
     { name = "cupy-cuda12x" },
 ]
@@ -1820,6 +1817,7 @@ datasheet = [
     { name = "pymupdf" },
 ]
 dev = [
+    { name = "cmaes" },
     { name = "fastmcp" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -1859,6 +1857,9 @@ native = [
 parts = [
     { name = "requests" },
 ]
+placement = [
+    { name = "cmaes" },
+]
 report = [
     { name = "jinja2" },
     { name = "markdown" },
@@ -1885,7 +1886,9 @@ requires-dist = [
     { name = "botorch", marker = "extra == 'bayesian'", specifier = ">=0.12.0" },
     { name = "cairosvg", marker = "extra == 'all'", specifier = ">=2.6" },
     { name = "cairosvg", marker = "extra == 'screenshot'", specifier = ">=2.6" },
-    { name = "cmaes", specifier = ">=0.12.0" },
+    { name = "cmaes", marker = "extra == 'all'", specifier = ">=0.12.0" },
+    { name = "cmaes", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+    { name = "cmaes", marker = "extra == 'placement'", specifier = ">=0.12.0" },
     { name = "cmake", marker = "extra == 'native'", specifier = ">=3.15" },
     { name = "cupy-cuda12x", marker = "extra == 'all'", specifier = ">=13.0" },
     { name = "cupy-cuda12x", marker = "extra == 'cuda'", specifier = ">=13.0" },
@@ -1926,7 +1929,6 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'all'", specifier = ">=6.0" },
-    { name = "pyyaml", marker = "extra == 'constraints'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "requests", marker = "extra == 'all'", specifier = ">=2.28" },
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.28" },
@@ -1943,7 +1945,7 @@ requires-dist = [
     { name = "weasyprint", marker = "extra == 'dev'", specifier = ">=60.0" },
     { name = "weasyprint", marker = "extra == 'report'", specifier = ">=60.0" },
 ]
-provides-extras = ["drc", "parts", "datasheet", "constraints", "mcp", "native", "cuda", "metal", "visualization", "bayesian", "screenshot", "report", "all", "dev"]
+provides-extras = ["drc", "parts", "datasheet", "placement", "mcp", "native", "cuda", "metal", "visualization", "bayesian", "screenshot", "report", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
Moves `cmaes` from core dependencies to an optional `[placement]` extra, reducing install weight for users who do not need the CMA-ES placement optimization strategy. Also removes the redundant `pyyaml` entry from the `constraints` extra and guards the `CMAESStrategy` import in `placement/__init__.py`.

## Changes
- Removed `cmaes>=0.12.0` from `[project.dependencies]`
- Replaced the `constraints` optional extra (which redundantly listed `pyyaml`, already a core dep) with a new `placement` extra containing `cmaes>=0.12.0`
- Added `cmaes>=0.12.0` to the `[all]` extra
- Added `cmaes>=0.12.0` to the `dev` extra so tests continue to pass
- Wrapped `CMAESStrategy` import in `placement/__init__.py` with `contextlib.suppress(ImportError)` (matching the existing `BayesianOptStrategy` pattern)
- Regenerated `uv.lock`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| cmaes removed from core deps | Done | Confirmed not in `[project.dependencies]` |
| New placement extra created | Done | `[project.optional-dependencies] placement` contains `cmaes>=0.12.0` |
| cmaes added to [all] extra | Done | Listed in `all` extras list |
| cmaes added to dev extra | Done | Listed in `dev` extras list |
| Redundant pyyaml removed from constraints | Done | constraints extra replaced by placement extra |
| CMAESStrategy import guarded | Done | Wrapped with `contextlib.suppress(ImportError)` |
| uv.lock regenerated | Done | `uv lock` ran successfully |
| Tests pass with dev deps | Done | 83 passed (3 pre-existing failures unrelated to this change) |
| Import works without cmaes | Done | `from kicad_tools.placement import PlacementAnalyzer` succeeds without cmaes |
| CMAESStrategy available with cmaes | Done | `from kicad_tools.placement import CMAESStrategy` succeeds with `.[placement]` |

## Test Plan
- Ran `uv run --extra dev pytest tests/test_optimize_placement_cmd.py tests/test_placement_strategy.py tests/test_placement_benchmark.py` -- 83 passed
- Verified `from kicad_tools.placement import PlacementAnalyzer, PlacementFixer` works without cmaes installed
- Verified `from kicad_tools.placement import CMAESStrategy` works with cmaes installed

Closes #1727