### PR TITLE
fix(erc): filter phantom wire_dangling violations with no matching schematic coordinates

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -31,6 +31,7 @@ from kicad_tools.cli.runner import find_kicad_cli
 from kicad_tools.erc.cross_sheet import (
     filter_cross_sheet_global_labels,
     filter_cross_sheet_power_violations,
+    filter_phantom_wire_violations,
     reattribute_wire_dangling_violations,
 )
 from kicad_tools.schema import Schematic
@@ -161,6 +162,13 @@ def run_erc(schematic_path: str) -> list[ValidationIssue]:
                         # violations from root sheet to the correct child
                         # sheet based on position coordinates.
                         raw_violations = reattribute_wire_dangling_violations(
+                            raw_violations, schematic_path
+                        )
+
+                        # Filter phantom wire_dangling violations whose
+                        # coordinates do not correspond to any wire,
+                        # junction, or label in the schematic files.
+                        raw_violations = filter_phantom_wire_violations(
                             raw_violations, schematic_path
                         )
 

--- a/src/kicad_tools/erc/cross_sheet.py
+++ b/src/kicad_tools/erc/cross_sheet.py
@@ -696,3 +696,164 @@ def _enrich_description_with_pos(v: dict) -> None:
     desc = v.get("description", "")
     if coord_str not in desc:
         v["description"] = f"{desc} {coord_str}"
