### PR TITLE
feat(pipeline): add --best-effort flag to continue past routing failures

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -102,6 +102,7 @@ class PipelineContext:
     force: bool = False
     is_project: bool = False
     commit: bool = False
+    best_effort: bool = False
     max_displacement: float = 2.0
     erc_error_count: int = 0
     _check_data: dict | None = None  # cached kct check --format json result
@@ -1234,6 +1235,9 @@ def run_pipeline(
             )
         )
 
+    # Track whether the route step has failed (used by --best-effort logic)
+    route_failed = False
+
     with Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),
@@ -1263,14 +1267,34 @@ def run_pipeline(
 
             # Stop on failure unless:
             # - it's the audit, report, or export step (always run informational steps), or
-            # - ERC just failed and FIX_ERC is the next step (auto-remediation path)
+            # - ERC just failed and FIX_ERC is the next step (auto-remediation path), or
+            # - --best-effort is set and route has failed (continue past routing
+            #   failure and any downstream consequences to zone fill, DRC, audit,
+            #   report, and export)
             if not result.success and step not in (
                 PipelineStep.AUDIT,
                 PipelineStep.REPORT,
                 PipelineStep.EXPORT,
             ):
                 next_step = steps[i + 1] if i + 1 < len(steps) else None
-                if not (step == PipelineStep.ERC and next_step == PipelineStep.FIX_ERC):
+                if step == PipelineStep.ERC and next_step == PipelineStep.FIX_ERC:
+                    pass  # allow ERC -> FIX_ERC auto-remediation
+                elif step == PipelineStep.ROUTE and ctx.best_effort:
+                    # Route failed in best-effort mode -- mark as warning
+                    # and let downstream steps continue.
+                    route_failed = True
+                    result.warning = True
+                    if not ctx.quiet:
+                        console.print(
+                            "  [yellow]--best-effort: continuing past routing failure[/yellow]"
+                        )
+                elif ctx.best_effort and route_failed:
+                    # In best-effort mode after a route failure, downstream
+                    # step failures are expected (incomplete routing causes
+                    # DRC violations, zone fill issues, etc.).  Mark them as
+                    # warnings and continue.
+                    result.warning = True
+                else:
                     break
 
     # Post-loop reclassification: when ERC failed but FIX_ERC resolved the errors,
@@ -1351,6 +1375,7 @@ Examples:
     kct pipeline board.kicad_pcb --force               # Force re-route
     kct pipeline board.kicad_pcb --commit              # Commit changes after success
     kct pipeline board.kicad_pcb --mfr jlcpcb --commit # Pipeline + auto-commit
+    kct pipeline board.kicad_pcb --best-effort         # Continue past routing failures
         """,
     )
 
@@ -1413,6 +1438,15 @@ Examples:
         action="store_true",
         default=False,
         help="Create a git commit with the modified PCB file after a successful pipeline run",
+    )
+    parser.add_argument(
+        "--best-effort",
+        action="store_true",
+        default=False,
+        help=(
+            "Continue past routing failures to zone fill, DRC, audit, report, and export. "
+            "Exit code 2 indicates partial success (routing incomplete but downstream steps ran)"
+        ),
     )
     parser.add_argument(
         "--max-displacement",
@@ -1510,6 +1544,7 @@ Examples:
         force=args.force,
         is_project=is_project,
         commit=args.commit,
+        best_effort=args.best_effort,
         max_displacement=args.max_displacement,
     )
 
@@ -1521,10 +1556,17 @@ Examples:
 
     results = run_pipeline(ctx, steps)
 
-    # Determine exit code: 0 if all succeeded, 1 if any failed
+    # Determine exit code:
+    #   0 = all steps succeeded
+    #   2 = partial success (--best-effort continued past a routing failure)
+    #   1 = hard failure
     all_succeeded = all(r.success for r in results)
+    has_route_warning = any(
+        r.step == PipelineStep.ROUTE and not r.success and r.warning
+        for r in results
+    )
 
-    if not all_succeeded:
+    if not all_succeeded and not has_route_warning:
         return 1
 
     # Handle --commit flag (silently ignored with --dry-run)
@@ -1533,6 +1575,10 @@ Examples:
         commit_rc = _git_commit_result(ctx, results, console)
         if commit_rc != 0:
             return commit_rc
+
+    # Exit code 2 for partial success (routing incomplete in best-effort mode)
+    if has_route_warning:
+        return 2
 
     return 0
 

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -3789,3 +3789,109 @@ class TestFinalSummaryIntegration:
         msg = _build_commit_message(ctx, results)  # no check_data param
 
         assert "1 DRC errors" in msg
+
+
+class TestBestEffort:
+    """Tests for the --best-effort flag that continues past routing failures."""
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_best_effort_continues_past_route_failure(self, mock_run, unrouted_pcb: Path):
+        """With --best-effort, pipeline continues to downstream steps after route failure."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error: routing failed", stdout="")
+
+        ctx = PipelineContext(pcb_file=unrouted_pcb, quiet=True, best_effort=True)
+        results = run_pipeline(
+            ctx,
+            [
+                PipelineStep.ROUTE,
+                PipelineStep.ZONES,
+                PipelineStep.AUDIT,
+                PipelineStep.REPORT,
+                PipelineStep.EXPORT,
+            ],
+        )
+
+        # All steps should have run
+        assert len(results) == 5
+        # Route failed but was reclassified as warning
+        assert results[0].step == PipelineStep.ROUTE
+        assert results[0].success is False
+        assert results[0].warning is True
+        # Downstream steps ran
+        assert results[1].step == PipelineStep.ZONES
+        assert results[2].step == PipelineStep.AUDIT
+        assert results[3].step == PipelineStep.REPORT
+        assert results[4].step == PipelineStep.EXPORT
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_without_best_effort_aborts_on_route_failure(self, mock_run, unrouted_pcb: Path):
+        """Without --best-effort, pipeline still aborts on route failure (default behavior)."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error: routing failed", stdout="")
+
+        ctx = PipelineContext(pcb_file=unrouted_pcb, quiet=True, best_effort=False)
+        results = run_pipeline(
+            ctx,
+            [
+                PipelineStep.ROUTE,
+                PipelineStep.ZONES,
+                PipelineStep.AUDIT,
+                PipelineStep.REPORT,
+                PipelineStep.EXPORT,
+            ],
+        )
+
+        # Pipeline should stop at route step
+        assert len(results) == 1
+        assert results[0].step == PipelineStep.ROUTE
+        assert results[0].success is False
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_best_effort_exit_code_2_partial_success(self, mock_run, unrouted_pcb: Path):
+        """--best-effort returns exit code 2 when routing fails but downstream steps run."""
+
+        def side_effect(cmd, **kwargs):
+            # Route fails, all other steps succeed
+            if "route" in cmd:
+                return MagicMock(returncode=1, stderr="routing incomplete", stdout="")
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        mock_run.side_effect = side_effect
+
+        result = main(["--best-effort", "--quiet", str(unrouted_pcb)])
+        assert result == 2
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_best_effort_exit_code_0_when_route_succeeds(self, mock_run, unrouted_pcb: Path):
+        """--best-effort returns exit code 0 when routing succeeds (identical to normal mode)."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        result = main(["--best-effort", "--quiet", str(unrouted_pcb)])
+        assert result == 0
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_best_effort_does_not_affect_non_route_failures(self, mock_run, unrouted_pcb: Path):
+        """--best-effort only applies to ROUTE failures; other step failures still abort."""
+        # FIX_DRC fails
+        def side_effect(cmd, **kwargs):
+            if "fix-drc" in cmd:
+                return MagicMock(returncode=1, stderr="fix-drc error", stdout="")
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        mock_run.side_effect = side_effect
+
+        ctx = PipelineContext(pcb_file=unrouted_pcb, quiet=True, best_effort=True)
+        results = run_pipeline(
+            ctx,
+            [PipelineStep.FIX_DRC, PipelineStep.AUDIT, PipelineStep.EXPORT],
+        )
+
+        # Pipeline should stop at FIX_DRC even with best_effort
+        assert len(results) == 1
+        assert results[0].step == PipelineStep.FIX_DRC
+        assert results[0].success is False
+
+    def test_best_effort_cli_flag_parsed(self, unrouted_pcb: Path):
+        """--best-effort flag is accepted by the CLI argument parser."""
+        # Just verify it parses without error (dry-run avoids subprocess calls)
+        result = main(["--best-effort", "--dry-run", "--quiet", str(unrouted_pcb)])
+        assert result == 0


