### PR TITLE
fix(drc): map all validate-module rule_ids to specific ViolationType members

### DIFF
--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -19,7 +19,15 @@ class ViolationType(Enum):
     CLEARANCE_SEGMENT_VIA = "clearance_segment_via"
     CLEARANCE_PAD_SEGMENT = "clearance_pad_segment"
     CLEARANCE_PAD_VIA = "clearance_pad_via"
+    CLEARANCE_PAD_PAD = "clearance_pad_pad"
+    CLEARANCE_SEGMENT_SEGMENT = "clearance_segment_segment"
+    CLEARANCE_VIA_VIA = "clearance_via_via"
     COPPER_EDGE_CLEARANCE = "copper_edge_clearance"
+    EDGE_CLEARANCE_TRACE = "edge_clearance_trace"
+    EDGE_CLEARANCE_PAD = "edge_clearance_pad"
+    EDGE_CLEARANCE_PAD_HOLE = "edge_clearance_pad_hole"
+    EDGE_CLEARANCE_VIA = "edge_clearance_via"
+    EDGE_CLEARANCE_ZONE = "edge_clearance_zone"
     COURTYARD_OVERLAP = "courtyard_overlap"
 
     # Connection issues
@@ -31,9 +39,14 @@ class ViolationType(Enum):
     VIA_ANNULAR_WIDTH = "via_annular_width"
     MICRO_VIA_HOLE_TOO_SMALL = "micro_via_hole_too_small"
 
-    # Track issues
+    # Track/trace dimension issues
     TRACK_WIDTH = "track_width"
     TRACK_ANGLE = "track_angle"
+    DIMENSION_TRACE_WIDTH = "dimension_trace_width"
+    DIMENSION_VIA_DRILL = "dimension_via_drill"
+    DIMENSION_VIA_DIAMETER = "dimension_via_diameter"
+    DIMENSION_ANNULAR_RING = "dimension_annular_ring"
+    DIMENSION_DRILL_CLEARANCE = "dimension_drill_clearance"
 
     # Hole issues
     DRILL_HOLE_TOO_SMALL = "drill_hole_too_small"
@@ -44,9 +57,18 @@ class ViolationType(Enum):
     # Silkscreen
     SILK_OVER_COPPER = "silk_over_copper"
     SILK_OVERLAP = "silk_overlap"
+    SILKSCREEN_LINE_WIDTH = "silkscreen_line_width"
+    SILKSCREEN_TEXT_HEIGHT = "silkscreen_text_height"
+    SILKSCREEN_OVER_PAD = "silkscreen_over_pad"
 
     # Solder mask
     SOLDER_MASK_BRIDGE = "solder_mask_bridge"
+    SOLDER_MASK_CLEARANCE = "solder_mask_clearance"
+    MIN_PAD_SIZE = "min_pad_size"
+    PTH_ANNULAR_RING = "pth_annular_ring"
+
+    # Impedance
+    IMPEDANCE = "impedance"
 
     # Misc
     FOOTPRINT = "footprint"
@@ -60,15 +82,66 @@ class ViolationType(Enum):
 
     @classmethod
     def from_string(cls, s: str) -> "ViolationType":
-        """Parse violation type from string."""
+        """Parse violation type from string.
+
+        Handles three sources of type strings:
+        - KiCad-cli DRC report types (e.g., "clearance", "track_width")
+        - Validate-module rule_id values (e.g., "clearance_pad_pad",
+          "dimension_trace_width", "silkscreen_line_width")
+        - Free-form descriptions from older reports
+        """
         s_lower = s.lower().strip()
 
-        # Try direct match
+        # Try direct enum value match first (covers both legacy and new members)
         for vtype in cls:
             if vtype.value == s_lower:
                 return vtype
 
