### PR TITLE
feat(pcb): add edit-outline command for Edge.Cuts contour management

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -11,7 +11,7 @@ def run_pcb_command(args) -> int:
     """Handle PCB subcommands."""
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
-        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist, remove-footprint, add-zone, snap-rotation")
+        print("Commands: summary, footprints, nets, traces, stackup, strip, reannotate, sync-netlist, remove-footprint, add-zone, snap-rotation, edit-outline")
         return 1
 
     pcb_path = Path(args.pcb)
@@ -42,6 +42,10 @@ def run_pcb_command(args) -> int:
     # Handle snap-rotation command
     if args.pcb_command == "snap-rotation":
         return _run_snap_rotation_command(args, pcb_path)
+
+    # Handle edit-outline command
+    if args.pcb_command == "edit-outline":
+        return _run_edit_outline_command(args, pcb_path)
 
     from ..pcb_query import main as pcb_main
 
@@ -787,3 +791,171 @@ def _run_snap_rotation_command(args, pcb_path: Path) -> int:
             return 1
 
     return 0
+
+
+def _run_edit_outline_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb edit-outline' command."""
+    from kicad_tools.schema.pcb import PCB
+
+    output_format = getattr(args, "format", "text")
+    dry_run = getattr(args, "dry_run", False)
+
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    # --list: display contours
+    if getattr(args, "list_contours", False):
+        contours = pcb.list_edge_contours()
+        if not contours:
+            if output_format == "json":
+                print(json.dumps({"contours": []}))
+            else:
+                print("No Edge.Cuts contours found.")
+            return 0
+
+        if output_format == "json":
+            data = []
+            for c in contours:
+                data.append({
+                    "index": c.index,
+                    "elements": c.element_count,
+                    "bbox": {
+                        "min_x": round(c.bbox[0], 2),
+                        "min_y": round(c.bbox[1], 2),
+                        "max_x": round(c.bbox[2], 2),
+                        "max_y": round(c.bbox[3], 2),
+                    },
+                    "width_mm": round(c.bbox_width, 2),
+                    "height_mm": round(c.bbox_height, 2),
+                    "area_mm2": round(c.bbox_area, 2),
+                    "is_mounting_hole": c.is_mounting_hole,
+                })
+            print(json.dumps({"contours": data}, indent=2))
+        else:
+            print(f"Found {len(contours)} Edge.Cuts contour(s):\n")
+            for c in contours:
+                label = " [mounting hole]" if c.is_mounting_hole else ""
+                print(
+                    f"  [{c.index}] {c.element_count} element(s), "
+                    f"bbox ({c.bbox[0]:.2f}, {c.bbox[1]:.2f}) - "
+                    f"({c.bbox[2]:.2f}, {c.bbox[3]:.2f}), "
+                    f"{c.bbox_width:.2f} x {c.bbox_height:.2f} mm"
+                    f"{label}"
+                )
+        return 0
+
+    # --remove-outline INDEX
+    remove_idx = getattr(args, "remove_outline", None)
+    if remove_idx is not None:
+        contours = pcb.list_edge_contours()
+        target = None
+        for c in contours:
+            if c.index == remove_idx:
+                target = c
+                break
+        if target is None:
+            print(f"Error: No contour with index {remove_idx}", file=sys.stderr)
+            return 1
+
+        if dry_run:
+            print(
+                f"Would remove contour [{remove_idx}]: "
+                f"{target.element_count} element(s), "
+                f"bbox ({target.bbox[0]:.2f}, {target.bbox[1]:.2f}) - "
+                f"({target.bbox[2]:.2f}, {target.bbox[3]:.2f})"
+            )
+            return 0
+
+        ok = pcb.remove_edge_contour(remove_idx)
+        if not ok:
+            print(f"Error: Failed to remove contour {remove_idx}", file=sys.stderr)
+            return 1
+
+        output = getattr(args, "output", None)
+        save_path = Path(output) if output else pcb_path
+        pcb.save(save_path)
+        print(f"Removed contour [{remove_idx}] ({target.element_count} element(s)). Saved to {save_path}")
+        return 0
+
+    # --keep-only INDEX
+    keep_idx = getattr(args, "keep_only", None)
+    if keep_idx is not None:
+        contours = pcb.list_edge_contours()
+        target = None
+        for c in contours:
+            if c.index == keep_idx:
+                target = c
+                break
+        if target is None:
+            print(f"Error: No contour with index {keep_idx}", file=sys.stderr)
+            return 1
+
+        to_remove = [
+            c for c in contours
+            if c.index != keep_idx and not c.is_mounting_hole
+        ]
+
+        if dry_run:
+            print(f"Would keep contour [{keep_idx}] and remove {len(to_remove)} other outline(s).")
+            for c in to_remove:
+                print(
+                    f"  Remove [{c.index}]: {c.element_count} element(s), "
+                    f"bbox ({c.bbox[0]:.2f}, {c.bbox[1]:.2f}) - "
+                    f"({c.bbox[2]:.2f}, {c.bbox[3]:.2f})"
+                )
+            return 0
+
+        # Remove in reverse index order to keep indices stable
+        for c in sorted(to_remove, key=lambda c: c.index, reverse=True):
+            pcb.remove_edge_contour(c.index)
+
+        output = getattr(args, "output", None)
+        save_path = Path(output) if output else pcb_path
+        pcb.save(save_path)
+        print(
+            f"Kept contour [{keep_idx}], removed {len(to_remove)} outline(s). "
+            f"Saved to {save_path}"
+        )
+        return 0
+
+    # --set-outline rect
+    set_outline = getattr(args, "set_outline", None)
+    if set_outline == "rect":
+        origin = getattr(args, "origin", None)
+        size = getattr(args, "size", None)
+        if not origin or not size:
+            print(
+                "Error: --set-outline rect requires --origin X Y and --size W H",
+                file=sys.stderr,
+            )
+            return 1
+
+        origin_x, origin_y = origin
+        width, height = size
+
+        if dry_run:
+            contours = pcb.list_edge_contours()
+            outline_count = sum(1 for c in contours if not c.is_mounting_hole)
+            print(
+                f"Would replace {outline_count} outline contour(s) with "
+                f"rect at ({origin_x}, {origin_y}), size {width} x {height} mm"
+            )
+            return 0
+
+        removed = pcb.replace_outline(origin_x, origin_y, width, height)
+
+        output = getattr(args, "output", None)
+        save_path = Path(output) if output else pcb_path
+        pcb.save(save_path)
+        print(
+            f"Replaced {removed} outline(s) with rect at "
+            f"({origin_x}, {origin_y}), size {width} x {height} mm. "
+            f"Saved to {save_path}"
+        )
+        return 0
+
+    print("Error: No action specified. Use --list, --remove-outline, --keep-only, or --set-outline.", file=sys.stderr)
+    return 1

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1349,6 +1349,75 @@ def _add_pcb_parser(subparsers) -> None:
     )
 
 
