### PR TITLE
fix(router): inner-layer segment clearance violations in DRC passes

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2875,7 +2875,6 @@ class Autorouter:
                 if getattr(v, "layer", None) is not None
                 and v.layer not in (Layer.F_CU, Layer.B_CU)
             ]
-            outer_count = len(seg_violations) - len(inner_layer_violations)
 
             # Collect the distinct layer names for the log message.
             violation_layers: set[str] = set()

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2868,11 +2868,37 @@ class Autorouter:
                 violating_nets.add(v.net)
                 violating_nets.add(v.obstacle_net)
 
+            # Issue #1798: Categorise violations by layer to identify
+            # inner-layer congestion that needs stronger repulsion.
+            inner_layer_violations = [
+                v for v in seg_violations
+                if getattr(v, "layer", None) is not None
+                and v.layer not in (Layer.F_CU, Layer.B_CU)
+            ]
+            outer_count = len(seg_violations) - len(inner_layer_violations)
+
+            # Collect the distinct layer names for the log message.
+            violation_layers: set[str] = set()
+            for v in seg_violations:
+                v_layer = getattr(v, "layer", None)
+                if v_layer is not None:
+                    violation_layers.add(v_layer.kicad_name)
+
+            layer_info = ", ".join(sorted(violation_layers)) if violation_layers else "unknown"
             flush_print(
                 f"\n--- Post-route clearance pass {pass_idx + 1}: "
                 f"{len(seg_violations)} seg-seg violation(s) across "
-                f"{len(violating_nets)} net(s) ---"
+                f"{len(violating_nets)} net(s) "
+                f"[layers: {layer_info}] ---"
             )
+
+            # Nets with inner-layer violations need a higher congestion
+            # penalty so the rerouter pushes traces further apart on the
+            # typically more congested inner layers.
+            inner_violating_nets: set[int] = set()
+            for v in inner_layer_violations:
+                inner_violating_nets.add(v.net)
+                inner_violating_nets.add(v.obstacle_net)
 
             neg_router = NegotiatedRouter(
                 self.grid, self.router, self.rules, self.net_class_map
@@ -2886,8 +2912,11 @@ class Autorouter:
             # catch violations introduced by sequential placement (Issue #1783).
             rerouted_count = 0
             for net_idx, net in enumerate(nets_to_reroute):
+                # Issue #1798: Use a higher present_factor for nets that had
+                # inner-layer violations, encouraging wider spacing.
+                net_pf = present_factor * 2.0 if net in inner_violating_nets else present_factor
                 routes = self._route_net_negotiated(
-                    net, present_factor, per_net_timeout=per_net_timeout
+                    net, net_pf, per_net_timeout=per_net_timeout
                 )
                 if routes:
                     net_routes[net] = routes
@@ -2912,10 +2941,17 @@ class Autorouter:
                             and (v.net == net or v.obstacle_net == net)
                         ]
                         if net_seg_violations:
-                            # Rip up just this net and try again
+                            # Rip up just this net and try again.
+                            # Issue #1798: Use a stronger factor for
+                            # inner-layer nets where congestion is tighter.
+                            retry_pf = (
+                                present_factor * 3.0
+                                if net in inner_violating_nets
+                                else present_factor * 1.5
+                            )
                             neg_router.rip_up_nets([net], net_routes, self.routes)
                             retry_routes = self._route_net_negotiated(
-                                net, present_factor * 1.5, per_net_timeout=per_net_timeout
+                                net, retry_pf, per_net_timeout=per_net_timeout
                             )
                             if retry_routes:
                                 net_routes[net] = retry_routes

--- a/src/kicad_tools/router/drc_nudge.py
+++ b/src/kicad_tools/router/drc_nudge.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from .core import Autorouter
 
 from .io import ClearanceViolation, validate_routes
+from .layers import Layer
 from .primitives import Route, Segment
 
 logger = logging.getLogger(__name__)