-        # Try partial matches for common patterns
+        # Explicit alias table for validate-module rule_ids and common
+        # variants that don't match an enum value directly.  This table
+        # is checked before the fuzzy heuristics so that specific rule
+        # names are never misclassified.
+        _ALIASES: dict[str, ViolationType] = {
+            # clearance subtypes produced by validate clearance checker
+            "clearance_pad_pad": cls.CLEARANCE_PAD_PAD,
+            "clearance_pad_segment": cls.CLEARANCE_PAD_SEGMENT,
+            "clearance_pad_via": cls.CLEARANCE_PAD_VIA,
+            "clearance_segment_segment": cls.CLEARANCE_SEGMENT_SEGMENT,
+            "clearance_segment_via": cls.CLEARANCE_SEGMENT_VIA,
+            "clearance_via_via": cls.CLEARANCE_VIA_VIA,
+            # clearance subtypes using "trace" (synonym for "segment")
+            "clearance_pad_trace": cls.CLEARANCE_PAD_SEGMENT,
+            "clearance_trace_trace": cls.CLEARANCE_SEGMENT_SEGMENT,
+            "clearance_trace_via": cls.CLEARANCE_SEGMENT_VIA,
+            # edge clearance subtypes
+            "edge_clearance_trace": cls.EDGE_CLEARANCE_TRACE,
+            "edge_clearance_pad": cls.EDGE_CLEARANCE_PAD,
+            "edge_clearance_pad_hole": cls.EDGE_CLEARANCE_PAD_HOLE,
+            "edge_clearance_via": cls.EDGE_CLEARANCE_VIA,
+            "edge_clearance_zone": cls.EDGE_CLEARANCE_ZONE,
+            # dimension rules from validate dimensions checker
+            "dimension_trace_width": cls.DIMENSION_TRACE_WIDTH,
+            "dimension_via_drill": cls.DIMENSION_VIA_DRILL,
+            "dimension_via_diameter": cls.DIMENSION_VIA_DIAMETER,
+            "dimension_annular_ring": cls.DIMENSION_ANNULAR_RING,
+            "dimension_drill_clearance": cls.DIMENSION_DRILL_CLEARANCE,
+            # silkscreen rules from validate silkscreen checker
+            "silkscreen_line_width": cls.SILKSCREEN_LINE_WIDTH,
+            "silkscreen_text_height": cls.SILKSCREEN_TEXT_HEIGHT,
+            "silkscreen_over_pad": cls.SILKSCREEN_OVER_PAD,
+            # solder mask rules from validate solder_mask checker
+            "solder_mask_clearance": cls.SOLDER_MASK_CLEARANCE,
+            "min_pad_size": cls.MIN_PAD_SIZE,
+            "pth_annular_ring": cls.PTH_ANNULAR_RING,
+            # impedance rule from validate impedance checker
+            "impedance": cls.IMPEDANCE,
+        }
+
+        alias_match = _ALIASES.get(s_lower)
+        if alias_match is not None:
+            return alias_match
+
+        # Fuzzy heuristics for free-form strings (e.g., KiCad-cli descriptions)
         # Check drill_clearance before general clearance (both contain "clearance")
         if "drill" in s_lower and "clearance" in s_lower:
             return cls.DRILL_CLEARANCE
@@ -88,7 +161,7 @@ class ViolationType(Enum):
             return cls.SHORTING_ITEMS
         if "courtyard" in s_lower:
             return cls.COURTYARD_OVERLAP
-        if "track" in s_lower and "width" in s_lower:
+        if ("track" in s_lower or "trace" in s_lower) and "width" in s_lower:
             return cls.TRACK_WIDTH
         if "via" in s_lower:
             if "annular" in s_lower:
@@ -102,9 +175,19 @@ class ViolationType(Enum):
         if "silk" in s_lower:
             if "copper" in s_lower:
                 return cls.SILK_OVER_COPPER
+            if "line" in s_lower and "width" in s_lower:
+                return cls.SILKSCREEN_LINE_WIDTH
+            if "text" in s_lower and "height" in s_lower:
+                return cls.SILKSCREEN_TEXT_HEIGHT
+            if "over" in s_lower and "pad" in s_lower:
+                return cls.SILKSCREEN_OVER_PAD
             return cls.SILK_OVERLAP
         if "solder" in s_lower and "mask" in s_lower:
+            if "clearance" in s_lower:
+                return cls.SOLDER_MASK_CLEARANCE
             return cls.SOLDER_MASK_BRIDGE
+        if "impedance" in s_lower:
+            return cls.IMPEDANCE
         if "footprint" in s_lower:
             if "duplicate" in s_lower:
                 return cls.DUPLICATE_FOOTPRINT
@@ -195,7 +278,15 @@ class DRCViolation:
             ViolationType.CLEARANCE_SEGMENT_VIA,
             ViolationType.CLEARANCE_PAD_SEGMENT,
             ViolationType.CLEARANCE_PAD_VIA,
+            ViolationType.CLEARANCE_PAD_PAD,
+            ViolationType.CLEARANCE_SEGMENT_SEGMENT,
+            ViolationType.CLEARANCE_VIA_VIA,
             ViolationType.COPPER_EDGE_CLEARANCE,
+            ViolationType.EDGE_CLEARANCE_TRACE,
+            ViolationType.EDGE_CLEARANCE_PAD,
+            ViolationType.EDGE_CLEARANCE_PAD_HOLE,
+            ViolationType.EDGE_CLEARANCE_VIA,
+            ViolationType.EDGE_CLEARANCE_ZONE,
         )
 
     @property

--- a/src/kicad_tools/validate/violations.py
+++ b/src/kicad_tools/validate/violations.py
@@ -51,9 +51,19 @@ class DRCViolation:
         return self.severity == "warning"
 
     def to_dict(self) -> dict:
-        """Convert to dictionary for serialization."""
+        """Convert to dictionary for serialization.
+
+        Includes a ``type`` field that mirrors ``rule_id`` so that
+        downstream consumers (e.g., ``drc.report._parse_kct_check_json``)
+        can resolve the violation to a ``ViolationType`` enum member via
+        ``ViolationType.from_string()``.
+        """
+        from kicad_tools.drc.violation import ViolationType
+
+        resolved_type = ViolationType.from_string(self.rule_id)
         return {
             "rule_id": self.rule_id,
+            "type": resolved_type.value,
             "severity": self.severity,
             "message": self.message,
             "location": list(self.location) if self.location else None,

--- a/tests/test_drc_violation_type_validate.py
+++ b/tests/test_drc_violation_type_validate.py
@@ -1,0 +1,337 @@
+"""Tests for ViolationType.from_string with validate-module rule_ids.
+
+Ensures that every rule_id produced by the pure-Python validate checker
+maps to a specific (non-UNKNOWN) ViolationType enum member, and that the
+validate DRCViolation.to_dict() round-trips correctly through
+drc.report._parse_kct_check_json().
+"""
+
+import json
+
+import pytest
+
+from kicad_tools.drc.violation import ViolationType
+
+
+class TestValidateRuleIdMapping:
+    """ViolationType.from_string must resolve every validate rule_id."""
+
+    # -- clearance subtypes (element_type pairs: pad, segment, via) ----------
+
+    @pytest.mark.parametrize(
+        "rule_id, expected",
+        [
+            ("clearance_pad_pad", ViolationType.CLEARANCE_PAD_PAD),
+            ("clearance_pad_segment", ViolationType.CLEARANCE_PAD_SEGMENT),
+            ("clearance_pad_via", ViolationType.CLEARANCE_PAD_VIA),
+            ("clearance_segment_segment", ViolationType.CLEARANCE_SEGMENT_SEGMENT),
+            ("clearance_segment_via", ViolationType.CLEARANCE_SEGMENT_VIA),
+            ("clearance_via_via", ViolationType.CLEARANCE_VIA_VIA),
+        ],
+    )
+    def test_clearance_subtypes(self, rule_id: str, expected: ViolationType):
+        assert ViolationType.from_string(rule_id) == expected
+
+    # -- "trace" synonyms for "segment" -------------------------------------
+
+    @pytest.mark.parametrize(
+        "rule_id, expected",
+        [
+            ("clearance_pad_trace", ViolationType.CLEARANCE_PAD_SEGMENT),
+            ("clearance_trace_trace", ViolationType.CLEARANCE_SEGMENT_SEGMENT),
+            ("clearance_trace_via", ViolationType.CLEARANCE_SEGMENT_VIA),
+        ],
+    )
+    def test_clearance_trace_synonyms(self, rule_id: str, expected: ViolationType):
+        assert ViolationType.from_string(rule_id) == expected
+
+    # -- edge clearance subtypes ---------------------------------------------
+
+    @pytest.mark.parametrize(
+        "rule_id, expected",
+        [
+            ("edge_clearance_trace", ViolationType.EDGE_CLEARANCE_TRACE),
+            ("edge_clearance_pad", ViolationType.EDGE_CLEARANCE_PAD),
+            ("edge_clearance_pad_hole", ViolationType.EDGE_CLEARANCE_PAD_HOLE),
+            ("edge_clearance_via", ViolationType.EDGE_CLEARANCE_VIA),
+            ("edge_clearance_zone", ViolationType.EDGE_CLEARANCE_ZONE),
+        ],
+    )
+    def test_edge_clearance_subtypes(self, rule_id: str, expected: ViolationType):
+        assert ViolationType.from_string(rule_id) == expected
+
+    # -- dimension rules -----------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "rule_id, expected",
+        [
+            ("dimension_trace_width", ViolationType.DIMENSION_TRACE_WIDTH),
+            ("dimension_via_drill", ViolationType.DIMENSION_VIA_DRILL),
+            ("dimension_via_diameter", ViolationType.DIMENSION_VIA_DIAMETER),
+            ("dimension_annular_ring", ViolationType.DIMENSION_ANNULAR_RING),
+            ("dimension_drill_clearance", ViolationType.DIMENSION_DRILL_CLEARANCE),
+        ],
+    )
+    def test_dimension_rules(self, rule_id: str, expected: ViolationType):
+        assert ViolationType.from_string(rule_id) == expected
+
+    # -- silkscreen rules ----------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "rule_id, expected",
+        [
+            ("silkscreen_line_width", ViolationType.SILKSCREEN_LINE_WIDTH),
+            ("silkscreen_text_height", ViolationType.SILKSCREEN_TEXT_HEIGHT),
+            ("silkscreen_over_pad", ViolationType.SILKSCREEN_OVER_PAD),
+        ],
+    )
+    def test_silkscreen_rules(self, rule_id: str, expected: ViolationType):
+        assert ViolationType.from_string(rule_id) == expected
+
+    # -- solder mask rules ---------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "rule_id, expected",
+        [
+            ("solder_mask_clearance", ViolationType.SOLDER_MASK_CLEARANCE),
+            ("min_pad_size", ViolationType.MIN_PAD_SIZE),
+            ("pth_annular_ring", ViolationType.PTH_ANNULAR_RING),
+        ],
+    )
+    def test_solder_mask_rules(self, rule_id: str, expected: ViolationType):
+        assert ViolationType.from_string(rule_id) == expected
+
+    # -- impedance rule ------------------------------------------------------
+
+    def test_impedance(self):
+        assert ViolationType.from_string("impedance") == ViolationType.IMPEDANCE
+
+    # -- no validate rule_id should resolve to UNKNOWN -----------------------
+
+    @pytest.mark.parametrize(
+        "rule_id",
+        [
+            "clearance_pad_pad",
+            "clearance_pad_segment",
+            "clearance_pad_via",
+            "clearance_segment_segment",
+            "clearance_segment_via",
+            "clearance_via_via",
+            "clearance_pad_trace",
+            "clearance_trace_trace",
+            "clearance_trace_via",
+            "edge_clearance_trace",
+            "edge_clearance_pad",
+            "edge_clearance_pad_hole",
+            "edge_clearance_via",
+            "edge_clearance_zone",
+            "dimension_trace_width",
+            "dimension_via_drill",
+            "dimension_via_diameter",
+            "dimension_annular_ring",
+            "dimension_drill_clearance",
+            "silkscreen_line_width",
+            "silkscreen_text_height",
+            "silkscreen_over_pad",
+            "solder_mask_clearance",
+            "min_pad_size",
+            "pth_annular_ring",
+            "impedance",
+        ],
+    )
+    def test_no_unknown_for_validate_rules(self, rule_id: str):
+        """Every validate rule_id must resolve to a specific type, never UNKNOWN."""
+        result = ViolationType.from_string(rule_id)
+        assert result != ViolationType.UNKNOWN, (
+            f"rule_id {rule_id!r} mapped to UNKNOWN"
+        )
+
+
+class TestValidateViolationToDict:
+    """validate.violations.DRCViolation.to_dict() includes a type field."""
+
+    def test_to_dict_has_type_field(self):
+        from kicad_tools.validate.violations import DRCViolation
+
+        v = DRCViolation(
+            rule_id="dimension_trace_width",
+            severity="error",
+            message="Trace width 0.10mm < minimum 0.13mm",
+            location=(10.0, 20.0),
+            layer="F.Cu",
+            actual_value=0.10,
+            required_value=0.13,
+        )
+        d = v.to_dict()
+        assert "type" in d
+        assert d["type"] == "dimension_trace_width"
+        assert d["rule_id"] == "dimension_trace_width"
+
+    def test_to_dict_type_not_unknown(self):
+        from kicad_tools.validate.violations import DRCViolation
+
+        v = DRCViolation(
+            rule_id="silkscreen_line_width",
+            severity="warning",
+            message="Silkscreen line too thin",
+        )
+        d = v.to_dict()
+        assert d["type"] != "unknown"
+        assert d["type"] == "silkscreen_line_width"
+
+    def test_to_dict_clearance_type(self):
+        from kicad_tools.validate.violations import DRCViolation
+
+        v = DRCViolation(
+            rule_id="clearance_pad_pad",
+            severity="error",
+            message="Pad clearance too small",
+        )
+        d = v.to_dict()
+        assert d["type"] == "clearance_pad_pad"
+
+
+class TestKctCheckJsonRoundTrip:
+    """Verify kct-check JSON -> _parse_kct_check_json preserves rule types."""
+
+    def test_round_trip_preserves_type(self):
+        from kicad_tools.drc.report import _parse_kct_check_json
+
+        kct_json = {
+            "file": "/tmp/test.kicad_pcb",
+            "manufacturer": "jlcpcb",
+            "layers": 2,
+            "summary": {"errors": 2, "warnings": 1, "rules_checked": 5, "passed": False},
+            "violations": [
+                {
+                    "rule_id": "dimension_trace_width",
+                    "severity": "error",
+                    "message": "Trace width 0.10mm < minimum 0.13mm",
+                    "location": [10.0, 20.0],
+                    "layer": "F.Cu",
+                    "actual_value": 0.10,
+                    "required_value": 0.13,
+                    "items": ["Trace on F.Cu"],
+                },
+                {
+                    "rule_id": "silkscreen_line_width",
+                    "severity": "warning",
+                    "message": "Silkscreen line width 0.10mm < minimum 0.15mm",
+                    "location": [30.0, 40.0],
+                    "layer": "F.SilkS",
+                    "actual_value": 0.10,
+                    "required_value": 0.15,
+                    "items": [],
+                },
+                {
+                    "rule_id": "clearance_pad_pad",
+                    "severity": "error",
+                    "message": "Pad to pad clearance 0.15mm < minimum 0.20mm",
+                    "location": [50.0, 60.0],
+                    "layer": "F.Cu",
+                    "actual_value": 0.15,
+                    "required_value": 0.20,
+                    "items": ["Pad 1", "Pad 2"],
+                },
+            ],
+        }
+
+        report = _parse_kct_check_json(kct_json, "test.json")
+        assert len(report.violations) == 3
+
+        v0 = report.violations[0]
+        assert v0.type == ViolationType.DIMENSION_TRACE_WIDTH
+        assert v0.type_str == "dimension_trace_width"
+        assert v0.rule == "dimension_trace_width"
+
+        v1 = report.violations[1]
+        assert v1.type == ViolationType.SILKSCREEN_LINE_WIDTH
+        assert v1.type_str == "silkscreen_line_width"
+
+        v2 = report.violations[2]
+        assert v2.type == ViolationType.CLEARANCE_PAD_PAD
+        assert v2.type_str == "clearance_pad_pad"
+
+    def test_round_trip_no_unknown_types(self):
+        """No violation from kct-check JSON should end up as UNKNOWN."""
+        from kicad_tools.drc.report import _parse_kct_check_json
+
+        rule_ids = [
+            "clearance_pad_pad",
+            "edge_clearance_trace",
+            "dimension_trace_width",
+            "silkscreen_line_width",
+            "solder_mask_clearance",
+            "impedance",
+            "pth_annular_ring",
+            "min_pad_size",
+        ]
+        kct_json = {
+            "file": "/tmp/test.kicad_pcb",
+            "manufacturer": "jlcpcb",
+            "layers": 2,
+            "summary": {
+                "errors": len(rule_ids),
+                "warnings": 0,
+                "rules_checked": len(rule_ids),
+                "passed": False,
+            },
+            "violations": [
+                {
+                    "rule_id": rid,
+                    "severity": "error",
+                    "message": f"Test violation for {rid}",
+                    "location": [0, 0],
+                    "layer": "F.Cu",
+                    "items": [],
+                }
+                for rid in rule_ids
+            ],
+        }
+
+        report = _parse_kct_check_json(kct_json, "test.json")
+        for v in report.violations:
+            assert v.type != ViolationType.UNKNOWN, (
+                f"rule_id {v.type_str!r} resolved to UNKNOWN after round-trip"
+            )
+
+
+class TestExistingBehaviorPreserved:
+    """Ensure existing KiCad-cli type strings still work after changes."""
+
+    @pytest.mark.parametrize(
+        "type_str, expected",
+        [
+            ("clearance", ViolationType.CLEARANCE),
+            ("unconnected_items", ViolationType.UNCONNECTED_ITEMS),
+            ("shorting_items", ViolationType.SHORTING_ITEMS),
+            ("track_width", ViolationType.TRACK_WIDTH),
+            ("via_annular_width", ViolationType.VIA_ANNULAR_WIDTH),
+            ("drill_hole_too_small", ViolationType.DRILL_HOLE_TOO_SMALL),
+            ("drill_clearance", ViolationType.DRILL_CLEARANCE),
+            ("silk_over_copper", ViolationType.SILK_OVER_COPPER),
+            ("silk_overlap", ViolationType.SILK_OVERLAP),
+            ("solder_mask_bridge", ViolationType.SOLDER_MASK_BRIDGE),
+            ("courtyard_overlap", ViolationType.COURTYARD_OVERLAP),
+            ("copper_edge_clearance", ViolationType.COPPER_EDGE_CLEARANCE),
+            ("footprint", ViolationType.FOOTPRINT),
+            ("duplicate_footprint", ViolationType.DUPLICATE_FOOTPRINT),
+            ("malformed_outline", ViolationType.MALFORMED_OUTLINE),
+        ],
+    )
+    def test_kicad_cli_types_preserved(self, type_str: str, expected: ViolationType):
+        assert ViolationType.from_string(type_str) == expected
+
+    @pytest.mark.parametrize(
+        "description, expected",
+        [
+            ("Track width too small", ViolationType.TRACK_WIDTH),
+            ("Trace width too narrow", ViolationType.TRACK_WIDTH),
+            ("edge clearance violation", ViolationType.COPPER_EDGE_CLEARANCE),
+            ("Drill size too small", ViolationType.DRILL_HOLE_TOO_SMALL),
+            ("Silkscreen overlap", ViolationType.SILK_OVERLAP),
+            ("Solder mask bridge", ViolationType.SOLDER_MASK_BRIDGE),
+        ],
+    )
+    def test_fuzzy_descriptions_preserved(self, description: str, expected: ViolationType):
+        assert ViolationType.from_string(description) == expected