+    # pcb edit-outline
+    pcb_edit_outline = pcb_subparsers.add_parser(
+        "edit-outline",
+        help="List, remove, or replace Edge.Cuts board outlines",
+        description="Manage Edge.Cuts contours in a PCB file. "
+        "Supports listing contours, removing specific contours by index, "
+        "keeping only a specific contour, and replacing all outlines with "
+        "a new rectangle. Mounting hole circles are preserved by default.",
+    )
+    pcb_edit_outline.add_argument("pcb", help="Path to .kicad_pcb file")
+
+    outline_action = pcb_edit_outline.add_mutually_exclusive_group(required=True)
+    outline_action.add_argument(
+        "--list",
+        dest="list_contours",
+        action="store_true",
+        help="List all Edge.Cuts contours with bounding boxes",
+    )
+    outline_action.add_argument(
+        "--remove-outline",
+        type=int,
+        metavar="INDEX",
+        help="Remove a contour by its index",
+    )
+    outline_action.add_argument(
+        "--keep-only",
+        type=int,
+        metavar="INDEX",
+        help="Remove all contours except the one at INDEX (preserves mounting holes)",
+    )
+    outline_action.add_argument(
+        "--set-outline",
+        choices=["rect"],
+        help="Replace all outlines with a new shape (preserves mounting holes)",
+    )
+
+    pcb_edit_outline.add_argument(
+        "--origin",
+        nargs=2,
+        type=float,
+        metavar=("X", "Y"),
+        help="Origin (top-left) for --set-outline in mm",
+    )
+    pcb_edit_outline.add_argument(
+        "--size",
+        nargs=2,
+        type=float,
+        metavar=("W", "H"),
+        help="Width and height for --set-outline in mm",
+    )
+    pcb_edit_outline.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        help="Output file path (default: overwrite input PCB)",
+    )
+    pcb_edit_outline.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for results",
+    )
+    pcb_edit_outline.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without modifying the PCB file",
+    )
+
+
 def _add_lib_parser(subparsers) -> None:
     """Add library subcommand parser with its subcommands."""
     lib_parser = subparsers.add_parser("lib", help="Symbol and footprint library tools")

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -934,6 +934,35 @@ class GraphicArc:
 
 
 @dataclass