@@ -227,6 +228,7 @@ def _try_nudge_seg_seg(
     target_seg = _find_segment(
         router, violation.net, violation.segment_index,
         violation.x1, violation.y1, violation.x2, violation.y2,
+        layer=violation.layer,
     )
     if target_seg is None:
         return False
@@ -271,6 +273,7 @@ def _try_nudge_seg_via(
     target_seg = _find_segment(
         router, violation.net, violation.segment_index,
         violation.x1, violation.y1, violation.x2, violation.y2,
+        layer=violation.layer,
     )
     if target_seg is None:
         return False
@@ -317,6 +320,7 @@ def _try_nudge_seg_pad(
     target_seg = _find_segment(
         router, violation.net, violation.segment_index,
         violation.x1, violation.y1, violation.x2, violation.y2,
+        layer=violation.layer,
     )
     if target_seg is None:
         return False
@@ -354,33 +358,38 @@ def _find_segment(
     x2: float,
     y2: float,
     tol: float = 0.001,
+    layer: "Layer | None" = None,
 ) -> Segment | None:
-    """Locate a segment in *router.routes* by net + coordinates.
+    """Locate a segment in *router.routes* by net + coordinates + optional layer.
 
     We first try the indexed lookup (net + seg_index), then fall back to a
-    coordinate search across all segments of matching nets.
+    coordinate search across all segments of matching nets.  When *layer* is
+    provided (non-None), only segments on that layer are considered.  This
+    prevents inner-layer segments from being confused with outer-layer
+    segments that share similar coordinates (Issue #1798).
     """
+    def _coords_match(seg: Segment) -> bool:
+        return (
+            abs(seg.x1 - x1) < tol
+            and abs(seg.y1 - y1) < tol
+            and abs(seg.x2 - x2) < tol
+            and abs(seg.y2 - y2) < tol
+        )
+
+    def _layer_match(seg: Segment) -> bool:
+        return layer is None or seg.layer == layer
+
     for route in router.routes:
         if route.net != net:
             continue
         # Try index lookup
         if 0 <= seg_index < len(route.segments):
             seg = route.segments[seg_index]
-            if (
-                abs(seg.x1 - x1) < tol
-                and abs(seg.y1 - y1) < tol
-                and abs(seg.x2 - x2) < tol
-                and abs(seg.y2 - y2) < tol
-            ):
+            if _coords_match(seg) and _layer_match(seg):
                 return seg
         # Fallback: coordinate search
         for seg in route.segments:
-            if (
-                abs(seg.x1 - x1) < tol
-                and abs(seg.y1 - y1) < tol
-                and abs(seg.x2 - x2) < tol
-                and abs(seg.y2 - y2) < tol
-            ):
+            if _coords_match(seg) and _layer_match(seg):
                 return seg
     return None
 

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -185,6 +185,7 @@ class ClearanceViolation:
     obstacle_net_name: str = ""  # Human-readable obstacle net name
     location: tuple[float, float] | None = None  # Approximate violation location (x, y)
     component_inherent: bool = False  # True if both pads are on the same component
+    layer: Layer | None = None  # Copper layer where the violation occurs
 
 
 def parse_pcb_design_rules(pcb_text: str) -> PCBDesignRules:
@@ -1359,6 +1360,7 @@ def validate_routes(
                             obstacle_net_name=_resolve_net_name(pad.net),
                             location=(pad.x, pad.y),
                             component_inherent=is_component_inherent,
+                            layer=segment.layer,
                         )
                     )
 
@@ -1412,6 +1414,7 @@ def validate_routes(
                                 net_name=_resolve_net_name(route_net),
                                 obstacle_net_name=_resolve_net_name(other_route.net),
                                 location=(loc_x, loc_y),
+                                layer=segment.layer,
                             )
                         )
 
@@ -1445,6 +1448,7 @@ def validate_routes(
                                 net_name=_resolve_net_name(route_net),
                                 obstacle_net_name=_resolve_net_name(other_route.net),
                                 location=(via.x, via.y),
+                                layer=segment.layer,
                             )
                         )
 
@@ -1570,8 +1574,9 @@ def format_clearance_violations(violations: list[ClearanceViolation]) -> str:
             loc_str = ""
             if v.location:
                 loc_str = f" at ({v.location[0]:.2f}, {v.location[1]:.2f})"
+            layer_str = f" on {v.layer.kicad_name}" if v.layer is not None else ""
             lines.append(
-                f"  [{v.obstacle_type}] {net_label} vs {obs_label}{loc_str}: "
+                f"  [{v.obstacle_type}] {net_label} vs {obs_label}{loc_str}{layer_str}: "
                 f"{v.distance:.3f}mm (required {v.required:.3f}mm)"
             )
 

--- a/tests/test_drc_nudge.py
+++ b/tests/test_drc_nudge.py
@@ -189,6 +189,56 @@ class TestDRCVerifyAndNudge:
         assert result.initial_violations > 0
         assert result.segments_nudged > 0
 
+
+    def test_inner_layer_segment_violation_nudged(self):
+        """Segments violating clearance on an inner layer should be nudged (Issue #1798)."""
+        seg_a = Segment(x1=0, y1=0, x2=10, y2=0, width=0.2, layer=Layer.IN1_CU, net=1)
+        seg_b = Segment(x1=0, y1=0.25, x2=10, y2=0.25, width=0.2, layer=Layer.IN1_CU, net=2)
+        route_a = Route(net=1, net_name="A", segments=[seg_a])
+        route_b = Route(net=2, net_name="B", segments=[seg_b])
+        rules = DesignRules(trace_clearance=0.2, via_clearance=0.2)
+        router = _StubAutorouter(routes=[route_a, route_b], rules=rules)
+
+        result = drc_verify_and_nudge(router)
+        assert result.initial_violations > 0
+        assert result.segments_nudged > 0
+
+    def test_inner_layer_no_cross_layer_violation(self):
+        """Segments on different inner layers should not report violations (Issue #1798)."""
+        # Two segments at the same position but on different layers
+        seg_a = Segment(x1=0, y1=0, x2=10, y2=0, width=0.2, layer=Layer.IN1_CU, net=1)
+        seg_b = Segment(x1=0, y1=0.25, x2=10, y2=0.25, width=0.2, layer=Layer.IN2_CU, net=2)
+        route_a = Route(net=1, net_name="A", segments=[seg_a])
+        route_b = Route(net=2, net_name="B", segments=[seg_b])
+        rules = DesignRules(trace_clearance=0.2, via_clearance=0.2)
+        router = _StubAutorouter(routes=[route_a, route_b], rules=rules)
+
+        result = drc_verify_and_nudge(router)
+        assert result.initial_violations == 0
+        assert result.segments_nudged == 0
+
+    def test_find_segment_matches_correct_layer(self):
+        """_find_segment should match the correct layer when specified (Issue #1798)."""
+        from kicad_tools.router.drc_nudge import _find_segment
+
+        # Two segments with same coordinates on different layers
+        seg_fcu = Segment(x1=0, y1=0, x2=10, y2=0, width=0.2, layer=Layer.F_CU, net=1)
+        seg_in1 = Segment(x1=0, y1=0, x2=10, y2=0, width=0.2, layer=Layer.IN1_CU, net=1)
+        route = Route(net=1, net_name="A", segments=[seg_fcu, seg_in1])
+        router = _StubAutorouter(routes=[route])
+
+        # Without layer filter, should find the first match (F_CU)
+        found = _find_segment(router, 1, 0, 0, 0, 10, 0)
+        assert found is seg_fcu
+
+        # With layer filter for IN1_CU, should find the inner-layer segment
+        found = _find_segment(router, 1, 0, 0, 0, 10, 0, layer=Layer.IN1_CU)
+        assert found is seg_in1
+
+        # With layer filter for F_CU, should find the outer-layer segment
+        found = _find_segment(router, 1, 0, 0, 0, 10, 0, layer=Layer.F_CU)
+        assert found is seg_fcu
+
     def test_violation_exceeding_budget_not_nudged(self):
         """Violations requiring more than max_displacement should not be nudged."""
         # Segments very close: edge-to-edge ~ -0.1mm (overlap)

--- a/tests/test_router_io.py
+++ b/tests/test_router_io.py
@@ -1047,6 +1047,57 @@ class TestValidateRoutes:
         seg_violations = [v for v in violations if v.obstacle_type == "segment"]
         assert len(seg_violations) == 0
 
+
+    def test_inner_layer_segment_violation_has_layer(self):
+        """Segment violations on inner layers should include layer info (Issue #1798)."""
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            grid_resolution=0.1,
+        )
+        router = Autorouter(width=50, height=50, rules=rules)
+
+        # Two parallel segments on In2.Cu, too close together
+        seg1 = Segment(x1=10, y1=10, x2=20, y2=10, layer=Layer.IN2_CU, width=0.2)
+        route1 = Route(net=1, net_name="NET1", segments=[seg1], vias=[])
+
+        seg2 = Segment(x1=10, y1=10.1, x2=20, y2=10.1, layer=Layer.IN2_CU, width=0.2)
+        route2 = Route(net=2, net_name="NET2", segments=[seg2], vias=[])
+
+        router.routes.extend([route1, route2])
+        router.net_names = {1: "NET1", 2: "NET2"}
+
+        violations = validate_routes(router)
+
+        seg_violations = [v for v in violations if v.obstacle_type == "segment"]
+        assert len(seg_violations) >= 1
+        # The violation should record the layer where it occurred
+        assert seg_violations[0].layer == Layer.IN2_CU
+
+    def test_outer_layer_segment_violation_has_layer(self):
+        """Segment violations on outer layers should include layer info (Issue #1798)."""
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            grid_resolution=0.1,
+        )
+        router = Autorouter(width=50, height=50, rules=rules)
+
+        seg1 = Segment(x1=10, y1=10, x2=20, y2=10, layer=Layer.F_CU, width=0.2)
+        route1 = Route(net=1, net_name="NET1", segments=[seg1], vias=[])
+
+        seg2 = Segment(x1=10, y1=10.1, x2=20, y2=10.1, layer=Layer.F_CU, width=0.2)
+        route2 = Route(net=2, net_name="NET2", segments=[seg2], vias=[])
+
+        router.routes.extend([route1, route2])
+        router.net_names = {1: "NET1", 2: "NET2"}
+
+        violations = validate_routes(router)
+
+        seg_violations = [v for v in violations if v.obstacle_type == "segment"]
+        assert len(seg_violations) >= 1
+        assert seg_violations[0].layer == Layer.F_CU
+
     def test_detects_segment_to_via_violation(self):
         """Test detection of clearance violations between segment and via."""
         rules = DesignRules(


### PR DESCRIPTION
## Summary

- Add `layer` field to `ClearanceViolation` so DRC passes can identify which copper layer a violation occurs on
- Update `_find_segment()` in `drc_nudge.py` to filter by layer, preventing wrong-layer segment matches when a net has segments on multiple layers
- Increase congestion penalty (present_factor) for inner-layer nets in `_post_route_clearance_correction()`, encouraging wider spacing on typically denser inner layers
- Include layer name in `format_clearance_violations()` output for better diagnostics

Closes #1798

## Test plan

- [x] New test: inner-layer segment violations are detected and nudged by `drc_verify_and_nudge`
- [x] New test: segments on different inner layers do not produce false violations
- [x] New test: `_find_segment` correctly matches by layer when segments share coordinates
- [x] New test: `validate_routes` populates `layer` field on inner-layer violations
- [x] New test: `validate_routes` populates `layer` field on outer-layer violations
- [x] All 324 existing tests in test_drc_nudge.py, test_router_io.py, and test_router_core.py pass

Generated with [Claude Code](https://claude.com/claude-code)