### PR TITLE
feat(sch): traverse full hierarchy in pin-map command

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -124,6 +124,8 @@ def run_sch_command(args) -> int:
         sub_argv = [str(schematic_path)]
         if args.ref:
             sub_argv.extend(["--ref", args.ref])
+        if getattr(args, "sheet", None):
+            sub_argv.extend(["--sheet", args.sheet])
         if args.format != "json":
             sub_argv.extend(["--format", args.format])
         return pin_map_main(sub_argv) or 0

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -488,6 +488,9 @@ def _add_sch_parser(subparsers) -> None:
     sch_pin_map.add_argument("schematic", help="Path to .kicad_sch file")
     sch_pin_map.add_argument("--ref", help="Filter by symbol reference (e.g., U1)")
     sch_pin_map.add_argument(
+        "--sheet", help="Restrict to a specific sheet (name or path substring)"
+    )
+    sch_pin_map.add_argument(
         "--format", choices=["table", "json"], default="json", help="Output format (default: json)"
     )
 

--- a/src/kicad_tools/cli/sch_pin_map.py
+++ b/src/kicad_tools/cli/sch_pin_map.py
@@ -14,11 +14,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from collections import defaultdict
 
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import Schematic
+from kicad_tools.schema.hierarchy import build_hierarchy
 from kicad_tools.schema.label import PowerSymbol
 
 # Use integer-scaled coordinates for fast set lookup (matches sch_check_connections.py)
@@ -430,20 +432,46 @@ def main(argv=None):
     parser.add_argument("schematic", help="Path to .kicad_sch file")
     parser.add_argument("--ref", help="Filter by symbol reference (e.g., U1)")
     parser.add_argument(
+        "--sheet", help="Restrict to a specific sheet (name or path substring)"
+    )
+    parser.add_argument(
         "--format", choices=["table", "json"], default="json", help="Output format (default: json)"
     )
 
     args = parser.parse_args(argv)
 
-    # Load schematic
-    try:
-        sch = Schematic.load(args.schematic)
-    except (FileNotFoundError, KiCadFileNotFoundError):
+    # Verify root schematic exists before building hierarchy
+    if not os.path.isfile(args.schematic):
         print(f"Error: Schematic not found: {args.schematic}", file=sys.stderr)
         return 1
 
-    # Resolve pin map
-    pin_map = resolve_pin_map(sch, ref_filter=args.ref)
+    # Build hierarchy to iterate all sheets (root + children)
+    hierarchy = build_hierarchy(args.schematic)
+
+    # Iterate all sheets, merging pin maps
+    pin_map: dict[str, dict] = {}
+    for node in hierarchy.all_nodes():
+        # Apply --sheet filter: skip nodes whose name or path don't match
+        if args.sheet:
+            sheet_filter = args.sheet.lower()
+            node_name = (node.name or "").lower()
+            node_path = (node.path or "").lower()
+            if sheet_filter not in node_name and sheet_filter not in node_path:
+                continue
+
+        try:
+            sch = Schematic.load(node.path)
+        except (FileNotFoundError, KiCadFileNotFoundError):
+            continue
+
+        sheet_map = resolve_pin_map(sch, ref_filter=args.ref)
+
+        # Merge results -- multi-unit symbols may span sheets
+        for ref, entry in sheet_map.items():
+            if ref in pin_map:
+                pin_map[ref]["pins"].update(entry["pins"])
+            else:
+                pin_map[ref] = entry
 
     if args.format == "json":
         output_json(pin_map)

