### PR TITLE
feat(pcb strip): add --layers filter for layer-specific trace stripping

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -169,12 +169,28 @@ def _run_zones_command(args, pcb_path: Path) -> int:
 
 def _run_strip_command(args, pcb_path: Path) -> int:
     """Handle the 'pcb strip' command."""
+    import re as _re
+
     from kicad_tools.schema.pcb import PCB
 
     # Parse net names if provided
     nets = None
     if args.nets:
         nets = [n.strip() for n in args.nets.split(",")]
+
+    # Parse layer names if provided
+    layers = None
+    if getattr(args, "layers", None):
+        layers = [l.strip() for l in args.layers.split(",")]
+
+    # Power net options — exclude power nets by default when --layers is used
+    include_power = getattr(args, "include_power", False)
+    exclude_power = not include_power if layers else False
+    power_pattern = None
+    if getattr(args, "power_pattern", None):
+        power_pattern = _re.compile(args.power_pattern, _re.IGNORECASE)
+
+    remove_orphan_vias = getattr(args, "remove_orphan_vias", False)
 
     # Load PCB
     try:
@@ -190,7 +206,14 @@ def _run_strip_command(args, pcb_path: Path) -> int:
 
     # Perform strip operation
     keep_zones = getattr(args, "keep_zones", True)
-    stats = pcb.strip_traces(nets=nets, keep_zones=keep_zones)
+    stats = pcb.strip_traces(
+        nets=nets,
+        layers=layers,
+        keep_zones=keep_zones,
+        exclude_power=exclude_power,
+        power_pattern=power_pattern,
+        remove_orphan_vias=remove_orphan_vias,
+    )
 
     # Determine output path
     output_path = pcb_path
@@ -209,7 +232,10 @@ def _run_strip_command(args, pcb_path: Path) -> int:
         "output": str(output_path) if not dry_run else None,
         "dry_run": dry_run,
         "nets_filtered": nets,
+        "layers_filtered": layers,
         "keep_zones": keep_zones,
