### PR TITLE
fix(zones): snapshot net-0 segments, relax proximity metric, and clear residual empty nets

### DIFF
--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -706,6 +706,7 @@ def _snapshot_element_nets(pcb_path: Path) -> dict[str, list]:
     An empty dict is returned if the file cannot be read.
     """
     from kicad_tools.core.sexp_file import load_pcb
+    from kicad_tools.sexp import SExp
 
     try:
         sexp = load_pcb(str(pcb_path))
@@ -740,15 +741,20 @@ def _snapshot_element_nets(pcb_path: Path) -> dict[str, list]:
             key = f"{fp_ref}:{pad_number}"
             snapshot[key] = [_canonicalize_net_node(net_node, name_to_number)]
 
-    # Snapshot segments and vias at the top level, keyed by geometry
+    # Snapshot segments and vias at the top level, keyed by geometry.
+    # Include ALL segments/vias — even (net 0) — so that zone fill
+    # corruption to (net "") can be restored to the original net.
     for child in sexp.children:
         if child.name in ("segment", "via"):
             net_node = child.get("net")
-            if not _has_nonzero_net(net_node):
-                continue
             geo_key = _make_segment_via_key(child)
             if geo_key:
-                snapshot[geo_key] = [_canonicalize_net_node(net_node, name_to_number, numeric_only=True)]
+                if _has_nonzero_net(net_node):
+                    snapshot[geo_key] = [_canonicalize_net_node(net_node, name_to_number, numeric_only=True)]
+                else:
+                    # Preserve (net 0) assignment so restore can distinguish
+                    # "originally unconnected" from "newly created by fill".
+                    snapshot[geo_key] = [SExp.list("net", 0)]
 
     return snapshot
 
@@ -822,7 +828,15 @@ def _fallback_restore_by_proximity(output_sexp, element_nets: dict[str, list]) -
             best_dist = PROXIMITY_THRESHOLD
             best_net = None
             for bsx, bsy, bex, bey, net_nodes in bucket:
-                dist = math.hypot(sx - bsx, sy - bsy) + math.hypot(ex - bex, ey - bey)
+                # Use the worst (max) single-endpoint distance rather
+                # than the sum of both.  The combined metric is too
+                # restrictive: when zone fill shifts both endpoints
+                # slightly, the sum can exceed the threshold even though
+                # each individual shift is small.  Using max() ensures
+                # *both* endpoints are within the threshold individually.
+                start_dist = math.hypot(sx - bsx, sy - bsy)
+                end_dist = math.hypot(ex - bex, ey - bey)
+                dist = max(start_dist, end_dist)
                 if dist < best_dist:
                     best_dist = dist
                     best_net = net_nodes
@@ -857,6 +871,38 @@ def _fallback_restore_by_proximity(output_sexp, element_nets: dict[str, list]) -
             child.append(best_net[0])
             changed = True
 
+    return changed
+
+
+def _assign_empty_nets_to_zero(output_sexp) -> bool:
+    """Replace remaining (net "") on segments/vias with (net 0).
+
+    After key-based and proximity-based restore passes, any segments or
+    vias still carrying (net "") are new geometry created by kicad-cli
+    zone fill that had no snapshot entry.  Rather than leaving the empty
+    string (which causes DRC errors), assign them (net 0) (the
+    unconnected net) — a valid KiCad net that will not trigger DRC
+    empty-net violations.
+
+    Returns True if any element was modified.
+    """
+    from kicad_tools.sexp import SExp
+
+    changed = False
+    for child in output_sexp.children:
+        if child.name not in ("segment", "via"):
+            continue
+        net_node = child.get("net")
+        if net_node is None:
+            continue
+        # Check for (net "") — empty string net
+        net_str = net_node.get_string(0)
+        if net_str is not None and net_str == "":
+            # Also check there is no numeric value (pure empty string)
+            if net_node.get_int(0) is None:
+                child.remove(net_node)
+                child.append(SExp.list("net", 0))
+                changed = True
     return changed
 
 
@@ -956,6 +1002,14 @@ def _restore_net_declarations(
         # or geometry created by kicad-cli during fill.  Use spatial proximity
         # to find the nearest snapshotted element on the same layer.
         if _fallback_restore_by_proximity(output_sexp, element_nets):
+            modified = True
+
+        # --- Final pass: assign remaining (net "") to (net 0) ---
+        # After key-based restore and proximity fallback, any segments/vias
+        # still carrying (net "") are new geometry created by zone fill
+        # with no snapshot entry.  Assign them (net 0) (unconnected) to
+        # prevent DRC errors from empty-string net corruption.
+        if _assign_empty_nets_to_zero(output_sexp):
             modified = True
 
     if modified:

--- a/tests/test_runner_net_restore.py
+++ b/tests/test_runner_net_restore.py
@@ -787,3 +787,232 @@ class TestRunFillZonesNativeProtection:
 
             assert result.success is False
             mock_restore.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #1845: snapshot includes (net 0) segments
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotIncludesNetZero:
+    """Verify ``_snapshot_element_nets`` captures (net 0) segments."""
+
+    @staticmethod
+    def _write_pcb(tmp_path: Path, content: str) -> Path:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(content)
+        return pcb
+
+    def test_net_zero_segment_is_snapshotted(self, tmp_path):
+        """A segment with (net 0) must appear in the snapshot."""
+        from kicad_tools.cli.runner import _snapshot_element_nets
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 1 "GND")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net 0) (uuid "z1"))
+)""",
+        )
+
+        snapshot = _snapshot_element_nets(pcb)
+        key = "seg:10.0,20.0:30.0,40.0:F.Cu"
+        assert key in snapshot, "Snapshot must include (net 0) segments"
+        net_node = snapshot[key][0]
+        assert net_node.get_int(0) == 0, "Snapshot must preserve (net 0)"
+
+    def test_nonzero_segment_still_snapshotted(self, tmp_path):
+        """Nonzero net segments must still be captured."""
+        from kicad_tools.cli.runner import _snapshot_element_nets
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 5 "VCC")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net 5) (uuid "a1"))
+)""",
+        )
+
+        snapshot = _snapshot_element_nets(pcb)
+        key = "seg:10.0,20.0:30.0,40.0:F.Cu"
+        assert key in snapshot
+        assert snapshot[key][0].get_int(0) == 5
+
+
+# ---------------------------------------------------------------------------
+# Issue #1845: proximity uses max(start, end) metric
+# ---------------------------------------------------------------------------
+
+
+class TestProximityMaxMetric:
+    """Verify proximity uses max single-endpoint distance, not sum."""
+
+    @staticmethod
+    def _write_pcb(tmp_path: Path, content: str) -> Path:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(content)
+        return pcb
+
+    def test_both_endpoints_shifted_within_threshold(self, tmp_path):
+        """Segment with both endpoints shifted 0.06mm should match.
+
+        Old metric (sum): hypot(0.06,0) + hypot(0.06,0) = 0.12 > 0.1 (FAIL).
+        New metric (max): max(hypot(0.06,0), hypot(0.06,0)) = 0.06 < 0.1 (PASS).
+        """
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 9 "MISO")
+  (segment (start 100.06 200.0) (end 300.06 400.0) (width 0.25) (layer "F.Cu") (net "") (uuid "shift1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(9, "MISO")]
+        element_nets = {
+            "seg:100.0,200.0:300.0,400.0:F.Cu": [_net_node(9)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 9, (
+                    "Both endpoints shifted 0.06mm should match with max() metric"
+                )
+                break
+        else:
+            pytest.fail("No segment found")
+
+
+# ---------------------------------------------------------------------------
+# Issue #1845: remaining (net "") assigned to (net 0)
+# ---------------------------------------------------------------------------
+
+
+class TestAssignEmptyNetsToZero:
+    """Verify remaining (net \"\") segments are assigned (net 0)."""
+
+    @staticmethod
+    def _write_pcb(tmp_path: Path, content: str) -> Path:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(content)
+        return pcb
+
+    def test_empty_net_segment_becomes_net_zero(self, tmp_path):
+        """A segment with (net \"\") and no snapshot match should become (net 0)."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 1 "GND")
+  (segment (start 999 999) (end 998 998) (width 0.25) (layer "F.Cu") (net "") (uuid "new1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(1, "GND")]
+        # No snapshot entry for this segment at all
+        element_nets = {
+            "seg:100.0,200.0:300.0,400.0:F.Cu": [_net_node(1)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                net_num = net_node.get_int(0)
+                assert net_num == 0, (
+                    f"Unmatched (net \"\") segment should become (net 0), got {net_node}"
+                )
+                break
+        else:
+            pytest.fail("No segment found")
+
+    def test_canonical_net_not_overwritten_to_zero(self, tmp_path):
+        """A segment with a valid net should NOT be changed to (net 0)."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 5 "VCC")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net 5) (uuid "ok1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(5, "VCC")]
+        element_nets = {}
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 5, "Valid net should be preserved"
+                break
+        else:
+            pytest.fail("No segment found")
+
+    def test_net_zero_restored_from_snapshot(self, tmp_path):
+        """A segment originally (net 0) corrupted to (net \"\") should restore to (net 0)."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 1 "GND")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net "") (uuid "z2"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(1, "GND")]
+        # Snapshot captured this segment with (net 0) — original assignment
+        element_nets = {
+            "seg:10.0,20.0:30.0,40.0:F.Cu": [_net_node(0)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 0, (
+                    "Segment originally (net 0) should be restored to (net 0)"
+                )
+                break
+        else:
+            pytest.fail("No segment found")


### PR DESCRIPTION
## Summary

Fixes zone fill net restore that was corrupting 178 segments to `(net "")`. Three independent failure modes addressed in `_snapshot_element_nets()`, `_fallback_restore_by_proximity()`, and a new final cleanup pass.

## Changes

- `_snapshot_element_nets()` now captures ALL segments/vias including `(net 0)` -- previously skipped by the `_has_nonzero_net()` filter, leaving originally-unconnected segments unrecoverable after zone fill corruption
- Proximity fallback distance metric changed from `sum(start, end)` to `max(start, end)` -- the combined metric was too restrictive when zone fill shifts both endpoints slightly (e.g., 0.06mm each = 0.12mm combined > 0.1mm threshold, but 0.06mm individually < 0.1mm)
- New `_assign_empty_nets_to_zero()` function converts any remaining `(net "")` segments after all restore passes to `(net 0)`, preventing DRC empty-net violations from new geometry created by zone fill
- 6 new test cases covering all three fixes

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_snapshot_element_nets()` captures ALL top-level segments including `(net 0)` | PASS | `TestSnapshotIncludesNetZero::test_net_zero_segment_is_snapshotted` |
| Proximity restore uses relaxed metric | PASS | `TestProximityMaxMetric::test_both_endpoints_shifted_within_threshold` |
| Remaining `(net "")` segments after restore are handled | PASS | `TestAssignEmptyNetsToZero::test_empty_net_segment_becomes_net_zero` |

## Test Plan

- 43/43 tests pass in `tests/test_runner_net_restore.py` (37 existing + 6 new)
- New tests validate each fix independently and verify no regressions

Closes #1845