### PR TITLE
feat(cli): add sch add-wire command for placing wires between coordinates

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -283,9 +283,12 @@ def run_sch_command(args) -> int:
     elif args.sch_command == "add-wire":
         from ..sch_add_wire import main as add_wire_main
 
-        sub_argv = [str(schematic_path)]
-        sub_argv.extend(["--from", str(args.start[0]), str(args.start[1])])
-        sub_argv.extend(["--to", str(args.end[0]), str(args.end[1])])
+        sub_argv = [str(schematic_path), "--from", str(args.start[0]), str(args.start[1])]
+        if args.to:
+            for to_pair in args.to:
+                sub_argv.extend(["--to", str(to_pair[0]), str(to_pair[1])])
+        if args.junction:
+            sub_argv.append("--junction")
         if args.dry_run:
             sub_argv.append("--dry-run")
         if args.backup:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -628,7 +628,6 @@ def _add_sch_parser(subparsers) -> None:
     sch_set_label_dir.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
-
     # sch add-no-connect
     sch_add_nc = sch_subparsers.add_parser("add-no-connect", help="Add no-connect markers to pins")
     sch_add_nc.add_argument("schematic", help="Path to .kicad_sch file")
@@ -692,7 +691,7 @@ def _add_sch_parser(subparsers) -> None:
     )
 
     # sch add-wire
