### PR TITLE
fix(schema): disambiguate .kicad_pro selection and auto-assign power symbol references

### DIFF
--- a/src/kicad_tools/schema/instances.py
+++ b/src/kicad_tools/schema/instances.py
@@ -11,17 +11,33 @@ from __future__ import annotations
 from pathlib import Path
 
 
+def _select_pro_file(pro_files: list[Path], schematic_path: Path) -> Path:
+    """Choose the best ``.kicad_pro`` from *pro_files*.
+
+    When multiple ``.kicad_pro`` files exist in the same directory (e.g.
+    ``board.kicad_pro`` and ``board-backup.kicad_pro``), prefer the one
+    whose stem matches the schematic stem.  Falls back to the first file
+    in sorted order for determinism.
+    """
+    sch_stem = schematic_path.stem
+    for pf in pro_files:
+        if pf.stem == sch_stem:
+            return pf
+    return sorted(pro_files)[0]
+
+
 def find_project_name(schematic_path: Path) -> str:
     """Derive the project name from the nearest ``.kicad_pro`` file.
 
     Walks up from *schematic_path* looking for a ``.kicad_pro`` file.
-    Falls back to the schematic stem if none is found.
+    When multiple are found, prefers the one whose stem matches the
+    schematic stem.  Falls back to the schematic stem if none is found.
     """
     directory = schematic_path.resolve().parent
     for parent in [directory, *directory.parents]:
         pro_files = list(parent.glob("*.kicad_pro"))
         if pro_files:
-            return pro_files[0].stem
+            return _select_pro_file(pro_files, schematic_path).stem
     return schematic_path.stem
 
 
@@ -43,7 +59,8 @@ def build_instance_path(schematic_path: Path, sch_uuid: str) -> str:
     for parent in [directory, *directory.parents]:
         pro_files = list(parent.glob("*.kicad_pro"))
         if pro_files:
-            candidate = pro_files[0].with_suffix(".kicad_sch")
+            best = _select_pro_file(pro_files, schematic_path)
+            candidate = best.with_suffix(".kicad_sch")
             if candidate.exists():
                 root_sch_path = candidate
             break

--- a/src/kicad_tools/schema/schematic.py
+++ b/src/kicad_tools/schema/schematic.py
@@ -6,6 +6,7 @@ Provides a high-level interface to KiCad schematic files.
 
 from __future__ import annotations
 
+import re
 import uuid as uuid_mod
 from collections.abc import Iterator
 from dataclasses import dataclass, field
@@ -457,10 +458,22 @@ class Schematic:
             # Power symbols typically have a single pin "1"
             pin_numbers = ["1"]
 
