### PR TITLE
feat(sync): place new components near net-neighbors using netlist adjacency

### DIFF
--- a/src/kicad_tools/sync/reconciler.py
+++ b/src/kicad_tools/sync/reconciler.py
@@ -21,7 +21,9 @@ Example:
 from __future__ import annotations
 
 import json
+import math
 import shutil
+from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -564,27 +566,27 @@ class Reconciler:
         # Load PCB as a PCB object for full API access (add_footprint, add_net, etc.)
         pcb = PCB.load(str(self._pcb_path))
 
-        # Compute placement position for new footprints (below board outline)
+        # Compute grid fallback position for new footprints (below board outline)
         placement_x, placement_y, placement_col = self._compute_placement_start(pcb)
         placement_start_x = placement_x
         placement_spacing = 15.0
         placement_columns = 10
+
+        # Compute smart placement positions for new footprints based on net adjacency
+        add_refs = [a["reference"] for a in actions_to_apply if a["type"] == "add_footprint"]
+        smart_positions = self._compute_smart_placement(pcb, add_refs) if add_refs else {}
 
         has_add_footprint = any(a["type"] == "add_footprint" for a in actions_to_apply)
         has_update_footprint = any(a["type"] == "update_footprint" for a in actions_to_apply)
 
         for action in actions_to_apply:
             if action["type"] == "add_footprint":
-                change = self._apply_add_footprint(
-                    pcb,
-                    action,
-                    dry_run,
-                    placement_x,
-                    placement_y,
-                )
-                if change:
-                    changes.append(change)
-                    # Advance grid position for next footprint
+                ref = action["reference"]
+                if ref in smart_positions:
+                    pos_x, pos_y = smart_positions[ref]
+                else:
+                    pos_x, pos_y = placement_x, placement_y
+                    # Advance grid position for next grid-placed footprint
                     placement_col += 1
                     if placement_col >= placement_columns:
                         placement_col = 0
@@ -592,6 +594,16 @@ class Reconciler:
                         placement_y += placement_spacing
                     else:
                         placement_x += placement_spacing
+
+                change = self._apply_add_footprint(
+                    pcb,
+                    action,
+                    dry_run,
+                    pos_x,
+                    pos_y,
+                )
+                if change:
+                    changes.append(change)
             elif action["type"] == "update_footprint":
                 change = self._apply_update_footprint(pcb, action, dry_run)
                 if change:
@@ -647,6 +659,163 @@ class Reconciler:
             start_x = 10.0
             start_y = 10.0
         return start_x, start_y, 0
