### PR TITLE
feat(pcb): sync-netlist --remove-orphans to delete unmatched footprints

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -11,7 +11,7 @@ def run_pcb_command(args) -> int:
     """Handle PCB subcommands."""
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
-        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist")
+        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist, remove-footprint")
         return 1
 
     pcb_path = Path(args.pcb)
@@ -30,6 +30,10 @@ def run_pcb_command(args) -> int:
     # Handle sync-netlist command
     if args.pcb_command == "sync-netlist":
         return _run_sync_netlist_command(args, pcb_path)
+
+    # Handle remove-footprint command
+    if args.pcb_command == "remove-footprint":
+        return _run_remove_footprint_command(args, pcb_path)
 
     from ..pcb_query import main as pcb_main
 
@@ -488,11 +492,40 @@ def _run_sync_netlist_command(args, pcb_path: Path) -> int:
     output_path = Path(output) if output else None
     dry_run = getattr(args, "dry_run", False)
     output_format = getattr(args, "format", "text")
+    remove_orphans = getattr(args, "remove_orphans", False)
+    force = getattr(args, "force", False)
 
     return run_sync_netlist(
         schematic_path=schematic_path,
         pcb_path=pcb_path,
         dry_run=dry_run,
         output_path=output_path,
+        output_format=output_format,
+        remove_orphans=remove_orphans,
+        force=force,
+    )
+
+
+def _run_remove_footprint_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb remove-footprint' command."""
+    from kicad_tools.cli.pcb_remove_footprint import run_remove_footprint
+
+    ref = getattr(args, "ref", None)
+    if not ref:
+        print("Error: --ref is required", file=sys.stderr)
+        return 1
+
+    output = getattr(args, "output", None)
+    output_path = Path(output) if output else None
+    dry_run = getattr(args, "dry_run", False)
+    force = getattr(args, "force", False)
+    output_format = getattr(args, "format", "text")
+
+    return run_remove_footprint(
+        pcb_path=pcb_path,
+        reference=ref,
+        dry_run=dry_run,
+        output_path=output_path,
+        force=force,
         output_format=output_format,
     )

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1152,6 +1152,53 @@ def _add_pcb_parser(subparsers) -> None:
         action="store_true",
         help="Preview sync actions without modifying the PCB file",
     )
+    pcb_sync_netlist.add_argument(
+        "--remove-orphans",
+        action="store_true",
+        help="Delete orphaned footprints (in PCB but not in schematic)",
+    )
+    pcb_sync_netlist.add_argument(
+        "--force",
+        action="store_true",
+        help="Remove orphans even if they have routed traces",
+    )
+
+    # pcb remove-footprint
+    pcb_remove_fp = pcb_subparsers.add_parser(
+        "remove-footprint",
+        help="Remove a footprint from the PCB by reference designator",
+        description="Remove a specific footprint from a PCB file. "
+        "By default, refuses to remove footprints with routed traces "
+        "unless --force is specified.",
+    )
+    pcb_remove_fp.add_argument("pcb", help="Path to .kicad_pcb file")
+    pcb_remove_fp.add_argument(
+        "--ref",
+        required=True,
+        help="Reference designator of footprint to remove (e.g., C1)",
+    )
+    pcb_remove_fp.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        help="Output file path (default: overwrite input PCB)",
+    )
+    pcb_remove_fp.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for results",
+    )
+    pcb_remove_fp.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview removal without modifying the PCB file",
+    )
+    pcb_remove_fp.add_argument(
+        "--force",
+        action="store_true",
+        help="Remove footprint even if it has routed traces",
+    )
 
 
 def _add_lib_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/pcb_remove_footprint.py
