### PR TITLE
fix(schema): add LibraryManager.load_embedded for inline schematic symbols

### DIFF
--- a/src/kicad_tools/schema/library.py
+++ b/src/kicad_tools/schema/library.py
@@ -1092,6 +1092,39 @@ class LibraryManager:
         self.libraries[lib_name] = lib
         return lib
 
+    def load_embedded(self, schematic: Any) -> None:
+        """Load embedded symbol definitions from a schematic.
+
+        KiCad schematics store inline symbol definitions in a ``lib_symbols``
+        section.  This method parses those definitions and registers them so
+        that :meth:`get_symbol` can resolve pin positions without requiring the
+        on-disk library files.
+
+        Args:
+            schematic: A :class:`~kicad_tools.schema.schematic.Schematic`
+                instance (or any object exposing a ``lib_symbols`` property
+                that returns an :class:`SExp` node or ``None``).
+        """
+        lib_symbols = schematic.lib_symbols
+        if lib_symbols is None:
+            return
+
+        for sym_sexp in lib_symbols.find_all("symbol"):
+            sym = LibrarySymbol.from_sexp(sym_sexp)
+            # Embedded symbol names use lib_id format, e.g. "Device:R"
+            lib_id = sym.name
+            if ":" in lib_id:
+                lib_name, short_name = lib_id.split(":", 1)
+            else:
+                lib_name = lib_id
+                short_name = lib_id
+
+            if lib_name not in self.libraries:
+                self.libraries[lib_name] = SymbolLibrary(
+                    path="<embedded>", symbols={}
+                )
+            self.libraries[lib_name].symbols[short_name] = sym
+
     def add_search_path(self, path: str) -> None:
         """Add a directory to search for libraries."""
         self.search_paths.append(path)

--- a/src/kicad_tools/schema/library.py
+++ b/src/kicad_tools/schema/library.py
@@ -1123,7 +1123,8 @@ class LibraryManager:
                 self.libraries[lib_name] = SymbolLibrary(
                     path="<embedded>", symbols={}
                 )
-            self.libraries[lib_name].symbols[short_name] = sym
+            if short_name not in self.libraries[lib_name].symbols:
+                self.libraries[lib_name].symbols[short_name] = sym
 
     def add_search_path(self, path: str) -> None:
         """Add a directory to search for libraries."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1025,6 +1025,134 @@ class TestLibraryManager:
         manager = LibraryManager()
         assert manager.get_symbol("Device:NonExistent") is None
 
+    def test_load_embedded_single_symbol(self):
+        """Test loading embedded symbols from a schematic."""
+
+        class FakeSchematic:
+            @property
+            def lib_symbols(self):
+                return parse_string(
+                    """(lib_symbols
+                    (symbol "Device:R"
+                        (property "Reference" "R")
+                        (symbol "Device:R_1_1"
+                            (pin passive line (at -2.54 0 0) (length 2.54)
+                                (name "1") (number "1"))
+                            (pin passive line (at 2.54 0 180) (length 2.54)
+                                (name "2") (number "2"))
+                        )
+                    )
+                )"""
+                )
+
+        manager = LibraryManager()
+        manager.load_embedded(FakeSchematic())
+
+        # Should be resolvable by full lib_id
+        sym = manager.get_symbol("Device:R")
+        assert sym is not None
+        assert len(sym.pins) == 2
+
+    def test_load_embedded_multiple_libraries(self):
+        """Test loading embedded symbols from multiple libraries."""
+
+        class FakeSchematic:
+            @property
+            def lib_symbols(self):
+                return parse_string(
+                    """(lib_symbols
+                    (symbol "Device:R"
+                        (property "Reference" "R")
+                        (symbol "Device:R_1_1"
+                            (pin passive line (at 0 0 0) (length 2.54)
+                                (name "1") (number "1"))
+                        )
+                    )
+                    (symbol "power:GND"
+                        (property "Reference" "#PWR")
+                        (symbol "power:GND_1_1"
+                            (pin power_in line (at 0 0 0) (length 0)
+                                (name "GND") (number "1"))
+                        )
+                    )
+                )"""
+                )
+
+        manager = LibraryManager()
+        manager.load_embedded(FakeSchematic())
+
+        assert manager.get_symbol("Device:R") is not None
+        assert manager.get_symbol("power:GND") is not None
+
+    def test_load_embedded_no_lib_symbols(self):
+        """Test load_embedded with schematic that has no lib_symbols."""
+
+        class FakeSchematic:
+            @property
+            def lib_symbols(self):
+                return None
+
+        manager = LibraryManager()
+        # Should not raise
+        manager.load_embedded(FakeSchematic())
+        assert len(manager.libraries) == 0
+
+    def test_load_embedded_no_colon_in_name(self):
+        """Test loading embedded symbol without library prefix."""
+
+        class FakeSchematic:
+            @property
+            def lib_symbols(self):
+                return parse_string(
+                    """(lib_symbols
+                    (symbol "MySymbol"
+                        (property "Reference" "U")
+                        (symbol "MySymbol_1_1"
+                            (pin input line (at 0 0 0) (length 2.54)
+                                (name "IN") (number "1"))
+                        )
+                    )
+                )"""
+                )
+
+        manager = LibraryManager()
+        manager.load_embedded(FakeSchematic())
+
+        # Symbol without colon uses its name as both lib name and symbol name
+        assert "MySymbol" in manager.libraries
+        sym = manager.get_symbol("MySymbol")
+        assert sym is not None
+
+    def test_load_embedded_does_not_overwrite_existing(self):
+        """Test that load_embedded does not overwrite symbols loaded from disk."""
+        manager = LibraryManager()
+        # Pre-load a symbol
+        existing_sym = LibrarySymbol(name="R", properties={"Reference": "R"}, pins=[])
+        lib = SymbolLibrary(path="Device.kicad_sym", symbols={"R": existing_sym})
+        manager.add_library("Device", lib)
+
+        class FakeSchematic:
+            @property
+            def lib_symbols(self):
+                return parse_string(
+                    """(lib_symbols
+                    (symbol "Device:C"
+                        (property "Reference" "C")
+                        (symbol "Device:C_1_1"
+                            (pin passive line (at 0 0 0) (length 2.54)
+                                (name "1") (number "1"))
+                        )
+                    )
+                )"""
+                )
+
+        manager.load_embedded(FakeSchematic())
+
+        # Existing symbol should still be there
+        assert manager.get_symbol("Device:R") is existing_sym
+        # New embedded symbol should also be available
+        assert manager.get_symbol("Device:C") is not None
+
 
 class TestHierarchySheetPin:
     """Tests for SheetPin in hierarchy module."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1126,7 +1126,7 @@ class TestLibraryManager:
     def test_load_embedded_does_not_overwrite_existing(self):
         """Test that load_embedded does not overwrite symbols loaded from disk."""
         manager = LibraryManager()
