### PR TITLE
fix(runner): prevent net format corruption in zone fill pipeline

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -733,6 +733,27 @@ def _run_step_zones(ctx: PipelineContext, console: Console) -> PipelineResult:
 
     success, message = _run_subprocess_step(cmd, ctx.pcb_file.parent, ctx.verbose)
 
+    # Validate net format after zone fill — kicad-cli may corrupt nets.
+    if success:
+        from .runner import validate_net_format
+
+        report = validate_net_format(ctx.pcb_file)
+        if not report.valid:
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "Net format corruption detected after zone fill: "
+                "%d element(s) have non-canonical net format "
+                "(name_only_segments=%d, name_only_vias=%d, name_only_pads=%d, "
+                "empty_net_segments=%d, empty_net_vias=%d, empty_net_pads=%d)",
+                report.total_corrupt,
+                report.name_only_segments,
+                report.name_only_vias,
+                report.name_only_pads,
+                report.empty_net_segments,
+                report.empty_net_vias,
+                report.empty_net_pads,
+            )
+
     return PipelineResult(
         step=PipelineStep.ZONES,
         success=success,
@@ -782,6 +803,27 @@ def _run_step_zones_refill(ctx: PipelineContext, console: Console) -> PipelineRe
         cmd.append("--quiet")
 
     success, message = _run_subprocess_step(cmd, ctx.pcb_file.parent, ctx.verbose)
+
+    # Validate net format after zone refill — kicad-cli may corrupt nets.
+    if success:
+        from .runner import validate_net_format
+
+        report = validate_net_format(ctx.pcb_file)
+        if not report.valid:
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "Net format corruption detected after zone refill: "
+                "%d element(s) have non-canonical net format "
+                "(name_only_segments=%d, name_only_vias=%d, name_only_pads=%d, "
+                "empty_net_segments=%d, empty_net_vias=%d, empty_net_pads=%d)",
+                report.total_corrupt,
+                report.name_only_segments,
+                report.name_only_vias,
+                report.name_only_pads,
+                report.empty_net_segments,
+                report.empty_net_vias,
+                report.empty_net_pads,
+            )
 
     return PipelineResult(
         step=PipelineStep.ZONES_REFILL,

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -345,7 +345,16 @@ def _run_fill_zones_native(
     output_path: Path | None,
     kicad_cli: Path,
 ) -> KiCadCLIResult:
-    """Fill zones using the native ``kicad-cli pcb fill-zones`` subcommand."""
+    """Fill zones using the native ``kicad-cli pcb fill-zones`` subcommand.
+
+    Snapshots net declarations and per-element net assignments before
+    running the external command, then restores them afterward — mirroring
+    the protection in :func:`_run_fill_zones_via_drc`.
+    """
+    # Snapshot net state before invoking kicad-cli.
+    input_net_nodes = _snapshot_net_declarations(pcb_path)
+    input_element_nets = _snapshot_element_nets(pcb_path)
+
     cmd = [str(kicad_cli), "pcb", "fill-zones"]
 
     if output_path is not None:
@@ -359,6 +368,14 @@ def _run_fill_zones_native(
         expected_path = output_path if output_path is not None else pcb_path
 
         if result.returncode == 0:
+            # Restore net declarations and per-element nets if kicad-cli
+            # rewrote them.  Guard on file existence since the output may
+            # be at a different path than the input.
+            if expected_path.exists():
+                _restore_net_declarations(
+                    expected_path, input_net_nodes, input_element_nets
+                )
+
             return KiCadCLIResult(
                 success=True,
                 output_path=expected_path,
@@ -463,6 +480,33 @@ def _has_nonzero_net(net_node) -> bool:
     return bool(net_name)
 
 
+def _has_canonical_net(net_node) -> bool:
+    """Check whether a ``(net ...)`` node is in canonical ``(net N ...)`` format.
+
+    Returns True only when the net has a numeric ID as its first child AND
+    the ID is nonzero.  Name-only format ``(net "name")`` — which kicad-cli
+    may emit as a corruption artefact — returns False so that the restore
+    logic will overwrite it with the snapshotted canonical form.
+
+    Returns True for:
+    - ``(net 1 "GND")`` — canonical format with nonzero net number
+    - ``(net 18)`` — numeric-only (valid, no name)
+
+    Returns False for:
+    - ``(net "SYNC_R")`` — name-only, missing numeric ID (corruption)
+    - ``(net "")`` — empty name-only (corruption)
+    - ``(net 0)`` or ``(net 0 "")`` — unconnected
+    - None
+    """
+    if net_node is None:
+        return False
+    net_num = net_node.get_int(0)
+    if net_num is not None:
+        return net_num != 0
+    # No numeric first child — this is name-only format, treat as needing restore
+    return False
+
+
 def _make_segment_via_key(child) -> str | None:
     """Build a geometry-based key for a segment or via S-expression node.
 
@@ -521,6 +565,108 @@ def _canonicalize_net_node(net_node, name_to_number: dict[str, int]):
     if net_name and net_name in name_to_number:
         return SExp.list("net", name_to_number[net_name], net_name)
     return net_node
+
+
+@dataclass
+class NetFormatReport:
+    """Result of :func:`validate_net_format`."""
+
+    valid: bool
+    """True when every checked element has canonical numeric net format."""
+    name_only_segments: int = 0
+    """Count of segments with name-only ``(net "name")`` format."""
+    name_only_vias: int = 0
+    """Count of vias with name-only ``(net "name")`` format."""
+    name_only_pads: int = 0
+    """Count of pads with name-only ``(net "name")`` format."""
+    empty_net_segments: int = 0
+    """Count of segments with empty ``(net "")`` format."""
+    empty_net_vias: int = 0
+    """Count of vias with empty ``(net "")`` format."""
+    empty_net_pads: int = 0
+    """Count of pads with empty ``(net "")`` format."""
+
+    @property
+    def total_corrupt(self) -> int:
+        return (
+            self.name_only_segments
+            + self.name_only_vias
+            + self.name_only_pads
+            + self.empty_net_segments
+            + self.empty_net_vias
+            + self.empty_net_pads
+        )
+
+
+def validate_net_format(pcb_path: Path) -> NetFormatReport:
+    """Validate that all segments, vias, and pads have canonical numeric net format.
+
+    Canonical format is ``(net N)`` or ``(net N "name")`` where N is a nonzero
+    integer.  Name-only format ``(net "name")`` and empty-net ``(net "")`` on
+    elements that should be connected are flagged as corrupt.
+
+    Elements with ``(net 0)`` (unconnected pads) are not flagged — those are
+    legitimately unconnected.
+
+    Args:
+        pcb_path: Path to a ``.kicad_pcb`` file.
+
+    Returns:
+        A :class:`NetFormatReport` summarising any corruption found.
+    """
+    from kicad_tools.core.sexp_file import load_pcb
+
+    try:
+        sexp = load_pcb(str(pcb_path))
+    except Exception:
+        # If we can't load the file, report as valid — the caller will
+        # surface the load failure through other channels.
+        return NetFormatReport(valid=True)
+
+    report = NetFormatReport(valid=True)
+
+    def _check_net_node(net_node, element_kind: str) -> None:
+        """Classify a ``(net ...)`` node and update *report* counters."""
+        if net_node is None:
+            return
+        net_num = net_node.get_int(0)
+        if net_num is not None:
+            # Has numeric ID — canonical (even if 0, that's just unconnected)
+            return
+        # Name-only or empty-string format
+        net_name = net_node.get_string(0)
+        if net_name:
+            # Name-only corruption: (net "SYNC_R")
+            if element_kind == "segment":
+                report.name_only_segments += 1
+            elif element_kind == "via":
+                report.name_only_vias += 1
+            elif element_kind == "pad":
+                report.name_only_pads += 1
+            report.valid = False
+        elif net_name == "":
+            # Empty-string corruption: (net "")
+            if element_kind == "segment":
+                report.empty_net_segments += 1
+            elif element_kind == "via":
+                report.empty_net_vias += 1
+            elif element_kind == "pad":
+                report.empty_net_pads += 1
+            report.valid = False
+
+    # Check top-level segments and vias
+    for child in sexp.children:
+        if child.name == "segment":
+            _check_net_node(child.get("net"), "segment")
+        elif child.name == "via":
+            _check_net_node(child.get("net"), "via")
+
+    # Check pads inside footprints
+    for fp_node in (c for c in sexp.children if c.name == "footprint"):
+        for pad_node in (c for c in fp_node.children if c.name == "pad"):
+            _check_net_node(pad_node.get("net"), "pad")
+
+    return report
 
 
 def _snapshot_element_nets(pcb_path: Path) -> dict[str, list]:
@@ -662,7 +808,7 @@ def _restore_net_declarations(
                 if key not in element_nets:
                     continue
                 current_net = pad_node.get("net")
-                if not _has_nonzero_net(current_net):
+                if not _has_canonical_net(current_net):
                     if current_net is not None:
                         pad_node.remove(current_net)
                     pad_node.append(element_nets[key][0])
@@ -674,7 +820,7 @@ def _restore_net_declarations(
                 geo_key = _make_segment_via_key(child)
                 if geo_key and geo_key in element_nets:
                     current_net = child.get("net")
-                    if not _has_nonzero_net(current_net):
+                    if not _has_canonical_net(current_net):
                         if current_net is not None:
                             child.remove(current_net)
                         child.append(element_nets[geo_key][0])

--- a/tests/test_runner_net_restore.py
+++ b/tests/test_runner_net_restore.py
@@ -1,0 +1,401 @@
+"""Unit tests for net restore logic and net format validation in runner.py.
+
+Covers the two failure modes from issue #1812:
+1. ``_run_fill_zones_native()`` missing snapshot/restore protection.
+2. ``_has_nonzero_net()`` treating name-only format as valid, causing
+   ``_restore_net_declarations()`` to skip restoration of corrupted nets.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.sexp import SExp
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RUNNER = "kicad_tools.cli.runner"
+
+
+def _net_node(
+    *args: int | str,
+) -> SExp:
+    """Build a ``(net ...)`` SExp node from positional arguments.
+
+    Examples:
+        _net_node(18, "SYNC_R")  -> (net 18 "SYNC_R")
+        _net_node(0)             -> (net 0)
+        _net_node("SYNC_R")     -> (net "SYNC_R")   # name-only
+        _net_node("")            -> (net "")          # empty-string
+    """
+    return SExp.list("net", *args)
+
+
+# ---------------------------------------------------------------------------
+# _has_nonzero_net
+# ---------------------------------------------------------------------------
+
+
+class TestHasNonzeroNet:
+    """Verify ``_has_nonzero_net`` behaviour for different net formats."""
+
+    def test_canonical_nonzero(self):
+        from kicad_tools.cli.runner import _has_nonzero_net
+
+        assert _has_nonzero_net(_net_node(18, "SYNC_R")) is True
+
+    def test_numeric_only_nonzero(self):
+        from kicad_tools.cli.runner import _has_nonzero_net
+
+        assert _has_nonzero_net(_net_node(18)) is True
+
+    def test_zero_net(self):
+        from kicad_tools.cli.runner import _has_nonzero_net
+
+        assert _has_nonzero_net(_net_node(0)) is False
+
+    def test_zero_with_empty_name(self):
+        from kicad_tools.cli.runner import _has_nonzero_net
+
+        assert _has_nonzero_net(_net_node(0, "")) is False
+
+    def test_name_only(self):
+        from kicad_tools.cli.runner import _has_nonzero_net
+
+        # Name-only format is still "has a net" for snapshot purposes.
+        assert _has_nonzero_net(_net_node("SYNC_R")) is True
+
+    def test_empty_string(self):
+        from kicad_tools.cli.runner import _has_nonzero_net
+
+        assert _has_nonzero_net(_net_node("")) is False
+
+    def test_none(self):
+        from kicad_tools.cli.runner import _has_nonzero_net
+
+        assert _has_nonzero_net(None) is False
+
+
+# ---------------------------------------------------------------------------
+# _has_canonical_net
+# ---------------------------------------------------------------------------
+
+
+class TestHasCanonicalNet:
+    """Verify ``_has_canonical_net`` returns False for name-only corruption."""
+
+    def test_canonical_nonzero(self):
+        from kicad_tools.cli.runner import _has_canonical_net
+
+        assert _has_canonical_net(_net_node(18, "SYNC_R")) is True
+
+    def test_numeric_only_nonzero(self):
+        from kicad_tools.cli.runner import _has_canonical_net
+
+        assert _has_canonical_net(_net_node(18)) is True
+
+    def test_zero_net(self):
+        from kicad_tools.cli.runner import _has_canonical_net
+
+        assert _has_canonical_net(_net_node(0)) is False
+
+    def test_name_only_returns_false(self):
+        """Name-only ``(net "SYNC_R")`` must be flagged as needing restore."""
+        from kicad_tools.cli.runner import _has_canonical_net
+
+        assert _has_canonical_net(_net_node("SYNC_R")) is False
+
+    def test_empty_string_returns_false(self):
+        from kicad_tools.cli.runner import _has_canonical_net
+
+        assert _has_canonical_net(_net_node("")) is False
+
+    def test_none(self):
+        from kicad_tools.cli.runner import _has_canonical_net
+
+        assert _has_canonical_net(None) is False
+
+
+# ---------------------------------------------------------------------------
+# validate_net_format
+# ---------------------------------------------------------------------------
+
+
+class TestValidateNetFormat:
+    """Verify ``validate_net_format`` detects corruption."""
+
+    @staticmethod
+    def _write_pcb(tmp_path: Path, segments: list[str], footprints: str = "") -> Path:
+        """Write a minimal ``.kicad_pcb`` with custom segments/footprints."""
+        pcb = tmp_path / "board.kicad_pcb"
+        seg_text = "\n".join(segments)
+        pcb.write_text(
+            f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 1 "GND")
+  (net 18 "SYNC_R")
+  {footprints}
+  {seg_text}
+)"""
+        )
+        return pcb
+
+    def test_valid_pcb(self, tmp_path):
+        from kicad_tools.cli.runner import validate_net_format
+
+        pcb = self._write_pcb(
+            tmp_path,
+            [
+                '(segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net 1) (uuid "a"))',
+                '(via (at 50 60) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 18) (uuid "b"))',
+            ],
+        )
+        report = validate_net_format(pcb)
+        assert report.valid is True
+        assert report.total_corrupt == 0
+
+    def test_name_only_segment(self, tmp_path):
+        from kicad_tools.cli.runner import validate_net_format
+
+        pcb = self._write_pcb(
+            tmp_path,
+            [
+                '(segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net "SYNC_R") (uuid "a"))',
+            ],
+        )
+        report = validate_net_format(pcb)
+        assert report.valid is False
+        assert report.name_only_segments == 1
+
+    def test_name_only_via(self, tmp_path):
+        from kicad_tools.cli.runner import validate_net_format
+
+        pcb = self._write_pcb(
+            tmp_path,
+            [
+                '(via (at 50 60) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net "SYNC_R") (uuid "b"))',
+            ],
+        )
+        report = validate_net_format(pcb)
+        assert report.valid is False
+        assert report.name_only_vias == 1
+
+    def test_empty_net_segment(self, tmp_path):
+        from kicad_tools.cli.runner import validate_net_format
+
+        pcb = self._write_pcb(
+            tmp_path,
+            [
+                '(segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net "") (uuid "a"))',
+            ],
+        )
+        report = validate_net_format(pcb)
+        assert report.valid is False
+        assert report.empty_net_segments == 1
+
+    def test_name_only_pad(self, tmp_path):
+        from kicad_tools.cli.runner import validate_net_format
+
+        fp = """(footprint "R_0603"
+    (property "Reference" "R1")
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net "GND"))
+  )"""
+        pcb = self._write_pcb(tmp_path, [], footprints=fp)
+        report = validate_net_format(pcb)
+        assert report.valid is False
+        assert report.name_only_pads == 1
+
+
+# ---------------------------------------------------------------------------
+# _restore_net_declarations with name-only corruption
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreNetDeclarations:
+    """Verify that name-only net format is overwritten during restore."""
+
+    @staticmethod
+    def _write_pcb(tmp_path: Path, content: str) -> Path:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(content)
+        return pcb
+
+    def test_restores_name_only_segment(self, tmp_path):
+        """A segment with ``(net "SYNC_R")`` should be restored to ``(net 18 "SYNC_R")``."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        # PCB with a segment corrupted to name-only format
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 18 "SYNC_R")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net "SYNC_R") (uuid "a"))
+)""",
+        )
+
+        # Build snapshot data: the canonical net node for this segment
+        net_nodes = [_net_node(0, ""), _net_node(18, "SYNC_R")]
+        element_nets = {
+            "seg:10.0,20.0:30.0,40.0:F.Cu": [_net_node(18, "SYNC_R")],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        # Verify the segment now has canonical format
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                net_num = net_node.get_int(0)
+                assert net_num == 18, f"Expected (net 18 ...) but got {net_node}"
+                break
+        else:
+            pytest.fail("No segment found in restored PCB")
+
+    def test_restores_empty_string_segment(self, tmp_path):
+        """A segment with ``(net "")`` should be restored."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 1 "GND")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net "") (uuid "a"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(1, "GND")]
+        element_nets = {
+            "seg:10.0,20.0:30.0,40.0:F.Cu": [_net_node(1, "GND")],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                net_num = net_node.get_int(0)
+                assert net_num == 1, f"Expected (net 1 ...) but got {net_node}"
+                break
+        else:
+            pytest.fail("No segment found in restored PCB")
+
+    def test_preserves_canonical_net(self, tmp_path):
+        """A segment with canonical ``(net 18)`` should NOT be overwritten."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 18 "SYNC_R")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net 18) (uuid "a"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(18, "SYNC_R")]
+        element_nets = {
+            "seg:10.0,20.0:30.0,40.0:F.Cu": [_net_node(18, "SYNC_R")],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                net_num = net_node.get_int(0)
+                assert net_num == 18
+                break
+        else:
+            pytest.fail("No segment found in restored PCB")
+
+
+# ---------------------------------------------------------------------------
+# _run_fill_zones_native snapshot/restore
+# ---------------------------------------------------------------------------
+
+
+class TestRunFillZonesNativeProtection:
+    """Verify ``_run_fill_zones_native`` snapshots and restores nets."""
+
+    def test_snapshots_and_restores(self, tmp_path):
+        """Native fill path must call snapshot and restore functions."""
+        from kicad_tools.cli.runner import _run_fill_zones_native
+
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 1 "GND")
+)"""
+        )
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with (
+            patch(f"{_RUNNER}.subprocess.run", return_value=mock_result),
+            patch(f"{_RUNNER}._snapshot_net_declarations") as mock_snap,
+            patch(f"{_RUNNER}._snapshot_element_nets") as mock_elem_snap,
+            patch(f"{_RUNNER}._restore_net_declarations") as mock_restore,
+        ):
+            mock_snap.return_value = [_net_node(0, ""), _net_node(1, "GND")]
+            mock_elem_snap.return_value = {}
+
+            result = _run_fill_zones_native(pcb, None, Path("/usr/bin/kicad-cli"))
+
+            assert result.success is True
+            mock_snap.assert_called_once_with(pcb)
+            mock_elem_snap.assert_called_once_with(pcb)
+            mock_restore.assert_called_once()
+
+    def test_no_restore_on_failure(self, tmp_path):
+        """Native fill should NOT restore nets when kicad-cli fails."""
+        from kicad_tools.cli.runner import _run_fill_zones_native
+
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240108) (generator test))")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "error"
+
+        with (
+            patch(f"{_RUNNER}.subprocess.run", return_value=mock_result),
+            patch(f"{_RUNNER}._snapshot_net_declarations", return_value=[]),
+            patch(f"{_RUNNER}._snapshot_element_nets", return_value={}),
+            patch(f"{_RUNNER}._restore_net_declarations") as mock_restore,
+        ):
+            result = _run_fill_zones_native(pcb, None, Path("/usr/bin/kicad-cli"))
+
+            assert result.success is False
+            mock_restore.assert_not_called()


