### PR TITLE
feat(router): use fine-zone resolution for sub-grid escape routing

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2730,6 +2730,18 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error loading PCB: {e}", file=sys.stderr)
         return 1
 
+    # Pass fine zones from multi-resolution plan to the router (Issue #1828).
+    # This enables SubGridRouter to use fine-grid resolution for escape
+    # routing of pads within dense IC packages (e.g. SSOP at 0.05mm)
+    # instead of the coarse global grid (e.g. 0.17mm).
+    if multi_res_plan is not None and multi_res_plan.is_multi_resolution:
+        router.fine_zones = list(multi_res_plan.fine_zones)
+        if not quiet:
+            flush_print(
+                f"  Fine zones: {len(router.fine_zones)} "
+                f"(sub-grid escape routing enabled)"
+            )
+
     # Set up Ctrl+C handling to save partial results
     _interrupt_state["router"] = router
     _interrupt_state["output_path"] = output_path

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from kicad_tools.physics import Stackup, TransmissionLine
     from kicad_tools.progress import ProgressCallback
 
+    from .io import FineZone
     from .pathfinder import Router
 
 from kicad_tools.cli.progress import flush_print
@@ -355,6 +356,12 @@ class Autorouter:
         self._diffpair_router: DiffPairRouter | None = None
         self._escape_router: EscapeRouter | None = None
         self._subgrid_router: SubGridRouter | None = None
+
+        # Fine zones for multi-resolution escape routing (Issue #1828)
+        # Set externally (e.g., from CLI's MultiResolutionGridPlan) before
+        # routing so the SubGridRouter uses fine grid resolution for pads
+        # within dense IC packages.
+        self.fine_zones: list[FineZone] = []
 
         # Length constraint tracking (Issue #630)
         self._length_tracker: LengthTracker = LengthTracker()
@@ -4237,9 +4244,18 @@ class Autorouter:
 
     @property
     def _subgrid(self) -> SubGridRouter:
-        """Lazy-initialize sub-grid router."""
+        """Lazy-initialize sub-grid router.
+
+        Passes any configured fine zones (Issue #1828) so that escape
+        routing uses fine-grid resolution for pads within dense IC packages
+        instead of the coarse global grid.
+        """
         if self._subgrid_router is None:
-            self._subgrid_router = SubGridRouter(self.grid, self.rules)
+            self._subgrid_router = SubGridRouter(
+                self.grid,
+                self.rules,
+                fine_zones=self.fine_zones if self.fine_zones else None,
+            )
         return self._subgrid_router
 
     def prepare_subgrid_escapes(self) -> SubGridResult:

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -483,6 +483,18 @@ class FineZone:
         rows = int(self.height / self.resolution) + 1
         return cols * rows
 
+    def contains(self, x: float, y: float) -> bool:
+        """Check if a point (x, y) falls within this fine zone.
+
+        Args:
+            x: X coordinate in mm (world units)
+            y: Y coordinate in mm (world units)
+
+        Returns:
+            True if the point is inside the zone bounding box.
+        """
+        return self.x_min <= x <= self.x_max and self.y_min <= y <= self.y_max
+
 
 @dataclass
 class MultiResolutionGridPlan:

--- a/src/kicad_tools/router/subgrid.py
+++ b/src/kicad_tools/router/subgrid.py
@@ -41,6 +41,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .grid import RoutingGrid
+    from .io import FineZone
     from .rules import DesignRules
 
 from .layers import Layer
@@ -226,6 +227,7 @@ class SubGridRouter:
         grid_tolerance: float | None = None,
         escape_search_radius: int | None = None,
         clearance_weight: float = 2.5,
+        fine_zones: list[FineZone] | None = None,
     ):
         self.grid = grid
         self.rules = rules
@@ -239,6 +241,7 @@ class SubGridRouter:
             min_search_mm = 0.3  # minimum physical search distance
             self.escape_search_radius = max(3, math.ceil(min_search_mm / grid.resolution))
         self.clearance_weight = clearance_weight
