### PR TITLE
fix(router): enforce minimum drill-to-drill spacing for same-net vias

### DIFF
--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -1174,6 +1174,72 @@ class RoutingGrid:
         is_valid = not has_violation
         return is_valid, min_actual_clearance, violation_loc
 
+    def validate_same_net_drill_spacing(
+        self,
+        via: "Via",
+        same_net: int,
+        min_drill_clearance: float | None = None,
+    ) -> tuple[bool, float, tuple[float, float] | None]:
+        """Validate drill-to-drill spacing between same-net vias.
+
+        Issue #1782: Even same-net vias must maintain minimum drill-to-drill
+        spacing to be manufacturable. Overlapping or near-overlapping drills
+        from the same net cause fabrication defects.
+
+        Uses center-to-center distance minus both drill radii to compute
+        edge-to-edge drill clearance. Only checks vias belonging to the
+        specified net (opposite logic to validate_via_to_via_clearance which
+        *excludes* the same net).
+
+        Args:
+            via: The via to validate
+            same_net: Net ID to check against (only same-net vias are checked)
+            min_drill_clearance: Minimum required drill-to-drill spacing
+                (default: rules.min_drill_clearance)
+
+        Returns:
+            Tuple of (is_valid, actual_clearance, violation_location)
+            - is_valid: True if via meets drill spacing requirements
+            - actual_clearance: Minimum drill clearance found
+            - violation_location: (x, y) of worst violation, or None if valid
+        """
+        import math
+
+        if min_drill_clearance is None:
+            min_drill_clearance = self.rules.min_drill_clearance
+
+        drill_radius = via.drill / 2
+        min_actual_clearance = float("inf")
+        violation_loc: tuple[float, float] | None = None
+        has_violation = False
+
+        for route in self.routes:
+            if route.net != same_net:
+                continue
+
+            for existing_via in route.vias:
+                # Skip checking against self (exact same position and drill)
+                if (
+                    abs(via.x - existing_via.x) < 1e-6
+                    and abs(via.y - existing_via.y) < 1e-6
+                ):
+                    continue
+
+                distance = math.sqrt(
+                    (via.x - existing_via.x) ** 2 + (via.y - existing_via.y) ** 2
+                )
+                existing_drill_radius = existing_via.drill / 2
+                clearance = distance - drill_radius - existing_drill_radius
+
+                if clearance < min_actual_clearance:
+                    min_actual_clearance = clearance
+                if clearance < min_drill_clearance:
+                    has_violation = True
+                    violation_loc = (via.x, via.y)
+
+        is_valid = not has_violation
+        return is_valid, min_actual_clearance, violation_loc
+
     def _point_to_segment_distance(
         self,
         px: float,

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -134,6 +134,8 @@ class PCBDesignRules:
     min_via_drill: float = 0.3  # mm
     # Clearances
     min_clearance: float = 0.2  # mm
+    # Drill-to-drill spacing (including same-net vias)
+    min_drill_clearance: float = 0.102  # mm
     # Copper to edge
     copper_edge_clearance: float = 0.3  # mm
 
@@ -160,6 +162,7 @@ class PCBDesignRules:
             via_drill=self.min_via_drill,
             via_diameter=self.min_via_diameter,
             via_clearance=self.min_clearance,
+            min_drill_clearance=self.min_drill_clearance,
             grid_resolution=grid_resolution,
         )
 
@@ -323,6 +326,15 @@ def parse_pcb_design_rules(pcb_text: str) -> PCBDesignRules:
         min_drill_match = re.search(r"\(min_via_drill\s+([\d.]+)\)", design_text)
         if min_drill_match:
             rules.min_via_drill = float(min_drill_match.group(1))
+
+        # Parse minimum drill-to-drill clearance (KiCad 8+: min_drill)
+        min_drill_clearance_match = re.search(
+            r"\(min_drill\s+([\d.]+)\)", design_text
+        )
+        if min_drill_clearance_match:
+            rules.min_drill_clearance = float(
+                min_drill_clearance_match.group(1)
+            )
 
     return rules
 

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -1923,7 +1923,73 @@ class Router:
             if not is_valid:
                 return False
 
+        # Issue #1782: Validate same-net drill-to-drill spacing
+        for via in route.vias:
+            is_valid, _clearance, _location = self.grid.validate_same_net_drill_spacing(
+                via, same_net=exclude_net
+            )
+            if not is_valid:
+                return False
+
         return True
