### PR TITLE
feat(cli): add sch re-annotate command

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -18,7 +18,7 @@ def run_sch_command(args) -> int:
         print(
             "          set-label-direction, add-no-connect, add-component,"
             " add-wire, add-junction,"
-            " add-label, cleanup-wires, remove-wire, disconnect"
+            " add-label, cleanup-wires, remove-wire, disconnect, re-annotate"
         )
         return 1
 
@@ -373,5 +373,22 @@ def run_sch_command(args) -> int:
         if args.backup:
             sub_argv.append("--backup")
         return disconnect_main(sub_argv) or 0
+
+    elif args.sch_command == "re-annotate":
+        from ..sch_re_annotate import run_re_annotate
+
+        prefix_list = None
+        if args.prefix:
+            prefix_list = [p.strip() for p in args.prefix.split(",")]
+
+        return run_re_annotate(
+            schematic_path=schematic_path,
+            dry_run=getattr(args, "dry_run", False),
+            backup=getattr(args, "backup", False),
+            prefixes=prefix_list,
+            start_from=getattr(args, "start_from", 1),
+            per_sheet=getattr(args, "per_sheet", False),
+            format=getattr(args, "format", "text"),
+        )
 
     return 1

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -847,6 +847,34 @@ def _add_sch_parser(subparsers) -> None:
         "--backup", action="store_true", help="Create backup before modifying"
     )
 
+    # sch re-annotate
+    sch_reannotate = sch_subparsers.add_parser(
+        "re-annotate", help="Renumber reference designators sequentially"
+    )
+    sch_reannotate.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_reannotate.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview changes without modifying"
+    )
+    sch_reannotate.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+    sch_reannotate.add_argument(
+        "--prefix",
+        help="Comma-separated list of prefixes to renumber (e.g., R,C,U)",
+    )
+    sch_reannotate.add_argument(
+        "--start-from",
+        type=int,
+        default=1,
+        help="Starting number for each prefix (default: 1)",
+    )
+    sch_reannotate.add_argument(
+        "--per-sheet",
+        action="store_true",
+        help="Restart numbering per sheet instead of continuous",
+    )
+    sch_reannotate.add_argument("--format", choices=["text", "json"], default="text")
+
 
 def _add_pcb_parser(subparsers) -> None:
     """Add PCB subcommand parser with its subcommands."""

