### PR TITLE
fix(zones): add overlap detection and 4-layer stackup-aware zone assignment

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -847,9 +847,9 @@ def _run_step_zones(ctx: BuildContext, console: Console) -> BuildResult:
     """Run automatic zone creation for power and ground nets.
 
     Identifies pour nets (POWER and GROUND) via net classification and
-    creates copper zone definitions on the PCB before routing.  GND gets
-    a zone on B.Cu with priority 1; other power nets get zones on F.Cu
-    with priority 0.
+    creates copper zone definitions on the PCB before routing.  Layer
+    assignment is stackup-aware: on 4-layer boards GND goes on In1.Cu
+    and power nets are distributed across In2.Cu / F.Cu.
 
     Zones are *defined* here (unfilled polygons).  Filling happens later
     after routing, typically via kicad-cli.

--- a/src/kicad_tools/cli/zones_cmd.py
+++ b/src/kicad_tools/cli/zones_cmd.py
@@ -232,6 +232,12 @@ def _run_add(args) -> int:
         print(f"  Clearance:   {zone.config.clearance}mm")
         print(f"  Boundary:    {len(zone.boundary)} points")
 
+    # Surface overlap warnings
+    if gen.warnings:
+        print(f"\n{len(gen.warnings)} overlap warning(s):", file=sys.stderr)
+        for w in gen.warnings:
+            print(f"  WARNING: {w.message}", file=sys.stderr)
+
     if args.dry_run:
         if not quiet:
             print("\n--- Dry run - not saving ---")
@@ -372,6 +378,12 @@ def _run_batch(args) -> int:
         print("\nErrors:", file=sys.stderr)
         for err in errors:
             print(err, file=sys.stderr)
+
+    # Surface overlap warnings
+    if gen.warnings:
+        print(f"\n{len(gen.warnings)} overlap warning(s):", file=sys.stderr)
+        for w in gen.warnings:
+            print(f"  WARNING: {w.message}", file=sys.stderr)
 
     if args.dry_run:
         if not quiet:

--- a/src/kicad_tools/zones/__init__.py
+++ b/src/kicad_tools/zones/__init__.py
@@ -31,11 +31,18 @@ Example::
     gen.save("board_with_zones.kicad_pcb")
 """
 
-from .generator import ZoneConfig, ZoneGenerator, auto_create_zones_for_pour_nets, parse_power_nets
+from .generator import (
+    ZoneConfig,
+    ZoneGenerator,
+    ZoneOverlapWarning,
+    auto_create_zones_for_pour_nets,
+    parse_power_nets,
+)
 
 __all__ = [
-    "ZoneGenerator",
     "ZoneConfig",
+    "ZoneGenerator",
+    "ZoneOverlapWarning",
     "auto_create_zones_for_pour_nets",
     "parse_power_nets",
 ]

--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -7,6 +7,7 @@ with automatic board outline detection and sensible defaults for power nets.
 
 from __future__ import annotations
 
+import sys
 import uuid as uuid_module
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -19,6 +20,23 @@ from kicad_tools.sexp.builders import zone_node
 
 if TYPE_CHECKING:
     from kicad_tools.router.net_class import NetClass
+
+
+@dataclass
+class ZoneOverlapWarning:
+    """Warning about overlapping zones on the same layer.
+
+    Attributes:
+        new_net: Net name of the zone being added
+        existing_net: Net name of the existing zone that overlaps
+        layer: The shared copper layer
+        message: Human-readable warning message
+    """
+
+    new_net: str
+    existing_net: str
+    layer: str
+    message: str
 
 
 @dataclass
@@ -110,6 +128,7 @@ class ZoneGenerator:
         self._pcb = pcb
         self._doc = doc
         self._zones: list[GeneratedZone] = []
+        self._warnings: list[ZoneOverlapWarning] = []
         self._board_outline: list[tuple[float, float]] | None = None
         self._applied = False
 
@@ -194,6 +213,120 @@ class ZoneGenerator:
             raise ValueError(f"Net '{net_name}' not found in PCB")
         return net.number
 
