### PR TITLE
fix(sch): make --sheet filter case-insensitive in set-label-direction

### DIFF
--- a/src/kicad_tools/cli/sch_set_label_direction.py
+++ b/src/kicad_tools/cli/sch_set_label_direction.py
@@ -179,9 +179,13 @@ def set_label_direction(
 
     all_files = _collect_schematic_files(root_path)
 
-    # Optionally filter to a single sheet
+    # Optionally filter to a single sheet (case-insensitive)
     if sheet_filter:
-        all_files = [f for f in all_files if sheet_filter in f.name or sheet_filter in str(f)]
+        sf_lower = sheet_filter.lower()
+        all_files = [
+            f for f in all_files
+            if sf_lower in f.name.lower() or sf_lower in str(f).lower()
+        ]
 
     all_changes: list[LabelChange] = []
     files_modified: set[str] = set()

--- a/tests/test_sch_set_label_direction.py
+++ b/tests/test_sch_set_label_direction.py
@@ -279,6 +279,40 @@ class TestSetLabelDirection:
         root_text = root_file.read_text(encoding="utf-8")
         assert '(global_label "SDA" (shape input)' in root_text
 
+    def test_sheet_filter_case_insensitive(self, tmp_path):
+        """Sheet filter should match regardless of case (e.g., 'DAC' matches 'dac.kicad_sch')."""
+        root_file = tmp_path / "root.kicad_sch"
+        sub_file = tmp_path / "dac.kicad_sch"
+        root_file.write_text(ROOT_SCHEMATIC_WITH_SUBSHEET, encoding="utf-8")
+        sub_file.write_text(SUBSHEET_CONTENT, encoding="utf-8")
+
+        # Uppercase filter against lowercase filename
+        result = set_label_direction(
+            str(root_file), name="SDA", new_shape="bidirectional", sheet_filter="DAC"
+        )
+
+        assert result.success
+        assert len(result.changes) == 1
+        assert str(sub_file) in result.files_modified
+        # Root should be unmodified
+        root_text = root_file.read_text(encoding="utf-8")
+        assert '(global_label "SDA" (shape input)' in root_text
+
+    def test_sheet_filter_mixed_case(self, tmp_path):
+        """Mixed-case filter (e.g., 'dAc') should also match."""
+        root_file = tmp_path / "root.kicad_sch"
+        sub_file = tmp_path / "dac.kicad_sch"
+        root_file.write_text(ROOT_SCHEMATIC_WITH_SUBSHEET, encoding="utf-8")
+        sub_file.write_text(SUBSHEET_CONTENT, encoding="utf-8")
+
+        result = set_label_direction(
+            str(root_file), name="SDA", new_shape="bidirectional", sheet_filter="dAc"
+        )
+
+        assert result.success
+        assert len(result.changes) == 1
+        assert str(sub_file) in result.files_modified
+
     def test_backup_created(self, tmp_path):
         sch_file = tmp_path / "test.kicad_sch"
         sch_file.write_text(SCHEMATIC_WITH_GLOBAL_LABELS, encoding="utf-8")


### PR DESCRIPTION
## Summary
The `--sheet` filter in `sch set-label-direction` performed a case-sensitive substring match against filenames. This caused `--sheet Connectors` to fail matching `connectors.kicad_sch`. The fix lowercases both sides of the comparison.

## Changes
- Made the sheet filter comparison case-insensitive by lowering both the filter and the filename/path before matching
- Added two test cases: uppercase filter (`DAC` vs `dac.kicad_sch`) and mixed-case filter (`dAc`)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--sheet Connectors` matches `connectors.kicad_sch` | Done | New test `test_sheet_filter_case_insensitive` passes with uppercase "DAC" against lowercase filename |
| Mixed-case filters work (e.g., `--sheet dAc`) | Done | New test `test_sheet_filter_mixed_case` passes |
| Existing lowercase filter still works | Done | Original `test_sheet_filter` with lowercase "dac" still passes |
| Non-matching sheets still excluded | Done | All filter tests verify root sheet is excluded when filtering to subsheet |

## Test Plan
All 24 tests pass in `tests/test_sch_set_label_direction.py`, including 2 new tests for case-insensitive matching.

Closes #1908