--- a/src/kicad_tools/cli/sch_re_annotate.py
+++ b/src/kicad_tools/cli/sch_re_annotate.py
@@ -60,15 +60,6 @@ def _extract_symbols_from_text(text: str) -> list[dict]:
     Returns list of dicts with keys: reference, prefix, number, unit_suffix,
     position_y, position_x, lib_id.
     """
-    # Match symbol instance blocks (not lib_symbols)
-    symbol_pattern = re.compile(
-        r'\(symbol\n'
-        r'\t\t\(lib_id "([^"]+)"\)'
-        r'.*?'
-        r'\(at ([\d.]+) ([\d.]+)',
-        re.DOTALL,
-    )
-
     ref_pattern = re.compile(r'\(property "Reference" "([^"]+)"')
     symbols = []
 

--- a/src/kicad_tools/cli/sch_re_annotate.py
+++ b/src/kicad_tools/cli/sch_re_annotate.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""
+Re-annotate reference designators in KiCad schematics.
+
+Renumbers reference designators sequentially across the hierarchy,
+closing gaps and making numbering contiguous.
+
+Usage:
+    # Preview changes
+    kicad-tools sch re-annotate board.kicad_sch --dry-run
+
+    # Renumber all refs starting from 1
+    kicad-tools sch re-annotate board.kicad_sch
+
+    # Only renumber resistors and capacitors
+    kicad-tools sch re-annotate board.kicad_sch --prefix R,C
+
+    # Start numbering from 100
+    kicad-tools sch re-annotate board.kicad_sch --start-from 100
+
+    # Restart numbering per sheet
+    kicad-tools sch re-annotate board.kicad_sch --per-sheet
+"""
+
+import re
+import sys
+from pathlib import Path
+
+from kicad_tools.cli.modify_schematic import create_backup
+from kicad_tools.cli.sch_set_footprint import _collect_schematic_files
+
+# Prefixes for power/flag symbols that should be excluded from renumbering
+EXCLUDED_PREFIXES = {"#PWR", "#FLG", "#SYM"}
+
+
+def _parse_reference(ref: str) -> tuple[str, int | None, str]:
+    """Parse a reference designator into (prefix, number, unit_suffix).
+
+    Examples:
+        "R1"   -> ("R", 1, "")
+        "U1A"  -> ("U", 1, "A")
+        "C32"  -> ("C", 32, "")
+        "#PWR01" -> ("#PWR", 1, "")
+        "R?"   -> ("R", None, "")
+    """
+    # Match prefix (letters, optionally starting with #), number, optional unit letter
+    m = re.match(r'^(#?[A-Za-z]+)(\d+)([A-Za-z]?)$', ref)
+    if m:
+        return m.group(1), int(m.group(2)), m.group(3)
+    # Unannotated reference like "R?"
+    m = re.match(r'^(#?[A-Za-z]+)\?$', ref)
+    if m:
+        return m.group(1), None, ""
+    return ref, None, ""
+
+
+def _extract_symbols_from_text(text: str) -> list[dict]:
+    """Extract symbol references and their positions from schematic text.
+
+    Returns list of dicts with keys: reference, prefix, number, unit_suffix,
+    position_y, position_x, lib_id.
+    """
+    # Match symbol instance blocks (not lib_symbols)
+    symbol_pattern = re.compile(
+        r'\(symbol\n'
+        r'\t\t\(lib_id "([^"]+)"\)'
+        r'.*?'
+        r'\(at ([\d.]+) ([\d.]+)',
+        re.DOTALL,
+    )
+
+    ref_pattern = re.compile(r'\(property "Reference" "([^"]+)"')
+    symbols = []
+
+    # Find all symbol blocks that have lib_id (instances, not lib definitions)
+    block_pattern = re.compile(
+        r'\t\(symbol\n'
+        r'\t\t\(lib_id "[^"]+"\)'
+        r'.*?'
+        r'(?:\t\t\(instances\n.*?\t\t\)\n\t\)|\t\t\(pin "[^"]+"\n\t\t\t\(uuid "[^"]+"\)\n\t\t\)\n\t\))',
+        re.DOTALL,
+    )
+
+    for match in block_pattern.finditer(text):
+        block = match.group(0)
+        lib_match = re.search(r'\(lib_id "([^"]+)"\)', block)
+        at_match = re.search(r'\(at ([\d.eE+-]+) ([\d.eE+-]+)', block)
+        ref_match = ref_pattern.search(block)
+
+        if not ref_match or not lib_match:
+            continue
+
+        ref = ref_match.group(1)
+        lib_id = lib_match.group(1)
+        x = float(at_match.group(1)) if at_match else 0.0
+        y = float(at_match.group(2)) if at_match else 0.0
+
+        prefix, number, unit_suffix = _parse_reference(ref)
+
+        symbols.append({
+            "reference": ref,
+            "prefix": prefix,
+            "number": number,
+            "unit_suffix": unit_suffix,
+            "position_x": x,
+            "position_y": y,
+            "lib_id": lib_id,
+        })
+
+    return symbols
+
+
+def _apply_reference_rename(text: str, old_ref: str, new_ref: str) -> str:
+    """Rename a reference designator in schematic text.
+
+    Updates both:
+    - (property "Reference" "OLD" ...) -> (property "Reference" "NEW" ...)
+    - (reference "OLD") -> (reference "NEW") in instances blocks
+    """
+    # Update property "Reference" value
+    text = re.sub(
+        r'(\(property "Reference" ")' + re.escape(old_ref) + r'"',
+        r'\g<1>' + new_ref + '"',
+        text,
+    )
+
+    # Update (reference "OLD") in instances blocks
+    text = re.sub(
+        r'(\(reference ")' + re.escape(old_ref) + r'"\)',
+        r'\g<1>' + new_ref + '")',
+        text,
+    )
+
+    return text
+
+
+def run_re_annotate(
+    schematic_path: Path,
+    dry_run: bool = False,
+    backup: bool = True,
+    prefixes: list[str] | None = None,
+    start_from: int = 1,
+    per_sheet: bool = False,
+    format: str = "text",
+) -> int:
+    """Run the re-annotate operation.
+
+    Args:
+        schematic_path: Path to root .kicad_sch file.
+        dry_run: If True, show mapping without modifying files.
+        backup: If True, create backups before modifying.
+        prefixes: If set, only renumber these prefixes (e.g., ["R", "C"]).
+        start_from: Starting number for each prefix (default 1).
+        per_sheet: If True, restart numbering per sheet.
+        format: Output format ("text" or "json").
+
+    Returns:
+        0 on success, 1 on error.
+    """
+    if not schematic_path.exists():
+        print(f"Error: File not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    # Collect all schematic files in hierarchy order
+    all_files = _collect_schematic_files(schematic_path)
+
+    if not all_files:
+        print("Error: No schematic files found", file=sys.stderr)
+        return 1
+
+    # Phase 1: Collect all symbols across hierarchy
+    file_symbols: dict[Path, list[dict]] = {}
+    file_texts: dict[Path, str] = {}
+
+    for sch_file in all_files:
+        try:
+            text = sch_file.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"Error reading {sch_file}: {e}", file=sys.stderr)
+            return 1
+        file_texts[sch_file] = text
+        file_symbols[sch_file] = _extract_symbols_from_text(text)
+
+    # Phase 2: Build rename mapping
+    # Group symbols by prefix, maintaining file/position order
+    # For multi-unit components, all units share the same base ref number
+
+    if per_sheet:
+        # Per-sheet mode: restart numbering for each file
+        mapping = _build_per_sheet_mapping(
+            all_files, file_symbols, prefixes, start_from
+        )
+    else:
+        # Continuous mode: number across all files
+        mapping = _build_continuous_mapping(
+            all_files, file_symbols, prefixes, start_from
+        )
+
+    if not mapping:
+        print("No references to renumber.")
+        return 0
+
+    # Filter out identity mappings
+    effective_mapping = {old: new for old, new in mapping.items() if old != new}
+
+    if not effective_mapping:
+        print("All references are already sequential. No changes needed.")
+        return 0
+
+    # Phase 3: Output mapping / apply changes
+    if format == "json":
+        import json
+        output = {
+            "mappings": [
+                {"old": old, "new": new}
+                for old, new in sorted(effective_mapping.items())
+            ],
+            "total": len(effective_mapping),
+            "dry_run": dry_run,
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print(f"Re-annotation mapping ({len(effective_mapping)} changes):")
+        print()
+
+        # Group by prefix for display
+        by_prefix: dict[str, list[tuple[str, str]]] = {}
+        for old, new in sorted(effective_mapping.items()):
+            prefix, _, _ = _parse_reference(old)
+            by_prefix.setdefault(prefix, []).append((old, new))
+
+        for prefix in sorted(by_prefix):
+            changes = by_prefix[prefix]
+            print(f"  {prefix}:")
+            for old, new in changes:
+                print(f"    {old} -> {new}")
+        print()
+
+    if dry_run:
+        if format == "text":
+            print("Dry run: no changes made.")
+        return 0
+
+    # Phase 4: Apply the full mapping to each file
+    # We need a two-pass rename to avoid collisions (e.g., R1->R2 and R2->R3).
+    # First rename all to temporary unique refs, then rename to final refs.
+    modified_files: dict[Path, str] = {}
+
+    for sch_file in all_files:
+        text = file_texts[sch_file]
+        syms = file_symbols[sch_file]
+        refs_in_file = {s["reference"] for s in syms}
+
+        # Find which mappings apply to this file
+        file_mapping = {
+            old: new for old, new in mapping.items() if old in refs_in_file
+        }
+        file_effective = {
+            old: new for old, new in file_mapping.items() if old != new
+        }
+
+        if not file_effective:
+            continue
+
+        # Two-pass rename to avoid collisions
+        # Pass 1: rename to temporary placeholders
+        temp_mapping: dict[str, str] = {}
+        for i, old_ref in enumerate(file_effective):
+            temp_ref = f"__REANNOTATE_TEMP_{i}__"
+            temp_mapping[old_ref] = temp_ref
+
+        current_text = text
+        for old_ref, temp_ref in temp_mapping.items():
+            current_text = _apply_reference_rename(current_text, old_ref, temp_ref)
+
+        # Pass 2: rename from temp to final
+        for old_ref, temp_ref in temp_mapping.items():
+            new_ref = file_effective[old_ref]
+            current_text = _apply_reference_rename(current_text, temp_ref, new_ref)
+
+        modified_files[sch_file] = current_text
+
+    # Phase 5: Write modified files
+    if modified_files:
+        for sch_file, new_text in modified_files.items():
+            if backup:
+                bak = create_backup(sch_file)
+                if format == "text":
+                    print(f"  Backup: {bak.name}")
+            try:
+                sch_file.write_text(new_text, encoding="utf-8")
+            except OSError as e:
+                print(f"Error writing {sch_file}: {e}", file=sys.stderr)
+                return 1
+
+    if format == "text":
+        print(
+            f"Re-annotated {len(effective_mapping)} reference(s) "
+            f"across {len(modified_files)} file(s)."
+        )
+
+    return 0
+
+
+def _build_continuous_mapping(
+    all_files: list[Path],
+    file_symbols: dict[Path, list[dict]],
+    prefixes: list[str] | None,
+    start_from: int,
+) -> dict[str, str]:
+    """Build a continuous mapping across all files.
+
+    Symbols are ordered by file order, then by position (top-to-bottom,
+    left-to-right) within each file. Multi-unit components share a base
+    number.
+    """
+    # Collect all symbols in order
+    ordered_symbols: list[dict] = []
+    for sch_file in all_files:
+        syms = file_symbols[sch_file]
+        # Sort by position: top-to-bottom (Y ascending), left-to-right (X ascending)
+        syms_sorted = sorted(syms, key=lambda s: (s["position_y"], s["position_x"]))
+        ordered_symbols.extend(syms_sorted)
+
+    return _assign_numbers(ordered_symbols, prefixes, start_from)
+
+
+def _build_per_sheet_mapping(
+    all_files: list[Path],
+    file_symbols: dict[Path, list[dict]],
+    prefixes: list[str] | None,
+    start_from: int,
+) -> dict[str, str]:
+    """Build a per-sheet mapping, restarting numbering per file."""
+    mapping: dict[str, str] = {}
+
+    for sch_file in all_files:
+        syms = file_symbols[sch_file]
+        syms_sorted = sorted(syms, key=lambda s: (s["position_y"], s["position_x"]))
+        sheet_mapping = _assign_numbers(syms_sorted, prefixes, start_from)
+        mapping.update(sheet_mapping)
+
+    return mapping
+
+
+def _assign_numbers(
+    symbols: list[dict],
+    prefixes: list[str] | None,
+    start_from: int,
+) -> dict[str, str]:
+    """Assign sequential numbers to symbols, handling multi-unit components.
+
+    Multi-unit components (e.g., U1A and U1B) share the same base reference
+    number but differ by their unit suffix.
+    """
+    mapping: dict[str, str] = {}
+    # Track next number per prefix
+    counters: dict[str, int] = {}
+    # Track base number assignments for multi-unit: (prefix, old_number) -> new_number
+    multi_unit_assigned: dict[tuple[str, int | None], int] = {}
+
+    for sym in symbols:
+        ref = sym["reference"]
+        prefix = sym["prefix"]
+        number = sym["number"]
+        unit_suffix = sym["unit_suffix"]
+
+        # Skip excluded prefixes (power symbols, flags)
+        if prefix in EXCLUDED_PREFIXES:
+            continue
+
+        # Skip if prefix filter is active and this prefix isn't included
+        if prefixes is not None and prefix not in prefixes:
+            continue
+
+        # Skip unannotated refs
+        if number is None:
+            continue
+
+        # Handle multi-unit components
+        if unit_suffix:
+            key = (prefix, number)
+            if key in multi_unit_assigned:
+                new_number = multi_unit_assigned[key]
+            else:
+                new_number = counters.get(prefix, start_from)
+                counters[prefix] = new_number + 1
+                multi_unit_assigned[key] = new_number
+            new_ref = f"{prefix}{new_number}{unit_suffix}"
+        else:
+            # Check if this is a multi-unit component without suffix
+            # (unit > 1 would share the same ref)
+            new_number = counters.get(prefix, start_from)
+            counters[prefix] = new_number + 1
+            new_ref = f"{prefix}{new_number}"
+
+        mapping[ref] = new_ref
+
+    return mapping
+
+
+def main(argv: list[str] | None = None):
+    """CLI entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Re-annotate reference designators in KiCad schematics",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", type=Path, help="Path to .kicad_sch file")
+    parser.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
+    )
+    parser.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+    parser.add_argument(
+        "--prefix",
+        help="Comma-separated list of prefixes to renumber (e.g., R,C,U)",
+    )
+    parser.add_argument(
+        "--start-from",
+        type=int,
+        default=1,
+        help="Starting number for each prefix (default: 1)",
+    )
+    parser.add_argument(
+        "--per-sheet",
+        action="store_true",
+        help="Restart numbering per sheet instead of continuous",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    args = parser.parse_args(argv)
+
+    prefix_list = None
+    if args.prefix:
+        prefix_list = [p.strip() for p in args.prefix.split(",")]
+
+    return run_re_annotate(
+        schematic_path=args.schematic,
+        dry_run=args.dry_run,
+        backup=args.backup,
+        prefixes=prefix_list,
+        start_from=args.start_from,
+        per_sheet=args.per_sheet,
+        format=args.format,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sch_re_annotate.py
+++ b/tests/test_sch_re_annotate.py
@@ -1,0 +1,801 @@
+"""Tests for the sch re-annotate command.
+
+Covers _parse_reference(), _extract_symbols_from_text(),
+_apply_reference_rename(), run_re_annotate() with dry-run,
+backup, prefix filtering, start-from, per-sheet mode,
+multi-unit components, power symbol exclusion, and
+hierarchical schematic traversal.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_re_annotate import (
+    _apply_reference_rename,
+    _assign_numbers,
+    _build_continuous_mapping,
+    _extract_symbols_from_text,
+    _parse_reference,
+    run_re_annotate,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal schematic content for testing
+# ---------------------------------------------------------------------------
+
+MINIMAL_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 80 0)
+\t\t(property "Reference" "R5"
+\t\t\t(at 100 78 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "4.7k"
+\t\t\t(at 100 82 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
+\t\t\t(at 100 84 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R5") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:C")
+\t\t(at 120 50 0)
+\t\t(property "Reference" "C3"
+\t\t\t(at 120 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "100nF"
+\t\t\t(at 120 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 120 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "33333333-3333-3333-3333-333333333333")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "C3") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+# Schematic with gaps: R1, R5 (gap), C3 (gap) -> should become R1, R2, C1
+GAPPED_SCHEMATIC = MINIMAL_SCHEMATIC
+
+# Schematic with power symbols that should be excluded
+POWER_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R3"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R3") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "power:GND")
+\t\t(at 100 70 0)
+\t\t(property "Reference" "#PWR01"
+\t\t\t(at 100 76 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(property "Value" "GND"
+\t\t\t(at 100 73 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 70 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "44444444-4444-4444-4444-444444444444")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "#PWR01") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+# Schematic without instances blocks (simpler format)
+NO_INSTANCES_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(unit 1)
+\t\t(in_bom yes)
+\t\t(on_board yes)
+\t\t(dnp no)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(property "Reference" "R5"
+\t\t\t(at 102 48 0)
+\t\t\t(effects (font (size 1.27 1.27)) (justify left))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 102 50 0)
+\t\t\t(effects (font (size 1.27 1.27)) (justify left))
+\t\t)
+\t\t(property "Footprint" "Resistor_SMD:R_0603_1608Metric"
+\t\t\t(at 100 50 0)
+\t\t\t(effects (font (size 1.27 1.27)) hide)
+\t\t)
+\t\t(property "Datasheet" "~"
+\t\t\t(at 100 50 0)
+\t\t\t(effects (font (size 1.27 1.27)) hide)
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-r5-1")
+\t\t)
+\t\t(pin "2"
+\t\t\t(uuid "pin-r5-2")
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 80 0)
+\t\t(unit 1)
+\t\t(in_bom yes)
+\t\t(on_board yes)
+\t\t(dnp no)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t\t(property "Reference" "R10"
+\t\t\t(at 102 78 0)
+\t\t\t(effects (font (size 1.27 1.27)) (justify left))
+\t\t)
+\t\t(property "Value" "4.7k"
+\t\t\t(at 102 80 0)
+\t\t\t(effects (font (size 1.27 1.27)) (justify left))
+\t\t)
+\t\t(property "Footprint" "Resistor_SMD:R_0603_1608Metric"
+\t\t\t(at 100 80 0)
+\t\t\t(effects (font (size 1.27 1.27)) hide)
+\t\t)
+\t\t(property "Datasheet" "~"
+\t\t\t(at 100 80 0)
+\t\t\t(effects (font (size 1.27 1.27)) hide)
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-r10-1")
+\t\t)
+\t\t(pin "2"
+\t\t\t(uuid "pin-r10-2")
+\t\t)
+\t)
+)
+"""
+
+# Hierarchical schematic (parent with sub-sheet)
+PARENT_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R3"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R3") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 80 0)
+\t\t(property "Reference" "R7"
+\t\t\t(at 100 78 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "4.7k"
+\t\t\t(at 100 82 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 84 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R7") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet
+\t\t(at 150 50)
+\t\t(size 20 20)
+\t\t(property "Sheetname" "SubSheet"
+\t\t\t(at 150 48 0)
+\t\t)
+\t\t(property "Sheetfile" "sub.kicad_sch"
+\t\t\t(at 150 68 0)
+\t\t)
+\t\t(uuid "33333333-3333-3333-3333-333333333333")
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+CHILD_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "44444444-4444-4444-4444-444444444444")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:C")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "C5"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "1uF"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "55555555-5555-5555-5555-555555555555")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/33333333-3333-3333-3333-333333333333" (reference "C5") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 80 0)
+\t\t(property "Reference" "R14"
+\t\t\t(at 100 78 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "100k"
+\t\t\t(at 100 82 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 84 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "66666666-6666-6666-6666-666666666666")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/33333333-3333-3333-3333-333333333333" (reference "R14") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/33333333-3333-3333-3333-333333333333" (page "2"))
+\t)
+)
+"""
+
+# Already sequential schematic
+SEQUENTIAL_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 80 0)
+\t\t(property "Reference" "R2"
+\t\t\t(at 100 78 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "4.7k"
+\t\t\t(at 100 82 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 84 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R2") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+
+def _write_sch(
+    tmp_path: Path,
+    content: str = MINIMAL_SCHEMATIC,
+    name: str = "test.kicad_sch",
+) -> Path:
+    p = tmp_path / name
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _parse_reference() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseReference:
+    def test_simple_resistor(self):
+        assert _parse_reference("R1") == ("R", 1, "")
+
+    def test_simple_capacitor(self):
+        assert _parse_reference("C32") == ("C", 32, "")
+
+    def test_multi_unit(self):
+        assert _parse_reference("U1A") == ("U", 1, "A")
+
+    def test_multi_unit_b(self):
+        assert _parse_reference("U1B") == ("U", 1, "B")
+
+    def test_power_symbol(self):
+        assert _parse_reference("#PWR01") == ("#PWR", 1, "")
+
+    def test_flag_symbol(self):
+        assert _parse_reference("#FLG01") == ("#FLG", 1, "")
+
+    def test_unannotated(self):
+        assert _parse_reference("R?") == ("R", None, "")
+
+    def test_large_number(self):
+        assert _parse_reference("R100") == ("R", 100, "")
+
+    def test_two_letter_prefix(self):
+        assert _parse_reference("SW1") == ("SW", 1, "")
+
+
+# ---------------------------------------------------------------------------
+# _extract_symbols_from_text() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSymbols:
+    def test_extracts_all_symbols(self):
+        symbols = _extract_symbols_from_text(MINIMAL_SCHEMATIC)
+        refs = {s["reference"] for s in symbols}
+        assert refs == {"R1", "R5", "C3"}
+
+    def test_extracts_positions(self):
+        symbols = _extract_symbols_from_text(MINIMAL_SCHEMATIC)
+        by_ref = {s["reference"]: s for s in symbols}
+        assert by_ref["R1"]["position_x"] == 100
+        assert by_ref["R1"]["position_y"] == 50
+        assert by_ref["R5"]["position_y"] == 80
+
+    def test_extracts_lib_id(self):
+        symbols = _extract_symbols_from_text(MINIMAL_SCHEMATIC)
+        by_ref = {s["reference"]: s for s in symbols}
+        assert by_ref["R1"]["lib_id"] == "Device:R"
+        assert by_ref["C3"]["lib_id"] == "Device:C"
+
+    def test_extracts_prefix_and_number(self):
+        symbols = _extract_symbols_from_text(MINIMAL_SCHEMATIC)
+        by_ref = {s["reference"]: s for s in symbols}
+        assert by_ref["R5"]["prefix"] == "R"
+        assert by_ref["R5"]["number"] == 5
+        assert by_ref["C3"]["prefix"] == "C"
+        assert by_ref["C3"]["number"] == 3
+
+    def test_power_symbols_extracted(self):
+        symbols = _extract_symbols_from_text(POWER_SCHEMATIC)
+        refs = {s["reference"] for s in symbols}
+        assert "#PWR01" in refs
+
+    def test_no_instances_format(self):
+        symbols = _extract_symbols_from_text(NO_INSTANCES_SCHEMATIC)
+        refs = {s["reference"] for s in symbols}
+        assert refs == {"R5", "R10"}
+
+
+# ---------------------------------------------------------------------------
+# _apply_reference_rename() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyRename:
+    def test_renames_property(self):
+        result = _apply_reference_rename(MINIMAL_SCHEMATIC, "R5", "R2")
+        assert '"Reference" "R2"' in result
+        assert '"Reference" "R5"' not in result
+        # R1 should be unchanged
+        assert '"Reference" "R1"' in result
+
+    def test_renames_instances(self):
+        result = _apply_reference_rename(MINIMAL_SCHEMATIC, "R5", "R2")
+        assert '(reference "R2")' in result
+        assert '(reference "R5")' not in result
+        # R1 instance should be unchanged
+        assert '(reference "R1")' in result
+
+    def test_no_match_unchanged(self):
+        result = _apply_reference_rename(MINIMAL_SCHEMATIC, "U99", "U1")
+        assert result == MINIMAL_SCHEMATIC
+
+
+# ---------------------------------------------------------------------------
+# _assign_numbers() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAssignNumbers:
+    def test_closes_gaps(self):
+        symbols = [
+            {"reference": "R1", "prefix": "R", "number": 1, "unit_suffix": ""},
+            {"reference": "R5", "prefix": "R", "number": 5, "unit_suffix": ""},
+            {"reference": "C3", "prefix": "C", "number": 3, "unit_suffix": ""},
+        ]
+        mapping = _assign_numbers(symbols, None, 1)
+        assert mapping == {"R1": "R1", "R5": "R2", "C3": "C1"}
+
+    def test_prefix_filter(self):
+        symbols = [
+            {"reference": "R5", "prefix": "R", "number": 5, "unit_suffix": ""},
+            {"reference": "C3", "prefix": "C", "number": 3, "unit_suffix": ""},
+        ]
+        mapping = _assign_numbers(symbols, ["R"], 1)
+        assert mapping == {"R5": "R1"}
+        assert "C3" not in mapping
+
+    def test_start_from(self):
+        symbols = [
+            {"reference": "R5", "prefix": "R", "number": 5, "unit_suffix": ""},
+        ]
+        mapping = _assign_numbers(symbols, None, 100)
+        assert mapping == {"R5": "R100"}
+
+    def test_multi_unit_shares_number(self):
+        symbols = [
+            {"reference": "U1A", "prefix": "U", "number": 1, "unit_suffix": "A"},
+            {"reference": "U1B", "prefix": "U", "number": 1, "unit_suffix": "B"},
+            {"reference": "U5A", "prefix": "U", "number": 5, "unit_suffix": "A"},
+        ]
+        mapping = _assign_numbers(symbols, None, 1)
+        assert mapping["U1A"] == "U1A"
+        assert mapping["U1B"] == "U1B"
+        assert mapping["U5A"] == "U2A"
+
+    def test_excludes_power_symbols(self):
+        symbols = [
+            {"reference": "#PWR01", "prefix": "#PWR", "number": 1, "unit_suffix": ""},
+            {"reference": "R3", "prefix": "R", "number": 3, "unit_suffix": ""},
+        ]
+        mapping = _assign_numbers(symbols, None, 1)
+        assert "#PWR01" not in mapping
+        assert mapping["R3"] == "R1"
+
+    def test_skips_unannotated(self):
+        symbols = [
+            {"reference": "R?", "prefix": "R", "number": None, "unit_suffix": ""},
+            {"reference": "R3", "prefix": "R", "number": 3, "unit_suffix": ""},
+        ]
+        mapping = _assign_numbers(symbols, None, 1)
+        assert "R?" not in mapping
+        assert mapping["R3"] == "R1"
+
+
+# ---------------------------------------------------------------------------
+# run_re_annotate() integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunReAnnotate:
+    def test_dry_run_does_not_modify(self, tmp_path):
+        sch = _write_sch(tmp_path, GAPPED_SCHEMATIC)
+        original = sch.read_text()
+        ret = run_re_annotate(schematic_path=sch, dry_run=True, backup=False)
+        assert ret == 0
+        assert sch.read_text() == original
+
+    def test_closes_gaps(self, tmp_path):
+        sch = _write_sch(tmp_path, GAPPED_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        text = sch.read_text()
+        # R1 stays R1, R5 becomes R2, C3 becomes C1
+        assert '"Reference" "R1"' in text
+        assert '"Reference" "R2"' in text
+        assert '"Reference" "C1"' in text
+        # Old refs should be gone
+        assert '"Reference" "R5"' not in text
+        assert '"Reference" "C3"' not in text
+
+    def test_updates_instances(self, tmp_path):
+        sch = _write_sch(tmp_path, GAPPED_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        text = sch.read_text()
+        assert '(reference "R2")' in text
+        assert '(reference "C1")' in text
+        assert '(reference "R5")' not in text
+        assert '(reference "C3")' not in text
+
+    def test_creates_backup(self, tmp_path):
+        sch = _write_sch(tmp_path, GAPPED_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=True)
+        assert ret == 0
+        backups = list(tmp_path.glob("test_backup_*"))
+        assert len(backups) == 1
+
+    def test_prefix_filter(self, tmp_path):
+        sch = _write_sch(tmp_path, GAPPED_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False, prefixes=["R"]
+        )
+        assert ret == 0
+        text = sch.read_text()
+        # R5 -> R2 (renumbered)
+        assert '"Reference" "R2"' in text
+        # C3 should stay unchanged (not in prefix filter)
+        assert '"Reference" "C3"' in text
+
+    def test_start_from(self, tmp_path):
+        sch = _write_sch(tmp_path, GAPPED_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False, start_from=10
+        )
+        assert ret == 0
+        text = sch.read_text()
+        assert '"Reference" "R10"' in text
+        assert '"Reference" "R11"' in text
+        assert '"Reference" "C10"' in text
+
+    def test_already_sequential(self, tmp_path):
+        sch = _write_sch(tmp_path, SEQUENTIAL_SCHEMATIC)
+        original = sch.read_text()
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        # File should be unchanged (no effective renames)
+        assert sch.read_text() == original
+
+    def test_power_symbols_excluded(self, tmp_path):
+        sch = _write_sch(tmp_path, POWER_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        text = sch.read_text()
+        # R3 -> R1
+        assert '"Reference" "R1"' in text
+        # Power symbol should be unchanged
+        assert '"Reference" "#PWR01"' in text
+
+    def test_missing_schematic(self, tmp_path):
+        ret = run_re_annotate(
+            schematic_path=tmp_path / "nonexistent.kicad_sch"
+        )
+        assert ret == 1
+
+    def test_json_output(self, tmp_path, capsys):
+        sch = _write_sch(tmp_path, GAPPED_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=True, backup=False, format="json"
+        )
+        assert ret == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["dry_run"] is True
+        assert data["total"] > 0
+
+    def test_no_instances_format(self, tmp_path):
+        sch = _write_sch(tmp_path, NO_INSTANCES_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        text = sch.read_text()
+        # R5 -> R1, R10 -> R2
+        assert '"Reference" "R1"' in text
+        assert '"Reference" "R2"' in text
+        assert '"Reference" "R5"' not in text
+        assert '"Reference" "R10"' not in text
+
+
+# ---------------------------------------------------------------------------
+# Hierarchical schematic support
+# ---------------------------------------------------------------------------
+
+
+class TestHierarchicalReAnnotate:
+    def test_continuous_across_sheets(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+
+        ret = run_re_annotate(
+            schematic_path=parent, dry_run=False, backup=False
+        )
+        assert ret == 0
+
+        parent_text = parent.read_text()
+        child_text = child.read_text()
+
+        # Parent: R3 -> R1, R7 -> R2
+        assert '"Reference" "R1"' in parent_text
+        assert '"Reference" "R2"' in parent_text
+
+        # Child: R14 -> R3, C5 -> C1
+        assert '"Reference" "R3"' in child_text
+        assert '"Reference" "C1"' in child_text
+
+    def test_per_sheet_mode(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+
+        ret = run_re_annotate(
+            schematic_path=parent, dry_run=False, backup=False, per_sheet=True
+        )
+        assert ret == 0
+
+        parent_text = parent.read_text()
+        child_text = child.read_text()
+
+        # Parent: R3 -> R1, R7 -> R2
+        assert '"Reference" "R1"' in parent_text
+        assert '"Reference" "R2"' in parent_text
+
+        # Child (per-sheet restart): R14 -> R1, C5 -> C1
+        assert '"Reference" "R1"' in child_text
+        assert '"Reference" "C1"' in child_text
+
+    def test_dry_run_hierarchical(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+        original_parent = parent.read_text()
+        original_child = child.read_text()
+
+        ret = run_re_annotate(
+            schematic_path=parent, dry_run=True, backup=False
+        )
+        assert ret == 0
+        assert parent.read_text() == original_parent
+        assert child.read_text() == original_child
+
+    def test_backup_hierarchical(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(PARENT_SCHEMATIC)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(CHILD_SCHEMATIC)
+
+        ret = run_re_annotate(
+            schematic_path=parent, dry_run=False, backup=True
+        )
+        assert ret == 0
+        # Both files should have backups
+        backups = list(tmp_path.glob("*_backup_*"))
+        assert len(backups) == 2


### PR DESCRIPTION
## Summary
- Adds `sch re-annotate` command for sequential reference designator renumbering in KiCad schematics
- Implements logic to renumber component references (e.g., R1, R2, C1, C2) sequentially based on position or other criteria
- Includes comprehensive test coverage (801 lines of tests)

Closes #1891

## Test plan
- [ ] Run `pytest tests/test_sch_re_annotate.py` to verify all unit tests pass
- [ ] Test `sch re-annotate` on a sample schematic and verify references are renumbered sequentially
- [ ] Verify CLI help output for the new subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)