### PR TITLE
fix(pipeline): reorder zone fill before fix-drc with post-nudge refill

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -8,11 +8,12 @@ Orchestrates the full repair pipeline:
 3. Fix vias (manufacturer compliance)
 4. [Optional] Route (if board is unrouted)
 5. Optimize traces
-6. Fix DRC violations
-7. Zone fill (requires kicad-cli)
-8. Audit / check
-9. Report generation (manufacturing report)
-10. Export manufacturing package (gerbers, BOM, CPL, project ZIP)
+6. Zone fill (requires kicad-cli)
+7. Fix DRC violations
+8. Zone refill (recompute zones after trace nudges)
+9. Audit / check
+10. Report generation (manufacturing report)
+11. Export manufacturing package (gerbers, BOM, CPL, project ZIP)
 
 Usage:
     kct pipeline board.kicad_pcb --mfr jlcpcb
@@ -55,12 +56,18 @@ class PipelineStep(str, Enum):
     FIX_DRC = "fix-drc"
     OPTIMIZE = "optimize"
     ZONES = "zones"
+    ZONES_REFILL = "zones-refill"
     AUDIT = "audit"
     REPORT = "report"
     EXPORT = "export"
 
 
-# Ordered list of all pipeline steps
+# Ordered list of all pipeline steps.
+#
+# Zone fill runs BEFORE fix-drc so that zone copper is computed against
+# current trace positions.  After fix-drc nudges traces, a zone refill
+# pass recomputes fill polygons to respect the new trace positions,
+# eliminating zone-to-trace clearance violations.
 ALL_STEPS = [
     PipelineStep.ERC,
     PipelineStep.FIX_ERC,
@@ -68,8 +75,9 @@ ALL_STEPS = [
     PipelineStep.FIX_VIAS,
     PipelineStep.ROUTE,
     PipelineStep.OPTIMIZE,
-    PipelineStep.FIX_DRC,
     PipelineStep.ZONES,
+    PipelineStep.FIX_DRC,
+    PipelineStep.ZONES_REFILL,
     PipelineStep.AUDIT,
     PipelineStep.REPORT,
     PipelineStep.EXPORT,
@@ -732,6 +740,56 @@ def _run_step_zones(ctx: PipelineContext, console: Console) -> PipelineResult:
     )
 
 
+def _run_step_zones_refill(ctx: PipelineContext, console: Console) -> PipelineResult:
+    """Re-fill zones after fix-drc has nudged traces.
+
+    This ensures zone copper is recomputed against post-nudge trace
+    positions, eliminating zone-to-trace clearance violations that would
+    otherwise appear in the audit step.
+    """
+    from .runner import find_kicad_cli
+
+    kicad_cli = find_kicad_cli()
+
+    if kicad_cli is None:
+        return PipelineResult(
+            step=PipelineStep.ZONES_REFILL,
+            success=True,
+            message="zones refill: skipped (kicad-cli not installed)",
+            skipped=True,
+        )
+
+    if ctx.dry_run:
+        return PipelineResult(
+            step=PipelineStep.ZONES_REFILL,
+            success=True,
+            message=f"[dry-run] Would run: kct zones fill {ctx.pcb_file.name} (refill)",
+        )
+
+    if not ctx.quiet:
+        console.print(f"  Re-filling zones in {ctx.pcb_file.name} (post fix-drc)...")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "zones",
+        "fill",
+        str(ctx.pcb_file),
+    ]
+
+    if ctx.quiet:
+        cmd.append("--quiet")
+
+    success, message = _run_subprocess_step(cmd, ctx.pcb_file.parent, ctx.verbose)
+
+    return PipelineResult(
+        step=PipelineStep.ZONES_REFILL,
+        success=success,
+        message=f"zones refill: {message}",
+    )
+
+
 def _run_step_audit(ctx: PipelineContext, console: Console) -> PipelineResult:
     """Run final audit/check step."""
     # Use project-level audit if we have a .kicad_pro, else PCB-level check
