### PR TITLE
fix(zones): add UUID-based net restore and widen proximity threshold to 0.5mm

### DIFF
--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -800,7 +800,7 @@ def _fallback_restore_by_proximity(output_sexp, element_nets: dict[str, list]) -
     This function builds per-layer spatial indices from the *element_nets*
     snapshot and assigns each remaining ``(net "")`` element the net of the
     nearest snapshotted element on the same layer, provided the distance is
-    within a generous tolerance (0.1 mm -- matching the fix-drc max_displacement
+    within a generous tolerance (0.5 mm -- matching the drill clearance max_displacement
     and still well below typical minimum trace clearance of 0.15 mm+).
 
     Returns True if any element was modified.

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -549,6 +549,17 @@ def _make_segment_via_key(child, *, precision: int = 4) -> str | None:
     return None
 
 
+def _get_element_uuid(child) -> str | None:
+    """Extract the UUID string from a segment or via S-expression node.
+
+    Returns the UUID value if a ``(uuid ...)`` child exists, else None.
+    """
+    uuid_node = child.get("uuid")
+    if uuid_node is None:
+        return None
+    return uuid_node.get_string(0)
+
+
 def _canonicalize_net_node(
     net_node, name_to_number: dict[str, int], *, numeric_only: bool = False
 ):
@@ -699,8 +710,15 @@ def _snapshot_element_nets(pcb_path: Path) -> dict[str, list]:
 
     - **Pads**: keyed by ``"<reference>:<pad_number>"`` using the footprint's
       reference designator, which is stable across kicad-cli UUID regeneration.
-    - **Segments**: keyed by ``"seg:<sx>,<sy>:<ex>,<ey>:<layer>"`` (geometry).
-    - **Vias**: keyed by ``"via:<x>,<y>:<size>:<layers>"`` (geometry).
+    - **Segments/Vias (UUID)**: keyed by ``"uuid:<uuid>"`` when the element
+      carries a ``(uuid ...)`` node.  UUID-based keys are immune to coordinate
+      drift from DRC displacement (up to 0.5 mm for drill clearance repair).
+    - **Segments (geometry)**: keyed by ``"seg:<sx>,<sy>:<ex>,<ey>:<layer>"``.
+    - **Vias (geometry)**: keyed by ``"via:<x>,<y>:<size>:<layers>"``.
+
+    Both UUID and geometry keys are stored for each element so that the
+    restore pass can try UUID first (handles displacement) then fall back
+    to geometry (handles UUID regeneration by kicad-cli).
 
     Net nodes are canonicalized to ``(net N "name")`` format using the PCB
     header net declarations, so that restoring always writes the full format
@@ -746,20 +764,28 @@ def _snapshot_element_nets(pcb_path: Path) -> dict[str, list]:
             key = f"{fp_ref}:{pad_number}"
             snapshot[key] = [_canonicalize_net_node(net_node, name_to_number)]
 
-    # Snapshot segments and vias at the top level, keyed by geometry.
-    # Include ALL segments/vias — even (net 0) — so that zone fill
-    # corruption to (net "") can be restored to the original net.
+    # Snapshot segments and vias at the top level, keyed by both UUID and
+    # geometry.  Include ALL segments/vias — even (net 0) — so that zone
+    # fill corruption to (net "") can be restored to the original net.
     for child in sexp.children:
         if child.name in ("segment", "via"):
             net_node = child.get("net")
+            if _has_nonzero_net(net_node):
+                canonical = [_canonicalize_net_node(net_node, name_to_number, numeric_only=True)]
+            else:
+                # Preserve (net 0) assignment so restore can distinguish
+                # "originally unconnected" from "newly created by fill".
+                canonical = [SExp.list("net", 0)]
+
+            # Store under geometry key (handles UUID regeneration).
             geo_key = _make_segment_via_key(child)
             if geo_key:
-                if _has_nonzero_net(net_node):
-                    snapshot[geo_key] = [_canonicalize_net_node(net_node, name_to_number, numeric_only=True)]
-                else:
-                    # Preserve (net 0) assignment so restore can distinguish
-                    # "originally unconnected" from "newly created by fill".
-                    snapshot[geo_key] = [SExp.list("net", 0)]
+                snapshot[geo_key] = canonical
+
+            # Store under UUID key (handles coordinate displacement).
+            elem_uuid = _get_element_uuid(child)
+            if elem_uuid:
+                snapshot[f"uuid:{elem_uuid}"] = canonical
 
     return snapshot
 
@@ -781,7 +807,7 @@ def _fallback_restore_by_proximity(output_sexp, element_nets: dict[str, list]) -
     """
     import math
 
-    PROXIMITY_THRESHOLD = 0.1  # mm — must cover fix-drc max_displacement (0.1 mm)
+    PROXIMITY_THRESHOLD = 0.5  # mm — must cover drill clearance max_displacement (0.5 mm)
 
     # Parse snapshot keys into spatial buckets by (element_type, layer_key).
     # segment keys: "seg:sx,sy:ex,ey:layer"
@@ -1062,17 +1088,34 @@ def _restore_net_declarations(
                     pad_node.append(element_nets[key][0])
                     modified = True
 
-        # Restore segment and via nets at the top level (keyed by geometry)
+        # Restore segment and via nets at the top level.
+        # Try UUID-based key first (immune to coordinate displacement),
+        # then fall back to geometry-based key (handles UUID regeneration).
         for child in output_sexp.children:
             if child.name in ("segment", "via"):
-                geo_key = _make_segment_via_key(child)
-                if geo_key and geo_key in element_nets:
-                    current_net = child.get("net")
-                    if not _has_canonical_net(current_net):
-                        if current_net is not None:
-                            child.remove(current_net)
-                        child.append(element_nets[geo_key][0])
-                        modified = True
+                current_net = child.get("net")
+                if _has_canonical_net(current_net):
+                    continue
+
+                # Try UUID-based lookup first.
+                snapshot_net = None
+                elem_uuid = _get_element_uuid(child)
+                if elem_uuid:
+                    uuid_key = f"uuid:{elem_uuid}"
+                    if uuid_key in element_nets:
+                        snapshot_net = element_nets[uuid_key]
+
+                # Fall back to geometry-based lookup.
+                if snapshot_net is None:
+                    geo_key = _make_segment_via_key(child)
+                    if geo_key and geo_key in element_nets:
+                        snapshot_net = element_nets[geo_key]
+
+                if snapshot_net is not None:
+                    if current_net is not None:
+                        child.remove(current_net)
+                    child.append(snapshot_net[0])
+                    modified = True
 
         # --- Fallback pass for remaining unmatched (net "") elements ---
         # After the primary key-based restore, some segments/vias may still

--- a/tests/test_runner_net_restore.py
+++ b/tests/test_runner_net_restore.py
@@ -697,16 +697,16 @@ class TestFallbackProximityRestore:
             pytest.fail("No segment found in restored PCB")
 
     def test_segment_not_restored_beyond_widened_threshold(self, tmp_path):
-        """Segment displaced > 0.1 mm must NOT be proximity-matched.
+        """Segment displaced > 0.5 mm must NOT be proximity-matched.
 
-        Even with the widened threshold, segments displaced beyond 0.1 mm
-        (which exceeds fix-drc max_displacement) should not match to avoid
-        cross-net mismatches.
+        The proximity threshold is 0.5 mm (to cover drill clearance
+        max_displacement).  Segments displaced beyond that should not match
+        to avoid cross-net mismatches.
         """
         from kicad_tools.cli.runner import _restore_net_declarations
         from kicad_tools.core.sexp_file import load_pcb
 
-        # Segment displaced 0.15 mm on start-x -- beyond the 0.1 threshold
+        # Segment displaced 0.6 mm on start-x -- beyond the 0.5 threshold
         pcb = self._write_pcb(
             tmp_path,
             """(kicad_pcb
@@ -714,7 +714,7 @@ class TestFallbackProximityRestore:
   (generator "test")
   (net 0 "")
   (net 18 "SCK")
-  (segment (start 100.15 200.0) (end 300.0 400.0) (width 0.25) (layer "F.Cu") (net "") (uuid "far2"))
+  (segment (start 100.6 200.0) (end 300.0 400.0) (width 0.25) (layer "F.Cu") (net "") (uuid "far2"))
 )""",
         )
 
@@ -735,7 +735,7 @@ class TestFallbackProximityRestore:
                         pass  # Expected: still empty
                     else:
                         net_num = net_node.get_int(0)
-                        assert net_num != 18, "Segment 0.15 mm away should not be proximity-matched"
+                        assert net_num != 18, "Segment 0.6 mm away should not be proximity-matched"
                 break
 
 
@@ -1267,3 +1267,283 @@ class TestRestoreNetDeclarationsStripsFormats:
                 break
         else:
             pytest.fail("No segment found")
+
+
+# ---------------------------------------------------------------------------
+# Issue #1848: UUID-based matching for displaced segments
+# ---------------------------------------------------------------------------
+
+
+class TestUuidBasedMatching:
+    """Verify UUID-based snapshot/restore handles DRC displacement."""
+
+    @staticmethod
+    def _write_pcb(tmp_path: Path, content: str) -> Path:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(content)
+        return pcb
+
+    def test_snapshot_includes_uuid_keys(self, tmp_path):
+        """Snapshot must include uuid:<value> keys for elements with UUIDs."""
+        from kicad_tools.cli.runner import _snapshot_element_nets
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 5 "VCC")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net 5) (uuid "abc-123"))
+)""",
+        )
+
+        snapshot = _snapshot_element_nets(pcb)
+        # Both geometry and UUID keys should be present
+        assert "seg:10.0,20.0:30.0,40.0:F.Cu" in snapshot
+        assert "uuid:abc-123" in snapshot
+        assert snapshot["uuid:abc-123"][0].get_int(0) == 5
+
+    def test_snapshot_uuid_key_for_via(self, tmp_path):
+        """Via with UUID must also get a uuid: key in the snapshot."""
+        from kicad_tools.cli.runner import _snapshot_element_nets
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 3 "GND")
+  (via (at 50 75) (size 0.8) (drill 0.4) (layers "F.Cu" "B.Cu") (net 3) (uuid "via-uuid-1"))
+)""",
+        )
+
+        snapshot = _snapshot_element_nets(pcb)
+        assert "uuid:via-uuid-1" in snapshot
+        assert snapshot["uuid:via-uuid-1"][0].get_int(0) == 3
+
+    def test_displaced_segment_restored_by_uuid(self, tmp_path):
+        """Segment displaced 0.3mm by DRC should be restored via UUID match.
+
+        This displacement exceeds the old 0.1mm proximity threshold but the
+        UUID is stable, so the segment must be restored correctly.
+        """
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 18 "SCK")
+  (segment (start 100.3 200.0) (end 300.3 400.0) (width 0.25) (layer "F.Cu") (net "") (uuid "displaced-1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(18, "SCK")]
+        # Snapshot has UUID key from pre-displacement coordinates
+        element_nets = {
+            "seg:100.0,200.0:300.0,400.0:F.Cu": [_net_node(18)],
+            "uuid:displaced-1": [_net_node(18)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 18, (
+                    f"Segment displaced 0.3mm should be restored via UUID; got {net_node}"
+                )
+                break
+        else:
+            pytest.fail("No segment found")
+
+    def test_displaced_via_restored_by_uuid(self, tmp_path):
+        """Via displaced beyond geometry match threshold restored via UUID."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 7 "MOSI")
+  (via (at 50.4 75.0) (size 0.8) (drill 0.4) (layers "F.Cu" "B.Cu") (net "") (uuid "via-disp-1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(7, "MOSI")]
+        element_nets = {
+            "via:50.0,75.0:0.8:F.Cu,B.Cu": [_net_node(7)],
+            "uuid:via-disp-1": [_net_node(7)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "via":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 7, (
+                    f"Via displaced 0.4mm should be restored via UUID; got {net_node}"
+                )
+                break
+        else:
+            pytest.fail("No via found")
+
+    def test_segment_without_uuid_falls_back_to_geometry(self, tmp_path):
+        """Segment without UUID should still be restored by geometry key."""
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 5 "VCC")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net ""))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(5, "VCC")]
+        element_nets = {
+            "seg:10.0,20.0:30.0,40.0:F.Cu": [_net_node(5)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 5, (
+                    "Segment without UUID should fall back to geometry key"
+                )
+                break
+        else:
+            pytest.fail("No segment found")
+
+    def test_net_zero_segment_snapshot_with_uuid(self, tmp_path):
+        """A (net 0) segment with UUID should have both keys in snapshot."""
+        from kicad_tools.cli.runner import _snapshot_element_nets
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 1 "GND")
+  (segment (start 10 20) (end 30 40) (width 0.25) (layer "F.Cu") (net 0) (uuid "zero-seg"))
+)""",
+        )
+
+        snapshot = _snapshot_element_nets(pcb)
+        assert "uuid:zero-seg" in snapshot
+        assert snapshot["uuid:zero-seg"][0].get_int(0) == 0
+        assert "seg:10.0,20.0:30.0,40.0:F.Cu" in snapshot
+
+
+# ---------------------------------------------------------------------------
+# Issue #1848: widened proximity threshold covers drill clearance displacement
+# ---------------------------------------------------------------------------
+
+
+class TestWidenedProximityThreshold:
+    """Verify proximity threshold covers drill clearance max_displacement (0.5mm)."""
+
+    @staticmethod
+    def _write_pcb(tmp_path: Path, content: str) -> Path:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(content)
+        return pcb
+
+    def test_segment_displaced_0_3mm_restored_by_proximity(self, tmp_path):
+        """Segment displaced 0.3mm (within 0.5mm threshold) should be proximity-matched.
+
+        This displacement exceeds the old 0.1mm threshold but is within the
+        new 0.5mm threshold needed for drill clearance repair.
+        """
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 12 "SCLK")
+  (segment (start 100.3 200.0) (end 300.0 400.0) (width 0.25) (layer "F.Cu") (net "") (uuid "drill-disp-1"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(12, "SCLK")]
+        # Only geometry key in snapshot (no UUID key) to test proximity
+        element_nets = {
+            "seg:100.0,200.0:300.0,400.0:F.Cu": [_net_node(12)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                assert net_node is not None
+                assert net_node.get_int(0) == 12, (
+                    f"Segment displaced 0.3mm should be proximity-matched with widened threshold; got {net_node}"
+                )
+                break
+        else:
+            pytest.fail("No segment found")
+
+    def test_segment_displaced_0_5mm_not_restored_by_proximity(self, tmp_path):
+        """Segment displaced exactly at threshold boundary should NOT match.
+
+        The threshold is strict less-than, so 0.5mm displacement should not match.
+        """
+        from kicad_tools.cli.runner import _restore_net_declarations
+        from kicad_tools.core.sexp_file import load_pcb
+
+        pcb = self._write_pcb(
+            tmp_path,
+            """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 12 "SCLK")
+  (segment (start 100.5 200.0) (end 300.0 400.0) (width 0.25) (layer "F.Cu") (net "") (uuid "at-thresh"))
+)""",
+        )
+
+        net_nodes = [_net_node(0, ""), _net_node(12, "SCLK")]
+        element_nets = {
+            "seg:100.0,200.0:300.0,400.0:F.Cu": [_net_node(12)],
+        }
+
+        _restore_net_declarations(pcb, net_nodes, element_nets)
+
+        sexp = load_pcb(str(pcb))
+        for child in sexp.children:
+            if child.name == "segment":
+                net_node = child.get("net")
+                if net_node is not None:
+                    net_num = net_node.get_int(0)
+                    # Should be (net 0) from assign-empty-nets-to-zero, not (net 12)
+                    assert net_num != 12, (
+                        "Segment at exactly 0.5mm should NOT be proximity-matched"
+                    )
+                break


### PR DESCRIPTION
## Summary
Segments displaced by DRC repair (up to 0.5mm for drill clearance) were losing their net assignments because geometry-based snapshot keys no longer matched post-displacement coordinates. This adds UUID-based keying as the primary restore strategy and widens the proximity fallback threshold from 0.1mm to 0.5mm.

## Changes
- Add `_get_element_uuid()` helper to extract UUID from segment/via S-expression nodes
- Store both UUID-based (`uuid:<value>`) and geometry-based keys in the snapshot for each element
- In `_restore_net_declarations()`, try UUID-based lookup first (immune to coordinate displacement), fall back to geometry-based lookup (handles UUID regeneration by kicad-cli)
- Widen proximity fallback threshold from 0.1mm to 0.5mm to cover drill clearance max_displacement
- Update pre-existing test that asserted the old 0.1mm boundary
- Add 8 new tests covering UUID-based matching (snapshot keys, displaced segments/vias, fallback to geometry, net-0 elements) and widened proximity threshold (0.3mm match, 0.5mm boundary rejection)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Number of (net 0) segments reduced (displacement-caused) | Pass | UUID-based matching handles segments displaced up to any distance, not just 0.1mm |
| No (net "") corruption in output | Pass | Existing restore logic maintained; canonical net format preserved |
| Existing tests continue to pass | Pass | All 51 tests pass (1 pre-existing test updated to reflect new 0.5mm threshold) |
| New tests cover displacement beyond proximity threshold | Pass | 8 new tests in TestUuidBasedMatching and TestWidenedProximityThreshold |

## Test Plan
- `python3 -m pytest tests/test_runner_net_restore.py -v -o "addopts="` -- 51/51 pass
- New TestUuidBasedMatching: verifies snapshot includes UUID keys, displaced segments/vias restored by UUID, fallback to geometry for elements without UUID, net-0 elements with UUID
- New TestWidenedProximityThreshold: verifies 0.3mm displacement matches, 0.5mm boundary rejects

Closes #1848