### PR TITLE
feat(sync): route value updates through PCB API, add orphan removal

### DIFF
--- a/src/kicad_tools/cli/commands/sync.py
+++ b/src/kicad_tools/cli/commands/sync.py
@@ -42,5 +42,9 @@ def run_sync_command(args) -> int:
     min_conf = getattr(args, "sync_min_confidence", "high")
     if min_conf != "high":
         sub_argv.extend(["--min-confidence", min_conf])
+    if getattr(args, "sync_remove_orphans", False):
+        sub_argv.append("--remove-orphans")
+    if getattr(args, "sync_force", False):
+        sub_argv.append("--force")
 
     return sync_main(sub_argv)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -4832,6 +4832,18 @@ def _add_sync_parser(subparsers) -> None:
         default="high",
         help="Minimum confidence level to apply (default: high)",
     )
+    sync_parser.add_argument(
+        "--remove-orphans",
+        dest="sync_remove_orphans",
+        action="store_true",
+        help="Remove PCB footprints not present in schematic (with --apply)",
+    )
+    sync_parser.add_argument(
+        "--force",
+        dest="sync_force",
+        action="store_true",
+        help="Force removal of orphans even if they have routed traces",
+    )
 
 
 def _add_run_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/sync_cmd.py
+++ b/src/kicad_tools/cli/sync_cmd.py
@@ -96,6 +96,16 @@ def main(argv: list[str] | None = None) -> int:
         default="high",
         help="Minimum confidence level to apply (default: high)",
     )
+    parser.add_argument(
+        "--remove-orphans",
+        action="store_true",
+        help="Remove PCB footprints not present in schematic (with --apply)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force removal of orphans even if they have routed traces",
+    )
 
     args = parser.parse_args(argv)
 
@@ -164,6 +174,8 @@ def main(argv: list[str] | None = None) -> int:
                 dry_run=args.dry_run,
                 min_confidence=args.min_confidence,
                 output=args.output,
+                remove_orphans=args.remove_orphans,
+                force=args.force,
             )
         except Exception as e:
             print(f"Error applying changes: {e}", file=sys.stderr)
@@ -274,9 +286,18 @@ def _output_changes_table(changes, dry_run: bool) -> None:
                 status = "(placed)"
             else:
                 status = "(failed - library not found)"
+        elif change.change_type == "remove_orphan":
+            if dry_run:
+                status = "(would remove)"
+            elif change.applied:
+                status = "(removed)"
+            else:
+                status = "(skipped)"
 
         print(f"\n  {change.change_type}: {change.reference}")
         if change.change_type == "add_footprint":
+            print(f"    {change.new_value} {status}")
+        elif change.change_type == "remove_orphan":
             print(f"    {change.new_value} {status}")
         else:
             print(f"    {change.old_value} -> {change.new_value} {status}")

--- a/src/kicad_tools/sync/reconciler.py
+++ b/src/kicad_tools/sync/reconciler.py
@@ -87,7 +87,7 @@ class SyncChange:
     """
 
     reference: str
-    change_type: str  # "rename", "update_value", "update_footprint", "add_footprint"
+    change_type: str  # "rename", "update_value", "update_footprint", "add_footprint", "remove_orphan"
     old_value: str
     new_value: str
     applied: bool = False
@@ -529,6 +529,8 @@ class Reconciler:
         dry_run: bool = True,
         min_confidence: str = "high",
         output: str | Path | None = None,
+        remove_orphans: bool = False,
+        force: bool = False,
     ) -> list[SyncChange]:
         """Apply proposed changes from an analysis to the PCB.
 
@@ -539,6 +541,8 @@ class Reconciler:
                 "high" = only high confidence, "medium" = high+medium,
                 "low" = all matches.
             output: Path to write the modified PCB (default: overwrite original).
+            remove_orphans: If True, remove PCB footprints not present in schematic.
+            force: If True, remove orphans even when they have routed traces.
 
         Returns:
             List of SyncChange records documenting what was (or would be) changed.
@@ -560,7 +564,9 @@ class Reconciler:
         # Include add_footprint actions from analysis
         actions_to_apply.extend(analysis.add_footprint_actions)
 
-        if not actions_to_apply:
+        has_orphans_to_remove = remove_orphans and bool(analysis.pcb_orphans)
+
+        if not actions_to_apply and not has_orphans_to_remove:
             return changes
 
         # Load PCB as a PCB object for full API access (add_footprint, add_net, etc.)
