### PR TITLE
fix(zones): support KiCad 9 name-only net format in zones

### DIFF
--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -155,6 +155,11 @@ def find_zones_for_net(sexp: SExp, net_name: str) -> list[str]:
             net_name_node = child.find_child("net_name")
             if net_name_node:
                 zone_net_name = net_name_node.get_string(0)
+            else:
+                # KiCad 9 name-only format: (net "GND") without separate net_name node
+                net_node = child.find_child("net")
+                if net_node and net_node.get_int(0) is None:
+                    zone_net_name = net_node.get_string(0)
 
             # Get layer from zone
             layer_node = child.find_child("layer")
@@ -191,6 +196,11 @@ def find_all_plane_nets(sexp: SExp) -> dict[str, str]:
             net_name_node = child.find_child("net_name")
             if net_name_node:
                 zone_net_name = net_name_node.get_string(0)
+            else:
+                # KiCad 9 name-only format: (net "GND") without separate net_name node
+                net_node = child.find_child("net")
+                if net_node and net_node.get_int(0) is None:
+                    zone_net_name = net_node.get_string(0)
 
             # Get layer from zone
             layer_node = child.find_child("layer")

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -703,9 +703,16 @@ class Zone:
             layer="",
         )
 
-        # Basic properties
+        # Basic properties — handles both (net N "name") and (net "name") formats.
+        # KiCad 9 may emit (net "name") without a numeric net number.
         if net := sexp.find("net"):
-            zone.net_number = net.get_int(0) or 0
+            first_int = net.get_int(0)
+            if first_int is not None:
+                zone.net_number = first_int
+            else:
+                zone.net_number = 0
+                # Name-only format: (net "GND") — store name from net node
+                zone.net_name = net.get_string(0) or ""
         if net_name := sexp.find("net_name"):
             zone.net_name = net_name.get_string(0) or ""
         if layer := sexp.find("layer"):
@@ -1334,6 +1341,11 @@ class PCB:
         for via in self._vias:
             if via.net_number == 0 and via.net_name:
                 via.net_number = name_to_number.get(via.net_name, 0)
+
+        # Fix zones
+        for zone in self._zones:
+            if zone.net_number == 0 and zone.net_name:
+                zone.net_number = name_to_number.get(zone.net_name, 0)
 
     def _parse_setup(self, sexp: SExp):
         """Parse setup/design rules."""

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -1329,6 +1329,90 @@ class TestFindAllPlaneNets:
         assert "GND" in plane_nets
 
 
+class TestKiCad9NameOnlyZoneFormat:
+    """Tests for KiCad 9 name-only net format in zones (no net_name node)."""
+
+    def test_find_zones_for_net_name_only_format(self, tmp_path: Path):
+        """find_zones_for_net should handle (net "GND") without net_name node."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (layers (0 "F.Cu" signal) (1 "In1.Cu" signal) (31 "B.Cu" signal))
+          (net 0 "")
+          (net 1 "GND")
+          (zone (net "GND") (layer "In1.Cu") (uuid "z1")
+            (connect_pads (clearance 0.2))
+            (min_thickness 0.2)
+            (fill yes)
+            (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10)))
+          )
+        )"""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        from kicad_tools.cli.stitch_cmd import find_zones_for_net
+
+        sexp = load_pcb(pcb_file)
+        layers = find_zones_for_net(sexp, "GND")
+        assert layers == ["In1.Cu"]
+
+    def test_find_all_plane_nets_name_only_format(self, tmp_path: Path):
+        """find_all_plane_nets should handle (net "GND") without net_name node."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (layers (0 "F.Cu" signal) (1 "In1.Cu" signal) (2 "In2.Cu" signal) (31 "B.Cu" signal))
+          (net 0 "")
+          (net 1 "GND")
+          (net 2 "+3.3V")
+          (zone (net "GND") (layer "In1.Cu") (uuid "z1")
+            (connect_pads (clearance 0.2))
+            (min_thickness 0.2)
+            (fill yes)
+            (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10)))
+          )
+          (zone (net "+3.3V") (layer "In2.Cu") (uuid "z2")
+            (connect_pads (clearance 0.2))
+            (min_thickness 0.2)
+            (fill yes)
+            (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10)))
+          )
+        )"""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        sexp = load_pcb(pcb_file)
+        plane_nets = find_all_plane_nets(sexp)
+        assert plane_nets == {"GND": "In1.Cu", "+3.3V": "In2.Cu"}
+
+    def test_traditional_format_still_works(self, tmp_path: Path):
+        """Traditional (net N) + (net_name "GND") format should still work."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (layers (0 "F.Cu" signal) (1 "In1.Cu" signal) (31 "B.Cu" signal))
+          (net 0 "")
+          (net 1 "GND")
+          (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "z1")
+            (connect_pads (clearance 0.2))
+            (min_thickness 0.2)
+            (fill yes)
+            (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10)))
+          )
+        )"""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        from kicad_tools.cli.stitch_cmd import find_zones_for_net
+
+        sexp = load_pcb(pcb_file)
+        layers = find_zones_for_net(sexp, "GND")
+        assert layers == ["In1.Cu"]
+
+        plane_nets = find_all_plane_nets(sexp)
+        assert plane_nets == {"GND": "In1.Cu"}
+
+
 class TestAutoDetectPlaneNets:
     """Tests for CLI auto-detection of power plane nets."""
 

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -854,3 +854,81 @@ class TestZoneFillerThermalIntegration:
         reliefs = filler.generate_thermal_reliefs(filled, [pad])
 
         assert len(reliefs) == 0  # No thermal relief for solid