+++ b/src/kicad_tools/cli/pcb_remove_footprint.py
@@ -1,0 +1,120 @@
+"""Remove a footprint from a PCB by reference designator.
+
+Provides a standalone command to remove a specific footprint from a PCB file.
+By default, refuses to remove footprints with routed traces unless --force
+is specified.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def run_remove_footprint(
+    pcb_path: Path,
+    reference: str,
+    dry_run: bool = False,
+    output_path: Path | None = None,
+    force: bool = False,
+    output_format: str = "text",
+) -> int:
+    """Remove a footprint from a PCB file.
+
+    Args:
+        pcb_path: Path to .kicad_pcb file.
+        reference: Reference designator to remove (e.g., "C1").
+        dry_run: Preview removal without modifying.
+        output_path: Alternative output path for modified PCB.
+        force: Remove even if the footprint has routed traces.
+        output_format: "text" or "json".
+
+    Returns:
+        Exit code (0 for success, 1 for errors).
+    """
+    from kicad_tools.schema.pcb import PCB
+
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        _print_error(f"Failed to load PCB: {e}", output_format)
+        return 1
+
+    # Check footprint exists
+    fp = pcb.get_footprint(reference)
+    if not fp:
+        _print_error(f"Footprint {reference} not found in PCB", output_format)
+        return 1
+
+    footprint_name = fp.name
+    value = fp.value
+
+    # Check for connected traces
+    has_traces = pcb.footprint_has_traces(reference)
+    if has_traces and not force:
+        _print_error(
+            f"Footprint {reference} has routed traces; use --force to remove",
+            output_format,
+        )
+        return 1
+
+    result = {
+        "pcb": str(pcb_path),
+        "reference": reference,
+        "footprint": footprint_name,
+        "value": value,
+        "has_traces": has_traces,
+        "dry_run": dry_run,
+        "removed": False,
+    }
+
+    if not dry_run:
+        success = pcb.remove_footprint(reference)
+        if not success:
+            _print_error(
+                f"Failed to remove footprint {reference}", output_format
+            )
+            return 1
+
+        result["removed"] = True
+
+        save_path = output_path or pcb_path
+        result["output"] = str(save_path)
+        try:
+            pcb.save(save_path)
+        except Exception as e:
+            _print_error(f"Failed to save PCB: {e}", output_format)
+            return 1
+
+    if output_format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        label = "PCB Remove Footprint (dry run)" if dry_run else "PCB Remove Footprint"
+        print(label)
+        print(f"  PCB: {pcb_path}")
+        print()
+        print(f"  Reference: {reference}")
+        print(f"  Footprint: {footprint_name}")
+        print(f"  Value: {value}")
+        print(f"  Has traces: {has_traces}")
+        print()
+        if dry_run:
+            if has_traces and not force:
+                print("  Would NOT remove (has routed traces; use --force)")
+            else:
+                print("  Would remove footprint")
+        else:
+            print(f"  Removed footprint {reference}")
+            print(f"  Saved to: {result.get('output', pcb_path)}")
+
+    return 0
+
+
+def _print_error(message: str, output_format: str) -> None:
+    """Print an error in the appropriate format."""
+    if output_format == "json":
+        print(json.dumps({"error": message}, indent=2))
+    else:
+        import sys
+
+        print(f"Error: {message}", file=sys.stderr)

--- a/src/kicad_tools/cli/pcb_sync_netlist.py
+++ b/src/kicad_tools/cli/pcb_sync_netlist.py
@@ -19,7 +19,7 @@ from pathlib import Path
 class SyncAction:
     """A single sync action to perform or report."""
 
-    action: str  # "add", "rename", "orphan"
+    action: str  # "add", "rename", "orphan", "remove"
     reference: str
     footprint: str = ""
     value: str = ""
@@ -34,11 +34,12 @@ class SyncResult:
     added: list[SyncAction] = field(default_factory=list)
     renamed: list[SyncAction] = field(default_factory=list)
     orphaned: list[SyncAction] = field(default_factory=list)
+    removed: list[SyncAction] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
     @property
     def has_changes(self) -> bool:
-        return bool(self.added or self.renamed or self.orphaned)
+        return bool(self.added or self.renamed or self.orphaned or self.removed)
 
 
 def _normalize_footprint(fp: str) -> str:
@@ -57,6 +58,8 @@ def sync_netlist(
     pcb_path: Path,
     dry_run: bool = False,
     output_path: Path | None = None,
+    remove_orphans: bool = False,
+    force: bool = False,
 ) -> SyncResult:
     """Sync PCB footprints from schematic.
 
