### PR TITLE
fix(sch): improve junction detection and add standalone add-wire/add-junction commands

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -15,7 +15,10 @@ def run_sch_command(args) -> int:
             "          connections, unconnected, set-footprint, set-value, replace,"
             " sync-hierarchy, rename-signal,"
         )
-        print("          add-no-connect, add-component, cleanup-wires, disconnect")
+        print(
+            "          add-no-connect, add-component, add-wire, add-junction,"
+            " cleanup-wires, disconnect"
+        )
         return 1
 
     schematic_path = Path(args.schematic)
@@ -263,6 +266,29 @@ def run_sch_command(args) -> int:
         if args.backup:
             sub_argv.append("--backup")
         return add_comp_main(sub_argv) or 0
+
+    elif args.sch_command == "add-wire":
+        from ..sch_add_wire import main as add_wire_main
+
+        sub_argv = [str(schematic_path)]
+        sub_argv.extend(["--from", str(args.start[0]), str(args.start[1])])
+        sub_argv.extend(["--to", str(args.end[0]), str(args.end[1])])
+        if args.dry_run:
+            sub_argv.append("--dry-run")
+        if args.backup:
+            sub_argv.append("--backup")
+        return add_wire_main(sub_argv) or 0
+
+    elif args.sch_command == "add-junction":
+        from ..sch_add_junction import main as add_junc_main
+
+        sub_argv = [str(schematic_path)]
+        sub_argv.extend(["--at", str(args.at[0]), str(args.at[1])])
+        if args.dry_run:
+            sub_argv.append("--dry-run")
+        if args.backup:
+            sub_argv.append("--backup")
+        return add_junc_main(sub_argv) or 0
 
     elif args.sch_command == "cleanup-wires":
         from ..sch_cleanup_wires import main as cleanup_main

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -685,6 +685,56 @@ def _add_sch_parser(subparsers) -> None:
         "--backup", action="store_true", help="Create backup before modifying"
     )
 
+    # sch add-wire
+    sch_add_wire = sch_subparsers.add_parser(
+        "add-wire", help="Add a wire segment to the schematic"
+    )
+    sch_add_wire.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_add_wire.add_argument(
+        "--from",
+        nargs=2,
+        type=float,
+        required=True,
+        dest="start",
+        metavar=("X", "Y"),
+        help="Wire start coordinates",
+    )
+    sch_add_wire.add_argument(
+        "--to",
+        nargs=2,
+        type=float,
+        required=True,
+        dest="end",
+        metavar=("X", "Y"),
+        help="Wire end coordinates",
+    )
+    sch_add_wire.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+    )
+    sch_add_wire.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+
+    # sch add-junction
+    sch_add_junc = sch_subparsers.add_parser(
+        "add-junction", help="Add a junction to the schematic"
+    )
+    sch_add_junc.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_add_junc.add_argument(
+        "--at",
+        nargs=2,
+        type=float,
+        required=True,
+        metavar=("X", "Y"),
+        help="Junction coordinates",
+    )
+    sch_add_junc.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+    )
+    sch_add_junc.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+
     # sch cleanup-wires
     sch_cleanup = sch_subparsers.add_parser(
         "cleanup-wires", help="Remove zero-length and dangling wires"

--- a/src/kicad_tools/cli/sch_add_component.py
+++ b/src/kicad_tools/cli/sch_add_component.py
@@ -146,6 +146,33 @@ def _point_on_wire_midpoint(
     return dist < tolerance
 
 
+def _point_on_wire_segment(
+    point: tuple[float, float],
+    wire_start: tuple[float, float],
+    wire_end: tuple[float, float],
+    tolerance: float = 0.1,
+) -> bool:
+    """Check if a point lies on a wire segment (including endpoints)."""
+    x, y = point
+    x1, y1 = wire_start
+    x2, y2 = wire_end
+
+    # Bounding box check
+    if not (min(x1, x2) - tolerance <= x <= max(x1, x2) + tolerance):
+        return False
+    if not (min(y1, y2) - tolerance <= y <= max(y1, y2) + tolerance):
+        return False
+
+    # Perpendicular distance check
+    length = ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
+    if length < tolerance:
+        # Wire is basically a point -- check distance to that point
+        return ((x - x1) ** 2 + (y - y1) ** 2) ** 0.5 < tolerance
+
+    dist = abs((y2 - y1) * x - (x2 - x1) * y + x2 * y1 - y2 * x1) / length
+    return dist < tolerance
+
+
 def run_add_component(args) -> int:
     """Execute the add-component command."""
     schematic_path = Path(args.schematic)
@@ -307,9 +334,9 @@ def run_add_component(args) -> int:
                 )
             )
 
