### PR TITLE
fix(export): preserve markdown report alongside PDF during manufacturing flattening

### DIFF
--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -69,6 +69,7 @@ class ManufacturingResult:
     output_dir: Path
     assembly_result: AssemblyPackageResult | None = None
     report_path: Path | None = None
+    report_md_path: Path | None = None
     project_zip_path: Path | None = None
     manifest_path: Path | None = None
     readme_path: Path | None = None
@@ -94,6 +95,8 @@ class ManufacturingResult:
                 files.append(self.assembly_result.gerber_path)
         if self.report_path:
             files.append(self.report_path)
+        if self.report_md_path:
+            files.append(self.report_md_path)
         if self.project_zip_path:
             files.append(self.project_zip_path)
         if self.readme_path:
@@ -638,6 +641,11 @@ class ManufacturingPackage:
             promoted = out_dir / "report.pdf"
             shutil.copy2(staged_pdf, promoted)
             result.report_path = promoted
+            # Also preserve the markdown source alongside the PDF
+            if staged_md.exists():
+                promoted_md = out_dir / "report.md"
+                shutil.copy2(staged_md, promoted_md)
+                result.report_md_path = promoted_md
         elif staged_md.exists():
             promoted = out_dir / "report.md"
             shutil.copy2(staged_md, promoted)

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -788,6 +788,10 @@ class TestLatestReportOnly:
         assert (out_dir / "report.pdf").exists()
         assert result.report_path == out_dir / "report.pdf"
 
+        # Markdown source should also be preserved alongside PDF
+        assert (out_dir / "report.md").exists()
+        assert result.report_md_path == out_dir / "report.md"
+
         # No report/ subdirectory
         assert not (out_dir / "report").exists()
 
@@ -901,6 +905,60 @@ class TestLatestReportOnly:
         # Manifest should have "report.md" key (at root), not "report/report.md"
         assert "report.md" in manifest["files"]
         assert "report/report.md" not in manifest.get("files", {})
+
+    def test_manifest_includes_both_pdf_and_md(self, tmp_path, monkeypatch):
+        """Manifest should include checksums for both report.pdf and report.md."""
+        pcb = self._setup_project(tmp_path)
+        out_dir = tmp_path / "output"
+
+        from kicad_tools.export import assembly
+
+        def fake_assembly_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        def fake_generate_report(self_pkg, od, result):
+            # Create both MD and PDF in v1/
+            report_path = self._fake_report_generate(od, 1)
+            pdf_path = report_path.with_suffix(".pdf")
+            pdf_path.write_bytes(b"%PDF-1.4 fake pdf content")
+            result.report_path = pdf_path
+
+        monkeypatch.setattr(ManufacturingPackage, "_generate_report", fake_generate_report)
+
+        config = ManufacturingConfig(
+            include_report=True,
+            include_project_zip=False,
+            include_manifest=True,
+            latest_report_only=True,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        result = pkg.export(out_dir)
+
+        # Both files should exist at root
+        assert (out_dir / "report.pdf").exists()
+        assert (out_dir / "report.md").exists()
+
+        # result should track both paths
+        assert result.report_path == out_dir / "report.pdf"
+        assert result.report_md_path == out_dir / "report.md"
+
+        # Both should appear in all_files
+        all_file_names = [f.name for f in result.all_files]
+        assert "report.pdf" in all_file_names
+        assert "report.md" in all_file_names
+
+        # Parse manifest -- both should have checksums
+        import json
+        manifest = json.loads((out_dir / "manifest.json").read_text())
+        assert "report.pdf" in manifest["files"]
+        assert "report.md" in manifest["files"]
 
     def test_cli_keep_build_artifacts_flag(self):
         """CLI --keep-build-artifacts flag parses correctly."""

--- a/tests/test_pcb_manufacturing_export.py
+++ b/tests/test_pcb_manufacturing_export.py
@@ -463,7 +463,12 @@ class TestFlattenLatestReportPdf:
 
             assert result.report_path is not None
             assert result.report_path.suffix == ".pdf"
-            assert "report" in result.report_path.parent.name
+            # After flattening, the PDF should be promoted to the output root
+            assert result.report_path == out_dir / "report.pdf"
+
+            # Markdown source should also be preserved alongside PDF
+            assert (out_dir / "report.md").exists(), "report.md should be preserved alongside report.pdf"
+            assert result.report_md_path == out_dir / "report.md"
 
     def test_flatten_falls_back_to_md(self, test_project_pcb):
         """_flatten_latest_report falls back to MD when no PDF exists."""
@@ -490,12 +495,17 @@ class TestFlattenLatestReportPdf:
             with patch(
                 "kicad_tools.report.renderers._weasyprint_available",
                 return_value=False,
+            ), patch(
+                "kicad_tools.report.renderers._pandoc_available",
+                return_value=False,
             ):
                 pkg._generate_report(out_dir, result)
                 pkg._flatten_latest_report(out_dir, result)
 
             assert result.report_path is not None
             assert result.report_path.suffix == ".md"
+            # When only MD exists (no PDF), report_md_path should not be set
+            assert result.report_md_path is None
 
 
 # Fixtures


### PR DESCRIPTION
## Summary
When `_flatten_latest_report` promotes `report.pdf` to the package root, the markdown source (`report.md`) was being discarded because the `if/elif` branch only copied one format. This fix copies both files when PDF exists and tracks the markdown via a new `report_md_path` field.

## Changes
- Add `report_md_path` optional field to `ManufacturingResult` dataclass
- Include `report_md_path` in `all_files` property so manifest checksums both files
- Fix `_flatten_latest_report` to also copy `report.md` when promoting `report.pdf`
- Update existing tests to verify markdown preservation alongside PDF
- Add new test verifying both files appear in manifest with correct checksums
- Fix pre-existing test assertion that incorrectly checked parent directory name

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Both report.pdf and report.md at package root when PDF available | PASS | test_pdf_promoted_over_md, test_flatten_prefers_pdf_over_md |
| report_md_path tracked in ManufacturingResult | PASS | test_manifest_includes_both_pdf_and_md |
| Manifest includes checksums for both files | PASS | test_manifest_includes_both_pdf_and_md |
| MD-only fallback unchanged (no PDF renderer) | PASS | test_flatten_falls_back_to_md |
| all_files includes both report.pdf and report.md | PASS | test_manifest_includes_both_pdf_and_md |

## Test Plan
```
python3 -m pytest tests/test_manufacturing_package.py::TestLatestReportOnly tests/test_pcb_manufacturing_export.py::TestFlattenLatestReportPdf -v
# 15 passed
```

Closes #2158