### PR TITLE
feat(sch): add set-symbol-property command for boolean flags

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -12,7 +12,8 @@ def run_sch_command(args) -> int:
         print("Usage: kicad-tools sch <command> [options] <file>")
         print("Commands: summary, hierarchy, labels, validate, preflight, wires, info, pins, pin-map,")
         print(
-            "          connections, unconnected, set-footprint, set-value, set-reference, replace,"
+            "          connections, unconnected, set-footprint, set-value, set-reference,"
+            " set-symbol-property, replace,"
             " sync-hierarchy, rename-signal,"
         )
         print(
@@ -194,6 +195,18 @@ def run_sch_command(args) -> int:
             ref=getattr(args, "ref", None),
             new_ref=getattr(args, "new_ref", None),
             map_path=map_path,
+            dry_run=getattr(args, "dry_run", False),
+            backup=getattr(args, "backup", True),
+        )
+
+    elif args.sch_command == "set-symbol-property":
+        from ..sch_set_symbol_property import run_set_symbol_property
+
+        return run_set_symbol_property(
+            schematic_path=schematic_path,
+            ref=args.ref,
+            property_name=args.property_name,
+            value=args.value,
             dry_run=getattr(args, "dry_run", False),
             backup=getattr(args, "backup", True),
         )

--- a/src/kicad_tools/cli/modify_schematic.py
+++ b/src/kicad_tools/cli/modify_schematic.py
@@ -315,6 +315,49 @@ def add_lib_symbol_text(text: str, lib_file: Path) -> tuple[str, bool, str]:
     return modified, True, "; ".join(msg_parts)
 
 
