### PR TITLE
feat(cli): add sch remove-wire command for deleting specific wire segments

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -17,7 +17,7 @@ def run_sch_command(args) -> int:
         )
         print(
             "          add-no-connect, add-component, add-wire, add-junction,"
-            " cleanup-wires, disconnect"
+            " cleanup-wires, remove-wire, disconnect"
         )
         return 1
 
@@ -301,6 +301,26 @@ def run_sch_command(args) -> int:
         if args.format != "text":
             sub_argv.extend(["--format", args.format])
         return cleanup_main(sub_argv) or 0
+
+    elif args.sch_command == "remove-wire":
+        from ..sch_remove_wire import main as remove_wire_main
+
+        sub_argv = [str(schematic_path)]
+        if args.from_pt:
+            sub_argv.extend(["--from", args.from_pt])
+        if args.to_pt:
+            sub_argv.extend(["--to", args.to_pt])
+        if args.near:
+            sub_argv.extend(["--near", args.near])
+        if args.tolerance != 1.27:
+            sub_argv.extend(["--tolerance", str(args.tolerance)])
+        if args.dry_run:
+            sub_argv.append("--dry-run")
+        if args.backup:
+            sub_argv.append("--backup")
+        if args.format != "text":
+            sub_argv.extend(["--format", args.format])
+        return remove_wire_main(sub_argv) or 0
 
     elif args.sch_command == "disconnect":
         from ..sch_disconnect import main as disconnect_main

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -456,12 +456,8 @@ def _add_sch_parser(subparsers) -> None:
     )
     sch_preflight.add_argument("schematic", help="Path to .kicad_sch file")
     sch_preflight.add_argument("--format", choices=["text", "json"], default="text")
-    sch_preflight.add_argument(
-        "--strict", action="store_true", help="Exit with error on warnings"
-    )
-    sch_preflight.add_argument(
-        "-q", "--quiet", action="store_true", help="Only show errors"
-    )
+    sch_preflight.add_argument("--strict", action="store_true", help="Exit with error on warnings")
+    sch_preflight.add_argument("-q", "--quiet", action="store_true", help="Only show errors")
 
     # sch wires
     sch_wires = sch_subparsers.add_parser("wires", help="List wire segments and junctions")
@@ -541,19 +537,13 @@ def _add_sch_parser(subparsers) -> None:
     sch_set_fp.add_argument(
         "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
     )
-    sch_set_fp.add_argument(
-        "--backup", action="store_true", help="Create backup before modifying"
-    )
+    sch_set_fp.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
     # sch set-value
-    sch_set_val = sch_subparsers.add_parser(
-        "set-value", help="Set value property for symbols"
-    )
+    sch_set_val = sch_subparsers.add_parser("set-value", help="Set value property for symbols")
     sch_set_val.add_argument("schematic", help="Path to .kicad_sch file")
     sch_set_val.add_argument("--ref", help="Symbol reference (e.g., U4, R1)")
