### PR TITLE
fix(schema): snap rotated pin offsets to 1.27mm grid and auto-correct wire endpoints

### DIFF
--- a/src/kicad_tools/cli/sch_add_component.py
+++ b/src/kicad_tools/cli/sch_add_component.py
@@ -113,16 +113,14 @@ def _snap(value: float, grid: float = 1.27) -> float:
     return round(value / grid) * grid
 
 
-def _round_pos(pos: tuple[float, float], decimals: int = 2) -> tuple[float, float]:
+def _round_pos(pos: tuple[float, float], decimals: int = 4) -> tuple[float, float]:
     """Round a position to *decimals* decimal places.
 
-    This is used instead of ``_snap()`` for pin positions that are already
-    computed from a grid-snapped symbol origin.  The pin offsets in library
-    coordinates are exact multiples of 1.27 mm, so the only source of error
-    is floating-point drift from trig-based rotation.  Rounding to two
-    decimal places eliminates that drift without risk of jumping to a
-    different grid point (which ``_snap()`` can do for values near the
-    midpoint between two grid lines).
+    This is a lightweight cleanup for residual floating-point noise
+    after the grid-aware snap in ``get_pin_position()`` has done the
+    heavy lifting.  Four decimal places (0.1 um) is well below KiCad's
+    ERC tolerance while still eliminating IEEE-754 artefacts like
+    ``1.2699999999999998``.
     """
     return (round(pos[0], decimals), round(pos[1], decimals))
 
@@ -191,16 +189,17 @@ def _validate_wire_endpoints(
     sch: Schematic,
     first_new_wire_index: int,
     tolerance: float = 0.01,
+    correction_radius: float = 0.5,
 ) -> None:
-    """Warn about dangling endpoints on newly added wires.
+    """Check and auto-correct dangling endpoints on newly added wires.
 
     Iterates every endpoint of wires added after *first_new_wire_index*
     and checks that it coincides (within *tolerance* mm) with a pin,
     another wire endpoint/midpoint, or a junction.
 
-    This is a best-effort guard -- it emits warnings on stderr but does
-    not prevent saving, because the caller may intentionally create a
-    stub that will be connected later.
+    If an endpoint is dangling but a valid connection point exists within
+    *correction_radius* mm, the endpoint is snapped to that point.
+    Otherwise a warning is emitted on stderr.
     """
     all_wires = sch.wires
     new_wires = all_wires[first_new_wire_index:]
@@ -230,7 +229,8 @@ def _validate_wire_endpoints(
         connection_points.extend(pin_positions.values())
 
     for wire in new_wires:
-        for endpoint in (wire.start, wire.end):
+        for attr in ("start", "end"):
+            endpoint = getattr(wire, attr)
             # An endpoint is valid if it coincides with at least TWO
             # connection points (itself counted once as a wire endpoint,
             # plus at least one other element).
@@ -240,7 +240,31 @@ def _validate_wire_endpoints(
                 if abs(cp[0] - endpoint[0]) < tolerance
                 and abs(cp[1] - endpoint[1]) < tolerance
             )
-            if matches < 2:
+            if matches >= 2:
+                continue
+
+            # Try to auto-correct: find the nearest connection point
+            # within correction_radius (excluding the endpoint itself).
+            best_cp = None
+            best_dist = correction_radius
+            for cp in connection_points:
+                dist = ((cp[0] - endpoint[0]) ** 2 + (cp[1] - endpoint[1]) ** 2) ** 0.5
+                if dist < tolerance:
+                    continue  # Skip the endpoint itself
+                if dist < best_dist:
+                    best_dist = dist
+                    best_cp = cp
+
+            if best_cp is not None:
+                print(
+                    f"Auto-corrected wire endpoint "
+                    f"({endpoint[0]:.4f}, {endpoint[1]:.4f}) -> "
+                    f"({best_cp[0]:.4f}, {best_cp[1]:.4f}) "
+                    f"(drift: {best_dist:.4f} mm)",
+                    file=sys.stderr,
+                )
+                setattr(wire, attr, best_cp)
+            else:
                 print(
                     f"Warning: wire endpoint ({endpoint[0]:.2f}, {endpoint[1]:.2f}) "
                     "may be dangling (not connected to any pin, wire, or junction)",

--- a/src/kicad_tools/schema/library.py
+++ b/src/kicad_tools/schema/library.py
@@ -419,6 +419,28 @@ class LibraryPin:
         return SExp(name="pin", children=children)
 
 
+KICAD_GRID = 1.27  # mm -- standard KiCad schematic grid
+
+
+def _snap_to_kicad_grid(
+    value: float,
+    grid: float = KICAD_GRID,
+    tolerance: float = 0.2,
+) -> float:
+    """Snap *value* to the nearest multiple of *grid* if within *tolerance*.
+
+    KiCad library pin offsets are exact multiples of 1.27 mm.  After
+    rotation by ``sin``/``cos`` the result drifts by a tiny amount (e.g.
+    ``3.81 * cos(90deg) = 4.66e-16`` instead of ``0``).  This helper
+    snaps to the grid when the residual is small, leaving values that
+    are genuinely off-grid untouched.
+    """
+    nearest = round(value / grid) * grid
+    if abs(value - nearest) <= tolerance:
+        return nearest
+    return value
+
+
 @dataclass
 class LibrarySymbol:
     """
