### PR TITLE
fix(router): merge same-net vias during save to prevent drill overlap

### DIFF
--- a/src/kicad_tools/router/drc_nudge.py
+++ b/src/kicad_tools/router/drc_nudge.py
@@ -135,6 +135,7 @@ def _segment_to_segment_distance(
 # ---------------------------------------------------------------------------
 
 COINCIDENT_THRESHOLD = 0.01  # mm -- legacy constant kept for backward compat
+_ENDPOINT_TOL = 0.05  # mm -- tolerance for matching segment endpoints to via positions
 
 
 def _compute_merge_threshold(router: Autorouter) -> float:
@@ -196,7 +197,7 @@ def _merge_same_net_vias(router: Autorouter) -> int:
                 if dist < merge_threshold:
                     _reconnect_segments(
                         route.segments, via_b.x, via_b.y,
-                        via_a.x, via_a.y, merge_threshold,
+                        via_a.x, via_a.y, _ENDPOINT_TOL,
                     )
                     merged_indices.add(j)
 
@@ -238,7 +239,7 @@ def _merge_same_net_vias(router: Autorouter) -> int:
                             # Keep via_a, remove via_b, reconnect route_b segments
                             _reconnect_segments(
                                 route_b.segments, via_b.x, via_b.y,
-                                via_a.x, via_a.y, merge_threshold,
+                                via_a.x, via_a.y, _ENDPOINT_TOL,
                             )
                             remove_from_b.add(bj)
 

--- a/src/kicad_tools/router/drc_nudge.py
+++ b/src/kicad_tools/router/drc_nudge.py
@@ -134,21 +134,48 @@ def _segment_to_segment_distance(
 # Same-net via merging
 # ---------------------------------------------------------------------------
 
-COINCIDENT_THRESHOLD = 0.01  # mm -- same as DrillClearanceRepairer
+COINCIDENT_THRESHOLD = 0.01  # mm -- legacy constant kept for backward compat
+
+
+def _compute_merge_threshold(router: Autorouter) -> float:
+    """Return the drill-overlap merge threshold from design rules.
+
+    Two same-net vias closer than ``via_diameter + min_drill_clearance``
+    would create a drill overlap DRC violation and must be merged.
+    Falls back to ``COINCIDENT_THRESHOLD`` when rules are unavailable.
+    """
+    rules = getattr(router, "rules", None)
+    if rules is None:
+        return COINCIDENT_THRESHOLD
+    via_diameter = getattr(rules, "via_diameter", 0.0)
+    min_drill = getattr(rules, "min_drill_clearance", 0.0)
+    threshold = via_diameter + min_drill
+    # Ensure we never go below the legacy coincident threshold
+    return max(threshold, COINCIDENT_THRESHOLD)
 
 
 def _merge_same_net_vias(router: Autorouter) -> int:
-    """Merge same-net vias that are nearly coincident.
+    """Merge same-net vias that are closer than the drill-overlap threshold.
 
-    For each route, find pairs of vias closer than ``COINCIDENT_THRESHOLD``.
-    Keep the first via and remove the second, then update any segment
-    endpoints that referenced the removed via's position.
+    Issue #1796: The previous implementation only merged nearly-coincident
+    vias (within 0.01 mm) and only within a single route.  Vias placed by
+    independent routing passes (e.g. escape routing) on the same net could
+    end up close enough to violate drill-to-drill clearance without being
+    merged.
+
+    This version:
+    * Uses ``via_diameter + min_drill_clearance`` as the merge threshold.
+    * Merges across different routes that share the same net.
+    * Keeps the first via encountered and reconnects all segments from
+      the removed via to the surviving one.
 
     Returns:
         Number of vias merged.
     """
+    merge_threshold = _compute_merge_threshold(router)
     total_merged = 0
 
+    # --- Phase 1: intra-route merges (vias within the same Route object) ---
     for route in router.routes:
         if len(route.vias) < 2:
             continue
@@ -166,14 +193,61 @@ def _merge_same_net_vias(router: Autorouter) -> int:
                 dist = math.sqrt(
                     (via_a.x - via_b.x) ** 2 + (via_a.y - via_b.y) ** 2
                 )
-                if dist < COINCIDENT_THRESHOLD:
-                    # Reconnect segments that reference via_b to via_a
-                    _reconnect_segments(route.segments, via_b.x, via_b.y, via_a.x, via_a.y)
+                if dist < merge_threshold:
+                    _reconnect_segments(
+                        route.segments, via_b.x, via_b.y,
+                        via_a.x, via_a.y, merge_threshold,
+                    )
                     merged_indices.add(j)
 
         if merged_indices:
-            route.vias = [v for idx, v in enumerate(route.vias) if idx not in merged_indices]
+            route.vias = [
+                v for idx, v in enumerate(route.vias) if idx not in merged_indices
+            ]
             total_merged += len(merged_indices)
+
+    # --- Phase 2: cross-route merges (different Route objects, same net) ---
+    # Group routes by net so we only compare routes that could conflict.
+    from collections import defaultdict
+
+    net_routes: dict[int, list[Route]] = defaultdict(list)
+    for route in router.routes:
+        if route.vias:
+            net_routes[route.net].append(route)
+
+    for net_id, routes in net_routes.items():
+        if len(routes) < 2:
+            continue
+
+        # For each pair of routes on the same net, check their vias.
+        for ri in range(len(routes)):
+            route_a = routes[ri]
+            for rj in range(ri + 1, len(routes)):
+                route_b = routes[rj]
+                remove_from_b: set[int] = set()
+
+                for via_a in route_a.vias:
+                    for bj, via_b in enumerate(route_b.vias):
+                        if bj in remove_from_b:
+                            continue
+                        dist = math.sqrt(
+                            (via_a.x - via_b.x) ** 2
+                            + (via_a.y - via_b.y) ** 2
+                        )
+                        if dist < merge_threshold:
+                            # Keep via_a, remove via_b, reconnect route_b segments
+                            _reconnect_segments(
+                                route_b.segments, via_b.x, via_b.y,
+                                via_a.x, via_a.y, merge_threshold,
+                            )
+                            remove_from_b.add(bj)
+
+                if remove_from_b:
+                    route_b.vias = [
+                        v for idx, v in enumerate(route_b.vias)
+                        if idx not in remove_from_b
+                    ]
+                    total_merged += len(remove_from_b)
 
     return total_merged
 
@@ -184,9 +258,19 @@ def _reconnect_segments(
     old_y: float,
     new_x: float,
     new_y: float,
+    tol: float | None = None,
 ) -> None:
-    """Snap segment endpoints at ``(old_x, old_y)`` to ``(new_x, new_y)``."""
-    tol = COINCIDENT_THRESHOLD
+    """Snap segment endpoints at ``(old_x, old_y)`` to ``(new_x, new_y)``.
+
+    Args:
+        segments: Segments to scan and update in place.
+        old_x, old_y: Position of the removed via.
+        new_x, new_y: Position of the surviving via.
+        tol: Coordinate tolerance for matching endpoints.
+            Defaults to ``COINCIDENT_THRESHOLD`` for backward compatibility.
+    """
+    if tol is None:
+        tol = COINCIDENT_THRESHOLD
     for seg in segments:
         if abs(seg.x1 - old_x) < tol and abs(seg.y1 - old_y) < tol:
             seg.x1 = new_x

--- a/tests/test_drc_nudge.py
+++ b/tests/test_drc_nudge.py
@@ -11,6 +11,7 @@ import pytest
 from kicad_tools.router.drc_nudge import (
     COINCIDENT_THRESHOLD,
     DRCNudgeResult,
+    _compute_merge_threshold,
     _merge_same_net_vias,
     _nudge_segment,
     _perpendicular_unit,
@@ -143,6 +144,112 @@ class TestReconnectSegments:
         _reconnect_segments([seg], 10.005, 10.005, 10.0, 10.0)
         assert math.isclose(seg.x2, 10.0)
         assert math.isclose(seg.y2, 10.0)
+
+
+class TestComputeMergeThreshold:
+    def test_uses_design_rules(self):
+        """Merge threshold should be via_diameter + min_drill_clearance."""
+        rules = DesignRules(via_diameter=0.7, min_drill_clearance=0.102)
+        router = _StubAutorouter(rules=rules)
+        threshold = _compute_merge_threshold(router)
+        assert math.isclose(threshold, 0.802)
+
+    def test_falls_back_to_coincident(self):
+        """When rules are missing, use COINCIDENT_THRESHOLD."""
+        router = _StubAutorouter()
+        router.rules = None  # type: ignore[assignment]
+        threshold = _compute_merge_threshold(router)
+        assert threshold == COINCIDENT_THRESHOLD
+
+
+class TestMergeSameNetViasWithDrillThreshold:
+    """Tests for the drill-overlap merge threshold (Issue #1796)."""
+
+    def test_vias_within_drill_overlap_merged(self):
+        """Vias within via_diameter + min_drill_clearance should be merged."""
+        # Default rules: via_diameter=0.7, min_drill_clearance=0.102
+        # merge threshold = 0.802mm
+        # Place two vias 0.5mm apart (< 0.802)
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        via_b = Via(x=10.5, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        seg = Segment(x1=5.0, y1=5.0, x2=10.5, y2=10.0,
+                      width=0.2, layer=Layer.F_CU, net=1)
+        route = Route(net=1, net_name="Net1", segments=[seg], vias=[via_a, via_b])
+        router = _StubAutorouter(routes=[route])
+
+        merged = _merge_same_net_vias(router)
+        assert merged == 1
+        assert len(route.vias) == 1
+        # Segment endpoint reconnected to surviving via_a
+        assert math.isclose(seg.x2, 10.0)
+        assert math.isclose(seg.y2, 10.0)
+
+    def test_vias_beyond_drill_overlap_not_merged(self):
+        """Vias farther than the threshold should NOT be merged."""
+        # merge threshold = 0.802mm; place vias 1.0mm apart
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        via_b = Via(x=11.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        route = Route(net=1, net_name="Net1", segments=[], vias=[via_a, via_b])
+        router = _StubAutorouter(routes=[route])
+
+        merged = _merge_same_net_vias(router)
+        assert merged == 0
+        assert len(route.vias) == 2
+
+
+class TestCrossRouteMerge:
+    """Tests for cross-route same-net via merging (Issue #1796)."""
+
+    def test_cross_route_vias_merged(self):
+        """Vias on different routes of the same net should be merged."""
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        via_b = Via(x=10.3, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        seg_b = Segment(x1=5.0, y1=5.0, x2=10.3, y2=10.0,
+                        width=0.2, layer=Layer.F_CU, net=1)
+        route_a = Route(net=1, net_name="Net1", segments=[], vias=[via_a])
+        route_b = Route(net=1, net_name="Net1", segments=[seg_b], vias=[via_b])
+        router = _StubAutorouter(routes=[route_a, route_b])
+
+        merged = _merge_same_net_vias(router)
+        assert merged == 1
+        # via_b should have been removed from route_b
+        assert len(route_a.vias) == 1
+        assert len(route_b.vias) == 0
+        # segment in route_b reconnected to via_a position
+        assert math.isclose(seg_b.x2, 10.0)
+        assert math.isclose(seg_b.y2, 10.0)
+
+    def test_cross_route_different_nets_not_merged(self):
+        """Vias on different nets should NOT be merged even if close."""
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        via_b = Via(x=10.3, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=2)
+        route_a = Route(net=1, net_name="Net1", segments=[], vias=[via_a])
+        route_b = Route(net=2, net_name="Net2", segments=[], vias=[via_b])
+        router = _StubAutorouter(routes=[route_a, route_b])
+
+        merged = _merge_same_net_vias(router)
+        assert merged == 0
+        assert len(route_a.vias) == 1
+        assert len(route_b.vias) == 1
+
+    def test_cross_route_only_one_has_vias(self):
+        """No crash when only one route on a net has vias."""
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        route_a = Route(net=1, net_name="Net1", segments=[], vias=[via_a])
+        route_b = Route(net=1, net_name="Net1", segments=[], vias=[])
+        router = _StubAutorouter(routes=[route_a, route_b])
+
+        merged = _merge_same_net_vias(router)
+        assert merged == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1796

- Widens the same-net via merge threshold from 0.01mm (coincident only) to `via_diameter + min_drill_clearance` (0.802mm with defaults), matching the actual drill overlap DRC rule
- Adds cross-route merging so vias placed by independent routing passes (e.g. escape routing) on the same net are also caught
- Reconnects segments from removed vias to the surviving via position

## Test plan

- [x] New unit tests for `_compute_merge_threshold` (design-rules and fallback)
- [x] New unit tests for intra-route drill-overlap merge (within and beyond threshold)
- [x] New unit tests for cross-route same-net merge (same net, different net, single-via edge case)
- [x] All 27 drc_nudge tests pass
- [x] 10500 tests pass across the full suite (pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)