### PR TITLE
fix(export): fall back to cached enrichment matches when LCSC API returns 403

### DIFF
--- a/src/kicad_tools/export/bom_enrich.py
+++ b/src/kicad_tools/export/bom_enrich.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ..cost.suggest import PartSuggester
+from ..parts.cache import PartsCache
 from ..parts.lcsc import LCSCForbiddenError
 
 if TYPE_CHECKING:
@@ -35,7 +36,7 @@ class EnrichmentEntry:
     footprint: str
     references: list[str]
     lcsc_part: str  # The assigned LCSC part number (empty if unmatched)
-    source: str  # "schematic" | "auto" | "unmatched"
+    source: str  # "schematic" | "auto" | "cache" | "unmatched"
     confidence: float = 0.0
     part_type: str = ""  # "Basic" | "Pref" | "Ext" | ""
     error: str = ""
@@ -68,6 +69,11 @@ class EnrichmentReport:
         return len([e for e in self.entries if e.source == "auto"])
 
     @property
+    def cache_matched(self) -> int:
+        """Groups matched from stale cache when API was unavailable."""
+        return len([e for e in self.entries if e.source == "cache"])
+
+    @property
     def unmatched(self) -> int:
         """Groups that could not be matched."""
         return len([e for e in self.entries if e.source == "unmatched"])
@@ -80,6 +86,8 @@ class EnrichmentReport:
     def summary_lines(self) -> list[str]:
         """Return human-readable summary lines."""
         parts = [f"{self.auto_matched} auto-matched"]
+        if self.cache_matched:
+            parts.append(f"{self.cache_matched} from cache")
         if self.spec_populated:
             parts.append(f"{self.spec_populated} from spec")
         parts.append(f"{self.already_populated} from schematic")
