### PR TITLE
feat(pcb): add pcb add-zone command for copper pour creation

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -11,7 +11,7 @@ def run_pcb_command(args) -> int:
     """Handle PCB subcommands."""
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
-        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist, remove-footprint")
+        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist, remove-footprint, add-zone")
         return 1
 
     pcb_path = Path(args.pcb)
@@ -34,6 +34,10 @@ def run_pcb_command(args) -> int:
     # Handle remove-footprint command
     if args.pcb_command == "remove-footprint":
         return _run_remove_footprint_command(args, pcb_path)
+
+    # Handle add-zone command
+    if args.pcb_command == "add-zone":
+        return _run_add_zone_command(args, pcb_path)
 
     from ..pcb_query import main as pcb_main
 
@@ -531,3 +535,134 @@ def _run_remove_footprint_command(args, pcb_path: Path) -> int:
         force=force,
         output_format=output_format,
     )
+
+
+def _run_add_zone_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb add-zone' command.
+
+    Delegates to the existing ZoneGenerator infrastructure from
+    kicad_tools.zones, adding support for --rect/--origin/--size
+    rectangular boundary specification.
+    """
+    from kicad_tools.zones import ZoneGenerator
+
+    # Validate --rect requires --origin and --size
+    use_rect = getattr(args, "rect", False)
+    origin = getattr(args, "origin", None)
+    size = getattr(args, "size", None)
+
+    if use_rect:
+        if origin is None or size is None:
+            print(
+                "Error: --rect requires both --origin X Y and --size W H",
+                file=sys.stderr,
+            )
+            return 1
+
+    # Build rectangular boundary polygon if requested
+    boundary = None
+    if use_rect and origin is not None and size is not None:
+        x0, y0 = origin
+        w, h = size
+        if w <= 0 or h <= 0:
+            print("Error: --size width and height must be positive", file=sys.stderr)
+            return 1
+        boundary = [
+            (x0, y0),
+            (x0 + w, y0),
+            (x0 + w, y0 + h),
+            (x0, y0 + h),
+        ]
+
+    # Determine output path
+    output = getattr(args, "output", None)
+    if output:
+        output_path = Path(output)
+    else:
+        output_path = pcb_path.with_stem(pcb_path.stem + "_zones")
+
+    dry_run = getattr(args, "dry_run", False)
+    output_format = getattr(args, "format", "text")
+
+    try:
+        gen = ZoneGenerator.from_pcb(str(pcb_path))
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    # Map CLI flags to ZoneGenerator parameters
+    try:
+        zone = gen.add_zone(
+            net=args.net,
+            layer=args.layer,
+            priority=getattr(args, "priority", 0),
+            clearance=getattr(args, "min_clearance", 0.3),
+            thermal_gap=getattr(args, "thermal_relief_gap", 0.3),
+            thermal_bridge_width=getattr(args, "thermal_relief_width", 0.4),
+            min_thickness=getattr(args, "min_thickness", 0.25),
+            boundary=boundary,
+        )
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    # Build result for reporting
+    result = {
+        "input": str(pcb_path),
+        "output": str(output_path) if not dry_run else None,
+        "dry_run": dry_run,
+        "zone": {
+            "net": zone.config.net,
+            "layer": zone.config.layer,
+            "priority": zone.config.priority,
+            "clearance": zone.config.clearance,
+            "thermal_gap": zone.config.thermal_gap,
+            "thermal_bridge_width": zone.config.thermal_bridge_width,
+            "boundary_points": len(zone.boundary),
+            "boundary_type": "rectangle" if use_rect else "board_outline",
+        },
+        "warnings": [w.message for w in gen.warnings],
+    }
+
+    if output_format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        label = "(dry run) " if dry_run else ""
+        print(f"PCB Add Zone {label}")
+        print(f"  Input:  {pcb_path}")
+        if not dry_run:
+            print(f"  Output: {output_path}")
+        print()
+        print(f"  Net:              {zone.config.net}")
+        print(f"  Layer:            {zone.config.layer}")
+        print(f"  Priority:         {zone.config.priority}")
+        print(f"  Clearance:        {zone.config.clearance}mm")
+        print(f"  Thermal gap:      {zone.config.thermal_gap}mm")
+        print(f"  Thermal width:    {zone.config.thermal_bridge_width}mm")
+        print(f"  Boundary:         {len(zone.boundary)} points", end="")
+        if use_rect:
+            print(" (rectangle)")
+        else:
+            print(" (board outline)")
+
+    # Surface overlap warnings
+    if gen.warnings:
+        if output_format == "text":
+            print(f"\n{len(gen.warnings)} overlap warning(s):")
+            for w in gen.warnings:
+                print(f"  WARNING: {w.message}", file=sys.stderr)
+
+    if dry_run:
+        return 0
+
+    # Save
+    try:
+        gen.save(output_path)
+    except Exception as e:
+        print(f"Error saving PCB: {e}", file=sys.stderr)
+        return 1
+
+    if output_format == "text":
+        print(f"\n  Saved to: {output_path}")
+
+    return 0

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1205,6 +1205,99 @@ def _add_pcb_parser(subparsers) -> None:
         help="Remove footprint even if it has routed traces",
     )
 
+    # pcb add-zone
+    pcb_add_zone = pcb_subparsers.add_parser(
+        "add-zone",
+        help="Add a copper pour zone to the PCB",
+        description="Create a copper pour zone on a specified layer and net. "
+        "By default the zone boundary follows the board outline (--fill-board). "
+        "Use --rect with --origin and --size to specify a rectangular boundary.",
+    )
+    pcb_add_zone.add_argument("pcb", help="Path to .kicad_pcb file")
+    pcb_add_zone.add_argument(
+        "--net",
+        required=True,
+        help="Net name for the zone (e.g., GND, +3.3V)",
+    )
+    pcb_add_zone.add_argument(
+        "--layer",
+        required=True,
+        help="Copper layer (e.g., F.Cu, B.Cu, In1.Cu)",
+    )
+    pcb_add_zone.add_argument(
+        "--priority",
+        type=int,
+        default=0,
+        help="Zone fill priority (higher = fills later, default: 0)",
+    )
+    pcb_add_zone.add_argument(
+        "--min-clearance",
+        type=float,
+        default=0.3,
+        help="Clearance to other nets in mm (default: 0.3)",
+    )
+    pcb_add_zone.add_argument(
+        "--thermal-relief-gap",
+        type=float,
+        default=0.3,
+        help="Thermal relief gap in mm (default: 0.3)",
+    )
+    pcb_add_zone.add_argument(
+        "--thermal-relief-width",
+        type=float,
+        default=0.4,
+        help="Thermal relief spoke width in mm (default: 0.4)",
+    )
+    pcb_add_zone.add_argument(
+        "--min-thickness",
+        type=float,
+        default=0.25,
+        help="Minimum copper thickness in mm (default: 0.25)",
+    )
+    pcb_add_zone.add_argument(
+        "--fill-board",
+        action="store_true",
+        default=False,
+        help="Use board outline as zone boundary (this is the default behavior)",
+    )
+    pcb_add_zone.add_argument(
+        "--rect",
+        action="store_true",
+        default=False,
+        help="Use a rectangular zone boundary (requires --origin and --size)",
+    )
+    pcb_add_zone.add_argument(
+        "--origin",
+        type=float,
+        nargs=2,
+        metavar=("X", "Y"),
+        help="Rectangle origin in mm (bottom-left corner)",
+    )
+    pcb_add_zone.add_argument(
+        "--size",
+        type=float,
+        nargs=2,
+        metavar=("W", "H"),
+        help="Rectangle size in mm (width height)",
+    )
+    pcb_add_zone.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        help="Output file path (default: <input>_zones.kicad_pcb)",
+    )
+    pcb_add_zone.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without writing output",
+    )
+    pcb_add_zone.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for results",
+    )
+
 
 def _add_lib_parser(subparsers) -> None:
     """Add library subcommand parser with its subcommands."""

--- a/tests/test_pcb_add_zone.py
+++ b/tests/test_pcb_add_zone.py
@@ -1,0 +1,282 @@
+"""Tests for the 'pcb add-zone' CLI command."""
+
+import json
+
+import pytest
+
+from kicad_tools.cli.commands.pcb import run_pcb_command
+
+
+@pytest.fixture
+def sample_pcb(tmp_path):
+    """Create a minimal valid PCB file for testing."""
+    pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (36 "B.SilkS" user "B.Silkscreen")
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (gr_rect
+    (start 0 0)
+    (end 50 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+)
+"""
+    pcb_file = tmp_path / "test.kicad_pcb"
+    pcb_file.write_text(pcb_content)
+    return pcb_file
+
+
+def _make_args(pcb_path, **kwargs):
+    """Build a namespace object mimicking argparse output for pcb add-zone."""
+    from argparse import Namespace
+
+    defaults = {
+        "pcb_command": "add-zone",
+        "pcb": str(pcb_path),
+        "net": "GND",
+        "layer": "B.Cu",
+        "priority": 0,
+        "min_clearance": 0.3,
+        "thermal_relief_gap": 0.3,
+        "thermal_relief_width": 0.4,
+        "min_thickness": 0.25,
+        "fill_board": False,
+        "rect": False,
+        "origin": None,
+        "size": None,
+        "output": None,
+        "dry_run": False,
+        "format": "text",
+    }
+    defaults.update(kwargs)
+    return Namespace(**defaults)
+
+
+class TestPcbAddZoneDryRun:
+    """Test pcb add-zone in dry-run mode (no file writes)."""
+
+    def test_dry_run_text_output(self, sample_pcb, capsys):
+        """Dry run produces text summary without writing files."""
+        args = _make_args(sample_pcb, dry_run=True)
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        assert "GND" in captured.out
+        assert "B.Cu" in captured.out
+        assert "board outline" in captured.out
+
+    def test_dry_run_json_output(self, sample_pcb, capsys):
+        """Dry run produces valid JSON output."""
+        args = _make_args(sample_pcb, dry_run=True, format="json")
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["dry_run"] is True
+        assert data["zone"]["net"] == "GND"
+        assert data["zone"]["layer"] == "B.Cu"
+        assert data["zone"]["boundary_type"] == "board_outline"
+        assert data["output"] is None
+
+    def test_dry_run_with_fill_board(self, sample_pcb, capsys):
+        """--fill-board flag is accepted (no-op, documents default)."""
+        args = _make_args(sample_pcb, dry_run=True, fill_board=True)
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        assert "board outline" in captured.out
+
+    def test_dry_run_inner_layer(self, sample_pcb, capsys):
+        """Zone on inner layer works (dry run)."""
+        # Note: Our sample PCB does not define In1.Cu, but ZoneGenerator
+        # accepts it. We test with F.Cu instead to stay safe.
+        args = _make_args(sample_pcb, dry_run=True, layer="F.Cu", net="+3.3V")
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        assert "+3.3V" in captured.out
+        assert "F.Cu" in captured.out
+
+
+class TestPcbAddZoneRect:
+    """Test pcb add-zone with rectangular boundary."""
+
+    def test_rect_dry_run(self, sample_pcb, capsys):
+        """Rectangular zone boundary in dry-run mode."""
+        args = _make_args(
+            sample_pcb,
+            dry_run=True,
+            rect=True,
+            origin=[10.0, 10.0],
+            size=[30.0, 30.0],
+        )
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        assert "rectangle" in captured.out
+
+    def test_rect_json_output(self, sample_pcb, capsys):
+        """Rectangular zone produces correct JSON boundary_type."""
+        args = _make_args(
+            sample_pcb,
+            dry_run=True,
+            format="json",
+            rect=True,
+            origin=[10.0, 10.0],
+            size=[30.0, 30.0],
+        )
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["zone"]["boundary_type"] == "rectangle"
+        assert data["zone"]["boundary_points"] == 4
+
+    def test_rect_without_origin_fails(self, sample_pcb, capsys):
+        """--rect without --origin produces error."""
+        args = _make_args(
+            sample_pcb,
+            rect=True,
+            origin=None,
+            size=[30.0, 30.0],
+        )
+        rc = run_pcb_command(args)
+        assert rc == 1
+
+        captured = capsys.readouterr()
+        assert "--rect requires" in captured.err
+
+    def test_rect_without_size_fails(self, sample_pcb, capsys):
+        """--rect without --size produces error."""
+        args = _make_args(
+            sample_pcb,
+            rect=True,
+            origin=[10.0, 10.0],
+            size=None,
+        )
+        rc = run_pcb_command(args)
+        assert rc == 1
+
+        captured = capsys.readouterr()
+        assert "--rect requires" in captured.err
+
+    def test_rect_negative_size_fails(self, sample_pcb, capsys):
+        """Negative size values produce error."""
+        args = _make_args(
+            sample_pcb,
+            rect=True,
+            origin=[10.0, 10.0],
+            size=[-5.0, 30.0],
+        )
+        rc = run_pcb_command(args)
+        assert rc == 1
+
+        captured = capsys.readouterr()
+        assert "positive" in captured.err
+
+
+class TestPcbAddZoneWrite:
+    """Test pcb add-zone with actual file writing."""
+
+    def test_write_zone_to_output(self, sample_pcb, tmp_path, capsys):
+        """Writing zone creates valid output file."""
+        output = tmp_path / "output.kicad_pcb"
+        args = _make_args(sample_pcb, output=str(output))
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        assert output.exists()
+        content = output.read_text()
+        assert "(zone" in content
+        assert '"GND"' in content
+
+    def test_write_rect_zone(self, sample_pcb, tmp_path, capsys):
+        """Writing rectangular zone produces valid output."""
+        output = tmp_path / "output_rect.kicad_pcb"
+        args = _make_args(
+            sample_pcb,
+            output=str(output),
+            rect=True,
+            origin=[5.0, 5.0],
+            size=[20.0, 20.0],
+        )
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        assert output.exists()
+        content = output.read_text()
+        assert "(zone" in content
+        assert '"GND"' in content
+
+    def test_default_output_path(self, sample_pcb, capsys):
+        """Default output path adds _zones suffix."""
+        args = _make_args(sample_pcb)
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        expected = sample_pcb.with_stem(sample_pcb.stem + "_zones")
+        assert expected.exists()
+
+    def test_custom_thermal_params(self, sample_pcb, tmp_path, capsys):
+        """Custom thermal relief parameters are passed through."""
+        output = tmp_path / "thermal.kicad_pcb"
+        args = _make_args(
+            sample_pcb,
+            output=str(output),
+            dry_run=True,
+            format="json",
+            thermal_relief_gap=0.5,
+            thermal_relief_width=0.6,
+            min_clearance=0.4,
+        )
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["zone"]["clearance"] == 0.4
+        assert data["zone"]["thermal_gap"] == 0.5
+        assert data["zone"]["thermal_bridge_width"] == 0.6
+
+
+class TestPcbAddZoneErrors:
+    """Test error handling for pcb add-zone."""
+
+    def test_unknown_net(self, sample_pcb, capsys):
+        """Unknown net name produces error."""
+        args = _make_args(sample_pcb, net="NONEXISTENT")
+        rc = run_pcb_command(args)
+        assert rc == 1
+
+        captured = capsys.readouterr()
+        assert "Error" in captured.err
+
+    def test_missing_pcb_file(self, tmp_path, capsys):
+        """Missing PCB file produces error."""
+        args = _make_args(tmp_path / "nonexistent.kicad_pcb")
+        rc = run_pcb_command(args)
+        assert rc == 1
+
+        captured = capsys.readouterr()
+        assert "not found" in captured.err or "Error" in captured.err


### PR DESCRIPTION
## Summary

- Adds `pcb add-zone` subcommand that delegates to the existing `ZoneGenerator` infrastructure
- Supports `--fill-board` (documents default board-outline behavior), `--rect --origin X Y --size W H` for rectangular boundaries
- Maps issue-specified flags (`--min-clearance`, `--thermal-relief-gap`, `--thermal-relief-width`) to existing zone config parameters
- Includes text and JSON output modes, `--dry-run` support, and overlap warning display

Closes #2071

## Test plan

- [x] 15 new tests in `tests/test_pcb_add_zone.py` covering dry-run, rect boundary, file write, error handling
- [x] All 47 existing `tests/test_zone_generator.py` tests continue to pass
- [x] CLI help output verified for `pcb add-zone --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)