+        "exclude_power": exclude_power,
+        "remove_orphan_vias": remove_orphan_vias,
         "before": {
             "segments": initial_segments,
             "vias": initial_vias,
@@ -237,7 +263,12 @@ def _run_strip_command(args, pcb_path: Path) -> int:
             print(f"  Filtering nets: {', '.join(nets)}")
         else:
             print("  Stripping all nets")
+        if layers:
+            print(f"  Filtering layers: {', '.join(layers)}")
+        print(f"  Exclude power nets: {exclude_power}")
         print(f"  Keep zones: {keep_zones}")
+        if remove_orphan_vias:
+            print("  Remove orphan vias: yes")
         print()
 
         print("  Removed:")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1157,6 +1157,29 @@ def _add_pcb_parser(subparsers) -> None:
         help="Comma-separated list of net names to strip (default: all nets)",
     )
     pcb_strip.add_argument(
+        "--layers",
+        help="Comma-separated list of layer names to strip "
+        "(e.g. In1.Cu,In2.Cu). Only segments on these layers are removed. "
+        "Vias are removed only when ALL their layers are in the set.",
+    )
+    pcb_strip.add_argument(
+        "--include-power",
+        action="store_true",
+        default=False,
+        help="Include power/ground nets in stripping (default: exclude them)",
+    )
+    pcb_strip.add_argument(
+        "--power-pattern",
+        help="Regex pattern for power net names (overrides built-in heuristic)",
+    )
+    pcb_strip.add_argument(
+        "--remove-orphan-vias",
+        action="store_true",
+        default=False,
+        help="Remove vias that no longer connect to any remaining segment "
+        "on either of their layers (only meaningful with --layers)",
+    )
+    pcb_strip.add_argument(
         "--no-keep-zones",
         dest="keep_zones",
         action="store_false",

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -6,6 +6,7 @@ Provides classes for parsing and manipulating KiCad PCB files (.kicad_pcb).
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass, field
@@ -27,6 +28,25 @@ from ..footprints.library_path import (
 if TYPE_CHECKING:
     from ..manufacturers import DesignRules
     from ..query.footprints import FootprintList
+
+# Default regex for detecting power/ground net names.
+# Matches names like GND, +3V3, +5V, VCC, VDD, VBUS, or names starting with '+'.
+_DEFAULT_POWER_NET_PATTERN = re.compile(
+    r"^(\+|GND|GNDA|GNDPWR|VCC|VDD|VBUS|VSS|V[0-9])",
+    re.IGNORECASE,
+)
+
+
+def _is_power_net(name: str, pattern: re.Pattern[str] | None = None) -> bool:
+    """Return True if *name* looks like a power or ground net.
+
+    Uses *pattern* if provided, otherwise falls back to the built-in
+    heuristic ``_DEFAULT_POWER_NET_PATTERN``.
+    """
+    if not name:
+        return False
+    pat = pattern if pattern is not None else _DEFAULT_POWER_NET_PATTERN
+    return pat.search(name) is not None
 
 
 @dataclass
@@ -3930,7 +3950,11 @@ class PCB:
         self,
         *,
         nets: list[str] | None = None,
+        layers: list[str] | None = None,
         keep_zones: bool = True,
+        exclude_power: bool = False,
+        power_pattern: re.Pattern[str] | None = None,
+        remove_orphan_vias: bool = False,
     ) -> dict[str, int]:
         """Remove trace segments and vias from the PCB.
 
@@ -3943,8 +3967,24 @@ class PCB:
             nets: Optional list of net names to strip. If None, strips all nets.
                   When specified, only segments/vias belonging to these nets
                   are removed.
+            layers: Optional list of layer names to strip (e.g. ``["In1.Cu"]``).
+                    When provided, only segments on the listed layers are
+                    candidates for removal.  Vias are removed only when ALL of
+                    their layers are in the strip set.  When both *nets* and
+                    *layers* are given they are ANDed together.
             keep_zones: If True (default), preserve copper pour zones.
                         If False, remove zones as well.
+            exclude_power: If True, power/ground nets are never stripped
+                           even when they match other filters.  Defaults to
+                           ``False`` for backward compatibility; the CLI
+                           defaults to excluding power nets.
+            power_pattern: Optional compiled regex overriding the built-in
+                           power-net heuristic used when *exclude_power* is
+                           ``True``.
+            remove_orphan_vias: If True, remove vias that no longer connect
+                                to any remaining segment on either of their
+                                layers after layer-filtered stripping.
+                                Only meaningful when *layers* is specified.
 
         Returns:
             Dictionary with counts of removed elements:
@@ -3963,6 +4003,9 @@ class PCB:
 
             # Strip everything including zones
             >>> stats = pcb.strip_traces(keep_zones=False)
+
+            # Strip only inner-layer signal traces (power excluded by default)
+            >>> stats = pcb.strip_traces(layers=["In1.Cu", "In2.Cu"])
         """
         # Build set of net numbers to strip (if filtering by net name)
         net_numbers_to_strip: set[int] | None = None
@@ -3974,6 +4017,32 @@ class PCB:
                         net_numbers_to_strip.add(net_num)
                         break
 
+        # Build layer set for fast membership tests
+        layer_set: set[str] | None = None
+        if layers is not None:
+            layer_set = set(layers)
+
+        # Build set of power-net numbers for exclusion
+        power_net_numbers: set[int] = set()
+        if exclude_power:
+            for net_num, net in self._nets.items():
+                if _is_power_net(net.name, power_pattern):
+                    power_net_numbers.add(net_num)
+
+        def _net_num_from_child(child: SExp) -> int:
+            net_node = child.find("net")
+            if net_node:
+                return net_node.get_int(0) or 0
+            return 0
+
+        def _should_strip_net(net_num: int) -> bool:
+            """Return True if *net_num* passes the net filter."""
+            if net_numbers_to_strip is not None and net_num not in net_numbers_to_strip:
+                return False
+            if exclude_power and net_num in power_net_numbers:
+                return False
+            return True
+
         removed_segments = 0
         removed_vias = 0
         removed_zones = 0
@@ -3984,46 +4053,61 @@ class PCB:
             should_remove = False
 
             if child.name == "segment":
-                if net_numbers_to_strip is None:
-                    # Remove all segments
-                    should_remove = True
-                else:
-                    # Check if segment belongs to a net we're stripping
-                    net_node = child.find("net")
-                    if net_node:
-                        net_num = net_node.get_int(0) or 0
-                        if net_num in net_numbers_to_strip:
-                            should_remove = True
+                net_num = _net_num_from_child(child)
+                if _should_strip_net(net_num):
+                    if layer_set is not None:
+                        # Only remove segments on specified layers
+                        layer_node = child.find("layer")
+                        if layer_node:
+                            seg_layer = layer_node.get_string(0) or ""
+                            if seg_layer in layer_set:
+                                should_remove = True
+                    elif net_numbers_to_strip is not None:
+                        # Net filter only — already passed net check
+                        should_remove = True
+                    else:
+                        # No net or layer filter — remove all (non-power) segments
+                        should_remove = True
 
                 if should_remove:
                     removed_segments += 1
 
             elif child.name == "via":
-                if net_numbers_to_strip is None:
-                    # Remove all vias
-                    should_remove = True
-                else:
-                    # Check if via belongs to a net we're stripping
-                    net_node = child.find("net")
-                    if net_node:
-                        net_num = net_node.get_int(0) or 0
-                        if net_num in net_numbers_to_strip:
-                            should_remove = True
+                net_num = _net_num_from_child(child)
+                if _should_strip_net(net_num):
+                    if layer_set is not None:
+                        # Remove via only if ALL its layers are in the strip set
+                        layers_node = child.find("layers")
+                        if layers_node:
+                            via_layers = [
+                                layers_node.get_string(i) or ""
+                                for i in range(len(layers_node.values))
+                                if isinstance(layers_node.values[i], str)
+                            ]
+                            if via_layers and all(vl in layer_set for vl in via_layers):
+                                should_remove = True
+                    elif net_numbers_to_strip is not None:
+                        should_remove = True
+                    else:
+                        should_remove = True
 
                 if should_remove:
                     removed_vias += 1
 
             elif child.name == "zone" and not keep_zones:
-                if net_numbers_to_strip is None:
-                    # Remove all zones
-                    should_remove = True
-                else:
-                    # Check if zone belongs to a net we're stripping
-                    net_node = child.find("net")
-                    if net_node:
-                        net_num = net_node.get_int(0) or 0
-                        if net_num in net_numbers_to_strip:
-                            should_remove = True
+                net_num = _net_num_from_child(child)
+                if _should_strip_net(net_num):
+                    if layer_set is not None:
+                        # Only remove zones on specified layers
+                        layer_node = child.find("layer")
+                        if layer_node:
+                            zone_layer = layer_node.get_string(0) or ""
+                            if zone_layer in layer_set:
+                                should_remove = True
+                    elif net_numbers_to_strip is not None:
+                        should_remove = True
+                    else:
+                        should_remove = True
 
                 if should_remove:
                     removed_zones += 1
@@ -4034,21 +4118,111 @@ class PCB:
         # Update the S-expression tree
         self._sexp.children = new_children
 
+        # --- Orphan via removal ------------------------------------------------
+        # After stripping layer-filtered segments, detect vias that no longer
+        # connect to any remaining segment on either of their layers.
+        removed_orphan_vias = 0
+        if remove_orphan_vias and layer_set is not None:
+            # Build a set of (position, layer) pairs from remaining segments
+            remaining_endpoints: set[tuple[float, float, str]] = set()
+            for child in self._sexp.children:
+                if child.name == "segment":
+                    layer_node = child.find("layer")
+                    seg_layer = (layer_node.get_string(0) or "") if layer_node else ""
+                    start_node = child.find("start")
+                    end_node = child.find("end")
+                    if start_node:
+                        sx = start_node.get_float(0) or 0.0
+                        sy = start_node.get_float(1) or 0.0
+                        remaining_endpoints.add((round(sx, 4), round(sy, 4), seg_layer))
+                    if end_node:
+                        ex = end_node.get_float(0) or 0.0
+                        ey = end_node.get_float(1) or 0.0
+                        remaining_endpoints.add((round(ex, 4), round(ey, 4), seg_layer))
+
+            new_children2 = []
+            for child in self._sexp.children:
+                if child.name == "via":
+                    at_node = child.find("at")
+                    layers_node = child.find("layers")
+                    if at_node and layers_node:
+                        vx = round(at_node.get_float(0) or 0.0, 4)
+                        vy = round(at_node.get_float(1) or 0.0, 4)
+                        via_layers = [
+                            layers_node.get_string(i) or ""
+                            for i in range(len(layers_node.values))
+                            if isinstance(layers_node.values[i], str)
+                        ]
+                        # Via is orphan if NONE of its layers have a segment endpoint at its position
+                        connected = any(
+                            (vx, vy, vl) in remaining_endpoints for vl in via_layers
+                        )
+                        if not connected:
+                            removed_orphan_vias += 1
+                            removed_vias += 1
+                            continue
+                new_children2.append(child)
+            self._sexp.children = new_children2
+
         # Update internal state to reflect the changes
-        if net_numbers_to_strip is None:
+        def _seg_matches(seg: Segment) -> bool:
+            """Return True if segment should be KEPT."""
+            if exclude_power and seg.net_number in power_net_numbers:
+                return True
+            if net_numbers_to_strip is not None and seg.net_number not in net_numbers_to_strip:
+                return True
+            if layer_set is not None and seg.layer not in layer_set:
+                return True
+            return False
+
+        def _via_matches(via: Via) -> bool:
+            """Return True if via should be KEPT."""
+            if exclude_power and via.net_number in power_net_numbers:
+                return True
+            if net_numbers_to_strip is not None and via.net_number not in net_numbers_to_strip:
+                return True
+            if layer_set is not None and not all(vl in layer_set for vl in via.layers):
+                return True
+            return False
+
+        def _zone_matches(zone: Zone) -> bool:
+            """Return True if zone should be KEPT."""
+            if exclude_power and zone.net_number in power_net_numbers:
+                return True
+            if net_numbers_to_strip is not None and zone.net_number not in net_numbers_to_strip:
+                return True
+            if layer_set is not None and zone.layer not in layer_set:
+                return True
+            return False
+
+        # Apply filtering helpers
+        has_any_filter = (
+            net_numbers_to_strip is not None
+            or layer_set is not None
+            or exclude_power
+        )
+        if has_any_filter:
+            self._segments = [seg for seg in self._segments if _seg_matches(seg)]
+            self._vias = [via for via in self._vias if _via_matches(via)]
+            if not keep_zones:
+                self._zones = [zone for zone in self._zones if _zone_matches(zone)]
+        else:
             self._segments = []
             self._vias = []
             if not keep_zones:
                 self._zones = []
-        else:
-            self._segments = [
-                seg for seg in self._segments if seg.net_number not in net_numbers_to_strip
+
+        # Handle orphan via removal in internal state
+        if remove_orphan_vias and layer_set is not None and removed_orphan_vias > 0:
+            remaining_ep_set: set[tuple[float, float, str]] = set()
+            for seg in self._segments:
+                remaining_ep_set.add((round(seg.start[0], 4), round(seg.start[1], 4), seg.layer))
+                remaining_ep_set.add((round(seg.end[0], 4), round(seg.end[1], 4), seg.layer))
+            self._vias = [
+                v for v in self._vias
+                if any((round(v.position[0], 4), round(v.position[1], 4), vl) in remaining_ep_set
+                       for vl in v.layers)
             ]
-            self._vias = [via for via in self._vias if via.net_number not in net_numbers_to_strip]
-            if not keep_zones:
-                self._zones = [
-                    zone for zone in self._zones if zone.net_number not in net_numbers_to_strip
-                ]
 
         return {
             "segments": removed_segments,

--- a/tests/test_cli_pcb.py
+++ b/tests/test_cli_pcb.py
@@ -672,6 +672,226 @@ class TestPcbStrip:
         expected_output = minimal_pcb.with_stem(f"{minimal_pcb.stem}-stripped")
         assert expected_output.exists()
 
+    def test_strip_layers_filter(self, tmp_path, capsys):
+        """Test --layers filter strips only specified layers."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+        from argparse import Namespace
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="F.Cu", net="SIG_A")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="In1.Cu", net="SIG_B")
+        pcb.add_trace(start=(10, 30), end=(50, 30), width=0.25, layer="B.Cu", net="SIG_C")
+
+        input_file = tmp_path / "multi_layer.kicad_pcb"
+        pcb.save(input_file)
+
+        output_file = tmp_path / "stripped.kicad_pcb"
+        args = Namespace(
+            pcb=str(input_file),
+            pcb_command="strip",
+            output=str(output_file),
+            nets=None,
+            layers="In1.Cu",
+            include_power=True,
+            power_pattern=None,
+            remove_orphan_vias=False,
+            keep_zones=True,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+
+        assert result == 0
+        stripped_pcb = PCB.load(output_file)
+        assert len(stripped_pcb.segments) == 2
+        remaining_layers = {seg.layer for seg in stripped_pcb.segments}
+        assert "In1.Cu" not in remaining_layers
+        assert "F.Cu" in remaining_layers
+        assert "B.Cu" in remaining_layers
+
+    def test_strip_layers_and_nets_combined_cli(self, tmp_path, capsys):
+        """Test combined --layers and --nets filter via CLI."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+        from argparse import Namespace
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="AUDIO_R")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="In1.Cu", net="AUDIO_L")
+        pcb.add_trace(start=(10, 30), end=(50, 30), width=0.25, layer="F.Cu", net="AUDIO_R")
+
+        input_file = tmp_path / "combined.kicad_pcb"
+        pcb.save(input_file)
+
+        output_file = tmp_path / "stripped.kicad_pcb"
+        args = Namespace(
+            pcb=str(input_file),
+            pcb_command="strip",
+            output=str(output_file),
+            nets="AUDIO_R",
+            layers="In1.Cu",
+            include_power=True,
+            power_pattern=None,
+            remove_orphan_vias=False,
+            keep_zones=True,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+
+        assert result == 0
+        stripped_pcb = PCB.load(output_file)
+        # Only In1.Cu + AUDIO_R removed, others kept
+        assert len(stripped_pcb.segments) == 2
+
+    def test_strip_power_exclusion_cli(self, tmp_path, capsys):
+        """Test that --layers excludes power nets by default in CLI."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+        from argparse import Namespace
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="GND")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="In1.Cu", net="SIG_A")
+
+        input_file = tmp_path / "power_test.kicad_pcb"
+        pcb.save(input_file)
+
+        output_file = tmp_path / "stripped.kicad_pcb"
+        args = Namespace(
+            pcb=str(input_file),
+            pcb_command="strip",
+            output=str(output_file),
+            nets=None,
+            layers="In1.Cu",
+            include_power=False,  # default — power excluded
+            power_pattern=None,
+            remove_orphan_vias=False,
+            keep_zones=True,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+
+        assert result == 0
+        stripped_pcb = PCB.load(output_file)
+        # GND preserved, SIG_A removed
+        assert len(stripped_pcb.segments) == 1
+        # The remaining segment should be on a GND net (check via net name lookup)
+        gnd_num = None
+        for num, net in stripped_pcb.nets.items():
+            if net.name == "GND":
+                gnd_num = num
+                break
+        assert stripped_pcb.segments[0].net_number == gnd_num
+
+    def test_strip_include_power_cli(self, tmp_path, capsys):
+        """Test --include-power overrides power exclusion."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+        from argparse import Namespace
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="GND")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="In1.Cu", net="SIG_A")
+
+        input_file = tmp_path / "power_include.kicad_pcb"
+        pcb.save(input_file)
+
+        output_file = tmp_path / "stripped.kicad_pcb"
+        args = Namespace(
+            pcb=str(input_file),
+            pcb_command="strip",
+            output=str(output_file),
+            nets=None,
+            layers="In1.Cu",
+            include_power=True,
+            power_pattern=None,
+            remove_orphan_vias=False,
+            keep_zones=True,
+            format="text",
+            dry_run=False,
+        )
+
+        result = run_pcb_command(args)
+
+        assert result == 0
+        stripped_pcb = PCB.load(output_file)
+        assert len(stripped_pcb.segments) == 0  # both stripped
+
+    def test_strip_json_output_includes_layers(self, tmp_path, capsys):
+        """Test JSON output includes layer filter info."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+        from argparse import Namespace
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="SIG_A")
+
+        input_file = tmp_path / "json_test.kicad_pcb"
+        pcb.save(input_file)
+
+        args = Namespace(
+            pcb=str(input_file),
+            pcb_command="strip",
+            output=None,
+            nets=None,
+            layers="In1.Cu",
+            include_power=True,
+            power_pattern=None,
+            remove_orphan_vias=False,
+            keep_zones=True,
+            format="json",
+            dry_run=True,
+        )
+
+        result = run_pcb_command(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["layers_filtered"] == ["In1.Cu"]
+        assert "exclude_power" in data
+        assert data["removed"]["segments"] == 1
+
+    def test_strip_dry_run_with_layers(self, tmp_path, capsys):
+        """Test --dry-run with --layers shows correct removal count."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+        from argparse import Namespace
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="SIG_A")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="F.Cu", net="SIG_B")
+
+        input_file = tmp_path / "dry_run_layers.kicad_pcb"
+        pcb.save(input_file)
+
+        args = Namespace(
+            pcb=str(input_file),
+            pcb_command="strip",
+            output=None,
+            nets=None,
+            layers="In1.Cu",
+            include_power=True,
+            power_pattern=None,
+            remove_orphan_vias=False,
+            keep_zones=True,
+            format="text",
+            dry_run=True,
+        )
+
+        result = run_pcb_command(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "dry run" in captured.out.lower()
+        assert "Filtering layers: In1.Cu" in captured.out
+
 
 # PCB with multiple footprints for reannotation testing
 MULTI_FOOTPRINT_PCB = """(kicad_pcb

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -2606,6 +2606,254 @@ class TestStripTraces:
         assert stats["vias"] == 0
         assert len(pcb.segments) == 0
 
+    # ------------------------------------------------------------------
+    # Layer filtering tests
+    # ------------------------------------------------------------------
+
+    def test_strip_layers_only_removes_matching_layer(self):
+        """Strip with layers=['In1.Cu'] removes only In1.Cu segments."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="F.Cu", net="SIG_A")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="In1.Cu", net="SIG_B")
+        pcb.add_trace(start=(10, 30), end=(50, 30), width=0.25, layer="In2.Cu", net="SIG_C")
+        pcb.add_trace(start=(10, 40), end=(50, 40), width=0.25, layer="B.Cu", net="SIG_D")
+
+        assert len(pcb.segments) == 4
+
+        stats = pcb.strip_traces(layers=["In1.Cu"])
+
+        assert stats["segments"] == 1
+        assert len(pcb.segments) == 3
+        remaining_layers = {seg.layer for seg in pcb.segments}
+        assert "In1.Cu" not in remaining_layers
+        assert "F.Cu" in remaining_layers
+        assert "B.Cu" in remaining_layers
+
+    def test_strip_multiple_layers(self):
+        """Strip with layers=['In1.Cu', 'In2.Cu'] removes both."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="F.Cu", net="SIG_A")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="In1.Cu", net="SIG_B")
+        pcb.add_trace(start=(10, 30), end=(50, 30), width=0.25, layer="In2.Cu", net="SIG_C")
+        pcb.add_trace(start=(10, 40), end=(50, 40), width=0.25, layer="B.Cu", net="SIG_D")
+
+        stats = pcb.strip_traces(layers=["In1.Cu", "In2.Cu"])
+
+        assert stats["segments"] == 2
+        assert len(pcb.segments) == 2
+        remaining_layers = {seg.layer for seg in pcb.segments}
+        assert remaining_layers == {"F.Cu", "B.Cu"}
+
+    def test_strip_layers_and_nets_combined(self):
+        """Combining layers and nets ANDs the two filters."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="AUDIO_R")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="In1.Cu", net="AUDIO_L")
+        pcb.add_trace(start=(10, 30), end=(50, 30), width=0.25, layer="F.Cu", net="AUDIO_R")
+
+        # Look up net numbers for verification
+        audio_r_num = None
+        audio_l_num = None
+        for num, net in pcb.nets.items():
+            if net.name == "AUDIO_R":
+                audio_r_num = num
+            elif net.name == "AUDIO_L":
+                audio_l_num = num
+
+        stats = pcb.strip_traces(layers=["In1.Cu"], nets=["AUDIO_R"])
+
+        # Only the AUDIO_R segment on In1.Cu should be removed
+        assert stats["segments"] == 1
+        assert len(pcb.segments) == 2
+        # Remaining: AUDIO_L on In1.Cu and AUDIO_R on F.Cu
+        remaining = {(seg.layer, seg.net_number) for seg in pcb.segments}
+        assert ("In1.Cu", audio_l_num) in remaining
+        assert ("F.Cu", audio_r_num) in remaining
+
+    # ------------------------------------------------------------------
+    # Power net exclusion tests
+    # ------------------------------------------------------------------
+
+    def test_strip_exclude_power_default_off(self):
+        """By default (API), power nets ARE stripped."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="GND")
+
+        stats = pcb.strip_traces(layers=["In1.Cu"])
+
+        assert stats["segments"] == 1
+        assert len(pcb.segments) == 0
+
+    def test_strip_exclude_power_preserves_power_nets(self):
+        """With exclude_power=True, power nets are preserved."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="GND")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="In1.Cu", net="SIG_A")
+
+        gnd_num = None
+        for num, net in pcb.nets.items():
+            if net.name == "GND":
+                gnd_num = num
+                break
+
+        stats = pcb.strip_traces(layers=["In1.Cu"], exclude_power=True)
+
+        assert stats["segments"] == 1  # only SIG_A removed
+        assert len(pcb.segments) == 1
+        assert pcb.segments[0].net_number == gnd_num
+
+    def test_strip_exclude_power_various_names(self):
+        """Power heuristic catches common power net names."""
+        pcb = PCB.create(width=100, height=100)
+        power_names = ["GND", "+3V3", "+5V", "VCC", "VDD", "VBUS"]
+        for i, name in enumerate(power_names):
+            pcb.add_trace(
+                start=(10, 10 + i * 10), end=(50, 10 + i * 10),
+                width=0.25, layer="In1.Cu", net=name,
+            )
+        pcb.add_trace(start=(10, 80), end=(50, 80), width=0.25, layer="In1.Cu", net="AUDIO")
+
+        stats = pcb.strip_traces(layers=["In1.Cu"], exclude_power=True)
+
+        # Only AUDIO should be removed
+        assert stats["segments"] == 1
+        assert len(pcb.segments) == len(power_names)
+
+    def test_strip_custom_power_pattern(self):
+        """Custom power_pattern overrides built-in heuristic."""
+        import re
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="PWR_RAIL")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="In1.Cu", net="SIG_A")
+
+        pwr_num = None
+        for num, net in pcb.nets.items():
+            if net.name == "PWR_RAIL":
+                pwr_num = num
+                break
+
+        # Custom pattern that matches PWR_*
+        pattern = re.compile(r"^PWR_", re.IGNORECASE)
+        stats = pcb.strip_traces(
+            layers=["In1.Cu"], exclude_power=True, power_pattern=pattern
+        )
+
+        assert stats["segments"] == 1
+        assert len(pcb.segments) == 1
+        assert pcb.segments[0].net_number == pwr_num
+
+    # ------------------------------------------------------------------
+    # Via behavior with layer filtering
+    # ------------------------------------------------------------------
+
+    def test_strip_via_kept_when_not_all_layers_match(self):
+        """Via connecting F.Cu-B.Cu is kept when stripping In1.Cu."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="SIG_A")
+        pcb.add_via(x=50, y=10, layers=("F.Cu", "B.Cu"), net="SIG_A")
+
+        stats = pcb.strip_traces(layers=["In1.Cu"])
+
+        assert stats["segments"] == 1
+        assert stats["vias"] == 0  # via NOT removed — it connects F.Cu-B.Cu
+        assert len(pcb.vias) == 1
+
+    def test_strip_via_removed_when_all_layers_match(self):
+        """Via whose layers are all in the strip set gets removed."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="SIG_A")
+        pcb.add_via(x=50, y=10, layers=("In1.Cu", "In2.Cu"), net="SIG_A")
+
+        stats = pcb.strip_traces(layers=["In1.Cu", "In2.Cu"])
+
+        assert stats["segments"] == 1
+        assert stats["vias"] == 1
+        assert len(pcb.vias) == 0
+
+    # ------------------------------------------------------------------
+    # Orphan via removal
+    # ------------------------------------------------------------------
+
+    def test_strip_orphan_via_removal(self):
+        """After stripping layer segments, orphan vias are removed."""
+        pcb = PCB.create(width=100, height=100)
+        # Segment on In1.Cu ending at (50, 10)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="SIG_A")
+        # Via at (50, 10) connecting F.Cu-B.Cu — after In1.Cu strip, no segment
+        # touches this via on F.Cu or B.Cu
+        pcb.add_via(x=50, y=10, layers=("F.Cu", "B.Cu"), net="SIG_A")
+
+        stats = pcb.strip_traces(layers=["In1.Cu"], remove_orphan_vias=True)
+
+        assert stats["segments"] == 1
+        assert stats["vias"] == 1  # orphan via removed
+        assert len(pcb.vias) == 0
+
+    def test_strip_orphan_via_kept_when_connected(self):
+        """Via with remaining segments on its layers is NOT orphaned."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="SIG_A")
+        pcb.add_trace(start=(50, 10), end=(90, 10), width=0.25, layer="F.Cu", net="SIG_A")
+        pcb.add_via(x=50, y=10, layers=("F.Cu", "B.Cu"), net="SIG_A")
+
+        stats = pcb.strip_traces(layers=["In1.Cu"], remove_orphan_vias=True)
+
+        assert stats["segments"] == 1  # In1.Cu segment removed
+        assert stats["vias"] == 0  # via still connected to F.Cu segment at (50,10)
+        assert len(pcb.vias) == 1
+
+    # ------------------------------------------------------------------
+    # Zone interaction with layer filter
+    # ------------------------------------------------------------------
+
+    def test_strip_zones_respect_layer_filter(self):
+        """Zones are only removed if their layer matches the filter."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="In1.Cu", net="SIG_A")
+        # We can't easily add zones via the API, so test via strip_traces
+        # with keep_zones=True (default) — zones should never be removed
+        stats = pcb.strip_traces(layers=["In1.Cu"], keep_zones=True)
+        assert stats["zones"] == 0
+
+    # ------------------------------------------------------------------
+    # Edge cases
+    # ------------------------------------------------------------------
+
+    def test_strip_empty_layers_list_is_noop(self):
+        """Empty layer list removes nothing."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="F.Cu", net="SIG_A")
+
+        stats = pcb.strip_traces(layers=[])
+
+        assert stats["segments"] == 0
+        assert len(pcb.segments) == 1
+
+    def test_strip_nonexistent_layer_removes_nothing(self):
+        """Non-existent layer name removes nothing."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="F.Cu", net="SIG_A")
+
+        stats = pcb.strip_traces(layers=["Nonexistent.Cu"])
+
+        assert stats["segments"] == 0
+        assert len(pcb.segments) == 1
+
+    def test_strip_roundtrip_with_layers(self, tmp_path):
+        """Stripping with layers saves/loads correctly."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10, 10), end=(50, 10), width=0.25, layer="F.Cu", net="SIG_A")
+        pcb.add_trace(start=(10, 20), end=(50, 20), width=0.25, layer="In1.Cu", net="SIG_B")
+
+        pcb.strip_traces(layers=["In1.Cu"])
+
+        out = tmp_path / "stripped.kicad_pcb"
+        pcb.save(out)
+        reloaded = PCB.load(out)
+        assert len(reloaded.segments) == 1
+        assert reloaded.segments[0].layer == "F.Cu"
+
 
 # ---------------------------------------------------------------------------
 # KiCad 10 name-only net format: net_number recovery from PCB headers


### PR DESCRIPTION
## Summary

Add `--layers` option to `pcb strip` so traces can be removed from specific copper layers while preserving routing on others. This is essential for converting auto-routed 4-layer boards (signals on all layers) to proper 4-layer layouts (signals on outer layers, planes on inner layers).

## Changes

- Add `layers`, `exclude_power`, `power_pattern`, and `remove_orphan_vias` parameters to `PCB.strip_traces()`
- Add `_is_power_net()` helper with regex-based heuristic for power/ground net detection
- Add `--layers`, `--include-power`, `--power-pattern`, and `--remove-orphan-vias` CLI arguments to `pcb strip`
- Layer and net filters AND together when both specified
- Vias removed only when ALL their layers are in the strip set
- Power nets excluded by default when `--layers` is used (CLI), overridable with `--include-power`
- Orphan via detection removes vias disconnected from all remaining segments

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `pcb strip --layers In1.Cu` removes only segments on In1.Cu | PASS | test_strip_layers_only_removes_matching_layer |
| `pcb strip --layers In1.Cu,In2.Cu --nets AUDIO_R` combines both filters | PASS | test_strip_layers_and_nets_combined |
| Power nets excluded by default with --include-power override | PASS | test_strip_power_exclusion_cli, test_strip_include_power_cli |
| --dry-run shows what would be removed | PASS | test_strip_dry_run_with_layers |
| Vias connecting only stripped layers optionally removed | PASS | test_strip_via_removed_when_all_layers_match, test_strip_orphan_via_removal |

## Test Plan

- 15 new unit tests in TestStripTraces covering layer filtering, combined net+layer, power exclusion, via behavior, orphan vias, edge cases, and roundtrip save/load
- 6 new CLI integration tests in TestPcbStrip covering --layers, combined --layers+--nets, power exclusion, --include-power, JSON output, and --dry-run
- All 224 existing PCB and CLI PCB tests continue to pass

Closes #2137