--- a/tests/test_fix_drc_cmd.py
+++ b/tests/test_fix_drc_cmd.py
@@ -676,9 +676,10 @@ class TestViolationTypeMapping:
         assert ViolationType.from_string("drill_clearance") == ViolationType.DRILL_CLEARANCE
 
     def test_dimension_drill_clearance(self):
-        """Should parse 'dimension_drill_clearance' to DRILL_CLEARANCE."""
+        """Should parse 'dimension_drill_clearance' to DIMENSION_DRILL_CLEARANCE."""
         assert (
-            ViolationType.from_string("dimension_drill_clearance") == ViolationType.DRILL_CLEARANCE
+            ViolationType.from_string("dimension_drill_clearance")
+            == ViolationType.DIMENSION_DRILL_CLEARANCE
         )
 
     def test_clearance_still_works(self):
@@ -686,8 +687,11 @@ class TestViolationTypeMapping:
         assert ViolationType.from_string("clearance") == ViolationType.CLEARANCE
 
     def test_clearance_segment_segment(self):
-        """clearance_segment_segment should map to CLEARANCE via partial match."""
-        assert ViolationType.from_string("clearance_segment_segment") == ViolationType.CLEARANCE
+        """clearance_segment_segment should map to CLEARANCE_SEGMENT_SEGMENT."""
+        assert (
+            ViolationType.from_string("clearance_segment_segment")
+            == ViolationType.CLEARANCE_SEGMENT_SEGMENT
+        )
 
     def test_clearance_segment_via(self):
         """clearance_segment_via should map to CLEARANCE_SEGMENT_VIA."""


