### PR TITLE
feat(sch): add repair-instances subcommand for missing project instances

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -21,8 +21,9 @@ def run_sch_command(args) -> int:
         )
         print(
             "          add-wire, add-junction,"
-            " add-label, cleanup-wires, remove-wire, disconnect, re-annotate"
+            " add-label, cleanup-wires, remove-wire, disconnect, re-annotate,"
         )
+        print("          repair-instances")
         return 1
 
     schematic_path = Path(args.schematic)
@@ -433,6 +434,16 @@ def run_sch_command(args) -> int:
         if args.backup:
             sub_argv.append("--backup")
         return disconnect_main(sub_argv) or 0
+
+    elif args.sch_command == "repair-instances":
+        from ..sch_repair_instances import run_repair_instances
+
+        return run_repair_instances(
+            schematic_path=schematic_path,
+            dry_run=getattr(args, "dry_run", False),
+            backup=getattr(args, "backup", True),
+            format=getattr(args, "format", "text"),
+        )
 
     elif args.sch_command == "re-annotate":
         from ..sch_re_annotate import run_re_annotate

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -997,6 +997,24 @@ def _add_sch_parser(subparsers) -> None:
     )
     sch_reannotate.add_argument("--format", choices=["text", "json"], default="text")
 
+    # sch repair-instances
+    sch_repair_instances = sch_subparsers.add_parser(
+        "repair-instances",
+        help="Fix symbols missing project instances blocks",
+    )
+    sch_repair_instances.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_repair_instances.add_argument(
+        "--dry-run", "-n", action="store_true",
+        help="Preview changes without modifying files",
+    )
+    sch_repair_instances.add_argument(
+        "--backup", action="store_true",
+        help="Create backup before modifying",
+    )
+    sch_repair_instances.add_argument(
+        "--format", choices=["text", "json"], default="text",
+    )
+
 
 def _add_pcb_parser(subparsers) -> None:
     """Add PCB subcommand parser with its subcommands."""