+
+    def _build_net_adjacency(
+        self,
+        new_refs: set[str],
+    ) -> dict[str, set[str]]:
+        """Build a map from each new component to its net-neighbor references.
+
+        A net-neighbor is any component that shares at least one net with the
+        given component. Only neighbors that are NOT in new_refs (i.e., already
+        placed on the PCB) are included.
+
+        Args:
+            new_refs: Set of reference designators for new (unplaced) components.
+
+        Returns:
+            Dict mapping each new ref to a set of existing (placed) neighbor refs.
+        """
+        try:
+            from kicad_tools.operations.netlist import export_netlist
+
+            netlist = export_netlist(str(self._schematic_path))
+        except Exception:
+            return {}
+
+        # For each net, collect all component references connected to it
+        adjacency: dict[str, set[str]] = defaultdict(set)
+        for net in netlist.nets:
+            if not net.name:
+                continue
+            refs_in_net = {node.reference for node in net.nodes if node.reference}
+            for ref in refs_in_net:
+                if ref in new_refs:
+                    # Add all non-new refs from this net as neighbors
+                    placed_neighbors = refs_in_net - new_refs - {ref}
+                    adjacency[ref].update(placed_neighbors)
+
+        return dict(adjacency)
+
+    def _compute_smart_placement(
+        self,
+        pcb,
+        new_refs: list[str],
+    ) -> dict[str, tuple[float, float]]:
+        """Compute placement positions for new components near their net neighbors.
+
+        For each new component, finds existing components that share nets with it,
+        computes the centroid of those neighbors' positions, and offsets the new
+        component to avoid overlap using a spiral search.
+
+        Components with no placed net-neighbors are omitted from the result;
+        the caller should fall back to grid placement for those.
+
+        Args:
+            pcb: The loaded PCB object.
+            new_refs: List of reference designators for components to place.
+
+        Returns:
+            Dict mapping ref to (x, y) board-relative placement position.
+            Only contains entries for components that have placed net-neighbors.
+        """
+        new_ref_set = set(new_refs)
+        adjacency = self._build_net_adjacency(new_ref_set)
+
+        if not adjacency:
+            return {}
+
+        # Build position lookup for existing footprints (sheet-absolute coords)
+        fp_positions: dict[str, tuple[float, float]] = {}
+        for fp in pcb.footprints:
+            if fp.reference and not fp.reference.startswith("#"):
+                fp_positions[fp.reference] = fp.position
+
+        origin_x, origin_y = pcb.board_origin
+
+        # Track all occupied positions (existing + newly assigned) for overlap avoidance
+        occupied: list[tuple[float, float]] = []
+        for pos in fp_positions.values():
+            # Convert to board-relative
+            occupied.append((pos[0] - origin_x, pos[1] - origin_y))
+
+        result: dict[str, tuple[float, float]] = {}
+        min_spacing = 5.0  # minimum distance between footprint centers (mm)
+
+        for ref in new_refs:
+            neighbors = adjacency.get(ref, set())
+            if not neighbors:
+                continue
+
+            # Compute centroid of neighbor positions (in board-relative coords)
+            neighbor_positions = []
+            for n_ref in neighbors:
+                if n_ref in fp_positions:
+                    abs_pos = fp_positions[n_ref]
+                    neighbor_positions.append(
+                        (abs_pos[0] - origin_x, abs_pos[1] - origin_y)
+                    )
+
+            if not neighbor_positions:
+                continue
+
+            cx = sum(p[0] for p in neighbor_positions) / len(neighbor_positions)
+            cy = sum(p[1] for p in neighbor_positions) / len(neighbor_positions)
+
+            # Find a non-overlapping position near the centroid using spiral search
+            x, y = self._find_non_overlapping_position(cx, cy, occupied, min_spacing)
+            result[ref] = (x, y)
+            occupied.append((x, y))
+
+        return result
+
+    @staticmethod
+    def _find_non_overlapping_position(
+        cx: float,
+        cy: float,
+        occupied: list[tuple[float, float]],
+        min_spacing: float,
+    ) -> tuple[float, float]:
+        """Find the nearest non-overlapping position to (cx, cy).
+
+        Uses a spiral search pattern, checking concentric rings of positions
+        at increasing distance from the target centroid.
+
+        Args:
+            cx: Target X position (board-relative).
+            cy: Target Y position (board-relative).
+            occupied: List of already-occupied (x, y) positions.
+            min_spacing: Minimum distance between footprint centers.
+
+        Returns:
+            (x, y) position that does not overlap with any occupied position.
+        """
+
+        def _is_clear(x: float, y: float) -> bool:
+            for ox, oy in occupied:
+                if math.sqrt((x - ox) ** 2 + (y - oy) ** 2) < min_spacing:
+                    return False
+            return True
+
+        # Try the centroid itself first
+        if _is_clear(cx, cy):
+            return cx, cy
+
+        # Spiral outward in concentric rings
+        step = min_spacing
+        for ring in range(1, 20):
+            radius = ring * step
+            # Check 8 * ring points around the ring for good coverage
+            num_points = 8 * ring
+            for i in range(num_points):
+                angle = 2.0 * math.pi * i / num_points
+                x = cx + radius * math.cos(angle)
+                y = cy + radius * math.sin(angle)
+                if _is_clear(x, y):
+                    return x, y
+
+        # Fallback: offset far enough that overlap is impossible
+        return cx + 20 * min_spacing, cy
 
     def _apply_add_footprint(
         self,
@@ -728,8 +897,6 @@ class Reconciler:
         Returns:
             SyncChange record, or None if the action failed.
         """
-        import math
-
         ref = action["reference"]
         old_fp_name = action["old_value"]
         new_fp_name = action["new_value"]

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,6 +1,7 @@
 """Tests for kicad_tools.sync.reconciler module."""
 
 import json
+import math
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -904,8 +905,9 @@ class TestReconcilerApplyIntegration:
 
         assert len(changes) == 1
         assert changes[0].applied is True
-        # Verify export_netlist was called for net assignment
-        mock_export.assert_called_once_with(sch_path)
+        # Verify export_netlist was called (for smart placement and net assignment)
+        mock_export.assert_called_with(sch_path)
+        assert mock_export.call_count >= 1
         mock_pcb.assign_nets_from_netlist.assert_called_once_with(mock_netlist)
 
         Path(sch_path).unlink()
@@ -1787,3 +1789,324 @@ class TestReconcilerSaveMapping:
         Path(sch_path).unlink()
         Path(pcb_path).unlink()
         Path(output_path).unlink()
+
+
+class TestSmartPlacement:
+    """Tests for net-adjacency-based proximity placement of new components."""
+
+    def _make_reconciler(self):
+        """Create a Reconciler instance without file validation."""
+        reconciler = Reconciler.__new__(Reconciler)
+        reconciler._schematic_path = Path("/tmp/test.kicad_sch")
+        reconciler._pcb_path = Path("/tmp/test.kicad_pcb")
+        return reconciler
+
+    def _make_mock_pcb(self, footprints=None, board_origin=(0.0, 0.0), outline=None):
+        """Create a mock PCB with the given footprints."""
+        mock_pcb = MagicMock()
+        mock_pcb.board_origin = board_origin
+
+        if footprints is None:
+            footprints = []
+        mock_fps = []
+        for ref, x, y in footprints:
+            fp = MagicMock()
+            fp.reference = ref
+            fp.position = (x, y)
+            mock_fps.append(fp)
+        mock_pcb.footprints = mock_fps
+        mock_pcb.get_board_outline.return_value = outline or []
+        return mock_pcb
+
+    def test_find_non_overlapping_clear_centroid(self):
+        """When centroid is clear, it should be returned directly."""
+        x, y = Reconciler._find_non_overlapping_position(10.0, 20.0, [], 5.0)
+        assert x == 10.0
+        assert y == 20.0
+
+    def test_find_non_overlapping_occupied_centroid(self):
+        """When centroid is occupied, a nearby clear position should be found."""
+        occupied = [(10.0, 20.0)]
+        x, y = Reconciler._find_non_overlapping_position(10.0, 20.0, occupied, 5.0)
+        dist = math.sqrt((x - 10.0) ** 2 + (y - 20.0) ** 2)
+        # Must be at least min_spacing away from the occupied position
+        assert dist >= 5.0
+        # But should be close -- within the first ring (radius = 5.0)
+        assert dist <= 6.0
+
+    def test_find_non_overlapping_multiple_occupied(self):
+        """Position found should be clear of all occupied positions."""
+        occupied = [(10.0, 20.0), (15.0, 20.0), (10.0, 25.0)]
+        x, y = Reconciler._find_non_overlapping_position(10.0, 20.0, occupied, 5.0)
+        for ox, oy in occupied:
+            dist = math.sqrt((x - ox) ** 2 + (y - oy) ** 2)
+            assert dist >= 5.0
+
+    @patch("kicad_tools.operations.netlist.export_netlist")
+    def test_build_net_adjacency_basic(self, mock_export):
+        """Components sharing nets should appear as neighbors."""
+        from kicad_tools.operations.netlist import NetlistNet, NetNode
+
+        # U1 and C1 share VCC net, U1 and R1 share SIG net
+        mock_netlist = MagicMock()
+        mock_netlist.nets = [
+            NetlistNet(code=1, name="VCC", nodes=[
+                NetNode(reference="U1", pin="1"),
+                NetNode(reference="C1", pin="1"),
+                NetNode(reference="C2", pin="1"),
+            ]),
+            NetlistNet(code=2, name="GND", nodes=[
+                NetNode(reference="U1", pin="2"),
+                NetNode(reference="C1", pin="2"),
+                NetNode(reference="C2", pin="2"),
+            ]),
+            NetlistNet(code=3, name="SIG", nodes=[
+                NetNode(reference="U1", pin="3"),
+                NetNode(reference="R1", pin="1"),
+            ]),
+        ]
+        mock_export.return_value = mock_netlist
+
+        reconciler = self._make_reconciler()
+        # C1 and R1 are new; U1 and C2 are existing
+        adjacency = reconciler._build_net_adjacency({"C1", "R1"})
+
+        # C1 should have U1 and C2 as neighbors (shares VCC and GND)
+        assert "U1" in adjacency["C1"]
+        assert "C2" in adjacency["C1"]
+        # R1 should have U1 as neighbor (shares SIG)
+        assert "U1" in adjacency["R1"]
+        # U1 is not new, so should not be in adjacency
+        assert "U1" not in adjacency
+
+    @patch("kicad_tools.operations.netlist.export_netlist")
+    def test_build_net_adjacency_no_placed_neighbors(self, mock_export):
+        """New components sharing nets only with other new components get no neighbors."""
+        from kicad_tools.operations.netlist import NetlistNet, NetNode
+
+        mock_netlist = MagicMock()
+        mock_netlist.nets = [
+            NetlistNet(code=1, name="VCC", nodes=[
+                NetNode(reference="C1", pin="1"),
+                NetNode(reference="C2", pin="1"),
+            ]),
+        ]
+        mock_export.return_value = mock_netlist
+
+        reconciler = self._make_reconciler()
+        adjacency = reconciler._build_net_adjacency({"C1", "C2"})
+
+        # Both are new, so neither has placed neighbors
+        assert adjacency.get("C1", set()) == set()
+        assert adjacency.get("C2", set()) == set()
+
+    @patch("kicad_tools.operations.netlist.export_netlist")
+    def test_compute_smart_placement_near_neighbor(self, mock_export):
+        """New component should be placed near its net-neighbor."""
+        from kicad_tools.operations.netlist import NetlistNet, NetNode
+
+        mock_netlist = MagicMock()
+        mock_netlist.nets = [
+            NetlistNet(code=1, name="VCC", nodes=[
+                NetNode(reference="U1", pin="1"),
+                NetNode(reference="C1", pin="1"),
+            ]),
+        ]
+        mock_export.return_value = mock_netlist
+
+        reconciler = self._make_reconciler()
+        # U1 is at sheet-absolute (50, 60), board origin is (0, 0)
+        mock_pcb = self._make_mock_pcb(
+            footprints=[("U1", 50.0, 60.0)],
+            board_origin=(0.0, 0.0),
+        )
+
+        positions = reconciler._compute_smart_placement(mock_pcb, ["C1"])
+
+        assert "C1" in positions
+        cx, cy = positions["C1"]
+        # Should be within 10mm of U1's position (the acceptance criterion)
+        dist = math.sqrt((cx - 50.0) ** 2 + (cy - 60.0) ** 2)
+        assert dist < 10.0
+
+    @patch("kicad_tools.operations.netlist.export_netlist")
+    def test_compute_smart_placement_centroid_of_multiple_neighbors(self, mock_export):
+        """New component with multiple neighbors should be near their centroid."""
+        from kicad_tools.operations.netlist import NetlistNet, NetNode
+
+        mock_netlist = MagicMock()
+        mock_netlist.nets = [
+            NetlistNet(code=1, name="VCC", nodes=[
+                NetNode(reference="U1", pin="1"),
+                NetNode(reference="U2", pin="1"),
+                NetNode(reference="C1", pin="1"),
+            ]),
+        ]
+        mock_export.return_value = mock_netlist
+
+        reconciler = self._make_reconciler()
+        # U1 at (20, 30), U2 at (40, 30) -> centroid at (30, 30)
+        mock_pcb = self._make_mock_pcb(
+            footprints=[("U1", 20.0, 30.0), ("U2", 40.0, 30.0)],
+            board_origin=(0.0, 0.0),
+        )
+
+        positions = reconciler._compute_smart_placement(mock_pcb, ["C1"])
+
+        assert "C1" in positions
+        cx, cy = positions["C1"]
+        # Should be within 10mm of the centroid (30, 30)
+        dist = math.sqrt((cx - 30.0) ** 2 + (cy - 30.0) ** 2)
+        assert dist < 10.0
+
+    @patch("kicad_tools.operations.netlist.export_netlist")
+    def test_compute_smart_placement_no_neighbors_returns_empty(self, mock_export):
+        """Component with no net-neighbors should not appear in smart positions."""
+        from kicad_tools.operations.netlist import NetlistNet, NetNode
+
+        mock_netlist = MagicMock()
+        mock_netlist.nets = [
+            NetlistNet(code=1, name="VCC", nodes=[
+                NetNode(reference="U1", pin="1"),
+            ]),
+        ]
+        mock_export.return_value = mock_netlist
+
+        reconciler = self._make_reconciler()
+        mock_pcb = self._make_mock_pcb(
+            footprints=[("U1", 50.0, 60.0)],
+            board_origin=(0.0, 0.0),
+        )
+
+        positions = reconciler._compute_smart_placement(mock_pcb, ["C1"])
+
+        # C1 shares no net with any existing component
+        assert "C1" not in positions
+
+    @patch("kicad_tools.operations.netlist.export_netlist")
+    def test_compute_smart_placement_with_board_origin(self, mock_export):
+        """Smart placement should account for board origin offset."""
+        from kicad_tools.operations.netlist import NetlistNet, NetNode
+
+        mock_netlist = MagicMock()
+        mock_netlist.nets = [
+            NetlistNet(code=1, name="VCC", nodes=[
+                NetNode(reference="U1", pin="1"),
+                NetNode(reference="C1", pin="1"),
+            ]),
+        ]
+        mock_export.return_value = mock_netlist
+
+        reconciler = self._make_reconciler()
+        # U1 at sheet-absolute (150, 160), board origin at (100, 100)
+        # -> board-relative position is (50, 60)
+        mock_pcb = self._make_mock_pcb(
+            footprints=[("U1", 150.0, 160.0)],
+            board_origin=(100.0, 100.0),
+        )
+
+        positions = reconciler._compute_smart_placement(mock_pcb, ["C1"])
+
+        assert "C1" in positions
+        cx, cy = positions["C1"]
+        # Board-relative centroid should be near (50, 60)
+        dist = math.sqrt((cx - 50.0) ** 2 + (cy - 60.0) ** 2)
+        assert dist < 10.0
+
+    @patch("kicad_tools.operations.netlist.export_netlist")
+    def test_smart_placement_no_overlap(self, mock_export):
+        """Multiple new components should not overlap each other."""
+        from kicad_tools.operations.netlist import NetlistNet, NetNode
+
+        mock_netlist = MagicMock()
+        mock_netlist.nets = [
+            NetlistNet(code=1, name="VCC", nodes=[
+                NetNode(reference="U1", pin="1"),
+                NetNode(reference="C1", pin="1"),
+                NetNode(reference="C2", pin="1"),
+                NetNode(reference="C3", pin="1"),
+            ]),
+        ]
+        mock_export.return_value = mock_netlist
+
+        reconciler = self._make_reconciler()
+        mock_pcb = self._make_mock_pcb(
+            footprints=[("U1", 50.0, 50.0)],
+            board_origin=(0.0, 0.0),
+        )
+
+        positions = reconciler._compute_smart_placement(mock_pcb, ["C1", "C2", "C3"])
+
+        assert len(positions) == 3
+        # Verify no two new positions are too close (min_spacing = 5.0)
+        placed = list(positions.values())
+        for i in range(len(placed)):
+            for j in range(i + 1, len(placed)):
+                dist = math.sqrt(
+                    (placed[i][0] - placed[j][0]) ** 2
+                    + (placed[i][1] - placed[j][1]) ** 2
+                )
+                assert dist >= 5.0, (
+                    f"Components too close: {placed[i]} and {placed[j]}, dist={dist}"
+                )
+
+    @patch("kicad_tools.operations.netlist.export_netlist")
+    def test_decoupling_cap_placed_near_ic(self, mock_export):
+        """Decoupling capacitor for an IC should be placed adjacent to it."""
+        from kicad_tools.operations.netlist import NetlistNet, NetNode
+
+        # IC U1 and decoupling cap C1 share VCC and GND nets
+        mock_netlist = MagicMock()
+        mock_netlist.nets = [
+            NetlistNet(code=1, name="VCC", nodes=[
+                NetNode(reference="U1", pin="14"),
+                NetNode(reference="C1", pin="1"),
+            ]),
+            NetlistNet(code=2, name="GND", nodes=[
+                NetNode(reference="U1", pin="7"),
+                NetNode(reference="C1", pin="2"),
+            ]),
+        ]
+        mock_export.return_value = mock_netlist
+
+        reconciler = self._make_reconciler()
+        mock_pcb = self._make_mock_pcb(
+            footprints=[("U1", 80.0, 80.0)],
+            board_origin=(0.0, 0.0),
+        )
+
+        positions = reconciler._compute_smart_placement(mock_pcb, ["C1"])
+
+        assert "C1" in positions
+        cx, cy = positions["C1"]
+        dist = math.sqrt((cx - 80.0) ** 2 + (cy - 80.0) ** 2)
+        # Decoupling cap must be within 10mm of the IC (acceptance criterion)
+        assert dist < 10.0
+
+    @patch("kicad_tools.operations.netlist.export_netlist")
+    def test_grid_fallback_for_orphan_components(self, mock_export):
+        """Components with no net-neighbors should fall back to grid placement."""
+        from kicad_tools.operations.netlist import NetlistNet, NetNode
+
+        # C1 shares a net with U1, C2 is isolated (no shared nets)
+        mock_netlist = MagicMock()
+        mock_netlist.nets = [
+            NetlistNet(code=1, name="VCC", nodes=[
+                NetNode(reference="U1", pin="1"),
+                NetNode(reference="C1", pin="1"),
+            ]),
+        ]
+        mock_export.return_value = mock_netlist
+
+        reconciler = self._make_reconciler()
+        mock_pcb = self._make_mock_pcb(
+            footprints=[("U1", 50.0, 50.0)],
+            board_origin=(0.0, 0.0),
+        )
+
+        positions = reconciler._compute_smart_placement(mock_pcb, ["C1", "C2"])
+
+        # C1 should get smart placement
+        assert "C1" in positions
+        # C2 has no neighbors, so it should not appear (grid fallback in apply())
+        assert "C2" not in positions


### PR DESCRIPTION
## Summary
Add net-adjacency-based proximity placement for newly added components during sync. New components are placed near the centroid of their net-neighbors (existing PCB components sharing nets), with spiral search to avoid overlap. Components with no placed net-neighbors fall back to the existing grid placement.

## Changes
- Add `_build_net_adjacency()` method to build a map from new component refs to their existing net-neighbor refs using the schematic netlist
- Add `_compute_smart_placement()` method to compute board-relative positions for new components near their net-neighbors' centroid
- Add `_find_non_overlapping_position()` static method implementing spiral search for overlap avoidance
- Modify `apply()` to use smart placement for add_footprint actions when net-neighbors exist, falling back to grid placement otherwise
- Add 12 new tests in `TestSmartPlacement` class covering adjacency computation, proximity placement, board origin handling, overlap avoidance, decoupling cap placement, and grid fallback

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New components sharing nets with existing placed within 10mm of nearest net-neighbor | Pass | `test_compute_smart_placement_near_neighbor` and `test_decoupling_cap_placed_near_ic` assert distance < 10mm |
| Decoupling capacitors placed adjacent to their IC | Pass | `test_decoupling_cap_placed_near_ic` verifies C1 sharing VCC/GND with U1 is placed within 10mm |
| Components with no net-neighbors fall back to grid placement | Pass | `test_grid_fallback_for_orphan_components` and `test_compute_smart_placement_no_neighbors_returns_empty` verify orphan components are excluded from smart placement |
| No overlapping footprints in placement output | Pass | `test_smart_placement_no_overlap` verifies all placed components maintain >= 5mm spacing |

## Test Plan
- All 72 tests in `tests/test_sync.py` pass (60 existing + 12 new)
- New tests cover: spiral search, net adjacency building, proximity placement near single/multiple neighbors, board origin offset, overlap avoidance, decoupling cap scenario, and grid fallback

Closes #1755