### PR TITLE
feat(report): add DRC violation-type breakdown table

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -61,15 +61,19 @@ class DRCStatus:
     passed: bool = True
     details: str = ""
     report_path: Path | None = None
+    violations_by_type: dict[str, int] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
-        return {
+        result = {
             "error_count": self.error_count,
             "warning_count": self.warning_count,
             "blocking_count": self.blocking_count,
             "passed": self.passed,
             "details": self.details,
         }
+        if self.violations_by_type:
+            result["violations_by_type"] = dict(self.violations_by_type)
+        return result
 
 
 @dataclass
@@ -643,13 +647,19 @@ class ManufacturingAudit:
             status.blocking_count = results.error_count  # Errors block manufacturing
             status.passed = results.error_count == 0
 
+            # Build per-type violation breakdown (all severities)
+            by_rule: dict[str, int] = {}
+            for v in results.violations:
+                by_rule[v.rule_id] = by_rule.get(v.rule_id, 0) + 1
+            status.violations_by_type = by_rule
+
             if results.error_count > 0:
-                # Get summary of errors
-                by_rule = {}
+                # Get summary of errors for the details string
+                error_rules: dict[str, int] = {}
                 for v in results.violations:
                     if v.is_error:
-                        by_rule[v.rule_id] = by_rule.get(v.rule_id, 0) + 1
-                top_rules = sorted(by_rule.items(), key=lambda x: -x[1])[:3]
+                        error_rules[v.rule_id] = error_rules.get(v.rule_id, 0) + 1
+                top_rules = sorted(error_rules.items(), key=lambda x: -x[1])[:3]
                 status.details = ", ".join(f"{r[0]} ({r[1]})" for r in top_rules)
 
         except Exception as e:

--- a/src/kicad_tools/report/models.py
+++ b/src/kicad_tools/report/models.py
@@ -29,7 +29,8 @@ class ReportData:
     """List of dicts: {value, footprint, qty, refs, mpn, lcsc}."""
 
     drc: dict | None = None
-    """DRC summary: {error_count, warning_count, blocking_count, passed}."""
+    """DRC summary: {error_count, warning_count, blocking_count, passed,
+    violations_by_type (optional): {rule_id: count}}."""
 
     erc: dict | None = None
     """ERC summary: {error_count, warning_count, passed, skipped, details}.

--- a/src/kicad_tools/report/templates/design_report.md.j2
+++ b/src/kicad_tools/report/templates/design_report.md.j2
@@ -204,6 +204,16 @@ header-includes:
 
 **Status**: {% if drc.passed | default(false) %}PASS{% else %}FAIL{% endif %}
 
+{% if drc.violations_by_type is defined and drc.violations_by_type %}
+### Violations by Type
+
+| Violation Type | Count |
+|----------------|-------|
+{% for vtype, count in drc.violations_by_type | dictsort(by='value', reverse=true) %}
+| {{ vtype }} | {{ count }} |
+{% endfor %}
+{% endif %}
+
 {% endif %}
 {% if audit %}
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -42,6 +42,31 @@ class TestERCStatusSkipped:
         assert d["skipped"] is False
 
 
+class TestDRCStatusViolationsByType:
+    """Tests for DRCStatus.violations_by_type field."""
+
+    def test_default_empty(self):
+        """DRCStatus defaults to empty violations_by_type."""
+        status = DRCStatus()
+        assert status.violations_by_type == {}
+
+    def test_to_dict_includes_violations_by_type_when_present(self):
+        """DRCStatus.to_dict() includes violations_by_type when non-empty."""
+        status = DRCStatus(
+            error_count=3,
+            violations_by_type={"clearance": 2, "edge_clearance": 1},
+        )
+        d = status.to_dict()
+        assert "violations_by_type" in d
+        assert d["violations_by_type"] == {"clearance": 2, "edge_clearance": 1}
+
+    def test_to_dict_omits_violations_by_type_when_empty(self):
+        """DRCStatus.to_dict() omits violations_by_type when empty."""
+        status = DRCStatus()
+        d = status.to_dict()
+        assert "violations_by_type" not in d
+
+
 class TestAuditResult:
     """Tests for AuditResult class."""
 

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -559,6 +559,91 @@ class TestReportGenerator:
         content = report_path.read_text(encoding="utf-8")
         assert "FAIL" in content
 
+    def test_drc_violations_by_type_rendered(self, tmp_path: Path) -> None:
+        """Violations by Type table renders when violations_by_type is present."""
+        data = _full_data(
+            drc={
+                "error_count": 5,
+                "warning_count": 2,
+                "blocking_count": 5,
+                "passed": False,
+                "violations_by_type": {
+                    "clearance_segment_segment": 3,
+                    "edge_clearance_trace": 2,
+                    "silk_over_copper": 2,
+                },
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "### Violations by Type" in content
+        assert "| Violation Type | Count |" in content
+        assert "| clearance_segment_segment | 3 |" in content
+        assert "| edge_clearance_trace | 2 |" in content
+        assert "| silk_over_copper | 2 |" in content
+
+    def test_drc_violations_by_type_sorted_descending(self, tmp_path: Path) -> None:
+        """Violations by Type rows are sorted by count descending."""
+        data = _full_data(
+            drc={
+                "error_count": 6,
+                "warning_count": 0,
+                "blocking_count": 6,
+                "passed": False,
+                "violations_by_type": {
+                    "footprint_outside_board": 1,
+                    "clearance_segment_segment": 5,
+                    "edge_clearance_trace": 3,
+                },
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        # Find positions to verify sort order
+        pos_clearance = content.index("clearance_segment_segment")
+        pos_edge = content.index("edge_clearance_trace")
+        pos_footprint = content.index("footprint_outside_board")
+        assert pos_clearance < pos_edge < pos_footprint
+
+    def test_drc_violations_by_type_omitted_when_absent(self, tmp_path: Path) -> None:
+        """Violations by Type table is omitted when key is absent (backward compat)."""
+        data = _full_data(
+            drc={
+                "error_count": 0,
+                "warning_count": 0,
+                "blocking_count": 0,
+                "passed": True,
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "## DRC Status" in content
+        assert "### Violations by Type" not in content
+
+    def test_drc_violations_by_type_omitted_when_empty(self, tmp_path: Path) -> None:
+        """Violations by Type table is omitted when dict is empty."""
+        data = _full_data(
+            drc={
+                "error_count": 0,
+                "warning_count": 0,
+                "blocking_count": 0,
+                "passed": True,
+                "violations_by_type": {},
+            }
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "## DRC Status" in content
+        assert "### Violations by Type" not in content
+
     def test_erc_pass_status(self, tmp_path: Path) -> None:
         """ERC section renders PASS when passed is True."""
         data = _full_data(


### PR DESCRIPTION
## Summary

Thread the per-rule DRC violation counts through the DRCStatus model into the design report template, adding a "Violations by Type" breakdown table sorted by count descending.

## Changes

- Added `violations_by_type: dict[str, int]` field to `DRCStatus` dataclass with conditional inclusion in `to_dict()`
- Populated `violations_by_type` in `_check_drc()` using all violations (errors + warnings), not just errors
- Added conditional "Violations by Type" table to the Jinja2 template after the DRC summary, guarded by `is defined and` check for backward compatibility
- Updated `drc` field docstring in `ReportData` to document the new key
- Added 4 report generator tests (rendered, sorted descending, omitted when absent, omitted when empty) and 3 DRCStatus unit tests

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Breakdown table shown when violations exist | Pass | test_drc_violations_by_type_rendered confirms table renders with correct rows |
| Rows sorted by count descending | Pass | test_drc_violations_by_type_sorted_descending verifies position ordering |
| Table omitted when DRC passes clean | Pass | test_drc_violations_by_type_omitted_when_empty and test_drc_violations_by_type_omitted_when_absent both confirm |
| Backward compatibility with old data | Pass | Template uses `is defined and` guard; tests verify absent key and empty dict |

## Test Plan

- 7 new tests all pass: 4 in TestReportGenerator + 3 in TestDRCStatusViolationsByType
- 8 pre-existing test failures in test_report_generator.py confirmed present on main (template cover-block changes unrelated to this PR)

Closes #2157