### PR TITLE
fix(sch-validate): warn on unresolved power pins and add power-symbol test fixtures

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -2130,11 +2130,33 @@ def check_power_pin_polarity(schematic_path: str) -> list[ValidationIssue]:
 
                     for pin_num, pin_info in pins_data.items():
                         net_name = pin_info.get("net")
-                        if net_name is None:
-                            continue
-
                         pin_name = pin_info.get("name", "")
                         pin_type = pin_info.get("type", "")
+
+                        if net_name is None:
+                            # Warn when a recognized power pin has no
+                            # resolved net -- silently skipping could
+                            # hide reversed wiring.
+                            if pin_type in ("power_in", "power_out"):
+                                _pin_tokens = _tokenize_name(pin_name)
+                                if _pin_tokens & (
+                                    _POWER_POSITIVE_KEYWORDS
+                                    | _POWER_NEGATIVE_KEYWORDS
+                                ):
+                                    issues.append(
+                                        ValidationIssue(
+                                            severity="warning",
+                                            category="power_polarity",
+                                            message=(
+                                                f"Power pin {ref}.{pin_name} "
+                                                f"(pin {pin_num}) has no "
+                                                f"resolved net -- polarity "
+                                                f"cannot be verified"
+                                            ),
+                                            location=sheet_path,
+                                        )
+                                    )
+                            continue
 
                         # Only consider power pins
                         if pin_type not in ("power_in", "power_out"):

