### PR TITLE
fix(sch): emit info-level issues for per-sheet parse failures in validate

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -176,8 +176,15 @@ def check_missing_footprints(schematic_path: str) -> list[ValidationIssue]:
                                 location=node.get_path_string(),
                             )
                         )
-            except Exception:
-                pass
+            except Exception as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="footprint",
+                        message=f"Skipped sheet {node.get_path_string()}: {e}",
+                        location=node.get_path_string(),
+                    )
+                )
 
     except Exception as e:
         issues.append(
@@ -216,8 +223,15 @@ def check_missing_values(schematic_path: str) -> list[ValidationIssue]:
                                 location=node.get_path_string(),
                             )
                         )
-            except Exception:
-                pass
+            except Exception as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="value",
+                        message=f"Skipped sheet {node.get_path_string()}: {e}",
+                        location=node.get_path_string(),
+                    )
+                )
 
     except Exception as e:
         issues.append(
@@ -346,8 +360,15 @@ def check_no_connect_on_input_pins(schematic_path: str) -> list[ValidationIssue]
                                     location=node.get_path_string(),
                                 )
                             )
-            except Exception:
-                pass
+            except Exception as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="no_connect",
+                        message=f"Skipped sheet {node.get_path_string()}: {e}",
+                        location=node.get_path_string(),
+                    )
+                )
 
     except Exception as e:
         issues.append(
@@ -388,8 +409,15 @@ def check_global_label_directions(schematic_path: str) -> list[ValidationIssue]:
                     if gl.text not in label_map:
                         label_map[gl.text] = []
                     label_map[gl.text].append((gl.shape, sheet_path))
-            except Exception:
-                pass
+            except Exception as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="global_label",
+                        message=f"Skipped sheet {node.get_path_string()}: {e}",
+                        location=node.get_path_string(),
+                    )
+                )
 
         # Shapes that count as driver (can source a signal)
         driver_shapes = {"output", "tri_state", "bidirectional", "passive"}

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -1518,6 +1518,125 @@ class TestSchValidateGlobalLabelDirections:
         assert "global_label_directions" in result.checks_run
 
 
