### PR TITLE
fix(sync): use on_board flag instead of is_virtual/dnp to filter sync components

### DIFF
--- a/src/kicad_tools/schema/bom.py
+++ b/src/kicad_tools/schema/bom.py
@@ -27,6 +27,7 @@ class BOMItem:
     lcsc: str = ""  # LCSC Part Number
     dnp: bool = False
     in_bom: bool = True
+    on_board: bool = True
 
     # Additional properties from schematic
     properties: dict[str, str] = field(default_factory=dict)
@@ -235,6 +236,7 @@ def extract_bom_from_schematic(schematic: Schematic) -> list[BOMItem]:
             datasheet=sym.datasheet,
             dnp=sym.dnp,
             in_bom=sym.in_bom,
+            on_board=sym.on_board,
         )
 
         # Extract additional properties

--- a/src/kicad_tools/sync/reconciler.py
+++ b/src/kicad_tools/sync/reconciler.py
@@ -492,17 +492,19 @@ class Reconciler:
         mirroring the approach in SchematicPCBChecker.check_lvs(). This ensures
         components in hierarchical sub-sheets are included in the analysis.
 
-        Skips virtual components, power symbols, and DNP components, consistent
-        with the LVS checker's filtering logic.
+        Skips power symbols and components with on_board=False. Components
+        that are in_bom=False or dnp=True but have on_board=True (e.g., net
+        ties, optional/unpopulated parts) are included because they have
+        physical footprints on the PCB.
         """
         components: dict[str, dict[str, str]] = {}
         sch_path = str(self._schematic_path)
         bom = extract_bom(sch_path, hierarchical=True)
 
         for item in bom.items:
-            if item.is_virtual or item.is_power_symbol:
+            if item.is_power_symbol:
                 continue
-            if item.dnp:
+            if not item.on_board:
                 continue
             if item.reference and not item.reference.startswith("#"):
                 components[item.reference] = {

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -483,8 +483,8 @@ class TestReconcilerAnalyze:
         Path(sch_path).unlink()
         Path(pcb_path).unlink()
 
-    def test_analyze_skips_virtual_and_power(self):
-        """Test that virtual/power symbols and DNP components are skipped."""
+    def test_analyze_skips_power_and_off_board(self):
+        """Test that power symbols and on_board=False components are skipped."""
         bom_items = [
             self._make_bom_item("R1", "10k", "R_0402", lib_id="Device:R"),
             BOMItem(
@@ -493,13 +493,15 @@ class TestReconcilerAnalyze:
                 footprint="",
                 lib_id="power:+3V3",
                 in_bom=False,
+                on_board=False,
             ),
             BOMItem(
-                reference="R2",
-                value="100",
-                footprint="R_0402",
-                lib_id="Device:R",
-                dnp=True,
+                reference="SIM1",
+                value="TestPoint",
+                footprint="",
+                lib_id="Simulation:VSIN",
+                in_bom=False,
+                on_board=False,
             ),
         ]
         footprints = [
@@ -514,9 +516,109 @@ class TestReconcilerAnalyze:
 
         assert analysis.is_in_sync
         assert len(analysis.matches) == 1
-        # PWR1 and R2 (DNP) should not appear anywhere
+        # PWR1 and SIM1 (on_board=False) should not appear anywhere
         assert "PWR1" not in analysis.schematic_orphans
-        assert "R2" not in analysis.schematic_orphans
+        assert "SIM1" not in analysis.schematic_orphans
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_analyze_includes_net_tie_in_bom_no(self):
+        """Test that net ties (in_bom=no, on_board=yes) are included in sync."""
+        bom_items = [
+            self._make_bom_item("R1", "10k", "R_0402", lib_id="Device:R"),
+            BOMItem(
+                reference="NT2",
+                value="NetTie_2",
+                footprint="NetTie:NetTie-2_SMD_Pad0.5mm",
+                lib_id="Device:NetTie_2",
+                in_bom=False,
+                on_board=True,
+            ),
+        ]
+        footprints = [
+            self._make_mock_footprint("R1", "10k", "R_0402"),
+            self._make_mock_footprint(
+                "NT2", "NetTie_2", "NetTie:NetTie-2_SMD_Pad0.5mm"
+            ),
+        ]
+
+        reconciler, mock_bom, mock_pcb, sch_path, pcb_path = self._make_reconciler_with_mocks(
+            bom_items, footprints
+        )
+
+        analysis = self._run_analyze(reconciler, mock_bom, mock_pcb)
+
+        assert analysis.is_in_sync
+        assert len(analysis.matches) == 2
+        matched_refs = {m.schematic_ref for m in analysis.matches}
+        assert "NT2" in matched_refs
+        assert "NT2" not in analysis.pcb_orphans
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_analyze_includes_dnp_on_board(self):
+        """Test that DNP components with on_board=yes are included in sync."""
+        bom_items = [
+            self._make_bom_item("R1", "10k", "R_0402", lib_id="Device:R"),
+            BOMItem(
+                reference="J5",
+                value="Conn_01x03_Pin",
+                footprint="Connector_PinHeader_2.54mm:PinHeader_1x03",
+                lib_id="Connector:Conn_01x03_Pin",
+                dnp=True,
+                on_board=True,
+            ),
+        ]
+        footprints = [
+            self._make_mock_footprint("R1", "10k", "R_0402"),
+            self._make_mock_footprint(
+                "J5", "Conn_01x03_Pin", "Connector_PinHeader_2.54mm:PinHeader_1x03"
+            ),
+        ]
+
+        reconciler, mock_bom, mock_pcb, sch_path, pcb_path = self._make_reconciler_with_mocks(
+            bom_items, footprints
+        )
+
+        analysis = self._run_analyze(reconciler, mock_bom, mock_pcb)
+
+        assert analysis.is_in_sync
+        assert len(analysis.matches) == 2
+        matched_refs = {m.schematic_ref for m in analysis.matches}
+        assert "J5" in matched_refs
+        assert "J5" not in analysis.pcb_orphans
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_analyze_excludes_on_board_no(self):
+        """Test that components with on_board=no are excluded from sync."""
+        bom_items = [
+            self._make_bom_item("R1", "10k", "R_0402", lib_id="Device:R"),
+            BOMItem(
+                reference="SIM1",
+                value="VSIN",
+                footprint="",
+                lib_id="Simulation:VSIN",
+                in_bom=False,
+                on_board=False,
+            ),
+        ]
+        footprints = [
+            self._make_mock_footprint("R1", "10k", "R_0402"),
+        ]
+
+        reconciler, mock_bom, mock_pcb, sch_path, pcb_path = self._make_reconciler_with_mocks(
+            bom_items, footprints
+        )
+
+        analysis = self._run_analyze(reconciler, mock_bom, mock_pcb)
+
+        assert analysis.is_in_sync
+        assert len(analysis.matches) == 1
+        assert "SIM1" not in analysis.schematic_orphans
 
         Path(sch_path).unlink()
         Path(pcb_path).unlink()


### PR DESCRIPTION
## Summary
The reconciler was incorrectly filtering out components with in_bom=False (like net ties) and DNP components from sync analysis, causing their PCB footprints to appear as orphans. Changed filtering to use the on_board flag, which correctly identifies components with physical board presence.

## Changes
- Added `on_board: bool = True` field to `BOMItem` dataclass in `bom.py`
- Set `on_board=sym.on_board` when constructing `BOMItem` in `extract_bom_from_schematic()`
- Updated `_get_schematic_components()` filter in `reconciler.py` to skip power symbols and `on_board=False` components instead of `is_virtual` and `dnp`
- Updated `test_analyze_skips_virtual_and_power` to `test_analyze_skips_power_and_off_board`
- Added tests for net ties (in_bom=no, on_board=yes), DNP components (on_board=yes), and on_board=no exclusion

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Net ties (in_bom=no, on_board=yes) not reported as PCB orphans | PASS | test_analyze_includes_net_tie_in_bom_no |
| DNP components (on_board=yes) not reported as PCB orphans | PASS | test_analyze_includes_dnp_on_board |
| Components with on_board=no excluded from sync | PASS | test_analyze_excludes_on_board_no and test_analyze_skips_power_and_off_board |
| Power symbols still excluded | PASS | test_analyze_skips_power_and_off_board |
| BOMItem includes on_board field | PASS | Field added with default True |
| Existing test updated | PASS | Renamed and updated to reflect new filtering |
| New test: net tie matched correctly | PASS | test_analyze_includes_net_tie_in_bom_no |
| New test: DNP matched correctly | PASS | test_analyze_includes_dnp_on_board |
| New test: on_board=no excluded | PASS | test_analyze_excludes_on_board_no |

## Test Plan
All 77 tests in tests/test_sync.py pass.

Closes #2204