@@ -65,6 +68,8 @@ def sync_netlist(
         pcb_path: Path to .kicad_pcb file.
         dry_run: If True, compute diff without modifying files.
         output_path: If set, write modified PCB here instead of overwriting.
+        remove_orphans: If True, delete orphaned footprints from the PCB.
+        force: If True, remove orphans even if they have routed traces.
 
     Returns:
         SyncResult describing all actions taken or planned.
@@ -175,16 +180,39 @@ def sync_netlist(
             detail=f"Add {ref} ({item.value}, {item.footprint})",
         ))
 
-    # Orphaned footprints
+    # Orphaned footprints -- categorize as remove or report-only
     for ref in sorted(truly_orphaned):
         info = pcb_refs[ref]
-        result.orphaned.append(SyncAction(
-            action="orphan",
-            reference=ref,
-            footprint=info["footprint"],
-            value=info["value"],
-            detail=f"Orphan: {ref} ({info['value']}, {info['footprint']})",
-        ))
+        if remove_orphans:
+            # Check for connected traces (safety check)
+            has_traces = pcb.footprint_has_traces(ref)
+            if has_traces and not force:
+                result.errors.append(
+                    f"Orphan {ref} has routed traces; use --force to remove"
+                )
+                result.orphaned.append(SyncAction(
+                    action="orphan",
+                    reference=ref,
+                    footprint=info["footprint"],
+                    value=info["value"],
+                    detail=f"Orphan: {ref} ({info['value']}, {info['footprint']}) - has traces",
+                ))
+            else:
+                result.removed.append(SyncAction(
+                    action="remove",
+                    reference=ref,
+                    footprint=info["footprint"],
+                    value=info["value"],
+                    detail=f"Remove: {ref} ({info['value']}, {info['footprint']})",
+                ))
+        else:
+            result.orphaned.append(SyncAction(
+                action="orphan",
+                reference=ref,
+                footprint=info["footprint"],
+                value=info["value"],
+                detail=f"Orphan: {ref} ({info['value']}, {info['footprint']})",
+            ))
 
     # --- Apply changes if not dry-run ---
     if not dry_run and result.has_changes:
@@ -208,6 +236,13 @@ def sync_netlist(
             except Exception as e:
                 result.errors.append(
                     f"Failed to add footprint for {action.reference}: {e}"
+                )
+
+        # Remove orphaned footprints
+        for action in result.removed:
+            if not pcb.remove_footprint(action.reference):
+                result.errors.append(
+                    f"Failed to remove footprint {action.reference}"
                 )
 
         # Update net assignments from schematic netlist (covers renamed refs
@@ -296,6 +331,12 @@ def format_text(result: SyncResult, dry_run: bool, pcb_path: Path) -> str:
             lines.append(f"    {action.reference}: {action.value} ({action.footprint})")
         lines.append("")
 
+    if result.removed:
+        lines.append(f"  Removed footprints ({len(result.removed)}):")
+        for action in result.removed:
+            lines.append(f"    {action.reference}: {action.value} ({action.footprint})")
+        lines.append("")
+
     if result.orphaned:
         lines.append(f"  Orphaned footprints ({len(result.orphaned)}):")
         for action in result.orphaned:
@@ -341,6 +382,14 @@ def format_json(result: SyncResult, dry_run: bool, pcb_path: Path) -> str:
             }
             for a in result.orphaned
         ],
+        "removed": [
+            {
+                "reference": a.reference,
+                "footprint": a.footprint,
+                "value": a.value,
+            }
+            for a in result.removed
+        ],
         "errors": result.errors,
     }
     return json.dumps(output, indent=2)
