### PR TITLE
fix(schema): negate Y after rotation in get_pin_position

### DIFF
--- a/src/kicad_tools/schema/library.py
+++ b/src/kicad_tools/schema/library.py
@@ -500,23 +500,25 @@ class LibrarySymbol:
             return None
 
         # Start with pin's local position in library coordinates (Y-up).
-        # Negate Y to convert to schematic coordinates (Y-down) before
-        # applying mirror/rotation transforms.
+        # Mirror and rotation are applied in library coordinate space,
+        # then Y is negated to convert to schematic coordinates (Y-down).
         x, y = pin.position
-        y = -y
 
-        # Apply mirror
+        # Apply mirror (in library coords, Y-up)
         if mirror == "x":
             x = -x
         elif mirror == "y":
             y = -y
 
-        # Apply rotation
+        # Apply rotation (in library coords, Y-up)
         if instance_rot != 0:
             angle_rad = math.radians(instance_rot)
             cos_a = math.cos(angle_rad)
             sin_a = math.sin(angle_rad)
             x, y = x * cos_a - y * sin_a, x * sin_a + y * cos_a
+
+        # Convert from library coords (Y-up) to schematic coords (Y-down)
+        y = -y
 
         # Snap rotated offset to nearest 1.27mm grid point when close.
         # Pin offsets in library coordinates are exact multiples of 1.27mm.

--- a/tests/test_sch_add_component.py
+++ b/tests/test_sch_add_component.py
@@ -1017,11 +1017,13 @@ class TestGridAwareSnap:
             "1", instance_pos=(100.33, 80.01), instance_rot=90
         )
         assert pos is not None
-        # Pin 1 is at (0, 3.81) in lib coords -> (0, -3.81) after Y-negate
-        # Rotated 90: x' = 0*cos90 - (-3.81)*sin90 = 3.81
-        #              y' = 0*sin90 + (-3.81)*cos90 = 0
-        # With grid snap: x = 100.33 + 3.81 = 104.14, y = 80.01 + 0 = 80.01
-        assert pos[0] == pytest.approx(104.14, abs=0.001)
+        # Pin 1 is at (0, 3.81) in lib coords.
+        # Rotated 90 in lib coords (Y-up):
+        #   x' = 0*cos90 - 3.81*sin90 = -3.81
+        #   y' = 0*sin90 + 3.81*cos90 = 0
+        # Then Y negated for schematic: y' = 0
+        # With grid snap: x = 100.33 + (-3.81) = 96.52, y = 80.01 + 0 = 80.01
+        assert pos[0] == pytest.approx(96.52, abs=0.001)
         assert pos[1] == pytest.approx(80.01, abs=0.001)
 
     def test_non_standard_pin_offset_snaps(self, tmp_path: Path):

