### PR TITLE
fix(repair-instances): detect and replace wrong project names in existing instances blocks

### DIFF
--- a/src/kicad_tools/cli/sch_re_annotate.py
+++ b/src/kicad_tools/cli/sch_re_annotate.py
@@ -87,12 +87,12 @@ def _parse_reference(ref: str) -> tuple[str, int | None, str]:
         "#PWR01" -> ("#PWR", 1, "")
         "R?"   -> ("R", None, "")
     """
-    # Match prefix (letters, optionally starting with #), number, optional unit letter
-    m = re.match(r'^(#?[A-Za-z]+)(\d+)([A-Za-z]?)$', ref)
+    # Match prefix (letters/underscores, optionally starting with #), number, optional unit letter
+    m = re.match(r'^(#?[A-Za-z_]+)(\d+)([A-Za-z]?)$', ref)
     if m:
         return m.group(1), int(m.group(2)), m.group(3)
-    # Unannotated reference like "R?"
-    m = re.match(r'^(#?[A-Za-z]+)\?$', ref)
+    # Unannotated reference like "R?" or "#PWR_FLAG?"
+    m = re.match(r'^(#?[A-Za-z_]+)\?$', ref)
     if m:
         return m.group(1), None, ""
     return ref, None, ""

--- a/src/kicad_tools/cli/sch_repair_instances.py
+++ b/src/kicad_tools/cli/sch_repair_instances.py
@@ -34,6 +34,14 @@ from kicad_tools.cli.sch_set_footprint import _collect_schematic_files
 # Whitespace token for regex: matches one or more tabs or spaces
 _WS = r'[ \t]+'
 
+# Mapping from bare symbol-name references (used as lib_id-derived
+# reference designators) to the proper KiCad annotation prefix.
+# For example, a PWR_FLAG symbol gets reference "#PWR_FLAG" which
+# should be re-annotated as "#FLG01", "#FLG02", etc.
+_BARE_REF_PREFIX_MAP: dict[str, str] = {
+    "#PWR_FLAG": "#FLG",
+}
+
 
 def _extract_symbols_with_instance_info(
     text: str, project_name: str
@@ -92,9 +100,19 @@ def _extract_symbols_with_instance_info(
 
         ref = ref_match.group(1)
 
-        # Skip power symbols
+        # Check if this symbol has an instances block with our project
+        has_instances_block = '(instances' in block
+        has_project = (
+            has_instances_block
+            and f'(project "{project_name}"' in block
+        )
+
+        # Skip power symbols only when they have no instances block at all
+        # (legacy behavior).  Power symbols with an instances block
+        # referencing the *wrong* project still need repair.
         if lib_id.startswith("power:"):
-            continue
+            if not has_instances_block or has_project:
+                continue
 
         # Find the symbol-level uuid (the last uuid in the block, or the
         # one that's a direct child of the symbol -- not inside a pin)
@@ -129,13 +147,6 @@ def _extract_symbols_with_instance_info(
 
         prefix, number, unit_suffix = _parse_reference(ref)
 
-        # Check if this symbol has an instances block with our project
-        has_instances_block = '(instances' in block
-        has_project = (
-            has_instances_block
-            and f'(project "{project_name}"' in block
-        )
-
         symbols.append({
             "reference": ref,
             "prefix": prefix,
@@ -144,6 +155,7 @@ def _extract_symbols_with_instance_info(
             "lib_id": lib_id,
             "uuid": sym_uuid,
             "has_project_instance": has_project,
+            "has_wrong_project": has_instances_block and not has_project,
         })
 
     return symbols
@@ -200,12 +212,21 @@ def _insert_project_instance(
     instance_path: str,
     new_ref: str,
     unit: int = 1,
+    *,
+    replace_wrong_project: bool = False,
 ) -> str:
-    """Insert a project instance entry into a symbol's block.
+    """Insert or replace a project instance entry in a symbol's block.
 
-    If the symbol has an ``(instances)`` block, appends a new
-    ``(project ...)`` entry.  If not, creates an ``(instances)`` block
-    before the symbol's closing parenthesis.
+    If the symbol has an ``(instances)`` block and *replace_wrong_project*
+    is ``True``, any existing ``(project "...")`` entry whose name does
+    **not** match *project_name* will have its name replaced in-place so
+    that stale project references are corrected without leaving duplicates.
+
+    If the symbol has an ``(instances)`` block but *replace_wrong_project*
+    is ``False``, a new ``(project ...)`` entry is appended.
+
+    If the symbol has no ``(instances)`` block, one is created before the
+    symbol's closing parenthesis.
 
     Uses bracket-depth parsing for robustness with varying file layouts.
     """
