### PR TITLE
fix(cli): sch labels --type global scans all sheets

### DIFF
--- a/src/kicad_tools/cli/sch_list_labels.py
+++ b/src/kicad_tools/cli/sch_list_labels.py
@@ -25,8 +25,87 @@ import argparse
 import fnmatch
 import json
 import sys
+from pathlib import Path
 
 from kicad_tools.schema import Schematic
+from kicad_tools.schema.hierarchy import build_hierarchy
+
+
+def _collect_labels_from_schematic(sch, label_type, sheet_name, sheet_file):
+    """Collect labels of the specified type from a single schematic.
+
+    Args:
+        sch: Loaded Schematic object
+        label_type: One of "all", "local", "global", "hierarchical", "power"
+        sheet_name: Name of the sheet (for location tracking)
+        sheet_file: Filename of the sheet
+
+    Returns:
+        List of label dicts with sheet info included
+    """
+    labels = []
+
+    if label_type in ["all", "local"]:
+        for lbl in sch.labels:
+            labels.append(
+                {
+                    "type": "local",
+                    "text": lbl.text,
+                    "position": lbl.position,
+                    "rotation": lbl.rotation,
+                    "uuid": lbl.uuid,
+                    "sheet": sheet_name,
+                    "sheet_file": sheet_file,
+                }
+            )
+
+    if label_type in ["all", "global"]:
+        for lbl in sch.global_labels:
+            labels.append(
+                {
+                    "type": "global",
+                    "text": lbl.text,
+                    "position": lbl.position,
+                    "rotation": lbl.rotation,
+                    "shape": lbl.shape,
+                    "uuid": lbl.uuid,
+                    "sheet": sheet_name,
+                    "sheet_file": sheet_file,
+                }
+            )
+
+    if label_type in ["all", "hierarchical"]:
+        for lbl in sch.hierarchical_labels:
+            labels.append(
+                {
+                    "type": "hierarchical",
+                    "text": lbl.text,
+                    "position": lbl.position,
+                    "rotation": lbl.rotation,
+                    "shape": lbl.shape,
+                    "uuid": lbl.uuid,
+                    "sheet": sheet_name,
+                    "sheet_file": sheet_file,
+                }
+            )
+
+    if label_type in ["all", "power"]:
+        for sym in sch.symbols:
+            if sym.lib_id.startswith("power:"):
+                labels.append(
+                    {
+                        "type": "power",
+                        "text": sym.value,
+                        "position": sym.position,
+                        "rotation": sym.rotation,
+                        "lib_id": sym.lib_id,
+                        "uuid": sym.uuid,
+                        "sheet": sheet_name,
+                        "sheet_file": sheet_file,
+                    }
+                )
+
+    return labels
 
 
 def main(argv=None):
@@ -58,60 +137,17 @@ def main(argv=None):
         print(f"Error loading schematic: {e}", file=sys.stderr)
         sys.exit(1)
 
-    # Collect labels by type
-    labels = []
+    # Collect labels from root schematic
+    root_file = Path(args.schematic).name
+    labels = _collect_labels_from_schematic(sch, args.type, "/", root_file)
 
-    if args.type in ["all", "local"]:
-        for lbl in sch.labels:
-            labels.append(
-                {
-                    "type": "local",
-                    "text": lbl.text,
-                    "position": lbl.position,
-                    "rotation": lbl.rotation,
-                    "uuid": lbl.uuid,
-                }
-            )
-
-    if args.type in ["all", "global"]:
-        for lbl in sch.global_labels:
-            labels.append(
-                {
-                    "type": "global",
-                    "text": lbl.text,
-                    "position": lbl.position,
-                    "rotation": lbl.rotation,
-                    "shape": lbl.shape,
-                    "uuid": lbl.uuid,
-                }
-            )
-
-    if args.type in ["all", "hierarchical"]:
-        for lbl in sch.hierarchical_labels:
-            labels.append(
-                {
-                    "type": "hierarchical",
-                    "text": lbl.text,
-                    "position": lbl.position,
-                    "rotation": lbl.rotation,
-                    "shape": lbl.shape,
-                    "uuid": lbl.uuid,
-                }
-            )
-
-    if args.type in ["all", "power"]:
-        for sym in sch.symbols:
-            if sym.lib_id.startswith("power:"):
-                labels.append(
-                    {
-                        "type": "power",
-                        "text": sym.value,
-                        "position": sym.position,
-                        "rotation": sym.rotation,
-                        "lib_id": sym.lib_id,
-                        "uuid": sym.uuid,
-                    }
-                )
+    # Traverse hierarchy to collect labels from child sheets
+    try:
+        root_node = build_hierarchy(args.schematic)
+        _collect_labels_recursive(root_node, args.type, labels)
+    except Exception:
+        # If hierarchy traversal fails, we still have root labels
+        pass
 
     # Apply pattern filter
     if args.pattern:
@@ -129,6 +165,30 @@ def main(argv=None):
         output_table(labels)
 
 
+def _collect_labels_recursive(node, label_type, labels):
+    """Recursively collect labels from child sheets in the hierarchy.
+
+    Args:
+        node: HierarchyNode from build_hierarchy
+        label_type: Label type filter
+        labels: List to append results to (mutated in place)
+    """
+    for child in node.children:
+        try:
+            child_sch = Schematic.load(child.path)
+        except Exception:
+            continue
+
+        sheet_name = child.get_path_string()
+        sheet_file = Path(child.path).name
+        labels.extend(
+            _collect_labels_from_schematic(child_sch, label_type, sheet_name, sheet_file)
+        )
+
+        # Recurse into grandchildren
+        _collect_labels_recursive(child, label_type, labels)
+
+
 def output_table(labels):
     """Output as formatted table."""
     if not labels:
@@ -142,13 +202,22 @@ def output_table(labels):
     text_width = max(len(lbl["text"]) for lbl in labels)
     text_width = max(text_width, 4)
 
-    print(f"{'Type':<{type_width}}  {'Text':<{text_width}}  {'Position':<20}  Shape/Lib")
-    print("-" * (type_width + text_width + 40))
+    sheet_width = max(len(lbl["sheet"]) for lbl in labels)
+    sheet_width = max(sheet_width, 5)
+
+    print(
+        f"{'Type':<{type_width}}  {'Text':<{text_width}}  "
+        f"{'Sheet':<{sheet_width}}  {'Position':<20}  Shape/Lib"
+    )
+    print("-" * (type_width + text_width + sheet_width + 40))
 
     for lbl in labels:
         pos = f"({lbl['position'][0]:.1f}, {lbl['position'][1]:.1f})"
         extra = lbl.get("shape", lbl.get("lib_id", ""))
-        print(f"{lbl['type']:<{type_width}}  {lbl['text']:<{text_width}}  {pos:<20}  {extra}")
+        print(
+            f"{lbl['type']:<{type_width}}  {lbl['text']:<{text_width}}  "
+            f"{lbl['sheet']:<{sheet_width}}  {pos:<20}  {extra}"
+        )
 
     print(f"\nTotal: {len(labels)} labels")
 
@@ -171,11 +240,12 @@ def output_json(labels):
 
 def output_csv(labels):
     """Output as CSV."""
-    print("Type,Text,X,Y,Rotation,Shape,UUID")
+    print("Type,Text,Sheet,Sheet File,X,Y,Rotation,Shape,UUID")
     for lbl in labels:
         shape = lbl.get("shape", lbl.get("lib_id", ""))
         print(
-            f"{lbl['type']},{lbl['text']},{lbl['position'][0]},{lbl['position'][1]},"
+            f"{lbl['type']},{lbl['text']},{lbl['sheet']},{lbl['sheet_file']},"
+            f"{lbl['position'][0]},{lbl['position'][1]},"
             f"{lbl['rotation']},{shape},{lbl['uuid']}"
         )
 

--- a/tests/fixtures/projects/logic_subsheet.kicad_sch
+++ b/tests/fixtures/projects/logic_subsheet.kicad_sch
@@ -28,4 +28,16 @@
 		(effects (font (size 1.27 1.27)) (justify left))
 		(uuid "hlabel-out")
 	)
+	(global_label "CLK"
+		(shape input)
+		(at 75 30 0)
+		(effects (font (size 1.27 1.27)) (justify left))
+		(uuid "glabel-clk-logic")
+	)
+	(global_label "RESET"
+		(shape input)
+		(at 75 70 0)
+		(effects (font (size 1.27 1.27)) (justify left))
+		(uuid "glabel-reset-logic")
+	)
 )

--- a/tests/fixtures/projects/output_subsheet.kicad_sch
+++ b/tests/fixtures/projects/output_subsheet.kicad_sch
@@ -16,4 +16,15 @@
 		(effects (font (size 1.27 1.27)) (justify right))
 		(uuid "hlabel-in")
 	)