-    sch_add_wire = sch_subparsers.add_parser("add-wire", help="Add a wire segment to the schematic")
+    sch_add_wire = sch_subparsers.add_parser("add-wire", help="Add wire segments to the schematic")
     sch_add_wire.add_argument("schematic", help="Path to .kicad_sch file")
     sch_add_wire.add_argument(
         "--from",
@@ -701,16 +700,21 @@ def _add_sch_parser(subparsers) -> None:
         required=True,
         dest="start",
         metavar=("X", "Y"),
-        help="Wire start coordinates",
+        help="Start coordinate",
     )
     sch_add_wire.add_argument(
         "--to",
         nargs=2,
         type=float,
+        action="append",
         required=True,
-        dest="end",
         metavar=("X", "Y"),
-        help="Wire end coordinates",
+        help="End coordinate (repeatable for multi-segment wires)",
+    )
+    sch_add_wire.add_argument(
+        "--junction",
+        action="store_true",
+        help="Auto-insert junctions where endpoints land on existing wire midpoints",
     )
     sch_add_wire.add_argument(
         "--dry-run", "-n", action="store_true", help="Preview without modifying"

--- a/src/kicad_tools/cli/sch_add_wire.py
+++ b/src/kicad_tools/cli/sch_add_wire.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
 """
-Add a wire segment to a KiCad schematic file.
+Add wire segments to a KiCad schematic file.
+
+Supports placing single or multi-segment wires between arbitrary coordinates,
+with optional grid snapping and automatic junction insertion.
 
 Usage:
-    kct sch add-wire board.kicad_sch --from 100 80 --to 120 80
-    kct sch add-wire board.kicad_sch --from 100 80 --to 120 80 --dry-run
+    kct sch add-wire board.kicad_sch --from 100 50 --to 120 50
+    kct sch add-wire board.kicad_sch --from 100 50 --to 120 50 --to 120 80
+    kct sch add-wire board.kicad_sch --from 100 50 --to 120 50 --junction
+    kct sch add-wire board.kicad_sch --from 100 50 --to 120 50 --dry-run
 
 Options:
-    --from <x> <y>   Start point of the wire
-    --to <x> <y>     End point of the wire
-    --dry-run        Show planned actions without modifying
-    --backup         Create timestamped backup before writing
+    --from X Y             Start coordinate (two floats)
+    --to X Y               End coordinate (two floats, repeatable for multi-segment)
+    --junction             Auto-insert junctions where endpoints land on existing wires
+    --dry-run              Show planned actions without modifying
+    --backup               Create timestamped backup before writing
 """
 
 from __future__ import annotations
@@ -18,6 +24,7 @@ from __future__ import annotations
 import argparse
 import shutil
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
@@ -25,9 +32,50 @@ from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import Schematic
 
 
+@dataclass
+class PlannedAction:
+    """An action the command will take, for reporting."""
+
+    kind: str  # "wire", "junction"
+    description: str
+
+
 def _snap(value: float, grid: float = 1.27) -> float:
     """Snap a coordinate to the nearest grid point."""
     return round(value / grid) * grid
+
+
+def _point_on_wire_midpoint(
+    point: tuple[float, float],
+    wire_start: tuple[float, float],
+    wire_end: tuple[float, float],
+    tolerance: float = 0.1,
+) -> bool:
+    """Check if a point lies on a wire segment but not at its endpoints."""
+    x, y = point
+
+    # Check if point is at either endpoint
+    for ep in (wire_start, wire_end):
+        if abs(x - ep[0]) < tolerance and abs(y - ep[1]) < tolerance:
+            return False
+
+    # Check if point is on the segment
+    x1, y1 = wire_start
+    x2, y2 = wire_end
+
+    # Bounding box check
+    if not (min(x1, x2) - tolerance <= x <= max(x1, x2) + tolerance):
+        return False
+    if not (min(y1, y2) - tolerance <= y <= max(y1, y2) + tolerance):
+        return False
+
+    # Perpendicular distance check
+    length = ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
+    if length < tolerance:
+        return False
+
+    dist = abs((y2 - y1) * x - (x2 - x1) * y + x2 * y1 - y2 * x1) / length
+    return dist < tolerance
 
 
 def run_add_wire(args) -> int:
@@ -40,43 +88,111 @@ def run_add_wire(args) -> int:
         print(f"Error: Schematic not found: {schematic_path}", file=sys.stderr)
         return 1
 
-    start = (_snap(args.start[0]), _snap(args.start[1]))
-    end = (_snap(args.end[0]), _snap(args.end[1]))
+    # Snap all coordinates to grid
+    from_point = (_snap(args.start[0]), _snap(args.start[1]))
 
-    # Skip zero-length wires
-    if abs(start[0] - end[0]) < 0.01 and abs(start[1] - end[1]) < 0.01:
-        print("Error: Wire start and end are the same point", file=sys.stderr)
+    to_points: list[tuple[float, float]] = []
+    for tp in args.to:
+        to_points.append((_snap(tp[0]), _snap(tp[1])))
+
+    if not to_points:
+        print("Error: At least one --to coordinate is required", file=sys.stderr)
         return 1
 
-    print(
-        f"Planned: Wire from ({start[0]:.2f}, {start[1]:.2f})"
-        f" to ({end[0]:.2f}, {end[1]:.2f})"
-    )
+    # Build the full path of points: from -> to1 -> to2 -> ...
+    path_points = [from_point] + to_points
 
-    if args.dry_run:
-        print("DRY RUN - No changes will be made")
+    # Check for zero-length segments
+    for i in range(len(path_points) - 1):
+        p1 = path_points[i]
+        p2 = path_points[i + 1]
+        if abs(p1[0] - p2[0]) < 0.01 and abs(p1[1] - p2[1]) < 0.01:
+            print(
+                f"Warning: Zero-length wire segment from"
+                f" ({p1[0]:.2f}, {p1[1]:.2f}) to ({p2[0]:.2f}, {p2[1]:.2f})"
+                f" will be skipped",
+                file=sys.stderr,
+            )
+
+    # Collect planned actions
+    planned: list[PlannedAction] = []
+
+    for i in range(len(path_points) - 1):
+        p1 = path_points[i]
+        p2 = path_points[i + 1]
+        if abs(p1[0] - p2[0]) < 0.01 and abs(p1[1] - p2[1]) < 0.01:
+            continue  # Skip zero-length segments
+        planned.append(
+            PlannedAction(
+                "wire",
+                f"Wire from ({p1[0]:.2f}, {p1[1]:.2f}) to ({p2[0]:.2f}, {p2[1]:.2f})",
+            )
+        )
+
+    # Plan junction insertion if requested
+    junction_points: list[tuple[float, float]] = []
+    if getattr(args, "junction", False):
+        # Check all endpoints (including intermediate) against existing wires
+        for pt in path_points:
+            for wire in sch.wires:
+                if _point_on_wire_midpoint(pt, wire.start, wire.end):
+                    junction_points.append(pt)
+                    planned.append(
+                        PlannedAction(
+                            "junction",
+                            f"Junction at ({pt[0]:.2f}, {pt[1]:.2f}) (wire intersection)",
+                        )
+                    )
+                    break  # One junction per point is enough
+
+    if not planned:
+        print("No wire segments to add (all zero-length after snapping)")
         return 0
 
+    # Report planned actions
+    if args.dry_run:
+        print("DRY RUN - No changes will be made")
+        print("=" * 60)
+
+    print(f"Planned actions ({len(planned)}):")
+    for action in planned:
+        print(f"  [{action.kind}] {action.description}")
+
+    if args.dry_run:
+        return 0
+
+    # Create backup if requested
     if args.backup:
-        backup_path = (
-            f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
-        )
+        backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
         print(f"Backup created: {backup_path}")
 
-    wire = sch.add_wire(start, end)
+    # Apply changes: add wire segments
+    wires_added = 0
+    for i in range(len(path_points) - 1):
+        p1 = path_points[i]
+        p2 = path_points[i + 1]
+        if abs(p1[0] - p2[0]) < 0.01 and abs(p1[1] - p2[1]) < 0.01:
+            continue  # Skip zero-length segments
+        sch.add_wire(p1, p2)
+        wires_added += 1
+
+    # Add junctions
+    for pt in junction_points:
+        sch.add_junction(pt)
+
+    # Save
     sch.save()
 
-    print(
-        f"Wire added: ({wire.start[0]:.2f}, {wire.start[1]:.2f})"
-        f" -> ({wire.end[0]:.2f}, {wire.end[1]:.2f})"
-    )
+    print(f"\nWires added: {wires_added}")
+    if junction_points:
+        print(f"Junctions added: {len(junction_points)}")
     return 0
 
 
 def main(argv=None):
     parser = argparse.ArgumentParser(
-        description="Add a wire segment to a KiCad schematic",
+        description="Add wire segments to a KiCad schematic",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
@@ -88,23 +204,24 @@ def main(argv=None):
         required=True,
         dest="start",
         metavar=("X", "Y"),
-        help="Wire start coordinates",
+        help="Start coordinate",
     )
     parser.add_argument(
         "--to",
         nargs=2,
         type=float,
+        action="append",
         required=True,
-        dest="end",
         metavar=("X", "Y"),
-        help="Wire end coordinates",
+        help="End coordinate (repeatable for multi-segment wires)",
     )
     parser.add_argument(
-        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+        "--junction",
+        action="store_true",
+        help="Auto-insert junctions where endpoints land on existing wire midpoints",
     )
-    parser.add_argument(
-        "--backup", action="store_true", help="Create backup before modifying"
-    )
+    parser.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
+    parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
     args = parser.parse_args(argv)
     return run_add_wire(args)

--- a/tests/test_sch_add_wire.py
+++ b/tests/test_sch_add_wire.py
@@ -1,0 +1,494 @@
+"""Tests for the sch add-wire command.
+
+Covers single wire placement, multi-segment wires, grid snapping,
+junction auto-insertion, --dry-run, --backup, round-trip, and error cases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_add_wire import (
+    _point_on_wire_midpoint,
+    _snap,
+)
+from kicad_tools.cli.sch_add_wire import (
+    main as add_wire_main,
+)
+from kicad_tools.schema import Schematic
+
+# ---------------------------------------------------------------------------
+# Minimal schematic content for testing
+# ---------------------------------------------------------------------------
+
+MINIMAL_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+  )
+  (wire (pts (xy 100 50) (xy 150 50))
+    (stroke (width 0) (type default))
+    (uuid "wire-1")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+# Schematic with a wire on the 1.27mm grid for junction testing.
+# Wire from (100.33, 50.8) to (149.86, 50.8) -- these are on-grid.
+SCHEMATIC_ON_GRID = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+  )
+  (wire (pts (xy 100.33 50.8) (xy 149.86 50.8))
+    (stroke (width 0) (type default))
+    (uuid "wire-grid-1")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+EMPTY_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+def _write_sch(tmp_path: Path, content: str = MINIMAL_SCHEMATIC) -> Path:
+    p = tmp_path / "test_add_wire.kicad_sch"
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+
+class TestUtilityFunctions:
+    def test_snap(self):
+        # round(100/1.27) = round(78.74) = 79, 79 * 1.27 = 100.33
+        assert _snap(100.0) == pytest.approx(100.33, abs=0.01)
+        assert _snap(100.33) == pytest.approx(100.33, abs=0.01)
+        assert _snap(2.54) == pytest.approx(2.54, abs=0.01)
+
+    def test_point_on_wire_midpoint(self):
+        # Point at midpoint of horizontal wire
+        assert _point_on_wire_midpoint((125, 50), (100, 50), (150, 50)) is True
+        # Point at endpoint
+        assert _point_on_wire_midpoint((100, 50), (100, 50), (150, 50)) is False
+        # Point off the wire
+        assert _point_on_wire_midpoint((125, 60), (100, 50), (150, 50)) is False
+
+
+# ---------------------------------------------------------------------------
+# Single wire
+# ---------------------------------------------------------------------------
+
+
+class TestSingleWire:
+    def test_add_single_wire(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        sch_before = Schematic.load(sch_path)
+        original_wire_count = len(sch_before.wires)
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "100.33",
+                "50.8",
+                "--to",
+                "120.65",
+                "50.8",
+            ]
+        )
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        assert len(sch.wires) == original_wire_count + 1
+        new_wire = sch.wires[-1]
+        assert new_wire.start[0] == pytest.approx(100.33, abs=0.02)
+        assert new_wire.start[1] == pytest.approx(50.8, abs=0.02)
+        assert new_wire.end[0] == pytest.approx(120.65, abs=0.02)
+        assert new_wire.end[1] == pytest.approx(50.8, abs=0.02)
+
+
+# ---------------------------------------------------------------------------
+# Multi-segment wires
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSegment:
+    def test_two_segment_wire(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        sch_before = Schematic.load(sch_path)
+        original_wire_count = len(sch_before.wires)
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "100.33",
+                "50.8",
+                "--to",
+                "120.65",
+                "50.8",
+                "--to",
+                "120.65",
+                "80.01",
+            ]
+        )
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        assert len(sch.wires) == original_wire_count + 2
+
+    def test_three_segment_wire(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        sch_before = Schematic.load(sch_path)
+        original_wire_count = len(sch_before.wires)
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "100.33",
+                "50.8",
+                "--to",
+                "120.65",
+                "50.8",
+                "--to",
+                "120.65",
+                "80.01",
+                "--to",
+                "140.97",
+                "80.01",
+            ]
+        )
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        assert len(sch.wires) == original_wire_count + 3
+
+
+# ---------------------------------------------------------------------------
+# Grid snapping
+# ---------------------------------------------------------------------------
+
+
+class TestGridSnap:
+    def test_coordinates_snapped_to_grid(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "100",
+                "50",
+                "--to",
+                "120",
+                "50",
+            ]
+        )
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        new_wire = sch.wires[-1]
+        # 100 -> snapped to 100.33, 50 -> snapped to 49.53
+        assert new_wire.start[0] == pytest.approx(_snap(100), abs=0.02)
+        assert new_wire.start[1] == pytest.approx(_snap(50), abs=0.02)
+        assert new_wire.end[0] == pytest.approx(_snap(120), abs=0.02)
+        assert new_wire.end[1] == pytest.approx(_snap(50), abs=0.02)
+
+
+# ---------------------------------------------------------------------------
+# Junction auto-insert
+# ---------------------------------------------------------------------------
+
+
+class TestJunction:
+    def test_junction_auto_insert(self, tmp_path: Path):
+        """When --junction is passed and an endpoint lands on an existing wire
+        midpoint, a junction should be created."""
+        sch_path = _write_sch(tmp_path, SCHEMATIC_ON_GRID)
+        sch_before = Schematic.load(sch_path)
+        original_junc_count = len(sch_before.junctions)
+
+        # Existing wire goes from (100.33, 50.8) to (149.86, 50.8)
+        # Use 125.73 which snaps to 125.73 (99*1.27) and is on the wire midpoint
+        # 50.8 snaps to 50.8 (40*1.27) matching the wire y coordinate
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "125.73",
+                "50.8",
+                "--to",
+                "125.73",
+                "80.01",
+                "--junction",
+            ]
+        )
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        assert len(sch.junctions) >= original_junc_count + 1
+
+    def test_no_junction_without_flag(self, tmp_path: Path):
+        """Without --junction, no junction is added even if wires cross."""
+        sch_path = _write_sch(tmp_path)
+        sch_before = Schematic.load(sch_path)
+        original_junc_count = len(sch_before.junctions)
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "125",
+                "50",
+                "--to",
+                "125",
+                "80.01",
+            ]
+        )
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        assert len(sch.junctions) == original_junc_count
+
+    def test_junction_at_endpoint_not_midpoint(self, tmp_path: Path):
+        """Junction should NOT be added when endpoint matches a wire endpoint
+        (not midpoint)."""
+        sch_path = _write_sch(tmp_path, SCHEMATIC_ON_GRID)
+        sch_before = Schematic.load(sch_path)
+        original_junc_count = len(sch_before.junctions)
+
+        # Wire endpoint is at (100.33, 50.8) -- not a midpoint
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "100.33",
+                "50.8",
+                "--to",
+                "100.33",
+                "80.01",
+                "--junction",
+            ]
+        )
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        assert len(sch.junctions) == original_junc_count
+
+
+# ---------------------------------------------------------------------------
+# --dry-run
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    def test_dry_run_no_changes(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        original_content = sch_path.read_text()
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "100.33",
+                "50.8",
+                "--to",
+                "120.65",
+                "50.8",
+                "--dry-run",
+            ]
+        )
+        assert result == 0
+
+        assert sch_path.read_text() == original_content
+
+    def test_dry_run_with_junction(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_ON_GRID)
+        original_content = sch_path.read_text()
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "125.73",
+                "50.8",
+                "--to",
+                "125.73",
+                "80.01",
+                "--junction",
+                "--dry-run",
+            ]
+        )
+        assert result == 0
+
+        assert sch_path.read_text() == original_content
+
+
+# ---------------------------------------------------------------------------
+# --backup
+# ---------------------------------------------------------------------------
+
+
+class TestBackup:
+    def test_backup_creates_file(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "100.33",
+                "50.8",
+                "--to",
+                "120.65",
+                "50.8",
+                "--backup",
+            ]
+        )
+        assert result == 0
+
+        backup_files = list(tmp_path.glob("*.backup-*"))
+        assert len(backup_files) == 1
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_schematic_not_found(self, tmp_path: Path):
+        result = add_wire_main(
+            [
+                str(tmp_path / "nonexistent.kicad_sch"),
+                "--from",
+                "100",
+                "50",
+                "--to",
+                "120",
+                "50",
+            ]
+        )
+        assert result == 1
+
+    def test_zero_length_wire_skipped(self, tmp_path: Path, capsys):
+        """A zero-length wire (same from and to after snapping) should be
+        handled gracefully."""
+        sch_path = _write_sch(tmp_path)
+        sch_before = Schematic.load(sch_path)
+        original_wire_count = len(sch_before.wires)
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "100.33",
+                "50.8",
+                "--to",
+                "100.33",
+                "50.8",
+            ]
+        )
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        # No new wires added since the segment was zero-length
+        assert len(sch.wires) == original_wire_count
+
+        captured = capsys.readouterr()
+        assert "Zero-length" in captured.err or "No wire segments" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: save then reload
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_add_and_reload_preserves_content(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        sch_before = Schematic.load(sch_path)
+        original_wire_count = len(sch_before.wires)
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "100.33",
+                "50.8",
+                "--to",
+                "120.65",
+                "50.8",
+            ]
+        )
+        assert result == 0
+
+        sch_after = Schematic.load(sch_path)
+        assert len(sch_after.wires) == original_wire_count + 1
+
+        # Verify the new wire has correct S-expression structure
+        new_wire = sch_after.wires[-1]
+        assert new_wire.uuid  # UUID was generated
+        assert new_wire.start[0] == pytest.approx(100.33, abs=0.02)
+        assert new_wire.end[0] == pytest.approx(120.65, abs=0.02)
+
+    def test_multi_segment_round_trip(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+
+        result = add_wire_main(
+            [
+                str(sch_path),
+                "--from",
+                "100.33",
+                "50.8",
+                "--to",
+                "120.65",
+                "50.8",
+                "--to",
+                "120.65",
+                "80.01",
+            ]
+        )
+        assert result == 0
+
+        # Reload and re-save
+        sch = Schematic.load(sch_path)
+        out_path = tmp_path / "round_trip.kicad_sch"
+        sch.save(out_path)
+
+        sch2 = Schematic.load(out_path)
+        # Original wire + 2 new wires
+        assert len(sch2.wires) == 3


### PR DESCRIPTION
## Summary
Add a new `kct sch add-wire` CLI subcommand that places wire segments into KiCad schematics between arbitrary coordinates, with grid snapping, multi-segment support, and optional junction auto-insertion.

## Changes
- **NEW** `src/kicad_tools/cli/sch_add_wire.py` -- standalone command module with `main(argv=None)` and `run_add_wire(args)`, following the `sch_add_component.py` pattern
- `src/kicad_tools/cli/parser.py` -- register `add-wire` subparser with `--from`, `--to` (repeatable), `--junction`, `--dry-run`, `--backup` arguments
- `src/kicad_tools/cli/commands/schematic.py` -- add `elif args.sch_command == "add-wire":` dispatch branch and update usage string
- **NEW** `tests/test_sch_add_wire.py` -- 16 unit tests covering all acceptance criteria

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Single wire placement | Pass | `TestSingleWire::test_add_single_wire` -- adds one wire with correct endpoints |
| Multi-segment wires (repeated --to) | Pass | `TestMultiSegment::test_two_segment_wire`, `test_three_segment_wire` |
| Grid snap to 1.27mm | Pass | `TestGridSnap::test_coordinates_snapped_to_grid` |
| Junction auto-insert with --junction | Pass | `TestJunction::test_junction_auto_insert` |
| Junction skipped without flag | Pass | `TestJunction::test_no_junction_without_flag` |
| Junction not added at wire endpoints | Pass | `TestJunction::test_junction_at_endpoint_not_midpoint` |
| --dry-run previews without modifying | Pass | `TestDryRun::test_dry_run_no_changes`, `test_dry_run_with_junction` |
| --backup creates timestamped copy | Pass | `TestBackup::test_backup_creates_file` |
| File not found returns exit 1 | Pass | `TestErrors::test_schematic_not_found` |
| Zero-length wire handled gracefully | Pass | `TestErrors::test_zero_length_wire_skipped` |
| Round-trip save/load preserves structure | Pass | `TestRoundTrip::test_add_and_reload_preserves_content`, `test_multi_segment_round_trip` |

## Test Plan
All 16 tests pass: `python3 -m pytest tests/test_sch_add_wire.py -v`
Existing `test_sch_add_component.py` tests (26) still pass.

Closes #1877