### PR TITLE
fix(router): filter unrouted net list to target signal population

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -278,10 +278,15 @@ def show_preview(
             stats["length"] += math.sqrt(dx * dx + dy * dy)
             stats["layers"].add(seg.layer.kicad_name)
 
-    # Identify unrouted nets
+    # Identify unrouted nets — filter to target population so the
+    # "No path found" list only shows actual routing candidates,
+    # not skipped power nets or single-pad nets (Issue #1833).
     routed_net_ids = set(net_stats.keys())
-    all_net_ids = {v for k, v in net_map.items() if v > 0}
-    unrouted_ids = all_net_ids - routed_net_ids
+    if nets_to_route_ids is not None:
+        unrouted_ids = nets_to_route_ids - routed_net_ids
+    else:
+        all_net_ids = {v for k, v in net_map.items() if v > 0}
+        unrouted_ids = all_net_ids - routed_net_ids
 
     # Print header
     print("\n" + "=" * 60)

--- a/src/kicad_tools/router/output.py
+++ b/src/kicad_tools/router/output.py
@@ -65,14 +65,18 @@ def show_routing_summary(
         route_vias_by_net[net_id] = route_vias_by_net.get(net_id, 0) + len(route.vias)
 
     # Identify routed and unrouted nets — filter to target population
-    # so numerator/denominator are consistent (Issue #1643)
+    # so numerator/denominator are consistent (Issue #1643, #1833)
     all_routed_net_ids = {route.net for route in router.routes}
     if nets_to_route_ids is not None:
         routed_net_ids = all_routed_net_ids & nets_to_route_ids
+        # Only report unrouted nets from the target population (multi-pad
+        # signal nets).  Skipped power nets and single-pad nets are not
+        # routing candidates and must not appear as "No path found".
+        unrouted_ids = nets_to_route_ids - all_routed_net_ids
     else:
         routed_net_ids = all_routed_net_ids
-    all_net_ids = {v for k, v in net_map.items() if v > 0}
-    unrouted_ids = all_net_ids - all_routed_net_ids
+        all_net_ids = {v for k, v in net_map.items() if v > 0}
+        unrouted_ids = all_net_ids - all_routed_net_ids
 
     # Group recorded failures by net
     failures_by_net: dict[int, list[RoutingFailure]] = {}
@@ -442,14 +446,18 @@ def get_routing_diagnostics_json(
         route_vias_by_net[net_id] = route_vias_by_net.get(net_id, 0) + len(route.vias)
 
     # Identify routed and unrouted nets — filter to target population
-    # so numerator/denominator are consistent (Issue #1643)
+    # so numerator/denominator are consistent (Issue #1643, #1833)
     all_routed_net_ids = {route.net for route in router.routes}
     if nets_to_route_ids is not None:
         routed_net_ids = all_routed_net_ids & nets_to_route_ids
+        # Only report unrouted nets from the target population (multi-pad
+        # signal nets).  Skipped power nets and single-pad nets are not
+        # routing candidates and must not appear as "No path found".
+        unrouted_ids = nets_to_route_ids - all_routed_net_ids
     else:
         routed_net_ids = all_routed_net_ids
-    all_net_ids = {v for k, v in net_map.items() if v > 0}
-    unrouted_ids = all_net_ids - all_routed_net_ids
+        all_net_ids = {v for k, v in net_map.items() if v > 0}
+        unrouted_ids = all_net_ids - all_routed_net_ids
 
     # Build successful routes list
     successful_routes = []

--- a/tests/test_routing_output.py
+++ b/tests/test_routing_output.py
@@ -488,3 +488,120 @@ class TestNetCountFiltering:
         output = capsys.readouterr().out
         assert "0/0" in output
         assert "0%" in output
+
+
+# ---------------------------------------------------------------------------
+# Issue #1833: Unrouted list must exclude skipped/single-pad nets
+# ---------------------------------------------------------------------------
+
+
+class TestUnroutedListFiltering:
+    """The 'Unrouted nets' section must only list nets from the target
+    population (nets_to_route_ids), not skipped power nets or single-pad nets.
+    """
+
+    def test_skipped_power_nets_excluded_from_unrouted(self, capsys):
+        """Power nets that were intentionally skipped (not in
+        nets_to_route_ids) must not appear as 'No path found'."""
+        # Net 1 = GND (power, skipped), Net 2 = SIG_A (signal, routed),
+        # Net 3 = SIG_B (signal, unrouted)
+        route = MagicMock()
+        route.net = 2
+        route.net_name = "SIG_A"
+        route.segments = []
+        route.vias = []
+
+        router = _make_router(routes=[route])
+        net_map = {"GND": 1, "SIG_A": 2, "SIG_B": 3}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=2,
+            nets_to_route_ids={2, 3},  # only signal nets
+        )
+
+        output = capsys.readouterr().out
+        # GND should NOT appear as unrouted
+        assert "GND" not in output
+        # SIG_B should appear as unrouted (it's a signal net that failed)
+        assert "SIG_B" in output
+        # Count should be 1/2
+        assert "1/2" in output
+
+    def test_single_pad_nets_excluded_from_unrouted(self, capsys):
+        """Single-pad nets (not in nets_to_route_ids) must not appear
+        as 'No path found'."""
+        # Net 1 = LATCH (single pad), Net 2 = SIG_A (routed)
+        route = MagicMock()
+        route.net = 2
+        route.net_name = "SIG_A"
+        route.segments = []
+        route.vias = []
+
+        router = _make_router(routes=[route])
+        net_map = {"LATCH": 1, "SIG_A": 2}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            nets_to_route_ids={2},  # only multi-pad net
+        )
+
+        output = capsys.readouterr().out
+        assert "LATCH" not in output
+        assert "1/1" in output
+
+    def test_unrouted_count_matches_summary(self, capsys):
+        """The number of nets listed as unrouted must equal
+        (denominator - numerator) from the summary line."""
+        # 3 signal nets, 1 routed, 2 power nets skipped
+        route = MagicMock()
+        route.net = 3
+        route.net_name = "SIG_A"
+        route.segments = []
+        route.vias = []
+
+        router = _make_router(routes=[route])
+        net_map = {"GND": 1, "+3.3V": 2, "SIG_A": 3, "SIG_B": 4, "SIG_C": 5}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=3,
+            nets_to_route_ids={3, 4, 5},
+        )
+
+        output = capsys.readouterr().out
+        # Should show 1/3 (only SIG_A routed out of 3 signal nets)
+        assert "1/3" in output
+        # GND and +3.3V must NOT appear
+        assert "GND" not in output
+        assert "+3.3V" not in output
+        # SIG_B and SIG_C should appear as unrouted
+        assert "SIG_B" in output
+        assert "SIG_C" in output
+
+    def test_legacy_no_filter_shows_all_unrouted(self, capsys):
+        """When nets_to_route_ids is None (legacy), all unrouted nets
+        appear (backward compat)."""
+        route = MagicMock()
+        route.net = 2
+        route.net_name = "SIG_A"
+        route.segments = []
+        route.vias = []
+
+        router = _make_router(routes=[route])
+        net_map = {"GND": 1, "SIG_A": 2}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=2,
+            nets_to_route_ids=None,
+        )
+
+        output = capsys.readouterr().out
+        # With no filter, GND should still appear as unrouted (legacy behavior)
+        assert "GND" in output


