### PR TITLE
feat(drc): add footprint nudge for pad-pad clearance violations

### DIFF
--- a/src/kicad_tools/cli/repair_clearance_cmd.py
+++ b/src/kicad_tools/cli/repair_clearance_cmd.py
@@ -36,7 +36,12 @@ import json
 import sys
 from pathlib import Path
 
-from kicad_tools.drc.repair_clearance import ClearanceRepairer, NudgeResult, RepairResult
+from kicad_tools.drc.repair_clearance import (
+    ClearanceRepairer,
+    FootprintNudgeResult,
+    NudgeResult,
+    RepairResult,
+)
 from kicad_tools.drc.report import DRCReport
 from kicad_tools.manufacturers import get_manufacturer_ids
 
@@ -92,6 +97,11 @@ Examples:
         help="Which object to move when both are movable (default: move-trace)",
     )
     parser.add_argument(
+        "--nudge-footprints",
+        action="store_true",
+        help="Enable footprint nudging for pad-pad clearance violations",
+    )
+    parser.add_argument(
         "-o",
         "--output",
         help="Output file path (default: overwrite input)",
@@ -135,13 +145,18 @@ Examples:
     from kicad_tools.drc.violation import ViolationType
 
     clearance_count = len(report.by_type(ViolationType.CLEARANCE))
-    if clearance_count == 0:
+    pad_pad_count = len(report.by_type(ViolationType.CLEARANCE_PAD_PAD)) if args.nudge_footprints else 0
+    total_count = clearance_count + pad_pad_count
+    if total_count == 0:
         if not args.quiet:
             print("No clearance violations found. Nothing to repair.")
         return 0
 
     if not args.quiet and args.format == "text":
-        print(f"Found {clearance_count} clearance violation(s) to repair")
+        msg = f"Found {clearance_count} clearance violation(s) to repair"
+        if pad_pad_count > 0:
+            msg += f" + {pad_pad_count} pad-pad violation(s)"
+        print(msg)
 
     # Create repairer and run
     try:
@@ -156,6 +171,7 @@ Examples:
         margin=args.margin,
         prefer=args.prefer,
         dry_run=args.dry_run,
+        nudge_footprints=args.nudge_footprints,
     )
 
     # Print results
@@ -281,6 +297,20 @@ def _print_json(
             }
             for n in result.nudges
         ],
+        "footprint_nudges": [
+            {
+                "reference": fn.reference,
+                "other_reference": fn.other_reference,
+                "x": fn.x,
+                "y": fn.y,
+                "displacement_x_mm": round(fn.displacement_x, 4),
+                "displacement_y_mm": round(fn.displacement_y, 4),
+                "displacement_mm": round(fn.displacement_mm, 4),
+                "old_clearance_mm": round(fn.old_clearance_mm, 4),
+                "new_clearance_mm": round(fn.new_clearance_mm, 4),
+            }
+            for fn in result.footprint_nudge_results
+        ],
     }
     print(json.dumps(data, indent=2))
 
