### PR TITLE
fix(sexp): add global, local, symbols to unquoted keywords set

### DIFF
--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -605,6 +605,11 @@ class SExp:
             "uvia_drill",
             "diff_pair_width",
             "diff_pair_gap",
+            # Scope keywords (power symbol scope)
+            "global",
+            "local",
+            # Symbol types
+            "symbols",
             # Other
             "allow_missing_courtyard",
             "allow_soldermask_bridges",

--- a/tests/test_sexp_parser.py
+++ b/tests/test_sexp_parser.py
@@ -390,6 +390,24 @@ class TestSerialization:
         result = node.to_string(compact=True)
         assert result == "(test value)"  # 'value' is a keyword
 
+    def test_serialize_power_global_unquoted(self):
+        """Keyword 'global' is not quoted (power symbol scope)."""
+        node = SExp.list("power", "global")
+        result = node.to_string(compact=True)
+        assert result == "(power global)"
+
+    def test_serialize_power_local_unquoted(self):
+        """Keyword 'local' is not quoted (power symbol scope)."""
+        node = SExp.list("power", "local")
+        result = node.to_string(compact=True)
+        assert result == "(power local)"
+
+    def test_serialize_power_symbols_unquoted(self):
+        """Keyword 'symbols' is not quoted."""
+        node = SExp.list("power", "symbols")
+        result = node.to_string(compact=True)
+        assert result == "(power symbols)"
+
     def test_serialize_roundtrip(self):
         """Parse and serialize preserves structure."""
         original = '(test 1 "hello" (nested 2))'
@@ -585,6 +603,44 @@ class TestRoundTrip:
 
             assert hatch_type in serialized
             assert f'"{hatch_type}"' not in serialized
+
+    def test_roundtrip_power_global_unquoted(self):
+        """Power scope keyword 'global' should not be quoted."""
+        sexp = "(power global)"
+        parsed = parse_string(sexp)
+        serialized = parsed.to_string()
+
+        assert "global" in serialized
+        assert '"global"' not in serialized
+        assert serialized.strip() == "(power global)"
+
+    def test_roundtrip_power_local_unquoted(self):
+        """Power scope keyword 'local' should not be quoted."""
+        sexp = "(power local)"
+        parsed = parse_string(sexp)
+        serialized = parsed.to_string()
+
+        assert "local" in serialized
+        assert '"local"' not in serialized
+        assert serialized.strip() == "(power local)"
+
+    def test_roundtrip_symbols_unquoted(self):
+        """Keyword 'symbols' should not be quoted."""
+        sexp = "(power symbols)"
+        parsed = parse_string(sexp)
+        serialized = parsed.to_string()
+
+        assert "symbols" in serialized
+        assert '"symbols"' not in serialized
+        assert serialized.strip() == "(power symbols)"
+
+    def test_roundtrip_global_with_spaces_still_quoted(self):
+        """Strings containing 'global' with spaces are still quoted."""
+        sexp = '(test "global warming")'
+        parsed = parse_string(sexp)
+        serialized = parsed.to_string()
+
+        assert '"global warming"' in serialized
 
     def test_roundtrip_boolean_values_unquoted(self):
         """Boolean values like yes, no are not quoted."""


### PR DESCRIPTION
## Summary
Add missing keywords `global`, `local`, and `symbols` to the `unquoted_keywords` set in `SExp._needs_quoting()` so they serialize without quotes, matching KiCad's native format.

## Changes
- Added `global`, `local`, and `symbols` to the `unquoted_keywords` set in `_needs_quoting()` in `src/kicad_tools/sexp/parser.py`
- Added 3 serialization tests in `TestSerialization` verifying each keyword produces unquoted output
- Added 4 roundtrip tests in `TestRoundTrip` verifying parse-serialize preserves bare atoms and that strings with spaces containing these keywords are still quoted

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `(power global)` roundtrips without quotes | Done | `test_roundtrip_power_global_unquoted` passes |
| `(power local)` roundtrips without quotes | Done | `test_roundtrip_power_local_unquoted` passes |
| `(power symbols)` roundtrips without quotes | Done | `test_roundtrip_symbols_unquoted` passes |
| Strings with spaces still quoted | Done | `test_roundtrip_global_with_spaces_still_quoted` passes |
| No regressions | Done | All 79 sexp_parser + 132 sexp/sexp_builders tests pass |

## Test Plan
- `python3 -m pytest tests/test_sexp_parser.py` -- 79 passed
- `python3 -m pytest tests/test_sexp_roundtrip.py tests/test_sexp_builders.py tests/test_sexp.py` -- 132 passed, 5 skipped

Closes #2023