### PR TITLE
feat(cli): add pcb zones subcommand for zone inspection

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -11,13 +11,17 @@ def run_pcb_command(args) -> int:
     """Handle PCB subcommands."""
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
-        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist, remove-footprint, move-footprint, add-zone, snap-rotation, edit-outline")
+        print("Commands: summary, footprints, nets, traces, stackup, zones, strip, reannotate, sync-netlist, remove-footprint, move-footprint, add-zone, snap-rotation, edit-outline")
         return 1
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
         print(f"Error: File not found: {pcb_path}", file=sys.stderr)
         return 1
+
+    # Handle zones command
+    if args.pcb_command == "zones":
+        return _run_zones_command(args, pcb_path)
 
     # Handle strip command separately (doesn't use pcb_query)
     if args.pcb_command == "strip":
@@ -94,6 +98,73 @@ def run_pcb_command(args) -> int:
         return pcb_main(sub_argv) or 0
 
     return 1
+
+
+def _run_zones_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb zones' command."""
+    from kicad_tools.schema.pcb import PCB
+
+    try:
+        pcb = PCB.load(str(pcb_path))
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    zones = pcb.zones
+    output_format = getattr(args, "format", "text")
+
+    if output_format == "json":
+        zone_data = []
+        for zone in zones:
+            # Compute bounding box from polygon points
+            bounding_box = None
+            if zone.polygon:
+                xs = [p[0] for p in zone.polygon]
+                ys = [p[1] for p in zone.polygon]
+                bounding_box = {
+                    "min_x": min(xs),
+                    "min_y": min(ys),
+                    "max_x": max(xs),
+                    "max_y": max(ys),
+                }
+            zone_data.append(
+                {
+                    "net_number": zone.net_number,
+                    "net_name": zone.net_name,
+                    "layer": zone.layer,
+                    "priority": zone.priority,
+                    "clearance": zone.clearance,
+                    "thermal_gap": zone.thermal_gap,
+                    "thermal_bridge_width": zone.thermal_bridge_width,
+                    "is_filled": zone.is_filled,
+                    "fill_type": zone.fill_type,
+                    "boundary_points": len(zone.polygon),
+                    "bounding_box": bounding_box,
+                }
+            )
+        print(json.dumps({"zones": zone_data, "count": len(zones)}, indent=2))
+    else:
+        if not zones:
+            print("No zones found in PCB.")
+            return 0
+
+        print(f"Found {len(zones)} zone(s):\n")
+        for i, zone in enumerate(zones, 1):
+            print(f"Zone {i}:")
+            print(f"  Net:       {zone.net_name or f'(net {zone.net_number})'}")
+            print(f"  Layer:     {zone.layer}")
+            print(f"  Priority:  {zone.priority}")
+            print(f"  Clearance: {zone.clearance}mm")
+            print(f"  Fill type: {zone.fill_type}")
+            print(f"  Filled:    {'Yes' if zone.is_filled else 'No'}")
+            print(f"  Boundary:  {len(zone.polygon)} points")
+            if zone.polygon:
+                xs = [p[0] for p in zone.polygon]
+                ys = [p[1] for p in zone.polygon]
+                print(f"  Bounds:    ({min(xs):.2f}, {min(ys):.2f}) to ({max(xs):.2f}, {max(ys):.2f})")
+            print()
+
+    return 0
 
 
 def _run_strip_command(args, pcb_path: Path) -> int:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1168,6 +1168,11 @@ def _add_pcb_parser(subparsers) -> None:
         help="Apply reference renames without interactive confirmation",
     )
 
