### PR TITLE
fix(schema): resolve inherited pins for derived symbols using extends chains

### DIFF
--- a/src/kicad_tools/cli/sch_pin_map.py
+++ b/src/kicad_tools/cli/sch_pin_map.py
@@ -20,7 +20,6 @@ from collections import defaultdict
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import Schematic
 from kicad_tools.schema.label import PowerSymbol
-from kicad_tools.schema.library import LibrarySymbol
 
 # Use integer-scaled coordinates for fast set lookup (matches sch_check_connections.py)
 Coord = tuple[int, int]
@@ -316,11 +315,9 @@ def resolve_pin_map(
         if symbol.lib_id.startswith("power:"):
             continue
 
-        lib_sexp = schematic.get_lib_symbol(symbol.lib_id)
-        if not lib_sexp:
+        lib_sym = schematic.get_lib_symbol_resolved(symbol.lib_id)
+        if not lib_sym:
             continue
-
-        lib_sym = LibrarySymbol.from_sexp(lib_sexp)
         pin_positions = lib_sym.get_all_pin_positions(
             instance_pos=symbol.position,
             instance_rot=symbol.rotation,

--- a/src/kicad_tools/cli/sch_preflight.py
+++ b/src/kicad_tools/cli/sch_preflight.py
@@ -28,7 +28,6 @@ from pathlib import Path
 
 from kicad_tools.schema import Schematic
 from kicad_tools.schema.hierarchy import build_hierarchy
-from kicad_tools.schema.library import LibrarySymbol
 
 from .sch_validate import (
     ValidationIssue,
@@ -129,37 +128,20 @@ def check_pin_pad_count(schematic_path: str) -> list[ValidationIssue]:
         for node in hierarchy.all_nodes():
             try:
                 sch = Schematic.load(node.path)
-                # Build map of library symbol name -> pin count from lib_symbols
+                # Build map of library symbol name -> pin count from lib_symbols.
+                # get_lib_symbol_resolved() handles extends chains so derived
+                # symbols return their effective (inherited) pin count.
                 lib_pin_counts: dict[str, int] = {}
-                extends_map: dict[str, str] = {}
                 lib_syms_sexp = sch.lib_symbols
                 if lib_syms_sexp is not None:
                     for sym_sexp in lib_syms_sexp.find_all("symbol"):
                         try:
-                            lib_sym = LibrarySymbol.from_sexp(sym_sexp)
-                            lib_pin_counts[lib_sym.name] = lib_sym.pin_count
-                            # Track extends relationships for derived symbols
-                            ext_node = sym_sexp.get("extends")
-                            if ext_node is not None:
-                                base_name = ext_node.get_string(0)
-                                if base_name:
-                                    extends_map[lib_sym.name] = base_name
+                            sym_name = sym_sexp.get_string(0) or ""
+                            lib_sym = sch.get_lib_symbol_resolved(sym_name)
+                            if lib_sym is not None:
+                                lib_pin_counts[lib_sym.name] = lib_sym.pin_count
                         except Exception:
                             pass
-
-                    # Resolve extends chains: derived symbols with 0 pins
-                    # inherit pin count from their base symbol.
-                    for name, base in extends_map.items():
-                        if lib_pin_counts.get(name, 0) == 0:
-                            visited: set[str] = {name}
-                            cur = base
-                            while cur and cur not in visited:
-                                count = lib_pin_counts.get(cur, 0)
-                                if count > 0:
-                                    lib_pin_counts[name] = count
-                                    break
-                                visited.add(cur)
-                                cur = extends_map.get(cur)
 
                 for sym in sch.symbols:
                     if sym.lib_id.startswith("power:"):

--- a/src/kicad_tools/schema/library.py
+++ b/src/kicad_tools/schema/library.py
@@ -1055,6 +1055,9 @@ class SymbolLibrary:
             sym = LibrarySymbol.from_sexp(sym_sexp)
             symbols[sym.name] = sym
 
+        # Resolve extends chains so derived symbols have populated pins
+        resolve_extends(symbols)
+
         return cls(
             path=path,
             symbols=symbols,
@@ -1198,6 +1201,77 @@ class SymbolLibrary:
         )
 
 
+def resolve_extends(symbols: dict[str, LibrarySymbol], *, max_depth: int = 10) -> None:
+    """Resolve extends chains in-place, copying base pins/graphics to derived symbols.
+
+    After calling this function, every symbol whose ``extends`` field is set
+    will have its ``pins`` and ``graphics`` lists populated from the base
+    symbol (unless it already defines its own pins).
+
+    Args:
+        symbols: Mapping of symbol name to ``LibrarySymbol``.  Names may be
+            either short (``"OpAmp"``) or fully-qualified (``"Device:OpAmp"``).
+            The ``extends`` value stored on derived symbols is always a short
+            name, so lookup tries both the raw value and a match against the
+            short portion of qualified keys.
+        max_depth: Maximum extends chain depth to prevent infinite loops.
+
+    Raises:
+        ValueError: If a circular extends chain or missing base is detected.
+    """
+
+    def _find_base(name: str) -> LibrarySymbol | None:
+        """Locate a base symbol by short or qualified name."""
+        if name in symbols:
+            return symbols[name]
+        # Fallback: match by short name portion of qualified keys
+        for key, sym in symbols.items():
+            short = key.split(":", 1)[1] if ":" in key else key
+            if short == name:
+                return sym
+        return None
+
+    for sym in symbols.values():
+        if sym.extends is None:
+            continue
+        # Only resolve if the symbol has no own pins
+        if sym.pins:
+            continue
+
+        # Walk the extends chain to find pins and graphics
+        visited: set[str] = {sym.name}
+        current_name = sym.extends
+        depth = 0
+        resolved_pins: list[LibraryPin] | None = None
+        resolved_graphics: list[SymbolPolyline | SymbolCircle | SymbolArc | SymbolRectangle] | None = None
+
+        while current_name is not None and depth < max_depth:
+            if current_name in visited:
+                raise ValueError(
+                    f"Circular extends chain detected: {sym.name} -> ... -> {current_name}"
+                )
+            visited.add(current_name)
+            depth += 1
+
+            base = _find_base(current_name)
+            if base is None:
+                # Base not found in this symbol set; leave unresolved
+                break
+
+            if base.pins:
+                resolved_pins = list(base.pins)
+                resolved_graphics = list(base.graphics)
+                break
+
+            # Base itself may also extend another symbol
+            current_name = base.extends
+
+        if resolved_pins is not None:
+            sym.pins = resolved_pins
+        if resolved_graphics is not None and not sym.graphics:
+            sym.graphics = resolved_graphics
+
+
 class LibraryManager:
     """
     Manages multiple symbol libraries.
@@ -1253,6 +1327,16 @@ class LibraryManager:
                 )
             if short_name not in self.libraries[lib_name].symbols:
                 self.libraries[lib_name].symbols[short_name] = sym
+
+        # Resolve extends chains: derived symbols inherit pins/graphics
+        # from their base.  We build a combined lookup across all embedded
+        # libraries so that cross-library extends (rare but valid) work.
+        all_embedded: dict[str, LibrarySymbol] = {}
+        for lib in self.libraries.values():
+            if lib.path == "<embedded>":
+                all_embedded.update(lib.symbols)
+        if all_embedded:
+            resolve_extends(all_embedded)
 
     def add_search_path(self, path: str) -> None:
         """Add a directory to search for libraries."""

--- a/src/kicad_tools/schema/schematic.py
+++ b/src/kicad_tools/schema/schematic.py
@@ -17,7 +17,7 @@ from kicad_tools.sexp import SExp
 
 from ..core.sexp_file import load_schematic, save_schematic
 from .label import GlobalLabel, HierarchicalLabel, Label
-from .library import LibrarySymbol
+from .library import LibrarySymbol, resolve_extends
 from .symbol import SymbolInstance, SymbolPin, SymbolProperty
 from .wire import Junction, Wire
 
@@ -291,6 +291,34 @@ class Schematic:
                     return sym
         return None
 
+    def get_lib_symbol_resolved(self, lib_id: str) -> LibrarySymbol | None:
+        """Return a :class:`LibrarySymbol` with extends chains resolved.
+
+        This is the recommended way for CLI commands to obtain a library
+        symbol from the schematic's embedded ``lib_symbols`` section.
+        If the symbol uses ``(extends "Base")``, its ``pins`` and
+        ``graphics`` will be populated from the base symbol.
+
+        Returns ``None`` if *lib_id* is not found in ``lib_symbols``.
+        """
+        sexp = self.get_lib_symbol(lib_id)
+        if sexp is None:
+            return None
+        sym = LibrarySymbol.from_sexp(sexp)
+        if sym.extends is not None and not sym.pins:
+            # Build a lookup of all embedded symbols for resolution
+            all_syms: dict[str, LibrarySymbol] = {}
+            if lib_syms := self.lib_symbols:
+                for s in lib_syms.find_all("symbol"):
+                    parsed = LibrarySymbol.from_sexp(s)
+                    all_syms[parsed.name] = parsed
+            resolve_extends(all_syms)
+            # The resolved copy is in all_syms
+            resolved = all_syms.get(sym.name)
+            if resolved is not None:
+                return resolved
+        return sym
+
     # Editing API
 
     def _find_insertion_index(self) -> int:
@@ -387,9 +415,8 @@ class Schematic:
 
         # Determine pin numbers from lib_symbols when not explicitly given
         if pin_numbers is None:
-            lib_sym_sexp = self.get_lib_symbol(lib_id)
-            if lib_sym_sexp is not None:
-                lib_sym = LibrarySymbol.from_sexp(lib_sym_sexp)
+            lib_sym = self.get_lib_symbol_resolved(lib_id)
+            if lib_sym is not None:
                 pin_numbers = [p.number for p in lib_sym.pins]
             else:
                 raise ValueError(
@@ -450,9 +477,8 @@ class Schematic:
 
         # Detect pins from lib_symbols
         pin_numbers: list[str] = []
-        lib_sym_sexp = self.get_lib_symbol(lib_id)
-        if lib_sym_sexp is not None:
-            lib_sym = LibrarySymbol.from_sexp(lib_sym_sexp)
+        lib_sym = self.get_lib_symbol_resolved(lib_id)
+        if lib_sym is not None:
             pin_numbers = [p.number for p in lib_sym.pins]
         else:
             # Power symbols typically have a single pin "1"
@@ -786,10 +812,9 @@ class Schematic:
 
         # Pin positions of existing symbol instances
         for sym in self.symbols:
-            lib_sym_sexp = self.get_lib_symbol(sym.lib_id)
-            if lib_sym_sexp is None:
+            lib_sym_obj = self.get_lib_symbol_resolved(sym.lib_id)
+            if lib_sym_obj is None:
                 continue
-            lib_sym_obj = LibrarySymbol.from_sexp(lib_sym_sexp)
             pin_positions = lib_sym_obj.get_all_pin_positions(
                 instance_pos=sym.position,
                 instance_rot=sym.rotation,

--- a/tests/test_library_extends.py
+++ b/tests/test_library_extends.py
@@ -1,0 +1,376 @@
+"""Tests for derived symbol (extends) resolution in the schema library module.
+
+Verifies that:
+- resolve_extends() copies base pins/graphics to derived symbols
+- Multi-level extends chains resolve correctly
+- Circular extends chains raise ValueError
+- Missing base symbols leave the derived symbol unresolved (no crash)
+- Derived symbols with own pins are not overwritten
+- LibraryManager.load_embedded() resolves extends automatically
+- SymbolLibrary.load() resolves extends automatically
+- Schematic.get_lib_symbol_resolved() resolves extends
+- Internal methods (pin_count, get_pin, get_all_pin_positions) work after resolution
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.schema.library import (
+    LibraryPin,
+    LibrarySymbol,
+    LibraryManager,
+    SymbolLibrary,
+    SymbolPolyline,
+    resolve_extends,
+)
+from kicad_tools.sexp import SExp, parse_string
+
+
+def _make_pin(number: str, name: str, pin_type: str = "passive") -> LibraryPin:
+    """Create a simple test pin."""
+    return LibraryPin(
+        number=number,
+        name=name,
+        type=pin_type,
+        position=(0.0, float(int(number)) * 2.54 if number.isdigit() else 0.0),
+        rotation=0,
+        length=2.54,
+    )
+
+
+def _make_polyline() -> SymbolPolyline:
+    """Create a simple test polyline."""
+    return SymbolPolyline(points=[(0, 0), (5, 0), (5, 5), (0, 5), (0, 0)])
+
+
+class TestResolveExtends:
+    """Tests for the resolve_extends() function."""
+
+    def test_basic_extends_resolution(self):
+        """Derived symbol with extends gets base symbol's pins."""
+        base = LibrarySymbol(
+            name="OpAmp",
+            pins=[_make_pin("1", "+"), _make_pin("2", "-"), _make_pin("3", "OUT")],
+            graphics=[_make_polyline()],
+        )
+        derived = LibrarySymbol(name="LM358", extends="OpAmp")
+
+        symbols = {"OpAmp": base, "LM358": derived}
+        resolve_extends(symbols)
+
+        assert len(derived.pins) == 3
+        assert derived.pins[0].name == "+"
+        assert derived.pins[1].name == "-"
+        assert derived.pins[2].name == "OUT"
+        assert len(derived.graphics) == 1
+
+    def test_multi_level_extends(self):
+        """A -> B -> C chain resolves correctly."""
+        base = LibrarySymbol(
+            name="Base",
+            pins=[_make_pin("1", "P1"), _make_pin("2", "P2")],
+        )
+        mid = LibrarySymbol(name="Mid", extends="Base")
+        leaf = LibrarySymbol(name="Leaf", extends="Mid")
+
+        symbols = {"Base": base, "Mid": mid, "Leaf": leaf}
+        resolve_extends(symbols)
+
+        # Both mid and leaf should have base's pins
+        assert len(mid.pins) == 2
+        assert len(leaf.pins) == 2
+        assert leaf.pins[0].name == "P1"
+
+    def test_circular_extends_raises(self):
+        """Circular extends chain raises ValueError."""
+        a = LibrarySymbol(name="A", extends="B")
+        b = LibrarySymbol(name="B", extends="A")
+
+        symbols = {"A": a, "B": b}
+        with pytest.raises(ValueError, match="Circular extends chain"):
+            resolve_extends(symbols)
+
+    def test_missing_base_leaves_unresolved(self):
+        """If base symbol is not in the dict, derived stays empty."""
+        derived = LibrarySymbol(name="Derived", extends="Missing")
+
+        symbols = {"Derived": derived}
+        resolve_extends(symbols)
+
+        assert len(derived.pins) == 0
+
+    def test_derived_with_own_pins_not_overwritten(self):
+        """Derived symbol that already has pins is not overwritten."""
+        base = LibrarySymbol(
+            name="Base",
+            pins=[_make_pin("1", "B1"), _make_pin("2", "B2")],
+        )
+        derived = LibrarySymbol(
+            name="Derived",
+            extends="Base",
+            pins=[_make_pin("1", "D1")],
+        )
+
+        symbols = {"Base": base, "Derived": derived}
+        resolve_extends(symbols)
+
+        # Should keep its own pins
+        assert len(derived.pins) == 1
+        assert derived.pins[0].name == "D1"
+
+    def test_qualified_name_resolution(self):
+        """Base name matches against qualified key (lib:symbol)."""
+        base = LibrarySymbol(
+            name="Amplifier_Operational:OpAmp",
+            pins=[_make_pin("1", "+"), _make_pin("2", "-")],
+        )
+        derived = LibrarySymbol(name="LM358", extends="OpAmp")
+
+        symbols = {"Amplifier_Operational:OpAmp": base, "LM358": derived}
+        resolve_extends(symbols)
+
+        assert len(derived.pins) == 2
+
+    def test_no_extends_symbols_unaffected(self):
+        """Symbols without extends are left unchanged."""
+        sym = LibrarySymbol(
+            name="Resistor",
+            pins=[_make_pin("1", "1"), _make_pin("2", "2")],
+        )
+
+        symbols = {"Resistor": sym}
+        resolve_extends(symbols)
+
+        assert len(sym.pins) == 2
+
+
+class TestLibrarySymbolInternalMethods:
+    """Verify internal methods work correctly after extends resolution."""
+
+    def test_pin_count_after_resolution(self):
+        """pin_count returns base pin count after resolution."""
+        base = LibrarySymbol(
+            name="Base",
+            pins=[_make_pin("1", "A"), _make_pin("2", "B"), _make_pin("3", "C")],
+        )
+        derived = LibrarySymbol(name="Derived", extends="Base")
+
+        assert derived.pin_count == 0  # Before resolution
+
+        resolve_extends({"Base": base, "Derived": derived})
+
+        assert derived.pin_count == 3  # After resolution
+
+    def test_get_pin_after_resolution(self):
+        """get_pin() finds inherited pins."""
+        base = LibrarySymbol(
+            name="Base",
+            pins=[_make_pin("1", "VCC"), _make_pin("2", "GND")],
+        )
+        derived = LibrarySymbol(name="Derived", extends="Base")
+
+        resolve_extends({"Base": base, "Derived": derived})
+
+        pin = derived.get_pin("1")
+        assert pin is not None
+        assert pin.name == "VCC"
+
+        assert derived.get_pin("99") is None
+
+    def test_get_pins_by_name_after_resolution(self):
+        """get_pins_by_name() finds inherited pins."""
+        base = LibrarySymbol(
+            name="Base",
+            pins=[_make_pin("1", "GND"), _make_pin("2", "VCC"), _make_pin("3", "GND")],
+        )
+        derived = LibrarySymbol(name="Derived", extends="Base")
+
+        resolve_extends({"Base": base, "Derived": derived})
+
+        gnd_pins = derived.get_pins_by_name("GND")
+        assert len(gnd_pins) == 2
+
+    def test_get_all_pin_positions_after_resolution(self):
+        """get_all_pin_positions() returns positions for inherited pins."""
+        base = LibrarySymbol(
+            name="Base",
+            pins=[
+                LibraryPin(
+                    number="1", name="A", type="passive",
+                    position=(2.54, 0), rotation=180, length=2.54,
+                ),
+                LibraryPin(
+                    number="2", name="B", type="passive",
+                    position=(-2.54, 0), rotation=0, length=2.54,
+                ),
+            ],
+        )
+        derived = LibrarySymbol(name="Derived", extends="Base")
+
+        resolve_extends({"Base": base, "Derived": derived})
+
+        positions = derived.get_all_pin_positions(
+            instance_pos=(10.0, 20.0),
+            instance_rot=0,
+        )
+        assert len(positions) == 2
+        assert "1" in positions
+        assert "2" in positions
+
+
+class TestLibraryManagerLoadEmbedded:
+    """Verify LibraryManager.load_embedded() resolves extends."""
+
+    def test_embedded_extends_resolved(self):
+        """Embedded derived symbols get their base's pins."""
+        # Build a minimal lib_symbols sexp with base and derived symbol
+        sexp_text = """(lib_symbols
+          (symbol "mylib:OpAmp"
+            (symbol "OpAmp_0_1"
+              (polyline (pts (xy 0 0) (xy 5 0)) (stroke (width 0) (type default)) (fill (type none)))
+            )
+            (symbol "OpAmp_1_1"
+              (pin input line (at -5.08 2.54 0) (length 2.54) (name "+" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+              (pin input line (at -5.08 -2.54 0) (length 2.54) (name "-" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+              (pin output line (at 5.08 0 180) (length 2.54) (name "OUT" (effects (font (size 1.27 1.27)))) (number "3" (effects (font (size 1.27 1.27)))))
+            )
+          )
+          (symbol "mylib:LM358"
+            (extends "OpAmp")
+            (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (property "Value" "LM358" (at 0 0 0) (effects (font (size 1.27 1.27))))
+          )
+        )"""
+        lib_symbols = parse_string(sexp_text)
+
+        class FakeSchematic:
+            @property
+            def lib_symbols(self):
+                return lib_symbols
+
+        mgr = LibraryManager()
+        mgr.load_embedded(FakeSchematic())
+
+        derived = mgr.get_symbol("mylib:LM358")
+        assert derived is not None
+        assert derived.extends == "OpAmp"
+        assert derived.pin_count == 3
+        assert derived.get_pin("1") is not None
+        assert derived.get_pin("1").name == "+"
+
+    def test_embedded_base_without_extends_unaffected(self):
+        """Base symbols without extends keep their own pins."""
+        sexp_text = """(lib_symbols
+          (symbol "mylib:OpAmp"
+            (symbol "OpAmp_1_1"
+              (pin input line (at 0 0 0) (length 2.54) (name "IN" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+            )
+          )
+        )"""
+        lib_symbols = parse_string(sexp_text)
+
+        class FakeSchematic:
+            @property
+            def lib_symbols(self):
+                return lib_symbols
+
+        mgr = LibraryManager()
+        mgr.load_embedded(FakeSchematic())
+
+        sym = mgr.get_symbol("mylib:OpAmp")
+        assert sym is not None
+        assert sym.pin_count == 1
+        assert sym.extends is None
+
+
+class TestSymbolLibraryLoad:
+    """Verify SymbolLibrary.load() resolves extends."""
+
+    def test_load_resolves_extends(self, tmp_path):
+        """Symbols loaded from .kicad_sym file have extends resolved."""
+        lib_content = """(kicad_symbol_lib
+          (version 20231120)
+          (generator "kicad_symbol_editor")
+          (symbol "OpAmp"
+            (symbol "OpAmp_1_1"
+              (pin input line (at -5.08 2.54 0) (length 2.54) (name "+" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+              (pin input line (at -5.08 -2.54 0) (length 2.54) (name "-" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+              (pin output line (at 5.08 0 180) (length 2.54) (name "OUT" (effects (font (size 1.27 1.27)))) (number "3" (effects (font (size 1.27 1.27)))))
+            )
+          )
+          (symbol "LM358"
+            (extends "OpAmp")
+            (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (property "Value" "LM358" (at 0 0 0) (effects (font (size 1.27 1.27))))
+          )
+        )"""
+        lib_path = tmp_path / "test.kicad_sym"
+        lib_path.write_text(lib_content)
+
+        lib = SymbolLibrary.load(str(lib_path))
+
+        derived = lib.get_symbol("LM358")
+        assert derived is not None
+        assert derived.extends == "OpAmp"
+        assert derived.pin_count == 3
+        assert derived.get_pin("1").name == "+"
+        assert derived.get_pin("3").name == "OUT"
+
+
+class TestSchematicGetLibSymbolResolved:
+    """Verify Schematic.get_lib_symbol_resolved() resolves extends."""
+
+    def test_resolved_method_returns_pins_for_derived(self, tmp_path):
+        """get_lib_symbol_resolved returns inherited pins for derived symbols."""
+        # Create a minimal schematic with embedded lib_symbols
+        sch_content = """(kicad_sch
+          (version 20231120)
+          (generator "kicad_tools")
+          (lib_symbols
+            (symbol "mylib:OpAmp"
+              (symbol "OpAmp_1_1"
+                (pin input line (at -5.08 2.54 0) (length 2.54) (name "+" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+                (pin input line (at -5.08 -2.54 0) (length 2.54) (name "-" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+                (pin output line (at 5.08 0 180) (length 2.54) (name "OUT" (effects (font (size 1.27 1.27)))) (number "3" (effects (font (size 1.27 1.27)))))
+              )
+            )
+            (symbol "mylib:LM358"
+              (extends "OpAmp")
+              (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+              (property "Value" "LM358" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            )
+          )
+        )"""
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text(sch_content)
+
+        from kicad_tools.schema import Schematic
+        sch = Schematic.load(str(sch_path))
+
+        # Non-derived symbol
+        base = sch.get_lib_symbol_resolved("mylib:OpAmp")
+        assert base is not None
+        assert base.pin_count == 3
+
+        # Derived symbol
+        derived = sch.get_lib_symbol_resolved("mylib:LM358")
+        assert derived is not None
+        assert derived.pin_count == 3
+        assert derived.get_pin("1").name == "+"
+
+    def test_resolved_method_returns_none_for_missing(self, tmp_path):
+        """get_lib_symbol_resolved returns None for missing lib_id."""
+        sch_content = """(kicad_sch
+          (version 20231120)
+          (generator "kicad_tools")
+          (lib_symbols)
+        )"""
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text(sch_content)
+
+        from kicad_tools.schema import Schematic
+        sch = Schematic.load(str(sch_path))
+
+        result = sch.get_lib_symbol_resolved("nonexistent:Symbol")
+        assert result is None


### PR DESCRIPTION
## Summary
Derived KiCad symbols using `(extends "BaseSymbol")` contain zero pins in their own definition -- they inherit pins from the base. This caused all internal methods (pin_count, get_pin, get_all_pin_positions, etc.) and 8+ CLI callers to return empty/wrong results for derived symbols.

This PR adds eager resolution of extends chains during library loading so that `.pins` always contains the effective pin set.

## Changes
- Add `resolve_extends()` function in `library.py` that walks extends chains and copies base symbol pins/graphics to derived symbols
- Integrate resolution into `LibraryManager.load_embedded()` and `SymbolLibrary.load()`
- Add `Schematic.get_lib_symbol_resolved()` helper for CLI commands that access embedded lib_symbols directly
- Update `sch_pin_map.py` to use `get_lib_symbol_resolved()` instead of raw `LibrarySymbol.from_sexp()`
- Remove ad-hoc `extends_map` workaround in `sch_preflight.py`, replaced by centralized resolution
- Update `schematic.py` internal callers (`add_symbol`, `add_power`, `_snap_to_nearest_connection_point`) to use resolved symbols

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Derived symbols have populated pins after loading | Pass | Test `test_basic_extends_resolution` verifies pins are copied from base |
| Multi-level extends chains resolve (A->B->C) | Pass | Test `test_multi_level_extends` verifies 3-level chains |
| Circular extends chains raise ValueError | Pass | Test `test_circular_extends_raises` |
| Missing base symbols leave derived unresolved (no crash) | Pass | Test `test_missing_base_leaves_unresolved` |
| Derived symbols with own pins not overwritten | Pass | Test `test_derived_with_own_pins_not_overwritten` |
| Internal methods (pin_count, get_pin, get_all_pin_positions) work | Pass | Tests in `TestLibrarySymbolInternalMethods` class |
| LibraryManager.load_embedded() auto-resolves | Pass | Test `test_embedded_extends_resolved` |
| SymbolLibrary.load() auto-resolves | Pass | Test `test_load_resolves_extends` |
| Schematic.get_lib_symbol_resolved() works | Pass | Tests in `TestSchematicGetLibSymbolResolved` class |
| sch_preflight extends_map workaround removed | Pass | Diff shows removal of extends_map logic |

## Test Plan
- 16 new tests in `tests/test_library_extends.py` covering all resolution scenarios
- 303 existing tests pass (1 pre-existing failure in `test_rotated_symbol_positions` unrelated to this change)
- Tests cover: basic resolution, multi-level chains, circular detection, missing bases, qualified name matching, LibraryManager integration, SymbolLibrary.load() integration, Schematic helper method

Closes #2155