+
+
+# ---------------------------------------------------------------------------
+# Phantom wire-dangling violation filtering
+# ---------------------------------------------------------------------------
+
+
+def _build_full_wire_coordinate_set(
+    root_schematic: str,
+    tolerance: float = 0.1,
+) -> set[tuple[float, float]]:
+    """Build a set of all known wire-related coordinates across the full hierarchy.
+
+    Unlike :func:`_build_wire_endpoint_map`, this includes the **root sheet**
+    and indexes additional coordinate sources (junctions, labels, hierarchical
+    labels, global labels) that KiCad's connectivity engine may use as
+    sub-segment break-points.
+
+    The returned set can be used to distinguish *real* ``wire_dangling``
+    violations (whose positions correspond to actual schematic objects) from
+    *phantom* violations (whose positions are internal to KiCad's connectivity
+    analysis and do not correspond to any S-expression in the ``.kicad_sch``
+    files).
+
+    Args:
+        root_schematic: Path to the root ``.kicad_sch`` file.
+        tolerance: Coordinate snapping bucket size in mm.
+
+    Returns:
+        A set of snapped ``(x, y)`` coordinate tuples.
+    """
+    from kicad_tools.schema import Schematic
+    from kicad_tools.schema.hierarchy import build_hierarchy
+
+    hierarchy = build_hierarchy(root_schematic)
+    coords: set[tuple[float, float]] = set()
+
+    def _snap(v: float) -> float:
+        return round(v / tolerance) * tolerance
+
+    for node in hierarchy.all_nodes():
+        try:
+            sch = Schematic.load(node.path)
+        except Exception:
+            continue
+
+        # Wire endpoints and midpoints
+        for wire in sch.wires:
+            sx, sy = wire.start[0], wire.start[1]
+            ex, ey = wire.end[0], wire.end[1]
+            coords.add((_snap(sx), _snap(sy)))
+            coords.add((_snap(ex), _snap(ey)))
+            mx = (sx + ex) / 2.0
+            my = (sy + ey) / 2.0
+            coords.add((_snap(mx), _snap(my)))
+
+        # Junctions
+        for junc in sch.junctions:
+            jx, jy = junc.position[0], junc.position[1]
+            coords.add((_snap(jx), _snap(jy)))
+
+        # Local labels
+        for lbl in sch.labels:
+            lx, ly = lbl.position[0], lbl.position[1]
+            coords.add((_snap(lx), _snap(ly)))
+
+        # Global labels
+        for gl in sch.global_labels:
+            gx, gy = gl.position[0], gl.position[1]
+            coords.add((_snap(gx), _snap(gy)))
+
+        # Hierarchical labels
+        for hl in sch.hierarchical_labels:
+            hx, hy = hl.position[0], hl.position[1]
+            coords.add((_snap(hx), _snap(hy)))
+
+    return coords
+
+
+def filter_phantom_wire_violations(
+    violations: list[dict],
+    root_schematic: str,
+) -> list[dict]:
+    """Remove phantom ``wire_dangling`` violations whose position coordinates
+    do not correspond to any wire endpoint, midpoint, junction, or label
+    in any sheet of the hierarchy.
+
+    KiCad's connectivity engine internally splits wires into sub-segments
+    at pin connections, junctions, and other connection points.  It may
+    then report ``wire_dangling`` violations at the computed sub-segment
+    coordinates -- coordinates that do not appear in any ``.kicad_sch``
+    file.  These are false positives that cannot be resolved by editing
+    the schematic.
+
+    This function builds a comprehensive coordinate index of all wire
+    endpoints/midpoints, junctions, and labels across the full hierarchy
+    (including the root sheet) and suppresses any ``wire_dangling``
+    violation whose position does not match any indexed coordinate.
+
+    Only ``wire_dangling`` violations are filtered.  Other position-based
+    violation types (``endpoint_off_grid``, ``label_dangling``, etc.) are
+    passed through unchanged because they have different semantics.
+
+    Filtered violations are logged at debug level for diagnostics.
+
+    Args:
+        violations: List of raw violation dicts (must already have
+            ``_sheet_path`` injected and re-attribution applied).
+        root_schematic: Path to the root ``.kicad_sch`` file.
+
+    Returns:
+        A new list with phantom ``wire_dangling`` violations removed.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    target_type = "wire_dangling"
+
+    # Quick check: skip the expensive hierarchy traversal if there are
+    # no wire_dangling violations at all.
+    has_target = any(v.get("type", "") == target_type for v in violations)
+    if not has_target:
+        return violations
+
+    tolerance = 0.1
+    known_coords = _build_full_wire_coordinate_set(root_schematic, tolerance=tolerance)
+
+    def _snap(val: float) -> float:
+        return round(val / tolerance) * tolerance
+
+    filtered: list[dict] = []
+    for v in violations:
+        if v.get("type", "") != target_type:
+            filtered.append(v)
+            continue
+
+        pos = v.get("pos", {})
+        x = pos.get("x", None)
+        y = pos.get("y", None)
+
+        if x is None or y is None:
+            # No position data -- keep to be safe.
+            filtered.append(v)
+            continue
+
+        key = (_snap(float(x)), _snap(float(y)))
+        if key in known_coords:
+            # Position matches a real schematic object -- keep it.
+            filtered.append(v)
+        else:
+            # Phantom violation -- coordinates do not correspond to any
+            # wire, junction, or label in any sheet.
+            logger.debug(
+                "Filtered phantom wire_dangling at (%.1f, %.1f) on sheet %s",
+                float(x),
+                float(y),
+                v.get("_sheet_path", "?"),
+            )
+
+    return filtered

--- a/tests/test_sch_validate_wire_dangling.py
+++ b/tests/test_sch_validate_wire_dangling.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 from kicad_tools.cli.sch_validate import ValidationIssue, run_erc
 from kicad_tools.erc.cross_sheet import (
     _enrich_description_with_pos,
+    filter_phantom_wire_violations,
     reattribute_wire_dangling_violations,
 )
 
@@ -354,6 +355,10 @@ class TestRunERCWireDanglingIntegration:
                 "kicad_tools.cli.sch_validate.reattribute_wire_dangling_violations",
                 side_effect=lambda v, p: v,
             ),
+            patch(
+                "kicad_tools.cli.sch_validate.filter_phantom_wire_violations",
+                side_effect=lambda v, p: v,
+            ),
             patch("tempfile.NamedTemporaryFile", return_value=_FakeTmp()),
         ):
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
@@ -665,3 +670,509 @@ class TestWireMidpointMatching:
             result = reattribute_wire_dangling_violations(violations, "test.kicad_sch")
 
         assert result[0]["_sheet_path"] == "/Power/Regulator"
+
+
+# ---------------------------------------------------------------------------
+# Helpers for phantom filtering tests
+# ---------------------------------------------------------------------------
+
+
+def _make_full_hierarchy_mocks(
+    sheets: list[dict],
+):
+    """Build fake hierarchy and schematics for phantom filtering tests.
+
+    Each entry in *sheets* is a dict with:
+      - ``path``: sheet path string (e.g. ``"/"``, ``"/DAC"``)
+      - ``is_root``: bool
+      - ``file``: fake file path
+      - ``wires``: list of ``(start, end)`` tuples
+      - ``junctions``: list of ``(x, y)`` tuples  (optional)
+      - ``labels``: list of ``(x, y)`` tuples  (optional)
+      - ``global_labels``: list of ``(x, y)`` tuples  (optional)
+      - ``hierarchical_labels``: list of ``(x, y)`` tuples  (optional)
+    """
+    nodes = []
+    sch_by_file: dict[str, MagicMock] = {}
+
+    for s in sheets:
+        node = MagicMock()
+        node.is_root = s.get("is_root", False)
+        node.path = s["file"]
+        node.get_path_string.return_value = s["path"]
+        nodes.append(node)
+
+        sch = MagicMock()
+
+        wires = []
+        for start, end in s.get("wires", []):
+            w = MagicMock()
+            w.start = start
+            w.end = end
+            wires.append(w)
+        sch.wires = wires
+
+        juncs = []
+        for pos in s.get("junctions", []):
+            j = MagicMock()
+            j.position = pos
+            juncs.append(j)
+        sch.junctions = juncs
+
+        labels = []
+        for pos in s.get("labels", []):
+            lbl = MagicMock()
+            lbl.position = pos
+            labels.append(lbl)
+        sch.labels = labels
+
+        gls = []
+        for pos in s.get("global_labels", []):
+            gl = MagicMock()
+            gl.position = pos
+            gls.append(gl)
+        sch.global_labels = gls
+
+        hls = []
+        for pos in s.get("hierarchical_labels", []):
+            hl = MagicMock()
+            hl.position = pos
+            hls.append(hl)
+        sch.hierarchical_labels = hls
+
+        sch_by_file[s["file"]] = sch
+
+    fake_hierarchy = MagicMock()
+    fake_hierarchy.all_nodes.return_value = nodes
+
+    def load_side_effect(path):
+        return sch_by_file[path]
+
+    return fake_hierarchy, load_side_effect
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: filter_phantom_wire_violations
+# ---------------------------------------------------------------------------
+
+
+class TestFilterPhantomWireViolations:
+    """Test phantom wire_dangling violation filtering."""
+
+    def test_phantom_violation_filtered(self):
+        """A wire_dangling at coordinates not matching any wire is removed."""
+        violations = [_wire_dangling(999.0, 888.0)]
+        violations[0]["_sheet_path"] = "/"
+
+        sheets = [
+            {
+                "path": "/",
+                "is_root": True,
+                "file": "/tmp/root.kicad_sch",
+                "wires": [((100.0, 50.0), (100.0, 80.0))],
+            },
+            {
+                "path": "/DAC",
+                "is_root": False,
+                "file": "/tmp/dac.kicad_sch",
+                "wires": [((200.0, 30.0), (200.0, 60.0))],
+            },
+        ]
+        fake_hierarchy, load_fn = _make_full_hierarchy_mocks(sheets)
+
+        with (
+            patch(
+                "kicad_tools.schema.hierarchy.build_hierarchy",
+                return_value=fake_hierarchy,
+            ),
+            patch(
+                "kicad_tools.schema.Schematic.load",
+                side_effect=load_fn,
+            ),
+        ):
+            result = filter_phantom_wire_violations(violations, "root.kicad_sch")
+
+        assert len(result) == 0
+
+    def test_real_violation_at_wire_endpoint_preserved(self):
+        """A wire_dangling at a real wire endpoint is kept."""
+        violations = [_wire_dangling(100.0, 50.0)]
+        violations[0]["_sheet_path"] = "/DAC"
+
+        sheets = [
+            {
+                "path": "/",
+                "is_root": True,
+                "file": "/tmp/root.kicad_sch",
+                "wires": [],
+            },
+            {
+                "path": "/DAC",
+                "is_root": False,
+                "file": "/tmp/dac.kicad_sch",
+                "wires": [((100.0, 50.0), (100.0, 80.0))],
+            },
+        ]
+        fake_hierarchy, load_fn = _make_full_hierarchy_mocks(sheets)
+
+        with (
+            patch(
+                "kicad_tools.schema.hierarchy.build_hierarchy",
+                return_value=fake_hierarchy,
+            ),
+            patch(
+                "kicad_tools.schema.Schematic.load",
+                side_effect=load_fn,
+            ),
+        ):
+            result = filter_phantom_wire_violations(violations, "root.kicad_sch")
+
+        assert len(result) == 1
+
+    def test_real_violation_at_root_wire_preserved(self):
+        """A wire_dangling at a root-sheet wire endpoint is preserved."""
+        violations = [_wire_dangling(50.0, 25.0)]
+        violations[0]["_sheet_path"] = "/"
+
+        sheets = [
+            {
+                "path": "/",
+                "is_root": True,
+                "file": "/tmp/root.kicad_sch",
+                "wires": [((50.0, 25.0), (50.0, 75.0))],
+            },
+        ]
+        fake_hierarchy, load_fn = _make_full_hierarchy_mocks(sheets)
+
+        with (
+            patch(
+                "kicad_tools.schema.hierarchy.build_hierarchy",
+                return_value=fake_hierarchy,
+            ),
+            patch(
+                "kicad_tools.schema.Schematic.load",
+                side_effect=load_fn,
+            ),
+        ):
+            result = filter_phantom_wire_violations(violations, "root.kicad_sch")
+
+        assert len(result) == 1
+        assert result[0]["_sheet_path"] == "/"
+
+    def test_violation_at_junction_preserved(self):
+        """A wire_dangling at a junction position is preserved."""
+        violations = [_wire_dangling(75.0, 40.0)]
+        violations[0]["_sheet_path"] = "/"
+
+        sheets = [
+            {
+                "path": "/",
+                "is_root": True,
+                "file": "/tmp/root.kicad_sch",
+                "wires": [],
+                "junctions": [(75.0, 40.0)],
+            },
+        ]
+        fake_hierarchy, load_fn = _make_full_hierarchy_mocks(sheets)
+
+        with (
+            patch(
+                "kicad_tools.schema.hierarchy.build_hierarchy",
+                return_value=fake_hierarchy,
+            ),
+            patch(
+                "kicad_tools.schema.Schematic.load",
+                side_effect=load_fn,
+            ),
+        ):
+            result = filter_phantom_wire_violations(violations, "root.kicad_sch")
+
+        assert len(result) == 1
+
+    def test_violation_at_label_preserved(self):
+        """A wire_dangling at a label position is preserved."""
+        violations = [_wire_dangling(60.0, 30.0)]
+        violations[0]["_sheet_path"] = "/DAC"
+
+        sheets = [
+            {
+                "path": "/",
+                "is_root": True,
+                "file": "/tmp/root.kicad_sch",
+                "wires": [],
+            },
+            {
+                "path": "/DAC",
+                "is_root": False,
+                "file": "/tmp/dac.kicad_sch",
+                "wires": [],
+                "labels": [(60.0, 30.0)],
+            },
+        ]
+        fake_hierarchy, load_fn = _make_full_hierarchy_mocks(sheets)
+
+        with (
+            patch(
+                "kicad_tools.schema.hierarchy.build_hierarchy",
+                return_value=fake_hierarchy,
+            ),
+            patch(
+                "kicad_tools.schema.Schematic.load",
+                side_effect=load_fn,
+            ),
+        ):
+            result = filter_phantom_wire_violations(violations, "root.kicad_sch")
+
+        assert len(result) == 1
+
+    def test_non_wire_dangling_types_pass_through(self):
+        """Non-wire_dangling violations (e.g. endpoint_off_grid) pass through even at phantom coords."""
+        violations = [_endpoint_off_grid(999.0, 888.0)]
+        violations[0]["_sheet_path"] = "/"
+
+        sheets = [
+            {
+                "path": "/",
+                "is_root": True,
+                "file": "/tmp/root.kicad_sch",
+                "wires": [((100.0, 50.0), (100.0, 80.0))],
+            },
+        ]
+        fake_hierarchy, load_fn = _make_full_hierarchy_mocks(sheets)
+
+        with (
+            patch(
+                "kicad_tools.schema.hierarchy.build_hierarchy",
+                return_value=fake_hierarchy,
+            ),
+            patch(
+                "kicad_tools.schema.Schematic.load",
+                side_effect=load_fn,
+            ),
+        ):
+            result = filter_phantom_wire_violations(violations, "root.kicad_sch")
+
+        assert len(result) == 1
+
+    def test_no_wire_dangling_skips_hierarchy(self):
+        """When no wire_dangling violations exist, hierarchy is not built."""
+        violations = [
+            {
+                "type": "pin_not_connected",
+                "severity": "error",
+                "description": "Pin not connected",
+                "_sheet_path": "/",
+                "items": [],
+            }
+        ]
+        with patch(
+            "kicad_tools.schema.hierarchy.build_hierarchy"
+        ) as mock_build:
+            filter_phantom_wire_violations(violations, "test.kicad_sch")
+            mock_build.assert_not_called()
+
+    def test_tolerance_matching_for_phantom_detection(self):
+        """Coordinates within tolerance (0.1mm) of a real wire match and are kept."""
+        violations = [_wire_dangling(100.04, 50.03)]
+        violations[0]["_sheet_path"] = "/"
+
+        sheets = [
+            {
+                "path": "/",
+                "is_root": True,
+                "file": "/tmp/root.kicad_sch",
+                "wires": [((100.0, 50.0), (100.0, 80.0))],
+            },
+        ]
+        fake_hierarchy, load_fn = _make_full_hierarchy_mocks(sheets)
+
+        with (
+            patch(
+                "kicad_tools.schema.hierarchy.build_hierarchy",
+                return_value=fake_hierarchy,
+            ),
+            patch(
+                "kicad_tools.schema.Schematic.load",
+                side_effect=load_fn,
+            ),
+        ):
+            result = filter_phantom_wire_violations(violations, "root.kicad_sch")
+
+        assert len(result) == 1
+
+    def test_flat_schematic_no_filtering(self):
+        """In a flat schematic (no hierarchy), real violations are preserved."""
+        violations = [_wire_dangling(100.0, 50.0)]
+        violations[0]["_sheet_path"] = "/"
+
+        sheets = [
+            {
+                "path": "/",
+                "is_root": True,
+                "file": "/tmp/root.kicad_sch",
+                "wires": [((100.0, 50.0), (100.0, 80.0))],
+            },
+        ]
+        fake_hierarchy, load_fn = _make_full_hierarchy_mocks(sheets)
+
+        with (
+            patch(
+                "kicad_tools.schema.hierarchy.build_hierarchy",
+                return_value=fake_hierarchy,
+            ),
+            patch(
+                "kicad_tools.schema.Schematic.load",
+                side_effect=load_fn,
+            ),
+        ):
+            result = filter_phantom_wire_violations(violations, "root.kicad_sch")
+
+        assert len(result) == 1
+
+    def test_missing_pos_data_kept(self):
+        """A wire_dangling violation with no pos data is kept (safety fallback)."""
+        violations = [
+            {
+                "type": "wire_dangling",
+                "severity": "warning",
+                "description": "Wire not connected",
+                "_sheet_path": "/",
+                "items": [],
+            }
+        ]
+
+        sheets = [
+            {
+                "path": "/",
+                "is_root": True,
+                "file": "/tmp/root.kicad_sch",
+                "wires": [],
+            },
+        ]
+        fake_hierarchy, load_fn = _make_full_hierarchy_mocks(sheets)
+
+        with (
+            patch(
+                "kicad_tools.schema.hierarchy.build_hierarchy",
+                return_value=fake_hierarchy,
+            ),
+            patch(
+                "kicad_tools.schema.Schematic.load",
+                side_effect=load_fn,
+            ),
+        ):
+            result = filter_phantom_wire_violations(violations, "root.kicad_sch")
+
+        assert len(result) == 1
+
+    def test_mixed_real_and_phantom_violations(self):
+        """Real and phantom wire_dangling violations are correctly separated."""
+        v_real = _wire_dangling(100.0, 50.0)
+        v_real["_sheet_path"] = "/"
+        v_phantom = _wire_dangling(777.0, 666.0)
+        v_phantom["_sheet_path"] = "/"
+        v_other = {
+            "type": "pin_not_connected",
+            "severity": "error",
+            "description": "Pin not connected",
+            "_sheet_path": "/",
+            "items": [],
+        }
+        violations = [v_real, v_phantom, v_other]
+
+        sheets = [
+            {
+                "path": "/",
+                "is_root": True,
+                "file": "/tmp/root.kicad_sch",
+                "wires": [((100.0, 50.0), (100.0, 80.0))],
+            },
+        ]
+        fake_hierarchy, load_fn = _make_full_hierarchy_mocks(sheets)
+
+        with (
+            patch(
+                "kicad_tools.schema.hierarchy.build_hierarchy",
+                return_value=fake_hierarchy,
+            ),
+            patch(
+                "kicad_tools.schema.Schematic.load",
+                side_effect=load_fn,
+            ),
+        ):
+            result = filter_phantom_wire_violations(violations, "root.kicad_sch")
+
+        assert len(result) == 2
+        types = [v.get("type") for v in result]
+        assert "wire_dangling" in types
+        assert "pin_not_connected" in types
+        # The phantom one should be gone
+        positions = [
+            (v["pos"]["x"], v["pos"]["y"])
+            for v in result
+            if v.get("type") == "wire_dangling"
+        ]
+        assert (100.0, 50.0) in positions
+        assert (777.0, 666.0) not in positions
+
+
+# ---------------------------------------------------------------------------
+# Integration test: run_erc with phantom filtering in pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestRunERCPhantomFilterIntegration:
+    """Verify that filter_phantom_wire_violations is called in run_erc pipeline."""
+
+    def test_phantom_filter_called_in_pipeline(self):
+        """Verify that filter_phantom_wire_violations is invoked during run_erc."""
+        erc_json = _make_erc_json(
+            [_make_sheet("/", [_wire_dangling(100.0, 50.0)])]
+        )
+
+        tmp = _tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
+        tmp.write(erc_json)
+        tmp.close()
+
+        class _FakeTmp:
+            name = tmp.name
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        with (
+            patch(
+                "kicad_tools.cli.sch_validate.find_kicad_cli",
+                return_value="/usr/bin/kicad-cli",
+            ),
+            patch("kicad_tools.cli.sch_validate.subprocess.run") as mock_run,
+            patch(
+                "kicad_tools.cli.sch_validate.filter_cross_sheet_global_labels",
+                side_effect=lambda v, p: v,
+            ),
+            patch(
+                "kicad_tools.cli.sch_validate.filter_cross_sheet_power_violations",
+                side_effect=lambda v, p: v,
+            ),
+            patch(
+                "kicad_tools.cli.sch_validate.reattribute_wire_dangling_violations",
+                side_effect=lambda v, p: v,
+            ),
+            patch(
+                "kicad_tools.cli.sch_validate.filter_phantom_wire_violations",
+                side_effect=lambda v, p: v,
+            ) as mock_phantom,
+            patch("tempfile.NamedTemporaryFile", return_value=_FakeTmp()),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            run_erc("test.kicad_sch")
+
+        mock_phantom.assert_called_once()
+        args = mock_phantom.call_args[0]
+        assert args[1] == "test.kicad_sch"
+
+        if os.path.exists(tmp.name):
+            os.unlink(tmp.name)


### PR DESCRIPTION
## Summary

Filter out phantom `wire_dangling` violations from KiCad's ERC engine whose position coordinates do not correspond to any wire endpoint, midpoint, junction, or label in any `.kicad_sch` file across the hierarchy. These false positives originate from KiCad's internal connectivity engine splitting wires into sub-segments at computed coordinates.

## Changes

- Added `_build_full_wire_coordinate_set()` in `cross_sheet.py` that indexes all wire endpoints/midpoints, junctions, labels, global labels, and hierarchical labels across the full hierarchy (including root sheet)
- Added `filter_phantom_wire_violations()` in `cross_sheet.py` that removes `wire_dangling` violations whose coordinates match no known schematic object; filtered phantoms are logged at debug level
- Integrated `filter_phantom_wire_violations()` into the `run_erc()` pipeline in `sch_validate.py`, called after `reattribute_wire_dangling_violations()`
- Added 12 new test cases covering phantom filtering, real violation preservation, tolerance matching, flat schematics, missing position data, and pipeline integration
- Updated existing integration test mocks to include the new filter function

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| wire_dangling violations with phantom coordinates are filtered | PASS | `test_phantom_violation_filtered` and `test_mixed_real_and_phantom_violations` verify removal |
| Filtered phantoms are logged at debug level | PASS | `filter_phantom_wire_violations()` calls `logger.debug()` for each filtered violation |
| Real wire_dangling violations at actual wire endpoints are preserved | PASS | `test_real_violation_at_wire_endpoint_preserved` and `test_real_violation_at_root_wire_preserved` verify retention |
| Violations at junctions and labels are preserved | PASS | `test_violation_at_junction_preserved` and `test_violation_at_label_preserved` verify retention |
| Non-wire_dangling types pass through unchanged | PASS | `test_non_wire_dangling_types_pass_through` verifies endpoint_off_grid is not filtered |
| Tolerance matching works within 0.1mm | PASS | `test_tolerance_matching_for_phantom_detection` verifies coordinate snapping |
| Flat schematic (no hierarchy) works correctly | PASS | `test_flat_schematic_no_filtering` verifies no false filtering |
| No regression in existing tests | PASS | All 36 tests in test_sch_validate_wire_dangling.py pass |

## Test Plan

All 36 tests pass in `tests/test_sch_validate_wire_dangling.py` (24 existing + 12 new). The 2 failures in the broader test suite (`test_mcp_http.py`, `test_pipeline_cmd.py`) are pre-existing and unrelated.

Closes #2205