+    @property
+    def warnings(self) -> list[ZoneOverlapWarning]:
+        """Overlap warnings generated during zone addition."""
+        return self._warnings
+
+    @staticmethod
+    def _boundaries_overlap(
+        boundary_a: list[tuple[float, float]],
+        boundary_b: list[tuple[float, float]],
+    ) -> bool:
+        """Check whether two boundary polygons overlap.
+
+        Uses bounding-box intersection as a conservative approximation.
+        Two polygons whose bounding boxes overlap are considered overlapping.
+        This is intentionally conservative -- it may report overlaps for
+        polygons that only share a bounding-box region but not actual area.
+        For the zone-overlap-warning use case, false positives are acceptable
+        while false negatives would hide real problems.
+
+        Returns:
+            True if the boundaries' bounding boxes overlap.
+        """
+        if not boundary_a or not boundary_b:
+            return False
+
+        a_xs = [p[0] for p in boundary_a]
+        a_ys = [p[1] for p in boundary_a]
+        b_xs = [p[0] for p in boundary_b]
+        b_ys = [p[1] for p in boundary_b]
+
+        # Axis-aligned bounding-box overlap test
+        return not (
+            max(a_xs) <= min(b_xs)
+            or max(b_xs) <= min(a_xs)
+            or max(a_ys) <= min(b_ys)
+            or max(b_ys) <= min(a_ys)
+        )
+
+    def _check_overlap(
+        self,
+        net: str,
+        layer: str,
+        priority: int,
+        boundary: list[tuple[float, float]],
+    ) -> list[ZoneOverlapWarning]:
+        """Check for overlapping zones on the same layer.
+
+        Checks both existing PCB zones and zones already queued in
+        this generator.
+
+        Returns:
+            List of overlap warnings (empty if no overlaps detected).
+        """
+        warnings: list[ZoneOverlapWarning] = []
+
+        # Check against existing zones in the PCB
+        for existing in self._pcb.zones:
+            if existing.layer != layer:
+                continue
+            if existing.net_name == net:
+                continue  # Same net on same layer is fine (e.g. re-run)
+
+            existing_boundary = existing.polygon
+            if self._boundaries_overlap(boundary, existing_boundary):
+                if priority <= existing.priority:
+                    msg = (
+                        f"Zone '{net}' on {layer} (priority {priority}) overlaps "
+                        f"existing zone '{existing.net_name}' (priority {existing.priority}). "
+                        f"The new zone will get zero copper because the existing zone "
+                        f"has equal or higher priority."
+                    )
+                else:
+                    msg = (
+                        f"Zone '{net}' on {layer} (priority {priority}) overlaps "
+                        f"existing zone '{existing.net_name}' (priority {existing.priority}). "
+                        f"The existing zone will get zero copper."
+                    )
+                warnings.append(ZoneOverlapWarning(
+                    new_net=net,
+                    existing_net=existing.net_name,
+                    layer=layer,
+                    message=msg,
+                ))
+
+        # Check against queued zones in this generator
+        for queued in self._zones:
+            if queued.config.layer != layer:
+                continue
+            if queued.config.net == net:
+                continue
+
+            if self._boundaries_overlap(boundary, queued.boundary):
+                if priority <= queued.config.priority:
+                    msg = (
+                        f"Zone '{net}' on {layer} (priority {priority}) overlaps "
+                        f"queued zone '{queued.config.net}' (priority {queued.config.priority}). "
+                        f"The new zone will get zero copper because the other zone "
+                        f"has equal or higher priority."
+                    )
+                else:
+                    msg = (
+                        f"Zone '{net}' on {layer} (priority {priority}) overlaps "
+                        f"queued zone '{queued.config.net}' (priority {queued.config.priority}). "
+                        f"The other zone will get zero copper."
+                    )
+                warnings.append(ZoneOverlapWarning(
+                    new_net=net,
+                    existing_net=queued.config.net,
+                    layer=layer,
+                    message=msg,
+                ))
+
+        return warnings
+
     def add_zone(
         self,
         net: str,
@@ -206,6 +339,9 @@ class ZoneGenerator:
         boundary: list[tuple[float, float]] | None = None,
     ) -> GeneratedZone:
         """Add a copper pour zone.
+
+        Checks for overlapping zones on the same layer and emits warnings
+        to stderr if conflicts are detected.
 
         Args:
             net: Net name (e.g., "GND", "+3.3V")
@@ -239,6 +375,12 @@ class ZoneGenerator:
 
         # Use board outline if no boundary specified
         actual_boundary = boundary if boundary is not None else self.board_outline
+
+        # Check for overlapping zones on the same layer
+        overlap_warnings = self._check_overlap(net, layer, priority, actual_boundary)
+        for warning in overlap_warnings:
+            self._warnings.append(warning)
+            print(f"WARNING: {warning.message}", file=sys.stderr)
 
         zone = GeneratedZone(
             config=config,
@@ -423,18 +565,83 @@ def parse_power_nets(spec: str) -> list[tuple[str, str]]:
     return result
 
 
+def _assign_layers_for_pour_nets(
+    copper_layer_count: int,
+    pour_nets: list[tuple[str, "NetClass"]],
+) -> list[tuple[str, str, int]]:
+    """Assign layers and priorities for pour nets based on board stackup.
+
+    For 2-layer boards:
+    - GROUND nets -> B.Cu, priority 1
+    - POWER nets  -> F.Cu, priority 0
+
+    For 4-layer boards:
+    - GROUND nets -> In1.Cu (dedicated ground plane), priority 1
+    - First POWER net  -> In2.Cu, priority 0
+    - Additional POWER nets -> F.Cu with descending priorities
+      so each successive power net gets a lower priority
+
+    Args:
+        copper_layer_count: Number of copper layers (2, 4, 6, etc.)
+        pour_nets: List of (net_name, NetClass) tuples
+
+    Returns:
+        List of (net_name, layer, priority) tuples
+    """
+    from kicad_tools.router.net_class import NetClass
+
+    ground_nets = [(n, c) for n, c in pour_nets if c == NetClass.GROUND]
+    power_nets = [(n, c) for n, c in pour_nets if c != NetClass.GROUND]
+
+    assignments: list[tuple[str, str, int]] = []
+
+    if copper_layer_count >= 4:
+        # 4+ layer board: use inner layers for power/ground planes
+        for net_name, _ in ground_nets:
+            assignments.append((net_name, "In1.Cu", 1))
+
+        if len(power_nets) == 1:
+            # Single power net gets its own inner layer
+            assignments.append((power_nets[0][0], "In2.Cu", 0))
+        else:
+            # Multiple power nets: first gets In2.Cu, rest go on F.Cu
+            # with decreasing priorities so they don't fully override each other.
+            # NOTE: Full-board overlapping zones on the same layer still produce
+            # zero-copper for lower-priority zones.  The overlap warning will
+            # fire, prompting the user to use smaller boundaries or `zones split`.
+            for i, (net_name, _) in enumerate(power_nets):
+                if i == 0:
+                    assignments.append((net_name, "In2.Cu", 0))
+                else:
+                    assignments.append((net_name, "F.Cu", i - 1))
+    else:
+        # 2-layer board
+        for net_name, _ in ground_nets:
+            assignments.append((net_name, "B.Cu", 1))
+
+        for net_name, _ in power_nets:
+            assignments.append((net_name, "F.Cu", 0))
+
+    return assignments
+
+
 def auto_create_zones_for_pour_nets(
     pcb_path: str | Path,
-    pour_nets: list[tuple[str, NetClass]],
+    pour_nets: list[tuple[str, "NetClass"]],
 ) -> int:
     """Create zones for power and ground nets on a PCB.
 
     Loads the PCB, creates zone definitions for each pour net, and saves
