### PR TITLE
fix(drc): handle KiCad 9 name-only net format in DRC repair modules

### DIFF
--- a/src/kicad_tools/drc/__init__.py
+++ b/src/kicad_tools/drc/__init__.py
@@ -18,6 +18,7 @@ With fix suggestions:
     ...         print(f"  Fix: {suggestion.description}")
 """
 
+from .net_compat import resolve_net_atom
 from .checker import (
     CheckResult,
     ManufacturerCheck,
@@ -83,4 +84,6 @@ __all__ = [
     "DrillClearanceRepairer",
     "DrillRepairAction",
     "DrillRepairResult",
+    # Net compatibility
+    "resolve_net_atom",
 ]

--- a/src/kicad_tools/drc/fixer.py
+++ b/src/kicad_tools/drc/fixer.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..sexp import SExp, parse_file
+from .net_compat import resolve_net_atom
 from .report import DRCReport
 from .violation import ViolationType
 
@@ -132,8 +133,11 @@ class DRCFixer:
             if layer and seg_layer != layer:
                 continue
 
-            net_num = int(net_node.get_first_atom()) if net_node else 0
-            seg_net_name = self.nets.get(net_num, "")
+            net_num, seg_net_name = resolve_net_atom(
+                net_node.get_first_atom() if net_node else None,
+                self.nets,
+                self.net_names,
+            )
 
             if net_name and seg_net_name != net_name:
                 continue
@@ -183,8 +187,11 @@ class DRCFixer:
                 continue
 
             net_node = via_node.find("net")
-            net_num = int(net_node.get_first_atom()) if net_node else 0
-            via_net_name = self.nets.get(net_num, "")
+            net_num, via_net_name = resolve_net_atom(
+                net_node.get_first_atom() if net_node else None,
+                self.nets,
+                self.net_names,
+            )
 
             if net_name and via_net_name != net_name:
                 continue
@@ -277,8 +284,14 @@ class DRCFixer:
                 continue
             if child.name == "segment" or child.name == "via":
                 net_node = child.find("net")
-                if net_node and int(net_node.get_first_atom()) == net_num:
-                    to_delete.append(child)
+                if net_node:
+                    child_net_num, _ = resolve_net_atom(
+                        net_node.get_first_atom(),
+                        self.nets,
+                        self.net_names,
+                    )
+                    if child_net_num == net_num:
+                        to_delete.append(child)
 
         # Delete collected nodes
         for node in to_delete:

--- a/src/kicad_tools/drc/local_rerouter.py
+++ b/src/kicad_tools/drc/local_rerouter.py
@@ -25,6 +25,7 @@ import uuid
 from dataclasses import dataclass, field
 
 from ..sexp import SExp
+from .net_compat import resolve_net_atom
 
 
 @dataclass(order=True)
@@ -76,6 +77,7 @@ class LocalRerouter:
         """
         self.doc = doc
         self.nets = nets
+        self.net_names: dict[str, int] = {name: num for num, name in nets.items()}
         self.resolution = resolution
         self.padding = padding
 
@@ -134,7 +136,11 @@ class LocalRerouter:
         seg_layer = layer_node.get_first_atom() if layer_node else "F.Cu"
 
         net_node = seg_node.find("net")
-        seg_net = int(net_node.get_first_atom()) if net_node else 0
+        seg_net, _ = resolve_net_atom(
+            net_node.get_first_atom() if net_node else None,
+            self.nets,
+            self.net_names,
+        )
 
         width_node = seg_node.find("width")
         seg_width = float(width_node.get_first_atom()) if width_node else trace_width
@@ -409,7 +415,11 @@ class LocalRerouter:
 
             # Same-net vias: don't block (our trace can touch our own via)
             via_net_node = via_node.find("net")
-            via_net = int(via_net_node.get_first_atom()) if via_net_node else 0
+            via_net, _ = resolve_net_atom(
+                via_net_node.get_first_atom() if via_net_node else None,
+                self.nets,
+                self.net_names,
+            )
             if via_net == net and net != 0:
                 continue
 
@@ -428,7 +438,11 @@ class LocalRerouter:
                 continue
 
             other_net_node = other_seg.find("net")
-            other_net = int(other_net_node.get_first_atom()) if other_net_node else 0
+            other_net, _ = resolve_net_atom(
+                other_net_node.get_first_atom() if other_net_node else None,
+                self.nets,
+                self.net_names,
+            )
 
             # Skip same-net segments unless they are explicitly listed as obstacles
             is_same_net_obstacle = id(other_seg) in same_net_obs_ids