-            # Check if target intersects existing wires at midpoints
+            # Check if target intersects existing wires (endpoint or midpoint)
             for wire in sch.wires:
-                if _point_on_wire_midpoint(cs.target, wire.start, wire.end):
+                if _point_on_wire_segment(cs.target, wire.start, wire.end):
                     planned.append(
                         PlannedAction(
                             "junction",
@@ -360,41 +387,33 @@ def run_add_component(args) -> int:
             mirror=mirror,
         )
 
-    # 3. Add wire connections
+    # 3. Add wire connections (reuse pin_positions computed during planning)
     if connect_specs:
-        # Re-resolve pin positions using the library symbol
-        if need_embed and lib_sym is not None:
-            pin_src = lib_sym
-        else:
-            lib_sym_sexp = sch.get_lib_symbol(args.lib_id)
-            if lib_sym_sexp is not None:
-                pin_src = LibrarySymbol.from_sexp(lib_sym_sexp)
-            else:
-                pin_src = lib_sym  # fallback
+        # Record wires that existed before we start adding, so we can
+        # correctly detect pre-existing wires for junction insertion.
+        pre_existing_wire_count = len(sch.wires)
 
-        if pin_src is not None:
-            pin_positions = pin_src.get_all_pin_positions(
-                instance_pos=position,
-                instance_rot=rotation,
-                mirror=mirror,
-            )
+        for cs in connect_specs:
+            pin_pos = pin_positions.get(cs.pin_number)
+            if pin_pos is None:
+                continue
 
-            for cs in connect_specs:
-                pin_pos = pin_positions.get(cs.pin_number)
-                if pin_pos is None:
-                    continue
+            pin_pos = (_snap(pin_pos[0]), _snap(pin_pos[1]))
 
-                pin_pos = (_snap(pin_pos[0]), _snap(pin_pos[1]))
-                sch.add_wire(pin_pos, cs.target)
+            # Skip duplicate: don't add a wire if start == end
+            if (
+                abs(pin_pos[0] - cs.target[0]) < 0.01
+                and abs(pin_pos[1] - cs.target[1]) < 0.01
+            ):
+                continue
 
-                # Add junction if target intersects an existing wire midpoint
-                for wire in sch.wires:
-                    # Skip the wire we just added (last wire in the list)
-                    if wire is sch.wires[-1]:
-                        continue
-                    if _point_on_wire_midpoint(cs.target, wire.start, wire.end):
-                        sch.add_junction(cs.target)
-                        break
+            sch.add_wire(pin_pos, cs.target)
+
+            # Add junction if target intersects a pre-existing wire segment
+            for wire in sch.wires[:pre_existing_wire_count]:
+                if _point_on_wire_segment(cs.target, wire.start, wire.end):
+                    sch.add_junction(cs.target)
+                    break
 
     # 4. Save
     sch.save()

--- a/src/kicad_tools/cli/sch_add_junction.py
+++ b/src/kicad_tools/cli/sch_add_junction.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Add a junction to a KiCad schematic file.
+
+Usage:
+    kct sch add-junction board.kicad_sch --at 125 50
+    kct sch add-junction board.kicad_sch --at 125 50 --dry-run
+
+Options:
+    --at <x> <y>   Position of the junction
+    --dry-run      Show planned actions without modifying
+    --backup       Create timestamped backup before writing
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
+from kicad_tools.schema import Schematic
+
+
+def _snap(value: float, grid: float = 1.27) -> float:
+    """Snap a coordinate to the nearest grid point."""
+    return round(value / grid) * grid
+
+
+def run_add_junction(args) -> int:
+    """Execute the add-junction command."""
+    schematic_path = Path(args.schematic)
+
+    try:
+        sch = Schematic.load(schematic_path)
+    except (FileNotFoundError, KiCadFileNotFoundError):
+        print(f"Error: Schematic not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    position = (_snap(args.at[0]), _snap(args.at[1]))
+
+    print(f"Planned: Junction at ({position[0]:.2f}, {position[1]:.2f})")
+
+    if args.dry_run:
+        print("DRY RUN - No changes will be made")
+        return 0
+
+    if args.backup:
+        backup_path = (
+            f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        )
+        shutil.copy2(schematic_path, backup_path)
+        print(f"Backup created: {backup_path}")
+
+    junc = sch.add_junction(position)
+    sch.save()
+
+    print(
+        f"Junction added at ({junc.position[0]:.2f}, {junc.position[1]:.2f})"
+    )
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Add a junction to a KiCad schematic",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", help="Path to .kicad_sch file")
+    parser.add_argument(
+        "--at",
+        nargs=2,
+        type=float,
+        required=True,
+        metavar=("X", "Y"),
+        help="Junction coordinates",
+    )
+    parser.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+    )
+    parser.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+
+    args = parser.parse_args(argv)
+    return run_add_junction(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/sch_add_wire.py
+++ b/src/kicad_tools/cli/sch_add_wire.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Add a wire segment to a KiCad schematic file.
+
+Usage:
+    kct sch add-wire board.kicad_sch --from 100 80 --to 120 80
+    kct sch add-wire board.kicad_sch --from 100 80 --to 120 80 --dry-run
+
+Options:
+    --from <x> <y>   Start point of the wire
+    --to <x> <y>     End point of the wire
+    --dry-run        Show planned actions without modifying
+    --backup         Create timestamped backup before writing
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
+from kicad_tools.schema import Schematic
+
+
+def _snap(value: float, grid: float = 1.27) -> float:
+    """Snap a coordinate to the nearest grid point."""
+    return round(value / grid) * grid
+
+
+def run_add_wire(args) -> int:
+    """Execute the add-wire command."""
+    schematic_path = Path(args.schematic)
+
+    try:
+        sch = Schematic.load(schematic_path)
+    except (FileNotFoundError, KiCadFileNotFoundError):
+        print(f"Error: Schematic not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    start = (_snap(args.start[0]), _snap(args.start[1]))
+    end = (_snap(args.end[0]), _snap(args.end[1]))
+
+    # Skip zero-length wires
+    if abs(start[0] - end[0]) < 0.01 and abs(start[1] - end[1]) < 0.01:
+        print("Error: Wire start and end are the same point", file=sys.stderr)
+        return 1
+
+    print(
+        f"Planned: Wire from ({start[0]:.2f}, {start[1]:.2f})"
+        f" to ({end[0]:.2f}, {end[1]:.2f})"
+    )
+
+    if args.dry_run:
+        print("DRY RUN - No changes will be made")
+        return 0
+
+    if args.backup:
+        backup_path = (
+            f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        )
+        shutil.copy2(schematic_path, backup_path)
+        print(f"Backup created: {backup_path}")
+
+    wire = sch.add_wire(start, end)
+    sch.save()
+
+    print(
+        f"Wire added: ({wire.start[0]:.2f}, {wire.start[1]:.2f})"
+        f" -> ({wire.end[0]:.2f}, {wire.end[1]:.2f})"
+    )
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Add a wire segment to a KiCad schematic",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", help="Path to .kicad_sch file")
+    parser.add_argument(
+        "--from",
+        nargs=2,
+        type=float,
+        required=True,
+        dest="start",
+        metavar=("X", "Y"),
+        help="Wire start coordinates",
+    )
+    parser.add_argument(
+        "--to",
+        nargs=2,
+        type=float,
+        required=True,
+        dest="end",
+        metavar=("X", "Y"),
+        help="Wire end coordinates",
+    )
+    parser.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+    )
+    parser.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+
+    args = parser.parse_args(argv)
+    return run_add_wire(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sch_add_component.py
+++ b/tests/test_sch_add_component.py
@@ -15,11 +15,14 @@ from kicad_tools.cli.sch_add_component import (
     ConnectSpec,
     _is_power_symbol,
     _point_on_wire_midpoint,
+    _point_on_wire_segment,
     _snap,
     main as add_component_main,
     parse_connect,
     run_add_component,
 )
+from kicad_tools.cli.sch_add_junction import main as add_junction_main
+from kicad_tools.cli.sch_add_wire import main as add_wire_main
 from kicad_tools.schema import Schematic
 
 # ---------------------------------------------------------------------------
@@ -138,6 +141,20 @@ class TestUtilityFunctions:
         assert _point_on_wire_midpoint((100, 50), (100, 50), (150, 50)) is False
         # Point off the wire
         assert _point_on_wire_midpoint((125, 60), (100, 50), (150, 50)) is False
+
+    def test_point_on_wire_segment_midpoint(self):
+        # Point at midpoint of horizontal wire
+        assert _point_on_wire_segment((125, 50), (100, 50), (150, 50)) is True
+
+    def test_point_on_wire_segment_endpoint(self):
+        # Point at start endpoint -- should return True (unlike midpoint)
+        assert _point_on_wire_segment((100, 50), (100, 50), (150, 50)) is True
+        # Point at end endpoint
+        assert _point_on_wire_segment((150, 50), (100, 50), (150, 50)) is True
+
+    def test_point_on_wire_segment_off_wire(self):
+        # Point off the wire
+        assert _point_on_wire_segment((125, 60), (100, 50), (150, 50)) is False
 
 
 # ---------------------------------------------------------------------------
@@ -469,3 +486,182 @@ class TestAddJunction:
         sch2 = Schematic.load(out_path)
         assert len(sch2.junctions) == 1
         assert sch2.junctions[0].position == (125.0, 50.0)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate wire regression test
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateWireRegression:
+    def test_connect_produces_exactly_one_wire_per_pin(self, tmp_path: Path):
+        """Each --connect spec should produce exactly one wire, not duplicates."""
+        sch_path = _write_sch(tmp_path)
+        sch_before = Schematic.load(sch_path)
+        original_wire_count = len(sch_before.wires)
+
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "Device:R",
+            "--reference", "R1",
+            "--value", "10k",
+            "--footprint", "SMD:R_0402",
+            "--at", "100.33", "80.01",
+            "--connect", "1:120.65,80.01",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        # Exactly 1 new wire should be added (original + 1)
+        assert len(sch.wires) == original_wire_count + 1
+
+    def test_two_connects_produce_exactly_two_wires(self, tmp_path: Path):
+        """Two --connect specs should produce exactly two new wires."""
+        sch_path = _write_sch(tmp_path)
+        sch_before = Schematic.load(sch_path)
+        original_wire_count = len(sch_before.wires)
+
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "Device:R",
+            "--reference", "R1",
+            "--value", "10k",
+            "--footprint", "SMD:R_0402",
+            "--at", "100.33", "80.01",
+            "--connect", "1:120.65,80.01",
+            "--connect", "2:80.01,80.01",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        # Exactly 2 new wires should be added (original + 2)
+        assert len(sch.wires) == original_wire_count + 2
+
+
+# ---------------------------------------------------------------------------
+# Junction at wire endpoint test
+# ---------------------------------------------------------------------------
+
+
+class TestJunctionAtEndpoint:
+    def test_junction_at_wire_endpoint(self, tmp_path: Path):
+        """Connecting to an existing wire endpoint should also create a junction."""
+        # Use a schematic with a wire on the 1.27 grid so snapping is exact.
+        # 100.33 = 79 * 1.27, 49.53 = 39 * 1.27, 149.86 = 118 * 1.27
+        sch_content = SCHEMATIC_WITH_LIB.replace(
+            "(wire (pts (xy 100 50) (xy 150 50))",
+            "(wire (pts (xy 100.33 49.53) (xy 149.86 49.53))",
+        )
+        sch_path = _write_sch(tmp_path, content=sch_content)
+        # Place component and connect pin 2 to the wire start endpoint
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "Device:R",
+            "--reference", "R1",
+            "--value", "10k",
+            "--footprint", "SMD:R_0402",
+            "--at", "100.33", "40.64",
+            "--connect", "2:100.33,49.53",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        # A junction should be created at the wire endpoint
+        assert len(sch.junctions) >= 1
+        # Verify the junction is near the target point
+        found = any(
+            abs(j.position[0] - 100.33) < 0.1 and abs(j.position[1] - 49.53) < 0.1
+            for j in sch.junctions
+        )
+        assert found, f"Expected junction near (100.33, 49.53), got {sch.junctions}"
+
+
+# ---------------------------------------------------------------------------
+# Standalone sch add-wire command
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneAddWire:
+    def test_add_wire(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        sch_before = Schematic.load(sch_path)
+        original_wire_count = len(sch_before.wires)
+
+        result = add_wire_main([
+            str(sch_path),
+            "--from", "100", "80",
+            "--to", "120", "80",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        assert len(sch.wires) == original_wire_count + 1
+
+    def test_add_wire_dry_run(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        original_content = sch_path.read_text()
+
+        result = add_wire_main([
+            str(sch_path),
+            "--from", "100", "80",
+            "--to", "120", "80",
+            "--dry-run",
+        ])
+        assert result == 0
+        assert sch_path.read_text() == original_content
+
+    def test_add_wire_zero_length_rejected(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+
+        result = add_wire_main([
+            str(sch_path),
+            "--from", "100", "80",
+            "--to", "100", "80",
+        ])
+        assert result == 1
+
+    def test_add_wire_schematic_not_found(self, tmp_path: Path):
+        result = add_wire_main([
+            str(tmp_path / "nonexistent.kicad_sch"),
+            "--from", "100", "80",
+            "--to", "120", "80",
+        ])
+        assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# Standalone sch add-junction command
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneAddJunction:
+    def test_add_junction(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+
+        result = add_junction_main([
+            str(sch_path),
+            "--at", "125", "50",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        assert len(sch.junctions) == 1
+
+    def test_add_junction_dry_run(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        original_content = sch_path.read_text()
+
+        result = add_junction_main([
+            str(sch_path),
+            "--at", "125", "50",
+            "--dry-run",
+        ])
+        assert result == 0
+        assert sch_path.read_text() == original_content
+
+    def test_add_junction_schematic_not_found(self, tmp_path: Path):
+        result = add_junction_main([
+            str(tmp_path / "nonexistent.kicad_sch"),
+            "--at", "125", "50",
+        ])
+        assert result == 1


### PR DESCRIPTION
## Summary
Fix junction insertion in `sch add-component` to detect wire endpoints (not just midpoints), eliminate redundant pin-position resolution that could cause duplicate wires, and add standalone `sch add-wire` and `sch add-junction` CLI commands.

## Changes
- Add `_point_on_wire_segment()` function that includes endpoints (unlike `_point_on_wire_midpoint` which excludes them)
- Switch junction detection in both planning and execution phases to use `_point_on_wire_segment`
- Refactor wire creation to reuse pin positions from planning phase, eliminating redundant resolution
- Add zero-length wire skip to prevent degenerate wires
- Use pre-existing wire count to avoid false junction detection on newly added wires
- Create `src/kicad_tools/cli/sch_add_wire.py` standalone command
- Create `src/kicad_tools/cli/sch_add_junction.py` standalone command
- Register both commands in parser and dispatch (parser.py, commands/schematic.py)
- Add 12 new tests covering all new functionality

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| --connect produces exactly one wire per pin | Done | TestDuplicateWireRegression: both single and double connect tests pass with exact wire counts |
| Wire direction goes from pin position to target coordinate | Done | Verified in existing TestConnect tests; pin_pos is always start, cs.target is always end |
| Junctions inserted at endpoint OR midpoint | Done | TestJunctionAtEndpoint passes; _point_on_wire_segment verified with unit tests |
| sch add-wire works standalone | Done | TestStandaloneAddWire: 4 tests (add, dry-run, zero-length rejection, not-found) |
| sch add-junction works standalone | Done | TestStandaloneAddJunction: 3 tests (add, dry-run, not-found) |

## Test Plan
All 39 tests in `tests/test_sch_add_component.py` pass, including 12 new tests:
- `_point_on_wire_segment` unit tests (midpoint, endpoint, off-wire)
- Duplicate wire regression tests (1 connect, 2 connects)
- Junction at wire endpoint test
- Standalone add-wire tests (basic, dry-run, zero-length, not-found)
- Standalone add-junction tests (basic, dry-run, not-found)

Closes #1874