### PR TITLE
fix(report): switch blank schematic detection from PNG size to SVG size

### DIFF
--- a/src/kicad_tools/report/figures.py
+++ b/src/kicad_tools/report/figures.py
@@ -30,11 +30,11 @@ logger = logging.getLogger(__name__)
 #: embedded in documents, not sent to a vision model.
 REPORT_MAX_SIZE_PX = 3000
 
-#: Minimum PNG file size (bytes) for a schematic sheet to be considered
-#: non-blank.  Title-block-only PNGs rendered at 3000 px max dimension
-#: are typically under 50 KB, while sheets with component graphics are
-#: 100 KB+.  A 60 KB threshold provides a reasonable safety margin.
-_BLANK_PNG_THRESHOLD_BYTES = 60_000
+#: Minimum SVG file size (bytes) for a schematic sheet to be considered
+#: non-blank.  Title-block-only SVGs exported by kicad-cli are ~93 KB
+#: of XML, while sheets with actual schematic content are ~436 KB+.
+#: A 150 KB threshold sits well within the gap between the two.
+_BLANK_SVG_THRESHOLD_BYTES = 150_000
 
 #: PCB presets to render, in order.
 #: Each tuple is (preset_name, output_filename, caption).
@@ -235,33 +235,36 @@ class ReportFigureGenerator:
                     )
                     return []
 
+                blank_count = 0
+                total_count = len(svg_files)
                 for svg_file in svg_files:
                     png_name = f"schematic_{svg_file.stem}.png"
                     png_path = output_dir / png_name
                     try:
+                        # Detect blank sheets via SVG file size before
+                        # spending time on PNG conversion.  Title-block-only
+                        # SVGs are ~93 KB; sheets with content are 400 KB+.
+                        svg_size = svg_file.stat().st_size
+                        if svg_size < _BLANK_SVG_THRESHOLD_BYTES:
+                            blank_count += 1
+                            logger.warning(
+                                "Excluding blank schematic sheet '%s' "
+                                "(SVG size %d bytes < %d byte threshold)",
+                                svg_file.stem,
+                                svg_size,
+                                _BLANK_SVG_THRESHOLD_BYTES,
+                            )
+                            continue
+
                         ok, err, _w, _h = _svg_to_png(svg_file, png_path, self.max_size_px)
                         if ok:
-                            # Detect blank sheets: kicad-cli may produce SVGs
-                            # that contain only the title block and page border
-                            # (no component graphics).  These render to small
-                            # PNGs that would be misleading in the report.
-                            png_size = png_path.stat().st_size if png_path.exists() else 0
-                            if png_size < _BLANK_PNG_THRESHOLD_BYTES:
-                                logger.warning(
-                                    "Excluding blank schematic sheet '%s' "
-                                    "(PNG size %d bytes < %d byte threshold)",
-                                    svg_file.stem,
-                                    png_size,
-                                    _BLANK_PNG_THRESHOLD_BYTES,
+                            entries.append(
+                                FigureEntry(
+                                    filename=png_name,
+                                    caption=f"Schematic: {svg_file.stem}",
+                                    figure_type="schematic",
                                 )
-                            else:
-                                entries.append(
-                                    FigureEntry(
-                                        filename=png_name,
-                                        caption=f"Schematic: {svg_file.stem}",
-                                        figure_type="schematic",
-                                    )
-                                )
+                            )
                         else:
                             logger.warning(
                                 "Failed to render schematic sheet '%s': %s",
@@ -274,6 +277,13 @@ class ReportFigureGenerator:
                             svg_file.name,
                             exc_info=True,
                         )
+
+                if blank_count:
+                    logger.warning(
+                        "Excluded %d of %d schematic sheets as blank",
+                        blank_count,
+                        total_count,
+                    )
         except subprocess.TimeoutExpired:
             logger.warning(
                 "kicad-cli schematic SVG export timed out for %s",

--- a/tests/test_report_figures.py
+++ b/tests/test_report_figures.py
@@ -13,7 +13,7 @@ from kicad_tools.report.figures import (
     REPORT_MAX_SIZE_PX,
     FigureEntry,
     ReportFigureGenerator,
-    _BLANK_PNG_THRESHOLD_BYTES,
+    _BLANK_SVG_THRESHOLD_BYTES,
 )
 
 # ---------------------------------------------------------------------------
@@ -49,10 +49,25 @@ def _make_failure_result(msg: str = "render failed"):
     }
 
 
+#: Default SVG size for "valid" (non-blank) schematic sheets in tests.
+#: Must exceed ``_BLANK_SVG_THRESHOLD_BYTES`` so sheets are not excluded.
+_VALID_SVG_SIZE = _BLANK_SVG_THRESHOLD_BYTES + 50_000
+
+#: Default SVG size for "blank" (title-block-only) schematic sheets in tests.
+#: Must be below ``_BLANK_SVG_THRESHOLD_BYTES`` so sheets are excluded.
+_BLANK_SVG_SIZE = _BLANK_SVG_THRESHOLD_BYTES - 50_000
+
+
+def _write_svg_stub(path: Path, size_bytes: int = _VALID_SVG_SIZE) -> None:
+    """Write an SVG stub file of approximately *size_bytes*."""
+    header = b"<svg>"
+    padding = max(0, size_bytes - len(header))
+    path.write_bytes(header + b" " * padding)
+
+
 def _svg_to_png_side_effect(size_bytes: int = 100_000):
     """Return a side_effect callable for ``_svg_to_png`` that writes a
-    PNG stub of *size_bytes* to the output path so blank-detection
-    logic sees a realistic file size.
+    PNG stub of *size_bytes* to the output path.
     """
 
     def _side_effect(svg_path, png_path, max_size_px=3000):
@@ -113,8 +128,8 @@ class TestGenerateAll:
             # The --output arg is at index 4 in the command list.
             output_idx = cmd.index("--output") + 1
             svg_dir = Path(cmd[output_idx])
-            (svg_dir / "main_sheet.svg").write_text("<svg/>")
-            (svg_dir / "power_sheet.svg").write_text("<svg/>")
+            _write_svg_stub(svg_dir / "main_sheet.svg")
+            _write_svg_stub(svg_dir / "power_sheet.svg")
             return MagicMock(returncode=0, stderr="")
 
         mock_subprocess.side_effect = fake_subprocess_run
@@ -219,13 +234,13 @@ class TestGenerateAll:
         def fake_subprocess_run(cmd, **kwargs):
             output_idx = cmd.index("--output") + 1
             svg_dir = Path(cmd[output_idx])
-            (svg_dir / "good_sheet.svg").write_text("<svg/>")
-            (svg_dir / "bad_sheet.svg").write_text("<svg/>")
+            _write_svg_stub(svg_dir / "good_sheet.svg")
+            _write_svg_stub(svg_dir / "bad_sheet.svg")
             return MagicMock(returncode=0, stderr="")
 
         mock_subprocess.side_effect = fake_subprocess_run
 
-        # First SVG fails, second succeeds (writes a valid-size file)
+        # First SVG fails PNG conversion, second succeeds
         def _mixed_side_effect(svg_path, png_path, max_size_px=3000):
             if "bad_sheet" in str(svg_path):
                 return (False, "bad conversion", 0, 0)
@@ -340,9 +355,9 @@ class TestMultiSheetSchematics:
         def fake_subprocess_run(cmd, **kwargs):
             output_idx = cmd.index("--output") + 1
             svg_dir = Path(cmd[output_idx])
-            (svg_dir / "main.svg").write_text("<svg/>")
-            (svg_dir / "logic.svg").write_text("<svg/>")
-            (svg_dir / "output.svg").write_text("<svg/>")
+            _write_svg_stub(svg_dir / "main.svg")
+            _write_svg_stub(svg_dir / "logic.svg")
+            _write_svg_stub(svg_dir / "output.svg")
             return MagicMock(returncode=0, stderr="")
 
         mock_subprocess.side_effect = fake_subprocess_run
@@ -389,7 +404,7 @@ class TestFilenameDeterminism:
         def fake_subprocess_run(cmd, **kwargs):
             output_idx = cmd.index("--output") + 1
             svg_dir = Path(cmd[output_idx])
-            (svg_dir / "sheet1.svg").write_text("<svg/>")
+            _write_svg_stub(svg_dir / "sheet1.svg")
             return MagicMock(returncode=0, stderr="")
 
         mock_subprocess.side_effect = fake_subprocess_run
@@ -457,7 +472,7 @@ class TestMaxSizePassedThrough:
         def fake_subprocess_run(cmd, **kwargs):
             output_idx = cmd.index("--output") + 1
             svg_dir = Path(cmd[output_idx])
-            (svg_dir / "sheet.svg").write_text("<svg/>")
+            _write_svg_stub(svg_dir / "sheet.svg")
             return MagicMock(returncode=0, stderr="")
 
         mock_subprocess.side_effect = fake_subprocess_run
@@ -510,7 +525,8 @@ class TestOutputDirCreation:
 
 
 class TestBlankSchematicDetection:
-    """Verify that blank schematic sheets are excluded from the manifest."""
+    """Verify that blank schematic sheets are detected via SVG file size
+    and excluded from the manifest before PNG conversion."""
 
     @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
     @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
@@ -527,7 +543,7 @@ class TestBlankSchematicDetection:
         tmp_path,
         caplog,
     ):
