### PR TITLE
fix(cli): standardize remove-wire coordinate format

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -341,11 +341,11 @@ def run_sch_command(args) -> int:
 
         sub_argv = [str(schematic_path)]
         if args.from_pt:
-            sub_argv.extend(["--from", args.from_pt])
+            sub_argv.extend(["--from", str(args.from_pt[0]), str(args.from_pt[1])])
         if args.to_pt:
-            sub_argv.extend(["--to", args.to_pt])
+            sub_argv.extend(["--to", str(args.to_pt[0]), str(args.to_pt[1])])
         if args.near:
-            sub_argv.extend(["--near", args.near])
+            sub_argv.extend(["--near", str(args.near[0]), str(args.near[1])])
         if args.tolerance != 1.27:
             sub_argv.extend(["--tolerance", str(args.tolerance)])
         if args.dry_run:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -802,17 +802,26 @@ def _add_sch_parser(subparsers) -> None:
     sch_remove_wire.add_argument("schematic", help="Path to .kicad_sch file")
     sch_remove_wire.add_argument(
         "--from",
+        nargs=2,
+        type=float,
         dest="from_pt",
-        help="Start endpoint X,Y of wire to remove",
+        metavar=("X", "Y"),
+        help="Start endpoint of wire to remove",
     )
     sch_remove_wire.add_argument(
         "--to",
+        nargs=2,
+        type=float,
         dest="to_pt",
-        help="End endpoint X,Y of wire to remove",
+        metavar=("X", "Y"),
+        help="End endpoint of wire to remove",
     )
     sch_remove_wire.add_argument(
         "--near",
-        help="Find and remove wire nearest to this point X,Y",
+        nargs=2,
+        type=float,
+        metavar=("X", "Y"),
+        help="Find and remove wire nearest to this point",
     )
     sch_remove_wire.add_argument(
         "--tolerance",

--- a/src/kicad_tools/cli/sch_remove_wire.py
+++ b/src/kicad_tools/cli/sch_remove_wire.py
@@ -3,22 +3,22 @@
 Remove a specific wire segment from a KiCad schematic.
 
 Supports two matching modes:
-  --from X1,Y1 --to X2,Y2   Match a wire by its exact endpoints
-  --near X,Y                 Match the nearest wire to a point
+  --from X1 Y1 --to X2 Y2   Match a wire by its exact endpoints
+  --near X Y                 Match the nearest wire to a point
 
 After removal, orphaned junctions (at points with fewer than 3 remaining
 wire endpoints) are automatically cleaned up.
 
 Usage:
-    kct sch remove-wire board.kicad_sch --from 100,50 --to 150,50
-    kct sch remove-wire board.kicad_sch --near 125,50
-    kct sch remove-wire board.kicad_sch --from 100,50 --to 150,50 --dry-run
-    kct sch remove-wire board.kicad_sch --near 125,50 --backup
+    kct sch remove-wire board.kicad_sch --from 100 50 --to 150 50
+    kct sch remove-wire board.kicad_sch --near 125 50
+    kct sch remove-wire board.kicad_sch --from 100 50 --to 150 50 --dry-run
+    kct sch remove-wire board.kicad_sch --near 125 50 --backup
 
 Options:
-    --from X,Y               Start endpoint of the wire to remove
-    --to X,Y                 End endpoint of the wire to remove
-    --near X,Y               Find and remove the wire nearest to this point
+    --from X Y               Start endpoint of the wire to remove
+    --to X Y                 End endpoint of the wire to remove
+    --near X Y               Find and remove the wire nearest to this point
     --tolerance <mm>         Coordinate matching tolerance (default: 1.27 mm)
     --dry-run                Show what would change without modifying
     --backup                 Create backup before modifying
@@ -183,17 +183,6 @@ def remove_wire_and_orphan_junctions(
     return True, junctions_removed
 
 
-def _parse_coordinate(value: str) -> tuple[float, float]:
-    """Parse a comma-separated coordinate pair like '100,50' or '100.5,50.3'."""
-    parts = value.split(",")
-    if len(parts) != 2:
-        raise argparse.ArgumentTypeError(f"Expected X,Y coordinate pair, got: {value!r}")
-    try:
-        return (float(parts[0]), float(parts[1]))
-    except ValueError:
-        raise argparse.ArgumentTypeError(f"Invalid coordinate values: {value!r}")
-
-
 def run_remove_wire(args) -> int:
     """Execute the remove-wire command."""
     schematic_path = Path(args.schematic)
@@ -337,20 +326,26 @@ def main(argv=None):
     parser.add_argument("schematic", help="Path to .kicad_sch file")
     parser.add_argument(
         "--from",
+        nargs=2,
+        type=float,
         dest="from_pt",
-        type=_parse_coordinate,
-        help="Start endpoint (X,Y) of wire to remove",
+        metavar=("X", "Y"),
+        help="Start endpoint of wire to remove",
     )
     parser.add_argument(
         "--to",
+        nargs=2,
+        type=float,
         dest="to_pt",
-        type=_parse_coordinate,
-        help="End endpoint (X,Y) of wire to remove",
+        metavar=("X", "Y"),
+        help="End endpoint of wire to remove",
     )
     parser.add_argument(
         "--near",
-        type=_parse_coordinate,
-        help="Find and remove wire nearest to this point (X,Y)",
+        nargs=2,
+        type=float,
+        metavar=("X", "Y"),
+        help="Find and remove wire nearest to this point",
     )
     parser.add_argument(
         "--tolerance",

--- a/tests/test_sch_wiring_commands.py
+++ b/tests/test_sch_wiring_commands.py
@@ -612,7 +612,7 @@ class TestRemoveWire:
         path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
         original_content = path.read_text()
 
-        result = main([str(path), "--from", "100,50", "--to", "150,50", "--dry-run"])
+        result = main([str(path), "--from", "100", "50", "--to", "150", "50", "--dry-run"])
 
         assert result == 0
         assert path.read_text() == original_content
@@ -623,7 +623,7 @@ class TestRemoveWire:
 
         path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
 
-        result = main([str(path), "--from", "100,50", "--to", "150,50", "--backup"])
+        result = main([str(path), "--from", "100", "50", "--to", "150", "50", "--backup"])
 
         assert result == 0
         backups = list(tmp_path.glob("*.backup-*"))
@@ -637,7 +637,7 @@ class TestRemoveWire:
         sch_before = Schematic.load(path)
         initial_count = len(list(sch_before.sexp.find_all("wire")))
 
-        result = main([str(path), "--from", "100,50", "--to", "150,50"])
+        result = main([str(path), "--from", "100", "50", "--to", "150", "50"])
         assert result == 0
 
         sch_after = Schematic.load(path)
@@ -651,21 +651,21 @@ class TestRemoveWire:
         sch_before = Schematic.load(path)
         initial_count = len(list(sch_before.sexp.find_all("wire")))
 
-        result = main([str(path), "--near", "149,50"])
+        result = main([str(path), "--near", "149", "50"])
         assert result == 0
 
         sch_after = Schematic.load(path)
         assert len(list(sch_after.sexp.find_all("wire"))) == initial_count - 1
 
     def test_zero_length_wire_match(self, tmp_path):
-        """--from X,Y --to X,Y can match and remove a zero-length wire."""
+        """--from X Y --to X Y can match and remove a zero-length wire."""
         from kicad_tools.cli.sch_remove_wire import main
 
         path = _write_sch(tmp_path, SCHEMATIC_WITH_ZERO_LENGTH_WIRE_REMOVE)
         sch_before = Schematic.load(path)
         initial_count = len(list(sch_before.sexp.find_all("wire")))
 
-        result = main([str(path), "--from", "100,50", "--to", "100,50"])
+        result = main([str(path), "--from", "100", "50", "--to", "100", "50"])
         assert result == 0
 
         sch_after = Schematic.load(path)
@@ -678,7 +678,7 @@ class TestRemoveWire:
         path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
 
         result = main([
-            str(path), "--from", "100,50", "--to", "150,50", "--near", "125,50"
+            str(path), "--from", "100", "50", "--to", "150", "50", "--near", "125", "50"
         ])
         assert result == 1
 
@@ -688,7 +688,7 @@ class TestRemoveWire:
 
         path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
 
-        result = main([str(path), "--from", "999,999", "--to", "888,888"])
+        result = main([str(path), "--from", "999", "999", "--to", "888", "888"])
         assert result == 1
 
     def test_json_output(self, tmp_path, capsys):
@@ -699,7 +699,7 @@ class TestRemoveWire:
 
         path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
         result = main([
-            str(path), "--from", "100,50", "--to", "150,50",
+            str(path), "--from", "100", "50", "--to", "150", "50",
             "--format", "json"
         ])
         assert result == 0


### PR DESCRIPTION
## Summary
- Standardizes the coordinate format in `sch remove-wire` to match `sch add-wire`, fixing the inconsistency reported in #1890

Closes #1890

## Test plan
- [ ] Verify `sch remove-wire` accepts coordinates in the same format as `sch add-wire`
- [ ] Run existing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)