### PR TITLE
fix(schema): use paren-balanced block finding in find_symbol_text_range

### DIFF
--- a/src/kicad_tools/cli/modify_schematic.py
+++ b/src/kicad_tools/cli/modify_schematic.py
@@ -44,27 +44,81 @@ def generate_uuid() -> str:
 # Text-based modification functions (preserve original formatting)
 
 
+def _find_matching_close_paren(text: str, open_pos: int) -> int:
+    """
+    Find the position of the closing paren that matches the open paren at open_pos.
+
+    Uses paren-balanced counting to handle arbitrary nesting.
+    Returns the index of the matching ')' character.
+    Raises ValueError if no matching paren is found.
+    """
+    depth = 0
+    in_string = False
+    i = open_pos
+    while i < len(text):
+        ch = text[i]
+        if in_string:
+            if ch == "\\" and i + 1 < len(text):
+                i += 2  # skip escaped character
+                continue
+            if ch == '"':
+                in_string = False
+        else:
+            if ch == '"':
+                in_string = True
+            elif ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    return i
+        i += 1
+    raise ValueError(f"No matching close paren found starting at position {open_pos}")
+
+
 def find_symbol_text_range(text: str, reference: str) -> tuple[int, int, dict] | None:
     """
     Find the text range of a symbol instance by reference.
 
+    Uses paren-balanced block finding to correctly identify symbol boundaries
+    regardless of whether an (instances ...) block is present.
+
     Returns (start, end, info) or None if not found.
     """
-    # Pattern to match symbol blocks with the given reference
-    # We need to find (symbol ... (property "Reference" "U1" ...) ...)
+    # Find the end of (lib_symbols ...) so we skip library symbol definitions
+    lib_symbols_end = 0
+    lib_sym_match = re.search(r"\(lib_symbols\b", text)
+    if lib_sym_match:
+        try:
+            lib_symbols_end = _find_matching_close_paren(text, lib_sym_match.start()) + 1
+        except ValueError:
+            pass
 
-    # First find all symbol instance blocks (not lib_symbols)
-    symbol_pattern = re.compile(
-        r"\n(\s+\(symbol\n"
-        r'\s+\(lib_id "[^"]+"\)'
-        r".*?"
-        r"\s+\(instances\n.*?\s+\)\n"
-        r"\s+\))",
-        re.DOTALL,
-    )
+    # Find each top-level (symbol ...) block after lib_symbols using paren balancing
+    symbol_start_pattern = re.compile(r"\n(\s+)\(symbol\n")
 
-    for match in symbol_pattern.finditer(text):
-        block = match.group(1)
+    pos = lib_symbols_end
+    while pos < len(text):
+        m = symbol_start_pattern.search(text, pos)
+        if not m:
+            break
+
+        # The opening paren of (symbol ...)
+        block_open = text.index("(symbol", m.start())
+
+        try:
+            block_close = _find_matching_close_paren(text, block_open)
+        except ValueError:
+            pos = m.end()
+            continue
+
+        block = text[block_open : block_close + 1]
+
+        # Skip blocks without lib_id (these are not placed symbol instances)
+        if '(lib_id "' not in block:
+            pos = block_close + 1
+            continue
+
         # Check if this block has the reference we want
         ref_pattern = re.compile(r'\(property "Reference" "' + re.escape(reference) + r'"')
         if ref_pattern.search(block):
@@ -72,9 +126,7 @@ def find_symbol_text_range(text: str, reference: str) -> tuple[int, int, dict] |
             lib_id_match = re.search(r'\(lib_id "([^"]+)"\)', block)
             pos_match = re.search(r"\(at ([\d.]+) ([\d.]+)", block)
             uuid_match = re.search(r'\(uuid "([^"]+)"\)', block)
-            # Value property spans multiple lines - just capture the quoted value
             value_match = re.search(r'\(property "Value" "([^"]*)"', block)
-
             footprint_match = re.search(r'\(property "Footprint" "([^"]*)"', block)
 
             info = {
@@ -87,7 +139,14 @@ def find_symbol_text_range(text: str, reference: str) -> tuple[int, int, dict] |
                 "footprint": footprint_match.group(1) if footprint_match else "",
             }
 
-            return (match.start(), match.end(), info)
+            # Return range including the preceding newline for consistency
+            # with callers that expect the block to start at a newline boundary
+            newline_pos = text.rfind("\n", 0, block_open)
+            if newline_pos == -1:
+                newline_pos = block_open
+            return (newline_pos, block_close + 1, info)
+
+        pos = block_close + 1
 
     return None
 

--- a/tests/test_sch_set_value.py
+++ b/tests/test_sch_set_value.py
@@ -9,7 +9,14 @@ from pathlib import Path
 
 import pytest
 
