### PR TITLE
fix(placement): subtract board origin from Edge.Cuts outline in optimize command

### DIFF
--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -52,6 +52,7 @@ _interrupt_state: dict = {
     "components": None,
     "pcb_path": None,
     "output_path": None,
+    "board_origin": (0.0, 0.0),
     "quiet": False,
 }
 
@@ -90,7 +91,10 @@ def _save_best_placement_on_interrupt() -> bool:
         return False
 
     try:
-        _write_placements_to_pcb_atomic(pcb_path, output_path, best_vector, components)
+        board_origin = _interrupt_state.get("board_origin", (0.0, 0.0))
+        _write_placements_to_pcb_atomic(
+            pcb_path, output_path, best_vector, components, board_origin,
+        )
         if not quiet:
             print(f"  Best placement saved to: {output_path}")
         return True
@@ -105,6 +109,7 @@ def _write_placements_to_pcb_atomic(
     output_path: str,
     vector,
     components: Sequence,
+    board_origin: tuple[float, float] = (0.0, 0.0),
 ) -> None:
     """Write placements via atomic write (temp file + rename).
 
@@ -119,7 +124,7 @@ def _write_placements_to_pcb_atomic(
     )
     os.close(fd)
     try:
-        _write_placements_to_pcb(pcb_path, tmp_path, vector, components)
+        _write_placements_to_pcb(pcb_path, tmp_path, vector, components, board_origin)
         Path(tmp_path).replace(out)
     except BaseException:
         # Clean up the temp file on failure
@@ -234,11 +239,15 @@ def _read_board_data(
     list[Net],
     BoardOutline,
     DesignRuleSet,
+    tuple[float, float],
 ]:
     """Read component, net, and board data from a .kicad_pcb file.
 
     Uses kicad_tools.schema.pcb.PCB to parse the file and extract
-    components, nets, board outline, and design rules.
+    components, nets, board outline, design rules, and board origin.
+
+    The returned board origin is needed by the writer to convert
+    board-relative optimizer output back to sheet-absolute coordinates.
     """
     from kicad_tools.placement.vector import PadDef
     from kicad_tools.schema.pcb import PCB as SchemaPCB
@@ -300,11 +309,17 @@ def _read_board_data(
     # --- Design rules (use defaults; PCB setup has limited rule info) ---
     rules = DesignRuleSet()
 
-    return components, nets, board_outline, rules
+    return components, nets, board_outline, rules, pcb.board_origin
 
 
 def _extract_board_outline(pcb) -> BoardOutline:
-    """Extract board outline from Edge.Cuts graphic lines."""
+    """Extract board outline from Edge.Cuts graphic lines.
+
+    Edge.Cuts coordinates are in sheet-absolute space, but footprint
+    positions on ``SchemaPCB`` are board-relative (the origin is already
+    subtracted).  We must convert the outline to the same board-relative
+    coordinate system so the optimizer bounds match component positions.
+    """
     xs: list[float] = []
     ys: list[float] = []
 
@@ -314,6 +329,10 @@ def _extract_board_outline(pcb) -> BoardOutline:
             ys.extend([line.start[1], line.end[1]])
 
     if xs and ys:
+        # Convert from sheet-absolute to board-relative coordinates.
+        ox, oy = pcb.board_origin
+        xs = [x - ox for x in xs]
+        ys = [y - oy for y in ys]
         return BoardOutline(min_x=min(xs), min_y=min(ys), max_x=max(xs), max_y=max(ys))
 
     # Fallback: use footprint bounding box with margin
@@ -360,13 +379,17 @@ def _write_placements_to_pcb(
     output_path: str,
     vector: PlacementVector,
     components: Sequence[ComponentDef],
+    board_origin: tuple[float, float] = (0.0, 0.0),
 ) -> None:
     """Write optimized placements back to a .kicad_pcb file.
 
     Reads the original file, updates footprint positions, and writes
