### PR TITLE
fix(optim): prevent force-directed placement divergence with 1/r^2 falloff and force clamping

### DIFF
--- a/src/kicad_tools/optim/config.py
+++ b/src/kicad_tools/optim/config.py
@@ -27,9 +27,10 @@ class PlacementConfig:
     clock_net_stiffness: float = 20.0  # Higher stiffness for clock nets
 
     # Physics parameters
-    damping: float = 0.95  # Linear velocity damping (0-1)
-    angular_damping: float = 0.90  # Angular velocity damping
+    damping: float = 0.85  # Linear velocity damping (0-1, lower = more damping)
+    angular_damping: float = 0.80  # Angular velocity damping
     max_velocity: float = 10.0  # Max velocity in mm/step
+    max_force: float = 0.0  # Max net force per component (0 = auto from board perimeter)
 
     # Rotation potential (torsion spring with 90 deg wells)
     rotation_stiffness: float = 10.0  # Torsion spring constant for 90 deg alignment

--- a/src/kicad_tools/optim/placement.py
+++ b/src/kicad_tools/optim/placement.py
@@ -962,8 +962,8 @@ class PlacementOptimizer:
         # Clamp minimum distance to prevent singularity
         distance = max(distance, self.config.min_distance)
 
-        # Force magnitude: lambda * L / r (total charge / distance)
-        force_mag = charge_density * edge_len / distance
+        # Force magnitude: lambda * L / r^2 (1/r^2 falloff prevents divergence)
+        force_mag = charge_density * edge_len / (distance * distance)
 
         # Force direction: away from edge
         return displacement.normalized() * force_mag
@@ -1718,6 +1718,18 @@ class PlacementOptimizer:
 
         return kinetic + potential
 
