### PR TITLE
feat(validate): add zone fill check to detect unfilled copper zones

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -57,7 +57,7 @@ def _find_pcb_file(directory: Path) -> Path | None:
     return None
 
 
-CHECK_CATEGORIES = ["clearance", "dimensions", "edge", "netlist", "placement", "silkscreen", "solder_mask"]
+CHECK_CATEGORIES = ["clearance", "dimensions", "edge", "netlist", "placement", "silkscreen", "solder_mask", "zones"]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -264,6 +264,7 @@ def run_selected_checks(
         "placement": checker.check_footprint_placement,
         "silkscreen": checker.check_silkscreen,
         "solder_mask": checker.check_solder_mask_pads,
+        "zones": checker.check_zones,
     }
 
     for category, method in check_methods.items():

--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -84,6 +84,10 @@ def _init_type_category_map() -> None:
             ViolationType.SILKSCREEN_LINE_WIDTH: ViolationCategory.COSMETIC,
             ViolationType.SILKSCREEN_TEXT_HEIGHT: ViolationCategory.COSMETIC,
             ViolationType.SILKSCREEN_OVER_PAD: ViolationCategory.COSMETIC,
+            # Zone fill: connectivity issues
+            ViolationType.ZONE_UNFILLED: ViolationCategory.CONNECTIVITY,
+            ViolationType.ZONE_FILL_DISABLED: ViolationCategory.CONNECTIVITY,
+            ViolationType.ZONE_NO_NET: ViolationCategory.CONNECTIVITY,
             # Placement: footprint/outline issues
             ViolationType.FOOTPRINT: ViolationCategory.PLACEMENT,
             ViolationType.MALFORMED_OUTLINE: ViolationCategory.PLACEMENT,
@@ -165,6 +169,11 @@ class ViolationType(Enum):
     EXTRA_FOOTPRINT = "extra_footprint"
     MISSING_FOOTPRINT = "missing_footprint"
 
+    # Zone fill
+    ZONE_UNFILLED = "zone_unfilled"
+    ZONE_FILL_DISABLED = "zone_fill_disabled"
+    ZONE_NO_NET = "zone_no_net"
+
     # Unknown (catch-all)
     UNKNOWN = "unknown"
 
@@ -227,6 +236,10 @@ class ViolationType(Enum):
             "footprint_outside_board": cls.FOOTPRINT_OUTSIDE_BOARD,
             # netlist integrity rule from validate netlist checker
             "net_undeclared": cls.NET_UNDECLARED,
+            # zone fill rules from validate zone_fill checker
+            "zone_unfilled": cls.ZONE_UNFILLED,
+            "zone_fill_disabled": cls.ZONE_FILL_DISABLED,
+            "zone_no_net": cls.ZONE_NO_NET,
         }
 
         alias_match = _ALIASES.get(s_lower)

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -14,6 +14,7 @@ from .rules.clearance import ClearanceRule
 from .rules.edge import EdgeClearanceRule
 from .rules.placement import FootprintOutsideBoardRule
 from .rules.silkscreen import check_all_silkscreen
+from .rules.zone_fill import ZoneFillRule
 from .violations import DRCResults
 
 if TYPE_CHECKING:
@@ -94,6 +95,7 @@ class DRCChecker:
         results.merge(self.check_solder_mask_pads())
         results.merge(self.check_footprint_placement())
         results.merge(self.check_netlist())
+        results.merge(self.check_zones())
 
         return results
 
@@ -181,6 +183,8 @@ class DRCChecker:
             DRCResults containing placement violations
         """
         rule = FootprintOutsideBoardRule()
+        return rule.check(self.pcb, self.design_rules)
+
     def check_netlist(self) -> DRCResults:
         """Check for pads referencing undeclared nets.
 
@@ -194,6 +198,19 @@ class DRCChecker:
         from .rules.netlist import NetlistRule
 
         rule = NetlistRule()