@@ -323,12 +353,31 @@ def _print_text(
         if len(result.nudges) > 5:
             print(f"\n  ... and {len(result.nudges) - 3} more")
 
+    if result.footprint_nudge_results:
+        print(f"\n{'-' * 60}")
+        print("FOOTPRINT NUDGES:")
+
+        display_fp_nudges = (
+            result.footprint_nudge_results
+            if len(result.footprint_nudge_results) <= 5
+            else result.footprint_nudge_results[:3]
+        )
+        for fn in display_fp_nudges:
+            _print_footprint_nudge(fn)
+
+        if len(result.footprint_nudge_results) > 5:
+            print(f"\n  ... and {len(result.footprint_nudge_results) - 3} more")
+
     # Show skipped details
     skipped_total = (
         result.skipped_exceeds_max
         + result.skipped_infeasible
         + result.skipped_no_location
         + result.skipped_no_delta
+        + result.footprint_skipped_locked
+        + result.footprint_skipped_connector
+        + result.footprint_skipped_same_component
+        + result.footprint_skipped_exceeds_max
     )
     if skipped_total > 0:
         print(f"\n{'-' * 60}")
@@ -341,6 +390,14 @@ def _print_text(
             print(f"  No location info: {result.skipped_no_location}")
         if result.skipped_no_delta > 0:
             print(f"  No clearance delta info: {result.skipped_no_delta}")
+        if result.footprint_skipped_locked > 0:
+            print(f"  Footprint locked: {result.footprint_skipped_locked}")
+        if result.footprint_skipped_connector > 0:
+            print(f"  Connector footprint: {result.footprint_skipped_connector}")
+        if result.footprint_skipped_same_component > 0:
+            print(f"  Same-component pads: {result.footprint_skipped_same_component}")
+        if result.footprint_skipped_exceeds_max > 0:
+            print(f"  Footprint exceeds max displacement: {result.footprint_skipped_exceeds_max}")
 
     print(f"\n{'=' * 60}")
 
@@ -363,6 +420,19 @@ def _print_nudge(nudge: NudgeResult) -> None:
     )
     print(
         f"    Clearance: {nudge.old_clearance_mm:.4f} -> {nudge.new_clearance_mm:.4f} mm"
+    )
+
+
+def _print_footprint_nudge(fn: FootprintNudgeResult) -> None:
+    """Print a single footprint nudge result."""
+    print(f"\n  [{fn.reference}] away from [{fn.other_reference}]")
+    print(f"    Position: ({fn.x:.4f}, {fn.y:.4f})")
+    print(
+        f"    Displacement: ({fn.displacement_x:+.4f}, {fn.displacement_y:+.4f}) mm "
+        f"= {fn.displacement_mm:.4f} mm"
+    )
+    print(
+        f"    Clearance: {fn.old_clearance_mm:.4f} -> {fn.new_clearance_mm:.4f} mm"
     )
 
 

--- a/src/kicad_tools/drc/repair_clearance.py
+++ b/src/kicad_tools/drc/repair_clearance.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 from ..sexp import SExp, parse_file
 from .net_compat import resolve_net_atom
 from .report import DRCReport
-from .violation import DRCViolation, ViolationType
+from .violation import DRCViolation, ViolationType, _extract_component_refs
 
 if TYPE_CHECKING:
     from .local_rerouter import LocalRerouter
@@ -59,6 +59,28 @@ class NudgeResult:
 
 
 @dataclass
+class FootprintNudgeResult:
+    """Record of a footprint nudge applied to fix a pad-pad clearance violation."""
+
+    reference: str
+    x: float
+    y: float
+    displacement_x: float
+    displacement_y: float
+    displacement_mm: float
+    old_clearance_mm: float
+    new_clearance_mm: float
+    other_reference: str
+
+    def __str__(self) -> str:
+        return (
+            f"footprint [{self.reference}] at ({self.x:.4f}, {self.y:.4f}): "
+            f"nudged {self.displacement_mm:.4f}mm away from {self.other_reference} "
+            f"(clearance {self.old_clearance_mm:.4f} -> {self.new_clearance_mm:.4f}mm)"
+        )
+
+
+@dataclass
 class RepairResult:
     """Summary of a clearance repair operation."""
 
@@ -74,7 +96,13 @@ class RepairResult:
     local_rerouted: int = 0
     cluster_rerouted: int = 0
     skipped_no_local_route: int = 0
+    footprint_nudges: int = 0
+    footprint_skipped_locked: int = 0
+    footprint_skipped_connector: int = 0
+    footprint_skipped_same_component: int = 0
+    footprint_skipped_exceeds_max: int = 0
     nudges: list[NudgeResult] = field(default_factory=list)
+    footprint_nudge_results: list[FootprintNudgeResult] = field(default_factory=list)
 
     @property
     def success_rate(self) -> float:
@@ -96,6 +124,14 @@ class RepairResult:
             lines.append(f"  Local reroutes: {self.local_rerouted}")
         if self.cluster_rerouted > 0:
             lines.append(f"  Cluster reroutes: {self.cluster_rerouted}")
+        if self.footprint_nudges > 0:
+            lines.append(f"  Footprint nudges (pad-pad): {self.footprint_nudges}")
+        if self.footprint_skipped_locked > 0:
+            lines.append(f"  Skipped (footprint locked): {self.footprint_skipped_locked}")
+        if self.footprint_skipped_connector > 0:
+            lines.append(f"  Skipped (connector footprint): {self.footprint_skipped_connector}")
+        if self.footprint_skipped_same_component > 0:
+            lines.append(f"  Skipped (same component pads): {self.footprint_skipped_same_component}")
         if self.skipped_exceeds_max > 0:
             lines.append(f"  Skipped (exceeds max displacement): {self.skipped_exceeds_max}")
         if self.skipped_infeasible > 0:
@@ -166,6 +202,7 @@ class ClearanceRepairer:
         dry_run: bool = False,
         local_reroute: bool = False,
         local_grid_padding: float = 0.5,
+        nudge_footprints: bool = False,
     ) -> RepairResult:
         """Repair clearance violations using a DRC report.
 
@@ -180,6 +217,8 @@ class ClearanceRepairer:
                           infeasible violations after nudge phase
             local_grid_padding: Padding around segment bounding box for
                                local reroute grid (mm, default: 0.5)
+            nudge_footprints: If True, attempt footprint nudges for
+                             pad-pad clearance violations (Phase 3)
 
         Returns:
             RepairResult with details of all repairs
@@ -266,6 +305,12 @@ class ClearanceRepairer:
                 self._run_local_reroute_phase(
                     all_reroute_candidates, result, margin, dry_run, local_grid_padding
                 )
+
+        # Phase 3: Footprint nudging for pad-pad violations
+        if nudge_footprints:
+            self._repair_pad_pad_violations(
+                report, result, max_displacement, margin, dry_run
+            )
 
         return result
 
@@ -1553,6 +1598,296 @@ class ClearanceRepairer:
             if item_lower.startswith("zone") or "zone " in item_lower:
                 return True
         return False
+
+    def _repair_pad_pad_violations(
+        self,
+        report: DRCReport,
+        result: RepairResult,
+        max_displacement: float,
+        margin: float,
+        dry_run: bool,
+    ) -> None:
+        """Phase 3: Repair pad-pad clearance violations by nudging footprints.
+
+        For each CLEARANCE_PAD_PAD violation between different components,
+        selects the smaller/less-connected footprint and nudges it away
+        from the other to resolve the clearance deficit.
+
+        Skips:
+        - Same-component violations (inherent to footprint geometry)
+        - Locked footprints (both locked -> skip entirely)
+        - Connector footprints (J-prefix references)
+        - Violations exceeding max_displacement
+        """
+        pad_pad_violations = [
+            v for v in report.by_type(ViolationType.CLEARANCE_PAD_PAD)
+            if not self._is_zone_fill_violation(v)
+        ]
+
+        for violation in pad_pad_violations:
+            # Skip same-component violations
+            if violation.is_same_component_pad_clearance():
+                result.footprint_skipped_same_component += 1
+                continue
+
+            delta = violation.delta_mm
+            if delta is None:
+                result.skipped_no_delta += 1
+                result.total_violations += 1
+                continue
+
+            required_displacement = delta + margin
+            result.total_violations += 1
+
+            if required_displacement > max_displacement:
+                result.footprint_skipped_exceeds_max += 1
+                continue
+
+            if len(violation.locations) < 2:
+                result.skipped_no_location += 1
+                continue
+
+            # Extract component references from the violation
+            refs = _extract_component_refs(violation.items)
+            if len(refs) < 2:
+                result.skipped_infeasible += 1
+                continue
+
+            ref_list = sorted(refs)
+
+            # Find the footprint nodes for each reference
+            fp1_info = self._find_footprint_by_ref(ref_list[0])
+            fp2_info = self._find_footprint_by_ref(ref_list[1])
+
+            if fp1_info is None or fp2_info is None:
+                result.skipped_infeasible += 1
+                continue
+
+            fp1_node, fp1_ref, fp1_x, fp1_y, fp1_locked, fp1_pad_count, fp1_is_connector = fp1_info
+            fp2_node, fp2_ref, fp2_x, fp2_y, fp2_locked, fp2_pad_count, fp2_is_connector = fp2_info
+
+            # Skip if both are locked
+            if fp1_locked and fp2_locked:
+                result.footprint_skipped_locked += 1
+                continue
+
+            # Select nudge target: prefer smaller/less-connected, skip locked/connectors
+            target, other = self._select_nudge_target(
+                fp1_info, fp2_info, result
+            )
+            if target is None:
+                continue
+
+            t_node, t_ref, t_x, t_y, _, _, _ = target
+            o_node, o_ref, o_x, o_y, _, _, _ = other
+
+            # Use pad locations from the violation for displacement direction
+            loc1 = violation.locations[0]
+            loc2 = violation.locations[1]
+
+            # Determine which location belongs to the target footprint
+            refs_from_items = []
+            for item in violation.items:
+                item_refs = _extract_component_refs([item])
+                refs_from_items.append(item_refs)
+
+            # Use violation locations for direction computation
+            # First item/location corresponds to first pad, second to second
+            if refs_from_items and any(t_ref.upper() in r for r in refs_from_items[:1]):
+                pad_x, pad_y = loc1.x_mm, loc1.y_mm
+                other_pad_x, other_pad_y = loc2.x_mm, loc2.y_mm
+            else:
+                pad_x, pad_y = loc2.x_mm, loc2.y_mm
+                other_pad_x, other_pad_y = loc1.x_mm, loc1.y_mm
+
+            # Compute displacement vector (move target footprint away from other)
+            nudge = self._compute_nudge(
+                pad_x, pad_y, other_pad_x, other_pad_y, required_displacement
+            )
+            if nudge is None:
+                result.skipped_infeasible += 1
+                continue
+
+            dx, dy, dist = nudge
+
+            actual_clearance = violation.actual_value_mm or 0.0
+
+            fp_nudge_result = FootprintNudgeResult(
+                reference=t_ref,
+                x=t_x,
+                y=t_y,
+                displacement_x=dx,
+                displacement_y=dy,
+                displacement_mm=dist,
+                old_clearance_mm=actual_clearance,
+                new_clearance_mm=actual_clearance + dist,
+                other_reference=o_ref,
+            )
+            result.footprint_nudge_results.append(fp_nudge_result)
+
+            if not dry_run:
+                self._nudge_footprint(t_node, dx, dy)
+                self.modified = True
+
+            result.footprint_nudges += 1
+            result.repaired += 1
+
+    def _find_footprint_by_ref(
+        self,
+        reference: str,
+    ) -> tuple[SExp, str, float, float, bool, int, bool] | None:
+        """Find a footprint node by reference designator.
+
+        Returns: (fp_node, reference, x, y, locked, pad_count, is_connector) or None.
+        """
+        ref_upper = reference.upper()
+
+        for fp_node in self.doc.find_all("footprint"):
+            # Check reference in property nodes (KiCad 8+)
+            fp_ref = ""
+            for prop in fp_node.find_all("property"):
+                prop_name = prop.get_string(0)
+                if prop_name == "Reference":
+                    fp_ref = prop.get_string(1) or ""
+                    break
+
+            # Fall back to fp_text (KiCad 7)
+            if not fp_ref:
+                for fp_text in fp_node.find_all("fp_text"):
+                    text_type = fp_text.get_string(0)
+                    if text_type == "reference":
+                        fp_ref = fp_text.get_string(1) or ""
+                        break
+
+            if fp_ref.upper() != ref_upper:
+                continue
+
+            # Get position
+            at_node = fp_node.find("at")
+            if not at_node:
+                continue
+            at_atoms = at_node.get_atoms()
+            fp_x = float(at_atoms[0]) if at_atoms else 0.0
+            fp_y = float(at_atoms[1]) if len(at_atoms) > 1 else 0.0
+
+            # Check locked status from attr
+            locked = False
+            attr_node = fp_node.find("attr")
+            if attr_node:
+                for i in range(len(attr_node.children)):
+                    token = attr_node.get_string(i)
+                    if token == "locked":
+                        locked = True
+                        break
+
+            # Count pads
+            pad_count = len(list(fp_node.find_all("pad")))
+
+            # Check if connector (J-prefix)
+            is_connector = fp_ref.upper().startswith("J")
+
+            return (fp_node, fp_ref, fp_x, fp_y, locked, pad_count, is_connector)
+
+        return None
+
+    def _select_nudge_target(
+        self,
+        fp1_info: tuple[SExp, str, float, float, bool, int, bool],
+        fp2_info: tuple[SExp, str, float, float, bool, int, bool],
+        result: RepairResult,
+    ) -> tuple[
+        tuple[SExp, str, float, float, bool, int, bool] | None,
+        tuple[SExp, str, float, float, bool, int, bool] | None,
+    ]:
+        """Select which footprint to nudge for a pad-pad violation.
+
+        Prefers the smaller (fewer pads) footprint. Skips locked footprints
+        and connectors (J-prefix), falling back to the other when possible.
+
+        Returns: (target, other) or (None, None) if neither can be nudged.
+        """
+        _, _, _, _, fp1_locked, fp1_pads, fp1_conn = fp1_info
+        _, _, _, _, fp2_locked, fp2_pads, fp2_conn = fp2_info
+
+        # Build candidates: (info, movable)
+        fp1_movable = not fp1_locked and not fp1_conn
+        fp2_movable = not fp2_locked and not fp2_conn
+
+        # If neither is movable, check why and report
+        if not fp1_movable and not fp2_movable:
+            if fp1_locked or fp2_locked:
+                result.footprint_skipped_locked += 1
+            elif fp1_conn or fp2_conn:
+                result.footprint_skipped_connector += 1
+            return (None, None)
+
+        # If only one is movable, use it
+        if fp1_movable and not fp2_movable:
+            return (fp1_info, fp2_info)
+        if fp2_movable and not fp1_movable:
+            return (fp2_info, fp1_info)
+
+        # Both movable: prefer the one with fewer pads (smaller/less connected)
+        if fp1_pads <= fp2_pads:
+            return (fp1_info, fp2_info)
+        return (fp2_info, fp1_info)
+
+    def _nudge_footprint(
+        self,
+        fp_node: SExp,
+        dx: float,
+        dy: float,
+    ) -> None:
+        """Apply a displacement to a footprint's position in the S-expression tree.
+
+        Also updates the endpoints of any trace segments connected to the
+        footprint's pads, so that net connectivity is preserved.
+        """
+        at_node = fp_node.find("at")
+        if not at_node:
+            return
+
+        at_atoms = at_node.get_atoms()
+        old_x = float(at_atoms[0]) if at_atoms else 0.0
+        old_y = float(at_atoms[1]) if len(at_atoms) > 1 else 0.0
+        fp_rot = float(at_atoms[2]) if len(at_atoms) > 2 else 0.0
+
+        new_x = round(old_x + dx, 4)
+        new_y = round(old_y + dy, 4)
+
+        # Compute absolute pad positions before the move
+        angle_rad = math.radians(fp_rot)
+        cos_a = math.cos(angle_rad)
+        sin_a = math.sin(angle_rad)
+
+        pad_positions: list[tuple[float, float]] = []
+        for pad_node in fp_node.find_all("pad"):
+            pad_at = pad_node.find("at")
+            if not pad_at:
+                continue
+            pad_atoms = pad_at.get_atoms()
+            local_x = float(pad_atoms[0]) if pad_atoms else 0.0
+            local_y = float(pad_atoms[1]) if len(pad_atoms) > 1 else 0.0
+
+            abs_x = old_x + local_x * cos_a - local_y * sin_a
+            abs_y = old_y + local_x * sin_a + local_y * cos_a
+            pad_positions.append((abs_x, abs_y))
+
+        # Move the footprint
+        at_node.set_value(0, new_x)
+        at_node.set_value(1, new_y)
+
+        # Update connected trace segment endpoints
+        for old_pad_x, old_pad_y in pad_positions:
+            new_pad_x = round(old_pad_x + dx, 4)
+            new_pad_y = round(old_pad_y + dy, 4)
+
+            connected = self._find_connected_segments(old_pad_x, old_pad_y)
+            for seg_node, endpoint in connected:
+                ep_node = seg_node.find(endpoint)
+                if ep_node:
+                    ep_node.set_value(0, new_pad_x)
+                    ep_node.set_value(1, new_pad_y)
 
     def save(self, output_path: str | Path | None = None) -> None:
         """Save the modified PCB.

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -458,6 +458,7 @@ class Footprint:
     attr: str = ""  # smd, through_hole
     exclude_from_pos_files: bool = False
     exclude_from_bom: bool = False
