### PR TITLE
fix(runner): strip dual-atom and name-only net format from segments/vias

### DIFF
--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -571,8 +571,13 @@ def _canonicalize_net_node(
 
     if net_node is None:
         return net_node
-    # Already has a numeric first value — nothing to fix
+    # Already has a numeric first value
     if net_node.get_int(0) is not None:
+        # When numeric_only is requested, strip any trailing name string.
+        # kicad-cli DRC may rewrite (net N) → (net N "name") on segments;
+        # KiCad 9 rejects the dual-atom format on segments/vias.
+        if numeric_only and len(net_node.children) > 1:
+            return SExp.list("net", net_node.get_int(0))
         return net_node
     # Name-only format: (net "name")
     net_name = net_node.get_string(0) or ""
@@ -906,6 +911,79 @@ def _assign_empty_nets_to_zero(output_sexp) -> bool:
     return changed
 
 
+def _strip_dual_atom_nets(output_sexp) -> bool:
+    """Strip trailing name from ``(net N "name")`` on segments and vias.
+
+    KiCad 9 rejects dual-atom ``(net N "name")`` format on segments and
+    vias — it expects ``(net N)`` only.  kicad-cli DRC may rewrite nets
+    into dual-atom format.  This final pass ensures all segments/vias
+    have numeric-only net nodes.
+
+    Returns True if any element was modified.
+    """
+    from kicad_tools.sexp import SExp
+
+    changed = False
+    for child in output_sexp.children:
+        if child.name not in ("segment", "via"):
+            continue
+        net_node = child.get("net")
+        if net_node is None:
+            continue
+        net_num = net_node.get_int(0)
+        if net_num is not None and len(net_node.children) > 1:
+            child.remove(net_node)
+            child.append(SExp.list("net", net_num))
+            changed = True
+    return changed
+
+
+def _resolve_name_only_nets(output_sexp) -> bool:
+    """Resolve name-only ``(net "NAME")`` on segments/vias to ``(net N)``.
+
+    kicad-cli zone fill may create new segments or vias with name-only
+    net references like ``(net "GND")`` instead of ``(net 2)``.  These
+    won't match any snapshot entry, so the key-based and proximity
+    restore passes leave them untouched.
+
+    This pass builds a name→number lookup from the PCB's net declarations
+    and resolves any remaining name-only references.
+
+    Returns True if any element was modified.
+    """
+    from kicad_tools.sexp import SExp
+
+    # Build name → number mapping from header net declarations.
+    name_to_number: dict[str, int] = {}
+    for child in output_sexp.children:
+        if child.name == "net":
+            net_num = child.get_int(0)
+            net_name = child.get_string(1) or ""
+            if net_num is not None and net_num != 0 and net_name:
+                name_to_number[net_name] = net_num
+
+    if not name_to_number:
+        return False
+
+    changed = False
+    for child in output_sexp.children:
+        if child.name not in ("segment", "via"):
+            continue
+        net_node = child.get("net")
+        if net_node is None:
+            continue
+        # Skip if already has a numeric ID
+        if net_node.get_int(0) is not None:
+            continue
+        # Name-only format: (net "GND")
+        net_name = net_node.get_string(0)
+        if net_name and net_name in name_to_number:
+            child.remove(net_node)
+            child.append(SExp.list("net", name_to_number[net_name]))
+            changed = True
+    return changed
+
+
 def _restore_net_declarations(
     target_pcb: Path,
     net_nodes: list,
@@ -1011,6 +1089,21 @@ def _restore_net_declarations(
         # prevent DRC errors from empty-string net corruption.
         if _assign_empty_nets_to_zero(output_sexp):
             modified = True
+
+    # --- Resolve name-only (net "NAME") on segments/vias ---
+    # kicad-cli zone fill may create new segments/vias with name-only net
+    # references that have no snapshot entry.  Resolve them using the
+    # PCB's net declarations.
+    if _resolve_name_only_nets(output_sexp):
+        modified = True
+
+    # --- Strip dual-atom (net N "name") from segments/vias ---
+    # KiCad 9 rejects dual-atom format on segments/vias.  kicad-cli DRC
+    # may rewrite (net N) → (net N "name"); this pass ensures only (net N).
+    # Runs unconditionally (not just when element_nets is populated) since
+    # the corruption can also come from the router output or other tools.
+    if _strip_dual_atom_nets(output_sexp):
+        modified = True
 
     if modified:
         save_pcb(output_sexp, target_pcb)

--- a/tests/test_runner_net_restore.py
+++ b/tests/test_runner_net_restore.py
@@ -156,6 +156,24 @@ class TestCanonicalizeNetNode:
         result = _canonicalize_net_node(original, {"X": 5}, numeric_only=True)
         assert result is original
 
+    def test_dual_atom_stripped_when_numeric_only(self):
+        """numeric_only=True strips trailing name from (net N "name")."""
+        from kicad_tools.cli.runner import _canonicalize_net_node
+
+        node = _canonicalize_net_node(
+            _net_node(79, "GNDA"), {"GNDA": 79}, numeric_only=True
+        )
+        assert node.get_int(0) == 79
+        assert node.get_string(1) is None
+
+    def test_dual_atom_preserved_when_not_numeric_only(self):
+        """Default mode preserves (net N "name") format."""
+        from kicad_tools.cli.runner import _canonicalize_net_node
+
+        original = _net_node(79, "GNDA")
+        result = _canonicalize_net_node(original, {"GNDA": 79})
+        assert result is original
+
     def test_none_returns_none(self):
         from kicad_tools.cli.runner import _canonicalize_net_node
 
@@ -1012,6 +1030,239 @@ class TestAssignEmptyNetsToZero:
                 assert net_node is not None
                 assert net_node.get_int(0) == 0, (
                     "Segment originally (net 0) should be restored to (net 0)"
+                )
+                break
+        else:
+            pytest.fail("No segment found")
+
+
+# ---------------------------------------------------------------------------
+# _strip_dual_atom_nets
+# ---------------------------------------------------------------------------
+
+
+class TestStripDualAtomNets:
+    """Verify ``_strip_dual_atom_nets`` strips trailing names from segments/vias."""
+
+    def test_segment_dual_atom_stripped(self):
+        """(net 5 \"GND\") on a segment becomes (net 5)."""
+        from kicad_tools.cli.runner import _strip_dual_atom_nets
+        from kicad_tools.sexp.parser import parse_string as load_sexp
+
+        tree = load_sexp(
+            '(kicad_pcb (segment (start 1 2) (end 3 4) (width 0.25) '
+            '(layer "F.Cu") (net 5 "GND") (uuid "s1")))'
+        )
+        changed = _strip_dual_atom_nets(tree)
+        assert changed is True
+        seg = [c for c in tree.children if c.name == "segment"][0]
+        net_node = seg.get("net")
+        assert net_node.get_int(0) == 5
+        assert net_node.get_string(1) is None
+
+    def test_via_dual_atom_stripped(self):
+        """(net 3 \"VCC\") on a via becomes (net 3)."""
+        from kicad_tools.cli.runner import _strip_dual_atom_nets
+        from kicad_tools.sexp.parser import parse_string as load_sexp
+
+        tree = load_sexp(
+            '(kicad_pcb (via (at 10 20) (size 0.6) (drill 0.3) '
+            '(layers "F.Cu" "B.Cu") (net 3 "VCC") (uuid "v1")))'
+        )
+        changed = _strip_dual_atom_nets(tree)
+        assert changed is True
+        via = [c for c in tree.children if c.name == "via"][0]
+        net_node = via.get("net")
+        assert net_node.get_int(0) == 3
+        assert net_node.get_string(1) is None
+
+    def test_pad_dual_atom_preserved(self):
+        """(net 5 \"GND\") on a pad is left unchanged (valid in KiCad 9)."""
+        from kicad_tools.cli.runner import _strip_dual_atom_nets
+        from kicad_tools.sexp.parser import parse_string as load_sexp
+
+        tree = load_sexp(
+            '(kicad_pcb (pad "1" smd rect (at 0 0) (size 1 1) '
+            '(layers "F.Cu") (net 5 "GND")))'
+        )
+        changed = _strip_dual_atom_nets(tree)
+        assert changed is False
+
+    def test_numeric_only_unchanged(self):
+        """(net 5) on a segment is left unchanged."""
+        from kicad_tools.cli.runner import _strip_dual_atom_nets
+        from kicad_tools.sexp.parser import parse_string as load_sexp
+
+        tree = load_sexp(
+            '(kicad_pcb (segment (start 1 2) (end 3 4) (width 0.25) '
+            '(layer "F.Cu") (net 5) (uuid "s2")))'
+        )
+        changed = _strip_dual_atom_nets(tree)
+        assert changed is False
+
+    def test_no_segments_returns_false(self):
+        """A PCB with no segments/vias returns False."""
+        from kicad_tools.cli.runner import _strip_dual_atom_nets
+        from kicad_tools.sexp.parser import parse_string as load_sexp
+
+        tree = load_sexp('(kicad_pcb (net 0 "") (net 1 "GND"))')
+        changed = _strip_dual_atom_nets(tree)
+        assert changed is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_name_only_nets
+# ---------------------------------------------------------------------------
+
+
+class TestResolveNameOnlyNets:
+    """Verify ``_resolve_name_only_nets`` resolves name-only nets on segments/vias."""
+
+    def test_name_only_segment_resolved(self):
+        """(net \"GND\") on a segment becomes (net 2)."""
+        from kicad_tools.cli.runner import _resolve_name_only_nets
+        from kicad_tools.sexp.parser import parse_string as load_sexp
+
+        tree = load_sexp(
+            '(kicad_pcb (net 0 "") (net 2 "GND") '
+            '(segment (start 1 2) (end 3 4) (width 0.25) '
+            '(layer "F.Cu") (net "GND") (uuid "s1")))'
+        )
+        changed = _resolve_name_only_nets(tree)
+        assert changed is True
+        seg = [c for c in tree.children if c.name == "segment"][0]
+        net_node = seg.get("net")
+        assert net_node.get_int(0) == 2
+        assert net_node.get_string(1) is None
+
+    def test_name_only_via_resolved(self):
+        """(net \"VCC\") on a via becomes (net 3)."""
+        from kicad_tools.cli.runner import _resolve_name_only_nets
+        from kicad_tools.sexp.parser import parse_string as load_sexp
+
+        tree = load_sexp(
+            '(kicad_pcb (net 0 "") (net 3 "VCC") '
+            '(via (at 10 20) (size 0.6) (drill 0.3) '
+            '(layers "F.Cu" "B.Cu") (net "VCC") (uuid "v1")))'
+        )
+        changed = _resolve_name_only_nets(tree)
+        assert changed is True
+        via = [c for c in tree.children if c.name == "via"][0]
+        net_node = via.get("net")
+        assert net_node.get_int(0) == 3
+
+    def test_unknown_name_left_unchanged(self):
+        """(net \"MYSTERY\") with no matching declaration is left unchanged."""
+        from kicad_tools.cli.runner import _resolve_name_only_nets
+        from kicad_tools.sexp.parser import parse_string as load_sexp
+
+        tree = load_sexp(
+            '(kicad_pcb (net 0 "") (net 1 "GND") '
+            '(segment (start 1 2) (end 3 4) (width 0.25) '
+            '(layer "F.Cu") (net "MYSTERY") (uuid "s2")))'
+        )
+        changed = _resolve_name_only_nets(tree)
+        assert changed is False
+
+    def test_numeric_net_not_touched(self):
+        """(net 5) on a segment is left unchanged."""
+        from kicad_tools.cli.runner import _resolve_name_only_nets
+        from kicad_tools.sexp.parser import parse_string as load_sexp
+
+        tree = load_sexp(
+            '(kicad_pcb (net 0 "") (net 5 "VCC") '
+            '(segment (start 1 2) (end 3 4) (width 0.25) '
+            '(layer "F.Cu") (net 5) (uuid "s3")))'
+        )
+        changed = _resolve_name_only_nets(tree)
+        assert changed is False
+
+    def test_no_net_declarations_returns_false(self):
+        """A PCB with no net declarations returns False."""
+        from kicad_tools.cli.runner import _resolve_name_only_nets
+        from kicad_tools.sexp.parser import parse_string as load_sexp
+
+        tree = load_sexp(
+            '(kicad_pcb (segment (start 1 2) (end 3 4) (width 0.25) '
+            '(layer "F.Cu") (net "GND") (uuid "s4")))'
+        )
+        changed = _resolve_name_only_nets(tree)
+        assert changed is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: _restore_net_declarations end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreNetDeclarationsStripsFormats:
+    """Verify the full pipeline strips dual-atom and name-only formats."""
+
+    @staticmethod
+    def _write_pcb(tmp_path: Path, content: str) -> Path:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(content)
+        return pcb
+
+    def test_dual_atom_stripped_in_pipeline(self, tmp_path):
+        """A segment with (net 5 \"GND\") is stripped to (net 5) by the full pipeline."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 5 "GND")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net 5 "GND") (uuid "d1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(5, "GND")]
+        _restore_net_declarations(pcb, net_nodes, element_nets=None)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 5
+                assert net_node.get_string(1) is None, (
+                    "Dual-atom format should be stripped from segments"
+                )
+                break
+        else:
+            pytest.fail("No segment found")
+
+    def test_name_only_resolved_in_pipeline(self, tmp_path):
+        """A segment with (net \"GND\") is resolved to (net 2) by the full pipeline."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 2 "GND")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net "GND") (uuid "n1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(2, "GND")]
+        _restore_net_declarations(pcb, net_nodes, element_nets=None)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 2
+                assert net_node.get_string(1) is None, (
+                    "Name-only format should be resolved to numeric-only"
                 )
                 break
         else:

--- a/tests/test_zones_cmd.py
+++ b/tests/test_zones_cmd.py
@@ -931,11 +931,10 @@ class TestKiCad10NetFormat:
         assert '(net "+3V3")' in result_content or '(net 2 "+3V3")' in result_content
 
     def test_snapshot_canonicalizes_name_only_to_number_format(self, tmp_path):
-        """_snapshot_element_nets canonicalizes (net "name") to (net N "name") format.
+        """_snapshot_element_nets canonicalizes net format per element type.
 
-        When the PCB header has (net 1 "GND") and an element has (net "GND"),
-        the snapshot should store the canonicalized (net 1 "GND") node so that
-        restore writes back the full format.
+        - Pads: (net "name") -> (net N "name")  (dual-atom valid for pads)
+        - Segments: (net "name") -> (net N)       (numeric-only for KiCad 9)
         """
         from kicad_tools.cli.runner import _snapshot_element_nets
 
@@ -978,19 +977,20 @@ class TestKiCad10NetFormat:
         assert pad2_net.get_int(0) == 2
         assert pad2_net.get_string(1) == "VCC"
 
-        # Verify segment snapshot is canonicalized
+        # Verify segment snapshot is canonicalized to numeric-only (net N)
+        # Segments use numeric_only=True because KiCad 9 rejects dual-atom
+        # format on segments/vias.
         seg_keys = [k for k in snapshot if k.startswith("seg:")]
         assert len(seg_keys) == 1
         seg_net = snapshot[seg_keys[0]][0]
         assert seg_net.get_int(0) == 1
-        assert seg_net.get_string(1) == "GND"
+        assert seg_net.get_string(1) is None
 
     def test_restore_writes_number_format_for_kicad10_input(self, tmp_path):
-        """After snapshot+restore cycle, pad net nodes use (net N "name") format.
+        """After snapshot+restore cycle, net format matches element type.
 
-        Even when the input PCB uses KiCad 10 name-only (net "GND") format,
-        the restored output should have (net 1 "GND") so downstream parsers
-        can read the net number directly.
+        Pads: (net N "name") — dual-atom valid for pads.
+        Segments/vias: (net N) — numeric-only required by KiCad 9.
         """
         from kicad_tools.cli.runner import (
             _restore_net_declarations,
@@ -1074,7 +1074,7 @@ class TestKiCad10NetFormat:
                             f"got number={net_num} but no name"
                         )
 
-        # Check segments
+        # Check segments — must be numeric-only (net N) for KiCad 9
         for child in output_sexp.children:
             if child.name == "segment":
                 net_node = child.get("net")
@@ -1082,8 +1082,9 @@ class TestKiCad10NetFormat:
                     net_num = net_node.get_int(0)
                     if net_num and net_num != 0:
                         net_name = net_node.get_string(1)
-                        assert net_name is not None, (
-                            f'Restored segment net should have (net N "name") format'
+                        assert net_name is None, (
+                            f"Restored segment net should have (net N) format "
+                            f"(numeric-only), got trailing name {net_name!r}"
                         )
 
     def test_pad_from_sexp_name_only_format(self):


### PR DESCRIPTION
## Summary

Strip `(net N "name")` dual-atom and `(net "NAME")` name-only format from segments and vias in the zone fill restore pipeline, ensuring KiCad 9 compatibility.

## Changes

- Enhanced `_canonicalize_net_node()` to strip trailing name string when `numeric_only=True` and the node already has dual-atom format `(net N "name")`
- Added `_strip_dual_atom_nets()` final pass that catches any remaining dual-atom format on segments/vias after all restore passes
- Added `_resolve_name_only_nets()` pass that resolves `(net "NAME")` format on segments/vias using PCB header net declarations
- Wired both new passes into `_restore_net_declarations()` after the existing empty-net-to-zero pass
- Updated `test_zones_cmd.py` assertions to reflect that segment snapshots now correctly use numeric-only format

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No `(net N "name")` format on segments/vias in output | Pass | `_strip_dual_atom_nets()` removes all dual-atom format; `_canonicalize_net_node()` also strips during snapshot |
| No `(net "name")` name-only format on segments/vias in output | Pass | `_resolve_name_only_nets()` resolves using PCB header declarations |
| Pad `(net N "name")` format preserved | Pass | `test_pad_dual_atom_preserved` confirms pads are untouched |
| `_strip_dual_atom_nets()` has dedicated unit tests | Pass | 5 tests in `TestStripDualAtomNets` |
| `_resolve_name_only_nets()` has dedicated unit tests | Pass | 5 tests in `TestResolveNameOnlyNets` |
| `_canonicalize_net_node()` dual-atom path has a dedicated test | Pass | `test_dual_atom_stripped_when_numeric_only` and `test_dual_atom_preserved_when_not_numeric_only` |
| All existing zone fill and net restore tests pass | Pass | 98 passed, 1 skipped (integration test requiring kicad-cli) |

## Test Plan

```
pytest tests/test_runner_net_restore.py tests/test_zones_cmd.py -x -v
# 98 passed, 1 skipped
```

Closes #1851