### PR TITLE
fix(router): add skip_cleanup option and improve cpp_backend diagnostics

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -972,7 +972,7 @@ def route_with_layer_escalation(
             original_content = update_pcb_layer_stackup(original_content, final_result.layer_count)
 
         # Get route S-expressions
-        route_sexp = final_result.router.to_sexp()
+        route_sexp = final_result.router.to_sexp(skip_cleanup=True)
 
         # Insert routes before final closing parenthesis
         if route_sexp:
@@ -1376,7 +1376,7 @@ def route_with_rule_relaxation(
         original_content = pcb_path.read_text()
 
         # Get route S-expressions
-        route_sexp = final_result.router.to_sexp()
+        route_sexp = final_result.router.to_sexp(skip_cleanup=True)
 
         # Insert routes before final closing parenthesis
         if route_sexp:
@@ -1806,7 +1806,7 @@ def route_with_combined_escalation(
             original_content = update_pcb_layer_stackup(original_content, final_result.layer_count)
 
         # Get route S-expressions
-        route_sexp = final_result.router.to_sexp()
+        route_sexp = final_result.router.to_sexp(skip_cleanup=True)
 
         # Insert routes before final closing parenthesis
         if route_sexp:
@@ -3432,8 +3432,9 @@ def main(argv: list[str] | None = None) -> int:
             # Read original PCB content
             original_content = pcb_path.read_text()
 
-            # Get route S-expressions
-            route_sexp = router.to_sexp()
+            # Get route S-expressions (skip cleanup — it removes valid routes;
+            # statistics have already been computed from the full route set)
+            route_sexp = router.to_sexp(skip_cleanup=True)
 
             # Insert routes and zones before final closing parenthesis
             # Note: KiCad's S-expression format doesn't support ; comments

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3705,13 +3705,15 @@ class Autorouter:
         self._cleanup_stats = stats
         return stats
 
-    def to_sexp(self) -> str:
+    def to_sexp(self, *, skip_cleanup: bool = False) -> str:
         """Generate KiCad S-expressions for all routes.
 
         Automatically runs ``cleanup_artifacts()`` before emitting to
-        remove net-0 orphans and out-of-bounds segments.
+        remove net-0 orphans and out-of-bounds segments, unless
+        *skip_cleanup* is True.
         """
-        self.cleanup_artifacts()
+        if not skip_cleanup:
+            self.cleanup_artifacts()
         return "\n\t".join(route.to_sexp() for route in self.routes)
 
     def get_statistics(self, nets_to_route_ids: set[int] | None = None) -> dict:

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -41,6 +41,25 @@ except ImportError as e:
     _CPP_IMPORT_ERROR = str(e)
     router_cpp = None  # type: ignore
 
+    # Check for common cause: .so built for a different Python version
+    import glob
+    import pathlib
+    import sys
+
+    _so_files = glob.glob(
+        str(pathlib.Path(__file__).parent / "router_cpp.cpython-*-darwin.so")
+    ) + glob.glob(
+        str(pathlib.Path(__file__).parent / "router_cpp.cpython-*-linux-*.so")
+    )
+    if _so_files:
+        _running_tag = f"cpython-{sys.version_info.major}{sys.version_info.minor}"
+        if _running_tag not in " ".join(_so_files):
+            _CPP_IMPORT_ERROR = (
+                f"C++ backend was built for {', '.join(pathlib.Path(f).name for f in _so_files)} "
+                f"but running Python {sys.version_info.major}.{sys.version_info.minor} "
+                f"({_running_tag}). Rebuild with: kicad-tools build-native"
+            )
+
 
 def is_cpp_available() -> bool:
     """Check if the C++ router backend is available."""
@@ -643,9 +662,11 @@ def create_hybrid_router(
 
     # Fall back to Python implementation
     if not force_python:
+        reason = _CPP_IMPORT_ERROR or "unknown reason"
         logger.warning(
             "C++ router backend not available -- using pure Python (10-100x slower). "
-            "Build the native backend for dramatically faster routing: kct build-native"
+            "Reason: %s",
+            reason,
         )
 
     from .pathfinder import Router


### PR DESCRIPTION
## Summary

- Adds `skip_cleanup` keyword parameter to `Autorouter.to_sexp()` so callers can opt out of `cleanup_artifacts()` before save. All four save paths in `route_cmd.py` now use `skip_cleanup=True` as a safety net — complementing #2043 which fixed cleanup itself but can't cover all edge cases (e.g. routes with net=0 parents before propagation).
- Improves `cpp_backend.py` import error diagnostics: when a `.so` exists but was built for a different Python version, the error message now names the version mismatch and suggests `kicad-tools build-native`.

## Test plan

- [ ] Route a board and verify all routed traces appear in saved output
- [ ] Confirm `to_sexp(skip_cleanup=False)` still runs cleanup (backward compat)
- [ ] Trigger cpp_backend import with wrong Python version, verify improved error message

Closes #2039

🤖 Generated with [Claude Code](https://claude.com/claude-code)