### PR TITLE
fix(router): relax oscillation detection and add full-reorder escape strategy

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -92,11 +92,27 @@ def detect_oscillation(overflow_history: list[int], window: int = 4) -> bool:
     Detects:
     - A-B-A-B patterns (alternating between two values)
     - Complete stagnation (all same value for window iterations)
+    - Bounded oscillation (only when the window does NOT contain a new
+      global minimum, since a new minimum means the router is still
+      making progress -- Issue #1823)
     """
     if len(overflow_history) < window:
         return False
 
     recent = overflow_history[-window:]
+
+    # Issue #1823: If the recent window contains a new global minimum,
+    # the router is still making progress -- do not declare oscillation.
+    # For example, [21, 21, 8, 21] has overflow 8 as a new best, which
+    # means the router found a better configuration even if it bounced back.
+    best_overall = min(overflow_history)
+    window_min = min(recent)
+    window_has_new_minimum = window_min <= best_overall and window_min < min(
+        overflow_history[:-window]
+    ) if len(overflow_history) > window else False
+
+    if window_has_new_minimum:
+        return False
 
     # Check for exact A-B-A-B repetition pattern
     if window >= 4 and recent[0] == recent[2] and recent[1] == recent[3]:
@@ -175,16 +191,29 @@ def should_terminate_early(
 
     recent = overflow_history[-5:]
 
+    # Issue #1823: Check if the recent window contains a new global minimum.
+    # If so, skip the "no improvement" stagnation check (but still allow
+    # other termination checks like monotonic divergence).
+    best_overall = min(overflow_history)
+    recent_has_new_global_min = False
+    if min(recent) == best_overall and len(overflow_history) > 5:
+        best_before_recent = min(overflow_history[:-5])
+        if min(recent) < best_before_recent:
+            recent_has_new_global_min = True
+
     # No improvement in last 5 iterations.
     # When len(overflow_history) == 5 there is no earlier window; use the
     # first recorded value as baseline instead of float('inf') which would
     # make this check unreachable and mask stale-baseline divergence.
-    if len(overflow_history) > 5:
-        earlier = overflow_history[:-5]
-    else:
-        earlier = overflow_history[:1]
-    if min(recent) >= min(earlier):
-        return True
+    # Issue #1823: Skip this check when recent window found a new global
+    # minimum -- the router is still making progress.
+    if not recent_has_new_global_min:
+        if len(overflow_history) > 5:
+            earlier = overflow_history[:-5]
+        else:
+            earlier = overflow_history[:1]
+        if min(recent) >= min(earlier):
+            return True
 
     # Monotonic divergence: the last N values are strictly increasing and
     # all above the best-seen minimum.  This catches patterns like
@@ -195,7 +224,9 @@ def should_terminate_early(
         return True
 
     # Oscillating with no progress
-    if detect_oscillation(overflow_history, window=4):
+    # Issue #1823: Skip this check when the recent 5-iteration window
+    # contains a new global minimum -- the router recently made progress.
+    if not recent_has_new_global_min and detect_oscillation(overflow_history, window=4):
         # Only terminate if we've tried enough and aren't improving
         if iteration >= min_iterations and min(recent) == min(overflow_history):
             return True
@@ -566,6 +597,7 @@ class NegotiatedRouter:
             self._escape_shuffle_order,
             self._escape_reverse_order,
             self._escape_random_subset,
+            self._escape_full_reorder,
         ]
 
         num_strategies = len(strategies)
@@ -750,4 +782,62 @@ class NegotiatedRouter:
         # Accept escape if overflow improved and at least some nets survived
         # (Issue #762: require rerouted_count > 0 to avoid false success on total loss)
         # (Issue #1638: relaxed from requiring ALL nets to allow partial progress)
+        return rerouted_count > 0 and new_overflow < best_overflow, new_overflow
+
+    def _escape_full_reorder(
+        self,
+        overflow_history: list[int],
+        net_routes: dict[int, list[Route]],
+        routes_list: list[Route],
+        pads_by_net: dict[int, list[Pad]],
+        net_order: list[int],
+        present_cost_factor: float,
+        mark_route_callback: callable,
+    ) -> tuple[bool, int]:
+        """Escape strategy: rip up ALL nets and reroute in alternative order.
+
+        Issue #1823: The existing escape strategies only perturb nets passing
+        through overused cells.  If the root ordering places net A before net B,
+        and A's path blocks B's only viable route without itself being in an
+        overused cell, none of the first three strategies will fix this.
+
+        This strategy rips up every routed net and reroutes them all in a
+        completely different order (reversed net_order).  It is more expensive
+        but can escape ordering-dependent local minima.
+        """
+        all_nets = list(net_routes.keys())
+        if not all_nets:
+            return False, overflow_history[-1] if overflow_history else 0
+
+        # Rip up ALL routed nets
+        self.rip_up_nets(all_nets, net_routes, routes_list)
+
+        # Build alternative order: reverse of the priority net_order,
+        # then append any nets not in net_order.
+        net_set = set(all_nets)
+        ordered = [n for n in reversed(net_order) if n in net_set]
+        remaining = [n for n in all_nets if n not in set(net_order)]
+        random.shuffle(remaining)
+        reorder = ordered + remaining
+
+        # Reroute all nets in the alternative order with boosted cost
+        boosted_cost = present_cost_factor * 1.5
+        rerouted_count = 0
+        for net in reorder:
+            net_pads = pads_by_net.get(net, [])
+            if net_pads and len(net_pads) >= 2:
+                routes = self.route_net_negotiated(
+                    net_pads, boosted_cost, mark_route_callback
+                )
+                if routes:
+                    net_routes[net] = routes
+                    rerouted_count += 1
+                    for route in routes:
+                        self.grid.mark_route_usage(route)
+                        routes_list.append(route)
+
+        new_overflow = self.grid.get_total_overflow()
+        best_overflow = min(overflow_history) if overflow_history else float("inf")
+
+        # Accept if overflow improved and at least some nets survived
         return rerouted_count > 0 and new_overflow < best_overflow, new_overflow

--- a/tests/test_negotiated_adaptive.py
+++ b/tests/test_negotiated_adaptive.py
@@ -88,6 +88,31 @@ class TestDetectOscillation:
         # The function doesn't distinguish - that's handled by the caller
         assert result is True  # Technically stagnation, but caller handles this
 
+    def test_no_oscillation_when_window_has_new_minimum(self):
+        """Issue #1823: Should NOT detect oscillation when window contains new best.
+
+        Pattern [21, 21, 8, 21] has overflow 8 as a new minimum compared to
+        earlier history -- this means the router is making progress even though
+        the values bounce back.
+        """
+        # History: earlier overflows were 21, then window [21, 21, 8, 21]
+        assert detect_oscillation([21, 21, 21, 21, 8, 21], window=4) is False
+
+    def test_oscillation_when_no_new_minimum_in_window(self):
+        """Should still detect oscillation when window has no new minimum.
+
+        Pattern [21, 21, 21, 21] with prior history showing best=8 means the
+        router is stuck and not improving.
+        """
+        assert detect_oscillation([21, 8, 21, 21, 21, 21], window=4) is True
+
+    def test_stagnation_still_detected_with_longer_history(self):
+        """Stagnation at the same value should still be detected.
+
+        [50, 50, 50, 50, 50, 50] -- all same value, no new minimum in window.
+        """
+        assert detect_oscillation([50, 50, 50, 50, 50, 50], window=4) is True
+
 
 class TestShouldTerminateEarly:
     """Tests for should_terminate_early function."""
@@ -176,6 +201,25 @@ class TestShouldTerminateEarly:
         assert should_terminate_early([100, 200, 300], iteration=5, min_iterations=3) is False
         assert should_terminate_early([100, 200, 300, 400], iteration=5, min_iterations=3) is False
 
+    def test_no_termination_when_recent_window_has_new_global_min(self):
+        """Issue #1823: Should NOT terminate when recent window found new best.
+
+        History [21, 21, 21, 21, 21, 8, 21, 21, 21, 21] has min(recent)=8
+        which is a new global minimum compared to earlier [21, 21, 21, 21, 21].
+        The router made real progress recently and should keep going.
+        """
+        history = [21, 21, 21, 21, 21, 8, 21, 21, 21, 21]
+        assert should_terminate_early(history, iteration=10, min_iterations=5) is False
+
+    def test_terminates_when_recent_min_equals_earlier_best(self):
+        """Should still terminate when recent best is not better than earlier best.
+
+        History [8, 21, 21, 21, 21, 21, 8, 21, 21, 21] has min(recent)=8
+        but min(earlier)=8 too, so no new improvement.
+        """
+        history = [8, 21, 21, 21, 21, 21, 8, 21, 21, 21]
+        assert should_terminate_early(history, iteration=10, min_iterations=5) is True
+
 
 class TestIsMonotonicallyDiverging:
     """Tests for _is_monotonically_diverging helper."""
@@ -219,7 +263,7 @@ class TestEscapeStrategyCycling:
     """Tests for escape_local_minimum trying all strategies (Issue #1638)."""
 
     def test_escape_tries_all_strategies_on_failure(self):
-        """escape_local_minimum should cycle through all 3 strategies before giving up."""
+        """escape_local_minimum should cycle through all 4 strategies before giving up."""
         from unittest.mock import MagicMock, patch
 
         from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
@@ -232,6 +276,7 @@ class TestEscapeStrategyCycling:
         neg._escape_shuffle_order = MagicMock(return_value=(False, 10))
         neg._escape_reverse_order = MagicMock(return_value=(False, 10))
         neg._escape_random_subset = MagicMock(return_value=(False, 10))
+        neg._escape_full_reorder = MagicMock(return_value=(False, 10))
 
         success, overflow, tried = neg.escape_local_minimum(
             overflow_history=[10, 10, 10, 10],
@@ -245,10 +290,11 @@ class TestEscapeStrategyCycling:
         )
 
         assert success is False
-        assert tried == 3
+        assert tried == 4
         assert neg._escape_shuffle_order.call_count == 1
         assert neg._escape_reverse_order.call_count == 1
         assert neg._escape_random_subset.call_count == 1
+        assert neg._escape_full_reorder.call_count == 1
 
     def test_escape_stops_on_first_success(self):
         """escape_local_minimum should stop as soon as one strategy succeeds."""
@@ -264,6 +310,7 @@ class TestEscapeStrategyCycling:
         neg._escape_shuffle_order = MagicMock(return_value=(False, 10))
         neg._escape_reverse_order = MagicMock(return_value=(True, 5))
         neg._escape_random_subset = MagicMock(return_value=(False, 10))
+        neg._escape_full_reorder = MagicMock(return_value=(False, 10))
 
         success, overflow, tried = neg.escape_local_minimum(
             overflow_history=[10, 10, 10, 10],
@@ -282,6 +329,7 @@ class TestEscapeStrategyCycling:
         assert neg._escape_shuffle_order.call_count == 1
         assert neg._escape_reverse_order.call_count == 1
         assert neg._escape_random_subset.call_count == 0  # Not tried
+        assert neg._escape_full_reorder.call_count == 0  # Not tried
 
     def test_escape_wraps_around_strategy_index(self):
         """escape_local_minimum should wrap strategy index modulo num strategies."""
@@ -297,8 +345,9 @@ class TestEscapeStrategyCycling:
         neg._escape_shuffle_order = MagicMock(return_value=(False, 10))
         neg._escape_reverse_order = MagicMock(return_value=(False, 10))
         neg._escape_random_subset = MagicMock(return_value=(False, 10))
+        neg._escape_full_reorder = MagicMock(return_value=(False, 10))
 
-        # Start from index 1 (reverse), should try reverse -> random -> shuffle
+        # Start from index 1 (reverse), should try reverse -> random -> full_reorder -> shuffle
         success, overflow, tried = neg.escape_local_minimum(
             overflow_history=[10, 10, 10, 10],
             net_routes={},
@@ -311,11 +360,139 @@ class TestEscapeStrategyCycling:
         )
 
         assert success is False
-        assert tried == 3
-        # All three should be called exactly once
+        assert tried == 4
+        # All four should be called exactly once
         assert neg._escape_shuffle_order.call_count == 1
         assert neg._escape_reverse_order.call_count == 1
         assert neg._escape_random_subset.call_count == 1
+        assert neg._escape_full_reorder.call_count == 1
+
+
+class TestEscapeFullReorder:
+    """Tests for the full-reorder escape strategy (Issue #1823)."""
+
+    def test_full_reorder_rips_up_all_nets(self):
+        """Full reorder should rip up ALL nets, not just conflicting ones."""
+        from unittest.mock import MagicMock, call
+
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        mock_grid = MagicMock()
+        mock_grid.get_total_overflow.return_value = 5
+        mock_router = MagicMock()
+        neg = NegotiatedRouter(mock_grid, mock_router, MagicMock(), {})
+
+        # Set up mock routes for 3 nets
+        mock_route_1 = MagicMock()
+        mock_route_2 = MagicMock()
+        mock_route_3 = MagicMock()
+        net_routes = {1: [mock_route_1], 2: [mock_route_2], 3: [mock_route_3]}
+        routes_list = [mock_route_1, mock_route_2, mock_route_3]
+
+        # Mock rip_up_nets to track what gets ripped
+        ripped_nets = []
+        original_rip_up = neg.rip_up_nets
+
+        def track_rip_up(nets, nr, rl):
+            ripped_nets.extend(nets)
+            original_rip_up(nets, nr, rl)
+
+        neg.rip_up_nets = track_rip_up
+
+        # Mock route_net_negotiated to return a route
+        mock_new_route = MagicMock()
+        neg.route_net_negotiated = MagicMock(return_value=[mock_new_route])
+
+        pads_by_net = {
+            1: [MagicMock(), MagicMock()],
+            2: [MagicMock(), MagicMock()],
+            3: [MagicMock(), MagicMock()],
+        }
+
+        success, new_overflow = neg._escape_full_reorder(
+            overflow_history=[10, 10, 10, 10],
+            net_routes=net_routes,
+            routes_list=routes_list,
+            pads_by_net=pads_by_net,
+            net_order=[1, 2, 3],
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+        )
+
+        # All 3 nets should have been ripped up
+        assert sorted(ripped_nets) == [1, 2, 3]
+        # All 3 nets should have been rerouted
+        assert neg.route_net_negotiated.call_count == 3
+
+    def test_full_reorder_reverses_net_order(self):
+        """Full reorder should route nets in reversed priority order."""
+        from unittest.mock import MagicMock, call
+
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        mock_grid = MagicMock()
+        mock_grid.get_total_overflow.return_value = 5
+        mock_router = MagicMock()
+        neg = NegotiatedRouter(mock_grid, mock_router, MagicMock(), {})
+
+        net_routes = {1: [MagicMock()], 2: [MagicMock()], 3: [MagicMock()]}
+        routes_list = list(net_routes[1] + net_routes[2] + net_routes[3])
+        neg.rip_up_nets = MagicMock()  # Don't actually rip up
+
+        # Track routing order
+        route_order = []
+        mock_route = MagicMock()
+
+        def track_route(pads, cost, callback, **kwargs):
+            # Identify net by matching pads object identity
+            for net_id, net_pads in pads_by_net.items():
+                if pads is net_pads:
+                    route_order.append(net_id)
+                    break
+            return [mock_route]
+
+        neg.route_net_negotiated = track_route
+
+        pads_by_net = {
+            1: [MagicMock(), MagicMock()],
+            2: [MagicMock(), MagicMock()],
+            3: [MagicMock(), MagicMock()],
+        }
+
+        neg._escape_full_reorder(
+            overflow_history=[10, 10, 10, 10],
+            net_routes=net_routes,
+            routes_list=routes_list,
+            pads_by_net=pads_by_net,
+            net_order=[1, 2, 3],
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+        )
+
+        # Should route in reversed order: 3, 2, 1
+        assert route_order == [3, 2, 1]
+
+    def test_full_reorder_returns_false_on_empty_nets(self):
+        """Full reorder should return False when no nets are routed."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        mock_grid = MagicMock()
+        neg = NegotiatedRouter(mock_grid, MagicMock(), MagicMock(), {})
+
+        success, overflow = neg._escape_full_reorder(
+            overflow_history=[10],
+            net_routes={},
+            routes_list=[],
+            pads_by_net={},
+            net_order=[],
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+        )
+
+        assert success is False
+        assert overflow == 10
 
 
 class TestCalculatePresentCost:


### PR DESCRIPTION
## Summary
The negotiated router was terminating prematurely on dense boards (e.g., chorus-test-revA routing only 8/16 nets) due to over-aggressive oscillation detection that triggered on patterns showing genuine progress, and escape strategies that only perturbed conflicting nets rather than exploring completely different orderings.

## Changes
- Relaxed `detect_oscillation()` to skip oscillation declaration when the recent window contains a new global minimum (e.g., [21, 21, 8, 21] where 8 is progress)
- Relaxed `should_terminate_early()` to skip stagnation and oscillation termination checks when the recent 5-iteration window found a new global best, while preserving monotonic divergence detection
- Added `_escape_full_reorder()` as a 4th escape strategy that rips up ALL routed nets and reroutes in reversed priority order, escaping ordering-dependent local minima

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Oscillation detection does not trigger on patterns with new minimum in window | Done | Test `test_no_oscillation_when_window_has_new_minimum` passes with [21,21,8,21] |
| Genuine oscillation/stagnation still detected | Done | Tests for stagnation [50,50,50,50,50,50] and bounded oscillation without progress pass |
| Early termination skipped when recent window has new global min | Done | Test `test_no_termination_when_recent_window_has_new_global_min` passes |
| Escape strategies include full-reorder option | Done | `_escape_full_reorder` added as 4th strategy, rips up all nets and reroutes in reversed order |
| Existing tests still pass | Done | All 45 tests in test_negotiated_adaptive.py pass |
| No regression in divergence detection (issue #1266) | Done | `test_terminates_on_diverging_overflow_from_issue_1266` still passes |

## Test Plan
- `python3 -m pytest tests/test_negotiated_adaptive.py -v` -- 45/45 tests pass
- Added 7 new tests covering oscillation relaxation, early termination relaxation, and full-reorder escape strategy behavior

Closes #1823