### PR TITLE
refactor: consolidate duplicate find_kicad_cli() into cli/runner.py

### DIFF
--- a/src/kicad_tools/cli/export_gerbers.py
+++ b/src/kicad_tools/cli/export_gerbers.py
@@ -22,6 +22,8 @@ from datetime import datetime
 from pathlib import Path
 from zipfile import ZipFile
 
+from kicad_tools.cli.runner import find_kicad_cli
+
 # Seeed Fusion layer naming convention
 SEEED_LAYER_NAMES = {
     "F.Cu": "GTL",  # Top copper
@@ -52,27 +54,6 @@ FOUR_LAYER_STACK = [
     "Edge.Cuts",
 ]
 
-
-def find_kicad_cli() -> Path | None:
-    """Find kicad-cli executable."""
-    locations = [
-        "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
-        "/usr/local/bin/kicad-cli",
-        "/opt/homebrew/bin/kicad-cli",
-    ]
-
-    for loc in locations:
-        if Path(loc).exists():
-            return Path(loc)
-
-    try:
-        result = subprocess.run(["which", "kicad-cli"], capture_output=True, text=True)
-        if result.returncode == 0:
-            return Path(result.stdout.strip())
-    except Exception:
-        pass
-
-    return None
 
 
 def export_gerbers(pcb_path: Path, output_dir: Path, kicad_cli: Path) -> bool:

--- a/src/kicad_tools/cli/export_netlist.py
+++ b/src/kicad_tools/cli/export_netlist.py
@@ -22,6 +22,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from kicad_tools.cli.runner import find_kicad_cli
 from kicad_tools.sexp import SExp, parse_string
 
 
@@ -283,27 +284,6 @@ class Netlist:
                     break
         return power_nets
 
-
-def find_kicad_cli() -> Path | None:
-    """Find kicad-cli executable."""
-    locations = [
-        "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
-        "/usr/local/bin/kicad-cli",
-        "/opt/homebrew/bin/kicad-cli",
-    ]
-
-    for loc in locations:
-        if Path(loc).exists():
-            return Path(loc)
-
-    try:
-        result = subprocess.run(["which", "kicad-cli"], capture_output=True, text=True)
-        if result.returncode == 0:
-            return Path(result.stdout.strip())
-    except Exception:
-        pass
-
-    return None
 
 
 def export_netlist(

--- a/src/kicad_tools/cli/generate_bom.py
+++ b/src/kicad_tools/cli/generate_bom.py
@@ -34,6 +34,8 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from kicad_tools.cli.runner import find_kicad_cli
+
 KICAD_SCRIPTS = Path(__file__).resolve().parent
 
 
@@ -157,29 +159,6 @@ class BOMLine:
             return self.components[0].get_field(name)
         return ""
 
-
-def find_kicad_cli() -> Path | None:
-    """Find kicad-cli executable."""
-    # Check common locations on macOS
-    locations = [
-        "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
-        "/usr/local/bin/kicad-cli",
-        "/opt/homebrew/bin/kicad-cli",
-    ]
-
-    for loc in locations:
-        if Path(loc).exists():
-            return Path(loc)
-
-    # Try PATH
-    try:
-        result = subprocess.run(["which", "kicad-cli"], capture_output=True, text=True)
-        if result.returncode == 0:
-            return Path(result.stdout.strip())
-    except Exception:
-        pass
-
-    return None
 
 
 def extract_components_from_schematic(sch_path: Path, sheet_name: str = "") -> list[Component]:

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -34,6 +34,7 @@ def find_kicad_cli() -> Path | None:
         "/usr/local/bin/kicad-cli",
         # Windows (common paths)
         "C:/Program Files/KiCad/8.0/bin/kicad-cli.exe",
+        "C:/Program Files/KiCad/7.0/bin/kicad-cli.exe",
         "C:/Program Files/KiCad/bin/kicad-cli.exe",
     ]
 

--- a/src/kicad_tools/export/gerber.py
+++ b/src/kicad_tools/export/gerber.py
@@ -7,7 +7,6 @@ Wraps kicad-cli for generating Gerber files with manufacturer presets.
 from __future__ import annotations
 
 import logging
-import shutil
 import subprocess
 import zipfile
 from dataclasses import dataclass, field
@@ -22,6 +21,7 @@ from kicad_tools.exceptions import (
     ExportError,
 )
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
+from kicad_tools.cli.runner import find_kicad_cli
 
 logger = logging.getLogger(__name__)
 
@@ -115,31 +115,6 @@ MANUFACTURER_PRESETS: dict[str, ManufacturerPreset] = {
     "oshpark": OSHPARK_PRESET,
 }
 
-
-def find_kicad_cli() -> Path | None:
-    """Find kicad-cli executable."""
-    # Check PATH first
-    cli = shutil.which("kicad-cli")
-    if cli:
-        return Path(cli)
-
-    # Check common locations
-    common_paths = [
-        # macOS
-        Path("/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"),
-        # Linux
-        Path("/usr/bin/kicad-cli"),
-        Path("/usr/local/bin/kicad-cli"),
-        # Windows
-        Path("C:/Program Files/KiCad/8.0/bin/kicad-cli.exe"),
-        Path("C:/Program Files/KiCad/7.0/bin/kicad-cli.exe"),
-    ]
-
-    for path in common_paths:
-        if path.exists():
-            return path
-
-    return None
 
 
 def get_kicad_cli_version(kicad_cli: Path) -> str | None:

--- a/src/kicad_tools/operations/netlist.py
+++ b/src/kicad_tools/operations/netlist.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from kicad_tools.cli.runner import find_kicad_cli
 from kicad_tools.sexp import SExp, parse_string
 
 logger = logging.getLogger(__name__)
@@ -391,27 +392,6 @@ class Netlist:
             "signal_net_count": len(self.nets) - len(power_nets),
         }
 