-        """A schematic PNG below the size threshold is excluded with a warning."""
+        """A schematic SVG below the size threshold is excluded with a warning."""
         pcb = tmp_path / "board.kicad_pcb"
         pcb.touch()
         sch = tmp_path / "main.kicad_sch"
@@ -539,14 +555,12 @@ class TestBlankSchematicDetection:
         def fake_subprocess_run(cmd, **kwargs):
             output_idx = cmd.index("--output") + 1
             svg_dir = Path(cmd[output_idx])
-            (svg_dir / "blank_sheet.svg").write_text("<svg/>")
+            # Write a small SVG (below threshold) to simulate a blank sheet
+            _write_svg_stub(svg_dir / "blank_sheet.svg", size_bytes=_BLANK_SVG_SIZE)
             return MagicMock(returncode=0, stderr="")
 
         mock_subprocess.side_effect = fake_subprocess_run
-        # Write a small PNG (below threshold) to simulate a blank sheet
-        mock_svg_to_png.side_effect = _svg_to_png_side_effect(
-            size_bytes=_BLANK_PNG_THRESHOLD_BYTES - 1000
-        )
+        mock_svg_to_png.side_effect = _svg_to_png_side_effect()
 
         gen = ReportFigureGenerator()
         with caplog.at_level(logging.WARNING):
@@ -557,6 +571,10 @@ class TestBlankSchematicDetection:
         assert len(sch_entries) == 0
         assert "Excluding blank schematic sheet" in caplog.text
         assert "blank_sheet" in caplog.text
+        assert "SVG size" in caplog.text
+
+        # PNG conversion should NOT have been called for the blank sheet
+        mock_svg_to_png.assert_not_called()
 
     @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
     @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
@@ -585,25 +603,14 @@ class TestBlankSchematicDetection:
         def fake_subprocess_run(cmd, **kwargs):
             output_idx = cmd.index("--output") + 1
             svg_dir = Path(cmd[output_idx])
-            (svg_dir / "dac.svg").write_text("<svg/>")       # blank
-            (svg_dir / "power.svg").write_text("<svg/>")     # valid
-            (svg_dir / "mcu.svg").write_text("<svg/>")       # blank
-            (svg_dir / "sync.svg").write_text("<svg/>")      # valid
+            _write_svg_stub(svg_dir / "dac.svg", size_bytes=_BLANK_SVG_SIZE)     # blank
+            _write_svg_stub(svg_dir / "power.svg", size_bytes=_VALID_SVG_SIZE)   # valid
+            _write_svg_stub(svg_dir / "mcu.svg", size_bytes=_BLANK_SVG_SIZE)     # blank
+            _write_svg_stub(svg_dir / "sync.svg", size_bytes=_VALID_SVG_SIZE)    # valid
             return MagicMock(returncode=0, stderr="")
 
         mock_subprocess.side_effect = fake_subprocess_run
