### PR TITLE
feat(validate): detect power pin polarity errors in schematic validation

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -1528,6 +1528,159 @@ def check_power_net_shorts(schematic_path: str) -> list[ValidationIssue]:
     return issues
 
 
+# ---------------------------------------------------------------------------
+# Power pin polarity error detection (VDD on GND net, GND on VCC net)
+# ---------------------------------------------------------------------------
+
+
+def _is_power_positive_net(net_name: str) -> bool:
+    """Return True if *net_name* represents a positive power rail.
+
+    Checks tokenized keywords against ``_POWER_POSITIVE_KEYWORDS`` and
+    common voltage patterns like ``+3.3V``, ``+5V``, ``3V3``, etc.
+    """
+    tokens = _tokenize_name(net_name)
+    if tokens & _POWER_POSITIVE_KEYWORDS:
+        return True
+    # Strip leading +/- (common in power net names like +3V3, +5V)
+    stripped = net_name.lstrip("+-")
+    if stripped != net_name:
+        tokens2 = _tokenize_name(stripped)
+        if tokens2 & _POWER_POSITIVE_KEYWORDS:
+            return True
+    # Match common voltage patterns: +3.3V, +5V, +1.8V, etc.
+    if re.match(r"^\+?\d+(\.\d+)?V$", net_name):
+        return True
+    return False
+
+
+def _is_power_negative_net(net_name: str) -> bool:
+    """Return True if *net_name* represents a ground/negative rail.
+
+    Checks tokenized keywords against ``_POWER_NEGATIVE_KEYWORDS``.
+    """
+    tokens = _tokenize_name(net_name)
+    if tokens & _POWER_NEGATIVE_KEYWORDS:
+        return True
+    # Strip leading +/- just in case
+    stripped = net_name.lstrip("+-")
+    if stripped != net_name:
+        tokens2 = _tokenize_name(stripped)
+        if tokens2 & _POWER_NEGATIVE_KEYWORDS:
+            return True
+    return False
+
+
+def check_power_pin_polarity(schematic_path: str) -> list[ValidationIssue]:
+    """Detect power pins connected to nets of opposite polarity.
+
+    For example, a VDD pin connected to a GND net, or a GND pin connected
+    to a +3.3V net.  This is different from the ``power_short`` check which
+    detects VCC and GND pins on the *same* net -- polarity errors involve a
+    single pin on a net whose polarity contradicts the pin name.
+
+    Power symbols (``lib_id`` starting with ``power:``) are skipped since
+    they define nets rather than consume them.
+    """
+    issues: list[ValidationIssue] = []
+
+    try:
+        from kicad_tools.cli.sch_pin_map import resolve_pin_map
+
+        hierarchy = build_hierarchy(schematic_path)
+
+        for node in hierarchy.all_nodes():
+            try:
+                sch = Schematic.load(node.path)
+                pin_map = resolve_pin_map(sch)
+                sheet_path = node.get_path_string()
+
+                for ref, entry in pin_map.items():
+                    lib_id: str = entry.get("lib_id", "")
+
+                    # Skip power symbols -- they define nets, not consume them
+                    if lib_id.startswith("power:"):
+                        continue
+
+                    pins_data: dict[str, dict] = entry.get("pins", {})
+
+                    for pin_num, pin_info in pins_data.items():
+                        net_name = pin_info.get("net")
+                        if net_name is None:
+                            continue
+
+                        pin_name = pin_info.get("name", "")
+                        pin_type = pin_info.get("type", "")
+
+                        # Only consider power pins
+                        if pin_type not in ("power_in", "power_out"):
+                            continue
+
+                        pin_tokens = _tokenize_name(pin_name)
+                        pin_is_positive = bool(pin_tokens & _POWER_POSITIVE_KEYWORDS)
+                        pin_is_negative = bool(pin_tokens & _POWER_NEGATIVE_KEYWORDS)
+
+                        # Skip ambiguous or unrecognized pin names
+                        if not pin_is_positive and not pin_is_negative:
+                            continue
+
+                        net_is_positive = _is_power_positive_net(net_name)
+                        net_is_negative = _is_power_negative_net(net_name)
+
+                        # Skip nets that don't match any power classification
+                        if not net_is_positive and not net_is_negative:
+                            continue
+
+                        # Detect polarity mismatch
+                        if pin_is_positive and net_is_negative:
+                            issues.append(
+                                ValidationIssue(
+                                    severity="error",
+                                    category="power_polarity",
+                                    message=(
+                                        f"Power pin polarity error: {ref}.{pin_name} "
+                                        f"(pin {pin_num}) is a positive supply pin "
+                                        f"but connected to negative net '{net_name}'"
+                                    ),
+                                    location=sheet_path,
+                                )
+                            )
+                        elif pin_is_negative and net_is_positive:
+                            issues.append(
+                                ValidationIssue(
+                                    severity="error",
+                                    category="power_polarity",
+                                    message=(
+                                        f"Power pin polarity error: {ref}.{pin_name} "
+                                        f"(pin {pin_num}) is a ground pin "
+                                        f"but connected to positive net '{net_name}'"
+                                    ),
+                                    location=sheet_path,
+                                )
+                            )
+
+            except Exception as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="power_polarity",
+                        message=f"Skipped sheet {node.get_path_string()}: {e}",
+                        location=node.get_path_string(),
+                    )
+                )
+
+    except Exception as e:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                category="power_polarity",
+                message=f"Power polarity check failed: {e}",
+            )
+        )
+
+    return issues
+
+
 def validate_schematic(schematic_path: str, lib_paths: list[str] = None) -> ValidationResult:
     """Run all validation checks."""
     result = ValidationResult(schematic=schematic_path)
