### PR TITLE
fix(net-status): account for zone fill connectivity in net analysis

### DIFF
--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -55,7 +55,8 @@ class NetStatus:
         connected_pads: List of connected pads
         unconnected_pads: List of unconnected pads
         is_plane_net: Whether this net is connected to a copper zone
-        plane_layer: Layer of the copper zone if is_plane_net
+        plane_layer: Primary layer of the copper zone if is_plane_net
+        plane_layers: All layers with copper zones for this net
         has_routing: Whether this net has any trace segments
         has_vias: Whether this net has any vias
     """
@@ -68,6 +69,7 @@ class NetStatus:
     unconnected_pads: list[PadInfo] = field(default_factory=list)
     is_plane_net: bool = False
     plane_layer: str = ""
+    plane_layers: list[str] = field(default_factory=list)
     has_routing: bool = False
     has_vias: bool = False
 
@@ -132,7 +134,9 @@ class NetStatus:
     def suggested_fix(self) -> str:
         """Suggest fix based on net type."""
         if self.is_plane_net:
-            return f"kct stitch board.kicad_pcb --net {self.net_name}"
+            layers = self.plane_layers or ([self.plane_layer] if self.plane_layer else [])
+            layers_info = ", ".join(layers) if layers else "unknown"
+            return f"kct stitch board.kicad_pcb --net {self.net_name} (zones on {layers_info})"
         return f"Route traces to connect {self.unconnected_count} pads"
 
     def to_dict(self) -> dict:
@@ -149,6 +153,7 @@ class NetStatus:
             "connection_percentage": round(self.connection_percentage, 1),
             "is_plane_net": self.is_plane_net,
             "plane_layer": self.plane_layer,
+            "plane_layers": list(self.plane_layers),
             "has_routing": self.has_routing,
             "has_vias": self.has_vias,
             "suggested_fix": self.suggested_fix if self.status != "complete" else "",
@@ -311,30 +316,30 @@ class NetStatusAnalyzer:
 
         return result
 
-    def _build_zone_net_map(self) -> dict[int, str]:
+    def _build_zone_net_map(self) -> dict[int, list[str]]:
         """Build mapping of net numbers to zone layers.
 
         Returns:
-            Dict mapping net_number to zone layer name
+            Dict mapping net_number to list of zone layer names
         """
-        zone_nets: dict[int, str] = {}
+        zone_nets: dict[int, list[str]] = defaultdict(list)
         for zone in self.pcb.zones:
-            if zone.net_number > 0:
-                zone_nets[zone.net_number] = zone.layer
-        return zone_nets
+            if zone.net_number > 0 and zone.layer not in zone_nets[zone.net_number]:
+                zone_nets[zone.net_number].append(zone.layer)
+        return dict(zone_nets)
 
     def _analyze_net(
         self,
         net_number: int,
         net_name: str,
-        zone_nets: dict[int, str],
+        zone_nets: dict[int, list[str]],
     ) -> NetStatus:
         """Analyze a single net.
 
         Args:
             net_number: Net number
             net_name: Net name
-            zone_nets: Mapping of net numbers to zone layers
+            zone_nets: Mapping of net numbers to zone layer lists
 
         Returns:
             NetStatus for this net
@@ -347,7 +352,8 @@ class NetStatusAnalyzer:
         # Check if this is a plane net
         if net_number in zone_nets:
             status.is_plane_net = True
-            status.plane_layer = zone_nets[net_number]
+            status.plane_layers = zone_nets[net_number]
+            status.plane_layer = zone_nets[net_number][0]
 
         # Check for routing
         segments = list(self.pcb.segments_in_net(net_number))
@@ -480,17 +486,23 @@ class NetStatusAnalyzer:
         # polygons but still within the zone boundary (and thus connected to the zone).
         net_zones: list[tuple[str, list[list[tuple[float, float]]]]] = []
         zone_boundaries: list[tuple[str, list[tuple[float, float]]]] = []
