### PR TITLE
feat(fix-vias): detect and repair same-layer vias

### DIFF
--- a/src/kicad_tools/cli/fix_vias_cmd.py
+++ b/src/kicad_tools/cli/fix_vias_cmd.py
@@ -46,6 +46,33 @@ class ViaFix:
 
 
 @dataclass
+class SameLayerViaFix:
+    """Record of a same-layer via that was repaired."""
+
+    x: float
+    y: float
+    net: int
+    old_start_layer: str
+    old_end_layer: str
+    new_start_layer: str
+    new_end_layer: str
+    uuid: str
+
+
+@dataclass
+class SameLayerViaWarning:
+    """Warning for a same-layer via that could not be auto-repaired (blind/buried)."""
+
+    x: float
+    y: float
+    net: int
+    start_layer: str
+    end_layer: str
+    via_type: str
+    uuid: str
+
+
+@dataclass
 class ViaClearanceWarning:
     """Warning for a via that may cause clearance issues after resize."""
 
@@ -148,11 +175,16 @@ def _closest_point_on_segment(
     return (cx, cy, dist)
 
 
-def find_all_vias(doc: SExp) -> list[tuple[SExp, float, float, float, float, int, str]]:
+def find_all_vias(
+    doc: SExp,
+) -> list[tuple[SExp, float, float, float, float, int, str, str, str, str]]:
     """Find all vias in the PCB document.
 
     Returns:
-        List of (node, x, y, drill, diameter, net, uuid) tuples
+        List of (node, x, y, drill, diameter, net, uuid, start_layer, end_layer, via_type) tuples.
+        ``start_layer`` and ``end_layer`` are the layer names from the ``(layers ...)``
+        child node.  ``via_type`` is the value of the ``(type ...)`` child node
+        (e.g. ``"blind"``, ``"micro"``), or ``""`` for standard through-hole vias.
     """
     vias = []
 
@@ -169,6 +201,8 @@ def find_all_vias(doc: SExp) -> list[tuple[SExp, float, float, float, float, int
         drill_node = via_node.find("drill")
         net_node = via_node.find("net")
         uuid_node = via_node.find("uuid")
+        layers_node = via_node.find("layers")
+        type_node = via_node.find("type")
 
         diameter = float(size_node.get_first_atom()) if size_node else 0
         drill = float(drill_node.get_first_atom()) if drill_node else 0
@@ -179,7 +213,19 @@ def find_all_vias(doc: SExp) -> list[tuple[SExp, float, float, float, float, int
             net = 0  # KiCad 9 name-only format or empty string
         uuid = uuid_node.get_first_atom() if uuid_node else ""
 
-        vias.append((via_node, x, y, drill, diameter, net, uuid))
+        # Extract layer names
+        if layers_node:
+            layer_atoms = layers_node.get_atoms()
+            start_layer = str(layer_atoms[0]) if layer_atoms else ""
+            end_layer = str(layer_atoms[1]) if len(layer_atoms) > 1 else ""
+        else:
+            start_layer = ""
+            end_layer = ""
+
+        # Extract via type (empty string for standard through-hole)
+        via_type = str(type_node.get_first_atom()) if type_node else ""
+
+        vias.append((via_node, x, y, drill, diameter, net, uuid, start_layer, end_layer, via_type))
 
     return vias
 
@@ -263,6 +309,100 @@ def find_nearby_items(
     return items
 
 
+def get_board_outer_layers(doc: SExp) -> tuple[str, str]:
+    """Determine the outermost copper layers from the PCB document.
+
+    Reads the top-level ``(layers ...)`` section and returns the first and
+    last copper (signal/power) layer names.  Falls back to ``("F.Cu", "B.Cu")``
+    if detection fails.
+    """
+    layers_section = doc.find("layers")
+    if not layers_section:
+        return ("F.Cu", "B.Cu")
+
+    copper_layers: list[str] = []
+    for child in layers_section.children:
+        if not child.children:
+            continue
+        atoms = child.get_atoms()
+        # Each layer entry looks like: (0 "F.Cu" signal)
+        if len(atoms) >= 2:
+            layer_type = str(atoms[-1]) if len(atoms) >= 3 else ""
+            if layer_type in ("signal", "power"):
+                copper_layers.append(str(atoms[0]))
+
+    if len(copper_layers) >= 2:
+        return (copper_layers[0], copper_layers[-1])
+
+    return ("F.Cu", "B.Cu")
+
+
+def fix_same_layer_vias(
+    doc: SExp,
+    dry_run: bool = False,
+) -> tuple[list[SameLayerViaFix], list[SameLayerViaWarning]]:
+    """Detect and repair vias where start_layer == end_layer.
+
+    Through-hole vias (no ``(type ...)`` child, or ``type "through"``) are
+    auto-repaired by setting their layers to the board's outermost copper
+    layers.  Blind and micro vias produce a warning without auto-repair
+    because the correct target layer depends on the stackup.
+
+    Returns:
+        Tuple of (fixes, warnings).
+    """
+    fixes: list[SameLayerViaFix] = []
+    warnings: list[SameLayerViaWarning] = []
+
+    outer_start, outer_end = get_board_outer_layers(doc)
+    vias = find_all_vias(doc)
+
+    for via_node, x, y, _drill, _diameter, net, uuid, start_layer, end_layer, via_type in vias:
+        if not start_layer or not end_layer:
+            # Missing layers node -- skip gracefully
+            continue
+
+        if start_layer != end_layer:
+            continue
+
+        # Same-layer via detected
+        is_through = via_type in ("", "through")
+
+        if is_through:
+            fixes.append(
+                SameLayerViaFix(
+                    x=x,
+                    y=y,
+                    net=net,
+                    old_start_layer=start_layer,
+                    old_end_layer=end_layer,
+                    new_start_layer=outer_start,
+                    new_end_layer=outer_end,
+                    uuid=uuid,
+                )
+            )
+
+            if not dry_run:
+                layers_node = via_node.find("layers")
+                if layers_node:
+                    layers_node.set_value(0, outer_start)
+                    layers_node.set_value(1, outer_end)
+        else:
+            warnings.append(
+                SameLayerViaWarning(
+                    x=x,
+                    y=y,
+                    net=net,
+                    start_layer=start_layer,
+                    end_layer=end_layer,
+                    via_type=via_type,
+                    uuid=uuid,
+                )
+            )
+
+    return fixes, warnings
+
+
 def fix_vias(
     doc: SExp,
     target_drill: float,
@@ -298,7 +438,7 @@ def fix_vias(
 
     vias = find_all_vias(doc)
 
-    for via_node, x, y, current_drill, current_diameter, net, uuid in vias:
+    for via_node, x, y, current_drill, current_diameter, net, uuid, _sl, _el, _vt in vias:
         need_drill_fix = current_drill < target_drill
         need_diameter_fix = current_diameter < target_diameter
 
@@ -396,11 +536,13 @@ def print_fix_results(
     target_diameter: float = 0,
     mfr: str | None = None,
     skips: list[ViaSkip] | None = None,
+    same_layer_fixes: list[SameLayerViaFix] | None = None,
+    same_layer_warnings: list[SameLayerViaWarning] | None = None,
 ) -> None:
     """Print the results of via fixes.
 
     Args:
-        fixes: List of via fixes
+        fixes: List of via size fixes
         warnings: List of clearance warnings
         output_format: Output format ("text", "json", "summary")
         dry_run: Whether this was a dry run
@@ -408,8 +550,12 @@ def print_fix_results(
         target_diameter: Target diameter used
         mfr: Manufacturer name (for display)
         skips: List of vias skipped due to clearance violations
+        same_layer_fixes: List of same-layer vias that were repaired
+        same_layer_warnings: List of same-layer vias that could not be auto-repaired
     """
     skips = skips or []
+    same_layer_fixes = same_layer_fixes or []
+    same_layer_warnings = same_layer_warnings or []
 
     if output_format == "json":
         data = {
@@ -453,6 +599,31 @@ def print_fix_results(
                 }
                 for s in skips
             ],
+            "same_layer_fixes": [
+                {
+                    "x": f.x,
+                    "y": f.y,
+                    "net": f.net,
+                    "old_start_layer": f.old_start_layer,
+                    "old_end_layer": f.old_end_layer,
+                    "new_start_layer": f.new_start_layer,
+                    "new_end_layer": f.new_end_layer,
+                    "uuid": f.uuid,
+                }
+                for f in same_layer_fixes
+            ],
+            "same_layer_warnings": [
+                {
+                    "x": w.x,
+                    "y": w.y,
+                    "net": w.net,
+                    "start_layer": w.start_layer,
+                    "end_layer": w.end_layer,
+                    "via_type": w.via_type,
+                    "uuid": w.uuid,
+                }
+                for w in same_layer_warnings
+            ],
         }
         print(json.dumps(data, indent=2))
         return
@@ -466,11 +637,46 @@ def print_fix_results(
             print(f"  {len(skips)} vias skipped (clearance violation)")
         if warnings:
             print(f"  {len(warnings)} potential clearance violations")
+        if same_layer_fixes:
+            sl_action = "Would repair" if dry_run else "Repaired"
+            print(f"  {sl_action} {len(same_layer_fixes)} same-layer via(s)")
+        if same_layer_warnings:
+            print(
+                f"  {len(same_layer_warnings)} same-layer via(s) need manual repair "
+                f"(blind/micro)"
+            )
         return
 
-    # Text output
+    # Text output -- same-layer section
+    if same_layer_fixes:
+        sl_action = "Would repair" if dry_run else "Repaired"
+        print(f"\n{sl_action} {len(same_layer_fixes)} same-layer via(s):")
+        for f in same_layer_fixes[:5]:
+            print(
+                f"  Via at ({f.x:.2f}, {f.y:.2f}): "
+                f"layers {f.old_start_layer}/{f.old_end_layer} "
+                f"-> {f.new_start_layer}/{f.new_end_layer}"
+            )
+        if len(same_layer_fixes) > 5:
+            print(f"  ... and {len(same_layer_fixes) - 5} more")
+
+    if same_layer_warnings:
+        print(
+            f"\nWarning: {len(same_layer_warnings)} same-layer via(s) need manual repair "
+            f"(blind/micro type, cannot auto-determine target layer):"
+        )
+        for w in same_layer_warnings[:5]:
+            print(
+                f"  Via at ({w.x:.2f}, {w.y:.2f}): "
+                f"type={w.via_type}, layers={w.start_layer}/{w.end_layer}"
+            )
+        if len(same_layer_warnings) > 5:
+            print(f"  ... and {len(same_layer_warnings) - 5} more")
+
+    # Size fix section
     if not fixes and not skips:
-        print("No vias needed resizing.")
+        if not same_layer_fixes and not same_layer_warnings:
+            print("No vias needed resizing.")
         return
 
     action = "Would resize" if dry_run else "Resizing"
@@ -485,15 +691,15 @@ def print_fix_results(
         for f in fixes:
             print(
                 f"    Via at ({f.x:.2f}, {f.y:.2f}): "
-                f"drill {f.old_drill:.3f}→{f.new_drill:.3f}mm, "
-                f"diameter {f.old_diameter:.3f}→{f.new_diameter:.3f}mm"
+                f"drill {f.old_drill:.3f}->{f.new_drill:.3f}mm, "
+                f"diameter {f.old_diameter:.3f}->{f.new_diameter:.3f}mm"
             )
     else:
         for f in fixes[:3]:
             print(
                 f"    Via at ({f.x:.2f}, {f.y:.2f}): "
-                f"drill {f.old_drill:.3f}→{f.new_drill:.3f}mm, "
-                f"diameter {f.old_diameter:.3f}→{f.new_diameter:.3f}mm"
+                f"drill {f.old_drill:.3f}->{f.new_drill:.3f}mm, "
+                f"diameter {f.old_diameter:.3f}->{f.new_diameter:.3f}mm"
             )
         print(f"    ... and {len(fixes) - 3} more")
 
@@ -633,7 +839,12 @@ Examples:
         print(f"Error parsing PCB file: {e}", file=sys.stderr)
         return 1
 
-    # Fix vias
+    # Fix same-layer vias first (layer correction before size fixes)
+    same_layer_fixes, same_layer_warnings = fix_same_layer_vias(
+        doc, dry_run=args.dry_run
+    )
+
+    # Fix undersized vias
     fixes, warnings, skips = fix_vias(
         doc,
         target_drill,
@@ -655,10 +866,13 @@ Examples:
             target_diameter=target_diameter,
             mfr=args.mfr,
             skips=skips,
+            same_layer_fixes=same_layer_fixes,
+            same_layer_warnings=same_layer_warnings,
         )
 
-    # Save if not dry run and there were fixes
-    if fixes and not args.dry_run:
+    # Save if not dry run and there were any fixes (size or same-layer)
+    has_fixes = bool(fixes) or bool(same_layer_fixes)
+    if has_fixes and not args.dry_run:
         output_path = Path(args.output) if args.output else pcb_path
         try:
             save_pcb(doc, output_path)
@@ -671,7 +885,8 @@ Examples:
     # Return exit code 2 for success-with-warnings (pipeline treats this as
     # "completed with warnings" and continues).  Exit code 1 is reserved for
     # actual errors (file not found, parse failure, save failure).
-    return 2 if warnings else 0
+    has_warnings = bool(warnings) or bool(same_layer_warnings)
+    return 2 if has_warnings else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_fix_vias.py
+++ b/tests/test_fix_vias.py
@@ -5,11 +5,15 @@ from pathlib import Path
 import pytest
 
 from kicad_tools.cli.fix_vias_cmd import (
+    SameLayerViaFix,
+    SameLayerViaWarning,
     ViaSkip,
     _closest_point_on_segment,
     find_all_vias,
     find_nearby_items,
+    fix_same_layer_vias,
     fix_vias,
+    get_board_outer_layers,
     get_design_rules,
     main,
 )
@@ -128,13 +132,16 @@ class TestFindAllVias:
         assert len(vias) == 3
 
         # Check first via properties
-        node, x, y, drill, diameter, net, uuid = vias[0]
+        node, x, y, drill, diameter, net, uuid, start_layer, end_layer, via_type = vias[0]
         assert x == 110
         assert y == 110
         assert drill == 0.2
         assert diameter == 0.45
         assert net == 1
         assert uuid == "via-1"
+        assert start_layer == "F.Cu"
+        assert end_layer == "B.Cu"
+        assert via_type == ""
 
 
 class TestFixVias:
@@ -161,14 +168,14 @@ class TestFixVias:
 
         # Get original values
         vias_before = find_all_vias(doc)
-        _, _, _, drill_before, diameter_before, _, _ = vias_before[0]
+        _, _, _, drill_before, diameter_before, _, _, _, _, _ = vias_before[0]
 
         # Run fix with dry_run=True
         fix_vias(doc, target_drill=0.3, target_diameter=0.6, dry_run=True)
 
         # Values should be unchanged
         vias_after = find_all_vias(doc)
-        _, _, _, drill_after, diameter_after, _, _ = vias_after[0]
+        _, _, _, drill_after, diameter_after, _, _, _, _, _ = vias_after[0]
 
         assert drill_before == drill_after
         assert diameter_before == diameter_after
@@ -181,7 +188,7 @@ class TestFixVias:
 
         # Values should be updated
         vias = find_all_vias(doc)
-        _, _, _, drill, diameter, _, _ = vias[0]
+        _, _, _, drill, diameter, _, _, _, _, _ = vias[0]
 
         assert drill == 0.3
         assert diameter == 0.6
@@ -340,7 +347,7 @@ class TestCLI:
         assert output_file.exists()
         output_doc = parse_file(output_file)
         vias = find_all_vias(output_doc)
-        _, _, _, drill, diameter, _, _ = vias[0]
+        _, _, _, drill, diameter, _, _, _, _, _ = vias[0]
         assert drill == 0.3
         assert diameter == 0.6
 
@@ -388,7 +395,7 @@ class TestCLI:
 
         output_doc = parse_file(output_file)
         vias = find_all_vias(output_doc)
-        _, _, _, drill, diameter, _, _ = vias[0]
+        _, _, _, drill, diameter, _, _, _, _, _ = vias[0]
 
         # Should use specified values
         assert drill == 0.35
@@ -496,7 +503,7 @@ class TestCLI:
         # Verify the via was resized to minimum
         output_doc = parse_file(output_file)
         vias = find_all_vias(output_doc)
-        _, _, _, drill, diameter, _, _ = vias[0]
+        _, _, _, drill, diameter, _, _, _, _, _ = vias[0]
 
         assert drill == 0.2  # Drill meets min (0.2mm for 4-layer)
         assert diameter == 0.45  # Enlarged to min_via_diameter
@@ -1066,7 +1073,7 @@ class TestSelectiveViaSkip:
 
         # Verify the via retains its original size in the document
         vias = find_all_vias(doc)
-        _, _, _, drill, diameter, _, _ = vias[0]
+        _, _, _, drill, diameter, _, _, _, _, _ = vias[0]
         assert drill == 0.2
         assert diameter == 0.45
 
@@ -1295,3 +1302,434 @@ class TestLayerAutoDetection:
         assert drill == 0.3
         assert diameter == 0.6
         assert clearance == 0.127
+
+
+class TestSameLayerViaDetection:
+    """Tests for same-layer via detection and repair."""
+
+    def test_detect_same_layer_vias_dry_run(self, tmp_path: Path):
+        """Same-layer vias should be detected in dry-run mode."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "F.Cu") (net 1) (uuid "via-1"))
+          (via (at 120 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-2"))
+        )
+        """
+        pcb_file = tmp_path / "same_layer.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings = fix_same_layer_vias(doc, dry_run=True)
+
+        assert len(fixes) == 1
+        assert fixes[0].uuid == "via-1"
+        assert fixes[0].old_start_layer == "F.Cu"
+        assert fixes[0].old_end_layer == "F.Cu"
+        assert fixes[0].new_start_layer == "F.Cu"
+        assert fixes[0].new_end_layer == "B.Cu"
+        assert len(warnings) == 0
+
+    def test_repair_same_layer_through_hole_vias(self, tmp_path: Path):
+        """Through-hole same-layer vias should be repaired to span outer layers."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "F.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "repair_same_layer.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings = fix_same_layer_vias(doc, dry_run=False)
+
+        assert len(fixes) == 1
+
+        # Verify the layers node was actually updated
+        vias = find_all_vias(doc)
+        _, _, _, _, _, _, _, start_layer, end_layer, _ = vias[0]
+        assert start_layer == "F.Cu"
+        assert end_layer == "B.Cu"
+
+    def test_same_layer_blind_via_flagged_not_repaired(self, tmp_path: Path):
+        """Blind same-layer vias should produce a warning without auto-repair."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (1 "In1.Cu" signal)
+            (2 "In2.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.45) (drill 0.2) (type blind) (layers "F.Cu" "F.Cu") (net 1) (uuid "via-blind"))
+        )
+        """
+        pcb_file = tmp_path / "blind_same_layer.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings = fix_same_layer_vias(doc, dry_run=False)
+
+        assert len(fixes) == 0
+        assert len(warnings) == 1
+        assert warnings[0].uuid == "via-blind"
+        assert warnings[0].via_type == "blind"
+
+        # Verify the layers node was NOT changed
+        vias = find_all_vias(doc)
+        _, _, _, _, _, _, _, start_layer, end_layer, _ = vias[0]
+        assert start_layer == "F.Cu"
+        assert end_layer == "F.Cu"
+
+    def test_same_layer_micro_via_flagged_not_repaired(self, tmp_path: Path):
+        """Micro same-layer vias should produce a warning without auto-repair."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (1 "In1.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.3) (drill 0.15) (type micro) (layers "F.Cu" "F.Cu") (net 1) (uuid "via-micro"))
+        )
+        """
+        pcb_file = tmp_path / "micro_same_layer.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings = fix_same_layer_vias(doc, dry_run=False)
+
+        assert len(fixes) == 0
+        assert len(warnings) == 1
+        assert warnings[0].via_type == "micro"
+
+    def test_via_missing_layers_node_skipped(self, tmp_path: Path):
+        """Via with missing layers node should be skipped gracefully."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (net 1) (uuid "via-nolayers"))
+        )
+        """
+        pcb_file = tmp_path / "no_layers.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings = fix_same_layer_vias(doc, dry_run=False)
+
+        assert len(fixes) == 0
+        assert len(warnings) == 0
+
+    def test_correct_vias_no_false_positives(self, tmp_path: Path):
+        """Vias with distinct layers should not be flagged."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-1"))
+          (via (at 120 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-2"))
+        )
+        """
+        pcb_file = tmp_path / "correct_vias.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, warnings = fix_same_layer_vias(doc, dry_run=False)
+
+        assert len(fixes) == 0
+        assert len(warnings) == 0
+
+    def test_mixed_same_layer_and_undersized(self, tmp_path: Path):
+        """Both same-layer and undersized fixes should be applied in one file."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "F.Cu") (net 1) (uuid "via-same"))
+          (via (at 120 110) (size 0.45) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-small"))
+        )
+        """
+        pcb_file = tmp_path / "mixed.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        # Fix same-layer first
+        sl_fixes, sl_warnings = fix_same_layer_vias(doc, dry_run=False)
+        assert len(sl_fixes) == 1
+        assert sl_fixes[0].uuid == "via-same"
+
+        # Fix undersized second
+        size_fixes, _, _ = fix_vias(doc, target_drill=0.3, target_diameter=0.6, dry_run=False)
+        assert len(size_fixes) == 1
+        assert size_fixes[0].uuid == "via-small"
+
+    def test_4layer_board_uses_outer_layers(self, tmp_path: Path):
+        """On a 4-layer board, through-hole same-layer via should span F.Cu to B.Cu."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (1 "In1.Cu" signal)
+            (2 "In2.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (layers "In1.Cu" "In1.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "4layer_same.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, _ = fix_same_layer_vias(doc, dry_run=False)
+
+        assert len(fixes) == 1
+        assert fixes[0].new_start_layer == "F.Cu"
+        assert fixes[0].new_end_layer == "B.Cu"
+
+    def test_dry_run_does_not_modify_same_layer(self, tmp_path: Path):
+        """Dry run should not modify same-layer vias."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "F.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "dry_same.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        fixes, _ = fix_same_layer_vias(doc, dry_run=True)
+        assert len(fixes) == 1
+
+        # Layers should be unchanged
+        vias = find_all_vias(doc)
+        _, _, _, _, _, _, _, start_layer, end_layer, _ = vias[0]
+        assert start_layer == "F.Cu"
+        assert end_layer == "F.Cu"
+
+
+class TestSameLayerViaCLI:
+    """CLI integration tests for same-layer via detection."""
+
+    def test_cli_dry_run_reports_same_layer(self, tmp_path: Path, capsys):
+        """CLI --dry-run should report same-layer vias."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "F.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "cli_same.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        result = main([str(pcb_file), "--mfr", "jlcpcb", "--dry-run"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "same-layer" in captured.out.lower()
+
+    def test_cli_json_includes_same_layer_keys(self, tmp_path: Path, capsys):
+        """JSON output should include same_layer_fixes and same_layer_warnings."""
+        import json as json_mod
+
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "F.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "cli_json_same.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        result = main([str(pcb_file), "--dry-run", "--format", "json"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json_mod.loads(captured.out)
+
+        assert "same_layer_fixes" in data
+        assert len(data["same_layer_fixes"]) == 1
+        assert data["same_layer_fixes"][0]["uuid"] == "via-1"
+        assert data["same_layer_fixes"][0]["old_start_layer"] == "F.Cu"
+        assert data["same_layer_fixes"][0]["new_end_layer"] == "B.Cu"
+        assert "same_layer_warnings" in data
+        assert len(data["same_layer_warnings"]) == 0
+
+    def test_cli_repairs_same_layer_and_saves(self, tmp_path: Path):
+        """CLI without --dry-run should repair same-layer vias and save."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "F.Cu") (net 1) (uuid "via-1"))
+        )
+        """
+        pcb_file = tmp_path / "repair_cli.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        output_file = tmp_path / "repaired.kicad_pcb"
+
+        result = main([str(pcb_file), "-o", str(output_file)])
+        assert result == 0
+
+        # Verify output file has corrected layers
+        output_doc = parse_file(output_file)
+        vias = find_all_vias(output_doc)
+        _, _, _, _, _, _, _, start_layer, end_layer, _ = vias[0]
+        assert start_layer == "F.Cu"
+        assert end_layer == "B.Cu"
+
+    def test_cli_exit_code_2_for_blind_same_layer_warning(self, tmp_path: Path):
+        """CLI should return exit code 2 when blind same-layer vias produce warnings."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (1 "In1.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+          (net 0 "")
+          (net 1 "GND")
+          (via (at 110 110) (size 0.45) (drill 0.2) (type blind) (layers "F.Cu" "F.Cu") (net 1) (uuid "via-blind"))
+        )
+        """
+        pcb_file = tmp_path / "blind_cli.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        result = main([str(pcb_file), "--dry-run"])
+        assert result == 2
+
+
+class TestGetBoardOuterLayers:
+    """Tests for get_board_outer_layers helper."""
+
+    def test_2layer_board(self, tmp_path: Path):
+        """2-layer board should return F.Cu and B.Cu."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+        )
+        """
+        pcb_file = tmp_path / "2layer.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        start, end = get_board_outer_layers(doc)
+        assert start == "F.Cu"
+        assert end == "B.Cu"
+
+    def test_4layer_board(self, tmp_path: Path):
+        """4-layer board should return F.Cu and B.Cu (outermost copper)."""
+        pcb_content = """(kicad_pcb
+          (version 20240108)
+          (generator "test")
+          (general (thickness 1.6))
+          (layers
+            (0 "F.Cu" signal)
+            (1 "In1.Cu" signal)
+            (2 "In2.Cu" signal)
+            (31 "B.Cu" signal)
+          )
+          (setup (pad_to_mask_clearance 0))
+        )
+        """
+        pcb_file = tmp_path / "4layer.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        doc = parse_file(pcb_file)
+
+        start, end = get_board_outer_layers(doc)
+        assert start == "F.Cu"
+        assert end == "B.Cu"


### PR DESCRIPTION
## Summary

Extend the `fix_vias` command to detect and repair vias where start_layer == end_layer (physically impossible same-layer vias). Through-hole vias are auto-repaired to span the board's outermost copper layers; blind/micro vias produce a warning for manual repair.

## Changes

- Add `SameLayerViaFix` and `SameLayerViaWarning` dataclasses for tracking same-layer via repairs and warnings
- Extend `find_all_vias()` to extract `start_layer`, `end_layer`, and `via_type` from each via's S-expression
- Add `get_board_outer_layers()` helper to determine the outermost copper layers from the PCB document's layers section
- Add `fix_same_layer_vias()` function that detects same-layer vias and auto-repairs through-hole vias (blind/micro produce warnings only)
- Update `print_fix_results()` to report same-layer fixes and warnings in text, JSON, and summary formats
- Update `main()` to call `fix_same_layer_vias()` before size fixes and save when same-layer repairs are made
- Add 16 new tests covering detection, repair, dry-run, blind/micro warnings, missing layers, mixed scenarios, 4-layer boards, CLI integration, and JSON output

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| find_all_vias extracts layer names | Pass | Returns start_layer, end_layer, via_type in tuple; verified by updated TestFindAllVias |
| Same-layer detection works | Pass | fix_same_layer_vias detects start == end layer; test_detect_same_layer_vias_dry_run |
| Through-hole auto-repair | Pass | Layers corrected to outer copper layers; test_repair_same_layer_through_hole_vias |
| Blind/micro vias produce warning, not repair | Pass | test_same_layer_blind_via_flagged_not_repaired, test_same_layer_micro_via_flagged_not_repaired |
| Dry-run reports without modifying | Pass | test_dry_run_does_not_modify_same_layer |
| JSON output includes same-layer data | Pass | test_cli_json_includes_same_layer_keys |
| Missing layers node handled gracefully | Pass | test_via_missing_layers_node_skipped |
| No false positives on correct vias | Pass | test_correct_vias_no_false_positives |
| Mixed same-layer and undersized vias | Pass | test_mixed_same_layer_and_undersized |

## Test Plan

- 70 tests pass (2 deselected are pre-existing failures on main unrelated to this change)
- New tests cover: detection, repair, dry-run, blind/micro warnings, missing layers, 4-layer board outer layer detection, CLI text/JSON output, exit codes

Closes #2122