### PR TITLE
fix(schema): sync Footprint position/rotation/layer setters to S-expression

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -407,7 +407,18 @@ class BoardGraphic:
 
 @dataclass
 class Footprint:
-    """PCB component footprint."""
+    """PCB component footprint.
+
+    The ``position``, ``rotation``, and ``layer`` attributes are backed by
+    a ``__setattr__`` override that keeps the underlying S-expression node
+    in sync.  After a :class:`PCB` is fully constructed (parsing and
+    board-origin detection complete), the PCB links each ``Footprint`` to
+    its S-expression node via :pyattr:`_sexp_node` and stores the board
+    origin offset in :pyattr:`_board_origin`.  From that point on, any
+    assignment to ``position``, ``rotation``, or ``layer`` is
+    automatically reflected in the S-expression tree that
+    :meth:`PCB.save` serialises.
+    """
 
     name: str
     layer: str
@@ -426,10 +437,59 @@ class Footprint:
     exclude_from_bom: bool = False
     dnp: bool = False
     properties: dict[str, str] = field(default_factory=dict)
+    _sexp_node: SExp | None = field(default=None, repr=False, compare=False)
+    _board_origin: tuple[float, float] = field(
+        default=(0.0, 0.0), repr=False, compare=False,
+    )
+
+    # ------------------------------------------------------------------
+    # __setattr__ override -- syncs position/rotation/layer to _sexp_node
+    # ------------------------------------------------------------------
+
+    def __setattr__(self, name: str, value: object) -> None:
+        # Always store the Python value first via the default mechanism.
+        super().__setattr__(name, value)
+
+        # Bail out during __init__ (before _sexp_node exists) or when
+        # there is no backing S-expression node.
+        sexp_node: SExp | None = self.__dict__.get("_sexp_node")
+        if sexp_node is None:
+            return
+
+        if name == "position":
+            at_node = sexp_node.find("at")
+            if at_node is not None:
+                x, y = value  # type: ignore[unpacking-non-sequence]
+                # ``fp.position`` stores board-relative coordinates but the
+                # S-expression ``(at ...)`` node uses sheet-absolute values.
+                # Add the board origin offset to convert.
+                origin = self.__dict__.get("_board_origin", (0.0, 0.0))
+                at_node.set_value(0, x + origin[0])
+                at_node.set_value(1, y + origin[1])
+
+        elif name == "rotation":
+            at_node = sexp_node.find("at")
+            if at_node is not None:
+                if len(at_node.children) >= 3:
+                    at_node.set_value(2, value)
+                elif value != 0.0:
+                    at_node.add(value)
+
+        elif name == "layer":
+            layer_node = sexp_node.find("layer")
+            if layer_node is not None:
+                layer_node.set_value(0, value)
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> Footprint:
-        """Parse footprint from S-expression."""
+        """Parse footprint from S-expression.
+
+        Note: ``_sexp_node`` is intentionally **not** set here.  It is
+        linked later by :meth:`PCB._link_footprint_sexp_nodes` after the
+        board origin has been detected and footprint positions have been
+        converted to board-relative coordinates.  This prevents the
+        ``__setattr__`` sync from writing stale values during parsing.
+        """
         name = sexp.get_string(0) or ""
 
         fp = cls(
@@ -954,6 +1014,7 @@ class PCB:
         self._board_origin: tuple[float, float] = (0.0, 0.0)
         self._parse()
         self._detect_board_origin()
+        self._link_footprint_sexp_nodes()
 
     @classmethod
     def load(cls, path: str | Path) -> PCB:
@@ -1435,6 +1496,52 @@ class PCB:
             for fp in self._footprints:
                 abs_x, abs_y = fp.position
                 fp.position = (abs_x - origin[0], abs_y - origin[1])
+
+    def _link_footprint_sexp_nodes(self) -> None:
+        """Attach S-expression back-references to parsed Footprint objects.
+
+        Called after ``_detect_board_origin()`` so that the ``__setattr__``
+        sync is only active once positions have been converted to
+        board-relative coordinates and the board origin is known.
+
+        Each ``Footprint`` receives:
+        * ``_sexp_node`` -- the S-expression ``(footprint ...)`` node from
+          the tree that :meth:`save` serialises.
+        * ``_board_origin`` -- the board origin offset so that the setter
+          can convert board-relative positions back to sheet-absolute
+          when writing to the S-expression.
+        """
+        # Build a UUID -> index lookup for fast matching.
+        fp_by_uuid: dict[str, int] = {}
+        for idx, fp in enumerate(self._footprints):
+            if fp.uuid:
+                fp_by_uuid[fp.uuid] = idx
+
+        # Walk the top-level S-expression children and match footprint
+        # nodes to parsed Footprint objects by UUID (preferred) or by
+        # iteration order (fallback for legacy files without UUIDs).
+        order_idx = 0
+        for child in self._sexp.iter_children():
+            if child.tag != "footprint":
+                continue
+
+            uuid_node = child.find("uuid")
+            child_uuid = uuid_node.get_string(0) if uuid_node else None
+
+            fp_idx: int | None = None
+            if child_uuid and child_uuid in fp_by_uuid:
+                fp_idx = fp_by_uuid[child_uuid]
+            elif order_idx < len(self._footprints):
+                fp_idx = order_idx
+
+            if fp_idx is not None:
+                fp = self._footprints[fp_idx]
+                # Use object.__setattr__ to avoid triggering sync before
+                # both _sexp_node and _board_origin are in place.
+                object.__setattr__(fp, "_board_origin", self._board_origin)
+                object.__setattr__(fp, "_sexp_node", child)
+
+            order_idx += 1
 
     # Public accessors
 
@@ -2056,16 +2163,23 @@ class PCB:
         if not fp:
             return False
 
-        # Apply board origin offset to convert board-relative to sheet-absolute
-        abs_x = x + self._board_origin[0]
-        abs_y = y + self._board_origin[1]
-
-        # Update the parsed footprint object with board-relative coordinates
+        # The Footprint.__setattr__ override automatically syncs the
+        # board-relative position to the S-expression ``(at ...)`` node,
+        # adding the board origin offset.  For footprints with a linked
+        # _sexp_node this is all that's needed.
         fp.position = (x, y)
         if rotation is not None:
             fp.rotation = rotation
 
-        # Find and update the footprint in the SExp tree
+        if fp._sexp_node is not None:
+            return True
+
+        # Fallback: walk the top-level S-expression tree when there is no
+        # back-reference (should not happen for footprints parsed via
+        # from_sexp, but kept for safety).
+        abs_x = x + self._board_origin[0]
+        abs_y = y + self._board_origin[1]
+
         for child in self._sexp.iter_children():
             if child.tag != "footprint":
                 continue
@@ -2862,8 +2976,16 @@ class PCB:
 
         # Parse and add to internal footprints list
         footprint = Footprint.from_sexp(fp_sexp)
-        # Store board-relative position in the footprint object for API consistency
+        # Store board-relative position in the footprint object for API consistency.
+        # _sexp_node is not yet set, so this won't sync to the S-expression
+        # (the S-expression already has the correct sheet-absolute coordinates).
         footprint.position = (x, y)
+
+        # Link the S-expression node so that future mutations to position,
+        # rotation, or layer are automatically persisted.
+        object.__setattr__(footprint, "_board_origin", self._board_origin)
+        object.__setattr__(footprint, "_sexp_node", fp_sexp)
+
         self._footprints.append(footprint)
 
         return footprint

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -651,6 +651,142 @@ class TestUpdateFootprintPosition:
         assert result is False
 
 
+class TestFootprintDirectSetPersistence:
+    """Regression tests for direct fp.position/rotation/layer assignment.
+
+    Setting ``fp.position`` directly must persist through ``PCB.save()``
+    without requiring ``update_footprint_position()``.  This was broken
+    before the ``_sexp_node`` back-reference was added to ``Footprint``.
+
+    See https://github.com/rjwalters/kicad-tools/issues/1990
+    """
+
+    def test_position_setter_persists(self, routing_test_pcb, tmp_path):
+        """Direct position assignment must round-trip through save/load."""
+        doc = load_pcb(str(routing_test_pcb))
+        pcb = PCB(doc)
+
+        fp = pcb.get_footprint("R1")
+        assert fp is not None
+        original_pos = fp.position
+
+        # Assign a new position directly (no update_footprint_position).
+        new_pos = (original_pos[0] + 5.0, original_pos[1] + 3.0)
+        fp.position = new_pos
+        assert fp.position == pytest.approx(new_pos)
+
+        # Save and reload.
+        out = tmp_path / "pos_direct.kicad_pcb"
+        pcb.save(out)
+
+        doc2 = load_pcb(str(out))
+        pcb2 = PCB(doc2)
+        fp2 = pcb2.get_footprint("R1")
+        assert fp2 is not None
+        assert fp2.position == pytest.approx(new_pos)
+
+    def test_rotation_setter_persists(self, routing_test_pcb, tmp_path):
+        """Direct rotation assignment must round-trip through save/load."""
+        doc = load_pcb(str(routing_test_pcb))
+        pcb = PCB(doc)
+
+        fp = pcb.get_footprint("R1")
+        assert fp is not None
+        assert fp.rotation == pytest.approx(0.0, abs=0.1)
+
+        fp.rotation = 90.0
+        assert fp.rotation == pytest.approx(90.0)
+
+        out = tmp_path / "rot_direct.kicad_pcb"
+        pcb.save(out)
+
+        doc2 = load_pcb(str(out))
+        pcb2 = PCB(doc2)
+        fp2 = pcb2.get_footprint("R1")
+        assert fp2 is not None
+        assert fp2.rotation == pytest.approx(90.0)
+
+    def test_layer_setter_persists(self, routing_test_pcb, tmp_path):
+        """Direct layer assignment must round-trip through save/load."""
+        doc = load_pcb(str(routing_test_pcb))
+        pcb = PCB(doc)
+
+        fp = pcb.get_footprint("R1")
+        assert fp is not None
+        assert fp.layer == "F.Cu"
+
+        fp.layer = "B.Cu"
+        assert fp.layer == "B.Cu"
+
+        out = tmp_path / "layer_direct.kicad_pcb"
+        pcb.save(out)
+
+        doc2 = load_pcb(str(out))
+        pcb2 = PCB(doc2)
+        fp2 = pcb2.get_footprint("R1")
+        assert fp2 is not None
+        assert fp2.layer == "B.Cu"
+
+    def test_position_and_rotation_together(self, routing_test_pcb, tmp_path):
+        """Setting both position and rotation directly must persist."""
+        doc = load_pcb(str(routing_test_pcb))
+        pcb = PCB(doc)
+
+        fp = pcb.get_footprint("U1")
+        assert fp is not None
+
+        fp.position = (120.0, 120.0)
+        fp.rotation = 45.0
+
+        out = tmp_path / "pos_rot_direct.kicad_pcb"
+        pcb.save(out)
+
+        doc2 = load_pcb(str(out))
+        pcb2 = PCB(doc2)
+        fp2 = pcb2.get_footprint("U1")
+        assert fp2 is not None
+        assert fp2.position == pytest.approx((120.0, 120.0))
+        assert fp2.rotation == pytest.approx(45.0)
+
+    def test_footprint_without_sexp_node(self):
+        """Footprint constructed without from_sexp must still work normally."""
+        from kicad_tools.schema.pcb import Footprint
+
+        fp = Footprint(
+            name="Test",
+            layer="F.Cu",
+            position=(10.0, 20.0),
+            rotation=0.0,
+            reference="R1",
+            value="10k",
+        )
+        # No _sexp_node -- setters should not raise.
+        fp.position = (30.0, 40.0)
+        fp.rotation = 90.0
+        fp.layer = "B.Cu"
+        assert fp.position == (30.0, 40.0)
+        assert fp.rotation == 90.0
+        assert fp.layer == "B.Cu"
+
+    def test_update_footprint_position_still_works(self, routing_test_pcb, tmp_path):
+        """Existing update_footprint_position must still persist correctly."""
+        doc = load_pcb(str(routing_test_pcb))
+        pcb = PCB(doc)
+
+        result = pcb.update_footprint_position("R1", 140.0, 120.0, rotation=45.0)
+        assert result is True
+
+        out = tmp_path / "update_method.kicad_pcb"
+        pcb.save(out)
+
+        doc2 = load_pcb(str(out))
+        pcb2 = PCB(doc2)
+        fp2 = pcb2.get_footprint("R1")
+        assert fp2 is not None
+        assert fp2.position == pytest.approx((140.0, 120.0))
+        assert fp2.rotation == pytest.approx(45.0)
+
+
 class TestUpdateFootprintReference:
     """Tests for PCB.update_footprint_reference method."""
 


### PR DESCRIPTION
## Summary

Footprint.position, .rotation, and .layer assignments now automatically persist through PCB.save(). Previously, these assignments only updated the Python dataclass fields while save() serialized the original, unmodified S-expression tree -- silently discarding mutations.

## Changes

- Add `_sexp_node` (SExp back-reference) and `_board_origin` (offset tuple) fields to the `Footprint` dataclass
- Override `__setattr__` to sync `position`, `rotation`, and `layer` writes to the S-expression node, applying board-origin offset for position
- Add `PCB._link_footprint_sexp_nodes()` method that attaches S-expression nodes to parsed footprints after board-origin detection completes (preventing stale writes during parsing)
- Link newly added footprints in `add_footprint_from_file()` so they also get setter sync
- Simplify `update_footprint_position()` to delegate to the setter when `_sexp_node` is available, keeping the fallback tree-walk for safety
- Add six regression tests covering round-trip persistence of position, rotation, layer, combined mutations, the no-sexp-node case, and backward compatibility with `update_footprint_position()`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| fp.position = (x, y) persists through save/reload | PASS | test_position_setter_persists |
| fp.rotation = angle persists through save/reload | PASS | test_rotation_setter_persists |
| fp.layer = "B.Cu" persists through save/reload | PASS | test_layer_setter_persists |
| Combined position+rotation persist | PASS | test_position_and_rotation_together |
| Footprint without _sexp_node still works | PASS | test_footprint_without_sexp_node |
| Existing update_footprint_position() still works | PASS | test_update_footprint_position_still_works + 4 existing tests |
| Board origin offset handled correctly | PASS | All tests use routing_test_pcb which has gr_rect at (100,100) |
| recovery/applicator.py callers work | PASS | No code changes needed; __setattr__ sync is transparent |
| placement/fixer.py callers work | PASS | No code changes needed; fixer uses text-based output separately |

## Test Plan

- `python3 -m pytest tests/test_pcb.py -x` -- all 149 tests pass
- `python3 -m pytest tests/test_placement_feedback.py tests/test_collision_detection.py tests/test_footprints.py tests/test_schema.py tests/test_integration.py -x` -- all 266 tests pass (4 skipped)

Closes #1990