### PR TITLE
fix(sch): support space-indented schematic files in re-annotate

### DIFF
--- a/src/kicad_tools/cli/sch_re_annotate.py
+++ b/src/kicad_tools/cli/sch_re_annotate.py
@@ -34,6 +34,31 @@ from kicad_tools.cli.sch_set_footprint import _collect_schematic_files
 # Prefixes for power/flag symbols that should be excluded from renumbering
 EXCLUDED_PREFIXES = {"#PWR", "#FLG", "#SYM"}
 
+# Whitespace token for regex: matches one or more tabs or spaces
+_WS = r'[ \t]+'
+
+
+def _detect_indent(text: str) -> str:
+    """Detect the indentation unit used in a schematic file.
+
+    Looks at the first indented line to determine whether the file uses
+    tabs or spaces (and how many spaces per level).
+
+    Returns:
+        The single-level indent string (e.g. ``'\\t'`` or ``'  '``).
+    """
+    for line in text.splitlines():
+        if line and line[0] in (' ', '\t'):
+            # Count leading whitespace
+            stripped = line.lstrip(' \t')
+            leading = line[:len(line) - len(stripped)]
+            if '\t' in leading:
+                return '\t'
+            # Assume the first indented line is at depth 1
+            # Common space counts: 2 or 4
+            return leading
+    return '\t'
+
 
 def _parse_reference(ref: str) -> tuple[str, int | None, str]:
     """Parse a reference designator into (prefix, number, unit_suffix).
@@ -66,11 +91,13 @@ def _extract_symbols_from_text(text: str) -> list[dict]:
     symbols = []
 
     # Find all symbol blocks that have lib_id (instances, not lib definitions)
+    # Use _WS instead of literal \t to support both tab and space indentation
     block_pattern = re.compile(
-        r'\t\(symbol\n'
-        r'\t\t\(lib_id "[^"]+"\)'
+        _WS + r'\(symbol\n'
+        + _WS + r'\(lib_id "[^"]+"\)'
         r'.*?'
-        r'(?:\t\t\(instances\n.*?\t\t\)\n\t\)|\t\t\(pin "[^"]+"\n\t\t\t\(uuid "[^"]+"\)\n\t\t\)\n\t\))',
+        r'(?:' + _WS + r'\(instances\n.*?' + _WS + r'\)\n' + _WS + r'\)'
+        r'|' + _WS + r'\(pin "[^"]+"\n' + _WS + r'\(uuid "[^"]+"\)\n' + _WS + r'\)\n' + _WS + r'\))',
         re.DOTALL,
     )
 
@@ -138,23 +165,28 @@ def _apply_uuid_reference_rename(text: str, sym_uuid: str, new_ref: str) -> str:
     Targets the symbol block containing the given UUID.
     """
     # Strategy: find the symbol block boundaries first, then modify within.
-    # Symbol blocks start with \t(symbol\n and end with \t).
+    # Symbol blocks start with <indent>(symbol\n and end with <indent>).
     # We find the block that contains our UUID and replace within it.
     uuid_str = f'(uuid "{sym_uuid}")'
     uuid_pos = text.find(uuid_str)
     if uuid_pos == -1:
         return text
 
-    # Walk backward to find the start of this symbol block
-    block_start = text.rfind('\t(symbol\n', 0, uuid_pos)
+    # Walk backward to find the start of this symbol block using regex
+    # to support both tab and space indentation
+    start_pattern = re.compile(_WS + r'\(symbol\n')
+    block_start = -1
+    for m in start_pattern.finditer(text, 0, uuid_pos):
+        block_start = m.start()
     if block_start == -1:
         return text
 
-    # Walk forward to find the end of this symbol block (\n\t) at the right depth)
-    block_end = text.find('\n\t)', uuid_pos)
-    if block_end == -1:
+    # Walk forward to find the end of this symbol block (\n<indent>) at depth 1)
+    end_pattern = re.compile(r'\n' + _WS + r'\)')
+    end_match = end_pattern.search(text, uuid_pos)
+    if end_match is None:
         return text
-    block_end += 3  # include the \n\t)
+    block_end = end_match.end()
 
     block = text[block_start:block_end]
 