-        zone_points: list[tuple[float, float]] = []
         for zone in self.pcb.zones:
             if zone.net_number == net_number:
-                # Collect boundary polygon (zone outline) for via-in-zone checking
+                # Collect boundary polygon (zone outline) for via-in-zone checking.
+                # If no boundary polygon exists, use the convex hull of filled
+                # polygons as a fallback boundary so that pad-in-zone checks
+                # still work when kicad-cli omits the outline for filled zones.
                 if zone.polygon:
                     zone_boundaries.append((zone.layer, zone.polygon))
-                # Collect filled polygons for sampling and backward compatibility
+                elif zone.filled_polygons:
+                    # Use the bounding box of all filled polygon vertices as a
+                    # conservative fallback boundary.
+                    fallback = self._bounding_box_polygon(zone.filled_polygons)
+                    if fallback:
+                        zone_boundaries.append((zone.layer, fallback))
+                # Collect filled polygons for copper overlap checks
                 if zone.filled_polygons:
                     net_zones.append((zone.layer, zone.filled_polygons))
-                    for poly in zone.filled_polygons:
-                        zone_points.extend(poly)
 
         # Build segment components for reuse
         segment_components = self._build_segment_components(segments)
@@ -558,6 +570,17 @@ class NetStatusAnalyzer:
                             graph[pad].add(other)
                             graph[other].add(pad)
 
+        # Build bounding-box indices for zone polygons to avoid O(n*v) point-in-polygon
+        # checks for zones whose bounding box doesn't contain the query point.
+        boundary_bboxes = [
+            (layer, boundary, self._polygon_bbox(boundary))
+            for layer, boundary in zone_boundaries
+        ]
+        filled_bboxes = [
+            (layer, polys, [self._polygon_bbox(p) for p in polys])
+            for layer, polys in net_zones
+        ]
+
         # Find zone connection points (via positions that touch zones)
         # Check BOTH filled polygons AND zone boundaries because:
         # - Filled polygons have thermal clearance cutouts around pads
@@ -569,19 +592,23 @@ class NetStatusAnalyzer:
         # This catches vias in thermal clearance cutouts that are still in the zone.
         # Use _via_spans_layer to handle through-vias whose layer list is
         # ["F.Cu", "B.Cu"] but which electrically connect all intermediate layers.
-        for zone_layer, boundary in zone_boundaries:
+        for zone_layer, boundary, bbox in boundary_bboxes:
             for via in vias:
                 if not self._via_spans_layer(via.layers, zone_layer):
+                    continue
+                if not self._point_in_bbox(via.position, bbox):
                     continue
                 if self._point_in_polygon(via.position, boundary):
                     zone_connection_points.add(via.position)
 
         # Also check vias against filled polygons (original behavior)
-        for zone_layer, filled_polys in net_zones:
+        for zone_layer, filled_polys, poly_bboxes in filled_bboxes:
             for via in vias:
                 if not self._via_spans_layer(via.layers, zone_layer):
                     continue
-                for poly in filled_polys:
+                for poly, bbox in zip(filled_polys, poly_bboxes):
+                    if not self._point_in_bbox(via.position, bbox):
+                        continue
                     if self._point_in_polygon(via.position, poly):
                         zone_connection_points.add(via.position)
                         break
@@ -602,17 +629,21 @@ class NetStatusAnalyzer:
         for pad_id, pad_pos in pad_positions.items():
             layers = pad_layers.get(pad_id, [])
             # Check zone boundaries (Issue #479 fix)
-            for zone_layer, boundary in zone_boundaries:
+            for zone_layer, boundary, bbox in boundary_bboxes:
                 if not self._pad_layer_matches_zone(layers, zone_layer):
+                    continue
+                if not self._point_in_bbox(pad_pos, bbox):
                     continue
                 if self._point_in_polygon(pad_pos, boundary):
                     zone_connected_pads.add(pad_id)
                     break
             # Also check filled polygons (original behavior)
