### PR TITLE
fix(stitch): move ZonePolygon before is_pad_connected to eliminate forward reference

### DIFF
--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -152,6 +152,15 @@ class FilledPolygon:
             self.max_y = max(ys)
 
 
+@dataclass
+class ZonePolygon:
+    """A zone boundary polygon with its net and layer."""
+
+    net_name: str
+    layer: str
+    points: list[tuple[float, float]]
+
+
 def get_net_map(sexp: SExp) -> dict[int, str]:
     """Build a mapping of net number to net name."""
     net_map = {}
@@ -209,6 +218,70 @@ def find_zones_for_net(sexp: SExp, net_name: str) -> list[str]:
                 layers.append(zone_layer)
 
     return layers
+
+
+def extract_zone_polygons(sexp: SExp, net_name: str) -> list[ZonePolygon]:
+    """Extract zone boundary polygons for a given net.
+
+    Parses the S-expression structure:
+        (zone ... (polygon (pts (xy X Y) (xy X Y) ...)))
+
+    Supports both KiCad 8 (net_name node) and KiCad 9 (name-only net node)
+    formats.
+
+    Args:
+        sexp: PCB S-expression
+        net_name: Net name to find zone polygons for
+
+    Returns:
+        List of ZonePolygon objects with boundary points
+    """
+    polygons = []
+    for child in sexp.iter_children():
+        if child.tag != "zone":
+            continue
+
+        # Get net name from zone (same dual-format logic as find_zones_for_net)
+        zone_net_name = None
+        net_name_node = child.find_child("net_name")
+        if net_name_node:
+            zone_net_name = net_name_node.get_string(0)
+        else:
+            # KiCad 9 name-only format: (net "GND") without separate net_name node
+            net_node = child.find_child("net")
+            if net_node and net_node.get_int(0) is None:
+                zone_net_name = net_node.get_string(0)
+
+        if zone_net_name != net_name:
+            continue
+
+        # Get layer
+        layer_node = child.find_child("layer")
+        if not layer_node:
+            continue
+        zone_layer = layer_node.get_string(0)
+        if not zone_layer:
+            continue
+
+        # Get polygon boundary
+        polygon_node = child.find_child("polygon")
+        if not polygon_node:
+            continue
+
+        pts_node = polygon_node.find_child("pts")
+        if not pts_node:
+            continue
+
+        points: list[tuple[float, float]] = []
+        for xy_node in pts_node.find_children("xy"):
+            x = xy_node.get_float(0) or 0.0
+            y = xy_node.get_float(1) or 0.0
+            points.append((x, y))
+
+        if len(points) >= 3:
+            polygons.append(ZonePolygon(net_name=net_name, layer=zone_layer, points=points))
+
+    return polygons
 
 
 def find_all_plane_nets(sexp: SExp) -> dict[str, str]:
@@ -1616,79 +1689,6 @@ def add_trace_to_pcb(sexp: SExp, trace: TraceSegment) -> None:
             uuid_str=str(uuid.uuid4()),
         )
         sexp.append(seg)
