### PR TITLE
fix(cli): detect duplicate wires in sch cleanup-wires

### DIFF
--- a/src/kicad_tools/cli/sch_cleanup_wires.py
+++ b/src/kicad_tools/cli/sch_cleanup_wires.py
@@ -34,7 +34,7 @@ from kicad_tools.sexp import SExp
 class WireIssue:
     """Describes a wire that should be cleaned up."""
 
-    reason: str  # "zero_length" or "dangling"
+    reason: str  # "zero_length", "dangling", or "duplicate"
     wire_sexp: SExp
     start: tuple[float, float]
     end: tuple[float, float]
@@ -136,11 +136,31 @@ def find_cleanup_candidates(schematic: Schematic) -> list[WireIssue]:
         else:
             non_zero_wires.append(ws)
 
-    # Phase 2: dangling wires (endpoints not connected to anything else)
-    connection_points = _build_connection_map(schematic, non_zero_wires)
-    endpoint_counts = _wire_endpoint_counts(non_zero_wires)
-
+    # Phase 2: duplicate wires (same endpoints, order-insensitive)
+    seen: dict[tuple[tuple[float, float], tuple[float, float]], SExp] = {}
+    unique_wires = []
     for ws in non_zero_wires:
+        start, end = _wire_start_end(ws)
+        # Normalize endpoint order so (A->B) and (B->A) produce the same key
+        key = (min(start, end), max(start, end))
+        if key in seen:
+            issues.append(
+                WireIssue(
+                    reason="duplicate",
+                    wire_sexp=ws,
+                    start=start,
+                    end=end,
+                )
+            )
+        else:
+            seen[key] = ws
+            unique_wires.append(ws)
+
+    # Phase 3: dangling wires (endpoints not connected to anything else)
+    connection_points = _build_connection_map(schematic, unique_wires)
+    endpoint_counts = _wire_endpoint_counts(unique_wires)
+
+    for ws in unique_wires:
         start, end = _wire_start_end(ws)
 
         dangling_ends = 0
@@ -204,6 +224,7 @@ def run_cleanup_wires(args) -> int:
     # Build output data
     zero_count = sum(1 for i in issues if i.reason == "zero_length")
     dangling_count = sum(1 for i in issues if i.reason == "dangling")