+    locked: bool = False
     dnp: bool = False
     properties: dict[str, str] = field(default_factory=dict)
     _sexp_node: SExp | None = field(default=None, repr=False, compare=False)
@@ -557,6 +558,8 @@ class Footprint:
                     fp.exclude_from_pos_files = True
                 elif token == "exclude_from_bom":
                     fp.exclude_from_bom = True
+                elif token == "locked":
+                    fp.locked = True
                 elif token == "dnp":
                     fp.dnp = True
 

--- a/tests/test_repair_clearance.py
+++ b/tests/test_repair_clearance.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from kicad_tools.cli.repair_clearance_cmd import main
-from kicad_tools.drc.repair_clearance import ClearanceRepairer, RepairResult
+from kicad_tools.drc.repair_clearance import ClearanceRepairer, FootprintNudgeResult, RepairResult
 from kicad_tools.drc.report import DRCReport, parse_text_report
 from kicad_tools.drc.violation import DRCViolation, Location, Severity, ViolationType
 
@@ -2419,3 +2419,420 @@ class TestWidthAwareDisplacement:
                 assert repairer._get_node_width(seg_node) == 0.5
             elif uuid_node and uuid_node.get_first_atom() == "narrow-seg":
                 assert repairer._get_node_width(seg_node) == 0.2
