### PR TITLE
fix(router): stop re-filtering pour nets that lack zones as pour nets

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -606,7 +606,7 @@ def _auto_skip_pour_nets(
     pcb_path: Path,
     skip_nets: list[str],
     quiet: bool = False,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     """Detect pour nets in the PCB and add them to the skip list.
 
     Reads net definitions from the PCB file and classifies them.  Nets
@@ -621,7 +621,12 @@ def _auto_skip_pour_nets(
         quiet: Suppress informational output.
 
     Returns:
-        List of net names that were auto-skipped (subset of *skip_nets*).
+        Tuple of (auto_skipped, no_zone_nets):
+        - auto_skipped: Net names that were auto-skipped (have zones).
+        - no_zone_nets: Pour net names that lack zones and must be
+          routed as signals.  Pass these to the autorouter's
+          ``_pour_nets_without_zones`` attribute so that
+          ``_filter_pour_nets()`` does not re-skip them (Issue #1841).
     """
     try:
         import re as _re
@@ -672,10 +677,10 @@ def _auto_skip_pour_nets(
             ]
             if no_zone and not quiet:
                 print(f"Routing: {', '.join(sorted(no_zone))} (power nets without zones)")
-            return auto_skip
+            return auto_skip, no_zone
     except Exception:
         pass  # Fall back to user-supplied skip_nets only
-    return []
+    return [], []
 
 
 def route_with_layer_escalation(
@@ -735,7 +740,7 @@ def route_with_layer_escalation(
         skip_nets = [n.strip() for n in args.skip_nets.split(",")]
 
     # Auto-classify pour nets and extend skip_nets
-    _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
+    _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
 
     # Layer stacks to try (in escalation order)
     layer_configs = [
@@ -787,6 +792,9 @@ def route_with_layer_escalation(
             if not quiet:
                 print(f"  Error loading PCB: {e}")
             continue
+
+        # Issue #1841: Tell the autorouter which pour nets lack zones
+        router._pour_nets_without_zones = set(_no_zone)
 
         # Count nets to route
         multi_pad_nets = [
@@ -1086,7 +1094,7 @@ def route_with_rule_relaxation(
         skip_nets = [n.strip() for n in args.skip_nets.split(",")]
 
     # Auto-classify pour nets and extend skip_nets
-    _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
+    _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
 
     # Get relaxation tiers
     tiers = get_relaxation_tiers(
@@ -1163,6 +1171,9 @@ def route_with_rule_relaxation(
             if not quiet:
                 print(f"  Error loading PCB: {e}")
             continue
+
+        # Issue #1841: Tell the autorouter which pour nets lack zones
+        router._pour_nets_without_zones = set(_no_zone)
 
         # Count nets to route
         multi_pad_nets = [
@@ -1479,7 +1490,7 @@ def route_with_combined_escalation(
         skip_nets = [n.strip() for n in args.skip_nets.split(",")]
 
     # Auto-classify pour nets and extend skip_nets
-    _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
+    _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
 
     # Get relaxation tiers
     tiers = get_relaxation_tiers(
@@ -1564,6 +1575,9 @@ def route_with_combined_escalation(
                     print(f"  Error loading PCB: {e}")
                 results_matrix[(tier.tier, layer_count)] = 0.0
                 continue
+
+            # Issue #1841: Tell the autorouter which pour nets lack zones
+            router._pour_nets_without_zones = set(_no_zone)
 
             # Count nets to route
             multi_pad_nets = [
@@ -2592,7 +2606,7 @@ def main(argv: list[str] | None = None) -> int:
         skip_nets = [n.strip() for n in args.skip_nets.split(",")]
 
     # Auto-classify pour nets and extend skip_nets
-    _auto_skip_pour_nets(pcb_path, skip_nets, quiet=args.quiet)
+    _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=args.quiet)
 
     # Import router modules
     from kicad_tools.analysis import ComplexityAnalyzer, ComplexityRating
@@ -2746,6 +2760,9 @@ def main(argv: list[str] | None = None) -> int:
                 f"  Fine zones: {len(router.fine_zones)} "
                 f"(sub-grid escape routing enabled)"
             )
+
+    # Issue #1841: Tell the autorouter which pour nets lack zones
+    router._pour_nets_without_zones = set(_no_zone)
 
     # Set up Ctrl+C handling to save partial results
     _interrupt_state["router"] = router

--- a/src/kicad_tools/router/algorithms/hierarchical.py
+++ b/src/kicad_tools/router/algorithms/hierarchical.py
@@ -48,6 +48,7 @@ class HierarchicalRouter:
         route_net: callable,
         route_net_with_corridor: callable,
         mark_route: callable,
+        pour_nets_without_zones: set[str] | None = None,
     ):
         self.grid = grid
         self.router = router
@@ -62,6 +63,7 @@ class HierarchicalRouter:
         self._route_net = route_net
         self._route_net_with_corridor = route_net_with_corridor
         self._mark_route = mark_route
+        self._pour_nets_without_zones = pour_nets_without_zones or set()
 
     def route_all(
         self,
@@ -98,10 +100,14 @@ class HierarchicalRouter:
         net_order = [n for n in net_order if n != 0]
 
         # Issue #1295: Filter out pour nets — they are connected via zone fills.
+        # Issue #1841: Exclude pour nets without zones (they route as signals).
         pour_nets = []
         signal_nets = []
         for n in net_order:
             net_name = self.net_names.get(n, "")
+            if net_name in self._pour_nets_without_zones:
+                signal_nets.append(n)
+                continue
             net_class = (self.net_class_map or {}).get(net_name)
             if net_class and net_class.is_pour_net:
                 pour_nets.append(n)

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -49,6 +49,7 @@ class TwoPhaseRouter:
         route_net: callable,
         route_net_with_corridor: callable,
         mark_route: callable,
+        pour_nets_without_zones: set[str] | None = None,
     ):
         self.grid = grid
         self.router = router
@@ -63,6 +64,7 @@ class TwoPhaseRouter:
         self._route_net = route_net
         self._route_net_with_corridor = route_net_with_corridor
         self._mark_route = mark_route
+        self._pour_nets_without_zones = pour_nets_without_zones or set()
 
     def route_all(
         self,
@@ -96,10 +98,14 @@ class TwoPhaseRouter:
         net_order = [n for n in net_order if n != 0]
 
         # Issue #1295: Filter out pour nets — they are connected via zone fills.
+        # Issue #1841: Exclude pour nets without zones (they route as signals).
         pour_nets = []
         signal_nets = []
         for n in net_order:
             net_name = self.net_names.get(n, "")
+            if net_name in self._pour_nets_without_zones:
+                signal_nets.append(n)
+                continue
             net_class = (self.net_class_map or {}).get(net_name)
             if net_class and net_class.is_pour_net:
                 pour_nets.append(n)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -363,6 +363,12 @@ class Autorouter:
         # within dense IC packages.
         self.fine_zones: list[FineZone] = []
 
+        # Pour nets without zones that should be routed as signals (Issue #1841)
+        # Set externally (e.g., from CLI's _auto_skip_pour_nets) after loading.
+        # Nets in this set have is_pour_net=True in their net class but lack a
+        # copper zone, so they must be routed as signal traces instead of skipped.
+        self._pour_nets_without_zones: set[str] = set()
+
         # Length constraint tracking (Issue #630)
         self._length_tracker: LengthTracker = LengthTracker()
 
@@ -1425,13 +1431,21 @@ class Autorouter:
         rather than individual traces.  They are identified by the
         ``is_pour_net`` flag on their :class:`NetClassRouting` entry.
 
+        Issue #1841: Pour nets that lack a copper zone in the PCB are stored
+        in :attr:`_pour_nets_without_zones` and must be routed as signals.
+        This method returns False for such nets even though their net class
+        has ``is_pour_net=True``.
+
         Args:
             net_id: The net ID to check.
 
         Returns:
-            True if the net's class has ``is_pour_net=True``, False otherwise.
+            True if the net's class has ``is_pour_net=True`` and the net
+            is not in ``_pour_nets_without_zones``, False otherwise.
         """
         net_name = self.net_names.get(net_id, "")
+        if net_name in self._pour_nets_without_zones:
+            return False
         net_class = self.net_class_map.get(net_name)
         return bool(net_class and net_class.is_pour_net)
 
@@ -2999,6 +3013,7 @@ class Autorouter:
             route_net=self.route_net,
             route_net_with_corridor=self._route_net_with_corridor,
             mark_route=self._mark_route,
+            pour_nets_without_zones=self._pour_nets_without_zones,
         )
 
     def route_all_two_phase(
@@ -3096,6 +3111,7 @@ class Autorouter:
             route_net=self.route_net,
             route_net_with_corridor=self._route_net_with_corridor,
             mark_route=self._mark_route,
+            pour_nets_without_zones=self._pour_nets_without_zones,
         )
 
     def route_all_hierarchical(

--- a/tests/test_pour_net_auto_skip.py
+++ b/tests/test_pour_net_auto_skip.py
@@ -645,7 +645,7 @@ class TestAutoSkipPourNetsHelper:
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
         skip_nets: list[str] = []
-        auto_skipped = _auto_skip_pour_nets(pcb_with_gnd, skip_nets, quiet=True)
+        auto_skipped, _no_zone = _auto_skip_pour_nets(pcb_with_gnd, skip_nets, quiet=True)
 
         assert "GND" in skip_nets
         assert "GND" in auto_skipped
@@ -664,7 +664,7 @@ class TestAutoSkipPourNetsHelper:
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
         skip_nets: list[str] = []
-        auto_skipped = _auto_skip_pour_nets(pcb_no_ground, skip_nets, quiet=True)
+        auto_skipped, _no_zone = _auto_skip_pour_nets(pcb_no_ground, skip_nets, quiet=True)
 
         assert auto_skipped == []
         assert skip_nets == []
@@ -674,7 +674,7 @@ class TestAutoSkipPourNetsHelper:
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
         skip_nets: list[str] = []
-        auto_skipped = _auto_skip_pour_nets(pcb_multi_pour, skip_nets, quiet=True)
+        auto_skipped, _no_zone = _auto_skip_pour_nets(pcb_multi_pour, skip_nets, quiet=True)
 
         assert "GND" in skip_nets
         assert "GNDA" in skip_nets
@@ -694,7 +694,7 @@ class TestAutoSkipZoneAwareness:
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
         skip_nets: list[str] = []
-        auto_skipped = _auto_skip_pour_nets(pcb_pour_no_zone, skip_nets, quiet=True)
+        auto_skipped, _no_zone = _auto_skip_pour_nets(pcb_pour_no_zone, skip_nets, quiet=True)
 
         assert "+5V" not in skip_nets
         assert auto_skipped == []
@@ -704,7 +704,7 @@ class TestAutoSkipZoneAwareness:
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
         skip_nets: list[str] = []
-        auto_skipped = _auto_skip_pour_nets(pcb_mixed_zone, skip_nets, quiet=True)
+        auto_skipped, _no_zone = _auto_skip_pour_nets(pcb_mixed_zone, skip_nets, quiet=True)
 
         assert "GND" in skip_nets
         assert "GND" in auto_skipped
@@ -716,7 +716,7 @@ class TestAutoSkipZoneAwareness:
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
         skip_nets: list[str] = []
-        auto_skipped = _auto_skip_pour_nets(pcb_with_gnd, skip_nets, quiet=True)
+        auto_skipped, _no_zone = _auto_skip_pour_nets(pcb_with_gnd, skip_nets, quiet=True)
 
         assert "GND" in skip_nets
         assert "GND" in auto_skipped
@@ -772,7 +772,7 @@ class TestAutoSkipZoneAwarenessTraditionalFormat:
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
         skip_nets: list[str] = []
-        auto_skipped = _auto_skip_pour_nets(pcb_traditional_gnd, skip_nets, quiet=True)
+        auto_skipped, _no_zone = _auto_skip_pour_nets(pcb_traditional_gnd, skip_nets, quiet=True)
 
         assert "GND" in skip_nets
         assert "GND" in auto_skipped
@@ -782,7 +782,7 @@ class TestAutoSkipZoneAwarenessTraditionalFormat:
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
         skip_nets: list[str] = []
-        auto_skipped = _auto_skip_pour_nets(pcb_traditional_mixed, skip_nets, quiet=True)
+        auto_skipped, _no_zone = _auto_skip_pour_nets(pcb_traditional_mixed, skip_nets, quiet=True)
 
         assert "GND" in skip_nets
         assert "GND" in auto_skipped
@@ -802,3 +802,86 @@ class TestAutoSkipZoneAwarenessTraditionalFormat:
         assert "Routing:" in out
         assert "+5V" in out
         assert "power nets without zones" in out
+
+
+# ===========================================================================
+# Tests for _is_pour_net / _filter_pour_nets with pour_nets_without_zones
+# (Issue #1841)
+# ===========================================================================
+
+
+class TestFilterPourNetsWithoutZones:
+    """Verify _filter_pour_nets respects _pour_nets_without_zones.
+
+    Issue #1841: Pour nets without zones (e.g. GNDA on chorus-test-revA)
+    were incorrectly re-filtered by _filter_pour_nets inside the autorouter
+    even though _auto_skip_pour_nets had already classified them as
+    'route as signal'.
+    """
+
+    def _make_autorouter(self):
+        """Create a minimal Autorouter with GNDA and GND nets."""
+        from kicad_tools.router.core import Autorouter
+        from kicad_tools.router.net_class import classify_and_apply_rules
+
+        router = Autorouter(width=50, height=40)
+        net_names = {1: "GND", 2: "GNDA", 3: "SPI_CLK"}
+        net_class_map = classify_and_apply_rules(net_names)
+        router.net_class_map = net_class_map
+        router.net_names = net_names
+        router.nets = {1: [], 2: [], 3: []}
+        return router
+
+    def test_is_pour_net_true_by_default(self) -> None:
+        """GNDA is a pour net by default (has is_pour_net=True in net class)."""
+        router = self._make_autorouter()
+        assert router._is_pour_net(2) is True  # GNDA
+
+    def test_is_pour_net_false_when_in_without_zones(self) -> None:
+        """GNDA returns False from _is_pour_net when marked as no-zone."""
+        router = self._make_autorouter()
+        router._pour_nets_without_zones = {"GNDA"}
+        assert router._is_pour_net(2) is False  # GNDA
+        # GND (not in the set) remains a pour net
+        assert router._is_pour_net(1) is True  # GND
+
+    def test_filter_pour_nets_keeps_no_zone_nets(self) -> None:
+        """_filter_pour_nets should NOT remove GNDA when it has no zone."""
+        router = self._make_autorouter()
+        router._pour_nets_without_zones = {"GNDA"}
+
+        net_order = [1, 2, 3]  # GND, GNDA, SPI_CLK
+        filtered = router._filter_pour_nets(net_order)
+
+        # GND (has is_pour_net, NOT in _pour_nets_without_zones) -> filtered out
+        assert 1 not in filtered
+        # GNDA (has is_pour_net, IS in _pour_nets_without_zones) -> kept
+        assert 2 in filtered
+        # SPI_CLK (not a pour net) -> kept
+        assert 3 in filtered
+
+    def test_filter_pour_nets_removes_all_when_no_override(self) -> None:
+        """Without _pour_nets_without_zones set, all pour nets are filtered."""
+        router = self._make_autorouter()
+        # _pour_nets_without_zones defaults to empty set
+
+        net_order = [1, 2, 3]  # GND, GNDA, SPI_CLK
+        filtered = router._filter_pour_nets(net_order)
+
+        assert 1 not in filtered  # GND filtered
+        assert 2 not in filtered  # GNDA filtered
+        assert 3 in filtered      # SPI_CLK kept
+
+    def test_auto_skip_returns_no_zone_list(self, pcb_mixed_zone: Path) -> None:
+        """_auto_skip_pour_nets returns (skipped, no_zone) where no_zone
+        contains power nets without zones."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        auto_skipped, no_zone = _auto_skip_pour_nets(
+            pcb_mixed_zone, skip_nets, quiet=True
+        )
+
+        assert "GND" in auto_skipped
+        assert "+5V" in no_zone
+        assert "+5V" not in auto_skipped


### PR DESCRIPTION
## Summary

Pour nets without zones (like GNDA on chorus-test-revA) were silently dropped from the routing order by `_filter_pour_nets()` in the autorouter, even though `_auto_skip_pour_nets()` had already correctly classified them as "power net without zone -- route as signal." This caused GNDA to fail routing across all strategies.

## Changes

- Added `_pour_nets_without_zones` set attribute to `Autorouter` in `core.py`
- Modified `_is_pour_net()` to return False for nets in this set
- Updated `_auto_skip_pour_nets()` in `route_cmd.py` to return the no-zone net list alongside the auto-skipped list
- All 4 call sites in `route_cmd.py` now pass no-zone info to the autorouter
- Fixed inline pour-net filters in `hierarchical.py` and `two_phase.py` to also respect the set
- Added 5 new tests; updated 6 existing tests for the new return type

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| GNDA not filtered by _filter_pour_nets when no zone | PASS | test_filter_pour_nets_keeps_no_zone_nets |
| All strategies respect no-zone classification | PASS | Fix in _is_pour_net + hierarchical + two_phase inline filters |
| Pour nets WITH zones still skipped | PASS | test_filter_pour_nets_removes_all_when_no_override |
| Unit test for pour-net-without-zone routing | PASS | 5 new tests in TestFilterPourNetsWithoutZones |

## Test Plan

All 33 tests in `test_pour_net_auto_skip.py` pass (28 existing + 5 new).
All 63 tests in `test_router_autorouter.py` pass unchanged.

Closes #1841