### PR TITLE
fix(sch-preflight): resolve extends chains in pin/pad count check

### DIFF
--- a/src/kicad_tools/cli/sch_preflight.py
+++ b/src/kicad_tools/cli/sch_preflight.py
@@ -131,14 +131,35 @@ def check_pin_pad_count(schematic_path: str) -> list[ValidationIssue]:
                 sch = Schematic.load(node.path)
                 # Build map of library symbol name -> pin count from lib_symbols
                 lib_pin_counts: dict[str, int] = {}
+                extends_map: dict[str, str] = {}
                 lib_syms_sexp = sch.lib_symbols
                 if lib_syms_sexp is not None:
                     for sym_sexp in lib_syms_sexp.find_all("symbol"):
                         try:
                             lib_sym = LibrarySymbol.from_sexp(sym_sexp)
                             lib_pin_counts[lib_sym.name] = lib_sym.pin_count
+                            # Track extends relationships for derived symbols
+                            ext_node = sym_sexp.get("extends")
+                            if ext_node is not None:
+                                base_name = ext_node.get_string(0)
+                                if base_name:
+                                    extends_map[lib_sym.name] = base_name
                         except Exception:
                             pass
+
+                    # Resolve extends chains: derived symbols with 0 pins
+                    # inherit pin count from their base symbol.
+                    for name, base in extends_map.items():
+                        if lib_pin_counts.get(name, 0) == 0:
+                            visited: set[str] = {name}
+                            cur = base
+                            while cur and cur not in visited:
+                                count = lib_pin_counts.get(cur, 0)
+                                if count > 0:
+                                    lib_pin_counts[name] = count
+                                    break
+                                visited.add(cur)
+                                cur = extends_map.get(cur)
 
                 for sym in sch.symbols:
                     if sym.lib_id.startswith("power:"):

--- a/tests/test_sch_preflight.py
+++ b/tests/test_sch_preflight.py
@@ -205,6 +205,142 @@ _SCH_SINGLE_PIN_NET = """(kicad_sch
 )
 """
 
