### PR TITLE
feat(sch): add remove-component command to delete symbols with exclusive wire cleanup

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -24,7 +24,7 @@ def run_sch_command(args) -> int:
             " add-label, cleanup-wires, remove-wire, insert-inline,"
         )
         print(
-            "          disconnect, re-annotate,"
+            "          disconnect, remove-component, re-annotate,"
         )
         print("          repair-instances")
         return 1
@@ -473,6 +473,24 @@ def run_sch_command(args) -> int:
         if args.backup:
             sub_argv.append("--backup")
         return disconnect_main(sub_argv) or 0
+
+    elif args.sch_command == "remove-component":
+        from ..sch_remove_component import main as remove_component_main
+
+        sub_argv = [str(schematic_path), "--ref", args.ref]
+        if args.lib_paths:
+            for path in args.lib_paths:
+                sub_argv.extend(["--lib-path", path])
+        if args.libs:
+            for lib in args.libs:
+                sub_argv.extend(["--lib", lib])
+        if args.dry_run:
+            sub_argv.append("--dry-run")
+        if args.backup:
+            sub_argv.append("--backup")
+        if args.format != "text":
+            sub_argv.extend(["--format", args.format])
+        return remove_component_main(sub_argv) or 0
 
     elif args.sch_command == "repair-instances":
         from ..sch_repair_instances import run_repair_instances

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1026,6 +1026,30 @@ def _add_sch_parser(subparsers) -> None:
         "--backup", action="store_true", help="Create backup before modifying"
     )
 