@@ -186,7 +218,7 @@ def _detect_project_info(
     root_text = root_path.read_text(encoding="utf-8")
 
     # Find root schematic UUID (first uuid at top level)
-    root_uuid_match = re.search(r'^\t\(uuid "([^"]+)"\)', root_text, re.MULTILINE)
+    root_uuid_match = re.search(r'^' + _WS + r'\(uuid "([^"]+)"\)', root_text, re.MULTILINE)
     root_uuid = root_uuid_match.group(1) if root_uuid_match else ""
 
     # Build map of sub-sheet file -> instance path
@@ -233,33 +265,40 @@ def _add_project_instance(
     Returns:
         Modified schematic text.
     """
+    # Detect the indentation unit used in this file
+    ind = _detect_indent(text)
+    i2 = ind * 2
+    i3 = ind * 3
+    i4 = ind * 4
+    i5 = ind * 5
+
     instance_entry = (
-        f'\t\t\t(project "{project_name}"\n'
-        f'\t\t\t\t(path "{instance_path}"\n'
-        f'\t\t\t\t\t(reference "{new_ref}")\n'
-        f'\t\t\t\t\t(unit {unit})\n'
-        f'\t\t\t\t)\n'
-        f'\t\t\t)\n'
+        f'{i3}(project "{project_name}"\n'
+        f'{i4}(path "{instance_path}"\n'
+        f'{i5}(reference "{new_ref}")\n'
+        f'{i5}(unit {unit})\n'
+        f'{i4})\n'
+        f'{i3})\n'
     )
 
     # Find the symbol block containing this UUID
     # Strategy: find the (instances block within the symbol that contains our UUID,
-    # and append the new project entry before the closing \t\t)
+    # and append the new project entry before the closing )
     block_pattern = re.compile(
-        r'(\t\(symbol\n'
-        r'\t\t\(lib_id "[^"]+"\)'
+        r'(' + _WS + r'\(symbol\n'
+        + _WS + r'\(lib_id "[^"]+"\)'
         r'.*?'
         r'\(uuid "' + re.escape(sym_uuid) + r'"\)'
         r'.*?)'
-        r'(\t\t\(instances\n)'
+        r'(' + _WS + r'\(instances\n)'
         r'(.*?)'
-        r'(\t\t\)\n\t\))',
+        r'(' + _WS + r'\)\n' + _WS + r'\))',
         re.DOTALL,
     )
 
     match = block_pattern.search(text)
     if match:
-        # Has instances block — append new project entry before closing \t\t)
+        # Has instances block — append new project entry before closing )
         before = match.group(1)
         instances_start = match.group(2)
         instances_body = match.group(3)
@@ -272,25 +311,25 @@ def _add_project_instance(
         new_block = before + instances_start + instances_body + instance_entry + instances_end
         return text[:match.start()] + new_block + text[match.end():]
 
-    # No instances block — find the symbol block and add one before closing \t)
-    # The symbol block ends with pin entries then \t)
+    # No instances block — find the symbol block and add one before closing )
+    # The symbol block ends with pin entries then )
     no_inst_pattern = re.compile(
-        r'(\t\(symbol\n'
-        r'\t\t\(lib_id "[^"]+"\)'
+        r'(' + _WS + r'\(symbol\n'
+        + _WS + r'\(lib_id "[^"]+"\)'
         r'.*?'
         r'\(uuid "' + re.escape(sym_uuid) + r'"\)'
         r'.*?'
-        r'(?:\t\t\(pin "[^"]+"\n\t\t\t\(uuid "[^"]+"\)\n\t\t\)\n))'
-        r'(\t\))',
+        r'(?:' + _WS + r'\(pin "[^"]+"\n' + _WS + r'\(uuid "[^"]+"\)\n' + _WS + r'\)\n))'
+        r'(' + _WS + r'\))',
         re.DOTALL,
     )
 
     match = no_inst_pattern.search(text)
     if match:
         instances_block = (
-            f'\t\t(instances\n'
+            f'{i2}(instances\n'
             f'{instance_entry}'
-            f'\t\t)\n'
+            f'{i2})\n'
         )
         return text[:match.start(2)] + instances_block + match.group(2) + text[match.end():]
 

--- a/tests/test_sch_re_annotate.py
+++ b/tests/test_sch_re_annotate.py
@@ -13,9 +13,13 @@ from pathlib import Path
 import pytest
 
 from kicad_tools.cli.sch_re_annotate import (
+    _add_project_instance,
     _apply_reference_rename,
+    _apply_uuid_reference_rename,
     _assign_numbers,
     _build_continuous_mapping,
+    _detect_indent,
+    _detect_project_info,
     _extract_symbols_from_text,
     _parse_reference,
     run_re_annotate,
@@ -521,6 +525,85 @@ UNANNOTATED_SCHEMATIC = """\
 """
 
 
+def _tabs_to_spaces(text: str, width: int = 2) -> str:
+    """Convert tab-indented schematic text to space-indented."""
+    lines = []
+    for line in text.splitlines(True):
+        # Count leading tabs
+        stripped = line.lstrip('\t')
+        n_tabs = len(line) - len(stripped)
+        lines.append(' ' * (n_tabs * width) + stripped)
+    return ''.join(lines)
+
+
+# Space-indented variants of key test fixtures
+SPACE_INDENTED_SCHEMATIC = _tabs_to_spaces(MINIMAL_SCHEMATIC)
+SPACE_INDENTED_POWER_SCHEMATIC = _tabs_to_spaces(POWER_SCHEMATIC)
+SPACE_INDENTED_NO_INSTANCES_SCHEMATIC = _tabs_to_spaces(NO_INSTANCES_SCHEMATIC)
+SPACE_INDENTED_UNANNOTATED_SCHEMATIC = _tabs_to_spaces(UNANNOTATED_SCHEMATIC)
+SPACE_INDENTED_SEQUENTIAL_SCHEMATIC = _tabs_to_spaces(SEQUENTIAL_SCHEMATIC)
+
+# Mixed indentation: first symbol uses tabs, second uses spaces
+MIXED_INDENTATION_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+  (symbol
+    (lib_id "Device:R")
+    (at 100 80 0)
+    (property "Reference" "R5"
+      (at 100 78 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Value" "4.7k"
+      (at 100 82 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Footprint" ""
+      (at 100 84 0)
+      (effects (font (size 1.27 1.27)) (hide yes))
+    )
+    (uuid "22222222-2222-2222-2222-222222222222")
+    (instances
+      (project "test"
+        (path "/" (reference "R5") (unit 1))
+      )
+    )
+  )
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+
 def _write_sch(
     tmp_path: Path,
     content: str = MINIMAL_SCHEMATIC,
@@ -972,3 +1055,201 @@ class TestUnannotatedComponents:
         assert "11111111-1111-1111-1111-111111111111" in by_uuid
         assert "22222222-2222-2222-2222-222222222222" in by_uuid
         assert by_uuid["22222222-2222-2222-2222-222222222222"]["reference"] == "R?"
+
+
+# ---------------------------------------------------------------------------
+# Space-indented schematic support
+# ---------------------------------------------------------------------------
+
+
+class TestDetectIndent:
+    def test_detects_tabs(self):
+        assert _detect_indent(MINIMAL_SCHEMATIC) == '\t'
+
+    def test_detects_spaces(self):
+        assert _detect_indent(SPACE_INDENTED_SCHEMATIC) == '  '
+
+    def test_detects_four_spaces(self):
+        text = _tabs_to_spaces(MINIMAL_SCHEMATIC, width=4)
+        assert _detect_indent(text) == '    '
+
+
+class TestSpaceIndentedExtractSymbols:
+    def test_extracts_all_symbols(self):
+        symbols = _extract_symbols_from_text(SPACE_INDENTED_SCHEMATIC)
+        refs = {s["reference"] for s in symbols}
+        assert refs == {"R1", "R5", "C3"}
+
+    def test_extracts_positions(self):
+        symbols = _extract_symbols_from_text(SPACE_INDENTED_SCHEMATIC)
+        by_ref = {s["reference"]: s for s in symbols}
+        assert by_ref["R1"]["position_x"] == 100
+        assert by_ref["R1"]["position_y"] == 50
+        assert by_ref["R5"]["position_y"] == 80
+
+    def test_extracts_lib_id(self):
+        symbols = _extract_symbols_from_text(SPACE_INDENTED_SCHEMATIC)
+        by_ref = {s["reference"]: s for s in symbols}
+        assert by_ref["R1"]["lib_id"] == "Device:R"
+        assert by_ref["C3"]["lib_id"] == "Device:C"
+
+    def test_power_symbols_extracted(self):
+        symbols = _extract_symbols_from_text(SPACE_INDENTED_POWER_SCHEMATIC)
+        refs = {s["reference"] for s in symbols}
+        assert "#PWR01" in refs
+
+    def test_no_instances_format(self):
+        symbols = _extract_symbols_from_text(SPACE_INDENTED_NO_INSTANCES_SCHEMATIC)
+        refs = {s["reference"] for s in symbols}
+        assert refs == {"R5", "R10"}
+
+    def test_unannotated_symbols(self):
+        symbols = _extract_symbols_from_text(SPACE_INDENTED_UNANNOTATED_SCHEMATIC)
+        refs = {s["reference"] for s in symbols}
+        assert "R?" in refs
+        assert "C?" in refs
+        assert "R1" in refs
+
+
+class TestSpaceIndentedRunReAnnotate:
+    def test_closes_gaps(self, tmp_path):
+        sch = _write_sch(tmp_path, SPACE_INDENTED_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        text = sch.read_text()
+        assert '"Reference" "R1"' in text
+        assert '"Reference" "R2"' in text
+        assert '"Reference" "C1"' in text
+        assert '"Reference" "R5"' not in text
+        assert '"Reference" "C3"' not in text
+
+    def test_updates_instances(self, tmp_path):
+        sch = _write_sch(tmp_path, SPACE_INDENTED_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        text = sch.read_text()
+        assert '(reference "R2")' in text
+        assert '(reference "C1")' in text
+
+    def test_already_sequential(self, tmp_path):
+        sch = _write_sch(tmp_path, SPACE_INDENTED_SEQUENTIAL_SCHEMATIC)
+        original = sch.read_text()
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        assert sch.read_text() == original
+
+    def test_power_symbols_excluded(self, tmp_path):
+        sch = _write_sch(tmp_path, SPACE_INDENTED_POWER_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        text = sch.read_text()
+        assert '"Reference" "R1"' in text
+        assert '"Reference" "#PWR01"' in text
+
+    def test_no_instances_format(self, tmp_path):
+        sch = _write_sch(tmp_path, SPACE_INDENTED_NO_INSTANCES_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        text = sch.read_text()
+        assert '"Reference" "R1"' in text
+        assert '"Reference" "R2"' in text
+
+    def test_annotates_unannotated_refs(self, tmp_path):
+        sch = _write_sch(tmp_path, SPACE_INDENTED_UNANNOTATED_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        text = sch.read_text()
+        assert '"Reference" "R1"' in text
+        assert '"Reference" "R2"' in text
+        assert '"Reference" "C1"' in text
+        assert '"Reference" "R?"' not in text
+        assert '"Reference" "C?"' not in text
+
+
+class TestSpaceIndentedApplyUuidRename:
+    def test_renames_in_space_indented_file(self):
+        text = _apply_uuid_reference_rename(
+            SPACE_INDENTED_SCHEMATIC,
+            "22222222-2222-2222-2222-222222222222",
+            "R99",
+        )
+        assert '"Reference" "R99"' in text
+        # R1 should be unchanged
+        assert '"Reference" "R1"' in text
+
+    def test_renames_in_tab_indented_file(self):
+        text = _apply_uuid_reference_rename(
+            MINIMAL_SCHEMATIC,
+            "22222222-2222-2222-2222-222222222222",
+            "R99",
+        )
+        assert '"Reference" "R99"' in text
+        assert '"Reference" "R1"' in text
+
+
+class TestSpaceIndentedDetectProjectInfo:
+    def test_finds_root_uuid_in_space_indented(self, tmp_path):
+        sch = _write_sch(tmp_path, SPACE_INDENTED_SCHEMATIC)
+        project_name, root_uuid, file_paths = _detect_project_info(sch, [sch])
+        assert root_uuid == "00000000-0000-0000-0000-000000000001"
+        assert project_name == "test"
+
+    def test_finds_root_uuid_in_tab_indented(self, tmp_path):
+        sch = _write_sch(tmp_path, MINIMAL_SCHEMATIC)
+        project_name, root_uuid, file_paths = _detect_project_info(sch, [sch])
+        assert root_uuid == "00000000-0000-0000-0000-000000000001"
+
+
+class TestSpaceIndentedAddProjectInstance:
+    def test_adds_instance_with_space_indentation(self):
+        text = _add_project_instance(
+            SPACE_INDENTED_UNANNOTATED_SCHEMATIC,
+            "33333333-3333-3333-3333-333333333333",
+            "newproject",
+            "/root-uuid",
+            "C1",
+        )
+        assert '(project "newproject"' in text
+        assert '(reference "C1")' in text
+        # Instance entry should use space indentation matching the file
+        assert '\t\t\t(project "newproject"' not in text
+
+
+class TestMixedIndentation:
+    def test_extracts_both_tab_and_space_symbols(self):
+        symbols = _extract_symbols_from_text(MIXED_INDENTATION_SCHEMATIC)
+        refs = {s["reference"] for s in symbols}
+        assert refs == {"R1", "R5"}
+
+    def test_run_re_annotate_on_mixed(self, tmp_path):
+        sch = _write_sch(tmp_path, MIXED_INDENTATION_SCHEMATIC)
+        ret = run_re_annotate(schematic_path=sch, dry_run=False, backup=False)
+        assert ret == 0
+        text = sch.read_text()
+        assert '"Reference" "R1"' in text
+        assert '"Reference" "R2"' in text
+        assert '"Reference" "R5"' not in text
+
+
+class TestSpaceIndentedHierarchical:
+    def test_continuous_across_space_indented_sheets(self, tmp_path):
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(_tabs_to_spaces(PARENT_SCHEMATIC))
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(_tabs_to_spaces(CHILD_SCHEMATIC))
+
+        ret = run_re_annotate(
+            schematic_path=parent, dry_run=False, backup=False
+        )
+        assert ret == 0
+
+        parent_text = parent.read_text()
+        child_text = child.read_text()
+
+        # Parent: R3 -> R1, R7 -> R2
+        assert '"Reference" "R1"' in parent_text
+        assert '"Reference" "R2"' in parent_text
+
+        # Child: R14 -> R3, C5 -> C1
+        assert '"Reference" "R3"' in child_text
+        assert '"Reference" "C1"' in child_text


### PR DESCRIPTION
## Summary
The `sch re-annotate` command failed to find symbols in space-indented schematic files (KiCad 9 format). All regex patterns and string searches used hardcoded tab characters, causing zero matches on space-indented input.

## Changes
- Add `_WS` regex constant (`[ \t]+`) to match both tab and space indentation
- Replace all 6 hardcoded tab locations in regex patterns with `_WS`
- Add `_detect_indent()` to detect whether a file uses tabs or spaces
- Fix `_apply_uuid_reference_rename()` block boundary detection to use regex instead of `rfind`/`find` with hardcoded `\t` and offset `+= 3`
- Fix `_add_project_instance()` to emit inserted content with indentation matching the file's style
- Fix `_detect_project_info()` root UUID pattern to accept space indentation

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Symbols found in space-indented files | Pass | 6 new tests in TestSpaceIndentedExtractSymbols |
| Symbols found in tab-indented files (regression) | Pass | All 45 original tests pass unchanged |
| _apply_uuid_reference_rename works with spaces | Pass | TestSpaceIndentedApplyUuidRename |
| _add_project_instance inserts with correct indent | Pass | TestSpaceIndentedAddProjectInstance |
| _detect_project_info finds UUID in space-indented root | Pass | TestSpaceIndentedDetectProjectInfo |
| Mixed indentation files handled | Pass | TestMixedIndentation (2 tests) |
| Hierarchical space-indented schematics work | Pass | TestSpaceIndentedHierarchical |

## Test Plan
68 tests pass (45 original + 23 new):
- `TestDetectIndent` (3 tests): tabs, 2-space, 4-space detection
- `TestSpaceIndentedExtractSymbols` (6 tests): symbol extraction from space-indented files
- `TestSpaceIndentedRunReAnnotate` (6 tests): full re-annotate on space-indented files
- `TestSpaceIndentedApplyUuidRename` (2 tests): UUID-targeted rename in both formats
- `TestSpaceIndentedDetectProjectInfo` (2 tests): root UUID detection in both formats
- `TestSpaceIndentedAddProjectInstance` (1 test): instance insertion with correct indentation
- `TestMixedIndentation` (2 tests): files with both tab and space-indented symbol blocks
- `TestSpaceIndentedHierarchical` (1 test): hierarchical schematic with space indentation

Closes #1919