### PR DESCRIPTION
## Summary

Fix two independent failure modes that cause net format corruption in the post-routing zone fill pipeline. The native zone fill path had zero net protection, and the restore logic silently accepted name-only net format as valid.

## Changes

- Add `_has_canonical_net()` function that correctly identifies name-only `(net "name")` format as needing restoration (unlike `_has_nonzero_net()` which treats it as valid)
- Switch restore logic in `_restore_net_declarations()` to use `_has_canonical_net()` so corrupted name-only and empty-string nets are overwritten with snapshotted canonical format
- Add snapshot/restore net protection to `_run_fill_zones_native()`, mirroring the existing protection in `_run_fill_zones_via_drc()`
- Add `validate_net_format()` utility with `NetFormatReport` dataclass for detecting name-only and empty-string net corruption across segments, vias, and pads
- Add post-step net format validation warnings in pipeline ZONES and ZONES_REFILL steps
- Add 23 unit tests covering all edge cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_run_fill_zones_native()` snapshots and restores nets | Done | `TestRunFillZonesNativeProtection` verifies snapshot/restore calls and no-restore on failure |
| Restore logic overwrites name-only `(net "name")` format | Done | `TestRestoreNetDeclarations::test_restores_name_only_segment` verifies restoration |
| Empty net `(net "")` segments are restored | Done | `TestRestoreNetDeclarations::test_restores_empty_string_segment` verifies restoration |
| `validate_net_format()` utility exists | Done | `TestValidateNetFormat` covers valid, name-only, and empty-net cases for segments/vias/pads |
| Pipeline validates net format after ZONES/ZONES_REFILL | Done | Both `_run_step_zones` and `_run_step_zones_refill` call `validate_net_format` and log warnings |
| No regression in existing tests | Done | All 64 existing zone tests pass (1 skipped as before) |

## Test Plan

- 23 new tests in `tests/test_runner_net_restore.py` all pass
- 64 existing tests in `tests/test_zones_cmd.py` all pass (no regression)

Closes #1812