### PR TITLE
feat(sch): detect global label driver/receiver direction mismatch in validate

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -361,6 +361,88 @@ def check_no_connect_on_input_pins(schematic_path: str) -> list[ValidationIssue]
     return issues
 
 
+def check_global_label_directions(schematic_path: str) -> list[ValidationIssue]:
+    """Check global label driver/receiver direction mismatches.
+
+    Groups global labels by net name across all sheets and checks that each
+    net has at least one driver and at least one receiver.
+
+    Direction semantics:
+      - ``output`` / ``tri_state``: driver only
+      - ``input``: receiver only
+      - ``bidirectional`` / ``passive``: counts as both driver and receiver
+    """
+    issues: list[ValidationIssue] = []
+
+    try:
+        hierarchy = build_hierarchy(schematic_path)
+
+        # Collect global labels across all sheets: net_name -> list of (shape, sheet_path)
+        label_map: dict[str, list[tuple[str, str]]] = {}
+
+        for node in hierarchy.all_nodes():
+            try:
+                sch = Schematic.load(node.path)
+                sheet_path = node.get_path_string()
+                for gl in sch.global_labels:
+                    if gl.text not in label_map:
+                        label_map[gl.text] = []
+                    label_map[gl.text].append((gl.shape, sheet_path))
+            except Exception:
+                pass
+
+        # Shapes that count as driver (can source a signal)
+        driver_shapes = {"output", "tri_state", "bidirectional", "passive"}
+        # Shapes that count as receiver (can sink a signal)
+        receiver_shapes = {"input", "bidirectional", "passive"}
+
+        for net_name, entries in sorted(label_map.items()):
+            shapes = {shape for shape, _ in entries}
+            sheets = sorted({sheet for _, sheet in entries})
+            has_driver = bool(shapes & driver_shapes)
+            has_receiver = bool(shapes & receiver_shapes)
+
+            if not has_driver:
+                # All instances are input -- no driver exists
+                shapes_str = ", ".join(sorted(shapes))
+                issues.append(
+                    ValidationIssue(
+                        severity="error",
+                        category="global_label",
+                        message=(
+                            f"Global label '{net_name}' has no driver "
+                            f"(shapes: {shapes_str})"
+                        ),
+                        location=", ".join(sheets),
+                    )
+                )
+            elif not has_receiver:
+                # All instances are output/tri_state -- no receiver exists
+                shapes_str = ", ".join(sorted(shapes))
+                issues.append(
+                    ValidationIssue(
+                        severity="warning",
+                        category="global_label",
+                        message=(
+                            f"Global label '{net_name}' has no receiver "
+                            f"(shapes: {shapes_str})"
+                        ),
+                        location=", ".join(sheets),
+                    )
+                )
+
+    except Exception as e:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                category="global_label",
+                message=f"Global label direction check failed: {e}",
+            )
+        )
+
+    return issues
+
+
 def validate_schematic(schematic_path: str, lib_paths: list[str] = None) -> ValidationResult:
     """Run all validation checks."""
     result = ValidationResult(schematic=schematic_path)
@@ -384,6 +466,10 @@ def validate_schematic(schematic_path: str, lib_paths: list[str] = None) -> Vali
     # No-connect on input pins
     result.checks_run.append("no_connect_input")
     result.issues.extend(check_no_connect_on_input_pins(schematic_path))
+
+    # Global label directions
+    result.checks_run.append("global_label_directions")
+    result.issues.extend(check_global_label_directions(schematic_path))
 
     return result
 

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -1325,6 +1325,199 @@ class TestSchValidateNoConnectInput:
         assert "(pin 1)" in issues[0].message
 
 
