### PR TITLE
fix(sch): use flexible whitespace in find_symbol_text_range regex

### DIFF
--- a/src/kicad_tools/cli/modify_schematic.py
+++ b/src/kicad_tools/cli/modify_schematic.py
@@ -55,11 +55,11 @@ def find_symbol_text_range(text: str, reference: str) -> tuple[int, int, dict] |
 
     # First find all symbol instance blocks (not lib_symbols)
     symbol_pattern = re.compile(
-        r"\n(\t\(symbol\n"
-        r'\t\t\(lib_id "[^"]+"\)'
+        r"\n(\s+\(symbol\n"
+        r'\s+\(lib_id "[^"]+"\)'
         r".*?"
-        r"\t\t\(instances\n.*?\t\t\)\n"
-        r"\t\))",
+        r"\s+\(instances\n.*?\s+\)\n"
+        r"\s+\))",
         re.DOTALL,
     )
 

--- a/tests/test_sch_set_footprint.py
+++ b/tests/test_sch_set_footprint.py
@@ -80,6 +80,45 @@ MINIMAL_SCHEMATIC = """\
 """
 
 
+# Space-indented schematic matching real KiCad 8 output (4 spaces per level)
+SPACE_INDENTED_SCHEMATIC = """\
+(kicad_sch
+    (version 20231120)
+    (generator "test")
+    (generator_version "8.0")
+    (uuid "00000000-0000-0000-0000-000000000001")
+    (paper "A4")
+    (lib_symbols
+    )
+    (symbol
+        (lib_id "Device:R_Small")
+        (at 100 50 0)
+        (property "Reference" "R8"
+            (at 100 48 0)
+            (effects (font (size 1.27 1.27)))
+        )
+        (property "Value" "1k"
+            (at 100 52 0)
+            (effects (font (size 1.27 1.27)))
+        )
+        (property "Footprint" "Resistor_SMD:R_0402_1005Metric"
+            (at 100 54 0)
+            (effects (font (size 1.27 1.27)) (hide yes))
+        )
+        (uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        (instances
+            (project "dac"
+                (path "/" (reference "R8") (unit 1))
+            )
+        )
+    )
+    (sheet_instances
+        (path "/" (page "1"))
+    )
+)
+"""
+
+
 def _write_sch(tmp_path: Path, content: str = MINIMAL_SCHEMATIC, name: str = "test.kicad_sch") -> Path:
     p = tmp_path / name
     p.write_text(content)
@@ -133,6 +172,45 @@ class TestSetFootprintText:
         result, success, _ = set_footprint_text(MINIMAL_SCHEMATIC, "R1", new_fp)
         assert success is True
         assert new_fp in result
