### PR TITLE
feat(check): add footprint-outside-board placement rule

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -57,7 +57,7 @@ def _find_pcb_file(directory: Path) -> Path | None:
     return None
 
 
-CHECK_CATEGORIES = ["clearance", "dimensions", "edge", "silkscreen", "solder_mask"]
+CHECK_CATEGORIES = ["clearance", "dimensions", "edge", "placement", "silkscreen", "solder_mask"]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -260,6 +260,7 @@ def run_selected_checks(
         "clearance": checker.check_clearances,
         "dimensions": checker.check_dimensions,
         "edge": checker.check_edge_clearances,
+        "placement": checker.check_footprint_placement,
         "silkscreen": checker.check_silkscreen,
         "solder_mask": checker.check_solder_mask_pads,
     }

--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -152,6 +152,9 @@ class ViolationType(Enum):
     # Impedance
     IMPEDANCE = "impedance"
 
+    # Placement
+    FOOTPRINT_OUTSIDE_BOARD = "footprint_outside_board"
+
     # Misc
     FOOTPRINT = "footprint"
     MALFORMED_OUTLINE = "malformed_outline"
@@ -217,6 +220,8 @@ class ViolationType(Enum):
             "pth_annular_ring": cls.PTH_ANNULAR_RING,
             # impedance rule from validate impedance checker
             "impedance": cls.IMPEDANCE,
+            # placement rule from validate placement checker
+            "footprint_outside_board": cls.FOOTPRINT_OUTSIDE_BOARD,
         }
 
         alias_match = _ALIASES.get(s_lower)
@@ -271,6 +276,8 @@ class ViolationType(Enum):
         if "impedance" in s_lower:
             return cls.IMPEDANCE
         if "footprint" in s_lower:
+            if "outside" in s_lower:
+                return cls.FOOTPRINT_OUTSIDE_BOARD
             if "duplicate" in s_lower:
                 return cls.DUPLICATE_FOOTPRINT
             if "extra" in s_lower:

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -12,6 +12,7 @@ from kicad_tools.manufacturers import DesignRules, get_profile
 
 from .rules.clearance import ClearanceRule
 from .rules.edge import EdgeClearanceRule
+from .rules.placement import FootprintOutsideBoardRule
 from .rules.silkscreen import check_all_silkscreen
 from .violations import DRCResults
 
@@ -91,6 +92,7 @@ class DRCChecker:
         results.merge(self.check_edge_clearances())
         results.merge(self.check_silkscreen())
         results.merge(self.check_solder_mask_pads())
+        results.merge(self.check_footprint_placement())
 
         return results
 
@@ -166,6 +168,18 @@ class DRCChecker:
         from .rules.solder_mask import SolderMaskPadRules
 
         rule = SolderMaskPadRules()
+        return rule.check(self.pcb, self.design_rules)
+
+    def check_footprint_placement(self) -> DRCResults:
+        """Check that footprints are placed inside the board outline.
+
+        Uses a point-in-polygon test on each footprint's centroid to
+        detect components placed entirely outside the Edge.Cuts boundary.
+
+        Returns:
+            DRCResults containing placement violations
+        """
+        rule = FootprintOutsideBoardRule()
         return rule.check(self.pcb, self.design_rules)
 
     def __repr__(self) -> str:

--- a/src/kicad_tools/validate/rules/placement.py
+++ b/src/kicad_tools/validate/rules/placement.py
@@ -1,0 +1,118 @@
+"""Footprint placement DRC rules.
+
+This module implements board placement validation rules that detect
+footprints placed outside the board outline polygon.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..violations import DRCResults, DRCViolation
+from .base import DRCRule
+from .edge import EdgeClearanceRule
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers import DesignRules
+    from kicad_tools.schema.pcb import PCB
+
+
+def point_in_polygon(
+    x: float, y: float, polygon: list[tuple[float, float]]
+) -> bool:
+    """Test if a point is inside a polygon using ray casting.
+
+    Casts a ray from the point in the +X direction and counts the number
+    of polygon edge crossings.  An odd count means inside.
+
+    A point exactly on the boundary is treated as inside (consistent
+    with the convention that boundary footprints are acceptable).
+
+    Args:
+        x: X coordinate to test.
+        y: Y coordinate to test.
+        polygon: Ordered list of (x, y) vertices forming the polygon.
+
+    Returns:
+        True if the point is inside (or on the boundary of) the polygon.
+    """
+    n = len(polygon)
+    inside = False
+    j = n - 1
+    for i in range(n):
+        xi, yi = polygon[i]
+        xj, yj = polygon[j]
+        if ((yi > y) != (yj > y)) and (
+            x < (xj - xi) * (y - yi) / (yj - yi) + xi
+        ):
+            inside = not inside
+        j = i
+    return inside
+
+
+class FootprintOutsideBoardRule(DRCRule):
+    """Detect footprints whose centroid falls outside the board outline.
+
+    For each footprint the rule tests whether its ``(at X Y)`` position
+    lies inside the Edge.Cuts polygon.  Footprints outside the board are
+    reported as errors together with the minimum distance from the
+    footprint centroid to the nearest board edge segment.
+
+    Rule IDs generated:
+        - footprint_outside_board: Footprint centroid is outside the outline.
+    """
+
+    rule_id = "footprint_outside_board"
+    name = "Footprint Placement"
+    description = "Check that footprints are placed inside the board outline"
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Check all footprints against the board outline polygon.
+
+        Args:
+            pcb: The PCB to check.
+            design_rules: Design rules (unused but required by interface).
+
+        Returns:
+            DRCResults containing placement violations.
+        """
+        results = DRCResults()
+
+        outline_polygon = pcb.get_board_outline()
+        if not outline_polygon or len(outline_polygon) < 3:
+            # No usable board outline -- nothing to check.
+            results.rules_checked += 1
+            return results
+
+        outline_segments = pcb.get_board_outline_segments()
+
+        for footprint in pcb.footprints:
+            fx, fy = footprint.position
+            if not point_in_polygon(fx, fy, outline_polygon):
+                # Compute distance to nearest edge for the message.
+                distance = EdgeClearanceRule()._min_distance_to_outline(
+                    (fx, fy), outline_segments
+                )
+                results.add(
+                    DRCViolation(
+                        rule_id="footprint_outside_board",
+                        severity="error",
+                        message=(
+                            f"Footprint {footprint.reference} at "
+                            f"({fx:.2f}, {fy:.2f}) is outside the board "
+                            f"outline by {distance:.2f}mm"
+                        ),
+                        location=(fx, fy),
+                        layer=footprint.layer,
+                        actual_value=distance,
+                        required_value=0.0,
+                        items=(footprint.reference,),
+                    )
+                )
+
+        results.rules_checked += 1
+        return results