+
+    def _merge_same_net_vias(self, route: Route) -> None:
+        """Merge vias in a new route that overlap with existing same-net vias.
+
+        Issue #1782: When routing multi-pad nets via MST edges, independent
+        sub-routes can place vias at nearby positions for the same net. If
+        the drill-to-drill distance is below the merge threshold
+        (via_diameter + min_drill_clearance), merge by keeping the midpoint
+        and updating connected segment endpoints.
+
+        Args:
+            route: The route to merge vias in (modified in place).
+        """
+        import math
+
+        merge_threshold = self.rules.via_diameter + self.rules.min_drill_clearance
+
+        # Collect all existing same-net vias from already-routed routes
+        existing_vias: list[Via] = []
+        for existing_route in self.grid.routes:
+            if existing_route.net == route.net:
+                existing_vias.extend(existing_route.vias)
+
+        if not existing_vias:
+            return
+
+        # Track which vias in the new route need merging
+        vias_to_remove: set[int] = set()
+
+        for i, new_via in enumerate(route.vias):
+            for existing_via in existing_vias:
+                distance = math.sqrt(
+                    (new_via.x - existing_via.x) ** 2
+                    + (new_via.y - existing_via.y) ** 2
+                )
+                if distance < merge_threshold and distance > 1e-6:
+                    # Merge: move the new via to the existing via's position
+                    # and update any segments that reference the old position
+                    old_x, old_y = new_via.x, new_via.y
+                    mid_x = existing_via.x
+                    mid_y = existing_via.y
+
+                    # Update segments that connect to this via
+                    for seg in route.segments:
+                        if abs(seg.x1 - old_x) < 1e-6 and abs(seg.y1 - old_y) < 1e-6:
+                            seg.x1 = mid_x
+                            seg.y1 = mid_y
+                        if abs(seg.x2 - old_x) < 1e-6 and abs(seg.y2 - old_y) < 1e-6:
+                            seg.x2 = mid_x
+                            seg.y2 = mid_y
+
+                    # Remove the new via since we're reusing the existing one
+                    vias_to_remove.add(i)
+                    break
+
+        # Remove merged vias (iterate in reverse to keep indices valid)
+        for idx in sorted(vias_to_remove, reverse=True):
+            route.vias.pop(idx)
 
     def _reconstruct_route(self, end_node: AStarNode, start_pad: Pad, end_pad: Pad) -> Route | None:
         """Reconstruct the route from A* result with geometric validation.
@@ -1950,6 +2016,9 @@ class Router:
 
         # Convert path to segments and vias
         self._convert_path_to_route(path, route, start_pad, end_pad)
+
+        # Issue #1782: Merge vias that overlap with existing same-net vias
+        self._merge_same_net_vias(route)
 
         # Validate layer transitions and insert any missing vias
         route.validate_layer_transitions(

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -55,6 +55,7 @@ class DesignRules:
     via_drill: float = 0.35  # mm (JLCPCB min is 0.3, use 0.35 for margin)
     via_diameter: float = 0.7  # mm (0.35 drill + 0.35 annular ring)
     via_clearance: float = 0.2  # mm
+    min_drill_clearance: float = 0.102  # mm (minimum drill-to-drill spacing, including same-net)
     grid_resolution: float = 0.1  # mm (routing grid)
 
     # Per-component clearance overrides (Issue #1016)

--- a/tests/test_router_grid.py
+++ b/tests/test_router_grid.py
@@ -1556,6 +1556,151 @@ class TestViaToViaClearanceValidation:
         assert clearance < grid.rules.via_clearance
 
 
+class TestSameNetDrillSpacing:
+    """Tests for validate_same_net_drill_spacing() -- Issue #1782.
+
+    Verifies that same-net vias maintain minimum drill-to-drill spacing
+    to avoid un-manufacturable drill overlap.
+    """
+
+    @pytest.fixture
+    def grid(self):
+        """Create a routing grid for same-net drill spacing testing."""
+        rules = DesignRules(
+            grid_resolution=0.1,
+            trace_width=0.2,
+            trace_clearance=0.127,
+            via_drill=0.35,
+            via_diameter=0.7,
+            via_clearance=0.2,
+            min_drill_clearance=0.102,
+        )
+        return RoutingGrid(width=20.0, height=20.0, rules=rules)
+
+    def test_same_net_vias_overlapping_drills(self, grid):
+        """Test that overlapping same-net drills are detected as violation.
+
+        Two same-net vias 0.347mm apart with 0.35mm drill diameter:
+        edge-to-edge = 0.347 - 0.175 - 0.175 = -0.003 (overlapping).
+        """
+        same_net_route = Route(net=1, net_name="NET1")
+        same_net_route.vias.append(
+            Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(same_net_route)
+
+        via = Via(
+            x=10.347, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1",
+        )
+
+        is_valid, clearance, location = grid.validate_same_net_drill_spacing(via, same_net=1)
+
+        assert is_valid is False
+        assert clearance < grid.rules.min_drill_clearance
+        assert location is not None
+
+    def test_same_net_vias_safe_distance(self, grid):
+        """Test that well-separated same-net vias pass validation."""
+        same_net_route = Route(net=1, net_name="NET1")
+        same_net_route.vias.append(
+            Via(x=5.0, y=5.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(same_net_route)
+
+        via = Via(
+            x=15.0, y=15.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1",
+        )
+
+        is_valid, clearance, location = grid.validate_same_net_drill_spacing(via, same_net=1)
+
+        assert is_valid is True
+        assert clearance > grid.rules.min_drill_clearance
+        assert location is None
+
+    def test_different_net_vias_ignored(self, grid):
+        """Test that different-net vias are not checked by same-net drill spacing."""
+        other_net_route = Route(net=2, net_name="NET2")
+        other_net_route.vias.append(
+            Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="NET2")
+        )
+        grid.routes.append(other_net_route)
+
+        # Place a via very close but on a different net -- should be ignored
+        via = Via(
+            x=10.1, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1",
+        )
+
+        is_valid, clearance, location = grid.validate_same_net_drill_spacing(via, same_net=1)
+
+        # No same-net vias exist, so validation passes trivially
+        assert is_valid is True
+
+    def test_self_via_not_checked(self, grid):
+        """Test that a via is not checked against itself (same position)."""
+        same_net_route = Route(net=1, net_name="NET1")
+        same_net_route.vias.append(
+            Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(same_net_route)
+
+        # Exact same position -- should be skipped (self-check)
+        via = Via(
+            x=10.0, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1",
+        )
+
+        is_valid, clearance, location = grid.validate_same_net_drill_spacing(via, same_net=1)
+
+        assert is_valid is True
+
+    def test_same_net_drill_just_below_threshold(self, grid):
+        """Test same-net vias just below min_drill_clearance threshold."""
+        same_net_route = Route(net=1, net_name="NET1")
+        same_net_route.vias.append(
+            Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(same_net_route)
+
+        # Drill edge-to-edge = 0.45 - 0.175 - 0.175 = 0.1 < 0.102
+        via = Via(
+            x=10.45, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1",
+        )
+
+        is_valid, clearance, location = grid.validate_same_net_drill_spacing(via, same_net=1)
+
+        assert is_valid is False
+        assert clearance < grid.rules.min_drill_clearance
+
+    def test_same_net_drill_at_threshold(self, grid):
+        """Test same-net vias at exactly min_drill_clearance pass."""
+        same_net_route = Route(net=1, net_name="NET1")
+        same_net_route.vias.append(
+            Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1")
+        )
+        grid.routes.append(same_net_route)
+
+        # Drill edge-to-edge = 0.453 - 0.175 - 0.175 = 0.103 > min_drill_clearance
+        via = Via(
+            x=10.453, y=10.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="NET1",
+        )
+
+        is_valid, clearance, location = grid.validate_same_net_drill_spacing(via, same_net=1)
+
+        assert is_valid is True
+        assert clearance >= grid.rules.min_drill_clearance
+
+
 class TestHeuristics:
     """Tests for heuristic classes."""
 


### PR DESCRIPTION
## Summary
Same-net vias placed overlapping or too close together now fail validation and are merged during post-route cleanup. Previously, both the pathfinder blocking check and via-to-via validation skipped same-net vias entirely, allowing un-manufacturable drill overlap when multi-pad nets placed independent vias at nearby positions.

## Changes
- Add `min_drill_clearance` field (default 0.102mm) to `DesignRules` in `rules.py`
- Add `min_drill_clearance` field to `PCBDesignRules` in `io.py` and parse `(min_drill ...)` from KiCad design_settings
- Pass `min_drill_clearance` through `PCBDesignRules.to_design_rules()`
- Add `validate_same_net_drill_spacing()` method to `RoutingGrid` in `grid.py` -- checks drill-to-drill edge clearance for same-net vias only
- Add `_merge_same_net_vias()` method to pathfinder -- consolidates new-route vias that overlap existing same-net vias by snapping to the existing via position and removing the duplicate
- Call `_merge_same_net_vias()` in `_reconstruct_route()` after path conversion
- Call `validate_same_net_drill_spacing()` in `_validate_route_clearance()` after existing via-to-via check
- Add 6 unit tests in `TestSameNetDrillSpacing` covering overlapping drills, safe distance, different-net exclusion, self-check, boundary conditions

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| min_drill_clearance in DesignRules | PASS | Field added with 0.102mm default |
| Drill spacing enforced for same-net vias | PASS | validate_same_net_drill_spacing() rejects violations |
| Overlapping same-net vias merged in post-route | PASS | _merge_same_net_vias() consolidates nearby vias |
| Different-net via checks unchanged | PASS | All 14 existing via clearance tests pass |
| KiCad min_drill parsed from PCB | PASS | Regex added to design_settings parsing |
| Backward compatible | PASS | All 136 grid tests + 51 via optimizer/conflict tests pass |

## Test Plan
- `pytest tests/test_router_grid.py::TestSameNetDrillSpacing` -- 6 new tests all pass
- `pytest tests/test_router_grid.py::TestViaToViaClearanceValidation` -- 7 existing tests pass (no regression)
- `pytest tests/test_router_grid.py::TestViaClearanceValidation` -- 7 existing tests pass (no regression)
- `pytest tests/test_router_grid.py` -- all 136+6=142 tests pass
- `pytest tests/test_via_optimizer.py tests/test_via_conflict.py` -- all 51 tests pass

Closes #1782