### PR DESCRIPTION
## Summary

The "Unrouted nets" and "No path found" sections in routing output included
skipped power nets and single-pad nets, making it impossible to identify which
actual signal net failed. This fixes the 15/16 reporting confusion from #1833.

## Changes

- `src/kicad_tools/router/output.py`: When `nets_to_route_ids` is provided, compute
  `unrouted_ids` as `nets_to_route_ids - routed` instead of `all_nets - routed`
- `src/kicad_tools/cli/route_cmd.py`: Same fix in `show_preview()`
- `tests/test_routing_output.py`: 4 new tests verifying skipped/single-pad nets are
  excluded and legacy None behavior is preserved

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| show_routing_summary() only lists multi-pad signal nets as unrouted | Done | New test `test_skipped_power_nets_excluded_from_unrouted` |
| show_preview() only lists multi-pad signal nets as unrouted | Done | Same filtering logic applied |
| Summary count and unrouted list are consistent | Done | New test `test_unrouted_count_matches_summary` |
| Skipped power/single-pad nets no longer show as "No path found" | Done | New tests verify GND/LATCH excluded |
| Existing tests pass; new tests cover filtering | Done | 25/25 tests pass |

## Test Plan

All 25 tests in `tests/test_routing_output.py` pass, including 4 new tests:
- `test_skipped_power_nets_excluded_from_unrouted`
- `test_single_pad_nets_excluded_from_unrouted`
- `test_unrouted_count_matches_summary`
- `test_legacy_no_filter_shows_all_unrouted`

Closes #1833