--- a/tests/test_validate_placement.py
+++ b/tests/test_validate_placement.py
@@ -1,0 +1,214 @@
+"""Tests for FootprintOutsideBoardRule placement validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock
+
+import pytest
+
+from kicad_tools.validate.rules.placement import (
+    FootprintOutsideBoardRule,
+    point_in_polygon,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers -- lightweight stand-ins for schema objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFootprint:
+    reference: str
+    position: tuple[float, float]
+    layer: str = "F.Cu"
+    rotation: float = 0.0
+    pads: list = field(default_factory=list)
+
+
+class _FakePCB:
+    """Minimal PCB stub that provides the methods used by the rule."""
+
+    def __init__(
+        self,
+        footprints: list[_FakeFootprint],
+        outline_polygon: list[tuple[float, float]],
+        outline_segments: list[tuple[tuple[float, float], tuple[float, float]]]
+        | None = None,
+    ) -> None:
+        self.footprints = footprints
+        self._outline_polygon = outline_polygon
+        # Derive segments from consecutive polygon vertices if not given.
+        if outline_segments is not None:
+            self._outline_segments = outline_segments
+        elif outline_polygon and len(outline_polygon) >= 3:
+            segs = []
+            for i in range(len(outline_polygon)):
+                segs.append(
+                    (
+                        outline_polygon[i],
+                        outline_polygon[(i + 1) % len(outline_polygon)],
+                    )
+                )
+            self._outline_segments = segs
+        else:
+            self._outline_segments = []
+
+    def get_board_outline(self) -> list[tuple[float, float]]:
+        return self._outline_polygon
+
+    def get_board_outline_segments(
+        self,
+    ) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+        return self._outline_segments
+
+
+# A simple 10x10 rectangle from (0,0) to (10,10)
+_RECT_OUTLINE = [(0, 0), (10, 0), (10, 10), (0, 10)]
+
+# Dummy design rules (unused by this rule but required by the interface)
+_DUMMY_RULES = MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# point_in_polygon unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestPointInPolygon:
+    """Direct tests for the ray-casting helper."""
+
+    def test_inside_rectangle(self):
+        assert point_in_polygon(5.0, 5.0, _RECT_OUTLINE) is True
+
+    def test_outside_rectangle(self):
+        assert point_in_polygon(15.0, 5.0, _RECT_OUTLINE) is False
+
+    def test_outside_negative(self):
+        assert point_in_polygon(-1.0, 5.0, _RECT_OUTLINE) is False
+
+    def test_concave_polygon_inside(self):
+        # L-shaped polygon (concave)
+        polygon = [(0, 0), (10, 0), (10, 5), (5, 5), (5, 10), (0, 10)]
+        # Inside the bottom leg
+        assert point_in_polygon(7.0, 2.0, polygon) is True
+        # Inside the left leg
+        assert point_in_polygon(2.0, 7.0, polygon) is True
+
+    def test_concave_polygon_outside_notch(self):
+        # Point in the concave "notch" of the L
+        polygon = [(0, 0), (10, 0), (10, 5), (5, 5), (5, 10), (0, 10)]
+        assert point_in_polygon(7.0, 7.0, polygon) is False
+
+
+# ---------------------------------------------------------------------------
+# FootprintOutsideBoardRule tests
+# ---------------------------------------------------------------------------
+
+
+class TestFootprintOutsideBoardRule:
+    """Tests for the DRC rule itself."""
+
+    def test_all_footprints_inside(self):
+        """No violations when all footprints are inside the board."""
+        pcb = _FakePCB(
+            footprints=[
+                _FakeFootprint("U1", (5.0, 5.0)),
+                _FakeFootprint("C1", (2.0, 3.0)),
+            ],
+            outline_polygon=_RECT_OUTLINE,
+        )
+        rule = FootprintOutsideBoardRule()
+        results = rule.check(pcb, _DUMMY_RULES)
+
+        assert len(results.violations) == 0
+        assert results.rules_checked == 1
+
+    def test_footprint_outside(self):
+        """Violations reported for footprints outside the board."""
+        pcb = _FakePCB(
+            footprints=[
+                _FakeFootprint("U1", (5.0, 5.0)),   # inside
+                _FakeFootprint("R1", (15.0, 5.0)),   # outside
+                _FakeFootprint("C1", (-5.0, 5.0)),   # outside
+            ],
+            outline_polygon=_RECT_OUTLINE,
+        )
+        rule = FootprintOutsideBoardRule()
+        results = rule.check(pcb, _DUMMY_RULES)
+
+        assert len(results.violations) == 2
+        refs = {v.items[0] for v in results.violations}
+        assert refs == {"R1", "C1"}
+        for v in results.violations:
+            assert v.rule_id == "footprint_outside_board"
+            assert v.severity == "error"
+            assert v.actual_value > 0
+
+    def test_no_board_outline(self):
+        """No violations and no crash when the board has no outline."""
+        pcb = _FakePCB(
+            footprints=[_FakeFootprint("U1", (5.0, 5.0))],
+            outline_polygon=[],
+        )
+        rule = FootprintOutsideBoardRule()
+        results = rule.check(pcb, _DUMMY_RULES)
+
+        assert len(results.violations) == 0
+        assert results.rules_checked == 1
+
+    def test_degenerate_outline(self):
+        """Fewer than 3 vertices -- treated as no outline."""
+        pcb = _FakePCB(
+            footprints=[_FakeFootprint("U1", (5.0, 5.0))],
+            outline_polygon=[(0, 0), (10, 0)],
+        )
+        rule = FootprintOutsideBoardRule()
+        results = rule.check(pcb, _DUMMY_RULES)
+
+        assert len(results.violations) == 0
+        assert results.rules_checked == 1
+
+    def test_concave_outline(self):
+        """Non-rectangular (concave) outline classifies correctly."""
+        polygon = [(0, 0), (10, 0), (10, 5), (5, 5), (5, 10), (0, 10)]
+        pcb = _FakePCB(
+            footprints=[
+                _FakeFootprint("U1", (2.0, 2.0)),   # inside bottom leg
+                _FakeFootprint("R1", (7.0, 7.0)),   # in the notch (outside)
+            ],
+            outline_polygon=polygon,
+        )
+        rule = FootprintOutsideBoardRule()
+        results = rule.check(pcb, _DUMMY_RULES)
+
+        assert len(results.violations) == 1
+        assert results.violations[0].items == ("R1",)
+
+    def test_violation_has_distance(self):
+        """Violation message includes distance from board edge."""
+        pcb = _FakePCB(
+            footprints=[_FakeFootprint("R1", (15.0, 5.0))],
+            outline_polygon=_RECT_OUTLINE,
+        )
+        rule = FootprintOutsideBoardRule()
+        results = rule.check(pcb, _DUMMY_RULES)
+
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        # Distance from (15, 5) to nearest edge at x=10 should be 5.0
+        assert v.actual_value == pytest.approx(5.0)
+        assert "5.00mm" in v.message
+
+    def test_no_footprints(self):
+        """Empty footprint list produces no violations."""
+        pcb = _FakePCB(
+            footprints=[],
+            outline_polygon=_RECT_OUTLINE,
+        )
+        rule = FootprintOutsideBoardRule()
+        results = rule.check(pcb, _DUMMY_RULES)
+
+        assert len(results.violations) == 0
+        assert results.rules_checked == 1


### PR DESCRIPTION
## Summary

Add a new DRC rule that detects footprints placed outside the board outline polygon, using point-in-polygon ray casting on each footprint centroid against the Edge.Cuts boundary.

## Changes

- Add `FootprintOutsideBoardRule` in `src/kicad_tools/validate/rules/placement.py` with ray-casting PIP test
- Wire into `DRCChecker.check_all()` via new `check_footprint_placement()` method
- Register `"placement"` category in `check_cmd.py` (`CHECK_CATEGORIES` and `check_methods`)
- Add `FOOTPRINT_OUTSIDE_BOARD` enum member and alias in `ViolationType`
- Add 12 unit tests covering inside/outside/no-outline/concave/degenerate cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Point-in-polygon test for each footprint centroid | Done | `FootprintOutsideBoardRule.check()` tests each `footprint.position` against `get_board_outline()` |
| Report violations with reference, position, distance | Done | Violation includes `items=(ref,)`, `location=(x,y)`, `actual_value=distance` |
| No crash on missing board outline | Done | Returns empty results when outline has <3 vertices |
| Wired into `check_all()` | Done | `checker.check_footprint_placement()` called in `check_all()` |
| "placement" category in CLI | Done | `--only placement` and `--skip placement` work |
| ViolationType registered | Done | `FOOTPRINT_OUTSIDE_BOARD` enum + alias + fuzzy heuristic |
| Unit tests for inside/outside/no-outline/concave | Done | 12 tests, all passing |
| Existing tests pass | Done | 93 passed, 5 skipped |

## Test Plan

- `python3 -m pytest tests/test_validate_placement.py -v` -- 12 tests pass
- `python3 -m pytest tests/test_validate.py tests/test_drc_tolerance.py -v` -- 93 passed, 5 skipped (no regressions)

Closes #2086