+	(global_label "CLK"
+		(shape input)
+		(at 75 30 0)
+		(effects (font (size 1.27 1.27)) (justify left))
+		(uuid "glabel-clk-output")
+	)
+	(label "LOCAL_NET"
+		(at 60 60 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "label-local-output")
+	)
 )

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -169,6 +169,90 @@ class TestSchListLabels:
         # Minimal schematic has NET1 label
         assert "NET1" in captured.out or "No labels" in captured.out
 
+    def test_hierarchy_global_labels_across_sheets(self, hierarchical_schematic: Path, capsys):
+        """Test that global labels from child sheets are included."""
+        from kicad_tools.cli.sch_list_labels import main
+
+        main([str(hierarchical_schematic), "--type", "global", "--format", "json"])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # Root has SIGNAL_OUT, Logic has CLK+RESET, Output has CLK
+        texts = [lbl["text"] for lbl in data]
+        assert "SIGNAL_OUT" in texts
+        assert "CLK" in texts
+        assert "RESET" in texts
+        # CLK appears in both Logic and Output sheets
+        clk_labels = [lbl for lbl in data if lbl["text"] == "CLK"]
+        assert len(clk_labels) == 2
+
+    def test_hierarchy_labels_include_sheet_info(self, hierarchical_schematic: Path, capsys):
+        """Test that each label entry includes sheet name and file."""
+        from kicad_tools.cli.sch_list_labels import main
+
+        main([str(hierarchical_schematic), "--type", "global", "--format", "json"])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        for lbl in data:
+            assert "sheet" in lbl, "Label entry should include 'sheet' field"
+            assert "sheet_file" in lbl, "Label entry should include 'sheet_file' field"
+
+        # Check specific sheet assignments
+        root_labels = [lbl for lbl in data if lbl["sheet"] == "/"]
+        assert any(lbl["text"] == "SIGNAL_OUT" for lbl in root_labels)
+
+        logic_labels = [lbl for lbl in data if lbl["sheet"] == "/Logic"]
+        assert any(lbl["text"] == "CLK" for lbl in logic_labels)
+        assert any(lbl["text"] == "RESET" for lbl in logic_labels)
+
+    def test_hierarchy_all_label_types(self, hierarchical_schematic: Path, capsys):
+        """Test that --type all collects all label types from all sheets."""
+        from kicad_tools.cli.sch_list_labels import main
+
+        main([str(hierarchical_schematic), "--type", "all", "--format", "json"])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        types_found = {lbl["type"] for lbl in data}
+        # Should find global labels (root + children), hierarchical (children),
+        # power symbols (root), and local labels (output child)
+        assert "global" in types_found
+        assert "hierarchical" in types_found
+        assert "power" in types_found
+        assert "local" in types_found
+
+    def test_hierarchy_csv_includes_sheet_columns(self, hierarchical_schematic: Path, capsys):
+        """Test that CSV output includes Sheet and Sheet File columns."""
+        from kicad_tools.cli.sch_list_labels import main
+
+        main([str(hierarchical_schematic), "--type", "global", "--format", "csv"])
+
+        captured = capsys.readouterr()
+        lines = captured.out.strip().split("\n")
+        assert "Sheet" in lines[0]
+        assert "Sheet File" in lines[0]
+
+    def test_hierarchy_table_includes_sheet_column(self, hierarchical_schematic: Path, capsys):
+        """Test that table output includes Sheet column."""
+        from kicad_tools.cli.sch_list_labels import main
+
+        main([str(hierarchical_schematic), "--type", "global"])
+
+        captured = capsys.readouterr()
+        assert "Sheet" in captured.out
+
+    def test_hierarchy_filter_works_across_sheets(self, hierarchical_schematic: Path, capsys):
+        """Test that --filter pattern works across all sheets."""
+        from kicad_tools.cli.sch_list_labels import main
+
+        main([str(hierarchical_schematic), "--type", "global", "--filter", "CLK", "--format", "json"])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data) == 2  # CLK in Logic and Output
+        assert all(lbl["text"] == "CLK" for lbl in data)
+
 
 class TestSchHierarchy:
     """Tests for sch_hierarchy.py CLI."""


### PR DESCRIPTION
## Summary
- Fix `sch labels --type global` to scan all sheets in hierarchical projects instead of only the root sheet
- Add recursive sheet traversal so global labels on sub-sheets are included in results
- Add test fixtures and tests for hierarchical label scanning

Closes #1887

## Test plan
- [ ] Run `pytest tests/test_cli_sch.py` to verify new and existing label tests pass
- [ ] Manually test `sch labels --type global` on a hierarchical project and confirm sub-sheet labels appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)