+class TestSchValidateSheetParseFailure:
+    """Tests that per-sheet parse failures emit info-level ValidationIssues."""
+
+    def _make_hierarchy_with_broken_sheet(self, tmp_path: Path) -> Path:
+        """Create a two-sheet hierarchy where the sub-sheet is unparseable."""
+        parent_sch = """(kicad_sch
+          (version 20231120)
+          (generator "test")
+          (uuid "00000000-0000-0000-0000-000000000001")
+          (paper "A4")
+          (lib_symbols)
+          (sheet (at 100 100) (size 10 10)
+            (uuid "00000000-0000-0000-0000-000000000002")
+            (property "Sheetname" "BrokenSub" (at 100 99 0))
+            (property "Sheetfile" "broken.kicad_sch" (at 100 111 0)))
+        )
+        """
+        parent_file = tmp_path / "top.kicad_sch"
+        parent_file.write_text(parent_sch)
+
+        # Write a truncated/broken sub-sheet
+        broken_file = tmp_path / "broken.kicad_sch"
+        broken_file.write_text("(kicad_sch (version 20231120) TRUNCATED")
+
+        return parent_file
+
+    def test_check_missing_footprints_reports_broken_sheet(self, tmp_path: Path):
+        """check_missing_footprints should emit an info issue for unparseable sheets."""
+        from kicad_tools.cli.sch_validate import check_missing_footprints
+
+        parent_file = self._make_hierarchy_with_broken_sheet(tmp_path)
+        issues = check_missing_footprints(str(parent_file))
+
+        info_issues = [i for i in issues if i.severity == "info" and i.category == "footprint"]
+        assert len(info_issues) >= 1
+        assert any("Skipped sheet" in i.message for i in info_issues)
+        # Verify location is populated
+        assert all(i.location for i in info_issues)
+
+    def test_check_missing_values_reports_broken_sheet(self, tmp_path: Path):
+        """check_missing_values should emit an info issue for unparseable sheets."""
+        from kicad_tools.cli.sch_validate import check_missing_values
+
+        parent_file = self._make_hierarchy_with_broken_sheet(tmp_path)
+        issues = check_missing_values(str(parent_file))
+
+        info_issues = [i for i in issues if i.severity == "info" and i.category == "value"]
+        assert len(info_issues) >= 1
+        assert any("Skipped sheet" in i.message for i in info_issues)
+
+    def test_check_global_label_directions_reports_broken_sheet(self, tmp_path: Path):
+        """check_global_label_directions should emit an info issue for unparseable sheets."""
+        from kicad_tools.cli.sch_validate import check_global_label_directions
+
+        parent_file = self._make_hierarchy_with_broken_sheet(tmp_path)
+        issues = check_global_label_directions(str(parent_file))
+
+        info_issues = [i for i in issues if i.severity == "info" and i.category == "global_label"]
+        assert len(info_issues) >= 1
+        assert any("Skipped sheet" in i.message for i in info_issues)
+
+    def test_all_sheets_broken_reports_one_per_sheet(self, tmp_path: Path):
+        """When all sheets fail to parse, result should contain one info issue per broken sheet."""
+        from kicad_tools.cli.sch_validate import check_missing_footprints
+
+        parent_sch = """(kicad_sch
+          (version 20231120)
+          (generator "test")
+          (uuid "00000000-0000-0000-0000-000000000001")
+          (paper "A4")
+          (lib_symbols)
+          (sheet (at 100 100) (size 10 10)
+            (uuid "00000000-0000-0000-0000-000000000002")
+            (property "Sheetname" "Sub1" (at 100 99 0))
+            (property "Sheetfile" "sub1.kicad_sch" (at 100 111 0)))
+          (sheet (at 200 100) (size 10 10)
+            (uuid "00000000-0000-0000-0000-000000000003")
+            (property "Sheetname" "Sub2" (at 200 99 0))
+            (property "Sheetfile" "sub2.kicad_sch" (at 200 111 0)))
+        )
+        """
+        parent_file = tmp_path / "top.kicad_sch"
+        parent_file.write_text(parent_sch)
+
+        # Both sub-sheets are broken
+        (tmp_path / "sub1.kicad_sch").write_text("BROKEN")
+        (tmp_path / "sub2.kicad_sch").write_text("BROKEN")
+
+        issues = check_missing_footprints(str(parent_file))
+
+        # The parent sheet itself may also fail to parse, so we check for at least 2
+        # broken sub-sheet issues (sub1 and sub2)
+        info_issues = [
+            i for i in issues
+            if i.severity == "info" and i.category == "footprint" and "Skipped sheet" in i.message
+        ]
+        assert len(info_issues) >= 2
+
+    def test_valid_sheets_produce_no_skip_issues(self, tmp_path: Path):
+        """Valid sheets should not produce any 'Skipped sheet' info issues."""
+        from kicad_tools.cli.sch_validate import check_missing_footprints
+
+        sch = """(kicad_sch
+          (version 20231120)
+          (generator "test")
+          (uuid "00000000-0000-0000-0000-000000000001")
+          (paper "A4")
+          (lib_symbols)
+        )
+        """
+        sch_file = tmp_path / "valid.kicad_sch"
+        sch_file.write_text(sch)
+
+        issues = check_missing_footprints(str(sch_file))
+
+        skip_issues = [i for i in issues if "Skipped sheet" in i.message]
+        assert len(skip_issues) == 0
+
+
 class TestSchCheckConnections:
     """Tests for sch_check_connections.py CLI."""
 


### PR DESCRIPTION
## Summary

Replace bare `except Exception: pass` blocks in `sch_validate.py` that silently swallowed per-sheet parse failures. Each skipped sheet now emits an info-level `ValidationIssue` with the sheet path and exception message, so users know which sheets were not validated.

## Changes

- Replace `except Exception: pass` with `except Exception as e:` blocks that append info-level `ValidationIssue` in four functions: `check_missing_footprints`, `check_missing_values`, `check_no_connect_on_input_pins`, `check_global_label_directions`
- Each emitted issue uses the function's own category, severity `info`, and `node.get_path_string()` as the location
- Outer `except Exception as e:` blocks (for top-level `build_hierarchy()` failures) are unchanged
- Add 5 new tests in `TestSchValidateSheetParseFailure` covering broken sheets, multiple broken sheets, and regression for valid sheets

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Every inner `except Exception: pass` replaced with info issue | Done | All 4 functions updated |
| Severity is `info` with function's category | Done | Verified in code and tests |
| Location set to `node.get_path_string()` | Done | Asserted in tests |
| Outer except blocks unchanged | Done | Verified via diff |
| Existing tests continue to pass | Done | 27 validate tests pass |

## Test Plan

- 5 new tests pass covering broken sheet detection in 3 check functions, multiple broken sheets, and no false positives on valid sheets
- All 27 existing validate-related tests pass with no regressions

Closes #1913