### PR TITLE
feat(sch-validate): add matched channel symmetry check for output filtering

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -2519,6 +2519,247 @@ def check_symbol_footprint_pin_mismatch(schematic_path: str) -> list[ValidationI
     return issues
 
 
+# ---------------------------------------------------------------------------
+# Matched channel symmetry detection
+# ---------------------------------------------------------------------------
+
+# Suffix pairs that indicate matched output channels.  Each tuple is
+# (suffix_a, suffix_b, pair_type) where pair_type controls severity:
+#   "stereo"       -> warning
+#   "differential" -> error
+_CHANNEL_SUFFIX_PAIRS: list[tuple[str, str, str]] = [
+    ("_L", "_R", "stereo"),
+    ("_P", "_N", "differential"),
+    ("_A", "_B", "stereo"),
+    ("+", "-", "differential"),
+]
+
+
+def _find_matched_pairs(
+    net_names: set[str],
+) -> list[tuple[str, str, str, str]]:
+    """Identify matched net pairs from a set of net names.
+
+    Returns a deduplicated list of (net_a, net_b, base_name, pair_type).
+    """
+    pairs: list[tuple[str, str, str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for net in sorted(net_names):
+        for suffix_a, suffix_b, pair_type in _CHANNEL_SUFFIX_PAIRS:
+            if net.endswith(suffix_a):
+                base = net[: -len(suffix_a)]
+                partner = base + suffix_b
+                if partner in net_names:
+                    key = (min(net, partner), max(net, partner))
+                    if key not in seen:
+                        seen.add(key)
+                        pairs.append((net, partner, base, pair_type))
+    return pairs
+
+
+def _classify_passive(lib_id: str) -> str | None:
+    """Return a passive type tag or None if not a passive component.
+
+    Recognized types: "R", "C", "L", "FB" (ferrite bead).
+    """
+    part = lib_id.split(":")[-1] if ":" in lib_id else lib_id
+    for prefix in ("R", "C", "L", "FB", "Ferrite"):
+        if part == prefix or part.startswith(prefix + "_"):
+            # Normalize ferrite variants to "FB"
+            if prefix in ("FB", "Ferrite"):
+                return "FB"
+            return prefix
+    return None
+
+
+@dataclass
+class _ChannelFilterSignature:
+    """Describes the passive filtering topology attached to a net."""
+
+    shunt_caps: int = 0
+    shunt_resistors: int = 0
+    series_components: list[str] = field(default_factory=list)
+    shunt_values: list[str] = field(default_factory=list)
+    series_values: list[str] = field(default_factory=list)
+
+    @property
+    def total_passives(self) -> int:
+        return self.shunt_caps + self.shunt_resistors + len(self.series_components)
+
+    def describe_diff(self, other: "_ChannelFilterSignature") -> str | None:
+        """Return a human-readable description of differences, or None if equal."""
+        diffs: list[str] = []
+        if self.shunt_caps != other.shunt_caps:
+            diffs.append(f"shunt caps: {self.shunt_caps} vs {other.shunt_caps}")
+        if self.shunt_resistors != other.shunt_resistors:
+            diffs.append(
+                f"shunt resistors: {self.shunt_resistors} vs {other.shunt_resistors}"
+            )
+        self_series_types = sorted(self.series_components)
+        other_series_types = sorted(other.series_components)
+        if self_series_types != other_series_types:
+            diffs.append(
+                f"series components: {self_series_types} vs {other_series_types}"
+            )
+        if not diffs:
+            return None
+        return "; ".join(diffs)
+
+
+def _build_filter_signature(
+    net_name: str,
+    pin_map_all: dict[str, dict],
+    all_net_names: set[str],
+) -> _ChannelFilterSignature:
+    """Build a filter signature for a single net.
+
+    Walks one hop through passive components attached to *net_name*:
+    - A shunt component has one pin on *net_name* and the other on a
+      ground/power net (not another signal net in the matched set).
+    - A series component has one pin on *net_name* and the other on
+      another signal-path net (not ground/power).
+    """
+    sig = _ChannelFilterSignature()
+
+    for ref, entry in pin_map_all.items():
+        lib_id: str = entry.get("lib_id", "")
+        ptype = _classify_passive(lib_id)
+        if ptype is None:
+            continue
+
+        pins_data: dict[str, dict] = entry.get("pins", {})
+        pin_nets: list[str | None] = [p.get("net") for p in pins_data.values()]
+
+        # Component must have at least one pin on our target net
+        if net_name not in pin_nets:
+            continue
+
+        # Determine the "other" nets (pins not on our target net)
+        other_nets = [n for n in pin_nets if n is not None and n != net_name]
+
+        if not other_nets:
+            # Single-pin connection or both pins on same net -- skip
+            continue
+
+        # Get value for reporting
+        value = entry.get("value", "")
+
+        for other_net in other_nets:
+            if _is_power_negative_net(other_net):
+                # Shunt to ground
+                if ptype == "C":
+                    sig.shunt_caps += 1
+                    if value:
+                        sig.shunt_values.append(value)
+                elif ptype == "R":
+                    sig.shunt_resistors += 1
+                    if value:
+                        sig.shunt_values.append(value)
+            elif _is_power_positive_net(other_net):
+                # Pull-up or shunt to power -- treat as shunt
+                if ptype == "R":
+                    sig.shunt_resistors += 1
+                    if value:
+                        sig.shunt_values.append(value)
+            else:
+                # Series component to another signal net
+                sig.series_components.append(ptype)
+                if value:
+                    sig.series_values.append(value)
+
+    return sig
+
+
+def check_matched_channel_symmetry(schematic_path: str) -> list[ValidationIssue]:
+    """Detect asymmetric filtering across matched output channels.
+
+    Identifies matched net pairs (e.g. AUDIO_L/AUDIO_R, USB_D_P/USB_D_N)
+    and compares the passive component topology attached to each channel.
+    Flags warnings (stereo) or errors (differential) when the filter
+    signatures differ.
+
+    Only pairs where at least one channel has passive components are
+    compared, to avoid false positives on nets that happen to share
+    matched naming but are not filtered outputs.
+    """
+    issues: list[ValidationIssue] = []
+
+    try:
+        from kicad_tools.cli.sch_pin_map import resolve_pin_map
+
+        hierarchy = build_hierarchy(schematic_path)
+
+        # Accumulate a combined pin_map and net name set across all sheets.
+        combined_pin_map: dict[str, dict] = {}
+        all_net_names: set[str] = set()
+
+        for node in hierarchy.all_nodes():
+            try:
+                sch = Schematic.load(node.path)
+                pin_map = resolve_pin_map(sch)
+
+                for ref, entry in pin_map.items():
+                    # Merge (first occurrence wins for multi-sheet)
+                    if ref not in combined_pin_map:
+                        combined_pin_map[ref] = entry
+                    else:
+                        combined_pin_map[ref]["pins"].update(entry.get("pins", {}))
+
+                    for pin_info in entry.get("pins", {}).values():
+                        net = pin_info.get("net")
+                        if net is not None:
+                            all_net_names.add(net)
+
+            except Exception as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="matched_channel_symmetry",
+                        message=f"Skipped sheet {node.get_path_string()}: {e}",
+                        location=node.get_path_string(),
+                    )
+                )
+
+        # Find matched pairs
+        pairs = _find_matched_pairs(all_net_names)
+
+        for net_a, net_b, base_name, pair_type in pairs:
+            sig_a = _build_filter_signature(net_a, combined_pin_map, all_net_names)
+            sig_b = _build_filter_signature(net_b, combined_pin_map, all_net_names)
+
+            # Only compare if at least one channel has passive components
+            if sig_a.total_passives == 0 and sig_b.total_passives == 0:
+                continue
+
+            diff = sig_a.describe_diff(sig_b)
+            if diff is None:
+                continue
+
+            severity = "error" if pair_type == "differential" else "warning"
+            issues.append(
+                ValidationIssue(
+                    severity=severity,
+                    category="matched_channel_symmetry",
+                    message=(
+                        f"Asymmetric filtering on matched pair "
+                        f"{net_a}/{net_b}: {diff}"
+                    ),
+                )
+            )
+
+    except Exception as e:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                category="matched_channel_symmetry",
+                message=f"Matched channel symmetry check failed: {e}",
+            )
+        )
+
+    return issues
+
+
 def validate_schematic(
     schematic_path: str,
     lib_paths: list[str] = None,
@@ -2594,6 +2835,9 @@ def validate_schematic(
 
     # Symbol-to-footprint pin/pad count mismatch
     _run("symbol_footprint_pin_count", check_symbol_footprint_pin_mismatch)
+
+    # Matched channel symmetry detection
+    _run("matched_channel_symmetry", check_matched_channel_symmetry)
 
     return result
 

--- a/tests/test_sch_validate_channel_symmetry.py
+++ b/tests/test_sch_validate_channel_symmetry.py
@@ -1,0 +1,537 @@
+"""Tests for matched channel symmetry detection in sch validate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_validate import (
+    ValidationIssue,
+    _ChannelFilterSignature,
+    _find_matched_pairs,
+    check_matched_channel_symmetry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for pair detection
+# ---------------------------------------------------------------------------
+
+
+class TestFindMatchedPairs:
+    """Test _find_matched_pairs suffix matching."""
+
+    def test_stereo_lr(self):
+        pairs = _find_matched_pairs({"AUDIO_L", "AUDIO_R", "GND"})
+        assert len(pairs) == 1
+        net_a, net_b, base, ptype = pairs[0]
+        assert {net_a, net_b} == {"AUDIO_L", "AUDIO_R"}
+        assert base == "AUDIO"
+        assert ptype == "stereo"
+
+    def test_differential_pn(self):
+        pairs = _find_matched_pairs({"USB_D_P", "USB_D_N", "GND"})
+        assert len(pairs) == 1
+        _, _, base, ptype = pairs[0]
+        assert base == "USB_D"
+        assert ptype == "differential"
+
+    def test_channel_ab(self):
+        pairs = _find_matched_pairs({"CH_A", "CH_B"})
+        assert len(pairs) == 1
+        _, _, _, ptype = pairs[0]
+        assert ptype == "stereo"
+
+    def test_plus_minus(self):
+        pairs = _find_matched_pairs({"VOUT+", "VOUT-"})
+        assert len(pairs) == 1
+        _, _, _, ptype = pairs[0]
+        assert ptype == "differential"
+
+    def test_no_pair(self):
+        pairs = _find_matched_pairs({"GPIO_A5", "UART_TX", "GND"})
+        assert pairs == []
+
+    def test_single_net_no_match(self):
+        pairs = _find_matched_pairs({"AUDIO_L"})
+        assert pairs == []
+
+    def test_deduplication(self):
+        """Each pair should appear exactly once even though both sides match."""
+        pairs = _find_matched_pairs({"SIG_L", "SIG_R"})
+        assert len(pairs) == 1
+
+    def test_multiple_pairs(self):
+        pairs = _find_matched_pairs(
+            {"AUDIO_L", "AUDIO_R", "USB_D_P", "USB_D_N"}
+        )
+        assert len(pairs) == 2
+
+
+class TestChannelFilterSignature:
+    """Test _ChannelFilterSignature.describe_diff."""
+
+    def test_identical_signatures_no_diff(self):
+        a = _ChannelFilterSignature(shunt_caps=2, series_components=["R"])
+        b = _ChannelFilterSignature(shunt_caps=2, series_components=["R"])
+        assert a.describe_diff(b) is None
+
+    def test_different_shunt_caps(self):
+        a = _ChannelFilterSignature(shunt_caps=2)
+        b = _ChannelFilterSignature(shunt_caps=0)
+        diff = a.describe_diff(b)
+        assert diff is not None
+        assert "shunt caps" in diff
+        assert "2 vs 0" in diff
+
+    def test_different_series(self):
+        a = _ChannelFilterSignature(series_components=["R", "C"])
+        b = _ChannelFilterSignature(series_components=["R"])
+        diff = a.describe_diff(b)
+        assert diff is not None
+        assert "series components" in diff
+
+    def test_total_passives(self):
+        sig = _ChannelFilterSignature(
+            shunt_caps=1, shunt_resistors=1, series_components=["R"]
+        )
+        assert sig.total_passives == 3
+
+
+# ---------------------------------------------------------------------------
+# Helpers to generate synthetic KiCad schematics
+# ---------------------------------------------------------------------------
+
+
+def _make_lib_symbol(
+    lib_id: str,
+    pins: list[tuple[str, str, str]],
+) -> str:
+    """Generate a lib_symbols entry."""
+    part_name = lib_id.split(":")[-1] if ":" in lib_id else lib_id
+    pin_blocks = []
+    for i, (num, name, ptype) in enumerate(pins):
+        y = i * 2.54
+        pin_blocks.append(
+            f"""(pin {ptype} line
+                    (at 0 {y:.2f} 0)
+                    (length 2.54)
+                    (name "{name}")
+                    (number "{num}")
+                )"""
+        )
+    pin_str = "\n".join(pin_blocks)
+    return f"""(symbol "{lib_id}"
+            (pin_names (offset 0.254))
+            (symbol "{part_name}_0_1"
+                (rectangle
+                    (start -5.08 -{(len(pins) * 2.54) + 1.27:.2f})
+                    (end 5.08 1.27)
+                    (stroke (width 0.254))
+                    (fill (type background))
+                )
+            )
+            (symbol "{part_name}_1_1"
+                {pin_str}
+            )
+        )"""
+
+
+def _make_symbol_instance(
+    ref: str, lib_id: str, pins: list[tuple[str, str, str]], x: float, y: float,
+) -> str:
+    """Generate a symbol instance S-expression."""
+    pin_entries = "\n".join(
+        f'(pin "{num}" (uuid "pin-{ref.lower()}-{num}"))' for num, _, _ in pins
+    )
+    return f"""(symbol
+        (lib_id "{lib_id}")
+        (at {x} {y} 0)
+        (unit 1)
+        (in_bom yes)
+        (on_board yes)
+        (dnp no)
+        (uuid "uuid-{ref.lower()}")
+        (property "Reference" "{ref}"
+            (at {x + 2} {y - 2} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Value" "{lib_id.split(':')[-1]}"
+            (at {x + 2} {y} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Footprint" ""
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        (property "Datasheet" "~"
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        {pin_entries}
+    )"""
+
+
+def _build_schematic(components: list[dict]) -> str:
+    """Build a complete schematic string from component descriptors."""
+    lib_symbols = []
+    symbol_instances = []
+    wires = []
+    labels = []
+    seen_lib_ids: set[str] = set()
+
+    for idx, comp in enumerate(components):
+        ref = comp["ref"]
+        lib_id = comp["lib_id"]
+        pins = comp["pins"]
+        pin_nets = comp.get("pin_nets", {})
+        x = comp.get("x", 100.0 + idx * 100.0)
+        y = comp.get("y", 50.0)
+
+        if lib_id not in seen_lib_ids:
+            lib_symbols.append(_make_lib_symbol(lib_id, pins))
+            seen_lib_ids.add(lib_id)
+
+        symbol_instances.append(_make_symbol_instance(ref, lib_id, pins, x, y))
+
+        for pin_idx, (pin_num, _, _) in enumerate(pins):
+            if pin_num not in pin_nets:
+                continue
+            net_name = pin_nets[pin_num]
+            pin_y = y - pin_idx * 2.54
+            pin_x = x
+            label_x = pin_x + 10.0
+
+            wires.append(
+                f"""(wire
+                (pts (xy {pin_x:.2f} {pin_y:.2f}) (xy {label_x:.2f} {pin_y:.2f}))
+                (stroke (width 0) (type default))
+                (uuid "wire-{ref.lower()}-{pin_num}")
+            )"""
+            )
+            labels.append(
+                f"""(label "{net_name}"
+                (at {label_x:.2f} {pin_y:.2f} 0)
+                (effects (font (size 1.27 1.27)) (justify left bottom))
+                (uuid "lbl-{ref.lower()}-{pin_num}")
+            )"""
+            )
+
+    lib_block = "\n".join(lib_symbols)
+    inst_block = "\n".join(symbol_instances)
+    wire_block = "\n".join(wires)
+    label_block = "\n".join(labels)
+
+    return f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "test-channel-symmetry-uuid")
+    (paper "A4")
+    (lib_symbols
+        {lib_block}
+    )
+    {inst_block}
+    {wire_block}
+    {label_block}
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMatchedChannelSymmetry:
+    """Test check_matched_channel_symmetry against synthetic schematics."""
+
+    def test_asymmetric_shunt_caps_detected(self, tmp_path: Path):
+        """AUDIO_R has 2 shunt caps to GND, AUDIO_L has 0 -- should warn."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "IC:DAC",
+                "pins": [
+                    ("1", "OUTL", "output"),
+                    ("2", "OUTR", "output"),
+                    ("3", "VCC", "power_in"),
+                    ("4", "GND", "power_in"),
+                ],
+                "pin_nets": {
+                    "1": "AUDIO_L",
+                    "2": "AUDIO_R",
+                    "3": "+3.3V",
+                    "4": "GND",
+                },
+            },
+            # Shunt cap on AUDIO_R only
+            {
+                "ref": "C1",
+                "lib_id": "Device:C",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "AUDIO_R",
+                    "2": "GND",
+                },
+            },
+            {
+                "ref": "C2",
+                "lib_id": "Device:C",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "AUDIO_R",
+                    "2": "GND",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "asymmetric_caps.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_matched_channel_symmetry(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "matched_channel_symmetry"
+            and i.severity == "warning"
+        ]
+        assert len(warnings) == 1
+        assert "AUDIO_L" in warnings[0].message
+        assert "AUDIO_R" in warnings[0].message
+        assert "shunt caps" in warnings[0].message
+        assert "2 vs 0" in warnings[0].message or "0 vs 2" in warnings[0].message
+
+    def test_symmetric_channels_no_warning(self, tmp_path: Path):
+        """Both channels have identical filter topology -- no warning."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "IC:DAC",
+                "pins": [
+                    ("1", "OUTL", "output"),
+                    ("2", "OUTR", "output"),
+                ],
+                "pin_nets": {
+                    "1": "AUDIO_L",
+                    "2": "AUDIO_R",
+                },
+            },
+            # Cap on AUDIO_L
+            {
+                "ref": "C1",
+                "lib_id": "Device:C",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "AUDIO_L",
+                    "2": "GND",
+                },
+            },
+            # Cap on AUDIO_R
+            {
+                "ref": "C2",
+                "lib_id": "Device:C",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "AUDIO_R",
+                    "2": "GND",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "symmetric.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_matched_channel_symmetry(str(sch_path))
+        symmetry_issues = [
+            i for i in issues
+            if i.category == "matched_channel_symmetry"
+            and i.severity in ("warning", "error")
+        ]
+        assert symmetry_issues == []
+
+    def test_no_passives_no_false_positive(self, tmp_path: Path):
+        """Matched nets with no passive components should not trigger."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "IC:DAC",
+                "pins": [
+                    ("1", "OUTL", "output"),
+                    ("2", "OUTR", "output"),
+                ],
+                "pin_nets": {
+                    "1": "AUDIO_L",
+                    "2": "AUDIO_R",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "no_passives.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_matched_channel_symmetry(str(sch_path))
+        symmetry_issues = [
+            i for i in issues
+            if i.category == "matched_channel_symmetry"
+            and i.severity in ("warning", "error")
+        ]
+        assert symmetry_issues == []
+
+    def test_differential_pair_error_severity(self, tmp_path: Path):
+        """Asymmetry on _P/_N differential pair should be flagged as error."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "IC:USB",
+                "pins": [
+                    ("1", "DP", "bidirectional"),
+                    ("2", "DN", "bidirectional"),
+                ],
+                "pin_nets": {
+                    "1": "USB_D_P",
+                    "2": "USB_D_N",
+                },
+            },
+            # Cap only on _P side
+            {
+                "ref": "C1",
+                "lib_id": "Device:C",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "USB_D_P",
+                    "2": "GND",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "diff_asymmetric.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_matched_channel_symmetry(str(sch_path))
+        errors = [
+            i for i in issues
+            if i.category == "matched_channel_symmetry"
+            and i.severity == "error"
+        ]
+        assert len(errors) == 1
+        assert "USB_D_P" in errors[0].message
+        assert "USB_D_N" in errors[0].message
+
+    def test_series_component_asymmetry(self, tmp_path: Path):
+        """One channel has a series resistor, the other does not."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "IC:DAC",
+                "pins": [
+                    ("1", "OUTL", "output"),
+                    ("2", "OUTR", "output"),
+                ],
+                "pin_nets": {
+                    "1": "AUDIO_L",
+                    "2": "AUDIO_R",
+                },
+            },
+            # Series resistor on AUDIO_R only (to a downstream net)
+            {
+                "ref": "R1",
+                "lib_id": "Device:R",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "AUDIO_R",
+                    "2": "AUDIO_R_FILT",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "series_asymmetric.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_matched_channel_symmetry(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "matched_channel_symmetry"
+            and i.severity == "warning"
+        ]
+        assert len(warnings) == 1
+        assert "series" in warnings[0].message
+
+    def test_check_registered_in_validate(self, tmp_path: Path):
+        """matched_channel_symmetry should appear in checks_run."""
+        from kicad_tools.cli.sch_validate import validate_schematic
+
+        # Minimal schematic with no components
+        sch_text = """(kicad_sch
+    (version 20231120)
+    (generator "test")
+    (uuid "test-uuid")
+    (paper "A4")
+    (lib_symbols)
+)
+"""
+        sch_path = tmp_path / "empty.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        result = validate_schematic(str(sch_path))
+        assert "matched_channel_symmetry" in result.checks_run
+
+    def test_ab_pair_detection(self, tmp_path: Path):
+        """_A/_B suffix pairs should be detected."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "IC:AMP",
+                "pins": [
+                    ("1", "OUTA", "output"),
+                    ("2", "OUTB", "output"),
+                ],
+                "pin_nets": {
+                    "1": "CH_A",
+                    "2": "CH_B",
+                },
+            },
+            # Cap only on CH_A
+            {
+                "ref": "C1",
+                "lib_id": "Device:C",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "CH_A",
+                    "2": "GND",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "ab_pair.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_matched_channel_symmetry(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "matched_channel_symmetry"
+            and i.severity == "warning"
+        ]
+        assert len(warnings) == 1
+        assert "CH_A" in warnings[0].message
+        assert "CH_B" in warnings[0].message


### PR DESCRIPTION
## Summary
Add a new `check_matched_channel_symmetry()` validation check to `sch validate` that detects asymmetric passive component topologies across matched output channel pairs (e.g. AUDIO_L/AUDIO_R with caps on one side but not the other).

## Changes
- Add `_find_matched_pairs()` to identify net pairs by suffix patterns: `_L`/`_R`, `_P`/`_N`, `_A`/`_B`, `+`/`-`
- Add `_classify_passive()` to identify passive component types from lib_id
- Add `_ChannelFilterSignature` dataclass to describe per-net filter topology (shunt caps, shunt resistors, series components)
- Add `_build_filter_signature()` to walk one hop through passives attached to a net
- Add `check_matched_channel_symmetry()` main check function
- Register check in `validate_schematic()` as `matched_channel_symmetry`
- Add 19 tests covering pair detection, signature comparison, and integration scenarios

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `sch validate` flags asymmetric component counts/topologies | Pass | test_asymmetric_shunt_caps_detected, test_series_component_asymmetry |
| Handles _L/_R, _P/_N, _A/_B naming patterns | Pass | test_stereo_lr, test_differential_pn, test_channel_ab, test_plus_minus, test_ab_pair_detection |
| Warning identifies specific asymmetry | Pass | test_asymmetric_shunt_caps_detected checks "shunt caps: 2 vs 0" in message |
| _P/_N at error severity, _L/_R at warning | Pass | test_differential_pair_error_severity, test_asymmetric_shunt_caps_detected |
| Registered in validate_schematic() as matched_channel_symmetry | Pass | test_check_registered_in_validate |
| No false positives when neither channel has passives | Pass | test_no_passives_no_false_positive |
| JSON output includes new category in checks_run | Pass | test_check_registered_in_validate confirms checks_run list |

## Test Plan
- All 19 new tests pass (unit + integration)
- All 147 existing sch_validate tests pass (regression check)

Closes #2099