### PR TITLE
fix(sch): create junction when power symbol pin lands on wire midpoint

### DIFF
--- a/src/kicad_tools/cli/sch_add_component.py
+++ b/src/kicad_tools/cli/sch_add_component.py
@@ -441,16 +441,23 @@ def run_add_component(args) -> int:
             # _snap() again can shift to the wrong grid point.
             pin_pos = _round_pos(pin_pos)
 
-            planned.append(
-                PlannedAction(
-                    "wire",
-                    f"Wire from pin {cs.pin_number} at"
-                    f" ({pin_pos[0]:.2f}, {pin_pos[1]:.2f})"
-                    f" to ({cs.target[0]:.2f}, {cs.target[1]:.2f})",
+            # Only plan a wire when start != end (mirrors execution phase).
+            if not (
+                abs(pin_pos[0] - cs.target[0]) < 0.01
+                and abs(pin_pos[1] - cs.target[1]) < 0.01
+            ):
+                planned.append(
+                    PlannedAction(
+                        "wire",
+                        f"Wire from pin {cs.pin_number} at"
+                        f" ({pin_pos[0]:.2f}, {pin_pos[1]:.2f})"
+                        f" to ({cs.target[0]:.2f}, {cs.target[1]:.2f})",
+                    )
                 )
-            )
 
-            # Check if target intersects existing wires (endpoint or midpoint)
+            # Check if target intersects existing wires (endpoint or midpoint).
+            # This must run even when no wire is planned -- a symbol pin
+            # landing on a wire midpoint still needs a junction.
             for wire in sch.wires:
                 if _point_on_wire_segment(cs.target, wire.start, wire.end):
                     planned.append(
@@ -548,16 +555,18 @@ def run_add_component(args) -> int:
 
             pin_pos = _round_pos(pin_pos)
 
-            # Skip duplicate: don't add a wire if start == end
-            if (
+            # Add wire unless start == end (e.g. power symbol pin
+            # already sits on the connect target).
+            if not (
                 abs(pin_pos[0] - cs.target[0]) < 0.01
                 and abs(pin_pos[1] - cs.target[1]) < 0.01
             ):
-                continue
+                sch.add_wire(pin_pos, cs.target)
 
-            sch.add_wire(pin_pos, cs.target)
-
-            # Add junction if target intersects a pre-existing wire segment
+            # Add junction if target intersects a pre-existing wire
+            # segment.  This must run even when no wire was added --
+            # the symbol pin still meets the existing wire and KiCad
+            # requires a junction at wire midpoints.
             for wire in sch.wires[:pre_existing_wire_count]:
                 if _point_on_wire_segment(cs.target, wire.start, wire.end):
                     sch.add_junction(cs.target)

--- a/tests/test_sch_add_component.py
+++ b/tests/test_sch_add_component.py
@@ -282,6 +282,43 @@ class TestConnect:
         # Let's just verify the command succeeded and a wire was added.
         assert len(sch.wires) >= 2
 
+    def test_power_symbol_on_wire_midpoint_creates_junction(self, tmp_path: Path):
+        """When a power symbol's pin lands directly on a wire midpoint
+        (pin_pos == connect target), a junction must still be created
+        even though no wire is added.  Regression test for #2119."""
+        # Use grid-aligned coordinates (multiples of 1.27) so that
+        # _snap() doesn't shift the placement away from the target.
+        # Wire from (100.33, 49.53) to (149.86, 49.53) -- y=49.53 is
+        # 39*1.27.  Midpoint x=124.46 is 98*1.27.
+        sch_content = SCHEMATIC_WITH_LIB.replace(
+            "(wire (pts (xy 100 50) (xy 150 50))",
+            "(wire (pts (xy 100.33 49.53) (xy 149.86 49.53))",
+        )
+        sch_path = _write_sch(tmp_path, content=sch_content)
+        # Place GND at (124.46, 49.53).  GND pin "1" is at offset (0,0),
+        # so pin_pos == target == (124.46, 49.53).  No wire needed but a
+        # junction IS required because the target is a wire midpoint.
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "power:GND",
+            "--at", "124.46", "49.53",
+            "--connect", "1:124.46,49.53",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        # No new wire should be added (only the original wire remains).
+        assert len(sch.wires) == 1
+        # A junction must exist at the midpoint.
+        assert len(sch.junctions) >= 1
+        jx = [j for j in sch.junctions
+              if abs(j.position[0] - 124.46) < 0.2
+              and abs(j.position[1] - 49.53) < 0.2]
+        assert len(jx) == 1, (
+            f"Expected exactly one junction near (124.46, 49.53), "
+            f"found {len(jx)}: {[(j.position) for j in sch.junctions]}"
+        )
+
     def test_connect_invalid_pin(self, tmp_path: Path):
         sch_path = _write_sch(tmp_path)
         result = add_component_main([


### PR DESCRIPTION
## Summary
Fix junction insertion being skipped when a power symbol's pin lands directly on a --connect target that lies on a wire midpoint. The junction check was incorrectly nested inside the wire-creation conditional, so the zero-length-wire skip also bypassed junction detection.

## Changes
- Move junction-insertion logic out of the wire-creation conditional in the execution phase (lines 551-564) so it runs for every connect spec regardless of whether a wire was added
- Align the planning phase to also skip reporting zero-length wires while still planning junctions, making --dry-run output consistent with actual execution
- Add regression test: place GND power symbol directly on a wire midpoint via --connect where pin_pos == target, verify junction is created

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Junction created when pin_pos == target on wire midpoint | Pass | New test `test_power_symbol_on_wire_midpoint_creates_junction` passes |
| Regression: existing connect+junction tests still pass | Pass | All 66 tests pass (1 pre-existing failure in unrelated `test_add_wire_zero_length_rejected`) |
| Dry-run consistency: planning phase matches execution phase | Pass | Planning phase now also skips zero-length wire reporting while keeping junction planning |

## Test Plan
- `python3 -m pytest tests/test_sch_add_component.py -x` -- 66 passed, 1 pre-existing failure in unrelated test

Closes #2119