### PR TITLE
fix(schema): emit instances block for symbols placed by add-bypass-cap and add-pull-resistor

### DIFF
--- a/src/kicad_tools/cli/sch_add_bypass_cap.py
+++ b/src/kicad_tools/cli/sch_add_bypass_cap.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import Schematic
+from kicad_tools.schema.instances import build_instance_path, find_project_name
 from kicad_tools.schema.library import LibrarySymbol
 
 
@@ -429,6 +430,11 @@ def run_add_bypass_cap(args) -> int:
         gnd_lib_sym = _make_default_gnd_lib_sym(args.ground_net)
         sch.embed_lib_symbol(gnd_lib_sym)
 
+    # 1b. Derive project name and instance path for the instances block
+    project_name = find_project_name(schematic_path)
+    sch_uuid = sch.uuid or ""
+    instance_path = build_instance_path(schematic_path, sch_uuid) if sch_uuid else ""
+
     # 2. Place the capacitor
     sch.add_symbol(
         lib_id=cap_lib_id,
@@ -437,10 +443,17 @@ def run_add_bypass_cap(args) -> int:
         footprint=args.footprint,
         position=cap_pos,
         rotation=cap_rotation,
+        project_name=project_name,
+        instance_path=instance_path,
     )
 
     # 3. Place the ground symbol
-    sch.add_power(args.ground_net, gnd_pos)
+    sch.add_power(
+        args.ground_net,
+        gnd_pos,
+        project_name=project_name,
+        instance_path=instance_path,
+    )
 
     # 4. Add wires
     # Wire from target pin to near (VDD) cap pin

--- a/src/kicad_tools/cli/sch_add_component.py
+++ b/src/kicad_tools/cli/sch_add_component.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import LibraryManager, Schematic
+from kicad_tools.schema.instances import build_instance_path, find_project_name
 from kicad_tools.schema.library import LibrarySymbol
 
 
@@ -272,68 +273,10 @@ def _validate_wire_endpoints(
                 )
 
 
-def _find_project_name(schematic_path: Path) -> str:
-    """Derive the project name from the nearest .kicad_pro file.
-
-    Walks up from *schematic_path* looking for a ``.kicad_pro`` file.
-    Falls back to the schematic stem if none is found.
-    """
-    directory = schematic_path.resolve().parent
-    for parent in [directory, *directory.parents]:
-        pro_files = list(parent.glob("*.kicad_pro"))
-        if pro_files:
-            return pro_files[0].stem
-    return schematic_path.stem
-
-
-def _build_instance_path(schematic_path: Path, sch_uuid: str) -> str:
-    """Build the hierarchical instance path for a symbol.
-
-    For a root schematic, returns ``/<sch_uuid>``.
-    For a sub-sheet, walks up the hierarchy from the project root to build
-    ``/<root_uuid>/<sheet_uuid>/...``.
-    """
-    from kicad_tools.schema.hierarchy import build_hierarchy
-
-    resolved = schematic_path.resolve()
-    directory = resolved.parent
-
-    # Find the project root schematic (same stem as .kicad_pro, or look
-    # for the .kicad_pro file and derive the root schematic from it).
-    root_sch_path: Path | None = None
-    for parent in [directory, *directory.parents]:
-        pro_files = list(parent.glob("*.kicad_pro"))
-        if pro_files:
-            candidate = pro_files[0].with_suffix(".kicad_sch")
-            if candidate.exists():
-                root_sch_path = candidate
-            break
-
-    # If no .kicad_pro found, assume the schematic *is* the root
-    if root_sch_path is None or root_sch_path.resolve() == resolved:
-        return f"/{sch_uuid}"
-
-    # Build hierarchy from root and find the node matching our schematic
-    try:
-        root_node = build_hierarchy(str(root_sch_path))
-    except Exception:
-        # If hierarchy building fails, fall back to simple root path
-        return f"/{sch_uuid}"
-
-    # Walk the hierarchy to find the node whose path matches our file
-    for node in root_node.all_nodes():
-        if Path(node.path).resolve() == resolved:
-            # Build the UUID path from root to this node
-            parts: list[str] = []
-            current: object = node
-            while current is not None:
-                parts.append(current.uuid)  # type: ignore[union-attr]
-                current = current.parent  # type: ignore[union-attr]
-            parts.reverse()
-            return "/" + "/".join(parts)
-
-    # Fallback: treat as root
-    return f"/{sch_uuid}"
+# Backward-compatible aliases -- the canonical implementations now live in
+# kicad_tools.schema.instances and are imported at the top of this module.
+_find_project_name = find_project_name
+_build_instance_path = build_instance_path
 
 
 def run_add_component(args) -> int:
@@ -572,7 +515,13 @@ def run_add_component(args) -> int:
     # 3. Place the symbol
     if is_power:
         power_name = args.lib_id.split(":", 1)[1]
-        sym_instance = sch.add_power(power_name, position, rotation)
+        sym_instance = sch.add_power(
+            power_name,
+            position,
+            rotation,
+            project_name=project_name,
+            instance_path=instance_path,
+        )
     else:
         sym_instance = sch.add_symbol(
             lib_id=args.lib_id,

--- a/src/kicad_tools/cli/sch_add_pull_resistor.py
+++ b/src/kicad_tools/cli/sch_add_pull_resistor.py
@@ -40,6 +40,7 @@ from pathlib import Path
 
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import LibraryManager, Schematic
+from kicad_tools.schema.instances import build_instance_path, find_project_name
 from kicad_tools.schema.wire import Wire
 
 
@@ -659,6 +660,11 @@ def run_add_pull_resistor(args) -> int:
             power_lib_sym.name = power_lib_id
         sch.embed_lib_symbol(power_lib_sym)
 
+    # 1b. Derive project name and instance path for the instances block
+    project_name = find_project_name(schematic_path)
+    sch_uuid = sch.uuid or ""
+    instance_path = build_instance_path(schematic_path, sch_uuid) if sch_uuid else ""
+
     # 2. Place the resistor
     sch.add_symbol(
         lib_id=resistor_lib_id,
@@ -667,10 +673,18 @@ def run_add_pull_resistor(args) -> int:
         footprint=footprint,
         position=res_position,
         rotation=res_rotation,
+        project_name=project_name,
+        instance_path=instance_path,
     )
 
     # 3. Place the power/ground symbol
-    sch.add_power(power_net, power_position, power_rotation)
+    sch.add_power(
+        power_net,
+        power_position,
+        power_rotation,
+        project_name=project_name,
+        instance_path=instance_path,
+    )
 
     # 4. Add wires
     for seg_start, seg_end in wire_segments:

--- a/src/kicad_tools/schema/instances.py
+++ b/src/kicad_tools/schema/instances.py
@@ -1,0 +1,75 @@
+"""Shared helpers for deriving project instance metadata.
+
+The ``(instances ...)`` block inside a KiCad symbol S-expression ties a
+placed symbol to a project and a hierarchy path.  These two functions --
+:func:`find_project_name` and :func:`build_instance_path` -- are used by
+every ``sch add-*`` command that places symbols.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def find_project_name(schematic_path: Path) -> str:
+    """Derive the project name from the nearest ``.kicad_pro`` file.
+
+    Walks up from *schematic_path* looking for a ``.kicad_pro`` file.
+    Falls back to the schematic stem if none is found.
+    """
+    directory = schematic_path.resolve().parent
+    for parent in [directory, *directory.parents]:
+        pro_files = list(parent.glob("*.kicad_pro"))
+        if pro_files:
+            return pro_files[0].stem
+    return schematic_path.stem
+
+
+def build_instance_path(schematic_path: Path, sch_uuid: str) -> str:
+    """Build the hierarchical instance path for a symbol.
+
+    For a root schematic, returns ``/<sch_uuid>``.
+    For a sub-sheet, walks up the hierarchy from the project root to build
+    ``/<root_uuid>/<sheet_uuid>/...``.
+    """
+    from kicad_tools.schema.hierarchy import build_hierarchy
+
+    resolved = schematic_path.resolve()
+    directory = resolved.parent
+
+    # Find the project root schematic (same stem as .kicad_pro, or look
+    # for the .kicad_pro file and derive the root schematic from it).
+    root_sch_path: Path | None = None
+    for parent in [directory, *directory.parents]:
+        pro_files = list(parent.glob("*.kicad_pro"))
+        if pro_files:
+            candidate = pro_files[0].with_suffix(".kicad_sch")
+            if candidate.exists():
+                root_sch_path = candidate
+            break
+
+    # If no .kicad_pro found, assume the schematic *is* the root
+    if root_sch_path is None or root_sch_path.resolve() == resolved:
+        return f"/{sch_uuid}"
+
+    # Build hierarchy from root and find the node matching our schematic
+    try:
+        root_node = build_hierarchy(str(root_sch_path))
+    except Exception:
+        # If hierarchy building fails, fall back to simple root path
+        return f"/{sch_uuid}"
+
+    # Walk the hierarchy to find the node whose path matches our file
+    for node in root_node.all_nodes():
+        if Path(node.path).resolve() == resolved:
+            # Build the UUID path from root to this node
+            parts: list[str] = []
+            current: object = node
+            while current is not None:
+                parts.append(current.uuid)  # type: ignore[union-attr]
+                current = current.parent  # type: ignore[union-attr]
+            parts.reverse()
+            return "/" + "/".join(parts)
+
+    # Fallback: treat as root
+    return f"/{sch_uuid}"

--- a/src/kicad_tools/schema/schematic.py
+++ b/src/kicad_tools/schema/schematic.py
@@ -425,6 +425,8 @@ class Schematic:
         name: str,
         position: tuple[float, float],
         rotation: float = 0,
+        project_name: str = "",
+        instance_path: str = "",
     ) -> SymbolInstance:
         """Add a power symbol (e.g. GND, +3V3).
 
@@ -435,6 +437,9 @@ class Schematic:
             name: Power symbol name (e.g. ``"GND"``, ``"+3V3"``).
             position: ``(x, y)`` placement.
             rotation: Rotation in degrees (default 0).
+            project_name: Optional project name for ``(instances)`` block.
+            instance_path: Optional hierarchy path for the ``(instances)``
+                block.
 
         Returns:
             The created :class:`SymbolInstance`.
@@ -497,6 +502,8 @@ class Schematic:
             dnp=False,
             properties=props,
             pins=pins,
+            project_name=project_name,
+            instance_path=instance_path,
         )
 
         idx = self._find_insertion_index()