### PR DESCRIPTION
## Summary
Add a `--best-effort` CLI flag to `kct pipeline` that allows the pipeline to continue past routing failures to zone fill, DRC, audit, report, and export steps. Without the flag, the default abort-on-failure behavior is unchanged.

## Changes
- Add `best_effort` field to `PipelineContext` dataclass
- Add `--best-effort` CLI argument to the pipeline argument parser
- Modify `run_pipeline()` break condition: when `--best-effort` is set and ROUTE fails, reclassify as warning and continue; downstream step failures after a route failure are also treated as warnings
- Return exit code 2 for partial success (routing incomplete but downstream steps ran), distinguishing from full success (0) and hard failure (1)
- Add 6 tests in `TestBestEffort` class covering: continuation past route failure, default abort behavior preserved, exit codes 0/2, non-route failures still abort, CLI flag parsing

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct pipeline board.kicad_pcb --best-effort` continues past partial routing | PASS | test_best_effort_continues_past_route_failure |
| Without `--best-effort`, pipeline still aborts on route failure | PASS | test_without_best_effort_aborts_on_route_failure |
| Exit code distinguishes full success (0) from partial success (2) from failure (1) | PASS | test_best_effort_exit_code_2_partial_success, test_best_effort_exit_code_0_when_route_succeeds |
| Zone fill runs even when signal routing is incomplete | PASS | test_best_effort_continues_past_route_failure verifies ZONES step runs |
| --best-effort only affects route failures, not other step failures | PASS | test_best_effort_does_not_affect_non_route_failures |

## Test Plan
- All 6 new tests pass (`pytest tests/test_pipeline_cmd.py::TestBestEffort`)
- Full test suite: 216 passed, 5 pre-existing failures (present on main, unrelated to this change)

Closes #1756