### PR TITLE
feat(drc): include net names in clearance violation output

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -380,6 +380,9 @@ def _print_violation(v: DRCViolation, verbose: bool, indent: str = "  ") -> None
             print(f"{indent}    Actual: {v.actual_value:.3f}mm, Required: {v.required_value:.3f}mm")
         if v.items:
             print(f"{indent}    Items: {', '.join(v.items)}")
+        if v.nets:
+            net_labels = [n if n else "<no net>" for n in v.nets]
+            print(f"{indent}    Nets: {', '.join(net_labels)}")
 
 
 def output_json(

--- a/src/kicad_tools/drc/compat.py
+++ b/src/kicad_tools/drc/compat.py
@@ -60,6 +60,7 @@ def drc_results_to_report(
                 message=v.message,
                 locations=loc_list,
                 items=list(v.items),
+                nets=list(v.nets),
                 required_value_mm=v.required_value,
                 actual_value_mm=v.actual_value,
             )

--- a/src/kicad_tools/drc/report.py
+++ b/src/kicad_tools/drc/report.py
@@ -313,7 +313,7 @@ def _parse_kct_check_json(data: dict, source_file: str = "") -> DRCReport:
             rule=type_str,
             locations=locations,
             items=items,
-            nets=[],
+            nets=[str(n) for n in item.get("nets", [])],
             required_value_mm=item.get("required_value"),
             actual_value_mm=item.get("actual_value"),
         )

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -34,6 +34,8 @@ class CopperElement:
     geometry: tuple[float, ...]
     # Reference for violation reporting
     reference: str
+    # Net name for violation output (empty string for unconnected/net 0)
+    net_name: str = ""
 
     @classmethod
     def from_segment(cls, seg: Segment) -> CopperElement:
@@ -44,6 +46,7 @@ class CopperElement:
             net_number=seg.net_number,
             geometry=(seg.start[0], seg.start[1], seg.end[0], seg.end[1], seg.width),
             reference=f"Trace-{seg.uuid[:8]}" if seg.uuid else "Trace",
+            net_name=seg.net_name if seg.net_number != 0 else "",
         )
 
     @classmethod
@@ -59,6 +62,7 @@ class CopperElement:
             net_number=pad.net_number,
             geometry=(abs_x, abs_y, width, height),
             reference=f"{footprint.reference}-{pad.number}",
+            net_name=pad.net_name if pad.net_number != 0 else "",
         )
 
     @classmethod
@@ -70,6 +74,7 @@ class CopperElement:
             net_number=via.net_number,
             geometry=(via.position[0], via.position[1], via.size, via.size),
             reference=f"Via-{via.uuid[:8]}" if via.uuid else "Via",
+            net_name=via.net_name if via.net_number != 0 else "",
         )
 
     def on_layer(self, layer: str) -> bool:
@@ -483,4 +488,5 @@ class ClearanceRule(DRCRule):
             actual_value=round(actual, 4),
             required_value=required,
             items=(elem1.reference, elem2.reference),
+            nets=(elem1.net_name, elem2.net_name),
         )

--- a/src/kicad_tools/validate/violations.py
+++ b/src/kicad_tools/validate/violations.py
@@ -34,6 +34,7 @@ class DRCViolation:
     actual_value: float | None = None
     required_value: float | None = None
     items: tuple[str, ...] = ()
+    nets: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         """Validate severity value."""
@@ -71,6 +72,7 @@ class DRCViolation:
             "actual_value": self.actual_value,
             "required_value": self.required_value,
             "items": list(self.items),
+            "nets": list(self.nets),
         }
 
 