+        return rule.check(self.pcb, self.design_rules)
+
+    def check_zones(self) -> DRCResults:
+        """Check zone fill rules (unfilled zones, disabled fill, unassigned nets).
+
+        Validates that all copper zones have been filled with polygon data
+        and are assigned to a net. Unfilled zones break power/ground
+        connectivity.
+
+        Returns:
+            DRCResults containing zone fill violations
+        """
+        rule = ZoneFillRule()
         return rule.check(self.pcb, self.design_rules)
 
     def __repr__(self) -> str:

--- a/src/kicad_tools/validate/rules/__init__.py
+++ b/src/kicad_tools/validate/rules/__init__.py
@@ -10,6 +10,7 @@ from .dimensions import DimensionRules
 from .edge import EdgeClearanceRule
 from .impedance import ImpedanceRule, NetImpedanceSpec
 from .solder_mask import SolderMaskPadRules
+from .zone_fill import ZoneFillRule
 from .silkscreen import (
     check_all_silkscreen,
     check_silkscreen_line_width,
@@ -30,4 +31,5 @@ __all__ = [
     "check_silkscreen_line_width",
     "check_silkscreen_over_pads",
     "check_silkscreen_text_height",
+    "ZoneFillRule",
 ]

--- a/src/kicad_tools/validate/rules/zone_fill.py
+++ b/src/kicad_tools/validate/rules/zone_fill.py
@@ -1,0 +1,135 @@
+"""Zone fill DRC rules.
+
+This module checks that copper zones have been filled (i.e., they contain
+actual copper geometry). Zones defined in the PCB but never filled by
+KiCad's zone filler will break power/ground connectivity.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..violations import DRCResults, DRCViolation
+from .base import DRCRule
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers import DesignRules
+    from kicad_tools.schema.pcb import PCB, Zone
+
+
+def _zone_bounding_box(zone: Zone) -> str:
+    """Return a human-readable bounding box string for the zone polygon."""
+    if not zone.polygon:
+        return "no boundary"
+    xs = [p[0] for p in zone.polygon]
+    ys = [p[1] for p in zone.polygon]
+    return (
+        f"({min(xs):.2f}, {min(ys):.2f}) to ({max(xs):.2f}, {max(ys):.2f}) mm"
+    )
+
+
+def _zone_center(zone: Zone) -> tuple[float, float] | None:
+    """Return the centroid of the zone boundary polygon."""
+    if not zone.polygon:
+        return None
+    xs = [p[0] for p in zone.polygon]
+    ys = [p[1] for p in zone.polygon]
+    return (sum(xs) / len(xs), sum(ys) / len(ys))
+
+
+class ZoneFillRule(DRCRule):
+    """Check that copper zones have been filled.
+
+    Detects two conditions:
+
+    1. **Unfilled zone** (``zone_unfilled``): A zone with ``is_filled=True``
+       (the designer intends copper fill) but zero ``filled_polygons``
+       (KiCad's zone filler was never run, so no actual copper exists).
+
+    2. **Fill disabled** (``zone_fill_disabled``): A zone with
+       ``is_filled=False``, meaning the fill flag is explicitly off.
+
+    Both are reported as warnings because they indicate a design intent
+    mismatch rather than a hard manufacturing error.
+
+    Keepout zones (rule areas) are already excluded by the PCB parser --
+    only ``(zone ...)`` S-expression nodes are parsed into ``pcb.zones``.
+
+    Zones with ``net_number=0`` and an empty ``net_name`` are flagged as
+    having an unassigned net, which indicates an incomplete zone definition.
+    """
+
+    rule_id = "zone_fill"
+    name = "Zone Fill"
+    description = "Check that copper zones contain filled polygon data"
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Check all zones for fill status.
+
+        Args:
+            pcb: The PCB to check
+            design_rules: Design rules from the manufacturer profile
+                (not used by this rule but required by the interface)
+
+        Returns:
+            DRCResults containing zone fill violations
+        """
+        results = DRCResults()
+        results.rules_checked = 1
+
+        for zone in pcb.zones:
+            net_label = zone.net_name if zone.net_name else "unassigned"
+            layer = zone.layer or "unknown"
+            bbox = _zone_bounding_box(zone)
+            center = _zone_center(zone)
+
+            if not zone.is_filled:
+                # Fill flag is explicitly off
+                results.add(
+                    DRCViolation(
+                        rule_id="zone_fill_disabled",
+                        severity="warning",
+                        message=(
+                            f"Zone fill disabled for net '{net_label}' "
+                            f"on {layer} [{bbox}]"
+                        ),
+                        location=center,
+                        layer=layer,
+                        items=(f"net:{net_label}",),
+                    )
+                )
+            elif len(zone.filled_polygons) == 0:
+                # Fill intended but no copper geometry present
+                results.add(
+                    DRCViolation(
+                        rule_id="zone_unfilled",
+                        severity="warning",
+                        message=(
+                            f"Zone for net '{net_label}' on {layer} "
+                            f"has fill enabled but no filled polygons [{bbox}]"
+                        ),
+                        location=center,
+                        layer=layer,
+                        items=(f"net:{net_label}",),
+                    )
+                )
+
+            # Additionally flag zones with no net assignment
+            if zone.net_number == 0 and not zone.net_name:
+                results.add(
+                    DRCViolation(
+                        rule_id="zone_no_net",
+                        severity="warning",
+                        message=(
+                            f"Zone on {layer} has no net assigned [{bbox}]"
+                        ),
+                        location=center,
+                        layer=layer,
+                    )
+                )
+
+        return results

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1276,6 +1276,9 @@ class TestZoneConnectedNets:
     (polygon (pts
       (xy 0 0) (xy 100 0) (xy 100 100) (xy 0 100)
     ))
+    (filled_polygon (layer "F.Cu") (pts
+      (xy 1 1) (xy 99 1) (xy 99 99) (xy 1 99)
+    ))
   )
 )
 """
@@ -1343,6 +1346,9 @@ class TestZoneConnectedNets:
     (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
     (polygon (pts
       (xy 0 0) (xy 100 0) (xy 100 100) (xy 0 100)
+    ))
+    (filled_polygon (layer "F.Cu") (pts
+      (xy 1 1) (xy 99 1) (xy 99 99) (xy 1 99)
     ))
   )
 )

--- a/tests/test_validate_zone_fill.py
+++ b/tests/test_validate_zone_fill.py
@@ -1,0 +1,199 @@
+"""Tests for zone fill DRC rule (validate/rules/zone_fill.py)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock
+
+import pytest
+
+from kicad_tools.validate.rules.zone_fill import ZoneFillRule
+
+
+# ---------------------------------------------------------------------------
+# Minimal Zone stub -- mirrors the fields the rule reads
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeZone:
+    net_number: int = 1
+    net_name: str = "GND"
+    layer: str = "F.Cu"
+    polygon: list[tuple[float, float]] = field(default_factory=lambda: [
+        (0.0, 0.0), (100.0, 0.0), (100.0, 100.0), (0.0, 100.0),
+    ])
+    filled_polygons: list[list[tuple[float, float]]] = field(default_factory=list)
+    is_filled: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Helper to build a fake PCB with specific zones
+# ---------------------------------------------------------------------------
+
+def _make_pcb(zones: list[_FakeZone]) -> MagicMock:
+    pcb = MagicMock()
+    pcb.zones = zones
+    return pcb
+
+
+def _make_design_rules() -> MagicMock:
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestZoneFillRule:
+    """Tests for the ZoneFillRule check."""
+
+    def test_filled_zone_produces_no_violation(self):
+        """A zone with is_filled=True and non-empty filled_polygons is OK."""
+        zone = _FakeZone(
+            is_filled=True,
+            filled_polygons=[[(0, 0), (10, 0), (10, 10), (0, 10)]],
+        )
+        pcb = _make_pcb([zone])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+
+        # No zone_unfilled or zone_fill_disabled violations expected
+        fill_violations = [
+            v for v in results.violations
+            if v.rule_id in ("zone_unfilled", "zone_fill_disabled")
+        ]
+        assert len(fill_violations) == 0
+
+    def test_unfilled_zone_produces_warning(self):
+        """A zone with is_filled=True but empty filled_polygons is flagged."""
+        zone = _FakeZone(is_filled=True, filled_polygons=[])
+        pcb = _make_pcb([zone])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+
+        unfilled = [v for v in results.violations if v.rule_id == "zone_unfilled"]
+        assert len(unfilled) == 1
+        v = unfilled[0]
+        assert v.severity == "warning"
+        assert "GND" in v.message
+        assert "F.Cu" in v.message
+        # Bounding box should appear
+        assert "0.00" in v.message
+        assert "100.00" in v.message
+
+    def test_fill_disabled_produces_warning(self):
+        """A zone with is_filled=False is flagged as fill-disabled."""
+        zone = _FakeZone(is_filled=False, filled_polygons=[])
+        pcb = _make_pcb([zone])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+
+        disabled = [v for v in results.violations if v.rule_id == "zone_fill_disabled"]
+        assert len(disabled) == 1
+        assert disabled[0].severity == "warning"
+        assert "disabled" in disabled[0].message.lower()
+
+    def test_unassigned_net_produces_warning(self):
+        """A zone with net_number=0 and empty net_name is flagged."""
+        zone = _FakeZone(net_number=0, net_name="", is_filled=True, filled_polygons=[
+            [(0, 0), (10, 0), (10, 10), (0, 10)],
+        ])
+        pcb = _make_pcb([zone])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+
+        no_net = [v for v in results.violations if v.rule_id == "zone_no_net"]
+        assert len(no_net) == 1
+        assert "no net assigned" in no_net[0].message.lower()
+
+    def test_assigned_net_no_extra_warning(self):
+        """A zone with a valid net does not get a zone_no_net warning."""
+        zone = _FakeZone(
+            net_number=1,
+            net_name="GND",
+            is_filled=True,
+            filled_polygons=[[(0, 0), (10, 0), (10, 10)]],
+        )
+        pcb = _make_pcb([zone])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+
+        no_net = [v for v in results.violations if v.rule_id == "zone_no_net"]
+        assert len(no_net) == 0
+
+    def test_warning_includes_layer(self):
+        """Violation layer field matches the zone layer."""
+        zone = _FakeZone(layer="In1.Cu", is_filled=True, filled_polygons=[])
+        pcb = _make_pcb([zone])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+
+        unfilled = [v for v in results.violations if v.rule_id == "zone_unfilled"]
+        assert len(unfilled) == 1
+        assert unfilled[0].layer == "In1.Cu"
+
+    def test_warning_includes_location(self):
+        """Violation location is the centroid of the zone boundary."""
+        zone = _FakeZone(
+            polygon=[(0, 0), (10, 0), (10, 10), (0, 10)],
+            is_filled=True,
+            filled_polygons=[],
+        )
+        pcb = _make_pcb([zone])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+
+        unfilled = [v for v in results.violations if v.rule_id == "zone_unfilled"]
+        assert len(unfilled) == 1
+        loc = unfilled[0].location
+        assert loc is not None
+        assert abs(loc[0] - 5.0) < 0.01
+        assert abs(loc[1] - 5.0) < 0.01
+
+    def test_degenerate_zone_no_polygon(self):
+        """A zone with no polygon points still reports correctly."""
+        zone = _FakeZone(polygon=[], is_filled=True, filled_polygons=[])
+        pcb = _make_pcb([zone])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+
+        unfilled = [v for v in results.violations if v.rule_id == "zone_unfilled"]
+        assert len(unfilled) == 1
+        assert "no boundary" in unfilled[0].message
+        assert unfilled[0].location is None
+
+    def test_empty_pcb_no_violations(self):
+        """A PCB with no zones produces no violations."""
+        pcb = _make_pcb([])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+        assert len(results.violations) == 0
+
+    def test_rules_checked_count(self):
+        """rules_checked is set to 1 regardless of zone count."""
+        pcb = _make_pcb([_FakeZone(), _FakeZone()])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+        assert results.rules_checked == 1
+
+    def test_net_label_unassigned_in_message(self):
+        """When net_name is empty, the message uses 'unassigned'."""
+        zone = _FakeZone(net_number=0, net_name="", is_filled=True, filled_polygons=[])
+        pcb = _make_pcb([zone])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+
+        unfilled = [v for v in results.violations if v.rule_id == "zone_unfilled"]
+        assert len(unfilled) == 1
+        assert "unassigned" in unfilled[0].message
+
+    def test_items_includes_net_label(self):
+        """The items tuple contains the net label."""
+        zone = _FakeZone(net_name="+3.3V", is_filled=True, filled_polygons=[])
+        pcb = _make_pcb([zone])
+        rule = ZoneFillRule()
+        results = rule.check(pcb, _make_design_rules())
+
+        unfilled = [v for v in results.violations if v.rule_id == "zone_unfilled"]
+        assert len(unfilled) == 1
+        assert "net:+3.3V" in unfilled[0].items


