### PR TITLE
fix(pcb): always display zone count in summary and add cross-validation logging

### DIFF
--- a/src/kicad_tools/cli/pcb_query.py
+++ b/src/kicad_tools/cli/pcb_query.py
@@ -56,8 +56,7 @@ def cmd_summary(pcb: PCB, args):
     print(f"Nets: {summary['nets']}")
     print(f"Traces: {summary['segments']} segments ({summary['trace_length_mm']} mm)")
     print(f"Vias: {summary['vias']}")
-    if summary["zones"]:
-        print(f"Zones: {summary['zones']}")
+    print(f"Zones: {summary['zones']}")
     print()
 
 

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -5,12 +5,15 @@ Provides classes for parsing and manipulating KiCad PCB files (.kicad_pcb).
 
 from __future__ import annotations
 
+import logging
 import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 from kicad_tools.sexp import SExp
 
@@ -2121,8 +2124,23 @@ class PCB:
         Counts top-level ``(zone ...)`` nodes in the S-expression tree
         so the result always reflects the actual file content, even if the
         in-memory ``_zones`` list has drifted.
+
+        Cross-validates against the in-memory ``_zones`` list and logs a
+        warning if the two disagree, which aids diagnosis of counting
+        discrepancies.
         """
-        return sum(1 for child in self._sexp.children if not child.is_atom and child.name == "zone")
+        sexp_count = sum(
+            1 for child in self._sexp.children if not child.is_atom and child.name == "zone"
+        )
+        mem_count = len(self._zones)
+        if sexp_count != mem_count:
+            logger.warning(
+                "Zone count mismatch: S-expression tree has %d zone nodes "
+                "but in-memory list has %d entries",
+                sexp_count,
+                mem_count,
+            )
+        return sexp_count
 
     @property
     def net_count(self) -> int:

--- a/tests/test_pcb_summary_counts.py
+++ b/tests/test_pcb_summary_counts.py
@@ -4,9 +4,12 @@ Verifies that ``pcb.summary()``, ``pcb.via_count``, ``pcb.zone_count``,
 and ``pcb.segment_count`` always reflect the actual S-expression tree
 content, even after in-memory list modifications.
 
-Addresses: https://github.com/rjwalters/kicad-tools/issues/1943
+Addresses:
+    https://github.com/rjwalters/kicad-tools/issues/1943
+    https://github.com/rjwalters/kicad-tools/issues/2064
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -309,3 +312,209 @@ class TestCountsAfterSaveReload:
         pcb2 = PCB.load(output)
         assert pcb2.via_count == 2
         assert pcb2.summary()["vias"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Fixture: KiCad 9-style PCB with zone_connect, net_class, groups but no zones
+# Regression test for https://github.com/rjwalters/kicad-tools/issues/2064
+# ---------------------------------------------------------------------------
+
+PCB_KICAD9_NO_ZONES = """(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (generator_version "9.0.2")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (32 "B.Adhes" user "B.Adhesive")
+    (33 "F.Adhes" user "F.Adhesive")
+    (34 "B.Paste" user)
+    (35 "F.Paste" user)
+    (36 "B.SilkS" user "B.Silkscreen")
+    (37 "F.SilkS" user "F.Silkscreen")
+    (38 "B.Mask" user "B.Mask")
+    (39 "F.Mask" user "F.Mask")
+    (44 "Edge.Cuts" user)
+    (46 "B.CrtYd" user "B.Courtyard")
+    (47 "F.CrtYd" user "F.Courtyard")
+    (48 "B.Fab" user)
+    (49 "F.Fab" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+    (allow_soldermask_bridges_in_footprints no)
+    (pcbplotparams
+      (layerselection 0x00010fc_ffffffff)
+      (plot_on_all_layers_selection 0x0000000_00000000)
+    )
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (net 3 "GNDD")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000050")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000051"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab")
+      (uuid "00000000-0000-0000-0000-000000000052"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 1 "GND") (zone_connect 2))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 2 "+3.3V") (zone_connect 2))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000060")
+    (at 110 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000061"))
+    (property "Value" "100nF" (at 0 1.5 0) (layer "F.Fab")
+      (uuid "00000000-0000-0000-0000-000000000062"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 3 "GNDD") (zone_connect 2))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 2 "+3.3V") (zone_connect 2))
+  )
+  (footprint "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000070")
+    (at 120 100)
+    (property "Reference" "U1" (at 0 -4 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000071"))
+    (property "Value" "NE555" (at 0 4 0) (layer "F.Fab")
+      (uuid "00000000-0000-0000-0000-000000000072"))
+    (pad "1" smd roundrect (at -2.7 -1.905) (size 1.5 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 1 "GND") (zone_connect 2))
+    (pad "2" smd roundrect (at -2.7 -0.635) (size 1.5 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 2 "+3.3V") (zone_connect 2))
+    (pad "3" smd roundrect (at -2.7 0.635) (size 1.5 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 3 "GNDD") (zone_connect 2))
+    (pad "4" smd roundrect (at -2.7 1.905) (size 1.5 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 1 "GND") (zone_connect 2))
+    (pad "5" smd roundrect (at 2.7 1.905) (size 1.5 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 2 "+3.3V"))
+    (pad "6" smd roundrect (at 2.7 0.635) (size 1.5 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 2 "+3.3V"))
+    (pad "7" smd roundrect (at 2.7 -0.635) (size 1.5 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 2 "+3.3V"))
+    (pad "8" smd roundrect (at 2.7 -1.905) (size 1.5 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 2 "+3.3V"))
+  )
+  (segment (start 100 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000080"))
+  (segment (start 110 100) (end 120 100) (width 0.25) (layer "F.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-000000000081"))
+  (gr_line (start 85 85) (end 145 85) (stroke (width 0.05) (type default)) (layer "Edge.Cuts")
+    (uuid "00000000-0000-0000-0000-000000000090"))
+  (gr_line (start 145 85) (end 145 115) (stroke (width 0.05) (type default)) (layer "Edge.Cuts")
+    (uuid "00000000-0000-0000-0000-000000000091"))
+  (gr_line (start 145 115) (end 85 115) (stroke (width 0.05) (type default)) (layer "Edge.Cuts")
+    (uuid "00000000-0000-0000-0000-000000000092"))
+  (gr_line (start 85 115) (end 85 85) (stroke (width 0.05) (type default)) (layer "Edge.Cuts")
+    (uuid "00000000-0000-0000-0000-000000000093"))
+  (group "" (uuid "00000000-0000-0000-0000-0000000000a0")
+    (members "00000000-0000-0000-0000-000000000050"
+             "00000000-0000-0000-0000-000000000060")
+  )
+)
+"""
+
+
+@pytest.fixture
+def pcb_kicad9_no_zones(tmp_path: Path) -> Path:
+    """Create a KiCad 9-style PCB file with multiple footprints but no zones."""
+    pcb_file = tmp_path / "kicad9_no_zones.kicad_pcb"
+    pcb_file.write_text(PCB_KICAD9_NO_ZONES)
+    return pcb_file
+
+
+# ---------------------------------------------------------------------------
+# Issue #2064: zone count must be zero when file has no zones
+# ---------------------------------------------------------------------------
+
+
+class TestZoneCountZeroRegression:
+    """Regression tests for zone_count accuracy on zone-less boards.
+
+    Addresses: https://github.com/rjwalters/kicad-tools/issues/2064
+    """
+
+    def test_zone_count_zero_kicad9_board(self, pcb_kicad9_no_zones: Path):
+        """Zone count must be 0 for KiCad 9 board with no zone S-expressions."""
+        pcb = PCB.load(pcb_kicad9_no_zones)
+        assert pcb.zone_count == 0
+
+    def test_summary_zone_count_zero_kicad9_board(self, pcb_kicad9_no_zones: Path):
+        """summary()['zones'] must be 0 for board with no zone S-expressions."""
+        pcb = PCB.load(pcb_kicad9_no_zones)
+        summary = pcb.summary()
+        assert summary["zones"] == 0
+
+    def test_zones_list_empty_kicad9_board(self, pcb_kicad9_no_zones: Path):
+        """pcb.zones must be empty for board with no zone S-expressions."""
+        pcb = PCB.load(pcb_kicad9_no_zones)
+        assert len(pcb.zones) == 0
+
+    def test_zone_connect_pads_not_counted(self, pcb_kicad9_no_zones: Path):
+        """Pad-level (zone_connect N) must not inflate zone_count."""
+        pcb = PCB.load(pcb_kicad9_no_zones)
+        # Board has multiple footprints with zone_connect on pads
+        assert pcb.footprint_count >= 3
+        # But zone_count must still be 0
+        assert pcb.zone_count == 0
+
+    def test_zone_count_matches_sexp_tree(self, pcb_kicad9_no_zones: Path):
+        """zone_count must match manual traversal of sexp children."""
+        pcb = PCB.load(pcb_kicad9_no_zones)
+        manual_count = sum(
+            1
+            for child in pcb._sexp.children
+            if not child.is_atom and child.name == "zone"
+        )
+        assert pcb.zone_count == manual_count == 0
+
+    def test_pcb_create_has_zero_zones(self):
+        """A freshly created PCB must have zero zones."""
+        pcb = PCB.create(width=50, height=50, title="test")
+        assert pcb.zone_count == 0
+        assert pcb.summary()["zones"] == 0
+
+    def test_zone_count_json_output(self, pcb_kicad9_no_zones: Path):
+        """CLI JSON output must include zones: 0 for zone-less board."""
+        pcb = PCB.load(pcb_kicad9_no_zones)
+        summary = pcb.summary()
+        output = json.dumps(summary, indent=2)
+        data = json.loads(output)
+        assert data["zones"] == 0
+
+    def test_zone_count_text_output_shows_zero(self, pcb_kicad9_no_zones: Path, capsys):
+        """Text output must display 'Zones: 0' for zone-less board."""
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.pcb_query import cmd_summary
+
+        pcb = PCB.load(pcb_kicad9_no_zones)
+        args = SimpleNamespace(format="text", pcb=str(pcb_kicad9_no_zones))
+        cmd_summary(pcb, args)
+        captured = capsys.readouterr()
+        assert "Zones: 0" in captured.out


### PR DESCRIPTION
## Summary
The pcb summary text output previously hid the Zones line when zone_count was 0, making it impossible to distinguish "zero zones" from "zones not reported". This fix ensures the Zones line always appears and adds diagnostic logging for zone count mismatches.

## Changes
- Always display the Zones line in `pcb summary` text output (previously hidden when count was 0)
- Add cross-validation logging in `zone_count` property that warns when S-expression tree count and in-memory `_zones` list disagree
- Add `logging` import and module-level logger to `schema/pcb.py`
- Add 8 new regression tests covering KiCad 9-style PCB files with zone_connect pad attributes, group elements, and multiple footprints

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `pcb summary` reports `zones: 0` when no zones exist | PASS | New test `test_zone_count_text_output_shows_zero` verifies "Zones: 0" appears in text output; `test_zone_count_json_output` verifies JSON output |
| Zone count matches actual `(zone ...)` block count | PASS | New test `test_zone_count_matches_sexp_tree` directly compares zone_count against manual sexp traversal |

## Test Plan
- All 26 tests in `tests/test_pcb_summary_counts.py` pass (18 existing + 8 new)
- All 13 zone-related tests across the test suite pass
- New tests cover: KiCad 9 format, zone_connect pad attributes, PCB.create(), JSON output, text output, sexp tree cross-validation

Closes #2064