### PR TITLE
feat(sch): add add-bypass-cap composite command for decoupling capacitor placement

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -305,8 +305,7 @@ def run_sch_command(args) -> int:
             sub_argv.extend(["--footprint", args.footprint])
         if args.reference:
             sub_argv.extend(["--reference", args.reference])
-        if args.offset != 5.08:
-            sub_argv.extend(["--offset", str(args.offset)])
+        sub_argv.extend(["--offset", str(args.offset)])
         if args.dry_run:
             sub_argv.append("--dry-run")
         if args.backup:

--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -17,8 +17,11 @@ def run_sch_command(args) -> int:
         )
         print(
             "          set-label-direction, add-no-connect, add-component,"
-            " add-wire, add-junction,"
-            " add-label, cleanup-wires, remove-wire, disconnect, re-annotate"
+            " add-bypass-cap, add-wire,"
+        )
+        print(
+            "          add-junction, add-label, cleanup-wires, remove-wire,"
+            " disconnect, re-annotate"
         )
         return 1
 
@@ -289,6 +292,26 @@ def run_sch_command(args) -> int:
         if args.backup:
             sub_argv.append("--backup")
         return add_comp_main(sub_argv) or 0
+
+    elif args.sch_command == "add-bypass-cap":
+        from ..sch_add_bypass_cap import main as add_bypass_main
+
+        sub_argv = [str(schematic_path), "--ref", args.ref, "--pin", args.pin]
+        if args.value:
+            sub_argv.extend(["--value", args.value])
+        if args.ground_net:
+            sub_argv.extend(["--ground-net", args.ground_net])
+        if args.footprint:
+            sub_argv.extend(["--footprint", args.footprint])
+        if args.reference:
+            sub_argv.extend(["--reference", args.reference])
+        if args.offset != 5.08:
+            sub_argv.extend(["--offset", str(args.offset)])
+        if args.dry_run:
+            sub_argv.append("--dry-run")
+        if args.backup:
+            sub_argv.append("--backup")
+        return add_bypass_main(sub_argv) or 0
 
     elif args.sch_command == "add-wire":
         from ..sch_add_wire import main as add_wire_main

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -700,6 +700,47 @@ def _add_sch_parser(subparsers) -> None:
         "--backup", action="store_true", help="Create backup before modifying"
     )
 
+    # sch add-bypass-cap
+    sch_add_bypass = sch_subparsers.add_parser(
+        "add-bypass-cap",
+        help="Add a bypass/decoupling capacitor to an IC power pin",
+    )
+    sch_add_bypass.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_add_bypass.add_argument(
+        "--ref", required=True, help="Target IC reference designator (e.g., U8)"
+    )
+    sch_add_bypass.add_argument(
+        "--pin", required=True, help="Target pin number on that IC (e.g., 4)"
+    )
+    sch_add_bypass.add_argument(
+        "--value", default="100nF", help="Capacitor value (default: 100nF)"
+    )
+    sch_add_bypass.add_argument(
+        "--ground-net",
+        default="GND",
+        help="Ground power symbol name (default: GND)",
+    )
+    sch_add_bypass.add_argument(
+        "--footprint",
+        default="Capacitor_SMD:C_0402_1005Metric",
+        help="Capacitor footprint (default: Capacitor_SMD:C_0402_1005Metric)",
+    )
+    sch_add_bypass.add_argument(
+        "--reference", default=None, help="Capacitor reference (auto-assigned if omitted)"
+    )
+    sch_add_bypass.add_argument(
+        "--offset",
+        type=float,
+        default=5.08,
+        help="Distance from pin to cap body centre in mm (default: 5.08)",
+    )
+    sch_add_bypass.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+    )
+    sch_add_bypass.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+
     # sch add-wire
     sch_add_wire = sch_subparsers.add_parser("add-wire", help="Add wire segments to the schematic")
     sch_add_wire.add_argument("schematic", help="Path to .kicad_sch file")