-            for zone_layer, filled_polys in net_zones:
+            for zone_layer, filled_polys, poly_bboxes in filled_bboxes:
                 if not self._pad_layer_matches_zone(layers, zone_layer):
                     continue
-                for poly in filled_polys:
+                for poly, bbox in zip(filled_polys, poly_bboxes):
+                    if not self._point_in_bbox(pad_pos, bbox):
+                        continue
                     if self._point_in_polygon(pad_pos, poly):
                         zone_connected_pads.add(pad_id)
                         break
@@ -643,10 +674,14 @@ class NetStatusAnalyzer:
                 graph[pad].add(other)
                 graph[other].add(pad)
 
-        # Connect pads at same copper positions (including zones)
+        # Connect pads at same copper positions (segments and vias only).
+        # Zone polygon vertices are NOT sampled here because the pad-to-zone
+        # and via-to-zone polygon containment checks above already handle zone
+        # connectivity properly.  The previous zone_points[:1000] sampling cap
+        # caused false-positive incomplete reports on boards with many filled
+        # polygons (Issue #2035).
         all_copper = [seg.start for seg in segments] + [seg.end for seg in segments]
         all_copper.extend([via.position for via in vias])
-        all_copper.extend(zone_points[:1000])  # Limit zone sampling
 
         for pad_id, pad_pos in pad_positions.items():
             for copper_pos in all_copper:
@@ -839,6 +874,63 @@ class NetStatusAnalyzer:
             if pad_layer.startswith("*.") and zone_layer.endswith(pad_layer[1:]):
                 return True
         return False
