### PR TITLE
feat(sch-validate): add SWD debug pin routing check for STM32 MCUs

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -1707,6 +1707,184 @@ def _detect_systematic_offset(
 
 
 # ---------------------------------------------------------------------------
+# SWD debug pin routing check
+# ---------------------------------------------------------------------------
+
+# Known SWD/JTAG dedicated pins on STM32 MCUs.
+# Maps alternate-function pin name -> expected net keyword.
+_ARM_DEBUG_PINS: dict[str, str] = {
+    "PA13": "SWDIO",
+    "PA14": "SWCLK",
+    # Extended JTAG pins on STM32F4/F7/H7 families:
+    "PA15": "JTDI",
+    "PB3": "JTDO",
+    "PB4": "JTRST",
+}
+
+# The core SWD pair that is universal across all STM32 families.
+_SWD_CORE_PINS: frozenset[str] = frozenset({"PA13", "PA14"})
+
+
+def _is_stm32_mcu(lib_id: str) -> bool:
+    """Return True if *lib_id* identifies an STM32 MCU symbol."""
+    # KiCad standard library uses "MCU_ST_STM32*" or "MCU_ST:STM32*".
+    # Normalise to uppercase for comparison.
+    upper = lib_id.upper()
+    # Match both "MCU_ST:STM32..." and "MCU_ST_STM32..." prefixes.
+    if "MCU_ST" in upper and "STM32" in upper:
+        return True
+    # Also accept lib_id that starts directly with "STM32" (custom libs).
+    if upper.startswith("STM32"):
+        return True
+    return False
+
+
+def _swd_net_ok(net_name: str, expected_keyword: str) -> bool:
+    """Return True if *net_name* is a valid SWD/JTAG net for *expected_keyword*.
+
+    Matches if:
+    - Any token in the net name equals the expected keyword (e.g. "SWDIO")
+    - The net name contains "SWD" and the keyword starts with "SWD"
+    - The net name contains "JTAG" or "JT" and the keyword starts with "JT"
+    """
+    tokens = _tokenize_name(net_name)
+    if expected_keyword in tokens:
+        return True
+    # Accept broader SWD/JTAG net names (e.g. "SWD_IO", "JTAG_TDI")
+    if expected_keyword.startswith("SWD") and "SWD" in tokens:
+        return True
+    if expected_keyword.startswith("JT") and ("JTAG" in tokens or "JT" in tokens):
+        return True
+    # Accept "SWDIO" inside a compound name like "MCU_SWDIO"
+    upper = net_name.upper()
+    if expected_keyword in upper:
+        return True
+    return False
+
+
+def _swd_override_present(net_name: str) -> bool:
+    """Return True if the net name indicates explicit GPIO reuse."""
+    tokens = _tokenize_name(net_name)
+    if "GPIO" in tokens:
+        return True
+    # Also match "GPIO13" etc. where the tokenizer keeps it as one token.
+    return any(t.startswith("GPIO") for t in tokens)
+
+
+def check_swd_pin_routing(schematic_path: str) -> list[ValidationIssue]:
+    """Check that SWD debug pins on STM32 MCUs are routed to SWD nets.
+
+    For each STM32 MCU symbol (identified by ``lib_id``), resolves pin-to-net
+    assignments via ``resolve_pin_map``.  For each known SWD debug pin
+    (PA13 = SWDIO, PA14 = SWCLK), verifies that the connected net name
+    contains the expected SWD keyword.
+
+    Unconnected SWD pins emit a warning (debug port unusable).  Mis-routed
+    SWD pins (connected to a non-SWD net) emit an error.
+
+    The check is suppressed for a pin when the net name contains "GPIO"
+    (explicit reuse acknowledgment).
+    """
+    issues: list[ValidationIssue] = []
+
+    try:
+        from kicad_tools.cli.sch_pin_map import resolve_pin_map
+
+        hierarchy = build_hierarchy(schematic_path)
+
+        for node in hierarchy.all_nodes():
+            try:
+                sch = Schematic.load(node.path)
+                pin_map = resolve_pin_map(sch)
+                sheet_path = node.get_path_string()
+
+                for ref, entry in pin_map.items():
+                    lib_id: str = entry.get("lib_id", "")
+
+                    if not _is_stm32_mcu(lib_id):
+                        continue
+
+                    pins_data: dict[str, dict] = entry.get("pins", {})
+
+                    # Build pin_name -> (pin_num, pin_info) lookup
+                    name_to_pin: dict[str, tuple[str, dict]] = {}
+                    for pin_num, pin_info in pins_data.items():
+                        pname = pin_info.get("name", "")
+                        if pname:
+                            name_to_pin[pname.upper()] = (pin_num, pin_info)
+
+                    for debug_pin, expected_kw in _ARM_DEBUG_PINS.items():
+                        pin_entry = name_to_pin.get(debug_pin.upper())
+                        if pin_entry is None:
+                            # Pin not present on this MCU variant -- skip
+                            continue
+
+                        _pin_num, pin_info = pin_entry
+                        net_name = pin_info.get("net")
+
+                        if net_name is None:
+                            # Only warn about unconnected *core* SWD pins
+                            # (PA13/PA14).  Extended JTAG pins (PA15, PB3,
+                            # PB4) are commonly left unconnected in
+                            # SWD-only designs.
+                            if debug_pin.upper() not in _SWD_CORE_PINS:
+                                continue
+                            issues.append(
+                                ValidationIssue(
+                                    severity="warning",
+                                    category="swd_routing",
+                                    message=(
+                                        f"{ref}: SWD pin {debug_pin} is "
+                                        f"unconnected (expected {expected_kw} "
+                                        f"net) -- debug port unusable"
+                                    ),
+                                    location=sheet_path,
+                                )
+                            )
+                            continue
+
+                        # Check for explicit GPIO override
+                        if _swd_override_present(net_name):
+                            continue
+
+                        # Verify net matches expected SWD keyword
+                        if not _swd_net_ok(net_name, expected_kw):
+                            issues.append(
+                                ValidationIssue(
+                                    severity="error",
+                                    category="swd_routing",
+                                    message=(
+                                        f"{ref}: SWD pin {debug_pin} "
+                                        f"connected to net '{net_name}' "
+                                        f"(expected {expected_kw})"
+                                    ),
+                                    location=sheet_path,
+                                )
+                            )
+
+            except Exception as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="swd_routing",
+                        message=f"Skipped sheet {sheet_path}: {e}",
+                        location=sheet_path,
+                    )
+                )
+
+    except Exception as e:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                category="swd_routing",
+                message=f"SWD pin routing check failed: {e}",
+            )
+        )
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
 # Power net short detection (VCC-to-GND)
 # ---------------------------------------------------------------------------
 
