### PR TITLE
refactor: rename parallel SignalIntegrityAnalyzer and CrosstalkRisk classes

### DIFF
--- a/src/kicad_tools/analysis/__init__.py
+++ b/src/kicad_tools/analysis/__init__.py
@@ -34,6 +34,8 @@ from .signal_integrity import (
     ImpedanceDiscontinuity,
     RiskLevel,
     SignalIntegrityAnalyzer,
+    TraceCrosstalkRisk,
+    TraceIntegrityAnalyzer,
 )
 from .thermal import (
     PowerEstimator,
@@ -68,6 +70,8 @@ __all__ = [
     "RoutingComplexity",
     "Severity",
     "SignalIntegrityAnalyzer",
+    "TraceCrosstalkRisk",
+    "TraceIntegrityAnalyzer",
     "ThermalAnalyzer",
     "ThermalHotspot",
     "ThermalSeverity",

--- a/src/kicad_tools/analysis/signal_integrity.py
+++ b/src/kicad_tools/analysis/signal_integrity.py
@@ -5,9 +5,9 @@ adjacent traces and impedance discontinuities from geometry changes.
 
 Example:
     >>> from kicad_tools.schema.pcb import PCB
-    >>> from kicad_tools.analysis import SignalIntegrityAnalyzer
+    >>> from kicad_tools.analysis import TraceIntegrityAnalyzer
     >>> pcb = PCB.load("board.kicad_pcb")
-    >>> analyzer = SignalIntegrityAnalyzer()
+    >>> analyzer = TraceIntegrityAnalyzer()
     >>> crosstalk = analyzer.analyze_crosstalk(pcb)
     >>> for risk in crosstalk:
     ...     print(f"{risk.risk_level}: {risk.aggressor_net} ↔ {risk.victim_net}")
@@ -66,7 +66,7 @@ HIGH_SPEED_NET_PATTERNS = [
 
 
 @dataclass
-class CrosstalkRisk:
+class TraceCrosstalkRisk:
     """Crosstalk risk between two nets.
 
     Attributes:
@@ -171,7 +171,7 @@ class _TrackRun:
         )
 
 
-class SignalIntegrityAnalyzer:
+class TraceIntegrityAnalyzer:
     """Analyze signal integrity concerns on a PCB.
 
     Detects crosstalk risk between adjacent traces and impedance
@@ -213,7 +213,7 @@ class SignalIntegrityAnalyzer:
             self._patterns.extend(high_speed_patterns)
         self._compiled_patterns = [re.compile(p) for p in self._patterns]
 
-    def analyze_crosstalk(self, board: PCB) -> list[CrosstalkRisk]:
+    def analyze_crosstalk(self, board: PCB) -> list[TraceCrosstalkRisk]:
         """Find traces with crosstalk risk.
 
         Identifies high-speed nets and finds adjacent parallel traces
@@ -223,7 +223,7 @@ class SignalIntegrityAnalyzer:
             board: PCB object to analyze.
 
         Returns:
-            List of CrosstalkRisk objects for concerning trace pairs,
+            List of TraceCrosstalkRisk objects for concerning trace pairs,
             sorted by risk level (highest first).
         """
         # Get high-speed net numbers
@@ -232,7 +232,7 @@ class SignalIntegrityAnalyzer:
             return []
 
         net_names = {net.number: net.name for net in board.nets.values()}
-        risks: list[CrosstalkRisk] = []
+        risks: list[TraceCrosstalkRisk] = []
         analyzed_pairs: set[tuple[int, int]] = set()
 
         # Build track runs for each high-speed net on each layer
@@ -507,7 +507,7 @@ class SignalIntegrityAnalyzer:
         spacing: float,
         net1_name: str,
         net_names: dict[int, str],
-    ) -> CrosstalkRisk:
+    ) -> TraceCrosstalkRisk:
         """Calculate crosstalk coupling between parallel tracks.
 
         Uses a simplified coupling model where coupling increases with
@@ -521,7 +521,7 @@ class SignalIntegrityAnalyzer:
             net_names: Mapping of net numbers to names.
 
         Returns:
-            CrosstalkRisk assessment.
+            TraceCrosstalkRisk assessment.
         """
         net2_name = net_names.get(run2.net_number, run2.net_name)
         parallel_length = min(run1.total_length, run2.total_length)
@@ -553,7 +553,7 @@ class SignalIntegrityAnalyzer:
                 target_spacing = 0.5
             suggestion = f"Increase spacing to {target_spacing:.2f}mm or add ground guard trace"
 
-        return CrosstalkRisk(
+        return TraceCrosstalkRisk(
             aggressor_net=net1_name,
             victim_net=net2_name,
             parallel_length_mm=parallel_length,
@@ -731,3 +731,13 @@ class SignalIntegrityAnalyzer:
                 return result
 
         return None
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatibility aliases (deprecated)
+# ---------------------------------------------------------------------------
+SignalIntegrityAnalyzer = TraceIntegrityAnalyzer
+"""Deprecated alias for :class:`TraceIntegrityAnalyzer`."""
+
+CrosstalkRisk = TraceCrosstalkRisk
+"""Deprecated alias for :class:`TraceCrosstalkRisk`."""

--- a/src/kicad_tools/cli/analyze_cmd.py
+++ b/src/kicad_tools/cli/analyze_cmd.py
@@ -36,7 +36,7 @@ from kicad_tools.analysis import (
     CongestionAnalyzer,
     RiskLevel,
     Severity,
-    SignalIntegrityAnalyzer,
+    TraceIntegrityAnalyzer,
     ThermalAnalyzer,
     ThermalSeverity,
     TraceLengthAnalyzer,
@@ -634,7 +634,7 @@ def _run_signal_integrity_analysis(args: argparse.Namespace) -> int:
         return 1
 
     # Run analysis
-    analyzer = SignalIntegrityAnalyzer()
+    analyzer = TraceIntegrityAnalyzer()
 
     crosstalk_risks = []
     impedance_discs = []

--- a/src/kicad_tools/mcp/tools/placement.py
+++ b/src/kicad_tools/mcp/tools/placement.py
@@ -10,7 +10,7 @@ import math
 from pathlib import Path
 
 from kicad_tools.analysis.congestion import CongestionAnalyzer, Severity
-from kicad_tools.analysis.signal_integrity import RiskLevel, SignalIntegrityAnalyzer
+from kicad_tools.analysis.signal_integrity import RiskLevel, TraceIntegrityAnalyzer
 from kicad_tools.analysis.thermal import ThermalAnalyzer, ThermalSeverity
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.exceptions import ParseError
@@ -344,7 +344,7 @@ def _analyze_signal_integrity(pcb: PCB) -> tuple[float, list[PlacementIssue]]:
     Returns:
         Tuple of (si_score, issues)
     """
-    analyzer = SignalIntegrityAnalyzer()
+    analyzer = TraceIntegrityAnalyzer()
 
     # Analyze crosstalk
     crosstalk_risks = analyzer.analyze_crosstalk(pcb)

--- a/src/kicad_tools/optim/signal_integrity.py
+++ b/src/kicad_tools/optim/signal_integrity.py
@@ -14,7 +14,7 @@ Example::
         classify_nets,
         analyze_placement_for_si,
         get_si_score,
-        SignalIntegrityAnalyzer,
+        PlacementSIAnalyzer,
     )
     from kicad_tools.schema.pcb import PCB
 
@@ -33,7 +33,7 @@ Example::
     print(f"Signal integrity score: {score:.1f}/100")
 
     # Use physics-aware analyzer for more accurate crosstalk
-    analyzer = SignalIntegrityAnalyzer(pcb)
+    analyzer = PlacementSIAnalyzer(pcb)
     if analyzer.physics_available:
         risk = analyzer.get_crosstalk_risk("CLK", "ADC_IN")
         print(f"Crosstalk risk: {risk}")
@@ -56,8 +56,8 @@ __all__ = [
     "SignalClass",
     "NetClassification",
     "SignalIntegrityHint",
-    "CrosstalkRisk",
-    "SignalIntegrityAnalyzer",
+    "PlacementCrosstalkRisk",
+    "PlacementSIAnalyzer",
     "classify_nets",
     "analyze_placement_for_si",
     "get_si_score",
@@ -116,7 +116,7 @@ class SignalIntegrityHint:
 
 
 @dataclass
-class CrosstalkRisk:
+class PlacementCrosstalkRisk:
     """Result of crosstalk risk analysis between two nets.
 
     Provides both physics-based calculations (when available) and
@@ -138,13 +138,13 @@ class CrosstalkRisk:
         """Human-readable representation."""
         mode = "calculated" if self.calculated else "estimated"
         return (
-            f"CrosstalkRisk({self.aggressor_net} → {self.victim_net}): "
+            f"PlacementCrosstalkRisk({self.aggressor_net} → {self.victim_net}): "
             f"NEXT={self.next_percent:.1f}%, FEXT={self.fext_percent:.1f}% "
             f"({mode}, {self.risk_level})"
         )
 
 
-class SignalIntegrityAnalyzer:
+class PlacementSIAnalyzer:
     """Physics-aware signal integrity analyzer.
 
     Uses the physics module for accurate crosstalk and impedance
@@ -153,11 +153,11 @@ class SignalIntegrityAnalyzer:
 
     Example::
 
-        from kicad_tools.optim.signal_integrity import SignalIntegrityAnalyzer
+        from kicad_tools.optim.signal_integrity import PlacementSIAnalyzer
         from kicad_tools.schema.pcb import PCB
 
         pcb = PCB.load("board.kicad_pcb")
-        analyzer = SignalIntegrityAnalyzer(pcb)
+        analyzer = PlacementSIAnalyzer(pcb)
 
         if analyzer.physics_available:
             print("Using physics-based analysis")
@@ -215,7 +215,7 @@ class SignalIntegrityAnalyzer:
         victim_net: str,
         layer: str = "F.Cu",
         rise_time_ns: float = 1.0,
-    ) -> CrosstalkRisk:
+    ) -> PlacementCrosstalkRisk:
         """Analyze crosstalk risk between two nets.
 
         Uses physics calculations when available, otherwise falls back
@@ -228,7 +228,7 @@ class SignalIntegrityAnalyzer:
             rise_time_ns: Signal rise time in nanoseconds
 
         Returns:
-            CrosstalkRisk with analysis results
+            PlacementCrosstalkRisk with analysis results
         """
         if self.physics_available:
             return self._physics_crosstalk(aggressor_net, victim_net, layer, rise_time_ns)
@@ -241,7 +241,7 @@ class SignalIntegrityAnalyzer:
         victim_net: str,
         layer: str,
         rise_time_ns: float,
-    ) -> CrosstalkRisk:
+    ) -> PlacementCrosstalkRisk:
         """Calculate crosstalk using physics module.
 
         Args:
@@ -251,7 +251,7 @@ class SignalIntegrityAnalyzer:
             rise_time_ns: Signal rise time
 
         Returns:
-            CrosstalkRisk with physics-based values
+            PlacementCrosstalkRisk with physics-based values
         """
         # Estimate geometry from net positions
         spacing, parallel_length = self._estimate_net_geometry(aggressor_net, victim_net)
@@ -269,7 +269,7 @@ class SignalIntegrityAnalyzer:
                 rise_time_ns=rise_time_ns,
             )
 
-            return CrosstalkRisk(
+            return PlacementCrosstalkRisk(
                 aggressor_net=aggressor_net,
                 victim_net=victim_net,
                 parallel_length_mm=parallel_length,
@@ -289,7 +289,7 @@ class SignalIntegrityAnalyzer:
         self,
         aggressor_net: str,
         victim_net: str,
-    ) -> CrosstalkRisk:
+    ) -> PlacementCrosstalkRisk:
         """Estimate crosstalk using heuristic rules.
 
         Uses distance-based approximation when physics module is unavailable.
@@ -299,7 +299,7 @@ class SignalIntegrityAnalyzer:
             victim_net: Victim net name
 
         Returns:
-            CrosstalkRisk with heuristic estimates
+            PlacementCrosstalkRisk with heuristic estimates
         """
         spacing, parallel_length = self._estimate_net_geometry(aggressor_net, victim_net)
 
@@ -342,7 +342,7 @@ class SignalIntegrityAnalyzer:
                 f"or route on different layers"
             )
 
-        return CrosstalkRisk(
+        return PlacementCrosstalkRisk(
             aggressor_net=aggressor_net,
             victim_net=victim_net,
             parallel_length_mm=parallel_length,
@@ -1029,3 +1029,13 @@ def add_si_constraints(
                 modified += 1
 
     return modified
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatibility aliases (deprecated)
+# ---------------------------------------------------------------------------
+SignalIntegrityAnalyzer = PlacementSIAnalyzer
+"""Deprecated alias for :class:`PlacementSIAnalyzer`."""
+
+CrosstalkRisk = PlacementCrosstalkRisk
+"""Deprecated alias for :class:`PlacementCrosstalkRisk`."""

--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -464,9 +464,9 @@ class ReportDataCollector:
 
         # Signal integrity
         try:
-            from kicad_tools.analysis.signal_integrity import SignalIntegrityAnalyzer
+            from kicad_tools.analysis.signal_integrity import TraceIntegrityAnalyzer
 
-            si = SignalIntegrityAnalyzer()
+            si = TraceIntegrityAnalyzer()
             crosstalk = si.analyze_crosstalk(pcb)
             impedance = si.analyze_impedance(pcb)
             result["signal_integrity"] = {

--- a/tests/test_analysis_signal_integrity.py
+++ b/tests/test_analysis_signal_integrity.py
@@ -6,10 +6,10 @@ from pathlib import Path
 import pytest
 
 from kicad_tools.analysis import (
-    CrosstalkRisk,
     ImpedanceDiscontinuity,
     RiskLevel,
-    SignalIntegrityAnalyzer,
+    TraceCrosstalkRisk,
+    TraceIntegrityAnalyzer,
 )
 from kicad_tools.schema.pcb import PCB
 
@@ -196,12 +196,12 @@ class TestRiskLevel:
         assert RiskLevel.HIGH.value == "high"
 
 
-class TestCrosstalkRisk:
-    """Tests for CrosstalkRisk dataclass."""
+class TestTraceCrosstalkRisk:
+    """Tests for TraceCrosstalkRisk dataclass."""
 
     def test_to_dict_basic(self):
         """Test basic to_dict conversion."""
-        risk = CrosstalkRisk(
+        risk = TraceCrosstalkRisk(
             aggressor_net="CLK",
             victim_net="DATA0",
             parallel_length_mm=15.0,
@@ -225,7 +225,7 @@ class TestCrosstalkRisk:
 
     def test_to_dict_serializable(self):
         """Test that to_dict output is JSON serializable."""
-        risk = CrosstalkRisk(
+        risk = TraceCrosstalkRisk(
             aggressor_net="NET1",
             victim_net="NET2",
             parallel_length_mm=10.0,
@@ -282,18 +282,18 @@ class TestImpedanceDiscontinuity:
         assert isinstance(json_str, str)
 
 
-class TestSignalIntegrityAnalyzer:
-    """Tests for SignalIntegrityAnalyzer class."""
+class TestTraceIntegrityAnalyzer:
+    """Tests for TraceIntegrityAnalyzer class."""
 
     def test_analyzer_init_defaults(self):
         """Test analyzer initialization with defaults."""
-        analyzer = SignalIntegrityAnalyzer()
+        analyzer = TraceIntegrityAnalyzer()
         assert analyzer.min_parallel_length == 3.0
         assert analyzer.max_coupling_distance == 0.5
 
     def test_analyzer_init_custom(self):
         """Test analyzer initialization with custom values."""
-        analyzer = SignalIntegrityAnalyzer(
+        analyzer = TraceIntegrityAnalyzer(
             min_parallel_length=5.0,
             max_coupling_distance=1.0,
         )
@@ -303,7 +303,7 @@ class TestSignalIntegrityAnalyzer:
     def test_analyze_crosstalk_returns_list(self, high_speed_pcb: Path):
         """Test that analyze_crosstalk returns a list."""
         pcb = PCB.load(str(high_speed_pcb))
-        analyzer = SignalIntegrityAnalyzer()
+        analyzer = TraceIntegrityAnalyzer()
 
         risks = analyzer.analyze_crosstalk(pcb)
 
@@ -312,7 +312,7 @@ class TestSignalIntegrityAnalyzer:
     def test_analyze_crosstalk_finds_issues(self, high_speed_pcb: Path):
         """Test that analyzer finds crosstalk issues in high-speed PCB."""
         pcb = PCB.load(str(high_speed_pcb))
-        analyzer = SignalIntegrityAnalyzer(
+        analyzer = TraceIntegrityAnalyzer(
             min_parallel_length=1.0,
             max_coupling_distance=1.0,
         )
@@ -326,7 +326,7 @@ class TestSignalIntegrityAnalyzer:
     def test_analyze_crosstalk_sorted_by_risk(self, high_speed_pcb: Path):
         """Test that risks are sorted by severity."""
         pcb = PCB.load(str(high_speed_pcb))
-        analyzer = SignalIntegrityAnalyzer(
+        analyzer = TraceIntegrityAnalyzer(
             min_parallel_length=1.0,
             max_coupling_distance=1.0,
         )
@@ -342,7 +342,7 @@ class TestSignalIntegrityAnalyzer:
     def test_analyze_impedance_returns_list(self, impedance_pcb: Path):
         """Test that analyze_impedance returns a list."""
         pcb = PCB.load(str(impedance_pcb))
-        analyzer = SignalIntegrityAnalyzer()
+        analyzer = TraceIntegrityAnalyzer()
 
         discs = analyzer.analyze_impedance(pcb)
 
@@ -351,7 +351,7 @@ class TestSignalIntegrityAnalyzer:
     def test_analyze_impedance_finds_width_changes(self, impedance_pcb: Path):
         """Test that analyzer finds width change discontinuities."""
         pcb = PCB.load(str(impedance_pcb))
-        analyzer = SignalIntegrityAnalyzer()
+        analyzer = TraceIntegrityAnalyzer()
 
         discs = analyzer.analyze_impedance(pcb)
 
@@ -363,7 +363,7 @@ class TestSignalIntegrityAnalyzer:
     def test_analyze_impedance_finds_vias(self, impedance_pcb: Path):
         """Test that analyzer finds via discontinuities."""
         pcb = PCB.load(str(impedance_pcb))
-        analyzer = SignalIntegrityAnalyzer()
+        analyzer = TraceIntegrityAnalyzer()
 
         discs = analyzer.analyze_impedance(pcb)
 
@@ -375,7 +375,7 @@ class TestSignalIntegrityAnalyzer:
     def test_analyze_clean_pcb(self, clean_pcb: Path):
         """Test analyzing a clean PCB with no SI issues."""
         pcb = PCB.load(str(clean_pcb))
-        analyzer = SignalIntegrityAnalyzer()
+        analyzer = TraceIntegrityAnalyzer()
 
         crosstalk = analyzer.analyze_crosstalk(pcb)
         impedance = analyzer.analyze_impedance(pcb)
@@ -387,7 +387,7 @@ class TestSignalIntegrityAnalyzer:
     def test_crosstalk_risk_fields(self, high_speed_pcb: Path):
         """Test that crosstalk risks have required fields."""
         pcb = PCB.load(str(high_speed_pcb))
-        analyzer = SignalIntegrityAnalyzer(
+        analyzer = TraceIntegrityAnalyzer(
             min_parallel_length=1.0,
             max_coupling_distance=1.0,
         )
@@ -407,7 +407,7 @@ class TestSignalIntegrityAnalyzer:
     def test_impedance_disc_fields(self, impedance_pcb: Path):
         """Test that impedance discontinuities have required fields."""
         pcb = PCB.load(str(impedance_pcb))
-        analyzer = SignalIntegrityAnalyzer()
+        analyzer = TraceIntegrityAnalyzer()
 
         discs = analyzer.analyze_impedance(pcb)
 
@@ -565,7 +565,7 @@ class TestHighSpeedNetDetection:
     def test_detect_clock_nets(self, high_speed_pcb: Path):
         """Test detection of clock nets."""
         pcb = PCB.load(str(high_speed_pcb))
-        analyzer = SignalIntegrityAnalyzer()
+        analyzer = TraceIntegrityAnalyzer()
 
         high_speed = analyzer._identify_high_speed_nets(pcb)
 
@@ -582,7 +582,7 @@ class TestHighSpeedNetDetection:
     def test_detect_usb_nets(self, high_speed_pcb: Path):
         """Test detection of USB nets."""
         pcb = PCB.load(str(high_speed_pcb))
-        analyzer = SignalIntegrityAnalyzer()
+        analyzer = TraceIntegrityAnalyzer()
 
         high_speed = analyzer._identify_high_speed_nets(pcb)
 
@@ -598,7 +598,7 @@ class TestHighSpeedNetDetection:
     def test_custom_patterns(self, high_speed_pcb: Path):
         """Test analyzer with custom high-speed patterns."""
         pcb = PCB.load(str(high_speed_pcb))
-        analyzer = SignalIntegrityAnalyzer(
+        analyzer = TraceIntegrityAnalyzer(
             high_speed_patterns=[r"DATA\d+"],
         )
 

--- a/tests/test_physics_integration.py
+++ b/tests/test_physics_integration.py
@@ -82,19 +82,19 @@ class TestRouterPhysicsIntegration:
             assert widths["F.Cu"] != widths["In1.Cu"]
 
 
-class TestCrosstalkRiskDataclass:
-    """Tests for CrosstalkRisk dataclass."""
+class TestPlacementCrosstalkRiskDataclass:
+    """Tests for PlacementCrosstalkRisk dataclass."""
 
     @pytest.fixture
     def crosstalk_risk_class(self):
-        """Import CrosstalkRisk, skipping if dependencies unavailable."""
+        """Import PlacementCrosstalkRisk, skipping if dependencies unavailable."""
         pytest.importorskip("yaml")
-        from kicad_tools.optim.signal_integrity import CrosstalkRisk
+        from kicad_tools.optim.signal_integrity import PlacementCrosstalkRisk
 
-        return CrosstalkRisk
+        return PlacementCrosstalkRisk
 
     def test_crosstalk_risk_structure(self, crosstalk_risk_class):
-        """Test CrosstalkRisk dataclass structure."""
+        """Test PlacementCrosstalkRisk dataclass structure."""
         risk = crosstalk_risk_class(
             aggressor_net="CLK",
             victim_net="ADC_IN",

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -477,7 +477,7 @@ class TestFaultTolerance:
         assert result["thermal"] is not None
 
     def test_si_failure_produces_null(self):
-        """If SignalIntegrityAnalyzer.analyze_crosstalk raises, SI is None."""
+        """If TraceIntegrityAnalyzer.analyze_crosstalk raises, SI is None."""
         pcb_path = PROJECT_FIXTURES / "test_project.kicad_pcb"
         if not pcb_path.exists():
             pytest.skip("test_project.kicad_pcb fixture not found")
@@ -488,7 +488,7 @@ class TestFaultTolerance:
         collector = ReportDataCollector(pcb_path)
 
         with patch(
-            "kicad_tools.analysis.signal_integrity.SignalIntegrityAnalyzer.analyze_crosstalk",
+            "kicad_tools.analysis.signal_integrity.TraceIntegrityAnalyzer.analyze_crosstalk",
             side_effect=RuntimeError("boom"),
         ):
             result = collector.collect_analysis(pcb)


### PR DESCRIPTION
## Summary
Disambiguate the two independently-authored `SignalIntegrityAnalyzer` classes and their `CrosstalkRisk` dataclasses that shared identical names across `analysis/signal_integrity.py` and `optim/signal_integrity.py`, causing import confusion.

## Changes
- Renamed `analysis/signal_integrity.py`: `SignalIntegrityAnalyzer` -> `TraceIntegrityAnalyzer`, `CrosstalkRisk` -> `TraceCrosstalkRisk`
- Renamed `optim/signal_integrity.py`: `SignalIntegrityAnalyzer` -> `PlacementSIAnalyzer`, `CrosstalkRisk` -> `PlacementCrosstalkRisk`
- Updated all import sites across CLI commands, MCP tools, report collector, and tests
- Added backward-compatibility aliases (`SignalIntegrityAnalyzer` and `CrosstalkRisk`) in both modules
- Updated `analysis/__init__.py` to re-export both new and deprecated names

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No two classes share the name `SignalIntegrityAnalyzer` | Pass | `grep -rn "class SignalIntegrityAnalyzer" src/` returns zero results |
| No two dataclasses share the name `CrosstalkRisk` | Pass | `grep -rn "class CrosstalkRisk" src/` returns zero results |
| All import sites updated | Pass | All consumer files use new names; backward-compat aliases ensure old imports still work |
| `analysis/__init__.py` and `optim/__init__.py` re-exports updated | Pass | analysis exports both new and deprecated names; optim did not previously export these classes |
| Public API backward compatibility | Pass | Deprecation aliases provided; `from kicad_tools.analysis.signal_integrity import SignalIntegrityAnalyzer` still works |
| All existing tests pass | Pass | 124 tests pass across test_analysis_signal_integrity, test_signal_integrity, test_physics_integration, test_report_collector |

## Test Plan
- Ran `python3 -m pytest tests/test_analysis_signal_integrity.py tests/test_signal_integrity.py tests/test_physics_integration.py tests/test_report_collector.py -v` -- all 124 tests pass
- Verified new imports: `from kicad_tools.analysis import TraceIntegrityAnalyzer` and `from kicad_tools.optim.signal_integrity import PlacementSIAnalyzer` both succeed
- Verified backward-compat aliases: `from kicad_tools.analysis.signal_integrity import SignalIntegrityAnalyzer, CrosstalkRisk` still works

Closes #1853