+
+    @staticmethod
+    def _polygon_bbox(
+        polygon: list[tuple[float, float]],
+    ) -> tuple[float, float, float, float]:
+        """Compute axis-aligned bounding box of a polygon.
+
+        Returns:
+            (min_x, min_y, max_x, max_y) tuple
+        """
+        xs = [p[0] for p in polygon]
+        ys = [p[1] for p in polygon]
+        return (min(xs), min(ys), max(xs), max(ys))
+
+    @staticmethod
+    def _point_in_bbox(
+        point: tuple[float, float],
+        bbox: tuple[float, float, float, float],
+    ) -> bool:
+        """Fast check whether a point is inside a bounding box.
+
+        Args:
+            point: (x, y) coordinates
+            bbox: (min_x, min_y, max_x, max_y) bounding box
+
+        Returns:
+            True if the point is within the bounding box (inclusive).
+        """
+        return bbox[0] <= point[0] <= bbox[2] and bbox[1] <= point[1] <= bbox[3]
+
+    @staticmethod
+    def _bounding_box_polygon(
+        filled_polygons: list[list[tuple[float, float]]],
+    ) -> list[tuple[float, float]]:
+        """Build a bounding-box rectangle from multiple filled polygons.
+
+        Used as a fallback zone boundary when the zone outline polygon is
+        absent (some KiCad versions omit it for zones that were filled by
+        kicad-cli).
+
+        Args:
+            filled_polygons: List of filled polygon vertex lists.
+
+        Returns:
+            Four-vertex polygon representing the bounding box, or empty list.
+        """
+        all_x: list[float] = []
+        all_y: list[float] = []
+        for poly in filled_polygons:
+            for px, py in poly:
+                all_x.append(px)
+                all_y.append(py)
+        if not all_x:
+            return []
+        min_x, max_x = min(all_x), max(all_x)
+        min_y, max_y = min(all_y), max(all_y)
+        return [(min_x, min_y), (max_x, min_y), (max_x, max_y), (min_x, max_y)]
 
     def _point_in_polygon(
         self,

--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -192,7 +192,9 @@ def _print_net_status(net: NetStatus, verbose: bool, indent: str = "") -> None:
     # Net type indicator
     type_info = ""
     if net.is_plane_net:
-        type_info = f" -- Plane net on {net.plane_layer}"
+        layers = net.plane_layers if net.plane_layers else ([net.plane_layer] if net.plane_layer else [])
+        layers_str = ", ".join(layers) if layers else "unknown"
+        type_info = f" -- Plane net on {layers_str}"
 
     print()
     print(

--- a/tests/test_analysis_net_status.py
+++ b/tests/test_analysis_net_status.py
@@ -1003,3 +1003,436 @@ class TestStitchingViaConnectivity:
         assert gnd is not None
         assert gnd.has_vias is True
         assert gnd.has_routing is True
+
+
+# ---- PCB fixtures for multi-zone and large zone fill tests (Issue #2035) ----
+
+# PCB with zones on multiple layers for the same net.
+# GND has zones on both In1.Cu and B.Cu, connected via through-vias.
+MULTI_ZONE_LAYER_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+
+  (footprint "C_0402"
+    (layer "F.Cu")
+    (at 15 15)
+    (property "Reference" "C1")
+    (pad "2" smd rect (at 0 0.25) (size 0.4 0.4) (layers "F.Cu") (net 1 "GND"))
+  )
+
+  (footprint "C_0402"
+    (layer "F.Cu")
+    (at 25 15)
+    (property "Reference" "C2")
+    (pad "2" smd rect (at 0 0.25) (size 0.4 0.4) (layers "F.Cu") (net 1 "GND"))
+  )
+
+  (segment (start 15 15.25) (end 15 17) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 25 15.25) (end 25 17) (width 0.25) (layer "F.Cu") (net 1))
+
+  (via (at 15 17) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1))
+  (via (at 25 17) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1))
+
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "In1.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.15)
+    (filled_areas_thickness no)
+    (fill yes (thermal_gap 0.2) (thermal_bridge_width 0.2))
+    (polygon
+      (pts
+        (xy 10 10)
+        (xy 30 10)
+        (xy 30 20)
+        (xy 10 20)
+      )
+    )
+    (filled_polygon
+      (layer "In1.Cu")
+      (pts
+        (xy 10 10)
+        (xy 30 10)
+        (xy 30 20)
+        (xy 10 20)
+      )
+    )
+  )
+
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "B.Cu")
+    (uuid "00000000-0000-0000-0000-000000000011")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.15)
+    (filled_areas_thickness no)
+    (fill yes (thermal_gap 0.2) (thermal_bridge_width 0.2))
+    (polygon
+      (pts
+        (xy 10 10)
+        (xy 30 10)
+        (xy 30 20)
+        (xy 10 20)
+      )
+    )
+    (filled_polygon
+      (layer "B.Cu")
+      (pts
+        (xy 10 10)
+        (xy 30 10)
+        (xy 30 20)
+        (xy 10 20)
+      )
+    )
+  )
+)
+"""
+
+
+def _generate_large_zone_pcb(num_filled_polygons: int = 500) -> str:
+    """Generate a PCB with many filled zone polygons to test performance.
+
+    Creates a GND zone with many small filled polygon islands to verify
+    that the zone_points sampling limit removal does not cause false positives
+    and that bounding-box spatial indexing keeps analysis fast.
+    """
+    header = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+
+  (footprint "C_0402"
+    (layer "F.Cu")
+    (at 50 50)
+    (property "Reference" "C1")
+    (pad "2" smd rect (at 0 0.25) (size 0.4 0.4) (layers "F.Cu") (net 1 "GND"))
+  )
+
+  (footprint "C_0402"
+    (layer "F.Cu")
+    (at 150 50)
+    (property "Reference" "C2")
+    (pad "2" smd rect (at 0 0.25) (size 0.4 0.4) (layers "F.Cu") (net 1 "GND"))
+  )
+
+  (segment (start 50 50.25) (end 50 52) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 150 50.25) (end 150 52) (width 0.25) (layer "F.Cu") (net 1))
+
+  (via (at 50 52) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1))
+  (via (at 150 52) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1))
+
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "In1.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.15)
+    (filled_areas_thickness no)
+    (fill yes (thermal_gap 0.2) (thermal_bridge_width 0.2))
+    (polygon
+      (pts
+        (xy 0 0)
+        (xy 200 0)
+        (xy 200 100)
+        (xy 0 100)
+      )
+    )
+"""
+    # Generate many filled polygons (small tiles across the zone)
+    filled_parts = []
+    cols = int(num_filled_polygons**0.5) + 1
+    for i in range(num_filled_polygons):
+        row = i // cols
+        col = i % cols
+        x = col * 2
+        y = row * 2
+        filled_parts.append(
+            f"""    (filled_polygon
+      (layer "In1.Cu")
+      (pts
+        (xy {x} {y})
+        (xy {x + 1.5} {y})
+        (xy {x + 1.5} {y + 1.5})
+        (xy {x} {y + 1.5})
+      )
+    )"""
+        )
+
+    footer = """  )
+)
+"""
+    return header + "\n".join(filled_parts) + "\n" + footer
+
+
+# PCB with zone that has filled_polygon data but no boundary polygon.
+# This tests the fallback boundary detection using bounding box.
+ZONE_NO_BOUNDARY_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+
+  (footprint "R_0805"
+    (layer "F.Cu")
+    (at 15 15)
+    (property "Reference" "R1")
+    (pad "1" thru_hole rect (at 0 0) (size 1.2 1.2) (drill 0.6) (layers "*.Cu") (net 1 "GND"))
+  )
+
+  (footprint "R_0805"
+    (layer "F.Cu")
+    (at 25 15)
+    (property "Reference" "R2")
+    (pad "1" thru_hole rect (at 0 0) (size 1.2 1.2) (drill 0.6) (layers "*.Cu") (net 1 "GND"))
+  )
+
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "In1.Cu")
+    (uuid "00000000-0000-0000-0000-000000000030")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.15)
+    (filled_areas_thickness no)
+    (fill yes (thermal_gap 0.2) (thermal_bridge_width 0.2))
+    (filled_polygon
+      (layer "In1.Cu")
+      (pts
+        (xy 10 10)
+        (xy 30 10)
+        (xy 30 20)
+        (xy 10 20)
+      )
+    )
+  )
+)
+"""
+
+
+@pytest.fixture
+def multi_zone_layer_pcb(tmp_path: Path) -> Path:
+    """Create a PCB with zones on multiple layers for the same net."""
+    pcb_file = tmp_path / "multi_zone.kicad_pcb"
+    pcb_file.write_text(MULTI_ZONE_LAYER_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def large_zone_pcb(tmp_path: Path) -> Path:
+    """Create a PCB with many filled zone polygons."""
+    pcb_file = tmp_path / "large_zone.kicad_pcb"
+    pcb_file.write_text(_generate_large_zone_pcb(500))
+    return pcb_file
+
+
+@pytest.fixture
+def zone_no_boundary_pcb(tmp_path: Path) -> Path:
+    """Create a PCB with zone that has no boundary polygon."""
+    pcb_file = tmp_path / "no_boundary.kicad_pcb"
+    pcb_file.write_text(ZONE_NO_BOUNDARY_PCB)
+    return pcb_file
+
+
+class TestMultiZoneConnectivity:
+    """Tests for zone fill connectivity improvements (Issue #2035).
+
+    These tests cover:
+    - Multiple zone layers per net reporting all layers
+    - Large zone fills (>1000 polygon vertices) without false positives
+    - Zones with missing boundary polygons (filled_polygon only)
+    - Performance with many filled polygons
+    """
+
+    def test_multi_zone_layers_reported(self, multi_zone_layer_pcb: Path):
+        """Net with zones on multiple layers reports all zone layers."""
+        analyzer = NetStatusAnalyzer(multi_zone_layer_pcb)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.is_plane_net is True
+        assert len(gnd.plane_layers) == 2
+        assert "In1.Cu" in gnd.plane_layers
+        assert "B.Cu" in gnd.plane_layers
+        # Backward compat: plane_layer returns first layer
+        assert gnd.plane_layer in ("In1.Cu", "B.Cu")
+
+    def test_multi_zone_complete(self, multi_zone_layer_pcb: Path):
+        """Net with zones on multiple layers is complete when vias connect."""
+        analyzer = NetStatusAnalyzer(multi_zone_layer_pcb)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.status == "complete", (
+            f"GND should be complete but is {gnd.status}; "
+            f"unconnected: {[p.full_name for p in gnd.unconnected_pads]}"
+        )
+
+    def test_multi_zone_to_dict_includes_plane_layers(self, multi_zone_layer_pcb: Path):
+        """to_dict includes both plane_layer and plane_layers."""
+        analyzer = NetStatusAnalyzer(multi_zone_layer_pcb)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        d = gnd.to_dict()
+        assert "plane_layer" in d
+        assert "plane_layers" in d
+        assert len(d["plane_layers"]) == 2
+        assert d["plane_layer"] in d["plane_layers"]
+
+    def test_multi_zone_suggested_fix_shows_all_layers(self):
+        """Suggested fix for plane net shows all zone layers."""
+        status = NetStatus(
+            net_number=1,
+            net_name="GND",
+            is_plane_net=True,
+            plane_layer="In1.Cu",
+            plane_layers=["In1.Cu", "B.Cu"],
+            total_pads=2,
+            unconnected_pads=[PadInfo("C1", "2", (15, 15), False)],
+        )
+        assert "In1.Cu" in status.suggested_fix
+        assert "B.Cu" in status.suggested_fix
+
+    def test_large_zone_no_false_positives(self, large_zone_pcb: Path):
+        """Board with 500+ filled polygons does not produce false positives.
+
+        Previously, the zone_points[:1000] sampling cap could miss zone
+        connectivity when zone polygon vertices exceeded the limit.
+        """
+        analyzer = NetStatusAnalyzer(large_zone_pcb)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.is_plane_net is True
+        assert gnd.status == "complete", (
+            f"GND should be complete but is {gnd.status}; "
+            f"unconnected: {[p.full_name for p in gnd.unconnected_pads]}"
+        )
+
+    def test_large_zone_performance(self, large_zone_pcb: Path):
+        """Analysis of board with 500+ filled polygons completes in <5s."""
+        import time
+
+        analyzer = NetStatusAnalyzer(large_zone_pcb)
+        start = time.monotonic()
+        result = analyzer.analyze()
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 5.0, f"Analysis took {elapsed:.2f}s (limit: 5s)"
+        assert result.total_nets >= 1
+
+    def test_zone_no_boundary_polygon(self, zone_no_boundary_pcb: Path):
+        """Zone with no boundary polygon (only filled_polygon) detects pads.
+
+        When kicad-cli omits the zone outline for filled zones, the
+        bounding-box fallback boundary should still detect pad connectivity.
+        """
+        analyzer = NetStatusAnalyzer(zone_no_boundary_pcb)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.is_plane_net is True
+        assert gnd.status == "complete", (
+            f"GND should be complete but is {gnd.status}; "
+            f"unconnected: {[p.full_name for p in gnd.unconnected_pads]}"
+        )
+
+    def test_bounding_box_polygon_helper(self):
+        """Test _bounding_box_polygon helper method."""
+        polys = [
+            [(0.0, 0.0), (5.0, 0.0), (5.0, 3.0)],
+            [(10.0, 10.0), (15.0, 10.0), (15.0, 15.0)],
+        ]
+        result = NetStatusAnalyzer._bounding_box_polygon(polys)
+        assert len(result) == 4
+        # Should be bounding box of all points
+        xs = [p[0] for p in result]
+        ys = [p[1] for p in result]
+        assert min(xs) == 0.0
+        assert max(xs) == 15.0
+        assert min(ys) == 0.0
+        assert max(ys) == 15.0
+
+    def test_bounding_box_polygon_empty(self):
+        """Test _bounding_box_polygon with empty input."""
+        result = NetStatusAnalyzer._bounding_box_polygon([])
+        assert result == []
+
+    def test_polygon_bbox_helper(self):
+        """Test _polygon_bbox static method."""
+        poly = [(1.0, 2.0), (5.0, 3.0), (3.0, 8.0)]
+        bbox = NetStatusAnalyzer._polygon_bbox(poly)
+        assert bbox == (1.0, 2.0, 5.0, 8.0)
+
+    def test_point_in_bbox_helper(self):
+        """Test _point_in_bbox static method."""
+        bbox = (0.0, 0.0, 10.0, 10.0)
+        assert NetStatusAnalyzer._point_in_bbox((5.0, 5.0), bbox) is True
+        assert NetStatusAnalyzer._point_in_bbox((0.0, 0.0), bbox) is True
+        assert NetStatusAnalyzer._point_in_bbox((10.0, 10.0), bbox) is True
+        assert NetStatusAnalyzer._point_in_bbox((-1.0, 5.0), bbox) is False
+        assert NetStatusAnalyzer._point_in_bbox((5.0, 11.0), bbox) is False
+
+    def test_plane_layer_backward_compat_setter(self):
+        """Setting plane_layer via constructor still works."""
+        status = NetStatus(
+            net_number=1,
+            net_name="GND",
+            is_plane_net=True,
+            plane_layer="F.Cu",
+        )
+        assert status.plane_layer == "F.Cu"
+        # plane_layers should remain empty when set via constructor
+        # (backward compat: old code sets plane_layer directly)
+        assert status.plane_layers == []
+
+    def test_plane_layers_with_three_layers(self):
+        """Net with zones on 3+ layers reports all layers in metadata."""
+        status = NetStatus(
+            net_number=1,
+            net_name="GND",
+            is_plane_net=True,
+            plane_layers=["F.Cu", "In1.Cu", "B.Cu"],
+            plane_layer="F.Cu",
+        )
+        assert len(status.plane_layers) == 3
+        d = status.to_dict()
+        assert len(d["plane_layers"]) == 3
+        assert d["plane_layer"] == "F.Cu"


### PR DESCRIPTION
## Summary
Fix false-positive incomplete net reports caused by zone fill connectivity gaps. The `zone_points[:1000]` sampling cap was discarding zone geometry on complex boards, and zone metadata only tracked a single layer per net.

## Changes
- Remove the `zone_points[:1000]` sampling cap that caused false positives on boards with many filled polygons (>1000 vertices)
- Track multiple zone layers per net via new `plane_layers` field (backward-compatible `plane_layer` field retained)
- Add bounding-box spatial indexing to skip expensive point-in-polygon checks for distant zones
- Add fallback boundary detection using bounding box when zone outline polygon is missing
- Update CLI display to show all zone layers for multi-layer plane nets
- Update `suggested_fix` to list all zone layers

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| net-status recognizes pad-to-via-to-filled_zone connections as complete | Pass | Existing stitching via tests + new multi-zone test pass |
| Power nets with zones + stitching vias show as "Complete" after zones fill | Pass | test_multi_zone_complete verifies this |
| Nets with zones on multiple layers report all zone layers | Pass | test_multi_zone_layers_reported verifies plane_layers contains both In1.Cu and B.Cu |
| zone_points[:1000] sampling limit does not cause false positives | Pass | test_large_zone_no_false_positives uses 500 filled polygons (>1000 vertices total) |
| Analysis completes in <5 seconds on boards with 400+ filled polygons | Pass | test_large_zone_performance verifies <5s for 500 polygons |
| Zone with no boundary polygon still detects pad connectivity | Pass | test_zone_no_boundary_polygon verifies bounding-box fallback |

## Test Plan
- 55 tests pass in test_analysis_net_status.py (42 existing + 13 new)
- 110 tests pass across all related test files (test_net_status.py, test_net_status_cmd.py, test_report_collector.py)
- New tests cover: multi-zone layers, large zone fills, missing boundary polygons, helper methods, backward compatibility

Closes #2035