### PR TITLE
feat(cli): add sch set-label-direction command to change label shape

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -16,7 +16,8 @@ def run_sch_command(args) -> int:
             " sync-hierarchy, rename-signal,"
         )
         print(
-            "          add-no-connect, add-component, add-wire, add-junction,"
+            "          set-label-direction, add-no-connect, add-component,"
+            " add-wire, add-junction,"
             " cleanup-wires, remove-wire, disconnect"
         )
         return 1
@@ -214,6 +215,18 @@ def run_sch_command(args) -> int:
         if args.format != "text":
             sub_argv.extend(["--format", args.format])
         return rename_signal_main(sub_argv) or 0
+
+    elif args.sch_command == "set-label-direction":
+        from ..sch_set_label_direction import main as set_label_dir_main
+
+        sub_argv = [str(schematic_path), "--name", args.name, "--shape", args.shape]
+        if args.sheet:
+            sub_argv.extend(["--sheet", args.sheet])
+        if args.dry_run:
+            sub_argv.append("--dry-run")
+        if args.backup:
+            sub_argv.append("--backup")
+        return set_label_dir_main(sub_argv) or 0
 
     elif args.sch_command == "add-no-connect":
         from ..sch_add_no_connect import main as add_nc_main

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -607,6 +607,28 @@ def _add_sch_parser(subparsers) -> None:
     )
     sch_rename_signal.add_argument("--format", choices=["text", "json"], default="text")
 
+    # sch set-label-direction
+    sch_set_label_dir = sch_subparsers.add_parser(
+        "set-label-direction", help="Change shape (direction) of global/hierarchical labels"
+    )
+    sch_set_label_dir.add_argument("schematic", help="Path to root .kicad_sch file")
+    sch_set_label_dir.add_argument("--name", required=True, help="Label name to match")
+    sch_set_label_dir.add_argument(
+        "--shape",
+        required=True,
+        choices=("input", "output", "bidirectional", "tri_state", "passive"),
+        help="New shape value",
+    )
+    sch_set_label_dir.add_argument(
+        "--sheet", help="Restrict to a specific sheet (name or path substring)"
+    )
+    sch_set_label_dir.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
+    )
+    sch_set_label_dir.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+
     # sch add-no-connect
     sch_add_nc = sch_subparsers.add_parser("add-no-connect", help="Add no-connect markers to pins")
     sch_add_nc.add_argument("schematic", help="Path to .kicad_sch file")

