### PR TITLE
feat(sch): add set-footprint command for symbol footprint assignment

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -11,7 +11,10 @@ def run_sch_command(args) -> int:
     if not args.sch_command:
         print("Usage: kicad-tools sch <command> [options] <file>")
         print("Commands: summary, hierarchy, labels, validate, wires, info, pins,")
-        print("          connections, unconnected, replace, sync-hierarchy, rename-signal")
+        print(
+            "          connections, unconnected, set-footprint, replace,"
+            " sync-hierarchy, rename-signal"
+        )
         return 1
 
     schematic_path = Path(args.schematic)
@@ -121,6 +124,19 @@ def run_sch_command(args) -> int:
         if args.include_dnp:
             sub_argv.append("--include-dnp")
         return unconnected_main(sub_argv) or 0
+
+    elif args.sch_command == "set-footprint":
+        from ..sch_set_footprint import run_set_footprint
+
+        map_path = Path(args.map_file) if getattr(args, "map_file", None) else None
+        return run_set_footprint(
+            schematic_path=schematic_path,
+            ref=getattr(args, "ref", None),
+            footprint=getattr(args, "footprint", None),
+            map_path=map_path,
+            dry_run=getattr(args, "dry_run", False),
+            backup=getattr(args, "backup", True),
+        )
 
     elif args.sch_command == "replace":
         from ..sch_replace_symbol import main as replace_main

--- a/src/kicad_tools/cli/modify_schematic.py
+++ b/src/kicad_tools/cli/modify_schematic.py
@@ -75,6 +75,8 @@ def find_symbol_text_range(text: str, reference: str) -> tuple[int, int, dict] |
             # Value property spans multiple lines - just capture the quoted value
             value_match = re.search(r'\(property "Value" "([^"]*)"', block)
 
+            footprint_match = re.search(r'\(property "Footprint" "([^"]*)"', block)
+
             info = {
                 "lib_id": lib_id_match.group(1) if lib_id_match else "",
                 "position": (float(pos_match.group(1)), float(pos_match.group(2)))
@@ -82,6 +84,7 @@ def find_symbol_text_range(text: str, reference: str) -> tuple[int, int, dict] |
                 else (0, 0),
                 "uuid": uuid_match.group(1) if uuid_match else "",
                 "value": value_match.group(1) if value_match else "",
+                "footprint": footprint_match.group(1) if footprint_match else "",
             }
 
             return (match.start(), match.end(), info)
@@ -134,6 +137,33 @@ def set_value_text(text: str, reference: str, new_value: str) -> tuple[str, bool
     modified = text[:start] + new_block + text[end:]
 
     return modified, True, f"Changed {reference} value: '{old_value}' -> '{new_value}'"
+
+
+def set_footprint_text(text: str, reference: str, new_footprint: str) -> tuple[str, bool, str]:
+    """
+    Set a symbol's Footprint property using text replacement.
+
+    Returns (modified_text, success, message).
+    """
+    result = find_symbol_text_range(text, reference)
+
+    if not result:
+        return text, False, f"Symbol '{reference}' not found"
+
+    start, end, info = result
+    block = text[start:end]
+    old_footprint = info["footprint"]
+
+    # Replace the footprint property in this block
+    footprint_pattern = re.compile(r'(\(property "Footprint" )"[^"]*"')
+    new_block = footprint_pattern.sub(rf'\g<1>"{new_footprint}"', block, count=1)
+
+    if new_block == block:
+        return text, False, f"Could not find Footprint property on {reference}"
+
+    modified = text[:start] + new_block + text[end:]
+
+    return modified, True, f"Changed {reference} footprint: '{old_footprint}' -> '{new_footprint}'"
 
 
 def set_lib_id_text(text: str, reference: str, new_lib_id: str) -> tuple[str, bool, str]:
@@ -539,6 +569,12 @@ def main():
         "--set-lib-id", nargs=2, metavar=("REF", "LIB_ID"), help="Change symbol library reference"
     )
     ops.add_argument(
+        "--set-footprint",
+        nargs=2,
+        metavar=("REF", "FOOTPRINT"),
+        help="Set symbol footprint property",
+    )
+    ops.add_argument(
         "--add-lib-symbol",
         type=Path,
         metavar="FILE",
@@ -606,6 +642,7 @@ def main():
         args.delete,
         args.set_value,
         args.set_lib_id,
+        args.set_footprint,
         args.add_lib_symbol,
         args.regen_uuids,
     ]
