### PR TITLE
fix(stitch): wire --blanket and --spacing args through main CLI parser

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -479,6 +479,10 @@ def _run_stitch_command(args) -> int:
         sub_argv.extend(["--target-layer", args.stitch_target_layer])
     if hasattr(args, "stitch_trace_width") and args.stitch_trace_width != 0.2:
         sub_argv.extend(["--trace-width", str(args.stitch_trace_width)])
+    if hasattr(args, "stitch_blanket") and args.stitch_blanket:
+        sub_argv.append("--blanket")
+    if hasattr(args, "stitch_spacing") and args.stitch_spacing != 3.0:
+        sub_argv.extend(["--spacing", str(args.stitch_spacing)])
     if hasattr(args, "stitch_dry_run") and args.stitch_dry_run:
         sub_argv.append("--dry-run")
     if hasattr(args, "stitch_output") and args.stitch_output:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -944,6 +944,20 @@ def _add_stitch_parser(subparsers) -> None:
         help="Width of pad-to-via trace segments in mm (default: 0.2)",
     )
     stitch_parser.add_argument(
+        "--blanket",
+        "-b",
+        action="store_true",
+        dest="stitch_blanket",
+        help="Place vias on a grid pattern across zone polygons (blanket stitching)",
+    )
+    stitch_parser.add_argument(
+        "--spacing",
+        type=float,
+        default=3.0,
+        dest="stitch_spacing",
+        help="Grid spacing for blanket stitching in mm (default: 3.0)",
+    )
+    stitch_parser.add_argument(
         "--dry-run",
         "-d",
         action="store_true",


### PR DESCRIPTION
## Summary
- Added `--blanket` and `--spacing` arguments to the main CLI parser in `parser.py`
- Added forwarding logic in `__init__.py:_run_stitch_command()` to pass these args through to `stitch_cmd.main()`

## Changes
- `src/kicad_tools/cli/parser.py`: Added `stitch_blanket` and `stitch_spacing` args to `_add_stitch_parser()`
- `src/kicad_tools/cli/__init__.py`: Added blanket/spacing forwarding in `_run_stitch_command()`

## Test Plan
- [x] `kicad-tools stitch --help` now shows `--blanket` and `--spacing` flags
- [x] All 148 stitch tests pass
- [ ] Manual test: `kicad-tools stitch board.kicad_pcb --blanket --spacing 3.0`

Closes #1794