### PR TITLE
feat: add prominent warnings and CLI hints for C++ native backends

### DIFF
--- a/src/kicad_tools/cli/config_cmd.py
+++ b/src/kicad_tools/cli/config_cmd.py
@@ -150,8 +150,40 @@ def _show_config() -> int:
     _print_value(
         "cache_ttl_days", config.parts.cache_ttl_days, config.get_source("parts.cache_ttl_days")
     )
+    print()
+
+    # Show native backend status
+    print("[native_backends]")
+    _print_native_backend_status()
 
     return 0
+
+
+def _print_native_backend_status() -> None:
+    """Print status of C++ native backends."""
+    backends = {
+        "router": ("kicad_tools.router.cpp_backend", "router"),
+        "placement": ("kicad_tools.placement.cpp_backend", "placement"),
+        "drc": ("kicad_tools.drc.cpp_backend", "drc"),
+    }
+    any_missing = False
+    for name, (module_path, _label) in backends.items():
+        try:
+            import importlib
+
+            mod = importlib.import_module(module_path)
+            info = mod.get_backend_info()
+            if info.get("available"):
+                version = info.get("version", "unknown")
+                print(f"{name} = \"cpp v{version}\"  # installed")
+            else:
+                print(f"{name} = \"python (fallback)\"  # NOT installed")
+                any_missing = True
+        except Exception:
+            print(f"{name} = \"python (fallback)\"  # NOT installed")
+            any_missing = True
+    if any_missing:
+        print("# Run 'kct build-native' for 10-100x faster routing/placement")
 
 
 def _print_value(key: str, value, source: str) -> None:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1427,7 +1427,16 @@ def _add_stitch_parser(subparsers) -> None:
 
 def _add_route_parser(subparsers) -> None:
     """Add route subcommand parser."""
-    route_parser = subparsers.add_parser("route", help="Autoroute a PCB")
+    route_parser = subparsers.add_parser(
+        "route",
+        help="Autoroute a PCB",
+        epilog=(
+            "PERFORMANCE: The C++ backend provides 10-100x faster routing. "
+            "Check status with 'kct build-native --check' and build with "
+            "'kct build-native'. The --backend flag defaults to 'auto' which "
+            "uses C++ when available and falls back to Python otherwise."
+        ),
+    )
     route_parser.add_argument("pcb", help="Path to .kicad_pcb file")
     route_parser.add_argument("-o", "--output", help="Output file path")
     route_parser.add_argument(
@@ -1582,8 +1591,9 @@ def _add_route_parser(subparsers) -> None:
         choices=["auto", "cpp", "python"],
         default="auto",
         help=(
-            "Router backend: 'auto' = C++ if available (default); "
-            "'cpp' = require C++; 'python' = force Python"
+            "Router backend: 'auto' = C++ if available, Python fallback (default); "
+            "'cpp' = require C++ (fails if not built); 'python' = force Python. "
+            "The C++ backend is 10-100x faster; build with 'kct build-native'."
         ),
     )
 