@@ -1575,6 +1728,10 @@ def validate_schematic(schematic_path: str, lib_paths: list[str] = None) -> Vali
     # Power net short detection (VCC-to-GND)
     result.checks_run.append("power_short")
     result.issues.extend(check_power_net_shorts(schematic_path))
+
+    # Power pin polarity error detection (VDD on GND net, etc.)
+    result.checks_run.append("power_polarity")
+    result.issues.extend(check_power_pin_polarity(schematic_path))
 
     # I2C pull-up resistor detection
     result.checks_run.append("i2c_pullups")

--- a/tests/test_sch_validate_power_polarity.py
+++ b/tests/test_sch_validate_power_polarity.py
@@ -1,0 +1,413 @@
+"""Tests for power pin polarity error detection (VDD/GND swap)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_validate import (
+    ValidationIssue,
+    check_power_pin_polarity,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to generate synthetic KiCad schematics
+# ---------------------------------------------------------------------------
+# Reuse the same pattern as test_sch_validate_power_short.py
+
+
+def _make_ic_lib_symbol(
+    lib_id: str,
+    pins: list[tuple[str, str, str]],
+) -> str:
+    """Generate a lib_symbols entry for an IC.
+
+    Args:
+        lib_id: e.g. "IC:SomeChip"
+        pins: list of (pin_number, pin_name, pin_type) tuples
+    """
+    part_name = lib_id.split(":")[-1] if ":" in lib_id else lib_id
+    pin_blocks = []
+    for i, (num, name, ptype) in enumerate(pins):
+        y = i * 2.54
+        pin_blocks.append(
+            f"""(pin {ptype} line
+                    (at 0 {y:.2f} 0)
+                    (length 2.54)
+                    (name "{name}")
+                    (number "{num}")
+                )"""
+        )
+    pin_str = "\n".join(pin_blocks)
+    return f"""(symbol "{lib_id}"
+            (pin_names (offset 0.254))
+            (symbol "{part_name}_0_1"
+                (rectangle
+                    (start -5.08 -{(len(pins) * 2.54) + 1.27:.2f})
+                    (end 5.08 1.27)
+                    (stroke (width 0.254))
+                    (fill (type background))
+                )
+            )
+            (symbol "{part_name}_1_1"
+                {pin_str}
+            )
+        )"""
+
+
+def _make_symbol_instance(
+    ref: str, lib_id: str, pins: list[tuple[str, str, str]], x: float, y: float,
+) -> str:
+    """Generate a symbol instance S-expression."""
+    pin_entries = "\n".join(
+        f'(pin "{num}" (uuid "pin-{ref.lower()}-{num}"))' for num, _, _ in pins
+    )
+    return f"""(symbol
+        (lib_id "{lib_id}")
+        (at {x} {y} 0)
+        (unit 1)
+        (in_bom yes)
+        (on_board yes)
+        (dnp no)
+        (uuid "uuid-{ref.lower()}")
+        (property "Reference" "{ref}"
+            (at {x + 2} {y - 2} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Value" "{lib_id.split(':')[-1]}"
+            (at {x + 2} {y} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Footprint" ""
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        (property "Datasheet" "~"
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        {pin_entries}
+    )"""
+
+
+def _make_single_ic_schematic(
+    lib_id: str,
+    pins: list[tuple[str, str, str]],
+    pin_nets: dict[str, str],
+    ref: str = "U1",
+) -> str:
+    """Build a schematic with a single IC."""
+    lib_sym = _make_ic_lib_symbol(lib_id, pins)
+    sym_inst = _make_symbol_instance(ref, lib_id, pins, 100.0, 50.0)
+
+    wires = []
+    labels = []
+    for pin_idx, (pin_num, _, _) in enumerate(pins):
+        if pin_num not in pin_nets:
+            continue
+        net_name = pin_nets[pin_num]
+        pin_y = 50.0 - pin_idx * 2.54
+        pin_x = 100.0
+        label_x = pin_x + 10.0
+
+        wires.append(
+            f"""(wire
+            (pts (xy {pin_x:.2f} {pin_y:.2f}) (xy {label_x:.2f} {pin_y:.2f}))
+            (stroke (width 0) (type default))
+            (uuid "wire-{ref.lower()}-{pin_num}")
+        )"""
+        )
+        labels.append(
+            f"""(label "{net_name}"
+            (at {label_x:.2f} {pin_y:.2f} 0)
+            (effects (font (size 1.27 1.27)) (justify left bottom))
+            (uuid "lbl-{ref.lower()}-{pin_num}")
+        )"""
+        )
+
+    wire_block = "\n".join(wires)
+    label_block = "\n".join(labels)
+
+    return f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "test-power-polarity-uuid")
+    (paper "A4")
+    (lib_symbols
+        {lib_sym}
+    )
+    {sym_inst}
+    {wire_block}
+    {label_block}
+)
+"""
+
+
+def _make_power_symbol_schematic(
+    net_name: str,
+) -> str:
+    """Build a schematic with a power symbol (lib_id power:...)."""
+    lib_id = "power:GND"
+    pins = [("1", "GND", "power_in")]
+    lib_sym = _make_ic_lib_symbol(lib_id, pins)
+    sym_inst = _make_symbol_instance("#PWR01", lib_id, pins, 100.0, 50.0)
+
+    wire = f"""(wire
+        (pts (xy 100.00 50.00) (xy 110.00 50.00))
+        (stroke (width 0) (type default))
+        (uuid "wire-pwr-1")
+    )"""
+    label = f"""(label "{net_name}"
+        (at 110.00 50.00 0)
+        (effects (font (size 1.27 1.27)) (justify left bottom))
+        (uuid "lbl-pwr-1")
+    )"""
+
+    return f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "test-power-sym-uuid")
+    (paper "A4")
+    (lib_symbols
+        {lib_sym}
+    )
+    {sym_inst}
+    {wire}
+    {label}
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPowerPinPolarity:
+    """Test check_power_pin_polarity against synthetic schematics."""
+
+    def test_vdd_pin_on_gnd_net_flagged(self, tmp_path: Path):
+        """VDD pin connected to a GND net should be flagged as error."""
+        pins = [
+            ("1", "VDD", "power_in"),
+            ("2", "GND", "power_in"),
+            ("3", "SDA", "bidirectional"),
+        ]
+        pin_nets = {
+            "1": "GNDD",   # VDD pin on a ground net -- polarity error
+            "2": "GND",    # GND pin on GND net -- correct
+            "3": "I2C_SDA",
+        }
+        sch_text = _make_single_ic_schematic("IC:Oscillator", pins, pin_nets)
+        sch_path = tmp_path / "vdd_on_gnd.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert len(polarity_errors) == 1
+        assert "VDD" in polarity_errors[0].message
+        assert "GNDD" in polarity_errors[0].message
+        assert "positive supply pin" in polarity_errors[0].message
+
+    def test_gnd_pin_on_positive_net_flagged(self, tmp_path: Path):
+        """GND pin connected to a positive supply net should be flagged."""
+        pins = [
+            ("1", "VDD", "power_in"),
+            ("2", "GND", "power_in"),
+        ]
+        pin_nets = {
+            "1": "+3.3V",  # Correct
+            "2": "+3.3V",  # GND pin on positive net -- polarity error
+        }
+        sch_text = _make_single_ic_schematic("IC:Chip", pins, pin_nets)
+        sch_path = tmp_path / "gnd_on_vcc.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert len(polarity_errors) == 1
+        assert "GND" in polarity_errors[0].message
+        assert "+3.3V" in polarity_errors[0].message
+        assert "ground pin" in polarity_errors[0].message
+
+    def test_correct_wiring_no_issues(self, tmp_path: Path):
+        """VDD on positive net and GND on negative net should not be flagged."""
+        pins = [
+            ("1", "VDD", "power_in"),
+            ("2", "GND", "power_in"),
+            ("3", "OUT", "output"),
+        ]
+        pin_nets = {
+            "1": "+3.3V",
+            "2": "GND",
+            "3": "SIG_OUT",
+        }
+        sch_text = _make_single_ic_schematic("IC:NormalChip", pins, pin_nets)
+        sch_path = tmp_path / "correct_wiring.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert polarity_errors == []
+
+    def test_ambiguous_pin_name_skipped(self, tmp_path: Path):
+        """Pins with ambiguous names (EP, V+) should not produce false positives."""
+        pins = [
+            ("1", "EP", "power_in"),
+            ("2", "NC", "power_in"),
+        ]
+        pin_nets = {
+            "1": "GND",
+            "2": "+3.3V",
+        }
+        sch_text = _make_single_ic_schematic("IC:QFN", pins, pin_nets)
+        sch_path = tmp_path / "ambiguous_pin.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert polarity_errors == []
+
+    def test_power_symbol_skipped(self, tmp_path: Path):
+        """Power symbols (lib_id power:*) should be skipped entirely."""
+        sch_text = _make_power_symbol_schematic("+3.3V")
+        sch_path = tmp_path / "power_sym.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert polarity_errors == []
+
+    def test_multiple_pins_only_swapped_reported(self, tmp_path: Path):
+        """Multiple power pins on one symbol: only swapped ones reported."""
+        pins = [
+            ("1", "AVDD", "power_in"),
+            ("2", "DVDD", "power_in"),
+            ("3", "AGND", "power_in"),
+            ("4", "DGND", "power_in"),
+        ]
+        pin_nets = {
+            "1": "+3.3V",    # Correct
+            "2": "GNDD",     # Swapped -- positive pin on negative net
+            "3": "GND",      # Correct
+            "4": "+5V",      # Swapped -- negative pin on positive net
+        }
+        sch_text = _make_single_ic_schematic("IC:MultiPower", pins, pin_nets)
+        sch_path = tmp_path / "multi_power.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert len(polarity_errors) == 2
+        messages = [e.message for e in polarity_errors]
+        # DVDD on GNDD
+        assert any("DVDD" in m and "GNDD" in m for m in messages)
+        # DGND on +5V
+        assert any("DGND" in m and "+5V" in m for m in messages)
+
+    def test_vcc_on_vss_net_flagged(self, tmp_path: Path):
+        """VCC pin on VSS net should be flagged."""
+        pins = [("1", "VCC", "power_in")]
+        pin_nets = {"1": "VSS"}
+        sch_text = _make_single_ic_schematic("IC:Chip", pins, pin_nets)
+        sch_path = tmp_path / "vcc_on_vss.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert len(polarity_errors) == 1
+        assert "VCC" in polarity_errors[0].message
+        assert "VSS" in polarity_errors[0].message
+
+    def test_vss_on_vdd_net_flagged(self, tmp_path: Path):
+        """VSS pin on VDD net should be flagged."""
+        pins = [("1", "VSS", "power_in")]
+        pin_nets = {"1": "VDD"}
+        sch_text = _make_single_ic_schematic("IC:Chip", pins, pin_nets)
+        sch_path = tmp_path / "vss_on_vdd.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert len(polarity_errors) == 1
+        assert "VSS" in polarity_errors[0].message
+        assert "ground pin" in polarity_errors[0].message
+
+    def test_non_power_pin_type_ignored(self, tmp_path: Path):
+        """Non-power pin types should not be checked even if names match."""
+        pins = [
+            ("1", "VCC", "input"),     # Not power_in
+            ("2", "GND", "passive"),   # Not power_in
+        ]
+        pin_nets = {
+            "1": "GND",     # Would be a polarity error if power pin
+            "2": "+3.3V",   # Would be a polarity error if power pin
+        }
+        sch_text = _make_single_ic_schematic("IC:Weird", pins, pin_nets)
+        sch_path = tmp_path / "non_power_type.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert polarity_errors == []
+
+    def test_pin_on_non_power_net_skipped(self, tmp_path: Path):
+        """Power pin on a non-power net (e.g. signal net) should be skipped."""
+        pins = [("1", "VDD", "power_in")]
+        pin_nets = {"1": "SOME_SIGNAL"}
+        sch_text = _make_single_ic_schematic("IC:Chip", pins, pin_nets)
+        sch_path = tmp_path / "signal_net.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert polarity_errors == []
+
+    def test_voltage_pattern_net_positive(self, tmp_path: Path):
+        """Net names like +5V, +1.8V should be classified as positive."""
+        pins = [("1", "GND", "power_in")]
+        pin_nets = {"1": "+5V"}
+        sch_text = _make_single_ic_schematic("IC:Chip", pins, pin_nets)
+        sch_path = tmp_path / "voltage_net.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert len(polarity_errors) == 1
+        assert "GND" in polarity_errors[0].message
+        assert "+5V" in polarity_errors[0].message


### PR DESCRIPTION
## Summary
Add a new `check_power_pin_polarity()` validation check that detects power pins connected to nets of opposite polarity -- for example, a VDD pin wired to a GNDD net, or a GND pin wired to +3.3V. This complements the existing `power_short` check (which detects VCC and GND on the same net) by catching the scenario where a single pin is on a net whose polarity contradicts the pin name.

## Changes
- Add module-level `_is_power_positive_net()` and `_is_power_negative_net()` helpers (refactored from the local helper inside `check_i2c_pullups`)
- Add `check_power_pin_polarity()` function that iterates all sheets, classifies power pins and their net names by polarity, and emits errors on mismatch
- Register the new check as `"power_polarity"` in `validate_schematic()`
- Add comprehensive test suite in `tests/test_sch_validate_power_polarity.py` (11 tests)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| VDD pin on GND net detected as error | Pass | test_vdd_pin_on_gnd_net_flagged |
| GND pin on positive net detected as error | Pass | test_gnd_pin_on_positive_net_flagged |
| Correct wiring produces no errors | Pass | test_correct_wiring_no_issues |
| Ambiguous pin names (EP, NC) skipped | Pass | test_ambiguous_pin_name_skipped |
| Power symbols (power:*) skipped | Pass | test_power_symbol_skipped |
| Multiple pins: only swapped ones reported | Pass | test_multiple_pins_only_swapped_reported |
| Non-power pin types ignored | Pass | test_non_power_pin_type_ignored |
| Existing power_short tests unchanged | Pass | 6/6 passing |

## Test Plan
- All 11 new tests in `test_sch_validate_power_polarity.py` pass
- All 6 existing tests in `test_sch_validate_power_short.py` pass (regression check)

Closes #2067