### PR TITLE
fix(validate): detect placed symbols with missing lib_symbols entries

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -2520,6 +2520,81 @@ def check_symbol_footprint_pin_mismatch(schematic_path: str) -> list[ValidationI
 
 
 # ---------------------------------------------------------------------------
+# lib_symbols definition mismatch detection
+# ---------------------------------------------------------------------------
+
+
+def check_lib_symbols_mismatch(schematic_path: str) -> list[ValidationIssue]:
+    """Check that every placed symbol's ``lib_id`` has a matching ``lib_symbols`` entry.
+
+    The ``lib_symbols`` section of a ``.kicad_sch`` file contains embedded
+    copies of library symbol definitions.  When a placed symbol's ``lib_id``
+    (e.g. ``Regulator_Linear:AP2112K-3.3``) has no matching entry in
+    ``lib_symbols``, downstream consumers such as ERC, pin-map, and other
+    validate checks silently fail because ``get_lib_symbol()`` returns ``None``.
+
+    Power symbols (``lib_id`` starting with ``power:``) are skipped because
+    KiCad handles them separately.
+    """
+    issues: list[ValidationIssue] = []
+
+    try:
+        hierarchy = build_hierarchy(schematic_path)
+
+        for node in hierarchy.all_nodes():
+            try:
+                sch = Schematic.load(node.path)
+
+                # Collect the set of lib_id names defined in lib_symbols
+                defined_lib_ids: set[str] = set()
+                if sch.lib_symbols is not None:
+                    for sym_sexp in sch.lib_symbols.find_all("symbol"):
+                        name = sym_sexp.get_string(0)
+                        if name:
+                            defined_lib_ids.add(name)
+
+                for sym in sch.symbols:
+                    # Skip power symbols
+                    if sym.lib_id.startswith("power:"):
+                        continue
+
+                    if sym.lib_id and sym.lib_id not in defined_lib_ids:
+                        issues.append(
+                            ValidationIssue(
+                                severity="error",
+                                category="lib_symbols_mismatch",
+                                message=(
+                                    f"{sym.reference}: placed symbol references "
+                                    f"lib_id '{sym.lib_id}' which has no matching "
+                                    f"entry in lib_symbols"
+                                ),
+                                location=node.get_path_string(),
+                            )
+                        )
+
+            except Exception as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="lib_symbols_mismatch",
+                        message=f"Skipped sheet {node.get_path_string()}: {e}",
+                        location=node.get_path_string(),
+                    )
+                )
+
+    except Exception as e:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                category="lib_symbols_mismatch",
+                message=f"lib_symbols mismatch check failed: {e}",
+            )
+        )
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
 # Matched channel symmetry detection
 # ---------------------------------------------------------------------------
 