-    sch_set_val.add_argument(
-        "--value", help="Value to assign (e.g., AP2204K-3.3TRG1)"
-    )
+    sch_set_val.add_argument("--value", help="Value to assign (e.g., AP2204K-3.3TRG1)")
     sch_set_val.add_argument(
         "--map",
         dest="map_file",
@@ -562,9 +552,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_set_val.add_argument(
         "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
     )
-    sch_set_val.add_argument(
-        "--backup", action="store_true", help="Create backup before modifying"
-    )
+    sch_set_val.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
     # sch sync-hierarchy
     sch_sync = sch_subparsers.add_parser(
@@ -620,9 +608,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_rename_signal.add_argument("--format", choices=["text", "json"], default="text")
 
     # sch add-no-connect
-    sch_add_nc = sch_subparsers.add_parser(
-        "add-no-connect", help="Add no-connect markers to pins"
-    )
+    sch_add_nc = sch_subparsers.add_parser("add-no-connect", help="Add no-connect markers to pins")
     sch_add_nc.add_argument("schematic", help="Path to .kicad_sch file")
     sch_add_nc.add_argument("--ref", help="Symbol reference (e.g., U1)")
     sch_add_nc.add_argument("--pin", help="Pin number to mark")
@@ -675,9 +661,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_add_comp.add_argument(
         "--lib-path", action="append", dest="lib_paths", help="Library search path"
     )
-    sch_add_comp.add_argument(
-        "--lib", action="append", dest="libs", help="Specific library file"
-    )
+    sch_add_comp.add_argument("--lib", action="append", dest="libs", help="Specific library file")
     sch_add_comp.add_argument(
         "--dry-run", "-n", action="store_true", help="Preview without modifying"
     )
@@ -686,9 +670,7 @@ def _add_sch_parser(subparsers) -> None:
     )
 
     # sch add-wire
-    sch_add_wire = sch_subparsers.add_parser(
-        "add-wire", help="Add a wire segment to the schematic"
-    )
+    sch_add_wire = sch_subparsers.add_parser("add-wire", help="Add a wire segment to the schematic")
     sch_add_wire.add_argument("schematic", help="Path to .kicad_sch file")
     sch_add_wire.add_argument(
         "--from",
@@ -716,9 +698,7 @@ def _add_sch_parser(subparsers) -> None:
     )
 
     # sch add-junction
-    sch_add_junc = sch_subparsers.add_parser(
-        "add-junction", help="Add a junction to the schematic"
-    )
+    sch_add_junc = sch_subparsers.add_parser("add-junction", help="Add a junction to the schematic")
     sch_add_junc.add_argument("schematic", help="Path to .kicad_sch file")
     sch_add_junc.add_argument(
         "--at",
@@ -743,9 +723,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_cleanup.add_argument(
         "--dry-run", "-n", action="store_true", help="Preview without modifying"
     )
-    sch_cleanup.add_argument(
-        "--backup", action="store_true", help="Create backup before modifying"
-    )
+    sch_cleanup.add_argument("--backup", action="store_true", help="Create backup before modifying")
     sch_cleanup.add_argument("--format", choices=["text", "json"], default="text")
 
     # sch remove-wire
@@ -782,18 +760,14 @@ def _add_sch_parser(subparsers) -> None:
     sch_remove_wire.add_argument("--format", choices=["text", "json"], default="text")
 
     # sch disconnect
-    sch_disconnect = sch_subparsers.add_parser(
-        "disconnect", help="Disconnect a pin from its net"
-    )
+    sch_disconnect = sch_subparsers.add_parser("disconnect", help="Disconnect a pin from its net")
     sch_disconnect.add_argument("schematic", help="Path to .kicad_sch file")
     sch_disconnect.add_argument("--ref", required=True, help="Symbol reference (e.g., U1)")
     sch_disconnect.add_argument("--pin", required=True, help="Pin number to disconnect")
     sch_disconnect.add_argument(
         "--lib-path", action="append", dest="lib_paths", help="Library search path"
     )
-    sch_disconnect.add_argument(
-        "--lib", action="append", dest="libs", help="Specific library file"
-    )
+    sch_disconnect.add_argument("--lib", action="append", dest="libs", help="Specific library file")
     sch_disconnect.add_argument(
         "--add-nc", action="store_true", help="Add no-connect marker after disconnecting"
     )

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -748,6 +748,39 @@ def _add_sch_parser(subparsers) -> None:
     )
     sch_cleanup.add_argument("--format", choices=["text", "json"], default="text")
 
+    # sch remove-wire
+    sch_remove_wire = sch_subparsers.add_parser(
+        "remove-wire", help="Remove a specific wire segment"
+    )
+    sch_remove_wire.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_remove_wire.add_argument(
+        "--from",
+        dest="from_pt",
+        help="Start endpoint X,Y of wire to remove",
+    )
+    sch_remove_wire.add_argument(
+        "--to",
+        dest="to_pt",
+        help="End endpoint X,Y of wire to remove",
+    )
+    sch_remove_wire.add_argument(
+        "--near",
+        help="Find and remove wire nearest to this point X,Y",
+    )
+    sch_remove_wire.add_argument(
+        "--tolerance",
+        type=float,
+        default=1.27,
+        help="Coordinate matching tolerance in mm (default: 1.27)",
+    )
+    sch_remove_wire.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+    )
+    sch_remove_wire.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+    sch_remove_wire.add_argument("--format", choices=["text", "json"], default="text")
+
     # sch disconnect
     sch_disconnect = sch_subparsers.add_parser(
         "disconnect", help="Disconnect a pin from its net"

--- a/src/kicad_tools/cli/sch_remove_wire.py
+++ b/src/kicad_tools/cli/sch_remove_wire.py
@@ -40,7 +40,6 @@ from kicad_tools.sexp import SExp
 
 POINT_TOLERANCE = 1.27  # mm - standard KiCad grid
 
-
 def _wire_start_end(wire_sexp: SExp) -> tuple[tuple[float, float], tuple[float, float]]:
     """Extract start and end points from a wire S-expression node."""
     pts_node = wire_sexp.find("pts")
@@ -58,7 +57,6 @@ def _wire_start_end(wire_sexp: SExp) -> tuple[tuple[float, float], tuple[float, 
 
     return (x1, y1), (x2, y2)
 
-
 def _wire_endpoint_counts(
     wire_sexps: list[SExp],
 ) -> dict[tuple[int, int], int]:
@@ -70,7 +68,6 @@ def _wire_endpoint_counts(
             key = (int(pt[0] * 10), int(pt[1] * 10))
             counts[key] = counts.get(key, 0) + 1
     return counts
-
 
 def find_wire_by_endpoints(
     schematic: Schematic,
@@ -110,7 +107,6 @@ def find_wire_by_endpoints(
 
     return None
 
-
 def find_nearest_wire(
     schematic: Schematic,
     point: tuple[float, float],
@@ -132,7 +128,6 @@ def find_nearest_wire(
                 best_wire = wire_sexp
 
     return best_wire
-
 
 def remove_wire_and_orphan_junctions(
     schematic: Schematic,
@@ -177,8 +172,8 @@ def remove_wire_and_orphan_junctions(
                 if schematic.sexp.remove(junc_sexp):
                     junctions_removed += 1
 
-    if junctions_removed or True:  # Wire was removed, always invalidate
-        schematic.invalidate_cache()
+    # Wire was removed, always invalidate
+    schematic.invalidate_cache()
 
     return True, junctions_removed
 
@@ -196,7 +191,6 @@ def _parse_coordinate(value: str) -> tuple[float, float]:
         raise argparse.ArgumentTypeError(
             f"Invalid coordinate values: {value!r}"
         )
-
 
 def run_remove_wire(args) -> int:
     """Execute the remove-wire command."""
@@ -345,7 +339,6 @@ def run_remove_wire(args) -> int:
 
     return 0
 
-
 def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Remove a specific wire segment from a KiCad schematic",
@@ -388,7 +381,6 @@ def main(argv=None):
 
     args = parser.parse_args(argv)
     return run_remove_wire(args)
-
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/kicad_tools/cli/sch_remove_wire.py
+++ b/src/kicad_tools/cli/sch_remove_wire.py
@@ -40,6 +40,7 @@ from kicad_tools.sexp import SExp
 
 POINT_TOLERANCE = 1.27  # mm - standard KiCad grid
 
+
 def _wire_start_end(wire_sexp: SExp) -> tuple[tuple[float, float], tuple[float, float]]:
     """Extract start and end points from a wire S-expression node."""
     pts_node = wire_sexp.find("pts")
@@ -57,6 +58,7 @@ def _wire_start_end(wire_sexp: SExp) -> tuple[tuple[float, float], tuple[float, 
 
     return (x1, y1), (x2, y2)
 
+
 def _wire_endpoint_counts(
     wire_sexps: list[SExp],
 ) -> dict[tuple[int, int], int]:
@@ -68,6 +70,7 @@ def _wire_endpoint_counts(
             key = (int(pt[0] * 10), int(pt[1] * 10))
             counts[key] = counts.get(key, 0) + 1
     return counts
+
 
 def find_wire_by_endpoints(
     schematic: Schematic,
@@ -107,6 +110,7 @@ def find_wire_by_endpoints(
 
     return None
 
+
 def find_nearest_wire(
     schematic: Schematic,
     point: tuple[float, float],
@@ -128,6 +132,7 @@ def find_nearest_wire(
                 best_wire = wire_sexp
 
     return best_wire
+
 
 def remove_wire_and_orphan_junctions(
     schematic: Schematic,
@@ -182,15 +187,12 @@ def _parse_coordinate(value: str) -> tuple[float, float]:
     """Parse a comma-separated coordinate pair like '100,50' or '100.5,50.3'."""
     parts = value.split(",")
     if len(parts) != 2:
-        raise argparse.ArgumentTypeError(
-            f"Expected X,Y coordinate pair, got: {value!r}"
-        )
+        raise argparse.ArgumentTypeError(f"Expected X,Y coordinate pair, got: {value!r}")
     try:
         return (float(parts[0]), float(parts[1]))
     except ValueError:
-        raise argparse.ArgumentTypeError(
-            f"Invalid coordinate values: {value!r}"
-        )
+        raise argparse.ArgumentTypeError(f"Invalid coordinate values: {value!r}")
+
 
 def run_remove_wire(args) -> int:
     """Execute the remove-wire command."""
@@ -229,9 +231,7 @@ def run_remove_wire(args) -> int:
 
     # Find the target wire
     if has_endpoints:
-        wire = find_wire_by_endpoints(
-            sch, args.from_pt, args.to_pt, tolerance=args.tolerance
-        )
+        wire = find_wire_by_endpoints(sch, args.from_pt, args.to_pt, tolerance=args.tolerance)
         if wire is None:
             msg = (
                 f"No wire found matching endpoints "
@@ -278,21 +278,14 @@ def run_remove_wire(args) -> int:
             print("DRY RUN - No changes will be made")
             print("=" * 60)
             if has_near:
-                print(
-                    f"Nearest wire to ({args.near[0]:.2f}, {args.near[1]:.2f}):"
-                )
-            print(
-                f"  Wire: ({start[0]:.2f}, {start[1]:.2f}) -> "
-                f"({end[0]:.2f}, {end[1]:.2f})"
-            )
+                print(f"Nearest wire to ({args.near[0]:.2f}, {args.near[1]:.2f}):")
+            print(f"  Wire: ({start[0]:.2f}, {start[1]:.2f}) -> ({end[0]:.2f}, {end[1]:.2f})")
             print("  Would be removed")
         return 0
 
     # Create backup if requested
     if args.backup:
-        backup_path = (
-            f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
-        )
+        backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
 
     # Execute removal
@@ -325,19 +318,15 @@ def run_remove_wire(args) -> int:
         print(json.dumps(data, indent=2))
     else:
         if has_near:
-            print(
-                f"Selected nearest wire to ({args.near[0]:.2f}, {args.near[1]:.2f}):"
-            )
-        print(
-            f"Removed wire: ({start[0]:.2f}, {start[1]:.2f}) -> "
-            f"({end[0]:.2f}, {end[1]:.2f})"
-        )
+            print(f"Selected nearest wire to ({args.near[0]:.2f}, {args.near[1]:.2f}):")
+        print(f"Removed wire: ({start[0]:.2f}, {start[1]:.2f}) -> ({end[0]:.2f}, {end[1]:.2f})")
         if junctions_removed:
             print(f"Removed {junctions_removed} orphaned junction(s)")
         if args.backup:
             print(f"Backup created: {backup_path}")
 
     return 0
+
 
 def main(argv=None):
     parser = argparse.ArgumentParser(
@@ -369,18 +358,13 @@ def main(argv=None):
         default=POINT_TOLERANCE,
         help=f"Coordinate matching tolerance in mm (default: {POINT_TOLERANCE})",
     )
-    parser.add_argument(
-        "--dry-run", "-n", action="store_true", help="Preview without modifying"
-    )
-    parser.add_argument(
-        "--backup", action="store_true", help="Create backup before modifying"
-    )
-    parser.add_argument(
-        "--format", choices=["text", "json"], default="text", help="Output format"
-    )
+    parser.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
+    parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
 
     args = parser.parse_args(argv)
     return run_remove_wire(args)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/kicad_tools/cli/sch_remove_wire.py
+++ b/src/kicad_tools/cli/sch_remove_wire.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""
+Remove a specific wire segment from a KiCad schematic.
+
+Supports two matching modes:
+  --from X1,Y1 --to X2,Y2   Match a wire by its exact endpoints
+  --near X,Y                 Match the nearest wire to a point
+
+After removal, orphaned junctions (at points with fewer than 3 remaining
+wire endpoints) are automatically cleaned up.
+
+Usage:
+    kct sch remove-wire board.kicad_sch --from 100,50 --to 150,50
+    kct sch remove-wire board.kicad_sch --near 125,50
+    kct sch remove-wire board.kicad_sch --from 100,50 --to 150,50 --dry-run
+    kct sch remove-wire board.kicad_sch --near 125,50 --backup
+
+Options:
+    --from X,Y               Start endpoint of the wire to remove
+    --to X,Y                 End endpoint of the wire to remove
+    --near X,Y               Find and remove the wire nearest to this point
+    --tolerance <mm>         Coordinate matching tolerance (default: 1.27 mm)
+    --dry-run                Show what would change without modifying
+    --backup                 Create backup before modifying
+    --format {text,json}     Output format (default: text)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from kicad_tools.schema import Schematic
+from kicad_tools.sexp import SExp
+
+POINT_TOLERANCE = 1.27  # mm - standard KiCad grid
+
+
+def _wire_start_end(wire_sexp: SExp) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Extract start and end points from a wire S-expression node."""
+    pts_node = wire_sexp.find("pts")
+    if not pts_node:
+        return (0.0, 0.0), (0.0, 0.0)
+
+    xy_nodes = pts_node.find_all("xy")
+    if len(xy_nodes) < 2:
+        return (0.0, 0.0), (0.0, 0.0)
+
+    x1 = xy_nodes[0].get_float(0) or 0.0
+    y1 = xy_nodes[0].get_float(1) or 0.0
+    x2 = xy_nodes[1].get_float(0) or 0.0
+    y2 = xy_nodes[1].get_float(1) or 0.0
+
+    return (x1, y1), (x2, y2)
+
+
+def _wire_endpoint_counts(
+    wire_sexps: list[SExp],
+) -> dict[tuple[int, int], int]:
+    """Count how many wires touch each endpoint."""
+    counts: dict[tuple[int, int], int] = {}
+    for ws in wire_sexps:
+        start, end = _wire_start_end(ws)
+        for pt in [start, end]:
+            key = (int(pt[0] * 10), int(pt[1] * 10))
+            counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def find_wire_by_endpoints(
+    schematic: Schematic,
+    from_pt: tuple[float, float],
+    to_pt: tuple[float, float],
+    tolerance: float = POINT_TOLERANCE,
+) -> SExp | None:
+    """Find a wire matching the given start and end points (order-insensitive).
+
+    Returns the matching wire S-expression node, or None if not found.
+    """
+    from_key = (int(from_pt[0] * 10), int(from_pt[1] * 10))
+    to_key = (int(to_pt[0] * 10), int(to_pt[1] * 10))
+    tol_units = int(tolerance * 10)
+
+    for wire_sexp in schematic.sexp.find_all("wire"):
+        start, end = _wire_start_end(wire_sexp)
+        start_key = (int(start[0] * 10), int(start[1] * 10))
+        end_key = (int(end[0] * 10), int(end[1] * 10))
+
+        # Order-insensitive: try both orderings
+        match_forward = (
+            abs(start_key[0] - from_key[0]) <= tol_units
+            and abs(start_key[1] - from_key[1]) <= tol_units
+            and abs(end_key[0] - to_key[0]) <= tol_units
+            and abs(end_key[1] - to_key[1]) <= tol_units
+        )
+        match_reverse = (
+            abs(start_key[0] - to_key[0]) <= tol_units
+            and abs(start_key[1] - to_key[1]) <= tol_units
+            and abs(end_key[0] - from_key[0]) <= tol_units
+            and abs(end_key[1] - from_key[1]) <= tol_units
+        )
+
+        if match_forward or match_reverse:
+            return wire_sexp
+
+    return None
+
+
+def find_nearest_wire(
+    schematic: Schematic,
+    point: tuple[float, float],
+) -> SExp | None:
+    """Find the wire whose endpoint is nearest to the given point.
+
+    Returns the nearest wire S-expression node, or None if no wires exist.
+    """
+    best_wire: SExp | None = None
+    best_dist = float("inf")
+
+    for wire_sexp in schematic.sexp.find_all("wire"):
+        start, end = _wire_start_end(wire_sexp)
+
+        for pt in [start, end]:
+            dist = math.hypot(pt[0] - point[0], pt[1] - point[1])
+            if dist < best_dist:
+                best_dist = dist
+                best_wire = wire_sexp
+
+    return best_wire
+
+
+def remove_wire_and_orphan_junctions(
+    schematic: Schematic,
+    wire_sexp: SExp,
+) -> tuple[bool, int]:
+    """Remove a wire and clean up any orphaned junctions at its endpoints.
+
+    A junction is considered orphaned if fewer than 3 wire endpoints remain
+    at that location after the wire is removed.
+
+    Returns (wire_removed, junctions_removed).
+    """
+    start, end = _wire_start_end(wire_sexp)
+
+    # Remove the wire
+    if not schematic.sexp.remove(wire_sexp):
+        return False, 0
+
+    # Check for orphaned junctions at the wire's former endpoints
+    remaining_wires = list(schematic.sexp.find_all("wire"))
+    endpoint_counts = _wire_endpoint_counts(remaining_wires)
+
+    junctions_removed = 0
+    for pt in [start, end]:
+        pt_key = (int(pt[0] * 10), int(pt[1] * 10))
+        wire_count = endpoint_counts.get(pt_key, 0)
+
+        # Junction is only meaningful at 3+ way intersections
+        if wire_count >= 3:
+            continue
+
+        # Find and remove junctions at this point
+        for junc_sexp in list(schematic.sexp.find_all("junction")):
+            at_node = junc_sexp.find("at")
+            if not at_node:
+                continue
+            jx = at_node.get_float(0) or 0.0
+            jy = at_node.get_float(1) or 0.0
+            junc_key = (int(jx * 10), int(jy * 10))
+
+            if junc_key == pt_key:
+                if schematic.sexp.remove(junc_sexp):
+                    junctions_removed += 1
+
+    if junctions_removed or True:  # Wire was removed, always invalidate
+        schematic.invalidate_cache()
+
+    return True, junctions_removed
+
+
+def _parse_coordinate(value: str) -> tuple[float, float]:
+    """Parse a comma-separated coordinate pair like '100,50' or '100.5,50.3'."""
+    parts = value.split(",")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError(
+            f"Expected X,Y coordinate pair, got: {value!r}"
+        )
+    try:
+        return (float(parts[0]), float(parts[1]))
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"Invalid coordinate values: {value!r}"
+        )
+
+
+def run_remove_wire(args) -> int:
+    """Execute the remove-wire command."""
+    schematic_path = Path(args.schematic)
+
+    # Validate mutually exclusive options
+    has_endpoints = args.from_pt is not None and args.to_pt is not None
+    has_near = args.near is not None
+
+    if has_endpoints and has_near:
+        print(
+            "Error: --from/--to and --near are mutually exclusive",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not has_endpoints and not has_near:
+        print(
+            "Error: Either --from and --to, or --near must be specified",
+            file=sys.stderr,
+        )
+        return 1
+
+    if (args.from_pt is not None) != (args.to_pt is not None):
+        print(
+            "Error: --from and --to must be used together",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        sch = Schematic.load(schematic_path)
+    except FileNotFoundError:
+        print(f"Error: Schematic not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    # Find the target wire
+    if has_endpoints:
+        wire = find_wire_by_endpoints(
+            sch, args.from_pt, args.to_pt, tolerance=args.tolerance
+        )
+        if wire is None:
+            msg = (
+                f"No wire found matching endpoints "
+                f"({args.from_pt[0]:.2f}, {args.from_pt[1]:.2f}) -> "
+                f"({args.to_pt[0]:.2f}, {args.to_pt[1]:.2f}) "
+                f"within tolerance {args.tolerance} mm"
+            )
+            if args.format == "json":
+                print(json.dumps({"error": msg, "removed": False}, indent=2))
+            else:
+                print(f"Error: {msg}", file=sys.stderr)
+            return 1
+    else:
+        wire = find_nearest_wire(sch, args.near)
+        if wire is None:
+            msg = "No wires found in schematic"
+            if args.format == "json":
+                print(json.dumps({"error": msg, "removed": False}, indent=2))
+            else:
+                print(f"Error: {msg}", file=sys.stderr)
+            return 1
+
+    start, end = _wire_start_end(wire)
+
+    # Dry run
+    if args.dry_run:
+        if args.format == "json":
+            data = {
+                "dry_run": True,
+                "removed": False,
+                "wire": {
+                    "start": list(start),
+                    "end": list(end),
+                },
+                "junctions_removed": 0,
+            }
+            if has_near:
+                data["matched_by"] = "nearest"
+                data["near"] = list(args.near)
+            else:
+                data["matched_by"] = "endpoints"
+            print(json.dumps(data, indent=2))
+        else:
+            print("DRY RUN - No changes will be made")
+            print("=" * 60)
+            if has_near:
+                print(
+                    f"Nearest wire to ({args.near[0]:.2f}, {args.near[1]:.2f}):"
+                )
+            print(
+                f"  Wire: ({start[0]:.2f}, {start[1]:.2f}) -> "
+                f"({end[0]:.2f}, {end[1]:.2f})"
+            )
+            print("  Would be removed")
+        return 0
+
+    # Create backup if requested
+    if args.backup:
+        backup_path = (
+            f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        )
+        shutil.copy2(schematic_path, backup_path)
+
+    # Execute removal
+    wire_removed, junctions_removed = remove_wire_and_orphan_junctions(sch, wire)
+
+    if not wire_removed:
+        if args.format == "json":
+            print(json.dumps({"error": "Failed to remove wire", "removed": False}, indent=2))
+        else:
+            print("Error: Failed to remove wire", file=sys.stderr)
+        return 1
+
+    sch.save()
+
+    if args.format == "json":
+        data = {
+            "dry_run": False,
+            "removed": True,
+            "wire": {
+                "start": list(start),
+                "end": list(end),
+            },
+            "junctions_removed": junctions_removed,
+        }
+        if has_near:
+            data["matched_by"] = "nearest"
+            data["near"] = list(args.near)
+        else:
+            data["matched_by"] = "endpoints"
+        print(json.dumps(data, indent=2))
+    else:
+        if has_near:
+            print(
+                f"Selected nearest wire to ({args.near[0]:.2f}, {args.near[1]:.2f}):"
+            )
+        print(
+            f"Removed wire: ({start[0]:.2f}, {start[1]:.2f}) -> "
+            f"({end[0]:.2f}, {end[1]:.2f})"
+        )
+        if junctions_removed:
+            print(f"Removed {junctions_removed} orphaned junction(s)")
+        if args.backup:
+            print(f"Backup created: {backup_path}")
+
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Remove a specific wire segment from a KiCad schematic",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", help="Path to .kicad_sch file")
+    parser.add_argument(
+        "--from",
+        dest="from_pt",
+        type=_parse_coordinate,
+        help="Start endpoint (X,Y) of wire to remove",
+    )
+    parser.add_argument(
+        "--to",
+        dest="to_pt",
+        type=_parse_coordinate,
+        help="End endpoint (X,Y) of wire to remove",
+    )
+    parser.add_argument(
+        "--near",
+        type=_parse_coordinate,
+        help="Find and remove wire nearest to this point (X,Y)",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=POINT_TOLERANCE,
+        help=f"Coordinate matching tolerance in mm (default: {POINT_TOLERANCE})",
+    )
+    parser.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+    )
+    parser.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+    parser.add_argument(
+        "--format", choices=["text", "json"], default="text", help="Output format"
+    )
+
+    args = parser.parse_args(argv)
+    return run_remove_wire(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sch_wiring_commands.py
+++ b/tests/test_sch_wiring_commands.py
@@ -1,4 +1,4 @@
-"""Tests for schematic wiring commands: add-no-connect, cleanup-wires, disconnect."""
+"""Tests for schematic wiring commands: add-no-connect, cleanup-wires, disconnect, remove-wire."""
 
 from __future__ import annotations
 
@@ -391,3 +391,322 @@ class TestDisconnect:
         at_node = node.find("at")
         assert at_node.get_float(0) == 150.0
         assert at_node.get_float(1) == 75.0
+
+
+# ---------------------------------------------------------------------------
+# remove-wire tests
+# ---------------------------------------------------------------------------
+
+# Schematic with a junction at a 3-way intersection
+SCHEMATIC_WITH_JUNCTION = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000010")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 100 50) (xy 150 50))
+    (stroke (width 0) (type default))
+    (uuid "wire-j1")
+  )
+  (wire (pts (xy 150 50) (xy 200 50))
+    (stroke (width 0) (type default))
+    (uuid "wire-j2")
+  )
+  (wire (pts (xy 150 50) (xy 150 100))
+    (stroke (width 0) (type default))
+    (uuid "wire-j3")
+  )
+  (junction (at 150 50) (diameter 0) (color 0 0 0 0)
+    (uuid "junc-1")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+# Schematic with a junction at a 4-way intersection
+SCHEMATIC_WITH_4WAY_JUNCTION = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000011")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 100 50) (xy 150 50))
+    (stroke (width 0) (type default))
+    (uuid "wire-4w1")
+  )
+  (wire (pts (xy 150 50) (xy 200 50))
+    (stroke (width 0) (type default))
+    (uuid "wire-4w2")
+  )
+  (wire (pts (xy 150 50) (xy 150 100))
+    (stroke (width 0) (type default))
+    (uuid "wire-4w3")
+  )
+  (wire (pts (xy 150 50) (xy 150 0))
+    (stroke (width 0) (type default))
+    (uuid "wire-4w4")
+  )
+  (junction (at 150 50) (diameter 0) (color 0 0 0 0)
+    (uuid "junc-4w")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+# Schematic with a zero-length wire for edge case testing
+SCHEMATIC_WITH_ZERO_LENGTH_WIRE_REMOVE = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000012")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 100 50) (xy 100 50))
+    (stroke (width 0) (type default))
+    (uuid "zero-wire-rm")
+  )
+  (wire (pts (xy 200 50) (xy 250 50))
+    (stroke (width 0) (type default))
+    (uuid "normal-wire-rm")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+class TestRemoveWire:
+    """Tests for the remove-wire command."""
+
+    def test_find_wire_by_endpoints_exact(self, tmp_path):
+        """Wire is found by exact endpoint coordinates."""
+        from kicad_tools.cli.sch_remove_wire import find_wire_by_endpoints
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        sch = Schematic.load(path)
+
+        wire = find_wire_by_endpoints(sch, (100.0, 50.0), (150.0, 50.0))
+        assert wire is not None
+
+    def test_find_wire_order_insensitive(self, tmp_path):
+        """Wire matching is order-insensitive (--from A --to B matches B->A)."""
+        from kicad_tools.cli.sch_remove_wire import find_wire_by_endpoints
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        sch = Schematic.load(path)
+
+        # Reversed order should still match
+        wire = find_wire_by_endpoints(sch, (150.0, 50.0), (100.0, 50.0))
+        assert wire is not None
+
+    def test_find_nearest_wire(self, tmp_path):
+        """Nearest wire is found by proximity to a point."""
+        from kicad_tools.cli.sch_remove_wire import _wire_start_end, find_nearest_wire
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        sch = Schematic.load(path)
+
+        # Point near (150, 50) should find the horizontal wire
+        wire = find_nearest_wire(sch, (149.0, 50.0))
+        assert wire is not None
+        start, end = _wire_start_end(wire)
+        # The nearest endpoint is (150, 50) which belongs to wire-1
+        assert (start == (100.0, 50.0) and end == (150.0, 50.0)) or (
+            start == (150.0, 50.0) and end == (100.0, 50.0)
+        )
+
+    def test_tolerance_matching(self, tmp_path):
+        """Wire at (100, 50) matches query for (100.5, 50.5) within tolerance."""
+        from kicad_tools.cli.sch_remove_wire import find_wire_by_endpoints
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        sch = Schematic.load(path)
+
+        # Slightly off coordinates within default 1.27mm tolerance
+        wire = find_wire_by_endpoints(sch, (100.5, 50.5), (150.5, 50.5))
+        assert wire is not None
+
+    def test_no_match_returns_none(self, tmp_path):
+        """Query for non-existent coordinates returns None."""
+        from kicad_tools.cli.sch_remove_wire import find_wire_by_endpoints
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        sch = Schematic.load(path)
+
+        wire = find_wire_by_endpoints(sch, (999.0, 999.0), (888.0, 888.0))
+        assert wire is None
+
+    def test_remove_wire_decreases_count(self, tmp_path):
+        """Removing a wire decreases wire count by 1."""
+        from kicad_tools.cli.sch_remove_wire import (
+            find_wire_by_endpoints,
+            remove_wire_and_orphan_junctions,
+        )
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        sch = Schematic.load(path)
+
+        initial_count = len(list(sch.sexp.find_all("wire")))
+        wire = find_wire_by_endpoints(sch, (100.0, 50.0), (150.0, 50.0))
+        assert wire is not None
+
+        removed, _ = remove_wire_and_orphan_junctions(sch, wire)
+        assert removed is True
+        assert len(list(sch.sexp.find_all("wire"))) == initial_count - 1
+
+    def test_orphan_junction_cleanup(self, tmp_path):
+        """Junction is removed when only 2 wires remain at that point."""
+        from kicad_tools.cli.sch_remove_wire import (
+            find_wire_by_endpoints,
+            remove_wire_and_orphan_junctions,
+        )
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_JUNCTION)
+        sch = Schematic.load(path)
+
+        # Initially 1 junction
+        assert len(list(sch.sexp.find_all("junction"))) == 1
+
+        # Remove one wire from the 3-way junction -> only 2 wires remain
+        wire = find_wire_by_endpoints(sch, (150.0, 50.0), (150.0, 100.0))
+        assert wire is not None
+
+        _, junctions_removed = remove_wire_and_orphan_junctions(sch, wire)
+        assert junctions_removed == 1
+        assert len(list(sch.sexp.find_all("junction"))) == 0
+
+    def test_junction_preserved_at_3plus_way(self, tmp_path):
+        """Junction at 4-way intersection is NOT removed when one wire is deleted."""
+        from kicad_tools.cli.sch_remove_wire import (
+            find_wire_by_endpoints,
+            remove_wire_and_orphan_junctions,
+        )
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_4WAY_JUNCTION)
+        sch = Schematic.load(path)
+
+        assert len(list(sch.sexp.find_all("junction"))) == 1
+
+        # Remove one wire from the 4-way junction -> 3 wires remain
+        wire = find_wire_by_endpoints(sch, (150.0, 50.0), (150.0, 0.0))
+        assert wire is not None
+
+        _, junctions_removed = remove_wire_and_orphan_junctions(sch, wire)
+        assert junctions_removed == 0
+        assert len(list(sch.sexp.find_all("junction"))) == 1
+
+    def test_dry_run_no_modification(self, tmp_path):
+        """Dry run mode does not modify the file."""
+        from kicad_tools.cli.sch_remove_wire import main
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        original_content = path.read_text()
+
+        result = main([str(path), "--from", "100,50", "--to", "150,50", "--dry-run"])
+
+        assert result == 0
+        assert path.read_text() == original_content
+
+    def test_backup_created(self, tmp_path):
+        """Backup flag creates a copy before modifying."""
+        from kicad_tools.cli.sch_remove_wire import main
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+
+        result = main([str(path), "--from", "100,50", "--to", "150,50", "--backup"])
+
+        assert result == 0
+        backups = list(tmp_path.glob("*.backup-*"))
+        assert len(backups) == 1
+
+    def test_cli_round_trip_endpoints(self, tmp_path):
+        """CLI with --from/--to removes a wire and decreases count by 1."""
+        from kicad_tools.cli.sch_remove_wire import main
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        sch_before = Schematic.load(path)
+        initial_count = len(list(sch_before.sexp.find_all("wire")))
+
+        result = main([str(path), "--from", "100,50", "--to", "150,50"])
+        assert result == 0
+
+        sch_after = Schematic.load(path)
+        assert len(list(sch_after.sexp.find_all("wire"))) == initial_count - 1
+
+    def test_cli_round_trip_near(self, tmp_path):
+        """CLI with --near removes the nearest wire."""
+        from kicad_tools.cli.sch_remove_wire import main
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        sch_before = Schematic.load(path)
+        initial_count = len(list(sch_before.sexp.find_all("wire")))
+
+        result = main([str(path), "--near", "149,50"])
+        assert result == 0
+
+        sch_after = Schematic.load(path)
+        assert len(list(sch_after.sexp.find_all("wire"))) == initial_count - 1
+
+    def test_zero_length_wire_match(self, tmp_path):
+        """--from X,Y --to X,Y can match and remove a zero-length wire."""
+        from kicad_tools.cli.sch_remove_wire import main
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_ZERO_LENGTH_WIRE_REMOVE)
+        sch_before = Schematic.load(path)
+        initial_count = len(list(sch_before.sexp.find_all("wire")))
+
+        result = main([str(path), "--from", "100,50", "--to", "100,50"])
+        assert result == 0
+
+        sch_after = Schematic.load(path)
+        assert len(list(sch_after.sexp.find_all("wire"))) == initial_count - 1
+
+    def test_mutual_exclusivity_error(self, tmp_path):
+        """Passing both --from/--to and --near produces an error."""
+        from kicad_tools.cli.sch_remove_wire import main
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+
+        result = main([
+            str(path), "--from", "100,50", "--to", "150,50", "--near", "125,50"
+        ])
+        assert result == 1
+
+    def test_no_match_returns_error(self, tmp_path):
+        """Query for non-existent coordinates returns exit code 1."""
+        from kicad_tools.cli.sch_remove_wire import main
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+
+        result = main([str(path), "--from", "999,999", "--to", "888,888"])
+        assert result == 1
+
+    def test_json_output(self, tmp_path, capsys):
+        """JSON output mode produces valid JSON."""
+        import json
+
+        from kicad_tools.cli.sch_remove_wire import main
+
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        result = main([
+            str(path), "--from", "100,50", "--to", "150,50",
+            "--format", "json"
+        ])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["removed"] is True
+        assert "wire" in data
+        assert data["wire"]["start"] == [100.0, 50.0]
+        assert data["wire"]["end"] == [150.0, 50.0]


### PR DESCRIPTION
## Summary

- Add `sch remove-wire` command with two matching modes: exact endpoint matching (`--from`/`--to`) and nearest-wire selection (`--near`)
- Automatic orphaned junction cleanup after wire removal (junctions removed when fewer than 3 wire endpoints remain)
- Full support for `--dry-run`, `--backup`, `--tolerance`, and `--format json` options

Closes #1878

## Test plan

- [x] Unit: exact match removal (`find_wire_by_endpoints` with exact coordinates)
- [x] Unit: order-insensitive matching (`--from A --to B` matches wire stored as B-to-A)
- [x] Unit: nearest wire removal (`find_nearest_wire` with a point near one endpoint)
- [x] Unit: tolerance matching (wire at (100,50) matches query for (100.5,50.5))
- [x] Unit: no match returns None/error exit code 1
- [x] Unit: orphan junction cleanup (junction removed when only 2 wires remain)
- [x] Unit: junction preserved at 3+ way (4-way junction kept when 3 wires remain)
- [x] Integration: dry-run mode (file unmodified)
- [x] Integration: backup creation
- [x] Integration: CLI round-trip with `--from`/`--to`
- [x] Integration: CLI round-trip with `--near`
- [x] Edge case: zero-length wire matching
- [x] Edge case: mutual exclusivity error
- [x] Integration: JSON output format

All 16 new tests pass; all 18 existing wiring command tests remain green (34 total).

Generated with [Claude Code](https://claude.com/claude-code)