-from kicad_tools.cli.modify_schematic import find_symbol_text_range, set_value_text
+from kicad_tools.cli.modify_schematic import (
+    delete_symbol_text,
+    find_symbol_text_range,
+    regen_uuids_text,
+    set_footprint_text,
+    set_lib_id_text,
+    set_value_text,
+)
 from kicad_tools.cli.sch_set_value import run_set_value
 
 # ---------------------------------------------------------------------------
@@ -539,3 +546,266 @@ class TestHierarchicalSchematic:
         # Should still succeed (partial match) but return 0 because some changed
         assert ret == 0
         assert '"Value" "4.7k"' in parent.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Regression: symbols without (instances ...) block (#2100)
+# ---------------------------------------------------------------------------
+
+# C18 lacks an (instances ...) block; C21 has one.
+# The old regex would span from C18 through C21, causing set-value on C21
+# to incorrectly modify C18's value.
+MULTI_SYMBOL_NO_INSTANCES = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:C")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "C18"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "100nF"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" "Capacitor_SMD:C_0402_1005Metric"
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+\t)
+\t(symbol
+\t\t(lib_id "Device:C")
+\t\t(at 120 50 0)
+\t\t(property "Reference" "C21"
+\t\t\t(at 120 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "1uF"
+\t\t\t(at 120 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" "Capacitor_SMD:C_0603_1608Metric"
+\t\t\t(at 120 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+\t\t(instances
+\t\t\t(project "test"
+\t\t\t\t(path "/" (reference "C21") (unit 1))
+\t\t\t)
+\t\t)
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+# Both symbols lack (instances ...) blocks
+MULTI_SYMBOL_BOTH_NO_INSTANCES = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R5"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "cccccccc-cccc-cccc-cccc-cccccccccccc")
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 120 50 0)
+\t\t(property "Reference" "R6"
+\t\t\t(at 120 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "4.7k"
+\t\t\t(at 120 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
+\t\t\t(at 120 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "dddddddd-dddd-dddd-dddd-dddddddddddd")
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+
+
+class TestNoInstancesBlock:
+    """Regression tests for issue #2100: symbols without (instances ...) block."""
+
+    def test_find_symbol_without_instances(self):
+        """find_symbol_text_range locates C18 which has no instances block."""
+        result = find_symbol_text_range(MULTI_SYMBOL_NO_INSTANCES, "C18")
+        assert result is not None
+        _, _, info = result
+        assert info["lib_id"] == "Device:C"
+        assert info["value"] == "100nF"
+        assert info["uuid"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+    def test_find_symbol_with_instances(self):
+        """find_symbol_text_range locates C21 which has an instances block."""
+        result = find_symbol_text_range(MULTI_SYMBOL_NO_INSTANCES, "C21")
+        assert result is not None
+        _, _, info = result
+        assert info["lib_id"] == "Device:C"
+        assert info["value"] == "1uF"
+        assert info["uuid"] == "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+    def test_set_value_targets_correct_symbol(self):
+        """set_value_text on C21 must not modify C18 (the bug in #2100)."""
+        result, success, msg = set_value_text(MULTI_SYMBOL_NO_INSTANCES, "C21", "2.2uF")
+        assert success is True
+        assert "Changed C21 value" in msg
+        # C21 should have the new value
+        c21 = find_symbol_text_range(result, "C21")
+        assert c21 is not None
+        assert c21[2]["value"] == "2.2uF"
+        # C18 must be unchanged
+        c18 = find_symbol_text_range(result, "C18")
+        assert c18 is not None
+        assert c18[2]["value"] == "100nF"
+
+    def test_set_value_on_symbol_without_instances(self):
+        """set_value_text on C18 (no instances block) works correctly."""
+        result, success, msg = set_value_text(MULTI_SYMBOL_NO_INSTANCES, "C18", "220nF")
+        assert success is True
+        assert "Changed C18 value" in msg
+        c18 = find_symbol_text_range(result, "C18")
+        assert c18 is not None
+        assert c18[2]["value"] == "220nF"
+        # C21 must be unchanged
+        c21 = find_symbol_text_range(result, "C21")
+        assert c21 is not None
+        assert c21[2]["value"] == "1uF"
+
+    def test_set_footprint_targets_correct_symbol(self):
+        """set_footprint_text on C21 must not modify C18."""
+        new_fp = "Capacitor_SMD:C_0805_2012Metric"
+        result, success, _ = set_footprint_text(MULTI_SYMBOL_NO_INSTANCES, "C21", new_fp)
+        assert success is True
+        c21 = find_symbol_text_range(result, "C21")
+        assert c21 is not None
+        assert c21[2]["footprint"] == new_fp
+        c18 = find_symbol_text_range(result, "C18")
+        assert c18 is not None
+        assert c18[2]["footprint"] == "Capacitor_SMD:C_0402_1005Metric"
+
+    def test_set_lib_id_targets_correct_symbol(self):
+        """set_lib_id_text on C21 must not modify C18."""
+        result, success, _ = set_lib_id_text(MULTI_SYMBOL_NO_INSTANCES, "C21", "Device:C_Polarized")
+        assert success is True
+        c21 = find_symbol_text_range(result, "C21")
+        assert c21 is not None
+        assert c21[2]["lib_id"] == "Device:C_Polarized"
+        c18 = find_symbol_text_range(result, "C18")
+        assert c18 is not None
+        assert c18[2]["lib_id"] == "Device:C"
+
+    def test_delete_targets_correct_symbol(self):
+        """delete_symbol_text on C21 must not delete C18."""
+        result, success, _ = delete_symbol_text(MULTI_SYMBOL_NO_INSTANCES, "C21")
+        assert success is True
+        # C18 must still be present
+        c18 = find_symbol_text_range(result, "C18")
+        assert c18 is not None
+        assert c18[2]["value"] == "100nF"
+        # C21 must be gone
+        assert find_symbol_text_range(result, "C21") is None
+
+    def test_regen_uuids_targets_correct_symbol(self):
+        """regen_uuids_text on C21 must not change C18 UUIDs."""
+        result, success, _ = regen_uuids_text(MULTI_SYMBOL_NO_INSTANCES, "C21")
+        assert success is True
+        # C18 UUID must be unchanged
+        c18 = find_symbol_text_range(result, "C18")
+        assert c18 is not None
+        assert c18[2]["uuid"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        # C21 UUID must be different
+        c21 = find_symbol_text_range(result, "C21")
+        assert c21 is not None
+        assert c21[2]["uuid"] != "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+    def test_both_symbols_without_instances(self):
+        """Operations work when both symbols lack instances blocks."""
+        result, success, _ = set_value_text(MULTI_SYMBOL_BOTH_NO_INSTANCES, "R6", "100k")
+        assert success is True
+        r6 = find_symbol_text_range(result, "R6")
+        assert r6 is not None
+        assert r6[2]["value"] == "100k"
+        r5 = find_symbol_text_range(result, "R5")
+        assert r5 is not None
+        assert r5[2]["value"] == "10k"
+
+    def test_single_symbol_without_instances(self):
+        """A schematic with a single symbol lacking instances still works."""
+        single = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R1"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "10k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Footprint" ""
+\t\t\t(at 100 54 0)
+\t\t\t(effects (font (size 1.27 1.27)) (hide yes))
+\t\t)
+\t\t(uuid "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+\t)
+\t(sheet_instances
+\t\t(path "/" (page "1"))
+\t)
+)
+"""
+        result = find_symbol_text_range(single, "R1")
+        assert result is not None
+        _, _, info = result
+        assert info["value"] == "10k"
+        # set-value should also work
+        modified, success, _ = set_value_text(single, "R1", "22k")
+        assert success is True
+        r1 = find_symbol_text_range(modified, "R1")
+        assert r1 is not None
+        assert r1[2]["value"] == "22k"


### PR DESCRIPTION
## Summary
Replace the regex-based symbol block finder in `find_symbol_text_range()` with paren-balanced counting so symbol boundaries are correctly identified regardless of whether an `(instances ...)` block is present.

## Changes
- Added `_find_matching_close_paren()` helper that walks text counting open/close parens (handling strings and escapes) to find the matching close paren for any open paren
- Rewrote `find_symbol_text_range()` to use paren-balanced block finding instead of a regex that required `(instances ...)` inside every symbol
- The new implementation skips `(lib_symbols ...)` by finding its balanced end, then iterates over `(symbol ...)` blocks using paren counting to correctly delimit each block
- Added 10 regression tests covering: finding symbols with/without instances, all five affected operations (set-value, set-footprint, set-lib-id, delete, regen-uuids), both-missing-instances case, and single-symbol-without-instances edge case

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| fix find_symbol_text_range to use paren-balanced matching | Done | Implemented `_find_matching_close_paren()` and rewrote finder |
| Correctly identifies symbol boundaries without (instances ...) | Done | Tests verify C18 (no instances) and C21 (with instances) are found independently |
| set-value on C21 does not modify C18 | Done | `test_set_value_targets_correct_symbol` verifies this exact scenario |
| All five text-based operations tested | Done | Tests for set-value, set-footprint, set-lib-id, delete, regen-uuids |
| Existing tests still pass | Done | All 53 pre-existing tests pass, plus 10 new ones (63 total) |

## Test Plan
- Ran `python3 -m pytest tests/test_sch_set_value.py tests/test_sch_set_footprint.py -v` -- all 63 tests pass

Closes #2100