### PR TITLE
feat(pcb): add move-footprint command for component relocation

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -11,7 +11,7 @@ def run_pcb_command(args) -> int:
     """Handle PCB subcommands."""
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
-        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist, remove-footprint, add-zone, snap-rotation, edit-outline")
+        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist, remove-footprint, move-footprint, add-zone, snap-rotation, edit-outline")
         return 1
 
     pcb_path = Path(args.pcb)
@@ -34,6 +34,10 @@ def run_pcb_command(args) -> int:
     # Handle remove-footprint command
     if args.pcb_command == "remove-footprint":
         return _run_remove_footprint_command(args, pcb_path)
+
+    # Handle move-footprint command
+    if args.pcb_command == "move-footprint":
+        return _run_move_footprint_command(args, pcb_path)
 
     # Handle add-zone command
     if args.pcb_command == "add-zone":
@@ -541,6 +545,54 @@ def _run_remove_footprint_command(args, pcb_path: Path) -> int:
         dry_run=dry_run,
         output_path=output_path,
         force=force,
+        output_format=output_format,
+    )
+
+
+def _run_move_footprint_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb move-footprint' command."""
+    from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+    ref = getattr(args, "ref", None)
+    to = getattr(args, "to", None)
+    rotation = getattr(args, "rotation", None)
+    batch_map_str = getattr(args, "batch_map", None)
+    output = getattr(args, "output", None)
+    output_path = Path(output) if output else None
+    dry_run = getattr(args, "dry_run", False)
+    output_format = getattr(args, "format", "text")
+
+    # Parse batch map JSON if provided
+    batch_map = None
+    if batch_map_str is not None:
+        try:
+            batch_map = json.loads(batch_map_str)
+        except json.JSONDecodeError as e:
+            print(f"Error: Invalid JSON in --map: {e}", file=sys.stderr)
+            return 1
+        if not isinstance(batch_map, dict):
+            print("Error: --map must be a JSON object", file=sys.stderr)
+            return 1
+
+    # Validate: need either --ref/--to or --map
+    if batch_map is None:
+        if not ref:
+            print("Error: --ref is required (or use --map for batch mode)", file=sys.stderr)
+            return 1
+        if not to:
+            print("Error: --to is required (or use --map for batch mode)", file=sys.stderr)
+            return 1
+
+    to_tuple = tuple(to) if to else None
+
+    return run_move_footprint(
+        pcb_path=pcb_path,
+        reference=ref,
+        to=to_tuple,
+        rotation=rotation,
+        batch_map=batch_map,
+        dry_run=dry_run,
+        output_path=output_path,
         output_format=output_format,
     )
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1205,6 +1205,53 @@ def _add_pcb_parser(subparsers) -> None:
         help="Remove footprint even if it has routed traces",
     )
 
