### PR TITLE
fix(router): via merge must check drill overlap across all layer pairs

### DIFF
--- a/src/kicad_tools/router/drc_nudge.py
+++ b/src/kicad_tools/router/drc_nudge.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 from .io import ClearanceViolation, validate_routes
 from .layers import Layer
-from .primitives import Route, Segment
+from .primitives import Route, Segment, Via
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +139,22 @@ COINCIDENT_THRESHOLD = 0.01  # mm -- legacy constant kept for backward compat
 _ENDPOINT_TOL = 0.05  # mm -- tolerance for matching segment endpoints to via positions
 
 
+def _expand_via_layers(surviving: Via, removed: Via) -> None:
+    """Expand the surviving via's layers to span both vias' layer ranges.
+
+    Issue #1802: When merging vias with different layer pairs (e.g.,
+    F.Cu/In1.Cu and B.Cu/F.Cu), the merged via must connect all layers
+    that either original via connected.  This converts the surviving via
+    to a through-via (or wider span) when necessary.
+    """
+    min_layer = min(surviving.layers[0].value, surviving.layers[1].value,
+                    removed.layers[0].value, removed.layers[1].value)
+    max_layer = max(surviving.layers[0].value, surviving.layers[1].value,
+                    removed.layers[0].value, removed.layers[1].value)
+    if min_layer != surviving.layers[0].value or max_layer != surviving.layers[1].value:
+        surviving.layers = (Layer(min_layer), Layer(max_layer))
+
+
 def _compute_merge_threshold(router: Autorouter) -> float:
     """Return the drill-overlap merge threshold from design rules.
 
@@ -200,6 +216,7 @@ def _merge_same_net_vias(router: Autorouter) -> int:
                         route.segments, via_b.x, via_b.y,
                         via_a.x, via_a.y, _ENDPOINT_TOL,
                     )
+                    _expand_via_layers(via_a, via_b)
                     merged_indices.add(j)
 
         if merged_indices:
@@ -242,6 +259,7 @@ def _merge_same_net_vias(router: Autorouter) -> int:
                                 route_b.segments, via_b.x, via_b.y,
                                 via_a.x, via_a.y, _ENDPOINT_TOL,
                             )
+                            _expand_via_layers(via_a, via_b)
                             remove_from_b.add(bj)
 
                 if remove_from_b:

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -1983,6 +1983,24 @@ class Router:
                             seg.x2 = mid_x
                             seg.y2 = mid_y
 
+                    # Issue #1802: expand surviving via layers to cover
+                    # all layers from both vias (cross-layer-pair merge)
+                    min_layer = min(
+                        existing_via.layers[0].value,
+                        existing_via.layers[1].value,
+                        new_via.layers[0].value,
+                        new_via.layers[1].value,
+                    )
+                    max_layer = max(
+                        existing_via.layers[0].value,
+                        existing_via.layers[1].value,
+                        new_via.layers[0].value,
+                        new_via.layers[1].value,
+                    )
+                    if (min_layer != existing_via.layers[0].value
+                            or max_layer != existing_via.layers[1].value):
+                        existing_via.layers = (Layer(min_layer), Layer(max_layer))
+
                     # Remove the new via since we're reusing the existing one
                     vias_to_remove.add(i)
                     break

--- a/tests/test_drc_nudge.py
+++ b/tests/test_drc_nudge.py
@@ -12,6 +12,7 @@ from kicad_tools.router.drc_nudge import (
     COINCIDENT_THRESHOLD,
     DRCNudgeResult,
     _compute_merge_threshold,
+    _expand_via_layers,
     _merge_same_net_vias,
     _nudge_segment,
     _perpendicular_unit,
@@ -250,6 +251,99 @@ class TestCrossRouteMerge:
 
         merged = _merge_same_net_vias(router)
         assert merged == 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-layer-pair via merge tests (Issue #1802)
+# ---------------------------------------------------------------------------
+
+class TestExpandViaLayers:
+    """Unit tests for _expand_via_layers helper."""
+
+    def test_same_layers_no_change(self):
+        """Vias with identical layers should not be modified."""
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        via_b = Via(x=10.3, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        _expand_via_layers(via_a, via_b)
+        assert via_a.layers == (Layer.F_CU, Layer.B_CU)
+
+    def test_different_layers_expanded(self):
+        """Surviving via should span all layers from both vias."""
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.IN1_CU), net=1)
+        via_b = Via(x=10.3, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.B_CU, Layer.F_CU), net=1)
+        _expand_via_layers(via_a, via_b)
+        assert via_a.layers[0] == Layer.F_CU
+        assert via_a.layers[1] == Layer.B_CU
+
+    def test_inner_layers_expanded(self):
+        """Merge of two inner-layer vias expands to cover both spans."""
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.IN1_CU), net=1)
+        via_b = Via(x=10.3, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.IN1_CU, Layer.IN2_CU), net=1)
+        _expand_via_layers(via_a, via_b)
+        assert via_a.layers[0] == Layer.F_CU
+        assert via_a.layers[1] == Layer.IN2_CU
+
+
+class TestCrossLayerPairMerge:
+    """Integration tests for cross-layer-pair via merging (Issue #1802)."""
+
+    def test_intra_route_different_layers_merged(self):
+        """Vias within one route with different layer pairs should be merged."""
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.IN1_CU), net=1)
+        via_b = Via(x=10.15, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.B_CU, Layer.F_CU), net=1)
+        seg = Segment(x1=5.0, y1=5.0, x2=10.15, y2=10.0,
+                      width=0.2, layer=Layer.F_CU, net=1)
+        route = Route(net=1, net_name="Net1", segments=[seg], vias=[via_a, via_b])
+        router = _StubAutorouter(routes=[route])
+
+        merged = _merge_same_net_vias(router)
+        assert merged == 1
+        assert len(route.vias) == 1
+        # Surviving via should span F.Cu to B.Cu (through-via)
+        assert route.vias[0].layers[0] == Layer.F_CU
+        assert route.vias[0].layers[1] == Layer.B_CU
+
+    def test_cross_route_different_layers_merged(self):
+        """Cross-route vias with different layer pairs should be merged."""
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.IN1_CU, Layer.F_CU), net=1)
+        via_b = Via(x=10.15, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.B_CU, Layer.F_CU), net=1)
+        seg_b = Segment(x1=5.0, y1=5.0, x2=10.15, y2=10.0,
+                        width=0.2, layer=Layer.F_CU, net=1)
+        route_a = Route(net=1, net_name="Net1", segments=[], vias=[via_a])
+        route_b = Route(net=1, net_name="Net1", segments=[seg_b], vias=[via_b])
+        router = _StubAutorouter(routes=[route_a, route_b])
+
+        merged = _merge_same_net_vias(router)
+        assert merged == 1
+        assert len(route_a.vias) == 1
+        assert len(route_b.vias) == 0
+        # Surviving via should span F.Cu to B.Cu
+        assert route_a.vias[0].layers[0] == Layer.F_CU
+        assert route_a.vias[0].layers[1] == Layer.B_CU
+
+    def test_same_layer_pair_still_works(self):
+        """Same layer pair merges still work as before (no regression)."""
+        via_a = Via(x=10.0, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        via_b = Via(x=10.15, y=10.0, drill=0.35, diameter=0.7,
+                    layers=(Layer.F_CU, Layer.B_CU), net=1)
+        route = Route(net=1, net_name="Net1", segments=[], vias=[via_a, via_b])
+        router = _StubAutorouter(routes=[route])
+
+        merged = _merge_same_net_vias(router)
+        assert merged == 1
+        assert len(route.vias) == 1
+        assert route.vias[0].layers == (Layer.F_CU, Layer.B_CU)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Same-net vias with different layer pairs (e.g., F.Cu/In1.Cu vs B.Cu/F.Cu) were being merged by position but the surviving via kept its original layer span, losing connectivity to layers from the removed via
- Added `_expand_via_layers()` helper in `drc_nudge.py` that expands the surviving via's layers to span the union of both vias' layer ranges (converting to through-via when needed)
- Applied the same layer expansion logic in `pathfinder.py`'s `_merge_same_net_vias()` for the A* pathfinder's merge pass

## Test plan

- [x] Unit tests for `_expand_via_layers()` helper: same layers (no-op), different layers (expanded), inner layers (expanded)
- [x] Integration tests for intra-route and cross-route merges with different layer pairs
- [x] Regression test confirming same-layer-pair merges still work unchanged
- [x] All 93 existing merge/via/drill/drc tests pass

Closes #1802

Generated with [Claude Code](https://claude.com/claude-code)