### PR TITLE
fix(cli): include position and rotation in default symbol output

### DIFF
--- a/src/kicad_tools/cli/sch_list_symbols.py
+++ b/src/kicad_tools/cli/sch_list_symbols.py
@@ -129,12 +129,12 @@ def output_json(symbols, verbose):
             "value": sym.value,
             "lib_id": sym.lib_id,
             "footprint": sym.footprint,
+            "position": list(sym.position),
+            "rotation": sym.rotation,
         }
         if verbose:
             entry.update(
                 {
-                    "position": list(sym.position),
-                    "rotation": sym.rotation,
                     "unit": sym.unit,
                     "uuid": sym.uuid,
                     "in_bom": sym.in_bom,
@@ -157,9 +157,12 @@ def output_csv(symbols, verbose):
                 f"{sym.position[0]},{sym.position[1]},{sym.rotation},{sym.unit},{sym.uuid}"
             )
     else:
-        print("Reference,Value,Library ID,Footprint")
+        print("Reference,Value,Library ID,Footprint,X,Y,Rotation")
         for sym in symbols:
-            print(f"{sym.reference},{sym.value},{sym.lib_id},{sym.footprint}")
+            print(
+                f"{sym.reference},{sym.value},{sym.lib_id},{sym.footprint},"
+                f"{sym.position[0]},{sym.position[1]},{sym.rotation}"
+            )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/symbols.py
+++ b/src/kicad_tools/cli/symbols.py
@@ -129,12 +129,12 @@ def output_json(symbols: list[SymbolInstance], verbose: bool) -> None:
             "value": sym.value,
             "lib_id": sym.lib_id,
             "footprint": sym.footprint,
+            "position": list(sym.position),
+            "rotation": sym.rotation,
         }
         if verbose:
             entry.update(
                 {
-                    "position": list(sym.position),
-                    "rotation": sym.rotation,
                     "unit": sym.unit,
                     "uuid": sym.uuid,
                     "in_bom": sym.in_bom,
@@ -157,9 +157,12 @@ def output_csv(symbols: list[SymbolInstance], verbose: bool) -> None:
                 f"{sym.position[0]},{sym.position[1]},{sym.rotation},{sym.unit},{sym.uuid}"
             )
     else:
-        print("Reference,Value,Library ID,Footprint")
+        print("Reference,Value,Library ID,Footprint,X,Y,Rotation")
         for sym in symbols:
-            print(f"{sym.reference},{sym.value},{sym.lib_id},{sym.footprint}")
+            print(
+                f"{sym.reference},{sym.value},{sym.lib_id},{sym.footprint},"
+                f"{sym.position[0]},{sym.position[1]},{sym.rotation}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Move position and rotation fields from the verbose-only block into the default output for `output_json()` and `output_csv()` in both `symbols.py` and `sch_list_symbols.py`. Without `-v`, these fields were omitted entirely, causing callers to see missing position data.

## Changes
- `src/kicad_tools/cli/symbols.py`: Added `position` and `rotation` to default entry dict in `output_json()`; added X, Y, Rotation columns to non-verbose CSV in `output_csv()`
- `src/kicad_tools/cli/sch_list_symbols.py`: Same changes as above

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| position and rotation included in default JSON output | Pass | Moved fields before `if verbose:` block in both files |
| position and rotation included in default CSV output | Pass | Added X,Y,Rotation columns to non-verbose CSV header and data |
| verbose block retains uuid, pins, in_bom, dnp, unit | Pass | These fields remain inside `if verbose:` in both files |
| Both files fixed (symbols.py and sch_list_symbols.py) | Pass | Identical fix applied to both files |

## Test Plan
- Ran `TestSchListSymbols` (6 tests) -- all pass
- Ran `TestSymbolsHelpers` and `TestSymbolsMain` (9 tests) -- all pass

Closes #2005