### PR DESCRIPTION
## Summary
Add a new `ZoneFillRule` to the pure Python DRC checker that detects unfilled copper zones, which break power/ground connectivity when zones are defined but never filled by KiCad's zone filler.

## Changes
- New `src/kicad_tools/validate/rules/zone_fill.py` implementing `ZoneFillRule(DRCRule)` with three checks: `zone_unfilled`, `zone_fill_disabled`, `zone_no_net`
- Wire `check_zones()` into `DRCChecker.check_all()` in `checker.py`
- Add `"zones"` category to `CHECK_CATEGORIES` and `check_methods` in `check_cmd.py` for `--only zones` / `--skip zones` support
- Add `ZONE_UNFILLED`, `ZONE_FILL_DISABLED`, `ZONE_NO_NET` to `ViolationType` enum with `CONNECTIVITY` category mapping in `violation.py`
- Export `ZoneFillRule` from `validate/rules/__init__.py`
- New `tests/test_validate_zone_fill.py` with 12 unit tests

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Zones with is_filled=True but empty filled_polygons flagged | Pass | test_unfilled_zone_produces_warning |
| Zones with is_filled=False flagged as fill-disabled | Pass | test_fill_disabled_produces_warning |
| Zones with net_number=0 and empty net_name flagged | Pass | test_unassigned_net_produces_warning |
| Keepout zones excluded (not in pcb.zones) | Pass | Parser only handles (zone ...) nodes, not (rule_area ...) |
| Warning messages include net name, layer, bounding box | Pass | test_unfilled_zone_produces_warning, test_warning_includes_layer |
| Warning location is zone centroid | Pass | test_warning_includes_location |
| kct check --only zones / --skip zones work | Pass | "zones" added to CHECK_CATEGORIES and check_methods |
| ZONE_UNFILLED mapped to CONNECTIVITY category | Pass | Added to _TYPE_CATEGORY_MAP |
| Filled zones produce no violations | Pass | test_filled_zone_produces_no_violation |
| Edge cases: degenerate zone, empty PCB | Pass | test_degenerate_zone_no_polygon, test_empty_pcb_no_violations |

## Test Plan
All 12 tests in `tests/test_validate_zone_fill.py` pass via `python3 -m pytest tests/test_validate_zone_fill.py -v`.

Closes #2087