### PR TITLE
fix(cost): query PartsCache in _is_basic_part instead of always returning True

### DIFF
--- a/src/kicad_tools/cost/estimator.py
+++ b/src/kicad_tools/cost/estimator.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from kicad_tools.parts import PartsCache
     from kicad_tools.schema.bom import BOM, BOMItem
     from kicad_tools.schema.pcb import PCB
 
@@ -240,7 +241,12 @@ _PRICING_DIR = Path(__file__).parent / "pricing"
 class ManufacturingCostEstimator:
     """Estimate PCB manufacturing costs for a given manufacturer."""
 
-    def __init__(self, manufacturer: str = "jlcpcb", use_lcsc_pricing: bool = True):
+    def __init__(
+        self,
+        manufacturer: str = "jlcpcb",
+        use_lcsc_pricing: bool = True,
+        parts_cache: "PartsCache | None" = None,
+    ):
         """
         Initialize cost estimator.
 
@@ -248,9 +254,14 @@ class ManufacturingCostEstimator:
             manufacturer: Manufacturer ID (jlcpcb, pcbway, etc.)
             use_lcsc_pricing: If True, fetch real pricing from LCSC for parts
                 with LCSC part numbers. Set to False for offline use or testing.
+            parts_cache: Optional PartsCache instance for looking up part
+                metadata (e.g. basic vs extended classification). When None,
+                parts without LCSC lookup data are conservatively assumed
+                to be extended.
         """
         self.manufacturer = manufacturer.lower()
         self.use_lcsc_pricing = use_lcsc_pricing
+        self._parts_cache = parts_cache
         self.pricing = self._load_pricing()
 
     def _load_pricing(self) -> dict:
@@ -728,10 +739,18 @@ class ManufacturingCostEstimator:
         return default_prices.get(prefix, pricing.get("default_price", 0.01))
 
     def _is_basic_part(self, lcsc: str) -> bool:
