### PR TITLE
feat(optim): wire ClearanceRepairer into place-route DRC fix-retry loop

### DIFF
--- a/src/kicad_tools/cli/fix_drc_cmd.py
+++ b/src/kicad_tools/cli/fix_drc_cmd.py
@@ -450,9 +450,7 @@ def _run_python_drc(pcb_path: Path) -> DRCReport | None:
     even when kicad-cli is not installed.
     """
     try:
-        from kicad_tools.core.types import Severity
-        from kicad_tools.drc.violation import DRCViolation as ReportViolation
-        from kicad_tools.drc.violation import Location, ViolationType
+        from kicad_tools.drc.compat import drc_results_to_report
         from kicad_tools.schema.pcb import PCB
         from kicad_tools.validate.checker import DRCChecker
 
@@ -460,34 +458,7 @@ def _run_python_drc(pcb_path: Path) -> DRCReport | None:
         checker = DRCChecker(pcb)
         results = checker.check_clearances()
 
-        violations: list[ReportViolation] = []
-        for v in results.violations:
-            vtype = ViolationType.from_string(v.rule_id)
-            loc_list: list[Location] = []
-            if v.location:
-                loc_list.append(
-                    Location(x_mm=v.location[0], y_mm=v.location[1], layer=v.layer or "")
-                )
-
-            violations.append(
-                ReportViolation(
-                    type=vtype,
-                    type_str=v.rule_id,
-                    severity=Severity.from_string(v.severity),
-                    message=v.message,
-                    locations=loc_list,
-                    items=list(v.items),
-                    required_value_mm=v.required_value,
-                    actual_value_mm=v.actual_value,
-                )
-            )
-
-        return DRCReport(
-            source_file=str(pcb_path),
-            created_at=None,
-            pcb_name=pcb_path.name,
-            violations=violations,
-        )
+        return drc_results_to_report(results, pcb_path)
 
     except Exception as e:
         print(f"Error running pure-Python DRC: {e}", file=sys.stderr)

--- a/src/kicad_tools/drc/compat.py
+++ b/src/kicad_tools/drc/compat.py
@@ -1,0 +1,80 @@
+"""Compatibility adapter between validate.violations and drc.violation types.
+
+The pure-Python DRC checker (``validate.checker.DRCChecker``) produces
+``validate.violations.DRCResults`` containing ``validate.violations.DRCViolation``
+objects with flat fields.  The DRC repair tools (``drc.repair_clearance``,
+``drc.fixer``) consume ``drc.report.DRCReport`` containing
+``drc.violation.DRCViolation`` objects with richer structure.
+
+This module provides a conversion function so that any code path that has
+``DRCResults`` from the pure-Python checker can produce a ``DRCReport``
+suitable for the repair tools.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from kicad_tools.core.types import Severity
+from kicad_tools.drc.report import DRCReport
+from kicad_tools.drc.violation import DRCViolation as ReportViolation
+from kicad_tools.drc.violation import Location, ViolationType
+
+if TYPE_CHECKING:
+    from kicad_tools.validate.violations import DRCResults
+
+
+def drc_results_to_report(
+    results: DRCResults,
+    pcb_path: str | Path | None = None,
+) -> DRCReport:
+    """Convert ``validate.violations.DRCResults`` to ``drc.report.DRCReport``.
+
+    This bridges the type mismatch between the pure-Python DRC checker
+    output and the repair tools' expected input.
+
+    Args:
+        results: DRC results from ``DRCChecker.check_all()`` or similar.
+        pcb_path: Optional path to the PCB file for metadata.
+
+    Returns:
+        A ``DRCReport`` containing converted violations.
+    """
+    violations: list[ReportViolation] = []
+
+    for v in results.violations:
+        vtype = ViolationType.from_string(v.rule_id)
+
+        loc_list: list[Location] = []
+        if v.location:
+            loc_list.append(
+                Location(x_mm=v.location[0], y_mm=v.location[1], layer=v.layer or "")
+            )
+
+        violations.append(
+            ReportViolation(
+                type=vtype,
+                type_str=v.rule_id,
+                severity=Severity.from_string(v.severity),
+                message=v.message,
+                locations=loc_list,
+                items=list(v.items),
+                required_value_mm=v.required_value,
+                actual_value_mm=v.actual_value,
+            )
+        )
+
+    pcb_name = ""
+    source_file = ""
+    if pcb_path is not None:
+        p = Path(pcb_path)
+        pcb_name = p.name
+        source_file = str(p)
+
+    return DRCReport(
+        source_file=source_file,
+        created_at=None,
+        pcb_name=pcb_name,
+        violations=violations,
+    )

