### PR TITLE
feat(sch): add pin-map command for resolved pin-to-net assignments

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -10,7 +10,7 @@ def run_sch_command(args) -> int:
     """Handle schematic subcommands."""
     if not args.sch_command:
         print("Usage: kicad-tools sch <command> [options] <file>")
-        print("Commands: summary, hierarchy, labels, validate, preflight, wires, info, pins,")
+        print("Commands: summary, hierarchy, labels, validate, preflight, wires, info, pins, pin-map,")
         print(
             "          connections, unconnected, set-footprint, set-value, replace,"
             " sync-hierarchy, rename-signal,"
@@ -109,6 +109,16 @@ def run_sch_command(args) -> int:
         if args.format != "table":
             sub_argv.extend(["--format", args.format])
         return pins_main(sub_argv) or 0
+
+    elif args.sch_command == "pin-map":
+        from ..sch_pin_map import main as pin_map_main
+
+        sub_argv = [str(schematic_path)]
+        if args.ref:
+            sub_argv.extend(["--ref", args.ref])
+        if args.format != "json":
+            sub_argv.extend(["--format", args.format])
+        return pin_map_main(sub_argv) or 0
 
     elif args.sch_command == "connections":
         from ..sch_check_connections import main as connections_main

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -481,6 +481,16 @@ def _add_sch_parser(subparsers) -> None:
     sch_pins.add_argument("--lib", required=True, help="Path to symbol library file")
     sch_pins.add_argument("--format", choices=["table", "json"], default="table")
 
+    # sch pin-map
+    sch_pin_map = sch_subparsers.add_parser(
+        "pin-map", help="Show resolved pin-to-net assignments"
+    )
+    sch_pin_map.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_pin_map.add_argument("--ref", help="Filter by symbol reference (e.g., U1)")
+    sch_pin_map.add_argument(
+        "--format", choices=["table", "json"], default="json", help="Output format (default: json)"
+    )
+
     # sch connections
     sch_connections = sch_subparsers.add_parser(
         "connections", help="Check pin connections using library positions"

--- a/src/kicad_tools/cli/sch_pin_map.py
+++ b/src/kicad_tools/cli/sch_pin_map.py
@@ -16,7 +16,6 @@ import argparse
 import json
 import sys
 from collections import defaultdict
-from pathlib import Path
 
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import Schematic

--- a/src/kicad_tools/cli/sch_pin_map.py
+++ b/src/kicad_tools/cli/sch_pin_map.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+Resolve pin-to-net assignments for schematic symbols.
+
+Usage:
+    kicad-tools sch pin-map <schematic.kicad_sch> [--ref <REF>] [--format json|table]
+
+Uses embedded lib_symbols from the schematic (no external library files needed).
+For each component, traces wires from pin positions to labels/power symbols
+to determine the net name.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
+from kicad_tools.schema import Schematic
+from kicad_tools.schema.label import PowerSymbol
+from kicad_tools.schema.library import LibrarySymbol
+
+# Use integer-scaled coordinates for fast set lookup (matches sch_check_connections.py)
+Coord = tuple[int, int]
+
+
+def _to_coord(x: float, y: float) -> Coord:
+    """Convert float coordinates to integer-scaled for set lookup."""
+    return (int(round(x * 10)), int(round(y * 10)))
+
+
+def _point_on_segment(
+    point: Coord, seg_start: Coord, seg_end: Coord
+) -> bool:
+    """Check if *point* lies strictly on the interior of the segment (not at endpoints).
+
+    All coordinates are integer-scaled (x*10, y*10).
+    Only axis-aligned (horizontal/vertical) and 45-degree wires are common in KiCad;
+    we handle the general case with a collinearity + bounding-box check.
+    """
+    if point == seg_start or point == seg_end:
+        return False
+
+    # Collinearity: cross product must be zero (or near-zero for int coords)
+    dx1 = seg_end[0] - seg_start[0]
+    dy1 = seg_end[1] - seg_start[1]
+    dx2 = point[0] - seg_start[0]
+    dy2 = point[1] - seg_start[1]
+    cross = dx1 * dy2 - dy1 * dx2
+    if abs(cross) > 1:  # allow rounding tolerance of 1 unit (0.1mm)
+        return False
+
+    # Bounding box check (point must be between start and end)
+    min_x = min(seg_start[0], seg_end[0])
+    max_x = max(seg_start[0], seg_end[0])
+    min_y = min(seg_start[1], seg_end[1])
+    max_y = max(seg_start[1], seg_end[1])
+    return min_x <= point[0] <= max_x and min_y <= point[1] <= max_y
+
+
+def _build_wire_graph(
+    schematic: Schematic,
+) -> tuple[dict[Coord, set[Coord]], dict[Coord, str]]:
+    """Build a connectivity graph from wires, labels, and power symbols.
+
+    Labels and other connection points may sit on the interior of a wire
+    segment (not just at endpoints). We split wire edges at such points
+    so that flood-fill can reach them.
+
+    Returns:
+        adjacency: Maps each coordinate node to its connected neighbors
+        net_names: Maps label/power-symbol coordinates to their net name
+    """
+    net_names: dict[Coord, str] = {}
+
+    # Collect all "special" coordinates that need to be graph nodes:
+    # labels, junctions, power symbols.
+    special_points: set[Coord] = set()
+
+    for lbl in schematic.labels:
+        coord = _to_coord(*lbl.position)
+        net_names[coord] = lbl.text
+        special_points.add(coord)
+
+    for lbl in schematic.global_labels:
+        coord = _to_coord(*lbl.position)
+        net_names[coord] = lbl.text
+        special_points.add(coord)
+
+    for lbl in schematic.hierarchical_labels:
+        coord = _to_coord(*lbl.position)
+        net_names[coord] = lbl.text
+        special_points.add(coord)
+
+    for junc in schematic.junctions:
+        special_points.add(_to_coord(*junc.position))
+
+    for sym_sexp in schematic.sexp.find_children("symbol"):
+        ps = PowerSymbol.from_symbol_sexp(sym_sexp)
+        if ps:
+            coord = _to_coord(*ps.position)
+            net_name = ps.value or ps.lib_id.split(":", 1)[-1]
+            net_names[coord] = net_name
+            special_points.add(coord)
+
+    # Build adjacency by processing each wire segment.
+    # If any special point lies on the interior of a wire, split the wire at that point.
+    adjacency: dict[Coord, set[Coord]] = defaultdict(set)
+
+    for wire in schematic.wires:
+        start = _to_coord(*wire.start)
+        end = _to_coord(*wire.end)
+
+        # Find special points on this wire's interior
+        on_wire = [p for p in special_points if _point_on_segment(p, start, end)]
+
+        if not on_wire:
+            # Simple case: no splits needed
+            adjacency[start].add(end)
+            adjacency[end].add(start)
+        else:
+            # Sort split points by distance from start
+            on_wire.sort(
+                key=lambda p: (p[0] - start[0]) ** 2 + (p[1] - start[1]) ** 2
+            )
+            # Create chain: start -> p1 -> p2 -> ... -> end
+            chain = [start] + on_wire + [end]
+            for i in range(len(chain) - 1):
+                adjacency[chain[i]].add(chain[i + 1])
+                adjacency[chain[i + 1]].add(chain[i])
+
+    # Ensure all special points exist as nodes even if no wire touches them
+    for p in special_points:
+        if p not in adjacency:
+            adjacency[p] = set()
+
+    return dict(adjacency), net_names
+
+
+def _flood_fill_net(
+    start: Coord,
+    adjacency: dict[Coord, set[Coord]],
+    net_names: dict[Coord, str],
+) -> str | None:
+    """BFS from a coordinate to find the first net name reachable along wires.
+
+    Returns the net name, or None if no label/power symbol is reachable.
+    """
+    visited: set[Coord] = set()
+    queue = [start]
+    visited.add(start)
+
+    while queue:
+        current = queue.pop(0)
+
+        # Check if this node has a net name
+        if current in net_names:
+            return net_names[current]
+
+        # Traverse neighbors
+        for neighbor in adjacency.get(current, set()):
+            if neighbor not in visited:
+                visited.add(neighbor)
+                queue.append(neighbor)
+
+    return None
+
+
+def resolve_pin_map(
+    schematic: Schematic,
+    ref_filter: str | None = None,
+) -> dict[str, dict]:
+    """Resolve pin-to-net assignments for all symbols in a schematic.
+
+    Args:
+        schematic: Loaded schematic
+        ref_filter: If provided, only include this reference designator
+
+    Returns:
+        Dict mapping reference -> {"lib_id": str, "pins": {pin_num: {name, net, type}}}
+    """
+    adjacency, net_names = _build_wire_graph(schematic)
+    result: dict[str, dict] = {}
+
+    for symbol in schematic.symbols:
+        # Skip power symbols
+        if symbol.lib_id.startswith("power:"):
+            continue
+
+        # Apply reference filter
+        if ref_filter and symbol.reference != ref_filter:
+            continue
+
+        # Look up embedded library symbol
+        lib_sexp = schematic.get_lib_symbol(symbol.lib_id)
+        if not lib_sexp:
+            continue
+
+        lib_sym = LibrarySymbol.from_sexp(lib_sexp)
+
+        # Get transformed pin positions
+        pin_positions = lib_sym.get_all_pin_positions(
+            instance_pos=symbol.position,
+            instance_rot=symbol.rotation,
+            mirror=symbol.mirror,
+        )
+
+        pins_data: dict[str, dict] = {}
+        for lib_pin in lib_sym.pins:
+            if lib_pin.number not in pin_positions:
+                continue
+
+            pos = pin_positions[lib_pin.number]
+            coord = _to_coord(*pos)
+
+            # Trace from pin position to find net name
+            net = _flood_fill_net(coord, adjacency, net_names)
+
+            pins_data[lib_pin.number] = {
+                "name": lib_pin.name,
+                "net": net,
+                "type": lib_pin.type,
+            }
+
+        # Handle multi-unit: if the same reference already exists, merge pins
+        if symbol.reference in result:
+            result[symbol.reference]["pins"].update(pins_data)
+        else:
+            result[symbol.reference] = {
+                "lib_id": symbol.lib_id,
+                "pins": pins_data,
+            }
+
+    return result
+
+
+def output_json(pin_map: dict[str, dict]) -> None:
+    """Output pin map as JSON."""
+    print(json.dumps(pin_map, indent=2))
+
+
+def output_table(pin_map: dict[str, dict]) -> None:
+    """Output pin map as formatted table."""
+    if not pin_map:
+        print("No symbols found.")
+        return
+
+    for ref in sorted(pin_map.keys()):
+        entry = pin_map[ref]
+        print(f"\n{ref} ({entry['lib_id']})")
+        print(f"  {'Pin':<6} {'Name':<20} {'Type':<15} {'Net'}")
+        print("  " + "-" * 60)
+
+        pins = entry["pins"]
+        for pin_num in sorted(
+            pins.keys(),
+            key=lambda p: (not p.isdigit(), int(p) if p.isdigit() else 0, p),
+        ):
+            pin = pins[pin_num]
+            net_str = pin["net"] if pin["net"] else "(unconnected)"
+            print(f"  {pin_num:<6} {pin['name']:<20} {pin['type']:<15} {net_str}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Show resolved pin-to-net assignments for schematic symbols",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", help="Path to .kicad_sch file")
+    parser.add_argument("--ref", help="Filter by symbol reference (e.g., U1)")
+    parser.add_argument(
+        "--format", choices=["table", "json"], default="json", help="Output format (default: json)"
+    )
+
+    args = parser.parse_args(argv)
+
+    # Load schematic
+    try:
+        sch = Schematic.load(args.schematic)
+    except (FileNotFoundError, KiCadFileNotFoundError):
+        print(f"Error: Schematic not found: {args.schematic}", file=sys.stderr)
+        return 1
+
+    # Resolve pin map
+    pin_map = resolve_pin_map(sch, ref_filter=args.ref)
+
+    if args.format == "json":
+        output_json(pin_map)
+    else:
+        output_table(pin_map)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/tests/test_sch_pin_map.py
+++ b/tests/test_sch_pin_map.py
@@ -1,0 +1,534 @@
+"""Tests for the sch pin-map command.
+
+Covers net tracing via wire graph, power symbol resolution, --ref filter,
+multi-unit symbol merging, unconnected pins, JSON/table output, and CLI smoke test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_pin_map import (
+    _build_wire_graph,
+    _flood_fill_net,
+    _point_on_segment,
+    _to_coord,
+    main as pin_map_main,
+    resolve_pin_map,
+)
+from kicad_tools.schema import Schematic
+
+# ---------------------------------------------------------------------------
+# Minimal schematic with symbols, wires, labels, and a power symbol
+# ---------------------------------------------------------------------------
+
+MINIMAL_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (symbol "R_1_1"
+        (pin passive line
+          (at 0 3.81 270)
+          (length 1.27)
+          (name "~")
+          (number "1")
+        )
+        (pin passive line
+          (at 0 -3.81 90)
+          (length 1.27)
+          (name "~")
+          (number "2")
+        )
+      )
+    )
+    (symbol "Device:C"
+      (symbol "C_1_1"
+        (pin passive line
+          (at 0 3.81 270)
+          (length 2.794)
+          (name "~")
+          (number "1")
+        )
+        (pin passive line
+          (at 0 -3.81 90)
+          (length 2.794)
+          (name "~")
+          (number "2")
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 100 50 0)
+    (unit 1)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "aaaa-aaaa")
+    (property "Reference" "R1" (at 102 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "10k" (at 102 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p1"))
+    (pin "2" (uuid "p2"))
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 120 50 0)
+    (unit 1)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "bbbb-bbbb")
+    (property "Reference" "C1" (at 122 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "100nF" (at 122 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p3"))
+    (pin "2" (uuid "p4"))
+  )
+  (wire (pts (xy 100 46.19) (xy 100 40))
+    (stroke (width 0) (type default)) (uuid "w1"))
+  (wire (pts (xy 100 40) (xy 120 40))
+    (stroke (width 0) (type default)) (uuid "w2"))
+  (wire (pts (xy 120 40) (xy 120 46.19))
+    (stroke (width 0) (type default)) (uuid "w3"))
+  (wire (pts (xy 100 53.81) (xy 100 60))
+    (stroke (width 0) (type default)) (uuid "w4"))
+  (wire (pts (xy 100 60) (xy 120 60))
+    (stroke (width 0) (type default)) (uuid "w5"))
+  (wire (pts (xy 120 60) (xy 120 53.81))
+    (stroke (width 0) (type default)) (uuid "w6"))
+  (label "VIN" (at 100 40 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid "lbl-vin"))
+  (label "GND" (at 100 60 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid "lbl-gnd"))
+)
+"""
+
+# Schematic with a power symbol instead of labels
+POWER_SYMBOL_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000002")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (symbol "R_1_1"
+        (pin passive line
+          (at 0 3.81 270)
+          (length 1.27)
+          (name "~")
+          (number "1")
+        )
+        (pin passive line
+          (at 0 -3.81 90)
+          (length 1.27)
+          (name "~")
+          (number "2")
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 100 50 0)
+    (unit 1)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "cccc-cccc")
+    (property "Reference" "R1" (at 102 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "4.7k" (at 102 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p1"))
+    (pin "2" (uuid "p2"))
+  )
+  (symbol
+    (lib_id "power:+3.3V")
+    (at 100 40 0)
+    (unit 1)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "dddd-dddd")
+    (property "Reference" "#PWR01" (at 100 36 0)
+      (effects (font (size 1.27 1.27)) hide))
+    (property "Value" "+3.3V" (at 100 36 0)
+      (effects (font (size 1.27 1.27))))
+    (pin "1" (uuid "p5"))
+  )
+  (wire (pts (xy 100 46.19) (xy 100 40))
+    (stroke (width 0) (type default)) (uuid "w1"))
+)
+"""
+
+# Schematic with an unconnected pin
+UNCONNECTED_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000003")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (symbol "R_1_1"
+        (pin passive line
+          (at 0 3.81 270)
+          (length 1.27)
+          (name "~")
+          (number "1")
+        )
+        (pin passive line
+          (at 0 -3.81 90)
+          (length 1.27)
+          (name "~")
+          (number "2")
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 100 50 0)
+    (unit 1)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "eeee-eeee")
+    (property "Reference" "R1" (at 102 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "1k" (at 102 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p1"))
+    (pin "2" (uuid "p2"))
+  )
+)
+"""
+
+
+def _write_sch(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "test.kicad_sch"
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: coordinate conversion
+# ---------------------------------------------------------------------------
+
+
+class TestToCoord:
+    def test_basic(self):
+        assert _to_coord(100.0, 50.0) == (1000, 500)
+
+    def test_fractional(self):
+        assert _to_coord(46.19, 3.81) == (462, 38)
+
+    def test_rounding(self):
+        # 0.05 * 10 = 0.5, rounds to 0 (banker's rounding) or 1
+        coord = _to_coord(10.05, 20.15)
+        assert coord == (100, 202) or coord == (101, 202)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: wire graph building
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWireGraph:
+    def test_basic_graph(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, MINIMAL_SCHEMATIC))
+        adjacency, net_names = _build_wire_graph(sch)
+
+        # Should have wire endpoint nodes
+        assert len(adjacency) > 0
+
+        # Labels should appear in net_names
+        vin_coord = _to_coord(100, 40)
+        gnd_coord = _to_coord(100, 60)
+        assert net_names[vin_coord] == "VIN"
+        assert net_names[gnd_coord] == "GND"
+
+    def test_power_symbol_in_net_names(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, POWER_SYMBOL_SCHEMATIC))
+        _, net_names = _build_wire_graph(sch)
+
+        power_coord = _to_coord(100, 40)
+        assert net_names[power_coord] == "+3.3V"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: wire splitting for labels on midpoints
+# ---------------------------------------------------------------------------
+
+
+class TestPointOnSegment:
+    def test_midpoint(self):
+        assert _point_on_segment((500, 500), (0, 500), (1000, 500)) is True
+
+    def test_endpoint_excluded(self):
+        assert _point_on_segment((0, 500), (0, 500), (1000, 500)) is False
+
+    def test_off_segment(self):
+        assert _point_on_segment((500, 600), (0, 500), (1000, 500)) is False
+
+    def test_vertical_wire(self):
+        assert _point_on_segment((100, 500), (100, 0), (100, 1000)) is True
+
+
+class TestLabelOnWireMidpoint:
+    """Labels placed on the middle of a wire (not at endpoints) must be reachable."""
+
+    def test_label_midpoint_resolution(self, tmp_path):
+        """A label at (110, 40) on a wire from (100, 40) to (120, 40)."""
+        sch_content = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000010")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (symbol "R_1_1"
+        (pin passive line
+          (at 0 3.81 270) (length 1.27) (name "~") (number "1"))
+        (pin passive line
+          (at 0 -3.81 90) (length 1.27) (name "~") (number "2"))
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R") (at 100 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (uuid "ff01")
+    (property "Reference" "R1" (at 102 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "1k" (at 102 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p1")) (pin "2" (uuid "p2"))
+  )
+  (wire (pts (xy 100 46.19) (xy 100 40))
+    (stroke (width 0) (type default)) (uuid "w1"))
+  (wire (pts (xy 100 40) (xy 120 40))
+    (stroke (width 0) (type default)) (uuid "w2"))
+  (label "SIG" (at 110 40 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid "lbl-sig"))
+)
+"""
+        sch = Schematic.load(_write_sch(tmp_path, sch_content))
+        pin_map = resolve_pin_map(sch)
+
+        # R1 pin 2 at (100, 46.19) -> wire to (100,40) -> wire to (110,40) label "SIG"
+        assert pin_map["R1"]["pins"]["2"]["net"] == "SIG"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: flood fill
+# ---------------------------------------------------------------------------
+
+
+class TestFloodFill:
+    def test_direct_label(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, MINIMAL_SCHEMATIC))
+        adjacency, net_names = _build_wire_graph(sch)
+
+        # R1 pin 2 at (100, 46.19) -> wire to (100, 40) -> label "VIN"
+        pin_coord = _to_coord(100, 46.19)
+        net = _flood_fill_net(pin_coord, adjacency, net_names)
+        assert net == "VIN"
+
+    def test_chain_through_wire(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, MINIMAL_SCHEMATIC))
+        adjacency, net_names = _build_wire_graph(sch)
+
+        # C1 pin 2 at (120, 46.19) -> wire to (120, 40) -> wire to (100, 40) -> "VIN"
+        pin_coord = _to_coord(120, 46.19)
+        net = _flood_fill_net(pin_coord, adjacency, net_names)
+        assert net == "VIN"
+
+    def test_no_label(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, UNCONNECTED_SCHEMATIC))
+        adjacency, net_names = _build_wire_graph(sch)
+
+        # R1 pin 1 at (100, 46.19), no wires at all
+        pin_coord = _to_coord(100, 46.19)
+        net = _flood_fill_net(pin_coord, adjacency, net_names)
+        assert net is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: resolve_pin_map
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePinMap:
+    def test_basic_resolution(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, MINIMAL_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        assert "R1" in pin_map
+        assert "C1" in pin_map
+
+        # Pin 1 is at (0, 3.81) -> y=50+3.81=53.81 -> connects to GND at y=60
+        # Pin 2 is at (0, -3.81) -> y=50-3.81=46.19 -> connects to VIN at y=40
+        assert pin_map["R1"]["pins"]["1"]["net"] == "GND"
+        assert pin_map["R1"]["pins"]["2"]["net"] == "VIN"
+        assert pin_map["R1"]["lib_id"] == "Device:R"
+
+        # C1 follows the same pin layout
+        assert pin_map["C1"]["pins"]["1"]["net"] == "GND"
+        assert pin_map["C1"]["pins"]["2"]["net"] == "VIN"
+
+    def test_pin_type(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, MINIMAL_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        assert pin_map["R1"]["pins"]["1"]["type"] == "passive"
+
+    def test_ref_filter(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, MINIMAL_SCHEMATIC))
+        pin_map = resolve_pin_map(sch, ref_filter="R1")
+
+        assert "R1" in pin_map
+        assert "C1" not in pin_map
+
+    def test_ref_filter_no_match(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, MINIMAL_SCHEMATIC))
+        pin_map = resolve_pin_map(sch, ref_filter="U99")
+
+        assert len(pin_map) == 0
+
+    def test_power_symbol_net(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, POWER_SYMBOL_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        assert "R1" in pin_map
+        # R1 pin 2 at (100, 46.19) connected via wire to +3.3V power symbol at (100, 40)
+        assert pin_map["R1"]["pins"]["2"]["net"] == "+3.3V"
+        # R1 pin 1 at (100, 53.81) is unconnected (no wire)
+        assert pin_map["R1"]["pins"]["1"]["net"] is None
+
+    def test_power_symbols_excluded(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, POWER_SYMBOL_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        # Power symbols should not appear as components
+        for ref in pin_map:
+            assert not ref.startswith("#PWR")
+
+    def test_unconnected_pin(self, tmp_path):
+        sch = Schematic.load(_write_sch(tmp_path, UNCONNECTED_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        assert "R1" in pin_map
+        assert pin_map["R1"]["pins"]["1"]["net"] is None
+        assert pin_map["R1"]["pins"]["2"]["net"] is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: real fixture
+# ---------------------------------------------------------------------------
+
+
+class TestWithFixture:
+    @pytest.fixture
+    def simple_rc_path(self):
+        return Path(__file__).parent / "fixtures" / "simple_rc.kicad_sch"
+
+    def test_fixture_loads(self, simple_rc_path):
+        if not simple_rc_path.exists():
+            pytest.skip("Fixture not available")
+
+        sch = Schematic.load(simple_rc_path)
+        pin_map = resolve_pin_map(sch)
+
+        assert "R1" in pin_map
+        assert "C1" in pin_map
+
+        # Both should have 2 pins each
+        assert len(pin_map["R1"]["pins"]) == 2
+        assert len(pin_map["C1"]["pins"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_json_output(self, tmp_path, capsys):
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        rc = pin_map_main([str(path), "--format", "json"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "R1" in data
+        assert "C1" in data
+        assert data["R1"]["pins"]["1"]["net"] == "GND"
+
+    def test_table_output(self, tmp_path, capsys):
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        rc = pin_map_main([str(path), "--format", "table"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "R1" in captured.out
+        assert "VIN" in captured.out
+        assert "GND" in captured.out
+
+    def test_ref_filter_cli(self, tmp_path, capsys):
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        rc = pin_map_main([str(path), "--ref", "C1", "--format", "json"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "C1" in data
+        assert "R1" not in data
+
+    def test_missing_file(self, tmp_path, capsys):
+        rc = pin_map_main([str(tmp_path / "nonexistent.kicad_sch")])
+        assert rc == 1
+
+    def test_default_format_is_json(self, tmp_path, capsys):
+        path = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        rc = pin_map_main([str(path)])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Should be valid JSON
+        data = json.loads(captured.out)
+        assert isinstance(data, dict)
+
+    def test_empty_schematic(self, tmp_path, capsys):
+        """Schematic with no symbols should produce empty JSON output."""
+        empty_sch = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000099")
+  (paper "A4")
+  (lib_symbols)
+)
+"""
+        path = _write_sch(tmp_path, empty_sch)
+        rc = pin_map_main([str(path), "--format", "json"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data == {}


### PR DESCRIPTION
## Summary
Add `kicad-tools sch pin-map` command that resolves pin-to-net assignments for all symbols in a schematic using embedded lib_symbols (zero-config, no external library files needed).

## Changes
- New `src/kicad_tools/cli/sch_pin_map.py` with net-tracing logic: wire graph construction, BFS flood-fill, wire-splitting for labels on midpoints
- CLI registration in `src/kicad_tools/cli/parser.py` (subparser with `--ref` and `--format` options)
- Command dispatch in `src/kicad_tools/cli/commands/schematic.py`
- 27 tests in `tests/test_sch_pin_map.py` covering: net tracing, power symbol resolution, `--ref` filter, unconnected pins, label-on-wire-midpoint, JSON/table output, CLI smoke tests

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| JSON output matches specified schema | Pass | Tests verify structure: `{ref: {lib_id, pins: {num: {name, net, type}}}}` |
| Uses embedded lib_symbols (zero-config) | Pass | No `--lib` or `--lib-path` args needed |
| Traces wires to labels/power symbols | Pass | BFS flood-fill with wire-splitting for midpoint labels |
| `--ref` filter works | Pass | Tests verify filtering and exclusion |
| Power symbols resolved to net names | Pass | Power symbol Value property used as net name |
| Unconnected pins report null | Pass | Test with no-wire schematic returns `null` |
| Power symbols excluded from output | Pass | `#PWR` references not in results |

## Test Plan
All 27 tests pass: `python3 -m pytest tests/test_sch_pin_map.py -v`

Smoke-tested against `tests/fixtures/simple_rc.kicad_sch` -- correctly resolves VIN and GND nets including labels placed on wire midpoints.

Closes #1900