### PR TITLE
feat(pcb): add board dimensions to summary output

### DIFF
--- a/src/kicad_tools/cli/pcb_query.py
+++ b/src/kicad_tools/cli/pcb_query.py
@@ -51,6 +51,12 @@ def cmd_summary(pcb: PCB, args):
     if summary["revision"]:
         print(f"Revision: {summary['revision']}")
 
+    if summary.get("width_mm") and summary.get("height_mm"):
+        print(
+            f"Board: {summary['width_mm']} x {summary['height_mm']} mm"
+            f" ({summary['area_mm2']} mm\u00b2)"
+        )
+
     print(f"\nLayers: {summary['copper_layers']} copper")
     print(f"Footprints: {summary['footprints']}")
     print(f"Nets: {summary['nets']}")

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -2491,9 +2491,13 @@ class PCB:
         cache lists, ensuring accuracy even after in-place modifications
         by other tools.
         """
+        w, h = self.board_size
         return {
             "title": self.title,
             "revision": self.revision,
+            "width_mm": round(w, 2),
+            "height_mm": round(h, 2),
+            "area_mm2": round(w * h, 2),
             "copper_layers": len(self.copper_layers),
             "footprints": self.footprint_count,
             "nets": self.net_count,

--- a/tests/test_cli_pcb.py
+++ b/tests/test_cli_pcb.py
@@ -45,6 +45,9 @@ class TestPcbQuery:
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert isinstance(data, dict)
+        assert "width_mm" in data
+        assert "height_mm" in data
+        assert "area_mm2" in data
 
     def test_footprints_command(self, minimal_pcb: Path, capsys, monkeypatch):
         """Test footprints command."""

--- a/tests/test_pcb_summary_counts.py
+++ b/tests/test_pcb_summary_counts.py
@@ -518,3 +518,103 @@ class TestZoneCountZeroRegression:
         cmd_summary(pcb, args)
         captured = capsys.readouterr()
         assert "Zones: 0" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Board dimensions in summary (issue #2169)
+# ---------------------------------------------------------------------------
+
+PCB_WITH_GR_RECT_OUTLINE = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (gr_rect (start 100 100) (end 150 130)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+)
+"""
+
+
+@pytest.fixture
+def pcb_with_gr_rect(tmp_path: Path) -> Path:
+    """Create a PCB with a gr_rect Edge.Cuts outline (50 x 30 mm)."""
+    pcb_file = tmp_path / "board_rect.kicad_pcb"
+    pcb_file.write_text(PCB_WITH_GR_RECT_OUTLINE)
+    return pcb_file
+
+
+class TestSummaryDimensions:
+    """Verify summary() includes board dimensions from Edge.Cuts."""
+
+    def test_dimensions_from_gr_rect(self, pcb_with_gr_rect: Path):
+        """summary() must report width/height from gr_rect outline."""
+        pcb = PCB.load(pcb_with_gr_rect)
+        summary = pcb.summary()
+        assert summary["width_mm"] == 50.0
+        assert summary["height_mm"] == 30.0
+        assert summary["area_mm2"] == 1500.0
+
+    def test_dimensions_from_gr_line_polygon(self, pcb_kicad9_no_zones: Path):
+        """summary() must report bounding-box dimensions from gr_line outline.
+
+        The PCB_KICAD9_NO_ZONES fixture has gr_line segments forming a
+        60 x 30 mm rectangle (85,85 to 145,115).
+        """
+        pcb = PCB.load(pcb_kicad9_no_zones)
+        summary = pcb.summary()
+        assert summary["width_mm"] == 60.0
+        assert summary["height_mm"] == 30.0
+        assert summary["area_mm2"] == 1800.0
+
+    def test_dimensions_zero_when_no_edge_cuts(self, pcb_no_vias_zones: Path):
+        """summary() must report 0.0 dimensions when no Edge.Cuts geometry."""
+        pcb = PCB.load(pcb_no_vias_zones)
+        summary = pcb.summary()
+        assert summary["width_mm"] == 0.0
+        assert summary["height_mm"] == 0.0
+        assert summary["area_mm2"] == 0.0
+
+    def test_dimensions_in_json_output(self, pcb_with_gr_rect: Path):
+        """JSON serialisation must include dimension fields."""
+        pcb = PCB.load(pcb_with_gr_rect)
+        summary = pcb.summary()
+        output = json.dumps(summary, indent=2)
+        data = json.loads(output)
+        assert "width_mm" in data
+        assert "height_mm" in data
+        assert "area_mm2" in data
+
+    def test_dimensions_in_text_output(self, pcb_with_gr_rect: Path, capsys):
+        """Text output must display board dimensions line."""
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.pcb_query import cmd_summary
+
+        pcb = PCB.load(pcb_with_gr_rect)
+        args = SimpleNamespace(format="text", pcb="board_rect.kicad_pcb")
+        cmd_summary(pcb, args)
+        captured = capsys.readouterr()
+        assert "50.0 x 30.0 mm" in captured.out
+
+    def test_no_dimensions_line_when_zero(self, pcb_no_vias_zones: Path, capsys):
+        """Text output must omit board dimensions when both are zero."""
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.pcb_query import cmd_summary
+
+        pcb = PCB.load(pcb_no_vias_zones)
+        args = SimpleNamespace(format="text", pcb="board.kicad_pcb")
+        cmd_summary(pcb, args)
+        captured = capsys.readouterr()
+        assert "Board:" not in captured.out


### PR DESCRIPTION
## Summary
Wires the existing `board_size` property into `PCB.summary()` to report board dimensions (width, height, area) from Edge.Cuts geometry.

## Changes
- Add `width_mm`, `height_mm`, and `area_mm2` fields to the dict returned by `PCB.summary()`
- Display a "Board: W x H mm (area mm2)" line in text output when Edge.Cuts geometry is present
- Add tests for gr_rect outlines, gr_line polygon outlines, and no-outline edge case
- Assert dimension keys are present in CLI JSON output

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| summary() includes width_mm, height_mm, area_mm2 | PASS | Tested with gr_rect (50x30mm) and gr_line (60x30mm) fixtures |
| gr_rect outline reports correct dimensions | PASS | test_dimensions_from_gr_rect asserts 50.0 x 30.0 mm = 1500.0 mm2 |
| gr_line polygon outline reports bounding-box dimensions | PASS | test_dimensions_from_gr_line_polygon asserts 60.0 x 30.0 mm = 1800.0 mm2 |
| No Edge.Cuts geometry returns 0.0 values | PASS | test_dimensions_zero_when_no_edge_cuts asserts all three fields are 0.0 |
| Text output displays board line when dimensions exist | PASS | test_dimensions_in_text_output checks for "50.0 x 30.0 mm" |
| Text output omits board line when dimensions are zero | PASS | test_no_dimensions_line_when_zero checks "Board:" is absent |
| JSON output includes dimension keys | PASS | test_dimensions_in_json_output and test_summary_json both verify keys |

## Test Plan
All 92 tests pass in test_pcb_summary_counts.py and test_cli_pcb.py (7 new tests added).

Closes #2169