--- a/src/kicad_tools/optim/place_route.py
+++ b/src/kicad_tools/optim/place_route.py
@@ -93,6 +93,7 @@ class PlaceRouteOptimizer:
         drc_checker_factory: Callable[[PCB], DRCChecker] | None = None,
         verbose: bool = True,
         escape_routing: bool | None = None,
+        max_fix_attempts: int = 3,
     ) -> None:
         """Initialize the optimizer.
 
@@ -110,6 +111,8 @@ class PlaceRouteOptimizer:
                 True = always use escape routing before global routing.
                 False = never use escape routing.
                 None = auto-detect dense packages (default).
+            max_fix_attempts: Maximum DRC fix attempts per optimization
+                iteration before giving up and reporting failure.
         """
         self.pcb_path = Path(pcb_path)
         self.analyzer = analyzer
@@ -118,10 +121,12 @@ class PlaceRouteOptimizer:
         self.drc_checker_factory = drc_checker_factory
         self.verbose = verbose
         self.escape_routing = escape_routing
+        self.max_fix_attempts = max_fix_attempts
 
         # Track state across iterations
         self._current_routes: list[Route] = []
         self._failed_nets: list[int] = []
+        self._fix_attempts: int = 0
 
     @classmethod
     def from_pcb(
@@ -332,6 +337,9 @@ class PlaceRouteOptimizer:
         for iteration in range(max_iterations):
             if self.verbose:
                 print(f"\n--- Iteration {iteration + 1}/{max_iterations} ---")
+
+            # Reset per-iteration DRC fix attempt counter
+            self._fix_attempts = 0
 
             # Phase 1: Fix placement conflicts
             if allow_placement_changes:
@@ -659,13 +667,14 @@ class PlaceRouteOptimizer:
             self.fixer.apply_fixes(self.pcb_path, fixes)
 
     def _fix_drc_violations(self, drc_results: DRCResults) -> bool:
-        """Attempt to fix DRC violations.
+        """Attempt to fix DRC violations using ClearanceRepairer.
 
-        Currently a placeholder - returns False to indicate no fix applied.
-        Future implementations could:
-        - Reroute specific nets causing violations
-        - Widen traces that violate minimum width
-        - Increase clearances
+        Converts the validate-module ``DRCResults`` into a ``DRCReport``
+        understood by the repair tools, then runs ``ClearanceRepairer``
+        to nudge traces/vias for clearance violations.  A per-iteration
+        attempt counter (``_fix_attempts``) prevents infinite fix-retry
+        cycles when the repairer makes changes that re-introduce the
+        same violations.
 
         Args:
             drc_results: DRC results containing violations
@@ -673,6 +682,52 @@ class PlaceRouteOptimizer:
         Returns:
             True if fixes were applied (should retry), False otherwise
         """
-        # For now, we don't have automated DRC fixing
-        # This is a hook for future implementation
+        # Guard: respect per-iteration attempt limit
+        if self._fix_attempts >= self.max_fix_attempts:
+            if self.verbose:
+                print(
+                    f"    DRC fix: max attempts ({self.max_fix_attempts}) "
+                    f"reached, giving up"
+                )
+            return False
+
+        self._fix_attempts += 1
+
+        # No violations to fix
+        if not drc_results.violations:
+            return False
+
+        try:
+            from kicad_tools.drc.compat import drc_results_to_report
+            from kicad_tools.drc.repair_clearance import ClearanceRepairer
+
+            # Convert validate DRCResults -> drc DRCReport
+            report = drc_results_to_report(drc_results, self.pcb_path)
+
+            if not report.violations:
+                return False
+
+            # Run ClearanceRepairer (non-destructive nudge/reroute)
+            repairer = ClearanceRepairer(str(self.pcb_path))
+            result = repairer.repair_from_report(
+                report,
+                max_displacement=0.5,
+                local_reroute=True,
+            )
+
+            if self.verbose:
+                print(
+                    f"    DRC fix attempt {self._fix_attempts}/"
+                    f"{self.max_fix_attempts}: "
+                    f"{result.repaired}/{result.total_violations} repaired"
+                )
+
+            if result.repaired > 0:
+                repairer.save()
+                return True
+
+        except Exception as exc:
+            if self.verbose:
+                print(f"    DRC fix: error during repair: {exc}")
+
         return False

--- a/tests/test_place_route_optimizer.py
+++ b/tests/test_place_route_optimizer.py
@@ -1,7 +1,7 @@
 """Tests for kicad_tools.optim.place_route module."""
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -714,3 +714,391 @@ class TestEscapeRoutingIntegration:
         )
 
         assert optimizer.escape_routing is None
+
+
+# =============================================================================
+# DRC fix-retry tests
+# =============================================================================
+
+
+class TestDRCResultsToReport:
+    """Tests for the drc_results_to_report adapter."""
+
+    def test_converts_violations(self):
+        """Adapter correctly converts validate DRCViolation fields."""
+        from kicad_tools.drc.compat import drc_results_to_report
+        from kicad_tools.validate.violations import DRCResults, DRCViolation
+
+        violations = [
+            DRCViolation(
+                rule_id="clearance_segment_segment",
+                severity="error",
+                message="Clearance violation (0.2mm required; actual 0.15mm)",
+                location=(10.0, 20.0),
+                layer="F.Cu",
+                actual_value=0.15,
+                required_value=0.2,
+                items=("Seg1", "Seg2"),
+            ),
+        ]
+        results = DRCResults(violations=violations, rules_checked=1)
+
+        report = drc_results_to_report(results, "/tmp/test.kicad_pcb")
+
+        assert len(report.violations) == 1
+        v = report.violations[0]
+        assert v.type_str == "clearance_segment_segment"
+        assert v.required_value_mm == 0.2
+        assert v.actual_value_mm == 0.15
+        assert len(v.locations) == 1
+        assert v.locations[0].x_mm == 10.0
+        assert v.locations[0].y_mm == 20.0
+        assert v.locations[0].layer == "F.Cu"
+        assert v.items == ["Seg1", "Seg2"]
+        assert report.pcb_name == "test.kicad_pcb"
+
+    def test_empty_violations(self):
+        """Empty DRCResults produces empty report without errors."""
+        from kicad_tools.drc.compat import drc_results_to_report
+        from kicad_tools.validate.violations import DRCResults
+
+        results = DRCResults(violations=[], rules_checked=0)
+        report = drc_results_to_report(results)
+
+        assert len(report.violations) == 0
+        assert report.pcb_name == ""
+
+    def test_violation_without_location(self):
+        """Violation with no location produces empty location list."""
+        from kicad_tools.drc.compat import drc_results_to_report
+        from kicad_tools.validate.violations import DRCResults, DRCViolation
+
+        violations = [
+            DRCViolation(
+                rule_id="clearance_segment_segment",
+                severity="warning",
+                message="test",
+                location=None,
+                layer=None,
+            ),
+        ]
+        results = DRCResults(violations=violations)
+
+        report = drc_results_to_report(results)
+
+        assert len(report.violations) == 1
+        assert len(report.violations[0].locations) == 0
+
+
+class TestFixDrcViolations:
+    """Tests for PlaceRouteOptimizer._fix_drc_violations."""
+
+    @pytest.fixture
+    def optimizer(self, tmp_path):
+        """Create a basic optimizer for testing _fix_drc_violations."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(find_conflicts=MagicMock(return_value=[])),
+            fixer=MagicMock(),
+            router_factory=lambda: MagicMock(),
+            verbose=False,
+            max_fix_attempts=3,
+        )
+        return optimizer
+
+    @patch("kicad_tools.optim.place_route.PlaceRouteOptimizer._fix_drc_violations")
+    def test_optimize_drc_failure_exercises_fix_path(
+        self, mock_fix, tmp_path
+    ):
+        """DRC failure with fixable violations triggers fix attempt before failing."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        mock_drc_results = MagicMock()
+        mock_drc_results.passed = False
+        mock_drc_results.errors = [MagicMock()]
+        mock_drc_results.warnings = []
+
+        mock_checker = MagicMock()
+        mock_checker.check_all.return_value = mock_drc_results
+
+        # _fix_drc_violations returns False (no fix possible)
+        mock_fix.return_value = False
+
+        mock_router = MagicMock()
+        mock_router.nets = {1: [("R1", "1"), ("R2", "1")], 2: [("R1", "2"), ("R2", "2")]}
+        mock_router.pads = {}
+        mock_router.route_all.return_value = [MagicMock(net=1), MagicMock(net=2)]
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(find_conflicts=MagicMock(return_value=[])),
+            fixer=MagicMock(),
+            router_factory=lambda: mock_router,
+            drc_checker_factory=lambda pcb: mock_checker,
+            verbose=False,
+        )
+
+        result = optimizer.optimize(max_iterations=1)
+
+        # _fix_drc_violations should have been called with the DRC results
+        mock_fix.assert_called_once_with(mock_drc_results)
+        assert result.success is False
+
+    def test_returns_true_when_repairs_applied(self, optimizer):
+        """_fix_drc_violations returns True when ClearanceRepairer fixes violations."""
+        from kicad_tools.validate.violations import DRCResults, DRCViolation
+
+        violations = [
+            DRCViolation(
+                rule_id="clearance_segment_segment",
+                severity="error",
+                message="test",
+                location=(10.0, 20.0),
+                layer="F.Cu",
+                actual_value=0.15,
+                required_value=0.2,
+            ),
+        ]
+        drc_results = DRCResults(violations=violations)
+
+        mock_repair_result = MagicMock()
+        mock_repair_result.repaired = 1
+        mock_repair_result.total_violations = 1
+
+        mock_repairer = MagicMock()
+        mock_repairer.repair_from_report.return_value = mock_repair_result
+
+        with patch(
+            "kicad_tools.drc.repair_clearance.ClearanceRepairer",
+            return_value=mock_repairer,
+        ):
+            result = optimizer._fix_drc_violations(drc_results)
+
+        assert result is True
+        mock_repairer.save.assert_called_once()
+
+    def test_returns_false_when_no_repairs(self, optimizer):
+        """_fix_drc_violations returns False when ClearanceRepairer fixes nothing."""
+        from kicad_tools.validate.violations import DRCResults, DRCViolation
+
+        violations = [
+            DRCViolation(
+                rule_id="clearance_segment_segment",
+                severity="error",
+                message="test",
+                location=(10.0, 20.0),
+                layer="F.Cu",
+                actual_value=0.15,
+                required_value=0.2,
+            ),
+        ]
+        drc_results = DRCResults(violations=violations)
+
+        mock_repair_result = MagicMock()
+        mock_repair_result.repaired = 0
+        mock_repair_result.total_violations = 1
+
+        mock_repairer = MagicMock()
+        mock_repairer.repair_from_report.return_value = mock_repair_result
+
+        with patch(
+            "kicad_tools.drc.repair_clearance.ClearanceRepairer",
+            return_value=mock_repairer,
+        ):
+            result = optimizer._fix_drc_violations(drc_results)
+
+        assert result is False
+        mock_repairer.save.assert_not_called()
+
+    def test_returns_false_when_max_attempts_exceeded(self, optimizer):
+        """_fix_drc_violations returns False after max_fix_attempts."""
+        from kicad_tools.validate.violations import DRCResults, DRCViolation
+
+        violations = [
+            DRCViolation(
+                rule_id="clearance_segment_segment",
+                severity="error",
+                message="test",
+                location=(10.0, 20.0),
+                layer="F.Cu",
+            ),
+        ]
+        drc_results = DRCResults(violations=violations)
+
+        mock_repair_result = MagicMock()
+        mock_repair_result.repaired = 1
+        mock_repair_result.total_violations = 1
+
+        mock_repairer = MagicMock()
+        mock_repairer.repair_from_report.return_value = mock_repair_result
+
+        with patch(
+            "kicad_tools.drc.repair_clearance.ClearanceRepairer",
+            return_value=mock_repairer,
+        ):
+            # Call max_fix_attempts times -- all should return True
+            for _ in range(optimizer.max_fix_attempts):
+                assert optimizer._fix_drc_violations(drc_results) is True
+
+            # Next call should return False (limit exceeded)
+            assert optimizer._fix_drc_violations(drc_results) is False
+
+    def test_returns_false_for_empty_violations(self, optimizer):
+        """_fix_drc_violations returns False when no violations present."""
+        from kicad_tools.validate.violations import DRCResults
+
+        drc_results = DRCResults(violations=[])
+
+        result = optimizer._fix_drc_violations(drc_results)
+
+        assert result is False
+
+    def test_fix_attempts_reset_each_iteration(self, tmp_path):
+        """Per-iteration fix attempt counter resets at each optimize iteration."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        call_count = 0
+
+        # DRC checker that fails on first call, passes on second
+        def make_drc_results():
+            nonlocal call_count
+            call_count += 1
+            results = MagicMock()
+            if call_count <= 1:
+                results.passed = False
+                results.errors = [MagicMock()]
+                results.warnings = []
+                # Provide real violations so _fix_drc_violations can convert them
+                results.violations = []
+            else:
+                results.passed = True
+                results.errors = []
+                results.warnings = []
+            return results
+
+        mock_checker = MagicMock()
+        mock_checker.check_all = MagicMock(side_effect=lambda: make_drc_results())
+
+        mock_router = MagicMock()
+        mock_router.nets = {1: [("R1", "1"), ("R2", "1")]}
+        mock_router.pads = {}
+        mock_router.route_all.return_value = [MagicMock(net=1)]
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(find_conflicts=MagicMock(return_value=[])),
+            fixer=MagicMock(),
+            router_factory=lambda: mock_router,
+            drc_checker_factory=lambda pcb: mock_checker,
+            verbose=False,
+            max_fix_attempts=3,
+        )
+
+        # Set _fix_attempts to simulate previous iteration usage
+        optimizer._fix_attempts = 2
+
+        # optimize() should reset _fix_attempts at the start of each iteration
+        optimizer.optimize(max_iterations=2)
+
+        # After the first iteration starts, _fix_attempts should have been reset to 0
+        # (not carried over from the previous value of 2)
+        # We verify this indirectly: since violations is empty, _fix_drc_violations
+        # returns False immediately (no attempts consumed) and the counter reset
+        # ensures fresh attempts for each iteration.
+        # The important thing is that the optimize loop did not crash and ran.
+        assert call_count >= 1
+
+    def test_handles_repairer_exception_gracefully(self, optimizer):
+        """_fix_drc_violations returns False when ClearanceRepairer raises."""
+        from kicad_tools.validate.violations import DRCResults, DRCViolation
+
+        violations = [
+            DRCViolation(
+                rule_id="clearance_segment_segment",
+                severity="error",
+                message="test",
+                location=(10.0, 20.0),
+                layer="F.Cu",
+            ),
+        ]
+        drc_results = DRCResults(violations=violations)
+
+        with patch(
+            "kicad_tools.drc.repair_clearance.ClearanceRepairer",
+            side_effect=Exception("PCB parse error"),
+        ):
+            result = optimizer._fix_drc_violations(drc_results)
+
+        assert result is False
+
+
+class TestFixDrcViolationsIntegration:
+    """Integration test: full optimization loop with fix-retry path."""
+
+    def test_fix_retry_loop_converges(self, tmp_path):
+        """Optimization loop retries after DRC fix and converges to success."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        drc_call_count = 0
+
+        def make_checker(pcb):
+            checker = MagicMock()
+
+            def check_all():
+                nonlocal drc_call_count
+                drc_call_count += 1
+                results = MagicMock()
+                if drc_call_count == 1:
+                    # First check: violations found
+                    results.passed = False
+                    results.errors = [MagicMock()]
+                    results.warnings = []
+                else:
+                    # Second check: clean
+                    results.passed = True
+                    results.errors = []
+                    results.warnings = []
+                return results
+
+            checker.check_all = check_all
+            return checker
+
+        mock_router = MagicMock()
+        mock_router.nets = {1: [("R1", "1"), ("R2", "1")], 2: [("R1", "2"), ("R2", "2")]}
+        mock_router.pads = {}
+        mock_router.route_all.return_value = [MagicMock(net=1), MagicMock(net=2)]
+
+        mock_repair_result = MagicMock()
+        mock_repair_result.repaired = 1
+        mock_repair_result.total_violations = 1
+
+        mock_repairer = MagicMock()
+        mock_repairer.repair_from_report.return_value = mock_repair_result
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(find_conflicts=MagicMock(return_value=[])),
+            fixer=MagicMock(),
+            router_factory=lambda: mock_router,
+            drc_checker_factory=make_checker,
+            verbose=False,
+        )
+
+        with patch(
+            "kicad_tools.drc.repair_clearance.ClearanceRepairer",
+            return_value=mock_repairer,
+        ):
+            result = optimizer.optimize(max_iterations=5)
+
+        # Should succeed on the second DRC check
+        assert result.success is True
+        # DRC was checked twice (fail, then pass after fix)
+        assert drc_call_count == 2
+        # The repairer was called once
+        mock_repairer.repair_from_report.assert_called_once()

--- a/tests/test_place_route_optimizer.py
+++ b/tests/test_place_route_optimizer.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from kicad_tools.optim import OptimizationResult, PlaceRouteOptimizer
+from kicad_tools.validate.violations import DRCViolation
 
 # =============================================================================
 # Test PCB fixtures
@@ -1059,11 +1060,24 @@ class TestFixDrcViolationsIntegration:
                     results.passed = False
                     results.errors = [MagicMock()]
                     results.warnings = []
+                    results.violations = [
+                        DRCViolation(
+                            rule_id="clearance_trace_trace",
+                            severity="error",
+                            message="Clearance violation between traces",
+                            location=(10.0, 20.0),
+                            layer="F.Cu",
+                            actual_value=0.15,
+                            required_value=0.2,
+                            items=("R1", "R2"),
+                        )
+                    ]
                 else:
                     # Second check: clean
                     results.passed = True
                     results.errors = []
                     results.warnings = []
+                    results.violations = []
                 return results
 
             checker.check_all = check_all


### PR DESCRIPTION
## Summary

Replace the `_fix_drc_violations` stub in `PlaceRouteOptimizer` with a real implementation that uses `ClearanceRepairer` to repair clearance violations, making the DRC fix-and-retry path in the optimization loop functional. Extract the `DRCResults`-to-`DRCReport` conversion into a shared adapter (`drc/compat.py`) to bridge the type mismatch between the validate module and the DRC repair tools.

## Changes

- Add `src/kicad_tools/drc/compat.py` with `drc_results_to_report()` function that converts `validate.violations.DRCResults` to `drc.report.DRCReport`
- Implement `_fix_drc_violations` in `optim/place_route.py` using `ClearanceRepairer` with non-destructive nudge/reroute
- Add `max_fix_attempts` parameter (default 3) and per-iteration `_fix_attempts` counter to prevent infinite fix-retry cycles
- Refactor `cli/fix_drc_cmd.py:_run_python_drc()` to use the shared adapter instead of inline conversion
- Add comprehensive tests for the adapter, fix method, attempt limiting, error handling, and integration

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_fix_drc_violations` uses `ClearanceRepairer` to repair clearance violations | Pass | Implementation calls `ClearanceRepairer.repair_from_report()` with `max_displacement=0.5` and `local_reroute=True` |
| Returns `True` when fixes applied, causing retry | Pass | Test `test_returns_true_when_repairs_applied` verifies this with mock repairer returning `repaired=1` |
| Returns `False` when no fixes possible or attempt limit reached | Pass | Tests `test_returns_false_when_no_repairs` and `test_returns_false_when_max_attempts_exceeded` verify both paths |
| DRCResults-to-DRCReport adapter is reusable (not duplicated) | Pass | `drc/compat.py:drc_results_to_report()` is used by both `place_route.py` and `fix_drc_cmd.py` |
| Fix-retry loop is bounded | Pass | `_fix_attempts` counter increments each call and checks against `max_fix_attempts`, reset per optimization iteration |
| Existing tests still pass | Pass | All 30 original tests in `test_place_route_optimizer.py` pass unchanged; all 88 tests in `test_fix_drc_cmd.py` pass |
| `test_optimize_drc_failure` exercises fix path | Pass | Test `test_optimize_drc_failure_exercises_fix_path` verifies `_fix_drc_violations` is called with DRC results |

## Test Plan

- 41 tests pass in `tests/test_place_route_optimizer.py` (30 original + 11 new)
- 88 tests pass in `tests/test_fix_drc_cmd.py` (validates refactored `_run_python_drc` still works)
- New tests cover: adapter conversion, empty violations, missing locations, fix success/failure, max attempts, exception handling, integration fix-retry convergence

Closes #1999