@@ -2341,77 +2519,84 @@ def check_symbol_footprint_pin_mismatch(schematic_path: str) -> list[ValidationI
     return issues
 
 
-def validate_schematic(schematic_path: str, lib_paths: list[str] = None) -> ValidationResult:
-    """Run all validation checks."""
+def validate_schematic(
+    schematic_path: str,
+    lib_paths: list[str] = None,
+    skip_checks: set[str] | None = None,
+) -> ValidationResult:
+    """Run all validation checks.
+
+    Args:
+        schematic_path: Path to the root ``.kicad_sch`` file.
+        lib_paths: Optional symbol library paths.
+        skip_checks: Set of check category names to skip (e.g.
+            ``{"swd_routing", "i2c_pullups"}``).
+    """
     result = ValidationResult(schematic=schematic_path)
+    _skip: set[str] = skip_checks or set()
+
+    def _run(category: str, fn):
+        if category in _skip:
+            return
+        result.checks_run.append(category)
+        result.issues.extend(fn(schematic_path))
 
     # ERC
-    result.checks_run.append("erc")
-    result.issues.extend(run_erc(schematic_path))
+    _run("erc", run_erc)
 
     # Missing footprints
-    result.checks_run.append("footprints")
-    result.issues.extend(check_missing_footprints(schematic_path))
+    _run("footprints", check_missing_footprints)
 
     # Missing values
-    result.checks_run.append("values")
-    result.issues.extend(check_missing_values(schematic_path))
+    _run("values", check_missing_values)
 
     # Hierarchy
-    result.checks_run.append("hierarchy")
-    result.issues.extend(check_hierarchy(schematic_path))
+    _run("hierarchy", check_hierarchy)
 
     # No-connect on input pins
-    result.checks_run.append("no_connect_input")
-    result.issues.extend(check_no_connect_on_input_pins(schematic_path))
+    _run("no_connect_input", check_no_connect_on_input_pins)
 
     # Global label directions
-    result.checks_run.append("global_label_directions")
-    result.issues.extend(check_global_label_directions(schematic_path))
+    _run("global_label_directions", check_global_label_directions)
 
     # Connector pinout verification
-    result.checks_run.append("connector_pinout")
-    result.issues.extend(check_connector_pinout(schematic_path))
+    _run("connector_pinout", check_connector_pinout)
 
     # Missing project instances
-    result.checks_run.append("project_instances")
-    result.issues.extend(check_missing_project_instances(schematic_path))
+    _run("project_instances", check_missing_project_instances)
 
     # Duplicate references across sheets
-    result.checks_run.append("duplicate_references")
-    result.issues.extend(check_duplicate_references(schematic_path))
+    _run("duplicate_references", check_duplicate_references)
 
     # Pin-net semantic mismatch (pin assignment audit)
-    result.checks_run.append("pin_assignment")
-    result.issues.extend(check_pin_net_semantic_mismatch(schematic_path))
+    _run("pin_assignment", check_pin_net_semantic_mismatch)
+
+    # SWD debug pin routing verification
+    _run("swd_routing", check_swd_pin_routing)
 
     # Power net short detection (VCC-to-GND)
-    result.checks_run.append("power_short")
-    result.issues.extend(check_power_net_shorts(schematic_path))
+    _run("power_short", check_power_net_shorts)
 
     # Power pin polarity error detection (VDD on GND net, etc.)
-    result.checks_run.append("power_polarity")
-    result.issues.extend(check_power_pin_polarity(schematic_path))
+    _run("power_polarity", check_power_pin_polarity)
 
     # I2C pull-up resistor detection
-    result.checks_run.append("i2c_pullups")
-    result.issues.extend(check_i2c_pullups(schematic_path))
+    _run("i2c_pullups", check_i2c_pullups)
 
     # BOOT0 pull-down resistor detection (STM32 MCUs)
-    result.checks_run.append("boot0_pulldown")
-    result.issues.extend(check_boot0_pulldown(schematic_path))
+    _run("boot0_pulldown", check_boot0_pulldown)
 
     # Fully unconnected component detection
-    result.checks_run.append("unconnected_component")
-    result.issues.extend(check_fully_unconnected_components(schematic_path))
+    _run("unconnected_component", check_fully_unconnected_components)
 
     # STM32 NRST filter capacitor detection
-    result.checks_run.append("nrst_filter")
-    result.issues.extend(check_nrst_filter_cap(schematic_path))
+    _run("nrst_filter", check_nrst_filter_cap)
 
     # Symbol-to-footprint pin/pad count mismatch
-    result.checks_run.append("symbol_footprint_pin_count")
-    result.issues.extend(check_symbol_footprint_pin_mismatch(schematic_path))
+    _run("symbol_footprint_pin_count", check_symbol_footprint_pin_mismatch)
+
+    # Matched channel symmetry detection
+    _run("matched_channel_symmetry", check_matched_channel_symmetry)
 
     return result
 
@@ -2429,6 +2614,13 @@ def main(argv=None):
     )
     parser.add_argument("--strict", action="store_true", help="Exit with error on any warning")
     parser.add_argument("--quiet", "-q", action="store_true", help="Only show errors")