@@ -352,6 +401,8 @@ def run_sync_netlist(
     dry_run: bool = False,
     output_path: Path | None = None,
     output_format: str = "text",
+    remove_orphans: bool = False,
+    force: bool = False,
 ) -> int:
     """Run the sync-netlist command.
 
@@ -361,6 +412,8 @@ def run_sync_netlist(
         dry_run: Preview changes without modifying.
         output_path: Alternative output path for modified PCB.
         output_format: "text" or "json".
+        remove_orphans: If True, delete orphaned footprints.
+        force: If True, remove orphans even with routed traces.
 
     Returns:
         Exit code (0 for success, 1 for errors).
@@ -370,6 +423,8 @@ def run_sync_netlist(
         pcb_path=pcb_path,
         dry_run=dry_run,
         output_path=output_path,
+        remove_orphans=remove_orphans,
+        force=force,
     )
 
     if output_format == "json":

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1585,6 +1585,44 @@ class PCB:
 
         return True
 
+    def footprint_has_traces(self, reference: str) -> bool:
+        """Check whether a footprint has any routed traces connected to its pads.
+
+        Examines each pad of the footprint and checks if any trace segment
+        in the same net touches the pad position (within 0.01mm tolerance).
+
+        Args:
+            reference: Footprint reference designator (e.g., "R1", "C1")
+
+        Returns:
+            True if at least one pad has a connected trace segment, False
+            if the footprint has no traces or does not exist.
+        """
+        import math
+
+        fp = self.get_footprint(reference)
+        if not fp:
+            return False
+
+        for pad in fp.pads:
+            if pad.net_number == 0:
+                continue
+            pos = self.get_pad_position(reference, pad.number)
+            if not pos:
+                continue
+            for seg in self.segments_in_net(pad.net_number):
+                tolerance = 0.01  # mm
+                start_dist = math.sqrt(
+                    (seg.start[0] - pos[0]) ** 2 + (seg.start[1] - pos[1]) ** 2
+                )
+                end_dist = math.sqrt(
+                    (seg.end[0] - pos[0]) ** 2 + (seg.end[1] - pos[1]) ** 2
+                )
+                if start_dist < tolerance or end_dist < tolerance:
+                    return True
+
+        return False
+
     def remove_segments(self, segments: list[Segment]) -> int:
         """Remove specific trace segments from the PCB.
 

