### PR TITLE
feat(validate): add check for symbols missing project instances blocks

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -499,7 +499,7 @@ def check_missing_project_instances(schematic_path: str) -> list[ValidationIssue
     - Power symbols (``lib_id`` starting with ``power:``)
     - Symbols with both ``in_bom=no`` and ``on_board=no`` (graphical-only)
 
-    Multi-unit symbols are deduplicated by UUID prefix so that a missing
+    Multi-unit symbols are deduplicated by (reference, lib_id) so that a missing
     ``instances`` block on a two-unit IC produces a single warning, not one
     per unit.
     """

--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -487,6 +487,104 @@ def check_global_label_directions(schematic_path: str) -> list[ValidationIssue]:
     return issues
 
 
+def check_missing_project_instances(schematic_path: str) -> list[ValidationIssue]:
+    """Check for symbols missing the ``instances`` block.
+
+    In KiCad 8+, every placed symbol must have an ``(instances ...)`` child
+    node that registers it to a project path.  Without this block the
+    component is invisible to the netlist exporter and BOM generator despite
+    being visually present on the schematic.
+
+    The check skips:
+    - Power symbols (``lib_id`` starting with ``power:``)
+    - Symbols with both ``in_bom=no`` and ``on_board=no`` (graphical-only)
+
+    Multi-unit symbols are deduplicated by UUID prefix so that a missing
+    ``instances`` block on a two-unit IC produces a single warning, not one
+    per unit.
+    """
+    issues: list[ValidationIssue] = []
+
+    try:
+        hierarchy = build_hierarchy(schematic_path)
+
+        for node in hierarchy.all_nodes():
+            try:
+                sch = Schematic.load(node.path)
+                # Track UUIDs already flagged to deduplicate multi-unit ICs.
+                # Multi-unit symbols share the same base UUID (only the first
+                # unit carries the instances block in the raw file, but after
+                # parsing each unit becomes a separate SymbolInstance sharing
+                # the same lib_id + reference).  Deduplicate by reference +
+                # lib_id so we report once per logical component.
+                seen: set[tuple[str, str]] = set()
+
+                for sym in sch.symbols:
+                    # Skip power symbols
+                    if sym.lib_id.startswith("power:"):
+                        continue
+
+                    # Skip graphical-only symbols (not in BOM and not on board)
+                    if not sym.in_bom and not sym.on_board:
+                        continue
+
+                    # Deduplicate multi-unit symbols
+                    dedup_key = (sym.reference, sym.lib_id)
+                    if dedup_key in seen:
+                        continue
+
+                    # Check for instances block in raw S-expression
+                    has_instances = False
+                    if sym._sexp is not None:
+                        if sym._sexp.find("instances") is not None:
+                            has_instances = True
+                    else:
+                        # Programmatically-created symbol without _sexp:
+                        # skip with info if desired, but don't flag as missing
+                        continue
+
+                    if not has_instances:
+                        seen.add(dedup_key)
+                        ref = sym.reference or "?"
+                        val = sym.value or "?"
+                        issues.append(
+                            ValidationIssue(
+                                severity="warning",
+                                category="project_instances",
+                                message=(
+                                    f"Missing project instances block: "
+                                    f"{ref} ({val}) - will be absent from "
+                                    f"netlist and BOM"
+                                ),
+                                location=node.get_path_string(),
+                            )
+                        )
+                    else:
+                        # Mark as seen even when instances are present, so
+                        # other units of the same IC don't get flagged.
+                        seen.add(dedup_key)
+            except Exception as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="project_instances",
+                        message=f"Skipped sheet {node.get_path_string()}: {e}",
+                        location=node.get_path_string(),
+                    )
+                )
+
+    except Exception as e:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                category="project_instances",
+                message=f"Project instances check failed: {e}",
+            )
+        )
+
+    return issues
+
+
 def validate_schematic(schematic_path: str, lib_paths: list[str] = None) -> ValidationResult:
     """Run all validation checks."""
     result = ValidationResult(schematic=schematic_path)
@@ -514,6 +612,10 @@ def validate_schematic(schematic_path: str, lib_paths: list[str] = None) -> Vali
     # Global label directions
     result.checks_run.append("global_label_directions")
     result.issues.extend(check_global_label_directions(schematic_path))
+
+    # Missing project instances
+    result.checks_run.append("project_instances")
+    result.issues.extend(check_missing_project_instances(schematic_path))
 
     return result
 

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -2098,3 +2098,190 @@ class TestSchRenameSignal:
         # Should find sheet pins and hierarchical labels
         assert "VCC" in captured.out
         assert "VCC_3V3" in captured.out
+
+
+class TestSchValidateMissingProjectInstances:
+    """Tests for check_missing_project_instances in sch_validate.py."""
+
+    # -- helpers ----------------------------------------------------------
+
+    _BASE_SYMBOL = """\
+  (symbol
+    (lib_id "{lib_id}")
+    (at 100 100 0)
+    (unit {unit})
+    (in_bom {in_bom})
+    (on_board {on_board})
+    (dnp no)
+    (uuid "{uuid}")
+    (property "Reference" "{ref}" (at 100 90 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Value" "{value}" (at 100 110 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Footprint" "" (at 100 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 100 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-f00000000001"))
+    (pin "2" (uuid "00000000-0000-0000-0000-f00000000002"))
+{instances}  )"""
+
+    _INSTANCES_BLOCK = """\
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "{ref}")
+          (unit {unit})
+        )
+      )
+    )
+"""
+
+    def _make_schematic(
+        self,
+        tmp_path: Path,
+        *,
+        lib_id: str = "Device:R",
+        ref: str = "R1",
+        value: str = "100k",
+        include_instances: bool = True,
+        in_bom: str = "yes",
+        on_board: str = "yes",
+        uuid: str = "00000000-0000-0000-0000-000000000002",
+        unit: int = 1,
+        extra_symbols: str = "",
+    ) -> Path:
+        instances = ""
+        if include_instances:
+            instances = self._INSTANCES_BLOCK.format(ref=ref, unit=unit)
+        sym = self._BASE_SYMBOL.format(
+            lib_id=lib_id,
+            ref=ref,
+            value=value,
+            in_bom=in_bom,
+            on_board=on_board,
+            uuid=uuid,
+            unit=unit,
+            instances=instances,
+        )
+        sch_text = f"""(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols)
+{sym}
+{extra_symbols}
+)"""
+        sch_file = tmp_path / "test_inst.kicad_sch"
+        sch_file.write_text(sch_text)
+        return sch_file
+
+    # -- tests ------------------------------------------------------------
+
+    def test_symbol_without_instances_flagged(self, tmp_path: Path):
+        """A symbol missing its instances block should produce a warning."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        sch_file = self._make_schematic(tmp_path, include_instances=False)
+        issues = check_missing_project_instances(str(sch_file))
+
+        assert len(issues) == 1
+        assert issues[0].severity == "warning"
+        assert issues[0].category == "project_instances"
+        assert "R1" in issues[0].message
+        assert "100k" in issues[0].message
+
+    def test_power_symbol_not_flagged(self, tmp_path: Path):
+        """Power symbols should never be reported."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        sch_file = self._make_schematic(
+            tmp_path,
+            lib_id="power:GND",
+            ref="#PWR01",
+            value="GND",
+            include_instances=False,
+        )
+        issues = check_missing_project_instances(str(sch_file))
+
+        assert len(issues) == 0
+
+    def test_in_bom_false_on_board_false_skipped(self, tmp_path: Path):
+        """Symbols with both in_bom=no and on_board=no should be skipped."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        sch_file = self._make_schematic(
+            tmp_path,
+            include_instances=False,
+            in_bom="no",
+            on_board="no",
+        )
+        issues = check_missing_project_instances(str(sch_file))
+
+        assert len(issues) == 0
+
+    def test_symbol_with_valid_instances_clean(self, tmp_path: Path):
+        """A symbol with a valid instances block should produce no issues."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        sch_file = self._make_schematic(tmp_path, include_instances=True)
+        issues = check_missing_project_instances(str(sch_file))
+
+        assert len(issues) == 0
+
+    def test_multi_unit_ic_flagged_once(self, tmp_path: Path):
+        """A two-unit IC with both units missing instances produces one warning."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        # Build a second unit of the same IC (same ref + lib_id, different uuid)
+        unit2 = self._BASE_SYMBOL.format(
+            lib_id="Device:R",
+            ref="R1",
+            value="100k",
+            in_bom="yes",
+            on_board="yes",
+            uuid="00000000-0000-0000-0000-000000000099",
+            unit=2,
+            instances="",
+        )
+        sch_file = self._make_schematic(
+            tmp_path,
+            include_instances=False,
+            extra_symbols=unit2,
+        )
+        issues = check_missing_project_instances(str(sch_file))
+
+        assert len(issues) == 1
+        assert "R1" in issues[0].message
+
+    def test_validate_schematic_includes_project_instances_check(self, tmp_path: Path):
+        """validate_schematic should include project_instances in checks_run."""
+        from kicad_tools.cli.sch_validate import validate_schematic
+
+        sch_file = self._make_schematic(tmp_path, include_instances=False)
+        result = validate_schematic(str(sch_file))
+
+        assert "project_instances" in result.checks_run
+        pi_issues = [i for i in result.issues if i.category == "project_instances"]
+        assert len(pi_issues) == 1
+
+    def test_json_output_includes_project_instances(
+        self, tmp_path: Path, capsys, monkeypatch
+    ):
+        """JSON output should include the project_instances category."""
+        from kicad_tools.cli.sch_validate import main
+
+        sch_file = self._make_schematic(tmp_path, include_instances=False)
+        monkeypatch.setattr(
+            "sys.argv", ["sch-validate", str(sch_file), "--format", "json"]
+        )
+        with contextlib.suppress(SystemExit):
+            main()
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        pi_issues = [i for i in data["issues"] if i["category"] == "project_instances"]
+        assert len(pi_issues) == 1
+        assert pi_issues[0]["severity"] == "warning"


