### PR TITLE
fix(erc): extract label names from KiCad 10 items array

### DIFF
--- a/src/kicad_tools/erc/cross_sheet.py
+++ b/src/kicad_tools/erc/cross_sheet.py
@@ -210,21 +210,33 @@ def build_global_label_inventory(root_schematic: str) -> dict[str, set[str]]:
     return dict(inventory)
 
 
-def _extract_label_name(description: str) -> str | None:
+def _extract_label_name(description: str, items: list[dict] | None = None) -> str | None:
     """Extract a label name from a KiCad ERC violation description.
 
-    KiCad formats these descriptions in several ways:
+    KiCad formats these descriptions in several ways depending on the
+    version:
+
+    **Older KiCad (label name in top-level description)**:
 
     * ``Label 'AUDIO_L' appears only once in the design``
-    * ``Pin connected to only other pins or labels on the sheet``
-      (followed by items that contain the label name)
     * ``Global label 'AUDIO_L' is not connected anywhere else in the
       schematic``
+
+    **KiCad 10+ (label name in items, not top-level description)**:
+
+    * Top-level: ``Label connected to only one pin``
+    * Item:      ``Global Label 'AUDIO_L'``
+
+    Args:
+        description: The violation's top-level description string.
+        items: Optional list of item dicts from the violation.  Each
+            dict may contain a ``"description"`` key with the label
+            name (e.g. ``"Global Label 'AUDIO_L'"``)
 
     Returns the extracted label name, or ``None`` if no label name
     could be parsed.
     """
-    # Match quoted label name patterns
+    # Match quoted label name patterns in the top-level description
     m = re.search(r"[Ll]abel\s+'([^']+)'", description)
     if m:
         return m.group(1)
@@ -232,6 +244,18 @@ def _extract_label_name(description: str) -> str | None:
     m = re.search(r'"([^"]+)"', description)
     if m:
         return m.group(1)
+
+    # KiCad 10+ puts the label name in the items array instead of the
+    # top-level description.  Scan item descriptions for a quoted name.
+    if items:
+        for item in items:
+            item_desc = item.get("description", "")
+            m = re.search(r"[Ll]abel\s+'([^']+)'", item_desc)
+            if m:
+                return m.group(1)
+            m = re.search(r'"([^"]+)"', item_desc)
+            if m:
+                return m.group(1)
 
     return None
 
@@ -279,7 +303,9 @@ def filter_cross_sheet_global_labels(
             filtered.append(v)
             continue
 
-        label_name = _extract_label_name(v.get("description", ""))
+        label_name = _extract_label_name(
+            v.get("description", ""), v.get("items")
+        )
         if label_name is None:
             # Could not parse label name -- keep the violation to be safe.
             filtered.append(v)

--- a/tests/test_erc_cross_sheet_globals.py
+++ b/tests/test_erc_cross_sheet_globals.py
@@ -102,6 +102,30 @@ class TestExtractLabelName:
         desc = "Label 'NET_3V3' appears only once in the design"
         assert _extract_label_name(desc) == "NET_3V3"
 
+    def test_kicad10_label_in_items_single_quoted(self):
+        """KiCad 10+ puts the label name in items, not the description."""
+        desc = "Global label only appears once in the schematic"
+        items = [{"description": "Global Label 'AUDIO_L'", "pos": {"x": 0, "y": 0}}]
+        assert _extract_label_name(desc, items) == "AUDIO_L"
+
+    def test_kicad10_label_in_items_isolated_pin(self):
+        """KiCad 10+ isolated_pin_label also uses items for the label name."""
+        desc = "Label connected to only one pin"
+        items = [{"description": "Global Label 'SYNC_R'", "pos": {"x": 0, "y": 0}}]
+        assert _extract_label_name(desc, items) == "SYNC_R"
+
+    def test_kicad10_no_items_returns_none(self):
+        """Generic description with no items should return None."""
+        desc = "Label connected to only one pin"
+        assert _extract_label_name(desc) is None
+        assert _extract_label_name(desc, []) is None
+
+    def test_kicad10_items_without_label_returns_none(self):
+        """Items that don't contain a label name should return None."""
+        desc = "Label connected to only one pin"
+        items = [{"description": "Pin 1 of R1", "pos": {"x": 0, "y": 0}}]
+        assert _extract_label_name(desc, items) is None
+
 
 # ---------------------------------------------------------------------------
 # Tests: build_global_label_inventory
@@ -437,3 +461,154 @@ class TestFilterCrossSheetGlobalLabels:
             [], str(tmp_path / "nonexistent.kicad_sch")
         )
         assert result == []