+    def _compute_max_force(self) -> float:
+        """Compute the max force limit for force clamping.
+
+        If config.max_force > 0, use that value directly.
+        Otherwise auto-compute from board perimeter:
+        max_force = boundary_charge * board_perimeter / 4.
+        """
+        if self.config.max_force > 0:
+            return self.config.max_force
+        perimeter = self.board_outline.perimeter()
+        return self.config.boundary_charge * perimeter / 4
+
     def step(self, dt: float):
         """
         Perform one simulation step.
@@ -1728,6 +1740,9 @@ class PlacementOptimizer:
         # Compute forces and torques together (more efficient)
         forces, torques = self.compute_forces_and_torques()
 
+        # Compute force clamp limit
+        max_force = self._compute_max_force()
+
         # Update velocities and apply forces/torques
         for comp in self.components:
             if comp.fixed:
@@ -1735,6 +1750,11 @@ class PlacementOptimizer:
 
             force = forces[comp.ref]
             torque = torques[comp.ref]
+
+            # Clamp net force magnitude to prevent runaway acceleration
+            force_mag = force.magnitude()
+            if force_mag > max_force:
+                force = force * (max_force / force_mag)
 
             comp.apply_force(force, dt)
             comp.apply_torque(torque, dt)
@@ -1749,6 +1769,15 @@ class PlacementOptimizer:
             # Apply damping
             comp.apply_damping(self.config.damping, self.config.angular_damping)
 
+        # Compute board bounding box for position clamping
+        if self.board_outline.vertices:
+            min_x = min(v.x for v in self.board_outline.vertices)
+            max_x = max(v.x for v in self.board_outline.vertices)
+            min_y = min(v.y for v in self.board_outline.vertices)
+            max_y = max(v.y for v in self.board_outline.vertices)
+        else:
+            min_x = max_x = min_y = max_y = 0.0
+
         # Update positions and rotations
         for comp in self.components:
             if comp.fixed:
@@ -1756,6 +1785,17 @@ class PlacementOptimizer:
 
             # Update position and rotation
             comp.update_position(dt)
+
+            # Hard-clamp position to board bounding box (prevents escape)
+            margin = self.config.boundary_margin
+            comp.x = max(min_x + margin, min(max_x - margin, comp.x))
+            comp.y = max(min_y + margin, min(max_y - margin, comp.y))
+
+            # If component was clamped, kill its outward velocity
+            if comp.x <= min_x + margin or comp.x >= max_x - margin:
+                comp.vx = 0.0
+            if comp.y <= min_y + margin or comp.y >= max_y - margin:
+                comp.vy = 0.0
 
             # Update pin positions based on new position and rotation
             comp.update_pin_positions()

--- a/src/kicad_tools/placement/cpp/include/force_engine.hpp
+++ b/src/kicad_tools/placement/cpp/include/force_engine.hpp
@@ -99,8 +99,8 @@ inline Vec2 compute_edge_to_point_force(
     // Clamp minimum distance
     distance = std::max(distance, min_distance);
 
-    // Force magnitude: lambda * L / r
-    double force_mag = charge_density * edge_len / distance;
+    // Force magnitude: lambda * L / r^2 (1/r^2 falloff prevents divergence)
+    double force_mag = charge_density * edge_len / (distance * distance);
 
     // Force direction: away from edge (normalized displacement)
     double disp_mag = std::sqrt(disp_x * disp_x + disp_y * disp_y);

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,5 +1,7 @@
 """Tests for the optimization module."""
 
+import math
+
 import pytest
 
 from kicad_tools.optim import (
@@ -424,7 +426,7 @@ class TestPlacementConfig:
         assert config.charge_density == 100.0
         assert config.min_distance == 0.5
         assert config.spring_stiffness == 10.0
-        assert config.damping == 0.95
+        assert config.damping == 0.85
         assert config.max_velocity == 10.0
 
 
@@ -1407,3 +1409,97 @@ class TestThermalOptimization:
         # Both components should have forces applied
         assert forces["U1"].magnitude() > 0
         assert forces["Y1"].magnitude() > 0
+
+
+class TestOptimizerConvergence:
+    """Tests for force-directed optimizer convergence (issue #1766)."""
+
+    def test_energy_decreases(self):
+        """Energy should decrease after the initial transient."""
+        board = Polygon.rectangle(50, 50, 80, 80)
+        config = PlacementConfig()
+        optimizer = PlacementOptimizer(board, config)
+
+        # Add 10 components in a cluster near center
+        for i in range(10):
+            x = 40.0 + (i % 5) * 4.0
+            y = 45.0 + (i // 5) * 4.0
+            comp = Component(ref=f"C{i}", x=x, y=y, width=3.0, height=2.0)
+            optimizer.add_component(comp)
+
+        # Run initial transient (energy rises as forces separate components)
+        optimizer.run(iterations=100, dt=0.01)
+        energy_after_transient = optimizer.compute_energy()
+
+        # Run more iterations -- system should be settling
+        optimizer.run(iterations=400, dt=0.01)
+        energy_end = optimizer.compute_energy()
+
+        # Energy should decrease after the transient phase
+        assert energy_end < energy_after_transient, (
+            f"Energy increased from {energy_after_transient:.2f} to {energy_end:.2f} "
+            f"after transient (divergence detected)"
+        )
+
+    def test_components_stay_within_bounds(self):
+        """All components must remain inside board bounding box after optimization."""
+        board = Polygon.rectangle(50, 50, 80, 80)
+        config = PlacementConfig()
+        optimizer = PlacementOptimizer(board, config)
+
+        # Place components in a tight cluster to generate high repulsion
+        for i in range(8):
+            x = 48.0 + (i % 4) * 2.0
+            y = 48.0 + (i // 4) * 2.0
+            comp = Component(ref=f"R{i}", x=x, y=y, width=2.5, height=1.5)
+            optimizer.add_component(comp)
+
+        optimizer.run(iterations=1000, dt=0.01)
+
+        # Board bounding box
+        min_x = min(v.x for v in board.vertices)
+        max_x = max(v.x for v in board.vertices)
+        min_y = min(v.y for v in board.vertices)
+        max_y = max(v.y for v in board.vertices)
+
+        for comp in optimizer.components:
+            assert min_x <= comp.x <= max_x, (
+                f"Component {comp.ref} escaped board: x={comp.x:.2f} "
+                f"(bounds [{min_x:.2f}, {max_x:.2f}])"
+            )
+            assert min_y <= comp.y <= max_y, (
+                f"Component {comp.ref} escaped board: y={comp.y:.2f} "
+                f"(bounds [{min_y:.2f}, {max_y:.2f}])"
+            )
+
+    def test_overlapping_components_converge(self):
+        """Components initially nearly overlapping should separate without diverging."""
+        board = Polygon.rectangle(50, 50, 100, 100)
+        config = PlacementConfig()
+        optimizer = PlacementOptimizer(board, config)
+
+        # Place three components very close together (near-overlap, worst realistic case)
+        for i in range(3):
+            # Offset by 0.1mm to avoid exact overlap degenerate case
+            comp = Component(ref=f"U{i}", x=50.0 + i * 0.1, y=50.0 + i * 0.1,
+                             width=5.0, height=5.0)
+            optimizer.add_component(comp)
+
+        optimizer.run(iterations=500, dt=0.01)
+
+        energy = optimizer.compute_energy()
+        # Energy should be finite (no NaN/inf from singularity)
+        assert math.isfinite(energy), f"Energy is not finite: {energy}"
+
+        # Components should have separated
+        positions = [(c.x, c.y) for c in optimizer.components]
+        # At least one pair should be separated by more than 1mm
+        separated = False
+        for i in range(len(positions)):
+            for j in range(i + 1, len(positions)):
+                dx = positions[i][0] - positions[j][0]
+                dy = positions[i][1] - positions[j][1]
+                if math.sqrt(dx * dx + dy * dy) > 1.0:
+                    separated = True
+                    break
+        assert separated, "Overlapping components did not separate"


### PR DESCRIPTION
## Summary

Fixes force-directed placement optimizer divergence where energy increased instead of decreasing, causing components to fly off the board. The root cause was a force imbalance: edge-to-edge repulsion (~80,000 units at close range) vastly overpowered spring attraction (~500) with insufficient damping (only 5%/step).

## Changes

- Switch repulsion force model from 1/r to 1/r^2 falloff in both Python (`placement.py`) and C++ (`force_engine.hpp`), reducing close-range force dominance
- Add per-component net force clamping in `step()` (max = boundary_charge * perimeter / 4)
- Add hard position clamping to board bounding box after each step, preventing permanent escape
- Increase default damping from 0.95/0.90 to 0.85/0.80 (linear/angular) for faster energy dissipation
- Add `max_force` config parameter for user-tunable force clamping

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Energy decreases after transient (energy[500] < energy[100]) | Done | test_energy_decreases passes |
| All components remain within board bounds | Done | test_components_stay_within_bounds passes |
| No regression in existing optimization tests | Done | All 130 tests in test_optim.py pass |
| C++ backend updated in sync with Python | Done | force_engine.hpp updated to 1/r^2 |
| Near-overlapping components separate without diverging | Done | test_overlapping_components_converge passes |

## Test Plan

- Added `TestOptimizerConvergence` class with 3 regression tests:
  - `test_energy_decreases`: verifies energy[500] < energy[100]
  - `test_components_stay_within_bounds`: 8 tightly packed components stay in board
  - `test_overlapping_components_converge`: near-overlapping components separate finitely
- All 130 existing tests in `tests/test_optim.py` pass
- All 28 tests in `tests/test_optimize_placement_cmd.py` pass

Closes #1766