-    the result.
+    the result.  Positions from the optimizer are in board-relative
+    coordinates; the board origin offset is added back to produce the
+    sheet-absolute values expected in the ``.kicad_pcb`` file.
     """
     placed = decode(vector, components)
+    ox, oy = board_origin
     ref_to_placement = {p.reference: p for p in placed}
 
     # Read the original PCB content
@@ -413,7 +436,10 @@ def _write_placements_to_pcb(
                 if at_match:
                     p = ref_to_placement[current_ref]
                     indent = at_match.group(1)
-                    new_at = f"{indent}(at {p.x:.6f} {p.y:.6f} {p.rotation:.0f})"
+                    # Convert board-relative back to sheet-absolute.
+                    abs_x = p.x + ox
+                    abs_y = p.y + oy
+                    new_at = f"{indent}(at {abs_x:.6f} {abs_y:.6f} {p.rotation:.0f})"
                     output_lines.append(new_at)
                     if paren_depth <= 0:
                         in_footprint = False
@@ -494,7 +520,7 @@ def run_optimize_placement(
 
     # Read board data
     try:
-        components, nets, board_outline, rules = _read_board_data(pcb_path)
+        components, nets, board_outline, rules, board_origin = _read_board_data(pcb_path)
     except Exception as e:
         print(f"Error reading PCB: {e}", file=sys.stderr)
         if verbose:
@@ -509,6 +535,7 @@ def run_optimize_placement(
 
     # Update interrupt state so handler can save intermediate results
     _interrupt_state["components"] = components
+    _interrupt_state["board_origin"] = board_origin
 
     if not quiet:
         print(f"  Components: {len(components)}")
@@ -758,7 +785,7 @@ def run_optimize_placement(
         print(f"\nWriting result to: {output_path}")
 
     try:
-        _write_placements_to_pcb_atomic(pcb_path, output_path, best_vector, components)
+        _write_placements_to_pcb_atomic(pcb_path, output_path, best_vector, components, board_origin)
     except Exception as e:
         print(f"Error writing output: {e}", file=sys.stderr)
         if verbose:

--- a/src/kicad_tools/mcp/tools/optimize_placement.py
+++ b/src/kicad_tools/mcp/tools/optimize_placement.py
@@ -71,17 +71,17 @@ def _validate_pcb_path(pcb_path: str) -> Path:
 
 def _read_board_data(
     pcb_path: str,
-) -> tuple[list[ComponentDef], list[Net], BoardOutline, DesignRuleSet]:
+) -> tuple[list[ComponentDef], list[Net], BoardOutline, DesignRuleSet, tuple[float, float]]:
     """Read component, net, and board data from a .kicad_pcb file.
 
     Uses kicad_tools.schema.pcb.PCB to parse the file and extract
-    components, nets, board outline, and design rules.
+    components, nets, board outline, design rules, and board origin.
 
     Args:
         pcb_path: Path to .kicad_pcb file.
 
     Returns:
-        Tuple of (components, nets, board_outline, rules).
+        Tuple of (components, nets, board_outline, rules, board_origin).
     """
     from kicad_tools.schema.pcb import PCB as SchemaPCB
 
@@ -138,11 +138,17 @@ def _read_board_data(
             nets.append(Net(name=net_name, pins=pins))
 
     rules = DesignRuleSet()
-    return components, nets, board_outline, rules
+    return components, nets, board_outline, rules, pcb.board_origin
 
 
 def _extract_board_outline(pcb: Any) -> BoardOutline:
-    """Extract board outline from Edge.Cuts graphic lines."""
+    """Extract board outline from Edge.Cuts graphic lines.
+
+    Edge.Cuts coordinates are in sheet-absolute space, but footprint
+    positions on ``SchemaPCB`` are board-relative (the origin is already
+    subtracted).  We must convert the outline to the same board-relative
+    coordinate system so the optimizer bounds match component positions.
+    """
     xs: list[float] = []
     ys: list[float] = []
 
@@ -152,6 +158,10 @@ def _extract_board_outline(pcb: Any) -> BoardOutline:
             ys.extend([line.start[1], line.end[1]])
 
     if xs and ys:
+        # Convert from sheet-absolute to board-relative coordinates.
+        ox, oy = pcb.board_origin
+        xs = [x - ox for x in xs]
+        ys = [y - oy for y in ys]
         return BoardOutline(min_x=min(xs), min_y=min(ys), max_x=max(xs), max_y=max(ys))
 
     # Fallback: use footprint bounding box with margin
@@ -346,7 +356,7 @@ def optimize_placement(
 
     # Parse board data
     try:
-        components, nets, board_outline, rules = _read_board_data(pcb_path)
+        components, nets, board_outline, rules, board_origin = _read_board_data(pcb_path)
     except Exception as e:
         raise ParseError(f"Failed to parse PCB file: {e}") from e
 
@@ -526,7 +536,7 @@ def optimize_placement(
     # Write output if requested
     if output_path:
         try:
-            _write_placements_to_pcb(pcb_path, output_path, best_vector, components)
+            _write_placements_to_pcb(pcb_path, output_path, best_vector, components, board_origin)
             result["output_path"] = output_path
         except Exception as e:
             result["warnings"] = [f"Optimization succeeded but save failed: {e}"]
@@ -569,7 +579,7 @@ def evaluate_placement(
 
     # Parse board data
     try:
-        components, nets, board_outline, rules = _read_board_data(pcb_path)
+        components, nets, board_outline, rules, _origin = _read_board_data(pcb_path)
     except Exception as e:
         raise ParseError(f"Failed to parse PCB file: {e}") from e
 
@@ -646,15 +656,19 @@ def _write_placements_to_pcb(
     output_path: str,
     vector: PlacementVector,
     components: Sequence[ComponentDef],
+    board_origin: tuple[float, float] = (0.0, 0.0),
 ) -> None:
     """Write optimized placements back to a .kicad_pcb file.
 
     Reads the original file, updates footprint positions, and writes