--- a/tests/test_pcb_remove_footprint.py
+++ b/tests/test_pcb_remove_footprint.py
@@ -1,0 +1,236 @@
+"""Tests for pcb remove-footprint command (pcb_remove_footprint module)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# Reuse PCB fixtures from sync-netlist tests
+MINIMAL_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "SIG")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (uuid "fp-c1")
+    (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+# PCB with a traced footprint
+MINIMAL_PCB_WITH_TRACES = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (segment (start 99.5 100) (end 90 100) (width 0.25) (layer "F.Cu") (net 1))
+)
+"""
+
+
+class TestRunRemoveFootprint:
+    """Tests for run_remove_footprint function."""
+
+    def test_removes_footprint(self, tmp_path):
+        """Successfully removes an existing footprint."""
+        from kicad_tools.cli.pcb_remove_footprint import run_remove_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_remove_footprint(pcb, "C1")
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("C1") is None
+        assert board.get_footprint("R1") is not None
+
+    def test_dry_run_does_not_modify(self, tmp_path):
+        """dry_run=True leaves file unchanged."""
+        from kicad_tools.cli.pcb_remove_footprint import run_remove_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+        original = pcb.read_text()
+
+        rc = run_remove_footprint(pcb, "C1", dry_run=True)
+        assert rc == 0
+        assert pcb.read_text() == original
+
+    def test_nonexistent_reference_returns_1(self, tmp_path):
+        """Removing a non-existent reference returns error."""
+        from kicad_tools.cli.pcb_remove_footprint import run_remove_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_remove_footprint(pcb, "Z99")
+        assert rc == 1
+
+    def test_blocks_removal_with_traces(self, tmp_path):
+        """Blocks removal when footprint has traces and force=False."""
+        from kicad_tools.cli.pcb_remove_footprint import run_remove_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB_WITH_TRACES)
+
+        rc = run_remove_footprint(pcb, "R1", force=False)
+        assert rc == 1
+
+    def test_force_removes_with_traces(self, tmp_path):
+        """--force allows removal of footprint with traces."""
+        from kicad_tools.cli.pcb_remove_footprint import run_remove_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB_WITH_TRACES)
+
+        rc = run_remove_footprint(pcb, "R1", force=True)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("R1") is None
+
+    def test_output_path(self, tmp_path):
+        """Writes to output path instead of overwriting input."""
+        from kicad_tools.cli.pcb_remove_footprint import run_remove_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        out = tmp_path / "output.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_remove_footprint(pcb, "C1", output_path=out)
+        assert rc == 0
+
+        # Original should be unchanged
+        board_orig = PCB.load(pcb)
+        assert board_orig.get_footprint("C1") is not None
+
+        # Output should have C1 removed
+        board_out = PCB.load(out)
+        assert board_out.get_footprint("C1") is None
+
+    def test_json_output(self, tmp_path, capsys):
+        """JSON output contains expected fields."""
+        from kicad_tools.cli.pcb_remove_footprint import run_remove_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_remove_footprint(pcb, "C1", output_format="json")
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["reference"] == "C1"
+        assert data["removed"] is True
+
+    def test_text_output(self, tmp_path, capsys):
+        """Text output contains key information."""
+        from kicad_tools.cli.pcb_remove_footprint import run_remove_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_remove_footprint(pcb, "C1", output_format="text")
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        assert "C1" in captured.out
+        assert "Removed" in captured.out
+
+
+class TestRemoveFootprintCLIParser:
+    """Tests for the remove-footprint CLI parser."""
+
+    def test_parser_has_remove_footprint_subcommand(self):
+        """Parser supports 'pcb remove-footprint' subcommand."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "remove-footprint",
+            "--ref", "C1",
+            "test.kicad_pcb",
+        ])
+        assert args.pcb_command == "remove-footprint"
+        assert args.ref == "C1"
+
+    def test_parser_force_flag(self):
+        """Parser accepts --force flag."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "remove-footprint",
+            "--ref", "C1",
+            "--force",
+            "test.kicad_pcb",
+        ])
+        assert args.force is True
+
+    def test_parser_dry_run_flag(self):
+        """Parser accepts --dry-run flag."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "remove-footprint",
+            "--ref", "C1",
+            "--dry-run",
+            "test.kicad_pcb",
+        ])
+        assert args.dry_run is True
+
+    def test_dispatcher_integration(self, tmp_path):
+        """Dispatcher correctly routes to remove-footprint handler."""
+        from kicad_tools.cli.commands.pcb import _run_remove_footprint_command
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        class Args:
+            ref = "C1"
+            output = None
+            dry_run = True
+            force = False
+            format = "text"
+
+        rc = _run_remove_footprint_command(Args(), pcb)
+        assert rc == 0

--- a/tests/test_pcb_sync_netlist.py
+++ b/tests/test_pcb_sync_netlist.py
@@ -671,6 +671,8 @@ class TestPcbSyncNetlistCLIDispatch:
             output = None
             dry_run = False
             format = "text"
+            remove_orphans = False
+            force = False
 
         rc = _run_sync_netlist_command(Args(), pcb)
         assert rc == 1
@@ -687,6 +689,314 @@ class TestPcbSyncNetlistCLIDispatch:
             output = None
             dry_run = False
             format = "text"
+            remove_orphans = False
+            force = False
 
         rc = _run_sync_netlist_command(Args(), pcb)
         assert rc == 1
+
+
+# --- PCB with orphan D1 that has routed traces ---
+PCB_WITH_ORPHAN_TRACED = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "LED_A")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (uuid "fp-c1")
+    (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "LED_SMD:LED_0603"
+    (layer "F.Cu")
+    (uuid "fp-d1")
+    (at 140 100)
+    (property "Reference" "D1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "LED" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "LED_A"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+  )
+  (segment (start 139.5 100) (end 130 100) (width 0.25) (layer "F.Cu") (net 2))
+)
+"""
+
+
+class TestRemoveOrphans:
+    """Tests for --remove-orphans functionality in sync_netlist."""
+
+    def test_remove_orphans_removes_untraced_footprint(self, tmp_path):
+        """Orphaned footprint without traces is removed."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_WITH_ORPHAN)
+
+        result = sync_netlist(sch, pcb, dry_run=False, remove_orphans=True)
+
+        assert len(result.removed) == 1
+        assert result.removed[0].reference == "D1"
+        assert result.removed[0].action == "remove"
+        assert not result.orphaned
+        assert not result.errors
+
+        # Verify D1 was actually removed from the PCB file
+        board = PCB.load(pcb)
+        assert board.get_footprint("D1") is None
+        assert board.get_footprint("R1") is not None
+        assert board.get_footprint("C1") is not None
+
+    def test_remove_orphans_dry_run_does_not_modify(self, tmp_path):
+        """--remove-orphans with --dry-run reports but does not modify."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_WITH_ORPHAN)
+        original = pcb.read_text()
+
+        result = sync_netlist(sch, pcb, dry_run=True, remove_orphans=True)
+
+        assert len(result.removed) == 1
+        assert result.removed[0].reference == "D1"
+        assert pcb.read_text() == original
+
+    def test_remove_orphans_blocks_traced_footprint(self, tmp_path):
+        """Orphaned footprint with traces is blocked without --force."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_WITH_ORPHAN_TRACED)
+
+        result = sync_netlist(sch, pcb, dry_run=True, remove_orphans=True)
+
+        assert len(result.orphaned) == 1
+        assert result.orphaned[0].reference == "D1"
+        assert not result.removed
+        assert any("D1" in e and "traces" in e for e in result.errors)
+
+    def test_remove_orphans_force_removes_traced_footprint(self, tmp_path):
+        """--force allows removal of orphaned footprint with traces."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_WITH_ORPHAN_TRACED)
+
+        result = sync_netlist(
+            sch, pcb, dry_run=False, remove_orphans=True, force=True
+        )
+
+        assert len(result.removed) == 1
+        assert result.removed[0].reference == "D1"
+        assert not result.orphaned
+        assert not result.errors
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("D1") is None
+
+    def test_remove_orphans_no_orphans_is_noop(self, tmp_path):
+        """--remove-orphans with no orphans is a clean no-op."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+
+        result = sync_netlist(sch, pcb, dry_run=True, remove_orphans=True)
+
+        assert not result.removed
+        assert not result.orphaned
+        assert not result.errors
+
+    def test_remove_orphans_all_orphaned(self, tmp_path):
+        """When all footprints are orphaned, they should all be removed."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "empty.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(
+            "(kicad_sch (version 20231120) (generator test) (uuid 0) (paper A4))"
+        )
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+
+        result = sync_netlist(sch, pcb, dry_run=False, remove_orphans=True)
+
+        assert len(result.removed) == 2
+        refs = {a.reference for a in result.removed}
+        assert refs == {"R1", "C1"}
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("R1") is None
+        assert board.get_footprint("C1") is None
+
+    def test_without_remove_orphans_behavior_unchanged(self, tmp_path):
+        """Without --remove-orphans, orphans are only reported (not removed)."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_WITH_ORPHAN)
+
+        result = sync_netlist(sch, pcb, dry_run=True, remove_orphans=False)
+
+        assert len(result.orphaned) == 1
+        assert result.orphaned[0].reference == "D1"
+        assert not result.removed
+
+
+class TestRemoveOrphansFormatting:
+    """Tests for removed footprints in text and JSON output."""
+
+    def test_removed_in_text_output(self, tmp_path):
+        """Removed footprints appear in text output."""
+        from kicad_tools.cli.pcb_sync_netlist import SyncAction, SyncResult, format_text
+
+        result = SyncResult(
+            removed=[SyncAction(
+                action="remove",
+                reference="D1",
+                footprint="LED_SMD:LED_0603",
+                value="LED",
+            )]
+        )
+        pcb = tmp_path / "test.kicad_pcb"
+        output = format_text(result, dry_run=False, pcb_path=pcb)
+
+        assert "Removed" in output
+        assert "D1" in output
+
+    def test_removed_in_json_output(self, tmp_path):
+        """Removed footprints appear in JSON output."""
+        from kicad_tools.cli.pcb_sync_netlist import SyncAction, SyncResult, format_json
+
+        result = SyncResult(
+            removed=[SyncAction(
+                action="remove",
+                reference="D1",
+                footprint="LED_SMD:LED_0603",
+                value="LED",
+            )]
+        )
+        pcb = tmp_path / "test.kicad_pcb"
+        output = format_json(result, dry_run=False, pcb_path=pcb)
+
+        data = json.loads(output)
+        assert "removed" in data
+        assert len(data["removed"]) == 1
+        assert data["removed"][0]["reference"] == "D1"
+
+
+class TestSyncNetlistCLIRemoveOrphansFlags:
+    """Tests for --remove-orphans and --force CLI flags."""
+
+    def test_parser_remove_orphans_flag(self):
+        """Parser accepts --remove-orphans flag."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "sync-netlist",
+            "--schematic", "test.kicad_sch",
+            "--remove-orphans",
+            "test.kicad_pcb",
+        ])
+        assert args.remove_orphans is True
+
+    def test_parser_force_flag(self):
+        """Parser accepts --force flag for sync-netlist."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "sync-netlist",
+            "--schematic", "test.kicad_sch",
+            "--remove-orphans",
+            "--force",
+            "test.kicad_pcb",
+        ])
+        assert args.force is True
+
+    def test_dispatcher_passes_remove_orphans(self, tmp_path):
+        """Dispatcher passes remove_orphans and force to run_sync_netlist."""
+        from kicad_tools.cli.commands.pcb import _run_sync_netlist_command
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_WITH_ORPHAN)
+
+        class Args:
+            schematic = str(sch)
+            output = None
+            dry_run = False
+            format = "text"
+            remove_orphans = True
+            force = False
+
+        rc = _run_sync_netlist_command(Args(), pcb)
+        assert rc == 0
+
+
+class TestFootprintHasTraces:
+    """Tests for PCB.footprint_has_traces helper."""
+
+    def test_footprint_without_traces(self, tmp_path):
+        """Footprint with no connected segments returns False."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(PCB_WITH_ORPHAN)
+        board = PCB.load(pcb)
+
+        # D1 has no net connections (net 0)
+        assert board.footprint_has_traces("D1") is False
+
+    def test_footprint_with_traces(self, tmp_path):
+        """Footprint with connected segments returns True."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(PCB_WITH_ORPHAN_TRACED)
+        board = PCB.load(pcb)
+
+        # D1 pad 1 is on net 2 with a segment touching it
+        assert board.footprint_has_traces("D1") is True
+
+    def test_nonexistent_footprint(self, tmp_path):
+        """Non-existent footprint returns False."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+        board = PCB.load(pcb)
+
+        assert board.footprint_has_traces("Z99") is False


### PR DESCRIPTION
## Summary

- Adds `--remove-orphans` flag to `pcb sync-netlist` that deletes footprints present in the PCB but absent from the schematic
- Adds safety check: orphans with routed traces are blocked unless `--force` is specified (uses new `PCB.footprint_has_traces()` helper)
- Adds standalone `pcb remove-footprint --ref <REF>` command for targeted single-footprint removal with the same trace safety check
- Both commands support `--dry-run`, `--force`, and `--format json` flags

Closes #1978

## Test plan

- [x] 27 new tests across `test_pcb_sync_netlist.py` and `test_pcb_remove_footprint.py`
- [x] Orphan removal without traces succeeds
- [x] Orphan with routed traces blocked without `--force`
- [x] `--force` overrides trace safety check
- [x] `--dry-run` previews without modifying files
- [x] No-op when no orphans exist
- [x] All footprints orphaned edge case
- [x] Standalone `remove-footprint` command with all flag combinations
- [x] Parser tests for new CLI flags
- [x] All 66 tests pass (39 existing + 27 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)