### PR TITLE
fix(cli): accept argv parameter in sch wires/info/pins main functions

### DIFF
--- a/src/kicad_tools/cli/sch_list_wires.py
+++ b/src/kicad_tools/cli/sch_list_wires.py
@@ -28,7 +28,7 @@ import sys
 from kicad_tools.schema import Schematic
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="List wires in a KiCad schematic",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -41,7 +41,7 @@ def main():
     parser.add_argument("--stats", action="store_true", help="Show statistics only")
     parser.add_argument("--junctions", action="store_true", help="Include junction points")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     try:
         sch = Schematic.load(args.schematic)

--- a/src/kicad_tools/cli/sch_pin_positions.py
+++ b/src/kicad_tools/cli/sch_pin_positions.py
@@ -24,7 +24,7 @@ import sys
 from kicad_tools.schema import Schematic, SymbolLibrary
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Show pin positions for a symbol instance",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -37,7 +37,7 @@ def main():
         "--format", choices=["table", "json"], default="table", help="Output format"
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # Load schematic
     try:

--- a/src/kicad_tools/cli/sch_symbol_info.py
+++ b/src/kicad_tools/cli/sch_symbol_info.py
@@ -28,7 +28,7 @@ import sys
 from kicad_tools.schema import Schematic
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Show symbol details in a KiCad schematic",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -40,7 +40,7 @@ def main():
     parser.add_argument("--show-pins", action="store_true", help="Show pin details")
     parser.add_argument("--show-properties", action="store_true", help="Show all properties")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     try:
         sch = Schematic.load(args.schematic)


### PR DESCRIPTION
## Summary

Fix TypeError in `sch wires`, `sch info`, and `sch pins` CLI commands caused by a function-signature mismatch between the CLI dispatcher and the subcommand main functions.

## Changes

- `src/kicad_tools/cli/sch_list_wires.py`: Change `def main():` to `def main(argv=None):` and `parser.parse_args()` to `parser.parse_args(argv)`
- `src/kicad_tools/cli/sch_symbol_info.py`: Same two-line fix
- `src/kicad_tools/cli/sch_pin_positions.py`: Same two-line fix

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| sch_list_wires accepts argv parameter | Pass | Signature updated to `main(argv=None)`, `parse_args(argv)` |
| sch_symbol_info accepts argv parameter | Pass | Same fix applied |
| sch_pin_positions accepts argv parameter | Pass | Same fix applied |
| Standalone usage still works (argv=None falls back to sys.argv) | Pass | Default `argv=None` preserves `parse_args()` fallback behavior |
| Matches established pattern (e.g. sch_cleanup_wires.py) | Pass | Identical pattern to 23+ other commands in the codebase |
| Existing tests pass | Pass | All 12 related tests pass (TestSchListWires, TestSchSymbolInfo) |

## Test Plan

- Ran `python3 -m pytest tests/test_cli_sch.py -v -k "wires or info or pins"` -- all 12 tests pass
- Full test suite: 108 passed, 1 pre-existing failure (unrelated TestSchSummary test)

Closes #2000