--- a/tests/test_clearance_net_names.py
+++ b/tests/test_clearance_net_names.py
@@ -1,0 +1,357 @@
+"""Tests for net name propagation in clearance violation output.
+
+Verifies that net names from PCB schema objects flow through the
+validate-layer DRCViolation, the compat bridge, and into CLI output.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from kicad_tools.validate.rules.clearance import CopperElement
+from kicad_tools.validate.violations import DRCViolation
+
+
+# ---------------------------------------------------------------------------
+# CopperElement carries net_name
+# ---------------------------------------------------------------------------
+
+
+class TestCopperElementNetName:
+    """CopperElement factory methods propagate net_name from schema objects."""
+
+    def test_from_segment_carries_net_name(self):
+        seg = MagicMock()
+        seg.layer = "F.Cu"
+        seg.net_number = 1
+        seg.net_name = "GND"
+        seg.start = (10.0, 20.0)
+        seg.end = (30.0, 20.0)
+        seg.width = 0.25
+        seg.uuid = "abcdef12"
+
+        elem = CopperElement.from_segment(seg)
+        assert elem.net_name == "GND"
+
+    def test_from_segment_net0_gives_empty_string(self):
+        seg = MagicMock()
+        seg.layer = "F.Cu"
+        seg.net_number = 0
+        seg.net_name = ""
+        seg.start = (10.0, 20.0)
+        seg.end = (30.0, 20.0)
+        seg.width = 0.25
+        seg.uuid = "abcdef12"
+
+        elem = CopperElement.from_segment(seg)
+        assert elem.net_name == ""
+
+    def test_from_via_carries_net_name(self):
+        via = MagicMock()
+        via.net_number = 2
+        via.net_name = "+3V3"
+        via.position = (50.0, 60.0)
+        via.size = 0.6
+        via.layers = ["F.Cu", "B.Cu"]
+        via.uuid = "deadbeef"
+
+        elem = CopperElement.from_via(via)
+        assert elem.net_name == "+3V3"
+
+    def test_from_via_net0_gives_empty_string(self):
+        via = MagicMock()
+        via.net_number = 0
+        via.net_name = ""
+        via.position = (50.0, 60.0)
+        via.size = 0.6
+        via.layers = ["F.Cu", "B.Cu"]
+        via.uuid = "deadbeef"
+
+        elem = CopperElement.from_via(via)
+        assert elem.net_name == ""
+
+    def test_from_pad_carries_net_name(self):
+        pad = MagicMock()
+        pad.net_number = 3
+        pad.net_name = "SDA"
+        pad.position = (0.0, 0.0)
+        pad.size = (1.0, 1.0)
+        pad.layers = ["F.Cu"]
+
+        footprint = MagicMock()
+        footprint.reference = "U1"
+        footprint.position = (100.0, 100.0)
+        footprint.rotation = 0.0
+
+        elem = CopperElement.from_pad(pad, footprint)
+        assert elem.net_name == "SDA"
+
+    def test_from_pad_net0_gives_empty_string(self):
+        pad = MagicMock()
+        pad.net_number = 0
+        pad.net_name = ""
+        pad.position = (0.0, 0.0)
+        pad.size = (1.0, 1.0)
+        pad.layers = ["F.Cu"]
+
+        footprint = MagicMock()
+        footprint.reference = "U1"
+        footprint.position = (100.0, 100.0)
+        footprint.rotation = 0.0
+
+        elem = CopperElement.from_pad(pad, footprint)
+        assert elem.net_name == ""
+
+
+# ---------------------------------------------------------------------------
+# Validate-layer DRCViolation carries nets
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDRCViolationNets:
+    """validate.violations.DRCViolation includes nets field."""
+
+    def test_default_nets_is_empty_tuple(self):
+        v = DRCViolation(
+            rule_id="clearance_segment_segment",
+            severity="error",
+            message="test",
+        )
+        assert v.nets == ()
+
+    def test_nets_field_populated(self):
+        v = DRCViolation(
+            rule_id="clearance_segment_segment",
+            severity="error",
+            message="test",
+            nets=("GND", "+3V3"),
+        )
+        assert v.nets == ("GND", "+3V3")
+
+    def test_to_dict_includes_nets(self):
+        v = DRCViolation(
+            rule_id="clearance_segment_segment",
+            severity="error",
+            message="test",
+            nets=("GND", "+3V3"),
+        )
+        d = v.to_dict()
+        assert "nets" in d
+        assert d["nets"] == ["GND", "+3V3"]
+
+    def test_to_dict_nets_empty_when_no_nets(self):
+        v = DRCViolation(
+            rule_id="clearance_segment_segment",
+            severity="error",
+            message="test",
+        )
+        d = v.to_dict()
+        assert d["nets"] == []
+
+
+# ---------------------------------------------------------------------------
+# Compat bridge propagates nets
+# ---------------------------------------------------------------------------
+
+
+class TestCompatBridgeNets:
+    """drc_results_to_report propagates nets from validate to report layer."""
+
+    def test_nets_propagated(self):
+        from kicad_tools.drc.compat import drc_results_to_report
+        from kicad_tools.validate.violations import DRCResults
+
+        results = DRCResults()
+        results.add(
+            DRCViolation(
+                rule_id="clearance_segment_segment",
+                severity="error",
+                message="Segment to segment clearance 0.100mm < minimum 0.200mm",
+                location=(10.0, 20.0),
+                layer="F.Cu",
+                actual_value=0.1,
+                required_value=0.2,
+                items=("Trace-abc", "Trace-def"),
+                nets=("GND", "+3V3"),
+            )
+        )
+        results.rules_checked = 1
+
+        report = drc_results_to_report(results)
+        assert len(report.violations) == 1
+        assert report.violations[0].nets == ["GND", "+3V3"]
+
+    def test_empty_nets_propagated(self):
+        from kicad_tools.drc.compat import drc_results_to_report
+        from kicad_tools.validate.violations import DRCResults
+
+        results = DRCResults()
+        results.add(
+            DRCViolation(
+                rule_id="clearance_segment_segment",
+                severity="error",
+                message="test",
+            )
+        )
+        results.rules_checked = 1
+
+        report = drc_results_to_report(results)
+        assert report.violations[0].nets == []
+
+
+# ---------------------------------------------------------------------------
+# kct-check JSON round-trip preserves nets
+# ---------------------------------------------------------------------------
+
+
+class TestKctCheckJsonNets:
+    """kct check JSON output includes nets and round-trips correctly."""
+
+    def test_json_round_trip_with_nets(self):
+        from kicad_tools.drc.report import _parse_kct_check_json
+
+        kct_json = {
+            "file": "/tmp/test.kicad_pcb",
+            "manufacturer": "jlcpcb",
+            "layers": 2,
+            "summary": {
+                "errors": 1,
+                "warnings": 0,
+                "rules_checked": 1,
+                "passed": False,
+            },
+            "violations": [
+                {
+                    "rule_id": "clearance_segment_segment",
+                    "severity": "error",
+                    "message": "Segment to segment clearance 0.100mm < minimum 0.200mm",
+                    "location": [10.0, 20.0],
+                    "layer": "F.Cu",
+                    "actual_value": 0.1,
+                    "required_value": 0.2,
+                    "items": ["Trace-abc", "Trace-def"],
+                    "nets": ["GND", "+3V3"],
+                },
+            ],
+        }
+
+        report = _parse_kct_check_json(kct_json, "test.json")
+        assert len(report.violations) == 1
+        assert report.violations[0].nets == ["GND", "+3V3"]
+
+    def test_json_round_trip_without_nets_key(self):
+        """Backward compatibility: missing nets key defaults to empty list."""
+        from kicad_tools.drc.report import _parse_kct_check_json
+
+        kct_json = {
+            "file": "/tmp/test.kicad_pcb",
+            "manufacturer": "jlcpcb",
+            "layers": 2,
+            "summary": {
+                "errors": 1,
+                "warnings": 0,
+                "rules_checked": 1,
+                "passed": False,
+            },
+            "violations": [
+                {
+                    "rule_id": "clearance_segment_segment",
+                    "severity": "error",
+                    "message": "test",
+                    "location": [10.0, 20.0],
+                    "layer": "F.Cu",
+                    "items": [],
+                },
+            ],
+        }
+
+        report = _parse_kct_check_json(kct_json, "test.json")
+        assert report.violations[0].nets == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: ClearanceRule produces violations with net names
+# ---------------------------------------------------------------------------
+
+
+class TestClearanceRuleNetNames:
+    """ClearanceRule populates nets in violations from a real PCB parse."""
+
+    PCB_CONTENT = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3V3")
+  (segment (start 100 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 1 "GND") (uuid "seg-gnd1"))
+  (segment (start 100 100.15) (end 110 100.15) (width 0.25) (layer "F.Cu") (net 2 "+3V3") (uuid "seg-3v3"))
+)
+"""
+
+    def test_clearance_violation_has_net_names(self, tmp_path: Path):
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(self.PCB_CONTENT)
+        pcb = PCB.load(pcb_path)
+
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2, copper_oz=1.0)
+        results = checker.check_clearances()
+
+        # Should find at least one clearance violation
+        assert len(results.violations) > 0
+
+        v = results.violations[0]
+        # Nets should contain both net names (order may vary due to sorted types)
+        assert set(v.nets) == {"GND", "+3V3"}
+
+    PCB_WITH_VIA = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3V3")
+  (segment (start 100 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 1 "GND") (uuid "seg-gnd1"))
+  (via (at 100 100.25) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 2 "+3V3") (uuid "via-3v3"))
+)
+"""
+
+    def test_segment_via_violation_has_net_names(self, tmp_path: Path):
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(self.PCB_WITH_VIA)
+        pcb = PCB.load(pcb_path)
+
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2, copper_oz=1.0)
+        results = checker.check_clearances()
+
+        assert len(results.violations) > 0
+        v = results.violations[0]
+        assert set(v.nets) == {"GND", "+3V3"}

--- a/tests/test_drc_tolerance.py
+++ b/tests/test_drc_tolerance.py
@@ -34,22 +34,24 @@ class MockNet:
 
 
 class MockSegment:
-    def __init__(self, start, end, width, layer, net_number, uuid="seg0001"):
+    def __init__(self, start, end, width, layer, net_number, net_name="", uuid="seg0001"):
         self.start = start
         self.end = end
         self.width = width
         self.layer = layer
         self.net_number = net_number
+        self.net_name = net_name
         self.uuid = uuid
 
 
 class MockVia:
-    def __init__(self, position, size, drill, layers, net_number, uuid="via0001"):
+    def __init__(self, position, size, drill, layers, net_number, net_name="", uuid="via0001"):
         self.position = position
         self.size = size
         self.drill = drill
         self.layers = layers
         self.net_number = net_number
+        self.net_name = net_name
         self.uuid = uuid
 
 


### PR DESCRIPTION
## Summary
Thread net names from PCB schema objects (Segment, Via, Pad) through the validate-layer DRCViolation and compat bridge so that clearance violations include the net names of both involved elements.

## Changes
- Add `net_name` field to `CopperElement` dataclass, populated by `from_segment`, `from_via`, and `from_pad` factory methods
- Add `nets: tuple[str, ...]` field to validate-layer `DRCViolation`, included in `to_dict()` output
- Populate `nets` in `ClearanceRule._create_violation` from element net names
- Propagate `nets` through compat bridge (`drc_results_to_report`)
- Display net names in `kct check` verbose text output (Nets line)
- Parse `nets` from JSON in `_parse_kct_check_json` for round-trip support
- Net 0 (unconnected) items produce empty string, not "0"

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| clearance_segment_segment violations include net names | Done | Integration test with two close traces on different nets |
| clearance_segment_via violations include net names | Done | Integration test with trace near via on different nets |
| clearance_pad_segment and clearance_pad_via also include net names | Done | CopperElement.from_pad carries net_name |
| Net names appear in kct check text output (verbose) | Done | _print_violation shows Nets line when nets present |
| Net names appear in kct check --output JSON format | Done | to_dict includes nets key |
| Net names propagate through compat bridge | Done | Unit test verifies nets flow to DRCReport |
| Existing KiCad-cli text report parsing continues to work | Done | test_repair_clearance passes (212 tests) |
| No-net/net 0 items show as empty string | Done | Unit tests for net_number==0 |

## Test Plan
16 new tests in `tests/test_clearance_net_names.py` covering:
- CopperElement factory methods carry net_name (6 tests)
- Validate DRCViolation nets field and to_dict (4 tests)
- Compat bridge propagation (2 tests)
- JSON round-trip with and without nets key (2 tests)
- Integration: ClearanceRule on real PCB produces violations with net names (2 tests)

All 212 existing DRC-related tests continue to pass.

Closes #2143