### PR TITLE
fix(pin-map): stop BFS net tracing at foreign component pin boundaries

### DIFF
--- a/src/kicad_tools/cli/sch_pin_map.py
+++ b/src/kicad_tools/cli/sch_pin_map.py
@@ -143,11 +143,26 @@ def _flood_fill_net(
     start: Coord,
     adjacency: dict[Coord, set[Coord]],
     net_names: dict[Coord, str],
+    barrier_pins: set[Coord] | None = None,
 ) -> str | None:
     """BFS from a coordinate to find the first net name reachable along wires.
 
+    Args:
+        start: Starting coordinate (a pin position of the component being traced).
+        adjacency: Wire connectivity graph.
+        net_names: Map of coordinates to net names (labels/power symbols).
+        barrier_pins: Pin coordinates of *other* components.  When the BFS
+            reaches a barrier pin it records any net name but does **not**
+            continue traversal through that node.  This prevents the flood
+            fill from crossing through another component's body (e.g. tracing
+            from one pin of a resistor through a wire that happens to
+            connect its other pin to a different net).
+
     Returns the net name, or None if no label/power symbol is reachable.
     """
+    if barrier_pins is None:
+        barrier_pins = set()
+
     visited: set[Coord] = set()
     queue = [start]
     visited.add(start)
