### PR TITLE
feat(placement): add place-unplaced command for grid placement of unplaced components

### DIFF
--- a/src/kicad_tools/cli/commands/placement.py
+++ b/src/kicad_tools/cli/commands/placement.py
@@ -7,7 +7,10 @@ def run_placement_command(args) -> int:
     """Handle placement command."""
     if not args.placement_command:
         print("Usage: kicad-tools placement <command> [options] <file>")
-        print("Commands: check, fix, nudge, optimize, snap, align, distribute, suggest, refine")
+        print(
+            "Commands: check, fix, nudge, optimize, snap, align, distribute, "
+            "suggest, place-unplaced, refine"
+        )
         return 1
 
     from ..placement_cmd import main as placement_main
@@ -170,6 +173,26 @@ def run_placement_command(args) -> int:
         if getattr(args, "format", "text") != "text":
             sub_argv.extend(["--format", args.format])
         if args.verbose:
+            sub_argv.append("--verbose")
+        if getattr(args, "quiet", False) or getattr(args, "global_quiet", False):
+            sub_argv.append("--quiet")
+        return placement_main(sub_argv) or 0
+
+    elif args.placement_command == "place-unplaced":
+        sub_argv = ["place-unplaced", args.pcb]
+        if getattr(args, "output", None):
+            sub_argv.extend(["-o", args.output])
+        if getattr(args, "margin", 2.0) != 2.0:
+            sub_argv.extend(["--margin", str(args.margin)])
+        if getattr(args, "spacing", 2.0) != 2.0:
+            sub_argv.extend(["--spacing", str(args.spacing)])
+        if getattr(args, "cluster", False):
+            sub_argv.append("--cluster")
+        if getattr(args, "dry_run", False):
+            sub_argv.append("--dry-run")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
+        if getattr(args, "verbose", False):
             sub_argv.append("--verbose")
         if getattr(args, "quiet", False) or getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")

--- a/src/kicad_tools/cli/placement_cmd.py
+++ b/src/kicad_tools/cli/placement_cmd.py
@@ -331,6 +331,83 @@ def cmd_snap(args) -> int:
     return 0
 
 
+def cmd_place_unplaced(args) -> int:
+    """Place unplaced components (at origin or outside board bounds) in a grid."""
+    import json as _json
+
+    from kicad_tools.cli.progress import spinner
+    from kicad_tools.placement.place_unplaced import place_unplaced
+
+    quiet = getattr(args, "quiet", False)
+    output_format = getattr(args, "format", "text")
+
+    pcb_path = Path(args.pcb)
+    if not pcb_path.exists():
+        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
+        return 1
+
+    try:
+        with spinner("Detecting and placing unplaced components...", quiet=quiet):
+            result = place_unplaced(
+                pcb_path=pcb_path,
+                margin=args.margin,
+                spacing=args.spacing,
+                cluster=args.cluster,
+                dry_run=args.dry_run,
+                output_path=args.output,
+                quiet=quiet,
+            )
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error placing components: {e}", file=sys.stderr)
+        return 1
+
+    if output_format == "json":
+        print(_json.dumps(result.to_dict(), indent=2))
+        return 0
+
+    # Text output
+    if not quiet:
+        if result.total_unplaced == 0:
+            print("No unplaced components detected.")
+            return 0
+
+        action = "Would place" if result.dry_run else "Placed"
+        print(f"\nDetected {result.total_unplaced} unplaced component(s).")
+        print(f"{action} {result.placed_count} component(s) into grid.")
+
+        if result.placed_refs:
+            if args.verbose:
+                print("\nPlaced components:")
+                for ref in result.placed_refs:
+                    print(f"  {ref}")
+            else:
+                refs_str = ", ".join(result.placed_refs[:10])
+                if len(result.placed_refs) > 10:
+                    refs_str += f" ... and {len(result.placed_refs) - 10} more"
+                print(f"  Components: {refs_str}")
+
+        if result.overflow_count > 0:
+            print(
+                f"\nWarning: {result.overflow_count} component(s) could not be placed "
+                f"(insufficient grid space)."
+            )
+            if args.verbose and result.overflow_refs:
+                print("Overflow components:")
+                for ref in result.overflow_refs:
+                    print(f"  {ref}")
+
+        if result.dry_run:
+            print("\n(Dry run - no changes made)")
+        elif result.placed_count > 0:
+            output = args.output or pcb_path
+            print(f"\nSaved to: {output}")
+
+    return 0
+
+
 def cmd_refine(args) -> int:
     """Interactive placement refinement session."""
     from kicad_tools.cli.progress import spinner
@@ -1855,6 +1932,54 @@ def main(argv: list[str] | None = None) -> int:
         "-q", "--quiet", action="store_true", help="Suppress progress output"
     )
 
+    # Place-unplaced subcommand
+    place_unplaced_parser = subparsers.add_parser(
+        "place-unplaced",
+        help="Place unplaced components (at origin or out of bounds) in a grid within the board",
+    )
+    place_unplaced_parser.add_argument("pcb", help="Path to .kicad_pcb file")
+    place_unplaced_parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file path (default: modify in place)",
+    )
+    place_unplaced_parser.add_argument(
+        "--margin",
+        type=float,
+        default=2.0,
+        help="Edge margin in mm (default: 2.0)",
+    )
+    place_unplaced_parser.add_argument(
+        "--spacing",
+        type=float,
+        default=2.0,
+        help="Component spacing in mm (default: 2.0)",
+    )
+    place_unplaced_parser.add_argument(
+        "--schematic",
+        help="Schematic for cross-reference (reserved for future use)",
+    )
+    place_unplaced_parser.add_argument(
+        "--cluster",
+        action="store_true",
+        help="Group by net connectivity before placing",
+    )
+    place_unplaced_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be placed without modifying PCB",
+    )
+    place_unplaced_parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    place_unplaced_parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    place_unplaced_parser.add_argument(
+        "-q", "--quiet", action="store_true", help="Suppress progress output"
+    )
+
     # Refine subcommand (interactive placement refinement)
     refine_parser = subparsers.add_parser("refine", help="Interactive placement refinement session")
     refine_parser.add_argument("pcb", help="Path to .kicad_pcb file")