+def set_symbol_flag_text(
+    text: str, reference: str, flag_name: str, flag_value: str
+) -> tuple[str, bool, str]:
+    """
+    Set a symbol-level boolean flag (on_board, in_bom, dnp, exclude_from_sim).
+
+    flag_value must already be normalized to "yes" or "no".
+
+    Returns (modified_text, success, message).
+    """
+    result = find_symbol_text_range(text, reference)
+
+    if not result:
+        return text, False, f"Symbol '{reference}' not found"
+
+    start, end, info = result
+    block = text[start:end]
+
+    # Match the flag node, e.g. (on_board yes) or (dnp no)
+    pattern = re.compile(rf"(\({re.escape(flag_name)}\s+)(yes|no)(\))")
+    match = pattern.search(block)
+    if not match:
+        return text, False, f"Flag '{flag_name}' not found on symbol '{reference}'"
+
+    old_value = match.group(2)
+    new_block = pattern.sub(rf"\g<1>{flag_value}\3", block, count=1)
+
+    if new_block == block:
+        return (
+            text,
+            True,
+            f"{reference} {flag_name} already set to '{flag_value}'",
+        )
+
+    modified = text[:start] + new_block + text[end:]
+
+    return (
+        modified,
+        True,
+        f"Changed {reference} {flag_name}: '{old_value}' -> '{flag_value}'",
+    )
+
+
 def regen_uuids_text(text: str, reference: str) -> tuple[str, bool, str]:
     """
     Regenerate UUIDs for a symbol and its pins using text replacement.

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -581,6 +581,31 @@ def _add_sch_parser(subparsers) -> None:
     )
     sch_set_ref.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
+    # sch set-symbol-property
+    sch_set_prop = sch_subparsers.add_parser(
+        "set-symbol-property",
+        help="Set symbol-level boolean flags (on_board, in_bom, dnp, exclude_from_sim)",
+    )
+    sch_set_prop.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_set_prop.add_argument(
+        "--ref", required=True, help="Symbol reference (e.g., #PWR052, U1)"
+    )
+    sch_set_prop.add_argument(
+        "--property",
+        dest="property_name",
+        required=True,
+        help="Flag to modify (on_board, in_bom, dnp, exclude_from_sim)",
+    )
+    sch_set_prop.add_argument(
+        "--value", required=True, help="Value to set (yes/no/true/false/1/0)"
+    )
+    sch_set_prop.add_argument(
+        "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
+    )
+    sch_set_prop.add_argument(
+        "--backup", action="store_true", help="Create backup before modifying"
+    )
+
     # sch sync-hierarchy
     sch_sync = sch_subparsers.add_parser(
         "sync-hierarchy", help="Synchronize sheet pins and hierarchical labels"

--- a/src/kicad_tools/cli/sch_set_symbol_property.py
+++ b/src/kicad_tools/cli/sch_set_symbol_property.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+Set symbol-level boolean flags in KiCad schematics.
+
+Modifies on_board, in_bom, dnp, and exclude_from_sim flags on placed
+symbol instances. Supports hierarchical schematic traversal.
+
+Usage:
+    # Set on_board to yes for a power symbol
+    kicad-tools sch set-symbol-property board.kicad_sch --ref "#PWR052" \
+        --property on_board --value yes
+
+    # Dry run
+    kicad-tools sch set-symbol-property board.kicad_sch --ref "#FLG05" \
+        --property on_board --value yes --dry-run
+"""
+
+import sys
+from pathlib import Path
+
+from kicad_tools.cli.modify_schematic import (
+    create_backup,
+    find_symbol_text_range,
+    set_symbol_flag_text,
+)
+from kicad_tools.cli.sch_set_footprint import _collect_schematic_files
+
+# Recognized symbol-level boolean flags
+RECOGNIZED_FLAGS = frozenset({"on_board", "in_bom", "dnp", "exclude_from_sim"})
+
+# Accepted truthy/falsy inputs normalized to KiCad yes/no
+_VALUE_MAP = {
+    "yes": "yes",
+    "no": "no",
+    "true": "yes",
+    "false": "no",
+    "1": "yes",
+    "0": "no",
+}
+
+
+def _normalize_flag_value(raw: str) -> str | None:
+    """Normalize a user-supplied flag value to 'yes' or 'no'.
+
+    Returns None if the value is not recognized.
+    """
+    return _VALUE_MAP.get(raw.lower())
+
+
+def run_set_symbol_property(
+    schematic_path: Path,
+    ref: str,
+    property_name: str,
+    value: str,
+    dry_run: bool = False,
+    backup: bool = True,
+) -> int:
+    """Run the set-symbol-property operation.
+
+    Returns 0 on success, 1 on error.
+    """
+    if not schematic_path.exists():
+        print(f"Error: File not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    # Validate property name
+    if property_name not in RECOGNIZED_FLAGS:
+        print(
+            f"Error: Unrecognized property '{property_name}'. "
+            f"Recognized properties: {', '.join(sorted(RECOGNIZED_FLAGS))}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Normalize value
+    normalized = _normalize_flag_value(value)
+    if normalized is None:
+        print(
+            f"Error: Invalid value '{value}'. "
+            f"Accepted values: yes, no, true, false, 1, 0",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Collect all schematic files (root + sub-sheets)
+    all_files = _collect_schematic_files(schematic_path)
+
+    for sch_file in all_files:
+        try:
+            text = sch_file.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"Error reading {sch_file}: {e}", file=sys.stderr)
+            continue
+
+        # Check if symbol exists in this file
+        result = find_symbol_text_range(text, ref)
+        if result is None:
+            continue
+
+        # Found the symbol in this file
+        if dry_run:
+            _, _, info = result
+            # Read the current flag value from the block
+            start, end, _ = result
+            block = text[start:end]
+            import re
+
+            flag_match = re.search(
+                rf"\({re.escape(property_name)}\s+(yes|no)\)", block
+            )
+            if flag_match:
+                old_val = flag_match.group(1)
+                print(
+                    f"  {ref}: {property_name} '{old_val}' -> '{normalized}'"
+                    f" (in {sch_file.name})"
+                )
+            else:
+                print(
+                    f"  Warning: Flag '{property_name}' not found on"
+                    f" symbol '{ref}' in {sch_file.name}",
+                    file=sys.stderr,
+                )
+                return 1
+            print()
+            print(
+                f"Dry run: {property_name} on {ref} would be changed"
+                f" to '{normalized}'"
+            )
+            return 0
+
+        # Apply the change
+        new_text, success, msg = set_symbol_flag_text(
+            text, ref, property_name, normalized
+        )
+        if not success:
+            print(f"Error: {msg}", file=sys.stderr)
+            return 1
+
+        # Write back
+        if backup:
+            bak = create_backup(sch_file)
+            print(f"  Backup: {bak.name}")
+
+        try:
+            sch_file.write_text(new_text, encoding="utf-8")
+        except OSError as e:
+            print(f"Error writing {sch_file}: {e}", file=sys.stderr)
+            return 1
+
+        print(f"  {msg} (in {sch_file.name})")
+        return 0
+
+    # Symbol not found in any file
+    print(
+        f"Error: Symbol '{ref}' not found in {schematic_path.name}"
+        f" or its sub-sheets",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None):
+    """CLI entry point for standalone usage."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Set symbol-level boolean flags in KiCad schematics",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", type=Path, help="Path to .kicad_sch file")
+    parser.add_argument(
+        "--ref", required=True, help="Symbol reference (e.g., #PWR052, U1)"
+    )
+    parser.add_argument(
+        "--property",
+        dest="property_name",
+        required=True,
+        help="Flag to modify (on_board, in_bom, dnp, exclude_from_sim)",
+    )
+    parser.add_argument(
+        "--value",
+        required=True,
+        help="Value to set (yes/no/true/false/1/0)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Preview changes without modifying files",
+    )
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip creating backup files",
+    )
+
+    args = parser.parse_args(argv)
+
+    return run_set_symbol_property(
+        schematic_path=args.schematic,
+        ref=args.ref,
+        property_name=args.property_name,
+        value=args.value,
+        dry_run=args.dry_run,
+        backup=not args.no_backup,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sch_set_symbol_property.py
+++ b/tests/test_sch_set_symbol_property.py
@@ -1,0 +1,542 @@
+"""Tests for the sch set-symbol-property command.
+
+Covers setting on_board, in_bom, dnp, and exclude_from_sim flags,
+value normalization, dry-run, backup, invalid property rejection,
+hierarchical traversal, and edge cases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.modify_schematic import set_symbol_flag_text
+from kicad_tools.cli.sch_set_symbol_property import (
+    RECOGNIZED_FLAGS,
+    _normalize_flag_value,
+    run_set_symbol_property,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal schematic content for testing
+# ---------------------------------------------------------------------------
+
+MINIMAL_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+  )
+
+  (symbol
+    (lib_id "power:GNDA")
+    (at 100 50 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board no)
+    (dnp no)
+    (uuid "11111111-1111-1111-1111-111111111111")
+    (property "Reference" "#PWR052"
+      (at 100 56 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "Value" "GNDA"
+      (at 100 53 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Footprint" ""
+      (at 100 50 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+  )
+
+  (symbol
+    (lib_id "Device:R")
+    (at 120 50 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "22222222-2222-2222-2222-222222222222")
+    (property "Reference" "R1"
+      (at 120 46 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Value" "10k"
+      (at 120 48 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Footprint" "Resistor_SMD:R_0402"
+      (at 120 50 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+  )
+
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+# Schematic without exclude_from_sim (older format)
+MINIMAL_SCHEMATIC_NO_EXCLUDE = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+  )
+
+  (symbol
+    (lib_id "Device:C")
+    (at 140 50 0)
+    (unit 1)
+    (in_bom yes)
+    (on_board yes)
+    (dnp no)
+    (uuid "33333333-3333-3333-3333-333333333333")
+    (property "Reference" "C1"
+      (at 140 46 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Value" "100nF"
+      (at 140 48 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Footprint" "Capacitor_SMD:C_0402"
+      (at 140 50 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+  )
+
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+def _write_sch(tmp_path: Path, content: str = MINIMAL_SCHEMATIC, name: str = "test.kicad_sch") -> Path:
+    p = tmp_path / name
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Value normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFlagValue:
+    def test_yes_no(self):
+        assert _normalize_flag_value("yes") == "yes"
+        assert _normalize_flag_value("no") == "no"
+
+    def test_true_false(self):
+        assert _normalize_flag_value("true") == "yes"
+        assert _normalize_flag_value("false") == "no"
+
+    def test_numeric(self):
+        assert _normalize_flag_value("1") == "yes"
+        assert _normalize_flag_value("0") == "no"
+
+    def test_case_insensitive(self):
+        assert _normalize_flag_value("YES") == "yes"
+        assert _normalize_flag_value("True") == "yes"
+        assert _normalize_flag_value("FALSE") == "no"
+
+    def test_invalid(self):
+        assert _normalize_flag_value("maybe") is None
+        assert _normalize_flag_value("") is None
+        assert _normalize_flag_value("2") is None
+
+
+# ---------------------------------------------------------------------------
+# set_symbol_flag_text unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetSymbolFlagText:
+    def test_change_on_board_no_to_yes(self):
+        modified, success, msg = set_symbol_flag_text(
+            MINIMAL_SCHEMATIC, "#PWR052", "on_board", "yes"
+        )
+        assert success
+        assert "(on_board yes)" in modified
+        assert "Changed #PWR052 on_board" in msg
+        # Verify other symbol unchanged
+        assert '(property "Reference" "R1"' in modified
+
+    def test_change_on_board_yes_to_no(self):
+        modified, success, msg = set_symbol_flag_text(
+            MINIMAL_SCHEMATIC, "R1", "on_board", "no"
+        )
+        assert success
+        assert "Changed R1 on_board" in msg
+        # The power symbol should still have on_board no (its original value)
+        # R1's on_board should now be no
+
+    def test_change_in_bom(self):
+        modified, success, msg = set_symbol_flag_text(
+            MINIMAL_SCHEMATIC, "#PWR052", "in_bom", "no"
+        )
+        assert success
+        assert "Changed #PWR052 in_bom" in msg
+
+    def test_change_dnp(self):
+        modified, success, msg = set_symbol_flag_text(
+            MINIMAL_SCHEMATIC, "R1", "dnp", "yes"
+        )
+        assert success
+        assert "Changed R1 dnp" in msg
+
+    def test_change_exclude_from_sim(self):
+        modified, success, msg = set_symbol_flag_text(
+            MINIMAL_SCHEMATIC, "R1", "exclude_from_sim", "yes"
+        )
+        assert success
+        assert "Changed R1 exclude_from_sim" in msg
+
+    def test_already_set_returns_success(self):
+        modified, success, msg = set_symbol_flag_text(
+            MINIMAL_SCHEMATIC, "#PWR052", "on_board", "no"
+        )
+        assert success
+        assert "already set" in msg
+        assert modified == MINIMAL_SCHEMATIC  # no change
+
+    def test_symbol_not_found(self):
+        modified, success, msg = set_symbol_flag_text(
+            MINIMAL_SCHEMATIC, "U99", "on_board", "yes"
+        )
+        assert not success
+        assert "not found" in msg
+        assert modified == MINIMAL_SCHEMATIC
+
+    def test_flag_not_found(self):
+        modified, success, msg = set_symbol_flag_text(
+            MINIMAL_SCHEMATIC_NO_EXCLUDE, "C1", "exclude_from_sim", "yes"
+        )
+        assert not success
+        assert "not found" in msg.lower()
+
+    def test_preserves_formatting(self):
+        """Verify only the target flag value changes, not other content."""
+        modified, success, msg = set_symbol_flag_text(
+            MINIMAL_SCHEMATIC, "#PWR052", "on_board", "yes"
+        )
+        assert success
+        # All other flags and properties should be unchanged
+        assert "(in_bom yes)" in modified
+        assert "(dnp no)" in modified
+        assert "(exclude_from_sim no)" in modified
+        assert '(property "Value" "GNDA"' in modified
+
+    def test_only_target_symbol_changed(self):
+        """Verify that changing on_board on #PWR052 doesn't affect R1."""
+        modified, success, _ = set_symbol_flag_text(
+            MINIMAL_SCHEMATIC, "#PWR052", "on_board", "yes"
+        )
+        assert success
+        # R1's symbol block should still have on_board yes
+        # Find R1's uuid (unique to R1's block) and search backwards for on_board
+        r1_uuid_idx = modified.index("22222222-2222-2222-2222-222222222222")
+        r1_block_start = modified.rfind("(symbol", 0, r1_uuid_idx)
+        r1_block = modified[r1_block_start : r1_uuid_idx + 50]
+        assert "(on_board yes)" in r1_block
+
+
+# ---------------------------------------------------------------------------
+# run_set_symbol_property integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunSetSymbolProperty:
+    def test_basic_set(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        rc = run_set_symbol_property(
+            schematic_path=sch,
+            ref="#PWR052",
+            property_name="on_board",
+            value="yes",
+            dry_run=False,
+            backup=False,
+        )
+        assert rc == 0
+        content = sch.read_text()
+        # The symbol block for #PWR052 should now have on_board yes
+        pwr_idx = content.index("#PWR052")
+        block_start = content.rfind("(symbol", 0, pwr_idx)
+        block_snippet = content[block_start : pwr_idx + 100]
+        assert "(on_board yes)" in block_snippet
+
+    def test_dry_run_no_modification(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        original = sch.read_text()
+        rc = run_set_symbol_property(
+            schematic_path=sch,
+            ref="#PWR052",
+            property_name="on_board",
+            value="yes",
+            dry_run=True,
+            backup=False,
+        )
+        assert rc == 0
+        assert sch.read_text() == original
+
+    def test_backup_created(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        rc = run_set_symbol_property(
+            schematic_path=sch,
+            ref="#PWR052",
+            property_name="on_board",
+            value="yes",
+            dry_run=False,
+            backup=True,
+        )
+        assert rc == 0
+        backups = list(tmp_path.glob("*_backup_*"))
+        assert len(backups) == 1
+
+    def test_invalid_property_name(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        rc = run_set_symbol_property(
+            schematic_path=sch,
+            ref="#PWR052",
+            property_name="bogus",
+            value="yes",
+            dry_run=False,
+            backup=False,
+        )
+        assert rc == 1
+
+    def test_invalid_value(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        rc = run_set_symbol_property(
+            schematic_path=sch,
+            ref="#PWR052",
+            property_name="on_board",
+            value="maybe",
+            dry_run=False,
+            backup=False,
+        )
+        assert rc == 1
+
+    def test_symbol_not_found_error(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        rc = run_set_symbol_property(
+            schematic_path=sch,
+            ref="U99",
+            property_name="on_board",
+            value="yes",
+            dry_run=False,
+            backup=False,
+        )
+        assert rc == 1
+
+    def test_file_not_found_error(self, tmp_path):
+        rc = run_set_symbol_property(
+            schematic_path=tmp_path / "nonexistent.kicad_sch",
+            ref="#PWR052",
+            property_name="on_board",
+            value="yes",
+        )
+        assert rc == 1
+
+    def test_value_normalization_true(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        rc = run_set_symbol_property(
+            schematic_path=sch,
+            ref="#PWR052",
+            property_name="on_board",
+            value="true",
+            dry_run=False,
+            backup=False,
+        )
+        assert rc == 0
+        content = sch.read_text()
+        pwr_idx = content.index("#PWR052")
+        block_start = content.rfind("(symbol", 0, pwr_idx)
+        block_snippet = content[block_start : pwr_idx + 100]
+        assert "(on_board yes)" in block_snippet
+
+    def test_value_normalization_numeric(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        rc = run_set_symbol_property(
+            schematic_path=sch,
+            ref="#PWR052",
+            property_name="on_board",
+            value="1",
+            dry_run=False,
+            backup=False,
+        )
+        assert rc == 0
+        content = sch.read_text()
+        pwr_idx = content.index("#PWR052")
+        block_start = content.rfind("(symbol", 0, pwr_idx)
+        block_snippet = content[block_start : pwr_idx + 100]
+        assert "(on_board yes)" in block_snippet
+
+    def test_other_symbol_unaffected(self, tmp_path):
+        sch = _write_sch(tmp_path)
+        rc = run_set_symbol_property(
+            schematic_path=sch,
+            ref="#PWR052",
+            property_name="on_board",
+            value="yes",
+            dry_run=False,
+            backup=False,
+        )
+        assert rc == 0
+        content = sch.read_text()
+        # R1's symbol block should still have on_board yes
+        r1_uuid_idx = content.index("22222222-2222-2222-2222-222222222222")
+        r1_block_start = content.rfind("(symbol", 0, r1_uuid_idx)
+        r1_block = content[r1_block_start : r1_uuid_idx + 50]
+        assert "(on_board yes)" in r1_block
+
+    def test_missing_flag_returns_error(self, tmp_path):
+        """Symbol without the target flag should return error."""
+        sch = _write_sch(tmp_path, MINIMAL_SCHEMATIC_NO_EXCLUDE)
+        rc = run_set_symbol_property(
+            schematic_path=sch,
+            ref="C1",
+            property_name="exclude_from_sim",
+            value="yes",
+            dry_run=False,
+            backup=False,
+        )
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Hierarchical traversal tests
+# ---------------------------------------------------------------------------
+
+
+class TestHierarchicalTraversal:
+    def _create_hierarchy(self, tmp_path: Path) -> Path:
+        """Create a root schematic that references a sub-sheet."""
+        subsheet_content = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "44444444-4444-4444-4444-444444444444")
+  (paper "A4")
+  (lib_symbols
+  )
+
+  (symbol
+    (lib_id "power:VCC")
+    (at 50 50 0)
+    (unit 1)
+    (exclude_from_sim no)
+    (in_bom no)
+    (on_board no)
+    (dnp no)
+    (uuid "55555555-5555-5555-5555-555555555555")
+    (property "Reference" "#PWR099"
+      (at 50 46 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "Value" "VCC"
+      (at 50 48 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Footprint" ""
+      (at 50 50 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+  )
+
+  (sheet_instances
+    (path "/sub/" (page "2"))
+  )
+)
+"""
+        sub_path = tmp_path / "subsheet.kicad_sch"
+        sub_path.write_text(subsheet_content)
+
+        root_content = f"""\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+  )
+
+  (sheet
+    (at 200 100) (size 20 15)
+    (property "Sheetname" "Power"
+      (at 200 99 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Sheetfile" "subsheet.kicad_sch"
+      (at 200 115 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (uuid "66666666-6666-6666-6666-666666666666")
+  )
+
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+        root_path = tmp_path / "root.kicad_sch"
+        root_path.write_text(root_content)
+        return root_path
+
+    def test_finds_symbol_in_subsheet(self, tmp_path):
+        root = self._create_hierarchy(tmp_path)
+        rc = run_set_symbol_property(
+            schematic_path=root,
+            ref="#PWR099",
+            property_name="on_board",
+            value="yes",
+            dry_run=False,
+            backup=False,
+        )
+        assert rc == 0
+        sub = tmp_path / "subsheet.kicad_sch"
+        content = sub.read_text()
+        pwr_idx = content.index("#PWR099")
+        block_start = content.rfind("(symbol", 0, pwr_idx)
+        block_snippet = content[block_start : pwr_idx + 100]
+        assert "(on_board yes)" in block_snippet
+
+    def test_dry_run_subsheet(self, tmp_path):
+        root = self._create_hierarchy(tmp_path)
+        sub = tmp_path / "subsheet.kicad_sch"
+        original = sub.read_text()
+        rc = run_set_symbol_property(
+            schematic_path=root,
+            ref="#PWR099",
+            property_name="on_board",
+            value="yes",
+            dry_run=True,
+            backup=False,
+        )
+        assert rc == 0
+        assert sub.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# Recognized flags constant
+# ---------------------------------------------------------------------------
+
+
+class TestRecognizedFlags:
+    def test_contains_all_four(self):
+        assert RECOGNIZED_FLAGS == {"on_board", "in_bom", "dnp", "exclude_from_sim"}


### PR DESCRIPTION
## Summary

Adds a new `sch set-symbol-property` CLI command that modifies symbol-level boolean flags (`on_board`, `in_bom`, `dnp`, `exclude_from_sim`) on placed symbol instances. This enables automated repair of power symbols with incorrect flag values (e.g., `on_board=no` on GNDA) that prevent net transfer to the PCB.

## Changes

- Added `set_symbol_flag_text()` function to `modify_schematic.py` for text-based flag modification
- Created `src/kicad_tools/cli/sch_set_symbol_property.py` with `run_set_symbol_property()` entry point
- Registered `set-symbol-property` subcommand in `parser.py`
- Added dispatch branch in `commands/schematic.py`
- Created comprehensive test suite (29 tests) covering all flags, normalization, dry-run, backup, hierarchical traversal, and edge cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Can set on_board, in_bom, dnp, exclude_from_sim on any placed symbol | PASS | Unit tests verify each flag change; integration tests confirm file modification |
| Supports --dry-run and --backup | PASS | Tests verify file unchanged with dry-run and backup file created |
| Validates the property name is recognized | PASS | Invalid property returns exit code 1 with error message |
| Value normalization (yes/no/true/false/1/0) | PASS | Tests confirm all accepted inputs normalize to yes/no |
| Hierarchical schematic traversal | PASS | Tests verify symbols in sub-sheets are found and modified |
| Preserves original formatting | PASS | Text-based modification only touches the target flag value |
| Exit code 0 on success, 1 on error | PASS | All integration tests verify return codes |

## Test Plan

All 29 tests pass: `python3 -m pytest tests/test_sch_set_symbol_property.py -v`

Closes #2173