@@ -608,8 +614,19 @@ class Reconciler:
                 change = self._apply_update_footprint(pcb, action, dry_run)
                 if change:
                     changes.append(change)
-            else:
-                change = self._apply_action(pcb._sexp, action, dry_run)
+            elif action["type"] == "update_value":
+                change = self._apply_update_value(pcb, action, dry_run)
+                if change:
+                    changes.append(change)
+            elif action["type"] == "rename":
+                change = self._apply_rename(pcb, action, dry_run)
+                if change:
+                    changes.append(change)
+
+        # Remove PCB orphans if requested
+        if has_orphans_to_remove:
+            for ref in analysis.pcb_orphans:
+                change = self._apply_remove_orphan(pcb, ref, dry_run, force)
                 if change:
                     changes.append(change)
 
@@ -1046,6 +1063,152 @@ class Reconciler:
             # Net assignment is best-effort; failures are not fatal.
             # The user can run assign_nets_from_netlist() separately.
             pass
+
+    def _apply_update_value(
+        self,
+        pcb,
+        action: dict[str, Any],
+        dry_run: bool,
+    ) -> SyncChange | None:
+        """Apply an update_value action using the PCB API.
+
+        Uses pcb.update_footprint_value() which handles both KiCad 7 (fp_text)
+        and KiCad 8+ (property) formats.
+
+        Args:
+            pcb: The PCB object.
+            action: Action dict with update_value details.
+            dry_run: If True, don't modify the PCB.
+
+        Returns:
+            SyncChange record, or None if the footprint was not found.
+        """
+        ref = action["reference"]
+        old_val = action["old_value"]
+        new_val = action["new_value"]
+
+        if dry_run:
+            return SyncChange(
+                reference=ref,
+                change_type="update_value",
+                old_value=old_val,
+                new_value=new_val,
+                applied=False,
+            )
+
+        success = pcb.update_footprint_value(ref, new_val)
+        if not success:
+            return None
+
+        return SyncChange(
+            reference=ref,
+            change_type="update_value",
+            old_value=old_val,
+            new_value=new_val,
+            applied=True,
+        )
+
+    def _apply_rename(
+        self,
+        pcb,
+        action: dict[str, Any],
+        dry_run: bool,
+    ) -> SyncChange | None:
+        """Apply a rename action using the PCB API.
+
+        Uses pcb.update_footprint_reference() which handles both KiCad 7 (fp_text)
+        and KiCad 8+ (property) formats.
+
+        Args:
+            pcb: The PCB object.
+            action: Action dict with rename details.
+            dry_run: If True, don't modify the PCB.
+
+        Returns:
+            SyncChange record, or None if the footprint was not found.
+        """
+        old_ref = action["old_value"]
+        new_ref = action["new_value"]
+
+        if dry_run:
+            return SyncChange(
+                reference=old_ref,
+                change_type="rename",
+                old_value=old_ref,
+                new_value=new_ref,
+                applied=False,
+            )
+
+        success = pcb.update_footprint_reference(old_ref, new_ref)
+        if not success:
+            return None
+
+        return SyncChange(
+            reference=old_ref,
+            change_type="rename",
+            old_value=old_ref,
+            new_value=new_ref,
+            applied=True,
+        )
+
+    def _apply_remove_orphan(
+        self,
+        pcb,
+        ref: str,
+        dry_run: bool,
+        force: bool,
+    ) -> SyncChange:
+        """Remove an orphan footprint from the PCB.
+
+        Checks for routed traces before removal. If the footprint has traces
+        and force is False, the removal is skipped.
+
+        Args:
+            pcb: The PCB object.
+            ref: Reference designator of the orphan footprint.
+            dry_run: If True, don't modify the PCB.
+            force: If True, remove even if the footprint has routed traces.
+
+        Returns:
+            SyncChange record documenting the removal (or skip).
+        """
+        has_traces = pcb.footprint_has_traces(ref)
+
+        if dry_run:
+            new_value = "removed"
+            if has_traces and not force:
+                new_value = "skipped (has traces, use --force)"
+            elif has_traces and force:
+                new_value = "removed (forced, had traces)"
+            return SyncChange(
+                reference=ref,
+                change_type="remove_orphan",
+                old_value=ref,
+                new_value=new_value,
+                applied=False,
+            )
+
+        if has_traces and not force:
+            return SyncChange(
+                reference=ref,
+                change_type="remove_orphan",
+                old_value=ref,
+                new_value="skipped (has traces, use --force)",
+                applied=False,
+            )
+
+        success = pcb.remove_footprint(ref)
+        new_value = "removed"
+        if has_traces:
+            new_value = "removed (forced, had traces)"
+
+        return SyncChange(
+            reference=ref,
+            change_type="remove_orphan",
+            old_value=ref,
+            new_value=new_value,
+            applied=success,
+        )
 
     def _apply_action(self, sexp, action: dict[str, Any], dry_run: bool) -> SyncChange | None:
         """Apply a single action to the PCB s-expression.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1758,6 +1758,324 @@ class TestUpdateFootprintSwapRegression:
         )
 
 
+class TestReconcilerApplyUpdateValueViaPCBAPI:
+    """Tests for update_value routing through PCB.update_footprint_value()."""
+
+    def _make_reconciler(self):
+        """Create a Reconciler with temp file paths."""
+        with tempfile.NamedTemporaryFile(suffix=".kicad_sch", delete=False) as sf:
+            sch_path = sf.name
+        with tempfile.NamedTemporaryFile(suffix=".kicad_pcb", delete=False) as pf:
+            pcb_path = pf.name
+
+        reconciler = Reconciler.__new__(Reconciler)
+        reconciler._schematic_path = Path(sch_path)
+        reconciler._pcb_path = Path(pcb_path)
+        return reconciler, sch_path, pcb_path
+
+    def test_update_value_calls_pcb_api(self):
+        """Test that update_value uses pcb.update_footprint_value() instead of raw sexp."""
+        reconciler, sch_path, pcb_path = self._make_reconciler()
+
+        analysis = SyncAnalysis(
+            matches=[
+                SyncMatch(
+                    schematic_ref="C1",
+                    pcb_ref="C1",
+                    confidence="high",
+                    match_type="exact",
+                    actions=(
+                        {
+                            "type": "update_value",
+                            "reference": "C1",
+                            "old_value": "2.2nF 50V",
+                            "new_value": "100nF 50V",
+                        },
+                    ),
+                ),
+            ]
+        )
+
+        mock_pcb = MagicMock()
+        mock_pcb.get_board_outline.return_value = []
+        mock_pcb.update_footprint_value.return_value = True
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=mock_pcb):
+            changes = reconciler.apply(analysis, dry_run=False)
+
+        assert len(changes) == 1
+        assert changes[0].change_type == "update_value"
+        assert changes[0].applied is True
+        assert changes[0].old_value == "2.2nF 50V"
+        assert changes[0].new_value == "100nF 50V"
+        # Verify PCB API was called (not raw sexp manipulation)
+        mock_pcb.update_footprint_value.assert_called_once_with("C1", "100nF 50V")
+        mock_pcb.save.assert_called_once()
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_update_value_dry_run(self):
+        """Test that update_value in dry-run does not call PCB API."""
+        reconciler, sch_path, pcb_path = self._make_reconciler()
+
+        analysis = SyncAnalysis(
+            matches=[
+                SyncMatch(
+                    schematic_ref="C1",
+                    pcb_ref="C1",
+                    confidence="high",
+                    match_type="exact",
+                    actions=(
+                        {
+                            "type": "update_value",
+                            "reference": "C1",
+                            "old_value": "2.2nF",
+                            "new_value": "100nF",
+                        },
+                    ),
+                ),
+            ]
+        )
+
+        mock_pcb = MagicMock()
+        mock_pcb.get_board_outline.return_value = []
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=mock_pcb):
+            changes = reconciler.apply(analysis, dry_run=True)
+
+        assert len(changes) == 1
+        assert changes[0].applied is False
+        mock_pcb.update_footprint_value.assert_not_called()
+        mock_pcb.save.assert_not_called()
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_rename_calls_pcb_api(self):
+        """Test that rename uses pcb.update_footprint_reference() instead of raw sexp."""
+        reconciler, sch_path, pcb_path = self._make_reconciler()
+
+        analysis = SyncAnalysis(
+            matches=[
+                SyncMatch(
+                    schematic_ref="R1",
+                    pcb_ref="R99",
+                    confidence="high",
+                    match_type="value_footprint",
+                    actions=(
+                        {
+                            "type": "rename",
+                            "reference": "R99",
+                            "old_value": "R99",
+                            "new_value": "R1",
+                        },
+                    ),
+                ),
+            ]
+        )
+
+        mock_pcb = MagicMock()
+        mock_pcb.get_board_outline.return_value = []
+        mock_pcb.update_footprint_reference.return_value = True
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=mock_pcb):
+            changes = reconciler.apply(analysis, dry_run=False)
+
+        assert len(changes) == 1
+        assert changes[0].change_type == "rename"
+        assert changes[0].applied is True
+        mock_pcb.update_footprint_reference.assert_called_once_with("R99", "R1")
+        mock_pcb.save.assert_called_once()
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_update_value_footprint_not_found_returns_none(self):
+        """Test that update_value returns None when footprint is not found."""
+        reconciler = Reconciler.__new__(Reconciler)
+        reconciler._schematic_path = Path("/tmp/test.kicad_sch")
+        reconciler._pcb_path = Path("/tmp/test.kicad_pcb")
+
+        action = {
+            "type": "update_value",
+            "reference": "MISSING",
+            "old_value": "10k",
+            "new_value": "4.7k",
+        }
+
+        mock_pcb = MagicMock()
+        mock_pcb.update_footprint_value.return_value = False
+
+        change = reconciler._apply_update_value(mock_pcb, action, dry_run=False)
+        assert change is None
+
+
+class TestReconcilerApplyRemoveOrphans:
+    """Tests for orphan removal in Reconciler.apply()."""
+
+    def _make_reconciler(self):
+        """Create a Reconciler with temp file paths."""
+        with tempfile.NamedTemporaryFile(suffix=".kicad_sch", delete=False) as sf:
+            sch_path = sf.name
+        with tempfile.NamedTemporaryFile(suffix=".kicad_pcb", delete=False) as pf:
+            pcb_path = pf.name
+
+        reconciler = Reconciler.__new__(Reconciler)
+        reconciler._schematic_path = Path(sch_path)
+        reconciler._pcb_path = Path(pcb_path)
+        return reconciler, sch_path, pcb_path
+
+    def test_remove_orphans_applied(self):
+        """Test that orphans are removed when remove_orphans=True."""
+        reconciler, sch_path, pcb_path = self._make_reconciler()
+
+        analysis = SyncAnalysis(pcb_orphans=["J5", "R11"])
+
+        mock_pcb = MagicMock()
+        mock_pcb.get_board_outline.return_value = []
+        mock_pcb.footprint_has_traces.return_value = False
+        mock_pcb.remove_footprint.return_value = True
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=mock_pcb):
+            changes = reconciler.apply(analysis, dry_run=False, remove_orphans=True)
+
+        assert len(changes) == 2
+        assert all(c.change_type == "remove_orphan" for c in changes)
+        assert all(c.applied for c in changes)
+        assert changes[0].reference == "J5"
+        assert changes[1].reference == "R11"
+        assert mock_pcb.remove_footprint.call_count == 2
+        mock_pcb.save.assert_called_once()
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_remove_orphans_dry_run(self):
+        """Test that dry-run does not remove orphans."""
+        reconciler, sch_path, pcb_path = self._make_reconciler()
+
+        analysis = SyncAnalysis(pcb_orphans=["J5"])
+
+        mock_pcb = MagicMock()
+        mock_pcb.get_board_outline.return_value = []
+        mock_pcb.footprint_has_traces.return_value = False
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=mock_pcb):
+            changes = reconciler.apply(analysis, dry_run=True, remove_orphans=True)
+
+        assert len(changes) == 1
+        assert changes[0].applied is False
+        assert changes[0].change_type == "remove_orphan"
+        assert changes[0].new_value == "removed"
+        mock_pcb.remove_footprint.assert_not_called()
+        mock_pcb.save.assert_not_called()
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_remove_orphans_skips_traced_without_force(self):
+        """Test that orphans with traces are skipped without --force."""
+        reconciler, sch_path, pcb_path = self._make_reconciler()
+
+        analysis = SyncAnalysis(pcb_orphans=["R11"])
+
+        mock_pcb = MagicMock()
+        mock_pcb.get_board_outline.return_value = []
+        mock_pcb.footprint_has_traces.return_value = True
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=mock_pcb):
+            changes = reconciler.apply(analysis, dry_run=False, remove_orphans=True)
+
+        assert len(changes) == 1
+        assert changes[0].applied is False
+        assert "has traces" in changes[0].new_value
+        mock_pcb.remove_footprint.assert_not_called()
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_remove_orphans_force_removes_traced(self):
+        """Test that --force removes orphans even with routed traces."""
+        reconciler, sch_path, pcb_path = self._make_reconciler()
+
+        analysis = SyncAnalysis(pcb_orphans=["R11"])
+
+        mock_pcb = MagicMock()
+        mock_pcb.get_board_outline.return_value = []
+        mock_pcb.footprint_has_traces.return_value = True
+        mock_pcb.remove_footprint.return_value = True
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=mock_pcb):
+            changes = reconciler.apply(
+                analysis, dry_run=False, remove_orphans=True, force=True
+            )
+
+        assert len(changes) == 1
+        assert changes[0].applied is True
+        assert "forced" in changes[0].new_value
+        mock_pcb.remove_footprint.assert_called_once_with("R11")
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_remove_orphans_not_enabled_by_default(self):
+        """Test that orphans are NOT removed without remove_orphans=True."""
+        reconciler, sch_path, pcb_path = self._make_reconciler()
+
+        analysis = SyncAnalysis(pcb_orphans=["J5", "R11"])
+
+        mock_pcb = MagicMock()
+        mock_pcb.get_board_outline.return_value = []
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=mock_pcb):
+            changes = reconciler.apply(analysis, dry_run=False)
+
+        assert len(changes) == 0
+        mock_pcb.remove_footprint.assert_not_called()
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_remove_orphans_empty_list_no_error(self):
+        """Test that empty orphan list with remove_orphans=True produces no errors."""
+        reconciler, sch_path, pcb_path = self._make_reconciler()
+
+        analysis = SyncAnalysis(pcb_orphans=[])
+
+        mock_pcb = MagicMock()
+        mock_pcb.get_board_outline.return_value = []
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=mock_pcb):
+            changes = reconciler.apply(analysis, dry_run=False, remove_orphans=True)
+
+        assert len(changes) == 0
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_remove_orphans_dry_run_traced_shows_skip(self):
+        """Test dry-run with traced orphans shows skip message."""
+        reconciler, sch_path, pcb_path = self._make_reconciler()
+
+        analysis = SyncAnalysis(pcb_orphans=["R11"])
+
+        mock_pcb = MagicMock()
+        mock_pcb.get_board_outline.return_value = []
+        mock_pcb.footprint_has_traces.return_value = True
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=mock_pcb):
+            changes = reconciler.apply(analysis, dry_run=True, remove_orphans=True)
+
+        assert len(changes) == 1
+        assert changes[0].applied is False
+        assert "has traces" in changes[0].new_value
+        assert "--force" in changes[0].new_value
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+
 class TestReconcilerSaveMapping:
     """Tests for Reconciler.save_mapping()."""
 

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -243,6 +243,94 @@ class TestOutputChangesTableFootprintStatus:
         assert "(failed - see error)" in captured.out
 
 
+class TestSyncCLIRemoveOrphans:
+    """Tests for --remove-orphans CLI flag."""
+
+    @patch("kicad_tools.sync.reconciler.Reconciler")
+    def test_remove_orphans_flag_parsed(self, MockReconciler, capsys):
+        """Test that --remove-orphans flag is accepted and passed through."""
+        from kicad_tools.sync.reconciler import SyncAnalysis, SyncChange
+
+        analysis = SyncAnalysis(pcb_orphans=["J5"])
+        mock = MagicMock()
+        mock.analyze.return_value = analysis
+        mock.apply.return_value = [
+            SyncChange("J5", "remove_orphan", "J5", "removed", applied=True),
+        ]
+        MockReconciler.return_value = mock
+
+        result = sync_main(
+            ["--apply", "--confirm", "--remove-orphans", "project.kicad_pro"]
+        )
+        assert result == 0
+
+        # Verify remove_orphans was passed to apply()
+        call_kwargs = mock.apply.call_args
+        assert call_kwargs[1]["remove_orphans"] is True
+
+    @patch("kicad_tools.sync.reconciler.Reconciler")
+    def test_force_flag_parsed(self, MockReconciler, capsys):
+        """Test that --force flag is accepted and passed through."""
+        from kicad_tools.sync.reconciler import SyncAnalysis, SyncChange
+
+        analysis = SyncAnalysis(pcb_orphans=["R11"])
+        mock = MagicMock()
+        mock.analyze.return_value = analysis
+        mock.apply.return_value = [
+            SyncChange("R11", "remove_orphan", "R11", "removed (forced, had traces)", applied=True),
+        ]
+        MockReconciler.return_value = mock
+
+        result = sync_main(
+            ["--apply", "--confirm", "--remove-orphans", "--force", "project.kicad_pro"]
+        )
+        assert result == 0
+
+        call_kwargs = mock.apply.call_args
+        assert call_kwargs[1]["force"] is True
+
+    @patch("kicad_tools.sync.reconciler.Reconciler")
+    def test_remove_orphan_dry_run_output(self, MockReconciler, capsys):
+        """Test that remove_orphan dry-run shows '(would remove)'."""
+        from kicad_tools.sync.reconciler import SyncAnalysis, SyncChange
+
+        analysis = SyncAnalysis()
+        mock = MagicMock()
+        mock.analyze.return_value = analysis
+        mock.apply.return_value = [
+            SyncChange("J5", "remove_orphan", "J5", "removed", applied=False),
+        ]
+        MockReconciler.return_value = mock
+
+        result = sync_main(
+            ["--apply", "--dry-run", "--remove-orphans", "project.kicad_pro"]
+        )
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "(would remove)" in captured.out
+        assert "J5" in captured.out
+
+    @patch("kicad_tools.sync.reconciler.Reconciler")
+    def test_remove_orphan_applied_output(self, MockReconciler, capsys):
+        """Test that remove_orphan when applied shows '(removed)'."""
+        from kicad_tools.sync.reconciler import SyncAnalysis, SyncChange
+
+        analysis = SyncAnalysis()
+        mock = MagicMock()
+        mock.analyze.return_value = analysis
+        mock.apply.return_value = [
+            SyncChange("J5", "remove_orphan", "J5", "removed", applied=True),
+        ]
+        MockReconciler.return_value = mock
+
+        result = sync_main(
+            ["--apply", "--confirm", "--remove-orphans", "project.kicad_pro"]
+        )
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "(removed)" in captured.out
+
+
 class TestSyncCLIMapping:
     """Tests for --output-mapping flag."""
 


### PR DESCRIPTION
## Summary
Routes sync --apply value update and rename actions through the PCB object API (which handles both KiCad 7 and KiCad 8+ formats) and adds --remove-orphans flag for removing PCB footprints not present in the schematic.

## Changes
- Replace raw s-expression manipulation in _apply_action() for update_value and rename with new _apply_update_value() and _apply_rename() methods that call PCB.update_footprint_value() and PCB.update_footprint_reference()
- Add _apply_remove_orphan() method with trace-safety check (skips traced orphans unless --force)
- Add remove_orphans and force parameters to Reconciler.apply()
- Add --remove-orphans and --force CLI flags to sync_cmd.py, parser.py, and commands/sync.py
- Add remove_orphan change type to SyncChange and display handling in output table
- Add 15 new tests covering value update via PCB API, rename via PCB API, orphan removal (applied, dry-run, traced skip, force, empty list), and CLI flag parsing/output

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| sync --apply updates Value property for matched components with value mismatches | Pass | _apply_update_value() calls pcb.update_footprint_value() which handles both KiCad 7 fp_text and KiCad 8+ property formats; test_update_value_calls_pcb_api verifies |
| sync --apply --remove-orphans removes footprints not present in schematic | Pass | _apply_remove_orphan() calls pcb.remove_footprint(); test_remove_orphans_applied verifies |
| Orphan removal requires explicit opt-in (not default behavior) | Pass | remove_orphans defaults to False; test_remove_orphans_not_enabled_by_default verifies |
| Both operations respect --dry-run | Pass | test_update_value_dry_run and test_remove_orphans_dry_run verify no PCB modification in dry-run |

## Test Plan
- 106 tests pass (all existing + 15 new) via python3 -m pytest tests/test_sync.py tests/test_sync_cli.py
- New tests cover: update_value via PCB API (applied, dry-run, not-found), rename via PCB API, orphan removal (applied, dry-run, traced skip, force, empty list, dry-run traced), CLI flag parsing and output display

Closes #2208