--- a/src/kicad_tools/drc/net_compat.py
+++ b/src/kicad_tools/drc/net_compat.py
@@ -1,0 +1,45 @@
+"""KiCad 8/9 net format compatibility helpers.
+
+KiCad 8 uses integer net IDs in element attributes: ``(net 5)``
+KiCad 9 uses name-only strings: ``(net "GND")``
+
+This module provides a single helper to safely parse net atoms regardless
+of format.
+"""
+
+from __future__ import annotations
+
+
+def resolve_net_atom(
+    atom: str | None,
+    nets: dict[int, str] | None = None,
+    net_names: dict[str, int] | None = None,
+) -> tuple[int, str]:
+    """Resolve a net atom that may be an integer ID or a name string.
+
+    Args:
+        atom: The raw atom value from ``net_node.get_first_atom()``.
+              May be an integer string (``"5"``), a net name (``"GND"``),
+              an empty string, or ``None``.
+        nets: Mapping of net number -> net name (for resolving int IDs to names).
+        net_names: Mapping of net name -> net number (for resolving names to IDs).
+
+    Returns:
+        Tuple of ``(net_num, net_name)``.  If the atom cannot be resolved,
+        returns ``(0, "")``.
+    """
+    if atom is None or atom == "":
+        return (0, "")
+
+    # Try integer parse first (KiCad 8 format)
+    try:
+        net_num = int(atom)
+        net_name = nets.get(net_num, "") if nets else ""
+        return (net_num, net_name)
+    except (ValueError, TypeError):
+        pass
+
+    # KiCad 9 name-only format -- look up the integer from name
+    net_name = str(atom)
+    net_num = net_names.get(net_name, 0) if net_names else 0
+    return (net_num, net_name)

--- a/src/kicad_tools/drc/repair_clearance.py
+++ b/src/kicad_tools/drc/repair_clearance.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..sexp import SExp, parse_file
+from .net_compat import resolve_net_atom
 from .report import DRCReport
 from .violation import DRCViolation, ViolationType
 
@@ -1114,8 +1115,11 @@ class ClearanceRepairer:
                 continue
 
             net_node = seg_node.find("net")
-            net_num = int(net_node.get_first_atom()) if net_node else 0
-            net_name = self.nets.get(net_num, "")
+            net_num, net_name = resolve_net_atom(
+                net_node.get_first_atom() if net_node else None,
+                self.nets,
+                self.net_names,
+            )
 
             if nets and net_name not in nets:
                 continue
@@ -1151,8 +1155,11 @@ class ClearanceRepairer:
                 continue
 
             net_node = via_node.find("net")
-            net_num = int(net_node.get_first_atom()) if net_node else 0
-            net_name = self.nets.get(net_num, "")
+            net_num, net_name = resolve_net_atom(
+                net_node.get_first_atom() if net_node else None,
+                self.nets,
+                self.net_names,
+            )
 
             # Relax net filter: allow vias with no net (net 0 / empty name)
             # or vias whose net is "<no net>", since these commonly appear

--- a/src/kicad_tools/drc/repair_drill_clearance.py
+++ b/src/kicad_tools/drc/repair_drill_clearance.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from ..sexp import SExp, parse_file
+from .net_compat import resolve_net_atom
 from .violation import DRCViolation, ViolationType
 
 
@@ -258,8 +259,11 @@ class DrillClearanceRepairer:
                 continue
 
             net_node = via_node.find("net")
-            net_num = int(net_node.get_first_atom()) if net_node else 0
-            net_name = self.nets.get(net_num, "")
+            net_num, net_name = resolve_net_atom(
+                net_node.get_first_atom() if net_node else None,
+                self.nets,
+                self.net_names,
+            )
 
             drill_node = via_node.find("drill")
             drill = float(drill_node.get_first_atom()) if drill_node else 0.3
@@ -431,7 +435,11 @@ class DrillClearanceRepairer:
             net_node = seg_node.find("net")
             if not net_node:
                 continue
-            seg_net = int(net_node.get_first_atom())
+            seg_net, _ = resolve_net_atom(
+                net_node.get_first_atom(),
+                self.nets,
+                self.net_names,
+            )
             if seg_net != net_num:
                 continue
 

