### PR TITLE
feat(route): add seeed/seeed-fusion manufacturer aliases and closest-match suggestions

### DIFF
--- a/src/kicad_tools/router/mfr_limits.py
+++ b/src/kicad_tools/router/mfr_limits.py
@@ -8,11 +8,13 @@ This module provides:
 
 Supported Manufacturers:
 - JLCPCB: Chinese low-cost PCB manufacturer
+- Seeed (Seeed Fusion): Uses JLCPCB-compatible manufacturing rules
 - OSHPark: US-based high-quality purple boards
 - PCBWay: Chinese manufacturer with good middle-ground specs
 """
 
 from dataclasses import dataclass
+from difflib import get_close_matches
 
 
 @dataclass(frozen=True)
@@ -73,13 +75,26 @@ MFR_PCBWAY = MfrLimits(
 # Mapping of manufacturer names to their limits
 MFR_LIMITS: dict[str, MfrLimits] = {
     "jlcpcb": MFR_JLCPCB,
+    "seeed": MFR_JLCPCB,  # Seeed Fusion uses JLCPCB-compatible rules
+    "seeed-fusion": MFR_JLCPCB,
     "oshpark": MFR_OSHPARK,
     "pcbway": MFR_PCBWAY,
+}
+
+# Aliases mapping alternative names to canonical MFR_LIMITS keys
+_MFR_ALIASES: dict[str, str] = {
+    "seeed_fusion": "seeed-fusion",
+    "seeedfusion": "seeed-fusion",
+    "seeedstudio": "seeed",
 }
 
 
 def get_mfr_limits(manufacturer: str) -> MfrLimits:
     """Get manufacturer limits by name.
+
+    Supports aliases (e.g., "seeed_fusion" -> "seeed-fusion") and
+    case-insensitive lookup. On unknown manufacturer, suggests close
+    matches via difflib.
 
     Args:
         manufacturer: Manufacturer name (case-insensitive)