+    # sch remove-component
+    sch_remove_component = sch_subparsers.add_parser(
+        "remove-component", help="Remove a symbol from a schematic"
+    )
+    sch_remove_component.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_remove_component.add_argument(
+        "--ref", required=True, help="Symbol reference designator (e.g., U1)"
+    )
+    sch_remove_component.add_argument(
+        "--lib-path", action="append", dest="lib_paths", help="Library search path"
+    )
+    sch_remove_component.add_argument(
+        "--lib", action="append", dest="libs", help="Specific library file"
+    )
+    sch_remove_component.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+    )
+    sch_remove_component.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+    sch_remove_component.add_argument(
+        "--format", choices=["text", "json"], default="text", help="Output format"
+    )
+
     # sch re-annotate
     sch_reannotate = sch_subparsers.add_parser(
         "re-annotate", help="Renumber reference designators sequentially"

--- a/src/kicad_tools/cli/sch_remove_component.py
+++ b/src/kicad_tools/cli/sch_remove_component.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""
+Remove a symbol (component) from a KiCad schematic.
+
+Removes the symbol S-expression node, any wires exclusively connected to it,
+orphaned junctions at former wire endpoints, the ``symbol_instances`` path
+entry, and the ``lib_symbols`` entry when the last instance is removed.
+
+Usage:
+    kct sch remove-component board.kicad_sch --ref PWR1
+    kct sch remove-component board.kicad_sch --ref PWR1 --dry-run
+    kct sch remove-component board.kicad_sch --ref PWR1 --backup
+    kct sch remove-component board.kicad_sch --ref PWR1 --format json
+
+Options:
+    --ref <reference>      Symbol reference designator (e.g., PWR1, U1)
+    --lib-path <path>      Path to search for symbol libraries (can be repeated)
+    --lib <file>           Specific library file to load (can be repeated)
+    --dry-run              Show what would be removed without modifying
+    --backup               Create backup before modifying
+    --format {text,json}   Output format (default: text)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from kicad_tools.schema import LibraryManager, Schematic
+from kicad_tools.sexp import SExp
+
+POINT_TOLERANCE = 1.27  # mm - standard KiCad grid
+
+
+@dataclass
+class RemoveComponentResult:
+    """Result of a remove-component operation."""
+
+    reference: str
+    symbol_removed: bool
+    wires_removed: int
+    junctions_removed: int
+    lib_symbol_removed: bool
+    instance_path_removed: bool
+
+
+def _find_wires_at_point(
+    schematic: Schematic,
+    point: tuple[float, float],
+    tolerance: float = POINT_TOLERANCE,
+) -> list[SExp]:
+    """Find all wire S-expression nodes with an endpoint at or near a point."""
+    target_key = (int(point[0] * 10), int(point[1] * 10))
+    matching = []
+
+    for wire_sexp in schematic.sexp.find_all("wire"):
+        pts_node = wire_sexp.find("pts")
+        if not pts_node:
+            continue
+
+        xy_nodes = pts_node.find_all("xy")
+        if len(xy_nodes) < 2:
+            continue
+
+        for xy in xy_nodes:
+            x = xy.get_float(0) or 0.0
+            y = xy.get_float(1) or 0.0
+            key = (int(x * 10), int(y * 10))
+
+            tol_units = int(tolerance * 10)
+            if (
+                abs(key[0] - target_key[0]) <= tol_units
+                and abs(key[1] - target_key[1]) <= tol_units
+            ):
+                matching.append(wire_sexp)
+                break  # Don't add same wire twice
+
+    return matching
+
+
+def _wire_start_end(wire_sexp: SExp) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Extract start and end points from a wire S-expression node."""
+    pts_node = wire_sexp.find("pts")
+    if not pts_node:
+        return (0.0, 0.0), (0.0, 0.0)
+
+    xy_nodes = pts_node.find_all("xy")
+    if len(xy_nodes) < 2:
+        return (0.0, 0.0), (0.0, 0.0)
+
+    x1 = xy_nodes[0].get_float(0) or 0.0
+    y1 = xy_nodes[0].get_float(1) or 0.0
+    x2 = xy_nodes[1].get_float(0) or 0.0
+    y2 = xy_nodes[1].get_float(1) or 0.0
+
+    return (x1, y1), (x2, y2)
+
+
+def _wire_endpoint_counts(
+    wire_sexps: list[SExp],
+) -> dict[tuple[int, int], int]:
+    """Count how many wires touch each endpoint."""
+    counts: dict[tuple[int, int], int] = {}
+    for ws in wire_sexps:
+        start, end = _wire_start_end(ws)
+        for pt in [start, end]:
+            key = (int(pt[0] * 10), int(pt[1] * 10))
+            counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _collect_all_connectable_points(
+    schematic: Schematic,
+    lib_manager: LibraryManager,
+    exclude_reference: str,
+) -> set[tuple[int, int]]:
+    """Collect all connectable points in the schematic *except* for the symbol
+    identified by ``exclude_reference``.
+
+    Connectable points include:
+    - Pin positions of all other symbols (resolved via library)
+    - Label positions (label, global_label, hierarchical_label)
+    - Power flag / power symbol pin positions (already covered by symbols)
+    - No-connect positions
+    """
+    points: set[tuple[int, int]] = set()
+
+    # Other symbol pin positions
+    for sym in schematic.symbols:
+        if sym.reference == exclude_reference:
+            continue
+
+        lib_sym = lib_manager.get_symbol(sym.lib_id)
+        if lib_sym is None and ":" in sym.lib_id:
+            sym_name = sym.lib_id.split(":", 1)[1]
+            lib_sym = lib_manager.get_symbol(sym_name)
+
+        if lib_sym is not None:
+            pin_positions = lib_sym.get_all_pin_positions(
+                instance_pos=sym.position,
+                instance_rot=sym.rotation,
+                mirror=sym.mirror,
+            )
+            for pos in pin_positions.values():
+                points.add((int(pos[0] * 10), int(pos[1] * 10)))
+        else:
+            # Fallback: use symbol origin as a connectable point
+            points.add((int(sym.position[0] * 10), int(sym.position[1] * 10)))
+
+    # Labels (local, global, hierarchical)
+    for tag in ("label", "global_label", "hierarchical_label"):
+        for lbl_sexp in schematic.sexp.find_all(tag):
+            at_node = lbl_sexp.find("at")
+            if at_node:
+                x = at_node.get_float(0) or 0.0
+                y = at_node.get_float(1) or 0.0
+                points.add((int(x * 10), int(y * 10)))
+
+    # No-connect markers (wire endpoints touching these are NOT exclusive)
+    for nc_sexp in schematic.sexp.find_all("no_connect"):
+        at_node = nc_sexp.find("at")
+        if at_node:
+            x = at_node.get_float(0) or 0.0
+            y = at_node.get_float(1) or 0.0
+            points.add((int(x * 10), int(y * 10)))
+
+    return points
+
+
+def _is_wire_exclusive(
+    wire_sexp: SExp,
+    pin_keys: set[tuple[int, int]],
+    other_connectable: set[tuple[int, int]],
+    tolerance: float = POINT_TOLERANCE,
+) -> bool:
+    """Determine if a wire is exclusively connected to the removed symbol.
+
+    A wire is exclusive if *every* endpoint either:
+    - Touches one of the removed symbol's pin positions, OR
+    - Does NOT touch any other connectable point (dangling end)
+
+    In other words, a wire is shared (not exclusive) if at least one of its
+    endpoints touches a connectable point belonging to another element.
+    """
+    tol_units = int(tolerance * 10)
+    start, end = _wire_start_end(wire_sexp)
+
+    for pt in [start, end]:
+        pt_key = (int(pt[0] * 10), int(pt[1] * 10))
+
+        # If this endpoint is one of the removed symbol's pins, it's fine
+        is_own_pin = False
+        for pk in pin_keys:
+            if abs(pt_key[0] - pk[0]) <= tol_units and abs(pt_key[1] - pk[1]) <= tol_units:
+                is_own_pin = True
+                break
+        if is_own_pin:
+            continue
+
+        # If this endpoint touches another connectable element, wire is shared
+        for cp in other_connectable:
+            if abs(pt_key[0] - cp[0]) <= tol_units and abs(pt_key[1] - cp[1]) <= tol_units:
+                return False
+
+        # Check if another wire also has an endpoint here (T-junction / continuation)
+        # If so, the wire is shared infrastructure
+        # This is handled implicitly: if the other end doesn't touch any
+        # connectable point, the wire endpoint is dangling and exclusive
+
+    return True
+
+
+def _find_symbol_sexp(schematic: Schematic, reference: str) -> SExp | None:
+    """Find the top-level symbol S-expression node by reference designator."""
+    for sym_sexp in schematic.sexp.find_all("symbol"):
+        for prop in sym_sexp.find_all("property"):
+            prop_name = prop.get_string(0)
+            if prop_name == "Reference":
+                prop_value = prop.get_string(1)
+                if prop_value == reference:
+                    return sym_sexp
+    return None
+
+
+def _get_symbol_uuid(sym_sexp: SExp) -> str | None:
+    """Extract UUID from a symbol S-expression node."""
+    uuid_node = sym_sexp.find("uuid")
+    if uuid_node:
+        return uuid_node.get_string(0)
+    return None
+
+
+def _remove_symbol_instance_path(schematic: Schematic, sym_uuid: str) -> bool:
+    """Remove the symbol_instances path entry for the given UUID."""
+    si_section = schematic.sexp.find("symbol_instances")
+    if si_section is None:
+        return False
+
+    for path_node in list(si_section.find_all("path")):
+        path_str = path_node.get_string(0)
+        if path_str and sym_uuid in path_str:
+            if si_section.remove(path_node):
+                return True
+    return False
+
+
+def _count_lib_id_usage(schematic: Schematic, lib_id: str) -> int:
+    """Count how many symbol instances use the given lib_id."""
+    count = 0
+    for sym in schematic.symbols:
+        if sym.lib_id == lib_id:
+            count += 1
+    return count
+
+
+def _remove_lib_symbol(schematic: Schematic, lib_id: str) -> bool:
+    """Remove the lib_symbols entry for the given lib_id."""
+    lib_syms = schematic.lib_symbols
+    if lib_syms is None:
+        return False
+
+    for sym_sexp in list(lib_syms.find_all("symbol")):
+        sym_name = sym_sexp.get_string(0)
+        if sym_name == lib_id:
+            if lib_syms.remove(sym_sexp):
+                return True
+    return False
+
+
+def remove_component(
+    schematic: Schematic,
+    lib_manager: LibraryManager,
+    reference: str,
+) -> RemoveComponentResult:
+    """Remove a symbol and its exclusive wires from the schematic.
+
+    Returns a RemoveComponentResult describing what was changed.
+    """
+    result = RemoveComponentResult(
+        reference=reference,
+        symbol_removed=False,
+        wires_removed=0,
+        junctions_removed=0,
+        lib_symbol_removed=False,
+        instance_path_removed=False,
+    )
+
+    # Find symbol instance
+    symbol = schematic.get_symbol(reference)
+    if symbol is None:
+        return result
+
+    sym_sexp = _find_symbol_sexp(schematic, reference)
+    if sym_sexp is None:
+        return result
+
+    sym_uuid = _get_symbol_uuid(sym_sexp) or ""
+    lib_id = symbol.lib_id
+
+    # Resolve pin positions
+    pin_positions: dict[str, tuple[float, float]] = {}
+    lib_sym = lib_manager.get_symbol(symbol.lib_id)
+    if lib_sym is None and ":" in symbol.lib_id:
+        sym_name = symbol.lib_id.split(":", 1)[1]
+        lib_sym = lib_manager.get_symbol(sym_name)
+
+    if lib_sym is not None:
+        pin_positions = lib_sym.get_all_pin_positions(
+            instance_pos=symbol.position,
+            instance_rot=symbol.rotation,
+            mirror=symbol.mirror,
+        )
+
+    pin_keys = {(int(p[0] * 10), int(p[1] * 10)) for p in pin_positions.values()}
+
+    # If no pin positions resolved, use symbol origin as fallback
+    if not pin_keys:
+        pin_keys = {(int(symbol.position[0] * 10), int(symbol.position[1] * 10))}
+
+    # Collect connectable points from other elements
+    other_connectable = _collect_all_connectable_points(
+        schematic, lib_manager, reference,
+    )
+
+    # Find wires connected to this symbol
+    all_connected_wires: list[SExp] = []
+    seen_ids: set[int] = set()
+    for pos in pin_positions.values():
+        for wire in _find_wires_at_point(schematic, pos):
+            wire_id = id(wire)
+            if wire_id not in seen_ids:
+                seen_ids.add(wire_id)
+                all_connected_wires.append(wire)
+
+    # Also check symbol origin for power symbols with no resolved pins
+    if not pin_positions:
+        for wire in _find_wires_at_point(schematic, symbol.position):
+            wire_id = id(wire)
+            if wire_id not in seen_ids:
+                seen_ids.add(wire_id)
+                all_connected_wires.append(wire)
+
+    # Determine which wires are exclusive
+    exclusive_wires: list[SExp] = []
+    for wire in all_connected_wires:
+        if _is_wire_exclusive(wire, pin_keys, other_connectable):
+            exclusive_wires.append(wire)
+
+    # Remove exclusive wires and collect their endpoints for junction cleanup
+    wire_endpoints: list[tuple[float, float]] = []
+    for wire in exclusive_wires:
+        start, end = _wire_start_end(wire)
+        wire_endpoints.extend([start, end])
+        if schematic.sexp.remove(wire):
+            result.wires_removed += 1
+
+    # Clean up orphaned junctions at former wire endpoints
+    if wire_endpoints:
+        remaining_wires = list(schematic.sexp.find_all("wire"))
+        endpoint_counts = _wire_endpoint_counts(remaining_wires)
+
+        checked_keys: set[tuple[int, int]] = set()
+        for pt in wire_endpoints:
+            pt_key = (int(pt[0] * 10), int(pt[1] * 10))
+            if pt_key in checked_keys:
+                continue
+            checked_keys.add(pt_key)
+
+            wire_count = endpoint_counts.get(pt_key, 0)
+            if wire_count >= 3:
+                continue
+
+            for junc_sexp in list(schematic.sexp.find_all("junction")):
+                at_node = junc_sexp.find("at")
+                if not at_node:
+                    continue
+                jx = at_node.get_float(0) or 0.0
+                jy = at_node.get_float(1) or 0.0
+                junc_key = (int(jx * 10), int(jy * 10))
+
+                if junc_key == pt_key:
+                    if schematic.sexp.remove(junc_sexp):
+                        result.junctions_removed += 1
+
+    # Remove the symbol node itself
+    if schematic.sexp.remove(sym_sexp):
+        result.symbol_removed = True
+
+    # Remove symbol_instances path entry
+    if sym_uuid:
+        result.instance_path_removed = _remove_symbol_instance_path(schematic, sym_uuid)
+
+    # Clean up lib_symbols if this was the last instance
+    # After removing the symbol, count remaining instances with this lib_id
+    # (invalidate cache first so symbols list is refreshed)
+    schematic.invalidate_cache()
+    remaining_count = _count_lib_id_usage(schematic, lib_id)
+    if remaining_count == 0:
+        result.lib_symbol_removed = _remove_lib_symbol(schematic, lib_id)
+        schematic.invalidate_cache()
+
+    return result
+
+
+def preview_remove_component(
+    schematic: Schematic,
+    lib_manager: LibraryManager,
+    reference: str,
+) -> dict:
+    """Preview what would be removed without modifying the schematic.
+
+    Returns a dict with preview information.
+    """
+    symbol = schematic.get_symbol(reference)
+    if symbol is None:
+        return {"error": f"Symbol '{reference}' not found"}
+
+    # Resolve pin positions
+    pin_positions: dict[str, tuple[float, float]] = {}
+    lib_sym = lib_manager.get_symbol(symbol.lib_id)
+    if lib_sym is None and ":" in symbol.lib_id:
+        sym_name = symbol.lib_id.split(":", 1)[1]
+        lib_sym = lib_manager.get_symbol(sym_name)
+
+    if lib_sym is not None:
+        pin_positions = lib_sym.get_all_pin_positions(
+            instance_pos=symbol.position,
+            instance_rot=symbol.rotation,
+            mirror=symbol.mirror,
+        )
+
+    pin_keys = {(int(p[0] * 10), int(p[1] * 10)) for p in pin_positions.values()}
+    if not pin_keys:
+        pin_keys = {(int(symbol.position[0] * 10), int(symbol.position[1] * 10))}
+
+    other_connectable = _collect_all_connectable_points(
+        schematic, lib_manager, reference,
+    )
+
+    # Find connected wires
+    all_connected_wires: list[SExp] = []
+    seen_ids: set[int] = set()
+    for pos in pin_positions.values():
+        for wire in _find_wires_at_point(schematic, pos):
+            wire_id = id(wire)
+            if wire_id not in seen_ids:
+                seen_ids.add(wire_id)
+                all_connected_wires.append(wire)
+
+    if not pin_positions:
+        for wire in _find_wires_at_point(schematic, symbol.position):
+            wire_id = id(wire)
+            if wire_id not in seen_ids:
+                seen_ids.add(wire_id)
+                all_connected_wires.append(wire)
+
+    exclusive_count = sum(
+        1 for w in all_connected_wires
+        if _is_wire_exclusive(w, pin_keys, other_connectable)
+    )
+    shared_count = len(all_connected_wires) - exclusive_count
+
+    lib_id = symbol.lib_id
+    remaining_after = _count_lib_id_usage(schematic, lib_id) - 1
+    will_remove_lib = remaining_after <= 0
+
+    return {
+        "reference": reference,
+        "lib_id": lib_id,
+        "position": list(symbol.position),
+        "pins": len(pin_positions),
+        "wires_connected": len(all_connected_wires),
+        "wires_exclusive": exclusive_count,
+        "wires_shared": shared_count,
+        "will_remove_lib_symbol": will_remove_lib,
+    }
+
+
+def run_remove_component(args) -> int:
+    """Execute the remove-component command."""
+    schematic_path = Path(args.schematic)
+
+    if not args.ref:
+        print("Error: --ref is required", file=sys.stderr)
+        return 1
+
+    try:
+        sch = Schematic.load(schematic_path)
+    except FileNotFoundError:
+        print(f"Error: Schematic not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    # Set up library manager
+    lib_manager = LibraryManager()
+
+    if args.lib_paths:
+        for lp in args.lib_paths:
+            lib_manager.add_search_path(lp)
+
+    if args.libs:
+        for lib_file in args.libs:
+            lib_manager.load_library(lib_file)
+
+    lib_manager.load_embedded(sch)
+
+    # Check symbol exists
+    symbol = sch.get_symbol(args.ref)
+    if symbol is None:
+        msg = f"Symbol '{args.ref}' not found in schematic"
+        if args.format == "json":
+            print(json.dumps({"error": msg, "removed": False}, indent=2))
+        else:
+            print(f"Error: {msg}", file=sys.stderr)
+        return 1
+
+    # Dry run
+    if args.dry_run:
+        preview = preview_remove_component(sch, lib_manager, args.ref)
+
+        if args.format == "json":
+            preview["dry_run"] = True
+            preview["removed"] = False
+            print(json.dumps(preview, indent=2))
+        else:
+            print("DRY RUN - No changes will be made")
+            print("=" * 60)
+            print(f"Symbol: {args.ref} ({preview.get('lib_id', '?')})")
+            pos = preview.get("position", [0, 0])
+            print(f"Position: ({pos[0]:.2f}, {pos[1]:.2f})")
+            print(f"Pins: {preview.get('pins', 0)}")
+            print(f"Wires connected: {preview.get('wires_connected', 0)}")
+            print(f"  Exclusive (would remove): {preview.get('wires_exclusive', 0)}")
+            print(f"  Shared (would preserve): {preview.get('wires_shared', 0)}")
+            if preview.get("will_remove_lib_symbol"):
+                print(f"Library symbol '{preview.get('lib_id')}': would be removed (last instance)")
+        return 0
+
+    # Create backup if requested
+    if args.backup:
+        backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        shutil.copy2(schematic_path, backup_path)
+        if args.format != "json":
+            print(f"Backup created: {backup_path}")
+
+    # Execute removal
+    result = remove_component(sch, lib_manager, args.ref)
+
+    if not result.symbol_removed:
+        msg = f"Failed to remove symbol '{args.ref}'"
+        if args.format == "json":
+            print(json.dumps({"error": msg, "removed": False}, indent=2))
+        else:
+            print(f"Error: {msg}", file=sys.stderr)
+        return 1
+
+    sch.save()
+
+    if args.format == "json":
+        data = {
+            "removed": True,
+            "reference": result.reference,
+            "wires_removed": result.wires_removed,
+            "junctions_removed": result.junctions_removed,
+            "lib_symbol_removed": result.lib_symbol_removed,
+            "instance_path_removed": result.instance_path_removed,
+        }
+        print(json.dumps(data, indent=2))
+    else:
+        print(f"Removed symbol: {result.reference}")
+        print(f"  Wires removed: {result.wires_removed}")
+        if result.junctions_removed:
+            print(f"  Junctions removed: {result.junctions_removed}")
+        if result.lib_symbol_removed:
+            print("  Library symbol removed (last instance)")
+        if result.instance_path_removed:
+            print("  Instance path entry removed")
+
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Remove a symbol from a KiCad schematic",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", help="Path to .kicad_sch file")
+    parser.add_argument("--ref", required=True, help="Symbol reference designator (e.g., U1)")
+    parser.add_argument(
+        "--lib-path", action="append", dest="lib_paths", help="Library search path"
+    )
+    parser.add_argument("--lib", action="append", dest="libs", help="Specific library file")
+    parser.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview without modifying"
+    )
+    parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    parser.add_argument(
+        "--format", choices=["text", "json"], default="text", help="Output format"
+    )
+
+    args = parser.parse_args(argv)
+    return run_remove_component(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sch_remove_component.py
+++ b/tests/test_sch_remove_component.py
@@ -1,0 +1,492 @@
+"""Tests for the sch remove-component command.
+
+Covers symbol removal, exclusive vs shared wire handling, orphaned junction
+cleanup, dry-run mode, JSON output, lib_symbols cleanup, symbol_instances
+cleanup, and error cases.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kicad_tools.cli.sch_remove_component import (
+    main as remove_component_main,
+)
+from kicad_tools.cli.sch_remove_component import (
+    remove_component,
+)
+from kicad_tools.schema import LibraryManager, Schematic
+
+# ---------------------------------------------------------------------------
+# Minimal schematic with a symbol that has one exclusive wire
+# ---------------------------------------------------------------------------
+
+SCHEMATIC_EXCLUSIVE_WIRE = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "power:PWR_FLAG"
+      (property "Reference" "#FLG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "PWR_FLAG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:PWR_FLAG_0_1"
+        (pin power_out line (at 0 0 0) (length 0) (name "pwr" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (symbol (lib_id "power:PWR_FLAG") (at 100 50 0) (unit 1)
+    (in_bom no) (on_board no) (dnp no)
+    (uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    (property "Reference" "#FLG01" (at 100 45 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "PWR_FLAG" (at 100 42 0) (effects (font (size 1.27 1.27))))
+    (pin "1" (uuid "pin-uuid-1"))
+  )
+  (wire (pts (xy 100 50) (xy 100 60))
+    (stroke (width 0) (type default))
+    (uuid "wire-exclusive-1")
+  )
+  (symbol_instances
+    (path "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+      (reference "#FLG01") (unit 1)
+    )
+  )
+)
+"""
+
+# ---------------------------------------------------------------------------
+# Schematic with a shared wire (another symbol also connects to the wire)
+# ---------------------------------------------------------------------------
+
+SCHEMATIC_SHARED_WIRE = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "power:PWR_FLAG"
+      (property "Reference" "#FLG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "PWR_FLAG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:PWR_FLAG_0_1"
+        (pin power_out line (at 0 0 0) (length 0) (name "pwr" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+    (symbol "power:GND"
+      (property "Reference" "#PWR" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "GND" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:GND_0_1"
+        (pin power_in line (at 0 0 0) (length 0) (name "GND" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (symbol (lib_id "power:PWR_FLAG") (at 100 50 0) (unit 1)
+    (in_bom no) (on_board no) (dnp no)
+    (uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    (property "Reference" "#FLG01" (at 100 45 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "PWR_FLAG" (at 100 42 0) (effects (font (size 1.27 1.27))))
+    (pin "1" (uuid "pin-uuid-1"))
+  )
+  (symbol (lib_id "power:GND") (at 100 60 0) (unit 1)
+    (in_bom no) (on_board no) (dnp no)
+    (uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    (property "Reference" "#PWR01" (at 100 65 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "GND" (at 100 63 0) (effects (font (size 1.27 1.27))))
+    (pin "1" (uuid "pin-uuid-2"))
+  )
+  (wire (pts (xy 100 50) (xy 100 60))
+    (stroke (width 0) (type default))
+    (uuid "wire-shared-1")
+  )
+  (symbol_instances
+    (path "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+      (reference "#FLG01") (unit 1)
+    )
+    (path "/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+      (reference "#PWR01") (unit 1)
+    )
+  )
+)
+"""
+
+# ---------------------------------------------------------------------------
+# Schematic with a symbol that has no wires
+# ---------------------------------------------------------------------------
+
+SCHEMATIC_NO_WIRES = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "power:PWR_FLAG"
+      (property "Reference" "#FLG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "PWR_FLAG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:PWR_FLAG_0_1"
+        (pin power_out line (at 0 0 0) (length 0) (name "pwr" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (symbol (lib_id "power:PWR_FLAG") (at 200 200 0) (unit 1)
+    (in_bom no) (on_board no) (dnp no)
+    (uuid "cccccccc-cccc-cccc-cccc-cccccccccccc")
+    (property "Reference" "#FLG02" (at 200 195 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "PWR_FLAG" (at 200 192 0) (effects (font (size 1.27 1.27))))
+    (pin "1" (uuid "pin-uuid-3"))
+  )
+  (symbol_instances
+    (path "/cccccccc-cccc-cccc-cccc-cccccccccccc"
+      (reference "#FLG02") (unit 1)
+    )
+  )
+)
+"""
+
+# ---------------------------------------------------------------------------
+# Schematic with two instances of the same lib_id (for lib_symbols cleanup test)
+# ---------------------------------------------------------------------------
+
+SCHEMATIC_TWO_INSTANCES = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "power:PWR_FLAG"
+      (property "Reference" "#FLG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "PWR_FLAG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:PWR_FLAG_0_1"
+        (pin power_out line (at 0 0 0) (length 0) (name "pwr" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (symbol (lib_id "power:PWR_FLAG") (at 100 50 0) (unit 1)
+    (in_bom no) (on_board no) (dnp no)
+    (uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    (property "Reference" "#FLG01" (at 100 45 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "PWR_FLAG" (at 100 42 0) (effects (font (size 1.27 1.27))))
+    (pin "1" (uuid "pin-uuid-1"))
+  )
+  (symbol (lib_id "power:PWR_FLAG") (at 200 50 0) (unit 1)
+    (in_bom no) (on_board no) (dnp no)
+    (uuid "dddddddd-dddd-dddd-dddd-dddddddddddd")
+    (property "Reference" "#FLG02" (at 200 45 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "PWR_FLAG" (at 200 42 0) (effects (font (size 1.27 1.27))))
+    (pin "1" (uuid "pin-uuid-4"))
+  )
+  (symbol_instances
+    (path "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+      (reference "#FLG01") (unit 1)
+    )
+    (path "/dddddddd-dddd-dddd-dddd-dddddddddddd"
+      (reference "#FLG02") (unit 1)
+    )
+  )
+)
+"""
+
+# ---------------------------------------------------------------------------
+# Schematic with a junction that becomes orphaned
+# ---------------------------------------------------------------------------
+
+SCHEMATIC_WITH_JUNCTION = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "power:PWR_FLAG"
+      (property "Reference" "#FLG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "PWR_FLAG" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (symbol "power:PWR_FLAG_0_1"
+        (pin power_out line (at 0 0 0) (length 0) (name "pwr" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (symbol (lib_id "power:PWR_FLAG") (at 100 50 0) (unit 1)
+    (in_bom no) (on_board no) (dnp no)
+    (uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    (property "Reference" "#FLG01" (at 100 45 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "PWR_FLAG" (at 100 42 0) (effects (font (size 1.27 1.27))))
+    (pin "1" (uuid "pin-uuid-1"))
+  )
+  (wire (pts (xy 100 50) (xy 100 60))
+    (stroke (width 0) (type default))
+    (uuid "wire-excl-1")
+  )
+  (junction (at 100 50)
+    (diameter 0)
+    (color 0 0 0 0)
+    (uuid "junc-1")
+  )
+  (symbol_instances
+    (path "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+      (reference "#FLG01") (unit 1)
+    )
+  )
+)
+"""
+
+
+def _write_sch(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "test_remove.kicad_sch"
+    p.write_text(content)
+    return p
+
+
+class TestRemoveExclusiveWire:
+    """Removing a symbol with one exclusive wire: wire is removed."""
+
+    def test_exclusive_wire_removed(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_EXCLUSIVE_WIRE)
+        sch = Schematic.load(sch_path)
+
+        lib_manager = LibraryManager()
+        lib_manager.load_embedded(sch)
+
+        result = remove_component(sch, lib_manager, "#FLG01")
+
+        assert result.symbol_removed is True
+        assert result.wires_removed == 1
+        assert result.lib_symbol_removed is True
+        assert result.instance_path_removed is True
+
+        # Verify the wire is gone
+        remaining_wires = list(sch.sexp.find_all("wire"))
+        assert len(remaining_wires) == 0
+
+        # Verify the symbol is gone
+        assert sch.get_symbol("#FLG01") is None
+
+
+class TestRemoveSharedWire:
+    """Removing a symbol with a shared wire: wire is preserved."""
+
+    def test_shared_wire_preserved(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_SHARED_WIRE)
+        sch = Schematic.load(sch_path)
+
+        lib_manager = LibraryManager()
+        lib_manager.load_embedded(sch)
+
+        result = remove_component(sch, lib_manager, "#FLG01")
+
+        assert result.symbol_removed is True
+        assert result.wires_removed == 0  # Wire is shared with GND
+
+        # Verify the wire still exists
+        remaining_wires = list(sch.sexp.find_all("wire"))
+        assert len(remaining_wires) == 1
+
+        # Verify the other symbol still exists
+        assert sch.get_symbol("#PWR01") is not None
+
+        # lib_symbols for PWR_FLAG should be removed (last instance of that lib_id)
+        assert result.lib_symbol_removed is True
+
+        # GND lib symbol should still exist
+        lib_syms = sch.lib_symbols
+        gnd_found = False
+        for sym in lib_syms.find_all("symbol"):
+            if sym.get_string(0) == "power:GND":
+                gnd_found = True
+        assert gnd_found
+
+
+class TestRemoveNoWires:
+    """Removing a symbol with no wires: only symbol is removed."""
+
+    def test_no_wires(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_NO_WIRES)
+        sch = Schematic.load(sch_path)
+
+        lib_manager = LibraryManager()
+        lib_manager.load_embedded(sch)
+
+        result = remove_component(sch, lib_manager, "#FLG02")
+
+        assert result.symbol_removed is True
+        assert result.wires_removed == 0
+        assert result.junctions_removed == 0
+        assert result.lib_symbol_removed is True
+
+
+class TestLibSymbolsNotRemovedWhenOtherInstances:
+    """lib_symbols entry preserved when other instances remain."""
+
+    def test_lib_symbol_preserved(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_TWO_INSTANCES)
+        sch = Schematic.load(sch_path)
+
+        lib_manager = LibraryManager()
+        lib_manager.load_embedded(sch)
+
+        result = remove_component(sch, lib_manager, "#FLG01")
+
+        assert result.symbol_removed is True
+        assert result.lib_symbol_removed is False  # #FLG02 still uses it
+
+        # Verify the other instance is still there
+        assert sch.get_symbol("#FLG02") is not None
+
+        # Verify lib_symbols entry still exists
+        lib_syms = sch.lib_symbols
+        found = False
+        for sym in lib_syms.find_all("symbol"):
+            if sym.get_string(0) == "power:PWR_FLAG":
+                found = True
+        assert found
+
+
+class TestOrphanedJunctionCleanup:
+    """Orphaned junctions are removed when exclusive wires are removed."""
+
+    def test_junction_removed(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_WITH_JUNCTION)
+        sch = Schematic.load(sch_path)
+
+        lib_manager = LibraryManager()
+        lib_manager.load_embedded(sch)
+
+        result = remove_component(sch, lib_manager, "#FLG01")
+
+        assert result.symbol_removed is True
+        assert result.wires_removed == 1
+        assert result.junctions_removed == 1
+
+        # Verify junction is gone
+        remaining_junctions = list(sch.sexp.find_all("junction"))
+        assert len(remaining_junctions) == 0
+
+
+class TestDryRun:
+    """--dry-run mode does not modify the file."""
+
+    def test_dry_run_text(self, tmp_path: Path, capsys):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_EXCLUSIVE_WIRE)
+        original_content = sch_path.read_text()
+
+        rc = remove_component_main([
+            str(sch_path), "--ref", "#FLG01", "--dry-run",
+        ])
+
+        assert rc == 0
+        # File should be unchanged
+        assert sch_path.read_text() == original_content
+
+        captured = capsys.readouterr()
+        assert "DRY RUN" in captured.out
+        assert "#FLG01" in captured.out
+
+    def test_dry_run_json(self, tmp_path: Path, capsys):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_EXCLUSIVE_WIRE)
+        original_content = sch_path.read_text()
+
+        rc = remove_component_main([
+            str(sch_path), "--ref", "#FLG01", "--dry-run", "--format", "json",
+        ])
+
+        assert rc == 0
+        assert sch_path.read_text() == original_content
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["dry_run"] is True
+        assert data["removed"] is False
+        assert data["reference"] == "#FLG01"
+        assert "wires_exclusive" in data
+
+
+class TestReferenceNotFound:
+    """Exit code 1 when reference not found."""
+
+    def test_not_found_text(self, tmp_path: Path, capsys):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_NO_WIRES)
+
+        rc = remove_component_main([
+            str(sch_path), "--ref", "NONEXISTENT",
+        ])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "not found" in captured.err
+
+    def test_not_found_json(self, tmp_path: Path, capsys):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_NO_WIRES)
+
+        rc = remove_component_main([
+            str(sch_path), "--ref", "NONEXISTENT", "--format", "json",
+        ])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["removed"] is False
+        assert "error" in data
+
+
+class TestJsonOutput:
+    """--format json produces valid structured output."""
+
+    def test_json_success(self, tmp_path: Path, capsys):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_EXCLUSIVE_WIRE)
+
+        rc = remove_component_main([
+            str(sch_path), "--ref", "#FLG01", "--format", "json",
+        ])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["removed"] is True
+        assert data["reference"] == "#FLG01"
+        assert isinstance(data["wires_removed"], int)
+        assert isinstance(data["junctions_removed"], int)
+        assert isinstance(data["lib_symbol_removed"], bool)
+        assert isinstance(data["instance_path_removed"], bool)
+
+
+class TestBackup:
+    """--backup creates a timestamped backup file."""
+
+    def test_backup_created(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_EXCLUSIVE_WIRE)
+        original_content = sch_path.read_text()
+
+        rc = remove_component_main([
+            str(sch_path), "--ref", "#FLG01", "--backup",
+        ])
+
+        assert rc == 0
+
+        # Find backup file
+        backup_files = list(tmp_path.glob("*.backup-*"))
+        assert len(backup_files) == 1
+        assert backup_files[0].read_text() == original_content
+
+
+class TestSaveRoundTrip:
+    """Verify schematic can be saved and reloaded after removal."""
+
+    def test_round_trip(self, tmp_path: Path):
+        sch_path = _write_sch(tmp_path, SCHEMATIC_EXCLUSIVE_WIRE)
+
+        rc = remove_component_main([
+            str(sch_path), "--ref", "#FLG01",
+        ])
+        assert rc == 0
+
+        # Reload and verify
+        sch = Schematic.load(sch_path)
+        assert sch.get_symbol("#FLG01") is None
+        assert len(list(sch.sexp.find_all("wire"))) == 0


### PR DESCRIPTION
## Summary

Adds `kicad-tools sch remove-component` CLI command that removes a symbol from a KiCad schematic along with its exclusively-connected wires, orphaned junctions, unused `lib_symbols` entries, and `symbol_instances` path entries.

## Changes

- `src/kicad_tools/cli/sch_remove_component.py` -- New command module with wire exclusivity checking as the core algorithm: for each wire connected to the target symbol, determines whether the wire's other endpoint touches any other connectable element (other symbol pins, labels, no-connect markers)
- `src/kicad_tools/cli/commands/schematic.py` -- Added `remove-component` dispatch branch and updated usage string
- `src/kicad_tools/cli/parser.py` -- Added `sch remove-component` subparser with `--ref`, `--lib-path`, `--lib`, `--dry-run`, `--backup`, `--format` arguments
- `tests/test_sch_remove_component.py` -- 12 tests covering exclusive wire removal, shared wire preservation, no-wire symbols, junction cleanup, lib_symbols cleanup, two-instance preservation, dry-run, JSON output, backup, error cases, and round-trip save/reload

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `sch remove-component <sch> --ref <ref>` removes symbol SExp node | Pass | TestRemoveExclusiveWire, TestRemoveNoWires confirm symbol_removed=True |
| Exclusive wires removed | Pass | TestRemoveExclusiveWire: wires_removed=1, remaining wires=0 |
| Shared wires preserved | Pass | TestRemoveSharedWire: wires_removed=0, remaining wires=1 |
| Orphaned junctions removed | Pass | TestOrphanedJunctionCleanup: junctions_removed=1 |
| --dry-run shows preview without modifying | Pass | TestDryRun: file content unchanged, output includes preview |
| --backup creates timestamped backup | Pass | TestBackup: backup file created with original content |
| --format json structured output | Pass | TestJsonOutput: valid JSON with all expected fields |
| Unused lib_symbols entries cleaned up | Pass | TestRemoveExclusiveWire: lib_symbol_removed=True |
| lib_symbols preserved when other instances exist | Pass | TestLibSymbolsNotRemovedWhenOtherInstances: lib_symbol_removed=False |
| Error exit if reference not found | Pass | TestReferenceNotFound: rc=1, error message |
| symbol_instances path entry removed | Pass | TestRemoveExclusiveWire: instance_path_removed=True |

## Test Plan

All 12 tests pass: `python3 -m pytest tests/test_sch_remove_component.py -v`

Closes #2120