-
-        # Blank sheets get small PNGs, valid sheets get large PNGs
-        def _mixed_size_effect(svg_path, png_path, max_size_px=3000):
-            blank_sheets = {"dac", "mcu"}
-            stem = svg_path.stem if hasattr(svg_path, "stem") else Path(svg_path).stem
-            if stem in blank_sheets:
-                png_path.write_bytes(b"\x00" * 30_000)  # below threshold
-            else:
-                png_path.write_bytes(b"\x00" * 150_000)  # above threshold
-            return (True, "", 2000, 1500)
-
-        mock_svg_to_png.side_effect = _mixed_size_effect
+        mock_svg_to_png.side_effect = _svg_to_png_side_effect()
 
         gen = ReportFigureGenerator()
         with caplog.at_level(logging.WARNING):
@@ -617,6 +624,12 @@ class TestBlankSchematicDetection:
         # Warnings logged for blank sheets
         assert "dac" in caplog.text
         assert "mcu" in caplog.text
+
+        # PNG conversion should only be called for the two valid sheets
+        assert mock_svg_to_png.call_count == 2
+
+        # Summary warning should be logged
+        assert "Excluded 2 of 4 schematic sheets as blank" in caplog.text
 
     @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
     @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
@@ -632,7 +645,7 @@ class TestBlankSchematicDetection:
         mock_cairosvg,
         tmp_path,
     ):
-        """A schematic PNG at or above the threshold is included normally."""
+        """A schematic SVG at or above the threshold is included normally."""
         pcb = tmp_path / "board.kicad_pcb"
         pcb.touch()
         sch = tmp_path / "main.kicad_sch"
@@ -644,14 +657,15 @@ class TestBlankSchematicDetection:
         def fake_subprocess_run(cmd, **kwargs):
             output_idx = cmd.index("--output") + 1
             svg_dir = Path(cmd[output_idx])
-            (svg_dir / "valid_sheet.svg").write_text("<svg/>")
+            # Write an SVG exactly at the threshold -- should be included
+            _write_svg_stub(
+                svg_dir / "valid_sheet.svg",
+                size_bytes=_BLANK_SVG_THRESHOLD_BYTES,
+            )
             return MagicMock(returncode=0, stderr="")
 
         mock_subprocess.side_effect = fake_subprocess_run
-        # Write a PNG exactly at the threshold
-        mock_svg_to_png.side_effect = _svg_to_png_side_effect(
-            size_bytes=_BLANK_PNG_THRESHOLD_BYTES
-        )
+        mock_svg_to_png.side_effect = _svg_to_png_side_effect()
 
         gen = ReportFigureGenerator()
         entries = gen.generate_all(pcb, sch, out_dir)
@@ -687,12 +701,12 @@ class TestBlankSchematicDetection:
         def fake_subprocess_run(cmd, **kwargs):
             output_idx = cmd.index("--output") + 1
             svg_dir = Path(cmd[output_idx])
-            (svg_dir / "sheet_a.svg").write_text("<svg/>")
-            (svg_dir / "sheet_b.svg").write_text("<svg/>")
+            _write_svg_stub(svg_dir / "sheet_a.svg", size_bytes=_BLANK_SVG_SIZE)
+            _write_svg_stub(svg_dir / "sheet_b.svg", size_bytes=_BLANK_SVG_SIZE)
             return MagicMock(returncode=0, stderr="")
 
         mock_subprocess.side_effect = fake_subprocess_run
-        mock_svg_to_png.side_effect = _svg_to_png_side_effect(size_bytes=10_000)
+        mock_svg_to_png.side_effect = _svg_to_png_side_effect()
 
         gen = ReportFigureGenerator()
         with caplog.at_level(logging.WARNING):
@@ -706,6 +720,53 @@ class TestBlankSchematicDetection:
         # Warnings for both sheets
         assert "sheet_a" in caplog.text
         assert "sheet_b" in caplog.text
