### PR TITLE
fix(report): update stale test assertions to match YAML front matter template

### DIFF
--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1731,9 +1731,8 @@ class TestReportCLI:
         assert report_path.exists()
 
         content = report_path.read_text(encoding="utf-8")
-        # Skeleton: header present, optional data sections absent
-        assert "# board" in content
-        assert "cover-block" in content
+        # Skeleton: YAML front matter present, optional data sections absent
+        assert 'title: "board"' in content
         assert "## Board Summary" not in content
 
     def test_version_dir_parameter_in_generator(self, tmp_path: Path) -> None:
@@ -1748,8 +1747,7 @@ class TestReportCLI:
         assert report_path.exists()
 
         content = report_path.read_text(encoding="utf-8")
-        assert "# TestBoard" in content
-        assert "cover-block" in content
+        assert 'title: "TestBoard"' in content
 
     def test_version_dir_none_auto_increments(self, tmp_path: Path) -> None:
         """When version_dir is None, generate() auto-increments as before."""


### PR DESCRIPTION
## Summary
Two tests in `TestReportCLI` were asserting H1 headings (`# board`, `# TestBoard`) and `cover-block` divs that no longer appear in raw markdown output after the template switched to YAML front matter. Updated assertions to check for the YAML `title:` field instead.

## Changes
- `test_skip_collect_produces_skeleton`: replaced `"# board"` assertion with `'title: "board"'` and removed `"cover-block"` assertion
- `test_version_dir_parameter_in_generator`: replaced `"# TestBoard"` assertion with `'title: "TestBoard"'` and removed `"cover-block"` assertion

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| test_full_render passes with current template | Already passing | Pre-existing correct assertion at line 244 |
| test_version_dir_parameter_in_generator passes | Passed | `pytest ...::test_version_dir_parameter_in_generator --no-cov -q` |
| test_skip_collect_produces_skeleton passes | Passed | `pytest ...::test_skip_collect_produces_skeleton --no-cov -q` |
| No regressions in TestReportGenerator or TestReportCLI | Passed | 55 passed, 1 pre-existing failure (test_generate_skeleton, fails on main too) |

## Test Plan
- `python3 -m pytest tests/test_report_generator.py::TestReportCLI::test_version_dir_parameter_in_generator --no-cov -q` -- passed
- `python3 -m pytest tests/test_report_generator.py::TestReportCLI::test_skip_collect_produces_skeleton --no-cov -q` -- passed
- `python3 -m pytest tests/test_report_generator.py -k "TestReportGenerator or TestReportCLI" --no-cov -q` -- 55 passed, 1 pre-existing failure unrelated to this change

Closes #2171