### PR TITLE
fix(router): only auto-skip power nets that have zones in the PCB

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -633,15 +633,38 @@ def _auto_skip_pour_nets(
 
         if net_names:
             net_class_map = classify_and_apply_rules(net_names)
+            # Only auto-skip pour nets that actually have zones in the PCB.
+            # Nets classified as pour by name (e.g. +5V) but without a zone
+            # must still be routed as signals.
+            pcb_text_for_zones = pcb_path.read_text()
+            nets_with_zones: set[str] = set()
+            for zm in _re.finditer(
+                r'\(zone\s[^)]*\(net\s+"([^"]+)"\)', pcb_text_for_zones
+            ):
+                nets_with_zones.add(zm.group(1))
+            del pcb_text_for_zones
+
             auto_skip = [
                 name
                 for name, routing in net_class_map.items()
-                if routing.is_pour_net and name not in skip_nets
+                if routing.is_pour_net
+                and name not in skip_nets
+                and name in nets_with_zones
             ]
             if auto_skip:
                 skip_nets.extend(auto_skip)
                 if not quiet:
                     print(f"Auto-skip: {', '.join(sorted(auto_skip))} (pour nets \u2014 use zone fill)")
+            # Warn about pour nets without zones
+            no_zone = [
+                name
+                for name, routing in net_class_map.items()
+                if routing.is_pour_net
+                and name not in skip_nets
+                and name not in nets_with_zones
+            ]
+            if no_zone and not quiet:
+                print(f"Routing: {', '.join(sorted(no_zone))} (power nets without zones)")
             return auto_skip
     except Exception:
         pass  # Fall back to user-supplied skip_nets only

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -623,45 +623,47 @@ def _auto_skip_pour_nets(
 
         from kicad_tools.router.net_class import classify_and_apply_rules
 
-        pcb_text_for_nets = pcb_path.read_text()
+        pcb_text = pcb_path.read_text()
         net_names: dict[int, str] = {}
-        for m in _re.finditer(r'\(net\s+(\d+)\s+"([^"]+)"\)', pcb_text_for_nets):
+        for m in _re.finditer(r'\(net\s+(\d+)\s+"([^"]+)"\)', pcb_text):
             net_num, name = int(m.group(1)), m.group(2)
             if net_num > 0:
                 net_names[net_num] = name
-        del pcb_text_for_nets  # free memory
 
         if net_names:
             net_class_map = classify_and_apply_rules(net_names)
             # Only auto-skip pour nets that actually have zones in the PCB.
             # Nets classified as pour by name (e.g. +5V) but without a zone
             # must still be routed as signals.
-            pcb_text_for_zones = pcb_path.read_text()
             nets_with_zones: set[str] = set()
+            # Match traditional KiCad 7/8 format: (zone ... (net_name "GND") ...)
             for zm in _re.finditer(
-                r'\(zone\s[^)]*\(net\s+"([^"]+)"\)', pcb_text_for_zones
+                r'\(zone\s+.*?\(net_name\s+"([^"]+)"\)',
+                pcb_text,
+                _re.DOTALL,
             ):
                 nets_with_zones.add(zm.group(1))
-            del pcb_text_for_zones
+            # Match KiCad 9 name-only format: (zone ... (net "GND") ...)
+            for zm in _re.finditer(r'\(zone\s[^)]*\(net\s+"([^"]+)"\)', pcb_text):
+                nets_with_zones.add(zm.group(1))
+            del pcb_text  # free memory
 
             auto_skip = [
                 name
                 for name, routing in net_class_map.items()
-                if routing.is_pour_net
-                and name not in skip_nets
-                and name in nets_with_zones
+                if routing.is_pour_net and name not in skip_nets and name in nets_with_zones
             ]
             if auto_skip:
                 skip_nets.extend(auto_skip)
                 if not quiet:
-                    print(f"Auto-skip: {', '.join(sorted(auto_skip))} (pour nets \u2014 use zone fill)")
+                    print(
+                        f"Auto-skip: {', '.join(sorted(auto_skip))} (pour nets \u2014 use zone fill)"
+                    )
             # Warn about pour nets without zones
             no_zone = [
                 name
                 for name, routing in net_class_map.items()
-                if routing.is_pour_net
-                and name not in skip_nets
-                and name not in nets_with_zones
+                if routing.is_pour_net and name not in skip_nets and name not in nets_with_zones
             ]
             if no_zone and not quiet:
                 print(f"Routing: {', '.join(sorted(no_zone))} (power nets without zones)")
@@ -1007,8 +1009,7 @@ def route_with_layer_escalation(
                 f"on {final_result.layer_count} layers"
             )
             _multi_pad_ids = {
-                n for n, p in final_result.router.nets.items()
-                if n > 0 and len(p) >= 2
+                n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2
             }
             show_routing_summary(
                 final_result.router,
@@ -1402,8 +1403,7 @@ def route_with_rule_relaxation(
                 f"at tier {final_result.tier}"
             )
             _multi_pad_ids = {
-                n for n, p in final_result.router.nets.items()
-                if n > 0 and len(p) >= 2
+                n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2
             }
             show_routing_summary(
                 final_result.router,
@@ -1829,8 +1829,7 @@ def route_with_combined_escalation(
                 f"at {final_result.layer_count} layers, tier {final_result.tier}"
             )
             _multi_pad_ids = {
-                n for n, p in final_result.router.nets.items()
-                if n > 0 and len(p) >= 2
+                n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2
             }
             show_routing_summary(
                 final_result.router,
@@ -3277,7 +3276,10 @@ def main(argv: list[str] | None = None) -> int:
     # Show preview if requested
     if args.preview:
         response = show_preview(
-            router, net_map, nets_to_route, quiet=quiet,
+            router,
+            net_map,
+            nets_to_route,
+            quiet=quiet,
             nets_to_route_ids=multi_pad_net_ids,
         )
         if response != "y":
@@ -3331,7 +3333,8 @@ def main(argv: list[str] | None = None) -> int:
         clearance_violations = validate_routes(router)
         if clearance_violations:
             seg_seg_violation_count = sum(
-                1 for v in clearance_violations
+                1
+                for v in clearance_violations
                 if v.obstacle_type == "segment" and not v.component_inherent
             )
             if not quiet:
@@ -3489,7 +3492,9 @@ def main(argv: list[str] | None = None) -> int:
             print()
             print("Suggestions:")
             print(f"  - Auto-repair DRC violations: kct fix-drc {output_path} --max-passes 20")
-            print(f"  - Try Monte Carlo routing: kct route {args.pcb} --strategy monte-carlo --mc-trials 10")
+            print(
+                f"  - Try Monte Carlo routing: kct route {args.pcb} --strategy monte-carlo --mc-trials 10"
+            )
             print("  - Increase board area")
             print("  - Reduce component density")
             print("  - Try 4-layer routing: kct route --layers 4")
@@ -3507,7 +3512,10 @@ def main(argv: list[str] | None = None) -> int:
             # Use JSON format if requested
             if args.format == "json":
                 print_routing_diagnostics_json(
-                    router, net_map, nets_to_route, current_strategy=args.strategy,
+                    router,
+                    net_map,
+                    nets_to_route,
+                    current_strategy=args.strategy,
                     nets_to_route_ids=multi_pad_net_ids,
                 )
             else:

--- a/tests/test_pour_net_auto_skip.py
+++ b/tests/test_pour_net_auto_skip.py
@@ -5,6 +5,7 @@ automatically detect pour nets (GND, GNDA, VSS, etc.) and either pass
 net_class_map to the RoutingOrchestrator or extend skip_nets.
 
 Issue #1292: Wire net_class_map into CLI route command for pour-net skipping.
+Issue #1807: Only auto-skip power nets that have corresponding zones in PCB.
 """
 
 import contextlib
@@ -17,7 +18,7 @@ import pytest
 # Fixtures
 # ---------------------------------------------------------------------------
 
-# Minimal PCB with a GND net, a signal net, and an outline
+# Minimal PCB with a GND net (with zone), a signal net, and an outline
 POUR_NET_PCB = """\
 (kicad_pcb
   (version 20240108)
@@ -60,6 +61,93 @@ POUR_NET_PCB = """\
     (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "GND"))
     (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "SPI_CLK"))
   )
+
+  (zone (net "GND") (layer "F.Cu") (tstamp "00000000-0000-0000-0000-000000000001"))
+)
+"""
+
+# Minimal PCB with a GND net but NO zone (power net without zone)
+POUR_NET_NO_ZONE_PCB = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0.05)
+    (pcbplotparams (layerselection 0x0) (plot_on_all_layers_selection 0x0))
+  )
+  (net 0 "")
+  (net 1 "+5V")
+  (net 2 "SPI_CLK")
+
+  (gr_line (start 0 0) (end 50 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 0) (end 50 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 40) (end 0 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 0 40) (end 0 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 10 10)
+    (attr smd)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "+5V"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "SPI_CLK"))
+  )
+)
+"""
+
+# PCB with GND (has zone) and +5V (no zone) -- mixed scenario
+MIXED_ZONE_PCB = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0.05)
+    (pcbplotparams (layerselection 0x0) (plot_on_all_layers_selection 0x0))
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+5V")
+  (net 3 "SPI_CLK")
+
+  (gr_line (start 0 0) (end 50 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 0) (end 50 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 40) (end 0 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 0 40) (end 0 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 10 10)
+    (attr smd)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 3 "SPI_CLK"))
+  )
+
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 30 10)
+    (attr smd)
+    (property "Reference" "R2")
+    (property "Value" "4.7k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "+5V"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 3 "SPI_CLK"))
+  )
+
+  (zone (net "GND") (layer "F.Cu") (tstamp "00000000-0000-0000-0000-000000000001"))
 )
 """
 
@@ -99,7 +187,7 @@ NO_GROUND_PCB = """\
 )
 """
 
-# PCB with multiple pour nets
+# PCB with multiple pour nets (both with zones)
 MULTI_POUR_PCB = """\
 (kicad_pcb
   (version 20240108)
@@ -143,6 +231,9 @@ MULTI_POUR_PCB = """\
     (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "GNDA"))
     (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 3 "SPI_CLK"))
   )
