### PR TITLE
feat(pcb): add snap-rotation command to normalize component angles

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -11,7 +11,7 @@ def run_pcb_command(args) -> int:
     """Handle PCB subcommands."""
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
-        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist, remove-footprint, add-zone")
+        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist, remove-footprint, add-zone, snap-rotation")
         return 1
 
     pcb_path = Path(args.pcb)
@@ -38,6 +38,10 @@ def run_pcb_command(args) -> int:
     # Handle add-zone command
     if args.pcb_command == "add-zone":
         return _run_add_zone_command(args, pcb_path)
+
+    # Handle snap-rotation command
+    if args.pcb_command == "snap-rotation":
+        return _run_snap_rotation_command(args, pcb_path)
 
     from ..pcb_query import main as pcb_main
 
@@ -664,5 +668,122 @@ def _run_add_zone_command(args, pcb_path: Path) -> int:
 
     if output_format == "text":
         print(f"\n  Saved to: {output_path}")
+
+    return 0
+
+
+def _run_snap_rotation_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb snap-rotation' command.
+
+    Normalizes footprint rotation angles to the nearest cardinal angle
+    (0, 90, 180, 270 by default).
+    """
+    from kicad_tools.schema.pcb import PCB
+
+    grid = getattr(args, "grid", 90.0)
+    tolerance = getattr(args, "tolerance", None)
+    exclude = getattr(args, "exclude", None)
+    only = getattr(args, "only", None)
+    dry_run = getattr(args, "dry_run", False)
+    output_format = getattr(args, "format", "text")
+
+    # Parse comma-separated reference lists
+    exclude_refs: set[str] = set()
+    if exclude:
+        exclude_refs = {r.strip() for r in exclude.split(",")}
+    only_refs: set[str] = set()
+    if only:
+        only_refs = {r.strip() for r in only.split(",")}
+
+    # Load PCB
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    # Snap rotations
+    changes: list[dict] = []
+    for fp in pcb.footprints:
+        ref = fp.reference
+
+        # Filter by --exclude / --only
+        if exclude_refs and ref in exclude_refs:
+            continue
+        if only_refs and ref not in only_refs:
+            continue
+
+        old_rotation = fp.rotation
+        snapped = round(old_rotation / grid) * grid % 360
+
+        # Apply tolerance filter: skip if delta exceeds tolerance
+        delta = abs(old_rotation - snapped)
+        # Handle wraparound (e.g., 359 -> 0 has delta 1, not 359)
+        if delta > 180:
+            delta = 360 - delta
+        if tolerance is not None and delta > tolerance:
+            continue
+
+        if abs(old_rotation - snapped) > 1e-6 or (abs(old_rotation - 360.0) < 1e-6 and snapped == 0.0):
+            changes.append({
+                "reference": ref,
+                "old_rotation": old_rotation,
+                "new_rotation": snapped,
+            })
+            if not dry_run:
+                fp.rotation = snapped
+                # When snapping to 0, remove the third child from the (at ...)
+                # node so KiCad does not serialize a stale rotation value.
+                if snapped == 0.0 and fp._sexp_node is not None:
+                    at_node = fp._sexp_node.find("at")
+                    if at_node is not None and len(at_node.children) >= 3:
+                        del at_node.children[2]
+
+    # Determine output path
+    output_path = pcb_path
+    if args.output:
+        output_path = Path(args.output)
+
+    # Build result
+    result = {
+        "input": str(pcb_path),
+        "output": str(output_path) if not dry_run else None,
+        "dry_run": dry_run,
+        "grid": grid,
+        "tolerance": tolerance,
+        "total_footprints": len(pcb.footprints),
+        "snapped": len(changes),
+        "changes": changes,
+    }
+
+    if output_format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"PCB Snap Rotation {'(dry run)' if dry_run else ''}")
+        print(f"  Input:  {pcb_path}")
+        if not dry_run:
+            print(f"  Output: {output_path}")
+        print(f"  Grid:   {grid} degrees")
+        if tolerance is not None:
+            print(f"  Tolerance: {tolerance} degrees")
+        print()
+
+        if changes:
+            print(f"  {len(changes)} footprint(s) snapped:")
+            for c in changes:
+                print(f"    {c['reference']}: {c['old_rotation']:.1f} -> {c['new_rotation']:.1f}")
+        else:
+            print("  No footprints needed rotation adjustment.")
+
+    # Save unless dry-run
+    if not dry_run and changes:
+        try:
+            pcb.save(output_path)
+            if output_format == "text":
+                print()
+                print(f"  Saved to: {output_path}")
+        except Exception as e:
+            print(f"Error saving PCB: {e}", file=sys.stderr)
+            return 1
 
     return 0

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1298,6 +1298,56 @@ def _add_pcb_parser(subparsers) -> None:
         help="Output format for results",
     )
 
+    # pcb snap-rotation
+    pcb_snap_rot = pcb_subparsers.add_parser(
+        "snap-rotation",
+        help="Normalize component rotation angles to cardinal directions",
+        description="Snap footprint rotations to the nearest multiple of a grid angle "
+        "(default 90 degrees). Useful for cleaning up arbitrary rotations left "
+        "by placement optimization.",
+    )
+    pcb_snap_rot.add_argument("pcb", help="Path to .kicad_pcb file")
+    pcb_snap_rot.add_argument(
+        "--grid",
+        type=float,
+        default=90.0,
+        help="Rotation grid in degrees (default: 90). Use 45 for 45-degree snapping.",
+    )
+    pcb_snap_rot.add_argument(
+        "--tolerance",
+        type=float,
+        default=None,
+        help="Maximum angular distance (degrees) from the nearest grid angle to snap. "
+        "Footprints further from the grid than this are left unchanged.",
+    )
+    pcb_snap_rot.add_argument(
+        "--exclude",
+        default=None,
+        help="Comma-separated reference designators to skip (e.g., --exclude U8,J1)",
+    )
+    pcb_snap_rot.add_argument(
+        "--only",
+        default=None,
+        help="Comma-separated reference designators to snap (only these are modified)",
+    )
+    pcb_snap_rot.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        help="Output file path (default: overwrite input)",
+    )
+    pcb_snap_rot.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for results",
+    )
+    pcb_snap_rot.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview rotation changes without modifying the PCB file",
+    )
+
 
 def _add_lib_parser(subparsers) -> None:
     """Add library subcommand parser with its subcommands."""

--- a/tests/test_pcb_snap_rotation.py
+++ b/tests/test_pcb_snap_rotation.py
@@ -1,0 +1,416 @@
+"""Tests for pcb snap-rotation command."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.schema.pcb import PCB
+
+# Minimal PCB with footprints at various non-cardinal angles
+MINIMAL_PCB_ROTATED = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100 15.6)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r2")
+    (at 110 100 91.2)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "4.7k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (uuid "fp-c1")
+    (at 120 100 179.8)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (uuid "fp-c2")
+    (at 130 100 315.6)
+    (property "Reference" "C2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10n" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Package_SO:SOIC-8"
+    (layer "F.Cu")
+    (uuid "fp-u1")
+    (at 140 100 28.5)
+    (property "Reference" "U1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "IC" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+# PCB with a footprint at 0 degrees (no rotation in at node)
+MINIMAL_PCB_ZERO_ROTATION = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+
+def _write_pcb(tmp_path: Path, content: str = MINIMAL_PCB_ROTATED) -> Path:
+    """Write a test PCB file and return its path."""
+    pcb_file = tmp_path / "test.kicad_pcb"
+    pcb_file.write_text(content)
+    return pcb_file
+
+
+class TestSnapRotationBasic:
+    """Basic snap-rotation tests."""
+
+    def test_snaps_all_to_cardinal(self, tmp_path):
+        """All non-cardinal rotations snap to nearest 90-degree multiple."""
+        pcb_file = _write_pcb(tmp_path)
+        pcb = PCB.load(pcb_file)
+
+        # Before: non-cardinal angles
+        assert pcb.get_footprint("R1").rotation == pytest.approx(15.6)
+        assert pcb.get_footprint("R2").rotation == pytest.approx(91.2)
+        assert pcb.get_footprint("C1").rotation == pytest.approx(179.8)
+        assert pcb.get_footprint("C2").rotation == pytest.approx(315.6)
+        assert pcb.get_footprint("U1").rotation == pytest.approx(28.5)
+
+        # Run snap-rotation via the command handler
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=90.0,
+            tolerance=None,
+            exclude=None,
+            only=None,
+            dry_run=False,
+            format="text",
+            output=None,
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+        # Reload and verify
+        pcb2 = PCB.load(pcb_file)
+        assert pcb2.get_footprint("R1").rotation == pytest.approx(0.0)
+        assert pcb2.get_footprint("R2").rotation == pytest.approx(90.0)
+        assert pcb2.get_footprint("C1").rotation == pytest.approx(180.0)
+        assert pcb2.get_footprint("C2").rotation == pytest.approx(0.0)  # 315.6 -> 360 -> 0
+        assert pcb2.get_footprint("U1").rotation == pytest.approx(0.0)
+
+    def test_tolerance_skips_large_delta(self, tmp_path):
+        """With --tolerance 10, footprints >10 degrees from grid are not snapped."""
+        pcb_file = _write_pcb(tmp_path)
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=90.0,
+            tolerance=10.0,
+            exclude=None,
+            only=None,
+            dry_run=False,
+            format="text",
+            output=None,
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+        pcb2 = PCB.load(pcb_file)
+        # R2 at 91.2 -> delta 1.2 < 10 -> snapped to 90
+        assert pcb2.get_footprint("R2").rotation == pytest.approx(90.0)
+        # C1 at 179.8 -> delta 0.2 < 10 -> snapped to 180
+        assert pcb2.get_footprint("C1").rotation == pytest.approx(180.0)
+        # R1 at 15.6 -> delta 15.6 > 10 -> NOT snapped
+        assert pcb2.get_footprint("R1").rotation == pytest.approx(15.6)
+        # U1 at 28.5 -> delta 28.5 > 10 -> NOT snapped
+        assert pcb2.get_footprint("U1").rotation == pytest.approx(28.5)
+
+    def test_exclude_refs(self, tmp_path):
+        """--exclude skips specified reference designators."""
+        pcb_file = _write_pcb(tmp_path)
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=90.0,
+            tolerance=None,
+            exclude="U1,R2",
+            only=None,
+            dry_run=False,
+            format="text",
+            output=None,
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+        pcb2 = PCB.load(pcb_file)
+        # U1 and R2 should NOT be snapped
+        assert pcb2.get_footprint("U1").rotation == pytest.approx(28.5)
+        assert pcb2.get_footprint("R2").rotation == pytest.approx(91.2)
+        # Others should be snapped
+        assert pcb2.get_footprint("R1").rotation == pytest.approx(0.0)
+        assert pcb2.get_footprint("C1").rotation == pytest.approx(180.0)
+
+    def test_only_refs(self, tmp_path):
+        """--only limits snapping to specified reference designators."""
+        pcb_file = _write_pcb(tmp_path)
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=90.0,
+            tolerance=None,
+            exclude=None,
+            only="C1,C2",
+            dry_run=False,
+            format="text",
+            output=None,
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+        pcb2 = PCB.load(pcb_file)
+        # Only C1 and C2 should be snapped
+        assert pcb2.get_footprint("C1").rotation == pytest.approx(180.0)
+        assert pcb2.get_footprint("C2").rotation == pytest.approx(0.0)
+        # Others should NOT be snapped
+        assert pcb2.get_footprint("R1").rotation == pytest.approx(15.6)
+        assert pcb2.get_footprint("R2").rotation == pytest.approx(91.2)
+        assert pcb2.get_footprint("U1").rotation == pytest.approx(28.5)
+
+    def test_dry_run_no_modification(self, tmp_path):
+        """--dry-run does not modify the PCB file."""
+        pcb_file = _write_pcb(tmp_path)
+        original_content = pcb_file.read_text()
+
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=90.0,
+            tolerance=None,
+            exclude=None,
+            only=None,
+            dry_run=True,
+            format="text",
+            output=None,
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+        # File should be unchanged
+        assert pcb_file.read_text() == original_content
+
+    def test_dry_run_json_output(self, tmp_path, capsys):
+        """--dry-run with --format json reports changes correctly."""
+        pcb_file = _write_pcb(tmp_path)
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=90.0,
+            tolerance=None,
+            exclude=None,
+            only=None,
+            dry_run=True,
+            format="json",
+            output=None,
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+        assert result["dry_run"] is True
+        assert result["snapped"] == 5  # all 5 footprints should be listed
+        assert result["output"] is None
+
+    def test_rotation_zero_serialization(self, tmp_path):
+        """Snapping to 0 degrees removes the rotation value from (at x y) node."""
+        pcb_file = _write_pcb(tmp_path)
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=90.0,
+            tolerance=None,
+            exclude=None,
+            only="R1",  # R1 is at 15.6 -> snaps to 0
+            dry_run=False,
+            format="text",
+            output=None,
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+        # Read the raw file content and verify (at 100 100) has no third value
+        content = pcb_file.read_text()
+        # Find the R1 footprint's at node -- it should be (at 100 100) not (at 100 100 0)
+        import re
+        # Find at nodes in the R1 footprint section
+        # The first (at ...) after fp-r1 uuid should be the footprint position
+        r1_match = re.search(r'uuid "fp-r1"\)\s*\(at ([^)]+)\)', content)
+        assert r1_match is not None
+        at_values = r1_match.group(1).split()
+        # Should have exactly 2 values (x, y) with no rotation
+        assert len(at_values) == 2, f"Expected 2 values in (at ...) but got: {at_values}"
+
+    def test_already_cardinal_no_changes(self, tmp_path):
+        """Footprints already at cardinal angles produce no changes."""
+        pcb_file = _write_pcb(tmp_path, MINIMAL_PCB_ZERO_ROTATION)
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=90.0,
+            tolerance=None,
+            exclude=None,
+            only=None,
+            dry_run=False,
+            format="json",
+            output=None,
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+    def test_output_to_separate_file(self, tmp_path):
+        """--output writes to a different file, leaving input unchanged."""
+        pcb_file = _write_pcb(tmp_path)
+        output_file = tmp_path / "output.kicad_pcb"
+
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=90.0,
+            tolerance=None,
+            exclude=None,
+            only=None,
+            dry_run=False,
+            format="text",
+            output=str(output_file),
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+        # Output file should exist with snapped rotations
+        assert output_file.exists()
+        pcb2 = PCB.load(output_file)
+        assert pcb2.get_footprint("R1").rotation == pytest.approx(0.0)
+
+    def test_grid_45_degrees(self, tmp_path):
+        """Custom grid of 45 degrees works correctly."""
+        pcb_file = _write_pcb(tmp_path)
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=45.0,
+            tolerance=None,
+            exclude=None,
+            only=None,
+            dry_run=False,
+            format="text",
+            output=None,
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+        pcb2 = PCB.load(pcb_file)
+        # R1 at 15.6 -> nearest 45 multiple is 0 -> 0
+        assert pcb2.get_footprint("R1").rotation == pytest.approx(0.0)
+        # R2 at 91.2 -> nearest 45 multiple is 90 -> 90
+        assert pcb2.get_footprint("R2").rotation == pytest.approx(90.0)
+        # C1 at 179.8 -> nearest 45 multiple is 180 -> 180
+        assert pcb2.get_footprint("C1").rotation == pytest.approx(180.0)
+        # C2 at 315.6 -> nearest 45 multiple is 315 -> 315
+        assert pcb2.get_footprint("C2").rotation == pytest.approx(315.0)
+        # U1 at 28.5 -> nearest 45 multiple is 45 -> 45
+        assert pcb2.get_footprint("U1").rotation == pytest.approx(45.0)
+
+
+class TestSnapRotationCLIIntegration:
+    """Integration tests through the CLI entry point."""
+
+    def test_cli_round_trip(self, tmp_path):
+        """Load PCB with non-cardinal angles, run command, reload, verify cardinal."""
+        pcb_file = _write_pcb(tmp_path)
+
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.pcb import _run_snap_rotation_command
+
+        args = SimpleNamespace(
+            pcb=str(pcb_file),
+            grid=90.0,
+            tolerance=None,
+            exclude=None,
+            only=None,
+            dry_run=False,
+            format="text",
+            output=None,
+        )
+        rc = _run_snap_rotation_command(args, pcb_file)
+        assert rc == 0
+
+        # Full round-trip: reload and verify all rotations are cardinal
+        pcb = PCB.load(pcb_file)
+        for fp in pcb.footprints:
+            assert fp.rotation % 90.0 == pytest.approx(0.0), (
+                f"{fp.reference} has non-cardinal rotation {fp.rotation}"
+            )


### PR DESCRIPTION
## Summary
Add a new `kicad-tools pcb snap-rotation` CLI command that normalizes footprint rotation angles to the nearest cardinal direction (0, 90, 180, 270 by default). This fills a gap where the placement optimizer has in-memory rotation snapping but no standalone CLI command for post-hoc cleanup.

## Changes
- Add `snap-rotation` subparser in `src/kicad_tools/cli/parser.py` with `--grid`, `--tolerance`, `--exclude`, `--only`, `--dry-run`, `--output`, `--format` arguments
- Add `_run_snap_rotation_command()` handler in `src/kicad_tools/cli/commands/pcb.py` with rotation snapping logic, tolerance filtering, reference filtering, and proper S-expression cleanup when snapping to 0 degrees
- Add 11 tests in `tests/test_pcb_snap_rotation.py` covering basic snapping, tolerance, exclude/only filters, dry-run, JSON output, rotation=0 serialization, custom grid, output file, and CLI round-trip

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New CLI subcommand `pcb snap-rotation` | Done | Added to parser and command dispatch |
| Snaps to nearest grid angle (default 90) | Done | test_snaps_all_to_cardinal passes |
| --tolerance flag limits snapping range | Done | test_tolerance_skips_large_delta passes |
| --exclude flag skips specified refs | Done | test_exclude_refs passes |
| --only flag limits to specified refs | Done | test_only_refs passes |
| --dry-run previews without modification | Done | test_dry_run_no_modification passes |
| --format json produces structured output | Done | test_dry_run_json_output passes |
| rotation=0 removes stale S-expr child | Done | test_rotation_zero_serialization passes |
| Custom --grid (e.g., 45) works | Done | test_grid_45_degrees passes |
| --output writes to separate file | Done | test_output_to_separate_file passes |
| Round-trip load/snap/save/reload | Done | test_cli_round_trip passes |

## Test Plan
All 11 tests pass: `python3 -m pytest tests/test_pcb_snap_rotation.py -v`

Closes #2072