+class EdgeContour:
+    """A group of connected Edge.Cuts graphic elements forming a contour.
+
+    Each contour is either a closed polygon (board outline) or a small
+    shape such as a mounting hole.  The ``sexp_nodes`` list stores the
+    raw S-expression nodes so the contour can be removed from the PCB.
+    """
+
+    index: int
+    element_count: int
+    bbox: tuple[float, float, float, float]  # (min_x, min_y, max_x, max_y)
+    is_mounting_hole: bool = False
+    sexp_nodes: list = field(default_factory=list)  # list[SExp]
+
+    @property
+    def bbox_area(self) -> float:
+        """Bounding box area in mm^2."""
+        return (self.bbox[2] - self.bbox[0]) * (self.bbox[3] - self.bbox[1])
+
+    @property
+    def bbox_width(self) -> float:
+        return self.bbox[2] - self.bbox[0]
+
+    @property
+    def bbox_height(self) -> float:
+        return self.bbox[3] - self.bbox[1]
+
+
+@dataclass
 class StackupLayer:
     """Stackup layer definition."""
 
@@ -2081,6 +2110,264 @@ class PCB:
                 segments.extend(self._rect_to_segments(graphic.start, graphic.end))
 
         return segments
+
+    # ------------------------------------------------------------------
+    # Edge.Cuts contour analysis and manipulation
+    # ------------------------------------------------------------------
+
+    _MOUNTING_HOLE_AREA_THRESHOLD = 25.0  # mm^2
+
+    def list_edge_contours(self) -> list[EdgeContour]:
+        """Group Edge.Cuts graphic elements into connected contours.
+
+        Each contour is a set of connected graphic elements (gr_line,
+        gr_arc, gr_rect, gr_circle) on the Edge.Cuts layer.  A gr_rect
+        or gr_circle is always its own contour; gr_line/gr_arc elements
+        are chained by endpoint proximity.
+
+        Small contours (bounding-box area < 25 mm^2) are flagged as
+        mounting holes.
+
+        Returns:
+            Ordered list of ``EdgeContour`` objects with index, bounding
+            box, element count, and sexp node references.
+        """
+        # Collect Edge.Cuts sexp nodes, keyed by identity, with endpoints
+        # Each entry: (sexp_node, endpoints_list)
+        # endpoints_list items are (x, y) tuples at segment ends
+        edge_elements: list[tuple[SExp, list[tuple[float, float]]]] = []
+
+        for child in self._sexp.children:
+            if child.is_atom:
+                continue
+            tag = child.tag
+            if tag not in ("gr_line", "gr_arc", "gr_rect", "gr_circle"):
+                continue
+            layer_node = child.find("layer")
+            if not layer_node:
+                continue
+            layer_name = layer_node.get_string(0) or ""
+            if layer_name != "Edge.Cuts":
+                continue
+
+            endpoints: list[tuple[float, float]] = []
+            if tag in ("gr_line", "gr_arc"):
+                s = child.find("start")
+                e = child.find("end")
+                if s and e:
+                    endpoints = [
+                        (s.get_float(0) or 0.0, s.get_float(1) or 0.0),
+                        (e.get_float(0) or 0.0, e.get_float(1) or 0.0),
+                    ]
+            elif tag in ("gr_rect", "gr_circle"):
+                # Self-contained shape -- not chainable with lines/arcs
+                endpoints = []  # sentinel: standalone contour
+
+            edge_elements.append((child, endpoints))
+
+        if not edge_elements:
+            return []
+
+        # Partition into groups.
+        # Standalone shapes (gr_rect, gr_circle) are each their own group.
+        # Line/arc elements are chained by endpoint proximity.
+        standalone: list[list[int]] = []
+        chainable_indices: list[int] = []
+        for idx, (node, eps) in enumerate(edge_elements):
+            tag = node.tag
+            if tag in ("gr_rect", "gr_circle"):
+                standalone.append([idx])
+            else:
+                chainable_indices.append(idx)
+
+        # Union-Find for chainable elements
+        parent = {i: i for i in chainable_indices}
+
+        def find(x: int) -> int:
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        def union(a: int, b: int) -> None:
+            ra, rb = find(a), find(b)
+            if ra != rb:
+                parent[ra] = rb
+
+        tolerance = 0.001
+        for i_pos, i in enumerate(chainable_indices):
+            eps_i = edge_elements[i][1]
+            for j in chainable_indices[i_pos + 1 :]:
+                eps_j = edge_elements[j][1]
+                for pi in eps_i:
+                    for pj in eps_j:
+                        dx = pi[0] - pj[0]
+                        dy = pi[1] - pj[1]
+                        if (dx * dx + dy * dy) < (tolerance * tolerance):
+                            union(i, j)
+
+        # Group chainable elements by root
+        from collections import defaultdict
+
+        chain_groups: dict[int, list[int]] = defaultdict(list)
+        for i in chainable_indices:
+            chain_groups[find(i)].append(i)
+
+        all_groups = standalone + list(chain_groups.values())
+
+        # Build EdgeContour objects
+        contours: list[EdgeContour] = []
+        for group_idx, group in enumerate(all_groups):
+            nodes = [edge_elements[i][0] for i in group]
+            all_points = self._collect_edge_points(nodes)
+            if not all_points:
+                continue
+            xs = [p[0] for p in all_points]
+            ys = [p[1] for p in all_points]
+            bbox = (min(xs), min(ys), max(xs), max(ys))
+            area = (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
+            contour = EdgeContour(
+                index=group_idx,
+                element_count=len(nodes),
+                bbox=bbox,
+                is_mounting_hole=area < self._MOUNTING_HOLE_AREA_THRESHOLD,
+                sexp_nodes=nodes,
+            )
+            contours.append(contour)
+
+        # Re-index
+        for idx, c in enumerate(contours):
+            c.index = idx
+        return contours
+
+    @staticmethod
+    def _collect_edge_points(nodes: list[SExp]) -> list[tuple[float, float]]:
+        """Collect all coordinate points from a list of sexp graphic nodes."""
+        points: list[tuple[float, float]] = []
+        for node in nodes:
+            for attr in ("start", "end", "mid", "center"):
+                n = node.find(attr)
+                if n:
+                    points.append((n.get_float(0) or 0.0, n.get_float(1) or 0.0))
+        return points
+
+    def remove_edge_contour(self, index: int) -> bool:
+        """Remove an Edge.Cuts contour by index.
+
+        Removes the graphic sexp nodes belonging to the contour from the
+        S-expression tree and from the in-memory ``_graphic_lines``,
+        ``_graphic_arcs``, and ``_graphics`` lists.
+
+        Args:
+            index: Contour index as returned by ``list_edge_contours()``.
+
+        Returns:
+            True if the contour was found and removed, False otherwise.
+        """
+        contours = self.list_edge_contours()
+        target = None
+        for c in contours:
+            if c.index == index:
+                target = c
+                break
+        if target is None:
+            return False
+
+        # Remove from sexp tree
+        for node in target.sexp_nodes:
+            self._sexp.remove(node)
+
+        # Clean in-memory lists by matching UUID
+        target_uuids: set[str] = set()
+        for node in target.sexp_nodes:
+            uuid_n = node.find("uuid")
+            if uuid_n:
+                u = uuid_n.get_string(0) or ""
+                if u:
+                    target_uuids.add(u)
+
+        if target_uuids:
+            self._graphic_lines = [
+                gl for gl in self._graphic_lines if gl.uuid not in target_uuids
+            ]
+            self._graphic_arcs = [
+                ga for ga in self._graphic_arcs if ga.uuid not in target_uuids
+            ]
+            self._graphics = [
+                g for g in self._graphics if g.uuid not in target_uuids
+            ]
+        else:
+            # Fallback: re-parse the in-memory lists from sexp
+            self._graphic_lines = []
+            self._graphic_arcs = []
+            self._graphics = []
+            for child in self._sexp.children:
+                if child.is_atom:
+                    continue
+                tag = child.tag
+                if tag == "gr_line":
+                    self._graphic_lines.append(GraphicLine.from_sexp(child))
+                elif tag == "gr_arc":
+                    self._graphic_arcs.append(GraphicArc.from_sexp(child))
+                elif tag in ("gr_rect", "gr_circle"):
+                    graphic_type = tag[3:]
+                    self._graphics.append(BoardGraphic.from_sexp(child, graphic_type))
+
+        return True
+
+    def replace_outline(
+        self,
+        origin_x: float,
+        origin_y: float,
+        width: float,
+        height: float,
+    ) -> int:
+        """Replace all outline contours with a single rectangle.
+
+        Removes every Edge.Cuts contour whose bounding-box area is above
+        the mounting-hole threshold, then inserts a new ``gr_rect`` at
+        the given origin and size.  Mounting-hole contours are preserved.
+
+        Args:
+            origin_x: X coordinate of top-left corner (mm).
+            origin_y: Y coordinate of top-left corner (mm).
+            width: Board width (mm).
+            height: Board height (mm).
+
+        Returns:
+            Number of outline contours removed.
+        """
+        contours = self.list_edge_contours()
+        removed = 0
+        # Remove outlines (non-mounting-hole contours)
+        # Process in reverse index order so earlier indices stay valid
+        for c in sorted(contours, key=lambda c: c.index, reverse=True):
+            if not c.is_mounting_hole:
+                for node in c.sexp_nodes:
+                    self._sexp.remove(node)
+                removed += 1
+
+        # Insert new rect outline
+        new_rect = PCB._build_board_outline_sexp(width, height, origin_x, origin_y)
+        self._sexp.append(new_rect)
+
+        # Rebuild in-memory lists
+        self._graphic_lines = []
+        self._graphic_arcs = []
+        self._graphics = []
+        for child in self._sexp.children:
+            if child.is_atom:
+                continue
+            tag = child.tag
+            if tag == "gr_line":
+                self._graphic_lines.append(GraphicLine.from_sexp(child))
+            elif tag == "gr_arc":
+                self._graphic_arcs.append(GraphicArc.from_sexp(child))
+            elif tag in ("gr_rect", "gr_circle"):
+                graphic_type = tag[3:]
+                self._graphics.append(BoardGraphic.from_sexp(child, graphic_type))
+
+        return removed
 
     @property
     def setup(self) -> Setup | None:

--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -418,6 +418,47 @@ def gr_line_node(
     )
 
 
+def gr_rect_node(
+    start_x: float,
+    start_y: float,
+    end_x: float,
+    end_y: float,
+    layer: str,
+    width: float = 0.1,
+    uuid_str: str = "",
+) -> SExp:
+    """Build a PCB graphic rectangle S-expression (gr_rect).
+
+    Used for board outlines on Edge.Cuts layer.
+
+    Args:
+        start_x, start_y: Top-left corner coordinates in mm
+        end_x, end_y: Bottom-right corner coordinates in mm
+        layer: Layer name (e.g., "Edge.Cuts")
+        width: Stroke width in mm (default 0.1)
+        uuid_str: Unique identifier
+
+    Example output:
+        (gr_rect
+            (start 100 100)
+            (end 150 130)
+            (stroke (width 0.1) (type default))
+            (fill none)
+            (layer "Edge.Cuts")
+            (uuid "...")
+        )
+    """
+    return SExp.list(
+        "gr_rect",
+        SExp.list("start", fmt(start_x), fmt(start_y)),
+        SExp.list("end", fmt(end_x), fmt(end_y)),
+        SExp.list("stroke", SExp.list("width", fmt(width)), SExp.list("type", "default")),
+        SExp.list("fill", "none"),
+        SExp.list("layer", layer),
+        uuid_node(uuid_str),
+    )
+
+
 def gr_text_node(
     text: str,
     x: float,

--- a/tests/test_pcb_edit_outline.py
+++ b/tests/test_pcb_edit_outline.py
@@ -1,0 +1,507 @@
+"""Tests for pcb edit-outline command and Edge.Cuts contour methods."""
+
+import json
+
+import pytest
+
+# PCB with a gr_rect outline and gr_line outline (two overlapping outlines)
+PCB_TWO_OUTLINES = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (gr_rect
+    (start 100 100)
+    (end 150 130)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "rect-outline-1")
+  )
+  (gr_line
+    (start 100 100)
+    (end 160 100)
+    (stroke (width 0.1) (type default))
+    (layer "Edge.Cuts")
+    (uuid "line-1")
+  )
+  (gr_line
+    (start 160 100)
+    (end 160 140)
+    (stroke (width 0.1) (type default))
+    (layer "Edge.Cuts")
+    (uuid "line-2")
+  )
+  (gr_line
+    (start 160 140)
+    (end 100 140)
+    (stroke (width 0.1) (type default))
+    (layer "Edge.Cuts")
+    (uuid "line-3")
+  )
+  (gr_line
+    (start 100 140)
+    (end 100 100)
+    (stroke (width 0.1) (type default))
+    (layer "Edge.Cuts")
+    (uuid "line-4")
+  )
+)
+"""
+
+# PCB with an outline and a small mounting hole circle
+PCB_WITH_MOUNTING_HOLE = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (gr_rect
+    (start 100 100)
+    (end 200 160)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "main-outline")
+  )
+  (gr_circle
+    (center 110 110)
+    (end 112 110)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "mounting-hole-1")
+  )
+)
+"""
+
+# PCB with no Edge.Cuts
+PCB_NO_OUTLINE = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+)
+"""
+
+# PCB with a single rect outline
+PCB_SINGLE_RECT = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (gr_rect
+    (start 100 100)
+    (end 150 130)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "single-rect")
+  )
+)
+"""
+
+
+class TestListEdgeContours:
+    """Tests for PCB.list_edge_contours()."""
+
+    def test_two_contours_detected(self, tmp_path):
+        """Two overlapping outlines (rect + lines) should yield two contours."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_TWO_OUTLINES)
+        pcb = PCB.load(pcb_file)
+
+        contours = pcb.list_edge_contours()
+        assert len(contours) == 2
+
+    def test_contour_bbox(self, tmp_path):
+        """Contour bounding boxes should cover the correct area."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_SINGLE_RECT)
+        pcb = PCB.load(pcb_file)
+
+        contours = pcb.list_edge_contours()
+        assert len(contours) == 1
+        c = contours[0]
+        assert c.bbox[0] == pytest.approx(100.0)
+        assert c.bbox[1] == pytest.approx(100.0)
+        assert c.bbox[2] == pytest.approx(150.0)
+        assert c.bbox[3] == pytest.approx(130.0)
+        assert c.bbox_width == pytest.approx(50.0)
+        assert c.bbox_height == pytest.approx(30.0)
+
+    def test_mounting_hole_detection(self, tmp_path):
+        """Small circles on Edge.Cuts should be flagged as mounting holes."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_MOUNTING_HOLE)
+        pcb = PCB.load(pcb_file)
+
+        contours = pcb.list_edge_contours()
+        assert len(contours) == 2
+        holes = [c for c in contours if c.is_mounting_hole]
+        outlines = [c for c in contours if not c.is_mounting_hole]
+        assert len(holes) == 1
+        assert len(outlines) == 1
+
+    def test_no_outline(self, tmp_path):
+        """Board with no Edge.Cuts should return empty list."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_NO_OUTLINE)
+        pcb = PCB.load(pcb_file)
+
+        contours = pcb.list_edge_contours()
+        assert contours == []
+
+    def test_line_contour_chaining(self, tmp_path):
+        """Connected gr_line segments should form a single contour."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_TWO_OUTLINES)
+        pcb = PCB.load(pcb_file)
+
+        contours = pcb.list_edge_contours()
+        # The rect is standalone; the 4 lines are chained into one contour
+        rect_contours = [c for c in contours if c.element_count == 1]
+        line_contours = [c for c in contours if c.element_count == 4]
+        assert len(rect_contours) == 1
+        assert len(line_contours) == 1
+
+
+class TestRemoveEdgeContour:
+    """Tests for PCB.remove_edge_contour()."""
+
+    def test_remove_rect_contour(self, tmp_path):
+        """Removing a rect contour should leave only line contours."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_TWO_OUTLINES)
+        pcb = PCB.load(pcb_file)
+
+        contours = pcb.list_edge_contours()
+        rect_idx = next(c.index for c in contours if c.element_count == 1)
+
+        ok = pcb.remove_edge_contour(rect_idx)
+        assert ok is True
+
+        remaining = pcb.list_edge_contours()
+        assert len(remaining) == 1
+        assert remaining[0].element_count == 4
+
+    def test_remove_line_contour(self, tmp_path):
+        """Removing a line contour should leave only the rect contour."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_TWO_OUTLINES)
+        pcb = PCB.load(pcb_file)
+
+        contours = pcb.list_edge_contours()
+        line_idx = next(c.index for c in contours if c.element_count == 4)
+
+        ok = pcb.remove_edge_contour(line_idx)
+        assert ok is True
+
+        remaining = pcb.list_edge_contours()
+        assert len(remaining) == 1
+        assert remaining[0].element_count == 1
+
+    def test_remove_invalid_index(self, tmp_path):
+        """Removing a non-existent contour should return False."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_SINGLE_RECT)
+        pcb = PCB.load(pcb_file)
+
+        ok = pcb.remove_edge_contour(999)
+        assert ok is False
+
+    def test_remove_persists_after_save(self, tmp_path):
+        """Removal should persist after save and reload."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_TWO_OUTLINES)
+        pcb = PCB.load(pcb_file)
+
+        contours = pcb.list_edge_contours()
+        rect_idx = next(c.index for c in contours if c.element_count == 1)
+        pcb.remove_edge_contour(rect_idx)
+
+        out_file = tmp_path / "saved.kicad_pcb"
+        pcb.save(out_file)
+
+        pcb2 = PCB.load(out_file)
+        remaining = pcb2.list_edge_contours()
+        assert len(remaining) == 1
+        assert remaining[0].element_count == 4
+
+
+class TestReplaceOutline:
+    """Tests for PCB.replace_outline()."""
+
+    def test_replace_creates_new_rect(self, tmp_path):
+        """Replace should remove old outlines and insert a new rect."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_TWO_OUTLINES)
+        pcb = PCB.load(pcb_file)
+
+        removed = pcb.replace_outline(50, 50, 80, 40)
+        assert removed == 2  # rect + line contour
+
+        contours = pcb.list_edge_contours()
+        assert len(contours) == 1
+        c = contours[0]
+        assert c.bbox[0] == pytest.approx(50.0)
+        assert c.bbox[1] == pytest.approx(50.0)
+        assert c.bbox[2] == pytest.approx(130.0)
+        assert c.bbox[3] == pytest.approx(90.0)
+
+    def test_replace_preserves_mounting_holes(self, tmp_path):
+        """Replace should keep mounting hole circles."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_MOUNTING_HOLE)
+        pcb = PCB.load(pcb_file)
+
+        removed = pcb.replace_outline(50, 50, 100, 60)
+        assert removed == 1  # only the main outline, not the mounting hole
+
+        contours = pcb.list_edge_contours()
+        # Should have: new rect outline + preserved mounting hole
+        assert len(contours) == 2
+        holes = [c for c in contours if c.is_mounting_hole]
+        assert len(holes) == 1
+
+    def test_replace_persists_after_save(self, tmp_path):
+        """Replaced outline should persist after save and reload."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_SINGLE_RECT)
+        pcb = PCB.load(pcb_file)
+
+        pcb.replace_outline(200, 200, 60, 40)
+
+        out_file = tmp_path / "replaced.kicad_pcb"
+        pcb.save(out_file)
+
+        pcb2 = PCB.load(out_file)
+        contours = pcb2.list_edge_contours()
+        assert len(contours) == 1
+        c = contours[0]
+        assert c.bbox[0] == pytest.approx(200.0)
+        assert c.bbox[1] == pytest.approx(200.0)
+        assert c.bbox[2] == pytest.approx(260.0)
+        assert c.bbox[3] == pytest.approx(240.0)
+
+
+class TestEditOutlineCLI:
+    """Tests for the pcb edit-outline CLI command."""
+
+    def test_list_text_output(self, tmp_path, capsys):
+        """--list should print human-readable contour info."""
+        from kicad_tools.cli.commands.pcb import _run_edit_outline_command
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_TWO_OUTLINES)
+
+        class Args:
+            pcb = str(pcb_file)
+            list_contours = True
+            remove_outline = None
+            keep_only = None
+            set_outline = None
+            format = "text"
+            dry_run = False
+            output = None
+            origin = None
+            size = None
+
+        result = _run_edit_outline_command(Args(), pcb_file)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "2 Edge.Cuts contour(s)" in captured.out
+
+    def test_list_json_output(self, tmp_path, capsys):
+        """--list --format json should emit valid JSON."""
+        from kicad_tools.cli.commands.pcb import _run_edit_outline_command
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_TWO_OUTLINES)
+
+        class Args:
+            pcb = str(pcb_file)
+            list_contours = True
+            remove_outline = None
+            keep_only = None
+            set_outline = None
+            format = "json"
+            dry_run = False
+            output = None
+            origin = None
+            size = None
+
+        result = _run_edit_outline_command(Args(), pcb_file)
+        assert result == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data["contours"]) == 2
+
+    def test_list_no_contours(self, tmp_path, capsys):
+        """--list on a board with no Edge.Cuts should report none."""
+        from kicad_tools.cli.commands.pcb import _run_edit_outline_command
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_NO_OUTLINE)
+
+        class Args:
+            pcb = str(pcb_file)
+            list_contours = True
+            remove_outline = None
+            keep_only = None
+            set_outline = None
+            format = "text"
+            dry_run = False
+            output = None
+            origin = None
+            size = None
+
+        result = _run_edit_outline_command(Args(), pcb_file)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "No Edge.Cuts contours found" in captured.out
+
+    def test_remove_dry_run(self, tmp_path, capsys):
+        """--remove-outline --dry-run should not modify the file."""
+        from kicad_tools.cli.commands.pcb import _run_edit_outline_command
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_TWO_OUTLINES)
+        original_content = pcb_file.read_text()
+
+        class Args:
+            pcb = str(pcb_file)
+            list_contours = False
+            remove_outline = 0
+            keep_only = None
+            set_outline = None
+            format = "text"
+            dry_run = True
+            output = None
+            origin = None
+            size = None
+
+        result = _run_edit_outline_command(Args(), pcb_file)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Would remove" in captured.out
+        # File should be unchanged
+        assert pcb_file.read_text() == original_content
+
+    def test_set_outline_rect(self, tmp_path, capsys):
+        """--set-outline rect should replace outlines with a new rectangle."""
+        from kicad_tools.cli.commands.pcb import _run_edit_outline_command
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_SINGLE_RECT)
+
+        class Args:
+            pcb = str(pcb_file)
+            list_contours = False
+            remove_outline = None
+            keep_only = None
+            set_outline = "rect"
+            format = "text"
+            dry_run = False
+            output = None
+            origin = [50, 50]
+            size = [80, 40]
+
+        result = _run_edit_outline_command(Args(), pcb_file)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Replaced" in captured.out
+        assert "80" in captured.out
+
+    def test_set_outline_missing_params(self, tmp_path, capsys):
+        """--set-outline rect without --origin/--size should error."""
+        from kicad_tools.cli.commands.pcb import _run_edit_outline_command
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_SINGLE_RECT)
+
+        class Args:
+            pcb = str(pcb_file)
+            list_contours = False
+            remove_outline = None
+            keep_only = None
+            set_outline = "rect"
+            format = "text"
+            dry_run = False
+            output = None
+            origin = None
+            size = None
+
+        result = _run_edit_outline_command(Args(), pcb_file)
+        assert result == 1
+
+    def test_keep_only(self, tmp_path, capsys):
+        """--keep-only should remove all contours except the specified one."""
+        from kicad_tools.cli.commands.pcb import _run_edit_outline_command
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_TWO_OUTLINES)
+
+        # First find which index has the line contour (4 elements)
+        pcb = PCB.load(pcb_file)
+        contours = pcb.list_edge_contours()
+        line_idx = next(c.index for c in contours if c.element_count == 4)
+
+        class Args:
+            pcb = str(pcb_file)
+            list_contours = False
+            remove_outline = None
+            keep_only = line_idx
+            set_outline = None
+            format = "text"
+            dry_run = False
+            output = None
+            origin = None
+            size = None
+
+        result = _run_edit_outline_command(Args(), pcb_file)
+        assert result == 0
+
+        pcb2 = PCB.load(pcb_file)
+        remaining = pcb2.list_edge_contours()
+        assert len(remaining) == 1
+        assert remaining[0].element_count == 4