@@ -91,10 +106,20 @@ def get_mfr_limits(manufacturer: str) -> MfrLimits:
         ValueError: If manufacturer is not recognized
     """
     mfr_lower = manufacturer.lower()
-    if mfr_lower not in MFR_LIMITS:
-        valid_mfrs = ", ".join(sorted(MFR_LIMITS.keys()))
-        raise ValueError(f"Unknown manufacturer '{manufacturer}'. Valid options: {valid_mfrs}")
-    return MFR_LIMITS[mfr_lower]
+
+    # Resolve aliases
+    mfr_lower = _MFR_ALIASES.get(mfr_lower, mfr_lower)
+
+    if mfr_lower in MFR_LIMITS:
+        return MFR_LIMITS[mfr_lower]
+
+    # Build error message with closest-match suggestions
+    all_names = sorted(set(MFR_LIMITS.keys()) | set(_MFR_ALIASES.keys()))
+    suggestions = get_close_matches(mfr_lower, all_names, n=3, cutoff=0.5)
+    msg = f"Unknown manufacturer '{manufacturer}'. Valid options: {', '.join(sorted(MFR_LIMITS.keys()))}"
+    if suggestions:
+        msg += f". Did you mean: {', '.join(suggestions)}?"
+    raise ValueError(msg)
 
 
 @dataclass

--- a/tests/test_mfr_limits.py
+++ b/tests/test_mfr_limits.py
@@ -59,9 +59,13 @@ class TestMfrLimits:
     def test_all_manufacturers_in_limits_dict(self):
         """Test that all manufacturer presets are in the MFR_LIMITS dict."""
         assert "jlcpcb" in MFR_LIMITS
+        assert "seeed" in MFR_LIMITS
+        assert "seeed-fusion" in MFR_LIMITS
         assert "oshpark" in MFR_LIMITS
         assert "pcbway" in MFR_LIMITS
         assert MFR_LIMITS["jlcpcb"] is MFR_JLCPCB
+        assert MFR_LIMITS["seeed"] is MFR_JLCPCB
+        assert MFR_LIMITS["seeed-fusion"] is MFR_JLCPCB
         assert MFR_LIMITS["oshpark"] is MFR_OSHPARK
         assert MFR_LIMITS["pcbway"] is MFR_PCBWAY
 
@@ -92,6 +96,54 @@ class TestGetMfrLimits:
         assert "jlcpcb" in error_msg
         assert "oshpark" in error_msg
         assert "pcbway" in error_msg
+
+    def test_seeed_alias_resolves_to_jlcpcb(self):
+        """Test that 'seeed' resolves to JLCPCB limits."""
+        result = get_mfr_limits("seeed")
+        assert result is MFR_JLCPCB
+
+    def test_seeed_fusion_alias_resolves_to_jlcpcb(self):
+        """Test that 'seeed-fusion' resolves to JLCPCB limits."""
+        assert get_mfr_limits("seeed-fusion") is MFR_JLCPCB
+        # Underscore variant via alias
+        assert get_mfr_limits("seeed_fusion") is MFR_JLCPCB
+        # No separator variant via alias
+        assert get_mfr_limits("seeedfusion") is MFR_JLCPCB
+
+    def test_seeedstudio_alias_resolves_to_jlcpcb(self):
+        """Test that 'seeedstudio' alias resolves to JLCPCB limits."""
+        assert get_mfr_limits("seeedstudio") is MFR_JLCPCB
+
+    def test_seeed_case_insensitive(self):
+        """Test that seeed aliases are case-insensitive."""
+        assert get_mfr_limits("Seeed") is MFR_JLCPCB
+        assert get_mfr_limits("SEEED") is MFR_JLCPCB
+        assert get_mfr_limits("Seeed-Fusion") is MFR_JLCPCB
+        assert get_mfr_limits("SEEED-FUSION") is MFR_JLCPCB
+        assert get_mfr_limits("SeeedStudio") is MFR_JLCPCB
+
+    def test_error_suggests_closest_match(self):
+        """Test that unknown manufacturer error includes 'Did you mean?' suggestion."""
+        with pytest.raises(ValueError) as exc_info:
+            get_mfr_limits("seeeeed")  # typo with extra 'e'
+        error_msg = str(exc_info.value)
+        assert "Did you mean" in error_msg
+        assert "seeed" in error_msg
+
+    def test_error_suggests_closest_match_for_jlcpcb_typo(self):
+        """Test that a JLCPCB typo gets a suggestion."""
+        with pytest.raises(ValueError) as exc_info:
+            get_mfr_limits("jlcpb")  # missing 'c'
+        error_msg = str(exc_info.value)
+        assert "Did you mean" in error_msg
+        assert "jlcpcb" in error_msg
+
+    def test_no_suggestion_for_completely_unrelated(self):
+        """Test that completely unrelated input does not produce suggestions."""
+        with pytest.raises(ValueError) as exc_info:
+            get_mfr_limits("xyz123")
+        error_msg = str(exc_info.value)
+        assert "Did you mean" not in error_msg
 
 
 class TestRelaxationTier:


### PR DESCRIPTION
## Summary
Add seeed and seeed-fusion as recognized manufacturers in the router's MFR_LIMITS dict, mapping to JLCPCB limits since Seeed Fusion uses JLCPCB-compatible manufacturing rules. Also add difflib-based closest-match suggestions for unknown manufacturer names.

## Changes
- Add `seeed` and `seeed-fusion` entries in `MFR_LIMITS` pointing to `MFR_JLCPCB`
- Add `_MFR_ALIASES` dict for variant spellings (`seeed_fusion`, `seeedfusion`, `seeedstudio`)
- Use `difflib.get_close_matches()` in `get_mfr_limits()` to suggest similar names on lookup failure
- Add 7 new tests covering alias resolution, case-insensitivity, and closest-match suggestions

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `get_mfr_limits("seeed")` returns JLCPCB limits | Done | test_seeed_alias_resolves_to_jlcpcb passes |
| `get_mfr_limits("seeed-fusion")` returns JLCPCB limits | Done | test_seeed_fusion_alias_resolves_to_jlcpcb passes |
| Case-insensitive lookup for Seeed, SEEED, Seeed-Fusion | Done | test_seeed_case_insensitive passes |
| Unknown manufacturer error suggests closest match | Done | test_error_suggests_closest_match passes |
| Completely unrelated input shows no suggestion | Done | test_no_suggestion_for_completely_unrelated passes |

## Test Plan
All 33 tests in `tests/test_mfr_limits.py` pass (26 existing + 7 new).

Closes #2019