### PR TITLE
fix(sch-validate): replace blanket shape-consistency warning with semantic driver-conflict check

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -521,28 +521,34 @@ def check_global_label_directions(schematic_path: str) -> list[ValidationIssue]:
                     )
                 )
 
-            # Check for shape consistency across sheets
+            # Semantic shape-combination checks (only warn on real problems)
             if len(shapes) > 1:
-                shape_locations: dict[str, list[str]] = {}
-                for shape, sheet in entries:
-                    if shape not in shape_locations:
-                        shape_locations[shape] = []
-                    shape_locations[shape].append(sheet)
-                detail = "; ".join(
-                    f"{s} on {', '.join(sorted(set(locs)))}"
-                    for s, locs in sorted(shape_locations.items())
-                )
-                issues.append(
-                    ValidationIssue(
-                        severity="warning",
-                        category="global_label",
-                        message=(
-                            f"Global label '{net_name}' has inconsistent "
-                            f"shapes: {detail}"
-                        ),
-                        location=", ".join(sheets),
+                exclusive_drivers = shapes & {"output", "tri_state"}
+                # Multiple exclusive drivers on the same net is a potential
+                # driver conflict (e.g. output + tri_state, or the code could
+                # be extended to count instances).  Complementary pairs like
+                # output+input or tri_state+input are valid by design.
+                if len(exclusive_drivers) > 1:
+                    shape_locations: dict[str, list[str]] = {}
+                    for shape, sheet in entries:
+                        if shape not in shape_locations:
+                            shape_locations[shape] = []
+                        shape_locations[shape].append(sheet)
+                    detail = "; ".join(
+                        f"{s} on {', '.join(sorted(set(locs)))}"
+                        for s, locs in sorted(shape_locations.items())
                     )
-                )
+                    issues.append(
+                        ValidationIssue(
+                            severity="warning",
+                            category="global_label",
+                            message=(
+                                f"Global label '{net_name}' has conflicting "
+                                f"driver shapes: {detail}"
+                            ),
+                            location=", ".join(sheets),
+                        )
+                    )
 
     except Exception as e:
         issues.append(

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -1398,8 +1398,7 @@ class TestSchValidateGlobalLabelDirections:
         assert "no receiver" in gl_issues[0].message
 
     def test_valid_output_input_mix(self, tmp_path: Path):
-        """One output and one input on the same net -- no driver/receiver issues,
-        but a shape-consistency warning is expected."""
+        """One output and one input on the same net -- complementary pair, no warnings."""
         from kicad_tools.cli.sch_validate import check_global_label_directions
 
         parent_sch = self._make_schematic("""
@@ -1419,20 +1418,8 @@ class TestSchValidateGlobalLabelDirections:
         (tmp_path / "sub.kicad_sch").write_text(child_sch)
 
         issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
-        driver_receiver_issues = [
-            i
-            for i in issues
-            if i.category == "global_label"
-            and ("no driver" in i.message or "no receiver" in i.message)
-        ]
-        assert len(driver_receiver_issues) == 0
-        # Shape-consistency warning IS expected since output != input
-        consistency_issues = [
-            i
-            for i in issues
-            if i.category == "global_label" and "inconsistent" in i.message
-        ]
-        assert len(consistency_issues) == 1
+        gl_issues = [i for i in issues if i.category == "global_label"]
+        assert len(gl_issues) == 0
 
     def test_bidirectional_counts_as_both(self, tmp_path: Path):
         """All bidirectional -- counts as both driver and receiver."""
@@ -1531,8 +1518,8 @@ class TestSchValidateGlobalLabelDirections:
         assert "global_label_directions" in result.checks_run
 
 
-    def test_inconsistent_shapes_detected(self, tmp_path: Path):
-        """Same label with different shapes across sheets emits a warning."""
+    def test_input_bidirectional_no_warning(self, tmp_path: Path):
+        """input + bidirectional is a valid complementary pair -- no warning."""
         from kicad_tools.cli.sch_validate import check_global_label_directions
 
         parent_sch = self._make_schematic("""
@@ -1552,17 +1539,8 @@ class TestSchValidateGlobalLabelDirections:
         (tmp_path / "sub.kicad_sch").write_text(child_sch)
 
         issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
-        gl_issues = [
-            i
-            for i in issues
-            if i.category == "global_label" and "inconsistent" in i.message
-        ]
-
-        assert len(gl_issues) == 1
-        assert gl_issues[0].severity == "warning"
-        assert "SWCLK" in gl_issues[0].message
-        assert "input" in gl_issues[0].message
-        assert "bidirectional" in gl_issues[0].message
+        gl_issues = [i for i in issues if i.category == "global_label"]
+        assert len(gl_issues) == 0
 
     def test_consistent_shapes_no_warning(self, tmp_path: Path):
         """Same shape on all sheets should not emit a shape-consistency warning."""
@@ -1611,8 +1589,8 @@ class TestSchValidateGlobalLabelDirections:
         ]
         assert len(consistency_issues) == 0
 
-    def test_multiple_shapes_across_three_sheets(self, tmp_path: Path):
-        """Inconsistent shapes across 3+ sheets lists all shapes and locations."""
+    def test_mixed_non_driver_shapes_no_warning(self, tmp_path: Path):
+        """input + bidirectional + passive across 3 sheets -- no conflicting drivers."""
         from kicad_tools.cli.sch_validate import check_global_label_directions
 
         parent_sch = self._make_schematic("""
@@ -1641,18 +1619,89 @@ class TestSchValidateGlobalLabelDirections:
         (tmp_path / "sub2.kicad_sch").write_text(sub2_sch)
 
         issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
-        consistency_issues = [
+        gl_issues = [i for i in issues if i.category == "global_label"]
+        assert len(gl_issues) == 0
+
+    def test_conflicting_drivers_detected(self, tmp_path: Path):
+        """output + tri_state on the same net -- conflicting drivers warning."""
+        from kicad_tools.cli.sch_validate import check_global_label_directions
+
+        parent_sch = self._make_schematic("""
+          (global_label "BUS_CONFLICT" (shape output) (at 10 20 0)
+            (effects (font (size 1.27 1.27))) (uuid "m1"))
+          (sheet (at 100 100) (size 10 10)
+            (uuid "00000000-0000-0000-0000-000000000002")
+            (property "Sheetname" "Sub" (at 100 99 0))
+            (property "Sheetfile" "sub.kicad_sch" (at 100 111 0)))
+        """)
+        child_sch = self._make_schematic("""
+          (global_label "BUS_CONFLICT" (shape tri_state) (at 30 40 0)
+            (effects (font (size 1.27 1.27))) (uuid "m2"))
+        """)
+
+        (tmp_path / "top.kicad_sch").write_text(parent_sch)
+        (tmp_path / "sub.kicad_sch").write_text(child_sch)
+
+        issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
+        conflict_issues = [
             i
             for i in issues
-            if i.category == "global_label" and "inconsistent" in i.message
+            if i.category == "global_label" and "conflicting" in i.message
         ]
 
-        assert len(consistency_issues) == 1
-        msg = consistency_issues[0].message
-        assert "MULTI" in msg
-        assert "input" in msg
-        assert "bidirectional" in msg
-        assert "passive" in msg
+        assert len(conflict_issues) == 1
+        assert conflict_issues[0].severity == "warning"
+        assert "BUS_CONFLICT" in conflict_issues[0].message
+        assert "output" in conflict_issues[0].message
+        assert "tri_state" in conflict_issues[0].message
+
+    def test_output_bidirectional_no_warning(self, tmp_path: Path):
+        """output + bidirectional is a valid combination -- no warning."""
+        from kicad_tools.cli.sch_validate import check_global_label_directions
+
+        parent_sch = self._make_schematic("""
+          (global_label "SIG_OB" (shape output) (at 10 20 0)
+            (effects (font (size 1.27 1.27))) (uuid "n1"))
+          (sheet (at 100 100) (size 10 10)
+            (uuid "00000000-0000-0000-0000-000000000002")
+            (property "Sheetname" "Sub" (at 100 99 0))
+            (property "Sheetfile" "sub.kicad_sch" (at 100 111 0)))
+        """)
+        child_sch = self._make_schematic("""
+          (global_label "SIG_OB" (shape bidirectional) (at 30 40 0)
+            (effects (font (size 1.27 1.27))) (uuid "n2"))
+        """)
+
+        (tmp_path / "top.kicad_sch").write_text(parent_sch)
+        (tmp_path / "sub.kicad_sch").write_text(child_sch)
+
+        issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
+        gl_issues = [i for i in issues if i.category == "global_label"]
+        assert len(gl_issues) == 0
+
+    def test_tri_state_input_no_warning(self, tmp_path: Path):
+        """tri_state + input is a valid complementary pair -- no warning."""
+        from kicad_tools.cli.sch_validate import check_global_label_directions
+
+        parent_sch = self._make_schematic("""
+          (global_label "SIG_TI" (shape tri_state) (at 10 20 0)
+            (effects (font (size 1.27 1.27))) (uuid "o1"))
+          (sheet (at 100 100) (size 10 10)
+            (uuid "00000000-0000-0000-0000-000000000002")
+            (property "Sheetname" "Sub" (at 100 99 0))
+            (property "Sheetfile" "sub.kicad_sch" (at 100 111 0)))
+        """)
+        child_sch = self._make_schematic("""
+          (global_label "SIG_TI" (shape input) (at 30 40 0)
+            (effects (font (size 1.27 1.27))) (uuid "o2"))
+        """)
+
+        (tmp_path / "top.kicad_sch").write_text(parent_sch)
+        (tmp_path / "sub.kicad_sch").write_text(child_sch)
+
+        issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
+        gl_issues = [i for i in issues if i.category == "global_label"]
+        assert len(gl_issues) == 0
 
 
 class TestSchValidateSheetParseFailure:


### PR DESCRIPTION
## Summary
Replace the unconditional "inconsistent shapes" warning in `check_global_label_directions()` with semantic validation that only warns on real driver conflicts (output + tri_state on the same net). Valid complementary pairs like output+input, tri_state+input, and output+bidirectional no longer produce false-positive warnings.

## Changes
- Replace blanket shape-consistency check (lines 524-545) with driver-conflict detection that only warns when multiple exclusive driver shapes coexist on the same net
- Update 3 existing tests that expected false-positive warnings for valid complementary pairs
- Add 4 new tests: conflicting drivers (output+tri_state), output+bidirectional (valid), tri_state+input (valid), mixed non-driver shapes across 3 sheets (valid)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Complementary output+input produces no warning | Pass | test_valid_output_input_mix passes with 0 issues |
| Multiple drivers (output+tri_state) produces warning | Pass | test_conflicting_drivers_detected passes |
| All-input-no-driver error preserved | Pass | test_no_driver_detected_as_error passes |
| Bidirectional-only no warning | Pass | test_bidirectional_counts_as_both passes |
| output+bidirectional valid | Pass | test_output_bidirectional_no_warning passes |
| tri_state+input valid | Pass | test_tri_state_input_no_warning passes |

## Test Plan
All 15 global label direction tests pass: `pytest tests/test_cli_sch.py -k "TestSchValidateGlobalLabelDirections or global_label"`.

Closes #2074