--- a/tests/test_sch_validate_unconnected_components.py
+++ b/tests/test_sch_validate_unconnected_components.py
@@ -65,6 +65,7 @@ def _make_symbol_instance(
     dnp: bool = False,
     in_bom: bool = True,
     on_board: bool = True,
+    rotation: float = 0,
 ) -> str:
     """Generate a symbol instance S-expression."""
     pin_entries = "\n".join(
@@ -75,7 +76,7 @@ def _make_symbol_instance(
     on_board_str = "yes" if on_board else "no"
     return f"""(symbol
         (lib_id "{lib_id}")
-        (at {x} {y} 0)
+        (at {x} {y} {rotation})
         (unit 1)
         (in_bom {in_bom_str})
         (on_board {on_board_str})
@@ -139,8 +140,11 @@ def _build_schematic(
             lib_symbols.append(_make_lib_symbol(lib_id, pins))
             seen_lib_ids.add(lib_id)
 
+        rotation = comp.get("rotation", 0)
         symbol_instances.append(
-            _make_symbol_instance(ref, lib_id, pins, x, y, dnp, in_bom, on_board)
+            _make_symbol_instance(
+                ref, lib_id, pins, x, y, dnp, in_bom, on_board, rotation
+            )
         )
 
         for pin_idx, (pin_num, _, _) in enumerate(pins):
@@ -492,3 +496,78 @@ class TestFullyUnconnectedComponent:
         assert "R1" in refs_flagged
         assert "C1" in refs_flagged
         assert "R2" not in refs_flagged
+
+    def test_rotated_component_not_false_positive(self, tmp_path: Path):
+        """A 90-degree rotated capacitor with correctly-placed wires must NOT
+        be flagged as unconnected.
+
+        This is the core regression from issue #2118: when Y was negated
+        before rotation, pin positions for rotated symbols were mirror-imaged,
+        causing every rotated component to appear unconnected.
+
+        C_Small has pins at library coords (0, 0) and (0, 2.54).
+        Placed at (100, 50) with 90-degree rotation:
+          Pin 1 (0,0)    -> rotate 90 -> (0,0)      -> negate Y -> (0,0)
+                           -> schematic (100, 50)
+          Pin 2 (0,2.54) -> rotate 90 -> (-2.54, 0) -> negate Y -> (-2.54, 0)
+                           -> schematic (97.46, 50)
+        """
+        # Build schematic with correctly-placed wires for the rotated symbol.
+        lib_sym = _make_lib_symbol(
+            "Device:C_Small",
+            [("1", "~", "passive"), ("2", "~", "passive")],
+        )
+        sym_inst = _make_symbol_instance(
+            "C1",
+            "Device:C_Small",
+            [("1", "~", "passive"), ("2", "~", "passive")],
+            x=100.0,
+            y=50.0,
+            rotation=90,
+        )
+        # Wires at correct pin positions (post-fix):
+        #   Pin 1 at (100, 50) -- wire runs right to a label
+        #   Pin 2 at (97.46, 50) -- wire runs left to a label
+        sch_text = f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "test-rotated-uuid")
+    (paper "A4")
+    (lib_symbols
+        {lib_sym}
+    )
+    {sym_inst}
+    (wire
+        (pts (xy 100.00 50.00) (xy 110.00 50.00))
+        (stroke (width 0) (type default))
+        (uuid "wire-c1-1")
+    )
+    (wire
+        (pts (xy 97.46 50.00) (xy 87.46 50.00))
+        (stroke (width 0) (type default))
+        (uuid "wire-c1-2")
+    )
+    (label "VCC"
+        (at 110.00 50.00 0)
+        (effects (font (size 1.27 1.27)) (justify left bottom))
+        (uuid "lbl-c1-1")
+    )
+    (label "GND"
+        (at 87.46 50.00 0)
+        (effects (font (size 1.27 1.27)) (justify left bottom))
+        (uuid "lbl-c1-2")
+    )
+)
+"""
+        sch_path = tmp_path / "rotated.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_fully_unconnected_components(str(sch_path))
+        errors = [
+            i for i in issues
+            if i.category == "unconnected_component" and i.severity == "error"
+        ]
+        # With the fix, the rotated C1 should NOT be flagged.
+        assert len(errors) == 0, (
+            f"Rotated component C1 should not be flagged; got: {errors}"
+        )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -920,12 +920,14 @@ class TestLibrarySymbol:
             name="Test",
             pins=[
                 LibraryPin(
-                    number="1", name="A", type="input", position=(5, 0), rotation=0, length=2.54
+                    number="1", name="A", type="input", position=(2.54, 0), rotation=0, length=2.54
                 ),
             ],
         )
+        # Pin at library (2.54, 0), no rotation.  Y negation has no effect
+        # on y=0.  Schematic position = (100+2.54, 100+0) = (102.54, 100).
         pos = sym.get_pin_position("1", instance_pos=(100, 100))
-        assert pos == (105.0, 100.0)
+        assert pos == (102.54, 100.0)
 
     def test_library_symbol_get_pin_position_with_rotation(self):
         """Test pin position with symbol rotation."""
@@ -933,15 +935,58 @@ class TestLibrarySymbol:
             name="Test",
             pins=[
                 LibraryPin(
-                    number="1", name="A", type="input", position=(5, 0), rotation=0, length=2.54
+                    number="1", name="A", type="input", position=(2.54, 0), rotation=0, length=2.54
                 ),
             ],
         )
