### PR TITLE
feat(route): add exit code epilog, fix consumer handling, disambiguate SIGINT

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -1108,16 +1108,23 @@ def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
                 message="Routing completed successfully",
                 output_file=output_file if output_file.exists() else None,
             )
-        elif result.returncode == 2:
-            # Exit code 2 = partial routing (some nets routed, some skipped).
-            # When pour nets (GND, +3.3V, etc.) are auto-skipped for zone fill,
-            # the router reports partial completion even though all signal nets
-            # routed successfully.  Treat this as success so the build pipeline
-            # continues to verification.
+        elif result.returncode in (2, 3, 4, 5):
+            # Exit codes 2-5 all produce usable output files:
+            #   2 = partial routing below --min-completion threshold
+            #   3 = routing meets threshold but DRC violations remain
+            #   4 = partial routing with segment-segment clearance violations
+            #   5 = interrupted by SIGINT with partial results saved
+            # Treat as non-fatal so the build pipeline continues to verification.
+            _route_warning_messages = {
+                2: "Routing completed (some nets skipped for zone fill)",
+                3: "Routing complete but DRC violations remain",
+                4: "Partial routing with clearance violations",
+                5: "Routing interrupted by user, partial results saved",
+            }
             return BuildResult(
                 step="route",
                 success=True,
-                message="Routing completed (some nets skipped for zone fill)",
+                message=_route_warning_messages[result.returncode],
                 output_file=output_file if output_file.exists() else None,
             )
         else:

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -541,8 +541,12 @@ def _run_subprocess_step(
 
         if result.returncode == 0:
             return True, "completed successfully"
-        elif result.returncode == 2:
-            # Some commands use exit code 2 for partial success (e.g., DRC-only failures)
+        elif result.returncode in (2, 3, 4, 5):
+            # Exit codes 2-5 indicate usable output exists:
+            #   2 = partial routing below threshold
+            #   3 = routing meets threshold but DRC violations remain
+            #   4 = partial routing with segment-segment clearance violations
+            #   5 = interrupted by SIGINT with partial results saved
             return True, "completed with warnings"
         else:
             error_msg = result.stderr.strip() if result.stderr else f"exit code {result.returncode}"

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -58,6 +58,7 @@ import logging
 import math
 import signal
 import sys
+import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -138,9 +139,10 @@ def _handle_interrupt(signum, frame):
         print("\n\n⚠ Interrupt received! Saving partial results...")
     # Save partial results immediately
     saved = _save_partial_results()
-    # Exit with code 2 to indicate partial results (interruption with saved output)
-    # Code 2 is shared with partial routing completion — both mean "some useful output exists"
-    sys.exit(2 if saved else 130)  # 130 = 128 + SIGINT (2)
+    # Exit with code 5 to indicate SIGINT interruption with saved partial results.
+    # This is distinct from code 2 (partial routing below threshold) so scripts can
+    # distinguish user-interrupted from router-decided-partial.
+    sys.exit(5 if saved else 130)  # 130 = 128 + SIGINT (2)
 
 
 def _save_partial_results() -> bool:
@@ -1941,6 +1943,16 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="kicad-tools route",
         description="Autoroute a KiCad PCB file",
+        epilog=textwrap.dedent("""\
+            exit codes:
+              0  all nets routed (or meets --min-completion), DRC clean
+              1  fatal failure -- no nets routed
+              2  partial routing -- below --min-completion threshold
+              3  routing meets threshold but DRC violations remain
+              4  partial routing AND segment-segment clearance violations
+              5  interrupted by SIGINT with partial results saved
+        """),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("pcb", help="Path to .kicad_pcb file")
     parser.add_argument(
@@ -3613,9 +3625,9 @@ def main(argv: list[str] | None = None) -> int:
     # 0 = Routing meets --min-completion threshold AND (DRC passed OR DRC not run)
     # 1 = Fatal failure — no nets routed, no useful output
     # 2 = Partial routing — some nets routed but below --min-completion threshold
-    #     (also used for SIGINT partial save, handled earlier in the function)
     # 3 = Meets threshold but DRC violations detected (includes seg-seg violations)
     # 4 = Seg-seg clearance violations remain AND routing is below threshold (Issue #1666)
+    # 5 = Interrupted by SIGINT with partial results saved (handled in _handle_interrupt)
     #
     # The --min-completion flag (default 0.95) controls the success threshold.
     # With --min-completion 0.80, routing 85% of nets returns exit code 0.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3239,7 +3239,7 @@ def main(argv: list[str] | None = None) -> int:
         # Check if interrupted and save partial results
         if _interrupt_state["interrupted"]:
             _save_partial_results()
-            return 2  # Exit code 2 indicates interruption with partial results saved
+            return 5  # Exit code 5 indicates interruption with partial results saved
 
         # Cache the routing result (if caching enabled and routing succeeded)
         if use_cache and cache_key is not None and router.routes:

--- a/tests/test_route_exit_codes.py
+++ b/tests/test_route_exit_codes.py
@@ -1,12 +1,12 @@
-"""Tests for route command exit codes (issue #1301, #1413, #1454, #1946).
+"""Tests for route command exit codes (issue #1301, #1413, #1454, #1946, #2018).
 
 Exit code semantics (updated for --min-completion threshold support):
   0 = Routing meets --min-completion threshold AND (DRC passed OR DRC not run)
   1 = Fatal failure -- no nets routed, no useful output
   2 = Partial routing -- some nets routed but below --min-completion threshold
-      (also used for SIGINT partial save)
   3 = Meets threshold but DRC violations detected (includes seg-seg violations)
   4 = Below threshold AND seg-seg clearance violations remain (Issue #1666)
+  5 = Interrupted by SIGINT with partial results saved
 """
 
 from io import StringIO
@@ -591,3 +591,216 @@ class TestPartialRoutingSuggestions:
         suggestions = result.get("suggestions", [])
         mc_suggestions = [s for s in suggestions if "monte-carlo" in s.get("fix", "")]
         assert len(mc_suggestions) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Exit code epilog in --help output (issue #2018)
+# ---------------------------------------------------------------------------
+
+
+class TestRouteExitCodeEpilog:
+    """Verify that exit codes are documented in --help output."""
+
+    def test_help_epilog_documents_all_exit_codes(self):
+        """The argparse epilog lists all exit codes 0-5."""
+        import argparse
+
+        from kicad_tools.cli import route_cmd
+
+        # Build the parser and check its epilog
+        # We need to capture the help output to verify epilog is included
+        with patch("sys.argv", ["kicad-tools", "route", "--help"]):
+            try:
+                result = route_cmd.main(["--help"])
+            except SystemExit:
+                pass  # --help causes SystemExit(0)
+
+        # Directly inspect the parser's epilog by constructing it the same way
+        parser = argparse.ArgumentParser(
+            prog="kicad-tools route",
+            description="Autoroute a KiCad PCB file",
+        )
+        # The real parser is created inside main(), so we check the source
+        import inspect
+        source = inspect.getsource(route_cmd.main)
+        assert "epilog=" in source, "Parser must have an epilog argument"
+
+    def test_help_epilog_contains_each_exit_code(self):
+        """The epilog text documents each individual exit code."""
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        source = inspect.getsource(route_cmd.main)
+        # Verify all six exit codes are documented in the epilog
+        for code in range(6):
+            assert f"  {code}  " in source, (
+                f"Exit code {code} must be documented in the parser epilog"
+            )
+
+    def test_help_epilog_mentions_sigint(self):
+        """The epilog documents that exit code 5 is for SIGINT interruption."""
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        source = inspect.getsource(route_cmd.main)
+        assert "SIGINT" in source, "Epilog must mention SIGINT for exit code 5"
+
+    def test_parser_uses_raw_description_formatter(self):
+        """Parser uses RawDescriptionHelpFormatter so epilog whitespace is preserved."""
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        source = inspect.getsource(route_cmd.main)
+        assert "RawDescriptionHelpFormatter" in source, (
+            "Parser must use RawDescriptionHelpFormatter for epilog formatting"
+        )
+
+
+# ---------------------------------------------------------------------------
+# SIGINT exit code disambiguation (issue #2018)
+# ---------------------------------------------------------------------------
+
+
+class TestSigintExitCode:
+    """Verify that SIGINT uses exit code 5, distinct from code 2."""
+
+    def test_sigint_handler_uses_exit_code_5(self):
+        """The SIGINT handler exits with code 5 when partial results are saved."""
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        source = inspect.getsource(route_cmd._handle_interrupt)
+        assert "sys.exit(5" in source, (
+            "SIGINT handler must use exit code 5 for saved partial results"
+        )
+
+    def test_sigint_handler_falls_back_to_130(self):
+        """The SIGINT handler exits with 130 when no partial results could be saved."""
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        source = inspect.getsource(route_cmd._handle_interrupt)
+        assert "130" in source, (
+            "SIGINT handler must fall back to 130 (128 + SIGINT) when save fails"
+        )
+
+    def test_sigint_exit_code_distinct_from_partial(self):
+        """Exit code 5 (SIGINT) is distinct from exit code 2 (partial routing)."""
+        # Verify the SIGINT handler doesn't use code 2
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        source = inspect.getsource(route_cmd._handle_interrupt)
+        assert "sys.exit(2" not in source, (
+            "SIGINT handler must NOT use exit code 2 (that is for partial routing)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Consumer exit code handling tests (issue #2018)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCmdExitCodeHandling:
+    """Verify build_cmd.py handles route exit codes 3, 4, and 5 as non-fatal."""
+
+    def test_build_cmd_treats_exit_3_as_success(self):
+        """build_cmd treats exit code 3 (DRC violations) as non-fatal."""
+        import inspect
+
+        from kicad_tools.cli import build_cmd
+
+        source = inspect.getsource(build_cmd)
+        # The returncode check should include 3
+        assert "result.returncode in (2, 3, 4, 5)" in source, (
+            "build_cmd must handle exit codes 2, 3, 4, and 5 as non-fatal"
+        )
+
+    def test_build_cmd_treats_exit_4_as_success(self):
+        """build_cmd treats exit code 4 (partial + seg-seg) as non-fatal."""
+        import inspect
+
+        from kicad_tools.cli import build_cmd
+
+        source = inspect.getsource(build_cmd)
+        assert "4" in source, "build_cmd must handle exit code 4"
+
+    def test_build_cmd_has_distinct_messages_per_code(self):
+        """build_cmd provides distinct warning messages for each exit code."""
+        import inspect
+
+        from kicad_tools.cli import build_cmd
+
+        source = inspect.getsource(build_cmd)
+        assert "DRC violations remain" in source, (
+            "build_cmd must have a message for exit code 3 (DRC violations)"
+        )
+        assert "clearance violations" in source, (
+            "build_cmd must have a message for exit code 4 (clearance violations)"
+        )
+        assert "interrupted" in source.lower(), (
+            "build_cmd must have a message for exit code 5 (SIGINT)"
+        )
+
+
+class TestPipelineCmdExitCodeHandling:
+    """Verify pipeline_cmd.py handles route exit codes 3, 4, and 5 as non-fatal."""
+
+    def test_pipeline_cmd_treats_exit_3_as_success(self):
+        """pipeline_cmd treats exit code 3 as completed with warnings."""
+        import inspect
+
+        from kicad_tools.cli import pipeline_cmd
+
+        source = inspect.getsource(pipeline_cmd._run_subprocess_step)
+        assert "result.returncode in (2, 3, 4, 5)" in source, (
+            "pipeline_cmd must handle exit codes 2, 3, 4, and 5 as non-fatal"
+        )
+
+    def test_pipeline_cmd_returns_true_for_codes_2_through_5(self):
+        """pipeline_cmd returns success=True for exit codes 2, 3, 4, and 5."""
+        import subprocess
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from kicad_tools.cli.pipeline_cmd import _run_subprocess_step
+
+        for code in (2, 3, 4, 5):
+            mock_result = MagicMock()
+            mock_result.returncode = code
+            mock_result.stderr = ""
+
+            with patch("kicad_tools.cli.pipeline_cmd.subprocess.run", return_value=mock_result):
+                success, msg = _run_subprocess_step(
+                    cmd=["kct", "route", "test.kicad_pcb"],
+                    cwd=Path("/tmp"),
+                )
+                assert success is True, (
+                    f"Exit code {code} should be treated as success, got failure"
+                )
+                assert "warnings" in msg, (
+                    f"Exit code {code} message should mention warnings, got: {msg}"
+                )
+
+    def test_pipeline_cmd_returns_false_for_code_1(self):
+        """pipeline_cmd returns success=False for exit code 1 (fatal failure)."""
+        from pathlib import Path
+
+        from kicad_tools.cli.pipeline_cmd import _run_subprocess_step
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "fatal error"
+
+        with patch("kicad_tools.cli.pipeline_cmd.subprocess.run", return_value=mock_result):
+            success, msg = _run_subprocess_step(
+                cmd=["kct", "route", "test.kicad_pcb"],
+                cwd=Path("/tmp"),
+            )
+            assert success is False, "Exit code 1 should be treated as failure"

--- a/tests/test_route_exit_codes.py
+++ b/tests/test_route_exit_codes.py
@@ -167,8 +167,11 @@ class TestRouteExitCodeLogic:
                     for seg_seg in [0, 3]:
                         for min_comp in [0.0, 0.5, 0.95, 1.0]:
                             exit_code = self._compute_exit_code(
-                                nets_routed, nets_to_route, drc_errors,
-                                min_completion=min_comp, seg_seg_violations=seg_seg,
+                                nets_routed,
+                                nets_to_route,
+                                drc_errors,
+                                min_completion=min_comp,
+                                seg_seg_violations=seg_seg,
                             )
                             assert exit_code in valid_exit_codes, (
                                 f"Unexpected exit code {exit_code} for "
@@ -257,16 +260,22 @@ class TestRouteExitCodeLogic:
     def test_seg_seg_violations_above_threshold_return_3(self):
         """Seg-seg violations when above threshold return exit 3 (DRC failure)."""
         exit_code = self._compute_exit_code(
-            nets_routed=20, nets_to_route=20, drc_errors=0,
-            min_completion=0.95, seg_seg_violations=5,
+            nets_routed=20,
+            nets_to_route=20,
+            drc_errors=0,
+            min_completion=0.95,
+            seg_seg_violations=5,
         )
         assert exit_code == 3, "Seg-seg violations above threshold should return 3"
 
     def test_seg_seg_violations_below_threshold_return_4(self):
         """Seg-seg violations when below threshold return exit 4."""
         exit_code = self._compute_exit_code(
-            nets_routed=10, nets_to_route=20, drc_errors=0,
-            min_completion=0.95, seg_seg_violations=5,
+            nets_routed=10,
+            nets_to_route=20,
+            drc_errors=0,
+            min_completion=0.95,
+            seg_seg_violations=5,
         )
         assert exit_code == 4, "Seg-seg violations below threshold should return 4"
 
@@ -275,18 +284,22 @@ class TestRouteExitCodeLogic:
         # Previously this returned 4 even when the real issue was partial routing.
         # Now exit 4 explicitly means both partial AND seg-seg violations.
         exit_code = self._compute_exit_code(
-            nets_routed=17, nets_to_route=20, drc_errors=0,
-            min_completion=0.95, seg_seg_violations=3,
+            nets_routed=17,
+            nets_to_route=20,
+            drc_errors=0,
+            min_completion=0.95,
+            seg_seg_violations=3,
         )
-        assert exit_code == 4, (
-            "Below threshold with seg-seg violations should return 4"
-        )
+        assert exit_code == 4, "Below threshold with seg-seg violations should return 4"
 
     def test_seg_seg_above_threshold_with_drc_errors_returns_3(self):
         """Above threshold with both DRC errors and seg-seg violations returns 3."""
         exit_code = self._compute_exit_code(
-            nets_routed=20, nets_to_route=20, drc_errors=5,
-            min_completion=0.95, seg_seg_violations=3,
+            nets_routed=20,
+            nets_to_route=20,
+            drc_errors=5,
+            min_completion=0.95,
+            seg_seg_violations=3,
         )
         assert exit_code == 3, "Above threshold with violations should return 3"
 
@@ -355,9 +368,7 @@ class TestRouteExitCodeDocumentation:
         assert "min_completion" in source, (
             "route_cmd.main() must reference min_completion in exit code logic"
         )
-        assert "meets_threshold" in source, (
-            "route_cmd.main() must use meets_threshold variable"
-        )
+        assert "meets_threshold" in source, "route_cmd.main() must use meets_threshold variable"
 
 
 # ---------------------------------------------------------------------------
@@ -601,61 +612,45 @@ class TestPartialRoutingSuggestions:
 class TestRouteExitCodeEpilog:
     """Verify that exit codes are documented in --help output."""
 
-    def test_help_epilog_documents_all_exit_codes(self):
-        """The argparse epilog lists all exit codes 0-5."""
-        import argparse
+    @staticmethod
+    def _capture_help_text():
+        """Capture the actual --help output from route_cmd.main()."""
+        import contextlib
+        from io import StringIO
 
         from kicad_tools.cli import route_cmd
 
-        # Build the parser and check its epilog
-        # We need to capture the help output to verify epilog is included
-        with patch("sys.argv", ["kicad-tools", "route", "--help"]):
-            try:
-                result = route_cmd.main(["--help"])
-            except SystemExit:
-                pass  # --help causes SystemExit(0)
+        help_text = StringIO()
+        with patch("sys.stdout", help_text), contextlib.suppress(SystemExit):
+            route_cmd.main(["--help"])
+        return help_text.getvalue()
 
-        # Directly inspect the parser's epilog by constructing it the same way
-        parser = argparse.ArgumentParser(
-            prog="kicad-tools route",
-            description="Autoroute a KiCad PCB file",
-        )
-        # The real parser is created inside main(), so we check the source
-        import inspect
-        source = inspect.getsource(route_cmd.main)
-        assert "epilog=" in source, "Parser must have an epilog argument"
+    def test_help_output_contains_exit_codes_section(self):
+        """The --help output contains an 'exit codes' section."""
+        text = self._capture_help_text()
+        assert "exit codes:" in text, "Help output must contain an 'exit codes:' section"
 
-    def test_help_epilog_contains_each_exit_code(self):
-        """The epilog text documents each individual exit code."""
-        import inspect
-
-        from kicad_tools.cli import route_cmd
-
-        source = inspect.getsource(route_cmd.main)
-        # Verify all six exit codes are documented in the epilog
+    def test_help_output_documents_each_exit_code(self):
+        """The --help output documents each individual exit code 0-5."""
+        text = self._capture_help_text()
         for code in range(6):
-            assert f"  {code}  " in source, (
-                f"Exit code {code} must be documented in the parser epilog"
+            assert f"  {code}  " in text, (
+                f"Exit code {code} must be documented in the --help output"
             )
 
-    def test_help_epilog_mentions_sigint(self):
-        """The epilog documents that exit code 5 is for SIGINT interruption."""
-        import inspect
+    def test_help_output_mentions_sigint(self):
+        """The --help output documents that exit code 5 is for SIGINT interruption."""
+        text = self._capture_help_text()
+        assert "SIGINT" in text, "Help output must mention SIGINT for exit code 5"
 
-        from kicad_tools.cli import route_cmd
-
-        source = inspect.getsource(route_cmd.main)
-        assert "SIGINT" in source, "Epilog must mention SIGINT for exit code 5"
-
-    def test_parser_uses_raw_description_formatter(self):
-        """Parser uses RawDescriptionHelpFormatter so epilog whitespace is preserved."""
-        import inspect
-
-        from kicad_tools.cli import route_cmd
-
-        source = inspect.getsource(route_cmd.main)
-        assert "RawDescriptionHelpFormatter" in source, (
-            "Parser must use RawDescriptionHelpFormatter for epilog formatting"
+    def test_help_preserves_epilog_formatting(self):
+        """The --help output preserves multi-line exit code formatting (not collapsed)."""
+        text = self._capture_help_text()
+        # With RawDescriptionHelpFormatter, each exit code is on its own line.
+        # Without it, argparse would collapse the whitespace.
+        lines_with_codes = [line for line in text.splitlines() if "fatal failure" in line]
+        assert len(lines_with_codes) == 1, (
+            "Exit code descriptions should be on separate lines (not collapsed)"
         )
 
 
@@ -667,39 +662,48 @@ class TestRouteExitCodeEpilog:
 class TestSigintExitCode:
     """Verify that SIGINT uses exit code 5, distinct from code 2."""
 
-    def test_sigint_handler_uses_exit_code_5(self):
+    def test_sigint_handler_exits_5_when_results_saved(self):
         """The SIGINT handler exits with code 5 when partial results are saved."""
-        import inspect
+        import signal
 
-        from kicad_tools.cli import route_cmd
+        from kicad_tools.cli.route_cmd import _handle_interrupt, _interrupt_state
 
-        source = inspect.getsource(route_cmd._handle_interrupt)
-        assert "sys.exit(5" in source, (
-            "SIGINT handler must use exit code 5 for saved partial results"
-        )
+        # Set up state so _save_partial_results returns True
+        with patch("kicad_tools.cli.route_cmd._save_partial_results", return_value=True):
+            _interrupt_state["quiet"] = True
+            with pytest.raises(SystemExit) as exc_info:
+                _handle_interrupt(signal.SIGINT, None)
+            assert exc_info.value.code == 5, (
+                f"SIGINT handler should exit with code 5 when results saved, got {exc_info.value.code}"
+            )
 
-    def test_sigint_handler_falls_back_to_130(self):
+    def test_sigint_handler_exits_130_when_save_fails(self):
         """The SIGINT handler exits with 130 when no partial results could be saved."""
-        import inspect
+        import signal
 
-        from kicad_tools.cli import route_cmd
+        from kicad_tools.cli.route_cmd import _handle_interrupt, _interrupt_state
 
-        source = inspect.getsource(route_cmd._handle_interrupt)
-        assert "130" in source, (
-            "SIGINT handler must fall back to 130 (128 + SIGINT) when save fails"
-        )
+        with patch("kicad_tools.cli.route_cmd._save_partial_results", return_value=False):
+            _interrupt_state["quiet"] = True
+            with pytest.raises(SystemExit) as exc_info:
+                _handle_interrupt(signal.SIGINT, None)
+            assert exc_info.value.code == 130, (
+                f"SIGINT handler should exit with code 130 when save fails, got {exc_info.value.code}"
+            )
 
     def test_sigint_exit_code_distinct_from_partial(self):
         """Exit code 5 (SIGINT) is distinct from exit code 2 (partial routing)."""
-        # Verify the SIGINT handler doesn't use code 2
-        import inspect
+        import signal
 
-        from kicad_tools.cli import route_cmd
+        from kicad_tools.cli.route_cmd import _handle_interrupt, _interrupt_state
 
-        source = inspect.getsource(route_cmd._handle_interrupt)
-        assert "sys.exit(2" not in source, (
-            "SIGINT handler must NOT use exit code 2 (that is for partial routing)"
-        )
+        with patch("kicad_tools.cli.route_cmd._save_partial_results", return_value=True):
+            _interrupt_state["quiet"] = True
+            with pytest.raises(SystemExit) as exc_info:
+                _handle_interrupt(signal.SIGINT, None)
+            assert exc_info.value.code != 2, (
+                "SIGINT handler must NOT use exit code 2 (that is for partial routing)"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -710,64 +714,82 @@ class TestSigintExitCode:
 class TestBuildCmdExitCodeHandling:
     """Verify build_cmd.py handles route exit codes 3, 4, and 5 as non-fatal."""
 
-    def test_build_cmd_treats_exit_3_as_success(self):
-        """build_cmd treats exit code 3 (DRC violations) as non-fatal."""
-        import inspect
+    @staticmethod
+    def _run_route_step_with_exit_code(exit_code, tmp_path):
+        """Run _run_step_route with a mocked subprocess returning the given exit code."""
+        from kicad_tools.cli.build_cmd import BuildContext, _run_step_route
 
-        from kicad_tools.cli import build_cmd
+        # Create minimal PCB file so the function reaches the subprocess call
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text('(kicad_pcb (version 20240101) (generator "test"))')
 
-        source = inspect.getsource(build_cmd)
-        # The returncode check should include 3
-        assert "result.returncode in (2, 3, 4, 5)" in source, (
-            "build_cmd must handle exit codes 2, 3, 4, and 5 as non-fatal"
+        mock_result = MagicMock()
+        mock_result.returncode = exit_code
+        mock_result.stderr = ""
+
+        ctx = MagicMock(spec=BuildContext)
+        ctx.project_dir = tmp_path
+        ctx.pcb_file = pcb_file
+        ctx.output_dir = tmp_path
+        ctx.quiet = True
+        ctx.verbose = False
+        ctx.dry_run = False
+        ctx.force = True
+
+        console = MagicMock()
+
+        with patch("kicad_tools.cli.build_cmd.subprocess.run", return_value=mock_result):
+            # Mock _get_routing_params to avoid needing a real spec
+            with patch(
+                "kicad_tools.cli.build_cmd._get_routing_params",
+                return_value=(0.25, 0.2, 0.25, 0.3, 0.6),
+            ):
+                # No route script exists, so it uses kct route subprocess path
+                result = _run_step_route(ctx, console)
+        return result
+
+    def test_build_cmd_treats_exit_codes_2_through_5_as_success(self, tmp_path):
+        """build_cmd treats exit codes 2, 3, 4, and 5 as non-fatal (success=True)."""
+        for code in (2, 3, 4, 5):
+            result = self._run_route_step_with_exit_code(code, tmp_path)
+            assert result.success is True, (
+                f"Exit code {code} should be treated as success, got failure"
+            )
+
+    def test_build_cmd_treats_exit_1_as_failure(self, tmp_path):
+        """build_cmd treats exit code 1 as fatal failure."""
+        result = self._run_route_step_with_exit_code(1, tmp_path)
+        assert result.success is False, "Exit code 1 should be treated as failure"
+
+    def test_build_cmd_has_distinct_messages_per_code(self, tmp_path):
+        """build_cmd provides distinct warning messages for each non-fatal exit code."""
+        messages = {}
+        for code in (2, 3, 4, 5):
+            result = self._run_route_step_with_exit_code(code, tmp_path)
+            messages[code] = result.message
+
+        # Each code should have a unique message
+        assert len(set(messages.values())) == 4, (
+            f"Each exit code should have a distinct message, got: {messages}"
         )
-
-    def test_build_cmd_treats_exit_4_as_success(self):
-        """build_cmd treats exit code 4 (partial + seg-seg) as non-fatal."""
-        import inspect
-
-        from kicad_tools.cli import build_cmd
-
-        source = inspect.getsource(build_cmd)
-        assert "4" in source, "build_cmd must handle exit code 4"
-
-    def test_build_cmd_has_distinct_messages_per_code(self):
-        """build_cmd provides distinct warning messages for each exit code."""
-        import inspect
-
-        from kicad_tools.cli import build_cmd
-
-        source = inspect.getsource(build_cmd)
-        assert "DRC violations remain" in source, (
-            "build_cmd must have a message for exit code 3 (DRC violations)"
+        # Spot-check key phrases in messages
+        assert "DRC violations" in messages[3], (
+            f"Exit code 3 message should mention DRC violations, got: {messages[3]}"
         )
-        assert "clearance violations" in source, (
-            "build_cmd must have a message for exit code 4 (clearance violations)"
+        assert "clearance" in messages[4], (
+            f"Exit code 4 message should mention clearance, got: {messages[4]}"
         )
-        assert "interrupted" in source.lower(), (
-            "build_cmd must have a message for exit code 5 (SIGINT)"
+        assert "interrupt" in messages[5].lower() or "partial" in messages[5].lower(), (
+            f"Exit code 5 message should mention interruption, got: {messages[5]}"
         )
 
 
 class TestPipelineCmdExitCodeHandling:
     """Verify pipeline_cmd.py handles route exit codes 3, 4, and 5 as non-fatal."""
 
-    def test_pipeline_cmd_treats_exit_3_as_success(self):
-        """pipeline_cmd treats exit code 3 as completed with warnings."""
-        import inspect
-
-        from kicad_tools.cli import pipeline_cmd
-
-        source = inspect.getsource(pipeline_cmd._run_subprocess_step)
-        assert "result.returncode in (2, 3, 4, 5)" in source, (
-            "pipeline_cmd must handle exit codes 2, 3, 4, and 5 as non-fatal"
-        )
-
     def test_pipeline_cmd_returns_true_for_codes_2_through_5(self):
         """pipeline_cmd returns success=True for exit codes 2, 3, 4, and 5."""
-        import subprocess
         from pathlib import Path
-        from unittest.mock import patch
 
         from kicad_tools.cli.pipeline_cmd import _run_subprocess_step
 
@@ -804,3 +826,20 @@ class TestPipelineCmdExitCodeHandling:
                 cwd=Path("/tmp"),
             )
             assert success is False, "Exit code 1 should be treated as failure"
+
+    def test_pipeline_cmd_returns_true_for_code_0(self):
+        """pipeline_cmd returns success=True for exit code 0 (full success)."""
+        from pathlib import Path
+
+        from kicad_tools.cli.pipeline_cmd import _run_subprocess_step
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+
+        with patch("kicad_tools.cli.pipeline_cmd.subprocess.run", return_value=mock_result):
+            success, msg = _run_subprocess_step(
+                cmd=["kct", "route", "test.kicad_pcb"],
+                cwd=Path("/tmp"),
+            )
+            assert success is True, "Exit code 0 should be treated as success"


### PR DESCRIPTION
## Summary
Completes the remaining gaps for distinct route exit codes: documents them in --help output, fixes consumers to treat codes 3/4/5 as usable output, and gives SIGINT its own exit code (5) so scripts can distinguish user-interrupted from router-decided-partial routing.

## Changes
- Add epilog to argparse parser in route_cmd.py documenting all exit codes 0-5
- Use RawDescriptionHelpFormatter so the epilog renders correctly
- Change SIGINT handler from exit code 2 to exit code 5
- Update build_cmd.py to treat exit codes 2, 3, 4, and 5 as non-fatal with distinct warning messages
- Update pipeline_cmd.py _run_subprocess_step() to handle codes 2-5 as "completed with warnings"
- Add comprehensive tests for epilog, SIGINT disambiguation, and consumer exit code handling

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Exit codes documented in --help epilog | Pass | epilog= added with codes 0-5, RawDescriptionHelpFormatter used |
| build_cmd handles codes 3 and 4 as non-fatal | Pass | returncode check expanded to (2, 3, 4, 5) with per-code messages |
| pipeline_cmd handles codes 3 and 4 as non-fatal | Pass | returncode check expanded to (2, 3, 4, 5) |
| SIGINT uses distinct exit code | Pass | Changed from sys.exit(2) to sys.exit(5) |
| Tests pass | Pass | 56 tests passed in test_route_exit_codes.py |

## Test Plan
- All 56 tests in tests/test_route_exit_codes.py pass (including new tests for epilog, SIGINT, and consumer handling)
- New tests verify: epilog content, SIGINT code 5 usage, build_cmd and pipeline_cmd handling of codes 2-5

Closes #2018