### PR TITLE
fix(sch-replace): update lib_symbols entry and instance pins on symbol replacement

### DIFF
--- a/src/kicad_tools/cli/sch_replace_symbol.py
+++ b/src/kicad_tools/cli/sch_replace_symbol.py
@@ -8,12 +8,19 @@ Usage:
 Options:
     --value <value>        Set new value for the symbol
     --footprint <fp>       Set new footprint
+    --lib-path <path>      Path to .kicad_sym library containing the new symbol.
+                           When provided, the embedded lib_symbols definition
+                           and instance pins are updated to match the new symbol.
     --dry-run              Show what would change without modifying
     --backup               Create backup before modifying
 
 Examples:
     # Replace U1 with a different library symbol
     python3 sch-replace-symbol.py amplifier.kicad_sch U1 "chorus-revA:TPA3116D2"
+
+    # Replace with full library update (recommended)
+    python3 sch-replace-symbol.py amplifier.kicad_sch U1 "chorus-revA:TPA3116D2" \\
+        --lib-path path/to/chorus-revA.kicad_sym
 
     # Replace with new value and footprint
     python3 sch-replace-symbol.py amplifier.kicad_sch U1 "chorus-revA:TPA3116D2" \\
@@ -43,6 +50,11 @@ def main(argv=None):
     parser.add_argument("new_lib_id", help="New library ID (e.g., 'chorus-revA:TPA3116D2')")
     parser.add_argument("--value", help="New value for the symbol")
     parser.add_argument("--footprint", help="New footprint")
+    parser.add_argument(
+        "--lib-path",
+        help="Path to .kicad_sym library file containing the new symbol. "
+        "Updates embedded pin definitions to prevent ERC regressions.",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Show changes without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
@@ -67,6 +79,7 @@ def main(argv=None):
             new_value=args.value,
             new_footprint=args.footprint,
             dry_run=args.dry_run,
+            lib_path=args.lib_path,
         )
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -81,16 +94,22 @@ def main(argv=None):
         print("=" * 50)
 
     print(f"Symbol: {result.reference}")
-    print(f"Library ID: {result.old_lib_id} → {result.new_lib_id}")
-    print(f"Pin count: {result.old_pin_count}")
+    print(f"Library ID: {result.old_lib_id} -> {result.new_lib_id}")
+    print(f"Pin count: {result.old_pin_count} -> {result.new_pin_count}")
     print()
 
     if result.changes_made:
         print("Changes:")
         for change in result.changes_made:
-            print(f"  • {change}")
+            print(f"  - {change}")
     else:
         print("No changes made")
+
+    if result.pin_type_changes:
+        print()
+        print("Pin type changes:")
+        for ptc in result.pin_type_changes:
+            print(f"  Pin {ptc.pin_number} ({ptc.pin_name}): {ptc.old_type} -> {ptc.new_type}")
 
     if result.preserved_properties:
         print()
@@ -98,14 +117,15 @@ def main(argv=None):
 
     if not args.dry_run:
         print()
-        print("✓ Schematic updated successfully")
-        print()
-        print("⚠️  Important: This replacement only updated the lib_id and properties.")
-        print("   The pin connections remain from the old symbol.")
-        print("   If the new symbol has a different pinout, you must:")
-        print("   1. Open the schematic in KiCad")
-        print("   2. Delete and re-place the symbol from the library")
-        print("   3. Reconnect all wires to the correct pins")
+        if result.lib_symbol_updated:
+            print("Schematic updated successfully (lib_symbols definition replaced)")
+        else:
+            print("Schematic updated successfully")
+            print()
+            print("Warning: This replacement only updated the lib_id and properties.")
+            print("   The embedded pin definitions were NOT updated.")
+            print("   Use --lib-path to provide the new symbol's library file")
+            print("   so that pin types are updated and ERC regressions are avoided.")
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/operations/symbol_ops.py
+++ b/src/kicad_tools/operations/symbol_ops.py
@@ -7,10 +7,20 @@ Provides functions to modify, replace, and update symbol instances.
 from __future__ import annotations
 
 import uuid as uuid_lib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from kicad_tools.sexp import SExp, parse_string, serialize_sexp
+
+
+@dataclass
+class PinTypeChange:
+    """Describes a change in pin electrical type between old and new symbol."""
+
+    pin_number: str
+    pin_name: str
+    old_type: str
+    new_type: str
 
 
 @dataclass
