### PR TITLE
feat(pipeline): add --no-cache and --clear-cache flags for route step

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -123,6 +123,8 @@ class PipelineContext:
     is_project: bool = False
     commit: bool = False
     best_effort: bool = False
+    no_cache: bool = False
+    clear_cache: bool = False
     max_displacement: float = 2.0
     erc_error_count: int = 0
     _check_data: dict | None = None  # cached kct check --format json result
@@ -544,6 +546,11 @@ def _run_step_route(ctx: PipelineContext, console: Console) -> PipelineResult:
     route_layers = ctx.layers or "auto"
 
     if ctx.dry_run:
+        cache_flags = ""
+        if ctx.no_cache:
+            cache_flags += " --no-cache"
+        if ctx.clear_cache:
+            cache_flags += " --clear-cache"
         if is_routed:
             return PipelineResult(
                 step=PipelineStep.ROUTE,
@@ -551,6 +558,7 @@ def _run_step_route(ctx: PipelineContext, console: Console) -> PipelineResult:
                 message=(
                     f"[dry-run] Would re-route (--force): {ctx.pcb_file.name} "
                     f"--grid auto --manufacturer {ctx.mfr} --layers {route_layers} --auto-fix"
+                    f"{cache_flags}"
                 ),
             )
         return PipelineResult(
@@ -559,6 +567,7 @@ def _run_step_route(ctx: PipelineContext, console: Console) -> PipelineResult:
             message=(
                 f"[dry-run] Would run: kct route {ctx.pcb_file.name} "
                 f"--grid auto --manufacturer {ctx.mfr} --layers {route_layers} --auto-fix"
+                f"{cache_flags}"
             ),
         )
 
@@ -584,6 +593,10 @@ def _run_step_route(ctx: PipelineContext, console: Console) -> PipelineResult:
 
     if ctx.quiet:
         cmd.append("--quiet")
+    if ctx.no_cache:
+        cmd.append("--no-cache")
+    if ctx.clear_cache:
+        cmd.append("--clear-cache")
 
     success, message = _run_subprocess_step(cmd, ctx.pcb_file.parent, ctx.verbose)
 
@@ -1562,6 +1575,8 @@ Examples:
     kct pipeline board.kicad_pcb --commit              # Commit changes after success
     kct pipeline board.kicad_pcb --mfr jlcpcb --commit # Pipeline + auto-commit
     kct pipeline board.kicad_pcb --best-effort         # Continue past routing failures
