### PR TITLE
fix(router): round geometry keys and add proximity fallback for net restore

### DIFF
--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -507,11 +507,15 @@ def _has_canonical_net(net_node) -> bool:
     return False
 
 
-def _make_segment_via_key(child) -> str | None:
+def _make_segment_via_key(child, *, precision: int = 4) -> str | None:
     """Build a geometry-based key for a segment or via S-expression node.
 
     Uses ``(start, end, layer)`` for segments and ``(position, size, layers)``
     for vias, which are stable across kicad-cli UUID regeneration.
+
+    Coordinates are rounded to *precision* decimal places (default 4) so that
+    minor floating-point drift introduced by kicad-cli re-serialization still
+    produces identical keys.
 
     Returns None if required geometry fields are missing.
     """
@@ -521,10 +525,10 @@ def _make_segment_via_key(child) -> str | None:
         layer_node = child.get("layer")
         if start_node is None or end_node is None or layer_node is None:
             return None
-        sx = start_node.get_float(0) or 0.0
-        sy = start_node.get_float(1) or 0.0
-        ex = end_node.get_float(0) or 0.0
-        ey = end_node.get_float(1) or 0.0
+        sx = round(start_node.get_float(0) or 0.0, precision)
+        sy = round(start_node.get_float(1) or 0.0, precision)
+        ex = round(end_node.get_float(0) or 0.0, precision)
+        ey = round(end_node.get_float(1) or 0.0, precision)
         layer = layer_node.get_string(0) or ""
         return f"seg:{sx},{sy}:{ex},{ey}:{layer}"
     elif child.name == "via":
@@ -533,9 +537,9 @@ def _make_segment_via_key(child) -> str | None:
         layers_node = child.get("layers")
         if at_node is None or size_node is None:
             return None
-        ax = at_node.get_float(0) or 0.0
-        ay = at_node.get_float(1) or 0.0
-        sz = size_node.get_float(0) or 0.0
+        ax = round(at_node.get_float(0) or 0.0, precision)
+        ay = round(at_node.get_float(1) or 0.0, precision)
+        sz = round(size_node.get_float(0) or 0.0, precision)
         layer_strs = []
         if layers_node is not None:
             for c in layers_node.children:
@@ -749,6 +753,113 @@ def _snapshot_element_nets(pcb_path: Path) -> dict[str, list]:
     return snapshot
 
 