@@ -1199,6 +1257,7 @@ STEP_RUNNERS = {
     PipelineStep.FIX_DRC: _run_step_fix_drc,
     PipelineStep.OPTIMIZE: _run_step_optimize,
     PipelineStep.ZONES: _run_step_zones,
+    PipelineStep.ZONES_REFILL: _run_step_zones_refill,
     PipelineStep.AUDIT: _run_step_audit,
     PipelineStep.REPORT: _run_step_report,
     PipelineStep.EXPORT: _run_step_export,

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -703,7 +703,7 @@ class TestPipelineStepOrder:
         assert set(ALL_STEPS) == set(PipelineStep)
 
     def test_step_order(self):
-        """Steps execute in the correct order: erc, fix-erc, fix-silkscreen, fix-vias, route, etc."""
+        """Steps execute in the correct order: zones before fix-drc, refill after fix-drc."""
         expected = [
             PipelineStep.ERC,
             PipelineStep.FIX_ERC,
@@ -711,8 +711,9 @@ class TestPipelineStepOrder:
             PipelineStep.FIX_VIAS,
             PipelineStep.ROUTE,
             PipelineStep.OPTIMIZE,
-            PipelineStep.FIX_DRC,
             PipelineStep.ZONES,
+            PipelineStep.FIX_DRC,
+            PipelineStep.ZONES_REFILL,
             PipelineStep.AUDIT,
             PipelineStep.REPORT,
             PipelineStep.EXPORT,
@@ -729,6 +730,24 @@ class TestPipelineStepOrder:
     def test_fix_silkscreen_in_all_steps(self):
         """PipelineStep.FIX_SILKSCREEN is present in ALL_STEPS."""
         assert PipelineStep.FIX_SILKSCREEN in ALL_STEPS
+
+    def test_zones_before_fix_drc(self):
+        """ZONES runs before FIX_DRC to fill zone copper before trace nudging."""
+        zones_idx = ALL_STEPS.index(PipelineStep.ZONES)
+        fix_drc_idx = ALL_STEPS.index(PipelineStep.FIX_DRC)
+        assert zones_idx < fix_drc_idx
+
+    def test_zones_refill_after_fix_drc(self):
+        """ZONES_REFILL runs after FIX_DRC to recompute zones for nudged traces."""
+        fix_drc_idx = ALL_STEPS.index(PipelineStep.FIX_DRC)
+        refill_idx = ALL_STEPS.index(PipelineStep.ZONES_REFILL)
+        assert refill_idx == fix_drc_idx + 1
+
+    def test_zones_refill_before_audit(self):
+        """ZONES_REFILL runs before AUDIT so the audit sees correct zone copper."""
+        refill_idx = ALL_STEPS.index(PipelineStep.ZONES_REFILL)
+        audit_idx = ALL_STEPS.index(PipelineStep.AUDIT)
+        assert refill_idx < audit_idx
 
 
 class TestPipelineLayerAutoDetection:
@@ -2950,6 +2969,51 @@ class TestZonesRunByDefault:
         """--zones CLI flag no longer exists."""
         with pytest.raises(SystemExit):
             main(["--zones", "dummy.kicad_pcb"])
+
+
+class TestZonesRefill:
+    """Tests for the zones-refill step that runs after fix-drc."""
+
+    def test_zones_refill_in_all_steps(self):
+        """ZONES_REFILL is present in ALL_STEPS."""
+        assert PipelineStep.ZONES_REFILL in ALL_STEPS
+
+    def test_zones_refill_enum_value(self):
+        """ZONES_REFILL has the expected string value."""
+        assert PipelineStep.ZONES_REFILL.value == "zones-refill"
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_step_zones_refill_as_targeted_single_step(self, mock_run, routed_pcb: Path):
+        """--step zones-refill executes the zone refill step in isolation."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        result = main(["--step", "zones-refill", str(routed_pcb), "--quiet"])
+        assert result == 0
+
+    def test_zones_refill_dry_run(self, routed_pcb: Path):
+        """Dry-run for zones-refill returns expected message."""
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_zones_refill
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, dry_run=True)
+        console = Console(quiet=True)
+        result = _run_step_zones_refill(ctx, console)
+
+        assert result.success is True
+        assert "refill" in result.message.lower()
+        assert result.step == PipelineStep.ZONES_REFILL
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_full_pipeline_runs_zones_refill(self, mock_run, routed_pcb: Path):
+        """Full pipeline includes zones-refill step after fix-drc."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True)
+        results = run_pipeline(ctx)
+
+        # Verify ZONES_REFILL appears in results
+        refill_results = [r for r in results if r.step == PipelineStep.ZONES_REFILL]
+        assert len(refill_results) == 1
 
 
 class TestFixDrcLocalReroute:


### PR DESCRIPTION
## Summary
Reorders pipeline steps so zone fill runs before fix-drc, and adds a zone-refill step after fix-drc. This eliminates zone-to-trace clearance violations caused by the previous ordering where zone copper was computed against pre-nudge trace positions.

## Changes
- Added `ZONES_REFILL` enum value to `PipelineStep`
- Reordered `ALL_STEPS`: ZONES now runs before FIX_DRC, with ZONES_REFILL immediately after
- Added `_run_step_zones_refill()` runner function that re-fills zones post fix-drc
- Registered `ZONES_REFILL` in `STEP_RUNNERS` map
- Updated module docstring to reflect new step ordering
- Added tests for step ordering constraints (zones before fix-drc, refill after fix-drc, refill before audit)
- Added tests for zones-refill step (dry-run, single-step, full pipeline inclusion)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Zone fill runs before fix-drc | Done | `ALL_STEPS` places ZONES at index 6, FIX_DRC at index 7 |
| Zone refill runs after fix-drc | Done | ZONES_REFILL at index 8, immediately after FIX_DRC |
| Zone refill runs before audit | Done | ZONES_REFILL (8) precedes AUDIT (9) |
| No regression in existing tests | Done | 224 tests pass, 4 pre-existing failures unrelated to this change |

## Test Plan
- `python3 -m pytest tests/test_pipeline_cmd.py -k "step_order or zones_refill or zones_before or TestZonesRefill or TestZonesRunByDefault"` -- 14 tests pass
- Full test suite: 224 pass, 4 pre-existing failures (report output dir, export after audit, fix-erc subprocess)

Closes #1786