### PR TITLE
fix(stitch): guard shutil.copy when input and output resolve to same file

### DIFF
--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -2683,15 +2683,18 @@ def main(argv: list[str] | None = None) -> int:
     # If output specified, copy to output first
     if args.output and not args.dry_run:
         output_path = Path(args.output)
-        import shutil
 
-        shutil.copy(pcb_path, output_path)
+        # Skip copy when input and output resolve to the same file
+        if not (output_path.exists() and output_path.resolve() == pcb_path.resolve()):
+            import shutil
 
-        # Also copy project file for DRC compatibility
-        pro_path = pcb_path.with_suffix(".kicad_pro")
-        if pro_path.exists():
-            output_pro = output_path.with_suffix(".kicad_pro")
-            shutil.copy(pro_path, output_pro)
+            shutil.copy(pcb_path, output_path)
+
+            # Also copy project file for DRC compatibility
+            pro_path = pcb_path.with_suffix(".kicad_pro")
+            if pro_path.exists():
+                output_pro = output_path.with_suffix(".kicad_pro")
+                shutil.copy(pro_path, output_pro)
 
         pcb_path = output_path
 

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -651,6 +651,24 @@ class TestCLIMain:
         output_pro = output_file.with_suffix(".kicad_pro")
         assert not output_pro.exists()
 
+    def test_main_output_same_file(self, stitch_test_pcb: Path):
+        """Main with -o pointing to the same file should not raise SameFileError."""
+        exit_code = main([str(stitch_test_pcb), "--net", "GND", "-o", str(stitch_test_pcb)])
+
+        assert exit_code == 0
+        assert "(via" in stitch_test_pcb.read_text()
+
+    def test_main_output_same_file_relative(self, stitch_test_pcb: Path):
+        """Main with -o as relative path resolving to input should succeed."""
+        # Build a relative path that resolves to the same file
+        parent = stitch_test_pcb.parent
+        relative_output = str(parent / "." / stitch_test_pcb.name)
+
+        exit_code = main([str(stitch_test_pcb), "--net", "GND", "-o", relative_output])
+
+        assert exit_code == 0
+        assert "(via" in stitch_test_pcb.read_text()
+
     def test_main_dry_run_skips_project_copy(self, stitch_test_pcb: Path, tmp_path):
         """Dry-run should not copy project file."""
         # Create matching project file


### PR DESCRIPTION
## Summary
Prevent `SameFileError` when the stitch command's `-o` flag points to the same file as the input. Adds a `Path.resolve()` comparison before calling `shutil.copy()` to skip the copy when paths match, treating it as in-place modification.

## Changes
- Add samefile guard in `main()` before `shutil.copy()` call using `Path.resolve()` comparison
- Add `test_main_output_same_file` test verifying same absolute path works
- Add `test_main_output_same_file_relative` test verifying relative path resolving to same file works

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No SameFileError when -o is same as input | Pass | New test `test_main_output_same_file` passes |
| Relative path resolving to same file works | Pass | New test `test_main_output_same_file_relative` passes |
| Existing output tests still pass | Pass | `test_main_output_file`, `test_main_output_copies_project_file`, `test_main_output_without_project_file` all pass |

## Test Plan
Ran `pytest tests/test_stitch_cmd.py -k test_main_output` -- all 5 tests pass (3 existing + 2 new).

Closes #1949