+        # Determine reference prefix: PWR_FLAG -> #FLG, everything else -> #PWR
+        ref_prefix = "#FLG" if name == "PWR_FLAG" else "#PWR"
+
+        # Find the next available number for this prefix
+        max_num = 0
+        pat = re.compile(re.escape(ref_prefix) + r"(\d+)")
+        for sym in self.symbols:
+            m = pat.fullmatch(sym.reference)
+            if m:
+                max_num = max(max_num, int(m.group(1)))
+        ref_value = f"{ref_prefix}{max_num + 1:02d}"
+
         props: dict[str, SymbolProperty] = {
             "Reference": SymbolProperty(
                 name="Reference",
-                value=f"#{name}",
+                value=ref_value,
                 position=position,
                 rotation=0,
                 visible=False,

--- a/tests/test_sch_add_component.py
+++ b/tests/test_sch_add_component.py
@@ -575,6 +575,143 @@ class TestInstancesBlock:
 
 
 # ---------------------------------------------------------------------------
+# Project name disambiguation (multiple .kicad_pro files)
+# ---------------------------------------------------------------------------
+
+
+class TestProjectNameDisambiguation:
+    """find_project_name must prefer the .kicad_pro matching the schematic stem."""
+
+    def test_prefers_matching_stem(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        # Create two .kicad_pro files -- only one matches the schematic stem
+        (tmp_path / "test_add_comp.kicad_pro").write_text("{}")
+        (tmp_path / "test_add_comp-backup.kicad_pro").write_text("{}")
+
+        from kicad_tools.schema.instances import find_project_name
+        assert find_project_name(sch_path) == "test_add_comp"
+
+    def test_falls_back_sorted_when_no_match(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        # Neither stem matches the schematic stem
+        (tmp_path / "alpha.kicad_pro").write_text("{}")
+        (tmp_path / "beta.kicad_pro").write_text("{}")
+
+        from kicad_tools.schema.instances import find_project_name
+        assert find_project_name(sch_path) == "alpha"
+
+    def test_falls_back_to_sch_stem_no_pro(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        # No .kicad_pro at all -> schematic stem
+        from kicad_tools.schema.instances import find_project_name
+        assert find_project_name(sch_path) == "test_add_comp"
+
+    def test_instances_block_uses_correct_project(self, tmp_path: Path):
+        """Integration: add-component picks the right project with multiple .kicad_pro."""
+        sch_path = _write_sch(tmp_path)
+        (tmp_path / "test_add_comp.kicad_pro").write_text("{}")
+        (tmp_path / "test_add_comp-fresh.kicad_pro").write_text("{}")
+
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "Device:R",
+            "--reference", "R1",
+            "--value", "10k",
+            "--footprint", "SMD:R_0402",
+            "--at", "100.33", "80.01",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        sym = sch.symbols[0]
+        assert sym.project_name == "test_add_comp"
+
+
+# ---------------------------------------------------------------------------
+# Power symbol reference auto-assignment
+# ---------------------------------------------------------------------------
+
+
+class TestPowerSymbolReference:
+    """add_power must auto-assign reference designators, not use bare names."""
+
+    def test_gnd_gets_pwr_prefix(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "power:GND",
+            "--at", "100.33", "90.17",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        sym = sch.symbols[0]
+        assert sym.reference == "#PWR01"
+
+    def test_pwr_flag_gets_flg_prefix(self, tmp_path: Path):
+        # Add PWR_FLAG lib_symbol to the schematic
+        pwr_flag_lib = """\
+    (symbol "power:PWR_FLAG"
+      (property "Reference" "#FLG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "PWR_FLAG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:PWR_FLAG_0_1"
+        (polyline (pts (xy 0 0) (xy 0 1.27)) (stroke (width 0) (type default)) (fill (type none)))
+      )
+      (symbol "power:PWR_FLAG_1_1"
+        (pin power_out line (at 0 0 0) (length 0) (name "pwr" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )"""
+        content = SCHEMATIC_WITH_LIB.replace(
+            "  )\n  (wire",
+            f"{pwr_flag_lib}\n  )\n  (wire",
+        )
+        sch_path = _write_sch(tmp_path, content=content)
+
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "power:PWR_FLAG",
+            "--at", "100.33", "90.17",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        sym = sch.symbols[0]
+        assert sym.reference == "#FLG01"
+
+    def test_sequential_numbering(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path)
+        # Place two GND symbols sequentially
+        add_component_main([
+            str(sch_path),
+            "--lib-id", "power:GND",
+            "--at", "100.33", "90.17",
+        ])
+        result = add_component_main([
+            str(sch_path),
+            "--lib-id", "power:GND",
+            "--at", "110.33", "90.17",
+        ])
+        assert result == 0
+
+        sch = Schematic.load(sch_path)
+        refs = sorted(sym.reference for sym in sch.symbols)
+        assert refs == ["#PWR01", "#PWR02"]
+
+    def test_reference_not_bare_name(self, tmp_path: Path):
+        """Regression: reference must never be '#GND' or '#PWR_FLAG'."""
+        sch_path = _write_sch(tmp_path)
+        add_component_main([
+            str(sch_path),
+            "--lib-id", "power:GND",
+            "--at", "100.33", "90.17",
+        ])
+        sch = Schematic.load(sch_path)
+        sym = sch.symbols[0]
+        assert sym.reference != "#GND"
+        assert sym.reference.startswith("#PWR")
+
+
+# ---------------------------------------------------------------------------
 # Schematic.add_junction method
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `sch add-component`: non-deterministic `.kicad_pro` file selection when multiple exist in the same directory, and bare symbol names (e.g. `#GND`) used as power symbol reference designators instead of proper sequential designators (`#PWR01`, `#FLG01`).

## Changes

- Added `_select_pro_file` helper in `instances.py` that prefers the `.kicad_pro` whose stem matches the schematic stem, with sorted fallback for determinism
- Updated both `find_project_name` and `build_instance_path` to use the new helper
- Updated `add_power` in `schematic.py` to scan existing symbols and auto-assign the next available reference designator (`#PWR` prefix for most power symbols, `#FLG` prefix for `PWR_FLAG`)
- Added 8 new test cases covering disambiguation, sequential numbering, and regression checks

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `find_project_name` prefers matching stem | Pass | `test_prefers_matching_stem` passes |
| `find_project_name` deterministic fallback | Pass | `test_falls_back_sorted_when_no_match` passes |
| `find_project_name` no-pro fallback preserved | Pass | `test_falls_back_to_sch_stem_no_pro` passes |
| Integration: correct project with multiple .kicad_pro | Pass | `test_instances_block_uses_correct_project` passes |
| GND gets `#PWR01` reference | Pass | `test_gnd_gets_pwr_prefix` passes |
| PWR_FLAG gets `#FLG01` reference | Pass | `test_pwr_flag_gets_flg_prefix` passes |
| Sequential numbering works | Pass | `test_sequential_numbering` passes |
| Reference is never bare name | Pass | `test_reference_not_bare_name` passes |

## Test Plan

73 tests pass in `tests/test_sch_add_component.py` (1 pre-existing failure in `test_add_wire_zero_length_rejected` excluded -- unrelated to this change).

Closes #2123