+# A schematic with a derived symbol using (extends ...).
+# The base symbol "Regulator_Linear:AP2204K-1.5" has 5 pins.
+# The derived symbol "Regulator_Linear:AP2112K-3.3" uses extends and has 0
+# direct pins -- its pin count should be inherited from the base.
+_SCH_EXTENDS_SYMBOL = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Regulator_Linear:AP2204K-1.5"
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "AP2204K-1.5" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "Package_TO_SOT_SMD:SOT-23-5" (at 0 0 0) (effects (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (hide yes)))
+      (symbol "AP2204K-1.5_1_1"
+        (pin input line (at -10 2.54 0) (length 2.54)
+          (name "VIN" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27))))
+        )
+        (pin power_in line (at 0 -7.62 90) (length 2.54)
+          (name "GND" (effects (font (size 1.27 1.27))))
+          (number "2" (effects (font (size 1.27 1.27))))
+        )
+        (pin input line (at -10 -2.54 0) (length 2.54)
+          (name "EN" (effects (font (size 1.27 1.27))))
+          (number "3" (effects (font (size 1.27 1.27))))
+        )
+        (pin passive line (at 10 -2.54 180) (length 2.54)
+          (name "NC" (effects (font (size 1.27 1.27))))
+          (number "4" (effects (font (size 1.27 1.27))))
+        )
+        (pin power_out line (at 10 2.54 180) (length 2.54)
+          (name "VOUT" (effects (font (size 1.27 1.27))))
+          (number "5" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+    (symbol "Regulator_Linear:AP2112K-3.3"
+      (extends "Regulator_Linear:AP2204K-1.5")
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "AP2112K-3.3" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "Package_TO_SOT_SMD:SOT-23-5" (at 0 0 0) (effects (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (hide yes)))
+    )
+  )
+  (symbol
+    (lib_id "Regulator_Linear:AP2112K-3.3")
+    (at 100 100 0)
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (property "Reference" "U1" (at 100 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "AP2112K-3.3" (at 100 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Package_TO_SOT_SMD:SOT-23-5" (at 100 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 100 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000101"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000102"))
+    (pin "3" (uuid "00000000-0000-0000-0000-000000000103"))
+    (pin "4" (uuid "00000000-0000-0000-0000-000000000104"))
+    (pin "5" (uuid "00000000-0000-0000-0000-000000000105"))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "U1")
+          (unit 1)
+        )
+      )
+    )
+  )
+)
+"""
+
+# A schematic with a multi-level extends chain: C extends B extends A.
+_SCH_MULTI_LEVEL_EXTENDS = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:BaseWidget"
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "BaseWidget" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "Package_SO:SOIC-8" (at 0 0 0) (effects (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (hide yes)))
+      (symbol "BaseWidget_1_1"
+        (pin input line (at -10 0 0) (length 2.54)
+          (name "A" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27))))
+        )
+        (pin output line (at 10 0 180) (length 2.54)
+          (name "B" (effects (font (size 1.27 1.27))))
+          (number "2" (effects (font (size 1.27 1.27))))
+        )
+        (pin power_in line (at 0 -5 90) (length 2.54)
+          (name "GND" (effects (font (size 1.27 1.27))))
+          (number "3" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+    (symbol "Device:MidWidget"
+      (extends "Device:BaseWidget")
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "MidWidget" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "Package_SO:SOIC-8" (at 0 0 0) (effects (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (hide yes)))
+    )
+    (symbol "Device:LeafWidget"
+      (extends "Device:MidWidget")
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "LeafWidget" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "Package_SO:SOIC-8" (at 0 0 0) (effects (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (hide yes)))
+    )
+  )
+  (symbol
+    (lib_id "Device:LeafWidget")
+    (at 100 100 0)
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (property "Reference" "U1" (at 100 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "LeafWidget" (at 100 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Package_SO:SOIC-8" (at 100 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 100 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000101"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000102"))
+    (pin "3" (uuid "00000000-0000-0000-0000-000000000103"))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "U1")
+          (unit 1)
+        )
+      )
+    )
+  )
+)
+"""
+
 # An empty schematic (no components) -- should pass cleanly.
 _SCH_EMPTY = """(kicad_sch
   (version 20231120)
@@ -313,6 +449,34 @@ class TestCheckPowerFlags:
         sch = _write_sch(_SCH_EMPTY)
         issues = check_power_flags(str(sch))
         assert len(issues) == 0
+
+
+class TestCheckPinPadCountExtends:
+    """Tests for check_pin_pad_count with derived (extends) symbols."""
+
+    def test_derived_symbol_inherits_pin_count(self, _write_sch):
+        """Derived symbol using (extends ...) should inherit base pin count."""
+        from kicad_tools.cli.sch_preflight import check_pin_pad_count
+
+        sch = _write_sch(_SCH_EXTENDS_SYMBOL)
+        issues = check_pin_pad_count(str(sch))
+        mismatch_issues = [i for i in issues if i.category == "pin_pad_mismatch"]
+        assert len(mismatch_issues) == 0, (
+            f"Expected no pin_pad_mismatch for derived symbol, got: "
+            f"{[i.message for i in mismatch_issues]}"
+        )
+
+    def test_multi_level_extends_chain(self, _write_sch):
+        """Multi-level extends chain (C extends B extends A) resolves transitively."""
+        from kicad_tools.cli.sch_preflight import check_pin_pad_count
+
+        sch = _write_sch(_SCH_MULTI_LEVEL_EXTENDS)
+        issues = check_pin_pad_count(str(sch))
+        mismatch_issues = [i for i in issues if i.category == "pin_pad_mismatch"]
+        assert len(mismatch_issues) == 0, (
+            f"Expected no pin_pad_mismatch for multi-level extends, got: "
+            f"{[i.message for i in mismatch_issues]}"
+        )
 
 
 class TestCheckSinglePinNets:


### PR DESCRIPTION
## Summary
Fix false `pin_pad_mismatch` warnings for derived library symbols that use the KiCad `(extends ...)` directive. These symbols contain zero direct pins (inheriting from their base), causing the preflight check to report a mismatch against the instance pin count.

## Changes
- Add extends chain resolution in `check_pin_pad_count()` in `sch_preflight.py`: after building the `lib_pin_counts` map, build an `extends_map` and resolve inheritance so derived symbols inherit pin counts from their base
- Guard against circular extends references and missing base symbols
- Support multi-level extends chains (A extends B extends C)
- Add two test cases: single-level extends and multi-level extends chain

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No false pin_pad_mismatch for derived symbols | Pass | Test `test_derived_symbol_inherits_pin_count` passes with AP2112K-3.3 extending AP2204K-1.5 |
| Multi-level extends chains resolve transitively | Pass | Test `test_multi_level_extends_chain` passes with LeafWidget -> MidWidget -> BaseWidget |
| Circular extends references do not cause infinite loops | Pass | Loop guard with `visited` set prevents infinite iteration |
| Missing extends target does not crash | Pass | `extends_map.get(cur)` returns None, terminating the while loop |

## Test Plan
- `python3 -m pytest tests/test_sch_preflight.py -v` -- all 22 tests pass (20 existing + 2 new)
- New tests use inline schematic fixtures with realistic KiCad s-expression structure

Closes #2148