--- a/tests/test_sch_add_bypass_cap.py
+++ b/tests/test_sch_add_bypass_cap.py
@@ -645,3 +645,103 @@ class TestErrors:
             "--pin", "4",
         ])
         assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# Instances block verification
+# ---------------------------------------------------------------------------
+
+
+class TestInstancesBlock:
+    """Verify that placed symbols include the (instances ...) S-expression."""
+
+    def test_capacitor_has_instances_block(self, tmp_path: Path):
+        """The capacitor placed by add-bypass-cap must have an instances block."""
+        sch_path = _write_sch(tmp_path)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "4",
+            "--value", "100nF",
+            "--ground-net", "GND",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        # Find the newly placed capacitor (C6, auto-assigned after C5)
+        cap_sym = None
+        for s in sch.symbols:
+            if s.reference == "C6":
+                cap_sym = s
+                break
+        assert cap_sym is not None, "Expected C6 to be placed"
+        assert cap_sym.project_name, "Capacitor must have project_name set"
+        assert cap_sym.instance_path, "Capacitor must have instance_path set"
+        assert cap_sym.instance_path.startswith("/")
+
+        # Verify the raw file contains the instances block for the cap
+        content = sch_path.read_text()
+        assert "(instances" in content
+        assert "(project" in content
+
+    def test_ground_symbol_has_instances_block(self, tmp_path: Path):
+        """The ground power symbol placed by add-bypass-cap must have an instances block."""
+        sch_path = _write_sch(tmp_path)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "4",
+            "--value", "100nF",
+            "--ground-net", "GND",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        # Find the newly placed GND power symbol
+        gnd_syms = [s for s in sch.symbols if s.lib_id == "power:GND"]
+        assert len(gnd_syms) >= 1
+        gnd_sym = gnd_syms[0]
+        assert gnd_sym.project_name, "Ground symbol must have project_name set"
+        assert gnd_sym.instance_path, "Ground symbol must have instance_path set"
+        assert gnd_sym.instance_path.startswith("/")
+
+    def test_instances_use_schematic_stem_as_project(self, tmp_path: Path):
+        """Without .kicad_pro, project name should be the schematic stem."""
+        sch_path = _write_sch(tmp_path)
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "4",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        cap_sym = None
+        for s in sch.symbols:
+            if s.reference == "C6":
+                cap_sym = s
+                break
+        assert cap_sym is not None
+        assert cap_sym.project_name == "test_bypass"
+
+    def test_instances_use_kicad_pro_name(self, tmp_path: Path):
+        """With a .kicad_pro file, project name comes from it."""
+        sch_path = _write_sch(tmp_path)
+        pro_path = tmp_path / "my-board.kicad_pro"
+        pro_path.write_text("{}")
+
+        result = add_bypass_main([
+            str(sch_path),
+            "--ref", "U1",
+            "--pin", "4",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        cap_sym = None
+        for s in sch.symbols:
+            if s.reference == "C6":
+                cap_sym = s
+                break
+        assert cap_sym is not None
+        assert cap_sym.project_name == "my-board"

--- a/tests/test_sch_add_pull_resistor.py
+++ b/tests/test_sch_add_pull_resistor.py
@@ -896,3 +896,98 @@ class TestLShapedReroute:
         # Straight route: 1 IC-to-R wire + 1 R-to-power wire = 2
         # (one may be zero-length and skipped)
         assert len(sch.wires) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Instances block verification
+# ---------------------------------------------------------------------------
+
+
+class TestInstancesBlock:
+    """Verify that placed symbols include the (instances ...) S-expression."""
+
+    def test_resistor_has_instances_block(self, tmp_path):
+        """The resistor placed by add-pull-resistor must have an instances block."""
+        sch_path = _write_sch(tmp_path)
+
+        rc = add_pull_main(
+            [
+                str(sch_path),
+                "--ref", "U1",
+                "--pin", "3",
+                "--direction", "up",
+                "--value", "10k",
+            ]
+        )
+        assert rc == 0
+
+        sch = Schematic.load(sch_path)
+        r_syms = [s for s in sch.symbols if s.lib_id == "Device:R"]
+        assert len(r_syms) == 1
+        r_sym = r_syms[0]
+        assert r_sym.project_name, "Resistor must have project_name set"
+        assert r_sym.instance_path, "Resistor must have instance_path set"
+        assert r_sym.instance_path.startswith("/")
+
+    def test_power_symbol_has_instances_block(self, tmp_path):
+        """The power symbol placed by add-pull-resistor must have an instances block."""
+        sch_path = _write_sch(tmp_path)
+
+        rc = add_pull_main(
+            [
+                str(sch_path),
+                "--ref", "U1",
+                "--pin", "3",
+                "--direction", "up",
+                "--value", "10k",
+            ]
+        )
+        assert rc == 0
+
+        sch = Schematic.load(sch_path)
+        power_syms = [s for s in sch.symbols if s.lib_id.startswith("power:")]
+        assert len(power_syms) >= 1
+        pwr_sym = power_syms[0]
+        assert pwr_sym.project_name, "Power symbol must have project_name set"
+        assert pwr_sym.instance_path, "Power symbol must have instance_path set"
+        assert pwr_sym.instance_path.startswith("/")
+
+    def test_instances_use_schematic_stem(self, tmp_path):
+        """Without .kicad_pro, project name should be the schematic stem."""
+        sch_path = _write_sch(tmp_path)
+
+        rc = add_pull_main(
+            [
+                str(sch_path),
+                "--ref", "U1",
+                "--pin", "3",
+                "--direction", "up",
+                "--value", "10k",
+            ]
+        )
+        assert rc == 0
+
+        sch = Schematic.load(sch_path)
+        r_syms = [s for s in sch.symbols if s.lib_id == "Device:R"]
+        assert len(r_syms) == 1
+        assert r_syms[0].project_name == "test_pull"
+
+    def test_instances_reference_and_unit_in_file(self, tmp_path):
+        """The instances block in the raw file must include reference and unit."""
+        sch_path = _write_sch(tmp_path)
+
+        rc = add_pull_main(
+            [
+                str(sch_path),
+                "--ref", "U1",
+                "--pin", "3",
+                "--direction", "up",
+                "--value", "10k",
+                "--reference", "R42",
+            ]
+        )
+        assert rc == 0
+
+        content = sch_path.read_text()
+        assert '(reference "R42")' in content
+        assert "(unit 1)" in content


### PR DESCRIPTION
## Summary
Composite commands `add-bypass-cap` and `add-pull-resistor` were placing symbols without the `(instances ...)` S-expression block, causing `sch validate` to emit `project_instances` warnings. This PR extracts the project/instance helpers into a shared module and wires them into all symbol-placement paths, including power symbols via `Schematic.add_power()`.

## Changes
- Created `src/kicad_tools/schema/instances.py` with shared `find_project_name()` and `build_instance_path()` helpers (extracted from `sch_add_component.py`)
- Extended `Schematic.add_power()` to accept optional `project_name` and `instance_path` parameters
- Updated `sch_add_bypass_cap.py` to derive and pass project/instance info to both `add_symbol()` and `add_power()`
- Updated `sch_add_pull_resistor.py` to derive and pass project/instance info to both `add_symbol()` and `add_power()`
- Updated `sch_add_component.py` to import from shared module (backward-compatible aliases kept)
- Added 4 new tests in `test_sch_add_bypass_cap.py` verifying instances block on capacitor and ground symbols
- Added 4 new tests in `test_sch_add_pull_resistor.py` verifying instances block on resistor and power symbols

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| add-bypass-cap generates instances block for capacitor symbol | Pass | test_capacitor_has_instances_block |
| add-bypass-cap generates instances block for ground power symbol | Pass | test_ground_symbol_has_instances_block |
| add-pull-resistor generates instances block for resistor symbol | Pass | test_resistor_has_instances_block |
| add-pull-resistor generates instances block for power/ground symbol | Pass | test_power_symbol_has_instances_block |
| Schematic.add_power() accepts and forwards project_name/instance_path | Pass | Used by both commands; verified through integration tests |
| _find_project_name and _build_instance_path are shared (not duplicated) | Pass | Extracted to schema/instances.py, imported by all three command files |
| Existing add-component tests still pass | Pass | 113 pre-existing tests pass (1 pre-existing failure unrelated to this PR) |

## Test Plan
- 121 tests pass (113 existing + 8 new), 1 deselected (pre-existing failure in `test_add_wire_zero_length_rejected`)
- New tests verify instances block presence, project name derivation from schematic stem and .kicad_pro, and reference/unit fields in raw output

Closes #2093