### PR TITLE
feat(sch-validate): add BOOT0 pull-down detection for STM32 MCUs

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -1210,6 +1210,216 @@ def check_i2c_pullups(schematic_path: str) -> list[ValidationIssue]:
     return issues
 
 
+# ---------------------------------------------------------------------------
+# BOOT0 pull-down detection helpers and check
+# ---------------------------------------------------------------------------
+
+# SWD / debug signal keywords used to detect unrelated signal contamination
+_SWD_KEYWORDS: frozenset[str] = frozenset({
+    "SWCLK", "SWDIO", "SWO", "JTAG", "TDI", "TDO", "TMS", "TCK", "NRST",
+    "NTRST", "TRACECLK", "TRACEDATA",
+})
+
+# Combined set of all bus + debug keywords for signal contamination checks
+_SIGNAL_CONTAMINATION_KEYWORDS: frozenset[str] = _ALL_BUS_KEYWORDS | _SWD_KEYWORDS
+
+
+def _is_stm32_symbol(lib_id: str) -> bool:
+    """Return True if *lib_id* refers to an STM32 MCU symbol.
+
+    Checks for ``STM32`` as a case-insensitive substring in the library
+    identifier, which matches patterns like ``MCU_ST_STM32:STM32C011F6Px``
+    or ``STM32:STM32F401``.
+    """
+    return "STM32" in lib_id.upper()
+
+
+def _is_boot0_pin(pin_name: str) -> bool:
+    """Return True if *pin_name* represents a BOOT0 pin.
+
+    Uses ``_tokenize_name`` to extract tokens and checks for ``BOOT0``
+    as a discrete token.
+    """
+    tokens = _tokenize_name(pin_name)
+    return "BOOT0" in tokens
+
+
+def _is_switch_or_button(lib_id: str) -> bool:
+    """Return True if *lib_id* refers to a switch or button symbol."""
+    part = lib_id.split(":")[-1] if ":" in lib_id else lib_id
+    switch_prefixes = ("SW", "BTN", "Button", "Key")
+    for prefix in switch_prefixes:
+        if part == prefix or part.startswith(prefix + "_"):
+            return True
+    return False
+
+
+def check_boot0_pulldown(schematic_path: str) -> list[ValidationIssue]:
+    """Detect missing BOOT0 pull-down resistors on STM32 MCUs.
+
+    STM32 microcontrollers require the BOOT0 pin to be pulled low via a
+    resistor to GND for normal flash boot.  Without this pull-down, the
+    MCU may enter bootloader mode or behave unpredictably on power-up.
+
+    This check also flags BOOT0 pins that are tied to unrelated signal
+    nets (e.g. SWCLK, SPI_MOSI) which indicates a wiring error.
+
+    The detection strategy mirrors ``check_i2c_pullups``:
+
+    1. Walk all sheets and resolve pin maps.
+    2. Find STM32 symbols (``lib_id`` contains ``STM32``).
+    3. For each BOOT0 pin, collect the net name.
+    4. Verify a resistor bridges the net to a GND-family rail.
+    5. Check for unrelated signal contamination on the net.
+    """
+    issues: list[ValidationIssue] = []
+
+    try:
+        from kicad_tools.cli.sch_pin_map import resolve_pin_map
+
+        hierarchy = build_hierarchy(schematic_path)
+
+        # Accumulated state across all sheets
+        boot0_nets: set[str] = set()
+        boot0_net_to_refs: dict[str, list[str]] = {}  # net -> [MCU refs]
+        net_to_sheets: dict[str, set[str]] = {}
+        resistor_pin_nets: dict[str, list[str]] = {}
+        # net -> set of (ref, lib_id, pin_name) for all connected pins
+        net_connections: dict[str, list[tuple[str, str, str]]] = {}
+
+        for node in hierarchy.all_nodes():
+            try:
+                sch = Schematic.load(node.path)
+                pin_map = resolve_pin_map(sch)
+                sheet_path = node.get_path_string()
+
+                for ref, entry in pin_map.items():
+                    lib_id: str = entry.get("lib_id", "")
+                    pins_data: dict[str, dict] = entry.get("pins", {})
+
+                    for pin_num, pin_info in pins_data.items():
+                        net_name = pin_info.get("net")
+                        if net_name is None:
+                            continue
+                        pin_name = pin_info.get("name", "")
+
+                        # Track which sheets each net appears on
+                        net_to_sheets.setdefault(net_name, set()).add(sheet_path)
+
+                        # Track all connections per net
+                        net_connections.setdefault(net_name, []).append(
+                            (ref, lib_id, pin_name)
+                        )
+
+                        # Identify BOOT0 nets on STM32 symbols
+                        if _is_stm32_symbol(lib_id) and _is_boot0_pin(pin_name):
+                            boot0_nets.add(net_name)
+                            boot0_net_to_refs.setdefault(net_name, []).append(ref)
+
+                    # Track resistor pin-to-net connections
+                    if _is_resistor(lib_id):
+                        nets_for_ref: list[str] = []
+                        for pin_num2, pin_info2 in pins_data.items():
+                            n = pin_info2.get("net")
+                            if n is not None:
+                                nets_for_ref.append(n)
+                        if ref not in resistor_pin_nets:
+                            resistor_pin_nets[ref] = nets_for_ref
+                        else:
+                            resistor_pin_nets[ref].extend(nets_for_ref)
+
+            except Exception as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="boot0_pulldown",
+                        message=f"Skipped sheet {node.get_path_string()}: {e}",
+                        location=node.get_path_string(),
+                    )
+                )
+
+        # Check 1: Verify pull-down resistor to GND exists for each BOOT0 net
+        boot0_nets_with_pulldown: set[str] = set()
+        for _ref, pin_net_list in resistor_pin_nets.items():
+            net_set = set(pin_net_list)
+            boot0_on_resistor = net_set & boot0_nets
+            gnd_on_resistor = {n for n in net_set if _is_power_negative_net(n)}
+            if boot0_on_resistor and gnd_on_resistor:
+                boot0_nets_with_pulldown.update(boot0_on_resistor)
+
+        for net_name in sorted(boot0_nets - boot0_nets_with_pulldown):
+            sheets = sorted(net_to_sheets.get(net_name, set()))
+            sheet_str = ", ".join(sheets) if sheets else "unknown"
+            mcu_refs = boot0_net_to_refs.get(net_name, [])
+            ref_str = ", ".join(sorted(set(mcu_refs)))
+            issues.append(
+                ValidationIssue(
+                    severity="warning",
+                    category="boot0_pulldown",
+                    message=(
+                        f"STM32 BOOT0 net '{net_name}' on {ref_str} has no "
+                        f"pull-down resistor to GND"
+                    ),
+                    location=sheet_str,
+                )
+            )
+
+        # Check 2: Detect signal contamination on BOOT0 nets
+        for net_name in sorted(boot0_nets):
+            connections = net_connections.get(net_name, [])
+            for conn_ref, conn_lib_id, conn_pin_name in connections:
+                # Skip the MCU itself
+                if _is_stm32_symbol(conn_lib_id):
+                    continue
+                # Skip resistors (pull-down or current-limiting)
+                if _is_resistor(conn_lib_id):
+                    continue
+                # Skip passive components (capacitors, inductors, etc.)
+                if _is_passive_component(conn_lib_id):
+                    continue
+                # Skip switches/buttons (legitimate for entering bootloader)
+                if _is_switch_or_button(conn_lib_id):
+                    continue
+                # Skip power symbols
+                if conn_lib_id.startswith("power:"):
+                    continue
+                # Skip pins that are themselves BOOT0-named
+                if _is_boot0_pin(conn_pin_name):
+                    continue
+
+                # Check if the pin name contains signal keywords
+                pin_tokens = _tokenize_name(conn_pin_name)
+                signal_match = pin_tokens & _SIGNAL_CONTAMINATION_KEYWORDS
+                if signal_match:
+                    sheets = sorted(net_to_sheets.get(net_name, set()))
+                    sheet_str = ", ".join(sheets) if sheets else "unknown"
+                    mcu_refs = boot0_net_to_refs.get(net_name, [])
+                    ref_str = ", ".join(sorted(set(mcu_refs)))
+                    issues.append(
+                        ValidationIssue(
+                            severity="error",
+                            category="boot0_pulldown",
+                            message=(
+                                f"STM32 BOOT0 net '{net_name}' on {ref_str} is "
+                                f"tied to signal pin {conn_ref}/{conn_pin_name} "
+                                f"(contains {', '.join(sorted(signal_match))})"
+                            ),
+                            location=sheet_str,
+                        )
+                    )
+
+    except Exception as e:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                category="boot0_pulldown",
+                message=f"BOOT0 pull-down check failed: {e}",
+            )
+        )
+
+    return issues
+
+
 def check_pin_net_semantic_mismatch(schematic_path: str) -> list[ValidationIssue]:
     """Flag pins where the connected net name has no semantic overlap with the pin name.
 
@@ -1866,6 +2076,10 @@ def validate_schematic(schematic_path: str, lib_paths: list[str] = None) -> Vali
     # I2C pull-up resistor detection
     result.checks_run.append("i2c_pullups")
     result.issues.extend(check_i2c_pullups(schematic_path))
+
+    # BOOT0 pull-down resistor detection (STM32 MCUs)
+    result.checks_run.append("boot0_pulldown")
+    result.issues.extend(check_boot0_pulldown(schematic_path))
 
     # Fully unconnected component detection
     result.checks_run.append("unconnected_component")

--- a/tests/test_sch_validate_boot0.py
+++ b/tests/test_sch_validate_boot0.py
@@ -1,0 +1,622 @@
+"""Tests for BOOT0 pull-down resistor detection in sch validate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_validate import (
+    ValidationIssue,
+    _is_boot0_pin,
+    _is_stm32_symbol,
+    _is_switch_or_button,
+    _tokenize_name,
+    check_boot0_pulldown,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestIsStm32Symbol:
+    """Test _is_stm32_symbol helper."""
+
+    def test_full_lib_id(self):
+        assert _is_stm32_symbol("MCU_ST_STM32:STM32C011F6Px") is True
+
+    def test_short_lib_id(self):
+        assert _is_stm32_symbol("STM32:STM32F401") is True
+
+    def test_lowercase_in_lib_id(self):
+        assert _is_stm32_symbol("mcu:stm32c011") is True
+
+    def test_bare_part_name(self):
+        assert _is_stm32_symbol("STM32F103C8T6") is True
+
+    def test_esp32_not_stm32(self):
+        assert _is_stm32_symbol("MCU_Espressif:ESP32-S3") is False
+
+    def test_generic_mcu(self):
+        assert _is_stm32_symbol("IC:MCU") is False
+
+    def test_atmega(self):
+        assert _is_stm32_symbol("MCU_Microchip:ATmega328P") is False
+
+    def test_empty_string(self):
+        assert _is_stm32_symbol("") is False
+
+    def test_resistor(self):
+        assert _is_stm32_symbol("Device:R_Small") is False
+
+
+class TestIsBoot0Pin:
+    """Test _is_boot0_pin helper."""
+
+    def test_plain_boot0(self):
+        assert _is_boot0_pin("BOOT0") is True
+
+    def test_boot0_lowercase(self):
+        # _tokenize_name uppercases tokens
+        assert _is_boot0_pin("boot0") is True
+
+    def test_boot0_with_prefix(self):
+        assert _is_boot0_pin("MCU_BOOT0") is True
+
+    def test_pa0_not_boot0(self):
+        assert _is_boot0_pin("PA0") is False
+
+    def test_boot1_not_boot0(self):
+        assert _is_boot0_pin("BOOT1") is False
+
+    def test_nboot0(self):
+        # nBOOT0 tokenizes to {N, BOOT0} via camelCase split, so BOOT0 is present.
+        # This is correct -- nBOOT0 is a negated BOOT0 pin and should be detected.
+        assert _is_boot0_pin("nBOOT0") is True
+
+    def test_swclk_not_boot0(self):
+        assert _is_boot0_pin("SWCLK") is False
+
+    def test_empty(self):
+        assert _is_boot0_pin("") is False
+
+    def test_tilde(self):
+        assert _is_boot0_pin("~") is False
+
+
+class TestIsSwitchOrButton:
+    """Test _is_switch_or_button helper."""
+
+    def test_sw_push(self):
+        assert _is_switch_or_button("Switch:SW_Push") is True
+
+    def test_sw_plain(self):
+        assert _is_switch_or_button("SW") is True
+
+    def test_sw_spdt(self):
+        assert _is_switch_or_button("SW_SPDT") is True
+
+    def test_btn(self):
+        assert _is_switch_or_button("BTN_Small") is True
+
+    def test_button(self):
+        assert _is_switch_or_button("Button_Reset") is True
+
+    def test_resistor_not_switch(self):
+        assert _is_switch_or_button("Device:R_Small") is False
+
+    def test_ic_not_switch(self):
+        assert _is_switch_or_button("IC:STM32F4") is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers to generate synthetic KiCad schematics
+# ---------------------------------------------------------------------------
+
+
+def _make_lib_symbol(
+    lib_id: str,
+    pins: list[tuple[str, str, str]],
+) -> str:
+    """Generate a lib_symbols entry."""
+    part_name = lib_id.split(":")[-1] if ":" in lib_id else lib_id
+    pin_blocks = []
+    for i, (num, name, ptype) in enumerate(pins):
+        y = i * 2.54
+        pin_blocks.append(
+            f"""(pin {ptype} line
+                    (at 0 {y:.2f} 0)
+                    (length 2.54)
+                    (name "{name}")
+                    (number "{num}")
+                )"""
+        )
+    pin_str = "\n".join(pin_blocks)
+    return f"""(symbol "{lib_id}"
+            (pin_names (offset 0.254))
+            (symbol "{part_name}_0_1"
+                (rectangle
+                    (start -5.08 -{(len(pins) * 2.54) + 1.27:.2f})
+                    (end 5.08 1.27)
+                    (stroke (width 0.254))
+                    (fill (type background))
+                )
+            )
+            (symbol "{part_name}_1_1"
+                {pin_str}
+            )
+        )"""
+
+
+def _make_symbol_instance(
+    ref: str, lib_id: str, pins: list[tuple[str, str, str]], x: float, y: float,
+) -> str:
+    """Generate a symbol instance S-expression."""
+    pin_entries = "\n".join(
+        f'(pin "{num}" (uuid "pin-{ref.lower()}-{num}"))' for num, _, _ in pins
+    )
+    return f"""(symbol
+        (lib_id "{lib_id}")
+        (at {x} {y} 0)
+        (unit 1)
+        (in_bom yes)
+        (on_board yes)
+        (dnp no)
+        (uuid "uuid-{ref.lower()}")
+        (property "Reference" "{ref}"
+            (at {x + 2} {y - 2} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Value" "{lib_id.split(':')[-1]}"
+            (at {x + 2} {y} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Footprint" ""
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        (property "Datasheet" "~"
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        {pin_entries}
+    )"""
+
+
+def _build_schematic(
+    components: list[dict],
+) -> str:
+    """Build a complete schematic string from component descriptors.
+
+    Each component dict has:
+        ref: str          - reference designator (e.g. "U1", "R1")
+        lib_id: str       - library identifier (e.g. "Device:R_Small")
+        pins: list        - [(pin_num, pin_name, pin_type), ...]
+        pin_nets: dict    - {pin_num: net_name, ...}
+        x: float          - X position (optional, defaults based on index)
+    """
+    lib_symbols = []
+    symbol_instances = []
+    wires = []
+    labels = []
+    seen_lib_ids: set[str] = set()
+
+    for idx, comp in enumerate(components):
+        ref = comp["ref"]
+        lib_id = comp["lib_id"]
+        pins = comp["pins"]
+        pin_nets = comp.get("pin_nets", {})
+        x = comp.get("x", 100.0 + idx * 100.0)
+        y = comp.get("y", 50.0)
+
+        if lib_id not in seen_lib_ids:
+            lib_symbols.append(_make_lib_symbol(lib_id, pins))
+            seen_lib_ids.add(lib_id)
+
+        symbol_instances.append(_make_symbol_instance(ref, lib_id, pins, x, y))
+
+        for pin_idx, (pin_num, _, _) in enumerate(pins):
+            if pin_num not in pin_nets:
+                continue
+            net_name = pin_nets[pin_num]
+            pin_y = y - pin_idx * 2.54
+            pin_x = x
+            label_x = pin_x + 10.0
+
+            wires.append(
+                f"""(wire
+                (pts (xy {pin_x:.2f} {pin_y:.2f}) (xy {label_x:.2f} {pin_y:.2f}))
+                (stroke (width 0) (type default))
+                (uuid "wire-{ref.lower()}-{pin_num}")
+            )"""
+            )
+            labels.append(
+                f"""(label "{net_name}"
+                (at {label_x:.2f} {pin_y:.2f} 0)
+                (effects (font (size 1.27 1.27)) (justify left bottom))
+                (uuid "lbl-{ref.lower()}-{pin_num}")
+            )"""
+            )
+
+    lib_block = "\n".join(lib_symbols)
+    inst_block = "\n".join(symbol_instances)
+    wire_block = "\n".join(wires)
+    label_block = "\n".join(labels)
+
+    return f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "test-boot0-uuid")
+    (paper "A4")
+    (lib_symbols
+        {lib_block}
+    )
+    {inst_block}
+    {wire_block}
+    {label_block}
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBoot0Pulldown:
+    """Test check_boot0_pulldown against synthetic schematics."""
+
+    def test_missing_pulldown_detected(self, tmp_path: Path):
+        """STM32 BOOT0 without pull-down resistor should produce a warning."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "MCU_ST_STM32:STM32C011F6Px",
+                "pins": [
+                    ("1", "BOOT0", "input"),
+                    ("2", "VDD", "power_in"),
+                    ("3", "VSS", "power_in"),
+                    ("4", "PA0", "bidirectional"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                    "2": "+3.3V",
+                    "3": "GND",
+                    "4": "GPIO_A0",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "missing_pulldown.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_boot0_pulldown(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "boot0_pulldown" and i.severity == "warning"
+        ]
+        assert len(warnings) == 1
+        assert "BOOT0" in warnings[0].message
+        assert "pull-down" in warnings[0].message
+        assert "U1" in warnings[0].message
+
+    def test_pulldown_present_no_warning(self, tmp_path: Path):
+        """STM32 BOOT0 with proper pull-down to GND should not produce warnings."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "MCU_ST_STM32:STM32C011F6Px",
+                "pins": [
+                    ("1", "BOOT0", "input"),
+                    ("2", "VDD", "power_in"),
+                    ("3", "VSS", "power_in"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                    "2": "+3.3V",
+                    "3": "GND",
+                },
+            },
+            # Pull-down resistor for BOOT0
+            {
+                "ref": "R1",
+                "lib_id": "Device:R_Small",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                    "2": "GND",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "with_pulldown.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_boot0_pulldown(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "boot0_pulldown" and i.severity == "warning"
+        ]
+        assert warnings == []
+
+    def test_resistor_to_vcc_not_pulldown(self, tmp_path: Path):
+        """A resistor between BOOT0 and VCC is NOT a pull-down -- warning expected."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "MCU_ST_STM32:STM32C011F6Px",
+                "pins": [
+                    ("1", "BOOT0", "input"),
+                    ("2", "VDD", "power_in"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                    "2": "+3.3V",
+                },
+            },
+            # Resistor to VCC, NOT a pull-down
+            {
+                "ref": "R1",
+                "lib_id": "Device:R_Small",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                    "2": "VCC",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "resistor_to_vcc.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_boot0_pulldown(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "boot0_pulldown" and i.severity == "warning"
+        ]
+        assert len(warnings) == 1
+        assert "BOOT0" in warnings[0].message
+
+    def test_boot0_tied_to_swclk_error(self, tmp_path: Path):
+        """BOOT0 tied to SWCLK pin should produce an error (signal contamination)."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "MCU_ST_STM32:STM32C011F6Px",
+                "pins": [
+                    ("1", "BOOT0", "input"),
+                    ("2", "PA14/SWCLK", "bidirectional"),
+                    ("3", "VDD", "power_in"),
+                ],
+                "pin_nets": {
+                    "1": "SWCLK_BOOT0",
+                    "2": "SWCLK_BOOT0",
+                    "3": "+3.3V",
+                },
+            },
+            # Debug header with SWCLK
+            {
+                "ref": "J1",
+                "lib_id": "Connector:Conn_01x04",
+                "pins": [
+                    ("1", "SWCLK", "passive"),
+                    ("2", "SWDIO", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "SWCLK_BOOT0",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "boot0_swclk.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_boot0_pulldown(str(sch_path))
+        errors = [
+            i for i in issues
+            if i.category == "boot0_pulldown" and i.severity == "error"
+        ]
+        assert len(errors) >= 1
+        # Should mention SWCLK signal contamination
+        assert any("SWCLK" in e.message for e in errors)
+
+    def test_non_stm32_mcu_ignored(self, tmp_path: Path):
+        """ESP32 or other MCU symbols should not trigger the BOOT0 check."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "MCU_Espressif:ESP32-S3",
+                "pins": [
+                    ("1", "GPIO0", "bidirectional"),
+                    ("2", "VDD", "power_in"),
+                    ("3", "GND", "power_in"),
+                ],
+                "pin_nets": {
+                    "1": "GPIO0",
+                    "2": "+3.3V",
+                    "3": "GND",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "esp32.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_boot0_pulldown(str(sch_path))
+        boot0_issues = [i for i in issues if i.category == "boot0_pulldown"]
+        # Should have no warnings or errors (info messages about skipped sheets are OK)
+        real_issues = [
+            i for i in boot0_issues if i.severity in ("warning", "error")
+        ]
+        assert real_issues == []
+
+    def test_boot0_with_button_no_contamination_error(self, tmp_path: Path):
+        """A switch between BOOT0 and VCC should not trigger contamination error."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "MCU_ST_STM32:STM32C011F6Px",
+                "pins": [
+                    ("1", "BOOT0", "input"),
+                    ("2", "VDD", "power_in"),
+                    ("3", "VSS", "power_in"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                    "2": "+3.3V",
+                    "3": "GND",
+                },
+            },
+            # Pull-down resistor
+            {
+                "ref": "R1",
+                "lib_id": "Device:R_Small",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                    "2": "GND",
+                },
+            },
+            # Bootloader mode button
+            {
+                "ref": "SW1",
+                "lib_id": "Switch:SW_Push",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                    "2": "+3.3V",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "boot0_button.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_boot0_pulldown(str(sch_path))
+        errors = [
+            i for i in issues
+            if i.category == "boot0_pulldown" and i.severity == "error"
+        ]
+        assert errors == []
+        warnings = [
+            i for i in issues
+            if i.category == "boot0_pulldown" and i.severity == "warning"
+        ]
+        assert warnings == []
+
+    def test_pulldown_to_vss_accepted(self, tmp_path: Path):
+        """A pull-down to VSS (alternative GND name) should satisfy the check."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "MCU_ST_STM32:STM32F401",
+                "pins": [
+                    ("1", "BOOT0", "input"),
+                    ("2", "VDD", "power_in"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                    "2": "+3.3V",
+                },
+            },
+            {
+                "ref": "R1",
+                "lib_id": "Device:R",
+                "pins": [
+                    ("1", "~", "passive"),
+                    ("2", "~", "passive"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                    "2": "VSS",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "pulldown_vss.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_boot0_pulldown(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "boot0_pulldown" and i.severity == "warning"
+        ]
+        assert warnings == []
+
+    def test_warning_includes_sheet_location(self, tmp_path: Path):
+        """Warning should report the sheet(s) where the net appears."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "MCU_ST_STM32:STM32C011F6Px",
+                "pins": [
+                    ("1", "BOOT0", "input"),
+                ],
+                "pin_nets": {
+                    "1": "BOOT0",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "sheet_location.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_boot0_pulldown(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "boot0_pulldown" and i.severity == "warning"
+        ]
+        assert len(warnings) == 1
+        assert warnings[0].location != ""
+
+    def test_boot0_tied_to_spi_signal_error(self, tmp_path: Path):
+        """BOOT0 tied to SPI signal pin should produce an error."""
+        components = [
+            {
+                "ref": "U1",
+                "lib_id": "MCU_ST_STM32:STM32C011F6Px",
+                "pins": [
+                    ("1", "BOOT0", "input"),
+                    ("2", "VDD", "power_in"),
+                ],
+                "pin_nets": {
+                    "1": "SPI_MOSI",
+                    "2": "+3.3V",
+                },
+            },
+            {
+                "ref": "U2",
+                "lib_id": "IC:Flash",
+                "pins": [
+                    ("1", "MOSI", "input"),
+                ],
+                "pin_nets": {
+                    "1": "SPI_MOSI",
+                },
+            },
+        ]
+        sch_text = _build_schematic(components)
+        sch_path = tmp_path / "boot0_spi.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_boot0_pulldown(str(sch_path))
+        errors = [
+            i for i in issues
+            if i.category == "boot0_pulldown" and i.severity == "error"
+        ]
+        assert len(errors) >= 1
+        assert any("MOSI" in e.message for e in errors)


### PR DESCRIPTION
## Summary
Add a new `check_boot0_pulldown()` validation check that detects missing BOOT0 pull-down resistors and signal contamination on STM32 MCU BOOT0 nets.

## Changes
- Add `_is_stm32_symbol()` helper to identify STM32 MCU symbols by lib_id
- Add `_is_boot0_pin()` helper to detect BOOT0 pins via token matching
- Add `_is_switch_or_button()` helper for excluding legitimate boot-mode switches
- Add `_SWD_KEYWORDS` and `_SIGNAL_CONTAMINATION_KEYWORDS` constants for signal contamination detection
- Add `check_boot0_pulldown()` function following the `check_i2c_pullups` pattern
- Register the new check in `validate_schematic()` as category `boot0_pulldown`
- Add comprehensive test file `tests/test_sch_validate_boot0.py` with 34 tests

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Unit tests for _is_stm32_symbol helper | PASS | 9 tests covering STM32, ESP32, ATmega, empty, etc. |
| Unit tests for _is_boot0_pin helper | PASS | 9 tests covering BOOT0, PA0, BOOT1, nBOOT0, etc. |
| Missing pull-down detection | PASS | Mock pin map with STM32 BOOT0 and no resistor to GND emits warning |
| Pull-down present (no false positive) | PASS | BOOT0 with 10k resistor to GND emits no issues |
| BOOT0 tied to unrelated signal | PASS | BOOT0 sharing net with SWCLK emits error |
| Non-STM32 MCU ignored | PASS | ESP32 symbol does not trigger the check |
| Edge case: BOOT0 with button | PASS | Switch on BOOT0 net not flagged as contamination |
| Regression: existing tests pass | PASS | All 30 I2C pullup tests still pass |

## Test Plan
- `python3 -m pytest tests/test_sch_validate_boot0.py -v` -- 34/34 tests pass
- `python3 -m pytest tests/test_sch_validate_i2c_pullups.py -v` -- 30/30 tests pass (no regressions)

Closes #2090