+
+    def _make_kicad10_violation(self, vtype: str, label_name: str) -> dict:
+        """Helper to create a KiCad 10 style violation dict.
+
+        KiCad 10 uses a generic top-level description and puts the
+        specific label name inside the ``items`` array.
+        """
+        if vtype == "single_global_label":
+            desc = "Global label only appears once in the schematic"
+        else:
+            desc = "Label connected to only one pin"
+        return {
+            "type": vtype,
+            "severity": "warning",
+            "description": desc,
+            "items": [
+                {
+                    "description": f"Global Label '{label_name}'",
+                    "pos": {"x": 0, "y": 0},
+                    "uuid": "test-uuid",
+                }
+            ],
+        }
+
+    def test_kicad10_single_global_label_filtered(self, tmp_path: Path):
+        """KiCad 10 format: single_global_label with label in items
+        should be filtered when the label appears on multiple sheets."""
+        sub_file = "sub.kicad_sch"
+
+        root_labels = _make_global_label("AUDIO_L", uuid="gl-root")
+        root_sheets = _make_sheet("Sub", sub_file, uuid="sheet-sub")
+        root_content = _ROOT_WITH_GLOBALS_TEMPLATE.format(
+            global_labels=root_labels, sheets=root_sheets
+        )
+
+        sub_labels = _make_global_label("AUDIO_L", uuid="gl-sub")
+        sub_content = _SUBSHEET_WITH_GLOBALS_TEMPLATE.format(
+            uuid="sub-uuid", global_labels=sub_labels
+        )
+
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+        (tmp_path / sub_file).write_text(sub_content)
+
+        violations = [
+            self._make_kicad10_violation("single_global_label", "AUDIO_L"),
+        ]
+        result = filter_cross_sheet_global_labels(
+            violations, str(tmp_path / "root.kicad_sch")
+        )
+
+        assert len(result) == 0
+
+    def test_kicad10_isolated_pin_label_filtered(self, tmp_path: Path):
+        """KiCad 10 format: isolated_pin_label with label in items
+        should be filtered when the label appears on multiple sheets."""
+        sub_file = "sub.kicad_sch"
+
+        root_labels = _make_global_label("SYNC_R", uuid="gl-root")
+        root_sheets = _make_sheet("Sub", sub_file, uuid="sheet-sub")
+        root_content = _ROOT_WITH_GLOBALS_TEMPLATE.format(
+            global_labels=root_labels, sheets=root_sheets
+        )
+
+        sub_labels = _make_global_label("SYNC_R", uuid="gl-sub")
+        sub_content = _SUBSHEET_WITH_GLOBALS_TEMPLATE.format(
+            uuid="sub-uuid", global_labels=sub_labels
+        )
+
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+        (tmp_path / sub_file).write_text(sub_content)
+
+        violations = [
+            self._make_kicad10_violation("isolated_pin_label", "SYNC_R"),
+        ]
+        result = filter_cross_sheet_global_labels(
+            violations, str(tmp_path / "root.kicad_sch")
+        )
+
+        assert len(result) == 0
+
+    def test_kicad10_mixed_format_chorus_scenario(self, tmp_path: Path):
+        """Reproduce the chorus-test-revA scenario: 8 violations (4
+        isolated_pin_label on root + 4 single_global_label on /Sync/)
+        should all be suppressed when labels exist on multiple sheets."""
+        sync_file = "sync.kicad_sch"
+        dac_file = "dac.kicad_sch"
+
+        labels = ["AUDIO_L", "AUDIO_R", "SYNC_L", "SYNC_R"]
+
+        root_labels = "\n".join(
+            _make_global_label(name, uuid=f"gl-root-{name}") for name in labels
+        )
+        root_sheets = (
+            _make_sheet("Sync", sync_file, uuid="sheet-sync")
+            + _make_sheet("DAC", dac_file, uuid="sheet-dac")
+        )
+        root_content = _ROOT_WITH_GLOBALS_TEMPLATE.format(
+            global_labels=root_labels, sheets=root_sheets
+        )
+
+        sync_labels = "\n".join(
+            _make_global_label(name, uuid=f"gl-sync-{name}") for name in labels
+        )
+        sync_content = _SUBSHEET_WITH_GLOBALS_TEMPLATE.format(
+            uuid="sync-uuid", global_labels=sync_labels
+        )
+
+        dac_labels = "\n".join(
+            _make_global_label(name, uuid=f"gl-dac-{name}") for name in labels
+        )
+        dac_content = _SUBSHEET_WITH_GLOBALS_TEMPLATE.format(
+            uuid="dac-uuid", global_labels=dac_labels
+        )
+
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+        (tmp_path / sync_file).write_text(sync_content)
+        (tmp_path / dac_file).write_text(dac_content)
+
+        # Build violations matching KiCad 10 output format
+        violations = []
+        for name in labels:
+            violations.append(
+                self._make_kicad10_violation("isolated_pin_label", name)
+            )
+            violations.append(
+                self._make_kicad10_violation("single_global_label", name)
+            )
+
+        result = filter_cross_sheet_global_labels(
+            violations, str(tmp_path / "root.kicad_sch")
+        )
+
+        assert len(result) == 0
+
+    def test_kicad10_genuine_single_label_preserved(self, tmp_path: Path):
+        """KiCad 10 format: a label that truly appears on only one
+        sheet should still be reported."""
+        root_labels = _make_global_label("LONELY_NET", uuid="gl-lonely")
+        root_content = _ROOT_WITH_GLOBALS_TEMPLATE.format(
+            global_labels=root_labels, sheets=""
+        )
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+
+        violations = [
+            self._make_kicad10_violation("single_global_label", "LONELY_NET"),
+        ]
+        result = filter_cross_sheet_global_labels(
+            violations, str(tmp_path / "root.kicad_sch")
+        )
+
+        assert len(result) == 1