### PR DESCRIPTION
## Summary
Add a new validation check that detects KiCad 8 schematic symbols missing the `(instances ...)` block. Without this block, components are invisible to the netlist exporter and BOM generator despite being visually present, which is what silently dropped R7 from the chorus-test-revA netlist.

## Changes
- Add `check_missing_project_instances()` function in `sch_validate.py` that walks the schematic hierarchy and flags symbols missing the `instances` S-expression node as `warning` severity
- Wire the new check into `validate_schematic()` so it runs as part of the standard validation pipeline
- Skip power symbols (`lib_id` starting with `power:`) since they never need instances blocks
- Skip graphical-only symbols (`in_bom=no` + `on_board=no`)
- Deduplicate multi-unit ICs by reference + lib_id to produce one warning per logical component
- Add `TestSchValidateMissingProjectInstances` test class with 7 tests covering all acceptance criteria

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Symbol without instances block produces warning | Pass | `test_symbol_without_instances_flagged` |
| Power symbols are never reported | Pass | `test_power_symbol_not_flagged` |
| in_bom=no + on_board=no symbols are skipped | Pass | `test_in_bom_false_on_board_false_skipped` |
| Symbol with valid instances produces no issues | Pass | `test_symbol_with_valid_instances_clean` |
| Multi-unit IC flagged once, not per unit | Pass | `test_multi_unit_ic_flagged_once` |
| project_instances included in checks_run | Pass | `test_validate_schematic_includes_project_instances_check` |
| JSON output includes project_instances category | Pass | `test_json_output_includes_project_instances` |

## Test Plan
All 7 new tests pass. The 1 pre-existing failure in `TestSchSummary::test_existing_hierarchical_fixture_aggregation` is unrelated (counts mismatch in hierarchical fixture).

```
tests/test_cli_sch.py::TestSchValidateMissingProjectInstances - 7 passed
```

Closes #1926