+    # pcb move-footprint
+    pcb_move_fp = pcb_subparsers.add_parser(
+        "move-footprint",
+        help="Move a footprint to new board-relative coordinates",
+        description="Relocate a footprint to a new position (and optionally "
+        "rotation) by reference designator.  Supports batch mode via --map.",
+    )
+    pcb_move_fp.add_argument("pcb", help="Path to .kicad_pcb file")
+    pcb_move_fp.add_argument(
+        "--ref",
+        help="Reference designator of footprint to move (e.g., J2)",
+    )
+    pcb_move_fp.add_argument(
+        "--to",
+        nargs=2,
+        type=float,
+        metavar=("X", "Y"),
+        help="New board-relative position (e.g., --to 132.5 98.25)",
+    )
+    pcb_move_fp.add_argument(
+        "--rotation",
+        type=float,
+        help="New rotation in degrees (optional)",
+    )
+    pcb_move_fp.add_argument(
+        "--map",
+        dest="batch_map",
+        help='JSON map for batch moves (e.g., \'{"J2": {"x": 132.5, "y": 98.25}}\')',
+    )
+    pcb_move_fp.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        help="Output file path (default: overwrite input PCB)",
+    )
+    pcb_move_fp.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for results",
+    )
+    pcb_move_fp.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview moves without modifying the PCB file",
+    )
+
     # pcb add-zone
     pcb_add_zone = pcb_subparsers.add_parser(
         "add-zone",

--- a/src/kicad_tools/cli/pcb_move_footprint.py
+++ b/src/kicad_tools/cli/pcb_move_footprint.py
@@ -1,0 +1,141 @@
+"""Move a footprint in a PCB by reference designator.
+
+Provides a standalone command to relocate a specific footprint to new
+board-relative coordinates, optionally setting a new rotation.  Supports
+batch mode via a JSON map for moving multiple footprints atomically.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def run_move_footprint(
+    pcb_path: Path,
+    reference: str | None = None,
+    to: tuple[float, float] | None = None,
+    rotation: float | None = None,
+    batch_map: dict | None = None,
+    dry_run: bool = False,
+    output_path: Path | None = None,
+    output_format: str = "text",
+) -> int:
+    """Move one or more footprints in a PCB file.
+
+    Args:
+        pcb_path: Path to .kicad_pcb file.
+        reference: Reference designator to move (single mode).
+        to: New (x, y) board-relative position (single mode).
+        rotation: Optional new rotation in degrees.
+        batch_map: JSON-parsed dict for batch mode.
+        dry_run: Preview moves without modifying.
+        output_path: Alternative output path for modified PCB.
+        output_format: "text" or "json".
+
+    Returns:
+        Exit code (0 for success, 1 for errors).
+    """
+    from kicad_tools.schema.pcb import PCB
+
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        _print_error(f"Failed to load PCB: {e}", output_format)
+        return 1
+
+    # Build list of moves: [(ref, x, y, rotation_or_None), ...]
+    moves: list[tuple[str, float, float, float | None]] = []
+
+    if batch_map is not None:
+        for ref, spec in batch_map.items():
+            if not isinstance(spec, dict) or "x" not in spec or "y" not in spec:
+                _print_error(
+                    f"Invalid batch entry for '{ref}': must have 'x' and 'y' keys",
+                    output_format,
+                )
+                return 1
+            rot = spec.get("rotation")
+            moves.append((ref, float(spec["x"]), float(spec["y"]), rot))
+    elif reference is not None and to is not None:
+        moves.append((reference, to[0], to[1], rotation))
+    else:
+        _print_error(
+            "Either --ref/--to or --map is required",
+            output_format,
+        )
+        return 1
+
+    # Validate all references exist before making any changes
+    move_details: list[dict] = []
+    for ref, x, y, rot in moves:
+        fp = pcb.get_footprint(ref)
+        if not fp:
+            _print_error(f"Footprint {ref} not found in PCB", output_format)
+            return 1
+        move_details.append({
+            "reference": ref,
+            "footprint": fp.name,
+            "old_position": list(fp.position),
+            "old_rotation": fp.rotation,
+            "new_position": [x, y],
+            "new_rotation": rot if rot is not None else fp.rotation,
+        })
+
+    result = {
+        "pcb": str(pcb_path),
+        "dry_run": dry_run,
+        "moves": move_details,
+        "moved": False,
+    }
+
+    if not dry_run:
+        for ref, x, y, rot in moves:
+            fp = pcb.get_footprint(ref)
+            # fp existence already validated above
+            fp.position = (x, y)  # type: ignore[union-attr]
+            if rot is not None:
+                fp.rotation = rot  # type: ignore[union-attr]
+
+        result["moved"] = True
+
+        save_path = output_path or pcb_path
+        result["output"] = str(save_path)
+        try:
+            pcb.save(save_path)
+        except Exception as e:
+            _print_error(f"Failed to save PCB: {e}", output_format)
+            return 1
+
+    if output_format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        label = "PCB Move Footprint (dry run)" if dry_run else "PCB Move Footprint"
+        print(label)
+        print(f"  PCB: {pcb_path}")
+        print()
+        for md in move_details:
+            old_pos = md["old_position"]
+            new_pos = md["new_position"]
+            print(f"  {md['reference']} ({md['footprint']}):")
+            print(f"    Position: ({old_pos[0]}, {old_pos[1]}) -> ({new_pos[0]}, {new_pos[1]})")
+            if md["old_rotation"] != md["new_rotation"]:
+                print(f"    Rotation: {md['old_rotation']} -> {md['new_rotation']}")
+        print()
+        if dry_run:
+            print("  Would move footprint(s)")
+        else:
+            print(f"  Moved {len(moves)} footprint(s)")
+            print(f"  Saved to: {result.get('output', pcb_path)}")
+
+    return 0
+
+
+def _print_error(message: str, output_format: str) -> None:
+    """Print an error in the appropriate format."""
+    if output_format == "json":
+        print(json.dumps({"error": message}, indent=2))
+    else:
+        import sys
+
+        print(f"Error: {message}", file=sys.stderr)

--- a/tests/test_pcb_move_footprint.py
+++ b/tests/test_pcb_move_footprint.py
@@ -1,0 +1,330 @@
+"""Tests for pcb move-footprint command (pcb_move_footprint module)."""
+
+import json
+
+import pytest
+
+MINIMAL_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Connector_JST:JST_XH_B2B"
+    (layer "F.Cu")
+    (uuid "fp-j2")
+    (at 100 100)
+    (property "Reference" "J2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "Conn_01x02" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" thru_hole roundrect (at -1.25 0) (size 1.7 1.7) (layers "*.Cu") (net 1 "GND"))
+    (pad "2" thru_hole roundrect (at 1.25 0) (size 1.7 1.7) (layers "*.Cu") (net 0 ""))
+  )
+  (footprint "Connector_JST:JST_XH_B3B"
+    (layer "F.Cu")
+    (uuid "fp-j3")
+    (at 120 100 90)
+    (property "Reference" "J3" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "Conn_01x03" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" thru_hole roundrect (at -2.5 0) (size 1.7 1.7) (layers "*.Cu") (net 1 "GND"))
+    (pad "2" thru_hole roundrect (at 0 0) (size 1.7 1.7) (layers "*.Cu") (net 0 ""))
+    (pad "3" thru_hole roundrect (at 2.5 0) (size 1.7 1.7) (layers "*.Cu") (net 0 ""))
+  )
+)
+"""
+
+
+class TestRunMoveFootprint:
+    """Tests for run_move_footprint function."""
+
+    def test_moves_footprint_position(self, tmp_path):
+        """Successfully moves a footprint to new coordinates."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_move_footprint(pcb, reference="J2", to=(132.5, 98.25))
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        fp = board.get_footprint("J2")
+        assert fp is not None
+        assert fp.position[0] == pytest.approx(132.5, abs=0.01)
+        assert fp.position[1] == pytest.approx(98.25, abs=0.01)
+
+    def test_moves_footprint_with_rotation(self, tmp_path):
+        """Moves a footprint and sets new rotation."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_move_footprint(pcb, reference="J2", to=(132.5, 98.25), rotation=90.0)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        fp = board.get_footprint("J2")
+        assert fp is not None
+        assert fp.position[0] == pytest.approx(132.5, abs=0.01)
+        assert fp.position[1] == pytest.approx(98.25, abs=0.01)
+        assert fp.rotation == pytest.approx(90.0, abs=0.01)
+
+    def test_batch_mode(self, tmp_path):
+        """Batch mode moves multiple footprints."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        batch = {
+            "J2": {"x": 132.5, "y": 98.25},
+            "J3": {"x": 140.0, "y": 98.25},
+        }
+        rc = run_move_footprint(pcb, batch_map=batch)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        j2 = board.get_footprint("J2")
+        j3 = board.get_footprint("J3")
+        assert j2 is not None
+        assert j3 is not None
+        assert j2.position[0] == pytest.approx(132.5, abs=0.01)
+        assert j3.position[0] == pytest.approx(140.0, abs=0.01)
+
+    def test_batch_mode_with_rotation(self, tmp_path):
+        """Batch mode supports per-footprint rotation."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        batch = {
+            "J2": {"x": 132.5, "y": 98.25, "rotation": 180.0},
+        }
+        rc = run_move_footprint(pcb, batch_map=batch)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        fp = board.get_footprint("J2")
+        assert fp is not None
+        assert fp.rotation == pytest.approx(180.0, abs=0.01)
+
+    def test_dry_run_does_not_modify(self, tmp_path):
+        """dry_run=True leaves file unchanged."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+        original = pcb.read_text()
+
+        rc = run_move_footprint(pcb, reference="J2", to=(200.0, 200.0), dry_run=True)
+        assert rc == 0
+        assert pcb.read_text() == original
+
+    def test_nonexistent_reference_returns_1(self, tmp_path):
+        """Moving a non-existent reference returns error."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_move_footprint(pcb, reference="Z99", to=(100.0, 100.0))
+        assert rc == 1
+
+    def test_batch_partial_failure_is_atomic(self, tmp_path):
+        """If any reference in batch is invalid, no footprints are moved."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        batch = {
+            "J2": {"x": 200.0, "y": 200.0},
+            "Z99": {"x": 300.0, "y": 300.0},
+        }
+        rc = run_move_footprint(pcb, batch_map=batch)
+        assert rc == 1
+
+        # J2 should not have moved
+        board = PCB.load(pcb)
+        j2 = board.get_footprint("J2")
+        assert j2 is not None
+        assert j2.position[0] == pytest.approx(100.0, abs=0.01)
+
+    def test_output_path(self, tmp_path):
+        """Writes to output path instead of overwriting input."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        out = tmp_path / "output.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_move_footprint(pcb, reference="J2", to=(150.0, 150.0), output_path=out)
+        assert rc == 0
+
+        # Original should be unchanged
+        board_orig = PCB.load(pcb)
+        j2_orig = board_orig.get_footprint("J2")
+        assert j2_orig is not None
+        assert j2_orig.position[0] == pytest.approx(100.0, abs=0.01)
+
+        # Output should have J2 moved
+        board_out = PCB.load(out)
+        j2_out = board_out.get_footprint("J2")
+        assert j2_out is not None
+        assert j2_out.position[0] == pytest.approx(150.0, abs=0.01)
+
+    def test_json_output(self, tmp_path, capsys):
+        """JSON output contains expected fields."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_move_footprint(
+            pcb, reference="J2", to=(132.5, 98.25), output_format="json"
+        )
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["moved"] is True
+        assert len(data["moves"]) == 1
+        assert data["moves"][0]["reference"] == "J2"
+        assert data["moves"][0]["new_position"] == [132.5, 98.25]
+        assert data["moves"][0]["old_position"] == [100.0, 100.0]
+
+    def test_text_output(self, tmp_path, capsys):
+        """Text output contains key information."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        rc = run_move_footprint(
+            pcb, reference="J2", to=(132.5, 98.25), output_format="text"
+        )
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        assert "J2" in captured.out
+        assert "Moved" in captured.out
+
+    def test_round_trip_integrity(self, tmp_path):
+        """Load, move, save, reload -- verify only target footprint changed."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        # Record J3's original position
+        board_before = PCB.load(pcb)
+        j3_before = board_before.get_footprint("J3")
+        assert j3_before is not None
+        j3_pos_before = j3_before.position
+        j3_rot_before = j3_before.rotation
+
+        # Move only J2
+        rc = run_move_footprint(pcb, reference="J2", to=(150.0, 75.0))
+        assert rc == 0
+
+        # Reload and verify
+        board_after = PCB.load(pcb)
+        j2 = board_after.get_footprint("J2")
+        j3 = board_after.get_footprint("J3")
+        assert j2 is not None
+        assert j3 is not None
+        assert j2.position[0] == pytest.approx(150.0, abs=0.01)
+        assert j2.position[1] == pytest.approx(75.0, abs=0.01)
+        # J3 should be unchanged
+        assert j3.position[0] == pytest.approx(j3_pos_before[0], abs=0.01)
+        assert j3.position[1] == pytest.approx(j3_pos_before[1], abs=0.01)
+        assert j3.rotation == pytest.approx(j3_rot_before, abs=0.01)
+
+
+class TestMoveFootprintCLIParser:
+    """Tests for the move-footprint CLI parser."""
+
+    def test_parser_has_move_footprint_subcommand(self):
+        """Parser supports 'pcb move-footprint' subcommand."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "move-footprint",
+            "--ref", "J2",
+            "--to", "132.5", "98.25",
+            "test.kicad_pcb",
+        ])
+        assert args.pcb_command == "move-footprint"
+        assert args.ref == "J2"
+        assert args.to == [132.5, 98.25]
+
+    def test_parser_rotation_flag(self):
+        """Parser accepts --rotation flag."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "move-footprint",
+            "--ref", "J2",
+            "--to", "132.5", "98.25",
+            "--rotation", "90",
+            "test.kicad_pcb",
+        ])
+        assert args.rotation == 90.0
+
+    def test_parser_dry_run_flag(self):
+        """Parser accepts --dry-run flag."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "move-footprint",
+            "--ref", "J2",
+            "--to", "132.5", "98.25",
+            "--dry-run",
+            "test.kicad_pcb",
+        ])
+        assert args.dry_run is True
+
+    def test_parser_map_flag(self):
+        """Parser accepts --map flag for batch mode."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "move-footprint",
+            "--map", '{"J2": {"x": 132.5, "y": 98.25}}',
+            "test.kicad_pcb",
+        ])
+        assert args.batch_map == '{"J2": {"x": 132.5, "y": 98.25}}'
+
+    def test_dispatcher_integration(self, tmp_path):
+        """Dispatcher correctly routes to move-footprint handler."""
+        from kicad_tools.cli.commands.pcb import _run_move_footprint_command
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB)
+
+        class Args:
+            ref = "J2"
+            to = [132.5, 98.25]
+            rotation = None
+            batch_map = None
+            output = None
+            dry_run = True
+            format = "text"
+
+        rc = _run_move_footprint_command(Args(), pcb)
+        assert rc == 0


### PR DESCRIPTION
## Summary
Add a new `pcb move-footprint` CLI subcommand that relocates footprints to new board-relative coordinates with optional rotation. Supports both single-footprint and batch modes.

## Changes
- Add `src/kicad_tools/cli/pcb_move_footprint.py` -- command handler with `run_move_footprint()` implementing single and batch move logic
- Add `move-footprint` subparser in `cli/parser.py` with `--ref`, `--to`, `--rotation`, `--map`, `--dry-run`, `--output`, `--format` arguments
- Add `move-footprint` dispatch case in `cli/commands/pcb.py` with JSON map parsing
- Add `tests/test_pcb_move_footprint.py` with 16 tests covering single move, rotation, batch, dry-run, atomic failure, output path, JSON/text output, round-trip integrity, and CLI parser integration

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Single move: --ref J2 --to 132.5 98.25 | Pass | test_moves_footprint_position |
| Move with rotation: --rotation 90 | Pass | test_moves_footprint_with_rotation |
| Batch mode: --map JSON | Pass | test_batch_mode, test_batch_mode_with_rotation |
| Dry run: --dry-run shows changes, no file modification | Pass | test_dry_run_does_not_modify |
| Missing reference returns error | Pass | test_nonexistent_reference_returns_1 |
| Batch partial failure is atomic | Pass | test_batch_partial_failure_is_atomic |
| JSON output: --format json | Pass | test_json_output |
| Output file: -o writes to alternate path | Pass | test_output_path |
| Round-trip integrity | Pass | test_round_trip_integrity |
| CLI parser integration | Pass | test_parser_*, test_dispatcher_integration |

## Test Plan
All 16 tests pass: `pytest tests/test_pcb_move_footprint.py -v`

Closes #2069