+class TestSchValidateGlobalLabelDirections:
+    """Tests for global label direction mismatch detection in sch_validate.py."""
+
+    def _make_schematic(self, global_labels_sexp: str) -> str:
+        """Build a minimal schematic string with the given global_label entries."""
+        return f"""(kicad_sch
+          (version 20231120)
+          (generator "test")
+          (uuid "00000000-0000-0000-0000-000000000001")
+          (paper "A4")
+          (lib_symbols)
+          {global_labels_sexp}
+        )
+        """
+
+    def test_no_driver_detected_as_error(self, tmp_path: Path):
+        """All instances are input -- no driver exists -- should be an error."""
+        from kicad_tools.cli.sch_validate import check_global_label_directions
+
+        # Parent with one global label input, child with another global label input
+        parent_sch = self._make_schematic("""
+          (global_label "SIG_A" (shape input) (at 10 20 0)
+            (effects (font (size 1.27 1.27))) (uuid "a1"))
+          (sheet (at 100 100) (size 10 10)
+            (uuid "00000000-0000-0000-0000-000000000002")
+            (property "Sheetname" "Sub" (at 100 99 0))
+            (property "Sheetfile" "sub.kicad_sch" (at 100 111 0)))
+        """)
+        child_sch = self._make_schematic("""
+          (global_label "SIG_A" (shape input) (at 30 40 0)
+            (effects (font (size 1.27 1.27))) (uuid "a2"))
+        """)
+
+        (tmp_path / "top.kicad_sch").write_text(parent_sch)
+        (tmp_path / "sub.kicad_sch").write_text(child_sch)
+
+        issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
+        gl_issues = [i for i in issues if i.category == "global_label"]
+
+        assert len(gl_issues) == 1
+        assert gl_issues[0].severity == "error"
+        assert "SIG_A" in gl_issues[0].message
+        assert "no driver" in gl_issues[0].message
+
+    def test_no_receiver_detected_as_warning(self, tmp_path: Path):
+        """All instances are output -- no receiver exists -- should be a warning."""
+        from kicad_tools.cli.sch_validate import check_global_label_directions
+
+        parent_sch = self._make_schematic("""
+          (global_label "SIG_B" (shape output) (at 10 20 0)
+            (effects (font (size 1.27 1.27))) (uuid "b1"))
+          (sheet (at 100 100) (size 10 10)
+            (uuid "00000000-0000-0000-0000-000000000002")
+            (property "Sheetname" "Sub" (at 100 99 0))
+            (property "Sheetfile" "sub.kicad_sch" (at 100 111 0)))
+        """)
+        child_sch = self._make_schematic("""
+          (global_label "SIG_B" (shape output) (at 30 40 0)
+            (effects (font (size 1.27 1.27))) (uuid "b2"))
+        """)
+
+        (tmp_path / "top.kicad_sch").write_text(parent_sch)
+        (tmp_path / "sub.kicad_sch").write_text(child_sch)
+
+        issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
+        gl_issues = [i for i in issues if i.category == "global_label"]
+
+        assert len(gl_issues) == 1
+        assert gl_issues[0].severity == "warning"
+        assert "SIG_B" in gl_issues[0].message
+        assert "no receiver" in gl_issues[0].message
+
+    def test_valid_output_input_mix(self, tmp_path: Path):
+        """One output and one input on the same net -- no issues."""
+        from kicad_tools.cli.sch_validate import check_global_label_directions
+
+        parent_sch = self._make_schematic("""
+          (global_label "SIG_C" (shape output) (at 10 20 0)
+            (effects (font (size 1.27 1.27))) (uuid "c1"))
+          (sheet (at 100 100) (size 10 10)
+            (uuid "00000000-0000-0000-0000-000000000002")
+            (property "Sheetname" "Sub" (at 100 99 0))
+            (property "Sheetfile" "sub.kicad_sch" (at 100 111 0)))
+        """)
+        child_sch = self._make_schematic("""
+          (global_label "SIG_C" (shape input) (at 30 40 0)
+            (effects (font (size 1.27 1.27))) (uuid "c2"))
+        """)
+
+        (tmp_path / "top.kicad_sch").write_text(parent_sch)
+        (tmp_path / "sub.kicad_sch").write_text(child_sch)
+
+        issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
+        gl_issues = [i for i in issues if i.category == "global_label"]
+        assert len(gl_issues) == 0
+
+    def test_bidirectional_counts_as_both(self, tmp_path: Path):
+        """All bidirectional -- counts as both driver and receiver."""
+        from kicad_tools.cli.sch_validate import check_global_label_directions
+
+        sch = self._make_schematic("""
+          (global_label "I2C_SDA" (shape bidirectional) (at 10 20 0)
+            (effects (font (size 1.27 1.27))) (uuid "d1"))
+          (global_label "I2C_SDA" (shape bidirectional) (at 30 40 0)
+            (effects (font (size 1.27 1.27))) (uuid "d2"))
+        """)
+
+        (tmp_path / "top.kicad_sch").write_text(sch)
+
+        issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
+        gl_issues = [i for i in issues if i.category == "global_label"]
+        assert len(gl_issues) == 0
+
+    def test_passive_counts_as_both(self, tmp_path: Path):
+        """All passive -- counts as both driver and receiver."""
+        from kicad_tools.cli.sch_validate import check_global_label_directions
+
+        sch = self._make_schematic("""
+          (global_label "GND_SENSE" (shape passive) (at 10 20 0)
+            (effects (font (size 1.27 1.27))) (uuid "e1"))
+        """)
+
+        (tmp_path / "top.kicad_sch").write_text(sch)
+
+        issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
+        gl_issues = [i for i in issues if i.category == "global_label"]
+        assert len(gl_issues) == 0
+
+    def test_tri_state_is_driver(self, tmp_path: Path):
+        """tri_state counts as a driver but not a receiver."""
+        from kicad_tools.cli.sch_validate import check_global_label_directions
+
+        parent_sch = self._make_schematic("""
+          (global_label "BUS_D0" (shape tri_state) (at 10 20 0)
+            (effects (font (size 1.27 1.27))) (uuid "f1"))
+          (sheet (at 100 100) (size 10 10)
+            (uuid "00000000-0000-0000-0000-000000000002")
+            (property "Sheetname" "Sub" (at 100 99 0))
+            (property "Sheetfile" "sub.kicad_sch" (at 100 111 0)))
+        """)
+        child_sch = self._make_schematic("""
+          (global_label "BUS_D0" (shape tri_state) (at 30 40 0)
+            (effects (font (size 1.27 1.27))) (uuid "f2"))
+        """)
+
+        (tmp_path / "top.kicad_sch").write_text(parent_sch)
+        (tmp_path / "sub.kicad_sch").write_text(child_sch)
+
+        issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
+        gl_issues = [i for i in issues if i.category == "global_label"]
+
+        # tri_state is driver-only, so no receiver -> warning
+        assert len(gl_issues) == 1
+        assert gl_issues[0].severity == "warning"
+        assert "no receiver" in gl_issues[0].message
+
+    def test_json_output_includes_global_label_category(self, tmp_path: Path, capsys, monkeypatch):
+        """JSON output should include category 'global_label'."""
+        from kicad_tools.cli.sch_validate import main
+
+        sch = self._make_schematic("""
+          (global_label "NOCAP" (shape input) (at 10 20 0)
+            (effects (font (size 1.27 1.27))) (uuid "g1"))
+        """)
+        sch_file = tmp_path / "top.kicad_sch"
+        sch_file.write_text(sch)
+
+        monkeypatch.setattr(
+            "sys.argv", ["sch-validate", str(sch_file), "--format", "json"]
+        )
+        import contextlib
+
+        with contextlib.suppress(SystemExit):
+            main()
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        gl_issues = [i for i in data["issues"] if i["category"] == "global_label"]
+        assert len(gl_issues) == 1
+        assert "NOCAP" in gl_issues[0]["message"]
+
+    def test_validate_schematic_includes_check(self, tmp_path: Path):
+        """validate_schematic() should include 'global_label_directions' in checks_run."""
+        from kicad_tools.cli.sch_validate import validate_schematic
+
+        sch = self._make_schematic("")
+        sch_file = tmp_path / "top.kicad_sch"
+        sch_file.write_text(sch)
+
+        result = validate_schematic(str(sch_file))
+        assert "global_label_directions" in result.checks_run
+
+
 class TestSchCheckConnections:
     """Tests for sch_check_connections.py CLI."""
 