+
+
+class TestFootprintNudge:
+    """Tests for Phase 3: footprint nudge for pad-pad violations."""
+
+    # PCB with two small footprints whose pads violate clearance
+    PCB_PAD_PAD_VIOLATION = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 100 100)
+    (attr smd)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1) (uuid "pad-r1-1"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 2) (uuid "pad-r1-2"))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 101.1 100)
+    (attr smd)
+    (property "Reference" "R2")
+    (property "Value" "10k")
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 2) (uuid "pad-r2-1"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1) (uuid "pad-r2-2"))
+  )
+  (segment (start 99.5 100) (end 98 100) (width 0.25) (layer "F.Cu") (net 1) (uuid "seg-r1"))
+)
+"""
+
+    # DRC report with pad-pad clearance violation
+    DRC_REPORT_PAD_PAD = """\
+** Drc report for test.kicad_pcb **
+** Created on 2025-12-28T21:29:34-08:00 **
+
+** Found 1 DRC violations **
+[clearance_pad_pad]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.1000 mm)
+    Rule: netclass 'Default'; error
+    @(100.5000 mm, 100.0000 mm): Pad 2 of R1 on F.Cu
+    @(100.6000 mm, 100.0000 mm): Pad 1 of R2 on F.Cu
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+
+    # PCB with a locked footprint
+    PCB_LOCKED_FOOTPRINT = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 100 100)
+    (attr smd locked)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1) (uuid "pad-r1-1"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 2) (uuid "pad-r1-2"))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 101.1 100)
+    (attr smd)
+    (property "Reference" "R2")
+    (property "Value" "10k")
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 2) (uuid "pad-r2-1"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1) (uuid "pad-r2-2"))
+  )
+)
+"""
+
+    # PCB with both footprints locked
+    PCB_BOTH_LOCKED = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 100 100)
+    (attr smd locked)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1) (uuid "pad-r1-1"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 2) (uuid "pad-r1-2"))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 101.1 100)
+    (attr smd locked)
+    (property "Reference" "R2")
+    (property "Value" "10k")
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 2) (uuid "pad-r2-1"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1) (uuid "pad-r2-2"))
+  )
+)
+"""
+
+    # PCB with a connector footprint
+    PCB_CONNECTOR = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (footprint "Connector_PinHeader_2.54mm:PinHeader_1x02"
+    (layer "F.Cu")
+    (at 100 100)
+    (attr through_hole)
+    (property "Reference" "J1")
+    (property "Value" "Conn")
+    (pad "1" thru_hole circle (at 0 0) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 1) (uuid "pad-j1-1"))
+    (pad "2" thru_hole circle (at 0 2.54) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 2) (uuid "pad-j1-2"))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 101.1 100)
+    (attr smd)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 2) (uuid "pad-r1-1"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1) (uuid "pad-r1-2"))
+  )
+)
+"""
+
+    DRC_REPORT_CONNECTOR = """\
+** Drc report for test.kicad_pcb **
+** Created on 2025-12-28T21:29:34-08:00 **
+
+** Found 1 DRC violations **
+[clearance_pad_pad]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.1000 mm)
+    Rule: netclass 'Default'; error
+    @(100.0000 mm, 100.0000 mm): Pad 1 of J1 on F.Cu
+    @(100.6000 mm, 100.0000 mm): Pad 1 of R1 on F.Cu
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+
+    # Same-component violation
+    DRC_REPORT_SAME_COMPONENT = """\
+** Drc report for test.kicad_pcb **
+** Created on 2025-12-28T21:29:34-08:00 **
+
+** Found 1 DRC violations **
+[clearance_pad_pad]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.1000 mm)
+    Rule: netclass 'Default'; error
+    @(99.5000 mm, 100.0000 mm): Pad 1 of R1 on F.Cu
+    @(100.5000 mm, 100.0000 mm): Pad 2 of R1 on F.Cu
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+
+    def test_basic_pad_pad_nudge_dry_run(self, tmp_path: Path):
+        """Dry run should report planned footprint nudge without modifying PCB."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(self.PCB_PAD_PAD_VIOLATION)
+
+        report = parse_text_report(self.DRC_REPORT_PAD_PAD, "test-drc.rpt")
+        repairer = ClearanceRepairer(pcb_file)
+
+        result = repairer.repair_from_report(
+            report, max_displacement=0.2, dry_run=True, nudge_footprints=True
+        )
+
+        assert result.footprint_nudges == 1
+        assert result.repaired == 1
+        assert not repairer.modified
+        assert len(result.footprint_nudge_results) == 1
+
+        fn = result.footprint_nudge_results[0]
+        assert fn.displacement_mm > 0
+        assert fn.reference in ("R1", "R2")
+        assert fn.other_reference in ("R1", "R2")
+        assert fn.reference != fn.other_reference
+
+    def test_basic_pad_pad_nudge_apply(self, tmp_path: Path):
+        """Apply should modify the PCB footprint position."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(self.PCB_PAD_PAD_VIOLATION)
+
+        report = parse_text_report(self.DRC_REPORT_PAD_PAD, "test-drc.rpt")
+        repairer = ClearanceRepairer(pcb_file)
+
+        # Record original positions
+        fp_positions_before = {}
+        for fp_node in repairer.doc.find_all("footprint"):
+            for prop in fp_node.find_all("property"):
+                if prop.get_string(0) == "Reference":
+                    ref = prop.get_string(1)
+                    at = fp_node.find("at")
+                    x = float(at.get_atoms()[0])
+                    y = float(at.get_atoms()[1])
+                    fp_positions_before[ref] = (x, y)
+
+        result = repairer.repair_from_report(
+            report, max_displacement=0.2, dry_run=False, nudge_footprints=True
+        )
+
+        assert result.footprint_nudges == 1
+        assert result.repaired == 1
+        assert repairer.modified
+
+        # Verify position changed for the nudged footprint
+        fn = result.footprint_nudge_results[0]
+        nudged_ref = fn.reference
+        for fp_node in repairer.doc.find_all("footprint"):
+            for prop in fp_node.find_all("property"):
+                if prop.get_string(0) == "Reference" and prop.get_string(1) == nudged_ref:
+                    at = fp_node.find("at")
+                    new_x = float(at.get_atoms()[0])
+                    new_y = float(at.get_atoms()[1])
+                    old_x, old_y = fp_positions_before[nudged_ref]
+                    assert (new_x, new_y) != (old_x, old_y), "Footprint should have moved"
+
+    def test_locked_footprint_skip(self, tmp_path: Path):
+        """When smaller footprint is locked, nudge the other one instead."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(self.PCB_LOCKED_FOOTPRINT)
+
+        report = parse_text_report(self.DRC_REPORT_PAD_PAD, "test-drc.rpt")
+        repairer = ClearanceRepairer(pcb_file)
+
+        result = repairer.repair_from_report(
+            report, max_displacement=0.2, dry_run=True, nudge_footprints=True
+        )
+
+        # R1 is locked, so R2 should be nudged
+        assert result.footprint_nudges == 1
+        assert result.footprint_nudge_results[0].reference == "R2"
+
+    def test_both_locked_skip(self, tmp_path: Path):
+        """When both footprints are locked, skip the violation."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(self.PCB_BOTH_LOCKED)
+
+        report = parse_text_report(self.DRC_REPORT_PAD_PAD, "test-drc.rpt")
+        repairer = ClearanceRepairer(pcb_file)
+
+        result = repairer.repair_from_report(
+            report, max_displacement=0.2, dry_run=True, nudge_footprints=True
+        )
+
+        assert result.footprint_nudges == 0
+        assert result.footprint_skipped_locked == 1
+
+    def test_connector_skip(self, tmp_path: Path):
+        """When one footprint is a connector (J-prefix), nudge the other."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(self.PCB_CONNECTOR)
+
+        report = parse_text_report(self.DRC_REPORT_CONNECTOR, "test-drc.rpt")
+        repairer = ClearanceRepairer(pcb_file)
+
+        result = repairer.repair_from_report(
+            report, max_displacement=0.2, dry_run=True, nudge_footprints=True
+        )
+
+        # J1 is a connector, R1 should be nudged
+        assert result.footprint_nudges == 1
+        assert result.footprint_nudge_results[0].reference == "R1"
+
+    def test_max_displacement_gate(self, tmp_path: Path):
+        """Violations requiring displacement beyond max should be skipped."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(self.PCB_PAD_PAD_VIOLATION)
+
+        report = parse_text_report(self.DRC_REPORT_PAD_PAD, "test-drc.rpt")
+        repairer = ClearanceRepairer(pcb_file)
+
+        # Very small max displacement
+        result = repairer.repair_from_report(
+            report, max_displacement=0.001, dry_run=True, nudge_footprints=True
+        )
+
+        assert result.footprint_nudges == 0
+        assert result.footprint_skipped_exceeds_max == 1
+
+    def test_same_component_excluded(self, tmp_path: Path):
+        """Same-component pad-pad violations should be skipped."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(self.PCB_PAD_PAD_VIOLATION)
+
+        report = parse_text_report(self.DRC_REPORT_SAME_COMPONENT, "test-drc.rpt")
+        repairer = ClearanceRepairer(pcb_file)
+
+        result = repairer.repair_from_report(
+            report, max_displacement=0.2, dry_run=True, nudge_footprints=True
+        )
+
+        assert result.footprint_nudges == 0
+        assert result.footprint_skipped_same_component == 1
+
+    def test_nudge_footprints_off_by_default(self, tmp_path: Path):
+        """Without --nudge-footprints, pad-pad violations are not processed."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(self.PCB_PAD_PAD_VIOLATION)
+
+        report = parse_text_report(self.DRC_REPORT_PAD_PAD, "test-drc.rpt")
+        repairer = ClearanceRepairer(pcb_file)
+
+        result = repairer.repair_from_report(
+            report, max_displacement=0.2, dry_run=True, nudge_footprints=False
+        )
+
+        assert result.footprint_nudges == 0
+        assert len(result.footprint_nudge_results) == 0
+
+    def test_connected_segments_updated(self, tmp_path: Path):
+        """Trace segments connected to nudged footprint pads should move too."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(self.PCB_PAD_PAD_VIOLATION)
+
+        report = parse_text_report(self.DRC_REPORT_PAD_PAD, "test-drc.rpt")
+        repairer = ClearanceRepairer(pcb_file)
+
+        # The PCB has a segment at (99.5, 100) connected to R1 pad 1 at (99.5, 100)
+        # If R1 is nudged, that segment endpoint should update
+
+        result = repairer.repair_from_report(
+            report, max_displacement=0.2, dry_run=False, nudge_footprints=True
+        )
+
+        if result.footprint_nudge_results and result.footprint_nudge_results[0].reference == "R1":
+            fn = result.footprint_nudge_results[0]
+            # Check that the segment start was updated
+            for seg_node in repairer.doc.find_all("segment"):
+                start_node = seg_node.find("start")
+                if start_node:
+                    sx = float(start_node.get_atoms()[0])
+                    sy = float(start_node.get_atoms()[1])
+                    # Original was (99.5, 100), should have moved by dx, dy
+                    if abs(sx - (99.5 + fn.displacement_x)) < 0.01:
+                        assert abs(sy - (100 + fn.displacement_y)) < 0.01
+
+    def test_cli_nudge_footprints_flag(self, tmp_path: Path):
+        """CLI should accept --nudge-footprints flag."""
+        pcb_file = tmp_path / "test.kicad_pcb"
+        pcb_file.write_text(self.PCB_PAD_PAD_VIOLATION)
+
+        report_file = tmp_path / "test-drc.rpt"
+        report_file.write_text(self.DRC_REPORT_PAD_PAD)
+
+        result = main([
+            str(pcb_file),
+            "--drc-report", str(report_file),
+            "--nudge-footprints",
+            "--max-displacement", "0.2",
+            "--dry-run",
+            "--format", "json",
+        ])
+
+        # Should not error -- exit code 0 means all violations repaired
+        assert result == 0
+
+    def test_footprint_nudge_result_str(self):
+        """FootprintNudgeResult should have a readable string representation."""
+        fn = FootprintNudgeResult(
+            reference="R1",
+            x=100.0,
+            y=100.0,
+            displacement_x=0.05,
+            displacement_y=0.0,
+            displacement_mm=0.05,
+            old_clearance_mm=0.1,
+            new_clearance_mm=0.15,
+            other_reference="R2",
+        )
+        s = str(fn)
+        assert "R1" in s
+        assert "R2" in s
+        assert "0.0500" in s