-    the result.
+    the result.  Positions from the optimizer are in board-relative
+    coordinates; the board origin offset is added back to produce the
+    sheet-absolute values expected in the ``.kicad_pcb`` file.
     """
     import re
 
     placed = decode(vector, components)
+    ox, oy = board_origin
     ref_to_placement = {p.reference: p for p in placed}
 
     pcb_content = Path(pcb_path).read_text()
@@ -689,7 +703,10 @@ def _write_placements_to_pcb(
                 if at_match:
                     p = ref_to_placement[current_ref]
                     indent = at_match.group(1)
-                    new_at = f"{indent}(at {p.x:.6f} {p.y:.6f} {p.rotation:.0f})"
+                    # Convert board-relative back to sheet-absolute.
+                    abs_x = p.x + ox
+                    abs_y = p.y + oy
+                    new_at = f"{indent}(at {abs_x:.6f} {abs_y:.6f} {p.rotation:.0f})"
                     output_lines.append(new_at)
                     if paren_depth <= 0:
                         in_footprint = False
@@ -744,7 +761,7 @@ def resolve_placement_overlaps(
     _validate_pcb_path(pcb_path)
 
     try:
-        components, nets, board_outline, rules = _read_board_data(pcb_path)
+        components, nets, board_outline, rules, board_origin = _read_board_data(pcb_path)
     except Exception as e:
         raise ParseError(f"Failed to parse PCB file: {e}") from e
 
@@ -812,7 +829,7 @@ def resolve_placement_overlaps(
 
     if output_path:
         try:
-            _write_placements_to_pcb(pcb_path, output_path, new_vector, components)
+            _write_placements_to_pcb(pcb_path, output_path, new_vector, components, board_origin)
             result["output_path"] = output_path
         except Exception as e:
             result["warnings"] = [f"Resolution succeeded but save failed: {e}"]

--- a/tests/test_optimize_placement_cmd.py
+++ b/tests/test_optimize_placement_cmd.py
@@ -612,7 +612,7 @@ class TestInterruptHandling:
             _write_placements_to_pcb_atomic,
         )
 
-        components, nets, board, rules = _read_board_data(str(tmp_pcb))
+        components, nets, board, rules, _origin = _read_board_data(str(tmp_pcb))
         seed = _generate_seed("random", components, nets, board)
         output = tmp_path / "atomic_output.kicad_pcb"
 
@@ -654,6 +654,161 @@ class TestInterruptHandling:
 
 # Import helpers needed by the new tests
 from kicad_tools.cli.optimize_placement_cmd import (
+    _extract_board_outline,
     _read_board_data,
+    _write_placements_to_pcb,
     _write_placements_to_pcb_atomic,
 )
+
+
+# ---------------------------------------------------------------------------
+# Board-origin coordinate system tests (issue #2054)
+# ---------------------------------------------------------------------------
+
+
+class TestBoardOriginCoordinates:
+    """Verify that board origin is correctly subtracted from Edge.Cuts
+    outline and added back when writing positions to the PCB file."""
+
+    @pytest.fixture
+    def offset_pcb(self, tmp_path: Path) -> Path:
+        """Create a PCB file with a non-zero board origin (116, 76.75).
+
+        The Edge.Cuts outline spans from (116, 76.75) to (181, 133.25)
+        in sheet-absolute coordinates — i.e. a 65x56.5 mm board.
+        Footprint positions are stored in sheet-absolute coordinates
+        in the file.
+        """
+        pcb_content = """\
+(kicad_pcb (version 20230101) (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup
+    (pad_to_mask_clearance 0.05)
+  )
+  (net 0 "")
+  (net 1 "N1")
+  (footprint "R_0805" (layer "F.Cu")
+    (at 126.0 86.75 0)
+    (property "Reference" "R1")
+    (fp_text reference "R1" (at 0 -1.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at -1.0 0.0) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "N1"))
+    (pad "2" smd rect (at 1.0 0.0) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+  )
+  (footprint "R_0805" (layer "F.Cu")
+    (at 146.0 96.75 0)
+    (property "Reference" "R2")
+    (fp_text reference "R2" (at 0 -1.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at -1.0 0.0) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "N1"))
+    (pad "2" smd rect (at 1.0 0.0) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+  )
+  (gr_line (start 116 76.75) (end 181 76.75) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 181 76.75) (end 181 133.25) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 181 133.25) (end 116 133.25) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 116 133.25) (end 116 76.75) (layer "Edge.Cuts") (width 0.05))
+)
+"""
+        pcb_file = tmp_path / "offset_board.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        return pcb_file
+
+    def test_extract_board_outline_subtracts_origin(self, offset_pcb):
+        """Board outline must be in board-relative coordinates (starting near 0,0)."""
+        from kicad_tools.schema.pcb import PCB as SchemaPCB
+
+        pcb = SchemaPCB.load(str(offset_pcb))
+        outline = _extract_board_outline(pcb)
+
+        # The Edge.Cuts spans (116,76.75)-(181,133.25) in absolute space.
+        # Board origin is (116, 76.75), so board-relative outline should be
+        # (0, 0) to (65, 56.5).
+        assert abs(outline.min_x - 0.0) < 0.01
+        assert abs(outline.min_y - 0.0) < 0.01
+        assert abs(outline.max_x - 65.0) < 0.01
+        assert abs(outline.max_y - 56.5) < 0.01
+
+    def test_component_positions_within_board_relative_outline(self, offset_pcb):
+        """Component positions must fall within the board-relative outline."""
+        components, nets, outline, rules, origin = _read_board_data(str(offset_pcb))
+
+        for comp in components:
+            # Components from SchemaPCB are already board-relative.
+            # With the fix, the outline is also board-relative.
+            # We don't have position info on ComponentDef directly, but
+            # we can verify the outline and origin are consistent.
+            pass
+
+        # Verify board origin was detected
+        assert abs(origin[0] - 116.0) < 0.01
+        assert abs(origin[1] - 76.75) < 0.01
+
+        # Verify outline is board-relative
+        assert abs(outline.min_x - 0.0) < 0.01
+        assert abs(outline.min_y - 0.0) < 0.01
+
+    def test_write_adds_origin_back(self, offset_pcb, tmp_path):
+        """Written positions must include the board origin offset (sheet-absolute)."""
+        import re
+
+        components, nets, outline, rules, origin = _read_board_data(str(offset_pcb))
+
+        # Create a vector that places R1 at board-relative (10, 10) and R2 at (30, 20)
+        data = np.array(
+            [10.0, 10.0, 0.0, 0.0, 30.0, 20.0, 0.0, 0.0],
+            dtype=np.float64,
+        )
+        from kicad_tools.placement.vector import PlacementVector
+
+        vector = PlacementVector(data=data)
+        output = tmp_path / "written.kicad_pcb"
+        _write_placements_to_pcb(str(offset_pcb), str(output), vector, components, origin)
+
+        content = output.read_text()
+
+        # R1 at board-relative (10, 10) should be written as
+        # sheet-absolute (10 + 116, 10 + 76.75) = (126, 86.75)
+        at_pattern = re.compile(r"\(at\s+([\d.]+)\s+([\d.]+)")
+        at_matches = at_pattern.findall(content)
+
+        # Collect footprint (at ...) values — should be sheet-absolute
+        # The file has two footprints; collect their (at ...) from the output.
+        # Filter to footprint-level (at ...) which are the first in each block.
+        footprint_ats = []
+        in_fp = False
+        for line in content.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("(footprint "):
+                in_fp = True
+            if in_fp:
+                m = re.match(r"\s*\(at\s+([\d.eE+-]+)\s+([\d.eE+-]+)", stripped)
+                if m:
+                    footprint_ats.append((float(m.group(1)), float(m.group(2))))
+                    in_fp = False  # Only capture first (at) per footprint
+
+        assert len(footprint_ats) == 2
+
+        # R1: board-relative (10, 10) + origin (116, 76.75) = (126, 86.75)
+        assert abs(footprint_ats[0][0] - 126.0) < 0.01
+        assert abs(footprint_ats[0][1] - 86.75) < 0.01
+
+        # R2: board-relative (30, 20) + origin (116, 76.75) = (146, 96.75)
+        assert abs(footprint_ats[1][0] - 146.0) < 0.01
+        assert abs(footprint_ats[1][1] - 96.75) < 0.01
+
+    def test_zero_origin_unaffected(self, tmp_pcb, tmp_path):
+        """Board with origin at (0, 0) should produce identical results."""
+        components, nets, outline, rules, origin = _read_board_data(str(tmp_pcb))
+
+        # Origin should be (0, 0) for the standard test fixture
+        assert abs(origin[0]) < 0.01
+        assert abs(origin[1]) < 0.01
+
+        # Outline should match the Edge.Cuts directly (no offset to subtract)
+        assert abs(outline.min_x - 0.0) < 0.01
+        assert abs(outline.min_y - 0.0) < 0.01
+        assert abs(outline.max_x - 30.0) < 0.01
+        assert abs(outline.max_y - 20.0) < 0.01


### PR DESCRIPTION
## Summary
Fixes coordinate system mismatch in placement optimize where the board outline was read in sheet-absolute coordinates while component positions were in board-relative coordinates. This caused the optimizer to place components far outside the board when board origin was non-zero.

## Changes
- `_extract_board_outline()` in both CLI and MCP entry points now subtracts `pcb.board_origin` from Edge.Cuts coordinates, matching the pattern used in `place_unplaced.py`
- `_write_placements_to_pcb()` now adds the board origin back when writing positions, since the text-based writer bypasses `Footprint.__setattr__` coordinate conversion
- `_read_board_data()` now returns the board origin so it can be threaded to the writer
- Interrupt handler state updated to carry `board_origin` for graceful-shutdown saves

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board outline in board-relative coordinates | Pass | Test `test_extract_board_outline_subtracts_origin` verifies outline is (0,0)-(65,56.5) for board at (116,76.75) |
| Written positions in sheet-absolute coordinates | Pass | Test `test_write_adds_origin_back` verifies R1 at board-relative (10,10) writes as (126,86.75) |
| Zero-origin boards unaffected | Pass | Test `test_zero_origin_unaffected` verifies (0,0) origin produces same outline |
| MCP entry point also fixed | Pass | 26 MCP tests pass |

## Test Plan
- 36 CLI tests pass (`python3 -m pytest tests/test_optimize_placement_cmd.py`)
- 26 MCP tests pass (`python3 -m pytest tests/test_mcp_optimize_placement.py`)
- New tests cover non-zero origin (116, 76.75), zero origin, and round-trip write verification

Closes #2054