@@ -24,6 +34,8 @@ class SymbolReplacement:
     new_pin_count: int
     preserved_properties: list[str]  # Properties that were kept
     changes_made: list[str]  # List of changes made
+    lib_symbol_updated: bool = False  # Whether the lib_symbols entry was updated
+    pin_type_changes: list[PinTypeChange] = field(default_factory=list)
 
 
 def find_symbol_by_reference(sexp: SExp, reference: str) -> SExp | None:
@@ -64,13 +76,16 @@ def replace_symbol_lib_id(
     new_value: str | None = None,
     new_footprint: str | None = None,
     dry_run: bool = False,
+    lib_path: str | None = None,
 ) -> SymbolReplacement:
     """
     Replace a symbol's library ID (and optionally value/footprint).
 
-    This is a "soft" replacement that changes the lib_id but keeps
-    the existing pin connections. Use this when the new symbol has
-    compatible pinout or when you'll rewire manually.
+    When *lib_path* is provided, the embedded ``lib_symbols`` entry is
+    replaced with the definition from the library file and the instance
+    pins are reconciled with the new definition.  Without *lib_path*
+    this is a "soft" replacement that changes only the ``lib_id`` and
+    selected properties while keeping the old pin definitions.
 
     Args:
         schematic_path: Path to the .kicad_sch file
@@ -79,14 +94,20 @@ def replace_symbol_lib_id(
         new_value: Optional new value for the symbol
         new_footprint: Optional new footprint
         dry_run: If True, don't write changes
+        lib_path: Optional path to the .kicad_sym library file
+            containing the new symbol.  When provided the embedded
+            ``lib_symbols`` definition and instance pins are updated.
 
     Returns:
         SymbolReplacement with details of changes
 
     Raises:
-        FileNotFoundError: If schematic doesn't exist
-        ValueError: If symbol not found
+        FileNotFoundError: If schematic or library doesn't exist
+        ValueError: If symbol not found in schematic or library
     """
+    from kicad_tools.schema.library import LibrarySymbol, SymbolLibrary
+    from kicad_tools.schema.schematic import Schematic
+
     path = Path(schematic_path)
     if not path.exists():
         raise FileNotFoundError(f"Schematic not found: {schematic_path}")