+    duplicate_count = sum(1 for i in issues if i.reason == "duplicate")
 
     if args.format == "json":
         data = {
@@ -211,6 +232,7 @@ def run_cleanup_wires(args) -> int:
             "removed": len(issues) if not args.dry_run else 0,
             "zero_length": zero_count,
             "dangling": dangling_count,
+            "duplicate": duplicate_count,
             "issues": [
                 {
                     "reason": i.reason,
@@ -240,12 +262,15 @@ def run_cleanup_wires(args) -> int:
     print(f"Wires to clean up: {len(issues)}")
     if zero_count:
         print(f"  Zero-length: {zero_count}")
+    if duplicate_count:
+        print(f"  Duplicate: {duplicate_count}")
     if dangling_count:
         print(f"  Dangling: {dangling_count}")
     print()
 
+    reason_labels = {"zero_length": "zero-length", "dangling": "dangling", "duplicate": "duplicate"}
     for issue in issues:
-        label = "zero-length" if issue.reason == "zero_length" else "dangling"
+        label = reason_labels.get(issue.reason, issue.reason)
         print(
             f"  [{label}] ({issue.start[0]:.2f}, {issue.start[1]:.2f}) -> "
             f"({issue.end[0]:.2f}, {issue.end[1]:.2f})"

--- a/tests/test_sch_wiring_commands.py
+++ b/tests/test_sch_wiring_commands.py
@@ -106,6 +106,72 @@ SCHEMATIC_WITH_DANGLING_WIRE = """\
 """
 
 
+SCHEMATIC_WITH_DUPLICATE_WIRES = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000005")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 116.84 149.86) (xy 116.84 142.24))
+    (stroke (width 0) (type default))
+    (uuid "dup-wire-1")
+  )
+  (wire (pts (xy 116.84 142.24) (xy 116.84 149.86))
+    (stroke (width 0) (type default))
+    (uuid "dup-wire-2")
+  )
+  (wire (pts (xy 100 50) (xy 150 50))
+    (stroke (width 0) (type default))
+    (uuid "unique-wire")
+  )
+  (label "NET1" (at 100 50 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-1")
+  )
+  (label "NET2" (at 116.84 149.86 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-2")
+  )
+  (label "NET3" (at 116.84 142.24 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-3")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+SCHEMATIC_WITH_SAME_ORDER_DUPLICATE_WIRES = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000006")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 100 50) (xy 150 50))
+    (stroke (width 0) (type default))
+    (uuid "dup-same-1")
+  )
+  (wire (pts (xy 100 50) (xy 150 50))
+    (stroke (width 0) (type default))
+    (uuid "dup-same-2")
+  )
+  (label "NET1" (at 100 50 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-1")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
 SCHEMATIC_WITH_NO_CONNECT = """\
 (kicad_sch
   (version 20231120)
@@ -237,6 +303,73 @@ class TestCleanupWires:
         data = json.loads(captured.out)
         assert "issues" in data
         assert data["zero_length"] == 1
+
+    def test_finds_duplicate_wires_reversed_endpoints(self, tmp_path):
+        """Duplicate wires with reversed endpoint order are detected."""
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_DUPLICATE_WIRES)
+        sch = Schematic.load(path)
+        issues = find_cleanup_candidates(sch)
+
+        duplicates = [i for i in issues if i.reason == "duplicate"]
+        assert len(duplicates) == 1
+        # The second wire (reversed endpoints) should be the duplicate
+        assert duplicates[0].start == (116.84, 142.24)
+        assert duplicates[0].end == (116.84, 149.86)
+
+    def test_finds_duplicate_wires_same_order(self, tmp_path):
+        """Duplicate wires with identical endpoint order are detected."""
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_SAME_ORDER_DUPLICATE_WIRES)
+        sch = Schematic.load(path)
+        issues = find_cleanup_candidates(sch)
+
+        duplicates = [i for i in issues if i.reason == "duplicate"]
+        assert len(duplicates) == 1
+
+    def test_remove_duplicate_wires(self, tmp_path):
+        """Duplicate wires are removed, keeping exactly one copy."""
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates, remove_wires
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_DUPLICATE_WIRES)
+        sch = Schematic.load(path)
+
+        initial_wire_count = len(list(sch.sexp.find_all("wire")))
+        issues = find_cleanup_candidates(sch)
+        removed = remove_wires(sch, issues)
+
+        assert removed == 1
+        final_wire_count = len(list(sch.sexp.find_all("wire")))
+        assert final_wire_count == initial_wire_count - 1
+
+    def test_duplicate_wires_dry_run_json(self, tmp_path, capsys):
+        """JSON output includes duplicate wire count."""
+        import json
+
+        from kicad_tools.cli.sch_cleanup_wires import main
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_DUPLICATE_WIRES)
+        result = main([str(path), "--dry-run", "--format", "json"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["duplicate"] == 1
+        assert any(i["reason"] == "duplicate" for i in data["issues"])
+
+    def test_duplicate_wires_dry_run_text(self, tmp_path, capsys):
+        """Text output reports duplicate wires in dry-run mode."""
+        from kicad_tools.cli.sch_cleanup_wires import main
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_DUPLICATE_WIRES)
+        result = main([str(path), "--dry-run"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Duplicate: 1" in captured.out
+        assert "[duplicate]" in captured.out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix `sch cleanup-wires` to detect and remove duplicate wires that share identical endpoints (regardless of point order)
- Closes #1889

## Test plan
- [ ] Run `sch cleanup-wires` on a schematic with duplicate wires and verify they are removed
- [ ] Verify existing cleanup-wires tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)