-        # 90 degree rotation
+        # Pin at library (2.54, 0), rotated 90 degrees CCW in library coords
+        # (Y-up): (0, 2.54).  Then Y negated for schematic: (0, -2.54).
+        # Schematic position = (100+0, 100-2.54) = (100, 97.46).
         pos = sym.get_pin_position("1", instance_pos=(100, 100), instance_rot=90)
         assert pos is not None
         assert pos[0] == pytest.approx(100.0, abs=0.01)
-        assert pos[1] == pytest.approx(105.0, abs=0.01)
+        assert pos[1] == pytest.approx(97.46, abs=0.01)
+
+    def test_library_symbol_get_pin_position_with_rotation_nonzero_y(self):
+        """Test pin position with rotation and non-zero Y offset.
+
+        This is the core bug scenario from issue #2118: when the pin has a
+        non-zero Y coordinate in library space, negating Y before rotation
+        produces mirror-image positions.
+        """
+        sym = LibrarySymbol(
+            name="C_Small",
+            pins=[
+                LibraryPin(
+                    number="1", name="~", type="passive",
+                    position=(0, 2.54), rotation=0, length=0,
+                ),
+                LibraryPin(
+                    number="2", name="~", type="passive",
+                    position=(0, -2.54), rotation=0, length=0,
+                ),
+            ],
+        )
+        # C_Small at (182.88, 97.79) rotated 90 degrees.
+        # Pin 1 library (0, 2.54) -> rotate 90 CCW -> (-2.54, 0)
+        #   -> negate Y -> (-2.54, 0)
+        #   -> translate -> (180.34, 97.79)
+        pos1 = sym.get_pin_position(
+            "1", instance_pos=(182.88, 97.79), instance_rot=90
+        )
+        assert pos1 is not None
+        assert pos1[0] == pytest.approx(180.34, abs=0.01)
+        assert pos1[1] == pytest.approx(97.79, abs=0.01)
+
+        # Pin 2 library (0, -2.54) -> rotate 90 CCW -> (2.54, 0)
+        #   -> negate Y -> (2.54, 0)
+        #   -> translate -> (185.42, 97.79)
+        pos2 = sym.get_pin_position(
+            "2", instance_pos=(182.88, 97.79), instance_rot=90
+        )
+        assert pos2 is not None
+        assert pos2[0] == pytest.approx(185.42, abs=0.01)
+        assert pos2[1] == pytest.approx(97.79, abs=0.01)
 
     def test_library_symbol_get_pin_position_with_mirror_x(self):
         """Test pin position with X mirror."""
@@ -949,12 +994,14 @@ class TestLibrarySymbol:
             name="Test",
             pins=[
                 LibraryPin(
-                    number="1", name="A", type="input", position=(5, 0), rotation=0, length=2.54
+                    number="1", name="A", type="input", position=(2.54, 0), rotation=0, length=2.54
                 ),
             ],
         )
+        # Mirror X negates library x: (-2.54, 0). Y negated: (−2.54, 0).
+        # Schematic position = (100-2.54, 100) = (97.46, 100).
         pos = sym.get_pin_position("1", instance_pos=(100, 100), mirror="x")
-        assert pos == (95.0, 100.0)
+        assert pos == (97.46, 100.0)
 
     def test_library_symbol_get_pin_position_with_mirror_y(self):
         """Test pin position with Y mirror."""
@@ -962,12 +1009,46 @@ class TestLibrarySymbol:
             name="Test",
             pins=[
                 LibraryPin(
-                    number="1", name="A", type="input", position=(0, 5), rotation=0, length=2.54
+                    number="1", name="A", type="input", position=(0, 2.54), rotation=0, length=2.54
                 ),
             ],
         )
+        # Mirror Y negates library y: (0, -2.54). Y negated for schematic:
+        # (0, 2.54).  Schematic position = (100, 100+2.54) = (100, 102.54).
         pos = sym.get_pin_position("1", instance_pos=(100, 100), mirror="y")