+        self.fine_zones: list[FineZone] = fine_zones or []
 
     def analyze_pads(
         self,
@@ -499,6 +502,132 @@ class SubGridRouter:
                 min_dist = dist
         return min_dist
 
+    def _get_pad_fine_resolution(self, pad: Pad) -> float | None:
+        """Return the fine-zone resolution for a pad, or None if not in a fine zone.
+
+        When a pad falls inside one or more fine zones, the finest (smallest)
+        resolution is returned so that escape candidates are generated on the
+        densest applicable grid.
+
+        Args:
+            pad: The pad to check.
+
+        Returns:
+            Fine resolution in mm, or None if the pad is outside all fine zones.
+        """
+        best: float | None = None
+        for zone in self.fine_zones:
+            if zone.contains(pad.x, pad.y):
+                if best is None or zone.resolution < best:
+                    best = zone.resolution
+        return best
+
+    def _generate_fine_grid_candidates(
+        self,
+        sgp: SubGridPad,
+        fine_resolution: float,
+    ) -> list[tuple[float, int, int, float, float]]:
+        """Generate escape candidates on a fine grid, bridging to the coarse grid.
+
+        For pads inside a fine zone, this generates candidate escape points on
+        the fine grid (``fine_resolution`` spacing) within the search radius,
+        then maps each fine-grid candidate to the nearest coarse-grid cell.
+        This ensures the escape segment terminates at a point the main A*
+        router can reach on the coarse grid.
+
+        Args:
+            sgp: The off-grid pad to generate candidates for.
+            fine_resolution: Fine grid resolution in mm.
+
+        Returns:
+            List of ``(score, gx, gy, snap_x, snap_y)`` tuples where
+            ``(gx, gy)`` is the coarse grid cell and ``(snap_x, snap_y)``
+            is the fine-grid world point used as the escape endpoint.
+        """
+        pad = sgp.pad
+
+        # Physical search distance: use the same minimum as the coarse search
+        # but expressed in fine-grid cells.
+        min_search_mm = 0.3
+        fine_radius = max(3, math.ceil(min_search_mm / fine_resolution))
+
+        # The fine grid is centred on the pad's nearest coarse-grid point
+        # (sgp.snap_x, sgp.snap_y) and extends ``fine_radius`` fine cells
+        # in each direction.
+        candidates: list[tuple[float, int, int, float, float]] = []
+
+        for dy in range(-fine_radius, fine_radius + 1):
+            for dx in range(-fine_radius, fine_radius + 1):
+                # Fine-grid candidate in world coordinates
+                fx = sgp.snap_x + dx * fine_resolution
+                fy = sgp.snap_y + dy * fine_resolution
+
+                # Distance from pad center to this fine-grid point
+                dist = math.sqrt((pad.x - fx) ** 2 + (pad.y - fy) ** 2)
+
+                # Map the fine candidate back to the nearest coarse grid cell
+                # so the main router can connect to it.
+                gx, gy = self.grid.world_to_grid(fx, fy)
+
+                if not (0 <= gx < self.grid.cols and 0 <= gy < self.grid.rows):
+                    continue
+
+                # The escape segment terminates at the fine-grid point (fx, fy),
+                # but the coarse grid cell (gx, gy) is what gets unblocked for
+                # the A* router.  Check accessibility on the coarse grid.
+                if pad.through_hole:
+                    check_layers = list(range(self.grid.num_layers))
+                else:
+                    check_layers = [self.grid.layer_to_index(pad.layer.value)]
+
+                accessible = False
+                for layer_idx in check_layers:
+                    cell = self.grid.grid[layer_idx][gy][gx]
+                    if not cell.blocked:
+                        accessible = True
+                        break
+                    elif not cell.pad_blocked:
+                        accessible = True
+                        break
+                if not accessible:
+                    continue
+
+                # Score: distance + escape direction bonus (same logic as coarse)
+                score = dist
+
+                if sgp.escape_direction != (0.0, 0.0):
+                    ex, ey = sgp.escape_direction
+                    cdx = fx - pad.x
+                    cdy = fy - pad.y
+                    cdist = math.sqrt(cdx * cdx + cdy * cdy)
+                    if cdist > 0.001:
+                        dot = (cdx / cdist) * ex + (cdy / cdist) * ey
+                        score -= dot * fine_resolution * 0.5
+
+                # Penalty for being too far (use fine resolution for threshold)
+                if dist > fine_resolution * fine_radius:
+                    score += dist * 2
+
+                # Clearance-aware scoring
+                if self.clearance_weight > 0:
+                    required_clearance = self.rules.trace_clearance
+                    neighbor_clearance = self._min_clearance_to_neighbors(
+                        fx, fy,
+                        self.rules.trace_width / 2 if self.rules.min_trace_width is None
+                        else self.rules.min_trace_width / 2,
+                        pad.net, check_layers[0],
+                    )
+                    threshold = required_clearance * 2
+                    if neighbor_clearance < threshold:
+                        clearance_penalty = (
+                            (threshold - neighbor_clearance) * self.clearance_weight
+                        )
+                        score += clearance_penalty
+
+                candidates.append((score, gx, gy, fx, fy))
+
+        return candidates
+
     def _find_escape_for_pad(self, sgp: SubGridPad) -> SubGridEscape | None:
         """Find the best escape point for a single off-grid pad.
 
@@ -628,8 +757,42 @@ class SubGridRouter:
 
                 candidates.append((score, gx, gy, snap_x, snap_y))
 
+        # Issue #1828: When the pad falls within a fine zone, generate
+        # additional candidates on the fine grid.  Fine-grid candidates
+        # produce shorter escape segments that better match dense IC pin
+        # spacing (e.g. 0.05mm vs 0.17mm coarse).  Each fine-grid candidate
+        # is mapped back to the nearest coarse grid cell so the main A*
+        # router can connect to it.
+        fine_res = self._get_pad_fine_resolution(pad)
+        if fine_res is not None and fine_res < self.grid.resolution:
+            fine_candidates = self._generate_fine_grid_candidates(sgp, fine_res)
+            candidates.extend(fine_candidates)
+            logger.debug(
+                "Fine-zone escape for %s.%s: %d fine candidates + %d coarse candidates "
+                "(fine_res=%.4fmm)",
+                pad.ref, pad.pin,
+                len(fine_candidates),
+                len(candidates) - len(fine_candidates),
+                fine_res,
+            )
+
         if not candidates:
             return None
+
+        # Deduplicate candidates that share the same coarse grid cell.
+        # When fine-grid candidates map to the same (gx, gy) as a coarse
+        # candidate, keep only the one with the best (lowest) score.
+        # However, different snap points for the same grid cell ARE useful
+        # if they produce different escape segment geometry, so we deduplicate
+        # by the full (gx, gy, snap_x_rounded, snap_y_rounded) key.
+        seen: dict[tuple[int, int, int, int], tuple[float, int, int, float, float]] = {}
+        for cand in candidates:
+            score, gx, gy, sx, sy = cand
+            # Round snap points to fine-grid precision to merge near-duplicates
+            key = (gx, gy, round(sx * 10000), round(sy * 10000))
+            if key not in seen or score < seen[key][0]:
+                seen[key] = cand
+        candidates = list(seen.values())
 
         # Sort candidates by score (lowest = best)
         candidates.sort(key=lambda c: c[0])

--- a/tests/test_subgrid.py
+++ b/tests/test_subgrid.py
@@ -1421,3 +1421,264 @@ class TestFineGridClearanceZoneUnblocking:
                 f"{escape.pad.net}) violates clearance={clearance:.4f}mm "
                 f"at {violation_loc}"
             )
+
+
+# =========================================================================
+# Fine-zone-aware escape routing tests (Issue #1828)
+# =========================================================================
+
+
+class TestFineZoneContains:
+    """Tests for FineZone.contains() method."""
+
+    def test_point_inside_zone(self):
+        from kicad_tools.router.io import FineZone
+
+        zone = FineZone(ref="U1", x_min=5.0, y_min=5.0, x_max=10.0, y_max=10.0, resolution=0.05)
+        assert zone.contains(7.0, 7.0) is True
+
+    def test_point_outside_zone(self):
+        from kicad_tools.router.io import FineZone
+
+        zone = FineZone(ref="U1", x_min=5.0, y_min=5.0, x_max=10.0, y_max=10.0, resolution=0.05)
+        assert zone.contains(3.0, 7.0) is False
+
+    def test_point_on_boundary(self):
+        from kicad_tools.router.io import FineZone
+
+        zone = FineZone(ref="U1", x_min=5.0, y_min=5.0, x_max=10.0, y_max=10.0, resolution=0.05)
+        assert zone.contains(5.0, 5.0) is True
+        assert zone.contains(10.0, 10.0) is True
+
+
+class TestFineZoneAwareEscape:
+    """Tests for SubGridRouter using fine zones for escape routing (Issue #1828)."""
+
+    def test_fine_zones_stored_on_subgrid_router(self):
+        """SubGridRouter stores fine_zones when provided."""
+        from kicad_tools.router.io import FineZone
+
+        grid, rules = make_grid_and_rules(resolution=0.17)
+        zone = FineZone(ref="U1", x_min=5.0, y_min=5.0, x_max=15.0, y_max=15.0, resolution=0.05)
+        subgrid = SubGridRouter(grid, rules, fine_zones=[zone])
+        assert len(subgrid.fine_zones) == 1
+        assert subgrid.fine_zones[0].resolution == 0.05
+
+    def test_no_fine_zones_default(self):
+        """SubGridRouter defaults to empty fine_zones list."""
+        grid, rules = make_grid_and_rules(resolution=0.17)
+        subgrid = SubGridRouter(grid, rules)
+        assert subgrid.fine_zones == []
+
+    def test_get_pad_fine_resolution_inside_zone(self):
+        """_get_pad_fine_resolution returns zone resolution for pad inside zone."""
+        from kicad_tools.router.io import FineZone
+
+        grid, rules = make_grid_and_rules(resolution=0.17)
+        zone = FineZone(ref="U1", x_min=5.0, y_min=5.0, x_max=15.0, y_max=15.0, resolution=0.05)
+        subgrid = SubGridRouter(grid, rules, fine_zones=[zone])
+
+        pad = make_pad(x=10.0, y=10.0, net=1, ref="U1", pin="1")
+        assert subgrid._get_pad_fine_resolution(pad) == 0.05
+
+    def test_get_pad_fine_resolution_outside_zone(self):
+        """_get_pad_fine_resolution returns None for pad outside all zones."""
+        from kicad_tools.router.io import FineZone
+
+        grid, rules = make_grid_and_rules(resolution=0.17)
+        zone = FineZone(ref="U1", x_min=5.0, y_min=5.0, x_max=15.0, y_max=15.0, resolution=0.05)
+        subgrid = SubGridRouter(grid, rules, fine_zones=[zone])
+
+        pad = make_pad(x=2.0, y=2.0, net=1, ref="R1", pin="1")
+        assert subgrid._get_pad_fine_resolution(pad) is None
+
+    def test_get_pad_fine_resolution_overlapping_zones_uses_finest(self):
+        """When pad is in multiple zones, the finest resolution is returned."""
+        from kicad_tools.router.io import FineZone
+
+        grid, rules = make_grid_and_rules(resolution=0.17)
+        zone1 = FineZone(ref="U1", x_min=5.0, y_min=5.0, x_max=15.0, y_max=15.0, resolution=0.05)
+        zone2 = FineZone(ref="U2", x_min=8.0, y_min=8.0, x_max=18.0, y_max=18.0, resolution=0.025)
+        subgrid = SubGridRouter(grid, rules, fine_zones=[zone1, zone2])
+
+        # Pad at (10, 10) is inside both zones
+        pad = make_pad(x=10.0, y=10.0, net=1, ref="U1", pin="1")
+        assert subgrid._get_pad_fine_resolution(pad) == 0.025
+
+    def test_fine_zone_escape_produces_shorter_segments(self):
+        """Pads in a fine zone should get escape segments at least as short as coarse."""
+        from kicad_tools.router.io import FineZone
+
+        # Coarse grid at 0.17mm
+        grid, rules = make_grid_and_rules(
+            width=20.0, height=20.0, resolution=0.17,
+            trace_width=0.15, trace_clearance=0.1,
+        )
+
+        # Place a pad at an off-grid position (offset > resolution/4 = 0.0425mm)
+        pad_x, pad_y = 10.075, 10.075  # off-grid for 0.17mm
+        pad = make_pad(x=pad_x, y=pad_y, net=1, ref="U1", pin="1")
+        grid.add_pad(pad)
+
+        # Fine zone covering the pad area
+        zone = FineZone(
+            ref="U1", x_min=9.0, y_min=9.0, x_max=11.0, y_max=11.0,
+            resolution=0.05,
+        )
+
+        # Route WITHOUT fine zone
+        subgrid_coarse = SubGridRouter(grid, rules)
+        analysis_coarse = subgrid_coarse.analyze_pads([pad])
+        result_coarse = subgrid_coarse.generate_escape_segments(analysis_coarse)
+
+        # Route WITH fine zone
+        subgrid_fine = SubGridRouter(grid, rules, fine_zones=[zone])
+        analysis_fine = subgrid_fine.analyze_pads([pad])
+        result_fine = subgrid_fine.generate_escape_segments(analysis_fine)
+
+        # Both should produce escape segments
+        assert result_coarse.success_count >= 1, "Coarse escape should succeed"
+        assert result_fine.success_count >= 1, "Fine-zone escape should succeed"
+
+        # Fine-zone escape segment should be no longer than coarse
+        # (fine grid candidates are closer to the pad)
+        coarse_seg = result_coarse.escapes[0].segment
+        fine_seg = result_fine.escapes[0].segment
+
+        coarse_len = math.sqrt(
+            (coarse_seg.x2 - coarse_seg.x1) ** 2 + (coarse_seg.y2 - coarse_seg.y1) ** 2
+        )
+        fine_len = math.sqrt(
+            (fine_seg.x2 - fine_seg.x1) ** 2 + (fine_seg.y2 - fine_seg.y1) ** 2
+        )
+
+        assert fine_len <= coarse_len + 0.001, (
+            f"Fine escape segment ({fine_len:.4f}mm) should be no longer than "
+            f"coarse ({coarse_len:.4f}mm)"
+        )
+
+    def test_fine_zone_escape_grid_point_is_coarse(self):
+        """Escape grid_point must be a valid coarse grid cell."""
+        from kicad_tools.router.io import FineZone
+
+        grid, rules = make_grid_and_rules(
+            width=20.0, height=20.0, resolution=0.17,
+            trace_width=0.15, trace_clearance=0.1,
+        )
+
+        pad = make_pad(x=10.075, y=10.075, net=1, ref="U1", pin="1")
+        grid.add_pad(pad)
+
+        zone = FineZone(
+            ref="U1", x_min=9.0, y_min=9.0, x_max=11.0, y_max=11.0,
+            resolution=0.05,
+        )
+
+        subgrid = SubGridRouter(grid, rules, fine_zones=[zone])
+        analysis = subgrid.analyze_pads([pad])
+        result = subgrid.generate_escape_segments(analysis)
+
+        assert result.success_count >= 1
+        escape = result.escapes[0]
+        gx, gy = escape.grid_point
+
+        # The grid point must be within the coarse grid bounds
+        assert 0 <= gx < grid.cols, f"gx={gx} out of bounds (cols={grid.cols})"
+        assert 0 <= gy < grid.rows, f"gy={gy} out of bounds (rows={grid.rows})"
+
+    def test_pads_outside_fine_zone_use_coarse_grid(self):
+        """Pads outside any fine zone should produce identical results."""
+        from kicad_tools.router.io import FineZone
+
+        grid, rules = make_grid_and_rules(
+            width=20.0, height=20.0, resolution=0.17,
+            trace_width=0.15, trace_clearance=0.1,
+        )
+
+        # Pad well outside the fine zone (offset > resolution/4 = 0.0425mm)
+        pad = make_pad(x=2.075, y=2.075, net=1, ref="R1", pin="1")
+        grid.add_pad(pad)
+
+        zone = FineZone(
+            ref="U1", x_min=9.0, y_min=9.0, x_max=11.0, y_max=11.0,
+            resolution=0.05,
+        )
+
+        subgrid_no_zone = SubGridRouter(grid, rules)
+        subgrid_with_zone = SubGridRouter(grid, rules, fine_zones=[zone])
+
+        analysis_no = subgrid_no_zone.analyze_pads([pad])
+        analysis_with = subgrid_with_zone.analyze_pads([pad])
+
+        result_no = subgrid_no_zone.generate_escape_segments(analysis_no)
+        result_with = subgrid_with_zone.generate_escape_segments(analysis_with)
+
+        # Both should have same escape grid point (pad is outside zone)
+        if result_no.success_count > 0 and result_with.success_count > 0:
+            assert result_no.escapes[0].grid_point == result_with.escapes[0].grid_point
+
+    def test_generate_fine_grid_candidates_count(self):
+        """Fine-grid candidate generation should produce candidates on fine grid."""
+        from kicad_tools.router.io import FineZone
+
+        grid, rules = make_grid_and_rules(
+            width=20.0, height=20.0, resolution=0.17,
+            trace_width=0.15, trace_clearance=0.1,
+        )
+
+        pad = make_pad(x=10.075, y=10.075, net=1, ref="U1", pin="1")
+        grid.add_pad(pad)
+
+        zone = FineZone(
+            ref="U1", x_min=9.0, y_min=9.0, x_max=11.0, y_max=11.0,
+            resolution=0.05,
+        )
+
+        subgrid = SubGridRouter(grid, rules, fine_zones=[zone])
+        analysis = subgrid.analyze_pads([pad])
+        assert analysis.has_off_grid_pads
+
+        # Generate fine candidates directly
+        sgp = analysis.off_grid_pads[0]
+        candidates = subgrid._generate_fine_grid_candidates(sgp, 0.05)
+
+        # Should have candidates -- fine grid 0.05mm with 0.3mm search radius
+        # gives radius of 6, so (2*6+1)^2 = 169 candidate points
+        # minus any that are out of bounds or inaccessible
+        assert len(candidates) > 0, "Fine-grid should produce candidates"
+
+    def test_fine_zone_escape_clearance_valid(self):
+        """Escape segments produced with fine zones must pass clearance validation."""
+        from kicad_tools.router.io import FineZone
+
+        grid, rules = make_grid_and_rules(
+            width=20.0, height=20.0, resolution=0.17,
+            trace_width=0.15, trace_clearance=0.1,
+        )
+
+        # Place two pads from the same component at fine pitch (0.65mm)
+        pad1 = make_pad(x=10.075, y=10.0, net=1, ref="U1", pin="1")
+        pad2 = make_pad(x=10.075, y=10.65, net=2, ref="U1", pin="2")
+        grid.add_pad(pad1)
+        grid.add_pad(pad2)
+
+        zone = FineZone(
+            ref="U1", x_min=9.0, y_min=9.0, x_max=11.0, y_max=12.0,
+            resolution=0.05,
+        )
+
+        subgrid = SubGridRouter(grid, rules, fine_zones=[zone])
+        result = subgrid.route_with_subgrid([pad1, pad2])
+
+        # All generated escapes should pass clearance
+        component_pitches = grid.compute_component_pitches()
+        for escape in result.escapes:
+            is_valid, clearance, violation_loc = grid.validate_segment_clearance(
+                escape.segment,
+                exclude_net=escape.pad.net,
+                component_pitches=component_pitches,
+            )
+            assert is_valid, (
+                f"Fine-zone escape for {escape.pad.ref}.{escape.pad.pin} "
+                f"violates clearance={clearance:.4f}mm at {violation_loc}"
+            )


### PR DESCRIPTION
## Summary
SubGridRouter now uses FineZone resolution (e.g. 0.05mm) for escape routing of pads within dense IC packages instead of always using the coarse global grid (e.g. 0.17mm). This bridges the architectural gap where FineZone objects were computed during grid selection but never consumed by the escape routing pipeline.

## Changes
- Add `FineZone.contains(x, y)` method for point-in-zone bounding box checks
- Extend `SubGridRouter.__init__()` with optional `fine_zones` parameter
- Add `_get_pad_fine_resolution()` helper that returns the finest zone resolution for a pad (handles overlapping zones)
- Add `_generate_fine_grid_candidates()` to produce escape candidates on the fine grid, mapped back to coarse grid cells
- Modify `_find_escape_for_pad()` to merge fine-grid candidates with coarse candidates (with deduplication)
- Store `fine_zones` on `Autorouter` and pass through `_subgrid` property to `SubGridRouter`
- Wire `MultiResolutionGridPlan.fine_zones` into router from CLI `route_cmd.py`
- Add 13 new tests covering fine zone containment, resolution lookup, fine-grid candidate generation, escape segment length, clearance validation, and coarse-grid bridging

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| SubGridRouter accepts fine zone information | Pass | New `fine_zones` parameter in `__init__()`, stored as `self.fine_zones` |
| Fine grid resolution used for escape segments in fine zones | Pass | `_get_pad_fine_resolution()` + `_generate_fine_grid_candidates()` produce candidates at zone resolution |
| Escape segments bridge from fine grid to coarse grid | Pass | Fine candidates mapped to coarse grid cells via `grid.world_to_grid()` |
| Fine zones passed from core.py to SubGridRouter | Pass | `Autorouter.fine_zones` wired through `_subgrid` property |
| Overlapping fine zones use finest resolution | Pass | Test `test_get_pad_fine_resolution_overlapping_zones_uses_finest` verifies min selection |
| Pads outside fine zones unchanged | Pass | Test `test_pads_outside_fine_zone_use_coarse_grid` verifies identical behavior |
| All 47 existing tests pass | Pass | No regressions in existing test suite |
| Escape segments pass clearance validation | Pass | Test `test_fine_zone_escape_clearance_valid` verifies DRC compliance |

## Test Plan
- 60 tests pass in `test_subgrid.py` (47 existing + 13 new)
- 26 tests pass in `test_multi_resolution.py` (unchanged)
- 15 tests pass in `test_subgrid_integration.py` (unchanged)

Closes #1828