@@ -456,6 +478,7 @@ class LibrarySymbol:
         instance_pos: tuple[float, float],
         instance_rot: float = 0,
         mirror: str = "",
+        snap_to_grid: bool = True,
     ) -> tuple[float, float] | None:
         """
         Calculate the actual schematic position of a pin.
@@ -465,6 +488,9 @@ class LibrarySymbol:
             instance_pos: The symbol instance position in schematic
             instance_rot: The symbol instance rotation in degrees
             mirror: Mirror mode ("", "x", "y")
+            snap_to_grid: If True, snap rotated pin offsets to the nearest
+                1.27mm grid point when within tolerance.  This eliminates
+                floating-point drift from trig-based rotation.
 
         Returns:
             (x, y) position in schematic coordinates, or None if pin not found
@@ -492,6 +518,17 @@ class LibrarySymbol:
             sin_a = math.sin(angle_rad)
             x, y = x * cos_a - y * sin_a, x * sin_a + y * cos_a
 
+        # Snap rotated offset to nearest 1.27mm grid point when close.
+        # Pin offsets in library coordinates are exact multiples of 1.27mm.
+        # Axis-aligned rotations (0/90/180/270) should preserve this, but
+        # floating-point trig introduces drift (e.g. cos(90deg) ~ 6e-17
+        # instead of 0).  Snap each offset coordinate to the nearest
+        # multiple of 1.27mm if within 0.2mm -- this eliminates trig drift
+        # without affecting genuinely non-grid positions.
+        if snap_to_grid:
+            x = _snap_to_kicad_grid(x)
+            y = _snap_to_kicad_grid(y)
+
         # Apply translation
         return (instance_pos[0] + x, instance_pos[1] + y)
 
@@ -500,6 +537,7 @@ class LibrarySymbol:
         instance_pos: tuple[float, float],
         instance_rot: float = 0,
         mirror: str = "",
+        snap_to_grid: bool = True,
     ) -> dict[str, tuple[float, float]]:
         """
         Get all pin positions for a symbol instance.
