### PR TITLE
feat(sch): add --unannotated-only flag to re-annotate command

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -399,6 +399,7 @@ def run_sch_command(args) -> int:
             start_from=getattr(args, "start_from", 1),
             per_sheet=getattr(args, "per_sheet", False),
             format=getattr(args, "format", "text"),
+            unannotated_only=getattr(args, "unannotated_only", False),
         )
 
     return 1

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -892,6 +892,11 @@ def _add_sch_parser(subparsers) -> None:
         action="store_true",
         help="Restart numbering per sheet instead of continuous",
     )
+    sch_reannotate.add_argument(
+        "--unannotated-only",
+        action="store_true",
+        help="Only assign numbers to unannotated (?) references",
+    )
     sch_reannotate.add_argument("--format", choices=["text", "json"], default="text")
 
 

--- a/src/kicad_tools/cli/sch_re_annotate.py
+++ b/src/kicad_tools/cli/sch_re_annotate.py
@@ -344,6 +344,7 @@ def run_re_annotate(
     start_from: int = 1,
     per_sheet: bool = False,
     format: str = "text",
+    unannotated_only: bool = False,
 ) -> int:
     """Run the re-annotate operation.
 
@@ -355,6 +356,8 @@ def run_re_annotate(
         start_from: Starting number for each prefix (default 1).
         per_sheet: If True, restart numbering per sheet.
         format: Output format ("text" or "json").
+        unannotated_only: If True, only assign numbers to unannotated (``?``)
+            references, leaving already-assigned references unchanged.
 
     Returns:
         0 on success, 1 on error.
@@ -394,11 +397,13 @@ def run_re_annotate(
 
     if per_sheet:
         uuid_mapping = _build_per_sheet_mapping(
-            all_files, file_symbols, prefixes, start_from
+            all_files, file_symbols, prefixes, start_from,
+            unannotated_only=unannotated_only,
         )
     else:
         uuid_mapping = _build_continuous_mapping(
-            all_files, file_symbols, prefixes, start_from
+            all_files, file_symbols, prefixes, start_from,
+            unannotated_only=unannotated_only,
         )
 
     if not uuid_mapping:
@@ -544,6 +549,8 @@ def _build_continuous_mapping(
     file_symbols: dict[Path, list[dict]],
     prefixes: list[str] | None,
     start_from: int,
+    *,
+    unannotated_only: bool = False,
 ) -> dict[str, dict]:
     """Build a continuous UUID-keyed mapping across all files.
 