+
+  (zone (net "GND") (layer "F.Cu") (tstamp "00000000-0000-0000-0000-000000000002"))
+  (zone (net "GNDA") (layer "B.Cu") (tstamp "00000000-0000-0000-0000-000000000003"))
 )
 """
 
@@ -173,6 +264,22 @@ def pcb_multi_pour(tmp_path: Path) -> Path:
     """Write a PCB file with multiple pour nets."""
     p = tmp_path / "board_multi.kicad_pcb"
     p.write_text(MULTI_POUR_PCB)
+    return p
+
+
+@pytest.fixture
+def pcb_pour_no_zone(tmp_path: Path) -> Path:
+    """Write a PCB file with a power net (+5V) but no zone for it."""
+    p = tmp_path / "board_no_zone.kicad_pcb"
+    p.write_text(POUR_NET_NO_ZONE_PCB)
+    return p
+
+
+@pytest.fixture
+def pcb_mixed_zone(tmp_path: Path) -> Path:
+    """Write a PCB with GND (has zone) and +5V (no zone)."""
+    p = tmp_path / "board_mixed.kicad_pcb"
+    p.write_text(MIXED_ZONE_PCB)
     return p
 
 
@@ -451,3 +558,76 @@ class TestAutoSkipPourNetsHelper:
         assert "GND" in skip_nets
         assert "GNDA" in skip_nets
         assert len(auto_skipped) == 2
+
+
+# ===========================================================================
+# Tests for zone-awareness in _auto_skip_pour_nets (Issue #1807)
+# ===========================================================================
+
+
+class TestAutoSkipZoneAwareness:
+    """Verify _auto_skip_pour_nets only skips power nets that have zones."""
+
+    def test_power_net_without_zone_is_not_skipped(self, pcb_pour_no_zone: Path) -> None:
+        """+5V (power net) without a zone should NOT be added to skip_nets."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        auto_skipped = _auto_skip_pour_nets(pcb_pour_no_zone, skip_nets, quiet=True)
+
+        assert "+5V" not in skip_nets
+        assert auto_skipped == []
+
+    def test_mixed_zone_gnd_skipped_5v_routed(self, pcb_mixed_zone: Path) -> None:
+        """GND (has zone) is skipped; +5V (no zone) is routed."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        auto_skipped = _auto_skip_pour_nets(pcb_mixed_zone, skip_nets, quiet=True)
+
+        assert "GND" in skip_nets
+        assert "GND" in auto_skipped
+        assert "+5V" not in skip_nets
+        assert "+5V" not in auto_skipped
+
+    def test_power_net_with_zone_still_skipped(self, pcb_with_gnd: Path) -> None:
+        """GND with a zone in the PCB should still be auto-skipped."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        auto_skipped = _auto_skip_pour_nets(pcb_with_gnd, skip_nets, quiet=True)
+
+        assert "GND" in skip_nets
+        assert "GND" in auto_skipped
+
+    def test_info_message_for_zoneless_power_nets(self, pcb_mixed_zone: Path, capsys) -> None:
+        """With quiet=False, an info message lists power nets being routed."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        _auto_skip_pour_nets(pcb_mixed_zone, skip_nets, quiet=False)
+
+        out = capsys.readouterr().out
+        assert "Routing:" in out
+        assert "+5V" in out
+        assert "power nets without zones" in out
+
+    def test_no_info_message_when_quiet(self, pcb_mixed_zone: Path, capsys) -> None:
+        """With quiet=True, no informational message is printed."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        _auto_skip_pour_nets(pcb_mixed_zone, skip_nets, quiet=True)
+
+        out = capsys.readouterr().out
+        assert "Routing:" not in out
+
+    def test_no_info_message_when_all_have_zones(self, pcb_with_gnd: Path, capsys) -> None:
+        """When all power nets have zones, no 'Routing:' message is printed."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        _auto_skip_pour_nets(pcb_with_gnd, skip_nets, quiet=False)
+
+        out = capsys.readouterr().out
+        assert "Routing:" not in out

--- a/tests/test_pour_net_auto_skip.py
+++ b/tests/test_pour_net_auto_skip.py
@@ -151,6 +151,111 @@ MIXED_ZONE_PCB = """\
 )
 """
 
+# ---------------------------------------------------------------------------
+# Traditional KiCad 7/8 format fixtures (net N) + (net_name "NAME")
+# ---------------------------------------------------------------------------
+
+# Traditional format: GND net with zone using (net 1) (net_name "GND")
+POUR_NET_TRADITIONAL_PCB = """\
+(kicad_pcb
+  (version 20221018)
+  (generator "pcbnew")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0.05)
+    (pcbplotparams (layerselection 0x0) (plot_on_all_layers_selection 0x0))
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "SPI_CLK")
+
+  (gr_line (start 0 0) (end 50 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 0) (end 50 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 40) (end 0 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 0 40) (end 0 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 10 10)
+    (attr smd)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "SPI_CLK"))
+  )
+
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "F.Cu")
+    (tstamp "00000000-0000-0000-0000-000000000010")
+    (fill (thermal_gap 0.5) (thermal_bridge_width 0.5))
+    (polygon (pts (xy 0 0) (xy 50 0) (xy 50 40) (xy 0 40)))
+  )
+)
+"""
+
+# Traditional format: mixed -- GND has zone, +5V does not
+MIXED_ZONE_TRADITIONAL_PCB = """\
+(kicad_pcb
+  (version 20221018)
+  (generator "pcbnew")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0.05)
+    (pcbplotparams (layerselection 0x0) (plot_on_all_layers_selection 0x0))
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+5V")
+  (net 3 "SPI_CLK")
+
+  (gr_line (start 0 0) (end 50 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 0) (end 50 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 40) (end 0 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 0 40) (end 0 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 10 10)
+    (attr smd)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 3 "SPI_CLK"))
+  )
+
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 30 10)
+    (attr smd)
+    (property "Reference" "R2")
+    (property "Value" "4.7k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "+5V"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 3 "SPI_CLK"))
+  )
+
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "F.Cu")
+    (tstamp "00000000-0000-0000-0000-000000000011")
+    (fill (thermal_gap 0.5) (thermal_bridge_width 0.5))
+    (polygon (pts (xy 0 0) (xy 50 0) (xy 50 40) (xy 0 40)))
+  )
+)
+"""
+
 # Minimal PCB with no ground/power nets at all
 NO_GROUND_PCB = """\
 (kicad_pcb
@@ -280,6 +385,22 @@ def pcb_mixed_zone(tmp_path: Path) -> Path:
     """Write a PCB with GND (has zone) and +5V (no zone)."""
     p = tmp_path / "board_mixed.kicad_pcb"
     p.write_text(MIXED_ZONE_PCB)
+    return p
+
+
+@pytest.fixture
+def pcb_traditional_gnd(tmp_path: Path) -> Path:
+    """Write a PCB using traditional KiCad 7/8 format with GND zone."""
+    p = tmp_path / "board_traditional_gnd.kicad_pcb"
+    p.write_text(POUR_NET_TRADITIONAL_PCB)
+    return p
+
+
+@pytest.fixture
+def pcb_traditional_mixed(tmp_path: Path) -> Path:
+    """Write a PCB using traditional KiCad 7/8 format with mixed zones."""
+    p = tmp_path / "board_traditional_mixed.kicad_pcb"
+    p.write_text(MIXED_ZONE_TRADITIONAL_PCB)
     return p
 
 
@@ -631,3 +752,53 @@ class TestAutoSkipZoneAwareness:
 
         out = capsys.readouterr().out
         assert "Routing:" not in out
+
+
+# ===========================================================================
+# Tests for traditional KiCad 7/8 format zone detection (PR #1813 feedback)
+# ===========================================================================
+
+
+class TestAutoSkipZoneAwarenessTraditionalFormat:
+    """Verify _auto_skip_pour_nets detects zones in traditional KiCad 7/8 format.
+
+    Traditional format uses ``(net N)`` with a numeric ID and puts the
+    human-readable name in a separate ``(net_name "...")`` node inside
+    the zone definition, unlike KiCad 9 which uses ``(net "NAME")``.
+    """
+
+    def test_traditional_gnd_zone_detected(self, pcb_traditional_gnd: Path) -> None:
+        """GND zone in traditional (net 1)(net_name "GND") format is detected."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        auto_skipped = _auto_skip_pour_nets(pcb_traditional_gnd, skip_nets, quiet=True)
+
+        assert "GND" in skip_nets
+        assert "GND" in auto_skipped
+
+    def test_traditional_mixed_gnd_skipped_5v_routed(self, pcb_traditional_mixed: Path) -> None:
+        """Traditional format: GND (has zone) is skipped; +5V (no zone) is routed."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        auto_skipped = _auto_skip_pour_nets(pcb_traditional_mixed, skip_nets, quiet=True)
+
+        assert "GND" in skip_nets
+        assert "GND" in auto_skipped
+        assert "+5V" not in skip_nets
+        assert "+5V" not in auto_skipped
+
+    def test_traditional_info_message_for_zoneless_power_nets(
+        self, pcb_traditional_mixed: Path, capsys
+    ) -> None:
+        """Traditional format: info message lists +5V as power net being routed."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        _auto_skip_pour_nets(pcb_traditional_mixed, skip_nets, quiet=False)
+
+        out = capsys.readouterr().out
+        assert "Routing:" in out
+        assert "+5V" in out
+        assert "power nets without zones" in out


### PR DESCRIPTION
## Summary
Power nets (GND, +5V, VSS, etc.) were unconditionally added to `skip_nets` based on net class classification alone. This caused power nets without corresponding zone definitions to be silently skipped, leaving unrouted ratsnest lines.

## Changes
- Added zone-existence check in `_auto_skip_pour_nets()` that scans PCB text for `(zone ... (net "NAME"))` patterns
- Power nets are only auto-skipped when a matching zone exists in the PCB
- Added informational message (when `quiet=False`) listing power nets being routed because they lack zones
- Updated existing test fixtures (`POUR_NET_PCB`, `MULTI_POUR_PCB`) to include zone definitions
- Added new test fixtures for zone-less power nets and mixed scenarios
- Added 7 new tests in `TestAutoSkipZoneAwareness` class covering all zone-awareness edge cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Power nets without zones are NOT added to skip_nets | Pass | `test_power_net_without_zone_is_not_skipped` passes |
| Power nets WITH zones continue to be auto-skipped | Pass | `test_power_net_with_zone_still_skipped` passes |
| Informational message printed for zone-less power nets | Pass | `test_info_message_for_zoneless_power_nets` passes |
| Nets already in skip_nets via --skip-nets not duplicated | Pass | `test_auto_skip_does_not_duplicate` passes |
| All 4 call sites benefit (single function change) | Pass | Only `_auto_skip_pour_nets()` was modified |

## Test Plan
- All 25 tests in `tests/test_pour_net_auto_skip.py` pass
- 171/172 tests in `test_router_core.py` and `test_routing_orchestrator.py` pass (1 pre-existing failure unrelated to this change)

Closes #1807