--- a/tests/test_sch_validate_power_polarity.py
+++ b/tests/test_sch_validate_power_polarity.py
@@ -180,6 +180,164 @@ def _make_power_symbol_schematic(
 """
 
 
+def _make_power_symbol_entry(
+    lib_id: str,
+    value: str,
+    ref: str,
+    x: float,
+    y: float,
+) -> tuple[str, str]:
+    """Generate a power symbol's lib_symbols entry and symbol instance.
+
+    Returns (lib_sym_sexp, symbol_instance_sexp).
+    """
+    part_name = lib_id.split(":")[-1] if ":" in lib_id else lib_id
+    lib_sym = f"""(symbol "{lib_id}"
+            (pin_names (offset 0))
+            (symbol "{part_name}_0_1"
+                (polyline
+                    (pts (xy 0 0) (xy 0 -1.27))
+                    (stroke (width 0))
+                    (fill (type none))
+                )
+            )
+            (symbol "{part_name}_1_1"
+                (pin power_in line
+                    (at 0 0 0)
+                    (length 0)
+                    (name "{value}")
+                    (number "1")
+                )
+            )
+        )"""
+    sym_inst = f"""(symbol
+        (lib_id "{lib_id}")
+        (at {x} {y} 0)
+        (unit 1)
+        (in_bom yes)
+        (on_board yes)
+        (dnp no)
+        (uuid "uuid-{ref.lower()}")
+        (property "Reference" "{ref}"
+            (at {x + 2} {y - 2} 0)
+            (effects (font (size 1.27 1.27)) (justify left) hide)
+        )
+        (property "Value" "{value}"
+            (at {x + 2} {y} 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Footprint" ""
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        (property "Datasheet" "~"
+            (at {x} {y} 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        (pin "1" (uuid "pin-{ref.lower()}-1"))
+    )"""
+    return lib_sym, sym_inst
+
+
+def _make_ic_with_power_symbols_schematic(
+    ic_lib_id: str,
+    ic_pins: list[tuple[str, str, str]],
+    pin_power_symbols: dict[str, tuple[str, str]],
+    ic_ref: str = "U1",
+) -> str:
+    """Build a schematic with an IC and power symbols providing nets.
+
+    Instead of labels, each IC power pin is connected via a wire to a
+    power symbol (e.g., ``power:+3.3V``).
+
+    Args:
+        ic_lib_id: e.g. "IC:SomeChip"
+        ic_pins: list of (pin_number, pin_name, pin_type) tuples
+        pin_power_symbols: Maps IC pin_number -> (power_lib_id, power_value)
+            e.g. {"1": ("power:+3V3", "+3.3V"), "2": ("power:GND", "GND")}
+        ic_ref: reference designator for the IC
+    """
+    ic_lib_sym = _make_ic_lib_symbol(ic_lib_id, ic_pins)
+    ic_sym_inst = _make_symbol_instance(
+        ic_ref, ic_lib_id, ic_pins, 100.0, 50.0,
+    )
+
+    power_lib_syms = []
+    power_sym_insts = []
+    wires = []
+
+    pwr_idx = 0
+    for pin_idx, (pin_num, _, _) in enumerate(ic_pins):
+        if pin_num not in pin_power_symbols:
+            continue
+        pwr_lib_id, pwr_value = pin_power_symbols[pin_num]
+        pwr_ref = f"#PWR{pwr_idx:02d}"
+        pwr_idx += 1
+
+        pin_y = 50.0 - pin_idx * 2.54
+        pin_x = 100.0
+        pwr_x = pin_x + 10.0
+
+        pwr_lib, pwr_inst = _make_power_symbol_entry(
+            pwr_lib_id, pwr_value, pwr_ref, pwr_x, pin_y,
+        )
+        power_lib_syms.append(pwr_lib)
+        power_sym_insts.append(pwr_inst)
+
+        wires.append(
+            f"""(wire
+            (pts (xy {pin_x:.2f} {pin_y:.2f}) (xy {pwr_x:.2f} {pin_y:.2f}))
+            (stroke (width 0) (type default))
+            (uuid "wire-pwr-{ic_ref.lower()}-{pin_num}")
+        )"""
+        )
+
+    all_lib_syms = ic_lib_sym + "\n" + "\n".join(power_lib_syms)
+    all_sym_insts = ic_sym_inst + "\n" + "\n".join(power_sym_insts)
+    wire_block = "\n".join(wires)
+
+    return f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "test-power-polarity-pwrsym-uuid")
+    (paper "A4")
+    (lib_symbols
+        {all_lib_syms}
+    )
+    {all_sym_insts}
+    {wire_block}
+)
+"""
+
+
+def _make_ic_with_unresolved_pins_schematic(
+    ic_lib_id: str,
+    ic_pins: list[tuple[str, str, str]],
+    ic_ref: str = "U1",
+) -> str:
+    """Build a schematic with an IC whose pins have no wires/labels.
+
+    This simulates the case where ``resolve_pin_map`` returns ``net=None``
+    for power pins because nothing connects them to a net name.
+    """
+    ic_lib_sym = _make_ic_lib_symbol(ic_lib_id, ic_pins)
+    ic_sym_inst = _make_symbol_instance(
+        ic_ref, ic_lib_id, ic_pins, 100.0, 50.0,
+    )
+
+    return f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "test-power-polarity-unresolved-uuid")
+    (paper "A4")
+    (lib_symbols
+        {ic_lib_sym}
+    )
+    {ic_sym_inst}
+)
+"""
+
+
 # ---------------------------------------------------------------------------
 # Integration tests
 # ---------------------------------------------------------------------------
@@ -411,3 +569,183 @@ class TestCheckPowerPinPolarity:
         assert len(polarity_errors) == 1
         assert "GND" in polarity_errors[0].message
         assert "+5V" in polarity_errors[0].message
+
+
+class TestPowerSymbolFixtures:
+    """Tests using power symbols (power:+3.3V etc.) instead of labels."""
+
+    def test_correct_wiring_with_power_symbols(self, tmp_path: Path):
+        """VDD on +3.3V power symbol, GND on GND power symbol -- no errors."""
+        ic_pins = [
+            ("1", "VDD", "power_in"),
+            ("2", "GND", "power_in"),
+            ("3", "OUT", "output"),
+        ]
+        pin_power = {
+            "1": ("power:+3V3", "+3.3V"),
+            "2": ("power:GND", "GND"),
+        }
+        sch_text = _make_ic_with_power_symbols_schematic(
+            "IC:NormalChip", ic_pins, pin_power,
+        )
+        sch_path = tmp_path / "correct_power_sym.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert polarity_errors == []
+
+    def test_reversed_vdd_gnd_with_power_symbols(self, tmp_path: Path):
+        """VDD pin wired to GND power symbol should be flagged."""
+        ic_pins = [
+            ("1", "VDD", "power_in"),
+            ("2", "GND", "power_in"),
+        ]
+        pin_power = {
+            "1": ("power:GND", "GND"),       # Reversed -- VDD on GND
+            "2": ("power:+3V3", "+3.3V"),     # Reversed -- GND on +3.3V
+        }
+        sch_text = _make_ic_with_power_symbols_schematic(
+            "IC:Oscillator", ic_pins, pin_power,
+        )
+        sch_path = tmp_path / "reversed_power_sym.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert len(polarity_errors) == 2
+        messages = [e.message for e in polarity_errors]
+        assert any("VDD" in m and "GND" in m for m in messages)
+        assert any("GND" in m and "+3.3V" in m for m in messages)
+
+    def test_single_reversed_vcc_with_power_symbol(self, tmp_path: Path):
+        """VCC pin wired to GNDD power symbol -- only that pin flagged."""
+        ic_pins = [
+            ("1", "VCC", "power_in"),
+            ("2", "GND", "power_in"),
+            ("3", "SDA", "bidirectional"),
+        ]
+        pin_power = {
+            "1": ("power:GNDD", "GNDD"),   # Reversed -- VCC on GNDD
+            "2": ("power:GND", "GND"),      # Correct
+        }
+        sch_text = _make_ic_with_power_symbols_schematic(
+            "IC:I2CChip", ic_pins, pin_power,
+        )
+        sch_path = tmp_path / "single_reversed_power_sym.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert len(polarity_errors) == 1
+        assert "VCC" in polarity_errors[0].message
+        assert "GNDD" in polarity_errors[0].message
+        assert "positive supply pin" in polarity_errors[0].message
+
+    def test_multi_power_pins_with_power_symbols(self, tmp_path: Path):
+        """Multiple power pins -- only swapped ones reported via power symbols."""
+        ic_pins = [
+            ("1", "AVDD", "power_in"),
+            ("2", "DVDD", "power_in"),
+            ("3", "AGND", "power_in"),
+            ("4", "DGND", "power_in"),
+        ]
+        pin_power = {
+            "1": ("power:+3V3", "+3.3V"),    # Correct
+            "2": ("power:GNDD", "GNDD"),      # Swapped
+            "3": ("power:GND", "GND"),        # Correct
+            "4": ("power:+5V", "+5V"),        # Swapped
+        }
+        sch_text = _make_ic_with_power_symbols_schematic(
+            "IC:MultiPower", ic_pins, pin_power,
+        )
+        sch_path = tmp_path / "multi_power_sym.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        polarity_errors = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "error"
+        ]
+        assert len(polarity_errors) == 2
+        messages = [e.message for e in polarity_errors]
+        assert any("DVDD" in m and "GNDD" in m for m in messages)
+        assert any("DGND" in m and "+5V" in m for m in messages)
+
+
+class TestUnresolvedPowerPinWarning:
+    """Tests for the warning emitted when power pins have net=None."""
+
+    def test_unresolved_power_pin_emits_warning(self, tmp_path: Path):
+        """Power pin with no wire/label should emit a warning."""
+        ic_pins = [
+            ("1", "VDD", "power_in"),
+            ("2", "GND", "power_in"),
+            ("3", "OUT", "output"),
+        ]
+        sch_text = _make_ic_with_unresolved_pins_schematic(
+            "IC:Floating", ic_pins,
+        )
+        sch_path = tmp_path / "unresolved_power.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "warning"
+            and "no resolved net" in i.message
+        ]
+        # Both VDD and GND should get warnings
+        assert len(warnings) == 2
+        warning_msgs = [w.message for w in warnings]
+        assert any("VDD" in m for m in warning_msgs)
+        assert any("GND" in m for m in warning_msgs)
+
+    def test_unresolved_non_power_pin_no_warning(self, tmp_path: Path):
+        """Non-power pins with no net should not emit warnings."""
+        ic_pins = [
+            ("1", "SDA", "bidirectional"),
+            ("2", "SCL", "bidirectional"),
+        ]
+        sch_text = _make_ic_with_unresolved_pins_schematic(
+            "IC:I2C", ic_pins,
+        )
+        sch_path = tmp_path / "unresolved_signal.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "warning"
+            and "no resolved net" in i.message
+        ]
+        assert warnings == []
+
+    def test_unresolved_ambiguous_power_pin_no_warning(self, tmp_path: Path):
+        """Power pins with ambiguous names (EP, NC) should not warn."""
+        ic_pins = [
+            ("1", "EP", "power_in"),
+            ("2", "NC", "power_in"),
+        ]
+        sch_text = _make_ic_with_unresolved_pins_schematic(
+            "IC:QFN", ic_pins,
+        )
+        sch_path = tmp_path / "unresolved_ambiguous.kicad_sch"
+        sch_path.write_text(sch_text)
+
+        issues = check_power_pin_polarity(str(sch_path))
+        warnings = [
+            i for i in issues
+            if i.category == "power_polarity" and i.severity == "warning"
+            and "no resolved net" in i.message
+        ]
+        assert warnings == []


### PR DESCRIPTION
## Summary
Add a defensive warning when `check_power_pin_polarity` encounters recognized power pins (VDD, GND, VCC, VSS, etc.) with no resolved net, and add comprehensive test coverage using power symbols instead of labels.

## Changes
- Emit a `warning`-severity `power_polarity` issue when a power_in/power_out pin with a recognized positive/negative name has `net=None` from `resolve_pin_map`, instead of silently skipping
- Add `_make_power_symbol_entry` and `_make_ic_with_power_symbols_schematic` test helpers that generate schematics using `power:` symbols (matching real KiCad patterns) instead of net labels
- Add `_make_ic_with_unresolved_pins_schematic` helper for testing the net=None warning path
- Add 4 power-symbol integration tests: correct wiring, reversed VDD/GND, single reversed pin, multi-pin mixed scenario
- Add 3 unresolved-net warning tests: recognized power pins warn, signal pins do not, ambiguous names do not

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Power-symbol test fixtures added | Pass | 4 new tests use `power:` lib_id symbols instead of labels |
| Defensive warning for net=None power pins | Pass | Warning emitted with message "has no resolved net -- polarity cannot be verified" |
| Existing 11 tests still pass | Pass | All 18 tests pass (11 original + 7 new) |
| No false positives on ambiguous/non-power pins | Pass | Tests verify EP, NC, SDA, SCL pins do not trigger warnings |

## Test Plan
```
python3 -m pytest tests/test_sch_validate_power_polarity.py -v
# 18 passed
```

Closes #2164