### PR TITLE
fix(pipeline): pass manufacturer via specs to stitch subprocess

### DIFF
--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -676,6 +676,19 @@ def _run_step_stitch(ctx: PipelineContext, console: Console) -> PipelineResult:
             skipped=True,
         )
 
+    # Look up manufacturer via specs so stitching vias meet DRC requirements.
+    try:
+        from ..manufacturers import get_profile
+
+        profile = get_profile(ctx.mfr)
+        rules = profile.get_design_rules(layers=ctx.layer_count)
+        via_size = rules.min_via_diameter_mm
+        via_drill = rules.min_via_drill_mm
+    except Exception:
+        # Fall back to conservative defaults if lookup fails
+        via_size = 0.6
+        via_drill = 0.3
+
     if ctx.dry_run:
         nets_str = ", ".join(sorted(plane_nets.keys()))
         return PipelineResult(
@@ -683,6 +696,7 @@ def _run_step_stitch(ctx: PipelineContext, console: Console) -> PipelineResult:
             success=True,
             message=(
                 f"[dry-run] Would run: kct stitch {ctx.pcb_file.name} "
+                f"--via-size {via_size} --drill {via_drill} "
                 f"(auto-detected nets: {nets_str})"
             ),
         )
@@ -690,7 +704,8 @@ def _run_step_stitch(ctx: PipelineContext, console: Console) -> PipelineResult:
     if not ctx.quiet:
         console.print(
             f"  Stitching vias on {ctx.pcb_file.name} "
-            f"({len(plane_nets)} plane net(s))..."
+            f"({len(plane_nets)} plane net(s), "
+            f"via {via_size}mm/{via_drill}mm drill for {ctx.mfr})..."
         )
 
     cmd = [
@@ -699,6 +714,10 @@ def _run_step_stitch(ctx: PipelineContext, console: Console) -> PipelineResult:
         "kicad_tools.cli",
         "stitch",
         str(ctx.pcb_file),
+        "--via-size",
+        str(via_size),
+        "--drill",
+        str(via_drill),
     ]
 
     success, message = _run_subprocess_step(cmd, ctx.pcb_file.parent, ctx.verbose)

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -4229,6 +4229,63 @@ class TestStitchStep:
         assert result.success is True
         assert result.skipped is True
 
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_stitch_passes_manufacturer_via_specs(self, mock_run, four_layer_pcb_with_zones: Path):
+        """Stitch step passes --via-size and --drill from manufacturer specs."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        console = MagicMock()
+        ctx = PipelineContext(
+            pcb_file=four_layer_pcb_with_zones, layers="4", mfr="seeed", quiet=True
+        )
+        result = _run_step_stitch(ctx, console)
+        assert result.success is True
+        assert result.skipped is False
+        # Verify subprocess was called with via specs from manufacturer
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "--via-size" in cmd
+        assert "--drill" in cmd
+        # Seeed requires 0.3mm drill / 0.6mm diameter minimum
+        via_size_idx = cmd.index("--via-size")
+        drill_idx = cmd.index("--drill")
+        via_size_val = float(cmd[via_size_idx + 1])
+        drill_val = float(cmd[drill_idx + 1])
+        assert via_size_val >= 0.6, f"Via size {via_size_val} too small for seeed"
+        assert drill_val >= 0.3, f"Drill {drill_val} too small for seeed"
+
+    def test_stitch_dry_run_includes_via_specs(self, four_layer_pcb_with_zones: Path):
+        """Stitch dry-run message includes via size and drill from manufacturer."""
+        console = MagicMock()
+        ctx = PipelineContext(
+            pcb_file=four_layer_pcb_with_zones, layers="4", mfr="seeed",
+            dry_run=True, quiet=True,
+        )
+        result = _run_step_stitch(ctx, console)
+        assert result.success is True
+        assert "--via-size" in result.message
+        assert "--drill" in result.message
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_stitch_default_jlcpcb_via_specs(self, mock_run, four_layer_pcb_with_zones: Path):
+        """Stitch step uses JLCPCB via specs when mfr is jlcpcb (default)."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        console = MagicMock()
+        ctx = PipelineContext(
+            pcb_file=four_layer_pcb_with_zones, layers="4", mfr="jlcpcb", quiet=True
+        )
+        result = _run_step_stitch(ctx, console)
+        assert result.success is True
+        cmd = mock_run.call_args[0][0]
+        assert "--via-size" in cmd
+        assert "--drill" in cmd
+        via_size_idx = cmd.index("--via-size")
+        drill_idx = cmd.index("--drill")
+        via_size_val = float(cmd[via_size_idx + 1])
+        drill_val = float(cmd[drill_idx + 1])
+        # JLCPCB minimum: 0.3mm drill / 0.6mm diameter
+        assert via_size_val >= 0.45, f"Via size {via_size_val} unexpectedly small for jlcpcb"
+        assert drill_val >= 0.2, f"Drill {drill_val} unexpectedly small for jlcpcb"
+
 
 class TestCacheFlagForwarding:
     """Tests for --no-cache and --clear-cache flag forwarding to route step."""


### PR DESCRIPTION
## Summary

The pipeline stitch step was using hardcoded default via sizes (0.2mm drill / 0.45mm diameter) regardless of the `--mfr` flag passed to the pipeline. This created undersized vias that immediately failed DRC for manufacturers like Seeed (min 0.3mm drill / 0.6mm diameter), producing 3 errors per stitching via.

Now the stitch step looks up `min_via_diameter_mm` and `min_via_drill_mm` from the manufacturer profile and passes `--via-size` and `--drill` to the stitch subprocess.

## Changes

- Modified `_run_step_stitch()` in `pipeline_cmd.py` to look up manufacturer design rules via `get_profile(ctx.mfr).get_design_rules(layers=ctx.layer_count)` and pass the via specs to the stitch subprocess
- Updated dry-run message to include `--via-size` and `--drill` values
- Updated progress message to show via specs and manufacturer name
- Falls back to conservative defaults (0.6mm / 0.3mm) if manufacturer lookup fails

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pipeline passes --via-size and --drill to stitch based on mfr | Done | Verified via test_stitch_passes_manufacturer_via_specs |
| Dry-run message shows via specs | Done | Verified via test_stitch_dry_run_includes_via_specs |
| Default JLCPCB specs are passed | Done | Verified via test_stitch_default_jlcpcb_via_specs |
| Seeed specs meet min 0.3mm drill / 0.6mm diameter | Done | Verified via assertion in test |
| Existing stitch tests still pass | Done | All 14 stitch tests pass |

## Test Plan

- Ran `python3 -m pytest tests/test_pipeline_cmd.py::TestStitchStep -x -v` -- all 14 tests pass (11 existing + 3 new)
- Ran full `test_pipeline_cmd.py` suite -- 249 passed, 3 pre-existing failures unrelated to this change (TestReportStep, TestExportStep, TestFixERCStep)

Closes #2224