### PR TITLE
fix(route): filter exported failed nets to multi-pad routing candidates

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -199,6 +199,7 @@ def _export_failed_nets(
     net_map: dict[str, int],
     export_path: str,
     quiet: bool = False,
+    nets_to_route_ids: set[int] | None = None,
 ) -> bool:
     """Export the list of failed (unrouted) net names to a file.
 
@@ -209,14 +210,21 @@ def _export_failed_nets(
         net_map: Mapping of net names to net IDs.
         export_path: File path to write the failed net names.
         quiet: If True, suppress output messages.
+        nets_to_route_ids: Optional set of net IDs targeted for routing
+            (multi-pad signal nets).  When provided, only nets in this set
+            are considered candidates so single-pad and power nets are
+            excluded from the export.
 
     Returns:
         True if the file was written successfully, False otherwise.
     """
     reverse_net = {v: k for k, v in net_map.items() if v > 0}
     routed_net_ids = {route.net for route in router.routes}
-    all_net_ids = {v for k, v in net_map.items() if v > 0}
-    unrouted_ids = all_net_ids - routed_net_ids
+    if nets_to_route_ids is not None:
+        unrouted_ids = nets_to_route_ids - routed_net_ids
+    else:
+        all_net_ids = {v for k, v in net_map.items() if v > 0}
+        unrouted_ids = all_net_ids - routed_net_ids
 
     if not unrouted_ids:
         if not quiet:
@@ -3643,7 +3651,13 @@ def main(argv: list[str] | None = None) -> int:
 
     # Export failed nets to file if requested
     if getattr(args, "export_failed_nets", None) and not all_nets_routed:
-        _export_failed_nets(router, net_map, args.export_failed_nets, quiet=quiet)
+        _export_failed_nets(
+            router,
+            net_map,
+            args.export_failed_nets,
+            quiet=quiet,
+            nets_to_route_ids=multi_pad_net_ids,
+        )
 
     # Exit codes:
     # 0 = Routing meets --min-completion threshold AND (DRC passed OR DRC not run)

--- a/tests/test_partial_routing_features.py
+++ b/tests/test_partial_routing_features.py
@@ -230,6 +230,59 @@ class TestExportFailedNets:
         # Verify trailing newline
         assert content.endswith("\n")
 
+    def test_export_failed_nets_filters_by_nets_to_route_ids(self, tmp_path):
+        """When nets_to_route_ids is provided, only those nets appear in export."""
+        from kicad_tools.cli.route_cmd import _export_failed_nets
+
+        # net_map includes single-pad nets (5, 6) and power nets that are
+        # NOT routing candidates, plus multi-pad signal nets (1-4).
+        net_map = {
+            "GND": 0,
+            "VCC": 1,
+            "SDA": 2,
+            "SCL": 3,
+            "NRST": 4,
+            "SINGLE_PAD_A": 5,
+            "SINGLE_PAD_B": 6,
+        }
+        # Only nets 1-4 are multi-pad signal nets targeted for routing
+        multi_pad_net_ids = {1, 2, 3, 4}
+        # Router successfully routed VCC(1) and SDA(2)
+        router = _make_mock_router(routed_nets=[1, 2])
+
+        export_file = tmp_path / "failed.txt"
+        result = _export_failed_nets(
+            router, net_map, str(export_file), quiet=True,
+            nets_to_route_ids=multi_pad_net_ids,
+        )
+
+        assert result is True
+        lines = export_file.read_text().strip().split("\n")
+        # Only SCL(3) and NRST(4) should appear -- NOT SINGLE_PAD_A/B
+        assert sorted(lines) == ["NRST", "SCL"]
+
+    def test_export_failed_nets_without_filter_includes_all(self, tmp_path):
+        """Without nets_to_route_ids, all non-GND unrouted nets appear (legacy)."""
+        from kicad_tools.cli.route_cmd import _export_failed_nets
+
+        net_map = {
+            "GND": 0,
+            "VCC": 1,
+            "SDA": 2,
+            "SINGLE_PAD": 3,
+        }
+        router = _make_mock_router(routed_nets=[1])
+
+        export_file = tmp_path / "failed.txt"
+        result = _export_failed_nets(
+            router, net_map, str(export_file), quiet=True,
+        )
+
+        assert result is True
+        lines = export_file.read_text().strip().split("\n")
+        # Without filter, both SDA and SINGLE_PAD appear
+        assert sorted(lines) == ["SDA", "SINGLE_PAD"]
+
     def test_export_failed_nets_cli_flag_in_help(self):
         """--export-failed-nets appears in help output."""
         from kicad_tools.cli.route_cmd import main as route_main


### PR DESCRIPTION
## Summary
The `--export-failed-nets` flag was exporting all nets missing from router.routes, including single-pad nets and power nets that were never routing candidates. This caused the exported file to contain far more entries than the actual failed nets shown in the routing summary. The fix passes the `multi_pad_net_ids` filter to `_export_failed_nets`, matching the pattern already used by `show_routing_summary`.

## Changes
- Added `nets_to_route_ids` optional parameter to `_export_failed_nets()` in `route_cmd.py`
- When provided, unrouted nets are computed as `nets_to_route_ids - routed_net_ids` instead of `all_net_ids - routed_net_ids`
- Updated the call site at line 3651 to pass `multi_pad_net_ids`
- Falls back to legacy behavior (all non-GND nets) when `nets_to_route_ids` is None

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Export contains only nets that failed in best trial, not all missing from net_map | PASS | `_export_failed_nets` now filters to `nets_to_route_ids` when provided |
| Fallback behavior preserved when no filter provided | PASS | `nets_to_route_ids=None` falls back to original `all_net_ids` logic |
| Pattern matches show_routing_summary | PASS | Same conditional logic at output.py lines 70-79 |

## Test Plan
- Added `test_export_failed_nets_filters_by_nets_to_route_ids` -- verifies single-pad nets excluded when filter provided
- Added `test_export_failed_nets_without_filter_includes_all` -- verifies legacy behavior preserved
- All 9 tests in `TestExportFailedNets` pass

Closes #2209