@@ -560,7 +567,8 @@ def _build_continuous_mapping(
         syms_sorted = sorted(syms, key=lambda s: (s["position_y"], s["position_x"]))
         ordered_symbols.extend(syms_sorted)
 
-    return _assign_numbers(ordered_symbols, prefixes, start_from)
+    return _assign_numbers(ordered_symbols, prefixes, start_from,
+                           unannotated_only=unannotated_only)
 
 
 def _build_per_sheet_mapping(
@@ -568,6 +576,8 @@ def _build_per_sheet_mapping(
     file_symbols: dict[Path, list[dict]],
     prefixes: list[str] | None,
     start_from: int,
+    *,
+    unannotated_only: bool = False,
 ) -> dict[str, dict]:
     """Build a per-sheet UUID-keyed mapping, restarting numbering per file."""
     mapping: dict[str, dict] = {}
@@ -575,7 +585,8 @@ def _build_per_sheet_mapping(
     for sch_file in all_files:
         syms = file_symbols[sch_file]
         syms_sorted = sorted(syms, key=lambda s: (s["position_y"], s["position_x"]))
-        sheet_mapping = _assign_numbers(syms_sorted, prefixes, start_from)
+        sheet_mapping = _assign_numbers(syms_sorted, prefixes, start_from,
+                                        unannotated_only=unannotated_only)
         mapping.update(sheet_mapping)
 
     return mapping
@@ -585,16 +596,29 @@ def _assign_numbers(
     symbols: list[dict],
     prefixes: list[str] | None,
     start_from: int,
+    *,
+    unannotated_only: bool = False,
 ) -> dict[str, dict]:
     """Assign sequential numbers to symbols, handling multi-unit components.
 
     Multi-unit components (e.g., U1A and U1B) share the same base reference
     number but differ by their unit suffix.
 
+    When *unannotated_only* is ``True``, only symbols with unannotated
+    references (e.g. ``R?``) receive new numbers.  Already-assigned
+    references are left unchanged and their numbers are reserved so that
+    new assignments do not collide with them.
+
     Returns:
         Dict mapping UUID -> {"old": str, "new": str, "unannotated": bool}.
     """
     mapping: dict[str, dict] = {}
+
+    if unannotated_only:
+        return _assign_numbers_unannotated_only(
+            symbols, prefixes, start_from,
+        )
+
     # Track next number per prefix
     counters: dict[str, int] = {}
     # Track base number assignments for multi-unit: (prefix, old_number) -> new_number
@@ -641,6 +665,89 @@ def _assign_numbers(
     return mapping
 
 
+def _assign_numbers_unannotated_only(
+    symbols: list[dict],
+    prefixes: list[str] | None,
+    start_from: int,
+) -> dict[str, dict]:
+    """Assign numbers only to unannotated symbols, preserving existing refs.
+
+    Collects existing numbers per prefix into a reserved set, then assigns
+    new sequential numbers to unannotated (``?``) symbols while skipping
+    over reserved numbers.
+
+    Returns:
+        Dict mapping UUID -> {"old": str, "new": str, "unannotated": bool}.
+    """
+    mapping: dict[str, dict] = {}
+
+    # Phase 1: Collect existing (reserved) numbers per prefix
+    existing: dict[str, set[int]] = {}
+    # Also collect multi-unit base numbers that are already assigned
+    multi_unit_assigned: dict[tuple[str, int | None], int] = {}
+
+    for sym in symbols:
+        prefix = sym["prefix"]
+        number = sym["number"]
+        unit_suffix = sym["unit_suffix"]
+
+        if prefix in EXCLUDED_PREFIXES or prefix.startswith("#"):
+            continue
+        if prefixes is not None and prefix not in prefixes:
+            continue
+        if number is not None:
+            existing.setdefault(prefix, set()).add(number)
+
+    # Phase 2: Assign numbers only to unannotated symbols
+    counters: dict[str, int] = {}
+
+    def _next_available(pfx: str) -> int:
+        """Return the next available number for *pfx*, skipping reserved."""
+        n = counters.get(pfx, start_from)
+        reserved = existing.get(pfx, set())
+        while n in reserved:
+            n += 1
+        counters[pfx] = n + 1
+        return n
+
+    for sym in symbols:
+        ref = sym["reference"]
+        prefix = sym["prefix"]
+        number = sym["number"]
+        unit_suffix = sym["unit_suffix"]
+        sym_uuid = sym.get("uuid") or ref
+
+        if prefix in EXCLUDED_PREFIXES or prefix.startswith("#"):
+            continue
+        if prefixes is not None and prefix not in prefixes:
+            continue
+
+        # Skip already-assigned references
+        if number is not None:
+            continue
+
+        # Handle multi-unit unannotated components
+        if unit_suffix:
+            key = (prefix, number)  # number is None for unannotated
+            if key in multi_unit_assigned:
+                new_number = multi_unit_assigned[key]
+            else:
+                new_number = _next_available(prefix)
+                multi_unit_assigned[key] = new_number
+            new_ref = f"{prefix}{new_number}{unit_suffix}"
+        else:
+            new_number = _next_available(prefix)
+            new_ref = f"{prefix}{new_number}"
+
+        mapping[sym_uuid] = {
+            "old": ref,
+            "new": new_ref,
+            "unannotated": True,
+        }
+
+    return mapping
+
+
 def main(argv: list[str] | None = None):
     """CLI entry point."""
     import argparse
@@ -673,6 +780,11 @@ def main(argv: list[str] | None = None):
         help="Restart numbering per sheet instead of continuous",
     )
     parser.add_argument(
+        "--unannotated-only",
+        action="store_true",
+        help="Only assign numbers to unannotated (?) references, leaving existing ones unchanged",
+    )
+    parser.add_argument(
         "--format",
         choices=["text", "json"],
         default="text",
@@ -693,6 +805,7 @@ def main(argv: list[str] | None = None):
         start_from=args.start_from,
         per_sheet=args.per_sheet,
         format=args.format,
+        unannotated_only=args.unannotated_only,
     )
 
 

--- a/tests/test_sch_re_annotate.py
+++ b/tests/test_sch_re_annotate.py
@@ -1253,3 +1253,294 @@ class TestSpaceIndentedHierarchical:
         # Child: R14 -> R3, C5 -> C1
         assert '"Reference" "R3"' in child_text
         assert '"Reference" "C1"' in child_text
+
+
+# ---------------------------------------------------------------------------
+# --unannotated-only mode tests
+# ---------------------------------------------------------------------------
+
+# Schematic with R1, R2, and R? -- R? should become R3 (avoiding 1 and 2)
+COLLISION_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 65 0)
+\t\t(property "Reference" "R2"
+\t\t\t(at 100 63 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "4.7k"
+\t\t\t(at 100 67 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 69 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R2") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 80 0)
+\t\t(property "Reference" "R?"
+\t\t\t(at 100 78 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "1k"
+\t\t\t(at 100 82 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 84 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "33333333-3333-3333-3333-333333333333")
+\t\t(instances
+\t\t\t(project ""
+\t\t\t\t(path "/00000000-0000-0000-0000-000000000001" (reference "R?") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+
+class TestUnannotatedOnly:
+    def test_skips_assigned(self, tmp_path):
+        """With --unannotated-only, R1 stays R1 and R? becomes R2."""
+        sch = _write_sch(tmp_path, UNANNOTATED_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False,
+            unannotated_only=True,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        # R1 must remain unchanged
+        assert '"Reference" "R1"' in text
+        # R? should be assigned R2 (next after R1)
+        assert '"Reference" "R2"' in text
+        # C? should be assigned C1
+        assert '"Reference" "C1"' in text
+        # No unannotated refs remain
+        assert '"Reference" "R?"' not in text
+        assert '"Reference" "C?"' not in text
+
+    def test_avoids_collisions(self, tmp_path):
+        """R1, R2 exist; R? must become R3, not R1 or R2."""
+        sch = _write_sch(tmp_path, COLLISION_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False,
+            unannotated_only=True,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        # Existing refs unchanged
+        assert '"Reference" "R1"' in text
+        assert '"Reference" "R2"' in text
+        # R? -> R3 (skipping 1 and 2)
+        assert '"Reference" "R3"' in text
+        assert '"Reference" "R?"' not in text
+
+    def test_no_unannotated(self, tmp_path, capsys):
+        """All refs already assigned -> no changes needed."""
+        sch = _write_sch(tmp_path, SEQUENTIAL_SCHEMATIC)
+        original = sch.read_text()
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False,
+            unannotated_only=True,
+        )
+        assert ret == 0
+        assert sch.read_text() == original
+        captured = capsys.readouterr()
+        assert "No references to renumber" in captured.out
+
+    def test_with_prefix_filter(self, tmp_path):
+        """--unannotated-only with --prefix R: only unannotated R refs assigned."""
+        sch = _write_sch(tmp_path, UNANNOTATED_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False,
+            prefixes=["R"], unannotated_only=True,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        # R? should be assigned
+        assert '"Reference" "R?"' not in text
+        assert '"Reference" "R2"' in text
+        # C? should remain unannotated (prefix filter excludes C)
+        assert '"Reference" "C?"' in text
+
+    def test_with_start_from(self, tmp_path):
+        """--unannotated-only with --start-from should respect start value."""
+        sch = _write_sch(tmp_path, UNANNOTATED_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False,
+            start_from=10, unannotated_only=True,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        # R1 stays R1 (already assigned)
+        assert '"Reference" "R1"' in text
+        # R? should become R10 (start_from=10, no collision with R1)
+        assert '"Reference" "R10"' in text
+        # C? should become C10
+        assert '"Reference" "C10"' in text
+
+    def test_assign_numbers_unit_level(self):
+        """_assign_numbers with unannotated_only preserves existing refs."""
+        symbols = [
+            {"reference": "R1", "prefix": "R", "number": 1, "unit_suffix": ""},
+            {"reference": "R5", "prefix": "R", "number": 5, "unit_suffix": ""},
+            {"reference": "R?", "prefix": "R", "number": None, "unit_suffix": "",
+             "uuid": "uuid-rq"},
+        ]
+        raw = _assign_numbers(symbols, None, 1, unannotated_only=True)
+        # Only the unannotated ref should be in the mapping
+        assert len(raw) == 1
+        assert raw["uuid-rq"]["old"] == "R?"
+        # Should get R2 (1 and 5 are reserved, next available from 1 is 2)
+        assert raw["uuid-rq"]["new"] == "R2"
+        assert raw["uuid-rq"]["unannotated"] is True
+
+    def test_per_sheet_mode(self, tmp_path):
+        """--unannotated-only with --per-sheet scopes reserved numbers per sheet."""
+        # Create a parent with R1 assigned and a child with R? unannotated
+        parent_sch = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet
+\t\t(at 150 50)
+\t\t(size 20 20)
+\t\t(property "Sheetname" "SubSheet"
+\t\t\t(at 150 48 0)
+\t\t)
+\t\t(property "Sheetfile" "sub.kicad_sch"
+\t\t\t(at 150 68 0)
+\t\t)
+\t\t(uuid "33333333-3333-3333-3333-333333333333")
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+        child_sch = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "44444444-4444-4444-4444-444444444444")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R?"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "4.7k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "55555555-5555-5555-5555-555555555555")
+\t\t(instances
+\t\t\t(project ""
+\t\t\t\t(path "/00000000-0000-0000-0000-000000000001/33333333-3333-3333-3333-333333333333" (reference "R?") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/33333333-3333-3333-3333-333333333333" (page "2"))
+\t)
+)
+"""
+        parent = tmp_path / "parent.kicad_sch"
+        parent.write_text(parent_sch)
+        child = tmp_path / "sub.kicad_sch"
+        child.write_text(child_sch)
+
+        ret = run_re_annotate(
+            schematic_path=parent, dry_run=False, backup=False,
+            per_sheet=True, unannotated_only=True,
+        )
+        assert ret == 0
+
+        parent_text = parent.read_text()
+        child_text = child.read_text()
+
+        # Parent: R1 stays R1 (already assigned, unannotated_only)
+        assert '"Reference" "R1"' in parent_text
+
+        # Child: R? gets assigned R1 (per-sheet restart, no reserved in child sheet)
+        assert '"Reference" "R1"' in child_text
+        assert '"Reference" "R?"' not in child_text


### PR DESCRIPTION
## Summary
Add `--unannotated-only` flag to the `sch re-annotate` command. When enabled, only unannotated (`?`) references receive new numbers; already-assigned designators are preserved and their numbers are reserved to prevent collisions.

## Changes
- Add `unannotated_only` parameter to `run_re_annotate()`, `_build_continuous_mapping()`, `_build_per_sheet_mapping()`, and `_assign_numbers()`
- Add `_assign_numbers_unannotated_only()` helper that collects existing numbers into a reserved set and assigns new numbers that skip over reserved values
- Add `--unannotated-only` CLI flag to both `parser.py` and the standalone `main()` entry point
- Pass `unannotated_only` through the command dispatch in `schematic.py`
- Add 7 new tests covering: skips assigned, avoids collisions, no unannotated refs, prefix filter combo, start-from combo, unit-level assign_numbers, and per-sheet mode

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--unannotated-only` flag added to CLI | Done | Added to `parser.py`, `sch_re_annotate.py main()`, and `schematic.py` dispatch |
| Assigned refs preserved when flag is set | Done | `test_skips_assigned` verifies R1 stays R1 |
| New numbers avoid collisions with existing | Done | `test_avoids_collisions` verifies R? becomes R3 when R1,R2 exist |
| No changes when all refs assigned | Done | `test_no_unannotated` verifies "No references to renumber" output |
| Works with `--prefix` filter | Done | `test_with_prefix_filter` verifies C? stays when only R prefix selected |
| Works with `--per-sheet` mode | Done | `test_per_sheet_mode` verifies per-sheet scoping of reserved numbers |
| Works with `--start-from` | Done | `test_with_start_from` verifies start value respected |

## Test Plan
All 52 tests pass (45 existing + 7 new):
```
python3 -m pytest tests/test_sch_re_annotate.py -v -o "addopts="
```

Closes #1916