-
-def find_kicad_cli() -> Path | None:
-    """Find kicad-cli executable."""
-    locations = [
-        "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
-        "/usr/local/bin/kicad-cli",
-        "/opt/homebrew/bin/kicad-cli",
-    ]
-
-    for loc in locations:
-        if Path(loc).exists():
-            return Path(loc)
-
-    try:
-        result = subprocess.run(["which", "kicad-cli"], capture_output=True, text=True)
-        if result.returncode == 0:
-            return Path(result.stdout.strip())
-    except Exception:
-        pass
-
-    return None
 
 
 def build_netlist_from_schematic(sch_path: str | Path) -> Netlist:


### PR DESCRIPTION
## Summary
Consolidates 5 duplicate `find_kicad_cli()` definitions into the single canonical implementation at `src/kicad_tools/cli/runner.py`. This eliminates code duplication and ensures all callers use the superior implementation that covers macOS, Linux, and Windows via `shutil.which`.

## Changes
- Remove local `find_kicad_cli()` from `export/gerber.py`, `operations/netlist.py`, `cli/generate_bom.py`, `cli/export_netlist.py`, and `cli/export_gerbers.py`
- Add `from kicad_tools.cli.runner import find_kicad_cli` import to each file
- Add KiCad 7.0 Windows path (`C:/Program Files/KiCad/7.0/bin/kicad-cli.exe`) to the canonical version in `runner.py`
- Remove unused `import shutil` from `export/gerber.py`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All 5 duplicate definitions removed | Pass | `rg "^def find_kicad_cli" --type py src/ -c` returns exactly 1 match (cli/runner.py) |
| Each file imports from cli.runner | Pass | Verified all 5 files have `from kicad_tools.cli.runner import find_kicad_cli` |
| `import shutil` removed from export/gerber.py | Pass | Confirmed shutil was only used by the removed function |
| export.__init__.py re-export still works | Pass | Import chain verified: `from kicad_tools.export import find_kicad_cli` resolves correctly |
| All existing tests pass without mock path changes | Pass | 161 tests passed with no modifications to test files |
| No circular imports | Pass | Verified runner.py does not import from any of the 5 files |

## Test Plan
- Ran `pytest tests/test_export.py tests/test_export_extended.py tests/test_cli_netlist.py` -- 161 passed
- Verified no circular imports via direct Python import checks
- Confirmed `rg "^def find_kicad_cli" --type py src/ -c` shows exactly 1 definition

Closes #1739