--- a/src/kicad_tools/cli/sch_set_label_direction.py
+++ b/src/kicad_tools/cli/sch_set_label_direction.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Change the shape (direction) of global and hierarchical labels in KiCad schematics.
+
+Updates the ``(shape ...)`` attribute of ``global_label`` and ``hierarchical_label``
+elements that match a given name.  Traverses the full schematic hierarchy by default,
+or restricts to a single sheet with ``--sheet``.
+
+Usage:
+    kct sch set-label-direction board.kicad_sch --name SDA --shape bidirectional
+
+    # Dry run (preview changes)
+    kct sch set-label-direction board.kicad_sch --name SDA --shape bidirectional --dry-run
+
+    # Restrict to a single sheet
+    kct sch set-label-direction board.kicad_sch --name SDA --shape output --sheet DAC
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+VALID_SHAPES = ("input", "output", "bidirectional", "tri_state", "passive")
+
+
+@dataclass
+class LabelChange:
+    """A single label shape change."""
+
+    file_path: str
+    element_type: str  # "global_label" or "hierarchical_label"
+    label_name: str
+    old_shape: str
+    new_shape: str
+    line_number: int
+
+
+@dataclass
+class SetLabelDirectionResult:
+    """Result of a set-label-direction operation."""
+
+    success: bool
+    changes: list[LabelChange] = field(default_factory=list)
+    files_modified: set[str] = field(default_factory=set)
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Hierarchy traversal (shared helper, duplicated from sch_set_footprint.py to
+# keep the module self-contained without circular imports).
+# ---------------------------------------------------------------------------
+
+
+def _find_subsheet_files(text: str, schematic_dir: Path) -> list[Path]:
+    """Extract sub-sheet file paths from schematic text."""
+    subsheets: list[Path] = []
+    pattern = re.compile(r'\(property "Sheetfile" "([^"]+)"')
+    for match in pattern.finditer(text):
+        subsheet_path = schematic_dir / match.group(1)
+        if subsheet_path.exists():
+            subsheets.append(subsheet_path)
+    return subsheets
+
+
+def _collect_schematic_files(root_path: Path) -> list[Path]:
+    """Recursively collect all schematic files in the hierarchy."""
+    visited: set[Path] = set()
+    result: list[Path] = []
+
+    def _walk(sch_path: Path) -> None:
+        resolved = sch_path.resolve()
+        if resolved in visited:
+            return
+        visited.add(resolved)
+        result.append(sch_path)
+
+        try:
+            text = sch_path.read_text(encoding="utf-8")
+        except OSError:
+            return
+
+        for sub in _find_subsheet_files(text, sch_path.parent):
+            _walk(sub)
+
+    _walk(root_path)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def _build_pattern(element_type: str, name: str) -> re.Pattern[str]:
+    """Build a regex that matches the shape attribute of *element_type* labels named *name*.
+
+    Groups:
+        1 - everything before the shape value (prefix including ``(shape ``)
+        2 - the old shape value
+        3 - closing paren
+    """
+    return re.compile(
+        r"(\(" + element_type + r'\s+"' + re.escape(name) + r'"\s+\(shape\s+)(\w+)(\))'
+    )
+
+
+def find_label_shape_occurrences(
+    file_path: str,
+    name: str,
+    text: str,
+) -> list[LabelChange]:
+    """Find all global/hierarchical labels with the given *name* in *text*."""
+    changes: list[LabelChange] = []
+    for element_type in ("global_label", "hierarchical_label"):
+        pattern = _build_pattern(element_type, name)
+        for match in pattern.finditer(text):
+            line_num = text[: match.start()].count("\n") + 1
+            changes.append(
+                LabelChange(
+                    file_path=file_path,
+                    element_type=element_type,
+                    label_name=name,
+                    old_shape=match.group(2),
+                    new_shape="",  # filled in later
+                    line_number=line_num,
+                )
+            )
+    return changes
+
+
+def replace_label_shapes(
+    text: str,
+    name: str,
+    new_shape: str,
+) -> tuple[str, int]:
+    """Replace shape values for all matching labels in *text*.
+
+    Returns:
+        Tuple of (modified_text, number_of_replacements).
+    """
+    total = 0
+    for element_type in ("global_label", "hierarchical_label"):
+        pattern = _build_pattern(element_type, name)
+        text, count = pattern.subn(r"\g<1>" + new_shape + r"\3", text)
+        total += count
+    return text, total
+
+
+def set_label_direction(
+    root_schematic: str,
+    name: str,
+    new_shape: str,
+    dry_run: bool = False,
+    backup: bool = False,
+    sheet_filter: str | None = None,
+) -> SetLabelDirectionResult:
+    """Change the shape of labels named *name* across the schematic hierarchy.
+
+    Args:
+        root_schematic: Path to the root ``.kicad_sch`` file.
+        name: Label name to match.
+        new_shape: New shape value (one of :data:`VALID_SHAPES`).
+        dry_run: If ``True`` report changes without writing files.
+        backup: If ``True`` create a backup before modifying each file.
+        sheet_filter: Optional sheet name/path substring to restrict processing.
+
+    Returns:
+        A :class:`SetLabelDirectionResult`.
+    """
+    root_path = Path(root_schematic)
+    if not root_path.exists():
+        return SetLabelDirectionResult(
+            success=False,
+            error=f"File not found: {root_schematic}",
+        )
+
+    all_files = _collect_schematic_files(root_path)
+
+    # Optionally filter to a single sheet
+    if sheet_filter:
+        all_files = [f for f in all_files if sheet_filter in f.name or sheet_filter in str(f)]
+
+    all_changes: list[LabelChange] = []
+    files_modified: set[str] = set()
+
+    for sch_file in all_files:
+        try:
+            text = sch_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"Error reading {sch_file}: {exc}", file=sys.stderr)
+            continue
+
+        file_changes = find_label_shape_occurrences(str(sch_file), name, text)
+        if not file_changes:
+            continue
+
+        # Fill in new_shape for reporting
+        for change in file_changes:
+            change.new_shape = new_shape
+
+        all_changes.extend(file_changes)
+
+        if dry_run:
+            continue
+
+        modified_text, count = replace_label_shapes(text, name, new_shape)
+        if count > 0:
+            if backup:
+                from kicad_tools.cli.modify_schematic import create_backup
+
+                bak = create_backup(sch_file)
+                print(f"  Backup: {bak.name}")
+            sch_file.write_text(modified_text, encoding="utf-8")
+            files_modified.add(str(sch_file))
+
+    if not all_changes:
+        return SetLabelDirectionResult(
+            success=True,
+            error=f"No labels named '{name}' found in hierarchy",
+        )
+
+    return SetLabelDirectionResult(
+        success=True,
+        changes=all_changes,
+        files_modified=files_modified,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for ``sch set-label-direction``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Change label shape (direction) in KiCad schematics",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", help="Path to root .kicad_sch file")
+    parser.add_argument("--name", required=True, help="Label name to match")
+    parser.add_argument(
+        "--shape",
+        required=True,
+        choices=VALID_SHAPES,
+        help="New shape value",
+    )
+    parser.add_argument("--sheet", help="Restrict to a specific sheet (name or path substring)")
+    parser.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
+    )
+    parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
+
+    args = parser.parse_args(argv)
+
+    schematic_path = Path(args.schematic)
+    if not schematic_path.exists():
+        print(f"Error: File not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    if not args.schematic.endswith(".kicad_sch"):
+        print(f"Error: Not a schematic file: {args.schematic}", file=sys.stderr)
+        return 1
+
+    result = set_label_direction(
+        root_schematic=args.schematic,
+        name=args.name,
+        new_shape=args.shape,
+        dry_run=args.dry_run,
+        backup=args.backup,
+        sheet_filter=args.sheet,
+    )
+
+    if not result.success:
+        print(f"Error: {result.error}", file=sys.stderr)
+        return 1
+
+    if not result.changes:
+        print(result.error or f"No labels named '{args.name}' found.")
+        return 0
+
+    # Print changes grouped by file
+    by_file: dict[str, list[LabelChange]] = {}
+    for change in result.changes:
+        by_file.setdefault(change.file_path, []).append(change)
+
+    for file_path, file_changes in sorted(by_file.items()):
+        rel_name = Path(file_path).name
+        print(f"  {rel_name}:")
+        for change in sorted(file_changes, key=lambda c: c.line_number):
+            label_desc = (
+                "Global label" if change.element_type == "global_label" else "Hierarchical label"
+            )
+            print(
+                f"    - {label_desc} '{change.label_name}': "
+                f"{change.old_shape} -> {change.new_shape} (line {change.line_number})"
+            )
+        print(f"    ({len(file_changes)} label(s) in this sheet)")
+
+    total = len(result.changes)
+    total_files = len(by_file)
+
+    if args.dry_run:
+        print(f"\nDry run: {total} label(s) would be changed in {total_files} file(s)")
+    else:
+        print(f"\nChanged {total} label(s) in {total_files} file(s)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sch_set_label_direction.py
+++ b/tests/test_sch_set_label_direction.py
@@ -1,0 +1,333 @@
+"""Tests for the sch set-label-direction command.
+
+Covers shape replacement for global and hierarchical labels, name filtering,
+dry-run mode, hierarchy traversal, sheet filtering, and edge cases.
+"""
+
+
+import pytest
+
+from kicad_tools.cli.sch_set_label_direction import (
+    find_label_shape_occurrences,
+    main,
+    replace_label_shapes,
+    set_label_direction,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal schematic content for testing
+# ---------------------------------------------------------------------------
+
+SCHEMATIC_WITH_GLOBAL_LABELS = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(global_label "SDA" (shape input)
+\t\t(at 100 50 0)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t)
+\t(global_label "SCL" (shape input)
+\t\t(at 120 50 0)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t)
+)
+"""
+
+SCHEMATIC_WITH_HIERARCHICAL_LABELS = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(uuid "00000000-0000-0000-0000-000000000002")
+\t(paper "A4")
+\t(hierarchical_label "SDA" (shape input)
+\t\t(at 100 50 0)
+\t\t(uuid "33333333-3333-3333-3333-333333333333")
+\t)
+\t(hierarchical_label "MCLK" (shape output)
+\t\t(at 120 50 0)
+\t\t(uuid "44444444-4444-4444-4444-444444444444")
+\t)
+)
+"""
+
+SCHEMATIC_WITH_BOTH = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(uuid "00000000-0000-0000-0000-000000000003")
+\t(paper "A4")
+\t(global_label "SDA" (shape input)
+\t\t(at 100 50 0)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t)
+\t(hierarchical_label "SDA" (shape input)
+\t\t(at 120 50 0)
+\t\t(uuid "55555555-5555-5555-5555-555555555555")
+\t)
+\t(global_label "SCL" (shape output)
+\t\t(at 140 50 0)
+\t\t(uuid "66666666-6666-6666-6666-666666666666")
+\t)
+)
+"""
+
+ROOT_SCHEMATIC_WITH_SUBSHEET = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(uuid "00000000-0000-0000-0000-000000000010")
+\t(paper "A4")
+\t(global_label "SDA" (shape input)
+\t\t(at 100 50 0)
+\t\t(uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+\t)
+\t(sheet
+\t\t(at 50 50)
+\t\t(size 20 20)
+\t\t(property "Sheetname" "DAC")
+\t\t(property "Sheetfile" "dac.kicad_sch")
+\t\t(pin "SDA" input (at 50 60 0)
+\t\t\t(uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+\t\t)
+\t)
+)
+"""
+
+SUBSHEET_CONTENT = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(uuid "00000000-0000-0000-0000-000000000020")
+\t(paper "A4")
+\t(hierarchical_label "SDA" (shape input)
+\t\t(at 10 20 0)
+\t\t(uuid "cccccccc-cccc-cccc-cccc-cccccccccccc")
+\t)
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - find_label_shape_occurrences
+# ---------------------------------------------------------------------------
+
+
+class TestFindLabelShapeOccurrences:
+    def test_finds_global_labels(self):
+        changes = find_label_shape_occurrences(
+            "/fake.kicad_sch", "SDA", SCHEMATIC_WITH_GLOBAL_LABELS
+        )
+        assert len(changes) == 1
+        assert changes[0].element_type == "global_label"
+        assert changes[0].old_shape == "input"
+
+    def test_finds_hierarchical_labels(self):
+        changes = find_label_shape_occurrences(
+            "/fake.kicad_sch", "SDA", SCHEMATIC_WITH_HIERARCHICAL_LABELS
+        )
+        assert len(changes) == 1
+        assert changes[0].element_type == "hierarchical_label"
+        assert changes[0].old_shape == "input"
+
+    def test_finds_both_types(self):
+        changes = find_label_shape_occurrences("/fake.kicad_sch", "SDA", SCHEMATIC_WITH_BOTH)
+        assert len(changes) == 2
+        types = {c.element_type for c in changes}
+        assert types == {"global_label", "hierarchical_label"}
+
+    def test_name_filtering(self):
+        """Only labels matching the given name are returned."""
+        changes = find_label_shape_occurrences("/fake.kicad_sch", "SCL", SCHEMATIC_WITH_BOTH)
+        assert len(changes) == 1
+        assert changes[0].label_name == "SCL"
+        assert changes[0].element_type == "global_label"
+        assert changes[0].old_shape == "output"
+
+    def test_no_matches(self):
+        changes = find_label_shape_occurrences(
+            "/fake.kicad_sch", "NONEXISTENT", SCHEMATIC_WITH_GLOBAL_LABELS
+        )
+        assert changes == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - replace_label_shapes
+# ---------------------------------------------------------------------------
+
+
+class TestReplaceLabelShapes:
+    def test_global_label_shape_change(self):
+        text, count = replace_label_shapes(SCHEMATIC_WITH_GLOBAL_LABELS, "SDA", "bidirectional")
+        assert count == 1
+        assert '(global_label "SDA" (shape bidirectional)' in text
+        # SCL should be untouched
+        assert '(global_label "SCL" (shape input)' in text
+
+    def test_hierarchical_label_shape_change(self):
+        text, count = replace_label_shapes(
+            SCHEMATIC_WITH_HIERARCHICAL_LABELS, "SDA", "bidirectional"
+        )
+        assert count == 1
+        assert '(hierarchical_label "SDA" (shape bidirectional)' in text
+        # MCLK should be untouched
+        assert '(hierarchical_label "MCLK" (shape output)' in text
+
+    def test_replaces_both_types(self):
+        text, count = replace_label_shapes(SCHEMATIC_WITH_BOTH, "SDA", "passive")
+        assert count == 2
+        assert '(global_label "SDA" (shape passive)' in text
+        assert '(hierarchical_label "SDA" (shape passive)' in text
+        # SCL should be untouched
+        assert '(global_label "SCL" (shape output)' in text
+
+    def test_name_filtering_in_replacement(self):
+        """Only the named label's shape is changed; others are untouched."""
+        text, count = replace_label_shapes(SCHEMATIC_WITH_GLOBAL_LABELS, "SCL", "tri_state")
+        assert count == 1
+        assert '(global_label "SCL" (shape tri_state)' in text
+        assert '(global_label "SDA" (shape input)' in text
+
+    def test_no_matches_returns_zero(self):
+        text, count = replace_label_shapes(SCHEMATIC_WITH_GLOBAL_LABELS, "NONEXISTENT", "output")
+        assert count == 0
+        assert text == SCHEMATIC_WITH_GLOBAL_LABELS
+
+
+# ---------------------------------------------------------------------------
+# Integration test - set_label_direction with files on disk
+# ---------------------------------------------------------------------------
+
+
+class TestSetLabelDirection:
+    def test_dry_run_does_not_modify(self, tmp_path):
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(SCHEMATIC_WITH_GLOBAL_LABELS, encoding="utf-8")
+
+        result = set_label_direction(
+            str(sch_file), name="SDA", new_shape="bidirectional", dry_run=True
+        )
+
+        assert result.success
+        assert len(result.changes) == 1
+        assert result.files_modified == set()
+        # File should not be changed
+        assert sch_file.read_text(encoding="utf-8") == SCHEMATIC_WITH_GLOBAL_LABELS
+
+    def test_applies_changes(self, tmp_path):
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(SCHEMATIC_WITH_GLOBAL_LABELS, encoding="utf-8")
+
+        result = set_label_direction(str(sch_file), name="SDA", new_shape="bidirectional")
+
+        assert result.success
+        assert len(result.changes) == 1
+        assert str(sch_file) in result.files_modified
+        modified = sch_file.read_text(encoding="utf-8")
+        assert '(global_label "SDA" (shape bidirectional)' in modified
+
+    def test_label_not_found(self, tmp_path):
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(SCHEMATIC_WITH_GLOBAL_LABELS, encoding="utf-8")
+
+        result = set_label_direction(str(sch_file), name="MISSING", new_shape="output")
+
+        assert result.success
+        assert result.changes == []
+        assert "No labels named" in (result.error or "")
+
+    def test_file_not_found(self):
+        result = set_label_direction("/nonexistent.kicad_sch", name="SDA", new_shape="output")
+        assert not result.success
+        assert "not found" in (result.error or "").lower()
+
+    def test_hierarchy_traversal(self, tmp_path):
+        """Both root and sub-sheet labels are updated."""
+        root_file = tmp_path / "root.kicad_sch"
+        sub_file = tmp_path / "dac.kicad_sch"
+        root_file.write_text(ROOT_SCHEMATIC_WITH_SUBSHEET, encoding="utf-8")
+        sub_file.write_text(SUBSHEET_CONTENT, encoding="utf-8")
+
+        result = set_label_direction(str(root_file), name="SDA", new_shape="bidirectional")
+
+        assert result.success
+        assert len(result.changes) == 2
+        assert str(root_file) in result.files_modified
+        assert str(sub_file) in result.files_modified
+
+        root_text = root_file.read_text(encoding="utf-8")
+        sub_text = sub_file.read_text(encoding="utf-8")
+        assert '(global_label "SDA" (shape bidirectional)' in root_text
+        assert '(hierarchical_label "SDA" (shape bidirectional)' in sub_text
+
+    def test_sheet_filter(self, tmp_path):
+        """With --sheet, only the matching sheet is modified."""
+        root_file = tmp_path / "root.kicad_sch"
+        sub_file = tmp_path / "dac.kicad_sch"
+        root_file.write_text(ROOT_SCHEMATIC_WITH_SUBSHEET, encoding="utf-8")
+        sub_file.write_text(SUBSHEET_CONTENT, encoding="utf-8")
+
+        result = set_label_direction(
+            str(root_file), name="SDA", new_shape="bidirectional", sheet_filter="dac"
+        )
+
+        assert result.success
+        assert len(result.changes) == 1
+        assert str(sub_file) in result.files_modified
+        # Root should be unmodified
+        root_text = root_file.read_text(encoding="utf-8")
+        assert '(global_label "SDA" (shape input)' in root_text
+
+    def test_backup_created(self, tmp_path):
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(SCHEMATIC_WITH_GLOBAL_LABELS, encoding="utf-8")
+
+        result = set_label_direction(str(sch_file), name="SDA", new_shape="output", backup=True)
+
+        assert result.success
+        # A backup file should exist in the same directory
+        backup_files = list(tmp_path.glob("test_backup_*"))
+        assert len(backup_files) == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI main() tests
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_dry_run_cli(self, tmp_path):
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(SCHEMATIC_WITH_GLOBAL_LABELS, encoding="utf-8")
+
+        rc = main([str(sch_file), "--name", "SDA", "--shape", "bidirectional", "--dry-run"])
+        assert rc == 0
+        # File should not be changed
+        assert sch_file.read_text(encoding="utf-8") == SCHEMATIC_WITH_GLOBAL_LABELS
+
+    def test_invalid_shape_rejected(self, tmp_path):
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(SCHEMATIC_WITH_GLOBAL_LABELS, encoding="utf-8")
+
+        with pytest.raises(SystemExit) as exc_info:
+            main([str(sch_file), "--name", "SDA", "--shape", "invalid_shape"])
+        assert exc_info.value.code != 0
+
+    def test_not_a_schematic_file(self, tmp_path):
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("hello", encoding="utf-8")
+
+        rc = main([str(txt_file), "--name", "SDA", "--shape", "input"])
+        assert rc == 1
+
+    def test_file_not_found_cli(self):
+        rc = main(["/nonexistent.kicad_sch", "--name", "SDA", "--shape", "input"])
+        assert rc == 1
+
+    def test_label_not_found_exits_zero(self, tmp_path):
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(SCHEMATIC_WITH_GLOBAL_LABELS, encoding="utf-8")
+
+        rc = main([str(sch_file), "--name", "NONEXISTENT", "--shape", "output"])
+        assert rc == 0


### PR DESCRIPTION
## Summary
Adds a new `sch set-label-direction` subcommand that changes the `(shape ...)` attribute of `global_label` and `hierarchical_label` elements in KiCad schematics, matching labels by name across the full hierarchy.

## Changes
- New module `src/kicad_tools/cli/sch_set_label_direction.py` with core logic: regex-based shape replacement, hierarchy traversal, dry-run and backup support
- Parser registration in `parser.py` with `--name`, `--shape` (choices-validated), `--sheet`, `--dry-run`, `--backup` arguments
- Dispatch branch in `commands/schematic.py` and updated usage string
- 22 tests in `tests/test_sch_set_label_direction.py` covering unit, integration, and CLI edge cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Global label shape change | Pass | Unit test `test_global_label_shape_change` |
| Hierarchical label shape change | Pass | Unit test `test_hierarchical_label_shape_change` |
| Name filtering (only target label changed) | Pass | Unit tests `test_name_filtering` and `test_name_filtering_in_replacement` |
| Dry run reports without modifying | Pass | Tests `test_dry_run_does_not_modify` and `test_dry_run_cli` |
| Invalid shape rejected by parser | Pass | Test `test_invalid_shape_rejected` |
| Hierarchy traversal (root + sub-sheets) | Pass | Test `test_hierarchy_traversal` |
| Sheet filter restricts to one sheet | Pass | Test `test_sheet_filter` |
| Label not found exits 0 with message | Pass | Tests `test_label_not_found` and `test_label_not_found_exits_zero` |
| Backup creation | Pass | Test `test_backup_created` |

## Test Plan
All 22 tests pass: `pytest tests/test_sch_set_label_direction.py -v`

Closes #1879