@@ -509,7 +547,10 @@ class LibrarySymbol:
         """
         positions = {}
         for pin in self.pins:
-            pos = self.get_pin_position(pin.number, instance_pos, instance_rot, mirror)
+            pos = self.get_pin_position(
+                pin.number, instance_pos, instance_rot, mirror,
+                snap_to_grid=snap_to_grid,
+            )
             if pos:
                 positions[pin.number] = pos
         return positions

--- a/tests/test_sch_add_component.py
+++ b/tests/test_sch_add_component.py
@@ -870,7 +870,8 @@ class TestNoDanglingStubs:
 
 class TestRoundPos:
     def test_round_pos_basic(self):
-        assert _round_pos((1.005, 2.995)) == (1.0, 3.0)
+        # Default is 4 decimal places (0.1 um precision)
+        assert _round_pos((1.00506, 2.99996)) == (1.0051, 3.0)
 
     def test_round_pos_no_change_on_clean(self):
         assert _round_pos((100.33, 80.01)) == (100.33, 80.01)
@@ -881,8 +882,205 @@ class TestRoundPos:
         drifted_x = 100.33 + 3.81 * math.cos(math.radians(90))
         drifted_y = 80.01 + 3.81 * math.sin(math.radians(90))
         result = _round_pos((drifted_x, drifted_y))
-        assert result[0] == pytest.approx(100.33, abs=0.01)
-        assert result[1] == pytest.approx(83.82, abs=0.01)
+        assert result[0] == pytest.approx(100.33, abs=0.001)
+        assert result[1] == pytest.approx(83.82, abs=0.001)
+
+
+# ---------------------------------------------------------------------------
+# Grid-aware snap: pin positions after rotation land on 1.27mm grid
+# ---------------------------------------------------------------------------
+
+
+class TestGridAwareSnap:
+    """Verify that get_pin_position grid-snaps rotated pin offsets."""
+
+    def test_90_degree_rotation_snaps_to_grid(self, tmp_path: Path):
+        """Pin at (0, -3.81) rotated 90 degrees should snap exactly."""
+        lib_sym = LibrarySymbol.from_sexp(
+            Schematic.load(_write_sch(tmp_path)).get_lib_symbol("Device:R")
+        )
+        pos = lib_sym.get_pin_position(
+            "1", instance_pos=(100.33, 80.01), instance_rot=90
+        )
+        assert pos is not None
+        # Pin 1 is at (0, 3.81) in lib coords -> (0, -3.81) after Y-negate
+        # Rotated 90: x' = 0*cos90 - (-3.81)*sin90 = 3.81
+        #              y' = 0*sin90 + (-3.81)*cos90 = 0
+        # With grid snap: x = 100.33 + 3.81 = 104.14, y = 80.01 + 0 = 80.01
+        assert pos[0] == pytest.approx(104.14, abs=0.001)
+        assert pos[1] == pytest.approx(80.01, abs=0.001)
+
+    def test_non_standard_pin_offset_snaps(self, tmp_path: Path):
+        """A 3.81mm pin offset (3 x 1.27) should snap after 90 deg rotation."""
+        lib_sym = LibrarySymbol.from_sexp(
+            Schematic.load(_write_sch(tmp_path)).get_lib_symbol("Device:R")
+        )
+        # Verify pin 1 offset is 3.81 (non-standard = 3 x 1.27, not 2 x 2.54)
+        pin = lib_sym.get_pin("1")
+        assert pin is not None
+        assert abs(pin.position[1]) == pytest.approx(3.81, abs=0.01)
+
+        # After 90-degree rotation, the offset should still land on grid
+        pos = lib_sym.get_pin_position(
+            "1", instance_pos=(0.0, 0.0), instance_rot=90
+        )
+        assert pos is not None
+        # Check that each coordinate is a multiple of 1.27
+        assert pos[0] % 1.27 == pytest.approx(0.0, abs=0.001)
+        assert pos[1] % 1.27 == pytest.approx(0.0, abs=0.001)
+
+    def test_snap_opt_out(self, tmp_path: Path):
+        """snap_to_grid=False should return raw trig result."""
+        lib_sym = LibrarySymbol.from_sexp(
+            Schematic.load(_write_sch(tmp_path)).get_lib_symbol("Device:R")
+        )
+        pos_snapped = lib_sym.get_pin_position(
+            "1", instance_pos=(0.0, 0.0), instance_rot=90, snap_to_grid=True
+        )
+        pos_raw = lib_sym.get_pin_position(
+            "1", instance_pos=(0.0, 0.0), instance_rot=90, snap_to_grid=False
+        )
+        assert pos_snapped is not None
+        assert pos_raw is not None
+        # Snapped should be clean; raw may have tiny trig drift
+        assert pos_snapped[1] == 0.0
+        # Raw y should be very close to 0 but may not be exactly 0
+        assert abs(pos_raw[1]) < 1e-10
+
+
+class TestGridSnapWithWires:
+    """Wire endpoints must land on grid after rotation -- integration tests."""
+
+    def test_45_degree_rotation_no_dangling(self, tmp_path: Path):
+        """Non-axis rotation (45 deg) should not produce dangling stubs.
+
+        At 45 degrees, pin positions won't be on the 1.27mm grid, but
+        the wire start should exactly match the computed pin position
+        (no rounding error gap).
+        """
+        sch_path = _write_sch(tmp_path)
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "Device:R",
+            "--reference", "R1",
+            "--value", "10k",
+            "--footprint", "SMD:R_0402",
+            "--at", "100.33", "80.01",
+            "--rotation", "45",
+            "--connect", "1:120.65,80.01",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        lib_sym_sexp = sch.get_lib_symbol("Device:R")
+        lib_sym = LibrarySymbol.from_sexp(lib_sym_sexp)
+        expected = lib_sym.get_pin_position(
+            "1", instance_pos=(100.33, 80.01), instance_rot=45
+        )
+        expected = _round_pos(expected)
+
+        new_wires = [
+            w for w in sch.wires
+            if not (
+                abs(w.start[0] - 100) < 1 and abs(w.start[1] - 50) < 1
+                and abs(w.end[0] - 150) < 1 and abs(w.end[1] - 50) < 1
+            )
+        ]
+        assert len(new_wires) == 1
+        assert new_wires[0].start[0] == pytest.approx(expected[0], abs=0.01)
+        assert new_wires[0].start[1] == pytest.approx(expected[1], abs=0.01)
+
+    def test_30_degree_rotation_wire_matches_pin(self, tmp_path: Path):
+        """30-degree rotation: wire start must match computed pin position."""
+        sch_path = _write_sch(tmp_path)
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "Device:R",
+            "--reference", "R1",
+            "--value", "10k",
+            "--footprint", "SMD:R_0402",
+            "--at", "100.33", "80.01",
+            "--rotation", "30",
+            "--connect", "1:120.65,80.01",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        lib_sym = LibrarySymbol.from_sexp(sch.get_lib_symbol("Device:R"))
+        expected = lib_sym.get_pin_position(
+            "1", instance_pos=(100.33, 80.01), instance_rot=30
+        )
+        expected = _round_pos(expected)
+
+        new_wires = [
+            w for w in sch.wires
+            if not (
+                abs(w.start[0] - 100) < 1 and abs(w.start[1] - 50) < 1
+                and abs(w.end[0] - 150) < 1 and abs(w.end[1] - 50) < 1
+            )
+        ]
+        assert len(new_wires) == 1
+        assert new_wires[0].start[0] == pytest.approx(expected[0], abs=0.01)
+        assert new_wires[0].start[1] == pytest.approx(expected[1], abs=0.01)
+
+    def test_60_degree_rotation_wire_matches_pin(self, tmp_path: Path):
+        """60-degree rotation: wire start must match computed pin position."""
+        sch_path = _write_sch(tmp_path)
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "Device:R",
+            "--reference", "R1",
+            "--value", "10k",
+            "--footprint", "SMD:R_0402",
+            "--at", "100.33", "80.01",
+            "--rotation", "60",
+            "--connect", "1:120.65,80.01",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        lib_sym = LibrarySymbol.from_sexp(sch.get_lib_symbol("Device:R"))
+        expected = lib_sym.get_pin_position(
+            "1", instance_pos=(100.33, 80.01), instance_rot=60
+        )
+        expected = _round_pos(expected)
+
+        new_wires = [
+            w for w in sch.wires
+            if not (
+                abs(w.start[0] - 100) < 1 and abs(w.start[1] - 50) < 1
+                and abs(w.end[0] - 150) < 1 and abs(w.end[1] - 50) < 1
+            )
+        ]
+        assert len(new_wires) == 1
+        assert new_wires[0].start[0] == pytest.approx(expected[0], abs=0.01)
+        assert new_wires[0].start[1] == pytest.approx(expected[1], abs=0.01)
+
+
+class TestValidateAutoCorrection:
+    """_validate_wire_endpoints should auto-correct near-miss endpoints."""
+
+    def test_autocorrect_within_radius(self, tmp_path: Path):
+        """A wire endpoint with small drift should be auto-corrected."""
+        from kicad_tools.cli.sch_add_component import _validate_wire_endpoints
+        from kicad_tools.schema.wire import Wire
+
+        sch_path = _write_sch(tmp_path)
+        sch = Schematic.load(sch_path)
+
+        # Add a wire with a slightly drifted start point
+        # Existing wire goes (100, 50) -> (150, 50)
+        # We place a wire from (100.1, 50.0) to (100.1, 70.0)
+        # The start is 0.1mm from wire endpoint (100, 50) -- should be corrected
+        drift_wire = Wire(start=(100.1, 50.0), end=(100.1, 70.0))
+        sch.wires.append(drift_wire)
+        first_new = len(sch.wires) - 1
+
+        _validate_wire_endpoints(sch, first_new, correction_radius=0.5)
+
+        # After correction, wire start should be snapped to (100, 50)
+        assert sch.wires[first_new].start[0] == pytest.approx(100.0, abs=0.01)
+        assert sch.wires[first_new].start[1] == pytest.approx(50.0, abs=0.01)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Eliminates dangling micro-wire stubs caused by floating-point drift in trig-based pin rotation. Replaces insufficient 2-decimal rounding with grid-aware snapping at the source (get_pin_position) and upgrades _validate_wire_endpoints from warn-only to auto-correct.

## Changes
- Add `_snap_to_kicad_grid()` helper in `library.py` that snaps values to the nearest 1.27mm grid point when within 0.2mm tolerance
- Add `snap_to_grid` parameter to `get_pin_position()` and `get_all_pin_positions()` (default True) -- fixes at the source so all callers benefit
- Change `_round_pos()` default from 2 to 4 decimal places -- now serves as lightweight cleanup after grid snap
- Upgrade `_validate_wire_endpoints()` to auto-correct endpoints within 0.5mm of a valid connection point (previously warn-only)
- Add 7 new test cases: grid-aware snap at 90deg, non-standard pin offsets, snap opt-out, 30/45/60 degree rotations, and auto-correction behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Wire endpoints land on valid connection points within ERC tolerance | PASS | Grid snap eliminates trig drift; existing TestWireEndpointAlignment passes |
| Post-placement validation auto-corrects sub-mm drift | PASS | TestValidateAutoCorrection verifies 0.1mm drift is corrected |
| 0/90/180/270 degree rotations produce no stubs | PASS | TestWireEndpointAlignment tests all four orientations |
| Non-axis rotations (30, 45, 60) produce no stubs | PASS | TestGridSnapWithWires tests 30, 45, 60 degree cases |
| Non-standard pin offsets (3.81mm = 3x1.27) no stubs when rotated | PASS | TestGridAwareSnap::test_non_standard_pin_offset_snaps |
| Placement without --connect unchanged | PASS | TestPlacementOnlyUnchanged passes |

## Test Plan
- All 60 tests pass (1 pre-existing failure in TestStandaloneAddWire::test_add_wire_zero_length_rejected unrelated to this change)
- `python3 -m pytest tests/test_sch_add_component.py --no-cov -q` -- 60 passed, 1 deselected

Closes #2057