### PR TITLE
fix(validate): DRC tolerance for sub-manufacturing-precision clearance shortfalls

### DIFF
--- a/src/kicad_tools/validate/rules/__init__.py
+++ b/src/kicad_tools/validate/rules/__init__.py
@@ -4,7 +4,7 @@ This subpackage contains the base rule class and individual rule
 implementations for the pure Python DRC checker.
 """
 
-from .base import DRCRule
+from .base import DRC_TOLERANCE, DRCRule
 from .clearance import ClearanceRule
 from .dimensions import DimensionRules
 from .edge import EdgeClearanceRule
@@ -18,6 +18,7 @@ from .silkscreen import (
 )
 
 __all__ = [
+    "DRC_TOLERANCE",
     "DRCRule",
     "ClearanceRule",
     "DimensionRules",

--- a/src/kicad_tools/validate/rules/base.py
+++ b/src/kicad_tools/validate/rules/base.py
@@ -16,6 +16,12 @@ if TYPE_CHECKING:
     from kicad_tools.schema.pcb import PCB
 
 
+# Manufacturing tolerance for DRC comparisons (in mm).
+# Clearance shortfalls below this threshold are within floating-point
+# rounding and fabrication precision and should not be flagged.
+DRC_TOLERANCE: float = 0.005
+
+
 class DRCRule(ABC):
     """Abstract base class for DRC rule implementations.
 

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from ..violations import DRCResults, DRCViolation
-from .base import DRCRule
+from .base import DRC_TOLERANCE, DRCRule
 
 if TYPE_CHECKING:
     from kicad_tools.manufacturers import DesignRules
@@ -427,7 +427,7 @@ class ClearanceRule(DRCRule):
                 clearance, loc_x, loc_y = _calculate_clearance(elem1, elem2)
 
                 # Check against minimum
-                if clearance < min_clearance:
+                if clearance + DRC_TOLERANCE < min_clearance:
                     violation = self._create_violation(
                         elem1, elem2, clearance, min_clearance, layer_name, loc_x, loc_y
                     )

--- a/src/kicad_tools/validate/rules/dimensions.py
+++ b/src/kicad_tools/validate/rules/dimensions.py
@@ -10,7 +10,7 @@ import math
 from typing import TYPE_CHECKING
 
 from ..violations import DRCResults, DRCViolation
-from .base import DRCRule
+from .base import DRC_TOLERANCE, DRCRule
 
 if TYPE_CHECKING:
     from kicad_tools.manufacturers import DesignRules
@@ -72,7 +72,7 @@ class DimensionRules(DRCRule):
         min_width = design_rules.min_trace_width_mm
 
         for segment in pcb.segments:
-            if segment.width < min_width:
+            if segment.width + DRC_TOLERANCE < min_width:
                 # Get net name if available
                 net = pcb.get_net(segment.net_number)
                 net_name = net.name if net else f"net:{segment.net_number}"
@@ -107,7 +107,7 @@ class DimensionRules(DRCRule):
             net_name = net.name if net else f"net:{via.net_number}"
 
             # Check drill diameter
