### PR TITLE
feat(sch): add set-value command to update symbol Value property

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -12,7 +12,7 @@ def run_sch_command(args) -> int:
         print("Usage: kicad-tools sch <command> [options] <file>")
         print("Commands: summary, hierarchy, labels, validate, preflight, wires, info, pins,")
         print(
-            "          connections, unconnected, set-footprint, replace,"
+            "          connections, unconnected, set-footprint, set-value, replace,"
             " sync-hierarchy, rename-signal,"
         )
         print("          add-no-connect, cleanup-wires, disconnect")
@@ -146,6 +146,19 @@ def run_sch_command(args) -> int:
             schematic_path=schematic_path,
             ref=getattr(args, "ref", None),
             footprint=getattr(args, "footprint", None),
+            map_path=map_path,
+            dry_run=getattr(args, "dry_run", False),
+            backup=getattr(args, "backup", True),
+        )
+
+    elif args.sch_command == "set-value":
+        from ..sch_set_value import run_set_value
+
+        map_path = Path(args.map_file) if getattr(args, "map_file", None) else None
+        return run_set_value(
+            schematic_path=schematic_path,
+            ref=getattr(args, "ref", None),
+            value=getattr(args, "value", None),
             map_path=map_path,
             dry_run=getattr(args, "dry_run", False),
             backup=getattr(args, "backup", True),

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -538,6 +538,27 @@ def _add_sch_parser(subparsers) -> None:
         "--backup", action="store_true", help="Create backup before modifying"
     )
 
