### PR TITLE
feat(report): split unrouted signal nets into named vs auto-generated

### DIFF
--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -418,6 +418,31 @@ class ReportDataCollector:
             and n.net_name not in single_set
         )[: self._INCOMPLETE_NET_NAMES_CAP]
 
+        # Split signal incomplete nets into named (human-assigned) vs
+        # auto-generated (KiCad default names like "Net-(...)" and
+        # "unconnected-(...)").  Named nets have higher information value
+        # and are listed individually; auto-generated nets are reduced to
+        # a count to avoid noise in the report.
+        _AUTO_NET_PREFIXES = ("Net-(", "unconnected-(")
+
+        signal_incomplete_named = sorted(
+            n.net_name
+            for n in result.nets
+            if n.status != "complete"
+            and n.net_name not in zone_set
+            and n.net_name not in single_set
+            and not n.net_name.startswith(_AUTO_NET_PREFIXES)
+        )[: self._INCOMPLETE_NET_NAMES_CAP]
+
+        signal_incomplete_auto_count = sum(
+            1
+            for n in result.nets
+            if n.status != "complete"
+            and n.net_name not in zone_set
+            and n.net_name not in single_set
+            and n.net_name.startswith(_AUTO_NET_PREFIXES)
+        )
+
         return {
             # Existing keys (backward compatible)
             "total_nets": result.total_nets,
@@ -432,6 +457,8 @@ class ReportDataCollector:
             "signal_complete_count": signal_complete_count,
             "signal_completion_percent": signal_completion_percent,
             "signal_incomplete_net_names": signal_incomplete_net_names,
+            "signal_incomplete_named": signal_incomplete_named,
+            "signal_incomplete_auto_count": signal_incomplete_auto_count,
             "zone_connected_count": len(all_zone_nets),
             "zone_connected_nets": all_zone_nets,
             "single_pad_count": len(single_pad_nets),

--- a/src/kicad_tools/report/models.py
+++ b/src/kicad_tools/report/models.py
@@ -44,8 +44,14 @@ class ReportData:
     unrouted_count, total_unconnected_pads, completion_percent,
     incomplete_net_names, signal_net_count, signal_complete_count,
     signal_completion_percent, signal_incomplete_net_names,
+    signal_incomplete_named, signal_incomplete_auto_count,
     zone_connected_count, zone_connected_nets, single_pad_count,
-    single_pad_nets}."""
+    single_pad_nets}.
+
+    ``signal_incomplete_named`` contains only human-assigned net names
+    (excludes ``Net-(...)`` and ``unconnected-(...)`` auto-generated
+    names).  ``signal_incomplete_auto_count`` is the count of
+    auto-generated incomplete signal nets."""
 
     cost: dict | None = None
     """Cost estimate: {pcb_cost, component_cost (nullable),

--- a/src/kicad_tools/report/templates/design_report.md.j2
+++ b/src/kicad_tools/report/templates/design_report.md.j2
@@ -272,7 +272,19 @@ header-includes:
 {% endfor %}
 
 {% endif %}
-{% if net_status.signal_incomplete_net_names is defined and net_status.signal_incomplete_net_names %}
+{% if net_status.signal_incomplete_named is defined and net_status.signal_incomplete_named %}
+### Unrouted Signal Nets
+
+{% for net in net_status.signal_incomplete_named %}
+- {{ net }}
+{% endfor %}
+
+{% endif %}
+{% if net_status.signal_incomplete_auto_count is defined and net_status.signal_incomplete_auto_count > 0 %}
+{{ net_status.signal_incomplete_auto_count }} auto-generated component nets (`Net-(...)` / `unconnected-(...)`) not listed individually.
+
+{% elif net_status.signal_incomplete_net_names is defined and net_status.signal_incomplete_net_names %}
+{# Backward-compatible fallback for data generated before the named/auto split #}
 ### Unrouted Signal Nets
 
 {% for net in net_status.signal_incomplete_net_names %}

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -1058,6 +1058,118 @@ class TestCollectNetStatusClassification:
         assert status["incomplete_count"] == 2
         assert status["unrouted_count"] == 0
 
+    def test_signal_incomplete_named_excludes_auto_generated(self, tmp_path):
+        """signal_incomplete_named excludes Net-(...) and unconnected-(...) nets."""
+        from kicad_tools.analysis.net_status import NetStatus, NetStatusResult
+
+        nets = []
+        # Named signal net (incomplete)
+        miso = NetStatus(net_number=1, net_name="MISO", total_pads=3)
+        miso.connected_pads = [object()]
+        miso.unconnected_pads = [object(), object()]
+        nets.append(miso)
+
+        # Auto-generated net (incomplete)
+        auto1 = NetStatus(net_number=2, net_name="Net-(U1-1)", total_pads=2)
+        auto1.connected_pads = [object()]
+        auto1.unconnected_pads = [object()]
+        nets.append(auto1)
+
+        # Another auto-generated net (incomplete)
+        auto2 = NetStatus(net_number=3, net_name="unconnected-(C40-2)", total_pads=2)
+        auto2.connected_pads = [object()]
+        auto2.unconnected_pads = [object()]
+        nets.append(auto2)
+
+        # Named signal net (incomplete)
+        sda = NetStatus(net_number=4, net_name="SDA", total_pads=2)
+        sda.connected_pads = [object()]
+        sda.unconnected_pads = [object()]
+        nets.append(sda)
+
+        # Named signal net (complete)
+        scl = NetStatus(net_number=5, net_name="SCL", total_pads=2)
+        scl.connected_pads = [object(), object()]
+        nets.append(scl)
+
+        mock_result = NetStatusResult(nets=nets, total_nets=5)
+        pcb_path = tmp_path / "dummy.kicad_pcb"
+        pcb_path.touch()
+        collector = ReportDataCollector(pcb_path)
+
+        with patch(
+            "kicad_tools.analysis.net_status.NetStatusAnalyzer.analyze",
+            return_value=mock_result,
+        ):
+            status = collector.collect_net_status(None)
+
+        # signal_incomplete_named should contain only named nets
+        assert status["signal_incomplete_named"] == ["MISO", "SDA"]
+        # signal_incomplete_auto_count should count the auto-generated ones
+        assert status["signal_incomplete_auto_count"] == 2
+        # signal_incomplete_net_names (backward compat) should contain all four
+        assert status["signal_incomplete_net_names"] == [
+            "MISO", "Net-(U1-1)", "SDA", "unconnected-(C40-2)"
+        ]
+
+    def test_signal_incomplete_all_auto_generated(self, tmp_path):
+        """When all incomplete signal nets are auto-generated, named list is empty."""
+        from kicad_tools.analysis.net_status import NetStatus, NetStatusResult
+
+        nets = []
+        auto1 = NetStatus(net_number=1, net_name="Net-(U1-1)", total_pads=2)
+        auto1.connected_pads = [object()]
+        auto1.unconnected_pads = [object()]
+        nets.append(auto1)
+
+        auto2 = NetStatus(net_number=2, net_name="Net-(R3-2)", total_pads=2)
+        auto2.connected_pads = [object()]
+        auto2.unconnected_pads = [object()]
+        nets.append(auto2)
+
+        mock_result = NetStatusResult(nets=nets, total_nets=2)
+        pcb_path = tmp_path / "dummy.kicad_pcb"
+        pcb_path.touch()
+        collector = ReportDataCollector(pcb_path)
+
+        with patch(
+            "kicad_tools.analysis.net_status.NetStatusAnalyzer.analyze",
+            return_value=mock_result,
+        ):
+            status = collector.collect_net_status(None)
+
+        assert status["signal_incomplete_named"] == []
+        assert status["signal_incomplete_auto_count"] == 2
+
+    def test_signal_incomplete_all_named(self, tmp_path):
+        """When all incomplete signal nets are named, auto count is zero."""
+        from kicad_tools.analysis.net_status import NetStatus, NetStatusResult
+
+        nets = []
+        sda = NetStatus(net_number=1, net_name="SDA", total_pads=2)
+        sda.connected_pads = [object()]
+        sda.unconnected_pads = [object()]
+        nets.append(sda)
+
+        scl = NetStatus(net_number=2, net_name="SCL", total_pads=2)
+        scl.connected_pads = [object()]
+        scl.unconnected_pads = [object()]
+        nets.append(scl)
+
+        mock_result = NetStatusResult(nets=nets, total_nets=2)
+        pcb_path = tmp_path / "dummy.kicad_pcb"
+        pcb_path.touch()
+        collector = ReportDataCollector(pcb_path)
+
+        with patch(
+            "kicad_tools.analysis.net_status.NetStatusAnalyzer.analyze",
+            return_value=mock_result,
+        ):
+            status = collector.collect_net_status(None)
+
+        assert status["signal_incomplete_named"] == ["SCL", "SDA"]
+        assert status["signal_incomplete_auto_count"] == 0
+
     def test_no_zone_or_single_pad_nets(self, tmp_path):
         """When all nets are signal nets, zone/single-pad counts are zero."""
         mock_result = _make_net_status_result(

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1911,6 +1911,144 @@ class TestNetClassification:
         assert "- GND" in content
         assert "- VCC" in content
 
+    def test_named_nets_listed_auto_count_shown(self, tmp_path: Path) -> None:
+        """Named nets are listed individually, auto-generated shown as count."""
+        data = _full_data(
+            net_status={
+                "total_nets": 20,
+                "complete_count": 10,
+                "completion_percent": 50.0,
+                "incomplete_count": 10,
+                "unrouted_count": 0,
+                "total_unconnected_pads": 20,
+                "incomplete_net_names": [
+                    "AUDIO_L", "I2S_DIN", "Net-(U1-1)", "Net-(U2-3)",
+                    "unconnected-(C40-2)",
+                ],
+                "signal_net_count": 18,
+                "signal_complete_count": 10,
+                "signal_completion_percent": 55.6,
+                "signal_incomplete_net_names": [
+                    "AUDIO_L", "I2S_DIN", "Net-(U1-1)", "Net-(U2-3)",
+                    "unconnected-(C40-2)",
+                ],
+                "signal_incomplete_named": ["AUDIO_L", "I2S_DIN"],
+                "signal_incomplete_auto_count": 3,
+                "zone_connected_count": 2,
+                "zone_connected_nets": ["GND", "VCC"],
+                "single_pad_count": 0,
+                "single_pad_nets": [],
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        # Named nets listed individually
+        assert "### Unrouted Signal Nets" in content
+        assert "- AUDIO_L" in content
+        assert "- I2S_DIN" in content
+        # Auto-generated nets shown as count, not listed
+        assert "3 auto-generated component nets" in content
+        assert "Net-(U1-1)" not in content
+        assert "unconnected-(C40-2)" not in content
+
+    def test_only_auto_generated_nets_no_heading(self, tmp_path: Path) -> None:
+        """When all incomplete signals are auto-generated, no named heading appears."""
+        data = _full_data(
+            net_status={
+                "total_nets": 10,
+                "complete_count": 5,
+                "completion_percent": 50.0,
+                "incomplete_count": 5,
+                "unrouted_count": 0,
+                "total_unconnected_pads": 10,
+                "incomplete_net_names": ["Net-(U1-1)", "Net-(U2-3)"],
+                "signal_net_count": 8,
+                "signal_complete_count": 5,
+                "signal_completion_percent": 62.5,
+                "signal_incomplete_net_names": ["Net-(U1-1)", "Net-(U2-3)"],
+                "signal_incomplete_named": [],
+                "signal_incomplete_auto_count": 2,
+                "zone_connected_count": 2,
+                "zone_connected_nets": ["GND", "VCC"],
+                "single_pad_count": 0,
+                "single_pad_nets": [],
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        # No "Unrouted Signal Nets" heading since named list is empty
+        assert "### Unrouted Signal Nets" not in content
+        # Count line still appears
+        assert "2 auto-generated component nets" in content
+
+    def test_only_named_nets_no_auto_count(self, tmp_path: Path) -> None:
+        """When all incomplete signals are named, no auto count line appears."""
+        data = _full_data(
+            net_status={
+                "total_nets": 10,
+                "complete_count": 7,
+                "completion_percent": 70.0,
+                "incomplete_count": 3,
+                "unrouted_count": 0,
+                "total_unconnected_pads": 6,
+                "incomplete_net_names": ["MISO", "MOSI", "SCL"],
+                "signal_net_count": 10,
+                "signal_complete_count": 7,
+                "signal_completion_percent": 70.0,
+                "signal_incomplete_net_names": ["MISO", "MOSI", "SCL"],
+                "signal_incomplete_named": ["MISO", "MOSI", "SCL"],
+                "signal_incomplete_auto_count": 0,
+                "zone_connected_count": 0,
+                "zone_connected_nets": [],
+                "single_pad_count": 0,
+                "single_pad_nets": [],
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "### Unrouted Signal Nets" in content
+        assert "- MISO" in content
+        assert "- MOSI" in content
+        assert "- SCL" in content
+        assert "auto-generated" not in content
+
+    def test_zero_named_zero_auto_no_section(self, tmp_path: Path) -> None:
+        """When no incomplete signal nets exist, neither section appears."""
+        data = _full_data(
+            net_status={
+                "total_nets": 5,
+                "complete_count": 5,
+                "completion_percent": 100.0,
+                "incomplete_count": 0,
+                "unrouted_count": 0,
+                "total_unconnected_pads": 0,
+                "incomplete_net_names": [],
+                "signal_net_count": 5,
+                "signal_complete_count": 5,
+                "signal_completion_percent": 100.0,
+                "signal_incomplete_net_names": [],
+                "signal_incomplete_named": [],
+                "signal_incomplete_auto_count": 0,
+                "zone_connected_count": 0,
+                "zone_connected_nets": [],
+                "single_pad_count": 0,
+                "single_pad_nets": [],
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "### Unrouted Signal Nets" not in content
+        assert "### Incomplete Nets" not in content
+        assert "auto-generated" not in content
+
     def test_backward_compat_old_net_status_keys(self, tmp_path: Path) -> None:
         """Old net_status dict without new keys still renders correctly."""
         data = _full_data(


### PR DESCRIPTION
## Summary
Classify incomplete signal nets by name pattern so human-assigned net names (high information value) are listed individually while KiCad auto-generated names (`Net-(...)` / `unconnected-(...)`) are collapsed to a single count line, reducing report noise.

## Changes
- Added `signal_incomplete_named` and `signal_incomplete_auto_count` keys to `collect_net_status()` in `collector.py`
- Updated `design_report.md.j2` template to render named nets individually and auto-generated nets as a count
- Updated `models.py` docstring to document new keys
- Preserved existing `signal_incomplete_net_names` key for backward compatibility
- Added 3 collector tests (mixed named/auto, all-auto, all-named scenarios)
- Added 4 template rendering tests (mixed, auto-only, named-only, zero-incomplete)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Named nets listed individually in report | Pass | Template renders `signal_incomplete_named` list with `### Unrouted Signal Nets` heading |
| Auto-generated nets shown as count only | Pass | Template renders count line like "3 auto-generated component nets" |
| Backward compatibility preserved | Pass | `signal_incomplete_net_names` key unchanged; old data without new keys falls back to existing rendering |
| Net-(...)  and unconnected-(...) detected | Pass | `startswith(("Net-(", "unconnected-("))` tuple handles both KiCad patterns |
| All-named edge case (zero auto) | Pass | No count line rendered, only named list |
| All-auto edge case (zero named) | Pass | No heading, only count line rendered |
| Cap applies to named list only | Pass | Auto nets reduced to count, cap on `signal_incomplete_named` |

## Test Plan
- `python3 -m pytest tests/test_report_collector.py::TestCollectNetStatusClassification -q` -- 10 passed
- `python3 -m pytest tests/test_report_generator.py::TestNetClassification -q` -- 10 passed
- Pre-existing failure in `TestReportGenerator::test_full_render` confirmed on main (unrelated header format issue)

Closes #2156