### PR DESCRIPTION
## Summary

Adds Phase 3 footprint nudge capability to `repair-clearance` that resolves pad-pad clearance violations by computing minimal displacements for footprints, rather than treating them as infeasible.

## Changes

- **`src/kicad_tools/drc/repair_clearance.py`**: Added `FootprintNudgeResult` dataclass, footprint nudge counters to `RepairResult`, `_repair_pad_pad_violations()` Phase 3 method, `_find_footprint_by_ref()`, `_select_nudge_target()`, and `_nudge_footprint()` methods. The `nudge_footprints` parameter gates the new phase.
- **`src/kicad_tools/cli/repair_clearance_cmd.py`**: Added `--nudge-footprints` CLI flag, updated violation counting to include pad-pad violations when enabled, added footprint nudge display in text and JSON output formats.
- **`src/kicad_tools/schema/pcb.py`**: Added `locked: bool` field to `Footprint` dataclass, parsed from S-expression `(attr ... locked)` node.
- **`tests/test_repair_clearance.py`**: Added `TestFootprintNudge` class with 11 test cases covering basic nudge (dry-run and apply), locked footprint skip, both-locked skip, connector skip, max-displacement gate, same-component exclusion, off-by-default behavior, connected segment updates, CLI flag acceptance, and `FootprintNudgeResult.__str__`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Phase 3 collects CLEARANCE_PAD_PAD violations | Pass | `_repair_pad_pad_violations` filters `report.by_type(ViolationType.CLEARANCE_PAD_PAD)` |
| Same-component violations excluded | Pass | `is_same_component_pad_clearance()` check, verified by `test_same_component_excluded` |
| Locked footprints skipped | Pass | Attr node parsed for "locked" token, verified by `test_locked_footprint_skip` and `test_both_locked_skip` |
| Connector (J-prefix) footprints skipped | Pass | Reference prefix check, verified by `test_connector_skip` |
| Smaller footprint preferred for nudge | Pass | `_select_nudge_target` compares pad counts |
| `--max-displacement` gates footprint nudges | Pass | Verified by `test_max_displacement_gate` |
| Connected trace endpoints updated | Pass | `_nudge_footprint` updates segment endpoints, verified by `test_connected_segments_updated` |
| `--nudge-footprints` CLI flag (off by default) | Pass | Verified by `test_nudge_footprints_off_by_default` and `test_cli_nudge_footprints_flag` |
| Footprint `locked` field added to schema | Pass | `Footprint.locked` parsed from `(attr ... locked)` in `from_sexp()` |

## Test Plan

All 90 tests in `test_repair_clearance.py` pass (79 existing + 11 new).

```
python3 -m pytest tests/test_repair_clearance.py -x -q
90 passed in 41.23s
```

Closes #2210