+    kct pipeline board.kicad_pcb --no-cache            # Bypass routing cache
+    kct pipeline board.kicad_pcb --clear-cache         # Clear cache before routing
         """,
     )
 
@@ -1633,6 +1648,18 @@ Examples:
             "Continue past routing failures to zone fill, DRC, audit, report, and export. "
             "Exit code 2 indicates partial success (routing incomplete but downstream steps ran)"
         ),
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        default=False,
+        help="Bypass routing cache (force fresh routing in the route step)",
+    )
+    parser.add_argument(
+        "--clear-cache",
+        action="store_true",
+        default=False,
+        help="Clear routing cache before the route step runs",
     )
     parser.add_argument(
         "--max-displacement",
@@ -1731,6 +1758,8 @@ Examples:
         is_project=is_project,
         commit=args.commit,
         best_effort=args.best_effort,
+        no_cache=args.no_cache,
+        clear_cache=args.clear_cache,
         max_displacement=args.max_displacement,
     )
 

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -4112,3 +4112,102 @@ class TestStitchStep:
         result = _run_step_stitch(ctx, console)
         assert result.success is True
         assert result.skipped is True
+
+
+class TestCacheFlagForwarding:
+    """Tests for --no-cache and --clear-cache flag forwarding to route step."""
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_no_cache_forwarded_to_route(self, mock_run, unrouted_pcb: Path):
+        """--no-cache flag is forwarded to the route subprocess command."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        ctx = PipelineContext(pcb_file=unrouted_pcb, quiet=True, no_cache=True)
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert len(results) == 1
+        assert results[0].success is True
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "--no-cache" in cmd_args
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_clear_cache_forwarded_to_route(self, mock_run, unrouted_pcb: Path):
+        """--clear-cache flag is forwarded to the route subprocess command."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        ctx = PipelineContext(pcb_file=unrouted_pcb, quiet=True, clear_cache=True)
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert len(results) == 1
+        assert results[0].success is True
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "--clear-cache" in cmd_args
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_both_cache_flags_forwarded(self, mock_run, unrouted_pcb: Path):
+        """Both --no-cache and --clear-cache flags forwarded together."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        ctx = PipelineContext(
+            pcb_file=unrouted_pcb, quiet=True, no_cache=True, clear_cache=True
+        )
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert len(results) == 1
+        assert results[0].success is True
+        mock_run.assert_called_once()
+        cmd_args = mock_run.call_args[0][0]
+        assert "--no-cache" in cmd_args
+        assert "--clear-cache" in cmd_args
+
+    def test_dry_run_includes_no_cache(self, unrouted_pcb: Path):
+        """--dry-run output includes --no-cache when set."""
+        ctx = PipelineContext(
+            pcb_file=unrouted_pcb, quiet=True, dry_run=True, no_cache=True
+        )
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert "--no-cache" in results[0].message
+
+    def test_dry_run_includes_clear_cache(self, unrouted_pcb: Path):
+        """--dry-run output includes --clear-cache when set."""
+        ctx = PipelineContext(
+            pcb_file=unrouted_pcb, quiet=True, dry_run=True, clear_cache=True
+        )
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert "--clear-cache" in results[0].message
+
+    def test_cache_flags_ignored_when_route_skipped(self, routed_pcb: Path):
+        """Cache flags cause no error when route step is skipped (already routed)."""
+        ctx = PipelineContext(
+            pcb_file=routed_pcb, quiet=True, no_cache=True, clear_cache=True
+        )
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert results[0].skipped is True
+
+    def test_no_cache_cli_flag_parsed(self, unrouted_pcb: Path):
+        """--no-cache is accepted by the CLI argument parser."""
+        result = main(["--no-cache", "--dry-run", "--quiet", str(unrouted_pcb)])
+        assert result == 0
+
+    def test_clear_cache_cli_flag_parsed(self, unrouted_pcb: Path):
+        """--clear-cache is accepted by the CLI argument parser."""
+        result = main(["--clear-cache", "--dry-run", "--quiet", str(unrouted_pcb)])
+        assert result == 0
+
+    def test_both_cache_flags_cli_parsed(self, unrouted_pcb: Path):
+        """Both --no-cache and --clear-cache accepted together via CLI."""
+        result = main(
+            ["--no-cache", "--clear-cache", "--dry-run", "--quiet", str(unrouted_pcb)]
+        )
+        assert result == 0


### PR DESCRIPTION
## Summary
Add `--no-cache` and `--clear-cache` CLI flags to the pipeline command that get forwarded to the route subprocess step, allowing users to control routing cache behavior from the pipeline.

## Changes
- Add `no_cache` and `clear_cache` fields to `PipelineContext` dataclass
- Add `--no-cache` and `--clear-cache` argparse arguments in `main()`
- Wire args into context construction
- Forward flags to subprocess command in `_run_step_route()`
- Include cache flags in dry-run output messages
- Add usage examples in epilog help text

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--no-cache` passes flag to route subprocess | Pass | test_no_cache_forwarded_to_route asserts `--no-cache` in cmd_args |
| `--clear-cache` passes flag to route subprocess | Pass | test_clear_cache_forwarded_to_route asserts `--clear-cache` in cmd_args |
| Both flags can be combined | Pass | test_both_cache_flags_forwarded asserts both present |
| Flags ignored when route step is skipped | Pass | test_cache_flags_ignored_when_route_skipped on routed board |
| `--dry-run` output reflects cache flags | Pass | test_dry_run_includes_no_cache and test_dry_run_includes_clear_cache |
| `kct pipeline --help` documents both flags | Pass | Args added with help text |
| Flags have no effect on non-route steps | Pass | Flags only appended in `_run_step_route()` |

## Test Plan
9 new tests in `TestCacheFlagForwarding` class, all passing:
- Subprocess forwarding for `--no-cache`, `--clear-cache`, and both combined
- Dry-run message includes cache flags
- Flags silently ignored when route is skipped (already routed)
- CLI argument parser accepts each flag and both together

Closes #1824