### PR TITLE
feat(sch): enrich show-pins output with name, type, net, position fields

### DIFF
--- a/src/kicad_tools/cli/sch_symbol_info.py
+++ b/src/kicad_tools/cli/sch_symbol_info.py
@@ -25,6 +25,7 @@ import argparse
 import json
 import sys
 
+from kicad_tools.cli.sch_pin_map import resolve_pin_map
 from kicad_tools.schema import Schematic
 
 
@@ -63,13 +64,20 @@ def main(argv=None):
                 print(f"  ... and {len(refs) - 20} more", file=sys.stderr)
         sys.exit(1)
 
+    # Resolve enriched pin data (name, type, net, position) when requested
+    pin_map_data = None
+    if args.show_pins:
+        pin_map = resolve_pin_map(sch, ref_filter=args.reference)
+        if args.reference in pin_map:
+            pin_map_data = pin_map[args.reference]["pins"]
+
     if args.json:
-        output_json(symbol, args.show_pins, args.show_properties)
+        output_json(symbol, args.show_pins, args.show_properties, pin_map_data)
     else:
-        output_text(symbol, args.show_pins, args.show_properties)
+        output_text(symbol, args.show_pins, args.show_properties, pin_map_data)
 
 
-def output_json(symbol, show_pins, show_properties):
+def output_json(symbol, show_pins, show_properties, pin_map_data=None):
     """Output symbol info as JSON."""
     data = {
         "reference": symbol.reference,
@@ -91,12 +99,22 @@ def output_json(symbol, show_pins, show_properties):
         ]
 
     if show_pins:
-        data["pins"] = [{"number": p.number, "uuid": p.uuid} for p in symbol.pins]
+        pins = []
+        for p in symbol.pins:
+            pin_entry = {"number": p.number, "uuid": p.uuid}
+            if pin_map_data and p.number in pin_map_data:
+                enriched = pin_map_data[p.number]
+                pin_entry["name"] = enriched.get("name")
+                pin_entry["type"] = enriched.get("type")
+                pin_entry["net"] = enriched.get("net")
+                pin_entry["position"] = enriched.get("position")
+            pins.append(pin_entry)
+        data["pins"] = pins
 
     print(json.dumps(data, indent=2))
 
 
-def output_text(symbol, show_pins, show_properties):
+def output_text(symbol, show_pins, show_properties, pin_map_data=None):
     """Output symbol info as formatted text."""
     print(f"Symbol: {symbol.reference}")
     print("=" * 50)
@@ -120,9 +138,19 @@ def output_text(symbol, show_pins, show_properties):
 
     if show_pins:
         print(f"\nPins ({len(symbol.pins)} total):")
-        print("-" * 50)
-        for pin in symbol.pins:
-            print(f"  Pin {pin.number}: uuid={pin.uuid}")
+        if pin_map_data:
+            print(f"  {'Pin':<6} {'Name':<20} {'Type':<15} {'Net':<20} {'UUID'}")
+            print("  " + "-" * 80)
+            for pin in symbol.pins:
+                enriched = pin_map_data.get(pin.number, {})
+                name = enriched.get("name", "")
+                pin_type = enriched.get("type", "")
+                net = enriched.get("net") or "(unconnected)"
+                print(f"  {pin.number:<6} {name:<20} {pin_type:<15} {net:<20} {pin.uuid}")
+        else:
+            print("-" * 50)
+            for pin in symbol.pins:
+                print(f"  Pin {pin.number}: uuid={pin.uuid}")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -957,6 +957,178 @@ class TestSchSymbolInfo:
         captured = capsys.readouterr()
         assert "Properties:" in captured.out
 