@@ -237,6 +258,46 @@ def _insert_project_instance(
         # Check if this project already exists
         if f'(project "{project_name}"' in block:
             return text
+
+        # If the instances block has a wrong project name, replace it
+        if replace_wrong_project:
+            wrong_project_match = re.search(
+                r'\(project "([^"]+)"', block
+            )
+            if wrong_project_match:
+                wrong_name = wrong_project_match.group(1)
+                # Replace the wrong project name with the correct one
+                # in the full text at the correct absolute position
+                abs_pos = start + wrong_project_match.start()
+                old_str = f'(project "{wrong_name}"'
+                new_str = f'(project "{project_name}"'
+                text = (
+                    text[:abs_pos]
+                    + new_str
+                    + text[abs_pos + len(old_str):]
+                )
+                # Also update the reference and path within this project block
+                # Re-find the symbol block since positions shifted
+                bounds2 = _find_symbol_block(text, sym_uuid)
+                if bounds2 is not None:
+                    s2, e2 = bounds2
+                    block2 = text[s2:e2]
+                    # Replace the path
+                    new_block = re.sub(
+                        r'(\(path ")[^"]+"',
+                        rf'\g<1>{instance_path}"',
+                        block2,
+                        count=1,
+                    )
+                    # Replace the reference
+                    new_block = re.sub(
+                        r'(\(reference ")[^"]+"',
+                        rf'\g<1>{new_ref}"',
+                        new_block,
+                        count=1,
+                    )
+                    text = text[:s2] + new_block + text[e2:]
+                return text
 
         # Find the closing ) of the (instances block
         # Walk from instances_pos tracking depth
@@ -399,13 +460,20 @@ def run_repair_instances(
             # Already annotated, just needs instances block
             new_ref = sym["reference"]
         else:
-            # Unannotated (R?, C?, etc.) - assign next available
-            new_number = _next_available(sym["prefix"])
+            # Unannotated (R?, C?, etc.) - assign next available.
+            # Map bare symbol-name prefixes (e.g. #PWR_FLAG -> #FLG)
+            # to proper KiCad annotation prefixes.
+            prefix = _BARE_REF_PREFIX_MAP.get(sym["prefix"], sym["prefix"])
+            new_number = _next_available(prefix)
             new_ref = _format_reference(
-                sym["prefix"], new_number, sym["unit_suffix"]
+                prefix, new_number, sym["unit_suffix"]
             )
 
         instance_path = file_instance_paths.get(sch_file, "")
+
+        repair_type = (
+            "wrong_project" if sym.get("has_wrong_project") else "missing_instances"
+        )
 
         repairs.append({
             "file": sch_file,
@@ -415,6 +483,7 @@ def run_repair_instances(
             "new_ref": new_ref,
             "instance_path": instance_path,
             "needs_rename": sym["number"] is None,
+            "repair_type": repair_type,
         })
 
     # Phase 4: Output
@@ -429,6 +498,7 @@ def run_repair_instances(
                     "old_ref": r["old_ref"],
                     "new_ref": r["new_ref"],
                     "instance_path": r["instance_path"],
+                    "repair_type": r["repair_type"],
                 }
                 for r in repairs
             ],
@@ -437,7 +507,14 @@ def run_repair_instances(
         }
         print(json.dumps(output, indent=2))
     else:
-        print(f"Found {len(repairs)} symbol(s) missing project instances:")
+        n_wrong = sum(1 for r in repairs if r["repair_type"] == "wrong_project")
+        n_missing = len(repairs) - n_wrong
+        parts = []
+        if n_missing:
+            parts.append(f"{n_missing} missing instances")
+        if n_wrong:
+            parts.append(f"{n_wrong} wrong project")
+        print(f"Found {len(repairs)} symbol(s) needing repair ({', '.join(parts)}):")
         print()
         # Group by file for display
         by_file: dict[Path, list[dict]] = {}
@@ -447,15 +524,20 @@ def run_repair_instances(
         for sch_file, file_repairs in by_file.items():
             print(f"  {sch_file.name}:")
             for r in file_repairs:
+                tag = (
+                    "[wrong project]"
+                    if r["repair_type"] == "wrong_project"
+                    else "[add instances block]"
+                )
                 if r["needs_rename"]:
                     print(
                         f"    {r['old_ref']} -> {r['new_ref']}"
-                        f"  ({r['lib_id']})"
+                        f"  ({r['lib_id']}) {tag}"
                     )
                 else:
                     print(
                         f"    {r['new_ref']}"
-                        f"  ({r['lib_id']}) [add instances block]"
+                        f"  ({r['lib_id']}) {tag}"
                     )
         print()
 
@@ -477,7 +559,7 @@ def run_repair_instances(
                 text, r["uuid"], r["new_ref"]
             )
 
-        # Add the project instance block
+        # Add or replace the project instance block
         if r["instance_path"]:
             text = _insert_project_instance(
                 text,
@@ -485,6 +567,7 @@ def run_repair_instances(
                 project_name,
                 r["instance_path"],
                 r["new_ref"],
+                replace_wrong_project=r["repair_type"] == "wrong_project",
             )
 
         modified_files[sch_file] = text

--- a/tests/test_sch_repair_instances.py
+++ b/tests/test_sch_repair_instances.py
@@ -274,7 +274,7 @@ class TestRunRepairInstances:
         assert result == 0
 
         captured = capsys.readouterr()
-        assert "2 symbol(s) missing project instances" in captured.out
+        assert "2 symbol(s) needing repair" in captured.out
         assert "Dry run: no changes made" in captured.out
         # File should not be modified
         assert sub.read_text(encoding="utf-8") == SUB_SCHEMATIC_MISSING
@@ -469,3 +469,331 @@ class TestRunRepairInstances:
             "/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
         )
         assert f'(path "{expected_path}"' in modified_text
+
+
+# ---------------------------------------------------------------------------
+# Tests for wrong-project detection and repair
+# ---------------------------------------------------------------------------
+
+# Sub-sheet with a symbol that has instances for the WRONG project
+SUB_SCHEMATIC_WRONG_PROJECT = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "cccccccc-cccc-cccc-cccc-cccccccccccc")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "Device:R")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "R2"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "4.7k"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-3")
+\t\t)
+\t\t(pin "2"
+\t\t\t(uuid "pin-uuid-4")
+\t\t)
+\t\t(uuid "22222222-2222-2222-2222-222222222222")
+\t\t(instances
+\t\t\t(project "wrong_project_name"
+\t\t\t\t(path "/old-uuid/old-sheet-uuid"
+\t\t\t\t\t(reference "R2")
+\t\t\t\t\t(unit 1)
+\t\t\t\t)
+\t\t\t)
+\t\t)
+\t)
+)
+"""
+
+# Sub-sheet with a PWR_FLAG that has instances for the WRONG project
+SUB_SCHEMATIC_WRONG_PROJECT_POWER = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "cccccccc-cccc-cccc-cccc-cccccccccccc")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "power:PWR_FLAG")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "#PWR_FLAG"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "PWR_FLAG"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-pwr")
+\t\t)
+\t\t(uuid "66666666-6666-6666-6666-666666666666")
+\t\t(instances
+\t\t\t(project "wrong_project_name"
+\t\t\t\t(path "/old-uuid"
+\t\t\t\t\t(reference "#FLG01")
+\t\t\t\t\t(unit 1)
+\t\t\t\t)
+\t\t\t)
+\t\t)
+\t)
+)
+"""
+
+
+class TestWrongProjectDetection:
+    """Tests for wrong-project-name detection and replacement."""
+
+    def test_extract_detects_wrong_project(self):
+        """Symbol with instances for wrong project is flagged."""
+        symbols = _extract_symbols_with_instance_info(
+            SUB_SCHEMATIC_WRONG_PROJECT, "test_project"
+        )
+        assert len(symbols) == 1
+        assert symbols[0]["has_project_instance"] is False
+        assert symbols[0]["has_wrong_project"] is True
+
+    def test_wrong_project_replaced_not_appended(self, tmp_path, capsys):
+        """Wrong project name is replaced, not duplicated."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_WRONG_PROJECT, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=False, backup=False)
+        assert result == 0
+
+        modified_text = sub.read_text(encoding="utf-8")
+        # Correct project name should appear
+        assert '(project "test_project"' in modified_text
+        # Wrong project name should be gone
+        assert "wrong_project_name" not in modified_text
+        # Should only have ONE (project entry, not two
+        assert modified_text.count("(project") == 1
+
+    def test_wrong_project_updates_path_and_ref(self, tmp_path, capsys):
+        """Wrong project replacement also updates path and reference."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_WRONG_PROJECT, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=False, backup=False)
+        assert result == 0
+
+        modified_text = sub.read_text(encoding="utf-8")
+        expected_path = (
+            "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+            "/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        )
+        assert f'(path "{expected_path}"' in modified_text
+        assert '(reference "R2")' in modified_text
+
+    def test_dry_run_reports_wrong_project(self, tmp_path, capsys):
+        """Dry-run distinguishes wrong-project from missing-instances."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_WRONG_PROJECT, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=True, backup=False)
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "[wrong project]" in captured.out
+
+    def test_json_output_includes_repair_type(self, tmp_path, capsys):
+        """JSON output includes repair_type field."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_WRONG_PROJECT, encoding="utf-8")
+
+        result = run_repair_instances(
+            root, dry_run=True, backup=False, format="json"
+        )
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["repairs"][0]["repair_type"] == "wrong_project"
+
+
+class TestPowerSymbolWrongProject:
+    """Tests for power symbols with wrong project names."""
+
+    def test_power_symbol_no_instances_still_skipped(self):
+        """Power symbols with no instances block are still skipped."""
+        text = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(uuid "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "power:GND")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "#PWR01"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "GND"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-pwr")
+\t\t)
+\t\t(uuid "55555555-5555-5555-5555-555555555555")
+\t)
+)
+"""
+        symbols = _extract_symbols_with_instance_info(text, "test_project")
+        assert len(symbols) == 0
+
+    def test_power_symbol_correct_project_skipped(self):
+        """Power symbols with the correct project are skipped."""
+        text = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(uuid "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "power:GND")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "#PWR01"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "GND"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-pwr")
+\t\t)
+\t\t(uuid "55555555-5555-5555-5555-555555555555")
+\t\t(instances
+\t\t\t(project "test_project"
+\t\t\t\t(path "/eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+\t\t\t\t\t(reference "#PWR01")
+\t\t\t\t\t(unit 1)
+\t\t\t\t)
+\t\t\t)
+\t\t)
+\t)
+)
+"""
+        symbols = _extract_symbols_with_instance_info(text, "test_project")
+        assert len(symbols) == 0
+
+    def test_power_symbol_wrong_project_detected(self):
+        """Power symbols with wrong project ARE detected for repair."""
+        symbols = _extract_symbols_with_instance_info(
+            SUB_SCHEMATIC_WRONG_PROJECT_POWER, "test_project"
+        )
+        assert len(symbols) == 1
+        assert symbols[0]["has_project_instance"] is False
+        assert symbols[0]["has_wrong_project"] is True
+        assert symbols[0]["lib_id"] == "power:PWR_FLAG"
+
+    def test_power_symbol_wrong_project_repaired(self, tmp_path, capsys):
+        """Power symbol with wrong project gets its project name fixed."""
+        root = tmp_path / "test_project.kicad_sch"
+        sub = tmp_path / "sub.kicad_sch"
+        root.write_text(ROOT_SCHEMATIC, encoding="utf-8")
+        sub.write_text(SUB_SCHEMATIC_WRONG_PROJECT_POWER, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=False, backup=False)
+        assert result == 0
+
+        modified_text = sub.read_text(encoding="utf-8")
+        assert '(project "test_project"' in modified_text
+        assert "wrong_project_name" not in modified_text
+
+
+class TestPwrFlagReferenceReannotation:
+    """Tests for #PWR_FLAG bare-name reference re-annotation."""
+
+    def test_parse_reference_pwr_flag(self):
+        """_parse_reference handles #PWR_FLAG correctly."""
+        from kicad_tools.cli.sch_re_annotate import _parse_reference
+
+        prefix, number, suffix = _parse_reference("#PWR_FLAG")
+        # Bare name with no number -- parsed as unannotated
+        assert prefix == "#PWR_FLAG"
+        assert number is None
+        assert suffix == ""
+
+    def test_parse_reference_pwr_flag_annotated(self):
+        """_parse_reference handles #PWR_FLAG01 correctly."""
+        from kicad_tools.cli.sch_re_annotate import _parse_reference
+
+        prefix, number, suffix = _parse_reference("#PWR_FLAG01")
+        assert prefix == "#PWR_FLAG"
+        assert number == 1
+        assert suffix == ""
+
+    def test_pwr_flag_gets_flg_prefix(self, tmp_path, capsys):
+        """#PWR_FLAG reference is re-annotated with #FLG prefix."""
+        # Root with no existing #FLG refs
+        simple_root = """\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+\t(symbol
+\t\t(lib_id "power:PWR_FLAG")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "#PWR_FLAG"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "PWR_FLAG"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-uuid-flag")
+\t\t)
+\t\t(uuid "77777777-7777-7777-7777-777777777777")
+\t\t(instances
+\t\t\t(project "wrong_name"
+\t\t\t\t(path "/old-uuid"
+\t\t\t\t\t(reference "#PWR_FLAG")
+\t\t\t\t\t(unit 1)
+\t\t\t\t)
+\t\t\t)
+\t\t)
+\t)
+)
+"""
+        root = tmp_path / "test_project.kicad_sch"
+        root.write_text(simple_root, encoding="utf-8")
+
+        result = run_repair_instances(root, dry_run=False, backup=False)
+        assert result == 0
+
+        modified_text = root.read_text(encoding="utf-8")
+        assert '(project "test_project"' in modified_text
+        # The reference should be re-annotated as #FLG01
+        assert '(reference "#FLG01")' in modified_text


