### PR TITLE
fix(sexp): use tab indentation for KiCad file compatibility

### DIFF
--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -322,8 +322,8 @@ class SExp:
         if not self.name and not self.children:
             return "()"
 
-        # KiCad uses 2 spaces for indentation
-        tab = "  "
+        # KiCad uses tab indentation
+        tab = "\t"
         tabs = tab * indent
 
         # Check if should render inline

--- a/tests/test_sexp_parser.py
+++ b/tests/test_sexp_parser.py
@@ -525,8 +525,8 @@ class TestRoundTrip:
         # Layer names with dots should be quoted
         assert '"F.Cu"' in serialized
 
-    def test_roundtrip_uses_spaces_not_tabs(self):
-        """Serialization uses 2-space indentation, not tabs."""
+    def test_roundtrip_uses_tabs_not_spaces(self):
+        """Serialization uses tab indentation, matching KiCad native format."""
         sexp = """(kicad_pcb
             (version 20240108)
             (general
@@ -536,10 +536,9 @@ class TestRoundTrip:
         parsed = parse_string(sexp)
         serialized = parsed.to_string()
 
-        # Should not contain tabs
-        assert "\t" not in serialized
-        # Should use 2-space indentation
-        assert "  (version" in serialized
+        # Should use tab indentation
+        assert "\t" in serialized
+        assert "\t(version" in serialized
 
     def test_roundtrip_fp_text_types_unquoted(self):
         """fp_text types like reference, value are not quoted."""

--- a/tests/test_sexp_roundtrip.py
+++ b/tests/test_sexp_roundtrip.py
@@ -96,16 +96,16 @@ class TestSExpRoundTripWithKiCad:
         doc = parse_file(demo_pcb_path)
         output = doc.to_string()
 
-        # Check indentation uses spaces, not tabs
-        assert "\t" not in output, "Output should use spaces, not tabs"
+        # Check indentation uses tabs, matching KiCad native format
+        assert "\t" in output, "Output should use tab indentation"
 
         # Check that known keywords are not quoted
         # These keywords appear in the demo file
-        assert " signal)" in output or " signal\n" in output, "signal keyword should not be quoted"
-        assert " user)" in output or " user " in output, "user keyword should not be quoted"
-        assert " no)" in output or " no\n" in output, "no keyword should not be quoted"
-        assert " none)" in output or " none\n" in output, "none keyword should not be quoted"
-        assert " default)" in output or " default\n" in output, (
+        assert "signal)" in output or "signal\n" in output, "signal keyword should not be quoted"
+        assert "user)" in output or "user " in output, "user keyword should not be quoted"
+        assert "no)" in output or "no\n" in output, "no keyword should not be quoted"
+        assert "none)" in output or "none\n" in output, "none keyword should not be quoted"
+        assert "default)" in output or "default\n" in output, (
             "default keyword should not be quoted"
         )
 


### PR DESCRIPTION
## Summary
Change SExp.to_string() indentation from two spaces to a single tab character, matching KiCad's native file format. This fixes files saved by kicad-tools being written with non-standard indentation.

## Changes
- `src/kicad_tools/sexp/parser.py`: Change `tab = "  "` to `tab = "\t"` and update comment in `SExp.to_string()`
- `tests/test_sexp_parser.py`: Rename and update `test_roundtrip_uses_spaces_not_tabs` to `test_roundtrip_uses_tabs_not_spaces`, asserting tab presence
- `tests/test_sexp_roundtrip.py`: Invert tab assertion in `test_serialized_output_format` and adjust keyword pattern checks

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| SExp.to_string() uses tab indentation | Pass | Changed `tab = "\t"` in parser.py line 325 |
| All sexp tests pass | Pass | 204 passed, 5 skipped (KiCad CLI not available) |
| Single production code change | Pass | Only parser.py modified; test files updated to match |

## Test Plan
- Ran `pytest tests/test_sexp_parser.py tests/test_sexp_roundtrip.py tests/test_sexp.py tests/test_sexp_builders.py` -- 204 passed, 5 skipped

Closes #2024