@@ -2835,6 +2910,9 @@ def validate_schematic(
 
     # Symbol-to-footprint pin/pad count mismatch
     _run("symbol_footprint_pin_count", check_symbol_footprint_pin_mismatch)
+
+    # lib_symbols definition mismatch (placed lib_id missing from lib_symbols)
+    _run("lib_symbols_mismatch", check_lib_symbols_mismatch)
 
     # Matched channel symmetry detection
     _run("matched_channel_symmetry", check_matched_channel_symmetry)

--- a/tests/test_sch_validate_lib_symbols_mismatch.py
+++ b/tests/test_sch_validate_lib_symbols_mismatch.py
@@ -1,0 +1,326 @@
+"""Tests for lib_symbols definition mismatch detection."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_validate import (
+    ValidationIssue,
+    check_lib_symbols_mismatch,
+    validate_schematic,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: synthetic KiCad schematic generation
+# ---------------------------------------------------------------------------
+
+
+def _make_lib_symbol(
+    lib_id: str,
+    pins: list[tuple[str, str, str]],
+) -> str:
+    """Generate a lib_symbols entry for a component.
+
+    Args:
+        lib_id: e.g. "Regulator_Linear:AP2204K-1.5"
+        pins: list of (pin_number, pin_name, pin_type) tuples
+    """
+    part_name = lib_id.split(":")[-1] if ":" in lib_id else lib_id
+    pin_blocks = []
+    for i, (num, name, ptype) in enumerate(pins):
+        y = i * 2.54
+        pin_blocks.append(
+            f"""(pin {ptype} line
+                    (at 0 {y:.2f} 0)
+                    (length 2.54)
+                    (name "{name}")
+                    (number "{num}")
+                )"""
+        )
+    pin_str = "\n".join(pin_blocks)
+    return f"""(symbol "{lib_id}"
+            (pin_names (offset 0.254))
+            (symbol "{part_name}_0_1"
+                (rectangle
+                    (start -5.08 -{(len(pins) * 2.54) + 1.27:.2f})
+                    (end 5.08 1.27)
+                    (stroke (width 0.254))
+                    (fill (type background))
+                )
+            )
+            (symbol "{part_name}_1_1"
+                {pin_str}
+            )
+        )"""
+
+
+def _make_symbol_instance(
+    ref: str,
+    lib_id: str,
+    footprint: str,
+    pins: list[tuple[str, str, str]],
+    x: float = 100.0,
+    y: float = 50.0,
+) -> str:
+    """Generate a symbol instance S-expression."""
+    pin_entries = "\n".join(
+        f'(pin "{num}" (uuid "pin-{ref.lower()}-{num}"))' for num, _, _ in pins
+    )
+    return f"""(symbol
+        (lib_id "{lib_id}")
+        (at {x} {y} 0)
+        (unit 1)
+        (in_bom yes)
+        (on_board yes)
+        (dnp no)
+        (uuid "uuid-{ref.lower()}")
+        (property "Reference" "{ref}"
+            (at {x + 2} {y - 2} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Value" "{lib_id.split(':')[-1]}"
+            (at {x + 2} {y} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Footprint" "{footprint}"
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        (property "Datasheet" "~"
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        {pin_entries}
+    )"""
+
+
+def _make_schematic(*blocks: str, lib_symbols: str = "") -> str:
+    """Wrap lib_symbols and symbol instances into a minimal schematic."""
+    body = "\n".join(blocks)
+    return f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "test-lib-sym-mismatch-uuid")
+    (paper "A4")
+    (lib_symbols
+        {lib_symbols}
+    )
+    {body}
+    (sheet_instances
+        (path "/"
+            (page "1")
+        )
+    )
+)"""
+
+
+def _write_sch(tmp_path: Path, content: str, name: str = "test.kicad_sch") -> str:
+    """Write schematic content to a file and return the path as string."""
+    p = tmp_path / name
+    p.write_text(content)
+    return str(p)
+
+
+# ---------------------------------------------------------------------------
+# Test: mismatch detected
+# ---------------------------------------------------------------------------
+
+
+class TestLibSymbolsMismatch:
+    """Tests for check_lib_symbols_mismatch()."""
+
+    def test_mismatch_detected(self, tmp_path):
+        """Placed symbol lib_id not in lib_symbols -> error."""
+        # lib_symbols has AP2204K-1.5 but instance references AP2112K-3.3
+        wrong_pins = [
+            ("1", "VIN", "input"),
+            ("2", "GND", "passive"),
+            ("3", "EN", "input"),
+            ("4", "NC", "passive"),
+            ("5", "VOUT", "output"),
+        ]
+        lib_sym = _make_lib_symbol("Regulator_Linear:AP2204K-1.5", wrong_pins)
+        inst = _make_symbol_instance(
+            "U1",
+            "Regulator_Linear:AP2112K-3.3",
+            "Package_TO_SOT_SMD:SOT-23-5",
+            wrong_pins,
+        )
+        content = _make_schematic(inst, lib_symbols=lib_sym)
+        sch_path = _write_sch(tmp_path, content)
+
+        issues = check_lib_symbols_mismatch(sch_path)
+        errors = [i for i in issues if i.severity == "error"]
+        assert len(errors) == 1
+        assert "U1" in errors[0].message
+        assert "AP2112K-3.3" in errors[0].message
+        assert errors[0].category == "lib_symbols_mismatch"
+
+    def test_no_false_positives(self, tmp_path):
+        """All placed lib_ids have matching lib_symbols entries -> no issues."""
+        pins = [
+            ("1", "VIN", "input"),
+            ("2", "GND", "passive"),
+            ("3", "EN", "input"),
+            ("4", "NC", "passive"),
+            ("5", "VOUT", "output"),
+        ]
+        lib_id = "Regulator_Linear:AP2204K-1.5"
+        lib_sym = _make_lib_symbol(lib_id, pins)
+        inst = _make_symbol_instance(
+            "U1", lib_id, "Package_TO_SOT_SMD:SOT-23-5", pins
+        )
+        content = _make_schematic(inst, lib_symbols=lib_sym)
+        sch_path = _write_sch(tmp_path, content)
+
+        issues = check_lib_symbols_mismatch(sch_path)
+        assert len(issues) == 0
+
+    def test_power_symbol_skipped(self, tmp_path):
+        """Power symbols with no lib_symbols entry should not be flagged."""
+        pins = [("1", "GND", "power_in")]
+        # No lib_symbols entry for power:GND
+        inst = _make_symbol_instance(
+            "PWR1", "power:GND", "~", pins
+        )
+        content = _make_schematic(inst, lib_symbols="")
+        sch_path = _write_sch(tmp_path, content)
+
+        issues = check_lib_symbols_mismatch(sch_path)
+        assert len(issues) == 0
+
+    def test_multiple_mismatches(self, tmp_path):
+        """Multiple placed symbols with missing lib_symbols entries."""
+        pins = [("1", "A", "passive"), ("2", "B", "passive")]
+        # lib_symbols is empty but we have two non-power instances
+        inst1 = _make_symbol_instance(
+            "U1", "IC:ChipA", "Package_SO:SOIC-8_3.9x4.9mm", pins, x=100.0
+        )
+        inst2 = _make_symbol_instance(
+            "U2", "IC:ChipB", "Package_SO:SOIC-8_3.9x4.9mm", pins, x=200.0
+        )
+        content = _make_schematic(inst1, inst2, lib_symbols="")
+        sch_path = _write_sch(tmp_path, content)
+
+        issues = check_lib_symbols_mismatch(sch_path)
+        errors = [i for i in issues if i.severity == "error"]
+        assert len(errors) == 2
+        refs = {e.message.split(":")[0] for e in errors}
+        assert refs == {"U1", "U2"}
+
+    def test_multi_sheet_hierarchy(self, tmp_path):
+        """Mismatch in sub-sheet is detected."""
+        # Root sheet references a sub-sheet
+        sub_pins = [("1", "A", "passive"), ("2", "B", "passive")]
+        sub_inst = _make_symbol_instance(
+            "R1", "Device:R_Missing", "Resistor_SMD:R_0603_1608Metric", sub_pins
+        )
+        sub_content = f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "sub-sheet-uuid")
+    (paper "A4")
+    (lib_symbols
+    )
+    {sub_inst}
+    (sheet_instances
+        (path "/sub-sheet-uuid"
+            (page "2")
+        )
+    )
+)"""
+        sub_path = tmp_path / "sub.kicad_sch"
+        sub_path.write_text(sub_content)
+
+        # Root sheet with a sheet reference to sub
+        root_content = f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "root-uuid")
+    (paper "A4")
+    (lib_symbols
+    )
+    (sheet
+        (at 100 50)
+        (size 20 10)
+        (uuid "sub-sheet-uuid")
+        (property "Sheetname" "sub"
+            (at 100 50 0)
+            (effects (font (size 1.27 1.27)))
+        )
+        (property "Sheetfile" "sub.kicad_sch"
+            (at 100 60 0)
+            (effects (font (size 1.27 1.27)))
+        )
+    )
+    (sheet_instances
+        (path "/"
+            (page "1")
+        )
+    )
+)"""
+        root_path = tmp_path / "root.kicad_sch"
+        root_path.write_text(root_content)
+
+        issues = check_lib_symbols_mismatch(str(root_path))
+        errors = [i for i in issues if i.severity == "error"]
+        assert len(errors) >= 1
+        assert any("R1" in e.message for e in errors)
+
+    def test_error_message_includes_sheet_location(self, tmp_path):
+        """Error message should include the sheet location."""
+        pins = [("1", "A", "passive")]
+        inst = _make_symbol_instance(
+            "U1", "IC:Missing", "Package_SO:SOIC-8_3.9x4.9mm", pins
+        )
+        content = _make_schematic(inst, lib_symbols="")
+        sch_path = _write_sch(tmp_path, content)
+
+        issues = check_lib_symbols_mismatch(sch_path)
+        errors = [i for i in issues if i.severity == "error"]
+        assert len(errors) == 1
+        assert errors[0].location != ""
+
+
+# ---------------------------------------------------------------------------
+# Test: integration with validate_schematic
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSchematicIntegration:
+    """Verify the check is registered in validate_schematic."""
+
+    def test_check_registered(self, tmp_path):
+        """lib_symbols_mismatch appears in checks_run."""
+        pins = [("1", "A", "passive"), ("2", "B", "passive")]
+        lib_id = "Device:R"
+        lib_sym = _make_lib_symbol(lib_id, pins)
+        inst = _make_symbol_instance("R1", lib_id, "Resistor_SMD:R_0603_1608Metric", pins)
+        content = _make_schematic(inst, lib_symbols=lib_sym)
+        sch_path = _write_sch(tmp_path, content)
+
+        result = validate_schematic(sch_path)
+        assert "lib_symbols_mismatch" in result.checks_run
+
+    def test_check_skippable(self, tmp_path):
+        """lib_symbols_mismatch can be skipped via skip_checks."""
+        pins = [("1", "A", "passive")]
+        inst = _make_symbol_instance(
+            "U1", "IC:Missing", "Package_SO:SOIC-8_3.9x4.9mm", pins
+        )
+        content = _make_schematic(inst, lib_symbols="")
+        sch_path = _write_sch(tmp_path, content)
+
+        result = validate_schematic(
+            sch_path, skip_checks={"lib_symbols_mismatch"}
+        )
+        assert "lib_symbols_mismatch" not in result.checks_run
+        # Should have no lib_symbols_mismatch errors since check was skipped
+        mismatch_errors = [
+            i for i in result.issues if i.category == "lib_symbols_mismatch"
+        ]
+        assert len(mismatch_errors) == 0


### PR DESCRIPTION
## Summary
Add `check_lib_symbols_mismatch()` to `sch_validate.py` that detects when a placed symbol's `lib_id` has no matching entry in the schematic's `lib_symbols` section. This condition causes `get_lib_symbol()` to return `None`, making ERC, pin-map, and multiple other validate checks silently skip the affected component.

## Changes
- Add `check_lib_symbols_mismatch()` function in `sch_validate.py` that traverses the full schematic hierarchy and reports errors for placed symbols whose `lib_id` is missing from `lib_symbols`
- Register the check as `lib_symbols_mismatch` in `validate_schematic()`, skippable via `--skip lib_symbols_mismatch`
- Power symbols (`power:` prefix) are skipped since KiCad handles them separately
- Add comprehensive test suite in `tests/test_sch_validate_lib_symbols_mismatch.py` with 8 tests covering mismatch detection, false positive prevention, power symbol exclusion, multi-sheet hierarchy traversal, and integration with `validate_schematic()`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Reports error when placed symbol lib_id has no matching lib_symbols entry | PASS | `test_mismatch_detected` confirms error with correct ref and lib_id |
| Error message includes reference designator, expected lib_id, and sheet location | PASS | `test_error_message_includes_sheet_location` and `test_mismatch_detected` verify all three |
| Check traverses full schematic hierarchy | PASS | `test_multi_sheet_hierarchy` verifies sub-sheet detection |
| Power symbols (power:) are skipped | PASS | `test_power_symbol_skipped` confirms no false positive |
| Registered in validate_schematic() and skippable | PASS | `test_check_registered` and `test_check_skippable` verify both |
| Existing checks that skip on missing lib_symbol are not modified | PASS | `git diff --stat` shows only sch_validate.py modified (new function + registration only) |

## Test Plan
All 8 new tests pass. Existing `test_sch_validate_pin_footprint_mismatch.py` tests (26 tests) continue to pass unchanged.

Closes #2125