+    parser.add_argument(
+        "--skip",
+        action="append",
+        dest="skip_checks",
+        metavar="CHECK",
+        help="Skip a validation check category (e.g. swd_routing, i2c_pullups). May be repeated.",
+    )
 
     args = parser.parse_args(argv)
 
@@ -2436,7 +2628,8 @@ def main(argv=None):
         print(f"Error: File not found: {args.schematic}", file=sys.stderr)
         sys.exit(1)
 
-    result = validate_schematic(args.schematic, args.lib_paths)
+    skip_set: set[str] = set(args.skip_checks) if args.skip_checks else set()
+    result = validate_schematic(args.schematic, args.lib_paths, skip_checks=skip_set)
 
     if args.format == "json":
         print(

--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -1867,8 +1867,8 @@ def check_swd_pin_routing(schematic_path: str) -> list[ValidationIssue]:
                     ValidationIssue(
                         severity="info",
                         category="swd_routing",
-                        message=f"Skipped sheet {sheet_path}: {e}",
-                        location=sheet_path,
+                        message=f"Skipped sheet {node.get_path_string()}: {e}",
+                        location=node.get_path_string(),
                     )
                 )
 
@@ -2594,9 +2594,6 @@ def validate_schematic(
 
     # Symbol-to-footprint pin/pad count mismatch
     _run("symbol_footprint_pin_count", check_symbol_footprint_pin_mismatch)
-
-    # Matched channel symmetry detection
-    _run("matched_channel_symmetry", check_matched_channel_symmetry)
 
     return result
 

--- a/tests/test_sch_validate_swd_routing.py
+++ b/tests/test_sch_validate_swd_routing.py
@@ -1,0 +1,423 @@
+"""Tests for SWD debug pin routing detection on STM32 MCUs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_validate import (
+    ValidationIssue,
+    _is_stm32_mcu,
+    _swd_net_ok,
+    _swd_override_present,
+    _tokenize_name,
+    check_swd_pin_routing,
+    validate_schematic,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to generate synthetic KiCad schematics
+# ---------------------------------------------------------------------------
+
+
+def _make_ic_lib_symbol(
+    lib_id: str,
+    pins: list[tuple[str, str, str]],
+) -> str:
+    """Generate a lib_symbols entry for an IC.
+
+    Args:
+        lib_id: e.g. "MCU_ST:STM32C011F6"
+        pins: list of (pin_number, pin_name, pin_type) tuples
+    """
+    part_name = lib_id.split(":")[-1] if ":" in lib_id else lib_id
+    pin_blocks = []
+    for i, (num, name, ptype) in enumerate(pins):
+        y = i * 2.54
+        pin_blocks.append(
+            f"""(pin {ptype} line
+                    (at 0 {y:.2f} 0)
+                    (length 2.54)
+                    (name "{name}")
+                    (number "{num}")
+                )"""
+        )
+    pin_str = "\n".join(pin_blocks)
+    return f"""(symbol "{lib_id}"
+            (pin_names (offset 0.254))
+            (symbol "{part_name}_0_1"
+                (rectangle
+                    (start -5.08 -{(len(pins) * 2.54) + 1.27:.2f})
+                    (end 5.08 1.27)
+                    (stroke (width 0.254))
+                    (fill (type background))
+                )
+            )
+            (symbol "{part_name}_1_1"
+                {pin_str}
+            )
+        )"""
+
+
+def _make_symbol_instance(
+    ref: str, lib_id: str, pins: list[tuple[str, str, str]], x: float, y: float,
+) -> str:
+    """Generate a symbol instance S-expression."""
+    pin_entries = "\n".join(
+        f'(pin "{num}" (uuid "pin-{ref.lower()}-{num}"))' for num, _, _ in pins
+    )
+    return f"""(symbol
+        (lib_id "{lib_id}")
+        (at {x} {y} 0)
+        (unit 1)
+        (in_bom yes)
+        (on_board yes)
+        (dnp no)
+        (uuid "uuid-{ref.lower()}")
+        (property "Reference" "{ref}"
+            (at {x + 2} {y - 2} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Value" "{lib_id.split(':')[-1]}"
+            (at {x + 2} {y} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Footprint" ""
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        (property "Datasheet" "~"
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        {pin_entries}
+    )"""
+
+
+def _make_schematic(
+    lib_id: str,
+    pins: list[tuple[str, str, str]],
+    pin_nets: dict[str, str],
+    ref: str = "U1",
+) -> str:
+    """Build a complete schematic with one IC and wired labels.
+
+    Args:
+        lib_id: Library ID for the symbol.
+        pins: List of (pin_number, pin_name, pin_type).
+        pin_nets: Mapping of pin_number -> net_name for connected pins.
+        ref: Reference designator.
+    """
+    lib_sym = _make_ic_lib_symbol(lib_id, pins)
+    sym_x, sym_y = 100.0, 50.0
+    sym_inst = _make_symbol_instance(ref, lib_id, pins, sym_x, sym_y)
+
+    wires = []
+    labels = []
+    for pin_idx, (pin_num, _, _) in enumerate(pins):
+        if pin_num not in pin_nets:
+            continue
+        net_name = pin_nets[pin_num]
+        pin_y = sym_y - pin_idx * 2.54
+        pin_x = sym_x
+        label_x = pin_x + 10.0
+
+        wires.append(
+            f"""(wire
+            (pts (xy {pin_x:.2f} {pin_y:.2f}) (xy {label_x:.2f} {pin_y:.2f}))
+            (stroke (width 0) (type default))
+            (uuid "wire-{ref.lower()}-{pin_num}")
+        )"""
+        )
+
+        labels.append(
+            f"""(label "{net_name}"
+            (at {label_x:.2f} {pin_y:.2f} 0)
+            (effects (font (size 1.27 1.27)) (justify left bottom))
+            (uuid "lbl-{ref.lower()}-{pin_num}")
+        )"""
+        )
+
+    wire_block = "\n".join(wires)
+    label_block = "\n".join(labels)
+
+    return f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "test-swd-routing-uuid")
+    (paper "A4")
+    (lib_symbols
+        {lib_sym}
+    )
+    {sym_inst}
+    {wire_block}
+    {label_block}
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# STM32 MCU pin definitions used across tests
+# ---------------------------------------------------------------------------
+
+_STM32_PINS = [
+    ("1", "VDD", "power_in"),
+    ("2", "VSS", "power_in"),
+    ("3", "PA0", "bidirectional"),
+    ("4", "PA13", "bidirectional"),
+    ("5", "PA14", "bidirectional"),
+    ("6", "PA15", "bidirectional"),
+    ("7", "PB3", "bidirectional"),
+    ("8", "PB4", "bidirectional"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests -- pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsStm32Mcu:
+    def test_standard_lib_id(self):
+        assert _is_stm32_mcu("MCU_ST:STM32C011F6") is True
+
+    def test_underscore_lib_id(self):
+        assert _is_stm32_mcu("MCU_ST_STM32:STM32F401RET6") is True
+
+    def test_custom_lib_starting_with_stm32(self):
+        assert _is_stm32_mcu("STM32G071RB") is True
+
+    def test_non_stm32(self):
+        assert _is_stm32_mcu("MCU_Microchip:ATSAMD21G18A") is False
+
+    def test_audio_codec(self):
+        assert _is_stm32_mcu("Audio_Codec:PCM5122") is False
+
+
+class TestSwdNetOk:
+    def test_exact_match_swdio(self):
+        assert _swd_net_ok("SWDIO", "SWDIO") is True
+
+    def test_prefixed_swdio(self):
+        assert _swd_net_ok("MCU_SWDIO", "SWDIO") is True
+
+    def test_underscore_separated(self):
+        assert _swd_net_ok("SWD_IO", "SWDIO") is True
+
+    def test_swclk_match(self):
+        assert _swd_net_ok("SWCLK", "SWCLK") is True
+
+    def test_jtdi_match(self):
+        assert _swd_net_ok("JTAG_TDI", "JTDI") is True  # "JTAG" token matches JT* prefix
+        assert _swd_net_ok("JTDI", "JTDI") is True
+
+    def test_mismatch(self):
+        assert _swd_net_ok("I2S_SYNC", "SWDIO") is False
+
+    def test_spi_sck_not_swclk(self):
+        assert _swd_net_ok("SPI_SCK", "SWCLK") is False
+
+
+class TestSwdOverridePresent:
+    def test_gpio_in_name(self):
+        assert _swd_override_present("GPIO_DEBUG") is True
+
+    def test_no_gpio(self):
+        assert _swd_override_present("I2S_SYNC") is False
+
+    def test_gpio_prefix(self):
+        assert _swd_override_present("GPIO13") is True
+
+
+# ---------------------------------------------------------------------------
+# Integration tests with synthetic schematics
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSwdPinRouting:
+    """Test check_swd_pin_routing against synthetic schematics."""
+
+    def test_correct_swd_wiring_no_issues(self, tmp_path: Path):
+        """STM32 with PA13->SWDIO and PA14->SWCLK produces no issues."""
+        pin_nets = {
+            "1": "+3V3",
+            "2": "GND",
+            "4": "SWDIO",
+            "5": "SWCLK",
+        }
+        sch_text = _make_schematic("MCU_ST:STM32C011F6", _STM32_PINS, pin_nets)
+        sch_path = tmp_path / "correct_swd.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_swd_pin_routing(str(sch_path))
+        swd_issues = [i for i in issues if i.category == "swd_routing"]
+        assert swd_issues == [], f"Unexpected issues: {swd_issues}"
+
+    def test_pa13_connected_to_i2s_sync_error(self, tmp_path: Path):
+        """PA13 connected to I2S_SYNC should flag an error."""
+        pin_nets = {
+            "1": "+3V3",
+            "2": "GND",
+            "4": "I2S_SYNC",
+            "5": "SWCLK",
+        }
+        sch_text = _make_schematic("MCU_ST:STM32C011F6", _STM32_PINS, pin_nets)
+        sch_path = tmp_path / "bad_pa13.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_swd_pin_routing(str(sch_path))
+        swd_errors = [i for i in issues if i.category == "swd_routing" and i.severity == "error"]
+        assert len(swd_errors) >= 1
+        assert "PA13" in swd_errors[0].message
+        assert "I2S_SYNC" in swd_errors[0].message
+
+    def test_pa14_connected_to_spi_sck_error(self, tmp_path: Path):
+        """PA14 connected to SPI_SCK should flag an error."""
+        pin_nets = {
+            "1": "+3V3",
+            "2": "GND",
+            "4": "SWDIO",
+            "5": "SPI_SCK",
+        }
+        sch_text = _make_schematic("MCU_ST:STM32C011F6", _STM32_PINS, pin_nets)
+        sch_path = tmp_path / "bad_pa14.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_swd_pin_routing(str(sch_path))
+        swd_errors = [i for i in issues if i.category == "swd_routing" and i.severity == "error"]
+        assert len(swd_errors) >= 1
+        assert "PA14" in swd_errors[0].message
+        assert "SPI_SCK" in swd_errors[0].message
+
+    def test_pa14_correct_no_error(self, tmp_path: Path):
+        """PA14 connected to SWCLK should produce no error."""
+        pin_nets = {
+            "1": "+3V3",
+            "2": "GND",
+            "4": "SWDIO",
+            "5": "SWCLK",
+        }
+        sch_text = _make_schematic("MCU_ST:STM32C011F6", _STM32_PINS, pin_nets)
+        sch_path = tmp_path / "correct_pa14.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_swd_pin_routing(str(sch_path))
+        swd_errors = [i for i in issues if i.category == "swd_routing" and i.severity == "error"]
+        assert swd_errors == []
+
+    def test_gpio_override_suppresses_error(self, tmp_path: Path):
+        """PA13 connected to GPIO_DEBUG should NOT flag an error."""
+        pin_nets = {
+            "1": "+3V3",
+            "2": "GND",
+            "4": "GPIO_DEBUG",
+            "5": "SWCLK",
+        }
+        sch_text = _make_schematic("MCU_ST:STM32C011F6", _STM32_PINS, pin_nets)
+        sch_path = tmp_path / "gpio_override.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_swd_pin_routing(str(sch_path))
+        swd_issues = [i for i in issues if i.category == "swd_routing"]
+        # PA13 is suppressed by GPIO, so no error for it
+        pa13_issues = [i for i in swd_issues if "PA13" in i.message]
+        assert pa13_issues == [], f"PA13 should be suppressed: {pa13_issues}"
+
+    def test_non_stm32_skipped(self, tmp_path: Path):
+        """MCU with non-STM32 lib_id should not trigger SWD check."""
+        pins = [
+            ("1", "VDD", "power_in"),
+            ("2", "VSS", "power_in"),
+            ("3", "PA13", "bidirectional"),
+            ("4", "PA14", "bidirectional"),
+        ]
+        pin_nets = {
+            "1": "+3V3",
+            "2": "GND",
+            "3": "SOME_SIGNAL",
+            "4": "OTHER_SIGNAL",
+        }
+        sch_text = _make_schematic("MCU_Microchip:ATSAMD21G18A", pins, pin_nets)
+        sch_path = tmp_path / "non_stm32.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_swd_pin_routing(str(sch_path))
+        swd_issues = [i for i in issues if i.category == "swd_routing"]
+        assert swd_issues == [], f"Non-STM32 should produce no SWD issues: {swd_issues}"
+
+    def test_unconnected_swd_pins_warning(self, tmp_path: Path):
+        """Unconnected PA13/PA14 should emit warnings."""
+        pin_nets = {
+            "1": "+3V3",
+            "2": "GND",
+            # PA13 (pin 4) and PA14 (pin 5) not connected
+        }
+        sch_text = _make_schematic("MCU_ST:STM32C011F6", _STM32_PINS, pin_nets)
+        sch_path = tmp_path / "unconnected_swd.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_swd_pin_routing(str(sch_path))
+        swd_warnings = [
+            i for i in issues
+            if i.category == "swd_routing" and i.severity == "warning"
+        ]
+        # Should warn about both PA13 and PA14
+        warning_pins = {i.message for i in swd_warnings}
+        pa13_warned = any("PA13" in m for m in warning_pins)
+        pa14_warned = any("PA14" in m for m in warning_pins)
+        assert pa13_warned, "Expected warning for unconnected PA13"
+        assert pa14_warned, "Expected warning for unconnected PA14"
+
+    def test_stm32f4_lib_id_detected(self, tmp_path: Path):
+        """STM32F4 family lib_id is detected as STM32."""
+        pin_nets = {
+            "1": "+3V3",
+            "2": "GND",
+            "4": "I2S_SYNC",  # Wrong net for PA13
+            "5": "SWCLK",
+        }
+        sch_text = _make_schematic("MCU_ST:STM32F401RET6", _STM32_PINS, pin_nets)
+        sch_path = tmp_path / "stm32f4.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_swd_pin_routing(str(sch_path))
+        swd_errors = [i for i in issues if i.category == "swd_routing" and i.severity == "error"]
+        assert len(swd_errors) >= 1, "STM32F4 should be detected and checked"
+
+
+class TestSkipFlag:
+    """Test the --skip CLI flag integration."""
+
+    def test_skip_swd_routing(self, tmp_path: Path):
+        """validate_schematic with skip_checks={'swd_routing'} skips the check."""
+        pin_nets = {
+            "1": "+3V3",
+            "2": "GND",
+            "4": "I2S_SYNC",  # Wrong -- would normally error
+            "5": "SPI_SCK",   # Wrong -- would normally error
+        }
+        sch_text = _make_schematic("MCU_ST:STM32C011F6", _STM32_PINS, pin_nets)
+        sch_path = tmp_path / "skip_test.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        result = validate_schematic(str(sch_path), skip_checks={"swd_routing"})
+        assert "swd_routing" not in result.checks_run
+        swd_issues = [i for i in result.issues if i.category == "swd_routing"]
+        assert swd_issues == []
+
+    def test_no_skip_runs_swd_routing(self, tmp_path: Path):
+        """validate_schematic without skip runs swd_routing check."""
+        pin_nets = {
+            "1": "+3V3",
+            "2": "GND",
+            "4": "SWDIO",
+            "5": "SWCLK",
+        }
+        sch_text = _make_schematic("MCU_ST:STM32C011F6", _STM32_PINS, pin_nets)
+        sch_path = tmp_path / "no_skip.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        result = validate_schematic(str(sch_path))
+        assert "swd_routing" in result.checks_run


### PR DESCRIPTION
## Summary
Add a new `check_swd_pin_routing()` validation check that detects SWD debug pin routing errors on STM32 MCUs. Also adds `--skip` CLI flag to allow skipping individual check categories.

## Changes
- Add `check_swd_pin_routing()` function that verifies PA13 (SWDIO) and PA14 (SWCLK) are routed to correct SWD nets on STM32 MCUs
- Add `_ARM_DEBUG_PINS` table mapping PA13/PA14/PA15/PB3/PB4 to expected SWD/JTAG keywords
- Add `_is_stm32_mcu()` helper for lib_id prefix matching (MCU_ST:STM32*, etc.)
- Add `_swd_net_ok()` for flexible net name matching (tokenized and substring)
- Add `_swd_override_present()` for GPIO reuse suppression
- Register `swd_routing` check in `validate_schematic()` between `pin_assignment` and `power_short`
- Add `--skip` CLI argument (repeatable) to skip any check category by name
- Refactor `validate_schematic()` to accept `skip_checks` parameter
- Add 25 tests in `tests/test_sch_validate_swd_routing.py` covering unit and integration scenarios

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| sch validate flags PA13 not on SWDIO/SWD net | PASS | test_pa13_connected_to_i2s_sync_error |
| sch validate flags PA14 not on SWCLK/SWD net | PASS | test_pa14_connected_to_spi_sck_error |
| Works for common STM32 families via lib_id prefix | PASS | test_stm32f4_lib_id_detected, TestIsStm32Mcu |
| Suppressible via --skip swd_routing | PASS | test_skip_swd_routing |
| Registered as category swd_routing | PASS | test_no_skip_runs_swd_routing |
| No false positives on non-STM32 MCUs | PASS | test_non_stm32_skipped |
| Unconnected PA13/PA14 emit warning | PASS | test_unconnected_swd_pins_warning |

## Test Plan
All 25 new tests pass. All 29 existing pin audit tests pass with no regressions.

```
tests/test_sch_validate_swd_routing.py: 25 passed
tests/test_sch_validate_pin_audit.py: 29 passed
```

Closes #2089