-        # Pre-load a symbol
+        # Pre-load a symbol under Device:R
         existing_sym = LibrarySymbol(name="R", properties={"Reference": "R"}, pins=[])
         lib = SymbolLibrary(path="Device.kicad_sym", symbols={"R": existing_sym})
         manager.add_library("Device", lib)
@@ -1136,9 +1136,9 @@ class TestLibraryManager:
             def lib_symbols(self):
                 return parse_string(
                     """(lib_symbols
-                    (symbol "Device:C"
-                        (property "Reference" "C")
-                        (symbol "Device:C_1_1"
+                    (symbol "Device:R"
+                        (property "Reference" "R")
+                        (symbol "Device:R_1_1"
                             (pin passive line (at 0 0 0) (length 2.54)
                                 (name "1") (number "1"))
                         )
@@ -1148,10 +1148,8 @@ class TestLibraryManager:
 
         manager.load_embedded(FakeSchematic())
 
-        # Existing symbol should still be there
+        # Existing symbol loaded from disk must be preserved
         assert manager.get_symbol("Device:R") is existing_sym
-        # New embedded symbol should also be available
-        assert manager.get_symbol("Device:C") is not None
 
 
 class TestHierarchySheetPin:


### PR DESCRIPTION
## Summary
Add the missing `LibraryManager.load_embedded()` method that `sch add-no-connect` and `sch disconnect` commands call to register inline symbol definitions from a schematic's `lib_symbols` section. Without this method, both commands raise `AttributeError: 'LibraryManager' object has no attribute 'load_embedded'`.

## Changes
- Add `load_embedded(self, schematic)` method to `LibraryManager` in `src/kicad_tools/schema/library.py`
- The method iterates `schematic.lib_symbols.find_all("symbol")`, parses each via `LibrarySymbol.from_sexp()`, and registers them under the correct library namespace
- Handles both `"Library:Symbol"` and bare `"Symbol"` name formats
- Add 5 unit tests covering: single symbol, multiple libraries, no lib_symbols, bare names, and non-overwrite of existing symbols

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `load_embedded` method exists on `LibraryManager` | Pass | Method added at line 1095 of library.py |
| Parses embedded `lib_symbols` from schematic | Pass | Iterates `lib_symbols.find_all("symbol")` and calls `LibrarySymbol.from_sexp()` |
| Registers symbols so `get_symbol()` resolves by full `lib_id` | Pass | Stores under `lib_name` key with `short_name`, verified in test |
| Handles schematic with no `lib_symbols` | Pass | Returns early if `lib_symbols is None`, tested |
| Handles multiple library namespaces | Pass | Tested with `Device:R` and `power:GND` |
| Does not overwrite symbols loaded from disk | Pass | Tested by pre-loading a symbol and verifying it survives `load_embedded` |
| `sch add-no-connect` and `sch disconnect` call sites unchanged | Pass | No changes to those files needed |

## Test Plan
All 9 `TestLibraryManager` tests pass including 5 new tests for `load_embedded`.

Closes #1907