### PR DESCRIPTION
## Summary
Fixes ViolationType.from_string() mapping gaps that caused validate-module rule_ids to resolve to 'unknown' or incorrect types when consumed via `kct check --format json`.

## Changes
- Added 18 new ViolationType enum members covering all validate-module rule_ids (clearance subtypes, edge clearance, dimensions, silkscreen, solder mask, impedance)
- Added explicit alias lookup table in from_string() that maps all validate rule_ids (including trace/segment synonyms) before falling through to fuzzy heuristics
- Fixed fuzzy heuristic to also match "trace" alongside "track" for width violations
- Added `type` field to validate.violations.DRCViolation.to_dict() that resolves rule_id to ViolationType for downstream consumers
- Updated is_clearance property to include new clearance subtypes
- Updated 2 existing tests that asserted old buggy behavior (generic fallback)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| ViolationType.from_string() handles all validate rule_ids | Done | 78 new parametrized tests covering every rule_id |
| dimension_trace_width no longer maps to UNKNOWN | Done | Direct test + round-trip test |
| silkscreen_line_width no longer maps to SILK_OVERLAP | Done | Maps to SILKSCREEN_LINE_WIDTH |
| validate DRCViolation.to_dict() includes type field | Done | 3 tests verify type field presence and value |
| kct-check JSON round-trip preserves types | Done | _parse_kct_check_json round-trip test with 8 rule_ids |
| Existing KiCad-cli type strings still work | Done | 21 parametrized backward-compatibility tests |

## Test Plan
- 78 new tests in tests/test_drc_violation_type_validate.py
- All 280 affected tests pass (test_drc.py, test_fix_drc_cmd.py, test_drc_report_formats.py, test_drc_suggestions.py, new test file)

Closes #1947