### PR TITLE
fix(optim): use courtyard-aware clamping in placement optimizer

### DIFF
--- a/src/kicad_tools/cli/placement_cmd.py
+++ b/src/kicad_tools/cli/placement_cmd.py
@@ -1053,6 +1053,7 @@ def cmd_optimize(args) -> int:
             print(f"Keepout zones: {len(keepout_zones)}")
 
     # Create workflow configuration
+    boundary_margin = getattr(args, "boundary_margin", None)
     workflow_config = WorkflowConfig(
         strategy=strategy,
         grid=args.grid,
@@ -1064,6 +1065,7 @@ def cmd_optimize(args) -> int:
         enable_clustering=enable_clustering,
         edge_detect=edge_detect,
         fixed_refs=fixed_refs,
+        boundary_margin=boundary_margin,
     )
 
     # Create and run workflow
@@ -1665,6 +1667,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         dest="check_routability",
         help="Check routability before and after optimization to show impact",
+    )
+    optimize_parser.add_argument(
+        "--boundary-margin",
+        type=float,
+        default=None,
+        dest="boundary_margin",
+        help="Extra margin in mm between component courtyards and board edge (default: 1.0)",
     )
     optimize_parser.add_argument(
         "--dry-run",

--- a/src/kicad_tools/optim/placement.py
+++ b/src/kicad_tools/optim/placement.py
@@ -1787,14 +1787,17 @@ class PlacementOptimizer:
             comp.update_position(dt)
 
             # Hard-clamp position to board bounding box (prevents escape)
-            margin = self.config.boundary_margin
-            comp.x = max(min_x + margin, min(max_x - margin, comp.x))
-            comp.y = max(min_y + margin, min(max_y - margin, comp.y))
+            # Use per-component courtyard extent so the entire physical
+            # footprint stays within the board, not just the center.
+            half_w = comp.width / 2 + self.config.boundary_margin
+            half_h = comp.height / 2 + self.config.boundary_margin
+            comp.x = max(min_x + half_w, min(max_x - half_w, comp.x))
+            comp.y = max(min_y + half_h, min(max_y - half_h, comp.y))
 
             # If component was clamped, kill its outward velocity
-            if comp.x <= min_x + margin or comp.x >= max_x - margin:
+            if comp.x <= min_x + half_w or comp.x >= max_x - half_w:
                 comp.vx = 0.0
-            if comp.y <= min_y + margin or comp.y >= max_y - margin:
+            if comp.y <= min_y + half_h or comp.y >= max_y - half_h:
                 comp.vy = 0.0
 
             # Update pin positions based on new position and rotation

--- a/src/kicad_tools/optim/workflow.py
+++ b/src/kicad_tools/optim/workflow.py
@@ -191,6 +191,9 @@ class WorkflowConfig:
     enable_clustering: bool = False
     edge_detect: bool = False
 
+    # Board boundary parameters
+    boundary_margin: float | None = None  # Extra margin in mm (None = use PlacementConfig default)
+
     # Fixed components (list of reference designators)
     fixed_refs: list[str] = field(default_factory=list)
 
@@ -276,11 +279,14 @@ class OptimizationWorkflow:
         """Run force-directed (physics-based) optimization."""
         from kicad_tools.optim import PlacementConfig, PlacementOptimizer, add_keepout_zones
 
-        config = PlacementConfig(
-            grid_size=self.config.grid if self.config.grid > 0 else 0.0,
-            rotation_grid=90.0,
-            thermal_enabled=self.config.thermal,
-        )
+        config_kwargs: dict = {
+            "grid_size": self.config.grid if self.config.grid > 0 else 0.0,
+            "rotation_grid": 90.0,
+            "thermal_enabled": self.config.thermal,
+        }
+        if self.config.boundary_margin is not None:
+            config_kwargs["boundary_margin"] = self.config.boundary_margin
+        config = PlacementConfig(**config_kwargs)
 
         optimizer = PlacementOptimizer.from_pcb(
             self.pcb,
@@ -395,10 +401,13 @@ class OptimizationWorkflow:
             grid_snap=self.config.grid if self.config.grid > 0 else 0.127,
         )
 
-        physics_config = PlacementConfig(
-            grid_size=self.config.grid if self.config.grid > 0 else 0.0,
-            rotation_grid=90.0,
-        )
+        physics_kwargs: dict = {
+            "grid_size": self.config.grid if self.config.grid > 0 else 0.0,
+            "rotation_grid": 90.0,
+        }
+        if self.config.boundary_margin is not None:
+            physics_kwargs["boundary_margin"] = self.config.boundary_margin
+        physics_config = PlacementConfig(**physics_kwargs)
 
         evo_optimizer = EvolutionaryPlacementOptimizer.from_pcb(
             self.pcb,

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1503,3 +1503,146 @@ class TestOptimizerConvergence:
                     separated = True
                     break
         assert separated, "Overlapping components did not separate"
+
+
+class TestCourtyardAwareClamping:
+    """Tests for courtyard-aware boundary clamping (issue #1945)."""
+
+    def test_courtyard_stays_within_board_after_optimization(self):
+        """Component courtyards must not extend beyond the board bounding box."""
+        board = Polygon.rectangle(50, 50, 50, 50)  # 50x50mm board centered at (50,50)
+        config = PlacementConfig(boundary_margin=1.0)
+        optimizer = PlacementOptimizer(board, config)
+
+        # Add 20 components in a tight cluster to generate high repulsion
+        for i in range(20):
+            x = 45.0 + (i % 5) * 2.0
+            y = 45.0 + (i // 5) * 2.0
+            comp = Component(ref=f"R{i}", x=x, y=y, width=3.0, height=2.0)
+            optimizer.add_component(comp)
+
+        optimizer.run(iterations=500, dt=0.01)
+
+        # Board bounding box
+        min_x = min(v.x for v in board.vertices)
+        max_x = max(v.x for v in board.vertices)
+        min_y = min(v.y for v in board.vertices)
+        max_y = max(v.y for v in board.vertices)
+
+        for comp in optimizer.components:
+            courtyard_min_x = comp.x - comp.width / 2
+            courtyard_max_x = comp.x + comp.width / 2
+            courtyard_min_y = comp.y - comp.height / 2
+            courtyard_max_y = comp.y + comp.height / 2
+            assert courtyard_min_x >= min_x - 0.01, (
+                f"Component {comp.ref} courtyard extends past left edge: "
+                f"courtyard_min_x={courtyard_min_x:.2f}, board_min_x={min_x:.2f}"
+            )
+            assert courtyard_max_x <= max_x + 0.01, (
+                f"Component {comp.ref} courtyard extends past right edge: "
+                f"courtyard_max_x={courtyard_max_x:.2f}, board_max_x={max_x:.2f}"
+            )
+            assert courtyard_min_y >= min_y - 0.01, (
+                f"Component {comp.ref} courtyard extends past bottom edge: "
+                f"courtyard_min_y={courtyard_min_y:.2f}, board_min_y={min_y:.2f}"
+            )
+            assert courtyard_max_y <= max_y + 0.01, (
+                f"Component {comp.ref} courtyard extends past top edge: "
+                f"courtyard_max_y={courtyard_max_y:.2f}, board_max_y={max_y:.2f}"
+            )
+
+    def test_large_component_clamped_with_courtyard(self):
+        """A large IC should be inset further than a small resistor."""
+        board = Polygon.rectangle(50, 50, 100, 80)
+        config = PlacementConfig(boundary_margin=0.5)
+        optimizer = PlacementOptimizer(board, config)
+
+        # Large component placed at board corner - should be pushed inward
+        big = Component(ref="U1", x=2.0, y=12.0, width=10.0, height=10.0)
+        optimizer.add_component(big)
+
+        # Small component at same corner - needs less inset
+        small = Component(ref="R1", x=2.0, y=30.0, width=1.6, height=0.8)
+        optimizer.add_component(small)
+
+        optimizer.run(iterations=100, dt=0.01)
+
+        # Board bounds
+        min_x = min(v.x for v in board.vertices)
+
+        # Large component center must be at least half_w from the edge
+        assert big.x >= min_x + big.width / 2 + config.boundary_margin - 0.01, (
+            f"Large component U1 center too close to edge: x={big.x:.2f}, "
+            f"needed >= {min_x + big.width / 2 + config.boundary_margin:.2f}"
+        )
+        # Small component can be closer to the edge
+        assert small.x >= min_x + small.width / 2 + config.boundary_margin - 0.01, (
+            f"Small component R1 center too close to edge: x={small.x:.2f}"
+        )
+        # The large component should be further from the edge than the small one
+        # (comparing the minimum allowed center position)
+        big_min = big.width / 2 + config.boundary_margin
+        small_min = small.width / 2 + config.boundary_margin
+        assert big_min > small_min, "Large component should need more inset than small one"
+
+    def test_boundary_margin_respected_with_custom_value(self):
+        """Custom boundary_margin should be respected in courtyard clamping."""
+        board = Polygon.rectangle(50, 50, 80, 80)  # 80x80 board
+        margin = 3.0
+        config = PlacementConfig(boundary_margin=margin)
+        optimizer = PlacementOptimizer(board, config)
+
+        # Place component at the edge - it should be pushed in by margin + half extent
+        comp = Component(ref="U1", x=10.0, y=10.0, width=6.0, height=4.0)
+        optimizer.add_component(comp)
+
+        optimizer.run(iterations=100, dt=0.01)
+
+        min_x = min(v.x for v in board.vertices)
+        min_y = min(v.y for v in board.vertices)
+
+        expected_min_x = min_x + comp.width / 2 + margin
+        expected_min_y = min_y + comp.height / 2 + margin
+
+        assert comp.x >= expected_min_x - 0.01, (
+            f"Component x={comp.x:.2f} should be >= {expected_min_x:.2f}"
+        )
+        assert comp.y >= expected_min_y - 0.01, (
+            f"Component y={comp.y:.2f} should be >= {expected_min_y:.2f}"
+        )
+
+    def test_component_larger_than_board_no_crash(self):
+        """A component wider than the board must not cause NaN or infinite loops."""
+        board = Polygon.rectangle(50, 50, 8, 8)  # Tiny 8x8mm board
+        config = PlacementConfig(boundary_margin=1.0)
+        optimizer = PlacementOptimizer(board, config)
+
+        # Component courtyard (10+2*1=12mm) exceeds board (8mm)
+        comp = Component(ref="U1", x=50.0, y=50.0, width=10.0, height=10.0)
+        optimizer.add_component(comp)
+
+        # Should complete without error or NaN
+        optimizer.run(iterations=100, dt=0.01)
+
+        assert math.isfinite(comp.x), f"Component x is not finite: {comp.x}"
+        assert math.isfinite(comp.y), f"Component y is not finite: {comp.y}"
+
+    def test_velocity_killed_on_courtyard_clamp(self):
+        """Velocity should be zeroed when a component is clamped at the courtyard boundary."""
+        board = Polygon.rectangle(50, 50, 60, 60)
+        config = PlacementConfig(boundary_margin=1.0)
+        optimizer = PlacementOptimizer(board, config)
+
+        # Component with significant width, placed right at the boundary
+        comp = Component(ref="U1", x=20.0, y=50.0, width=8.0, height=4.0)
+        comp.vx = -100.0  # Strong outward velocity
+        optimizer.add_component(comp)
+
+        optimizer.step(dt=0.01)
+
+        min_x = min(v.x for v in board.vertices)
+        half_w = comp.width / 2 + config.boundary_margin
+
+        # The component should be clamped and its velocity killed
+        assert comp.x >= min_x + half_w - 0.01
+        assert comp.vx == 0.0, f"Outward velocity should be zeroed, got {comp.vx}"


### PR DESCRIPTION
## Summary
The hard-clamp in `PlacementOptimizer.step()` previously constrained only component centers with a flat 1.0mm margin, allowing large component courtyards to extend beyond the board edge. This fix uses per-component half-width/half-height plus `boundary_margin` so the entire physical footprint stays within the board bounding box.

## Changes
- Replace flat-margin center clamp with courtyard-aware clamp using `comp.width/2 + margin` and `comp.height/2 + margin` in `PlacementOptimizer.step()`
- Add `--boundary-margin` CLI argument to the `placement optimize` subcommand
- Add `boundary_margin` field to `WorkflowConfig` and plumb it through to `PlacementConfig` for both force-directed and hybrid strategies
- Add 5 new tests in `TestCourtyardAwareClamping` covering courtyard containment, per-component sizing, custom margin, oversized component edge case, and velocity zeroing

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Per-component courtyard clamping | Pass | `step()` now uses `comp.width/2 + margin` and `comp.height/2 + margin` instead of flat `margin` |
| Large components inset further than small ones | Pass | `test_large_component_clamped_with_courtyard` verifies U1 (10mm) needs more inset than R1 (1.6mm) |
| `--boundary-margin` CLI argument | Pass | Added to `placement_cmd.py`, plumbed through `WorkflowConfig` to `PlacementConfig` |
| Component courtyard stays within board | Pass | `test_courtyard_stays_within_board_after_optimization` verifies 20 components after 500 iterations |
| Component larger than board does not crash | Pass | `test_component_larger_than_board_no_crash` verifies no NaN or infinite loops |
| Velocity killed on clamp | Pass | `test_velocity_killed_on_courtyard_clamp` verifies outward velocity zeroed |
| Existing tests pass | Pass | All 135 tests in `test_optim.py` and 43 in `test_edge_placement.py` pass |

## Test Plan
- All 135 existing tests in `test_optim.py` pass (no regressions)
- All 43 tests in `test_edge_placement.py` pass (no regressions)
- 5 new tests in `TestCourtyardAwareClamping` all pass

Closes #1945