### PR TITLE
fix(cli): accept argv parameter in sch replace command

### DIFF
--- a/src/kicad_tools/cli/sch_replace_symbol.py
+++ b/src/kicad_tools/cli/sch_replace_symbol.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from kicad_tools.operations.symbol_ops import replace_symbol_lib_id
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Replace a symbol in a KiCad schematic",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -46,7 +46,7 @@ def main():
     parser.add_argument("--dry-run", action="store_true", help="Show changes without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # Validate input
     if not Path(args.schematic).exists():


### PR DESCRIPTION
## Summary
Fix TypeError crash when running `kct sch replace` via the kct dispatcher. The `main()` function in `sch_replace_symbol.py` did not accept an `argv` parameter, so the dispatcher's `sub_argv` argument was silently ignored or caused a TypeError.

## Changes
- Add `argv=None` parameter to `main()` in `sch_replace_symbol.py`
- Pass `argv` to `parser.parse_args(argv)` instead of bare `parser.parse_args()`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| main() accepts argv parameter | Done | `def main(argv=None):` added at line 35 |
| parse_args receives argv | Done | `parser.parse_args(argv)` at line 49 |
| Pattern matches other sch commands | Done | Matches sch_disconnect.py, sch_set_footprint.py, sch_add_component.py |
| Direct invocation still works | Done | `main()` with no args defaults to `argv=None`, which makes `parse_args()` read from `sys.argv` |

## Test Plan
- `kct sch replace <sch> <ref> <new_lib_id>` no longer raises TypeError
- Direct script invocation (`python3 sch_replace_symbol.py ...`) continues to work since `argv=None` falls back to `sys.argv`

Closes #1875