@@ -106,6 +127,8 @@ def replace_symbol_lib_id(
 
     changes = []
     preserved = []
+    lib_symbol_updated = False
+    pin_type_changes: list[PinTypeChange] = []
 
     # Update lib_id
     lib_id_node = symbol.find("lib_id")
@@ -127,14 +150,92 @@ def replace_symbol_lib_id(
         else:
             preserved.append(name)
 
+    # Update lib_symbols entry and reconcile instance pins
+    new_pin_count = len(old_pins)
+    if lib_path:
+        lib_file = Path(lib_path)
+        if not lib_file.exists():
+            raise FileNotFoundError(f"Library not found: {lib_path}")
+
+        lib = SymbolLibrary.load(str(lib_file))
+
+        # The new_lib_id is typically "LibName:SymbolName".  The symbol
+        # is stored in the library under the full qualified name.  Some
+        # libraries use just the short name as the key.
+        new_lib_sym = lib.get_symbol(new_lib_id)
+        if new_lib_sym is None:
+            # Try the short name (part after colon)
+            short_name = new_lib_id.split(":", 1)[1] if ":" in new_lib_id else new_lib_id
+            new_lib_sym = lib.get_symbol(short_name)
+        if new_lib_sym is None:
+            raise ValueError(
+                f"Symbol '{new_lib_id}' not found in library '{lib_path}'"
+            )
+
+        # Compare old and new pin types for reporting
+        old_lib_sym_sexp = _find_lib_symbol_sexp(sexp, old_lib_id)
+        if old_lib_sym_sexp is not None:
+            old_lib_sym = LibrarySymbol.from_sexp(old_lib_sym_sexp)
+            old_pin_map = {p.number: p for p in old_lib_sym.pins}
+            for new_pin in new_lib_sym.pins:
+                old_pin = old_pin_map.get(new_pin.number)
+                if old_pin and old_pin.type != new_pin.type:
+                    pin_type_changes.append(
+                        PinTypeChange(
+                            pin_number=new_pin.number,
+                            pin_name=new_pin.name,
+                            old_type=old_pin.type,
+                            new_type=new_pin.type,
+                        )
+                    )
+
+        # Replace the lib_symbols entry.  We need to rename the new
+        # library symbol to match the lib_id used in the schematic so
+        # that KiCad can resolve the reference.
+        renamed_sym = LibrarySymbol(
+            name=new_lib_id,
+            properties=new_lib_sym.properties,
+            pins=new_lib_sym.pins,
+            graphics=new_lib_sym.graphics,
+            units=new_lib_sym.units,
+        )
+
+        # Use Schematic helper to swap the lib_symbols entry
+        sch = Schematic.__new__(Schematic)
+        sch._sexp = sexp
+        sch.replace_lib_symbol(old_lib_id, renamed_sym)
+        lib_symbol_updated = True
+        changes.append(f"lib_symbols: replaced embedded definition for {old_lib_id}")
+
+        # Reconcile instance pins with the new library definition
+        new_pin_numbers = {p.number for p in new_lib_sym.pins}
+        old_instance_pins = {p.get_string(0) for p in old_pins}
+
+        # Remove instance pins that don't exist in the new symbol
+        for pin in list(old_pins):
+            pin_num = pin.get_string(0)
+            if pin_num not in new_pin_numbers:
+                symbol.remove(pin)
+                changes.append(f"Removed instance pin {pin_num} (not in new symbol)")
+
+        # Add instance pins that exist in new symbol but not in instance
+        for pin in new_lib_sym.pins:
+            if pin.number not in old_instance_pins:
+                add_symbol_pin(symbol, pin.number)
+                changes.append(f"Added instance pin {pin.number} (new in replacement symbol)")
+
+        new_pin_count = len(get_symbol_pins(symbol))
+
     result = SymbolReplacement(
         reference=reference,
         old_lib_id=old_lib_id,
         new_lib_id=new_lib_id,
         old_pin_count=len(old_pins),
-        new_pin_count=len(old_pins),  # Pins not changed in soft replace
+        new_pin_count=new_pin_count,
         preserved_properties=preserved,
         changes_made=changes,
+        lib_symbol_updated=lib_symbol_updated,
+        pin_type_changes=pin_type_changes,
     )
 
     # Write back if not dry run
@@ -143,6 +244,17 @@ def replace_symbol_lib_id(
         path.write_text(new_text)
 
     return result
+
+
+def _find_lib_symbol_sexp(sexp: SExp, lib_id: str) -> SExp | None:
+    """Find a library symbol definition in the schematic's lib_symbols section."""
+    lib_syms = sexp.find("lib_symbols")
+    if lib_syms is None:
+        return None
+    for sym in lib_syms.find_all("symbol"):
+        if sym.get_string(0) == lib_id:
+            return sym
+    return None
 
 
 def update_symbol_pins(

--- a/src/kicad_tools/schema/schematic.py
+++ b/src/kicad_tools/schema/schematic.py
@@ -674,6 +674,59 @@ class Schematic:
 
         lib_syms.append(lib_sym.to_sexp_node())
 
+    def replace_lib_symbol(self, old_name: str, lib_sym: LibrarySymbol) -> bool:
+        """Replace an existing library symbol definition in ``lib_symbols``.
+
+        Removes the entry named *old_name* and inserts the definition from
+        *lib_sym*.  If *old_name* is not found the new definition is simply
+        appended (equivalent to :meth:`embed_lib_symbol`).
+
+        Args:
+            old_name: The ``lib_id`` of the symbol to remove.
+            lib_sym: The :class:`LibrarySymbol` to insert in its place.
+
+        Returns:
+            ``True`` if an existing entry was replaced, ``False`` if a new
+            entry was appended.
+        """
+        lib_syms = self.lib_symbols
+        if lib_syms is None:
+            # Create the lib_symbols section
+            lib_syms = SExp.list("lib_symbols")
+            insert_idx = 0
+            for i, child in enumerate(self._sexp.children):
+                if child.name in (
+                    "uuid",
+                    "paper",
+                    "title_block",
+                    "generator",
+                    "generator_version",
+                    "version",
+                ):
+                    insert_idx = i + 1
+            self._sexp.insert(insert_idx, lib_syms)
+
+        # Find and remove the old entry
+        replaced = False
+        for sym in lib_syms.find_all("symbol"):
+            sym_name = sym.get_string(0)
+            if sym_name == old_name:
+                lib_syms.remove(sym)
+                replaced = True
+                break
+
+        # Also remove any pre-existing entry with the new name to avoid
+        # duplicates when old_name != lib_sym.name
+        if old_name != lib_sym.name:
+            for sym in lib_syms.find_all("symbol"):
+                sym_name = sym.get_string(0)
+                if sym_name == lib_sym.name:
+                    lib_syms.remove(sym)
+                    break
+
+        lib_syms.append(lib_sym.to_sexp_node())
+        return replaced
+
     @staticmethod
     def snap_to_grid(
         value: float,

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -27,6 +27,7 @@ from kicad_tools.operations.pinmap import (
     match_pins,
 )
 from kicad_tools.operations.symbol_ops import (
+    PinTypeChange,
     find_symbol_by_reference,
     get_symbol_lib_id,
     get_symbol_pins,
@@ -389,6 +390,267 @@ class TestSymbolOps:
 
         with pytest.raises(ValueError, match="not found"):
             replace_symbol_lib_id(str(test_file), "U99", "New:Symbol")
+
+
+# Schematic with a voltage regulator symbol and embedded lib_symbols entry
+# that has power_out pin type on the output pin.
+REGULATOR_SCHEMATIC = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Regulator_Linear:AP2204K-3.3"
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "AP2204K-3.3" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+      (symbol "AP2204K-3.3_1_1"
+        (pin power_in line (at -5.08 2.54 0) (length 2.54) (name "VIN") (number "1"))
+        (pin power_in line (at 0 -5.08 90) (length 2.54) (name "GND") (number "2"))
+        (pin power_out line (at 5.08 2.54 180) (length 2.54) (name "VOUT") (number "3"))
+      )
+    )
+  )
+  (symbol
+    (lib_id "Regulator_Linear:AP2204K-3.3")
+    (at 120 100 0)
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (property "Reference" "U1" (at 120 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "AP2204K-3.3" (at 120 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Package_TO_SOT_SMD:SOT-23-5" (at 120 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000011"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000012"))
+    (pin "3" (uuid "00000000-0000-0000-0000-000000000013"))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "U1")
+          (unit 1)
+        )
+      )
+    )
+  )
+)
+"""
+
+# Library file with a replacement symbol that uses "output" instead of
+# "power_out" on pin 3, triggering the ERC regression described in #2048.
+REPLACEMENT_LIB = """(kicad_symbol_lib
+  (version 20231120)
+  (generator "test")
+  (symbol "XC6206P332MR"
+    (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "XC6206P332MR" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+    (symbol "XC6206P332MR_1_1"
+      (pin power_in line (at -5.08 2.54 0) (length 2.54) (name "VIN") (number "1"))
+      (pin power_in line (at 0 -5.08 90) (length 2.54) (name "GND") (number "2"))
+      (pin output line (at 5.08 2.54 180) (length 2.54) (name "VOUT") (number "3"))
+    )
+  )
+)
+"""
+
+# Library with a symbol that has different pin count (4 pins vs 3)
+DIFFERENT_PIN_COUNT_LIB = """(kicad_symbol_lib
+  (version 20231120)
+  (generator "test")
+  (symbol "AltReg:REG4PIN"
+    (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "REG4PIN" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+    (symbol "REG4PIN_1_1"
+      (pin power_in line (at -5.08 2.54 0) (length 2.54) (name "VIN") (number "1"))
+      (pin power_in line (at 0 -5.08 90) (length 2.54) (name "GND") (number "2"))
+      (pin output line (at 5.08 2.54 180) (length 2.54) (name "VOUT") (number "3"))
+      (pin input line (at -5.08 -2.54 0) (length 2.54) (name "EN") (number "4"))
+    )
+  )
+)
+"""
+
+
+class TestReplaceSymbolWithLibUpdate:
+    """Tests for replace_symbol_lib_id with --lib-path (lib_symbols update)."""
+
+    def _write_schematic(self, tmp_path: Path) -> Path:
+        """Write the regulator schematic fixture."""
+        sch_file = tmp_path / "regulator.kicad_sch"
+        sch_file.write_text(REGULATOR_SCHEMATIC)
+        return sch_file
+
+    def _write_lib(self, tmp_path: Path, content: str, name: str = "replacement.kicad_sym") -> Path:
+        lib_file = tmp_path / name
+        lib_file.write_text(content)
+        return lib_file
+
+    def test_lib_symbols_updated_on_replace(self, tmp_path: Path):
+        """Replacing with lib_path updates the embedded lib_symbols entry."""
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, REPLACEMENT_LIB)
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "Regulator_Linear:XC6206P332MR",
+            lib_path=str(lib_file),
+        )
+
+        assert result.lib_symbol_updated is True
+        assert result.old_lib_id == "Regulator_Linear:AP2204K-3.3"
+        assert result.new_lib_id == "Regulator_Linear:XC6206P332MR"
+
+        # Verify the schematic now has the new lib_symbols entry
+        sexp = parse_string(sch_file.read_text())
+        lib_syms = sexp.find("lib_symbols")
+        assert lib_syms is not None
+
+        # Old entry should be gone
+        old_found = False
+        new_found = False
+        for sym in lib_syms.find_all("symbol"):
+            name = sym.get_string(0)
+            if name == "Regulator_Linear:AP2204K-3.3":
+                old_found = True
+            if name == "Regulator_Linear:XC6206P332MR":
+                new_found = True
+        assert not old_found, "Old lib_symbols entry should be removed"
+        assert new_found, "New lib_symbols entry should be present"
+
+    def test_pin_type_changes_reported(self, tmp_path: Path):
+        """Pin type differences between old and new symbols are reported."""
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, REPLACEMENT_LIB)
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "Regulator_Linear:XC6206P332MR",
+            lib_path=str(lib_file),
+        )
+
+        # Pin 3 changed from power_out to output
+        assert len(result.pin_type_changes) == 1
+        ptc = result.pin_type_changes[0]
+        assert ptc.pin_number == "3"
+        assert ptc.old_type == "power_out"
+        assert ptc.new_type == "output"
+
+    def test_dry_run_does_not_modify_file(self, tmp_path: Path):
+        """Dry run with lib_path reports changes but does not write."""
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, REPLACEMENT_LIB)
+        original_text = sch_file.read_text()
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "Regulator_Linear:XC6206P332MR",
+            lib_path=str(lib_file),
+            dry_run=True,
+        )
+
+        assert result.lib_symbol_updated is True
+        assert result.pin_type_changes
+        # File should be untouched
+        assert sch_file.read_text() == original_text
+
+    def test_different_pin_count_adds_new_pins(self, tmp_path: Path):
+        """When new symbol has extra pins, they are added to the instance."""
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, DIFFERENT_PIN_COUNT_LIB)
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "AltReg:REG4PIN",
+            lib_path=str(lib_file),
+        )
+
+        assert result.old_pin_count == 3
+        assert result.new_pin_count == 4
+        assert result.lib_symbol_updated is True
+
+        # Verify the instance now has 4 pins
+        sexp = parse_string(sch_file.read_text())
+        symbol = find_symbol_by_reference(sexp, "U1")
+        pins = get_symbol_pins(symbol)
+        assert len(pins) == 4
+
+    def test_library_not_found_raises(self, tmp_path: Path):
+        """Providing a non-existent lib_path raises FileNotFoundError."""
+        sch_file = self._write_schematic(tmp_path)
+
+        with pytest.raises(FileNotFoundError, match="Library not found"):
+            replace_symbol_lib_id(
+                str(sch_file),
+                "U1",
+                "Regulator_Linear:XC6206P332MR",
+                lib_path=str(tmp_path / "nonexistent.kicad_sym"),
+            )
+
+    def test_symbol_not_in_library_raises(self, tmp_path: Path):
+        """Providing a lib_path that doesn't contain the symbol raises ValueError."""
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, REPLACEMENT_LIB)
+
+        with pytest.raises(ValueError, match="not found in library"):
+            replace_symbol_lib_id(
+                str(sch_file),
+                "U1",
+                "Regulator_Linear:NonExistentSymbol",
+                lib_path=str(lib_file),
+            )
+
+    def test_new_lib_symbol_has_correct_pin_types(self, tmp_path: Path):
+        """After replacement, the embedded lib symbol has the new pin types."""
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, REPLACEMENT_LIB)
+
+        replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "Regulator_Linear:XC6206P332MR",
+            lib_path=str(lib_file),
+        )
+
+        # Parse the updated schematic and check the embedded lib symbol
+        sexp = parse_string(sch_file.read_text())
+        lib_syms = sexp.find("lib_symbols")
+        new_sym = None
+        for sym in lib_syms.find_all("symbol"):
+            if sym.get_string(0) == "Regulator_Linear:XC6206P332MR":
+                new_sym = sym
+                break
+        assert new_sym is not None
+
+        # Find pin 3 in the unit sub-symbol and check its type
+        from kicad_tools.schema.library import LibrarySymbol
+
+        lib_sym = LibrarySymbol.from_sexp(new_sym)
+        pin3 = lib_sym.get_pin("3")
+        assert pin3 is not None
+        assert pin3.type == "output", (
+            f"Pin 3 should be 'output' (from new symbol), got '{pin3.type}'"
+        )
+
+    def test_without_lib_path_soft_replace_unchanged(self, tmp_path: Path):
+        """Without lib_path, replacement is still soft (no lib_symbols update)."""
+        sch_file = self._write_schematic(tmp_path)
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "Regulator_Linear:XC6206P332MR",
+        )
+
+        assert result.lib_symbol_updated is False
+        assert len(result.pin_type_changes) == 0
+
+        # lib_symbols should still have the OLD definition
+        from kicad_tools.schema.schematic import Schematic
+
+        sch = Schematic.load(sch_file)
+        old_sym = sch.get_lib_symbol("Regulator_Linear:AP2204K-3.3")
+        assert old_sym is not None, "Old lib_symbols entry should still be present"
 
 
 class TestNetOpsHelpers:


### PR DESCRIPTION
## Summary

When `sch replace` swaps a symbol's `lib_id`, the embedded `lib_symbols` definition was left unchanged. KiCad ERC uses pin types from `lib_symbols`, so replacing a symbol with different pin electrical types (e.g. `power_out` vs `output`) introduced false ERC violations like "Input Power pin not driven."

This PR adds a `--lib-path` option that loads the new symbol's library file and replaces the embedded `lib_symbols` entry, preventing ERC regressions.

## Changes

- Added `--lib-path` parameter to `replace_symbol_lib_id()` in `symbol_ops.py` that loads the new symbol's `.kicad_sym` library file
- When `--lib-path` is provided: replaces the embedded `lib_symbols` entry, reconciles instance pins (removes pins absent from new symbol, adds new pins), and reports pin type changes
- Added `PinTypeChange` dataclass and `lib_symbol_updated` / `pin_type_changes` fields to `SymbolReplacement` result
- Added `Schematic.replace_lib_symbol()` method that removes an old `lib_symbols` entry and inserts a new one (complements the existing `embed_lib_symbol()` which is a no-op for existing names)
- Updated CLI `sch_replace_symbol.py` to accept `--lib-path`, display pin type changes, and show appropriate warnings when `--lib-path` is omitted
- Without `--lib-path`, behavior is unchanged (backward compatible soft replace)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| lib_symbols entry replaced when --lib-path provided | Pass | `test_lib_symbols_updated_on_replace` confirms old entry removed and new entry present |
| Pin type changes reported | Pass | `test_pin_type_changes_reported` verifies pin 3 change from power_out to output is detected |
| Dry-run shows changes without modifying file | Pass | `test_dry_run_does_not_modify_file` verifies file unchanged |
| Different pin counts handled | Pass | `test_different_pin_count_adds_new_pins` verifies 3-pin to 4-pin reconciliation |
| Missing library raises clear error | Pass | `test_library_not_found_raises` and `test_symbol_not_in_library_raises` |
| New embedded symbol has correct pin types | Pass | `test_new_lib_symbol_has_correct_pin_types` parses updated schematic and verifies pin 3 type is "output" |
| Without --lib-path, backward compatible | Pass | `test_without_lib_path_soft_replace_unchanged` verifies soft replace behavior unchanged |

## Test Plan

- 8 new tests in `TestReplaceSymbolWithLibUpdate` covering lib_symbols replacement, pin type change reporting, dry-run, different pin counts, error cases, and backward compatibility
- All 71 existing tests in `test_operations.py` pass
- All 186 schematic tests pass (no regressions)

Closes #2048