@@ -158,6 +173,13 @@ def _flood_fill_net(
         # Check if this node has a net name
         if current in net_names:
             return net_names[current]
+
+        # If this node is a pin of another component, do not traverse further
+        # from it.  The pin is a terminal -- the net stops here.  We already
+        # checked for a net name above, so unnamed junctions at foreign pins
+        # simply become dead-ends for BFS.
+        if current != start and current in barrier_pins:
+            continue
 
         # Traverse neighbors
         for neighbor in adjacency.get(current, set()):
@@ -184,28 +206,56 @@ def resolve_pin_map(
     adjacency, net_names = _build_wire_graph(schematic)
     result: dict[str, dict] = {}
 
+    # ------------------------------------------------------------------
+    # Pre-compute pin coordinates for every non-power symbol so that we
+    # can build per-component barrier sets.  A barrier set for symbol S
+    # contains every pin coordinate that does NOT belong to S.  This
+    # prevents the BFS from traversing *through* another component's
+    # body (i.e. hopping from pin 1 to pin 2 of an intermediate
+    # resistor/diode via a wire that connects them in the schematic
+    # drawing).
+    # ------------------------------------------------------------------
+    # Map: reference -> set of Coord for that symbol's pins
+    ref_pin_coords: dict[str, set[Coord]] = defaultdict(set)
+    # All non-power pin coordinates across the whole schematic
+    all_pin_coords: set[Coord] = set()
+
+    # We also cache resolved LibrarySymbol + pin_positions per symbol
+    # instance so we don't have to compute them twice.
+    _sym_cache: list[tuple] = []  # (symbol, lib_sym, pin_positions)
+
     for symbol in schematic.symbols:
-        # Skip power symbols
         if symbol.lib_id.startswith("power:"):
             continue
 
-        # Apply reference filter
-        if ref_filter and symbol.reference != ref_filter:
-            continue
-
-        # Look up embedded library symbol
         lib_sexp = schematic.get_lib_symbol(symbol.lib_id)
         if not lib_sexp:
             continue
 
         lib_sym = LibrarySymbol.from_sexp(lib_sexp)
-
-        # Get transformed pin positions
         pin_positions = lib_sym.get_all_pin_positions(
             instance_pos=symbol.position,
             instance_rot=symbol.rotation,
             mirror=symbol.mirror,
         )
+
+        coords: set[Coord] = set()
+        for pin_num, pos in pin_positions.items():
+            coords.add(_to_coord(*pos))
+        ref_pin_coords[symbol.reference].update(coords)
+        all_pin_coords.update(coords)
+        _sym_cache.append((symbol, lib_sym, pin_positions))
+
+    # ------------------------------------------------------------------
+    # Resolve nets for each symbol using per-component barrier sets.
+    # ------------------------------------------------------------------
+    for symbol, lib_sym, pin_positions in _sym_cache:
+        # Apply reference filter
+        if ref_filter and symbol.reference != ref_filter:
+            continue
+
+        # Barrier = all pin coords except this symbol's own pins
+        barrier_pins = all_pin_coords - ref_pin_coords[symbol.reference]
 
         pins_data: dict[str, dict] = {}
         for lib_pin in lib_sym.pins:
@@ -216,7 +266,7 @@ def resolve_pin_map(
             coord = _to_coord(*pos)
 
             # Trace from pin position to find net name
-            net = _flood_fill_net(coord, adjacency, net_names)
+            net = _flood_fill_net(coord, adjacency, net_names, barrier_pins)
 
             pins_data[lib_pin.number] = {
                 "name": lib_pin.name,

--- a/tests/test_sch_pin_map.py
+++ b/tests/test_sch_pin_map.py
@@ -307,6 +307,115 @@ MIRRORED_SCHEMATIC = """\
 """
 
 
+# ---------------------------------------------------------------------------
+# Schematic with diode + resistor where wire path traverses through resistor
+# body to a power net.  Without BFS barriers, D1 pin K (cathode) would
+# incorrectly resolve to GND by hopping through R1's body.
+#
+# Topology:
+#   D1 (D_Schottky) at (120, 50) rotated 90 degrees
+#     Pin 1 (K, cathode) -> (120, 46.19) -> wire to (110, 46.19) = R1 pin 1
+#     Pin 2 (A, anode)   -> (120, 53.81) -> wire to (120, 60)    -> label "VBUS"
+#
+#   R1 (Device:R) at (110, 50) rotation 0
+#     Pin 1 at (110, 46.19) -- shared junction with D1 cathode
+#     Pin 2 at (110, 53.81) -> wire to (110, 60) -> label "GND"
+#
+# Without barriers, BFS from D1 cathode (120, 46.19) traverses:
+#   -> (110, 46.19) [R1 pin 1] -> (110, 53.81) [R1 pin 2] -> (110, 60) [GND]
+# and incorrectly returns "GND".
+#
+# With barriers, BFS stops at R1 pin 1 (110, 46.19) because it belongs to
+# another component.  D1 cathode should resolve to None (unnamed net).
+# ---------------------------------------------------------------------------
+DIODE_RESISTOR_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000020")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:D_Schottky"
+      (symbol "D_Schottky_0_1"
+      )
+      (symbol "D_Schottky_1_1"
+        (pin passive line
+          (at 0 3.81 270)
+          (length 1.27)
+          (name "K")
+          (number "1")
+        )
+        (pin passive line
+          (at 0 -3.81 90)
+          (length 1.27)
+          (name "A")
+          (number "2")
+        )
+      )
+    )
+    (symbol "Device:R"
+      (symbol "R_1_1"
+        (pin passive line
+          (at 0 3.81 270)
+          (length 1.27)
+          (name "~")
+          (number "1")
+        )
+        (pin passive line
+          (at 0 -3.81 90)
+          (length 1.27)
+          (name "~")
+          (number "2")
+        )
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:D_Schottky")
+    (at 120 50 0)
+    (unit 1)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "d1-uuid")
+    (property "Reference" "D1" (at 122 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "BAT54" (at 122 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "d1p1"))
+    (pin "2" (uuid "d1p2"))
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 110 50 0)
+    (unit 1)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "r1-uuid")
+    (property "Reference" "R1" (at 112 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "10k" (at 112 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "r1p1"))
+    (pin "2" (uuid "r1p2"))
+  )
+  (wire (pts (xy 120 46.19) (xy 110 46.19))
+    (stroke (width 0) (type default)) (uuid "w-d1k-r1p1"))
+  (wire (pts (xy 120 53.81) (xy 120 60))
+    (stroke (width 0) (type default)) (uuid "w-d1a-vbus"))
+  (wire (pts (xy 110 53.81) (xy 110 60))
+    (stroke (width 0) (type default)) (uuid "w-r1p2-gnd"))
+  (label "VBUS" (at 120 60 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid "lbl-vbus"))
+  (label "GND" (at 110 60 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid "lbl-gnd"))
+)
+"""
+
+
 def _write_sch(tmp_path: Path, content: str) -> Path:
     p = tmp_path / "test.kicad_sch"
     p.write_text(content)
@@ -572,6 +681,55 @@ class TestResolvePinMap:
         assert abs(pos1[1] - 46.19) < 0.01
         assert abs(pos2[0] - 100.0) < 0.01
         assert abs(pos2[1] - 53.81) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: BFS barrier prevents traversal through other components
+# ---------------------------------------------------------------------------
+
+
+class TestBFSBarrier:
+    """Verify that net tracing does not traverse through another component's body."""
+
+    def test_diode_cathode_does_not_resolve_through_resistor(self, tmp_path):
+        """D1 cathode connects to R1 pin 1 via wire.  R1 pin 2 connects to GND.
+
+        Without BFS barriers, D1 cathode would incorrectly resolve to GND by
+        traversing through R1's body.  With barriers, the BFS stops at R1 pin 1
+        and D1 cathode resolves to None (unnamed net at the junction).
+        """
+        sch = Schematic.load(_write_sch(tmp_path, DIODE_RESISTOR_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        assert "D1" in pin_map
+        assert "R1" in pin_map
+
+        # D1 cathode (pin 1) must NOT resolve to GND
+        d1_pin1_net = pin_map["D1"]["pins"]["1"]["net"]
+        assert d1_pin1_net is None, (
+            f"D1 cathode should be None (unnamed net), got {d1_pin1_net!r}"
+        )
+
+        # D1 anode (pin 2) should resolve to VBUS
+        assert pin_map["D1"]["pins"]["2"]["net"] == "VBUS"
+
+        # R1 should still resolve correctly
+        # R1 pin 1 shares junction with D1 cathode -- unnamed net
+        assert pin_map["R1"]["pins"]["1"]["net"] is None
+        # R1 pin 2 connects to GND
+        assert pin_map["R1"]["pins"]["2"]["net"] == "GND"
+
+    def test_shared_junction_still_resolves(self, tmp_path):
+        """Components sharing a junction (same coordinate) should both see the
+        net name at that junction, even with barriers enabled."""
+        sch = Schematic.load(_write_sch(tmp_path, MINIMAL_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        # R1 and C1 share the VIN junction at (100, 40) and GND at (100, 60)
+        assert pin_map["R1"]["pins"]["1"]["net"] == "VIN"
+        assert pin_map["C1"]["pins"]["1"]["net"] == "VIN"
+        assert pin_map["R1"]["pins"]["2"]["net"] == "GND"
+        assert pin_map["C1"]["pins"]["2"]["net"] == "GND"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fix incorrect net resolution in `sch pin-map` where the BFS flood-fill traversed through other components' bodies (e.g. hopping from pin 1 to pin 2 of an intermediate resistor via connecting wires), causing a Schottky diode cathode to incorrectly resolve to GNDD.

## Changes
- Pre-compute all non-power symbol pin coordinates in `resolve_pin_map()` before running BFS
- Add `barrier_pins` parameter to `_flood_fill_net()` -- a set of pin coordinates belonging to other components
- When BFS reaches a barrier pin, check for net name but do not enqueue neighbors (prevents traversal through component body)
- Cache `LibrarySymbol` and pin position lookups to avoid redundant computation

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| D_Schottky cathode does not resolve through intermediate component to wrong net | Pass | New test `test_diode_cathode_does_not_resolve_through_resistor` verifies D1 pin 1 resolves to None, not GND |
| D_Schottky anode still resolves correctly (direct wire to label) | Pass | Test verifies D1 pin 2 resolves to VBUS |
| Net tracing stops at pin positions belonging to other components | Pass | BFS barrier logic implemented and tested |
| Existing tests pass (no regressions in simple R/C circuits) | Pass | All 31 tests pass including shared junction tests for R1/C1 |
| Components sharing a junction still correctly share the same net | Pass | New test `test_shared_junction_still_resolves` confirms R1 and C1 both see VIN/GND |

## Test Plan
- `python3 -m pytest tests/test_sch_pin_map.py -v` -- all 31 tests pass
- New `TestBFSBarrier` class with two tests covering the diode+resistor traversal bug and the shared-junction regression case

Closes #2097