+    def test_show_pins_json_includes_name_type_net(self, tmp_path, capsys, monkeypatch):
+        """Test that --show-pins --json includes name, type, net, position fields."""
+        from kicad_tools.cli.sch_symbol_info import main
+
+        # Schematic with lib_symbols so resolve_pin_map can enrich pin data
+        sch_content = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (pin_numbers hide)
+      (pin_names (offset 0) hide)
+      (in_bom yes) (on_board yes)
+      (symbol "Device:R_0_1"
+        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
+          (stroke (width 0.254) (type default)) (fill (type none)))
+      )
+      (symbol "Device:R_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+        (pin passive line (at 0 -3.81 90) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (wire
+    (pts (xy 100 96.19) (xy 100 90))
+    (stroke (width 0) (type default))
+    (uuid "00000000-0000-0000-0000-000000000010")
+  )
+  (label "VIN"
+    (at 100 90 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "00000000-0000-0000-0000-000000000011")
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 100 100 0)
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (property "Reference" "R1" (at 100 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "10k" (at 100 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Resistor_SMD:R_0402_1005Metric" (at 100 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 100 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000003"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000004"))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "R1")
+          (unit 1)
+        )
+      )
+    )
+  )
+)
+"""
+        sch_file = tmp_path / "test_enriched.kicad_sch"
+        sch_file.write_text(sch_content)
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["sch-symbol-info", str(sch_file), "R1", "--show-pins", "--json"],
+        )
+        main()
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "pins" in data
+        assert len(data["pins"]) == 2
+
+        # Verify enriched fields are present
+        pin1 = next(p for p in data["pins"] if p["number"] == "1")
+        assert "name" in pin1
+        assert "type" in pin1
+        assert "net" in pin1
+        assert "position" in pin1
+        assert pin1["type"] == "passive"
+        assert pin1["net"] == "VIN"
+
+    def test_show_pins_text_includes_name_type_net(self, tmp_path, capsys, monkeypatch):
+        """Test that --show-pins table output includes name, type, net columns."""
+        from kicad_tools.cli.sch_symbol_info import main
+
+        sch_content = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (pin_numbers hide)
+      (pin_names (offset 0) hide)
+      (in_bom yes) (on_board yes)
+      (symbol "Device:R_0_1"
+        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
+          (stroke (width 0.254) (type default)) (fill (type none)))
+      )
+      (symbol "Device:R_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+        (pin passive line (at 0 -3.81 90) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (wire
+    (pts (xy 100 96.19) (xy 100 90))
+    (stroke (width 0) (type default))
+    (uuid "00000000-0000-0000-0000-000000000010")
+  )
+  (label "VIN"
+    (at 100 90 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "00000000-0000-0000-0000-000000000011")
+  )
+  (symbol
+    (lib_id "Device:R")
+    (at 100 100 0)
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (property "Reference" "R1" (at 100 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "10k" (at 100 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Resistor_SMD:R_0402_1005Metric" (at 100 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 100 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000003"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000004"))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "R1")
+          (unit 1)
+        )
+      )
+    )
+  )
+)
+"""
+        sch_file = tmp_path / "test_enriched.kicad_sch"
+        sch_file.write_text(sch_content)
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["sch-symbol-info", str(sch_file), "R1", "--show-pins"],
+        )
+        main()
+
+        captured = capsys.readouterr()
+        # Table output should include column headers
+        assert "Name" in captured.out
+        assert "Type" in captured.out
+        assert "Net" in captured.out
+        # Should show actual pin data
+        assert "passive" in captured.out
+        assert "VIN" in captured.out
+
+    def test_show_pins_graceful_without_lib_symbols(self, minimal_schematic, capsys, monkeypatch):
+        """Test that --show-pins degrades gracefully when lib_symbols is empty."""
+        from kicad_tools.cli.sch_symbol_info import main
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["sch-symbol-info", str(minimal_schematic), "R1", "--show-pins", "--json"],
+        )
+        main()
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "pins" in data
+        # Pins should still have number and uuid even without enrichment
+        for pin in data["pins"]:
+            assert "number" in pin
+            assert "uuid" in pin
+
 
 class TestSchValidate:
     """Tests for sch_validate.py CLI."""


### PR DESCRIPTION
## Summary
The `sch info --show-pins` command only output pin number and uuid. This PR enriches the pin data by reusing `resolve_pin_map()` from `sch_pin_map.py` to include name, type, net assignment, and position for each pin.

## Changes
- Import and call `resolve_pin_map()` in `sch_symbol_info.py` when `--show-pins` is requested
- Merge enriched pin data (name, type, net, position) into both JSON and table output
- Table output now shows columnar format with Name, Type, Net, UUID headers when enriched data is available
- Graceful degradation: when lib_symbols is empty, output falls back to number/uuid only

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| JSON output includes name, type, net, position fields | Pass | test_show_pins_json_includes_name_type_net asserts all fields present with correct values |
| Table output shows new fields | Pass | test_show_pins_text_includes_name_type_net asserts column headers and data appear |
| Net values match sch pin-map output | Pass | Both use the same resolve_pin_map() function |
| Graceful degradation without lib_symbols | Pass | test_show_pins_graceful_without_lib_symbols verifies number/uuid still appear |

## Test Plan
- 9/9 tests pass in TestSchSymbolInfo (6 existing + 3 new)
- New tests use a schematic fixture with populated lib_symbols and wires to verify enriched pin data
- Existing tests continue to pass with the minimal schematic (empty lib_symbols)

Closes #2197