@@ -1899,6 +2024,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_optimize(args)
     elif args.command == "suggest":
         return cmd_suggest(args)
+    elif args.command == "place-unplaced":
+        return cmd_place_unplaced(args)
     elif args.command == "refine":
         return cmd_refine(args)
 

--- a/src/kicad_tools/mcp/tools/__init__.py
+++ b/src/kicad_tools/mcp/tools/__init__.py
@@ -55,6 +55,7 @@ from kicad_tools.mcp.tools.registry import (
     list_tools,
     register_tool,
 )
+from kicad_tools.mcp.tools.placement import placement_place_unplaced
 from kicad_tools.mcp.tools.routing import (
     get_unrouted_nets,
     route_net,
@@ -97,6 +98,7 @@ __all__ = [
     "list_available_subsystem_types",
     "list_mistake_categories",
     "measure_clearance",
+    "placement_place_unplaced",
     "plan_subsystem",
     "record_decision",
     "restore_checkpoint",

--- a/src/kicad_tools/mcp/tools/placement.py
+++ b/src/kicad_tools/mcp/tools/placement.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import Any
 
 from kicad_tools.analysis.congestion import CongestionAnalyzer, Severity
 from kicad_tools.analysis.signal_integrity import RiskLevel, TraceIntegrityAnalyzer
@@ -129,6 +130,61 @@ def placement_analyze(
         clusters=clusters,
         routing_estimate=routing_estimate,
     )
+
+
+def placement_place_unplaced(
+    pcb_path: str,
+    margin: float = 2.0,
+    spacing: float = 2.0,
+    cluster: bool = False,
+    dry_run: bool = False,
+    output_path: str | None = None,
+) -> dict[str, Any]:
+    """Place unplaced components into a grid within the board outline.
+
+    Detects components sitting at the sheet origin or outside the board
+    bounds and arranges them in a grid inside the board.  Typically used
+    after ``sync-netlist`` to move newly-added footprints into a
+    reasonable initial layout.
+
+    Args:
+        pcb_path: Absolute path to ``.kicad_pcb`` file.
+        margin: Inward margin from board edge in mm.
+        spacing: Spacing between grid cells in mm.
+        cluster: Group components by shared nets before placing.
+        dry_run: When True, report what would change without modifying.
+        output_path: Where to save the modified PCB (defaults to *pcb_path*).
+
+    Returns:
+        Dictionary with placement results (placed_count, overflow_count, etc.)
+
+    Raises:
+        FileNotFoundError: If the PCB file does not exist.
+        ParseError: If the PCB file cannot be parsed.
+        ValueError: If the PCB has no ``Edge.Cuts`` board outline.
+    """
+    from kicad_tools.placement.place_unplaced import (
+        PlaceUnplacedResult,
+        place_unplaced,
+    )
+
+    path = Path(pcb_path)
+    if not path.exists():
+        raise KiCadFileNotFoundError(f"PCB file not found: {pcb_path}")
+
+    if path.suffix != ".kicad_pcb":
+        raise ParseError(f"Invalid file extension: {path.suffix} (expected .kicad_pcb)")
+
+    result = place_unplaced(
+        pcb_path=pcb_path,
+        margin=margin,
+        spacing=spacing,
+        cluster=cluster,
+        dry_run=dry_run,
+        output_path=output_path,
+        quiet=True,
+    )
+    return result.to_dict()
 
 
 def _compute_wire_length_score(pcb: PCB) -> float:

--- a/src/kicad_tools/mcp/tools/registry.py
+++ b/src/kicad_tools/mcp/tools/registry.py
@@ -387,6 +387,67 @@ register_tool(
 )
 
 
+def _handler_placement_place_unplaced(params: dict[str, Any]) -> dict[str, Any]:
+    """Handle placement_place_unplaced tool call."""
+    from kicad_tools.mcp.tools.placement import placement_place_unplaced
+
+    return placement_place_unplaced(
+        pcb_path=params["pcb_path"],
+        margin=params.get("margin", 2.0),
+        spacing=params.get("spacing", 2.0),
+        cluster=params.get("cluster", False),
+        dry_run=params.get("dry_run", False),
+        output_path=params.get("output_path"),
+    )
+
+
+register_tool(
+    name="placement_place_unplaced",
+    description=(
+        "Detect and place unplaced components on a PCB. Finds components at the "
+        "sheet origin or outside the board outline (typically added by sync-netlist) "
+        "and arranges them in a grid within the board bounds. Supports dry-run mode "
+        "to preview changes, adjustable margin/spacing, and optional net-based "
+        "clustering to place related components adjacently."
+    ),
+    parameters=_make_params(
+        properties={
+            "pcb_path": {
+                "type": "string",
+                "description": "Absolute path to .kicad_pcb file",
+            },
+            "margin": {
+                "type": "number",
+                "description": "Inward margin from board edge in mm (default: 2.0)",
+                "default": 2.0,
+            },
+            "spacing": {
+                "type": "number",
+                "description": "Spacing between grid cells in mm (default: 2.0)",
+                "default": 2.0,
+            },
+            "cluster": {
+                "type": "boolean",
+                "description": "Group components by shared net connectivity before placing (default: false)",
+                "default": False,
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "Report what would change without modifying the PCB (default: false)",
+                "default": False,
+            },
+            "output_path": {
+                "type": "string",
+                "description": "Output file path (optional, overwrites original if not specified)",
+            },
+        },
+        required=["pcb_path"],
+    ),
+    handler=_handler_placement_place_unplaced,
+    category="placement",
+)
+
+
 def _handler_placement_suggestions(params: dict[str, Any]) -> dict[str, Any]:
     """Handle placement_suggestions tool call."""
     from kicad_tools.mcp.tools.placement import placement_suggestions

--- a/src/kicad_tools/placement/place_unplaced.py
+++ b/src/kicad_tools/placement/place_unplaced.py
@@ -1,0 +1,401 @@
+"""Place unplaced components within the board outline.
+
+Detects components at the origin or outside the board bounds and arranges
+them in a grid within the board outline.  Used after ``sync-netlist`` to
+move newly-added footprints into a reasonable initial layout.
+
+Example::
+
+    >>> from kicad_tools.placement.place_unplaced import place_unplaced
+    >>> result = place_unplaced("board.kicad_pcb", dry_run=True)
+    >>> for ref in result.placed_refs:
+    ...     print(ref)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from kicad_tools.schema.pcb import PCB, Footprint
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PlaceUnplacedResult:
+    """Result of placing unplaced components.
+
+    Attributes:
+        total_unplaced: Number of unplaced components detected.
+        placed_count: Number of components successfully placed.
+        overflow_count: Number of components that could not be placed
+            because the available area was exhausted.
+        placed_refs: References of placed components (in placement order).
+        overflow_refs: References of components that could not be placed.
+        board_bounds: Board bounding rectangle as ``(min_x, min_y, max_x, max_y)``.
+        dry_run: Whether the run was a dry run (no PCB modifications).
+    """
+
+    total_unplaced: int = 0
+    placed_count: int = 0
+    overflow_count: int = 0
+    placed_refs: list[str] = field(default_factory=list)
+    overflow_refs: list[str] = field(default_factory=list)
+    board_bounds: tuple[float, float, float, float] | None = None
+    dry_run: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "total_unplaced": self.total_unplaced,
+            "placed_count": self.placed_count,
+            "overflow_count": self.overflow_count,
+            "placed_refs": self.placed_refs,
+            "overflow_refs": self.overflow_refs,
+            "board_bounds": list(self.board_bounds) if self.board_bounds else None,
+            "dry_run": self.dry_run,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Detection helpers
+# ---------------------------------------------------------------------------
+
+ORIGIN_THRESHOLD = 0.1  # mm – matches validate/placement.py
+
+
+def _get_board_bounds(pcb: PCB) -> tuple[float, float, float, float] | None:
+    """Return board bounding rectangle in board-relative coordinates.
+
+    Returns ``(min_x, min_y, max_x, max_y)`` or ``None`` when no
+    ``Edge.Cuts`` outline is found.
+    """
+    outline = pcb.get_board_outline()
+    if not outline:
+        return None
+
+    # Outline points are in sheet-absolute coordinates.
+    # Convert to board-relative by subtracting the board origin.
+    ox, oy = pcb.board_origin
+    xs = [p[0] - ox for p in outline]
+    ys = [p[1] - oy for p in outline]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def _is_at_origin_absolute(fp: Footprint, origin: tuple[float, float]) -> bool:
+    """Check whether *fp* sits at the sheet-absolute origin.
+
+    Footprint positions stored on the ``PCB`` object are board-relative.
+    We convert back to sheet-absolute by adding ``origin`` and check
+    proximity to ``(0, 0)``.
+    """
+    abs_x = fp.position[0] + origin[0]
+    abs_y = fp.position[1] + origin[1]
+    return abs(abs_x) < ORIGIN_THRESHOLD and abs(abs_y) < ORIGIN_THRESHOLD
+
+
+def _is_outside_bounds(
+    fp: Footprint,
+    bounds: tuple[float, float, float, float],
+) -> bool:
+    """Check whether *fp* centre lies outside the board bounding rectangle.
+
+    ``bounds`` is ``(min_x, min_y, max_x, max_y)`` in board-relative
+    coordinates.
+    """
+    x, y = fp.position
+    min_x, min_y, max_x, max_y = bounds
+    return x < min_x or x > max_x or y < min_y or y > max_y
+
+
+def _detect_unplaced(
+    pcb: PCB,
+    bounds: tuple[float, float, float, float],
+) -> list[Footprint]:
+    """Return footprints considered unplaced.
+
+    A footprint is unplaced when it is either at the sheet-absolute origin
+    or outside the board bounding rectangle.
+    """
+    origin = pcb.board_origin
+    unplaced: list[Footprint] = []
+    for fp in pcb.footprints:
+        if _is_at_origin_absolute(fp, origin) or _is_outside_bounds(fp, bounds):
+            unplaced.append(fp)
+    return unplaced
+
+
+# ---------------------------------------------------------------------------
+# Footprint sizing helpers
+# ---------------------------------------------------------------------------
+
+
+def _footprint_size(fp: Footprint, default_margin: float = 0.5) -> tuple[float, float]:
+    """Estimate footprint width and height from courtyard or pad extents.
+
+    Checks courtyard graphics first; falls back to pad bounding box plus
+    *default_margin* on each side.
+
+    Returns ``(width, height)`` in mm.
+    """
+    # Try courtyard graphics
+    cy_points: list[tuple[float, float]] = []
+    for g in fp.graphics:
+        layer = getattr(g, "layer", "")
+        if "Courtyard" in layer:
+            if hasattr(g, "start") and hasattr(g, "end"):
+                cy_points.append(g.start)
+                cy_points.append(g.end)
+
+    if cy_points:
+        xs = [p[0] for p in cy_points]
+        ys = [p[1] for p in cy_points]
+        return (max(xs) - min(xs), max(ys) - min(ys))
+
+    # Fallback: pad bounding box + margin
+    if fp.pads:
+        xs: list[float] = []
+        ys: list[float] = []
+        for pad in fp.pads:
+            px, py = pad.position
+            hw, hh = pad.size[0] / 2, pad.size[1] / 2
+            xs.extend([px - hw, px + hw])
+            ys.extend([py - hh, py + hh])
+        return (
+            max(xs) - min(xs) + 2 * default_margin,
+            max(ys) - min(ys) + 2 * default_margin,
+        )
+
+    # Ultimate fallback
+    return (2.0, 2.0)
+
+
+# ---------------------------------------------------------------------------
+# Grid placement
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _GridCell:
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+def _build_grid(
+    bounds: tuple[float, float, float, float],
+    margin: float,
+    spacing: float,
+    cell_w: float,
+    cell_h: float,
+) -> list[_GridCell]:
+    """Build a list of grid cells inside the placeable area."""
+    min_x, min_y, max_x, max_y = bounds
+    area_x = min_x + margin
+    area_y = min_y + margin
+    area_w = (max_x - min_x) - 2 * margin
+    area_h = (max_y - min_y) - 2 * margin
+
+    if area_w <= 0 or area_h <= 0:
+        return []
+
+    step_x = cell_w + spacing
+    step_y = cell_h + spacing
+
+    cells: list[_GridCell] = []
+    y = area_y
+    while y + cell_h <= area_y + area_h:
+        x = area_x
+        while x + cell_w <= area_x + area_w:
+            cells.append(_GridCell(x=x, y=y, w=cell_w, h=cell_h))
+            x += step_x
+        y += step_y
+
+    return cells
+
+
+def _cell_occupied(
+    cell: _GridCell,
+    placed_positions: list[tuple[float, float, float, float]],
+) -> bool:
+    """Return ``True`` if *cell* overlaps any already-placed bounding box.
+
+    Each item in *placed_positions* is ``(x, y, w, h)`` where ``(x, y)``
+    is the centre.
+    """
+    cx = cell.x + cell.w / 2
+    cy = cell.y + cell.h / 2
+    for px, py, pw, ph in placed_positions:
+        if (
+            abs(cx - px) < (cell.w + pw) / 2
+            and abs(cy - py) < (cell.h + ph) / 2
+        ):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Clustering helpers
+# ---------------------------------------------------------------------------
+
+
+def _cluster_footprints(
+    footprints: list[Footprint],
+    pcb: PCB,
+) -> list[list[Footprint]]:
+    """Group *footprints* by shared net connectivity.
+
+    Components sharing at least one net are placed in the same cluster.
+    Uses a simple union-find algorithm on net membership.
+    """
+    # Build a mapping from net number to footprint indices
+    net_to_fps: dict[int, list[int]] = {}
+    for idx, fp in enumerate(footprints):
+        for pad in fp.pads:
+            if pad.net_number > 0:
+                net_to_fps.setdefault(pad.net_number, []).append(idx)
+
+    # Union-find
+    parent = list(range(len(footprints)))
+
+    def find(a: int) -> int:
+        while parent[a] != a:
+            parent[a] = parent[parent[a]]
+            a = parent[a]
+        return a
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for indices in net_to_fps.values():
+        for i in range(1, len(indices)):
+            union(indices[0], indices[i])
+
+    # Collect clusters
+    clusters: dict[int, list[int]] = {}
+    for idx in range(len(footprints)):
+        root = find(idx)
+        clusters.setdefault(root, []).append(idx)
+
+    return [[footprints[i] for i in idxs] for idxs in clusters.values()]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def place_unplaced(
+    pcb_path: str | Path,
+    *,
+    margin: float = 2.0,
+    spacing: float = 2.0,
+    cluster: bool = False,
+    dry_run: bool = False,
+    output_path: str | Path | None = None,
+    quiet: bool = False,
+) -> PlaceUnplacedResult:
+    """Detect and grid-place unplaced components.
+
+    Args:
+        pcb_path: Path to ``.kicad_pcb`` file.
+        margin: Inward margin from board edge in mm.
+        spacing: Spacing between grid cells in mm.
+        cluster: Group components by shared nets before placing.
+        dry_run: When ``True`` report what would change without writing.
+        output_path: Where to save the modified PCB (defaults to *pcb_path*).
+        quiet: Suppress informational output.
+
+    Returns:
+        :class:`PlaceUnplacedResult` describing what was (or would be) done.
+    """
+    pcb_path = Path(pcb_path)
+    pcb = PCB.load(str(pcb_path))
+
+    # Determine board bounds
+    bounds = _get_board_bounds(pcb)
+    if bounds is None:
+        raise ValueError(
+            f"No Edge.Cuts board outline found in {pcb_path}. "
+            "Cannot determine placement area."
+        )
+
+    # Detect unplaced components
+    unplaced = _detect_unplaced(pcb, bounds)
+
+    result = PlaceUnplacedResult(
+        total_unplaced=len(unplaced),
+        board_bounds=bounds,
+        dry_run=dry_run,
+    )
+
+    if not unplaced:
+        return result
+
+    # Compute a representative cell size from the largest footprint dimension
+    sizes = [_footprint_size(fp) for fp in unplaced]
+    max_w = max(s[0] for s in sizes)
+    max_h = max(s[1] for s in sizes)
+    cell_w = max(max_w, 2.0)
+    cell_h = max(max_h, 2.0)
+
+    # Gather already-placed footprint positions (for overlap avoidance)
+    placed_positions: list[tuple[float, float, float, float]] = []
+    for fp in pcb.footprints:
+        if fp in unplaced:
+            continue
+        fw, fh = _footprint_size(fp)
+        placed_positions.append((fp.position[0], fp.position[1], fw, fh))
+
+    # Build grid
+    cells = _build_grid(bounds, margin, spacing, cell_w, cell_h)
+
+    # Remove cells that overlap existing placements
+    free_cells = [c for c in cells if not _cell_occupied(c, placed_positions)]
+
+    # Optionally cluster
+    if cluster:
+        ordered: list[Footprint] = []
+        for group in _cluster_footprints(unplaced, pcb):
+            ordered.extend(group)
+    else:
+        ordered = list(unplaced)
+
+    # Place components into free cells
+    cell_idx = 0
+    for fp in ordered:
+        if cell_idx >= len(free_cells):
+            result.overflow_refs.append(fp.reference)
+            result.overflow_count += 1
+            continue
+
+        cell = free_cells[cell_idx]
+        new_x = cell.x + cell.w / 2
+        new_y = cell.y + cell.h / 2
+
+        if not dry_run:
+            pcb.update_footprint_position(fp.reference, new_x, new_y)
+
+        result.placed_refs.append(fp.reference)
+        result.placed_count += 1
+
+        # Mark this position as occupied for future overlap checks
+        fw, fh = _footprint_size(fp)
+        placed_positions.append((new_x, new_y, fw, fh))
+        cell_idx += 1
+
+    # Save
+    if not dry_run:
+        save_path = Path(output_path) if output_path else pcb_path
+        pcb.save(str(save_path))
+
+    return result

--- a/src/kicad_tools/placement/place_unplaced.py
+++ b/src/kicad_tools/placement/place_unplaced.py
@@ -14,7 +14,6 @@ Example::
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any

--- a/tests/test_place_unplaced.py
+++ b/tests/test_place_unplaced.py
@@ -1,0 +1,646 @@
+"""Tests for place-unplaced command and module (issue #1984).
+
+Verifies:
+- Detection of components at sheet origin and outside board bounds
+- Grid computation with margin and spacing parameters
+- Placement algorithm assigns unplaced components to free grid cells
+- Overflow reporting when grid space is exhausted
+- Dry-run mode reports without modifying the PCB
+- Clustering by shared nets groups related components
+- Graceful error when no Edge.Cuts outline exists
+- All-placed scenario returns zero count
+- CLI dispatch and subcommand parsing
+- MCP tool registration and delegation
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.placement.place_unplaced import (
+    PlaceUnplacedResult,
+    _build_grid,
+    _cell_occupied,
+    _cluster_footprints,
+    _detect_unplaced,
+    _footprint_size,
+    _get_board_bounds,
+    _GridCell,
+    _is_at_origin_absolute,
+    _is_outside_bounds,
+    place_unplaced,
+)
+from kicad_tools.schema.pcb import PCB
+
+# ---------------------------------------------------------------------------
+# Inline PCB fixtures
+# ---------------------------------------------------------------------------
+
+# A 50x50mm board at sheet position (100, 100) with two footprints:
+#   R1 at origin (0, 0) -- unplaced
+#   R2 properly placed inside the board at (125, 125) -- board-relative (25, 25)
+BOARD_WITH_UNPLACED = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+  (gr_rect (start 100 100) (end 150 150) (layer "Edge.Cuts") (stroke (width 0.05) (type default)))
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000001")
+    (at 0 0)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "GND"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (at 125 125)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "GND"))
+  )
+)
+"""
+
+# Same board, but R1 is far outside the board outline instead of at origin.
+BOARD_WITH_OUT_OF_BOUNDS = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+  (gr_rect (start 100 100) (end 150 150) (layer "Edge.Cuts") (stroke (width 0.05) (type default)))
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000001")
+    (at 300 300)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "GND"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (at 125 125)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "GND"))
+  )
+)
+"""
+
+# Board where all components are properly placed inside the outline.
+BOARD_ALL_PLACED = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "VCC")
+  (gr_rect (start 100 100) (end 150 150) (layer "Edge.Cuts") (stroke (width 0.05) (type default)))
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000001")
+    (at 120 120)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VCC"))
+  )
+)
+"""
+
+# Board with no Edge.Cuts outline.
+BOARD_NO_OUTLINE = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "VCC")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000001")
+    (at 0 0)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VCC"))
+  )
+)
+"""
+
+# Board with many components at origin to test overflow.
+# Tiny 10x10mm board with 20 components at origin -- not all will fit.
+_ORIGIN_FP_TEMPLATE = """\
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000{idx:02d}")
+    (at 0 0)
+    (property "Reference" "R{idx}" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net {net_a} "N{net_a}"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net {net_b} "N{net_b}"))
+  )"""
+
+
+def _make_overflow_board() -> str:
+    fps = []
+    for i in range(1, 21):
+        fps.append(
+            _ORIGIN_FP_TEMPLATE.format(idx=i, net_a=(i * 2 - 1), net_b=(i * 2))
+        )
+    nets = "\n".join(f'  (net {n} "N{n}")' for n in range(1, 41))
+    return f"""\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+{nets}
+  (gr_rect (start 100 100) (end 110 110) (layer "Edge.Cuts") (stroke (width 0.05) (type default)))
+{"".join(fps)}
+)
+"""
+
+
+# Board with cluster-able components: R1 and R2 share net 1, R3 is isolated.
+BOARD_WITH_CLUSTERS = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+  (net 3 "SIG")
+  (gr_rect (start 100 100) (end 200 200) (layer "Edge.Cuts") (stroke (width 0.05) (type default)))
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000001")
+    (at 0 0)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "GND"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (at 0 0)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 3 "SIG"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000003")
+    (at 0 0)
+    (property "Reference" "R3" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 3 "SIG"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "GND"))
+  )
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_pcb(tmp_path: Path, content: str, name: str = "test.kicad_pcb") -> Path:
+    p = tmp_path / name
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Unit: detection logic
+# ---------------------------------------------------------------------------
+
+
+class TestDetection:
+    """Tests for _is_at_origin_absolute and _is_outside_bounds."""
+
+    def test_at_origin_detects_origin_component(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        pcb = PCB.load(str(pcb_path))
+        # R1 is at sheet-absolute (0, 0) which is at origin
+        r1 = [fp for fp in pcb.footprints if fp.reference == "R1"][0]
+        assert _is_at_origin_absolute(r1, pcb.board_origin)
+
+    def test_at_origin_does_not_flag_placed_component(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        pcb = PCB.load(str(pcb_path))
+        # R2 at (125, 125) is not at origin
+        r2 = [fp for fp in pcb.footprints if fp.reference == "R2"][0]
+        assert not _is_at_origin_absolute(r2, pcb.board_origin)
+
+    def test_outside_bounds_detects_far_component(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_OUT_OF_BOUNDS)
+        pcb = PCB.load(str(pcb_path))
+        bounds = _get_board_bounds(pcb)
+        assert bounds is not None
+        r1 = [fp for fp in pcb.footprints if fp.reference == "R1"][0]
+        assert _is_outside_bounds(r1, bounds)
+
+    def test_inside_bounds_not_flagged(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_OUT_OF_BOUNDS)
+        pcb = PCB.load(str(pcb_path))
+        bounds = _get_board_bounds(pcb)
+        assert bounds is not None
+        r2 = [fp for fp in pcb.footprints if fp.reference == "R2"][0]
+        assert not _is_outside_bounds(r2, bounds)
+
+    def test_detect_unplaced_returns_only_unplaced(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        pcb = PCB.load(str(pcb_path))
+        bounds = _get_board_bounds(pcb)
+        assert bounds is not None
+        unplaced = _detect_unplaced(pcb, bounds)
+        refs = {fp.reference for fp in unplaced}
+        assert "R1" in refs
+        assert "R2" not in refs
+
+
+# ---------------------------------------------------------------------------
+# Unit: board bounds
+# ---------------------------------------------------------------------------
+
+
+class TestBoardBounds:
+    """Tests for _get_board_bounds."""
+
+    def test_returns_correct_bounds(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        pcb = PCB.load(str(pcb_path))
+        bounds = _get_board_bounds(pcb)
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+        # The board is 50x50, so width and height should be ~50
+        assert pytest.approx(max_x - min_x, abs=0.5) == 50.0
+        assert pytest.approx(max_y - min_y, abs=0.5) == 50.0
+
+    def test_returns_none_without_outline(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_NO_OUTLINE)
+        pcb = PCB.load(str(pcb_path))
+        assert _get_board_bounds(pcb) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit: grid computation
+# ---------------------------------------------------------------------------
+
+
+class TestGrid:
+    """Tests for _build_grid and _cell_occupied."""
+
+    def test_grid_cells_fit_inside_area(self):
+        bounds = (0.0, 0.0, 20.0, 20.0)
+        cells = _build_grid(bounds, margin=2.0, spacing=1.0, cell_w=3.0, cell_h=3.0)
+        assert len(cells) > 0
+        for cell in cells:
+            assert cell.x >= 2.0
+            assert cell.y >= 2.0
+            assert cell.x + cell.w <= 18.0
+            assert cell.y + cell.h <= 18.0
+
+    def test_grid_returns_empty_for_tiny_area(self):
+        bounds = (0.0, 0.0, 2.0, 2.0)
+        cells = _build_grid(bounds, margin=2.0, spacing=1.0, cell_w=3.0, cell_h=3.0)
+        assert len(cells) == 0
+
+    def test_grid_count_matches_expected(self):
+        # 100x100 area, 5mm margin each side -> 90x90 usable
+        # Cell 10x10 with 2mm spacing -> step 12mm
+        # Columns: floor(90 / 12) ~= 7 (since 7*12=84, 8*12=96 > 90 but check fit)
+        # Actually: 5 + 10 = 15 first cell end, and area goes to 95
+        # 7 cells fit: 5, 17, 29, 41, 53, 65, 77 (77+10=87 <= 95)
+        bounds = (0.0, 0.0, 100.0, 100.0)
+        cells = _build_grid(bounds, margin=5.0, spacing=2.0, cell_w=10.0, cell_h=10.0)
+        # 90mm usable / 12mm step = 7 per row/col
+        assert len(cells) == 7 * 7
+
+    def test_cell_occupied_detects_overlap(self):
+        cell = _GridCell(x=10.0, y=10.0, w=5.0, h=5.0)
+        # A component at the same center
+        placed = [(12.5, 12.5, 5.0, 5.0)]
+        assert _cell_occupied(cell, placed)
+
+    def test_cell_occupied_no_overlap(self):
+        cell = _GridCell(x=10.0, y=10.0, w=5.0, h=5.0)
+        # A component far away
+        placed = [(50.0, 50.0, 5.0, 5.0)]
+        assert not _cell_occupied(cell, placed)
+
+
+# ---------------------------------------------------------------------------
+# Unit: footprint sizing
+# ---------------------------------------------------------------------------
+
+
+class TestFootprintSizing:
+    """Tests for _footprint_size."""
+
+    def test_pad_fallback_size(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        pcb = PCB.load(str(pcb_path))
+        r1 = [fp for fp in pcb.footprints if fp.reference == "R1"][0]
+        w, h = _footprint_size(r1)
+        # 0402 has two pads ~1mm apart, each ~0.54 wide, with 0.5mm margin
+        assert w > 0
+        assert h > 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: place_unplaced public API
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceUnplaced:
+    """Integration tests for the place_unplaced() function."""
+
+    def test_dry_run_reports_without_modifying(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        original = pcb_path.read_text()
+
+        result = place_unplaced(pcb_path, dry_run=True)
+
+        assert result.dry_run is True
+        assert result.total_unplaced >= 1
+        assert result.placed_count >= 1
+        assert "R1" in result.placed_refs
+        # File should be unmodified
+        assert pcb_path.read_text() == original
+
+    def test_placement_moves_component(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        result = place_unplaced(pcb_path)
+
+        assert result.dry_run is False
+        assert result.placed_count >= 1
+        assert "R1" in result.placed_refs
+
+        # Reload and verify R1 is now inside bounds
+        pcb = PCB.load(str(pcb_path))
+        bounds = _get_board_bounds(pcb)
+        assert bounds is not None
+        r1 = [fp for fp in pcb.footprints if fp.reference == "R1"][0]
+        min_x, min_y, max_x, max_y = bounds
+        assert min_x <= r1.position[0] <= max_x
+        assert min_y <= r1.position[1] <= max_y
+
+    def test_out_of_bounds_component_detected(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_OUT_OF_BOUNDS)
+        result = place_unplaced(pcb_path, dry_run=True)
+
+        assert result.total_unplaced >= 1
+        assert "R1" in result.placed_refs
+
+    def test_all_placed_returns_zero_count(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_ALL_PLACED)
+        result = place_unplaced(pcb_path, dry_run=True)
+
+        assert result.total_unplaced == 0
+        assert result.placed_count == 0
+        assert result.overflow_count == 0
+
+    def test_no_outline_raises_value_error(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_NO_OUTLINE)
+        with pytest.raises(ValueError, match="No Edge.Cuts"):
+            place_unplaced(pcb_path)
+
+    def test_overflow_reported_for_small_board(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, _make_overflow_board())
+        result = place_unplaced(pcb_path, dry_run=True)
+
+        assert result.total_unplaced == 20
+        # Not all 20 can fit in a 10x10mm board
+        assert result.overflow_count > 0
+        assert len(result.overflow_refs) == result.overflow_count
+        assert result.placed_count + result.overflow_count == result.total_unplaced
+
+    def test_output_path_writes_to_separate_file(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        out_path = tmp_path / "output.kicad_pcb"
+
+        result = place_unplaced(pcb_path, output_path=out_path)
+
+        assert result.placed_count >= 1
+        assert out_path.exists()
+        # Original should be untouched
+        pcb_original = PCB.load(str(pcb_path))
+        r1_orig = [fp for fp in pcb_original.footprints if fp.reference == "R1"][0]
+        # R1 in original is still at origin (approximately)
+        abs_x = r1_orig.position[0] + pcb_original.board_origin[0]
+        abs_y = r1_orig.position[1] + pcb_original.board_origin[1]
+        assert abs(abs_x) < 1.0 and abs(abs_y) < 1.0
+
+    def test_cluster_mode_groups_by_net(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_CLUSTERS)
+        result = place_unplaced(pcb_path, cluster=True, dry_run=True)
+
+        assert result.total_unplaced == 3
+        assert result.placed_count == 3
+        # All three share nets (VCC, GND, SIG) so they end up in one cluster
+        # and are placed adjacently. We cannot verify adjacency in dry_run
+        # but we can verify all were placed.
+        assert set(result.placed_refs) == {"R1", "R2", "R3"}
+
+
+# ---------------------------------------------------------------------------
+# Unit: clustering
+# ---------------------------------------------------------------------------
+
+
+class TestClustering:
+    """Tests for _cluster_footprints."""
+
+    def test_shared_net_creates_single_cluster(self, tmp_path: Path):
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_CLUSTERS)
+        pcb = PCB.load(str(pcb_path))
+        bounds = _get_board_bounds(pcb)
+        assert bounds is not None
+        unplaced = _detect_unplaced(pcb, bounds)
+        clusters = _cluster_footprints(unplaced, pcb)
+        # R1 shares VCC with R2; R2 shares SIG with R3; R3 shares GND with R1
+        # So all three should be in one cluster
+        assert len(clusters) == 1
+        refs = {fp.reference for fp in clusters[0]}
+        assert refs == {"R1", "R2", "R3"}
+
+
+# ---------------------------------------------------------------------------
+# Unit: PlaceUnplacedResult serialization
+# ---------------------------------------------------------------------------
+
+
+class TestResultSerialization:
+    """Tests for PlaceUnplacedResult.to_dict."""
+
+    def test_to_dict_roundtrip(self):
+        result = PlaceUnplacedResult(
+            total_unplaced=5,
+            placed_count=3,
+            overflow_count=2,
+            placed_refs=["R1", "R2", "R3"],
+            overflow_refs=["R4", "R5"],
+            board_bounds=(0.0, 0.0, 50.0, 50.0),
+            dry_run=True,
+        )
+        d = result.to_dict()
+        assert d["total_unplaced"] == 5
+        assert d["placed_count"] == 3
+        assert d["overflow_count"] == 2
+        assert d["placed_refs"] == ["R1", "R2", "R3"]
+        assert d["overflow_refs"] == ["R4", "R5"]
+        assert d["board_bounds"] == [0.0, 0.0, 50.0, 50.0]
+        assert d["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch test
+# ---------------------------------------------------------------------------
+
+
+class TestCLIDispatch:
+    """Test that the CLI main() dispatches place-unplaced correctly."""
+
+    def test_cli_dry_run(self, tmp_path: Path):
+        from kicad_tools.cli.placement_cmd import main
+
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        rc = main(["place-unplaced", str(pcb_path), "--dry-run", "--quiet"])
+        assert rc == 0
+
+    def test_cli_json_output(self, tmp_path: Path, capsys):
+        from kicad_tools.cli.placement_cmd import main
+
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        rc = main(["place-unplaced", str(pcb_path), "--dry-run", "--format", "json"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        import json
+
+        data = json.loads(captured.out)
+        assert "total_unplaced" in data
+        assert "placed_count" in data
+
+    def test_cli_no_outline_returns_error(self, tmp_path: Path):
+        from kicad_tools.cli.placement_cmd import main
+
+        pcb_path = _write_pcb(tmp_path, BOARD_NO_OUTLINE)
+        rc = main(["place-unplaced", str(pcb_path), "--quiet"])
+        assert rc == 1
+
+    def test_cli_file_not_found_returns_error(self):
+        from kicad_tools.cli.placement_cmd import main
+
+        rc = main(["place-unplaced", "/nonexistent/board.kicad_pcb", "--quiet"])
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# MCP tool registration test
+# ---------------------------------------------------------------------------
+
+
+class TestMCPRegistration:
+    """Test that the MCP tool is registered and callable."""
+
+    def test_tool_registered(self):
+        from kicad_tools.mcp.tools.registry import get_tool
+
+        tool = get_tool("placement_place_unplaced")
+        assert tool is not None
+        assert tool.category == "placement"
+        assert "pcb_path" in tool.parameters["properties"]
+
+    def test_mcp_handler_dry_run(self, tmp_path: Path):
+        from kicad_tools.mcp.tools.registry import get_tool
+
+        pcb_path = _write_pcb(tmp_path, BOARD_WITH_UNPLACED)
+        tool = get_tool("placement_place_unplaced")
+        assert tool is not None
+        result = tool.handler({"pcb_path": str(pcb_path), "dry_run": True})
+        assert result["total_unplaced"] >= 1
+        assert result["placed_count"] >= 1
+        assert result["dry_run"] is True


### PR DESCRIPTION
## Summary
Add `placement place-unplaced` CLI subcommand, core placement module, MCP tool, and comprehensive tests for detecting components at the sheet origin or outside the board outline and arranging them in a grid within the board bounds. This is typically used after `sync-netlist` to move newly-added footprints into a reasonable initial layout.

## Changes
- **New module** `src/kicad_tools/placement/place_unplaced.py` -- core logic: detection (at-origin + out-of-bounds), grid computation, footprint sizing, net-based clustering, and `place_unplaced()` public API with `PlaceUnplacedResult` dataclass
- **CLI handler** `cmd_place_unplaced()` in `placement_cmd.py` -- supports `--margin`, `--spacing`, `--cluster`, `--dry-run`, `--format json/text`, `--output`, `-v`, `-q`
- **CLI dispatch** added `place-unplaced` case to `commands/placement.py` dispatcher
- **MCP tool** `placement_place_unplaced` registered in `registry.py` with full JSON Schema, delegating to `mcp/tools/placement.py` wrapper
- **MCP exports** updated `mcp/tools/__init__.py`
- **Tests** 29 unit/integration tests covering detection logic, grid computation, overflow, dry-run, clustering, CLI dispatch, error handling, result serialization, and MCP tool registration

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Detect components at sheet origin | Pass | `TestDetection::test_at_origin_detects_origin_component` |
| Detect components outside board bounds | Pass | `TestDetection::test_outside_bounds_detects_far_component` |
| Grid placement within board outline | Pass | `TestPlaceUnplaced::test_placement_moves_component` verifies R1 ends up inside bounds |
| Dry-run mode reports without modifying | Pass | `TestPlaceUnplaced::test_dry_run_reports_without_modifying` checks file unchanged |
| Overflow reporting for small boards | Pass | `TestPlaceUnplaced::test_overflow_reported_for_small_board` with 20 components on 10x10mm |
| Graceful error with no Edge.Cuts | Pass | `TestPlaceUnplaced::test_no_outline_raises_value_error` |
| All-placed returns zero count | Pass | `TestPlaceUnplaced::test_all_placed_returns_zero_count` |
| Clustering by shared nets | Pass | `TestClustering::test_shared_net_creates_single_cluster` + `TestPlaceUnplaced::test_cluster_mode_groups_by_net` |
| CLI subcommand dispatch | Pass | `TestCLIDispatch` (4 tests: dry-run, json, no-outline error, file-not-found) |
| MCP tool registered and callable | Pass | `TestMCPRegistration` (2 tests: registration check, handler dry-run) |

## Test Plan
All 29 tests pass: `python3 -m pytest tests/test_place_unplaced.py -v`

Closes #1984