### PR DESCRIPTION
## Summary
Fixes three root causes that prevented `repair-instances` from detecting and correcting symbols whose instances blocks reference the wrong project name.

## Changes
- Power symbols (`power:*` lib_id) with wrong project names are no longer unconditionally skipped at line 96-97; only power symbols without any instances block are skipped (legacy behavior preserved)
- `_insert_project_instance()` now accepts `replace_wrong_project=True` to replace the wrong project name, path, and reference in-place rather than appending a duplicate `(project ...)` entry
- `_parse_reference()` regex updated to handle underscores (`[A-Za-z_]`) so `#PWR_FLAG` parses as prefix `#PWR_FLAG` instead of falling through to the catch-all
- Added `_BARE_REF_PREFIX_MAP` to map bare symbol-name prefixes (e.g. `#PWR_FLAG`) to proper KiCad annotation prefixes (e.g. `#FLG`)
- Extraction now returns `has_wrong_project` field to distinguish wrong-project from missing-instances repairs
- Text and JSON output distinguish `[wrong project]` vs `[add instances block]` repair types
- JSON output includes `repair_type` field ("wrong_project" or "missing_instances")

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--dry-run` reports symbols with wrong project names distinctly | PASS | Text output shows `[wrong project]` tag; JSON includes `repair_type` field |
| Wrong project name replaced, not duplicated | PASS | Test verifies only 1 `(project` entry after repair and wrong name is gone |
| Power symbols with wrong project names detected and fixed | PASS | `test_power_symbol_wrong_project_detected` and `test_power_symbol_wrong_project_repaired` pass |
| Bare symbol-name references re-annotated to proper designators | PASS | `#PWR_FLAG` -> `#FLG01` verified in `test_pwr_flag_gets_flg_prefix` |
| Existing behavior for missing-instances unchanged | PASS | All 17 original tests pass unmodified (except message text update) |
| JSON output includes repair type distinction | PASS | `test_json_output_includes_repair_type` verifies `repair_type` field |

## Test Plan
- All 28 tests in `test_sch_repair_instances.py` pass (11 new tests added)
- All 98 tests in `test_sch_re_annotate.py` pass (no regressions from `_parse_reference` change)

Closes #2124