--- a/tests/test_drc_net_compat.py
+++ b/tests/test_drc_net_compat.py
@@ -1,0 +1,73 @@
+"""Tests for KiCad 8/9 net format compatibility in DRC modules."""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.drc.net_compat import resolve_net_atom
+
+
+class TestResolveNetAtom:
+    """Tests for the resolve_net_atom helper function."""
+
+    def setup_method(self):
+        self.nets = {0: "", 1: "GND", 5: "VCC", 10: "+3V3"}
+        self.net_names = {"": 0, "GND": 1, "VCC": 5, "+3V3": 10}
+
+    def test_integer_format_kicad8(self):
+        """KiCad 8 format: (net 5) -> atom is '5'."""
+        net_num, net_name = resolve_net_atom("5", self.nets, self.net_names)
+        assert net_num == 5
+        assert net_name == "VCC"
+
+    def test_name_format_kicad9(self):
+        """KiCad 9 format: (net "GND") -> atom is 'GND'."""
+        net_num, net_name = resolve_net_atom("GND", self.nets, self.net_names)
+        assert net_num == 1
+        assert net_name == "GND"
+
+    def test_name_format_plus_prefix(self):
+        """KiCad 9 format with special chars: (net "+3V3")."""
+        net_num, net_name = resolve_net_atom("+3V3", self.nets, self.net_names)
+        assert net_num == 10
+        assert net_name == "+3V3"
+
+    def test_none_atom(self):
+        """None atom returns (0, '')."""
+        net_num, net_name = resolve_net_atom(None, self.nets, self.net_names)
+        assert net_num == 0
+        assert net_name == ""
+
+    def test_empty_string(self):
+        """Empty string returns (0, '')."""
+        net_num, net_name = resolve_net_atom("", self.nets, self.net_names)
+        assert net_num == 0
+        assert net_name == ""
+
+    def test_unknown_name(self):
+        """Unknown name string returns (0, name)."""
+        net_num, net_name = resolve_net_atom("UNKNOWN", self.nets, self.net_names)
+        assert net_num == 0
+        assert net_name == "UNKNOWN"
+
+    def test_unknown_integer(self):
+        """Unknown integer returns (int, '')."""
+        net_num, net_name = resolve_net_atom("99", self.nets, self.net_names)
+        assert net_num == 99
+        assert net_name == ""
+
+    def test_zero_integer(self):
+        """Zero net ID returns (0, '') -- unconnected net."""
+        net_num, net_name = resolve_net_atom("0", self.nets, self.net_names)
+        assert net_num == 0
+        assert net_name == ""
+
+    def test_no_dicts(self):
+        """Works with None dicts (graceful fallback)."""
+        net_num, net_name = resolve_net_atom("5", None, None)
+        assert net_num == 5
+        assert net_name == ""
+
+        net_num, net_name = resolve_net_atom("GND", None, None)
+        assert net_num == 0
+        assert net_name == "GND"


### PR DESCRIPTION
## Summary

Adds a shared `resolve_net_atom` helper that safely parses net attributes as either integer IDs (KiCad 8: `(net 5)`) or name strings (KiCad 9: `(net "GND")`), preventing `ValueError: invalid literal for int()` crashes when running fix-drc on KiCad 9 PCB files.

## Changes

- New `src/kicad_tools/drc/net_compat.py` with `resolve_net_atom(atom, nets, net_names)` helper
- Replaced 10 bare `int(net_node.get_first_atom())` calls across 4 DRC files with the helper
- Added reverse `net_names` dict to `LocalRerouter` for name-to-number lookups
- Added unit tests for the helper covering integer, name, empty, and None inputs

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No ValueError on KiCad 9 name-only net format | Done | `resolve_net_atom("GND", ...)` returns `(1, "GND")` without error |
| Backward compatible with KiCad 8 integer format | Done | `resolve_net_atom("5", ...)` returns `(5, "VCC")` correctly |
| Empty/None atoms handled gracefully | Done | Returns `(0, "")` for edge cases |
| All 8+ call sites fixed | Done | `grep` confirms zero remaining bare `int(net_node.get_first_atom())` in drc/ |
| Existing tests pass | Done | 303 DRC-related tests pass (189 + 114) |

## Test Plan

- `pytest tests/test_drc_net_compat.py` -- 9 unit tests for the helper
- `pytest tests/test_repair_clearance.py tests/test_local_rerouter.py tests/test_fix_drc_cmd.py` -- 189 existing tests pass
- `pytest tests/test_drc.py tests/test_drc_suggestions.py tests/test_progressive_clearance.py` -- 114 additional DRC tests pass

Closes #1777