-        """Check if LCSC part is a basic part (no setup fee)."""
-        # In reality, this would need an API lookup
-        # Basic parts are typically common passives
-        return True  # Assume basic for estimation
+        """Check if LCSC part is a basic part (no setup fee).
+
+        Queries the parts cache when available.  Falls back to ``False``
+        (extended) when the part is not in the cache so that cost estimates
+        are conservative -- overestimating by $3 per unknown part is safer
+        than silently omitting the fee.
+        """
+        if self._parts_cache is not None:
+            part = self._parts_cache.get(lcsc, ignore_expiry=True)
+            if part is not None:
+                return part.is_basic
+        return False  # Conservative: assume extended when unknown
 
     def _estimate_assembly_cost(
         self,

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1460,3 +1460,125 @@ class TestLCSCPricingIntegration:
 
         # Should call price_at_quantity with 60 * 5 = 300
         mock_part.price_at_quantity.assert_called_with(300)
+
+
+class TestIsBasicPartWithCache:
+    """Tests for _is_basic_part() with and without a PartsCache."""
+
+    def _make_bom_group(self, lcsc="", value="10k", footprint="0402", ref="R1", qty=1, dnp=False):
+        """Create a mock BOM group."""
+        mock_item = MagicMock()
+        mock_item.reference = ref
+        mock_item.dnp = dnp
+
+        group = MagicMock()
+        group.value = value
+        group.footprint = footprint
+        group.lcsc = lcsc
+        group.mpn = ""
+        group.quantity = qty
+        group.references = ref
+        group.items = [mock_item] * qty
+        return group
+
+    def test_no_cache_returns_false(self):
+        """Without a parts cache, _is_basic_part should return False (conservative)."""
+        estimator = ManufacturingCostEstimator(use_lcsc_pricing=False)
+        assert estimator._is_basic_part("C123456") is False
+
+    def test_cache_returns_basic_true(self):
+        """Cache hit with is_basic=True should return True."""
+        mock_cache = MagicMock()
+        mock_part = MagicMock()
+        mock_part.is_basic = True
+        mock_cache.get.return_value = mock_part
+
+        estimator = ManufacturingCostEstimator(
+            use_lcsc_pricing=False, parts_cache=mock_cache
+        )
+        assert estimator._is_basic_part("C123456") is True
+        mock_cache.get.assert_called_once_with("C123456", ignore_expiry=True)
+
+    def test_cache_returns_basic_false(self):
+        """Cache hit with is_basic=False should return False."""
+        mock_cache = MagicMock()
+        mock_part = MagicMock()
+        mock_part.is_basic = False
+        mock_cache.get.return_value = mock_part
+
+        estimator = ManufacturingCostEstimator(
+            use_lcsc_pricing=False, parts_cache=mock_cache
+        )
+        assert estimator._is_basic_part("C999999") is False
+
+    def test_cache_miss_returns_false(self):
+        """Cache miss (part not found) should return False (conservative)."""
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        estimator = ManufacturingCostEstimator(
+            use_lcsc_pricing=False, parts_cache=mock_cache
+        )
+        assert estimator._is_basic_part("C000001") is False
+
+    def test_assembly_cost_counts_extended_parts(self):
+        """_estimate_assembly_cost should produce nonzero extended_fee for extended parts."""
+        mock_cache = MagicMock()
+        # Two parts: one basic, one extended
+        basic_part = MagicMock()
+        basic_part.is_basic = True
+        extended_part = MagicMock()
+        extended_part.is_basic = False
+
+        def cache_get(lcsc, ignore_expiry=False):
+            lookup = {"C100": basic_part, "C200": extended_part}
+            return lookup.get(lcsc.upper())
+
+        mock_cache.get.side_effect = cache_get
+
+        mock_bom = MagicMock()
+        group_basic = self._make_bom_group(lcsc="C100", ref="R1", qty=10)
+        group_extended = self._make_bom_group(lcsc="C200", ref="U1", qty=1, footprint="LQFP-48")
+        mock_bom.grouped.return_value = [group_basic, group_extended]
+
+        estimator = ManufacturingCostEstimator(
+            use_lcsc_pricing=False, parts_cache=mock_cache
+        )
+        assembly = estimator._estimate_assembly_cost(mock_bom, pcb=None, quantity=5)
+
+        # extended_fee ($3.00 for 1 extended part) is folded into setup_cost.
+        # Base setup = setup_fee ($8.0) + stencil_fee ($1.5) = $9.5
+        # With 1 extended part: setup_cost = $9.5 + $3.0 = $12.5
+        assert assembly.setup_cost == 12.5
+
+    def test_component_cost_fallback_is_basic_false_for_extended(self):
+        """Fallback path (no LCSC hit) should set is_basic=False for extended parts."""
+        mock_cache = MagicMock()
+        extended_part = MagicMock()
+        extended_part.is_basic = False
+        mock_cache.get.return_value = extended_part
+
+        mock_bom = MagicMock()
+        group = self._make_bom_group(lcsc="C200", ref="U1", qty=1, footprint="LQFP-48")
+        mock_bom.grouped.return_value = [group]
+
+        estimator = ManufacturingCostEstimator(
+            use_lcsc_pricing=False, parts_cache=mock_cache
+        )
+        costs = estimator._estimate_component_costs(mock_bom, quantity=1)
+
+        assert len(costs) == 1
+        assert costs[0].is_basic is False
+
+    def test_use_lcsc_pricing_false_still_uses_cache_for_is_basic(self):
+        """Even with use_lcsc_pricing=False, cache should be used for is_basic classification."""
+        mock_cache = MagicMock()
+        basic_part = MagicMock()
+        basic_part.is_basic = True
+        mock_cache.get.return_value = basic_part
+
+        estimator = ManufacturingCostEstimator(
+            use_lcsc_pricing=False, parts_cache=mock_cache
+        )
+        # _is_basic_part should still query the cache
+        assert estimator._is_basic_part("C100") is True


### PR DESCRIPTION
## Summary
The `_is_basic_part()` stub in `ManufacturingCostEstimator` always returned `True`, silently omitting JLCPCB extended part fees ($3 per unique extended part) from cost estimates. This fix queries an optional `PartsCache` for the real `is_basic` classification and defaults to `False` (extended) when the part is unknown.

## Changes
- Added optional `parts_cache` parameter to `ManufacturingCostEstimator.__init__()`
- Rewrote `_is_basic_part()` to query the cache with `ignore_expiry=True`, falling back to `False`
- Added `PartsCache` to `TYPE_CHECKING` imports
- Added 7 new tests covering cache hit/miss, assembly cost integration, and component cost fallback

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_is_basic_part()` queries the parts cache when available | Pass | `test_cache_returns_basic_true`, `test_cache_returns_basic_false` |
| `_is_basic_part()` returns `False` when part not in cache | Pass | `test_cache_miss_returns_false`, `test_no_cache_returns_false` |
| `ManufacturingCostEstimator` accepts optional `parts_cache` | Pass | All new tests construct with `parts_cache=mock_cache` |
| Extended part fee calculation produces nonzero values | Pass | `test_assembly_cost_counts_extended_parts` asserts `setup_cost == 12.5` ($9.5 base + $3.0 extended) |
| Component cost `is_basic` is `False` in fallback for extended parts | Pass | `test_component_cost_fallback_is_basic_false_for_extended` |
| Existing tests pass (backward compatible) | Pass | All 77 tests pass; no cache means `False` default |

## Test Plan
- 77/77 tests pass including 7 new tests
- Existing `test_lcsc_stock_reflected_in_component_cost` still passes (LCSC-hit path unchanged)
- Edge case: `use_lcsc_pricing=False` still uses cache for `is_basic` classification

Closes #1862