### PR TITLE
fix(schema): add TypeError guard for PCB() path misuse

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -921,7 +921,15 @@ class PCB:
         Args:
             sexp: Parsed S-expression data
             path: Optional path to the PCB file (used for export operations)
+
+        Raises:
+            TypeError: If sexp is a string or Path instead of a parsed SExp
         """
+        if isinstance(sexp, (str, Path)):
+            raise TypeError(
+                f"PCB() expects a parsed SExp, not a file path. "
+                f"Use PCB.load({str(sexp)!r}) instead."
+            )
         self._sexp = sexp
         self._path: Path | None = Path(path) if path else None
         self._layers: dict[int, Layer] = {}
@@ -1230,6 +1238,8 @@ class PCB:
         """Parse the PCB data structure."""
         for child in self._sexp.iter_children():
             tag = child.tag
+            if tag is None:
+                continue  # Skip unnamed list nodes
 
             if tag == "layers":
                 self._parse_layers(child)

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -2777,3 +2777,35 @@ class TestRemoveSegments:
             if not c.is_atom and c.name == "segment"
         ]
         assert len(seg_nodes_after) == 0
+
+
+class TestPCBConstructorGuard:
+    """Tests for PCB constructor type guard (issue #1770)."""
+
+    def test_pcb_constructor_rejects_string_path(self):
+        """PCB('path/to/file.kicad_pcb') raises TypeError with helpful message."""
+        with pytest.raises(TypeError, match=r"PCB\(\) expects a parsed SExp"):
+            PCB("/path/to/board.kicad_pcb")
+
+    def test_pcb_constructor_rejects_path_object(self):
+        """PCB(Path('file.kicad_pcb')) raises TypeError with helpful message."""
+        with pytest.raises(TypeError, match=r"Use PCB\.load\("):
+            PCB(Path("/path/to/board.kicad_pcb"))
+
+    def test_pcb_constructor_accepts_sexp(self, minimal_pcb: Path):
+        """PCB(sexp) works when passed a proper SExp object."""
+        from kicad_tools import load_pcb
+
+        doc = load_pcb(str(minimal_pcb))
+        pcb = PCB(doc)
+        assert len(pcb.layers) > 0
+
+    def test_pcb_load_kicad9_fixture(self):
+        """PCB.load() succeeds on KiCad 9/10 format fixture files."""
+        fixture_path = Path(__file__).parent / "fixtures" / "test_zone_fill.kicad_pcb"
+        if not fixture_path.exists():
+            pytest.skip("test_zone_fill.kicad_pcb fixture not available")
+
+        pcb = PCB.load(fixture_path)
+        assert len(pcb.layers) > 0
+        assert len(pcb.nets) >= 0


### PR DESCRIPTION
## Summary
Add a runtime type guard in `PCB.__init__()` that raises `TypeError` with a helpful message when a file path string/Path is passed instead of a parsed `SExp`. Also add defensive handling for unnamed list nodes in `_parse()`.

## Changes
- Add `isinstance(sexp, (str, Path))` guard in `PCB.__init__()` that raises `TypeError` directing users to `PCB.load()`
- Add `tag is None` skip in `_parse()` to handle unnamed list nodes gracefully
- Add 4 tests: string rejection, Path rejection, valid SExp acceptance, KiCad 9/10 fixture loading

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `PCB("path")` raises TypeError with message mentioning PCB.load() | ✅ | test_pcb_constructor_rejects_string_path |
| `PCB.load('/path/to/kicad9.kicad_pcb')` loads successfully | ✅ | test_pcb_load_kicad9_fixture |
| `_parse()` handles `child.tag is None` gracefully | ✅ | Defensive skip added at line 1235 |
| Backward compatible with KiCad 7/8 files | ✅ | All 143 existing tests pass |

## Test Plan
- `pytest tests/test_pcb.py` — all 143 tests pass (4 new + 139 existing)

Closes #1770