+
+
+class TestZoneFromSexpKiCad9:
+    """Tests for Zone.from_sexp handling KiCad 9 name-only net format."""
+
+    def test_name_only_net_format(self):
+        """Zone.from_sexp should handle (net "GND") without numeric ID."""
+        from kicad_tools.sexp.parser import parse_string
+
+        sexp = parse_string("""(zone (net "GND") (layer "In1.Cu") (uuid "z1")
+            (connect_pads (clearance 0.2))
+            (min_thickness 0.2)
+            (fill yes)
+            (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10)))
+        )""")
+
+        zone = Zone.from_sexp(sexp)
+        assert zone.net_name == "GND"
+        assert zone.net_number == 0  # No numeric ID available yet
+        assert zone.layer == "In1.Cu"
+
+    def test_traditional_format(self):
+        """Zone.from_sexp should still handle (net N) + (net_name "GND")."""
+        from kicad_tools.sexp.parser import parse_string
+
+        sexp = parse_string("""(zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "z1")
+            (connect_pads (clearance 0.2))
+            (min_thickness 0.2)
+            (fill yes)
+            (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10)))
+        )""")
+
+        zone = Zone.from_sexp(sexp)
+        assert zone.net_name == "GND"
+        assert zone.net_number == 1
+        assert zone.layer == "In1.Cu"
+
+    def test_fixup_net_numbers_for_zones(self, tmp_path):
+        """_fixup_net_numbers should recover net_number for zones."""
+        from pathlib import Path
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (layers (0 "F.Cu" signal) (1 "In1.Cu" signal) (31 "B.Cu" signal))
+          (net 0 "")
+          (net 1 "GND")
+          (net 2 "+3.3V")
+          (zone (net "GND") (layer "In1.Cu") (uuid "z1")
+            (connect_pads (clearance 0.2))
+            (min_thickness 0.2)
+            (fill yes)
+            (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10)))
+          )
+          (zone (net "+3.3V") (layer "In2.Cu") (uuid "z2")
+            (connect_pads (clearance 0.2))
+            (min_thickness 0.2)
+            (fill yes)
+            (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10)))
+          )
+        )"""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        pcb = PCB.load(pcb_file)
+        zones = pcb.zones
+
+        # After fixup, net numbers should be recovered from header
+        gnd_zones = [z for z in zones if z.net_name == "GND"]
+        v33_zones = [z for z in zones if z.net_name == "+3.3V"]
+
+        assert len(gnd_zones) == 1
+        assert gnd_zones[0].net_number == 1
+
+        assert len(v33_zones) == 1
+        assert v33_zones[0].net_number == 2


### PR DESCRIPTION
## Summary
Zones list/stitch failed to parse KiCad 9 name-based net format where zones use `(net "GND")` instead of `(net 1)` with a separate `(net_name "GND")` node.

## Changes
- `Zone.from_sexp()` in `schema/pcb.py`: detect string-vs-int in `(net ...)` node, matching the pad/via pattern from commit 57a3920
- `_fixup_net_numbers()` in `schema/pcb.py`: add zone fixup block to recover net numbers from PCB header declarations
- `find_zones_for_net()` in `stitch_cmd.py`: fall back to reading net node string when `net_name` node is absent
- `find_all_plane_nets()` in `stitch_cmd.py`: same fallback logic

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Zone.from_sexp handles (net "GND") | Pass | test_name_only_net_format passes |
| _fixup_net_numbers recovers zone net numbers | Pass | test_fixup_net_numbers_for_zones passes |
| find_zones_for_net works with name-only format | Pass | test_find_zones_for_net_name_only_format passes |
| find_all_plane_nets works with name-only format | Pass | test_find_all_plane_nets_name_only_format passes |
| Traditional format still works | Pass | test_traditional_format passes, 202 existing tests pass |

## Test Plan
- 6 new tests covering KiCad 9 name-only format and regression for traditional format
- All 202 existing zone/stitch tests pass with no regressions

Closes #1776