### PR TITLE
fix(pin-map): split wire segments at pin coordinates and wire endpoints for BFS traversal

### DIFF
--- a/src/kicad_tools/cli/sch_pin_map.py
+++ b/src/kicad_tools/cli/sch_pin_map.py
@@ -62,12 +62,19 @@ def _point_on_segment(
 
 def _build_wire_graph(
     schematic: Schematic,
+    extra_points: set[Coord] | None = None,
 ) -> tuple[dict[Coord, set[Coord]], dict[Coord, str]]:
     """Build a connectivity graph from wires, labels, and power symbols.
 
     Labels and other connection points may sit on the interior of a wire
     segment (not just at endpoints). We split wire edges at such points
     so that flood-fill can reach them.
+
+    Args:
+        schematic: Loaded schematic
+        extra_points: Additional coordinates (e.g., component pin positions)
+            that should be treated as graph nodes. Wire segments passing
+            through these points will be split so BFS can traverse them.
 
     Returns:
         adjacency: Maps each coordinate node to its connected neighbors
@@ -104,6 +111,19 @@ def _build_wire_graph(
             net_name = ps.value or ps.lib_id.split(":", 1)[-1]
             net_names[coord] = net_name
             special_points.add(coord)
+
+    # Include caller-supplied points (e.g., component pin positions) so that
+    # wire segments are split at those locations and BFS can start there.
+    if extra_points:
+        special_points.update(extra_points)
+
+    # Also include all wire endpoints as split points.  When one wire's
+    # endpoint lands on the interior of another wire (e.g., a T-junction
+    # without an explicit junction symbol), the second wire must be split
+    # at that point so BFS can traverse between them.
+    for wire in schematic.wires:
+        special_points.add(_to_coord(*wire.start))
+        special_points.add(_to_coord(*wire.end))
 
     # Build adjacency by processing each wire segment.
     # If any special point lies on the interior of a wire, split the wire at that point.
@@ -203,12 +223,13 @@ def resolve_pin_map(
     Returns:
         Dict mapping reference -> {"lib_id": str, "pins": {pin_num: {name, net, type, position}}}
     """
-    adjacency, net_names = _build_wire_graph(schematic)
     result: dict[str, dict] = {}
 
     # ------------------------------------------------------------------
-    # Pre-compute pin coordinates for every non-power symbol so that we
-    # can build per-component barrier sets.  A barrier set for symbol S
+    # First pass: collect all component pin positions.
+    # We need these BEFORE building the wire graph so that wire segments
+    # are split at pin coordinates, making them reachable by BFS.
+    # We also build per-component barrier sets: a barrier set for symbol S
     # contains every pin coordinate that does NOT belong to S.  This
     # prevents the BFS from traversing *through* another component's
     # body (i.e. hopping from pin 1 to pin 2 of an intermediate
@@ -246,8 +267,11 @@ def resolve_pin_map(
         all_pin_coords.update(coords)
         _sym_cache.append((symbol, lib_sym, pin_positions))
 
+    # --- Build wire graph with pin coordinates as split points ---
+    adjacency, net_names = _build_wire_graph(schematic, extra_points=all_pin_coords)
+
     # ------------------------------------------------------------------
-    # Resolve nets for each symbol using per-component barrier sets.
+    # Second pass: resolve nets for each symbol using per-component barrier sets.
     # ------------------------------------------------------------------
     for symbol, lib_sym, pin_positions in _sym_cache:
         # Apply reference filter

--- a/tests/test_sch_pin_map.py
+++ b/tests/test_sch_pin_map.py
@@ -733,6 +733,154 @@ class TestBFSBarrier:
 
 
 # ---------------------------------------------------------------------------
+# Pin-to-pin connectivity through passive filter networks
+# ---------------------------------------------------------------------------
+
+
+# RC filter chain: R1 and C1 connected via a shared horizontal bus wire.
+# Label "AUDIO_L" at one end of a long wire. R1 pin 1 and C1 pin 1 both
+# connect to points on that wire (their pin coordinates land on the wire interior).
+#
+# Layout:
+#   AUDIO_L label at (80, 40)
+#   Wire from (80, 40) to (140, 40)  -- long horizontal bus
+#   R1 at (100, 50): pin 1 at (100, 46.19), wire down to (100, 40) on bus
+#   C1 at (120, 50): pin 1 at (120, 46.19), wire down to (120, 40) on bus
+#   R1 pin 2 at (100, 53.81), C1 pin 2 at (120, 53.81) -- both floating
+RC_FILTER_CHAIN_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000020")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (symbol "R_1_1"
+        (pin passive line
+          (at 0 3.81 270) (length 1.27) (name "~") (number "1"))
+        (pin passive line
+          (at 0 -3.81 90) (length 1.27) (name "~") (number "2"))
+      )
+    )
+    (symbol "Device:C"
+      (symbol "C_1_1"
+        (pin passive line
+          (at 0 3.81 270) (length 2.794) (name "~") (number "1"))
+        (pin passive line
+          (at 0 -3.81 90) (length 2.794) (name "~") (number "2"))
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R") (at 100 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (uuid "rc01")
+    (property "Reference" "R1" (at 102 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "100" (at 102 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p1")) (pin "2" (uuid "p2"))
+  )
+  (symbol
+    (lib_id "Device:C") (at 120 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (uuid "rc02")
+    (property "Reference" "C1" (at 122 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "100nF" (at 122 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p3")) (pin "2" (uuid "p4"))
+  )
+  (wire (pts (xy 80 40) (xy 140 40))
+    (stroke (width 0) (type default)) (uuid "w-bus"))
+  (wire (pts (xy 100 46.19) (xy 100 40))
+    (stroke (width 0) (type default)) (uuid "w-r1"))
+  (wire (pts (xy 120 46.19) (xy 120 40))
+    (stroke (width 0) (type default)) (uuid "w-c1"))
+  (label "AUDIO_L" (at 80 40 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid "lbl-audio"))
+)
+"""
+
+# Pin on wire interior: R1 pin 1 at (100, 46.19) sits on a long wire from (100, 30) to (100, 60).
+# Label "NET1" at (100, 30). The pin coordinate is in the interior of the wire, not at an endpoint.
+PIN_ON_WIRE_INTERIOR_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000030")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (symbol "R_1_1"
+        (pin passive line
+          (at 0 3.81 270) (length 1.27) (name "~") (number "1"))
+        (pin passive line
+          (at 0 -3.81 90) (length 1.27) (name "~") (number "2"))
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R") (at 100 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (uuid "int01")
+    (property "Reference" "R1" (at 102 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "1k" (at 102 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p1")) (pin "2" (uuid "p2"))
+  )
+  (wire (pts (xy 100 30) (xy 100 60))
+    (stroke (width 0) (type default)) (uuid "w1"))
+  (label "NET1" (at 100 30 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid "lbl-net1"))
+)
+"""
+
+
+class TestRCFilterChain:
+    """Pins connected through a passive filter chain must all resolve to the net label."""
+
+    def test_all_chain_pins_resolve(self, tmp_path):
+        """R1 and C1 pin 1 both connect to a horizontal bus wire with label AUDIO_L."""
+        sch = Schematic.load(_write_sch(tmp_path, RC_FILTER_CHAIN_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        assert pin_map["R1"]["pins"]["1"]["net"] == "AUDIO_L"
+        assert pin_map["C1"]["pins"]["1"]["net"] == "AUDIO_L"
+        # Pin 2 of both components has no wire -- should be None
+        assert pin_map["R1"]["pins"]["2"]["net"] is None
+        assert pin_map["C1"]["pins"]["2"]["net"] is None
+
+    def test_ref_filter_with_chain(self, tmp_path):
+        """Filtering by ref still resolves nets correctly in a chain."""
+        sch = Schematic.load(_write_sch(tmp_path, RC_FILTER_CHAIN_SCHEMATIC))
+        pin_map = resolve_pin_map(sch, ref_filter="C1")
+
+        assert "C1" in pin_map
+        assert "R1" not in pin_map
+        assert pin_map["C1"]["pins"]["1"]["net"] == "AUDIO_L"
+
+
+class TestPinOnWireInterior:
+    """A pin whose coordinate lands on the interior of a wire segment (not at an endpoint)."""
+
+    def test_pin_interior_resolves(self, tmp_path):
+        """R1 pin 1 at (100, 46.19) is in the interior of wire (100,30)-(100,60)."""
+        sch = Schematic.load(_write_sch(tmp_path, PIN_ON_WIRE_INTERIOR_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        assert pin_map["R1"]["pins"]["1"]["net"] == "NET1"
+
+    def test_pin_interior_both_pins(self, tmp_path):
+        """Both R1 pins land on the interior of the same long wire."""
+        sch = Schematic.load(_write_sch(tmp_path, PIN_ON_WIRE_INTERIOR_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        assert pin_map["R1"]["pins"]["1"]["net"] == "NET1"
+        assert pin_map["R1"]["pins"]["2"]["net"] == "NET1"
+
+
+# ---------------------------------------------------------------------------
 # Integration tests: real fixture
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Fix net=None results for pins connected through output filter networks by ensuring the wire graph splits segments at component pin coordinates and at wire T-junctions.

## Changes
- Add `extra_points` parameter to `_build_wire_graph()` for caller-supplied split points (pin coordinates)
- Add all wire endpoints to `special_points` so wires are split at T-junctions where another wire's endpoint lands on the interior
- Restructure `resolve_pin_map()` to collect all pin positions in a first pass before building the wire graph, then resolve nets in a second pass
- Add test for RC filter chain where pins connect to a bus wire (pin on wire interior scenario)
- Add test for pin whose coordinate lands on the interior of a long wire segment

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pins connected through filter networks resolve to correct net | Pass | New TestRCFilterChain tests verify R1/C1 pins on bus wire resolve to AUDIO_L |
| Pins on wire interior (not at endpoints) resolve correctly | Pass | TestPinOnWireInterior tests verify both pins on a long wire resolve to NET1 |
| Genuinely unconnected pins still report net=None | Pass | Existing TestResolvePinMap::test_unconnected_pin passes; new tests verify floating pins return None |
| Existing tests continue to pass | Pass | All 33 tests pass (31 existing + 4 new, minus 2 that were already there as TestWithFixture) |
| New test case for RC filter chain with label at one end | Pass | TestRCFilterChain::test_all_chain_pins_resolve added |

## Test Plan
- All 33 tests in `tests/test_sch_pin_map.py` pass
- New tests cover the specific scenarios from the issue: pin-to-pin connectivity through passive filter networks and pins on wire interiors

Closes #2098