-            if via.drill < min_drill:
+            if via.drill + DRC_TOLERANCE < min_drill:
                 results.add(
                     DRCViolation(
                         rule_id="dimension_via_drill",
@@ -122,7 +122,7 @@ class DimensionRules(DRCRule):
                 )
 
             # Check via outer diameter
-            if via.size < min_diameter:
+            if via.size + DRC_TOLERANCE < min_diameter:
                 results.add(
                     DRCViolation(
                         rule_id="dimension_via_diameter",
@@ -138,7 +138,7 @@ class DimensionRules(DRCRule):
 
             # Check annular ring: (outer diameter - drill) / 2
             annular_ring = (via.size - via.drill) / 2
-            if annular_ring < min_annular:
+            if annular_ring + DRC_TOLERANCE < min_annular:
                 results.add(
                     DRCViolation(
                         rule_id="dimension_annular_ring",
@@ -207,7 +207,7 @@ class DimensionRules(DRCRule):
                 # Edge-to-edge distance
                 edge_distance = center_distance - (drill1 / 2) - (drill2 / 2)
 
-                if edge_distance < min_clearance:
+                if edge_distance + DRC_TOLERANCE < min_clearance:
                     # Downgrade to warning when both holes belong to the
                     # same footprint (e.g. dense connector pads).  These
                     # are intentional by design and should not block builds.

--- a/tests/test_drc_tolerance.py
+++ b/tests/test_drc_tolerance.py
@@ -1,0 +1,254 @@
+"""Tests for DRC tolerance on clearance and dimension checks.
+
+Verifies that clearance shortfalls within DRC_TOLERANCE (0.005mm) are
+not flagged as violations, while genuine violations are still caught.
+
+Regression test for issue #1803: segment-to-via clearance 0.101mm
+flagged against 0.102mm minimum (0.001mm false positive).
+"""
+
+import pytest
+
+from kicad_tools.validate.rules.base import DRC_TOLERANCE
+from kicad_tools.validate.rules.clearance import ClearanceRule
+from kicad_tools.validate.rules.dimensions import DimensionRules
+
+
+# ---------------------------------------------------------------------------
+# Mock objects (minimal, matching the interfaces used by the rules)
+# ---------------------------------------------------------------------------
+
+class MockDesignRules:
+    def __init__(self, **kwargs):
+        self.min_clearance_mm = kwargs.get("min_clearance_mm", 0.102)
+        self.min_trace_width_mm = kwargs.get("min_trace_width_mm", 0.127)
+        self.min_via_drill_mm = kwargs.get("min_via_drill_mm", 0.3)
+        self.min_via_diameter_mm = kwargs.get("min_via_diameter_mm", 0.6)
+        self.min_annular_ring_mm = kwargs.get("min_annular_ring_mm", 0.15)
+
+
+class MockNet:
+    def __init__(self, number, name):
+        self.number = number
+        self.name = name
+
+
+class MockSegment:
+    def __init__(self, start, end, width, layer, net_number, uuid="seg0001"):
+        self.start = start
+        self.end = end
+        self.width = width
+        self.layer = layer
+        self.net_number = net_number
+        self.uuid = uuid
+
+
+class MockVia:
+    def __init__(self, position, size, drill, layers, net_number, uuid="via0001"):
+        self.position = position
+        self.size = size
+        self.drill = drill
+        self.layers = layers
+        self.net_number = net_number
+        self.uuid = uuid
+
+
+class MockPad:
+    def __init__(self, position, size, layers, net_number, net_name="", number="1",
+                 type="smd", drill=0):
+        self.position = position
+        self.size = size
+        self.layers = layers
+        self.net_number = net_number
+        self.net_name = net_name
+        self.number = number
+        self.type = type
+        self.drill = drill
+
+
+class MockFootprint:
+    def __init__(self, position, rotation, pads, reference="U1"):
+        self.position = position
+        self.rotation = rotation
+        self.pads = pads
+        self.reference = reference
+
+
+class MockLayer:
+    def __init__(self, name):
+        self.name = name
+
+
+class MockPCB:
+    def __init__(self, segments=None, vias=None, footprints=None, nets=None):
+        self.segments = segments or []
+        self.vias = vias or []
+        self.footprints = footprints or []
+        self._nets = {n.number: n for n in (nets or [])}
+        self.copper_layers = [MockLayer("F.Cu")]
+
+    def segments_on_layer(self, layer_name):
+        return [s for s in self.segments if s.layer == layer_name]
+
+    def get_net(self, number):
+        return self._nets.get(number)
+
+
+# ---------------------------------------------------------------------------
+# Tests for the DRC_TOLERANCE constant
+# ---------------------------------------------------------------------------
+
+class TestDRCToleranceConstant:
+    def test_tolerance_is_positive(self):
+        assert DRC_TOLERANCE > 0
+
+    def test_tolerance_value(self):
+        assert DRC_TOLERANCE == pytest.approx(0.005)
+
+
+# ---------------------------------------------------------------------------
+# Tests for clearance tolerance (issue #1803 regression)
+# ---------------------------------------------------------------------------
+
+class TestClearanceRuleTolerance:
+    """Verify the ClearanceRule respects DRC_TOLERANCE."""
+
+    def _make_segment_via_pcb(self, gap_mm: float) -> tuple:
+        """Create a PCB with a segment and via separated by gap_mm edge-to-edge.
+
+        The segment is horizontal, width 0.2mm, centered at y=0.
+        The via is circular, diameter 0.6mm (radius 0.3mm), centered below.
+        We position them so edge-to-edge clearance is exactly gap_mm.
+
+        Edge clearance = center_distance - seg_half_width - via_radius
+        center_distance = gap_mm + 0.1 + 0.3 = gap_mm + 0.4
+        """
+        seg_width = 0.2
+        via_size = 0.6
+        center_dist = gap_mm + (seg_width / 2) + (via_size / 2)
+
+        seg = MockSegment(
+            start=(0.0, 0.0), end=(10.0, 0.0),
+            width=seg_width, layer="F.Cu", net_number=1,
+        )
+        via = MockVia(
+            position=(5.0, center_dist), size=via_size, drill=0.3,
+            layers=["F.Cu", "B.Cu"], net_number=2,
+        )
+        nets = [MockNet(1, "VCC"), MockNet(2, "GND")]
+        pcb = MockPCB(segments=[seg], vias=[via], nets=nets)
+        rules = MockDesignRules(min_clearance_mm=0.102)
+        return pcb, rules
+
+    def test_exact_issue_1803_case_passes(self):
+        """0.101mm clearance vs 0.102mm minimum -- within tolerance, should pass."""
+        pcb, rules = self._make_segment_via_pcb(0.101)
+        result = ClearanceRule().check(pcb, rules)
+        assert result.error_count == 0, (
+            f"Expected no errors for 0.101mm vs 0.102mm, got: "
+            f"{[v.message for v in result.violations]}"
+        )
+
+    def test_clearance_within_tolerance_passes(self):
+        """Clearance short by less than DRC_TOLERANCE should pass."""
+        # 0.098mm clearance vs 0.102mm min => 0.004mm short, within 0.005mm tol
+        pcb, rules = self._make_segment_via_pcb(0.098)
+        result = ClearanceRule().check(pcb, rules)
+        assert result.error_count == 0
+
+    def test_clearance_at_tolerance_boundary_passes(self):
+        """Clearance short by exactly DRC_TOLERANCE should pass (boundary)."""
+        # 0.097mm clearance vs 0.102mm min => 0.005mm short, exactly at tol
+        pcb, rules = self._make_segment_via_pcb(0.097)
+        result = ClearanceRule().check(pcb, rules)
+        assert result.error_count == 0
+
+    def test_clearance_beyond_tolerance_fails(self):
+        """Clearance short by more than DRC_TOLERANCE should fail."""
+        # 0.090mm clearance vs 0.102mm min => 0.012mm short, beyond 0.005mm tol
+        pcb, rules = self._make_segment_via_pcb(0.090)
+        result = ClearanceRule().check(pcb, rules)
+        assert result.error_count == 1
+
+    def test_exact_clearance_passes(self):
+        """Clearance exactly at minimum should pass."""
+        pcb, rules = self._make_segment_via_pcb(0.102)
+        result = ClearanceRule().check(pcb, rules)
+        assert result.error_count == 0
+
+    def test_generous_clearance_passes(self):
+        """Clearance well above minimum should pass."""
+        pcb, rules = self._make_segment_via_pcb(0.200)
+        result = ClearanceRule().check(pcb, rules)
+        assert result.error_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for dimension tolerance
+# ---------------------------------------------------------------------------
+
+class TestDimensionRulesTolerance:
+    """Verify DimensionRules respects DRC_TOLERANCE for all checks."""
+
+    def test_trace_width_within_tolerance_passes(self):
+        """Trace 0.124mm vs 0.127mm minimum -- 0.003mm short, within tolerance."""
+        seg = MockSegment(
+            start=(0, 0), end=(10, 0), width=0.124,
+            layer="F.Cu", net_number=1,
+        )
+        pcb = MockPCB(segments=[seg], nets=[MockNet(1, "VCC")])
+        rules = MockDesignRules(min_trace_width_mm=0.127)
+        result = DimensionRules().check(pcb, rules)
+        width_violations = [v for v in result.violations if v.rule_id == "dimension_trace_width"]
+        assert len(width_violations) == 0
+
+    def test_trace_width_beyond_tolerance_fails(self):
+        """Trace 0.110mm vs 0.127mm minimum -- 0.017mm short, should fail."""
+        seg = MockSegment(
+            start=(0, 0), end=(10, 0), width=0.110,
+            layer="F.Cu", net_number=1,
+        )
+        pcb = MockPCB(segments=[seg], nets=[MockNet(1, "VCC")])
+        rules = MockDesignRules(min_trace_width_mm=0.127)
+        result = DimensionRules().check(pcb, rules)
+        width_violations = [v for v in result.violations if v.rule_id == "dimension_trace_width"]
+        assert len(width_violations) == 1
+
+    def test_via_drill_within_tolerance_passes(self):
+        """Via drill 0.297mm vs 0.300mm minimum -- 0.003mm short, passes."""
+        via = MockVia(
+            position=(5, 5), size=0.8, drill=0.297,
+            layers=["F.Cu", "B.Cu"], net_number=1,
+        )
+        pcb = MockPCB(vias=[via], nets=[MockNet(1, "VCC")])
+        rules = MockDesignRules(min_via_drill_mm=0.3, min_via_diameter_mm=0.6,
+                                min_annular_ring_mm=0.15)
+        result = DimensionRules().check(pcb, rules)
+        drill_violations = [v for v in result.violations if v.rule_id == "dimension_via_drill"]
+        assert len(drill_violations) == 0
+
+    def test_drill_clearance_within_tolerance_passes(self):
+        """Drill edge-to-edge 0.124mm vs 0.127mm min -- 0.003mm short, passes."""
+        via1 = MockVia(
+            position=(0, 0), size=0.6, drill=0.3,
+            layers=["F.Cu", "B.Cu"], net_number=1,
+        )
+        via2 = MockVia(
+            position=(0.724, 0), size=0.6, drill=0.3,
+            layers=["F.Cu", "B.Cu"], net_number=2, uuid="via0002",
+        )
+        # edge distance = 0.724 - 0.15 - 0.15 = 0.424 ... let me recalculate
+        # edge = center_dist - r1 - r2 = 0.724 - 0.15 - 0.15 = 0.424
+        # That's too large. Let me use drill/2 values.
+        # edge = center_dist - drill1/2 - drill2/2
+        # Want edge = 0.124, drill = 0.3, so center = 0.124 + 0.15 + 0.15 = 0.424
+        via2 = MockVia(
+            position=(0.424, 0), size=0.6, drill=0.3,
+            layers=["F.Cu", "B.Cu"], net_number=2, uuid="via0002",
+        )
+        pcb = MockPCB(vias=[via1, via2], nets=[MockNet(1, "VCC"), MockNet(2, "GND")])
+        rules = MockDesignRules(min_clearance_mm=0.127)
+        result = DimensionRules().check(pcb, rules)
+        drill_violations = [v for v in result.violations
+                           if v.rule_id == "dimension_drill_clearance"]
+        assert len(drill_violations) == 0


### PR DESCRIPTION
## Summary

- Add `DRC_TOLERANCE = 0.005mm` constant to `validate/rules/base.py` for all DRC comparisons
- Apply tolerance to clearance checks in `clearance.py` (copper element spacing)
- Apply tolerance to all dimension checks in `dimensions.py` (trace width, via drill, via diameter, annular ring, drill-to-drill clearance)
- Add 12 targeted regression tests covering the exact issue scenario (0.101mm vs 0.102mm), boundary cases, and genuine violations

Closes #1803

## Test plan

- [x] All 1343 existing DRC/clearance/validate tests pass
- [x] 12 new tolerance-specific tests pass
- [x] 0.101mm vs 0.102mm case (from issue) passes DRC
- [x] Genuine violations (beyond tolerance) are still caught
- [x] Boundary case at exactly DRC_TOLERANCE passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)