--- a/src/kicad_tools/cli/sch_repair_instances.py
+++ b/src/kicad_tools/cli/sch_repair_instances.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""
+Repair missing project instances in KiCad hierarchical schematics.
+
+Finds all symbols that lack ``(instances ...)`` blocks for the current
+project, assigns non-conflicting reference designators, and writes the
+instances blocks into the sub-sheet files.
+
+Usage:
+    # Preview changes
+    kicad-tools sch repair-instances board.kicad_sch --dry-run
+
+    # Fix all missing instances
+    kicad-tools sch repair-instances board.kicad_sch
+
+    # Fix with backup
+    kicad-tools sch repair-instances board.kicad_sch --backup
+"""
+
+import re
+import sys
+from pathlib import Path
+
+from kicad_tools.cli.modify_schematic import create_backup
+from kicad_tools.cli.sch_re_annotate import (
+    _detect_indent,
+    _detect_project_info,
+    _parse_reference,
+    _format_reference,
+    _apply_uuid_reference_rename,
+)
+from kicad_tools.cli.sch_set_footprint import _collect_schematic_files
+
+# Whitespace token for regex: matches one or more tabs or spaces
+_WS = r'[ \t]+'
+
+
+def _extract_symbols_with_instance_info(
+    text: str, project_name: str
+) -> list[dict]:
+    """Extract symbols and whether they have instances for the given project.
+
+    Uses a bracket-depth approach to find complete symbol blocks, which is
+    more robust than the regex-only approach used in ``sch_re_annotate``.
+
+    Returns list of dicts with keys: reference, prefix, number, unit_suffix,
+    lib_id, uuid, has_project_instance.
+    """
+    symbols = []
+    ref_pattern = re.compile(r'\(property "Reference" "([^"]+)"')
+
+    # Find symbol block starts: lines matching <ws>(symbol\n<ws>(lib_id "...")
+    start_pattern = re.compile(
+        r'(?:^|\n)(' + _WS + r')\(symbol\n' + _WS + r'\(lib_id "([^"]+)"\)',
+        re.DOTALL,
+    )
+
+    for start_match in start_pattern.finditer(text):
+        indent = start_match.group(1)
+        lib_id = start_match.group(2)
+        block_start = start_match.start()
+
+        # Find the end of this symbol block by tracking parenthesis depth
+        # Start from the opening '(' of '(symbol'
+        paren_start = text.index("(symbol", block_start)
+        depth = 0
+        i = paren_start
+        block_end = len(text)
+        while i < len(text):
+            ch = text[i]
+            if ch == '(':
+                depth += 1
+            elif ch == ')':
+                depth -= 1
+                if depth == 0:
+                    block_end = i + 1
+                    break
+            elif ch == '"':
+                # Skip over quoted strings to avoid counting parens inside
+                i += 1
+                while i < len(text) and text[i] != '"':
+                    if text[i] == '\\':
+                        i += 1  # skip escaped char
+                    i += 1
+            i += 1
+
+        block = text[paren_start:block_end]
+
+        ref_match = ref_pattern.search(block)
+        if not ref_match:
+            continue
+
+        ref = ref_match.group(1)
+
+        # Skip power symbols
+        if lib_id.startswith("power:"):
+            continue
+
+        # Find the symbol-level uuid (the last uuid in the block, or the
+        # one that's a direct child of the symbol -- not inside a pin)
+        # Strategy: find all uuids, the symbol-level one is typically the
+        # one right before (instances) or at the end of the block.
+        # We search for (uuid "...") that is NOT inside a (pin ...) block.
+        # Simple approach: find the uuid that appears after all pin blocks.
+        all_uuids = list(re.finditer(r'\(uuid "([^"]+)"\)', block))
+        # The symbol-level uuid is typically the last one before instances,
+        # or the last one in the block if no instances.
+        # Pin uuids are nested inside (pin "X" (uuid "...")) blocks.
+        # The symbol uuid is at indent level 2 (direct child of symbol).
+        sym_uuid = ""
+        for uuid_m in reversed(all_uuids):
+            # Check if this uuid is inside a (pin ...) block
+            preceding = block[:uuid_m.start()]
+            # Count unmatched (pin openings
+            pin_opens = len(re.findall(r'\(pin\b', preceding))
+            pin_closes = preceding.count(')')  # rough estimate
+            # Better approach: check if (pin appears after the last )
+            # before our uuid position
+            last_paren_close = preceding.rfind(')')
+            last_pin_open = preceding.rfind('(pin ')
+            if last_pin_open > last_paren_close:
+                # uuid is inside a pin block
+                continue
+            sym_uuid = uuid_m.group(1)
+            break
+
+        if not sym_uuid and all_uuids:
+            sym_uuid = all_uuids[-1].group(1)
+
+        prefix, number, unit_suffix = _parse_reference(ref)
+
+        # Check if this symbol has an instances block with our project
+        has_instances_block = '(instances' in block
+        has_project = (
+            has_instances_block
+            and f'(project "{project_name}"' in block
+        )
+
+        symbols.append({
+            "reference": ref,
+            "prefix": prefix,
+            "number": number,
+            "unit_suffix": unit_suffix,
+            "lib_id": lib_id,
+            "uuid": sym_uuid,
+            "has_project_instance": has_project,
+        })
+
+    return symbols
+
+
+def _find_symbol_block(text: str, sym_uuid: str) -> tuple[int, int] | None:
+    """Find the start and end positions of the symbol block containing *sym_uuid*.
+
+    Uses bracket-depth parsing for robustness.
+    Returns (start, end) positions or None if not found.
+    """
+    uuid_str = f'(uuid "{sym_uuid}")'
+    uuid_pos = text.find(uuid_str)
+    if uuid_pos == -1:
+        return None
+
+    # Walk backward to find the start of this symbol block
+    start_pattern = re.compile(_WS + r'\(symbol\n')
+    block_start = -1
+    for m in start_pattern.finditer(text, 0, uuid_pos):
+        block_start = m.start()
+    if block_start == -1:
+        return None
+
+    # Find the opening paren of (symbol
+    paren_start = text.index("(symbol", block_start)
+
+    # Walk forward tracking depth to find closing paren
+    depth = 0
+    i = paren_start
+    while i < len(text):
+        ch = text[i]
+        if ch == '(':
+            depth += 1
+        elif ch == ')':
+            depth -= 1
+            if depth == 0:
+                return paren_start, i + 1
+        elif ch == '"':
+            i += 1
+            while i < len(text) and text[i] != '"':
+                if text[i] == '\\':
+                    i += 1
+                i += 1
+        i += 1
+
+    return None
+
+
+def _insert_project_instance(
+    text: str,
+    sym_uuid: str,
+    project_name: str,
+    instance_path: str,
+    new_ref: str,
+    unit: int = 1,
+) -> str:
+    """Insert a project instance entry into a symbol's block.
+
+    If the symbol has an ``(instances)`` block, appends a new
+    ``(project ...)`` entry.  If not, creates an ``(instances)`` block
+    before the symbol's closing parenthesis.
+
+    Uses bracket-depth parsing for robustness with varying file layouts.
+    """
+    bounds = _find_symbol_block(text, sym_uuid)
+    if bounds is None:
+        return text
+
+    start, end = bounds
+    block = text[start:end]
+
+    ind = _detect_indent(text)
+    i2 = ind * 2
+    i3 = ind * 3
+    i4 = ind * 4
+    i5 = ind * 5
+
+    project_entry = (
+        f'{i3}(project "{project_name}"\n'
+        f'{i4}(path "{instance_path}"\n'
+        f'{i5}(reference "{new_ref}")\n'
+        f'{i5}(unit {unit})\n'
+        f'{i4})\n'
+        f'{i3})\n'
+    )
+
+    # Check if block already has (instances
+    instances_pos = block.find('(instances')
+    if instances_pos != -1:
+        # Check if this project already exists
+        if f'(project "{project_name}"' in block:
+            return text
+
+        # Find the closing ) of the (instances block
+        # Walk from instances_pos tracking depth
+        depth = 0
+        i = instances_pos
+        while i < len(block):
+            ch = block[i]
+            if ch == '(':
+                depth += 1
+            elif ch == ')':
+                depth -= 1
+                if depth == 0:
+                    # Insert the new project entry before this closing )
+                    insert_pos = start + i
+                    # Find the start of the line containing this )
+                    line_start = text.rfind('\n', 0, insert_pos) + 1
+                    return (
+                        text[:line_start]
+                        + project_entry
+                        + text[line_start:]
+                    )
+            elif ch == '"':
+                i += 1
+                while i < len(block) and block[i] != '"':
+                    if block[i] == '\\':
+                        i += 1
+                    i += 1
+            i += 1
+
+        return text  # Couldn't find instances closing
+
+    # No instances block - insert one before the symbol's closing )
+    # The closing ) of the symbol block is at position `end - 1`
+    # We want to insert before the line containing that closing paren
+    closing_paren_pos = end - 1
+    line_start = text.rfind('\n', 0, closing_paren_pos) + 1
+
+    instances_block = (
+        f'{i2}(instances\n'
+        f'{project_entry}'
+        f'{i2})\n'
+    )
+
+    return text[:line_start] + instances_block + text[line_start:]
+
+
+def _collect_existing_refs(
+    all_file_symbols: dict[Path, list[dict]],
+) -> dict[str, set[int]]:
+    """Collect all existing reference numbers per prefix across all files.
+
+    Only counts symbols that already have project instances (i.e. already
+    annotated in the project).
+    """
+    existing: dict[str, set[int]] = {}
+    for symbols in all_file_symbols.values():
+        for sym in symbols:
+            if sym["has_project_instance"] and sym["number"] is not None:
+                existing.setdefault(sym["prefix"], set()).add(sym["number"])
+    return existing
+
+
+def run_repair_instances(
+    schematic_path: Path,
+    dry_run: bool = False,
+    backup: bool = True,
+    format: str = "text",
+) -> int:
+    """Run the repair-instances operation.
+
+    Args:
+        schematic_path: Path to root .kicad_sch file.
+        dry_run: If True, show what would change without modifying files.
+        backup: If True, create backups before modifying.
+        format: Output format ("text" or "json").
+
+    Returns:
+        0 on success, 1 on error.
+    """
+    if not schematic_path.exists():
+        print(f"Error: File not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    # Collect all schematic files in hierarchy order
+    all_files = _collect_schematic_files(schematic_path)
+
+    if not all_files:
+        print("Error: No schematic files found", file=sys.stderr)
+        return 1
+
+    # Detect project info
+    project_name, root_uuid, file_instance_paths = _detect_project_info(
+        schematic_path, all_files
+    )
+
+    if not root_uuid:
+        print("Error: Could not detect project UUID from root schematic", file=sys.stderr)
+        return 1
+
+    # Phase 1: Collect all symbols across hierarchy with instance info
+    file_symbols: dict[Path, list[dict]] = {}
+    file_texts: dict[Path, str] = {}
+
+    for sch_file in all_files:
+        try:
+            text = sch_file.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"Error reading {sch_file}: {e}", file=sys.stderr)
+            return 1
+        file_texts[sch_file] = text
+        file_symbols[sch_file] = _extract_symbols_with_instance_info(
+            text, project_name
+        )
+
+    # Phase 2: Find symbols missing project instances
+    missing: list[dict] = []  # [{file, sym}, ...]
+    for sch_file in all_files:
+        for sym in file_symbols[sch_file]:
+            if not sym["has_project_instance"]:
+                missing.append({"file": sch_file, "sym": sym})
+
+    if not missing:
+        if format == "text":
+            print("All symbols have project instances. No repairs needed.")
+        elif format == "json":
+            import json
+            print(json.dumps({"repairs": [], "total": 0, "dry_run": dry_run}))
+        return 0
+
+    # Phase 3: Assign reference designators for unannotated symbols
+    # Collect existing refs to avoid conflicts
+    existing_refs = _collect_existing_refs(file_symbols)
+
+    # Also collect refs from the missing symbols that are already annotated
+    # (have a number but just lack the instances block)
+    for entry in missing:
+        sym = entry["sym"]
+        if sym["number"] is not None:
+            existing_refs.setdefault(sym["prefix"], set()).add(sym["number"])
+
+    # Track counters for assigning new refs
+    counters: dict[str, int] = {}
+
+    def _next_available(prefix: str) -> int:
+        n = counters.get(prefix, 1)
+        reserved = existing_refs.get(prefix, set())
+        while n in reserved:
+            n += 1
+        counters[prefix] = n + 1
+        # Also reserve so subsequent calls don't reuse
+        reserved.add(n)
+        return n
+
+    repairs: list[dict] = []
+    for entry in missing:
+        sym = entry["sym"]
+        sch_file = entry["file"]
+
+        if sym["number"] is not None:
+            # Already annotated, just needs instances block
+            new_ref = sym["reference"]
+        else:
+            # Unannotated (R?, C?, etc.) - assign next available
+            new_number = _next_available(sym["prefix"])
+            new_ref = _format_reference(
+                sym["prefix"], new_number, sym["unit_suffix"]
+            )
+
+        instance_path = file_instance_paths.get(sch_file, "")
+
+        repairs.append({
+            "file": sch_file,
+            "uuid": sym["uuid"],
+            "lib_id": sym["lib_id"],
+            "old_ref": sym["reference"],
+            "new_ref": new_ref,
+            "instance_path": instance_path,
+            "needs_rename": sym["number"] is None,
+        })
+
+    # Phase 4: Output
+    if format == "json":
+        import json
+        output = {
+            "repairs": [
+                {
+                    "file": str(r["file"]),
+                    "uuid": r["uuid"],
+                    "lib_id": r["lib_id"],
+                    "old_ref": r["old_ref"],
+                    "new_ref": r["new_ref"],
+                    "instance_path": r["instance_path"],
+                }
+                for r in repairs
+            ],
+            "total": len(repairs),
+            "dry_run": dry_run,
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print(f"Found {len(repairs)} symbol(s) missing project instances:")
+        print()
+        # Group by file for display
+        by_file: dict[Path, list[dict]] = {}
+        for r in repairs:
+            by_file.setdefault(r["file"], []).append(r)
+
+        for sch_file, file_repairs in by_file.items():
+            print(f"  {sch_file.name}:")
+            for r in file_repairs:
+                if r["needs_rename"]:
+                    print(
+                        f"    {r['old_ref']} -> {r['new_ref']}"
+                        f"  ({r['lib_id']})"
+                    )
+                else:
+                    print(
+                        f"    {r['new_ref']}"
+                        f"  ({r['lib_id']}) [add instances block]"
+                    )
+        print()
+
+    if dry_run:
+        if format == "text":
+            print("Dry run: no changes made.")
+        return 0
+
+    # Phase 5: Apply changes
+    modified_files: dict[Path, str] = {}
+
+    for r in repairs:
+        sch_file = r["file"]
+        text = modified_files.get(sch_file, file_texts[sch_file])
+
+        # If unannotated, rename the reference first
+        if r["needs_rename"]:
+            text = _apply_uuid_reference_rename(
+                text, r["uuid"], r["new_ref"]
+            )
+
+        # Add the project instance block
+        if r["instance_path"]:
+            text = _insert_project_instance(
+                text,
+                r["uuid"],
+                project_name,
+                r["instance_path"],
+                r["new_ref"],
+            )
+
+        modified_files[sch_file] = text
+
+    # Phase 6: Write modified files
+    if modified_files:
+        for sch_file, new_text in modified_files.items():
+            if backup:
+                bak = create_backup(sch_file)
+                if format == "text":
+                    print(f"  Backup: {bak.name}")
+            try:
+                sch_file.write_text(new_text, encoding="utf-8")
+            except OSError as e:
+                print(f"Error writing {sch_file}: {e}", file=sys.stderr)
+                return 1
+
+    if format == "text":
+        print(
+            f"Repaired {len(repairs)} instance(s) "
+            f"across {len(modified_files)} file(s)."
+        )
+
+    return 0
+
+
+def main(argv: list[str] | None = None):
+    """CLI entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Repair missing project instances in KiCad schematics",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", type=Path, help="Path to .kicad_sch file")
+    parser.add_argument(
+        "--dry-run", "-n", action="store_true",
+        help="Preview changes without modifying files",
+    )
+    parser.add_argument(
+        "--backup", action="store_true",
+        help="Create backup before modifying",
+    )
+    parser.add_argument(
+        "--format", choices=["text", "json"], default="text",
+        help="Output format (default: text)",
+    )
+
+    args = parser.parse_args(argv)
+
+    return run_repair_instances(
+        schematic_path=args.schematic,
+        dry_run=args.dry_run,
+        backup=args.backup,
+        format=args.format,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sch_repair_instances.py
+++ b/tests/test_sch_repair_instances.py
@@ -1,0 +1,471 @@
+"""Tests for the sch repair-instances command.
+
+Covers detection of missing project instances, assignment of
+non-conflicting reference designators, dry-run mode, backup,
+and hierarchical schematic support.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_repair_instances import (
+    _collect_existing_refs,
+    _extract_symbols_with_instance_info,
+    run_repair_instances,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal schematic content for testing
+# ---------------------------------------------------------------------------
+
+# Root schematic with one annotated symbol (has instances) and a sub-sheet
+ROOT_SCHEMATIC = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-1")
+\t\t)
+\t\t(pin "2"
+\t\t\t(uuid "pin-uuid-2")
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test_project"
+\t\t\t\t(path "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+\t\t\t\t\t(reference "R1")
+\t\t\t\t\t(unit 1)
+\t\t\t\t)
+\t\t\t)
+\t\t)
+\t)
+\t(sheet
+\t\t(at 150 50)
+\t\t(size 20 15)
+\t\t(uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+\t\t(property "Sheetname" "sub"
+\t\t\t(at 150 49 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Sheetfile" "sub.kicad_sch"
+\t\t\t(at 150 65.5 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t)
+)
+"""
+
+# Sub-sheet with two symbols missing instances
+SUB_SCHEMATIC_MISSING = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "cccccccc-cccc-cccc-cccc-cccccccccccc")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R2"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "4.7k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-3")
+\t\t)
+\t\t(pin "2"
+\t\t\t(uuid "pin-uuid-4")
+\t\t)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t)
+\t(symbol
+\t\t(lib_id "Device:C")
+\t\t(at 120 50 0)
+\t\t(property "Reference" "C?"
+\t\t\t(at 120 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "100nF"
+\t\t\t(at 120 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-5")
+\t\t)
+\t\t(pin "2"
+\t\t\t(uuid "pin-uuid-6")
+\t\t)
+\t\t(uuid "33333333-3333-3333-3333-333333333333")
+\t)
+)
+"""
+
+# Sub-sheet where all symbols already have instances
+SUB_SCHEMATIC_OK = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "dddddddd-dddd-dddd-dddd-dddddddddddd")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R3"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "1k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-7")
+\t\t)
+\t\t(pin "2"
+\t\t\t(uuid "pin-uuid-8")
+\t\t)
+\t\t(uuid "44444444-4444-4444-4444-444444444444")
+\t\t(instances
+\t\t\t(project "test_project"
+\t\t\t\t(path "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+\t\t\t\t\t(reference "R3")
+\t\t\t\t\t(unit 1)
+\t\t\t\t)
+\t\t\t)
+\t\t)
+\t)
+)
+"""
+
+
+class TestExtractSymbolsWithInstanceInfo:
+    """Tests for _extract_symbols_with_instance_info."""
+
+    def test_symbol_with_instances(self):
+        symbols = _extract_symbols_with_instance_info(
+            ROOT_SCHEMATIC, "test_project"
+        )
+        assert len(symbols) == 1
+        assert symbols[0]["reference"] == "R1"
+        assert symbols[0]["has_project_instance"] is True
+
+    def test_symbol_missing_instances(self):
+        symbols = _extract_symbols_with_instance_info(
+            SUB_SCHEMATIC_MISSING, "test_project"
+        )
+        assert len(symbols) == 2
+        # Both should be missing instances
+        assert all(not s["has_project_instance"] for s in symbols)
+        refs = {s["reference"] for s in symbols}
+        assert refs == {"R2", "C?"}
+
+    def test_symbol_with_wrong_project(self):
+        """Symbols with instances for a different project are flagged."""
+        symbols = _extract_symbols_with_instance_info(
+            ROOT_SCHEMATIC, "other_project"
+        )
+        assert len(symbols) == 1
+        # Has instances but not for "other_project"
+        assert symbols[0]["has_project_instance"] is False
+
+    def test_power_symbols_skipped(self):
+        """Power symbols (lib_id starting with power:) are skipped."""
+        text = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(uuid "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "power:GND")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "#PWR01"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "GND"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-pwr")
+\t\t)
+\t\t(uuid "55555555-5555-5555-5555-555555555555")
+\t)
+)
+"""
+        symbols = _extract_symbols_with_instance_info(text, "test_project")
+        assert len(symbols) == 0
+
+
+class TestCollectExistingRefs:
+    """Tests for _collect_existing_refs."""
+
+    def test_collects_annotated_refs(self):
+        file_symbols = {
+            Path("a.kicad_sch"): [
+                {"prefix": "R", "number": 1, "has_project_instance": True},
+                {"prefix": "R", "number": 3, "has_project_instance": True},
+                {"prefix": "C", "number": 1, "has_project_instance": True},
+            ]
+        }
+        existing = _collect_existing_refs(file_symbols)
+        assert existing["R"] == {1, 3}
+        assert existing["C"] == {1}
+
+    def test_skips_unannotated(self):
+        file_symbols = {
+            Path("a.kicad_sch"): [
+                {"prefix": "R", "number": None, "has_project_instance": False},
+            ]
+        }
+        existing = _collect_existing_refs(file_symbols)
+        assert "R" not in existing
+
+    def test_skips_symbols_without_instances(self):
+        file_symbols = {
+            Path("a.kicad_sch"): [
+                {"prefix": "R", "number": 5, "has_project_instance": False},
+            ]
+        }
+        existing = _collect_existing_refs(file_symbols)
+        assert "R" not in existing
+
+
+class TestRunRepairInstances:
+    """Integration tests for run_repair_instances."""
+
+    def test_dry_run_finds_missing(self, tmp_path, capsys):
+        """Dry run identifies missing instances without modifying files."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_MISSING, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=True, backup=False)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "2 symbol(s) missing project instances" in captured.out
+        assert "Dry run: no changes made" in captured.out
+        # File should not be modified
+        assert sub.read_text(encoding="utf-8") == SUB_SCHEMATIC_MISSING
+
+    def test_dry_run_json(self, tmp_path, capsys):
+        """Dry run with JSON output."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_MISSING, encoding="utf-8")
+
+        result = run_repair_instances(
+            root, dry_run=True, backup=False, format="json"
+        )
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["total"] == 2
+        assert data["dry_run"] is True
+
+    def test_repairs_missing_instances(self, tmp_path, capsys):
+        """Actually repairs missing instances."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_MISSING, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=False, backup=False)
+        assert result == 0
+
+        # Verify the sub-sheet was modified
+        modified_text = sub.read_text(encoding="utf-8")
+        assert '(instances' in modified_text
+        assert '(project "test_project"' in modified_text
+
+        # R2 should keep its reference
+        assert '(reference "R2")' in modified_text
+
+        # C? should have been assigned C1
+        assert '(reference "C1")' in modified_text
+
+    def test_preserves_existing_annotated_refs(self, tmp_path, capsys):
+        """Annotated symbols keep their reference designators."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_MISSING, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=False, backup=False)
+        assert result == 0
+
+        modified_text = sub.read_text(encoding="utf-8")
+        # R2 should keep its reference (annotated but missing instances)
+        assert '(reference "R2")' in modified_text
+
+    def test_avoids_ref_conflicts(self, tmp_path, capsys):
+        """New refs assigned to unannotated symbols avoid existing numbers."""
+        # Create a root with R1 already in use
+        root = tmp_path / "test_project.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+
+        # Sub-sheet with unannotated R? (should get R2, not R1)
+        sub_text = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "cccccccc-cccc-cccc-cccc-cccccccccccc")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R?"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "4.7k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-3")
+\t\t)
+\t\t(pin "2"
+\t\t\t(uuid "pin-uuid-4")
+\t\t)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t)
+)
+"""
+        sub = tmp_path / "sub.kicad_sch"
+        sub.write_text(sub_text, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=False, backup=False)
+        assert result == 0
+
+        modified_text = sub.read_text(encoding="utf-8")
+        # Should get R2 (R1 is already used in root)
+        assert '(reference "R2")' in modified_text
+
+    def test_no_changes_needed(self, tmp_path, capsys):
+        """Returns 0 and reports no changes when all instances present."""
+        root = tmp_path / "test_project.kicad_sch"
+        # Use a root schematic without sub-sheets referencing missing files
+        simple_root = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-1")
+\t\t)
+\t\t(pin "2"
+\t\t\t(uuid "pin-uuid-2")
+\t\t)
+\t\t(uuid "11111111-1111-1111-1111-111111111111")
+\t\t(instances
+\t\t\t(project "test_project"
+\t\t\t\t(path "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+\t\t\t\t\t(reference "R1")
+\t\t\t\t\t(unit 1)
+\t\t\t\t)
+\t\t\t)
+\t\t)
+\t)
+)
+"""
+        root.write_text(simple_root, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=False, backup=False)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "No repairs needed" in captured.out
+
+    def test_backup_created(self, tmp_path, capsys):
+        """Backup files are created when backup=True."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_MISSING, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=False, backup=True)
+        assert result == 0
+
+        # Check that backup file exists — create_backup() produces
+        # <stem>_backup_<timestamp><suffix>, e.g. sub_backup_20260423_120000.kicad_sch
+        backups = list(tmp_path.glob("*_backup_*.kicad_sch"))
+        assert len(backups) >= 1
+
+    def test_file_not_found(self, tmp_path, capsys):
+        """Returns 1 for non-existent file."""
+        result = run_repair_instances(
+            tmp_path / "nonexistent.kicad_sch",
+            dry_run=True,
+            backup=False,
+        )
+        assert result == 1
+
+    def test_correct_instance_path(self, tmp_path, capsys):
+        """Instance path includes root UUID and sheet UUID."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_MISSING, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=False, backup=False)
+        assert result == 0
+
+        modified_text = sub.read_text(encoding="utf-8")
+        # The instance path should be /root-uuid/sheet-uuid
+        expected_path = (
+            "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+            "/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        )
+        assert f'(path "{expected_path}"' in modified_text


### PR DESCRIPTION
## Summary
Adds `kct sch repair-instances root.kicad_sch` to automatically fix symbols that are missing `(instances ...)` blocks for the current project. This addresses a pain point where components added to sub-sheets lack the project instance data needed for netlists and BOMs.

## Changes
- New `src/kicad_tools/cli/sch_repair_instances.py`:
  - `_extract_symbols_with_instance_info()` uses bracket-depth parsing to identify which symbols have project instance entries for the current project name
  - `_find_symbol_block()` locates a symbol block by UUID using depth-tracking for robustness
  - `_insert_project_instance()` creates or extends `(instances)` blocks for a specific symbol
  - `_collect_existing_refs()` gathers annotated reference numbers across all files to avoid conflicts
  - `run_repair_instances()` orchestrates the full pipeline: detect → assign → output → write
- Registered `repair-instances` in `parser.py` (argparse) and `schematic.py` (dispatch)
- Supports `--dry-run`, `--backup`, `--format text|json`
- 16 tests in `tests/test_sch_repair_instances.py`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct sch repair-instances root.kicad_sch` finds and fixes all missing instances | ✅ | `test_repairs_missing_instances` — verified instances block is written to sub-sheet |
| Assigns non-conflicting reference designators for unannotated (?) components | ✅ | `test_avoids_ref_conflicts` — R? gets R2 when R1 already exists in root |
| Preserves existing reference designators for annotated components | ✅ | `test_preserves_existing_annotated_refs` — R2 keeps its reference, only gains instances block |
| `--dry-run` shows what would change | ✅ | `test_dry_run_finds_missing` — reports 2 symbols, file unchanged after dry run |
| Works with hierarchical schematics (multiple sub-sheets) | ✅ | Full hierarchy traversal via `_collect_schematic_files`; `test_correct_instance_path` verifies `/root-uuid/sheet-uuid` path |

## Test Plan
- 16 unit/integration tests all pass: `pytest tests/test_sch_repair_instances.py`
- Existing `tests/test_sch_re_annotate.py` (87 tests) unaffected

Closes #1960