--- a/src/kicad_tools/cli/sch_add_bypass_cap.py
+++ b/src/kicad_tools/cli/sch_add_bypass_cap.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""
+Add a bypass/decoupling capacitor to an IC power pin in a KiCad schematic.
+
+This is a composite command that places a capacitor, ground power symbol,
+and wires connecting them to a specified IC pin.
+
+Usage:
+    kct sch add-bypass-cap board.kicad_sch --ref U8 --pin 4 \\
+        --value 100nF --ground-net GNDD
+    kct sch add-bypass-cap board.kicad_sch --ref U1 --pin 3 --dry-run
+
+Options:
+    --ref <REF>            Target IC reference designator (e.g., U8)
+    --pin <PIN>            Target pin number on that IC (e.g., 4)
+    --value <VALUE>        Capacitor value (default: 100nF)
+    --ground-net <NET>     Ground power symbol name (default: GND)
+    --footprint <FP>       Capacitor footprint (default: Capacitor_SMD:C_0402_1005Metric)
+    --reference <REF>      Capacitor reference (auto-assigned if omitted)
+    --offset <mm>          Distance from pin to cap body centre (default: 5.08)
+    --dry-run              Preview without modifying
+    --backup               Create timestamped backup before writing
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
+from kicad_tools.schema import Schematic
+from kicad_tools.schema.library import LibrarySymbol
+
+
+@dataclass
+class PlannedAction:
+    """An action the command will take, for reporting."""
+
+    kind: str  # "capacitor", "ground", "wire", "junction", "embed"
+    description: str
+
+
+def _snap(value: float, grid: float = 1.27) -> float:
+    """Snap a coordinate to the nearest grid point."""
+    return round(value / grid) * grid
+
+
+def _point_on_wire_midpoint(
+    point: tuple[float, float],
+    wire_start: tuple[float, float],
+    wire_end: tuple[float, float],
+    tolerance: float = 0.1,
+) -> bool:
+    """Check if a point lies on a wire segment but not at its endpoints."""
+    x, y = point
+
+    # Check if point is at either endpoint
+    for ep in (wire_start, wire_end):
+        if abs(x - ep[0]) < tolerance and abs(y - ep[1]) < tolerance:
+            return False
+
+    # Check if point is on the segment
+    x1, y1 = wire_start
+    x2, y2 = wire_end
+
+    # Bounding box check
+    if not (min(x1, x2) - tolerance <= x <= max(x1, x2) + tolerance):
+        return False
+    if not (min(y1, y2) - tolerance <= y <= max(y1, y2) + tolerance):
+        return False
+
+    # Perpendicular distance check
+    length = ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
+    if length < tolerance:
+        return False
+
+    dist = abs((y2 - y1) * x - (x2 - x1) * y + x2 * y1 - y2 * x1) / length
+    return dist < tolerance
+
+
+def _point_on_wire_segment(
+    point: tuple[float, float],
+    wire_start: tuple[float, float],
+    wire_end: tuple[float, float],
+    tolerance: float = 0.1,
+) -> bool:
+    """Check if a point lies on a wire segment (including endpoints)."""
+    x, y = point
+    x1, y1 = wire_start
+    x2, y2 = wire_end
+
+    # Bounding box check
+    if not (min(x1, x2) - tolerance <= x <= max(x1, x2) + tolerance):
+        return False
+    if not (min(y1, y2) - tolerance <= y <= max(y1, y2) + tolerance):
+        return False
+
+    # Perpendicular distance check
+    length = ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
+    if length < tolerance:
+        return ((x - x1) ** 2 + (y - y1) ** 2) ** 0.5 < tolerance
+
+    dist = abs((y2 - y1) * x - (x2 - x1) * y + x2 * y1 - y2 * x1) / length
+    return dist < tolerance
+
+
+def _auto_reference(sch: Schematic, prefix: str = "C") -> str:
+    """Find the next available reference designator for a given prefix.
+
+    Scans existing symbols and returns ``prefix + (max_N + 1)``
+    where max_N is the highest existing number for that prefix.
+    Falls back to ``prefix + "1"`` if none exist.
+    """
+    max_num = 0
+    pattern = re.compile(rf"^{re.escape(prefix)}(\d+)$")
+    for sym in sch.symbols:
+        ref = sym.reference
+        m = pattern.match(ref)
+        if m:
+            num = int(m.group(1))
+            if num > max_num:
+                max_num = num
+    return f"{prefix}{max_num + 1}"
+
+
+def _compute_cap_offset(
+    pin_rotation: float, offset_distance: float
+) -> tuple[float, float]:
+    """Compute the offset direction for cap placement from a pin.
+
+    Pin rotation in KiCad library symbols:
+      0   = pin points right (stub extends right from IC body)
+      90  = pin points up
+      180 = pin points left
+      270 = pin points down
+
+    The capacitor is placed in the direction the pin stub extends
+    (i.e., away from the IC body, continuing outward from the pin tip).
+
+    Returns (dx, dy) offset from the pin's schematic position.
+    """
+    # Normalize rotation to 0-360
+    rot = pin_rotation % 360
+
+    if abs(rot - 0) < 1:
+        # Pin points right -> place cap to the right
+        return (offset_distance, 0)
+    elif abs(rot - 90) < 1:
+        # Pin points up -> place cap above (negative y in KiCad)
+        return (0, -offset_distance)
+    elif abs(rot - 180) < 1:
+        # Pin points left -> place cap to the left
+        return (-offset_distance, 0)
+    elif abs(rot - 270) < 1:
+        # Pin points down -> place cap below (positive y in KiCad)
+        return (0, offset_distance)
+    else:
+        # Diagonal or non-standard -- default to below
+        return (0, offset_distance)
+
+
+def _compute_ground_offset(
+    pin_rotation: float, cap_offset: tuple[float, float], offset_distance: float
+) -> tuple[float, float]:
+    """Compute ground symbol position relative to pin position.
+
+    The ground symbol is placed beyond the capacitor in the same direction.
+    Total offset = cap_offset + another offset_distance in the same direction.
+    """
+    rot = pin_rotation % 360
+
+    if abs(rot - 0) < 1:
+        return (cap_offset[0] + offset_distance, cap_offset[1])
+    elif abs(rot - 90) < 1:
+        return (cap_offset[0], cap_offset[1] - offset_distance)
+    elif abs(rot - 180) < 1:
+        return (cap_offset[0] - offset_distance, cap_offset[1])
+    elif abs(rot - 270) < 1:
+        return (cap_offset[0], cap_offset[1] + offset_distance)
+    else:
+        return (cap_offset[0], cap_offset[1] + offset_distance)
+
+
+def _cap_rotation_for_pin(pin_rotation: float) -> float:
+    """Determine the capacitor rotation so its pins align with the wire axis.
+
+    A Device:C in KiCad has pin 1 at (0, 3.81) pointing down (270 deg)
+    and pin 2 at (0, -3.81) pointing up (90 deg) when rotation=0.
+    That means at rotation 0 the cap is vertical (pins top/bottom).
+
+    For a pin pointing right/left, we want the cap horizontal -> rotate 90.
+    For a pin pointing up/down, we want the cap vertical -> rotate 0.
+    """
+    rot = pin_rotation % 360
+    if abs(rot - 0) < 1 or abs(rot - 180) < 1:
+        # Horizontal pin -> rotate cap 90 degrees
+        return 90
+    else:
+        # Vertical pin -> keep cap at 0
+        return 0
+
+
+def run_add_bypass_cap(args) -> int:
+    """Execute the add-bypass-cap command."""
+    schematic_path = Path(args.schematic)
+
+    try:
+        sch = Schematic.load(schematic_path)
+    except (FileNotFoundError, KiCadFileNotFoundError):
+        print(f"Error: Schematic not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    # --- Resolve the target symbol ---
+    target_sym = sch.get_symbol(args.ref)
+    if target_sym is None:
+        available_refs = sorted({s.reference for s in sch.symbols if s.reference})
+        print(
+            f"Error: Symbol '{args.ref}' not found in schematic. "
+            f"Available references: {', '.join(available_refs[:20])}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # --- Get the library symbol definition to resolve pin positions ---
+    lib_sym_sexp = sch.get_lib_symbol(target_sym.lib_id)
+    if lib_sym_sexp is None:
+        print(
+            f"Error: Library definition for '{target_sym.lib_id}' not found "
+            "in schematic lib_symbols section.",
+            file=sys.stderr,
+        )
+        return 1
+
+    lib_sym = LibrarySymbol.from_sexp(lib_sym_sexp)
+
+    # --- Resolve the target pin position ---
+    pin_pos = lib_sym.get_pin_position(
+        pin_number=args.pin,
+        instance_pos=target_sym.position,
+        instance_rot=target_sym.rotation,
+        mirror=target_sym.mirror,
+    )
+    if pin_pos is None:
+        available_pins = sorted(p.number for p in lib_sym.pins)
+        print(
+            f"Error: Pin '{args.pin}' not found on {args.ref} ({target_sym.lib_id}). "
+            f"Available pins: {', '.join(available_pins)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    pin_pos = (_snap(pin_pos[0]), _snap(pin_pos[1]))
+
+    # Get pin orientation from the library definition for offset computation.
+    # We need the pin's rotation in library coordinates, adjusted for instance
+    # rotation and mirror.
+    lib_pin = lib_sym.get_pin(args.pin)
+    if lib_pin is not None:
+        # Adjust pin rotation for instance rotation
+        effective_pin_rot = (lib_pin.rotation + target_sym.rotation) % 360
+        if target_sym.mirror == "x":
+            # X mirror flips vertical direction
+            if abs(effective_pin_rot - 90) < 1:
+                effective_pin_rot = 270
+            elif abs(effective_pin_rot - 270) < 1:
+                effective_pin_rot = 90
+        elif target_sym.mirror == "y":
+            # Y mirror flips horizontal direction
+            if abs(effective_pin_rot - 0) < 1:
+                effective_pin_rot = 180
+            elif abs(effective_pin_rot - 180) < 1:
+                effective_pin_rot = 0
+    else:
+        # Fallback: place below
+        effective_pin_rot = 270
+
+    offset_distance = args.offset
+
+    cap_offset = _compute_cap_offset(effective_pin_rot, offset_distance)
+    cap_pos = (_snap(pin_pos[0] + cap_offset[0]), _snap(pin_pos[1] + cap_offset[1]))
+
+    cap_rotation = _cap_rotation_for_pin(effective_pin_rot)
+
+    ground_offset = _compute_ground_offset(effective_pin_rot, cap_offset, offset_distance)
+    gnd_pos = (
+        _snap(pin_pos[0] + ground_offset[0]),
+        _snap(pin_pos[1] + ground_offset[1]),
+    )
+
+    # --- Determine capacitor reference ---
+    cap_reference = args.reference if args.reference else _auto_reference(sch, "C")
+
+    # --- Determine cap pin positions ---
+    # Device:C has pin 1 at (0, 3.81) and pin 2 at (0, -3.81) at rotation 0.
+    # We need to compute where pins 1 and 2 end up when the cap is placed.
+    cap_lib_id = "Device:C"
+    cap_lib_sexp = sch.get_lib_symbol(cap_lib_id)
+    need_cap_embed = cap_lib_sexp is None
+
+    gnd_lib_id = f"power:{args.ground_net}"
+    gnd_lib_sexp = sch.get_lib_symbol(gnd_lib_id)
+    need_gnd_embed = gnd_lib_sexp is None
+
+    # Build a temporary LibrarySymbol for pin position calculation
+    if cap_lib_sexp is not None:
+        cap_lib_sym = LibrarySymbol.from_sexp(cap_lib_sexp)
+    else:
+        # Construct a minimal Device:C representation for planning
+        cap_lib_sym = _make_default_cap_lib_sym()
+
+    cap_pin_positions = cap_lib_sym.get_all_pin_positions(
+        instance_pos=cap_pos,
+        instance_rot=cap_rotation,
+    )
+
+    cap_pin1_pos = cap_pin_positions.get("1")
+    cap_pin2_pos = cap_pin_positions.get("2")
+
+    if cap_pin1_pos is None or cap_pin2_pos is None:
+        print(
+            "Error: Cannot resolve capacitor pin positions. "
+            "Device:C library symbol may be malformed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    cap_pin1_pos = (_snap(cap_pin1_pos[0]), _snap(cap_pin1_pos[1]))
+    cap_pin2_pos = (_snap(cap_pin2_pos[0]), _snap(cap_pin2_pos[1]))
+
+    # --- Collect planned actions ---
+    planned: list[PlannedAction] = []
+
+    if need_cap_embed:
+        planned.append(
+            PlannedAction("embed", f"Embed library definition for {cap_lib_id}")
+        )
+    if need_gnd_embed:
+        planned.append(
+            PlannedAction("embed", f"Embed library definition for {gnd_lib_id}")
+        )
+
+    planned.append(
+        PlannedAction(
+            "capacitor",
+            f"Place {cap_lib_id} as {cap_reference} (value={args.value!r},"
+            f" footprint={args.footprint!r}) at ({cap_pos[0]:.2f}, {cap_pos[1]:.2f})"
+            f" rotation={cap_rotation}",
+        )
+    )
+
+    planned.append(
+        PlannedAction(
+            "ground",
+            f"Place power symbol {args.ground_net} at"
+            f" ({gnd_pos[0]:.2f}, {gnd_pos[1]:.2f})",
+        )
+    )
+
+    # Wire from target pin to cap pin 1
+    if abs(pin_pos[0] - cap_pin1_pos[0]) > 0.01 or abs(pin_pos[1] - cap_pin1_pos[1]) > 0.01:
+        planned.append(
+            PlannedAction(
+                "wire",
+                f"Wire from target pin {args.pin} at"
+                f" ({pin_pos[0]:.2f}, {pin_pos[1]:.2f})"
+                f" to cap pin 1 at ({cap_pin1_pos[0]:.2f}, {cap_pin1_pos[1]:.2f})",
+            )
+        )
+
+    # Wire from cap pin 2 to ground symbol
+    if abs(cap_pin2_pos[0] - gnd_pos[0]) > 0.01 or abs(cap_pin2_pos[1] - gnd_pos[1]) > 0.01:
+        planned.append(
+            PlannedAction(
+                "wire",
+                f"Wire from cap pin 2 at"
+                f" ({cap_pin2_pos[0]:.2f}, {cap_pin2_pos[1]:.2f})"
+                f" to ground at ({gnd_pos[0]:.2f}, {gnd_pos[1]:.2f})",
+            )
+        )
+
+    # Check for junction at target pin (if it lands on existing wire midpoint)
+    needs_junction = False
+    for wire in sch.wires:
+        if _point_on_wire_midpoint(pin_pos, wire.start, wire.end):
+            needs_junction = True
+            planned.append(
+                PlannedAction(
+                    "junction",
+                    f"Junction at ({pin_pos[0]:.2f}, {pin_pos[1]:.2f})"
+                    f" (target pin intersects existing wire)",
+                )
+            )
+            break
+
+    # --- Report planned actions ---
+    if args.dry_run:
+        print("DRY RUN - No changes will be made")
+        print("=" * 60)
+
+    print(f"Planned actions ({len(planned)}):")
+    for action in planned:
+        print(f"  [{action.kind}] {action.description}")
+
+    if args.dry_run:
+        return 0
+
+    # --- Create backup if requested ---
+    if args.backup:
+        backup_path = (
+            f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        )
+        shutil.copy2(schematic_path, backup_path)
+        print(f"Backup created: {backup_path}")
+
+    # --- Apply changes ---
+
+    # 1. Embed library symbols if needed
+    if need_cap_embed:
+        sch.embed_lib_symbol(cap_lib_sym)
+    if need_gnd_embed:
+        gnd_lib_sym = _make_default_gnd_lib_sym(args.ground_net)
+        sch.embed_lib_symbol(gnd_lib_sym)
+
+    # 2. Place the capacitor
+    sch.add_symbol(
+        lib_id=cap_lib_id,
+        reference=cap_reference,
+        value=args.value,
+        footprint=args.footprint,
+        position=cap_pos,
+        rotation=cap_rotation,
+    )
+
+    # 3. Place the ground symbol
+    sch.add_power(args.ground_net, gnd_pos)
+
+    # 4. Add wires
+    # Wire from target pin to cap pin 1
+    if abs(pin_pos[0] - cap_pin1_pos[0]) > 0.01 or abs(pin_pos[1] - cap_pin1_pos[1]) > 0.01:
+        sch.add_wire(pin_pos, cap_pin1_pos)
+
+    # Wire from cap pin 2 to ground
+    if abs(cap_pin2_pos[0] - gnd_pos[0]) > 0.01 or abs(cap_pin2_pos[1] - gnd_pos[1]) > 0.01:
+        sch.add_wire(cap_pin2_pos, gnd_pos)
+
+    # 5. Add junction if target pin lands on existing wire midpoint
+    if needs_junction:
+        sch.add_junction(pin_pos)
+
+    # 6. Save
+    sch.save()
+
+    print(f"\nBypass capacitor placed successfully:")
+    print(f"  Reference: {cap_reference}")
+    print(f"  Value: {args.value}")
+    print(f"  Target: {args.ref} pin {args.pin} at ({pin_pos[0]:.2f}, {pin_pos[1]:.2f})")
+    print(f"  Cap position: ({cap_pos[0]:.2f}, {cap_pos[1]:.2f})")
+    print(f"  Ground: {args.ground_net} at ({gnd_pos[0]:.2f}, {gnd_pos[1]:.2f})")
+    return 0
+
+
+def _make_default_cap_lib_sym() -> LibrarySymbol:
+    """Create a minimal Device:C library symbol for embedding.
+
+    This matches the standard KiCad Device:C with pin 1 at (0, 3.81)
+    pointing down (270 deg) and pin 2 at (0, -3.81) pointing up (90 deg).
+    """
+    from kicad_tools.schema.library import LibraryPin
+
+    return LibrarySymbol(
+        name="Device:C",
+        properties={
+            "Reference": "C",
+            "Value": "C",
+            "Footprint": "",
+            "Datasheet": "",
+        },
+        pins=[
+            LibraryPin(
+                number="1",
+                name="~",
+                type="passive",
+                position=(0, 3.81),
+                rotation=270,
+                length=1.27,
+            ),
+            LibraryPin(
+                number="2",
+                name="~",
+                type="passive",
+                position=(0, -3.81),
+                rotation=90,
+                length=1.27,
+            ),
+        ],
+    )
+
+
+def _make_default_gnd_lib_sym(name: str) -> LibrarySymbol:
+    """Create a minimal power ground symbol for embedding.
+
+    This creates a standard ground power symbol with a single
+    power_in pin at (0, 0).
+    """
+    from kicad_tools.schema.library import LibraryPin
+
+    return LibrarySymbol(
+        name=f"power:{name}",
+        properties={
+            "Reference": "#PWR",
+            "Value": name,
+        },
+        pins=[
+            LibraryPin(
+                number="1",
+                name=name,
+                type="power_in",
+                position=(0, 0),
+                rotation=0,
+                length=0,
+            ),
+        ],
+    )
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Add a bypass/decoupling capacitor to an IC power pin",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", help="Path to .kicad_sch file")
+    parser.add_argument(
+        "--ref", required=True, help="Target IC reference designator (e.g., U8)"
+    )
+    parser.add_argument(
+        "--pin", required=True, help="Target pin number on that IC (e.g., 4)"
+    )
+    parser.add_argument(
+        "--value", default="100nF", help="Capacitor value (default: 100nF)"
+    )
+    parser.add_argument(
+        "--ground-net",
+        default="GND",
+        help="Ground power symbol name (default: GND)",
+    )
+    parser.add_argument(
+        "--footprint",
+        default="Capacitor_SMD:C_0402_1005Metric",
+        help="Capacitor footprint (default: Capacitor_SMD:C_0402_1005Metric)",
+    )
+    parser.add_argument(
+        "--reference", default=None, help="Capacitor reference (auto-assigned if omitted)"
+    )
+    parser.add_argument(
+        "--offset",
+        type=float,
+        default=5.08,
+        help="Distance from pin to cap body centre in mm (default: 5.08)",
+    )
+    parser.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+    )
+    parser.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+
+    args = parser.parse_args(argv)
+    return run_add_bypass_cap(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/sch_add_bypass_cap.py
+++ b/src/kicad_tools/cli/sch_add_bypass_cap.py
@@ -83,31 +83,6 @@ def _point_on_wire_midpoint(
     return dist < tolerance
 
 
-def _point_on_wire_segment(
-    point: tuple[float, float],
-    wire_start: tuple[float, float],
-    wire_end: tuple[float, float],
-    tolerance: float = 0.1,
-) -> bool:
-    """Check if a point lies on a wire segment (including endpoints)."""
-    x, y = point
-    x1, y1 = wire_start
-    x2, y2 = wire_end
-
-    # Bounding box check
-    if not (min(x1, x2) - tolerance <= x <= max(x1, x2) + tolerance):
-        return False
-    if not (min(y1, y2) - tolerance <= y <= max(y1, y2) + tolerance):
-        return False
-
-    # Perpendicular distance check
-    length = ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
-    if length < tolerance:
-        return ((x - x1) ** 2 + (y - y1) ** 2) ** 0.5 < tolerance
-
-    dist = abs((y2 - y1) * x - (x2 - x1) * y + x2 * y1 - y2 * x1) / length
-    return dist < tolerance
-
 
 def _auto_reference(sch: Schematic, prefix: str = "C") -> str:
     """Find the next available reference designator for a given prefix.
@@ -332,6 +307,27 @@ def run_add_bypass_cap(args) -> int:
     cap_pin1_pos = (_snap(cap_pin1_pos[0]), _snap(cap_pin1_pos[1]))
     cap_pin2_pos = (_snap(cap_pin2_pos[0]), _snap(cap_pin2_pos[1]))
 
+    # --- Select near (VDD) and far (GND) cap pins based on distance from IC pin ---
+    # The cap pin closer to the IC pin connects to VDD; the other connects to GND.
+    # This handles all orientations correctly: for left/down-pointing pins the
+    # physical pin numbering would create a short if we always used pin 1 for VDD.
+    dist1 = (
+        (cap_pin1_pos[0] - pin_pos[0]) ** 2 + (cap_pin1_pos[1] - pin_pos[1]) ** 2
+    ) ** 0.5
+    dist2 = (
+        (cap_pin2_pos[0] - pin_pos[0]) ** 2 + (cap_pin2_pos[1] - pin_pos[1]) ** 2
+    ) ** 0.5
+    if dist1 <= dist2:
+        cap_vdd_pin_pos = cap_pin1_pos
+        cap_gnd_pin_pos = cap_pin2_pos
+        cap_vdd_pin_num = "1"
+        cap_gnd_pin_num = "2"
+    else:
+        cap_vdd_pin_pos = cap_pin2_pos
+        cap_gnd_pin_pos = cap_pin1_pos
+        cap_vdd_pin_num = "2"
+        cap_gnd_pin_num = "1"
+
     # --- Collect planned actions ---
     planned: list[PlannedAction] = []
 
@@ -361,24 +357,31 @@ def run_add_bypass_cap(args) -> int:
         )
     )
 
-    # Wire from target pin to cap pin 1
-    if abs(pin_pos[0] - cap_pin1_pos[0]) > 0.01 or abs(pin_pos[1] - cap_pin1_pos[1]) > 0.01:
+    # Wire from target pin to near (VDD) cap pin
+    if (
+        abs(pin_pos[0] - cap_vdd_pin_pos[0]) > 0.01
+        or abs(pin_pos[1] - cap_vdd_pin_pos[1]) > 0.01
+    ):
         planned.append(
             PlannedAction(
                 "wire",
                 f"Wire from target pin {args.pin} at"
                 f" ({pin_pos[0]:.2f}, {pin_pos[1]:.2f})"
-                f" to cap pin 1 at ({cap_pin1_pos[0]:.2f}, {cap_pin1_pos[1]:.2f})",
+                f" to cap pin {cap_vdd_pin_num} at"
+                f" ({cap_vdd_pin_pos[0]:.2f}, {cap_vdd_pin_pos[1]:.2f})",
             )
         )
 
-    # Wire from cap pin 2 to ground symbol
-    if abs(cap_pin2_pos[0] - gnd_pos[0]) > 0.01 or abs(cap_pin2_pos[1] - gnd_pos[1]) > 0.01:
+    # Wire from far (GND) cap pin to ground symbol
+    if (
+        abs(cap_gnd_pin_pos[0] - gnd_pos[0]) > 0.01
+        or abs(cap_gnd_pin_pos[1] - gnd_pos[1]) > 0.01
+    ):
         planned.append(
             PlannedAction(
                 "wire",
-                f"Wire from cap pin 2 at"
-                f" ({cap_pin2_pos[0]:.2f}, {cap_pin2_pos[1]:.2f})"
+                f"Wire from cap pin {cap_gnd_pin_num} at"
+                f" ({cap_gnd_pin_pos[0]:.2f}, {cap_gnd_pin_pos[1]:.2f})"
                 f" to ground at ({gnd_pos[0]:.2f}, {gnd_pos[1]:.2f})",
             )
         )
@@ -440,13 +443,19 @@ def run_add_bypass_cap(args) -> int:
     sch.add_power(args.ground_net, gnd_pos)
 
     # 4. Add wires
-    # Wire from target pin to cap pin 1
-    if abs(pin_pos[0] - cap_pin1_pos[0]) > 0.01 or abs(pin_pos[1] - cap_pin1_pos[1]) > 0.01:
-        sch.add_wire(pin_pos, cap_pin1_pos)
+    # Wire from target pin to near (VDD) cap pin
+    if (
+        abs(pin_pos[0] - cap_vdd_pin_pos[0]) > 0.01
+        or abs(pin_pos[1] - cap_vdd_pin_pos[1]) > 0.01
+    ):
+        sch.add_wire(pin_pos, cap_vdd_pin_pos)
 
-    # Wire from cap pin 2 to ground
-    if abs(cap_pin2_pos[0] - gnd_pos[0]) > 0.01 or abs(cap_pin2_pos[1] - gnd_pos[1]) > 0.01:
-        sch.add_wire(cap_pin2_pos, gnd_pos)
+    # Wire from far (GND) cap pin to ground
+    if (
+        abs(cap_gnd_pin_pos[0] - gnd_pos[0]) > 0.01
+        or abs(cap_gnd_pin_pos[1] - gnd_pos[1]) > 0.01
+    ):
+        sch.add_wire(cap_gnd_pin_pos, gnd_pos)
 
     # 5. Add junction if target pin lands on existing wire midpoint
     if needs_junction:

--- a/tests/test_sch_add_bypass_cap.py
+++ b/tests/test_sch_add_bypass_cap.py
@@ -1,0 +1,379 @@
+"""Tests for the sch add-bypass-cap command.
+
+Covers capacitor placement, ground symbol placement, wire creation,
+junction insertion, auto-reference, --dry-run, --backup, and error cases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_add_bypass_cap import (
+    _auto_reference,
+    _compute_cap_offset,
+    _make_default_cap_lib_sym,
+    _snap,
+    main as add_bypass_main,
+)
+from kicad_tools.schema import Schematic
+
+# ---------------------------------------------------------------------------
+# Minimal schematic content for testing -- includes a symbol U1 with a
+# power pin (pin 4, VDD) placed at known coordinates plus a Device:C and
+# power:GND lib_symbol definition so the command can resolve pin positions.
+# ---------------------------------------------------------------------------
+
+# U1 is placed at (100, 80) with rotation 0.
+# It has pin 4 at local position (0, -5.08) pointing down (rotation 270),
+# which puts pin 4's schematic position at (100, 85.09) (snapped).
+# There is a horizontal wire at y=85.09 from x=80 to x=120 to simulate
+# a VDD bus so we can test junction insertion.
+
+SCHEMATIC_WITH_IC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "test:IC"
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "IC" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (symbol "test:IC_1_1"
+        (pin power_in line (at 0 -5.08 270) (length 1.27) (name "VDD" (effects (font (size 1.27 1.27)))) (number "4" (effects (font (size 1.27 1.27)))))
+        (pin input line (at -5.08 0 180) (length 1.27) (name "IN" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+    (symbol "Device:C"
+      (property "Reference" "C" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "C" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (symbol "Device:C_0_1"
+        (polyline (pts (xy -1.016 -0.762) (xy 1.016 -0.762)) (stroke (width 0) (type default)) (fill (type none)))
+      )
+      (symbol "Device:C_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+        (pin passive line (at 0 -3.81 90) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+      )
+    )
+    (symbol "power:GND"
+      (property "Reference" "#PWR" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "GND" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:GND_0_1"
+        (polyline (pts (xy 0 0) (xy 0 -1.27)) (stroke (width 0) (type default)) (fill (type none)))
+      )
+      (symbol "power:GND_1_1"
+        (pin power_in line (at 0 0 0) (length 0) (name "GND" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+    (symbol "power:GNDD"
+      (property "Reference" "#PWR" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "GNDD" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:GNDD_0_1"
+        (polyline (pts (xy 0 0) (xy 0 -1.27)) (stroke (width 0) (type default)) (fill (type none)))
+      )
+      (symbol "power:GNDD_1_1"
+        (pin power_in line (at 0 0 0) (length 0) (name "GNDD" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (symbol (lib_id "test:IC") (at 100 80 0) (unit 1)
+    (in_bom yes) (on_board yes)
+    (uuid "11111111-1111-1111-1111-111111111111")
+    (property "Reference" "U1" (at 100 75 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "IC" (at 100 77 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+    (pin "4" (uuid "pin-4-uuid"))
+    (pin "1" (uuid "pin-1-uuid"))
+    (instances
+      (project "test_project"
+        (path "/" (reference "U1") (unit 1))
+      )
+    )
+  )
+  (symbol (lib_id "Device:C") (at 50 50 0) (unit 1)
+    (in_bom yes) (on_board yes)
+    (uuid "22222222-2222-2222-2222-222222222222")
+    (property "Reference" "C1" (at 50 45 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "100nF" (at 50 47 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+    (pin "1" (uuid "pin-c1-1"))
+    (pin "2" (uuid "pin-c1-2"))
+    (instances
+      (project "test_project"
+        (path "/" (reference "C1") (unit 1))
+      )
+    )
+  )
+  (symbol (lib_id "Device:C") (at 60 50 0) (unit 1)
+    (in_bom yes) (on_board yes)
+    (uuid "33333333-3333-3333-3333-333333333333")
+    (property "Reference" "C5" (at 60 45 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "10nF" (at 60 47 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+    (pin "1" (uuid "pin-c5-1"))
+    (pin "2" (uuid "pin-c5-2"))
+    (instances
+      (project "test_project"
+        (path "/" (reference "C5") (unit 1))
+      )
+    )
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+# Same schematic but with a VDD bus wire crossing pin 4's position
+# to test junction insertion.
+# Pin 4 is at library position (0, -5.08) with rotation 270.
+# Instance is at (100, 80) rotation 0.
+# Pin schematic position: approximately (100.33, 74.93) after snapping.
+# Place the bus wire at y=74.93 crossing through pin 4.
+SCHEMATIC_WITH_BUS = SCHEMATIC_WITH_IC.replace(
+    "  (sheet_instances",
+    """\
+  (wire (pts (xy 80 74.93) (xy 120 74.93))
+    (stroke (width 0) (type default))
+    (uuid "bus-wire-1")
+  )
+  (sheet_instances""",
+)
+
+
+def _write_sch(tmp_path: Path, content: str = SCHEMATIC_WITH_IC) -> Path:
+    p = tmp_path / "test_bypass.kicad_sch"
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestAutoReference:
+    def test_next_after_existing(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        sch = Schematic.load(sch_path)
+        # Schematic has C1 and C5, so next should be C6
+        ref = _auto_reference(sch, "C")
+        assert ref == "C6"
+
+    def test_no_existing(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        sch = Schematic.load(sch_path)
+        # No R-prefix symbols exist
+        ref = _auto_reference(sch, "R")
+        assert ref == "R1"
+
+
+class TestComputeCapOffset:
+    def test_pin_pointing_right(self):
+        dx, dy = _compute_cap_offset(0, 5.08)
+        assert dx == pytest.approx(5.08)
+        assert dy == pytest.approx(0)
+
+    def test_pin_pointing_down(self):
+        dx, dy = _compute_cap_offset(270, 5.08)
+        assert dx == pytest.approx(0)
+        assert dy == pytest.approx(5.08)
+
+    def test_pin_pointing_up(self):
+        dx, dy = _compute_cap_offset(90, 5.08)
+        assert dx == pytest.approx(0)
+        assert dy == pytest.approx(-5.08)
+
+    def test_pin_pointing_left(self):
+        dx, dy = _compute_cap_offset(180, 5.08)
+        assert dx == pytest.approx(-5.08)
+        assert dy == pytest.approx(0)
+
+
+class TestMakeDefaultCapLibSym:
+    def test_has_two_pins(self):
+        sym = _make_default_cap_lib_sym()
+        assert len(sym.pins) == 2
+        pin_numbers = {p.number for p in sym.pins}
+        assert pin_numbers == {"1", "2"}
+
+    def test_name(self):
+        sym = _make_default_cap_lib_sym()
+        assert sym.name == "Device:C"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: basic placement
+# ---------------------------------------------------------------------------
+
+
+class TestBasicPlacement:
+    def test_place_bypass_cap(self, tmp_path: Path):
+        """Place a bypass cap on U1 pin 4 and verify symbols and wires appear."""
+        sch_path = _write_sch(tmp_path)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "4",
+            "--value", "100nF",
+            "--ground-net", "GND",
+        ])
+        assert result == 0
+
+        # Reload and verify
+        sch = Schematic.load(sch_path)
+
+        # Should have the original U1 + C1 + C5 + new cap + new ground
+        # At least one new cap symbol should exist
+        cap_refs = [s.reference for s in sch.symbols if s.reference.startswith("C")]
+        assert "C6" in cap_refs  # auto-assigned after C5
+
+        # Should have at least one GND power symbol added
+        gnd_symbols = [s for s in sch.symbols if s.lib_id == "power:GND"]
+        assert len(gnd_symbols) >= 1
+
+        # Should have new wires
+        assert len(sch.wires) >= 1
+
+    def test_custom_reference(self, tmp_path: Path):
+        """Explicitly provide --reference."""
+        sch_path = _write_sch(tmp_path)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "4",
+            "--reference", "C42",
+            "--value", "22nF",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        cap_refs = [s.reference for s in sch.symbols if s.reference == "C42"]
+        assert len(cap_refs) == 1
+
+    def test_custom_ground_net(self, tmp_path: Path):
+        """Use --ground-net GNDD."""
+        sch_path = _write_sch(tmp_path)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "4",
+            "--ground-net", "GNDD",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        gndd_symbols = [s for s in sch.symbols if s.lib_id == "power:GNDD"]
+        assert len(gndd_symbols) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Junction insertion
+# ---------------------------------------------------------------------------
+
+
+class TestJunctionInsertion:
+    def test_junction_on_bus_wire(self, tmp_path: Path):
+        """When the target pin coordinate is on an existing wire midpoint,
+        a junction should be inserted."""
+        sch_path = _write_sch(tmp_path, SCHEMATIC_WITH_BUS)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "4",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        # There should be at least one junction near pin 4's position
+        junctions = sch.junctions
+        assert len(junctions) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Dry run
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    def test_no_file_changes(self, tmp_path: Path):
+        """--dry-run should not modify the schematic file."""
+        sch_path = _write_sch(tmp_path)
+        original_content = sch_path.read_text()
+
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "4",
+            "--dry-run",
+        ])
+        assert result == 0
+
+        # File should be unchanged
+        assert sch_path.read_text() == original_content
+
+
+# ---------------------------------------------------------------------------
+# Backup
+# ---------------------------------------------------------------------------
+
+
+class TestBackup:
+    def test_backup_created(self, tmp_path: Path):
+        """--backup should create a backup file before modifying."""
+        sch_path = _write_sch(tmp_path)
+
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "4",
+            "--backup",
+        ])
+        assert result == 0
+
+        # A backup file should exist
+        backup_files = list(tmp_path.glob("*.backup-*"))
+        assert len(backup_files) == 1
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_unknown_ref(self, tmp_path: Path):
+        """Error when --ref symbol doesn't exist."""
+        sch_path = _write_sch(tmp_path)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U99",
+            "--pin", "4",
+        ])
+        assert result == 1
+
+    def test_unknown_pin(self, tmp_path: Path):
+        """Error when --pin doesn't exist on the symbol."""
+        sch_path = _write_sch(tmp_path)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "99",
+        ])
+        assert result == 1
+
+    def test_missing_schematic(self, tmp_path: Path):
+        """Error when schematic file doesn't exist."""
+        result = add_bypass_main([
+            str(tmp_path / "nonexistent.kicad_sch"),
+            "--ref", "U1",
+            "--pin", "4",
+        ])
+        assert result == 1

--- a/tests/test_sch_add_bypass_cap.py
+++ b/tests/test_sch_add_bypass_cap.py
@@ -147,6 +147,122 @@ SCHEMATIC_WITH_BUS = SCHEMATIC_WITH_IC.replace(
   (sheet_instances""",
 )
 
+# Schematic with an IC whose VDD pin (pin 5) points LEFT (rotation=180).
+# Pin 5 is at library position (5.08, 0) with rotation 180 (stub points left).
+# Instance is at (100, 80) rotation 0.
+# Pin schematic position: approximately (105.08, 80).
+SCHEMATIC_LEFT_PIN = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000002")
+  (paper "A4")
+  (lib_symbols
+    (symbol "test:IC2"
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "IC2" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (symbol "test:IC2_1_1"
+        (pin power_in line (at 5.08 0 180) (length 1.27) (name "VDD" (effects (font (size 1.27 1.27)))) (number "5" (effects (font (size 1.27 1.27)))))
+      )
+    )
+    (symbol "Device:C"
+      (property "Reference" "C" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "C" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (symbol "Device:C_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+        (pin passive line (at 0 -3.81 90) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+      )
+    )
+    (symbol "power:GND"
+      (property "Reference" "#PWR" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "GND" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:GND_1_1"
+        (pin power_in line (at 0 0 0) (length 0) (name "GND" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (symbol (lib_id "test:IC2") (at 100 80 0) (unit 1)
+    (in_bom yes) (on_board yes)
+    (uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    (property "Reference" "U2" (at 100 75 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "IC2" (at 100 77 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+    (pin "5" (uuid "pin-5-uuid"))
+    (instances
+      (project "test_project"
+        (path "/" (reference "U2") (unit 1))
+      )
+    )
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+# Schematic with an IC whose VDD pin (pin 6) points UP (rotation=90).
+# Pin 6 is at library position (0, 5.08) with rotation 90 (stub points up, i.e. negative Y in KiCad).
+# Instance is at (100, 80) rotation 0.
+# Pin schematic position: approximately (100, 85.08).
+SCHEMATIC_UP_PIN = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000003")
+  (paper "A4")
+  (lib_symbols
+    (symbol "test:IC3"
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "IC3" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (symbol "test:IC3_1_1"
+        (pin power_in line (at 0 5.08 90) (length 1.27) (name "VDD" (effects (font (size 1.27 1.27)))) (number "6" (effects (font (size 1.27 1.27)))))
+      )
+    )
+    (symbol "Device:C"
+      (property "Reference" "C" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "C" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (symbol "Device:C_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+        (pin passive line (at 0 -3.81 90) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+      )
+    )
+    (symbol "power:GND"
+      (property "Reference" "#PWR" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "GND" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:GND_1_1"
+        (pin power_in line (at 0 0 0) (length 0) (name "GND" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (symbol (lib_id "test:IC3") (at 100 80 0) (unit 1)
+    (in_bom yes) (on_board yes)
+    (uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    (property "Reference" "U3" (at 100 75 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "IC3" (at 100 77 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+    (pin "6" (uuid "pin-6-uuid"))
+    (instances
+      (project "test_project"
+        (path "/" (reference "U3") (unit 1))
+      )
+    )
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
 
 def _write_sch(tmp_path: Path, content: str = SCHEMATIC_WITH_IC) -> Path:
     p = tmp_path / "test_bypass.kicad_sch"
@@ -272,6 +388,158 @@ class TestBasicPlacement:
         sch = Schematic.load(sch_path)
         gndd_symbols = [s for s in sch.symbols if s.lib_id == "power:GNDD"]
         assert len(gndd_symbols) >= 1
+
+
+def _wire_distance(
+    w_start: tuple[float, float],
+    w_end: tuple[float, float],
+    pt: tuple[float, float],
+    tol: float = 0.1,
+) -> bool:
+    """Return True if ``pt`` lies on the wire segment (including endpoints)."""
+    x, y = pt
+    x1, y1 = w_start
+    x2, y2 = w_end
+    if not (min(x1, x2) - tol <= x <= max(x1, x2) + tol):
+        return False
+    if not (min(y1, y2) - tol <= y <= max(y1, y2) + tol):
+        return False
+    length = ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
+    if length < tol:
+        return ((x - x1) ** 2 + (y - y1) ** 2) ** 0.5 < tol
+    dist = abs((y2 - y1) * x - (x2 - x1) * y + x2 * y1 - y2 * x1) / length
+    return dist < tol
+
+
+def _check_no_short(
+    sch: Schematic,
+    ic_pin_pos: tuple[float, float],
+    gnd_pos: tuple[float, float],
+    tol: float = 0.5,
+) -> None:
+    """Assert that no single wire connects the IC pin to the GND symbol.
+
+    A short circuit is present when a wire starts (or ends) at the IC pin
+    position AND ends (or starts) at the GND symbol position, bypassing
+    the capacitor entirely.
+    """
+    for wire in sch.wires:
+        starts_at_ic = _wire_distance(wire.start, wire.end, ic_pin_pos, tol) or (
+            abs(wire.start[0] - ic_pin_pos[0]) < tol
+            and abs(wire.start[1] - ic_pin_pos[1]) < tol
+        )
+        ends_at_gnd = (
+            abs(wire.end[0] - gnd_pos[0]) < tol
+            and abs(wire.end[1] - gnd_pos[1]) < tol
+        ) or (
+            abs(wire.start[0] - gnd_pos[0]) < tol
+            and abs(wire.start[1] - gnd_pos[1]) < tol
+        )
+        starts_at_gnd = (
+            abs(wire.start[0] - gnd_pos[0]) < tol
+            and abs(wire.start[1] - gnd_pos[1]) < tol
+        ) or (
+            abs(wire.end[0] - gnd_pos[0]) < tol
+            and abs(wire.end[1] - gnd_pos[1]) < tol
+        )
+        ends_at_ic = (
+            abs(wire.end[0] - ic_pin_pos[0]) < tol
+            and abs(wire.end[1] - ic_pin_pos[1]) < tol
+        ) or (
+            abs(wire.start[0] - ic_pin_pos[0]) < tol
+            and abs(wire.start[1] - ic_pin_pos[1]) < tol
+        )
+        # A single wire from IC pin to GND (or GND to IC pin) is a short circuit
+        if (starts_at_ic and ends_at_gnd) or (starts_at_gnd and ends_at_ic):
+            raise AssertionError(
+                f"Short circuit detected: wire from {wire.start} to {wire.end} "
+                f"connects IC pin at {ic_pin_pos} directly to GND at {gnd_pos}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Orientation-specific placement tests (verifies no short circuits)
+# ---------------------------------------------------------------------------
+
+
+class TestPinOrientations:
+    def test_left_pointing_pin_no_short(self, tmp_path: Path):
+        """Bypass cap on a left-pointing pin must not create a VDD-GND short.
+
+        For a left-pointing pin the cap is placed to the left. At cap
+        rotation=90, pin 2 (right side) is nearest the IC -- it must connect
+        to VDD. Pin 1 (left side) connects to GND. The old code always wired
+        pin 1 to VDD, which would short VDD→GND.
+        """
+        sch_path = _write_sch(tmp_path, SCHEMATIC_LEFT_PIN)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U2",
+            "--pin", "5",
+            "--value", "100nF",
+            "--ground-net", "GND",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+
+        # Verify cap was placed
+        cap_refs = [s.reference for s in sch.symbols if s.reference.startswith("C")]
+        assert len(cap_refs) >= 1
+
+        # Verify GND symbol was placed
+        gnd_syms = [s for s in sch.symbols if "GND" in s.lib_id]
+        assert len(gnd_syms) >= 1
+        gnd_pos = gnd_syms[0].position
+
+        # Resolve IC pin position (pin 5 at library (5.08, 0), instance at (100, 80))
+        # pin schematic pos ≈ (105.08, 80) snapped
+        ic_pin_x = _snap(100 + 5.08)
+        ic_pin_y = _snap(80 + 0)
+        ic_pin_pos = (ic_pin_x, ic_pin_y)
+
+        # No single wire should bridge IC pin directly to GND
+        _check_no_short(sch, ic_pin_pos, gnd_pos)
+
+        # Wires must exist
+        assert len(sch.wires) >= 2
+
+    def test_upward_pointing_pin_no_short(self, tmp_path: Path):
+        """Bypass cap on an upward-pointing pin must not create a VDD-GND short.
+
+        For an upward-pointing pin the cap is placed above the IC pin. At
+        cap rotation=0, pin 1 is at the bottom (nearest IC) and pin 2 is at
+        the top. The placement must connect pin 1 to VDD and pin 2 to GND --
+        this was correct already; this test guards against regression.
+        """
+        sch_path = _write_sch(tmp_path, SCHEMATIC_UP_PIN)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U3",
+            "--pin", "6",
+            "--value", "100nF",
+            "--ground-net", "GND",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+
+        cap_refs = [s.reference for s in sch.symbols if s.reference.startswith("C")]
+        assert len(cap_refs) >= 1
+
+        gnd_syms = [s for s in sch.symbols if "GND" in s.lib_id]
+        assert len(gnd_syms) >= 1
+        gnd_pos = gnd_syms[0].position
+
+        # Pin 6 at library (0, 5.08) with rotation=90 (points up), instance at (100, 80)
+        # In KiCad Y-down coords, pin at (0, 5.08) in library transforms to (100, 85.08)
+        ic_pin_x = _snap(100 + 0)
+        ic_pin_y = _snap(80 + 5.08)
+        ic_pin_pos = (ic_pin_x, ic_pin_y)
+
+        _check_no_short(sch, ic_pin_pos, gnd_pos)
+
+        assert len(sch.wires) >= 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a new `sch add-bypass-cap` command that automates the placement of bypass/decoupling capacitors on IC power pins. This composite command places a capacitor symbol, a ground power symbol, and connecting wires in a single operation -- eliminating the manual multi-step geometry that was previously required.

## Changes

- `src/kicad_tools/cli/sch_add_bypass_cap.py` -- new module implementing `run_add_bypass_cap()` with pin coordinate resolution, cap/ground placement, wire creation, junction insertion, and auto-reference assignment
- `src/kicad_tools/cli/parser.py` -- add `sch add-bypass-cap` subparser with `--ref`, `--pin`, `--value`, `--ground-net`, `--footprint`, `--reference`, `--offset`, `--dry-run`, `--backup` arguments
- `src/kicad_tools/cli/commands/schematic.py` -- add dispatch case for `add-bypass-cap` and update usage string
- `tests/test_sch_add_bypass_cap.py` -- 17 tests covering unit helpers, integration placement, junction insertion, dry-run, backup, and error cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `sch add-bypass-cap` places capacitor + ground symbol wired to specified pin | Pass | TestBasicPlacement.test_place_bypass_cap verifies cap, ground, and wires appear after placement |
| Auto-inserts junctions when connecting to existing wires | Pass | TestJunctionInsertion.test_junction_on_bus_wire verifies junction at pin coordinate on bus wire |
| Auto-assigns reference designator if not provided | Pass | TestAutoReference.test_next_after_existing confirms C6 assigned after C1+C5; test_place_bypass_cap confirms auto-ref in integration |
| Supports `--dry-run` to preview | Pass | TestDryRun.test_no_file_changes verifies file is unchanged after dry-run |
| Handles pin coordinate resolution from embedded lib_symbols | Pass | All placement tests resolve pin positions from embedded lib_symbols section |

## Test Plan

All 17 tests pass:
```
python3 -m pytest tests/test_sch_add_bypass_cap.py -v -o addopts=""
```

Note: `tests/test_sch_add_component.py::TestStandaloneAddWire::test_add_wire_zero_length_rejected` is a pre-existing failure on main, unrelated to this change.

Closes #1930