### PR DESCRIPTION
## Summary
Add a new `kicad-tools pcb edit-outline` subcommand for listing, removing, and replacing Edge.Cuts board outlines. This provides the missing write-path for outline manipulation that the PCB subsystem lacked.

## Changes
- Add `gr_rect_node()` builder to `sexp/builders.py` for constructing gr_rect S-expressions
- Add `EdgeContour` dataclass and `list_edge_contours()`, `remove_edge_contour()`, `replace_outline()` methods to `PCB` class in `schema/pcb.py`
- Add `edit-outline` subparser to `cli/parser.py` with `--list`, `--remove-outline`, `--keep-only`, `--set-outline rect` actions
- Add `_run_edit_outline_command()` handler to `cli/commands/pcb.py`
- Contour grouping uses union-find on connected Edge.Cuts elements (gr_line/gr_arc endpoint proximity); gr_rect and gr_circle are treated as standalone contours
- Mounting hole detection: contours with bbox area < 25mm^2 are preserved during removal/replacement operations
- Add 19 tests in `tests/test_pcb_edit_outline.py` covering contour listing, removal, replacement, persistence, CLI output, and edge cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| --list shows contours with bounding boxes | Pass | test_list_text_output, test_list_json_output verify text and JSON output |
| --remove-outline removes targeted contour | Pass | test_remove_rect_contour, test_remove_line_contour verify selective removal |
| --keep-only removes all except target | Pass | test_keep_only verifies only specified contour remains |
| --set-outline rect replaces outlines with rectangle | Pass | test_replace_creates_new_rect, test_set_outline_rect verify replacement |
| Preserves mounting hole circles on Edge.Cuts | Pass | test_mounting_hole_detection, test_replace_preserves_mounting_holes verify small circles preserved |
| No Edge.Cuts board reports "no outlines found" | Pass | test_no_outline, test_list_no_contours verify empty case |
| Changes persist after save/reload | Pass | test_remove_persists_after_save, test_replace_persists_after_save verify round-trip |
| --dry-run does not modify file | Pass | test_remove_dry_run verifies file unchanged |

## Test Plan
All 19 tests pass: `python3 -m pytest tests/test_pcb_edit_outline.py -v`

Closes #2070