### PR DESCRIPTION
## Summary
Add a new `check_global_label_directions()` check to `sch validate` that detects global labels whose direction shapes are inconsistent across sheets -- nets with no driver (all inputs) or no receiver (all outputs/tri_state).

## Changes
- Add `check_global_label_directions()` function in `sch_validate.py` that traverses the hierarchy, collects all global labels grouped by net name, and analyzes their shape sets
- Wire the new check into `validate_schematic()` as the `global_label_directions` check
- Add 8 test cases in `TestSchValidateGlobalLabelDirections` covering: no-driver error, no-receiver warning, valid output/input mix, bidirectional-counts-as-both, passive-counts-as-both, tri_state-is-driver-only, JSON output format, and checks_run inclusion

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All-input nets flagged as error (no driver) | Done | test_no_driver_detected_as_error passes |
| All-output nets flagged as warning (no receiver) | Done | test_no_receiver_detected_as_warning passes |
| Valid output+input mix produces no issue | Done | test_valid_output_input_mix passes |
| bidirectional counts as both driver and receiver | Done | test_bidirectional_counts_as_both passes |
| passive counts as both driver and receiver | Done | test_passive_counts_as_both passes |
| tri_state counts as driver only | Done | test_tri_state_is_driver passes |
| JSON output includes category "global_label" | Done | test_json_output_includes_global_label_category passes |
| Check appears in checks_run list | Done | test_validate_schematic_includes_check passes |
| Existing TestSchValidate and TestSchValidateHierarchy tests still pass | Done | All 6 existing tests pass |

## Test Plan
All 14 tests pass (8 new + 6 existing validate tests):
```
pytest tests/test_cli_sch.py::TestSchValidateGlobalLabelDirections -v  # 8 passed
pytest tests/test_cli_sch.py::TestSchValidate tests/test_cli_sch.py::TestSchValidateHierarchy -v  # 6 passed
```

Closes #1905