### PR TITLE
fix(stitch): infer inner plane layers from board stackup when zones are missing

### DIFF
--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -119,8 +119,10 @@ class StitchResult:
     already_connected: int = 0
     # Per-net detected layers: {net_name: layer} for auto-detected layers
     detected_layers: dict[str, str] = field(default_factory=dict)
-    # Nets that fell back to default B.Cu (no zone found)
+    # Nets that fell back to default B.Cu (no zone found, 2-layer board)
     fallback_nets: list[str] = field(default_factory=list)
+    # Nets whose target layer was inferred from board stackup (no zone on inner layer)
+    stackup_inferred_nets: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -218,6 +220,125 @@ def find_zones_for_net(sexp: SExp, net_name: str) -> list[str]:
                 layers.append(zone_layer)
 
     return layers
+
+
+# Ordered list of KiCad copper layer names (front to back).
+# KiCad numbers inner layers 1..30 as In1.Cu .. In30.Cu.
+_COPPER_LAYER_ORDER = (
+    ["F.Cu"]
+    + [f"In{i}.Cu" for i in range(1, 31)]
+    + ["B.Cu"]
+)
+
+
+def get_copper_layers(sexp: SExp) -> list[str]:
+    """Return the ordered list of copper layers defined in the PCB.
+
+    Parses the ``(layers ...)`` block and returns only copper layers
+    (signal / power type) sorted in physical stackup order
+    (F.Cu first, B.Cu last).
+
+    Args:
+        sexp: PCB S-expression root
+
+    Returns:
+        Ordered list of copper layer names, e.g. ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+    """
+    layers_node = sexp.find_child("layers")
+    if layers_node is None:
+        return ["F.Cu", "B.Cu"]
+
+    copper_names: list[str] = []
+    for child in layers_node.iter_children():
+        if len(child.values) < 1:
+            continue
+        name = child.get_string(0)
+        layer_type = child.get_string(1) or ""
+        if name and layer_type in ("signal", "power"):
+            copper_names.append(name)
+
+    if not copper_names:
+        return ["F.Cu", "B.Cu"]
+
+    # Sort into physical stackup order using the canonical ordering
+    order_map = {name: idx for idx, name in enumerate(_COPPER_LAYER_ORDER)}
+    copper_names.sort(key=lambda n: order_map.get(n, 999))
+
+    return copper_names
+
+
+def _is_ground_net(net_name: str) -> bool:
+    """Return True if the net name matches common ground naming patterns."""
+    name_lower = net_name.lower()
+    return any(
+        g in name_lower
+        for g in ["gnd", "vss", "ground", "agnd", "dgnd", "gndd", "gnda"]
+    )
+
+
+def infer_target_layer_from_stackup(
+    copper_layers: list[str],
+    net_name: str,
+    pad_layer: str,
+) -> str | None:
+    """Infer the target plane layer for a net using standard stackup conventions.
+
+    For multi-layer boards (4+ layers), the conventional stackup assigns:
+    - Ground nets to the first inner layer (In1.Cu for 4-layer)
+    - Power nets to the second inner layer (In2.Cu for 4-layer)
+
+    For 2-layer boards, returns None (no inner layers available, so the
+    caller should use the default F.Cu/B.Cu through-via behavior).
+
+    Args:
+        copper_layers: Ordered list of copper layers from get_copper_layers()
+        net_name: The net name (used to classify as ground vs power)
+        pad_layer: The layer the component pad is on
+
+    Returns:
+        Target inner layer name, or None if no inner layers exist
+    """
+    # Extract inner layers (everything except F.Cu and B.Cu)
+    inner_layers = [l for l in copper_layers if l not in ("F.Cu", "B.Cu")]
+
+    if not inner_layers:
+        # 2-layer board: no inner layers, caller uses default behavior
+        return None
+
+    if _is_ground_net(net_name):
+        # Ground nets -> first inner layer (In1.Cu for 4-layer)
+        return inner_layers[0]
+    else:
+        # Power nets -> last inner layer (In2.Cu for 4-layer, or
+        # furthest inner layer for 6+ layer boards)
+        return inner_layers[-1]
+
+
+def _should_use_stackup_fallback(
+    zone_layers: list[str],
+    copper_layers: list[str],
+) -> bool:
+    """Return True if zone layers indicate we should use stackup inference.
+
+    This detects the case where zones exist but are placed on outer layers
+    (F.Cu/B.Cu) for a multi-layer board -- meaning the zone creation step
+    didn't properly target inner layers.
+
+    Args:
+        zone_layers: Layers where zones were found for the net
+        copper_layers: All copper layers in the board
+
+    Returns:
+        True if we should fall back to stackup inference
+    """
+    inner_layers = [l for l in copper_layers if l not in ("F.Cu", "B.Cu")]
+    if not inner_layers:
+        # 2-layer board: no inner layers, no need for fallback
+        return False
+
+    # If all zone layers are outer layers, we should use stackup inference
+    outer_only = all(zl in ("F.Cu", "B.Cu") for zl in zone_layers)
+    return outer_only
 
 
 def extract_zone_polygons(sexp: SExp, net_name: str) -> list[ZonePolygon]:
@@ -2149,6 +2270,7 @@ def run_blanket_stitch(
         StitchResult with details of what was done
     """
     sexp = load_pcb(pcb_path)
+    copper_layers = get_copper_layers(sexp)
 
     result = StitchResult(
         pcb_name=pcb_path.name,
@@ -2201,12 +2323,20 @@ def run_blanket_stitch(
             net_target_layer = target_layer
         else:
             zone_layers = find_zones_for_net(sexp, net_name)
-            if zone_layers:
+            if zone_layers and not _should_use_stackup_fallback(zone_layers, copper_layers):
                 net_target_layer = zone_layers[0]
                 result.detected_layers[net_name] = zone_layers[0]
             else:
-                net_target_layer = None
-                result.fallback_nets.append(net_name)
+                # No zone or zones only on outer layers -- infer from stackup
+                inferred = infer_target_layer_from_stackup(
+                    copper_layers, net_name, "F.Cu"
+                )
+                if inferred:
+                    net_target_layer = inferred
+                    result.detected_layers[net_name] = inferred
+                else:
+                    net_target_layer = None
+                    result.fallback_nets.append(net_name)
 
         for zone_poly in zone_polygons:
             # Generate grid positions inside this zone polygon
@@ -2320,17 +2450,28 @@ def run_stitch(
 
     # Auto-detect target layers per net if not specified
     net_target_layers: dict[str, str | None] = {}
+    copper_layers = get_copper_layers(sexp)
     if target_layer is None:
         for net_name in net_names:
             zone_layers = find_zones_for_net(sexp, net_name)
-            if zone_layers:
-                # Use first zone layer found (typically there's only one per net)
+            if zone_layers and not _should_use_stackup_fallback(zone_layers, copper_layers):
+                # Zone found on an inner layer -- use it directly
                 net_target_layers[net_name] = zone_layers[0]
                 result.detected_layers[net_name] = zone_layers[0]
             else:
-                # No zone found, will fall back to B.Cu
-                net_target_layers[net_name] = None
-                result.fallback_nets.append(net_name)
+                # No zone or zones only on outer layers for a multi-layer
+                # board.  Infer the correct inner layer from the stackup.
+                inferred = infer_target_layer_from_stackup(
+                    copper_layers, net_name, "F.Cu"
+                )
+                if inferred:
+                    net_target_layers[net_name] = inferred
+                    result.detected_layers[net_name] = inferred
+                    result.stackup_inferred_nets.append(net_name)
+                else:
+                    # 2-layer board: no inner layers, fall back to B.Cu
+                    net_target_layers[net_name] = None
+                    result.fallback_nets.append(net_name)
     else:
         # Use explicit target layer for all nets
         for net_name in net_names:
@@ -2655,9 +2796,14 @@ def output_result(result: StitchResult, dry_run: bool = False, run_drc: bool = F
 
     # Show detected layers
     if result.detected_layers:
-        print("\nAuto-detected target layers from zones:")
+        print("\nAuto-detected target layers:")
         for net_name, layer in sorted(result.detected_layers.items()):
-            print(f"  {net_name} -> {layer}")
+            source = (
+                " (inferred from stackup)"
+                if net_name in result.stackup_inferred_nets
+                else " (from zone)"
+            )
+            print(f"  {net_name} -> {layer}{source}")
 
     if not result.vias_added and not result.pads_skipped:
         if result.already_connected > 0:

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -279,7 +279,6 @@ def _is_ground_net(net_name: str) -> bool:
 def infer_target_layer_from_stackup(
     copper_layers: list[str],
     net_name: str,
-    pad_layer: str,
 ) -> str | None:
     """Infer the target plane layer for a net using standard stackup conventions.
 
@@ -293,7 +292,6 @@ def infer_target_layer_from_stackup(
     Args:
         copper_layers: Ordered list of copper layers from get_copper_layers()
         net_name: The net name (used to classify as ground vs power)
-        pad_layer: The layer the component pad is on
 
     Returns:
         Target inner layer name, or None if no inner layers exist
@@ -2329,11 +2327,12 @@ def run_blanket_stitch(
             else:
                 # No zone or zones only on outer layers -- infer from stackup
                 inferred = infer_target_layer_from_stackup(
-                    copper_layers, net_name, "F.Cu"
+                    copper_layers, net_name
                 )
                 if inferred:
                     net_target_layer = inferred
                     result.detected_layers[net_name] = inferred
+                    result.stackup_inferred_nets.append(net_name)
                 else:
                     net_target_layer = None
                     result.fallback_nets.append(net_name)
@@ -2462,7 +2461,7 @@ def run_stitch(
                 # No zone or zones only on outer layers for a multi-layer
                 # board.  Infer the correct inner layer from the stackup.
                 inferred = infer_target_layer_from_stackup(
-                    copper_layers, net_name, "F.Cu"
+                    copper_layers, net_name
                 )
                 if inferred:
                     net_target_layers[net_name] = inferred

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -11,6 +11,8 @@ from kicad_tools.cli.stitch_cmd import (
     TraceSegment,
     TrackSegment,
     ZonePolygon,
+    _is_ground_net,
+    _should_use_stackup_fallback,
     calculate_dogleg_via_position,
     calculate_extended_escape_position,
     calculate_via_position,
@@ -26,9 +28,11 @@ from kicad_tools.cli.stitch_cmd import (
     find_pads_on_nets,
     find_same_net_filled_polygons,
     generate_grid_positions,
+    get_copper_layers,
     get_net_map,
     get_net_number,
     get_via_layers,
+    infer_target_layer_from_stackup,
     is_pad_connected,
     main,
     point_in_polygon,
@@ -1235,8 +1239,8 @@ class TestZoneAutoDetection:
         for via in v33_vias:
             assert via.layers[1] == "In2.Cu"
 
-    def test_fallback_to_bcu_when_no_zone(self, stitch_zone_pcb: Path):
-        """Should fall back to B.Cu when no zone found for net."""
+    def test_no_zone_infers_inner_layer_for_power_net(self, stitch_zone_pcb: Path):
+        """Should infer inner layer from stackup when no zone found for net on 4-layer board."""
         result = run_stitch(
             pcb_path=stitch_zone_pcb,
             net_names=["VCC"],  # VCC has no zone
@@ -1244,20 +1248,22 @@ class TestZoneAutoDetection:
             dry_run=True,
         )
 
-        # Should record VCC as fallback
-        assert "VCC" in result.fallback_nets
-        assert "VCC" not in result.detected_layers
+        # VCC is a power net -> should be inferred to In2.Cu (last inner layer)
+        assert "VCC" in result.detected_layers
+        assert result.detected_layers["VCC"] == "In2.Cu"
+        assert "VCC" in result.stackup_inferred_nets
+        assert len(result.fallback_nets) == 0
 
-        # VCC vias should target B.Cu (default)
+        # VCC vias should target In2.Cu
         vcc_vias = [v for v in result.vias_added if v.pad.net_name == "VCC"]
         for via in vcc_vias:
-            assert via.layers[1] == "B.Cu"
+            assert via.layers[1] == "In2.Cu"
 
     def test_mixed_zone_and_no_zone_nets(self, stitch_zone_pcb: Path):
-        """Should handle mix of nets with and without zones."""
+        """Should handle mix of nets with zones and nets inferred from stackup."""
         result = run_stitch(
             pcb_path=stitch_zone_pcb,
-            net_names=["GND", "VCC"],  # GND has zone, VCC doesn't
+            net_names=["GND", "VCC"],  # GND has zone on In1.Cu, VCC doesn't
             target_layer=None,
             dry_run=True,
         )
@@ -1265,8 +1271,10 @@ class TestZoneAutoDetection:
         # GND detected from zone
         assert result.detected_layers.get("GND") == "In1.Cu"
 
-        # VCC falls back to B.Cu
-        assert "VCC" in result.fallback_nets
+        # VCC inferred from stackup to In2.Cu (power net -> last inner layer)
+        assert result.detected_layers.get("VCC") == "In2.Cu"
+        assert "VCC" in result.stackup_inferred_nets
+        assert len(result.fallback_nets) == 0
 
         # Check layers match
         gnd_vias = [v for v in result.vias_added if v.pad.net_name == "GND"]
@@ -1275,7 +1283,7 @@ class TestZoneAutoDetection:
         for via in gnd_vias:
             assert via.layers[1] == "In1.Cu"
         for via in vcc_vias:
-            assert via.layers[1] == "B.Cu"
+            assert via.layers[1] == "In2.Cu"
 
     def test_explicit_target_overrides_zone(self, stitch_zone_pcb: Path):
         """Explicit target layer should override zone auto-detection."""
@@ -1294,8 +1302,8 @@ class TestZoneAutoDetection:
         for via in result.vias_added:
             assert via.layers[1] == "In2.Cu"
 
-    def test_no_zone_without_explicit_target(self, stitch_test_pcb: Path):
-        """PCB without zones should fall back to B.Cu for all nets."""
+    def test_no_zone_infers_inner_layer_on_4layer_board(self, stitch_test_pcb: Path):
+        """4-layer PCB without zones should infer inner layer from stackup."""
         result = run_stitch(
             pcb_path=stitch_test_pcb,
             net_names=["GND"],
@@ -1303,13 +1311,15 @@ class TestZoneAutoDetection:
             dry_run=True,
         )
 
-        # GND should fall back (no zones in test PCB)
-        assert "GND" in result.fallback_nets
-        assert len(result.detected_layers) == 0
+        # GND should be inferred to In1.Cu (first inner layer) via stackup
+        assert "GND" in result.detected_layers
+        assert result.detected_layers["GND"] == "In1.Cu"
+        assert "GND" in result.stackup_inferred_nets
+        assert len(result.fallback_nets) == 0
 
-        # Vias should target B.Cu
+        # Vias should target In1.Cu
         for via in result.vias_added:
-            assert via.layers[1] == "B.Cu"
+            assert via.layers[1] == "In1.Cu"
 
 
 class TestCLIOutputWithZones:
@@ -1324,15 +1334,230 @@ class TestCLIOutputWithZones:
         assert "Auto-detected target layers" in captured.out
         assert "GND -> In1.Cu" in captured.out
 
-    def test_output_shows_fallback_warning(self, stitch_zone_pcb: Path, capsys):
-        """CLI should show warning when falling back to B.Cu."""
+    def test_output_shows_stackup_inferred(self, stitch_zone_pcb: Path, capsys):
+        """CLI should show stackup-inferred layers in output."""
         exit_code = main([str(stitch_zone_pcb), "--net", "VCC", "--dry-run"])
 
         assert exit_code == 0
         captured = capsys.readouterr()
-        assert "Warning" in captured.err
-        assert "VCC" in captured.err
-        assert "B.Cu" in captured.err
+        assert "Auto-detected target layers" in captured.out
+        assert "VCC -> In2.Cu" in captured.out
+        assert "inferred from stackup" in captured.out
+
+
+# 2-layer PCB for testing true fallback to B.Cu (no inner layers available)
+STITCH_2LAYER_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000100")
+    (at 110 110)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-uuid-c1"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "+3.3V"))
+  )
+)
+"""
+
+# 4-layer PCB with zones on OUTER layers only (the bug scenario from #2040)
+STITCH_OUTER_ZONE_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000100")
+    (at 110 110)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-uuid-c1"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "+3.3V"))
+  )
+  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "zone-gnd-outer")
+    (name "GND_plane")
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 100 100) (xy 140 100) (xy 140 130) (xy 100 130)))
+  )
+  (zone (net 2) (net_name "+3.3V") (layer "F.Cu") (uuid "zone-3v3-outer")
+    (name "3V3_plane")
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 100 100) (xy 140 100) (xy 140 130) (xy 100 130)))
+  )
+)
+"""
+
+
+@pytest.fixture
+def stitch_2layer_pcb(tmp_path: Path) -> Path:
+    """Create a 2-layer PCB file for testing true B.Cu fallback."""
+    pcb_file = tmp_path / "stitch_2layer.kicad_pcb"
+    pcb_file.write_text(STITCH_2LAYER_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def stitch_outer_zone_pcb(tmp_path: Path) -> Path:
+    """Create a 4-layer PCB with zones on outer layers only (bug #2040 scenario)."""
+    pcb_file = tmp_path / "stitch_outer_zone.kicad_pcb"
+    pcb_file.write_text(STITCH_OUTER_ZONE_PCB)
+    return pcb_file
+
+
+class TestStackupAwareFallback:
+    """Tests for stackup-aware layer inference (#2040)."""
+
+    def test_get_copper_layers_4layer(self, stitch_zone_pcb: Path):
+        """Should extract ordered copper layers from a 4-layer PCB."""
+        sexp = load_pcb(stitch_zone_pcb)
+        layers = get_copper_layers(sexp)
+        assert layers == ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+
+    def test_get_copper_layers_2layer(self, stitch_2layer_pcb: Path):
+        """Should extract ordered copper layers from a 2-layer PCB."""
+        sexp = load_pcb(stitch_2layer_pcb)
+        layers = get_copper_layers(sexp)
+        assert layers == ["F.Cu", "B.Cu"]
+
+    def test_is_ground_net(self):
+        """Should identify ground net names."""
+        assert _is_ground_net("GND")
+        assert _is_ground_net("GNDD")
+        assert _is_ground_net("GNDA")
+        assert _is_ground_net("AGND")
+        assert _is_ground_net("DGND")
+        assert _is_ground_net("VSS")
+        assert not _is_ground_net("+3.3V")
+        assert not _is_ground_net("VCC")
+        assert not _is_ground_net("+5V")
+
+    def test_infer_ground_to_first_inner_layer(self):
+        """Ground nets should target first inner layer on 4-layer board."""
+        copper = ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+        assert infer_target_layer_from_stackup(copper, "GND", "F.Cu") == "In1.Cu"
+        assert infer_target_layer_from_stackup(copper, "GNDD", "F.Cu") == "In1.Cu"
+        assert infer_target_layer_from_stackup(copper, "AGND", "F.Cu") == "In1.Cu"
+
+    def test_infer_power_to_last_inner_layer(self):
+        """Power nets should target last inner layer on 4-layer board."""
+        copper = ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+        assert infer_target_layer_from_stackup(copper, "+3.3V", "F.Cu") == "In2.Cu"
+        assert infer_target_layer_from_stackup(copper, "+5V", "F.Cu") == "In2.Cu"
+        assert infer_target_layer_from_stackup(copper, "VCC", "F.Cu") == "In2.Cu"
+
+    def test_infer_returns_none_for_2layer(self):
+        """2-layer board should return None (no inner layers)."""
+        copper = ["F.Cu", "B.Cu"]
+        assert infer_target_layer_from_stackup(copper, "GND", "F.Cu") is None
+        assert infer_target_layer_from_stackup(copper, "+3.3V", "F.Cu") is None
+
+    def test_infer_6layer_board(self):
+        """6-layer board should use first/last inner layer appropriately."""
+        copper = ["F.Cu", "In1.Cu", "In2.Cu", "In3.Cu", "In4.Cu", "B.Cu"]
+        assert infer_target_layer_from_stackup(copper, "GND", "F.Cu") == "In1.Cu"
+        assert infer_target_layer_from_stackup(copper, "+3.3V", "F.Cu") == "In4.Cu"
+
+    def test_should_use_stackup_fallback_outer_zones(self):
+        """Zones on outer layers should trigger stackup fallback on multi-layer board."""
+        copper_4layer = ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+        assert _should_use_stackup_fallback(["B.Cu"], copper_4layer) is True
+        assert _should_use_stackup_fallback(["F.Cu"], copper_4layer) is True
+        assert _should_use_stackup_fallback(["F.Cu", "B.Cu"], copper_4layer) is True
+
+    def test_should_not_use_stackup_fallback_inner_zones(self):
+        """Zones on inner layers should not trigger stackup fallback."""
+        copper_4layer = ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+        assert _should_use_stackup_fallback(["In1.Cu"], copper_4layer) is False
+        assert _should_use_stackup_fallback(["In2.Cu"], copper_4layer) is False
+
+    def test_should_not_use_stackup_fallback_2layer(self):
+        """2-layer board should not trigger stackup fallback."""
+        copper_2layer = ["F.Cu", "B.Cu"]
+        assert _should_use_stackup_fallback(["B.Cu"], copper_2layer) is False
+
+    def test_2layer_board_falls_back_to_bcu(self, stitch_2layer_pcb: Path):
+        """2-layer PCB without zones should fall back to B.Cu (no inner layers)."""
+        result = run_stitch(
+            pcb_path=stitch_2layer_pcb,
+            net_names=["GND"],
+            target_layer=None,
+            dry_run=True,
+        )
+
+        assert "GND" in result.fallback_nets
+        assert "GND" not in result.detected_layers
+
+        for via in result.vias_added:
+            assert via.layers[1] == "B.Cu"
+
+    def test_outer_zone_triggers_stackup_inference(self, stitch_outer_zone_pcb: Path):
+        """4-layer board with zones on outer layers should infer inner layers."""
+        result = run_stitch(
+            pcb_path=stitch_outer_zone_pcb,
+            net_names=["GND", "+3.3V"],
+            target_layer=None,
+            dry_run=True,
+        )
+
+        # GND has zone on B.Cu (outer) -> should be inferred to In1.Cu
+        assert result.detected_layers.get("GND") == "In1.Cu"
+        assert "GND" in result.stackup_inferred_nets
+
+        # +3.3V has zone on F.Cu (outer) -> should be inferred to In2.Cu
+        assert result.detected_layers.get("+3.3V") == "In2.Cu"
+        assert "+3.3V" in result.stackup_inferred_nets
+
+        assert len(result.fallback_nets) == 0
+
+        # Verify via layers
+        gnd_vias = [v for v in result.vias_added if v.pad.net_name == "GND"]
+        v33_vias = [v for v in result.vias_added if v.pad.net_name == "+3.3V"]
+
+        for via in gnd_vias:
+            assert via.layers[1] == "In1.Cu"
+        for via in v33_vias:
+            assert via.layers[1] == "In2.Cu"
+
+    def test_inner_zone_not_overridden(self, stitch_zone_pcb: Path):
+        """Zones on inner layers should be used directly, not overridden by stackup."""
+        result = run_stitch(
+            pcb_path=stitch_zone_pcb,
+            net_names=["GND", "+3.3V"],
+            target_layer=None,
+            dry_run=True,
+        )
+
+        # Zones are on In1.Cu and In2.Cu respectively -> use directly
+        assert result.detected_layers.get("GND") == "In1.Cu"
+        assert result.detected_layers.get("+3.3V") == "In2.Cu"
+        assert len(result.stackup_inferred_nets) == 0
+        assert len(result.fallback_nets) == 0
 
 
 class TestFindAllPlaneNets:

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -1460,28 +1460,28 @@ class TestStackupAwareFallback:
     def test_infer_ground_to_first_inner_layer(self):
         """Ground nets should target first inner layer on 4-layer board."""
         copper = ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
-        assert infer_target_layer_from_stackup(copper, "GND", "F.Cu") == "In1.Cu"
-        assert infer_target_layer_from_stackup(copper, "GNDD", "F.Cu") == "In1.Cu"
-        assert infer_target_layer_from_stackup(copper, "AGND", "F.Cu") == "In1.Cu"
+        assert infer_target_layer_from_stackup(copper, "GND") == "In1.Cu"
+        assert infer_target_layer_from_stackup(copper, "GNDD") == "In1.Cu"
+        assert infer_target_layer_from_stackup(copper, "AGND") == "In1.Cu"
 
     def test_infer_power_to_last_inner_layer(self):
         """Power nets should target last inner layer on 4-layer board."""
         copper = ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
-        assert infer_target_layer_from_stackup(copper, "+3.3V", "F.Cu") == "In2.Cu"
-        assert infer_target_layer_from_stackup(copper, "+5V", "F.Cu") == "In2.Cu"
-        assert infer_target_layer_from_stackup(copper, "VCC", "F.Cu") == "In2.Cu"
+        assert infer_target_layer_from_stackup(copper, "+3.3V") == "In2.Cu"
+        assert infer_target_layer_from_stackup(copper, "+5V") == "In2.Cu"
+        assert infer_target_layer_from_stackup(copper, "VCC") == "In2.Cu"
 
     def test_infer_returns_none_for_2layer(self):
         """2-layer board should return None (no inner layers)."""
         copper = ["F.Cu", "B.Cu"]
-        assert infer_target_layer_from_stackup(copper, "GND", "F.Cu") is None
-        assert infer_target_layer_from_stackup(copper, "+3.3V", "F.Cu") is None
+        assert infer_target_layer_from_stackup(copper, "GND") is None
+        assert infer_target_layer_from_stackup(copper, "+3.3V") is None
 
     def test_infer_6layer_board(self):
         """6-layer board should use first/last inner layer appropriately."""
         copper = ["F.Cu", "In1.Cu", "In2.Cu", "In3.Cu", "In4.Cu", "B.Cu"]
-        assert infer_target_layer_from_stackup(copper, "GND", "F.Cu") == "In1.Cu"
-        assert infer_target_layer_from_stackup(copper, "+3.3V", "F.Cu") == "In4.Cu"
+        assert infer_target_layer_from_stackup(copper, "GND") == "In1.Cu"
+        assert infer_target_layer_from_stackup(copper, "+3.3V") == "In4.Cu"
 
     def test_should_use_stackup_fallback_outer_zones(self):
         """Zones on outer layers should trigger stackup fallback on multi-layer board."""


### PR DESCRIPTION
## Summary
The stitch command now uses stackup-aware fallback logic to target inner copper layers when zones are missing or placed on outer layers. Previously, all vias defaulted to F.Cu-B.Cu through-vias, leaving inner plane layers electrically isolated.

## Changes
- Added `get_copper_layers()` to extract ordered copper layers from PCB layer definitions
- Added `infer_target_layer_from_stackup()` to map ground nets to first inner layer and power nets to last inner layer based on standard stackup conventions
- Added `_should_use_stackup_fallback()` to detect when zones exist only on outer layers of a multi-layer board
- Updated `run_stitch()` and `run_blanket_stitch()` auto-detection logic to use stackup inference when zone-based detection fails or finds only outer-layer zones
- Added `stackup_inferred_nets` field to `StitchResult` for reporting
- Updated CLI output to distinguish zone-detected vs stackup-inferred layers

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Vias include inner layers in their layer span | Pass | Tests verify GND vias target In1.Cu and power vias target In2.Cu on 4-layer boards |
| Via layer span matches zone layer for target net | Pass | `test_inner_zone_not_overridden` confirms zones on inner layers are used directly |
| Existing stitching via tests updated for inner layer connectivity | Pass | Updated 4 existing tests and added 12 new tests covering 2/4/6-layer boards, outer-zone fallback, and 2-layer B.Cu fallback |

## Test Plan
- All 207 stitch tests pass (22 directly test the new stackup-aware behavior)
- New `TestStackupAwareFallback` class covers: copper layer extraction, ground/power net classification, stackup inference for 2/4/6-layer boards, outer-zone detection, and end-to-end stitch with stackup inference
- Updated existing tests that expected B.Cu fallback on 4-layer boards to expect inner layer inference

Closes #2040