@@ -664,6 +701,22 @@ def main():
         else:
             modified_text, success, msg = set_lib_id_text(modified_text, ref, lib_id)
             results.append(("Set Lib ID", success, msg))
+            if success:
+                modified = True
+
+    if args.set_footprint:
+        ref, footprint = args.set_footprint
+        if args.dry_run:
+            result = find_symbol_text_range(modified_text, ref)
+            if result:
+                _, _, info = result
+                msg = f"Would change {ref} footprint: '{info['footprint']}' -> '{footprint}'"
+                results.append(("Set Footprint", True, msg))
+            else:
+                results.append(("Set Footprint", False, f"Symbol '{ref}' not found"))
+        else:
+            modified_text, success, msg = set_footprint_text(modified_text, ref, footprint)
+            results.append(("Set Footprint", success, msg))
             if success:
                 modified = True
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -504,6 +504,27 @@ def _add_sch_parser(subparsers) -> None:
     sch_replace.add_argument("--dry-run", action="store_true", help="Show changes without applying")
     sch_replace.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
+    # sch set-footprint
+    sch_set_fp = sch_subparsers.add_parser(
+        "set-footprint", help="Set footprint assignments for symbols"
+    )
+    sch_set_fp.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_set_fp.add_argument("--ref", help="Symbol reference (e.g., U2, R1)")
+    sch_set_fp.add_argument(
+        "--footprint", help="Footprint to assign (e.g., Package_TO_SOT_SMD:SOT-23-5)"
+    )
+    sch_set_fp.add_argument(
+        "--map",
+        dest="map_file",
+        help="Path to JSON or CSV mapping file (ref -> footprint)",
+    )
+    sch_set_fp.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
+    )
+    sch_set_fp.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+
     # sch sync-hierarchy
     sch_sync = sch_subparsers.add_parser(
         "sync-hierarchy", help="Synchronize sheet pins and hierarchical labels"

--- a/src/kicad_tools/cli/sch_set_footprint.py
+++ b/src/kicad_tools/cli/sch_set_footprint.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Set footprint assignments for symbols in KiCad schematics.
+
+Supports single-ref mode, batch mode via JSON/CSV mapping files,
+and hierarchical schematic traversal.
+
+Usage:
+    # Single symbol
+    kicad-tools sch set-footprint board.kicad_sch --ref U2 \\
+        --footprint "Package_TO_SOT_SMD:SOT-23-5"
+
+    # Batch mode with JSON mapping
+    kicad-tools sch set-footprint board.kicad_sch \\
+        --map footprint-map.json
+
+    # Dry run
+    kicad-tools sch set-footprint board.kicad_sch --ref R1 \\
+        --footprint "Resistor_SMD:R_0805_2012Metric" --dry-run
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+from kicad_tools.cli.modify_schematic import (
+    create_backup,
+    find_symbol_text_range,
+    set_footprint_text,
+)
+
+
+def _find_subsheet_files(text: str, schematic_dir: Path) -> list[Path]:
+    """Extract sub-sheet file paths from schematic text.
+
+    Looks for (sheet ... (property "Sheetfile" "filename.kicad_sch" ...)) blocks.
+    """
+    subsheets = []
+    pattern = re.compile(r'\(property "Sheetfile" "([^"]+)"')
+    for match in pattern.finditer(text):
+        subsheet_path = schematic_dir / match.group(1)
+        if subsheet_path.exists():
+            subsheets.append(subsheet_path)
+    return subsheets
+
+
+def _collect_schematic_files(root_path: Path) -> list[Path]:
+    """Recursively collect all schematic files in the hierarchy.
+
+    Returns list starting with root, followed by sub-sheets (depth-first).
+    """
+    visited: set[Path] = set()
+    result: list[Path] = []
+
+    def _walk(sch_path: Path) -> None:
+        resolved = sch_path.resolve()
+        if resolved in visited:
+            return
+        visited.add(resolved)
+        result.append(sch_path)
+
+        try:
+            text = sch_path.read_text(encoding="utf-8")
+        except OSError:
+            return
+
+        for sub in _find_subsheet_files(text, sch_path.parent):
+            _walk(sub)
+
+    _walk(root_path)
+    return result
+
+
+def _load_mapping(map_path: Path) -> dict[str, str]:
+    """Load a reference-to-footprint mapping from JSON or CSV file.
+
+    JSON format: {"R1": "Resistor_SMD:R_0805", "C1": "Capacitor_SMD:C_0603"}
+    CSV format (no header): R1,Resistor_SMD:R_0805
+    """
+    text = map_path.read_text(encoding="utf-8").strip()
+
+    # Try JSON first
+    if text.startswith("{"):
+        mapping = json.loads(text)
+        if not isinstance(mapping, dict):
+            raise ValueError(f"JSON mapping must be an object, got {type(mapping).__name__}")
+        return mapping
+
+    # Fall back to CSV (ref,footprint per line)
+    mapping: dict[str, str] = {}
+    for line_num, line in enumerate(text.splitlines(), 1):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(",", 1)
+        if len(parts) != 2:
+            raise ValueError(f"Line {line_num}: expected 'REF,FOOTPRINT', got: {line}")
+        ref, fp = parts[0].strip(), parts[1].strip()
+        if not ref:
+            raise ValueError(f"Line {line_num}: empty reference")
+        mapping[ref] = fp
+    return mapping
+
+
+def run_set_footprint(
+    schematic_path: Path,
+    ref: str | None = None,
+    footprint: str | None = None,
+    map_path: Path | None = None,
+    dry_run: bool = False,
+    backup: bool = True,
+) -> int:
+    """Run the set-footprint operation.
+
+    Returns 0 on success, 1 on error.
+    """
+    if not schematic_path.exists():
+        print(f"Error: File not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    # Build the ref -> footprint mapping
+    if map_path is not None:
+        if not map_path.exists():
+            print(f"Error: Mapping file not found: {map_path}", file=sys.stderr)
+            return 1
+        try:
+            mapping = _load_mapping(map_path)
+        except (json.JSONDecodeError, ValueError) as e:
+            print(f"Error reading mapping file: {e}", file=sys.stderr)
+            return 1
+        if not mapping:
+            print("Error: Mapping file is empty", file=sys.stderr)
+            return 1
+    elif ref is not None and footprint is not None:
+        mapping = {ref: footprint}
+    else:
+        print("Error: Provide either --ref/--footprint or --map", file=sys.stderr)
+        return 1
+
+    # Collect all schematic files (root + sub-sheets)
+    all_files = _collect_schematic_files(schematic_path)
+
+    total_changed = 0
+    total_errors = 0
+    remaining = dict(mapping)
+    modified_files: dict[Path, str] = {}
+
+    for sch_file in all_files:
+        try:
+            text = sch_file.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"Error reading {sch_file}: {e}", file=sys.stderr)
+            total_errors += 1
+            continue
+
+        file_modified = False
+        current_text = text
+
+        # Try each remaining reference against this file
+        for r in list(remaining.keys()):
+            fp = remaining[r]
+            result = find_symbol_text_range(current_text, r)
+            if result is None:
+                continue
+
+            if dry_run:
+                _, _, info = result
+                old_fp = info.get("footprint", "")
+                print(f"  {r}: '{old_fp}' -> '{fp}' (in {sch_file.name})")
+                total_changed += 1
+                del remaining[r]
+            else:
+                current_text, success, msg = set_footprint_text(current_text, r, fp)
+                if success:
+                    print(f"  {msg} (in {sch_file.name})")
+                    file_modified = True
+                    total_changed += 1
+                    del remaining[r]
+                else:
+                    print(f"  Warning: {msg}", file=sys.stderr)
+                    total_errors += 1
+
+        if file_modified:
+            modified_files[sch_file] = current_text
+
+    # Write out modified files
+    if not dry_run and modified_files:
+        for sch_file, new_text in modified_files.items():
+            if backup:
+                bak = create_backup(sch_file)
+                print(f"  Backup: {bak.name}")
+            try:
+                sch_file.write_text(new_text, encoding="utf-8")
+            except OSError as e:
+                print(f"Error writing {sch_file}: {e}", file=sys.stderr)
+                total_errors += 1
+
+    # Summary
+    print()
+    if dry_run:
+        print(f"Dry run: {total_changed} footprint(s) would be changed")
+    else:
+        print(f"Changed {total_changed} footprint(s)")
+
+    if remaining:
+        print(f"Warning: {len(remaining)} reference(s) not found: {', '.join(sorted(remaining))}")
+        total_errors += len(remaining)
+
+    return 1 if total_errors > 0 and total_changed == 0 else 0
+
+
+def main(argv: list[str] | None = None):
+    """CLI entry point for standalone usage."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Set footprint assignments in KiCad schematics",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", type=Path, help="Path to .kicad_sch file")
+    parser.add_argument("--ref", help="Symbol reference (e.g., U2, R1)")
+    parser.add_argument(
+        "--footprint", help="Footprint to assign (e.g., Package_TO_SOT_SMD:SOT-23-5)"
+    )
+    parser.add_argument(
+        "--map",
+        dest="map_file",
+        type=Path,
+        help="Path to JSON or CSV mapping file (ref -> footprint)",
+    )
+    parser.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
+    )
+    parser.add_argument(
+        "--no-backup", action="store_true", help="Skip creating backup files"
+    )
+
+    args = parser.parse_args(argv)
+
+    # Validate argument combinations
+    if args.map_file and (args.ref or args.footprint):
+        print("Error: Cannot use --map with --ref/--footprint", file=sys.stderr)
+        return 1
+    if args.ref and not args.footprint:
+        print("Error: --footprint is required when using --ref", file=sys.stderr)
+        return 1
+    if args.footprint and not args.ref:
+        print("Error: --ref is required when using --footprint", file=sys.stderr)
+        return 1
+    if not args.ref and not args.map_file:
+        print("Error: Provide either --ref/--footprint or --map", file=sys.stderr)
+        return 1
+
+    return run_set_footprint(
+        schematic_path=args.schematic,
+        ref=args.ref,
+        footprint=args.footprint,
+        map_path=args.map_file,
+        dry_run=args.dry_run,
+        backup=not args.no_backup,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sch_set_footprint.py
+++ b/tests/test_sch_set_footprint.py
@@ -1,0 +1,447 @@
+"""Tests for the sch set-footprint command.
+
+Covers set_footprint_text(), run_set_footprint(), batch mapping,
+hierarchical schematic traversal, and dry-run mode.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.modify_schematic import find_symbol_text_range, set_footprint_text
+from kicad_tools.cli.sch_set_footprint import (
+    _collect_schematic_files,
+    _load_mapping,
+    run_set_footprint,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal schematic content for testing
+# ---------------------------------------------------------------------------
+
+MINIMAL_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:C")
+\t\t(at 120 50 0)
+\t\t(property "Reference" "C1"
+\t\t\t(at 120 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "100nF"
+\t\t\t(at 120 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 120 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "C1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+
+def _write_sch(tmp_path: Path, content: str = MINIMAL_SCHEMATIC, name: str = "test.kicad_sch") -> Path:
+    p = tmp_path / name
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# set_footprint_text() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetFootprintText:
+    def test_update_existing_footprint(self):
+        """Update a symbol that already has a footprint assigned."""
+        new_fp = "Resistor_SMD:R_0805_2012Metric"
+        result, success, msg = set_footprint_text(MINIMAL_SCHEMATIC, "R1", new_fp)
+        assert success is True
+        assert new_fp in result
+        assert "R_0402_1005Metric" not in result
+        assert "Changed R1 footprint" in msg
+
+    def test_assign_empty_footprint(self):
+        """Assign a footprint to a symbol with an empty footprint property."""
+        new_fp = "Capacitor_SMD:C_0603_1608Metric"
+        result, success, msg = set_footprint_text(MINIMAL_SCHEMATIC, "C1", new_fp)
+        assert success is True
+        assert new_fp in result
+        assert "Changed C1 footprint" in msg
+
+    def test_nonexistent_reference(self):
+        """Trying to set footprint on a non-existent ref returns failure."""
+        result, success, msg = set_footprint_text(MINIMAL_SCHEMATIC, "U99", "some:fp")
+        assert success is False
+        assert result == MINIMAL_SCHEMATIC
+        assert "not found" in msg
+
+    def test_preserves_other_symbols(self):
+        """Changing R1 footprint should not affect C1."""
+        new_fp = "Resistor_SMD:R_0805_2012Metric"
+        result, success, _ = set_footprint_text(MINIMAL_SCHEMATIC, "R1", new_fp)
+        assert success is True
+        # C1 should still have empty footprint
+        c1_result = find_symbol_text_range(result, "C1")
+        assert c1_result is not None
+        _, _, info = c1_result
+        assert info["footprint"] == ""
+
+    def test_footprint_with_special_characters(self):
+        """Footprint strings with colons, underscores, and numbers."""
+        new_fp = "Package_TO_SOT_SMD:SOT-23-5"
+        result, success, _ = set_footprint_text(MINIMAL_SCHEMATIC, "R1", new_fp)
+        assert success is True
+        assert new_fp in result
+
+
+# ---------------------------------------------------------------------------
+# find_symbol_text_range() footprint extraction
+# ---------------------------------------------------------------------------
+
+
+class TestFindSymbolFootprint:
+    def test_extracts_footprint_from_info(self):
+        result = find_symbol_text_range(MINIMAL_SCHEMATIC, "R1")
+        assert result is not None
+        _, _, info = result
+        assert info["footprint"] == "Resistor_SMD:R_0402_1005Metric"
+
+    def test_extracts_empty_footprint(self):
+        result = find_symbol_text_range(MINIMAL_SCHEMATIC, "C1")
+        assert result is not None
+        _, _, info = result
+        assert info["footprint"] == ""
+
+
+# ---------------------------------------------------------------------------
+# _load_mapping() tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMapping:
+    def test_json_mapping(self, tmp_path):
+        data = {"R1": "Resistor_SMD:R_0805", "C1": "Capacitor_SMD:C_0603"}
+        p = tmp_path / "map.json"
+        p.write_text(json.dumps(data))
+        result = _load_mapping(p)
+        assert result == data
+
+    def test_csv_mapping(self, tmp_path):
+        p = tmp_path / "map.csv"
+        p.write_text("R1,Resistor_SMD:R_0805\nC1,Capacitor_SMD:C_0603\n")
+        result = _load_mapping(p)
+        assert result == {"R1": "Resistor_SMD:R_0805", "C1": "Capacitor_SMD:C_0603"}
+
+    def test_csv_with_comments(self, tmp_path):
+        p = tmp_path / "map.csv"
+        p.write_text("# Header comment\nR1,Resistor_SMD:R_0805\n\n# Another comment\nC1,Capacitor_SMD:C_0603\n")
+        result = _load_mapping(p)
+        assert len(result) == 2
+
+    def test_invalid_csv_line(self, tmp_path):
+        p = tmp_path / "map.csv"
+        p.write_text("R1\n")
+        with pytest.raises(ValueError, match="expected"):
+            _load_mapping(p)
+
+    def test_csv_empty_ref_raises(self, tmp_path):
+        p = tmp_path / "map.csv"
+        p.write_text(",Resistor_SMD:R_0805\n")
+        with pytest.raises(ValueError, match="empty reference"):
+            _load_mapping(p)
+
+    def test_empty_json_object(self, tmp_path):
+        p = tmp_path / "map.json"
+        p.write_text("{}")
+        result = _load_mapping(p)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# run_set_footprint() integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunSetFootprint:
+    def test_single_ref_mode(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        ret = run_set_footprint(
+            schematic_path=sch,
+            ref="R1",
+            footprint="Resistor_SMD:R_0805_2012Metric",
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        assert "Resistor_SMD:R_0805_2012Metric" in text
+        assert "R_0402_1005Metric" not in text
+
+    def test_single_ref_creates_backup(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        ret = run_set_footprint(
+            schematic_path=sch,
+            ref="R1",
+            footprint="Resistor_SMD:R_0805_2012Metric",
+            dry_run=False,
+            backup=True,
+        )
+        assert ret == 0
+        backups = list(tmp_path.glob("test_backup_*"))
+        assert len(backups) == 1
+
+    def test_dry_run_does_not_modify(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        original = sch.read_text()
+        ret = run_set_footprint(
+            schematic_path=sch,
+            ref="R1",
+            footprint="Resistor_SMD:R_0805_2012Metric",
+            dry_run=True,
+            backup=False,
+        )
+        assert ret == 0
+        assert sch.read_text() == original
+
+    def test_batch_json_mapping(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        map_path = tmp_path / "map.json"
+        map_path.write_text(json.dumps({
+            "R1": "Resistor_SMD:R_0805_2012Metric",
+            "C1": "Capacitor_SMD:C_0603_1608Metric",
+        }))
+        ret = run_set_footprint(
+            schematic_path=sch,
+            map_path=map_path,
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        assert "Resistor_SMD:R_0805_2012Metric" in text
+        assert "Capacitor_SMD:C_0603_1608Metric" in text
+
+    def test_nonexistent_ref_returns_error(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        ret = run_set_footprint(
+            schematic_path=sch,
+            ref="U99",
+            footprint="some:fp",
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 1
+
+    def test_missing_schematic(self, tmp_path):
+        ret = run_set_footprint(
+            schematic_path=tmp_path / "nonexistent.kicad_sch",
+            ref="R1",
+            footprint="some:fp",
+        )
+        assert ret == 1
+
+    def test_no_ref_or_map_returns_error(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        ret = run_set_footprint(schematic_path=sch)
+        assert ret == 1
+
+
+# ---------------------------------------------------------------------------
+# Hierarchical schematic support
+# ---------------------------------------------------------------------------
+
+
+PARENT_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet
+\t\t(at 150 50)
+\t\t(size 20 20)
+\t\t(property "Sheetname" "SubSheet"
+\t\t\t(at 150 48 0)
+\t\t)
+\t\t(property "Sheetfile" "sub.kicad_sch"
+\t\t\t(at 150 68 0)
+\t\t)
+\t\t(uuid "33333333-3333-3333-3333-333333333333")
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+CHILD_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "44444444-4444-4444-4444-444444444444")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:C")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "C2"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "1uF"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "55555555-5555-5555-5555-555555555555")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/33333333-3333-3333-3333-333333333333" (reference "C2") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/33333333-3333-3333-3333-333333333333" (page "2"))
+\t)
+)
+"""
+
+
+class TestHierarchicalSchematic:
+    def test_collect_schematic_files(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+
+        files = _collect_schematic_files(parent)
+        assert len(files) == 2
+        assert files[0] == parent
+        assert files[1] == child
+
+    def test_set_footprint_in_subsheet(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+
+        ret = run_set_footprint(
+            schematic_path=parent,
+            ref="C2",
+            footprint="Capacitor_SMD:C_0805_2012Metric",
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        text = child.read_text()
+        assert "Capacitor_SMD:C_0805_2012Metric" in text
+
+    def test_batch_across_hierarchy(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+
+        map_path = tmp_path / "map.json"
+        map_path.write_text(json.dumps({
+            "R1": "Resistor_SMD:R_0805_2012Metric",
+            "C2": "Capacitor_SMD:C_0805_2012Metric",
+        }))
+        ret = run_set_footprint(
+            schematic_path=parent,
+            map_path=map_path,
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        assert "Resistor_SMD:R_0805_2012Metric" in parent.read_text()
+        assert "Capacitor_SMD:C_0805_2012Metric" in child.read_text()
+
+    def test_dry_run_hierarchical(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+        original_child = child.read_text()
+
+        ret = run_set_footprint(
+            schematic_path=parent,
+            ref="C2",
+            footprint="Capacitor_SMD:C_0805_2012Metric",
+            dry_run=True,
+            backup=False,
+        )
+        assert ret == 0
+        # File should be unchanged
+        assert child.read_text() == original_child


### PR DESCRIPTION
## Summary
Add a new `sch set-footprint` CLI subcommand that assigns footprints to schematic symbols using the established text-based modification pattern in `modify_schematic.py`.

## Changes
- Add `set_footprint_text()` function in `modify_schematic.py` (mirrors `set_value_text()`)
- Add footprint extraction to `find_symbol_text_range()` info dict
- Add `--set-footprint` argument to `modify_schematic.py` CLI entry point
- Add `sch set-footprint` subparser in `parser.py` with `--ref`, `--footprint`, `--map`, `--dry-run`, `--backup` args
- Create `sch_set_footprint.py` with `run_set_footprint()` supporting single-ref, batch JSON/CSV, and hierarchical schematic traversal
- Wire `set-footprint` handler into `commands/schematic.py`
- Add 24 tests covering: unit (set_footprint_text), info extraction, mapping loaders, integration (single/batch/dry-run/backup/error), and hierarchical schematic support

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `set_footprint_text()` follows `set_value_text()` pattern | Done | Identical structure: find_symbol_text_range -> regex sub in block -> reassemble |
| `--set-footprint` arg in modify_schematic CLI | Done | Added nargs=2 arg and execution block |
| `sch set-footprint` subparser with --ref/--map/--dry-run/--backup | Done | Parser wired in parser.py |
| Single-ref mode (--ref + --footprint) | Done | Tested in test_single_ref_mode |
| Batch mode (--map with JSON/CSV) | Done | Tested in test_batch_json_mapping, test_csv_mapping |
| Hierarchical schematic traversal | Done | Tested in test_set_footprint_in_subsheet, test_batch_across_hierarchy |
| Dry-run mode | Done | Tested: file unchanged after dry run |
| Backup creation | Done | Tested: backup file created |
| Update existing footprint | Done | Tested in test_update_existing_footprint |
| Assign to empty footprint | Done | Tested in test_assign_empty_footprint |
| Non-existent reference error | Done | Tested in test_nonexistent_reference |
| Special characters in footprint strings | Done | Tested in test_footprint_with_special_characters |

## Test Plan
- 24 pytest tests all passing (`python3 -m pytest tests/test_sch_set_footprint.py -v`)
- 68 existing `test_cli_sch.py` tests still passing (no regressions)

Closes #1849