+    # sch set-value
+    sch_set_val = sch_subparsers.add_parser(
+        "set-value", help="Set value property for symbols"
+    )
+    sch_set_val.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_set_val.add_argument("--ref", help="Symbol reference (e.g., U4, R1)")
+    sch_set_val.add_argument(
+        "--value", help="Value to assign (e.g., AP2204K-3.3TRG1)"
+    )
+    sch_set_val.add_argument(
+        "--map",
+        dest="map_file",
+        help="Path to JSON or CSV mapping file (ref -> value)",
+    )
+    sch_set_val.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
+    )
+    sch_set_val.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+
     # sch sync-hierarchy
     sch_sync = sch_subparsers.add_parser(
         "sync-hierarchy", help="Synchronize sheet pins and hierarchical labels"

--- a/src/kicad_tools/cli/sch_set_value.py
+++ b/src/kicad_tools/cli/sch_set_value.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Set value assignments for symbols in KiCad schematics.
+
+Supports single-ref mode, batch mode via JSON/CSV mapping files,
+and hierarchical schematic traversal.
+
+Usage:
+    # Single symbol
+    kicad-tools sch set-value board.kicad_sch --ref U4 \\
+        --value "AP2204K-3.3TRG1"
+
+    # Batch mode with JSON mapping
+    kicad-tools sch set-value board.kicad_sch \\
+        --map value-map.json
+
+    # Dry run
+    kicad-tools sch set-value board.kicad_sch --ref R1 \\
+        --value "4.7k" --dry-run
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from kicad_tools.cli.modify_schematic import (
+    create_backup,
+    find_symbol_text_range,
+    set_value_text,
+)
+from kicad_tools.cli.sch_set_footprint import (
+    _collect_schematic_files,
+    _load_mapping,
+)
+
+
+def run_set_value(
+    schematic_path: Path,
+    ref: str | None = None,
+    value: str | None = None,
+    map_path: Path | None = None,
+    dry_run: bool = False,
+    backup: bool = True,
+) -> int:
+    """Run the set-value operation.
+
+    Returns 0 on success, 1 on error.
+    """
+    if not schematic_path.exists():
+        print(f"Error: File not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    # Build the ref -> value mapping
+    if map_path is not None:
+        if not map_path.exists():
+            print(f"Error: Mapping file not found: {map_path}", file=sys.stderr)
+            return 1
+        try:
+            mapping = _load_mapping(map_path)
+        except (json.JSONDecodeError, ValueError) as e:
+            print(f"Error reading mapping file: {e}", file=sys.stderr)
+            return 1
+        if not mapping:
+            print("Error: Mapping file is empty", file=sys.stderr)
+            return 1
+    elif ref is not None and value is not None:
+        mapping = {ref: value}
+    else:
+        print("Error: Provide either --ref/--value or --map", file=sys.stderr)
+        return 1
+
+    # Collect all schematic files (root + sub-sheets)
+    all_files = _collect_schematic_files(schematic_path)
+
+    total_changed = 0
+    total_errors = 0
+    remaining = dict(mapping)
+    modified_files: dict[Path, str] = {}
+
+    for sch_file in all_files:
+        try:
+            text = sch_file.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"Error reading {sch_file}: {e}", file=sys.stderr)
+            total_errors += 1
+            continue
+
+        file_modified = False
+        current_text = text
+
+        # Try each remaining reference against this file
+        for r in list(remaining.keys()):
+            v = remaining[r]
+            result = find_symbol_text_range(current_text, r)
+            if result is None:
+                continue
+
+            if dry_run:
+                _, _, info = result
+                old_val = info.get("value", "")
+                print(f"  {r}: '{old_val}' -> '{v}' (in {sch_file.name})")
+                total_changed += 1
+                del remaining[r]
+            else:
+                current_text, success, msg = set_value_text(current_text, r, v)
+                if success:
+                    print(f"  {msg} (in {sch_file.name})")
+                    file_modified = True
+                    total_changed += 1
+                    del remaining[r]
+                else:
+                    print(f"  Warning: {msg}", file=sys.stderr)
+                    total_errors += 1
+
+        if file_modified:
+            modified_files[sch_file] = current_text
+
+    # Write out modified files
+    if not dry_run and modified_files:
+        for sch_file, new_text in modified_files.items():
+            if backup:
+                bak = create_backup(sch_file)
+                print(f"  Backup: {bak.name}")
+            try:
+                sch_file.write_text(new_text, encoding="utf-8")
+            except OSError as e:
+                print(f"Error writing {sch_file}: {e}", file=sys.stderr)
+                total_errors += 1
+
+    # Summary
+    print()
+    if dry_run:
+        print(f"Dry run: {total_changed} value(s) would be changed")
+    else:
+        print(f"Changed {total_changed} value(s)")
+
+    if remaining:
+        print(f"Warning: {len(remaining)} reference(s) not found: {', '.join(sorted(remaining))}")
+        total_errors += len(remaining)
+
+    return 1 if total_errors > 0 and total_changed == 0 else 0
+
+
+def main(argv: list[str] | None = None):
+    """CLI entry point for standalone usage."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Set value assignments in KiCad schematics",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", type=Path, help="Path to .kicad_sch file")
+    parser.add_argument("--ref", help="Symbol reference (e.g., U4, R1)")
+    parser.add_argument(
+        "--value", help="Value to assign (e.g., AP2204K-3.3TRG1)"
+    )
+    parser.add_argument(
+        "--map",
+        dest="map_file",
+        type=Path,
+        help="Path to JSON or CSV mapping file (ref -> value)",
+    )
+    parser.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
+    )
+    parser.add_argument(
+        "--no-backup", action="store_true", help="Skip creating backup files"
+    )
+
+    args = parser.parse_args(argv)
+
+    # Validate argument combinations
+    if args.map_file and (args.ref or args.value):
+        print("Error: Cannot use --map with --ref/--value", file=sys.stderr)
+        return 1
+    if args.ref and not args.value:
+        print("Error: --value is required when using --ref", file=sys.stderr)
+        return 1
+    if args.value and not args.ref:
+        print("Error: --ref is required when using --value", file=sys.stderr)
+        return 1
+    if not args.ref and not args.map_file:
+        print("Error: Provide either --ref/--value or --map", file=sys.stderr)
+        return 1
+
+    return run_set_value(
+        schematic_path=args.schematic,
+        ref=args.ref,
+        value=args.value,
+        map_path=args.map_file,
+        dry_run=args.dry_run,
+        backup=not args.no_backup,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sch_set_value.py
+++ b/tests/test_sch_set_value.py
@@ -1,0 +1,457 @@
+"""Tests for the sch set-value command.
+
+Covers set_value_text(), run_set_value(), batch mapping,
+hierarchical schematic traversal, and dry-run mode.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.modify_schematic import find_symbol_text_range, set_value_text
+from kicad_tools.cli.sch_set_value import run_set_value
+
+# ---------------------------------------------------------------------------
+# Minimal schematic content for testing
+# ---------------------------------------------------------------------------
+
+MINIMAL_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:C")
+\t\t(at 120 50 0)
+\t\t(property "Reference" "C1"
+\t\t\t(at 120 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "100nF"
+\t\t\t(at 120 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 120 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "C1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+
+def _write_sch(tmp_path: Path, content: str = MINIMAL_SCHEMATIC, name: str = "test.kicad_sch") -> Path:
+    p = tmp_path / name
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# set_value_text() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetValueText:
+    def test_update_existing_value(self):
+        """Update a symbol that already has a value assigned."""
+        new_val = "4.7k"
+        result, success, msg = set_value_text(MINIMAL_SCHEMATIC, "R1", new_val)
+        assert success is True
+        assert '"Value" "4.7k"' in result
+        assert '"Value" "10k"' not in result
+        assert "Changed R1 value" in msg
+
+    def test_set_empty_value(self):
+        """Set an empty value string."""
+        result, success, msg = set_value_text(MINIMAL_SCHEMATIC, "R1", "")
+        assert success is True
+        assert '"Value" ""' in result
+        assert "Changed R1 value" in msg
+
+    def test_nonexistent_reference(self):
+        """Trying to set value on a non-existent ref returns failure."""
+        result, success, msg = set_value_text(MINIMAL_SCHEMATIC, "U99", "SomeValue")
+        assert success is False
+        assert result == MINIMAL_SCHEMATIC
+        assert "not found" in msg
+
+    def test_preserves_other_symbols(self):
+        """Changing R1 value should not affect C1."""
+        new_val = "4.7k"
+        result, success, _ = set_value_text(MINIMAL_SCHEMATIC, "R1", new_val)
+        assert success is True
+        # C1 should still have its original value
+        c1_result = find_symbol_text_range(result, "C1")
+        assert c1_result is not None
+        _, _, info = c1_result
+        assert info["value"] == "100nF"
+
+    def test_value_with_special_characters(self):
+        """Value strings with hyphens, dots, and mixed case."""
+        new_val = "AP2204K-3.3TRG1"
+        result, success, _ = set_value_text(MINIMAL_SCHEMATIC, "R1", new_val)
+        assert success is True
+        assert new_val in result
+
+
+# ---------------------------------------------------------------------------
+# find_symbol_text_range() value extraction
+# ---------------------------------------------------------------------------
+
+
+class TestFindSymbolValue:
+    def test_extracts_value_from_info(self):
+        result = find_symbol_text_range(MINIMAL_SCHEMATIC, "R1")
+        assert result is not None
+        _, _, info = result
+        assert info["value"] == "10k"
+
+    def test_extracts_value_c1(self):
+        result = find_symbol_text_range(MINIMAL_SCHEMATIC, "C1")
+        assert result is not None
+        _, _, info = result
+        assert info["value"] == "100nF"
+
+
+# ---------------------------------------------------------------------------
+# run_set_value() integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunSetValue:
+    def test_single_ref_mode(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        ret = run_set_value(
+            schematic_path=sch,
+            ref="R1",
+            value="4.7k",
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        assert '"Value" "4.7k"' in text
+        assert '"Value" "10k"' not in text
+
+    def test_single_ref_creates_backup(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        ret = run_set_value(
+            schematic_path=sch,
+            ref="R1",
+            value="4.7k",
+            dry_run=False,
+            backup=True,
+        )
+        assert ret == 0
+        backups = list(tmp_path.glob("test_backup_*"))
+        assert len(backups) == 1
+
+    def test_dry_run_does_not_modify(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        original = sch.read_text()
+        ret = run_set_value(
+            schematic_path=sch,
+            ref="R1",
+            value="4.7k",
+            dry_run=True,
+            backup=False,
+        )
+        assert ret == 0
+        assert sch.read_text() == original
+
+    def test_batch_json_mapping(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        map_path = tmp_path / "map.json"
+        map_path.write_text(json.dumps({
+            "R1": "4.7k",
+            "C1": "220nF",
+        }))
+        ret = run_set_value(
+            schematic_path=sch,
+            map_path=map_path,
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        assert '"Value" "4.7k"' in text
+        assert '"Value" "220nF"' in text
+
+    def test_batch_csv_mapping(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        map_path = tmp_path / "map.csv"
+        map_path.write_text("R1,4.7k\nC1,220nF\n")
+        ret = run_set_value(
+            schematic_path=sch,
+            map_path=map_path,
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        assert '"Value" "4.7k"' in text
+        assert '"Value" "220nF"' in text
+
+    def test_nonexistent_ref_returns_error(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        ret = run_set_value(
+            schematic_path=sch,
+            ref="U99",
+            value="SomeValue",
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 1
+
+    def test_missing_schematic(self, tmp_path):
+        ret = run_set_value(
+            schematic_path=tmp_path / "nonexistent.kicad_sch",
+            ref="R1",
+            value="4.7k",
+        )
+        assert ret == 1
+
+    def test_no_ref_or_map_returns_error(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        ret = run_set_value(schematic_path=sch)
+        assert ret == 1
+
+    def test_empty_mapping_file(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        map_path = tmp_path / "map.json"
+        map_path.write_text("{}")
+        ret = run_set_value(
+            schematic_path=sch,
+            map_path=map_path,
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 1
+
+    def test_missing_mapping_file(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        ret = run_set_value(
+            schematic_path=sch,
+            map_path=tmp_path / "nonexistent.json",
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 1
+
+    def test_invalid_mapping_format(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        map_path = tmp_path / "map.csv"
+        map_path.write_text("R1\n")
+        ret = run_set_value(
+            schematic_path=sch,
+            map_path=map_path,
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 1
+
+
+# ---------------------------------------------------------------------------
+# Hierarchical schematic support
+# ---------------------------------------------------------------------------
+
+
+PARENT_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet
+\t\t(at 150 50)
+\t\t(size 20 20)
+\t\t(property "Sheetname" "SubSheet"
+\t\t\t(at 150 48 0)
+\t\t)
+\t\t(property "Sheetfile" "sub.kicad_sch"
+\t\t\t(at 150 68 0)
+\t\t)
+\t\t(uuid "33333333-3333-3333-3333-333333333333")
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+CHILD_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "44444444-4444-4444-4444-444444444444")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:C")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "C2"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "1uF"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "55555555-5555-5555-5555-555555555555")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/33333333-3333-3333-3333-333333333333" (reference "C2") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/33333333-3333-3333-3333-333333333333" (page "2"))
+\t)
+)
+"""
+
+
+class TestHierarchicalSchematic:
+    def test_set_value_in_subsheet(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+
+        ret = run_set_value(
+            schematic_path=parent,
+            ref="C2",
+            value="2.2uF",
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        text = child.read_text()
+        assert '"Value" "2.2uF"' in text
+
+    def test_batch_across_hierarchy(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+
+        map_path = tmp_path / "map.json"
+        map_path.write_text(json.dumps({
+            "R1": "4.7k",
+            "C2": "2.2uF",
+        }))
+        ret = run_set_value(
+            schematic_path=parent,
+            map_path=map_path,
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        assert '"Value" "4.7k"' in parent.read_text()
+        assert '"Value" "2.2uF"' in child.read_text()
+
+    def test_dry_run_hierarchical(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+        original_child = child.read_text()
+
+        ret = run_set_value(
+            schematic_path=parent,
+            ref="C2",
+            value="2.2uF",
+            dry_run=True,
+            backup=False,
+        )
+        assert ret == 0
+        # File should be unchanged
+        assert child.read_text() == original_child
+
+    def test_warning_for_unmatched_ref_in_hierarchy(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+
+        map_path = tmp_path / "map.json"
+        map_path.write_text(json.dumps({
+            "R1": "4.7k",
+            "ZZZZ": "NotFound",
+        }))
+        ret = run_set_value(
+            schematic_path=parent,
+            map_path=map_path,
+            dry_run=False,
+            backup=False,
+        )
+        # Should still succeed (partial match) but return 0 because some changed
+        assert ret == 0
+        assert '"Value" "4.7k"' in parent.read_text()


### PR DESCRIPTION
## Summary
Add `sch set-value` CLI command that updates the Value property of symbols in KiCad schematics. Mirrors the existing `sch set-footprint` command, reusing its hierarchical traversal and batch mapping infrastructure.

## Changes
- New `src/kicad_tools/cli/sch_set_value.py` with `run_set_value()` function supporting single-ref, batch JSON/CSV, dry-run, and backup modes
- Parser wiring in `src/kicad_tools/cli/parser.py` adding `set-value` subparser under `sch`
- Dispatch in `src/kicad_tools/cli/commands/schematic.py` routing `set-value` to `run_set_value()`
- New `tests/test_sch_set_value.py` with 22 tests covering unit, integration, hierarchical, and error cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `sch set-value <sch> --ref U4 --value "..."` updates Value property | Pass | TestRunSetValue::test_single_ref_mode |
| `--map values.json` applies batch ref-to-value mapping (JSON and CSV) | Pass | test_batch_json_mapping, test_batch_csv_mapping |
| `--dry-run` previews changes without writing | Pass | test_dry_run_does_not_modify |
| `--backup` creates timestamped backup before modifying | Pass | test_single_ref_creates_backup |
| Hierarchical schematic traversal works | Pass | TestHierarchicalSchematic (4 tests) |
| Error handling for missing schematic, missing ref, empty mapping, invalid format | Pass | 4 dedicated error tests |
| Non-matching references produce warning | Pass | test_warning_for_unmatched_ref_in_hierarchy |
| Existing set-footprint tests still pass | Pass | All 24 tests pass unchanged |

## Test Plan
- All 22 new tests pass: `python3 -m pytest tests/test_sch_set_value.py -v`
- All 24 existing set-footprint tests pass: `python3 -m pytest tests/test_sch_set_footprint.py -v`

Closes #1866