+def _fallback_restore_by_proximity(output_sexp, element_nets: dict[str, list]) -> bool:
+    """Second-pass restore for segments/vias still carrying ``(net "")``.
+
+    After the primary geometry-key restore, some elements may remain
+    unmatched due to coordinate drift exceeding the rounding tolerance or
+    new geometry created by kicad-cli during zone fill.
+
+    This function builds per-layer spatial indices from the *element_nets*
+    snapshot and assigns each remaining ``(net "")`` element the net of the
+    nearest snapshotted element on the same layer, provided the distance is
+    within a generous tolerance (0.01 mm -- well above floating-point drift
+    but small enough to avoid cross-net mismatches on dense boards).
+
+    Returns True if any element was modified.
+    """
+    import math
+
+    PROXIMITY_THRESHOLD = 0.01  # mm
+
+    # Parse snapshot keys into spatial buckets by (element_type, layer_key).
+    # segment keys: "seg:sx,sy:ex,ey:layer"
+    # via keys:     "via:ax,ay:sz:layer1,layer2,..."
+    spatial_index: dict[tuple[str, str], list[tuple[float, float, float, float, list]]] = {}
+    for key, net_nodes in element_nets.items():
+        parts = key.split(":")
+        if len(parts) < 4:
+            continue
+        etype = parts[0]
+        if etype == "seg":
+            try:
+                sx, sy = float(parts[1].split(",")[0]), float(parts[1].split(",")[1])
+                ex, ey = float(parts[2].split(",")[0]), float(parts[2].split(",")[1])
+            except (ValueError, IndexError):
+                continue
+            layer_key = parts[3]
+            bucket = spatial_index.setdefault(("segment", layer_key), [])
+            bucket.append((sx, sy, ex, ey, net_nodes))
+        elif etype == "via":
+            try:
+                ax, ay = float(parts[1].split(",")[0]), float(parts[1].split(",")[1])
+            except (ValueError, IndexError):
+                continue
+            layer_key = parts[3]  # comma-joined layers string
+            bucket = spatial_index.setdefault(("via", layer_key), [])
+            bucket.append((ax, ay, 0.0, 0.0, net_nodes))
+
+    changed = False
+    for child in output_sexp.children:
+        if child.name not in ("segment", "via"):
+            continue
+        current_net = child.get("net")
+        if _has_canonical_net(current_net):
+            continue
+        # This element still has a bad net -- attempt proximity match.
+        if child.name == "segment":
+            start_node = child.get("start")
+            end_node = child.get("end")
+            layer_node = child.get("layer")
+            if start_node is None or end_node is None or layer_node is None:
+                continue
+            sx = start_node.get_float(0) or 0.0
+            sy = start_node.get_float(1) or 0.0
+            ex = end_node.get_float(0) or 0.0
+            ey = end_node.get_float(1) or 0.0
+            layer_key = layer_node.get_string(0) or ""
+            bucket = spatial_index.get(("segment", layer_key), [])
+            best_dist = PROXIMITY_THRESHOLD
+            best_net = None
+            for bsx, bsy, bex, bey, net_nodes in bucket:
+                dist = math.hypot(sx - bsx, sy - bsy) + math.hypot(ex - bex, ey - bey)
+                if dist < best_dist:
+                    best_dist = dist
+                    best_net = net_nodes
+        elif child.name == "via":
+            at_node = child.get("at")
+            if at_node is None:
+                continue
+            ax = at_node.get_float(0) or 0.0
+            ay = at_node.get_float(1) or 0.0
+            # Build the layers string to match the bucket key
+            layers_node = child.get("layers")
+            layer_strs = []
+            if layers_node is not None:
+                for c in layers_node.children:
+                    if c.is_atom and isinstance(c.value, str):
+                        layer_strs.append(c.value)
+            layer_key = ",".join(layer_strs)
+            bucket = spatial_index.get(("via", layer_key), [])
+            best_dist = PROXIMITY_THRESHOLD
+            best_net = None
+            for bax, bay, _, _, net_nodes in bucket:
+                dist = math.hypot(ax - bax, ay - bay)
+                if dist < best_dist:
+                    best_dist = dist
+                    best_net = net_nodes
+        else:
+            continue
+
+        if best_net is not None:
+            if current_net is not None:
+                child.remove(current_net)
+            child.append(best_net[0])
+            changed = True
+
+    return changed
+
+
 def _restore_net_declarations(
     target_pcb: Path,
     net_nodes: list,
@@ -838,6 +949,14 @@ def _restore_net_declarations(
                             child.remove(current_net)
                         child.append(element_nets[geo_key][0])
                         modified = True
+
+        # --- Fallback pass for remaining unmatched (net "") elements ---
+        # After the primary key-based restore, some segments/vias may still
+        # have (net "") due to coordinate drift beyond the rounding threshold
+        # or geometry created by kicad-cli during fill.  Use spatial proximity
+        # to find the nearest snapshotted element on the same layer.
+        if _fallback_restore_by_proximity(output_sexp, element_nets):
+            modified = True
 
     if modified:
         save_pcb(output_sexp, target_pcb)

--- a/tests/test_runner_net_restore.py
+++ b/tests/test_runner_net_restore.py
@@ -386,6 +386,256 @@ class TestRestoreNetDeclarations:
 
 
 # ---------------------------------------------------------------------------
+# _make_segment_via_key coordinate rounding (issue #1822)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeSegmentViaKeyRounding:
+    """Verify coordinate rounding absorbs float drift in key generation."""
+
+    def test_identical_keys_within_rounding_threshold(self):
+        """Coordinates differing by < 0.00005 must produce identical keys.
+
+        With precision=4, round(100.00004, 4) == round(100.0, 4) == 100.0.
+        """
+        from kicad_tools.cli.runner import _make_segment_via_key
+
+        seg_a = SExp.list(
+            "segment",
+            SExp.list("start", 100.0, 200.0),
+            SExp.list("end", 300.0, 400.0),
+            SExp.list("layer", "F.Cu"),
+        )
+        seg_b = SExp.list(
+            "segment",
+            SExp.list("start", 100.00004, 200.0),
+            SExp.list("end", 300.0, 399.99996),
+            SExp.list("layer", "F.Cu"),
+        )
+        key_a = _make_segment_via_key(seg_a)
+        key_b = _make_segment_via_key(seg_b)
+        assert key_a is not None
+        assert key_a == key_b
+
+    def test_distinct_keys_beyond_rounding_threshold(self):
+        """Coordinates differing by > 0.001 must produce distinct keys."""
+        from kicad_tools.cli.runner import _make_segment_via_key
+
+        seg_a = SExp.list(
+            "segment",
+            SExp.list("start", 100.0, 200.0),
+            SExp.list("end", 300.0, 400.0),
+            SExp.list("layer", "F.Cu"),
+        )
+        seg_b = SExp.list(
+            "segment",
+            SExp.list("start", 100.005, 200.0),
+            SExp.list("end", 300.0, 400.0),
+            SExp.list("layer", "F.Cu"),
+        )
+        key_a = _make_segment_via_key(seg_a)
+        key_b = _make_segment_via_key(seg_b)
+        assert key_a is not None
+        assert key_b is not None
+        assert key_a != key_b
+
+    def test_via_rounding(self):
+        """Via coordinates must also be rounded for consistent keys."""
+        from kicad_tools.cli.runner import _make_segment_via_key
+
+        via_a = SExp.list(
+            "via",
+            SExp.list("at", 50.0, 75.0),
+            SExp.list("size", 0.8),
+            SExp.list("layers", "F.Cu", "B.Cu"),
+        )
+        via_b = SExp.list(
+            "via",
+            SExp.list("at", 50.00004, 74.99996),
+            SExp.list("size", 0.8),
+            SExp.list("layers", "F.Cu", "B.Cu"),
+        )
+        key_a = _make_segment_via_key(via_a)
+        key_b = _make_segment_via_key(via_b)
+        assert key_a is not None
+        assert key_a == key_b
+
+
+# ---------------------------------------------------------------------------
+# Restore with drifted coordinates (issue #1822)
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreWithDriftedCoordinates:
+    """Verify restore succeeds when kicad-cli drifts coordinates slightly."""
+
+    @staticmethod
+    def _write_pcb(tmp_path: Path, content: str) -> Path:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(content)
+        return pcb
+
+    def test_drifted_segment_restored_by_rounded_key(self, tmp_path):
+        """Segment at (100.0001, 200.0) with (net "") should be restored
+        when snapshot was taken at (100.0, 200.0)."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 5 "VCC")
+  (segment (start 100.0001 200.0) (end 300.0 400.0) (width 0.25) (layer "F.Cu") (net "") (uuid "drift1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(5, "VCC")]
+        # Snapshot taken at exact coordinates (before kicad-cli drift)
+        element_nets = {
+            "seg:100.0,200.0:300.0,400.0:F.Cu": [_net_node(5)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 5, f"Expected (net 5) but got {net_node}"
+                break
+        else:
+            pytest.fail("No segment found in restored PCB")
+
+    def test_drifted_via_restored_by_rounded_key(self, tmp_path):
+        """Via at (50.00005, 75.0) with (net "") should match snapshot at (50.0, 75.0)."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 3 "GND")
+  (via (at 50.00005 75.0) (size 0.8) (drill 0.4) (layers "F.Cu" "B.Cu") (net "") (uuid "vdrift"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(3, "GND")]
+        element_nets = {
+            "via:50.0,75.0:0.8:F.Cu,B.Cu": [_net_node(3)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "via":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 3, f"Expected (net 3) but got {net_node}"
+                break
+        else:
+            pytest.fail("No via found in restored PCB")
+
+
+# ---------------------------------------------------------------------------
+# Fallback proximity restore for wholly unmatched elements (issue #1822)
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackProximityRestore:
+    """Verify the fallback mechanism for segments/vias with no snapshot match."""
+
+    @staticmethod
+    def _write_pcb(tmp_path: Path, content: str) -> Path:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(content)
+        return pcb
+
+    def test_unmatched_segment_restored_by_proximity(self, tmp_path):
+        """A segment with (net "") and no exact key match should be restored
+        via spatial proximity to a nearby snapshotted segment on the same layer."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        # Post-fill PCB: segment coordinates drifted beyond rounding tolerance
+        # but within proximity threshold (0.01 mm)
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 7 "MOSI")
+  (segment (start 100.009 200.0) (end 300.0 400.0) (width 0.25) (layer "F.Cu") (net "") (uuid "prox1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(7, "MOSI")]
+        # Snapshot at exact coords -- key won't match due to rounding difference
+        # (100.009 rounds to 100.009, not 100.0)
+        element_nets = {
+            "seg:100.0,200.0:300.0,400.0:F.Cu": [_net_node(7)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 7, f"Expected (net 7) but got {net_node}"
+                break
+        else:
+            pytest.fail("No segment found in restored PCB")
+
+    def test_unmatched_segment_not_restored_beyond_threshold(self, tmp_path):
+        """A segment too far from any snapshot should NOT be proximity-matched."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        # Segment at (200, 200) -- far from snapshot at (100, 200)
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 7 "MOSI")
+  (segment (start 200 200) (end 300 400) (width 0.25) (layer "F.Cu") (net "") (uuid "far1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(7, "MOSI")]
+        element_nets = {
+            "seg:100.0,200.0:300.0,400.0:F.Cu": [_net_node(7)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                # Should still be empty -- too far for proximity match
+                if net_node is not None:
+                    net_str = net_node.get_string(0)
+                    if net_str == "":
+                        pass  # Expected: still empty
+                    else:
+                        net_num = net_node.get_int(0)
+                        assert net_num != 7, "Segment too far should not be proximity-matched"
+                break
+
+
+# ---------------------------------------------------------------------------
 # _run_fill_zones_native snapshot/restore
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Zone refill corrupted 22+ segment nets to empty `(net "")` because `_make_segment_via_key()` used raw float formatting with no rounding, causing coordinate drift from kicad-cli to produce mismatched snapshot keys. This PR adds coordinate rounding and a spatial proximity fallback to ensure all segments/vias are restored.

## Changes
- Round all coordinates to 4 decimal places in `_make_segment_via_key()` so minor float drift (e.g., `100.0` vs `100.00004`) produces identical keys
- Add `_fallback_restore_by_proximity()` second-pass function that matches remaining `(net "")` elements to the nearest snapshotted element on the same layer within 0.01mm
- Add 7 new tests: key rounding tolerance, key distinctness for distant segments, via rounding, drifted-coordinate restore for segments and vias, proximity fallback match, and proximity threshold rejection

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_make_segment_via_key()` rounds coordinates to 4 decimal places | Done | Coordinates wrapped in `round(..., precision)` with default precision=4 |
| Fallback mechanism for unmatched `(net "")` elements | Done | `_fallback_restore_by_proximity()` uses spatial proximity on same-layer elements |
| No regression in existing 28 tests | Done | All 28 original tests pass |
| New tests for coordinate drift tolerance | Done | 7 new tests covering rounding, drift restore, and proximity fallback |

## Test Plan
- All 35 tests pass: `uv run python -m pytest tests/test_runner_net_restore.py -v --no-cov` (28 existing + 7 new)
- Key rounding tests verify identical keys for sub-threshold drift and distinct keys for large differences
- Drifted coordinate tests verify end-to-end restore through `_restore_net_declarations`
- Proximity fallback tests verify matching within threshold and rejection beyond threshold

Closes #1822