+
+        # PNG conversion should NOT have been called at all
+        mock_svg_to_png.assert_not_called()
+
+        # Summary warning should be logged
+        assert "Excluded 2 of 2 schematic sheets as blank" in caplog.text
+
+    @patch("kicad_tools.report.figures._check_cairosvg", return_value=True)
+    @patch("kicad_tools.report.figures.find_kicad_cli", return_value=Path("/usr/bin/kicad-cli"))
+    @patch("kicad_tools.report.figures.subprocess.run")
+    @patch("kicad_tools.report.figures._svg_to_png")
+    @patch("kicad_tools.report.figures.screenshot_board")
+    def test_summary_warning_logged(
+        self,
+        mock_board,
+        mock_svg_to_png,
+        mock_subprocess,
+        mock_find_cli,
+        mock_cairosvg,
+        tmp_path,
+        caplog,
+    ):
+        """Summary warning is logged after the loop when sheets are excluded."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.touch()
+        sch = tmp_path / "main.kicad_sch"
+        sch.touch()
+        out_dir = tmp_path / "figures"
+
+        mock_board.return_value = _make_success_result()
+
+        def fake_subprocess_run(cmd, **kwargs):
+            output_idx = cmd.index("--output") + 1
+            svg_dir = Path(cmd[output_idx])
+            _write_svg_stub(svg_dir / "blank.svg", size_bytes=_BLANK_SVG_SIZE)
+            _write_svg_stub(svg_dir / "valid1.svg", size_bytes=_VALID_SVG_SIZE)
+            _write_svg_stub(svg_dir / "valid2.svg", size_bytes=_VALID_SVG_SIZE)
+            return MagicMock(returncode=0, stderr="")
+
+        mock_subprocess.side_effect = fake_subprocess_run
+        mock_svg_to_png.side_effect = _svg_to_png_side_effect()
+
+        gen = ReportFigureGenerator()
+        with caplog.at_level(logging.WARNING):
+            gen.generate_all(pcb, sch, out_dir)
+
+        assert "Excluded 1 of 3 schematic sheets as blank" in caplog.text
 
 
 class TestReportPackageInit:


### PR DESCRIPTION
## Summary
Switch blank schematic sheet detection from a fragile PNG file-size threshold (60KB) to a more reliable SVG file-size threshold (150KB). SVG size provides a much wider margin between blank title-block-only sheets (~93KB) and sheets with actual content (~436KB+). The check now runs before PNG conversion, saving compute for blank sheets.

## Changes
- Replace `_BLANK_PNG_THRESHOLD_BYTES` (60KB) with `_BLANK_SVG_THRESHOLD_BYTES` (150KB) in `figures.py`
- Check `svg_file.stat().st_size` before calling `_svg_to_png()`, skipping PNG conversion for blank sheets
- Add summary warning after the loop (e.g., "Excluded 2 of 4 schematic sheets as blank")
- Update all tests in `TestBlankSchematicDetection` to use SVG-size-based detection
- Add new test `test_summary_warning_logged` verifying the summary warning message
- Add assertions that `_svg_to_png` is not called for blank sheets
- Update all `fake_subprocess_run` helpers to write SVG stubs with realistic sizes

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Blank sheets detected using SVG file size with `_BLANK_SVG_THRESHOLD_BYTES` constant | PASS | New constant at 150KB, checked before PNG conversion |
| WARNING logged for each excluded blank sheet with sheet name and SVG size | PASS | Log message includes sheet stem, SVG size, and threshold |
| Summary warning logged after loop | PASS | "Excluded N of M schematic sheets as blank" logged; tested in `test_summary_warning_logged` |
| Blank sheets excluded from manifest and PNG conversion skipped | PASS | `continue` before `_svg_to_png()`; verified by `mock_svg_to_png.assert_not_called()` |
| Valid sheets above threshold still included | PASS | `test_valid_sheet_above_threshold_included` passes with SVG at exact threshold |
| Old PNG threshold removed | PASS | `_BLANK_PNG_THRESHOLD_BYTES` constant and all PNG-size checking code removed |

## Test Plan
All 23 tests in `tests/test_report_figures.py` pass, including updated blank detection tests and new summary warning test.

Closes #2025