### PR TITLE
fix(stitch): include through-hole pads and check zone connectivity

### DIFF
--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -47,6 +47,7 @@ class PadInfo:
     layer: str  # "F.Cu" or "B.Cu"
     width: float  # Pad width
     height: float  # Pad height
+    pad_type: str = "smd"  # "smd", "thru_hole", etc.
 
 
 @dataclass
@@ -255,7 +256,7 @@ def find_all_plane_nets(sexp: SExp) -> dict[str, str]:
 
 
 def find_pads_on_nets(sexp: SExp, net_names: set[str]) -> list[PadInfo]:
-    """Find all SMD pads on the specified nets."""
+    """Find all pads (SMD and through-hole) on the specified nets."""
     net_map = get_net_map(sexp)
     target_net_nums = {num for num, name in net_map.items() if name in net_names}
 
@@ -297,8 +298,9 @@ def find_pads_on_nets(sexp: SExp, net_names: set[str]) -> list[PadInfo]:
             pad_number = pad.get_string(0)
             pad_type = pad.get_string(1)  # smd, thru_hole, etc.
 
-            # Only consider SMD pads (need vias for plane connection)
-            if pad_type != "smd":
+            # Include SMD and through-hole pads; skip other types
+            # (e.g., "np_thru_hole" non-plated holes have no copper)
+            if pad_type not in ("smd", "thru_hole"):
                 continue
 
             # Check if pad is on a target net
@@ -341,6 +343,7 @@ def find_pads_on_nets(sexp: SExp, net_names: set[str]) -> list[PadInfo]:
                     layer=fp_layer,
                     width=pad_width,
                     height=pad_height,
+                    pad_type=pad_type or "smd",
                 )
             )
 
@@ -648,8 +651,27 @@ def is_pad_connected(
     vias: list[tuple[float, float, int]],
     track_points: list[tuple[float, float, int]],
     connection_radius: float = 0.5,
+    same_net_filled_polygons: list[FilledPolygon] | None = None,
+    same_net_zone_polygons: list[ZonePolygon] | None = None,
 ) -> bool:
-    """Check if a pad has any connection (via or track) nearby."""
+    """Check if a pad has any connection (via or track) nearby.
+
+    For through-hole pads, also checks whether the pad overlaps with a
+    filled zone polygon (actual copper pour) or, when zones are unfilled,
+    whether the pad falls within a zone boundary polygon on the same net.
+    A through-hole pad inside a same-net filled zone is already connected
+    to that plane and does not need an additional stitching via.
+
+    Args:
+        pad: The pad to check connectivity for
+        vias: Existing vias as (x, y, net_num)
+        track_points: Track endpoints as (x, y, net_num)
+        connection_radius: Radius for proximity-based via/track matching
+        same_net_filled_polygons: Filled zone polygons on the same net
+            (actual copper pour after zone fill)
+        same_net_zone_polygons: Zone boundary polygons on the same net
+            (used as fallback when zones are unfilled)
+    """
     # Check for nearby vias on the same net
     for vx, vy, vnet in vias:
         if vnet != pad.net_number:
@@ -665,6 +687,34 @@ def is_pad_connected(
         dist = math.sqrt((tx - pad.x) ** 2 + (ty - pad.y) ** 2)
         if dist < connection_radius + max(pad.width, pad.height) / 2:
             return True
+
+    # For through-hole pads, check zone connectivity.
+    # Through-hole pads span all copper layers, so if they sit inside a
+    # same-net zone fill they are already connected to that plane.
+    if pad.pad_type == "thru_hole":
+        # First check filled polygons (actual copper pour -- most accurate)
+        if same_net_filled_polygons:
+            for fp in same_net_filled_polygons:
+                if fp.net_name != pad.net_name:
+                    continue
+                # Fast bounding-box pre-filter
+                if (
+                    pad.x < fp.min_x
+                    or pad.x > fp.max_x
+                    or pad.y < fp.min_y
+                    or pad.y > fp.max_y
+                ):
+                    continue
+                if point_in_polygon(pad.x, pad.y, fp.points):
+                    return True
+
+        # Fallback: check zone boundary polygons (when zones are unfilled)
+        if same_net_zone_polygons:
+            for zp in same_net_zone_polygons:
+                if zp.net_name != pad.net_name:
+                    continue
+                if point_in_polygon(pad.x, pad.y, zp.points):
+                    return True
 
     return False
 
@@ -1726,6 +1776,80 @@ def find_all_filled_polygons(
     return polygons
 
 
+def find_same_net_filled_polygons(
+    sexp: SExp, net_numbers: set[int]
+) -> list[FilledPolygon]:
+    """Extract filled polygon geometry for specific nets (same-net connectivity).
+
+    Similar to ``find_all_filled_polygons`` but includes only the specified nets,
+    for use in checking whether through-hole pads overlap with same-net zone fills.
+
+    Args:
+        sexp: PCB S-expression
+        net_numbers: Net numbers to include
+
+    Returns:
+        List of FilledPolygon objects for the specified nets
+    """
+    polygons: list[FilledPolygon] = []
+    net_map = get_net_map(sexp)
+
+    for child in sexp.iter_children():
+        if child.tag != "zone":
+            continue
+
+        net_node = child.find_child("net")
+        if not net_node:
+            continue
+        net_num = net_node.get_int(0)
+        if net_num is None:
+            net_name_str = net_node.get_string(0)
+            if net_name_str:
+                for num, name in net_map.items():
+                    if name == net_name_str:
+                        net_num = num
+                        break
+            if net_num is None:
+                continue
+        if net_num not in net_numbers:
+            continue
+
+        zone_net_name = net_map.get(net_num, "")
+        net_name_node = child.find_child("net_name")
+        if net_name_node:
+            zone_net_name = net_name_node.get_string(0) or zone_net_name
+
+        layer_node = child.find_child("layer")
+        if not layer_node:
+            continue
+        zone_layer = layer_node.get_string(0)
+        if not zone_layer:
+            continue
+
+        for filled_poly_node in child.find_children("filled_polygon"):
+            pts_node = filled_poly_node.find_child("pts")
+            if not pts_node:
+                continue
+
+            points: list[tuple[float, float]] = []
+            for xy_node in pts_node.find_children("xy"):
+                x = xy_node.get_float(0) or 0.0
+                y = xy_node.get_float(1) or 0.0
+                points.append((x, y))
+
+            if len(points) >= 3:
+                polygons.append(
+                    FilledPolygon(
+                        net_number=net_num,
+                        net_name=zone_net_name,
+                        layer=zone_layer,
+                        points=points,
+                    )
+                )
+
+    return polygons
+
+
 def _check_point_filled_polygon_clearance(
     px: float,
     py: float,
@@ -2223,6 +2347,12 @@ def run_stitch(
     existing_vias = find_existing_vias(sexp, net_numbers)
     track_points = find_existing_tracks(sexp, net_numbers)
 
+    # Find same-net zone data for through-hole pad connectivity checking
+    same_net_filled_polys = find_same_net_filled_polygons(sexp, net_numbers)
+    same_net_zone_polys: list[ZonePolygon] = []
+    for net_name in net_names:
+        same_net_zone_polys.extend(extract_zone_polygons(sexp, net_name))
+
     # Find other-net copper for clearance checking to prevent shorts
     other_net_tracks = find_all_track_segments(sexp, exclude_nets=net_numbers)
     other_net_vias = find_all_board_vias(sexp, exclude_nets=net_numbers)
@@ -2232,7 +2362,13 @@ def run_stitch(
     # Process each pad
     for pad in pads:
         # Check if already connected
-        if is_pad_connected(pad, existing_vias, track_points):
+        if is_pad_connected(
+            pad,
+            existing_vias,
+            track_points,
+            same_net_filled_polygons=same_net_filled_polys,
+            same_net_zone_polygons=same_net_zone_polys,
+        ):
             result.already_connected += 1
             continue
 

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -10,6 +10,7 @@ from kicad_tools.cli.stitch_cmd import (
     PadInfo,
     TraceSegment,
     TrackSegment,
+    ZonePolygon,
     calculate_dogleg_via_position,
     calculate_extended_escape_position,
     calculate_via_position,
@@ -23,6 +24,7 @@ from kicad_tools.cli.stitch_cmd import (
     find_existing_tracks,
     find_existing_vias,
     find_pads_on_nets,
+    find_same_net_filled_polygons,
     generate_grid_positions,
     get_net_map,
     get_net_number,
@@ -4035,3 +4037,477 @@ class TestStitchFilledPolygons:
         # The via placement should either avoid the polygon or skip the pad.
         assert isinstance(result.vias_added, list)
         assert isinstance(result.pads_skipped, list)
+
+
+# ---------------------------------------------------------------------------
+# Through-hole pad fixtures and tests (issue #1942)
+# ---------------------------------------------------------------------------
+
+# PCB with through-hole pads on a power net (no zones, no fills)
+THRU_HOLE_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000500")
+    (at 100 100)
+    (property "Reference" "J1" (at 0 -2 0) (layer "F.SilkS") (uuid "ref-uuid-j1"))
+    (pad "1" thru_hole circle (at 0 0) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 1 "GND"))
+    (pad "2" thru_hole circle (at 0 2.54) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 2 "+3.3V"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000600")
+    (at 110 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-uuid-c1b"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+)
+"""
+
+# PCB with through-hole pad inside a filled zone (should be skipped as connected)
+THRU_HOLE_ZONE_FILLED_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000700")
+    (at 100 100)
+    (property "Reference" "J1" (at 0 -2 0) (layer "F.SilkS") (uuid "ref-uuid-j1b"))
+    (pad "1" thru_hole circle (at 0 0) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 1 "GND"))
+    (pad "2" thru_hole circle (at 0 2.54) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 2 "+3.3V"))
+  )
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-gnd-1")
+    (polygon (pts (xy 90 90) (xy 110 90) (xy 110 110) (xy 90 110)))
+    (filled_polygon (layer "In1.Cu") (pts (xy 90 90) (xy 110 90) (xy 110 110) (xy 90 110)))
+  )
+)
+"""
+
+# PCB with through-hole pad inside a zone boundary but NOT filled (unfilled zone)
+THRU_HOLE_ZONE_UNFILLED_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000800")
+    (at 100 100)
+    (property "Reference" "J1" (at 0 -2 0) (layer "F.SilkS") (uuid "ref-uuid-j1c"))
+    (pad "1" thru_hole circle (at 0 0) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 1 "GND"))
+    (pad "2" thru_hole circle (at 0 2.54) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 2 "+3.3V"))
+  )
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-gnd-2")
+    (polygon (pts (xy 90 90) (xy 110 90) (xy 110 110) (xy 90 110)))
+  )
+)
+"""
+
+# PCB with mixed SMD and through-hole pads on the same power net
+MIXED_PAD_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000900")
+    (at 100 100)
+    (property "Reference" "J1" (at 0 -2 0) (layer "F.SilkS") (uuid "ref-uuid-j1d"))
+    (pad "1" thru_hole circle (at 0 0) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 1 "GND"))
+    (pad "2" thru_hole circle (at 0 2.54) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 2 "+3.3V"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000001000")
+    (at 110 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-uuid-c1d"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000001100")
+    (at 120 100)
+    (property "Reference" "C2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-uuid-c2d"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-gnd-3")
+    (polygon (pts (xy 90 90) (xy 130 90) (xy 130 110) (xy 90 110)))
+  )
+)
+"""
+
+
+@pytest.fixture
+def thru_hole_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "thru_hole.kicad_pcb"
+    pcb_file.write_text(THRU_HOLE_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def thru_hole_zone_filled_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "thru_hole_zone_filled.kicad_pcb"
+    pcb_file.write_text(THRU_HOLE_ZONE_FILLED_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def thru_hole_zone_unfilled_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "thru_hole_zone_unfilled.kicad_pcb"
+    pcb_file.write_text(THRU_HOLE_ZONE_UNFILLED_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def mixed_pad_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "mixed_pad.kicad_pcb"
+    pcb_file.write_text(MIXED_PAD_PCB)
+    return pcb_file
+
+
+class TestThruHolePadDetection:
+    """Tests for through-hole pad detection in find_pads_on_nets (issue #1942)."""
+
+    def test_find_thru_hole_pads_on_net(self, thru_hole_pcb: Path):
+        """find_pads_on_nets should include through-hole pads."""
+        sexp = load_pcb(thru_hole_pcb)
+        pads = find_pads_on_nets(sexp, {"GND"})
+
+        refs = {f"{p.reference}.{p.pad_number}" for p in pads}
+        # J1.1 is thru_hole on GND, C1.1 is SMD on GND
+        assert "J1.1" in refs
+        assert "C1.1" in refs
+        assert len(pads) == 2
+
+    def test_thru_hole_pad_type_field(self, thru_hole_pcb: Path):
+        """Through-hole pads should have pad_type='thru_hole'."""
+        sexp = load_pcb(thru_hole_pcb)
+        pads = find_pads_on_nets(sexp, {"GND"})
+
+        j1_pad = next(p for p in pads if p.reference == "J1")
+        assert j1_pad.pad_type == "thru_hole"
+
+        c1_pad = next(p for p in pads if p.reference == "C1")
+        assert c1_pad.pad_type == "smd"
+
+    def test_find_thru_hole_pads_multiple_nets(self, thru_hole_pcb: Path):
+        """Should find through-hole pads on multiple nets."""
+        sexp = load_pcb(thru_hole_pcb)
+        pads = find_pads_on_nets(sexp, {"GND", "+3.3V"})
+
+        # J1.1 (GND), J1.2 (+3.3V), C1.1 (GND), C1.2 (+3.3V)
+        assert len(pads) == 4
+        thru_hole_pads = [p for p in pads if p.pad_type == "thru_hole"]
+        smd_pads = [p for p in pads if p.pad_type == "smd"]
+        assert len(thru_hole_pads) == 2
+        assert len(smd_pads) == 2
+
+
+class TestThruHoleZoneConnectivity:
+    """Tests for through-hole pad zone connectivity in is_pad_connected."""
+
+    def test_thru_hole_pad_connected_via_filled_zone(self):
+        """Through-hole pad inside filled zone polygon should be connected."""
+        pad = PadInfo(
+            reference="J1",
+            pad_number="1",
+            net_number=1,
+            net_name="GND",
+            x=100,
+            y=100,
+            layer="F.Cu",
+            width=1.7,
+            height=1.7,
+            pad_type="thru_hole",
+        )
+
+        filled_poly = FilledPolygon(
+            net_number=1,
+            net_name="GND",
+            layer="In1.Cu",
+            points=[(90, 90), (110, 90), (110, 110), (90, 110)],
+        )
+
+        assert is_pad_connected(
+            pad,
+            vias=[],
+            track_points=[],
+            same_net_filled_polygons=[filled_poly],
+        )
+
+    def test_thru_hole_pad_connected_via_zone_boundary(self):
+        """Through-hole pad inside zone boundary should be connected (unfilled)."""
+        pad = PadInfo(
+            reference="J1",
+            pad_number="1",
+            net_number=1,
+            net_name="GND",
+            x=100,
+            y=100,
+            layer="F.Cu",
+            width=1.7,
+            height=1.7,
+            pad_type="thru_hole",
+        )
+
+        zone_poly = ZonePolygon(
+            net_name="GND",
+            layer="In1.Cu",
+            points=[(90, 90), (110, 90), (110, 110), (90, 110)],
+        )
+
+        assert is_pad_connected(
+            pad,
+            vias=[],
+            track_points=[],
+            same_net_zone_polygons=[zone_poly],
+        )
+
+    def test_thru_hole_pad_outside_zone_not_connected(self):
+        """Through-hole pad outside zone should not be connected."""
+        pad = PadInfo(
+            reference="J1",
+            pad_number="1",
+            net_number=1,
+            net_name="GND",
+            x=200,
+            y=200,
+            layer="F.Cu",
+            width=1.7,
+            height=1.7,
+            pad_type="thru_hole",
+        )
+
+        filled_poly = FilledPolygon(
+            net_number=1,
+            net_name="GND",
+            layer="In1.Cu",
+            points=[(90, 90), (110, 90), (110, 110), (90, 110)],
+        )
+
+        assert not is_pad_connected(
+            pad,
+            vias=[],
+            track_points=[],
+            same_net_filled_polygons=[filled_poly],
+        )
+
+    def test_smd_pad_not_checked_for_zone_connectivity(self):
+        """SMD pads should NOT be considered connected just because of zones."""
+        pad = PadInfo(
+            reference="C1",
+            pad_number="1",
+            net_number=1,
+            net_name="GND",
+            x=100,
+            y=100,
+            layer="F.Cu",
+            width=0.54,
+            height=0.64,
+            pad_type="smd",
+        )
+
+        filled_poly = FilledPolygon(
+            net_number=1,
+            net_name="GND",
+            layer="In1.Cu",
+            points=[(90, 90), (110, 90), (110, 110), (90, 110)],
+        )
+
+        # SMD pad is on F.Cu only -- it cannot reach In1.Cu zone without a via
+        assert not is_pad_connected(
+            pad,
+            vias=[],
+            track_points=[],
+            same_net_filled_polygons=[filled_poly],
+        )
+
+    def test_thru_hole_pad_different_net_zone_not_connected(self):
+        """Through-hole pad should not match zone on different net."""
+        pad = PadInfo(
+            reference="J1",
+            pad_number="1",
+            net_number=1,
+            net_name="GND",
+            x=100,
+            y=100,
+            layer="F.Cu",
+            width=1.7,
+            height=1.7,
+            pad_type="thru_hole",
+        )
+
+        filled_poly = FilledPolygon(
+            net_number=2,
+            net_name="+3.3V",
+            layer="In1.Cu",
+            points=[(90, 90), (110, 90), (110, 110), (90, 110)],
+        )
+
+        assert not is_pad_connected(
+            pad,
+            vias=[],
+            track_points=[],
+            same_net_filled_polygons=[filled_poly],
+        )
+
+    def test_thru_hole_pad_with_existing_via_connected(self):
+        """Through-hole pad with nearby via should be connected (existing logic)."""
+        pad = PadInfo(
+            reference="J1",
+            pad_number="1",
+            net_number=1,
+            net_name="GND",
+            x=100,
+            y=100,
+            layer="F.Cu",
+            width=1.7,
+            height=1.7,
+            pad_type="thru_hole",
+        )
+
+        # Via right next to the pad
+        assert is_pad_connected(pad, vias=[(100.1, 100, 1)], track_points=[])
+
+
+class TestThruHoleStitchIntegration:
+    """Integration tests for stitch with through-hole pads."""
+
+    def test_stitch_finds_thru_hole_pads(self, thru_hole_pcb: Path):
+        """run_stitch should detect through-hole pads needing vias."""
+        result = run_stitch(
+            pcb_path=thru_hole_pcb,
+            net_names=["GND"],
+            dry_run=True,
+        )
+
+        # J1.1 (thru_hole) + C1.1 (smd) = 2 GND pads, both needing vias
+        assert len(result.vias_added) == 2
+
+    def test_stitch_skips_thru_hole_in_filled_zone(
+        self, thru_hole_zone_filled_pcb: Path
+    ):
+        """Through-hole pad inside filled zone should be skipped."""
+        result = run_stitch(
+            pcb_path=thru_hole_zone_filled_pcb,
+            net_names=["GND"],
+            dry_run=True,
+        )
+
+        # J1.1 is thru_hole inside filled GND zone -- should be skipped
+        assert result.already_connected >= 1
+        # No SMD pads on this PCB, so the only GND pad is J1.1
+        via_refs = {v.pad.reference for v in result.vias_added}
+        assert "J1" not in via_refs
+
+    def test_stitch_skips_thru_hole_in_unfilled_zone(
+        self, thru_hole_zone_unfilled_pcb: Path
+    ):
+        """Through-hole pad inside zone boundary (unfilled) should be skipped."""
+        result = run_stitch(
+            pcb_path=thru_hole_zone_unfilled_pcb,
+            net_names=["GND"],
+            dry_run=True,
+        )
+
+        # J1.1 is thru_hole inside GND zone boundary -- connected via fallback
+        assert result.already_connected >= 1
+        via_refs = {v.pad.reference for v in result.vias_added}
+        assert "J1" not in via_refs
+
+    def test_stitch_mixed_pad_types(self, mixed_pad_pcb: Path):
+        """Mixed board: SMD pads get vias, thru_hole in zone is skipped."""
+        result = run_stitch(
+            pcb_path=mixed_pad_pcb,
+            net_names=["GND"],
+            dry_run=True,
+        )
+
+        # J1.1 (thru_hole, inside GND zone) should be skipped
+        # C1.1 and C2.1 (smd) should get vias
+        via_refs = [v.pad.reference for v in result.vias_added]
+        assert "J1" not in via_refs
+        assert via_refs.count("C1") == 1
+        assert via_refs.count("C2") == 1
+        assert result.already_connected >= 1
+
+    def test_stitch_thru_hole_outside_zone_gets_via(self, mixed_pad_pcb: Path):
+        """Through-hole pad NOT inside a zone should get a via."""
+        result = run_stitch(
+            pcb_path=mixed_pad_pcb,
+            net_names=["+3.3V"],
+            dry_run=True,
+        )
+
+        # J1.2 is thru_hole on +3.3V -- no +3.3V zone, so it needs a via
+        # C1.2 and C2.2 are SMD on +3.3V -- also need vias
+        assert len(result.vias_added) == 3
+
+    def test_find_same_net_filled_polygons(
+        self, thru_hole_zone_filled_pcb: Path
+    ):
+        """find_same_net_filled_polygons should return polys for specified nets."""
+        sexp = load_pcb(thru_hole_zone_filled_pcb)
+        polys = find_same_net_filled_polygons(sexp, {1})
+
+        assert len(polys) == 1
+        assert polys[0].net_name == "GND"
+        assert polys[0].net_number == 1
+
+    def test_find_same_net_filled_polygons_excludes_other_nets(
+        self, thru_hole_zone_filled_pcb: Path
+    ):
+        """find_same_net_filled_polygons should not return other-net polys."""
+        sexp = load_pcb(thru_hole_zone_filled_pcb)
+        polys = find_same_net_filled_polygons(sexp, {2})
+
+        assert len(polys) == 0


### PR DESCRIPTION
## Summary

Fix the stitch command reporting zero unconnected pads when through-hole power pads are disconnected from inner planes. The root cause was a dual filter issue: `find_pads_on_nets()` excluded all non-SMD pads, and `is_pad_connected()` lacked zone connectivity checking.

## Changes

- Remove the SMD-only filter in `find_pads_on_nets()` -- now includes both `smd` and `thru_hole` pad types (still excludes `np_thru_hole` non-plated holes)
- Add `pad_type` field to `PadInfo` dataclass to enable type-aware connectivity checks
- Enhance `is_pad_connected()` with zone connectivity evaluation for through-hole pads:
  - Checks filled zone polygons (actual copper pour) for same-net overlap
  - Falls back to zone boundary polygons when zones are unfilled
  - Only applies to through-hole pads (SMD pads still require explicit vias)
- Add `find_same_net_filled_polygons()` helper for extracting same-net zone fill data
- Update `run_stitch()` to pass zone data to connectivity checking

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Stitch identifies through-hole pads on power nets | Done | `test_stitch_finds_thru_hole_pads` -- 2 GND pads detected |
| Stitch identifies SMD pads on power nets | Done | Existing tests unchanged (174 pass) |
| Works with filled zones | Done | `test_stitch_skips_thru_hole_in_filled_zone` |
| Works with unfilled zones | Done | `test_stitch_skips_thru_hole_in_unfilled_zone` |
| Through-hole pads in filled zones correctly skipped | Done | `test_thru_hole_pad_connected_via_filled_zone` |
| Pads with existing nearby vias still correctly skipped | Done | `test_thru_hole_pad_with_existing_via_connected` |
| No regression in blanket stitching | Done | All existing blanket stitch tests pass |
| Mixed SMD/through-hole boards work correctly | Done | `test_stitch_mixed_pad_types` |

## Test Plan

- 190 tests pass (174 existing + 16 new), zero regressions
- New test classes: `TestThruHolePadDetection`, `TestThruHoleZoneConnectivity`, `TestThruHoleStitchIntegration`
- Covers: through-hole detection, zone fill overlap, unfilled zone boundary fallback, mixed pad types, different-net zone rejection, SMD zone exclusion

Closes #1942