### PR TITLE
fix(cli): accept argv parameter in sch unconnected and sch connections commands

### DIFF
--- a/src/kicad_tools/cli/sch_check_connections.py
+++ b/src/kicad_tools/cli/sch_check_connections.py
@@ -168,7 +168,7 @@ def check_symbol_connections(
     return results
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Check pin connections using library pin positions",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -187,7 +187,7 @@ def main():
         "--verbose", "-v", action="store_true", help="Show all pins, not just unconnected"
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # Load schematic
     try:

--- a/src/kicad_tools/cli/sch_find_unconnected.py
+++ b/src/kicad_tools/cli/sch_find_unconnected.py
@@ -197,7 +197,7 @@ def analyze_schematic(
     return unconnected, issues
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Find unconnected pins in a KiCad schematic",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -211,7 +211,7 @@ def main():
     parser.add_argument("--include-power", action="store_true", help="Include power symbols")
     parser.add_argument("--include-dnp", action="store_true", help="Include DNP symbols")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     try:
         sch = Schematic.load(args.schematic)

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -964,6 +964,33 @@ class TestSchCheckConnections:
             assert "pins" in data
             assert "summary" in data
 
+    def test_argv_parameter(
+        self, minimal_schematic: Path, minimal_symbol_library: Path, capsys
+    ):
+        """Test calling main() with an explicit argv list (CLI runner path)."""
+        from kicad_tools.cli.sch_check_connections import main
+
+        try:
+            main([str(minimal_schematic), "--lib", str(minimal_symbol_library)])
+        except SystemExit as e:
+            assert e.code in (0, 1)
+
+        captured = capsys.readouterr()
+        assert len(captured.out) > 0
+
+    def test_argv_parameter_no_library(self, minimal_schematic: Path, capsys, tmp_path):
+        """Test calling main() with argv when no libraries are found."""
+        from kicad_tools.cli.sch_check_connections import main
+
+        empty_dir = tmp_path / "empty_lib"
+        empty_dir.mkdir()
+        with pytest.raises(SystemExit) as exc_info:
+            main([str(minimal_schematic), "--lib-path", str(empty_dir)])
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "No symbol libraries loaded" in captured.err
+
 
 class TestSchFindUnconnected:
     """Tests for sch_find_unconnected.py CLI."""
@@ -1006,6 +1033,31 @@ class TestSchFindUnconnected:
         if captured.out.strip():
             data = json.loads(captured.out)
             assert isinstance(data, (list, dict))
+
+    def test_argv_parameter(self, minimal_schematic: Path, capsys):
+        """Test calling main() with an explicit argv list (CLI runner path)."""
+        from kicad_tools.cli.sch_find_unconnected import main
+
+        try:
+            main([str(minimal_schematic)])
+        except SystemExit as e:
+            assert e.code in (0, 1)
+
+        captured = capsys.readouterr()
+        assert len(captured.out) > 0
+
+    def test_argv_parameter_json(self, minimal_schematic: Path, capsys):
+        """Test calling main() with argv and --format json."""
+        from kicad_tools.cli.sch_find_unconnected import main
+
+        with contextlib.suppress(SystemExit):
+            main([str(minimal_schematic), "--format", "json"])
+
+        captured = capsys.readouterr()
+        if captured.out.strip():
+            data = json.loads(captured.out)
+            assert isinstance(data, dict)
+            assert "unconnected_pins" in data
 
 
 class TestSchRenameSignal:


### PR DESCRIPTION
## Summary
The `sch unconnected` and `sch connections` CLI commands raised `TypeError` when invoked through the CLI runner because their `main()` functions accepted zero parameters while the runner passed a `sub_argv` list.

## Changes
- Changed `def main():` to `def main(argv=None):` in `sch_find_unconnected.py` and `sch_check_connections.py`
- Changed `parser.parse_args()` to `parser.parse_args(argv)` in both files
- Added 4 new tests that call `main()` with an explicit argv list to cover the CLI runner invocation path

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `sch unconnected <file>` runs without TypeError via CLI runner | Pass | `main([str(schematic)])` now works; test_argv_parameter passes |
| `sch connections <file> --lib <path>` runs without TypeError via CLI runner | Pass | `main([str(schematic), "--lib", str(lib)])` now works; test_argv_parameter passes |
| Both commands still work as standalone scripts (argv=None falls back to sys.argv) | Pass | Existing monkeypatch-based tests continue to pass |
| Existing tests in test_cli_sch.py continue to pass | Pass | All 72 tests pass |

## Test Plan
- Ran `python3 -m pytest tests/test_cli_sch.py` -- all 72 tests pass (including 4 new argv-parameter tests)

Closes #1867