-
-
-@dataclass
-class ZonePolygon:
-    """A zone boundary polygon with its net and layer."""
-
-    net_name: str
-    layer: str
-    points: list[tuple[float, float]]
-
-
-def extract_zone_polygons(sexp: SExp, net_name: str) -> list[ZonePolygon]:
-    """Extract zone boundary polygons for a given net.
-
-    Parses the S-expression structure:
-        (zone ... (polygon (pts (xy X Y) (xy X Y) ...)))
-
-    Supports both KiCad 8 (net_name node) and KiCad 9 (name-only net node)
-    formats.
-
-    Args:
-        sexp: PCB S-expression
-        net_name: Net name to find zone polygons for
-
-    Returns:
-        List of ZonePolygon objects with boundary points
-    """
-    polygons = []
-    for child in sexp.iter_children():
-        if child.tag != "zone":
-            continue
-
-        # Get net name from zone (same dual-format logic as find_zones_for_net)
-        zone_net_name = None
-        net_name_node = child.find_child("net_name")
-        if net_name_node:
-            zone_net_name = net_name_node.get_string(0)
-        else:
-            # KiCad 9 name-only format: (net "GND") without separate net_name node
-            net_node = child.find_child("net")
-            if net_node and net_node.get_int(0) is None:
-                zone_net_name = net_node.get_string(0)
-
-        if zone_net_name != net_name:
-            continue
-
-        # Get layer
-        layer_node = child.find_child("layer")
-        if not layer_node:
-            continue
-        zone_layer = layer_node.get_string(0)
-        if not zone_layer:
-            continue
-
-        # Get polygon boundary
-        polygon_node = child.find_child("polygon")
-        if not polygon_node:
-            continue
-
-        pts_node = polygon_node.find_child("pts")
-        if not pts_node:
-            continue
-
-        points: list[tuple[float, float]] = []
-        for xy_node in pts_node.find_children("xy"):
-            x = xy_node.get_float(0) or 0.0
-            y = xy_node.get_float(1) or 0.0
-            points.append((x, y))
-
-        if len(points) >= 3:
-            polygons.append(ZonePolygon(net_name=net_name, layer=zone_layer, points=points))
-
-    return polygons
 
 
 def find_all_filled_polygons(

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -39,6 +39,31 @@ from kicad_tools.cli.stitch_cmd import (
     segment_to_segment_distance,
 )
 from kicad_tools.core.sexp_file import load_pcb
+
+
+class TestStitchModuleImport:
+    """Verify stitch_cmd imports without NameError (regression for #1988).
+
+    ZonePolygon is referenced in the type annotation of is_pad_connected().
+    If ZonePolygon is defined after is_pad_connected and annotations are
+    eagerly evaluated, a NameError would occur on import.
+    """
+
+    def test_import_does_not_crash(self) -> None:
+        """Importing stitch_cmd must not raise NameError for ZonePolygon."""
+        import importlib
+        mod = importlib.import_module("kicad_tools.cli.stitch_cmd")
+        assert hasattr(mod, "ZonePolygon")
+        assert hasattr(mod, "is_pad_connected")
+
+    def test_type_hints_resolve(self) -> None:
+        """typing.get_type_hints on is_pad_connected must resolve ZonePolygon."""
+        import typing
+        hints = typing.get_type_hints(is_pad_connected)
+        # same_net_zone_polygons should resolve to list[ZonePolygon] | None
+        assert "same_net_zone_polygons" in hints
+
+
 # PCB with SMD components on GND and +3.3V nets for testing stitching
 STITCH_TEST_PCB = """(kicad_pcb
   (version 20240108)


### PR DESCRIPTION
## Summary
Move `ZonePolygon` dataclass and `extract_zone_polygons()` to appear before `is_pad_connected()`, eliminating a forward type reference that can crash under eager annotation evaluation (Python 3.14 PEP 649, serialization libraries, IDE introspection).

## Changes
- Relocated `ZonePolygon` dataclass from line 1623 to after `FilledPolygon` (line 155), co-locating it with the other dataclass definitions
- Relocated `extract_zone_polygons()` from line 1632 to after `find_zones_for_net` (line 222), co-locating it with the other zone-related functions
- Added `TestStitchModuleImport` regression test class with two tests verifying clean import and type hint resolution

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `from kicad_tools.cli.stitch_cmd import is_pad_connected, ZonePolygon` succeeds | Pass | Verified via `python3 -c` and new test |
| `typing.get_type_hints(is_pad_connected)` resolves without NameError | Pass | Verified via `python3 -c` and new test |
| All existing tests pass | Pass | 194/194 tests pass (192 existing + 2 new) |
| No other forward references introduced | Pass | Only `ZonePolygon` and `extract_zone_polygons()` were moved; no new forward references |

## Test Plan
- `pytest tests/test_stitch_cmd.py -x` -- all 194 tests pass
- `python3 -c "from kicad_tools.cli.stitch_cmd import is_pad_connected, ZonePolygon"` -- succeeds
- `python3 -c "import typing; from kicad_tools.cli.stitch_cmd import is_pad_connected; print(typing.get_type_hints(is_pad_connected))"` -- resolves ZonePolygon

Closes #1988