@@ -2579,6 +2589,11 @@ def _add_optimize_placement_parser(subparsers) -> None:
     op_parser = subparsers.add_parser(
         "optimize-placement",
         help="Run CMA-ES placement optimization on a KiCad PCB",
+        epilog=(
+            "PERFORMANCE: A C++ backend is available for faster placement "
+            "evaluation. Check status with 'kct build-native --check' and "
+            "build with 'kct build-native'."
+        ),
     )
     op_parser.add_argument("pcb", help="Path to .kicad_pcb file")
     op_parser.add_argument(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -725,6 +725,13 @@ def route_with_layer_escalation(
     elif args.backend == "python":
         force_python = True
 
+    # Warn prominently when auto-backend falls back to Python
+    if args.backend == "auto" and not is_cpp_available() and not quiet:
+        flush_print("WARNING: C++ router backend not installed -- using Python (10-100x slower).")
+        flush_print("  Build it now:  kct build-native")
+        flush_print("  Check status:  kct build-native --check")
+        flush_print()
+
     # Configure design rules
     rules = DesignRules(
         grid_resolution=args.grid,
@@ -1087,6 +1094,13 @@ def route_with_rule_relaxation(
             return 1
     elif args.backend == "python":
         force_python = True
+
+    # Warn prominently when auto-backend falls back to Python
+    if args.backend == "auto" and not is_cpp_available() and not quiet:
+        flush_print("WARNING: C++ router backend not installed -- using Python (10-100x slower).")
+        flush_print("  Build it now:  kct build-native")
+        flush_print("  Check status:  kct build-native --check")
+        flush_print()
 
     # Parse skip nets
     skip_nets = []
@@ -1483,6 +1497,13 @@ def route_with_combined_escalation(
             return 1
     elif args.backend == "python":
         force_python = True
+
+    # Warn prominently when auto-backend falls back to Python
+    if args.backend == "auto" and not is_cpp_available() and not quiet:
+        flush_print("WARNING: C++ router backend not installed -- using Python (10-100x slower).")
+        flush_print("  Build it now:  kct build-native")
+        flush_print("  Check status:  kct build-native --check")
+        flush_print()
 
     # Parse skip nets
     skip_nets = []

--- a/src/kicad_tools/placement/cpp_backend.py
+++ b/src/kicad_tools/placement/cpp_backend.py
@@ -8,14 +8,22 @@ falling back to pure Python.
 The C++ backend provides significant speedup for the O(N^2) pairwise
 AABB loops in compute_overlap, compute_drc_violations, and
 compute_boundary_violation.
+
+If placement optimization is slow, the C++ backend is likely not
+installed. Build it with:
+
+    kct build-native
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Sequence
 
 if TYPE_CHECKING:
     from .cost import BoardOutline, ComponentPlacement, DesignRuleSet
+
+logger = logging.getLogger(__name__)
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
@@ -297,6 +305,11 @@ class BatchCostEvaluatorWrapper:
             )
         else:
             self._cpp_evaluator = None
+            if not force_python:
+                logger.warning(
+                    "C++ placement backend not available -- using pure Python (slower). "
+                    "Build the native backend for faster placement: kct build-native"
+                )
 
     @property
     def backend(self) -> str:

--- a/src/kicad_tools/router/algorithms/__init__.py
+++ b/src/kicad_tools/router/algorithms/__init__.py
@@ -6,6 +6,10 @@ This package contains various routing algorithms:
 - Monte Carlo multi-start routing
 - Two-phase global+detailed routing
 - Hierarchical global-to-detailed routing
+
+NOTE: These algorithms use the pure Python pathfinder by default. A C++
+backend is available that provides 10-100x speedup for the core A* loop.
+Build it with 'kct build-native' for production use.
 """
 
 from .hierarchical import HierarchicalRouter

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -6,10 +6,20 @@ uses the C++ implementation when available, falling back to pure Python.
 
 The C++ backend provides 10-100x speedup for the core A* loop and grid
 operations, making fine-grid routing (0.0635mm) practical for production use.
+
+If you are seeing slow routing performance, the C++ backend is likely not
+installed. Build it with:
+
+    kct build-native
+
+Or check its status with:
+
+    kct build-native --check
 """
 
 from __future__ import annotations
 
+import logging
 import math
 from typing import TYPE_CHECKING
 
@@ -17,6 +27,8 @@ if TYPE_CHECKING:
     from .grid import RoutingGrid
     from .primitives import Pad, Route
     from .rules import DesignRules, NetClassRouting
+
+logger = logging.getLogger(__name__)
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
@@ -630,6 +642,12 @@ def create_hybrid_router(
             pass
 
     # Fall back to Python implementation
+    if not force_python:
+        logger.warning(
+            "C++ router backend not available -- using pure Python (10-100x slower). "
+            "Build the native backend for dramatically faster routing: kct build-native"
+        )
+
     from .pathfinder import Router
 
     return Router(grid, rules, net_class_map=net_class_map, diagonal_routing=diagonal_routing)

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -1,5 +1,13 @@
 """
-A* pathfinding for PCB routing.
+A* pathfinding for PCB routing (pure Python fallback).
+
+NOTE: This is the pure Python implementation. A C++ backend is available
+that provides 10-100x speedup. Build it with:
+
+    kct build-native
+
+The C++ backend is used automatically when available. This module serves
+as the fallback when the C++ extension is not installed.
 
 This module provides:
 - AStarNode: Node for priority queue in A* search


### PR DESCRIPTION
## Summary

Improves discoverability of C++ native backends (router, placement, DRC) which provide 10-100x speedup. Users and agents now see clear warnings when falling back to the slower Python implementation, rather than silently degrading.

## Changes

- Add prominent `WARNING` message in `route` CLI output when `--backend auto` falls back to Python (across all 3 routing functions)
- Add `logging.warning()` in `create_hybrid_router()` and `BatchCostEvaluatorWrapper` when C++ is unavailable
- Add epilog text to `route` and `optimize-placement` CLI help mentioning `kct build-native`
- Improve `--backend` flag help text to highlight 10-100x speedup
- Add `[native_backends]` section to `kct config --show` displaying router/placement/DRC backend status
- Update module docstrings in `pathfinder.py`, `router/algorithms/__init__.py`, `router/cpp_backend.py`, and `placement/cpp_backend.py` to note C++ alternative

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Prominent note in CLI help for route and optimize-placement | PASS | Added epilog text to both parsers referencing kct build-native |
| Module-level docstrings noting C++ alternative | PASS | Updated pathfinder.py, algorithms/__init__.py, and both cpp_backend.py files |
| Startup check suggesting kct build-native | PASS | Added WARNING block in route_cmd.py when auto-backend falls back |
| build-native --check output in kct config | PASS | Added [native_backends] section to config --show |

## Test Plan

- Ran `pytest tests/ -k "config or parser or route_cmd or placement_backend"` -- 313 passed, 2 skipped
- Ran `pytest tests/test_router_cpp_backend.py` -- 15 passed
- Verified `kct config --show` prints native_backends section with correct status
- Verified all imports work correctly

Closes #1959