-        assert pos == (100.0, 105.0)
+        assert pos == (100.0, 102.54)
+
+    def test_library_symbol_get_pin_position_all_rotations(self):
+        """Test pin positions at 0, 90, 180, 270 degrees for a vertical pin."""
+        sym = LibrarySymbol(
+            name="C_Small",
+            pins=[
+                LibraryPin(
+                    number="1", name="~", type="passive",
+                    position=(0, 2.54), rotation=0, length=0,
+                ),
+            ],
+        )
+        center = (100.0, 100.0)
+
+        # 0 deg: (0, 2.54) -> negate Y -> (0, -2.54). Pos: (100, 97.46)
+        pos = sym.get_pin_position("1", instance_pos=center, instance_rot=0)
+        assert pos == pytest.approx((100.0, 97.46), abs=0.01)
+
+        # 90 deg: rotate (0,2.54) -> (-2.54, 0), negate Y -> (-2.54, 0).
+        # Pos: (97.46, 100)
+        pos = sym.get_pin_position("1", instance_pos=center, instance_rot=90)
+        assert pos == pytest.approx((97.46, 100.0), abs=0.01)
+
+        # 180 deg: rotate (0,2.54) -> (0, -2.54), negate Y -> (0, 2.54).
+        # Pos: (100, 102.54)
+        pos = sym.get_pin_position("1", instance_pos=center, instance_rot=180)
+        assert pos == pytest.approx((100.0, 102.54), abs=0.01)
+
+        # 270 deg: rotate (0,2.54) -> (2.54, 0), negate Y -> (2.54, 0).
+        # Pos: (102.54, 100)
+        pos = sym.get_pin_position("1", instance_pos=center, instance_rot=270)
+        assert pos == pytest.approx((102.54, 100.0), abs=0.01)
 
     def test_library_symbol_get_all_pin_positions(self):
         """Test getting all pin positions."""
@@ -975,17 +1056,17 @@ class TestLibrarySymbol:
             name="Test",
             pins=[
                 LibraryPin(
-                    number="1", name="A", type="input", position=(5, 0), rotation=0, length=2.54
+                    number="1", name="A", type="input", position=(2.54, 0), rotation=0, length=2.54
                 ),
                 LibraryPin(
-                    number="2", name="B", type="output", position=(-5, 0), rotation=0, length=2.54
+                    number="2", name="B", type="output", position=(-2.54, 0), rotation=0, length=2.54
                 ),
             ],
         )
         positions = sym.get_all_pin_positions(instance_pos=(100, 100))
         assert len(positions) == 2
-        assert positions["1"] == (105.0, 100.0)
-        assert positions["2"] == (95.0, 100.0)
+        assert positions["1"] == (102.54, 100.0)
+        assert positions["2"] == (97.46, 100.0)
 
 
 class TestLibraryManager:


### PR DESCRIPTION
## Summary

Fix Y coordinate negation order in `LibrarySymbol.get_pin_position()` so that rotated symbols compute correct pin positions. The bug caused systematic false positives in the `unconnected_component` checker for every rotated component.

## Changes

- Move `y = -y` (library Y-up to schematic Y-down conversion) from before mirror/rotation to after, matching KiCad's transform pipeline
- Update existing unit tests to use grid-aligned pin positions (multiples of 1.27mm) and correct expected values
- Add `test_library_symbol_get_pin_position_with_rotation_nonzero_y` reproducing the C32 example from the issue
- Add `test_library_symbol_get_pin_position_all_rotations` covering 0/90/180/270 degrees
- Add `test_rotated_component_not_false_positive` integration test verifying no false positives for rotated capacitors

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Y negation occurs after rotation | Done | `library.py` line 522: `y = -y` moved after mirror and rotation blocks |
| Rotated C_Small pins match expected schematic positions | Done | `test_library_symbol_get_pin_position_with_rotation_nonzero_y` passes with exact C32 coordinates from issue |
| All 4 rotation angles produce correct positions | Done | `test_library_symbol_get_pin_position_all_rotations` passes for 0/90/180/270 |
| No false positives for rotated components | Done | `test_rotated_component_not_false_positive` integration test passes |
| Existing 0-degree tests still pass | Done | All 10 pre-existing unconnected component tests pass |
| Mirror tests updated and passing | Done | mirror_x and mirror_y tests pass with correct expected values |

## Test Plan

- 87 tests pass across `test_schema.py`, `test_sch_add_component.py`, and `test_sch_validate_unconnected_components.py`
- 1 pre-existing failure (`test_add_wire_zero_length_rejected`) confirmed failing on main, unrelated to this change

Closes #2118