-    the modified PCB in place.
+    the modified PCB in place.  Layer assignment is stackup-aware:
 
     For 2-layer boards:
     - GROUND nets get a zone on B.Cu with priority 1
     - POWER nets get a zone on F.Cu with priority 0
+
+    For 4-layer boards:
+    - GROUND nets get a zone on In1.Cu with priority 1
+    - First POWER net gets a zone on In2.Cu with priority 0
+    - Additional POWER nets get zones on F.Cu
 
     Args:
         pcb_path: Path to .kicad_pcb file (modified in place)
@@ -444,18 +651,15 @@ def auto_create_zones_for_pour_nets(
     Returns:
         Number of zones created
     """
-    from kicad_tools.router.net_class import NetClass
-
     pcb_path = Path(pcb_path)
     gen = ZoneGenerator.from_pcb(pcb_path)
 
+    copper_layer_count = len(gen.pcb.copper_layers)
+    assignments = _assign_layers_for_pour_nets(copper_layer_count, pour_nets)
+
     count = 0
-    for net_name, net_class in pour_nets:
-        if net_class == NetClass.GROUND:
-            gen.add_zone(net=net_name, layer="B.Cu", priority=1)
-        else:
-            # POWER nets go on F.Cu
-            gen.add_power_plane(net=net_name, layer="F.Cu", priority=0)
+    for net_name, layer, priority in assignments:
+        gen.add_zone(net=net_name, layer=layer, priority=priority)
         count += 1
 
     if count > 0:

--- a/tests/test_zone_generator.py
+++ b/tests/test_zone_generator.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from kicad_tools.zones import ZoneConfig, ZoneGenerator, parse_power_nets
-from kicad_tools.zones.generator import GeneratedZone
+from kicad_tools.zones import ZoneConfig, ZoneGenerator, ZoneOverlapWarning, parse_power_nets
+from kicad_tools.zones.generator import GeneratedZone, _assign_layers_for_pour_nets
 
 
 class TestParsePowerNets:
@@ -329,3 +329,339 @@ class TestZoneGeneratorIntegration:
         )
 
         assert zone.boundary == custom_boundary
+
+
+class TestZoneOverlapDetection:
+    """Tests for overlap detection in ZoneGenerator.add_zone()."""
+
+    @pytest.fixture
+    def sample_pcb_path(self, tmp_path):
+        """Create a minimal valid PCB file for overlap testing."""
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (36 "B.SilkS" user "B.Silkscreen")
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (net 3 "+5V")
+  (gr_rect
+    (start 0 0)
+    (end 50 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+)
+"""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        return pcb_file
+
+    def test_no_warning_different_layers(self, sample_pcb_path):
+        """No warning when zones are on different layers."""
+        gen = ZoneGenerator.from_pcb(sample_pcb_path)
+
+        gen.add_zone(net="GND", layer="B.Cu", priority=1)
+        gen.add_zone(net="+3.3V", layer="F.Cu", priority=0)
+
+        assert len(gen.warnings) == 0
+
+    def test_warning_same_layer_same_boundary(self, sample_pcb_path):
+        """Warning when two zones share the same layer and boundary."""
+        gen = ZoneGenerator.from_pcb(sample_pcb_path)
+
+        gen.add_zone(net="+3.3V", layer="F.Cu", priority=0)
+        gen.add_zone(net="+5V", layer="F.Cu", priority=0)
+
+        assert len(gen.warnings) == 1
+        w = gen.warnings[0]
+        assert w.new_net == "+5V"
+        assert w.existing_net == "+3.3V"
+        assert w.layer == "F.Cu"
+        assert "zero copper" in w.message
+
+    def test_warning_lower_priority_gets_zero_copper(self, sample_pcb_path):
+        """Warning identifies that lower-priority zone gets zero copper."""
+        gen = ZoneGenerator.from_pcb(sample_pcb_path)
+
+        gen.add_zone(net="GND", layer="F.Cu", priority=1)
+        gen.add_zone(net="+3.3V", layer="F.Cu", priority=0)
+
+        assert len(gen.warnings) == 1
+        w = gen.warnings[0]
+        assert "new zone will get zero copper" in w.message
+
+    def test_warning_higher_priority_overrides(self, sample_pcb_path):
+        """Warning identifies that higher-priority zone overrides existing."""
+        gen = ZoneGenerator.from_pcb(sample_pcb_path)
+
+        gen.add_zone(net="+3.3V", layer="F.Cu", priority=0)
+        gen.add_zone(net="GND", layer="F.Cu", priority=1)
+
+        assert len(gen.warnings) == 1
+        w = gen.warnings[0]
+        assert "other zone will get zero copper" in w.message
+
+    def test_no_warning_same_net_same_layer(self, sample_pcb_path):
+        """No warning for the same net on the same layer (idempotent re-add)."""
+        gen = ZoneGenerator.from_pcb(sample_pcb_path)
+
+        gen.add_zone(net="GND", layer="B.Cu", priority=1)
+        gen.add_zone(net="GND", layer="B.Cu", priority=1)
+
+        assert len(gen.warnings) == 0
+
+    def test_no_warning_non_overlapping_boundaries(self, sample_pcb_path):
+        """No warning when custom boundaries don't overlap."""
+        gen = ZoneGenerator.from_pcb(sample_pcb_path)
+
+        gen.add_zone(
+            net="+3.3V",
+            layer="F.Cu",
+            priority=0,
+            boundary=[(0, 0), (20, 0), (20, 50), (0, 50)],
+        )
+        gen.add_zone(
+            net="+5V",
+            layer="F.Cu",
+            priority=0,
+            boundary=[(25, 0), (50, 0), (50, 50), (25, 50)],
+        )
+
+        assert len(gen.warnings) == 0
+
+    def test_warning_overlapping_custom_boundaries(self, sample_pcb_path):
+        """Warning when custom boundaries overlap on the same layer."""
+        gen = ZoneGenerator.from_pcb(sample_pcb_path)
+
+        gen.add_zone(
+            net="+3.3V",
+            layer="F.Cu",
+            priority=0,
+            boundary=[(0, 0), (30, 0), (30, 50), (0, 50)],
+        )
+        gen.add_zone(
+            net="+5V",
+            layer="F.Cu",
+            priority=0,
+            boundary=[(20, 0), (50, 0), (50, 50), (20, 50)],
+        )
+
+        assert len(gen.warnings) == 1
+
+    def test_warning_emitted_to_stderr(self, sample_pcb_path, capsys):
+        """Overlap warnings are printed to stderr."""
+        gen = ZoneGenerator.from_pcb(sample_pcb_path)
+
+        gen.add_zone(net="+3.3V", layer="F.Cu", priority=0)
+        gen.add_zone(net="+5V", layer="F.Cu", priority=0)
+
+        captured = capsys.readouterr()
+        assert "WARNING:" in captured.err
+        assert "zero copper" in captured.err
+
+
+class TestBoundariesOverlap:
+    """Tests for the static _boundaries_overlap method."""
+
+    def test_identical_boundaries(self):
+        """Identical boundaries overlap."""
+        b = [(0, 0), (10, 0), (10, 10), (0, 10)]
+        assert ZoneGenerator._boundaries_overlap(b, b) is True
+
+    def test_disjoint_boundaries(self):
+        """Non-overlapping boundaries do not overlap."""
+        a = [(0, 0), (10, 0), (10, 10), (0, 10)]
+        b = [(20, 0), (30, 0), (30, 10), (20, 10)]
+        assert ZoneGenerator._boundaries_overlap(a, b) is False
+
+    def test_adjacent_boundaries_no_overlap(self):
+        """Boundaries sharing an edge do not overlap (exclusive comparison)."""
+        a = [(0, 0), (10, 0), (10, 10), (0, 10)]
+        b = [(10, 0), (20, 0), (20, 10), (10, 10)]
+        assert ZoneGenerator._boundaries_overlap(a, b) is False
+
+    def test_nested_boundaries(self):
+        """Smaller boundary inside larger one overlaps."""
+        outer = [(0, 0), (100, 0), (100, 100), (0, 100)]
+        inner = [(10, 10), (20, 10), (20, 20), (10, 20)]
+        assert ZoneGenerator._boundaries_overlap(outer, inner) is True
+
+    def test_empty_boundary(self):
+        """Empty boundary does not overlap."""
+        b = [(0, 0), (10, 0), (10, 10), (0, 10)]
+        assert ZoneGenerator._boundaries_overlap([], b) is False
+        assert ZoneGenerator._boundaries_overlap(b, []) is False
+
+
+class TestAssignLayersForPourNets:
+    """Tests for _assign_layers_for_pour_nets layer assignment logic."""
+
+    def test_2_layer_ground_on_bcu(self):
+        """2-layer board: GND goes on B.Cu."""
+        from kicad_tools.router.net_class import NetClass
+
+        result = _assign_layers_for_pour_nets(
+            2,
+            [("GND", NetClass.GROUND)],
+        )
+        assert result == [("GND", "B.Cu", 1)]
+
+    def test_2_layer_power_on_fcu(self):
+        """2-layer board: power nets go on F.Cu."""
+        from kicad_tools.router.net_class import NetClass
+
+        result = _assign_layers_for_pour_nets(
+            2,
+            [("GND", NetClass.GROUND), ("+3.3V", NetClass.POWER)],
+        )
+        assert ("GND", "B.Cu", 1) in result
+        assert ("+3.3V", "F.Cu", 0) in result
+
+    def test_4_layer_ground_on_in1cu(self):
+        """4-layer board: GND goes on In1.Cu."""
+        from kicad_tools.router.net_class import NetClass
+
+        result = _assign_layers_for_pour_nets(
+            4,
+            [("GND", NetClass.GROUND)],
+        )
+        assert result == [("GND", "In1.Cu", 1)]
+
+    def test_4_layer_single_power_on_in2cu(self):
+        """4-layer board: single power net goes on In2.Cu."""
+        from kicad_tools.router.net_class import NetClass
+
+        result = _assign_layers_for_pour_nets(
+            4,
+            [("GND", NetClass.GROUND), ("+3.3V", NetClass.POWER)],
+        )
+        assert ("GND", "In1.Cu", 1) in result
+        assert ("+3.3V", "In2.Cu", 0) in result
+
+    def test_4_layer_multiple_power_nets(self):
+        """4-layer board: multiple power nets distributed across layers."""
+        from kicad_tools.router.net_class import NetClass
+
+        result = _assign_layers_for_pour_nets(
+            4,
+            [
+                ("GND", NetClass.GROUND),
+                ("+3.3V", NetClass.POWER),
+                ("+5V", NetClass.POWER),
+            ],
+        )
+        assert ("GND", "In1.Cu", 1) in result
+        assert ("+3.3V", "In2.Cu", 0) in result
+        assert ("+5V", "F.Cu", 0) in result
+
+    def test_4_layer_three_power_nets(self):
+        """4-layer board: three power nets -- first on In2.Cu, rest on F.Cu."""
+        from kicad_tools.router.net_class import NetClass
+
+        result = _assign_layers_for_pour_nets(
+            4,
+            [
+                ("GND", NetClass.GROUND),
+                ("+3.3V", NetClass.POWER),
+                ("+5V", NetClass.POWER),
+                ("+1.8V", NetClass.POWER),
+            ],
+        )
+        assert ("GND", "In1.Cu", 1) in result
+        assert ("+3.3V", "In2.Cu", 0) in result
+        # Additional power nets go on F.Cu with increasing priority index
+        assert ("+5V", "F.Cu", 0) in result
+        assert ("+1.8V", "F.Cu", 1) in result
+
+
+class TestAutoCreateZones4Layer:
+    """Tests for auto_create_zones_for_pour_nets with 4-layer boards."""
+
+    @pytest.fixture
+    def four_layer_pcb_path(self, tmp_path):
+        """Create a 4-layer PCB file for testing."""
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+    (36 "B.SilkS" user "B.Silkscreen")
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (net 3 "+5V")
+  (gr_rect
+    (start 0 0)
+    (end 50 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+)
+"""
+        pcb_file = tmp_path / "four_layer.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        return pcb_file
+
+    def test_4_layer_assigns_inner_layers(self, four_layer_pcb_path):
+        """auto_create_zones assigns inner layers for 4-layer boards."""
+        from kicad_tools.router.net_class import NetClass
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.zones.generator import auto_create_zones_for_pour_nets
+
+        count = auto_create_zones_for_pour_nets(
+            four_layer_pcb_path,
+            [("GND", NetClass.GROUND), ("+3.3V", NetClass.POWER)],
+        )
+
+        assert count == 2
+
+        # Verify zones were saved correctly
+        pcb = PCB.load(str(four_layer_pcb_path))
+        zone_layers = {z.net_name: z.layer for z in pcb.zones}
+
+        assert zone_layers["GND"] == "In1.Cu"
+        assert zone_layers["+3.3V"] == "In2.Cu"
+
+    def test_4_layer_multiple_power_nets_warns(self, four_layer_pcb_path, capsys):
+        """auto_create_zones emits overlap warnings for multiple power on F.Cu."""
+        from kicad_tools.router.net_class import NetClass
+        from kicad_tools.zones.generator import auto_create_zones_for_pour_nets
+
+        count = auto_create_zones_for_pour_nets(
+            four_layer_pcb_path,
+            [
+                ("GND", NetClass.GROUND),
+                ("+3.3V", NetClass.POWER),
+                ("+5V", NetClass.POWER),
+            ],
+        )
+
+        assert count == 3
+
+        # The two power nets should NOT overlap since first goes to In2.Cu
+        # and second goes to F.Cu -- no warning expected
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.err

--- a/tests/test_zones_cmd.py
+++ b/tests/test_zones_cmd.py
@@ -46,6 +46,38 @@ def _mock_kicad_cli():
 
 
 # ---------------------------------------------------------------------------
+# Test: overlap warnings in add and batch subcommands
+# ---------------------------------------------------------------------------
+
+
+class TestAddOverlapWarnings:
+    """Verify overlap warnings are surfaced in zones add."""
+
+    def test_add_no_warning_different_layer(self, tmp_pcb, capsys):
+        """zones add on a unique layer produces no warning."""
+        ret = main(["add", str(tmp_pcb), "--net", "GND", "--layer", "B.Cu", "--priority", "1", "-o", str(tmp_pcb)])
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "overlap warning" not in captured.err
+
+
+class TestBatchOverlapWarnings:
+    """Verify overlap warnings are surfaced in zones batch."""
+
+    def test_batch_warns_same_layer_overlap(self, tmp_pcb, capsys):
+        """zones batch emits overlap warning for same-layer full-board zones."""
+        ret = main([
+            "batch", str(tmp_pcb),
+            "--power-nets", "GND:F.Cu,+3V3:F.Cu",
+            "-o", str(tmp_pcb),
+        ])
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "overlap warning" in captured.err
+        assert "zero copper" in captured.err
+
+
+# ---------------------------------------------------------------------------
 # Test: fill subcommand appears in help
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds overlap detection to `zones add` / `zones batch` and makes `auto_create_zones_for_pour_nets` stackup-aware so that 4-layer boards assign GND to In1.Cu and power nets to In2.Cu instead of creating overlapping full-board zones on F.Cu.

## Changes

- Added `ZoneOverlapWarning` dataclass and `_check_overlap()` method to `ZoneGenerator`
- `add_zone()` now checks for overlapping zones on the same layer (both existing PCB zones and queued zones) and emits warnings to stderr
- CLI commands `zones add` and `zones batch` surface overlap warnings
- New `_assign_layers_for_pour_nets()` function distributes zones across layers based on copper layer count
- `auto_create_zones_for_pour_nets()` now uses the stackup-aware assignment: on 4-layer boards GND goes to In1.Cu, first power net to In2.Cu, additional power nets to F.Cu
- Updated `_run_step_zones` docstring to reflect stackup-aware behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `zones add` emits warning when zone will be fully overridden by higher-priority zone | Done | Unit test `test_warning_lower_priority_gets_zero_copper` |
| `zones add` emits warning for same boundary and layer (regardless of priority) | Done | Unit test `test_warning_same_layer_same_boundary` |
| `zones batch` emits warnings for each conflicting zone | Done | CLI test `test_batch_warns_same_layer_overlap` |
| `auto_create_zones_for_pour_nets` assigns inner layers for 4-layer boards | Done | Integration test `test_4_layer_assigns_inner_layers` |

## Test Plan

- 160 tests pass (all zone-related tests), 1 skipped (kicad-cli integration)
- New test classes: `TestZoneOverlapDetection`, `TestBoundariesOverlap`, `TestAssignLayersForPourNets`, `TestAutoCreateZones4Layer`, `TestAddOverlapWarnings`, `TestBatchOverlapWarnings`

Closes #2041