### PR TITLE
fix(erc): suppress false-positive power_pin_not_driven for cross-sheet drivers

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -27,7 +27,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from kicad_tools.cli.runner import find_kicad_cli
-from kicad_tools.erc.cross_sheet import filter_cross_sheet_global_labels
+from kicad_tools.erc.cross_sheet import (
+    filter_cross_sheet_global_labels,
+    filter_cross_sheet_power_violations,
+)
 from kicad_tools.schema import Schematic
 from kicad_tools.schema.hierarchy import build_hierarchy
 from kicad_tools.schematic.blocks.interface.debug import DebugHeader
@@ -142,6 +145,13 @@ def run_erc(schematic_path: str) -> list[ValidationIssue]:
                         # isolated_pin_label violations for labels that
                         # actually appear on multiple sheets.
                         raw_violations = filter_cross_sheet_global_labels(
+                            raw_violations, schematic_path
+                        )
+
+                        # Filter false-positive power_pin_not_driven
+                        # violations for power nets that have a
+                        # power_out driver on another sheet.
+                        raw_violations = filter_cross_sheet_power_violations(
                             raw_violations, schematic_path
                         )
 

--- a/src/kicad_tools/erc/__init__.py
+++ b/src/kicad_tools/erc/__init__.py
@@ -14,6 +14,7 @@ Example:
 from .cross_sheet import (
     check_cross_sheet_duplicates,
     filter_cross_sheet_global_labels,
+    filter_cross_sheet_power_violations,
 )
 from .report import (
     ERCReport,
@@ -46,4 +47,5 @@ __all__ = [
     # Cross-sheet checks
     "check_cross_sheet_duplicates",
     "filter_cross_sheet_global_labels",
+    "filter_cross_sheet_power_violations",
 ]

--- a/src/kicad_tools/erc/cross_sheet.py
+++ b/src/kicad_tools/erc/cross_sheet.py
@@ -1,6 +1,6 @@
 """Cross-sheet ERC helpers.
 
-Provides two cross-sheet checks that complement KiCad's built-in ERC:
+Provides cross-sheet checks that complement KiCad's built-in ERC:
 
 1. **Duplicate reference detection** -- detects duplicate reference
    designators that span different hierarchical sheets.  KiCad's built-in
@@ -12,6 +12,12 @@ Provides two cross-sheet checks that complement KiCad's built-in ERC:
    without aggregating across the full hierarchy.  A global label that
    appears in multiple sheets is *not* truly isolated; this module
    suppresses those false positives.
+
+3. **False-positive power-pin filtering** -- KiCad reports
+   ``power_pin_not_driven`` on a per-sheet basis without checking for
+   ``power_out`` drivers on other sheets.  A power net driven by a
+   ``PWR_FLAG`` or voltage regulator output on one sheet should not be
+   flagged as undriven on another sheet.
 """
 
 from __future__ import annotations
@@ -362,6 +368,172 @@ def filter_cross_sheet_global_labels(
         sheets = inventory.get(label_name, set())
         if len(sheets) >= 2:
             # Label appears on multiple sheets -- this is a false positive.
+            continue
+
+        filtered.append(v)
+
+    return filtered
+
+
+# ---------------------------------------------------------------------------
+# Cross-sheet power-pin false-positive filtering
+# ---------------------------------------------------------------------------
+
+
+def build_power_driver_inventory(root_schematic: str) -> set[str]:
+    """Build an inventory of power net names that have a ``power_out`` driver.
+
+    Traverses the full schematic hierarchy and inspects every symbol's
+    library definition for ``power_out`` pins.  Power symbols (lib_id
+    starting with ``power:``) contribute their *value* as the net name
+    (e.g. a ``power:+3V3`` symbol drives the ``+3V3`` net).  Non-power
+    symbols contribute the pin *name* for each ``power_out`` pin (e.g. a
+    voltage regulator with a ``power_out`` pin named ``VOUT``).
+
+    ``PWR_FLAG`` symbols are included -- they have a single ``power_out``
+    pin and act as explicit power-source declarations.
+
+    Args:
+        root_schematic: Path to the root ``.kicad_sch`` file.
+
+    Returns:
+        A set of net names that have at least one ``power_out`` driver
+        somewhere in the hierarchy.
+    """
+    from kicad_tools.schema.hierarchy import build_hierarchy
+    from kicad_tools.schema.library import LibraryPin
+    from kicad_tools.schema.schematic import Schematic
+
+    hierarchy = build_hierarchy(root_schematic)
+
+    driven_nets: set[str] = set()
+
+    for node in hierarchy.all_nodes():
+        try:
+            sch = Schematic.load(node.path)
+        except Exception:
+            continue
+
+        for sym in sch.symbols:
+            lib_sym = sch.get_lib_symbol(sym.lib_id)
+            if lib_sym is None:
+                continue
+
+            # Collect all pins with power_out type from the library def.
+            power_out_pins: list[LibraryPin] = []
+            for sub_sym in lib_sym.find_all("symbol"):
+                for pin_sexp in sub_sym.find_all("pin"):
+                    pin = LibraryPin.from_sexp(pin_sexp)
+                    if pin.type == "power_out":
+                        power_out_pins.append(pin)
+
+            if not power_out_pins:
+                continue
+
+            # For power symbols the net name is the symbol's value
+            # property (e.g. "+3V3", "GND").  For non-power symbols
+            # (e.g. a voltage regulator) the net name is the pin name.
+            if sym.lib_id.startswith("power:"):
+                net_name = sym.value
+                if net_name:
+                    driven_nets.add(net_name)
+            else:
+                for pin in power_out_pins:
+                    if pin.name:
+                        driven_nets.add(pin.name)
+
+    return driven_nets
+
+
+def _extract_power_net_name(
+    description: str, items: list[dict] | None = None
+) -> str | None:
+    """Extract the power net / pin name from a ``power_pin_not_driven`` violation.
+
+    KiCad formats these violations as:
+
+    * Description: ``"Power input pin not driven by any power output"``
+      (or similar generic text)
+    * Item description: ``"Pin VCC (power_in) of U1"``
+
+    The pin name (``VCC``) is used as the power net name because KiCad
+    power pins are named after the net they connect to.
+
+    Returns:
+        The extracted net name, or ``None`` if parsing fails.
+    """
+    # Try items first -- more reliable in modern KiCad
+    if items:
+        for item in items:
+            item_desc = item.get("description", "")
+            # Match "Pin <name> (power_in) of <ref>"
+            m = re.search(r"Pin\s+(\S+)\s+\(power_in\)", item_desc)
+            if m:
+                return m.group(1)
+            # Also match "Pin <name> of <ref>" without the type qualifier
+            m = re.search(r"Pin\s+(\S+)\s+of\s+", item_desc)
+            if m:
+                return m.group(1)
+
+    # Fall back to the top-level description
+    m = re.search(r"Pin\s+(\S+)", description)
+    if m:
+        return m.group(1)
+
+    return None
+
+
+def filter_cross_sheet_power_violations(
+    violations: list[dict],
+    root_schematic: str,
+) -> list[dict]:
+    """Remove false-positive ``power_pin_not_driven`` violations for power
+    nets that have a ``power_out`` driver on another sheet.
+
+    KiCad's ERC engine evaluates ``power_pin_not_driven`` on a per-sheet
+    basis without aggregating power drivers across the full hierarchy.
+    A ``power_in`` pin connected to ``+3V3`` is flagged as "not driven"
+    even when a ``PWR_FLAG`` or voltage regulator output on a different
+    sheet drives that same net.
+
+    This function builds a cross-sheet inventory of ``power_out`` drivers
+    and suppresses violations whose power net has a driver anywhere in
+    the hierarchy.
+
+    Args:
+        violations: List of raw violation dicts as parsed from KiCad's
+            JSON report.  Each dict must have at least ``"type"`` and
+            ``"description"`` keys.
+        root_schematic: Path to the root ``.kicad_sch`` file used to
+            build the power driver inventory.
+
+    Returns:
+        A new list with false-positive ``power_pin_not_driven``
+        violations removed.  All other violation types pass through
+        unchanged.
+    """
+    target_type = "power_pin_not_driven"
+
+    # Quick check: skip the expensive hierarchy traversal if there are
+    # no power_pin_not_driven violations.
+    has_target = any(v.get("type", "") == target_type for v in violations)
+    if not has_target:
+        return violations
+
+    driven_nets = build_power_driver_inventory(root_schematic)
+
+    filtered: list[dict] = []
+    for v in violations:
+        if v.get("type", "") != target_type:
+            filtered.append(v)
+            continue
+
+        net_name = _extract_power_net_name(
+            v.get("description", ""), v.get("items")
+        )
+
+        if net_name is not None and net_name in driven_nets:
+            # Power net has a driver on some sheet -- false positive.
             continue
 
         filtered.append(v)

--- a/tests/test_erc.py
+++ b/tests/test_erc.py
@@ -1,6 +1,7 @@
 """Tests for kicad_tools.erc module."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -9,6 +10,10 @@ from kicad_tools.erc import (
     ERCReport,
     ERCViolationType,
     Severity,
+)
+from kicad_tools.erc.cross_sheet import (
+    _extract_power_net_name,
+    filter_cross_sheet_power_violations,
 )
 
 
@@ -301,3 +306,116 @@ class TestERCTypeDescriptions:
         assert ERC_TYPE_DESCRIPTIONS["pin_not_connected"] == "Unconnected pin"
         assert ERC_TYPE_DESCRIPTIONS["power_pin_not_driven"] == "Power input not driven"
         assert ERC_TYPE_DESCRIPTIONS["label_dangling"] == "Label not connected"
+
+
+class TestExtractPowerNetName:
+    """Tests for _extract_power_net_name helper."""
+
+    def test_extract_from_item_with_type(self):
+        """Extract net name from 'Pin VCC (power_in) of U1' format."""
+        items = [{"description": "Pin VCC (power_in) of U1"}]
+        assert _extract_power_net_name("Power pin not driven", items) == "VCC"
+
+    def test_extract_from_item_without_type(self):
+        """Extract net name from 'Pin +3V3 of U3' format."""
+        items = [{"description": "Pin +3V3 of U3"}]
+        assert _extract_power_net_name("Power pin not driven", items) == "+3V3"
+
+    def test_extract_from_description_fallback(self):
+        """Extract net name from top-level description when items empty."""
+        assert _extract_power_net_name("Pin GND not driven") == "GND"
+
+    def test_returns_none_for_unparseable(self):
+        """Return None when no pin name can be extracted."""
+        assert _extract_power_net_name("Some random text") is None
+        assert _extract_power_net_name("Some random text", []) is None
+
+    def test_prefers_power_in_match(self):
+        """When (power_in) qualifier is present, prefer that match."""
+        items = [{"description": "Pin +3.3V (power_in) of U3"}]
+        assert _extract_power_net_name("", items) == "+3.3V"
+
+
+class TestFilterCrossSheetPowerViolations:
+    """Tests for filter_cross_sheet_power_violations."""
+
+    def _make_violation(self, vtype: str, net_name: str) -> dict:
+        """Create a synthetic violation dict."""
+        return {
+            "type": vtype,
+            "severity": "error",
+            "description": "Power input pin not driven by any power output",
+            "items": [{"description": f"Pin {net_name} (power_in) of U1"}],
+        }
+
+    @patch("kicad_tools.erc.cross_sheet.build_power_driver_inventory")
+    def test_suppresses_driven_net(self, mock_inventory):
+        """Violation for a net with a driver on another sheet is suppressed."""
+        mock_inventory.return_value = {"+3V3", "GND", "VCC"}
+
+        violations = [
+            self._make_violation("power_pin_not_driven", "VCC"),
+            {"type": "pin_not_connected", "description": "other"},
+        ]
+
+        result = filter_cross_sheet_power_violations(violations, "/fake/path")
+        assert len(result) == 1
+        assert result[0]["type"] == "pin_not_connected"
+
+    @patch("kicad_tools.erc.cross_sheet.build_power_driver_inventory")
+    def test_preserves_undriven_net(self, mock_inventory):
+        """Violation for a net with NO driver anywhere is preserved (true positive)."""
+        mock_inventory.return_value = {"GND"}  # VCC is NOT driven
+
+        violations = [
+            self._make_violation("power_pin_not_driven", "VCC"),
+        ]
+
+        result = filter_cross_sheet_power_violations(violations, "/fake/path")
+        assert len(result) == 1
+        assert result[0]["type"] == "power_pin_not_driven"
+
+    @patch("kicad_tools.erc.cross_sheet.build_power_driver_inventory")
+    def test_preserves_unparseable_violation(self, mock_inventory):
+        """Violation with unparseable description is preserved to be safe."""
+        mock_inventory.return_value = {"+3V3"}
+
+        violations = [
+            {
+                "type": "power_pin_not_driven",
+                "severity": "error",
+                "description": "Some generic message",
+                "items": [],
+            },
+        ]
+
+        result = filter_cross_sheet_power_violations(violations, "/fake/path")
+        assert len(result) == 1
+
+    def test_skips_traversal_when_no_target_violations(self):
+        """No hierarchy traversal if no power_pin_not_driven violations exist."""
+        violations = [
+            {"type": "pin_not_connected", "description": "other"},
+        ]
+
+        # Should return immediately without calling build_power_driver_inventory
+        result = filter_cross_sheet_power_violations(violations, "/nonexistent/path")
+        assert len(result) == 1
+
+    @patch("kicad_tools.erc.cross_sheet.build_power_driver_inventory")
+    def test_other_types_pass_through(self, mock_inventory):
+        """Non-power violations pass through unchanged."""
+        mock_inventory.return_value = {"+3V3"}
+
+        violations = [
+            {"type": "label_dangling", "description": "Label issue"},
+            {"type": "pin_not_connected", "description": "Pin issue"},
+            self._make_violation("power_pin_not_driven", "+3V3"),
+        ]
+
+        result = filter_cross_sheet_power_violations(violations, "/fake/path")
+        assert len(result) == 2
+        types = [v["type"] for v in result]
+        assert "label_dangling" in types
+        assert "pin_not_connected" in types
+        assert "power_pin_not_driven" not in types

--- a/tests/test_erc_cross_sheet.py
+++ b/tests/test_erc_cross_sheet.py
@@ -1,10 +1,14 @@
-"""Tests for cross-sheet duplicate reference designator detection."""
+"""Tests for cross-sheet ERC checks (duplicates & power filtering)."""
 
 from pathlib import Path
 
 import pytest
 
-from kicad_tools.erc.cross_sheet import check_cross_sheet_duplicates
+from kicad_tools.erc.cross_sheet import (
+    build_power_driver_inventory,
+    check_cross_sheet_duplicates,
+    filter_cross_sheet_power_violations,
+)
 from kicad_tools.erc.violation import ERCViolationType, Severity
 
 
@@ -269,3 +273,249 @@ class TestCrossSheetDuplicates:
         violations = check_cross_sheet_duplicates(str(tmp_path / "root.kicad_sch"))
         # Either 0 or 1 violations is acceptable; assert no crash.
         assert isinstance(violations, list)
+
+
+# ---------------------------------------------------------------------------
+# Templates for power driver inventory tests
+# ---------------------------------------------------------------------------
+
+# Root schematic template that includes lib_symbols definitions
+_POWER_ROOT_TEMPLATE = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "root-uuid-001")
+  (paper "A4")
+  (lib_symbols
+    {lib_symbols}
+  )
+  {symbols}
+  {sheets}
+)
+"""
+
+_POWER_SUBSHEET_TEMPLATE = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "{uuid}")
+  (paper "A4")
+  (lib_symbols
+    {lib_symbols}
+  )
+  {symbols}
+)
+"""
+
+# Library symbol definition for a PWR_FLAG (has power_out pin)
+_LIB_PWR_FLAG = """\
+    (symbol "power:PWR_FLAG"
+      (pin_names (offset 0) hide)
+      (in_bom no) (on_board yes)
+      (property "Reference" "#FLG"
+        (at 0 0 0)
+        (effects (font (size 1.27 1.27)) hide)
+      )
+      (property "Value" "PWR_FLAG"
+        (at 0 0 0)
+        (effects (font (size 1.27 1.27)))
+      )
+      (symbol "PWR_FLAG_0_0"
+        (pin power_out line (at 0 0 90) (length 0) (name "pwr" (effects (font (size 0 0)))) (number "1" (effects (font (size 0 0)))))
+      )
+    )
+"""
+
+# Library symbol definition for a power symbol like +3V3
+_LIB_POWER_3V3 = """\
+    (symbol "power:+3V3"
+      (pin_names (offset 0) hide)
+      (in_bom no) (on_board yes)
+      (property "Reference" "#PWR"
+        (at 0 0 0)
+        (effects (font (size 1.27 1.27)) hide)
+      )
+      (property "Value" "+3V3"
+        (at 0 0 0)
+        (effects (font (size 1.27 1.27)))
+      )
+      (symbol "+3V3_0_0"
+        (pin power_in line (at 0 0 90) (length 0) (name "+3V3" (effects (font (size 0 0)))) (number "1" (effects (font (size 0 0)))))
+      )
+    )
+"""
+
+# Symbol instance template for power symbols
+_POWER_SYMBOL_TEMPLATE = """\
+  (symbol
+    (lib_id "{lib_id}")
+    (at 100 100 0)
+    (unit 1)
+    (uuid "{uuid}")
+    (property "Reference" "{reference}"
+      (at 100 90 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "Value" "{value}"
+      (at 100 110 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (pin "1" (uuid "{uuid}-pin1"))
+  )
+"""
+
+
+class TestBuildPowerDriverInventory:
+    """Tests for build_power_driver_inventory."""
+
+    def test_finds_pwr_flag_driver(self, tmp_path: Path):
+        """PWR_FLAG symbol with power_out pin should register as a driver."""
+        pwr_flag_sym = _POWER_SYMBOL_TEMPLATE.format(
+            lib_id="power:PWR_FLAG",
+            uuid="pwr-flag-001",
+            reference="#FLG01",
+            value="PWR_FLAG",
+        )
+        power_3v3_sym = _POWER_SYMBOL_TEMPLATE.format(
+            lib_id="power:+3V3",
+            uuid="pwr-3v3-001",
+            reference="#PWR01",
+            value="+3V3",
+        )
+
+        root_content = _POWER_ROOT_TEMPLATE.format(
+            lib_symbols=_LIB_PWR_FLAG + _LIB_POWER_3V3,
+            symbols=pwr_flag_sym + power_3v3_sym,
+            sheets="",
+        )
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+
+        driven = build_power_driver_inventory(str(tmp_path / "root.kicad_sch"))
+
+        # PWR_FLAG is a power: symbol with power_out -- its value is the net
+        assert "PWR_FLAG" in driven
+
+    def test_power_in_symbol_not_a_driver(self, tmp_path: Path):
+        """A power:+3V3 symbol with only power_in pin should NOT register."""
+        power_sym = _POWER_SYMBOL_TEMPLATE.format(
+            lib_id="power:+3V3",
+            uuid="pwr-3v3-001",
+            reference="#PWR01",
+            value="+3V3",
+        )
+        root_content = _POWER_ROOT_TEMPLATE.format(
+            lib_symbols=_LIB_POWER_3V3,
+            symbols=power_sym,
+            sheets="",
+        )
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+
+        driven = build_power_driver_inventory(str(tmp_path / "root.kicad_sch"))
+        # +3V3 has only power_in, not power_out -- should not be in inventory
+        assert "+3V3" not in driven
+
+    def test_finds_driver_on_subsheet(self, tmp_path: Path):
+        """Power driver on a sub-sheet should be detected."""
+        sub_file = "power_sub.kicad_sch"
+
+        root_sheets = _SHEET_TEMPLATE.format(
+            name="Power", filename=sub_file, uuid="sheet-pwr"
+        )
+        root_content = _POWER_ROOT_TEMPLATE.format(
+            lib_symbols="", symbols="", sheets=root_sheets
+        )
+
+        pwr_flag_sym = _POWER_SYMBOL_TEMPLATE.format(
+            lib_id="power:PWR_FLAG",
+            uuid="sub-pwr-flag",
+            reference="#FLG01",
+            value="PWR_FLAG",
+        )
+        sub_content = _POWER_SUBSHEET_TEMPLATE.format(
+            uuid="sub-uuid-pwr",
+            lib_symbols=_LIB_PWR_FLAG,
+            symbols=pwr_flag_sym,
+        )
+
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+        (tmp_path / sub_file).write_text(sub_content)
+
+        driven = build_power_driver_inventory(str(tmp_path / "root.kicad_sch"))
+        assert "PWR_FLAG" in driven
+
+    def test_empty_schematic(self, tmp_path: Path):
+        """Schematic with no symbols returns empty set."""
+        root_content = _POWER_ROOT_TEMPLATE.format(
+            lib_symbols="", symbols="", sheets=""
+        )
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+
+        driven = build_power_driver_inventory(str(tmp_path / "root.kicad_sch"))
+        assert driven == set()
+
+
+class TestFilterCrossSheetPowerIntegration:
+    """Integration tests: filter_cross_sheet_power_violations with real schematics."""
+
+    def test_suppresses_violation_when_pwr_flag_exists(self, tmp_path: Path):
+        """power_pin_not_driven for VCC should be suppressed when PWR_FLAG exists."""
+        # Root sheet has a PWR_FLAG (power_out driver)
+        pwr_flag_sym = _POWER_SYMBOL_TEMPLATE.format(
+            lib_id="power:PWR_FLAG",
+            uuid="pwr-flag-001",
+            reference="#FLG01",
+            value="PWR_FLAG",
+        )
+        root_content = _POWER_ROOT_TEMPLATE.format(
+            lib_symbols=_LIB_PWR_FLAG,
+            symbols=pwr_flag_sym,
+            sheets="",
+        )
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+
+        violations = [
+            {
+                "type": "power_pin_not_driven",
+                "severity": "error",
+                "description": "Power input pin not driven",
+                "items": [{"description": "Pin PWR_FLAG (power_in) of U3"}],
+            },
+        ]
+
+        result = filter_cross_sheet_power_violations(
+            violations, str(tmp_path / "root.kicad_sch")
+        )
+        assert len(result) == 0
+
+    def test_preserves_violation_when_no_driver(self, tmp_path: Path):
+        """power_pin_not_driven should be kept when no power_out driver exists."""
+        # Root sheet has only a +3V3 symbol (power_in only)
+        power_sym = _POWER_SYMBOL_TEMPLATE.format(
+            lib_id="power:+3V3",
+            uuid="pwr-3v3-001",
+            reference="#PWR01",
+            value="+3V3",
+        )
+        root_content = _POWER_ROOT_TEMPLATE.format(
+            lib_symbols=_LIB_POWER_3V3,
+            symbols=power_sym,
+            sheets="",
+        )
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+
+        violations = [
+            {
+                "type": "power_pin_not_driven",
+                "severity": "error",
+                "description": "Power input pin not driven",
+                "items": [{"description": "Pin VCC (power_in) of U1"}],
+            },
+        ]
+
+        result = filter_cross_sheet_power_violations(
+            violations, str(tmp_path / "root.kicad_sch")
+        )
+        # VCC is not in the driven set -- violation is a true positive
+        assert len(result) == 1


### PR DESCRIPTION
## Summary
Add cross-sheet power driver filtering to suppress false-positive `power_pin_not_driven` ERC violations when a `power_out` driver (e.g. `PWR_FLAG`, voltage regulator output) exists on another sheet in the hierarchy.

## Changes
- Add `build_power_driver_inventory()` in `cross_sheet.py` to traverse the hierarchy and collect all nets driven by `power_out` pins
- Add `_extract_power_net_name()` helper to parse power net names from KiCad violation descriptions
- Add `filter_cross_sheet_power_violations()` to suppress false-positive `power_pin_not_driven` violations for nets with a driver on any sheet
- Chain the new filter after `filter_cross_sheet_global_labels` in `run_erc()` in `sch_validate.py`
- Export the new function from `kicad_tools.erc.__init__`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| power_pin_not_driven suppressed when power_out exists on another sheet | PASS | Unit test with mocked inventory + integration test with synthetic schematic |
| True positives preserved when no driver exists | PASS | Unit test verifies violation is kept when net has no power_out driver |
| Other violation types pass through unchanged | PASS | Unit test verifies label_dangling and pin_not_connected are unaffected |
| No hierarchy traversal when no target violations | PASS | Unit test calls filter with nonexistent path and no power violations -- returns immediately |
| PWR_FLAG recognized as power_out driver | PASS | Integration test with synthetic PWR_FLAG lib symbol |

## Test Plan
- `python3 -m pytest tests/test_erc.py tests/test_erc_cross_sheet.py -v` -- all 56 tests pass
- Unit tests for `_extract_power_net_name` covering multiple KiCad description formats
- Unit tests for `filter_cross_sheet_power_violations` with mocked inventory (driven net suppressed, undriven net preserved, unparseable preserved, other types pass through)
- Integration tests with synthetic schematics for `build_power_driver_inventory` (PWR_FLAG detected, power_in-only not detected, sub-sheet driver detected)
- Integration tests for full filter pipeline with real schematic parsing

Closes #2010