--- a/tests/test_sch_pin_map.py
+++ b/tests/test_sch_pin_map.py
@@ -1133,3 +1133,79 @@ class TestCLI:
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert data == {}
+
+
+# ---------------------------------------------------------------------------
+# Hierarchy traversal tests
+# ---------------------------------------------------------------------------
+
+HIERARCHICAL_ROOT = Path(__file__).parent / "fixtures" / "hierarchical" / "root.kicad_sch"
+
+
+class TestHierarchyTraversal:
+    """Verify that pin-map iterates all sheets in a hierarchical design."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_missing(self):
+        if not HIERARCHICAL_ROOT.exists():
+            pytest.skip("Hierarchical fixture not available")
+
+    def test_all_sheets_included(self, capsys):
+        """Components from root AND child sheets must appear in the output."""
+        rc = pin_map_main([str(HIERARCHICAL_ROOT), "--format", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+
+        # root.kicad_sch has R1
+        assert "R1" in data, "R1 from root sheet should be present"
+        # sub_a.kicad_sch has R2, C1
+        assert "R2" in data, "R2 from sub_a sheet should be present"
+        assert "C1" in data, "C1 from sub_a sheet should be present"
+        # sub_b.kicad_sch has R3, R4
+        assert "R3" in data, "R3 from sub_b sheet should be present"
+        assert "R4" in data, "R4 from sub_b sheet should be present"
+        # nested.kicad_sch has C2
+        assert "C2" in data, "C2 from nested sheet should be present"
+
+    def test_ref_filter_finds_child_component(self, capsys):
+        """--ref for a component on a child sheet must return it."""
+        rc = pin_map_main([str(HIERARCHICAL_ROOT), "--ref", "R3", "--format", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+
+        assert "R3" in data, "R3 from sub_b should be found with --ref filter"
+        assert len(data) == 1, "Only R3 should be returned"
+
+    def test_ref_filter_no_match(self, capsys):
+        """--ref for a non-existent component returns empty across all sheets."""
+        rc = pin_map_main([str(HIERARCHICAL_ROOT), "--ref", "U99", "--format", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data == {}
+
+    def test_sheet_filter(self, capsys):
+        """--sheet restricts output to components on the matching sheet."""
+        rc = pin_map_main([
+            str(HIERARCHICAL_ROOT), "--sheet", "sub_b", "--format", "json"
+        ])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+
+        # sub_b.kicad_sch has R3 and R4
+        assert "R3" in data
+        assert "R4" in data
+        # Components from other sheets should NOT be present
+        assert "R1" not in data
+        assert "R2" not in data
+        assert "C1" not in data
+        assert "C2" not in data
+
+    def test_single_sheet_still_works(self, capsys):
+        """A schematic with no child sheets should still work (just root)."""
+        # sub_b.kicad_sch has no child sheets
+        sub_b = Path(__file__).parent / "fixtures" / "hierarchical" / "sub_b.kicad_sch"
+        rc = pin_map_main([str(sub_b), "--format", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert "R3" in data
+        assert "R4" in data


### PR DESCRIPTION
## Summary
The `sch pin-map` command previously loaded only the root sheet, missing all components on child sheets in hierarchical designs. This fix iterates the full sheet hierarchy using `build_hierarchy()` + `all_nodes()`, merging pin maps from every sheet.

## Changes
- `src/kicad_tools/cli/sch_pin_map.py` -- Replaced single `Schematic.load()` call in `main()` with hierarchy traversal loop; added `--sheet` filter option; added `os.path.isfile` check for missing root file
- `src/kicad_tools/cli/parser.py` -- Added `--sheet` argument to the `sch pin-map` subparser
- `src/kicad_tools/cli/commands/schematic.py` -- Pass `--sheet` through to `pin_map_main`
- `tests/test_sch_pin_map.py` -- Added `TestHierarchyTraversal` class with 5 tests covering all-sheets output, `--ref` on child sheet, `--sheet` filter, single-sheet backward compat

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Components from ALL sheets returned | Pass | `test_all_sheets_included` finds R1 (root), R2/C1 (sub_a), R3/R4 (sub_b), C2 (nested) |
| `--ref` finds child-sheet component | Pass | `test_ref_filter_finds_child_component` finds R3 on sub_b sheet |
| `--sheet` filter restricts output | Pass | `test_sheet_filter` with `sub_b` returns only R3/R4 |
| Single-sheet schematics still work | Pass | `test_single_sheet_still_works` loads sub_b directly |
| Missing file returns error code 1 | Pass | `test_missing_file` passes |

## Test Plan
41 tests pass (1 pre-existing failure on `test_rotated_symbol_positions` unrelated to this change -- it also fails on main).

Closes #2195