### PR TITLE
fix(sync): update footprint change display to reflect applied status

### DIFF
--- a/src/kicad_tools/cli/sync_cmd.py
+++ b/src/kicad_tools/cli/sync_cmd.py
@@ -261,7 +261,12 @@ def _output_changes_table(changes, dry_run: bool) -> None:
     for change in changes:
         status = "(would apply)" if dry_run else "(applied)"
         if change.change_type == "update_footprint":
-            status = "(manual - footprint change invalidates routing)"
+            if dry_run:
+                status = "(would swap)"
+            elif change.applied:
+                status = "(swapped)"
+            else:
+                status = "(failed - see error)"
         elif change.change_type == "add_footprint":
             if dry_run:
                 status = "(would add)"

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -185,6 +185,64 @@ class TestSyncCLIApplyMode:
         assert len(data["changes"]) == 1
 
 
+class TestOutputChangesTableFootprintStatus:
+    """Tests for update_footprint status display in _output_changes_table."""
+
+    @patch("kicad_tools.sync.reconciler.Reconciler")
+    def test_update_footprint_dry_run_shows_would_swap(self, MockReconciler, capsys):
+        """Test update_footprint in dry-run shows '(would swap)'."""
+        from kicad_tools.sync.reconciler import SyncAnalysis, SyncChange
+
+        analysis = SyncAnalysis()
+        mock = MagicMock()
+        mock.analyze.return_value = analysis
+        mock.apply.return_value = [
+            SyncChange("U1", "update_footprint", "SOIC-8", "QFN-16", applied=False),
+        ]
+        MockReconciler.return_value = mock
+
+        result = sync_main(["--apply", "--dry-run", "project.kicad_pro"])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "(would swap)" in captured.out
+
+    @patch("kicad_tools.sync.reconciler.Reconciler")
+    def test_update_footprint_applied_shows_swapped(self, MockReconciler, capsys):
+        """Test update_footprint when applied shows '(swapped)'."""
+        from kicad_tools.sync.reconciler import SyncAnalysis, SyncChange
+
+        analysis = SyncAnalysis()
+        mock = MagicMock()
+        mock.analyze.return_value = analysis
+        mock.apply.return_value = [
+            SyncChange("U1", "update_footprint", "SOIC-8", "QFN-16", applied=True),
+        ]
+        MockReconciler.return_value = mock
+
+        result = sync_main(["--apply", "--confirm", "project.kicad_pro"])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "(swapped)" in captured.out
+
+    @patch("kicad_tools.sync.reconciler.Reconciler")
+    def test_update_footprint_failed_shows_error(self, MockReconciler, capsys):
+        """Test update_footprint when not applied shows '(failed - see error)'."""
+        from kicad_tools.sync.reconciler import SyncAnalysis, SyncChange
+
+        analysis = SyncAnalysis()
+        mock = MagicMock()
+        mock.analyze.return_value = analysis
+        mock.apply.return_value = [
+            SyncChange("U1", "update_footprint", "SOIC-8", "QFN-16", applied=False),
+        ]
+        MockReconciler.return_value = mock
+
+        result = sync_main(["--apply", "--confirm", "project.kicad_pro"])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "(failed - see error)" in captured.out
+
+
 class TestSyncCLIMapping:
     """Tests for --output-mapping flag."""
 


### PR DESCRIPTION
## Summary
Updates the `_output_changes_table` display logic for `update_footprint` changes to check `change.applied` status instead of always showing a stale manual intervention message. This was a leftover from before #1746 implemented the footprint swap feature.

## Changes
- Updated `update_footprint` branch in `_output_changes_table` to check `dry_run` and `change.applied` like other change types
- Added 3 tests covering dry-run, success, and failure display states

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Dry-run shows "(would swap)" | Pass | Test `test_update_footprint_dry_run_shows_would_swap` passes |
| Applied shows "(swapped)" | Pass | Test `test_update_footprint_applied_shows_swapped` passes |
| Failed shows "(failed - see error)" | Pass | Test `test_update_footprint_failed_shows_error` passes |
| No stale "manual" message | Pass | Old string removed from code |

## Test Plan
All 17 tests in `test_sync_cli.py` pass, including 3 new tests for footprint status display.

Closes #1754