### PR TITLE
feat(sch): add --include-power flag to re-annotate for #PWR?/#FLG? symbols

### DIFF
--- a/src/kicad_tools/cli/sch_re_annotate.py
+++ b/src/kicad_tools/cli/sch_re_annotate.py
@@ -32,10 +32,27 @@ from kicad_tools.cli.modify_schematic import create_backup
 from kicad_tools.cli.sch_set_footprint import _collect_schematic_files
 
 # Prefixes for power/flag symbols that should be excluded from renumbering
+# by default.  When ``include_power=True`` is passed, ``#PWR`` and ``#FLG``
+# are allowed through; ``#SYM`` is always excluded (internal KiCad artifact).
 EXCLUDED_PREFIXES = {"#PWR", "#FLG", "#SYM"}
+
+# Prefixes that may be included when ``--include-power`` is active.
+_POWER_PREFIXES = {"#PWR", "#FLG"}
 
 # Whitespace token for regex: matches one or more tabs or spaces
 _WS = r'[ \t]+'
+
+
+def _format_reference(prefix: str, number: int, unit_suffix: str = "") -> str:
+    """Format a reference designator, applying zero-padding for power prefixes.
+
+    KiCad uses 2-digit zero-padded numbers for power symbols
+    (``#PWR01``, ``#FLG01``, ``#PWR12``).  All other prefixes use
+    plain integers (``R1``, ``C10``).
+    """
+    if prefix in _POWER_PREFIXES:
+        return f"{prefix}{number:02d}{unit_suffix}"
+    return f"{prefix}{number}{unit_suffix}"
 
 
 def _detect_indent(text: str) -> str:
@@ -345,6 +362,7 @@ def run_re_annotate(
     per_sheet: bool = False,
     format: str = "text",
     unannotated_only: bool = False,
+    include_power: bool = False,
 ) -> int:
     """Run the re-annotate operation.
 
@@ -358,6 +376,8 @@ def run_re_annotate(
         format: Output format ("text" or "json").
         unannotated_only: If True, only assign numbers to unannotated (``?``)
             references, leaving already-assigned references unchanged.
+        include_power: If True, also annotate ``#PWR?`` and ``#FLG?`` power
+            symbols (excluded by default).
 
     Returns:
         0 on success, 1 on error.
@@ -399,11 +419,13 @@ def run_re_annotate(
         uuid_mapping = _build_per_sheet_mapping(
             all_files, file_symbols, prefixes, start_from,
             unannotated_only=unannotated_only,
+            include_power=include_power,
         )
     else:
         uuid_mapping = _build_continuous_mapping(
             all_files, file_symbols, prefixes, start_from,
             unannotated_only=unannotated_only,
+            include_power=include_power,
         )
 
     if not uuid_mapping:
@@ -551,6 +573,7 @@ def _build_continuous_mapping(
     start_from: int,
     *,
     unannotated_only: bool = False,
+    include_power: bool = False,
 ) -> dict[str, dict]:
     """Build a continuous UUID-keyed mapping across all files.
 
