### PR TITLE
fix(pipeline): exclude zone fill segments from 'already routed' detection

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -147,17 +147,19 @@ class PipelineContext:
 
 
 def _detect_routing_status(pcb_file: Path) -> tuple[bool, int, int]:
-    """Detect whether a PCB has been routed by counting segments and nets.
+    """Detect whether a PCB has been routed by counting top-level segments and nets.
 
-    Reads the PCB file and counts (segment ...) and (arc ...) nodes
-    to determine if routing has been performed.
+    Reads the PCB file and counts ``(segment ...)`` and ``(arc ...)`` nodes that
+    are direct children of the root ``(kicad_pcb ...)`` node (depth 1).  Segments
+    and arcs nested inside ``(zone ...)`` or ``(filled_polygon ...)`` blocks are
+    excluded so that zone fill polygons are not mistaken for routed traces.
 
     Args:
         pcb_file: Path to .kicad_pcb file
 
     Returns:
         Tuple of (is_routed, segment_count, net_count) where is_routed
-        is True if the board has routing segments.
+        is True if the board has top-level routing segments.
     """
     try:
         content = pcb_file.read_text(encoding="utf-8")
@@ -165,10 +167,31 @@ def _detect_routing_status(pcb_file: Path) -> tuple[bool, int, int]:
         logger.warning("Could not read PCB file %s: %s", pcb_file, e)
         return False, 0, 0
 
-    # Count segment and arc nodes (routing traces)
-    # Match both "(segment " and "(segment\n" (KiCad may use either format)
-    segment_count = content.count("(segment ") + content.count("(segment\n")
-    arc_count = content.count("(arc ") + content.count("(arc\n")
+    # Count only top-level (segment ...) and (arc ...) entries.
+    # In KiCad s-expression format, routed traces live at depth 1 (direct
+    # children of the root (kicad_pcb ...) node).  Zone fills nest segments
+    # inside (zone ... (filled_polygon ...)) at depth >= 2, so we track
+    # parenthesis depth and only count matches at depth 1.
+    segment_count = 0
+    arc_count = 0
+    depth = 0
+    i = 0
+    length = len(content)
+    while i < length:
+        ch = content[i]
+        if ch == "(":
+            # Check for tokens at depth 1 (inside root kicad_pcb node)
+            if depth == 1:
+                rest = content[i : i + 12]  # longest prefix we need
+                if rest.startswith("(segment ") or rest.startswith("(segment\n"):
+                    segment_count += 1
+                elif rest.startswith("(arc ") or rest.startswith("(arc\n"):
+                    arc_count += 1
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        i += 1
+
     total_traces = segment_count + arc_count
 
     # Count nets (excluding net 0 which is the unconnected net)

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -104,6 +104,89 @@ EMPTY_PCB = """\
 )
 """
 
+# PCB with zone fills but no routed traces (issue #1835)
+ZONE_FILL_ONLY_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VCC")
+  (footprint "Resistor_SMD:R_0603_1608Metric"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 50)
+    (pad "1" smd roundrect (at -0.8 0) (size 0.9 0.95) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.8 0) (size 0.9 0.95) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "VCC"))
+  )
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "F.Cu")
+    (uuid "zone-1")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 90 40) (xy 120 40) (xy 120 60) (xy 90 60)))
+    (filled_polygon
+      (layer "F.Cu")
+      (pts (xy 90.1 40.1) (xy 119.9 40.1) (xy 119.9 59.9) (xy 90.1 59.9))
+    )
+  )
+)
+"""
+
+# PCB with both zone fills and routed traces
+ZONE_FILL_WITH_TRACES_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VCC")
+  (footprint "Resistor_SMD:R_0603_1608Metric"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 50)
+    (pad "1" smd roundrect (at -0.8 0) (size 0.9 0.95) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.8 0) (size 0.9 0.95) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "VCC"))
+  )
+  (segment (start 100.8 50) (end 110 50) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-1"))
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "F.Cu")
+    (uuid "zone-1")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 90 40) (xy 120 40) (xy 120 60) (xy 90 60)))
+    (filled_polygon
+      (layer "F.Cu")
+      (pts (xy 90.1 40.1) (xy 119.9 40.1) (xy 119.9 59.9) (xy 90.1 59.9))
+    )
+  )
+)
+"""
+
 
 @pytest.fixture
 def routed_pcb(tmp_path: Path) -> Path:
@@ -127,6 +210,22 @@ def empty_pcb(tmp_path: Path) -> Path:
     pcb_file = tmp_path / "empty.kicad_pcb"
     pcb_file.write_text(EMPTY_PCB)
     return pcb_file
+
+@pytest.fixture
+def zone_fill_only_pcb(tmp_path: Path) -> Path:
+    """Create a PCB with zone fills but no routed traces."""
+    pcb_file = tmp_path / "zone_fill_only.kicad_pcb"
+    pcb_file.write_text(ZONE_FILL_ONLY_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def zone_fill_with_traces_pcb(tmp_path: Path) -> Path:
+    """Create a PCB with both zone fills and routed traces."""
+    pcb_file = tmp_path / "zone_fill_with_traces.kicad_pcb"
+    pcb_file.write_text(ZONE_FILL_WITH_TRACES_PCB)
+    return pcb_file
+
 
 
 @pytest.fixture
@@ -161,6 +260,23 @@ class TestDetectRoutingStatus:
         assert is_routed is False
         assert trace_count == 0
         assert net_count == 0
+
+
+    def test_zone_fill_only_not_routed(self, zone_fill_only_pcb: Path):
+        """A PCB with only zone fills (no top-level segments) is unrouted (#1835)."""
+        is_routed, trace_count, net_count = _detect_routing_status(zone_fill_only_pcb)
+        assert is_routed is False
+        assert trace_count == 0
+        assert net_count > 0
+
+    def test_zone_fill_with_traces_detected(self, zone_fill_with_traces_pcb: Path):
+        """A PCB with zone fills AND top-level segments is detected as routed."""
+        is_routed, trace_count, net_count = _detect_routing_status(
+            zone_fill_with_traces_pcb
+        )
+        assert is_routed is True
+        assert trace_count == 1
+        assert net_count > 0
 
     def test_nonexistent_file(self, tmp_path: Path):
         """Non-existent file returns unrouted with zero counts."""


### PR DESCRIPTION
## Summary

- Fix `_detect_routing_status()` to only count top-level `(segment ...)` and `(arc ...)` entries at s-expression depth 1, excluding those nested inside `(zone ... (filled_polygon ...))` blocks
- Boards with zone fills but no actual routed traces are now correctly detected as unrouted instead of triggering a false "already routed" skip
- Add two new test cases covering zone-fill-only and zone-fill-with-traces scenarios

Closes #1835

## Test plan

- [x] Existing `TestDetectRoutingStatus` tests pass (routed, unrouted, empty, nonexistent)
- [x] New `test_zone_fill_only_not_routed` verifies zone-fill-only PCB is detected as unrouted
- [x] New `test_zone_fill_with_traces_detected` verifies PCB with both zones and traces is detected as routed
- [x] All 246 passing tests in `test_pipeline_cmd.py` still pass (5 pre-existing failures unrelated to this change)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>