+
+
+# ---------------------------------------------------------------------------
+# Space-indented schematic tests (KiCad 8 real output format)
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceIndentedSetFootprint:
+    def test_find_symbol_in_space_indented(self):
+        """find_symbol_text_range works with space-indented schematics."""
+        result = find_symbol_text_range(SPACE_INDENTED_SCHEMATIC, "R8")
+        assert result is not None
+        _, _, info = result
+        assert info["lib_id"] == "Device:R_Small"
+        assert info["footprint"] == "Resistor_SMD:R_0402_1005Metric"
+
+    def test_set_footprint_space_indented(self):
+        """set_footprint_text works with space-indented schematics."""
+        new_fp = "Resistor_SMD:R_0805_2012Metric"
+        result, success, msg = set_footprint_text(SPACE_INDENTED_SCHEMATIC, "R8", new_fp)
+        assert success is True
+        assert new_fp in result
+        assert "R_0402_1005Metric" not in result
+        assert "Changed R8 footprint" in msg
+
+    def test_run_set_footprint_space_indented(self, tmp_path):
+        """run_set_footprint integration test with space-indented schematic."""
+        sch = _write_sch(tmp_path, SPACE_INDENTED_SCHEMATIC)
+        ret = run_set_footprint(
+            schematic_path=sch,
+            ref="R8",
+            footprint="Resistor_SMD:R_0805_2012Metric",
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        assert "Resistor_SMD:R_0805_2012Metric" in text
+        assert "R_0402_1005Metric" not in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sch_set_value.py
+++ b/tests/test_sch_set_value.py
@@ -76,6 +76,45 @@ MINIMAL_SCHEMATIC = """\
 """
 
 
+# Space-indented schematic matching real KiCad 8 output (4 spaces per level)
+SPACE_INDENTED_SCHEMATIC = """\
+(kicad_sch
+    (version 20231120)
+    (generator "test")
+    (generator_version "8.0")
+    (uuid "00000000-0000-0000-0000-000000000001")
+    (paper "A4")
+    (lib_symbols
+    )
+    (symbol
+        (lib_id "Device:R_Small")
+        (at 100 50 0)
+        (property "Reference" "R8"
+            (at 100 48 0)
+            (effects (font (size 1.27 1.27)))
+        )
+        (property "Value" "1k"
+            (at 100 52 0)
+            (effects (font (size 1.27 1.27)))
+        )
+        (property "Footprint" "Resistor_SMD:R_0402_1005Metric"
+            (at 100 54 0)
+            (effects (font (size 1.27 1.27)) (hide yes))
+        )
+        (uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        (instances
+            (project "dac"
+                (path "/" (reference "R8") (unit 1))
+            )
+        )
+    )
+    (sheet_instances
+        (path "/" (page "1"))
+    )
+)
+"""
+
+
 def _write_sch(tmp_path: Path, content: str = MINIMAL_SCHEMATIC, name: str = "test.kicad_sch") -> Path:
     p = tmp_path / name
     p.write_text(content)
@@ -128,6 +167,51 @@ class TestSetValueText:
         result, success, _ = set_value_text(MINIMAL_SCHEMATIC, "R1", new_val)
         assert success is True
         assert new_val in result
+
+
+# ---------------------------------------------------------------------------
+# Space-indented schematic tests (KiCad 8 real output format)
+# ---------------------------------------------------------------------------
+
+
+class TestSpaceIndentedSetValue:
+    def test_find_symbol_in_space_indented(self):
+        """find_symbol_text_range works with space-indented schematics."""
+        result = find_symbol_text_range(SPACE_INDENTED_SCHEMATIC, "R8")
+        assert result is not None
+        _, _, info = result
+        assert info["lib_id"] == "Device:R_Small"
+        assert info["value"] == "1k"
+        assert info["footprint"] == "Resistor_SMD:R_0402_1005Metric"
+
+    def test_set_value_space_indented(self):
+        """set_value_text works with space-indented schematics."""
+        result, success, msg = set_value_text(SPACE_INDENTED_SCHEMATIC, "R8", "470R")
+        assert success is True
+        assert '"Value" "470R"' in result
+        assert '"Value" "1k"' not in result
+        assert "Changed R8 value" in msg
+
+    def test_nonexistent_ref_space_indented(self):
+        """Non-existent ref returns failure on space-indented schematic."""
+        result, success, msg = set_value_text(SPACE_INDENTED_SCHEMATIC, "U99", "x")
+        assert success is False
+        assert "not found" in msg
+
+    def test_run_set_value_space_indented(self, tmp_path):
+        """run_set_value integration test with space-indented schematic."""
+        sch = _write_sch(tmp_path, SPACE_INDENTED_SCHEMATIC)
+        ret = run_set_value(
+            schematic_path=sch,
+            ref="R8",
+            value="470R",
+            dry_run=False,
+            backup=False,
+        )
+        assert ret == 0
+        text = sch.read_text()
+        assert '"Value" "470R"' in text
+        assert '"Value" "1k"' not in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Replace hardcoded tab (`\t`) indentation patterns with flexible whitespace (`\s+`) in the `find_symbol_text_range()` regex so it matches both tab-indented and space-indented KiCad schematics. KiCad 8 uses 4-space indentation, causing the old regex to never find symbols in real schematics.

## Changes
- Replace literal `\t` / `\t\t` patterns with `\s+` in the symbol-matching regex in `modify_schematic.py`
- Add `SPACE_INDENTED_SCHEMATIC` test fixture and `TestSpaceIndentedSetValue` test class in `test_sch_set_value.py`
- Add `SPACE_INDENTED_SCHEMATIC` test fixture and `TestSpaceIndentedSetFootprint` test class in `test_sch_set_footprint.py`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Regex matches space-indented schematics | Pass | New tests find R8 in space-indented fixture |
| set_value_text works on space-indented input | Pass | TestSpaceIndentedSetValue.test_set_value_space_indented |
| set_footprint_text works on space-indented input | Pass | TestSpaceIndentedSetFootprint.test_set_footprint_space_indented |
| Existing tab-indented tests still pass | Pass | All 53 tests pass |
| Integration tests with run_set_value/run_set_footprint | Pass | Space-indented integration tests included |

## Test Plan
All 53 tests pass: `python3 -m pytest tests/test_sch_set_value.py tests/test_sch_set_footprint.py -v`

Closes #2006