+    # pcb zones
+    pcb_zones = pcb_subparsers.add_parser("zones", help="List copper pour zones")
+    pcb_zones.add_argument("pcb", help="Path to .kicad_pcb file")
+    pcb_zones.add_argument("--format", choices=["text", "json"], default="text")
+
     # pcb remove-footprint
     pcb_remove_fp = pcb_subparsers.add_parser(
         "remove-footprint",

--- a/src/kicad_tools/cli/zones_cmd.py
+++ b/src/kicad_tools/cli/zones_cmd.py
@@ -283,6 +283,17 @@ def _run_list(args) -> int:
     if args.format == "json":
         zone_data = []
         for zone in zones:
+            # Compute bounding box from polygon points
+            bounding_box = None
+            if zone.polygon:
+                xs = [p[0] for p in zone.polygon]
+                ys = [p[1] for p in zone.polygon]
+                bounding_box = {
+                    "min_x": min(xs),
+                    "min_y": min(ys),
+                    "max_x": max(xs),
+                    "max_y": max(ys),
+                }
             zone_data.append(
                 {
                     "net_number": zone.net_number,
@@ -293,7 +304,9 @@ def _run_list(args) -> int:
                     "thermal_gap": zone.thermal_gap,
                     "thermal_bridge_width": zone.thermal_bridge_width,
                     "is_filled": zone.is_filled,
+                    "fill_type": zone.fill_type,
                     "boundary_points": len(zone.polygon),
+                    "bounding_box": bounding_box,
                 }
             )
         print(json.dumps({"zones": zone_data, "count": len(zones)}, indent=2))

--- a/tests/test_pcb_zones.py
+++ b/tests/test_pcb_zones.py
@@ -1,0 +1,225 @@
+"""Tests for the ``pcb zones`` subcommand."""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.commands.pcb import run_pcb_command
+
+FIXTURE_PCB = Path(__file__).parent / "fixtures" / "projects" / "multilayer_zones.kicad_pcb"
+
+
+class _Args:
+    """Minimal namespace to mimic argparse output for run_pcb_command."""
+
+    def __init__(self, pcb: str, fmt: str = "text"):
+        self.pcb_command = "zones"
+        self.pcb = pcb
+        self.format = fmt
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_pcb(tmp_path: Path) -> Path:
+    """Copy the multilayer_zones fixture into a temp directory."""
+    dest = tmp_path / "board.kicad_pcb"
+    shutil.copy2(FIXTURE_PCB, dest)
+    return dest
+
+
+@pytest.fixture
+def empty_pcb(tmp_path: Path) -> Path:
+    """Create a minimal PCB with no zones."""
+    from kicad_tools.schema.pcb import PCB
+
+    pcb = PCB.create(width=50, height=50)
+    pcb_path = tmp_path / "empty.kicad_pcb"
+    pcb.save(str(pcb_path))
+    return pcb_path
+
+
+# ---------------------------------------------------------------------------
+# JSON output tests
+# ---------------------------------------------------------------------------
+
+
+class TestPcbZonesJson:
+    """Verify JSON output from ``pcb zones``."""
+
+    def test_json_output_has_required_fields(self, tmp_pcb, capsys):
+        """JSON output includes all required fields including fill_type and bounding_box."""
+        args = _Args(str(tmp_pcb), "json")
+        ret = run_pcb_command(args)
+        assert ret == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "zones" in data
+        assert "count" in data
+        assert data["count"] == len(data["zones"])
+        assert data["count"] > 0, "Fixture must have at least one zone"
+
+        for zone in data["zones"]:
+            # Core fields
+            assert "net_number" in zone
+            assert "net_name" in zone
+            assert "layer" in zone
+            assert "priority" in zone
+            assert "clearance" in zone
+            assert "thermal_gap" in zone
+            assert "thermal_bridge_width" in zone
+            assert "is_filled" in zone
+            assert "boundary_points" in zone
+            # New fields
+            assert "fill_type" in zone
+            assert zone["fill_type"] in ("solid", "hatch")
+            assert "bounding_box" in zone
+
+    def test_json_bounding_box_structure(self, tmp_pcb, capsys):
+        """Bounding box has min_x, min_y, max_x, max_y keys."""
+        args = _Args(str(tmp_pcb), "json")
+        run_pcb_command(args)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        for zone in data["zones"]:
+            bb = zone["bounding_box"]
+            if bb is not None:
+                assert "min_x" in bb
+                assert "min_y" in bb
+                assert "max_x" in bb
+                assert "max_y" in bb
+                assert bb["max_x"] >= bb["min_x"]
+                assert bb["max_y"] >= bb["min_y"]
+
+    def test_json_empty_pcb(self, empty_pcb, capsys):
+        """An empty PCB returns count 0 and an empty zones list."""
+        args = _Args(str(empty_pcb), "json")
+        ret = run_pcb_command(args)
+        assert ret == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data == {"zones": [], "count": 0}
+
+
+# ---------------------------------------------------------------------------
+# Text output tests
+# ---------------------------------------------------------------------------
+
+
+class TestPcbZonesText:
+    """Verify text output from ``pcb zones``."""
+
+    def test_text_output_shows_zones(self, tmp_pcb, capsys):
+        """Text output includes zone details."""
+        args = _Args(str(tmp_pcb), "text")
+        ret = run_pcb_command(args)
+        assert ret == 0
+
+        captured = capsys.readouterr()
+        assert "zone(s)" in captured.out.lower() or "Zone" in captured.out
+        assert "Net:" in captured.out
+        assert "Layer:" in captured.out
+        assert "Fill type:" in captured.out
+        assert "Bounds:" in captured.out
+
+    def test_text_empty_pcb(self, empty_pcb, capsys):
+        """An empty PCB prints 'No zones found'."""
+        args = _Args(str(empty_pcb), "text")
+        ret = run_pcb_command(args)
+        assert ret == 0
+
+        captured = capsys.readouterr()
+        assert "No zones found" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestPcbZonesErrors:
+    """Verify error handling for ``pcb zones``."""
+
+    def test_missing_file_returns_1(self, capsys):
+        """Non-existent file returns exit code 1."""
+        args = _Args("/nonexistent/board.kicad_pcb", "text")
+        ret = run_pcb_command(args)
+        assert ret == 1
+
+        captured = capsys.readouterr()
+        assert "not found" in captured.err.lower() or "Error" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Bounding box calculation
+# ---------------------------------------------------------------------------
+
+
+class TestBoundingBoxCalculation:
+    """Unit tests for bounding box computation from polygon points."""
+
+    def test_bounding_box_from_square(self, tmp_pcb, capsys):
+        """Bounding box is correctly computed from zone polygon."""
+        args = _Args(str(tmp_pcb), "json")
+        run_pcb_command(args)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        # Verify at least one zone has a non-null bounding box with valid extents
+        has_bbox = False
+        for zone in data["zones"]:
+            bb = zone["bounding_box"]
+            if bb is not None:
+                has_bbox = True
+                # Width and height must be positive (non-degenerate)
+                width = bb["max_x"] - bb["min_x"]
+                height = bb["max_y"] - bb["min_y"]
+                assert width > 0, "Bounding box width must be positive"
+                assert height > 0, "Bounding box height must be positive"
+
+        assert has_bbox, "At least one zone should have a bounding box"
+
+
+# ---------------------------------------------------------------------------
+# Regression: top-level zones list still works
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelZonesListRegression:
+    """Verify the top-level ``zones list`` command still works."""
+
+    def test_zones_list_json(self, tmp_pcb, capsys):
+        """Top-level zones list JSON output still includes fill_type and bounding_box."""
+        from kicad_tools.cli.zones_cmd import main as zones_main
+
+        ret = zones_main(["list", str(tmp_pcb), "--format", "json"])
+        assert ret == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "zones" in data
+        assert data["count"] > 0
+
+        for zone in data["zones"]:
+            assert "fill_type" in zone
+            assert "bounding_box" in zone
+
+    def test_zones_list_text(self, tmp_pcb, capsys):
+        """Top-level zones list text output still works."""
+        from kicad_tools.cli.zones_cmd import main as zones_main
+
+        ret = zones_main(["list", str(tmp_pcb)])
+        assert ret == 0
+
+        captured = capsys.readouterr()
+        assert "zone(s)" in captured.out.lower() or "Zone" in captured.out


### PR DESCRIPTION
## Summary
Add a `pcb zones` subcommand that provides zone/copper pour inspection, wiring existing zone listing logic into the `pcb` subcommand namespace and adding two missing output fields (`fill_type` and `bounding_box`).

## Changes
- Register `pcb zones` subparser in `_add_pcb_parser()` in `parser.py`
- Add `zones` handler in `run_pcb_command()` in `commands/pcb.py` with JSON and text output
- Add `fill_type` and `bounding_box` fields to existing `zones list` JSON output in `zones_cmd.py`
- Add 9 tests covering JSON output, text output, empty PCB, error handling, bounding box calculation, and top-level `zones list` regression

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `pcb zones board.kicad_pcb --format json` returns JSON with all required fields | Pass | test_json_output_has_required_fields confirms all fields including fill_type and bounding_box |
| `pcb zones empty.kicad_pcb --format json` returns `{"zones": [], "count": 0}` | Pass | test_json_empty_pcb verifies exact output |
| `pcb zones board.kicad_pcb` (text) prints human-readable summary | Pass | test_text_output_shows_zones checks for Net, Layer, Fill type, Bounds |
| Top-level `zones list` continues to work unchanged | Pass | test_zones_list_json and test_zones_list_text verify no regression |
| Bounding box calculation from polygon points | Pass | test_bounding_box_from_square verifies positive width/height |

## Test Plan
- `python3 -m pytest tests/test_pcb_zones.py -v` -- all 9 tests pass
- `python3 -m pytest tests/test_zones_cmd.py -v` -- all 43 existing tests pass (no regression)

Closes #2066