@@ -568,7 +591,8 @@ def _build_continuous_mapping(
         ordered_symbols.extend(syms_sorted)
 
     return _assign_numbers(ordered_symbols, prefixes, start_from,
-                           unannotated_only=unannotated_only)
+                           unannotated_only=unannotated_only,
+                           include_power=include_power)
 
 
 def _build_per_sheet_mapping(
@@ -578,6 +602,7 @@ def _build_per_sheet_mapping(
     start_from: int,
     *,
     unannotated_only: bool = False,
+    include_power: bool = False,
 ) -> dict[str, dict]:
     """Build a per-sheet UUID-keyed mapping, restarting numbering per file."""
     mapping: dict[str, dict] = {}
@@ -586,7 +611,8 @@ def _build_per_sheet_mapping(
         syms = file_symbols[sch_file]
         syms_sorted = sorted(syms, key=lambda s: (s["position_y"], s["position_x"]))
         sheet_mapping = _assign_numbers(syms_sorted, prefixes, start_from,
-                                        unannotated_only=unannotated_only)
+                                        unannotated_only=unannotated_only,
+                                        include_power=include_power)
         mapping.update(sheet_mapping)
 
     return mapping
@@ -598,6 +624,7 @@ def _assign_numbers(
     start_from: int,
     *,
     unannotated_only: bool = False,
+    include_power: bool = False,
 ) -> dict[str, dict]:
     """Assign sequential numbers to symbols, handling multi-unit components.
 
@@ -609,6 +636,9 @@ def _assign_numbers(
     references are left unchanged and their numbers are reserved so that
     new assignments do not collide with them.
 
+    When *include_power* is ``True``, ``#PWR`` and ``#FLG`` prefixes are
+    no longer excluded, allowing power/flag symbols to be annotated.
+
     Returns:
         Dict mapping UUID -> {"old": str, "new": str, "unannotated": bool}.
     """
@@ -617,6 +647,7 @@ def _assign_numbers(
     if unannotated_only:
         return _assign_numbers_unannotated_only(
             symbols, prefixes, start_from,
+            include_power=include_power,
         )
 
     # Track next number per prefix
@@ -633,7 +664,8 @@ def _assign_numbers(
 
         # Skip excluded prefixes (power symbols, flags, ground symbols)
         if prefix in EXCLUDED_PREFIXES or prefix.startswith("#"):
-            continue
+            if not (include_power and prefix in _POWER_PREFIXES):
+                continue
 
         # Skip if prefix filter is active and this prefix isn't included
         if prefixes is not None and prefix not in prefixes:
@@ -650,11 +682,11 @@ def _assign_numbers(
                 new_number = counters.get(prefix, start_from)
                 counters[prefix] = new_number + 1
                 multi_unit_assigned[key] = new_number
-            new_ref = f"{prefix}{new_number}{unit_suffix}"
+            new_ref = _format_reference(prefix, new_number, unit_suffix)
         else:
             new_number = counters.get(prefix, start_from)
             counters[prefix] = new_number + 1
-            new_ref = f"{prefix}{new_number}"
+            new_ref = _format_reference(prefix, new_number)
 
         mapping[sym_uuid] = {
             "old": ref,
@@ -669,6 +701,8 @@ def _assign_numbers_unannotated_only(
     symbols: list[dict],
     prefixes: list[str] | None,
     start_from: int,
+    *,
+    include_power: bool = False,
 ) -> dict[str, dict]:
     """Assign numbers only to unannotated symbols, preserving existing refs.
 
@@ -676,10 +710,21 @@ def _assign_numbers_unannotated_only(
     new sequential numbers to unannotated (``?``) symbols while skipping
     over reserved numbers.
 
+    When *include_power* is ``True``, ``#PWR`` and ``#FLG`` prefixes are
+    no longer excluded.
+
     Returns:
         Dict mapping UUID -> {"old": str, "new": str, "unannotated": bool}.
     """
     mapping: dict[str, dict] = {}
+
+    def _is_excluded(prefix: str) -> bool:
+        """Return True if *prefix* should be skipped."""
+        if prefix in EXCLUDED_PREFIXES or prefix.startswith("#"):
+            if include_power and prefix in _POWER_PREFIXES:
+                return False
+            return True
+        return False
 
     # Phase 1: Collect existing (reserved) numbers per prefix
     existing: dict[str, set[int]] = {}
@@ -691,7 +736,7 @@ def _assign_numbers_unannotated_only(
         number = sym["number"]
         unit_suffix = sym["unit_suffix"]
 
-        if prefix in EXCLUDED_PREFIXES or prefix.startswith("#"):
+        if _is_excluded(prefix):
             continue
         if prefixes is not None and prefix not in prefixes:
             continue
@@ -717,7 +762,7 @@ def _assign_numbers_unannotated_only(
         unit_suffix = sym["unit_suffix"]
         sym_uuid = sym.get("uuid") or ref
 
-        if prefix in EXCLUDED_PREFIXES or prefix.startswith("#"):
+        if _is_excluded(prefix):
             continue
         if prefixes is not None and prefix not in prefixes:
             continue
@@ -734,10 +779,10 @@ def _assign_numbers_unannotated_only(
             else:
                 new_number = _next_available(prefix)
                 multi_unit_assigned[key] = new_number
-            new_ref = f"{prefix}{new_number}{unit_suffix}"
+            new_ref = _format_reference(prefix, new_number, unit_suffix)
         else:
             new_number = _next_available(prefix)
-            new_ref = f"{prefix}{new_number}"
+            new_ref = _format_reference(prefix, new_number)
 
         mapping[sym_uuid] = {
             "old": ref,
@@ -785,6 +830,11 @@ def main(argv: list[str] | None = None):
         help="Only assign numbers to unannotated (?) references, leaving existing ones unchanged",
     )
     parser.add_argument(
+        "--include-power",
+        action="store_true",
+        help="Also annotate unannotated #PWR? and #FLG? power symbols",
+    )
+    parser.add_argument(
         "--format",
         choices=["text", "json"],
         default="text",
@@ -806,6 +856,7 @@ def main(argv: list[str] | None = None):
         per_sheet=args.per_sheet,
         format=args.format,
         unannotated_only=args.unannotated_only,
+        include_power=args.include_power,
     )
 
 

--- a/tests/test_sch_re_annotate.py
+++ b/tests/test_sch_re_annotate.py
@@ -21,6 +21,7 @@ from kicad_tools.cli.sch_re_annotate import (
     _detect_indent,
     _detect_project_info,
     _extract_symbols_from_text,
+    _format_reference,
     _parse_reference,
     run_re_annotate,
 )
@@ -1544,3 +1545,287 @@ class TestUnannotatedOnly:
         # Child: R? gets assigned R1 (per-sheet restart, no reserved in child sheet)
         assert '"Reference" "R1"' in child_text
         assert '"Reference" "R?"' not in child_text
+
+
+# ---------------------------------------------------------------------------
+# --include-power flag tests
+# ---------------------------------------------------------------------------
+
+# Schematic with unannotated power and flag symbols
+POWER_UNANNOTATED_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "R1") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "power:+5V")
+\t\t(at 100 30 0)
+\t\t(property "Reference" "#PWR?"
+\t\t\t(at 100 26 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(property "Value" "+5V"
+\t\t\t(at 100 23 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 30 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+\t\t(instances
+\t\t\t(project ""
+\t\t\t\t(path "/00000000-0000-0000-0000-000000000001" (reference "#PWR?") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "power:PWR_FLAG")
+\t\t(at 120 30 0)
+\t\t(property "Reference" "#FLG?"
+\t\t\t(at 120 26 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(property "Value" "PWR_FLAG"
+\t\t\t(at 120 23 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 120 30 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "bbbb1111-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+\t\t(instances
+\t\t\t(project ""
+\t\t\t\t(path "/00000000-0000-0000-0000-000000000001" (reference "#FLG?") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+# Schematic with existing #PWR01 and unannotated #PWR?
+POWER_COLLISION_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "power:GND")
+\t\t(at 100 70 0)
+\t\t(property "Reference" "#PWR01"
+\t\t\t(at 100 76 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(property "Value" "GND"
+\t\t\t(at 100 73 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 70 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "44444444-4444-4444-4444-444444444444")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "#PWR01") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(symbol
+\t\t(lib_id "power:+5V")
+\t\t(at 100 30 0)
+\t\t(property "Reference" "#PWR?"
+\t\t\t(at 100 26 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(property "Value" "+5V"
+\t\t\t(at 100 23 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 30 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+\t\t(instances
+\t\t\t(project ""
+\t\t\t\t(path "/00000000-0000-0000-0000-000000000001" (reference "#PWR?") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+
+class TestFormatReference:
+    def test_normal_prefix(self):
+        assert _format_reference("R", 1) == "R1"
+        assert _format_reference("C", 10) == "C10"
+
+    def test_power_prefix_zero_padded(self):
+        assert _format_reference("#PWR", 1) == "#PWR01"
+        assert _format_reference("#PWR", 10) == "#PWR10"
+        assert _format_reference("#PWR", 99) == "#PWR99"
+        assert _format_reference("#PWR", 100) == "#PWR100"
+
+    def test_flag_prefix_zero_padded(self):
+        assert _format_reference("#FLG", 1) == "#FLG01"
+        assert _format_reference("#FLG", 12) == "#FLG12"
+
+    def test_unit_suffix(self):
+        assert _format_reference("U", 1, "A") == "U1A"
+        assert _format_reference("#PWR", 1, "") == "#PWR01"
+
+
+class TestIncludePower:
+    def test_power_symbols_annotated_with_flag(self, tmp_path):
+        """--include-power annotates #PWR? and #FLG? symbols."""
+        sch = _write_sch(tmp_path, POWER_UNANNOTATED_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False,
+            include_power=True,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        # Power and flag symbols should be annotated with zero-padding
+        assert '"Reference" "#PWR01"' in text
+        assert '"Reference" "#FLG01"' in text
+        assert '"Reference" "#PWR?"' not in text
+        assert '"Reference" "#FLG?"' not in text
+        # R1 should still be present (renumbered to R1)
+        assert '"Reference" "R1"' in text
+
+    def test_power_symbols_excluded_without_flag(self, tmp_path):
+        """Without --include-power, #PWR? and #FLG? remain unannotated."""
+        sch = _write_sch(tmp_path, POWER_UNANNOTATED_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False,
+            include_power=False,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        # Power/flag symbols should remain unannotated
+        assert '"Reference" "#PWR?"' in text
+        assert '"Reference" "#FLG?"' in text
+
+    def test_power_annotation_collision_avoidance(self, tmp_path):
+        """#PWR? avoids collision with existing #PWR01."""
+        sch = _write_sch(tmp_path, POWER_COLLISION_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False,
+            unannotated_only=True, include_power=True,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        # Existing #PWR01 should remain unchanged
+        assert '"Reference" "#PWR01"' in text
+        # #PWR? should become #PWR02 (avoiding collision with 01)
+        assert '"Reference" "#PWR02"' in text
+        assert '"Reference" "#PWR?"' not in text
+
+    def test_power_annotation_zero_padding(self):
+        """Number 1 produces #PWR01, number 10 produces #PWR10."""
+        symbols = [
+            {"reference": "#PWR?", "prefix": "#PWR", "number": None,
+             "unit_suffix": "", "uuid": "uuid-pwr1"},
+        ]
+        raw = _assign_numbers(symbols, None, 1, include_power=True)
+        assert raw["uuid-pwr1"]["new"] == "#PWR01"
+
+        symbols2 = [
+            {"reference": "#PWR?", "prefix": "#PWR", "number": None,
+             "unit_suffix": "", "uuid": "uuid-pwr1"},
+        ]
+        raw2 = _assign_numbers(symbols2, None, 10, include_power=True)
+        assert raw2["uuid-pwr1"]["new"] == "#PWR10"
+
+    def test_include_power_without_unannotated_only(self, tmp_path):
+        """Full renumber mode with --include-power re-sequences power symbols."""
+        sch = _write_sch(tmp_path, POWER_COLLISION_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False,
+            include_power=True,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        # Both power symbols should be sequentially numbered
+        assert '"Reference" "#PWR01"' in text
+        assert '"Reference" "#PWR02"' in text
+        assert '"Reference" "#PWR?"' not in text
+
+    def test_sym_prefix_always_excluded(self):
+        """#SYM symbols are never annotated even with --include-power."""
+        symbols = [
+            {"reference": "#SYM1", "prefix": "#SYM", "number": 1,
+             "unit_suffix": ""},
+            {"reference": "R3", "prefix": "R", "number": 3, "unit_suffix": ""},
+        ]
+        mapping = _old_new_map(_assign_numbers(symbols, None, 1,
+                                               include_power=True))
+        assert "#SYM1" not in mapping
+        assert mapping["R3"] == "R1"
+
+    def test_json_output_includes_power_mappings(self, tmp_path, capsys):
+        """--format json output includes power symbol mappings."""
+        sch = _write_sch(tmp_path, POWER_UNANNOTATED_SCHEMATIC)
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=True, backup=False,
+            format="json", include_power=True,
+        )
+        assert ret == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        new_refs = {m["new"] for m in data["mappings"]}
+        assert "#PWR01" in new_refs
+        assert "#FLG01" in new_refs
+
+    def test_unannotated_only_without_include_power_skips_power(self, tmp_path):
+        """--unannotated-only without --include-power skips #PWR? symbols."""
+        sch = _write_sch(tmp_path, POWER_UNANNOTATED_SCHEMATIC)
+        original = sch.read_text()
+        ret = run_re_annotate(
+            schematic_path=sch, dry_run=False, backup=False,
+            unannotated_only=True, include_power=False,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        # Power symbols remain unannotated
+        assert '"Reference" "#PWR?"' in text
+        assert '"Reference" "#FLG?"' in text


### PR DESCRIPTION
## Summary
Add an opt-in `--include-power` CLI flag to `sch re-annotate` that enables annotation of unannotated `#PWR?` and `#FLG?` power symbols. Previously these were always excluded from re-annotation.

## Changes
- Add `_POWER_PREFIXES` constant and `_format_reference()` helper for zero-padded power symbol formatting (`#PWR01`, `#FLG01`)
- Add `include_power: bool` parameter threaded through `run_re_annotate()`, `_build_continuous_mapping()`, `_build_per_sheet_mapping()`, `_assign_numbers()`, and `_assign_numbers_unannotated_only()`
- Update exclusion checks to conditionally allow `#PWR`/`#FLG` through when `include_power=True` (while always excluding `#SYM`)
- Add `--include-power` CLI argument in `main()`
- Add 8 new tests covering annotation, exclusion, collision avoidance, zero-padding, full renumber, `#SYM` exclusion, and JSON output

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `sch re-annotate --unannotated-only --include-power` assigns references to #PWR? and #FLG? symbols | Pass | `test_power_symbols_annotated_with_flag` and `test_power_annotation_collision_avoidance` |
| Assigned numbers don't conflict with existing #PWR/#FLG references | Pass | `test_power_annotation_collision_avoidance` verifies existing #PWR01 is preserved and #PWR? becomes #PWR02 |
| Test coverage for power symbol annotation | Pass | 8 new tests in `TestFormatReference` and `TestIncludePower` classes |

## Test Plan
All 87 tests pass (79 existing + 8 new):
```
python3 -m pytest tests/test_sch_re_annotate.py -v -o "addopts=" # 87 passed
```

Closes #1927