@@ -136,10 +144,61 @@ def enrich_bom_lcsc(
     api_forbidden = False
     forbidden_error = "JLCPCB API unavailable (403)"
 
+    def _try_cache_fallback(
+        cache: PartsCache | None,
+        value: str,
+        footprint: str,
+        refs: list[str],
+        group_items: list[BOMItem],
+    ) -> EnrichmentEntry:
+        """Attempt to resolve a part from the enrichment cache.
+
+        Returns an ``EnrichmentEntry`` with ``source="cache"`` on hit,
+        or ``source="unmatched"`` on miss.
+        """
+        if cache is not None:
+            match = cache.get_enrichment_match(
+                value, footprint, ignore_expiry=True
+            )
+            if match is not None:
+                lcsc = match["lcsc_part"]
+                for it in group_items:
+                    it.lcsc = lcsc
+                logger.info(
+                    "Cache fallback %s [%s] -> %s (stale cache)",
+                    value,
+                    footprint,
+                    lcsc,
+                )
+                return EnrichmentEntry(
+                    value=value,
+                    footprint=footprint,
+                    references=refs,
+                    lcsc_part=lcsc,
+                    source="cache",
+                    confidence=match["confidence"],
+                    part_type=match["part_type"],
+                )
+        return EnrichmentEntry(
+            value=value,
+            footprint=footprint,
+            references=refs,
+            lcsc_part="",
+            source="unmatched",
+            error=forbidden_error,
+        )
+
     with PartSuggester(
         prefer_basic=prefer_basic,
         min_stock=min_stock,
     ) as suggester:
+        # Obtain the parts cache from the underlying LCSC client so we
+        # can store and retrieve enrichment matches.
+        cache: PartsCache | None = None
+        client = suggester._get_client()
+        if client is not None:
+            cache = client.cache
+
         for (value, footprint), group_items in groups.items():
             refs = [it.reference for it in group_items]
 
@@ -175,17 +234,11 @@ def enrich_bom_lcsc(
                 )
                 continue
 
-            # If the API is known to be forbidden, skip without calling
+            # If the API is known to be forbidden, try the cache before
+            # marking as unmatched.
             if api_forbidden:
                 report.entries.append(
-                    EnrichmentEntry(
-                        value=value,
-                        footprint=footprint,
-                        references=refs,
-                        lcsc_part="",
-                        source="unmatched",
-                        error=forbidden_error,
-                    )
+                    _try_cache_fallback(cache, value, footprint, refs, group_items)
                 )
                 continue
 
@@ -201,22 +254,15 @@ def enrich_bom_lcsc(
                 )
             except LCSCForbiddenError:
                 # API is globally unavailable -- emit a single warning and
-                # mark this and all remaining groups as unmatched.
+                # fall back to cache for this and all remaining groups.
                 api_forbidden = True
                 logger.warning(
                     "JLCPCB API returned 403 Forbidden -- "
-                    "skipping remaining LCSC auto-matching. "
+                    "falling back to enrichment cache for remaining groups. "
                     "Use --no-auto-lcsc to suppress."
                 )
                 report.entries.append(
-                    EnrichmentEntry(
-                        value=value,
-                        footprint=footprint,
-                        references=refs,
-                        lcsc_part="",
-                        source="unmatched",
-                        error=forbidden_error,
-                    )
+                    _try_cache_fallback(cache, value, footprint, refs, group_items)
                 )
                 continue
 
@@ -228,6 +274,16 @@ def enrich_bom_lcsc(
                 # Write back to all items in the group
                 for it in group_items:
                     it.lcsc = lcsc
+
+                # Store the match in the enrichment cache for offline use
+                if cache is not None:
+                    cache.put_enrichment_match(
+                        value,
+                        footprint,
+                        lcsc,
+                        confidence=best.confidence,
+                        part_type=best.type_str,
+                    )
 
                 report.entries.append(
                     EnrichmentEntry(

--- a/src/kicad_tools/parts/cache.py
+++ b/src/kicad_tools/parts/cache.py
@@ -57,7 +57,7 @@ class PartsCache:
         print(f"Cached parts: {stats['total']}")
     """
 
-    SCHEMA_VERSION = 1
+    SCHEMA_VERSION = 2
     DEFAULT_TTL_DAYS = 7
 
     def __init__(
@@ -113,6 +113,16 @@ class PartsCache:
                 CREATE INDEX IF NOT EXISTS idx_parts_mfr ON parts(mfr_part);
                 CREATE INDEX IF NOT EXISTS idx_parts_category ON parts(category);
                 CREATE INDEX IF NOT EXISTS idx_parts_cached ON parts(cached_at);
+
+                CREATE TABLE IF NOT EXISTS enrichment_matches (
+                    component_value TEXT NOT NULL,
+                    footprint TEXT NOT NULL,
+                    lcsc_part TEXT NOT NULL,
+                    confidence REAL NOT NULL DEFAULT 0.0,
+                    part_type TEXT NOT NULL DEFAULT '',
+                    cached_at TEXT NOT NULL,
+                    PRIMARY KEY (component_value, footprint)
+                );
             """)
 
             # Check schema version
@@ -128,7 +138,18 @@ class PartsCache:
 
     def _migrate(self, conn: sqlite3.Connection, from_version: int) -> None:
         """Migrate database schema."""
-        # Future migrations would go here
+        if from_version < 2:
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS enrichment_matches (
+                    component_value TEXT NOT NULL,
+                    footprint TEXT NOT NULL,
+                    lcsc_part TEXT NOT NULL,
+                    confidence REAL NOT NULL DEFAULT 0.0,
+                    part_type TEXT NOT NULL DEFAULT '',
+                    cached_at TEXT NOT NULL,
+                    PRIMARY KEY (component_value, footprint)
+                );
+            """)
         conn.execute(
             "UPDATE meta SET value = ? WHERE key = 'schema_version'",
             (str(self.SCHEMA_VERSION),),
@@ -343,6 +364,77 @@ class PartsCache:
                 )
                 """,
                 rows,
+            )
+
+    def get_enrichment_match(
+        self,
+        component_value: str,
+        footprint: str,
+        ignore_expiry: bool = False,
+    ) -> dict | None:
+        """
+        Look up a previously auto-matched enrichment result by value+footprint.
+
+        Args:
+            component_value: Component value (e.g., "10k")
+            footprint: KiCad footprint string
+            ignore_expiry: If True, return expired entries
+
+        Returns:
+            Dict with ``lcsc_part``, ``confidence``, and ``part_type`` keys,
+            or None if no cached match exists.
+        """
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "SELECT lcsc_part, confidence, part_type, cached_at "
+                "FROM enrichment_matches "
+                "WHERE component_value = ? AND footprint = ?",
+                (component_value, footprint),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            if not ignore_expiry and self._is_expired(row["cached_at"]):
+                return None
+            return {
+                "lcsc_part": row["lcsc_part"],
+                "confidence": row["confidence"],
+                "part_type": row["part_type"],
+            }
+
+    def put_enrichment_match(
+        self,
+        component_value: str,
+        footprint: str,
+        lcsc_part: str,
+        confidence: float = 0.0,
+        part_type: str = "",
+    ) -> None:
+        """
+        Store an enrichment match mapping value+footprint to an LCSC part.
+
+        Args:
+            component_value: Component value (e.g., "10k")
+            footprint: KiCad footprint string
+            lcsc_part: The matched LCSC part number
+            confidence: Match confidence score
+            part_type: Part type string ("Basic", "Pref", "Ext")
+        """
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO enrichment_matches
+                    (component_value, footprint, lcsc_part, confidence, part_type, cached_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    component_value,
+                    footprint,
+                    lcsc_part,
+                    confidence,
+                    part_type,
+                    datetime.now().isoformat(),
+                ),
             )
 
     def delete(self, lcsc_part: str) -> bool:

--- a/tests/test_bom_enrich.py
+++ b/tests/test_bom_enrich.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from kicad_tools.export.bom_enrich import EnrichmentReport, enrich_bom_lcsc
+from kicad_tools.parts.cache import PartsCache
 from kicad_tools.schema.bom import BOMItem
 
 # ---------------------------------------------------------------------------
@@ -28,6 +31,16 @@ def _make_item(
         lcsc=lcsc,
         dnp=dnp,
     )
+
+
+def _make_suggester_mock(mock_instance: MagicMock) -> None:
+    """Configure a mock PartSuggester with no cache (default for tests)."""
+    mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+    mock_instance.__exit__ = MagicMock(return_value=False)
+    # Ensure the cache fallback path finds no cache
+    mock_client = MagicMock()
+    mock_client.cache = None
+    mock_instance._get_client.return_value = mock_client
 
 
 def _mock_suggestion(lcsc_part: str, is_basic: bool = True, confidence: float = 0.8):
@@ -84,8 +97,7 @@ class TestEnrichBomLcsc:
     def test_auto_matches_missing_lcsc(self, MockSuggester):
         """Items without LCSC get populated from PartSuggester."""
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
         mock_instance.suggest_for_component.return_value = _mock_suggestion("C25744")
         MockSuggester.return_value = mock_instance
 
@@ -109,8 +121,7 @@ class TestEnrichBomLcsc:
     def test_preserves_existing_lcsc(self, MockSuggester):
         """Items with existing LCSC are not searched and are left as-is."""
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
         MockSuggester.return_value = mock_instance
 
         items = [
@@ -134,8 +145,7 @@ class TestEnrichBomLcsc:
     def test_reports_unmatched(self, MockSuggester):
         """Unmatched parts appear in the report."""
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
         mock_instance.suggest_for_component.return_value = _mock_no_match()
         MockSuggester.return_value = mock_instance
 
@@ -154,8 +164,7 @@ class TestEnrichBomLcsc:
     def test_skips_dnp_items(self, MockSuggester):
         """DNP items are not searched."""
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
         MockSuggester.return_value = mock_instance
 
         items = [
@@ -172,8 +181,7 @@ class TestEnrichBomLcsc:
     def test_groups_by_value_footprint(self, MockSuggester):
         """Same value+footprint searched only once, result applied to all."""
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
         mock_instance.suggest_for_component.return_value = _mock_suggestion("C25744")
         MockSuggester.return_value = mock_instance
 
@@ -197,8 +205,7 @@ class TestEnrichBomLcsc:
     def test_different_values_searched_separately(self, MockSuggester):
         """Different value+footprint combos are searched independently."""
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
 
         # Return different parts for different searches
         def side_effect(*, reference, value, footprint, existing_lcsc):
@@ -225,8 +232,7 @@ class TestEnrichBomLcsc:
     def test_mixed_existing_and_missing(self, MockSuggester):
         """Mix of items with and without LCSC numbers."""
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
         mock_instance.suggest_for_component.return_value = _mock_suggestion("C25744")
         MockSuggester.return_value = mock_instance
 
@@ -246,8 +252,7 @@ class TestEnrichBomLcsc:
     def test_suggester_exception_handled(self, MockSuggester):
         """If PartSuggester.suggest_for_component raises, item is unmatched."""
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
         # The suggest_for_component itself doesn't raise; errors are reported
         # via suggestion.error. But the PartSuggester catches exceptions internally.
         # Let's test the case where it returns an error suggestion.
@@ -279,12 +284,11 @@ class TestEnrichBomLcscCircuitBreaker:
 
     @patch("kicad_tools.export.bom_enrich.PartSuggester")
     def test_403_stops_remaining_lookups(self, MockSuggester):
-        """After a 403, remaining groups are marked unmatched without API calls."""
+        """After a 403 with empty cache, remaining groups are unmatched."""
         from kicad_tools.parts.lcsc import LCSCForbiddenError
 
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
 
         # First call raises LCSCForbiddenError
         mock_instance.suggest_for_component.side_effect = LCSCForbiddenError(
@@ -315,8 +319,7 @@ class TestEnrichBomLcscCircuitBreaker:
         from kicad_tools.parts.lcsc import LCSCForbiddenError
 
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
 
         # The first group that needs a lookup will get 403
         mock_instance.suggest_for_component.side_effect = LCSCForbiddenError(
@@ -349,8 +352,7 @@ class TestEnrichBomLcscCircuitBreaker:
         from kicad_tools.parts.lcsc import LCSCForbiddenError
 
         mock_instance = MagicMock()
-        mock_instance.__enter__ = MagicMock(return_value=mock_instance)
-        mock_instance.__exit__ = MagicMock(return_value=False)
+        _make_suggester_mock(mock_instance)
 
         call_count = [0]
 
@@ -382,6 +384,177 @@ class TestEnrichBomLcscCircuitBreaker:
         assert mock_instance.suggest_for_component.call_count == 2
 
 
+class TestEnrichBomLcscCacheFallback:
+    """Tests for cache fallback when API returns 403."""
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_403_falls_back_to_enrichment_cache(self, MockSuggester):
+        """When API is forbidden, cached enrichment matches are used."""
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        # Create a real PartsCache with pre-populated enrichment matches
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PartsCache(db_path=Path(tmp) / "test.db")
+            cache.put_enrichment_match(
+                "10k", "Resistor_SMD:R_0402_1005Metric", "C25744",
+                confidence=0.85, part_type="Basic",
+            )
+            cache.put_enrichment_match(
+                "100nF", "Capacitor_SMD:C_0402_1005Metric", "C1525",
+                confidence=0.9, part_type="Basic",
+            )
+
+            mock_instance = MagicMock()
+            _make_suggester_mock(mock_instance)
+            # Wire up the real cache
+            mock_instance._get_client.return_value.cache = cache
+
+            mock_instance.suggest_for_component.side_effect = LCSCForbiddenError(
+                "403 Forbidden"
+            )
+            MockSuggester.return_value = mock_instance
+
+            items = [
+                _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+                _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric"),
+            ]
+
+            report = enrich_bom_lcsc(items)
+
+            # Both should be resolved from cache
+            assert items[0].lcsc == "C25744"
+            assert items[1].lcsc == "C1525"
+            assert report.cache_matched == 2
+            assert report.unmatched == 0
+
+            # Verify source is "cache" for both entries
+            for entry in report.entries:
+                assert entry.source == "cache"
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_403_mixed_cache_hit_and_miss(self, MockSuggester):
+        """When API is forbidden, parts not in cache remain unmatched."""
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PartsCache(db_path=Path(tmp) / "test.db")
+            # Only cache the resistor, not the capacitor
+            cache.put_enrichment_match(
+                "10k", "Resistor_SMD:R_0402_1005Metric", "C25744",
+                confidence=0.85, part_type="Basic",
+            )
+
+            mock_instance = MagicMock()
+            _make_suggester_mock(mock_instance)
+            mock_instance._get_client.return_value.cache = cache
+
+            mock_instance.suggest_for_component.side_effect = LCSCForbiddenError(
+                "403 Forbidden"
+            )
+            MockSuggester.return_value = mock_instance
+
+            items = [
+                _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+                _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric"),
+            ]
+
+            report = enrich_bom_lcsc(items)
+
+            assert items[0].lcsc == "C25744"
+            assert items[1].lcsc == ""
+            assert report.cache_matched == 1
+            assert report.unmatched == 1
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_auto_match_populates_enrichment_cache(self, MockSuggester):
+        """Successful auto-matches are stored in the enrichment cache."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PartsCache(db_path=Path(tmp) / "test.db")
+
+            mock_instance = MagicMock()
+            _make_suggester_mock(mock_instance)
+            mock_instance._get_client.return_value.cache = cache
+            mock_instance.suggest_for_component.return_value = _mock_suggestion(
+                "C25744", confidence=0.8
+            )
+            MockSuggester.return_value = mock_instance
+
+            items = [
+                _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            ]
+
+            enrich_bom_lcsc(items)
+
+            # Verify the match was stored in the enrichment cache
+            match = cache.get_enrichment_match(
+                "10k", "Resistor_SMD:R_0402_1005Metric"
+            )
+            assert match is not None
+            assert match["lcsc_part"] == "C25744"
+            assert match["confidence"] == 0.8
+            assert match["part_type"] == "Basic"
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_403_cache_fallback_uses_expired_entries(self, MockSuggester):
+        """Expired enrichment cache entries are still used when API is forbidden."""
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # Create cache with very short TTL so entries expire immediately
+            cache = PartsCache(db_path=Path(tmp) / "test.db", ttl_days=0)
+            cache.put_enrichment_match(
+                "10k", "Resistor_SMD:R_0402_1005Metric", "C25744",
+                confidence=0.85, part_type="Basic",
+            )
+
+            mock_instance = MagicMock()
+            _make_suggester_mock(mock_instance)
+            mock_instance._get_client.return_value.cache = cache
+
+            mock_instance.suggest_for_component.side_effect = LCSCForbiddenError(
+                "403 Forbidden"
+            )
+            MockSuggester.return_value = mock_instance
+
+            items = [
+                _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            ]
+
+            report = enrich_bom_lcsc(items)
+
+            # Should still resolve from expired cache
+            assert items[0].lcsc == "C25744"
+            assert report.cache_matched == 1
+            assert report.unmatched == 0
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_403_empty_cache_reports_unmatched(self, MockSuggester):
+        """With empty cache and API forbidden, parts are unmatched (no crash)."""
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PartsCache(db_path=Path(tmp) / "test.db")
+
+            mock_instance = MagicMock()
+            _make_suggester_mock(mock_instance)
+            mock_instance._get_client.return_value.cache = cache
+
+            mock_instance.suggest_for_component.side_effect = LCSCForbiddenError(
+                "403 Forbidden"
+            )
+            MockSuggester.return_value = mock_instance
+
+            items = [
+                _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            ]
+
+            report = enrich_bom_lcsc(items)
+
+            assert items[0].lcsc == ""
+            assert report.unmatched == 1
+            assert report.cache_matched == 0
+
+
 class TestEnrichmentReport:
     """Tests for the EnrichmentReport dataclass."""
 
@@ -405,6 +578,27 @@ class TestEnrichmentReport:
         lines = report.summary_lines()
         assert "1 auto-matched" in lines[0]
         assert "0 unmatched" in lines[0]
+
+    def test_summary_lines_with_cache(self):
+        """Summary includes cache hit count when present."""
+        from kicad_tools.export.bom_enrich import EnrichmentEntry
+
+        report = EnrichmentReport(
+            entries=[
+                EnrichmentEntry(
+                    value="10k",
+                    footprint="R_0402",
+                    references=["R1"],
+                    lcsc_part="C25744",
+                    source="cache",
+                    confidence=0.85,
+                    part_type="Basic",
+                ),
+            ]
+        )
+        lines = report.summary_lines()
+        assert "1 from cache" in lines[0]
+        assert "0 auto-matched" in lines[0]
 
     def test_summary_lines_with_unmatched(self):
         """Summary includes detail lines for unmatched parts."""
@@ -448,6 +642,13 @@ class TestEnrichmentReport:
                     source="schematic",
                 ),
                 EnrichmentEntry(
+                    value="4.7uH",
+                    footprint="L_0603",
+                    references=["L1"],
+                    lcsc_part="C99999",
+                    source="cache",
+                ),
+                EnrichmentEntry(
                     value="IC1",
                     footprint="QFN-32",
                     references=["U1"],
@@ -456,7 +657,8 @@ class TestEnrichmentReport:
                 ),
             ]
         )
-        assert report.total_groups == 3
+        assert report.total_groups == 4
         assert report.auto_matched == 1
         assert report.already_populated == 1
+        assert report.cache_matched == 1
         assert report.unmatched == 1


### PR DESCRIPTION
## Summary
When the JLCPCB API returns 403 Forbidden, the BOM enrichment circuit breaker now falls back to a local enrichment cache instead of marking all remaining parts as unmatched. This enables offline and rate-limited operation for previously seen components.

## Changes
- Added `enrichment_matches` table to `PartsCache` (schema v2 with migration) mapping `(value, footprint)` to LCSC part numbers
- Added `get_enrichment_match()` and `put_enrichment_match()` methods to `PartsCache` with `ignore_expiry` support
- Modified `enrich_bom_lcsc()` to store successful auto-matches in the enrichment cache and fall back to it (with `ignore_expiry=True`) when the API is forbidden
- Added `source="cache"` to distinguish cache fallback hits from fresh API results
- Added `cache_matched` property and updated `summary_lines()` in `EnrichmentReport`
- Added 5 new test cases for cache fallback scenarios and 1 new report test

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| When LCSC API returns 403, previously cached parts are still matched | Pass | `test_403_falls_back_to_enrichment_cache` - pre-populated cache entries are resolved with `source="cache"` |
| EnrichmentReport output distinguishes cache hits from API hits | Pass | `test_summary_lines_with_cache` - "from cache" appears in summary; `cache_matched` property tested |
| When API is available, behavior is unchanged | Pass | All 8 existing tests pass without modification to assertions |
| Cache TTL is respected for fresh API calls but bypassed when API is unavailable | Pass | `test_403_cache_fallback_uses_expired_entries` - zero-TTL cache still resolves on 403 |
| kct export completes with cached BOM data even when fully offline | Pass | `test_403_empty_cache_reports_unmatched` - no crash with empty cache; mixed hit/miss tested |

## Test Plan
- 20 tests pass in `tests/test_bom_enrich.py` (8 existing + 5 cache fallback + 1 report + 6 circuit breaker)
- Pre-existing failures in `tests/report/test_renderers.py` and `tests/test_audit.py` confirmed on main

Closes #1757