### PR TITLE
fix(zones,stitch): add post-write verification to catch silent persistence failures

### DIFF
--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -29,7 +29,7 @@ import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from kicad_tools.core.sexp_file import load_pcb, save_pcb
+from kicad_tools.core.sexp_file import load_pcb, save_pcb, verify_pcb_write
 from kicad_tools.sexp import SExp
 from kicad_tools.sexp.builders import segment_node, via_node
 
@@ -2152,6 +2152,9 @@ def run_blanket_stitch(
             add_via_to_pcb(sexp, placement)
         save_pcb(sexp, pcb_path)
 
+        # Post-write verification
+        verify_pcb_write(pcb_path, expected_vias=len(result.vias_added))
+
     return result
 
 
@@ -2393,6 +2396,13 @@ def run_stitch(
         for trace in result.traces_added:
             add_trace_to_pcb(sexp, trace)
         save_pcb(sexp, pcb_path)
+
+        # Post-write verification
+        verify_pcb_write(
+            pcb_path,
+            expected_vias=len(result.vias_added),
+            expected_segments=len(result.traces_added),
+        )
 
     return result
 

--- a/src/kicad_tools/cli/zones_cmd.py
+++ b/src/kicad_tools/cli/zones_cmd.py
@@ -243,7 +243,11 @@ def _run_add(args) -> int:
     if not quiet:
         print(f"\nSaving to: {output_path}")
 
-    gen.save(output_path)
+    try:
+        gen.save(output_path)
+    except Exception as e:
+        print(f"Error: Write verification failed: {e}", file=sys.stderr)
+        return 1
 
     if not quiet:
         print("Done!")
@@ -381,7 +385,11 @@ def _run_batch(args) -> int:
     if not quiet:
         print(f"\nSaving to: {output_path}")
 
-    gen.save(output_path)
+    try:
+        gen.save(output_path)
+    except Exception as e:
+        print(f"Error: Write verification failed: {e}", file=sys.stderr)
+        return 1
 
     if not quiet:
         stats = gen.get_statistics()

--- a/src/kicad_tools/core/sexp_file.py
+++ b/src/kicad_tools/core/sexp_file.py
@@ -182,6 +182,65 @@ def save_pcb(sexp: SExp, path: str | Path) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+class WriteVerificationError(Exception):
+    """Raised when post-write verification detects missing structures."""
+
+    pass
+
+
+def verify_pcb_write(
+    path: str | Path,
+    expected_zones: int = 0,
+    expected_vias: int = 0,
+    expected_segments: int = 0,
+) -> None:
+    """Re-read a PCB file and verify expected structures are present.
+
+    This catches silent persistence failures where in-memory modifications
+    are not reflected in the written file (e.g., serializer bugs, append
+    targeting wrong node, truncation).
+
+    Args:
+        path: Path to the PCB file to verify
+        expected_zones: Minimum number of ``(zone ...)`` nodes expected
+        expected_vias: Minimum number of ``(via ...)`` nodes expected
+        expected_segments: Minimum number of ``(segment ...)`` nodes expected
+
+    Raises:
+        WriteVerificationError: If the file does not contain the expected
+            number of structures.
+    """
+    sexp = load_pcb(path)
+    errors: list[str] = []
+
+    if expected_zones > 0:
+        actual = len(sexp.find_all("zone"))
+        if actual < expected_zones:
+            errors.append(
+                f"Expected at least {expected_zones} zone(s), found {actual}"
+            )
+
+    if expected_vias > 0:
+        actual = len(sexp.find_all("via"))
+        if actual < expected_vias:
+            errors.append(
+                f"Expected at least {expected_vias} via(s), found {actual}"
+            )
+
+    if expected_segments > 0:
+        actual = len(sexp.find_all("segment"))
+        if actual < expected_segments:
+            errors.append(
+                f"Expected at least {expected_segments} segment(s), found {actual}"
+            )
+
+    if errors:
+        raise WriteVerificationError(
+            f"Post-write verification failed for {path}: "
+            + "; ".join(errors)
+        )
+
+
 def load_footprint(path: str | Path) -> SExp:
     """
     Load a KiCad footprint file.

--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from kicad_tools.core.sexp_file import save_pcb, verify_pcb_write
 from kicad_tools.schema.pcb import PCB
 from kicad_tools.sexp import SExp, parse_file
 from kicad_tools.sexp.builders import zone_node
@@ -110,6 +111,7 @@ class ZoneGenerator:
         self._doc = doc
         self._zones: list[GeneratedZone] = []
         self._board_outline: list[tuple[float, float]] | None = None
+        self._applied = False
 
     @classmethod
     def from_pcb(cls, path: str | Path) -> ZoneGenerator:
@@ -314,21 +316,31 @@ class ZoneGenerator:
 
         Modifies the internal document by appending zone definitions.
         Call save() after this to write changes to disk.
+
+        Safe to call multiple times -- zones are only appended once.
         """
         if not self._doc:
             raise ValueError("No document loaded - use from_pcb() to load a PCB")
 
+        if self._applied:
+            return
+
         for zone in self._zones:
             self._doc.append(zone.to_sexp_node())
 
+        self._applied = True
+
     def save(self, output_path: str | Path | None = None) -> Path:
-        """Save PCB with generated zones.
+        """Save PCB with generated zones and verify persistence.
 
         Args:
-            output_path: Output file path, or None to return path only
+            output_path: Output file path
 
         Returns:
             Path to the output file
+
+        Raises:
+            WriteVerificationError: If zones are missing from the written file.
         """
         if not self._doc:
             raise ValueError("No document loaded - use from_pcb() to load a PCB")
@@ -340,7 +352,12 @@ class ZoneGenerator:
             raise ValueError("Output path required")
 
         output_path = Path(output_path)
-        output_path.write_text(self._doc.to_string())
+        save_pcb(self._doc, output_path)
+
+        # Post-write verification: re-read and confirm zones are present
+        if self._zones:
+            verify_pcb_write(output_path, expected_zones=len(self._zones))
+
         return output_path
 
     def get_statistics(self) -> dict:

--- a/tests/test_write_verification.py
+++ b/tests/test_write_verification.py
@@ -1,0 +1,455 @@
+"""Tests for post-write verification of zones and stitch persistence.
+
+Covers the fix for issue #1944: zones batch and stitch commands silently
+fail to persist changes.
+"""
+
+import pytest
+from pathlib import Path
+
+from kicad_tools.core.sexp_file import (
+    load_pcb,
+    save_pcb,
+    verify_pcb_write,
+    WriteVerificationError,
+)
+from kicad_tools.sexp import SExp, parse_string
+from kicad_tools.sexp.builders import via_node, zone_node, segment_node
+
+
+# ---------------------------------------------------------------------------
+# Minimal PCB fixture text
+# ---------------------------------------------------------------------------
+
+MINIMAL_PCB = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+)"""
+
+
+def _write_minimal_pcb(tmp_path: Path) -> Path:
+    """Write a minimal PCB fixture and return its path."""
+    pcb = tmp_path / "test.kicad_pcb"
+    pcb.write_text(MINIMAL_PCB, encoding="utf-8")
+    return pcb
+
+
+# ---------------------------------------------------------------------------
+# SExp round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestSExpRoundTrip:
+    """Verify that append + to_string correctly persists new children."""
+
+    def test_append_zone_round_trip(self):
+        """Parse a PCB, append a zone, serialize, re-parse, verify zone exists."""
+        doc = parse_string(MINIMAL_PCB)
+        zone = zone_node(
+            net=1,
+            net_name="GND",
+            layer="B.Cu",
+            points=[(0, 0), (100, 0), (100, 100), (0, 100)],
+            uuid_str="test-uuid-zone",
+        )
+        doc.append(zone)
+        text = doc.to_string()
+
+        reparsed = parse_string(text)
+        zones = reparsed.find_all("zone")
+        assert len(zones) == 1
+        # Verify net_name is correct
+        net_name_node = zones[0].get("net_name")
+        assert net_name_node is not None
+        assert net_name_node.get_first_atom() == "GND"
+
+    def test_append_via_round_trip(self):
+        """Parse a PCB, append a via, serialize, re-parse, verify via exists."""
+        doc = parse_string(MINIMAL_PCB)
+        via = via_node(
+            x=50,
+            y=50,
+            size=0.45,
+            drill=0.2,
+            layers=("F.Cu", "B.Cu"),
+            net=1,
+            uuid_str="test-uuid-via",
+        )
+        doc.append(via)
+        text = doc.to_string()
+
+        reparsed = parse_string(text)
+        vias = reparsed.find_all("via")
+        assert len(vias) == 1
+
+    def test_append_segment_round_trip(self):
+        """Parse a PCB, append a segment, serialize, re-parse, verify segment exists."""
+        doc = parse_string(MINIMAL_PCB)
+        seg = segment_node(
+            start_x=10,
+            start_y=20,
+            end_x=30,
+            end_y=40,
+            width=0.2,
+            layer="F.Cu",
+            net=1,
+            uuid_str="test-uuid-seg",
+        )
+        doc.append(seg)
+        text = doc.to_string()
+
+        reparsed = parse_string(text)
+        segments = reparsed.find_all("segment")
+        assert len(segments) == 1
+
+    def test_append_multiple_elements(self):
+        """Append zones, vias, and segments together; all survive round-trip."""
+        doc = parse_string(MINIMAL_PCB)
+
+        for i in range(3):
+            doc.append(
+                zone_node(
+                    net=1,
+                    net_name="GND",
+                    layer="B.Cu",
+                    points=[(0, 0), (100, 0), (100, 100), (0, 100)],
+                    uuid_str=f"zone-{i}",
+                )
+            )
+
+        for i in range(5):
+            doc.append(
+                via_node(
+                    x=10 + i * 10,
+                    y=50,
+                    size=0.45,
+                    drill=0.2,
+                    layers=("F.Cu", "B.Cu"),
+                    net=1,
+                    uuid_str=f"via-{i}",
+                )
+            )
+
+        text = doc.to_string()
+        reparsed = parse_string(text)
+
+        assert len(reparsed.find_all("zone")) == 3
+        assert len(reparsed.find_all("via")) == 5
+
+
+# ---------------------------------------------------------------------------
+# verify_pcb_write tests
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPcbWrite:
+    """Tests for the verify_pcb_write helper."""
+
+    def test_passes_when_structures_present(self, tmp_path):
+        """Verification passes when expected structures exist."""
+        pcb = _write_minimal_pcb(tmp_path)
+        sexp = load_pcb(pcb)
+
+        sexp.append(
+            zone_node(
+                net=1,
+                net_name="GND",
+                layer="B.Cu",
+                points=[(0, 0), (100, 0), (100, 100), (0, 100)],
+                uuid_str="zone-1",
+            )
+        )
+        sexp.append(
+            via_node(
+                x=50,
+                y=50,
+                size=0.45,
+                drill=0.2,
+                layers=("F.Cu", "B.Cu"),
+                net=1,
+                uuid_str="via-1",
+            )
+        )
+        save_pcb(sexp, pcb)
+
+        # Should not raise
+        verify_pcb_write(pcb, expected_zones=1, expected_vias=1)
+
+    def test_fails_when_zones_missing(self, tmp_path):
+        """Verification raises error when expected zones are missing."""
+        pcb = _write_minimal_pcb(tmp_path)
+
+        with pytest.raises(WriteVerificationError, match="zone"):
+            verify_pcb_write(pcb, expected_zones=3)
+
+    def test_fails_when_vias_missing(self, tmp_path):
+        """Verification raises error when expected vias are missing."""
+        pcb = _write_minimal_pcb(tmp_path)
+
+        with pytest.raises(WriteVerificationError, match="via"):
+            verify_pcb_write(pcb, expected_vias=10)
+
+    def test_fails_when_segments_missing(self, tmp_path):
+        """Verification raises error when expected segments are missing."""
+        pcb = _write_minimal_pcb(tmp_path)
+
+        with pytest.raises(WriteVerificationError, match="segment"):
+            verify_pcb_write(pcb, expected_segments=5)
+
+    def test_passes_with_zero_expectations(self, tmp_path):
+        """Verification passes when no structures expected (all defaults)."""
+        pcb = _write_minimal_pcb(tmp_path)
+        # Should not raise
+        verify_pcb_write(pcb)
+
+    def test_multiple_failures_reported(self, tmp_path):
+        """All missing structure types reported in error message."""
+        pcb = _write_minimal_pcb(tmp_path)
+
+        with pytest.raises(WriteVerificationError) as exc_info:
+            verify_pcb_write(pcb, expected_zones=1, expected_vias=1, expected_segments=1)
+
+        msg = str(exc_info.value)
+        assert "zone" in msg
+        assert "via" in msg
+        assert "segment" in msg
+
+
+# ---------------------------------------------------------------------------
+# ZoneGenerator persistence tests
+# ---------------------------------------------------------------------------
+
+
+class TestZoneGeneratorPersistence:
+    """Test that ZoneGenerator.save() persists zones to disk."""
+
+    def test_save_persists_zones(self, tmp_path):
+        """Zones added via ZoneGenerator appear in the written file."""
+        from kicad_tools.zones import ZoneGenerator
+
+        pcb = _write_minimal_pcb(tmp_path)
+        out = tmp_path / "output.kicad_pcb"
+
+        gen = ZoneGenerator.from_pcb(str(pcb))
+        gen.add_zone(net="GND", layer="B.Cu", priority=1)
+        gen.save(out)
+
+        # Re-read and verify
+        sexp = load_pcb(out)
+        zones = sexp.find_all("zone")
+        assert len(zones) == 1
+        assert zones[0].get("net_name").get_first_atom() == "GND"
+
+    def test_save_multiple_zones(self, tmp_path):
+        """Multiple zones all persist correctly."""
+        from kicad_tools.zones import ZoneGenerator
+
+        pcb = _write_minimal_pcb(tmp_path)
+        out = tmp_path / "output.kicad_pcb"
+
+        gen = ZoneGenerator.from_pcb(str(pcb))
+        gen.add_zone(net="GND", layer="B.Cu", priority=1)
+        gen.add_zone(net="+3.3V", layer="F.Cu", priority=0)
+        gen.save(out)
+
+        sexp = load_pcb(out)
+        zones = sexp.find_all("zone")
+        assert len(zones) == 2
+
+    def test_save_idempotent(self, tmp_path):
+        """Calling save() twice does not duplicate zones."""
+        from kicad_tools.zones import ZoneGenerator
+
+        pcb = _write_minimal_pcb(tmp_path)
+        out = tmp_path / "output.kicad_pcb"
+
+        gen = ZoneGenerator.from_pcb(str(pcb))
+        gen.add_zone(net="GND", layer="B.Cu")
+        gen.save(out)
+        # Second save should not duplicate
+        gen.save(out)
+
+        sexp = load_pcb(out)
+        zones = sexp.find_all("zone")
+        assert len(zones) == 1
+
+    def test_apply_then_save_no_duplicate(self, tmp_path):
+        """Calling apply() then save() does not duplicate zones."""
+        from kicad_tools.zones import ZoneGenerator
+
+        pcb = _write_minimal_pcb(tmp_path)
+        out = tmp_path / "output.kicad_pcb"
+
+        gen = ZoneGenerator.from_pcb(str(pcb))
+        gen.add_zone(net="GND", layer="B.Cu")
+        gen.apply()
+        gen.save(out)
+
+        sexp = load_pcb(out)
+        zones = sexp.find_all("zone")
+        assert len(zones) == 1
+
+    def test_save_in_place(self, tmp_path):
+        """Saving in-place (output == input) works correctly."""
+        from kicad_tools.zones import ZoneGenerator
+
+        pcb = _write_minimal_pcb(tmp_path)
+
+        gen = ZoneGenerator.from_pcb(str(pcb))
+        gen.add_zone(net="GND", layer="B.Cu")
+        gen.save(pcb)
+
+        sexp = load_pcb(pcb)
+        zones = sexp.find_all("zone")
+        assert len(zones) == 1
+
+
+# ---------------------------------------------------------------------------
+# Stitch persistence tests
+# ---------------------------------------------------------------------------
+
+
+STITCH_PCB = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "B.Cu")
+    (uuid "existing-zone")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (filled_areas_thickness no)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon
+      (pts
+        (xy 0 0)
+        (xy 200 0)
+        (xy 200 200)
+        (xy 0 200)
+      )
+    )
+  )
+  (footprint "R_0402"
+    (layer "F.Cu")
+    (at 100 100)
+    (pad "1" smd rect
+      (at -0.5 0)
+      (size 0.6 0.5)
+      (layers "F.Cu" "F.Paste" "F.Mask")
+      (net 1 "GND")
+    )
+  )
+)"""
+
+
+class TestStitchPersistence:
+    """Test that stitch commands persist vias to disk."""
+
+    def test_blanket_stitch_persists_vias(self, tmp_path):
+        """Blanket stitching vias appear in the written file."""
+        from kicad_tools.cli.stitch_cmd import run_blanket_stitch
+
+        pcb = tmp_path / "stitch_test.kicad_pcb"
+        pcb.write_text(STITCH_PCB, encoding="utf-8")
+
+        result = run_blanket_stitch(
+            pcb_path=pcb,
+            net_names=["GND"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            spacing=5.0,
+        )
+
+        if result.vias_added:
+            # Re-read and verify vias are present
+            sexp = load_pcb(pcb)
+            vias = sexp.find_all("via")
+            assert len(vias) >= len(result.vias_added)
+
+    def test_pad_stitch_persists_vias_and_traces(self, tmp_path):
+        """Pad-based stitching vias and traces appear in the written file."""
+        from kicad_tools.cli.stitch_cmd import run_stitch
+
+        pcb = tmp_path / "stitch_test.kicad_pcb"
+        pcb.write_text(STITCH_PCB, encoding="utf-8")
+
+        result = run_stitch(
+            pcb_path=pcb,
+            net_names=["GND"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            offset=0.5,
+        )
+
+        if result.vias_added:
+            sexp = load_pcb(pcb)
+            vias = sexp.find_all("via")
+            assert len(vias) >= len(result.vias_added)
+
+        if result.traces_added:
+            sexp = load_pcb(pcb)
+            segments = sexp.find_all("segment")
+            assert len(segments) >= len(result.traces_added)
+
+
+# ---------------------------------------------------------------------------
+# Sequential zones-then-stitch test
+# ---------------------------------------------------------------------------
+
+
+class TestZonesThenStitch:
+    """Test running zones batch then stitch sequentially on same file."""
+
+    def test_zones_then_stitch_both_persist(self, tmp_path):
+        """Both zones and vias present after sequential operations."""
+        from kicad_tools.cli.stitch_cmd import run_blanket_stitch
+        from kicad_tools.zones import ZoneGenerator
+
+        pcb = _write_minimal_pcb(tmp_path)
+
+        # Step 1: Add zones
+        gen = ZoneGenerator.from_pcb(str(pcb))
+        gen.add_zone(net="GND", layer="B.Cu", priority=1)
+        gen.save(pcb)
+
+        # Verify zones exist after step 1
+        sexp = load_pcb(pcb)
+        assert len(sexp.find_all("zone")) == 1
+
+        # Step 2: Run blanket stitch on the same file
+        result = run_blanket_stitch(
+            pcb_path=pcb,
+            net_names=["GND"],
+            via_size=0.45,
+            drill=0.2,
+            spacing=5.0,
+        )
+
+        # Verify both zones AND vias still present
+        sexp = load_pcb(pcb)
+        assert len(sexp.find_all("zone")) >= 1, "Zones lost after stitch"
+        if result.vias_added:
+            assert len(sexp.find_all("via")) >= 1, "Vias not persisted"


### PR DESCRIPTION
## Summary
Adds post-write verification to the zones batch and stitch commands so that silent persistence failures are detected and reported as errors instead of appearing to succeed.

## Changes
- Added `verify_pcb_write()` helper in `core/sexp_file.py` that re-reads a written PCB file and confirms expected structures (zones, vias, segments) are present
- Added `WriteVerificationError` exception class for verification failures
- Fixed `ZoneGenerator.save()` to use `save_pcb()` (consistent serialization with encoding) instead of raw `write_text()`
- Fixed `ZoneGenerator.apply()` idempotency: tracks `_applied` flag to prevent duplicate zone insertion when `save()` is called multiple times or after explicit `apply()`
- Added post-write verification to `run_blanket_stitch()` and `run_stitch()` after `save_pcb()`
- Wrapped `gen.save()` calls in `zones_cmd.py` with error handling that returns exit code 1 on verification failure
- Added 18 tests covering SExp round-trip, verify_pcb_write, ZoneGenerator persistence, stitch persistence, and sequential zones-then-stitch workflow

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| zones batch output contains expected zone definitions when re-parsed | Pass | `TestZoneGeneratorPersistence` tests verify zones survive save + re-parse |
| stitch output contains expected via definitions when re-parsed | Pass | `TestStitchPersistence` tests verify vias survive save + re-parse |
| Commands return non-zero exit code if write fails | Pass | `WriteVerificationError` propagates to CLI handlers; zones_cmd catches and returns 1, stitch_cmd's existing `except Exception` returns 1 |

## Test Plan
- `pytest tests/test_write_verification.py` -- 18 new tests all pass
- `pytest tests/test_zone_generator.py tests/test_zones_cmd.py tests/test_stitch_cmd.py tests/test_sexp_roundtrip.py` -- 241 existing tests pass, 6 skipped (pre-existing)

Closes #1944