### PR DESCRIPTION
## Summary

KiCad 10 changed the ERC JSON output format: the specific label name (e.g. `AUDIO_L`) is no longer in the top-level violation `description` field but instead in the `items[].description` field. This caused `_extract_label_name()` to return `None`, preventing the cross-sheet false-positive filter from suppressing per-sheet orphaned label warnings.

## Changes

- Extended `_extract_label_name()` to accept an optional `items` parameter and fall back to scanning item descriptions when the top-level description is generic
- Updated `filter_cross_sheet_global_labels()` to pass `items` data through to `_extract_label_name()`
- Added 8 new tests covering KiCad 10 output format (total: 26 tests, up from 18)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `sch validate` does not report orphaned global labels when matching labels exist in other sheets | PASS | Verified against actual KiCad 10 ERC JSON output from chorus-test-revA board; the filter now correctly parses label names from the items array |
| Test coverage for multi-sheet global label connectivity checking | PASS | 26 tests pass including 8 new KiCad 10 format tests covering single_global_label, isolated_pin_label, chorus-test-revA scenario, and genuine single-label preservation |

## Test Plan

- `python3 -m pytest tests/test_erc_cross_sheet_globals.py -v` -- 26/26 pass
- `python3 -m pytest tests/test_erc_cross_sheet.py -v` -- 8/8 pass
- Verified with actual `kicad-cli sch erc --format json` output from chorus-test-revA board

Closes #1923