### PR TITLE
fix(erc): handle unconnected_wire_endpoint and wire_dangling in fix-erc

### DIFF
--- a/src/kicad_tools/cli/fix_erc_cmd.py
+++ b/src/kicad_tools/cli/fix_erc_cmd.py
@@ -25,7 +25,7 @@ class FixAction:
     """A single fix action applied to the schematic."""
 
     violation_type: str
-    action: str  # "insert_pwr_flag" or "insert_no_connect"
+    action: str  # "insert_pwr_flag", "insert_no_connect", or "remove_wire"
     x: float
     y: float
     description: str
@@ -38,6 +38,7 @@ class FixERCResult:
     total_violations: int = 0
     pwr_flag_inserted: int = 0
     no_connect_inserted: int = 0
+    wires_removed: int = 0
     skipped_unknown: int = 0
     skipped_duplicate: int = 0
     actions: list[FixAction] = field(default_factory=list)
@@ -45,7 +46,7 @@ class FixERCResult:
     @property
     def total_fixed(self) -> int:
         """Total number of fixes applied."""
-        return self.pwr_flag_inserted + self.no_connect_inserted
+        return self.pwr_flag_inserted + self.no_connect_inserted + self.wires_removed
 
     @property
     def total_skipped(self) -> int:
@@ -184,14 +185,22 @@ def _apply_fixes(sch_path: Path, report, *, dry_run: bool, quiet: bool) -> FixER
     # Classify violations
     pwr_violations = report.by_type(ERCViolationType.POWER_PIN_NOT_DRIVEN)
     nc_violations = report.by_type(ERCViolationType.PIN_NOT_CONNECTED)
+    wire_dangling_violations = report.by_type(ERCViolationType.WIRE_DANGLING)
+    unconnected_wire_violations = report.by_type(ERCViolationType.UNCONNECTED_WIRE_ENDPOINT)
+    wire_violations = wire_dangling_violations + unconnected_wire_violations
 
     # Count unknown/unhandled types
-    handled_types = {ERCViolationType.POWER_PIN_NOT_DRIVEN, ERCViolationType.PIN_NOT_CONNECTED}
+    handled_types = {
+        ERCViolationType.POWER_PIN_NOT_DRIVEN,
+        ERCViolationType.PIN_NOT_CONNECTED,
+        ERCViolationType.WIRE_DANGLING,
+        ERCViolationType.UNCONNECTED_WIRE_ENDPOINT,
+    }
     all_violations = [v for v in report.violations if not v.excluded]
     unhandled = [v for v in all_violations if v.type not in handled_types]
     unknown_violations = [v for v in unhandled if v.type == ERCViolationType.UNKNOWN]
 
-    result.total_violations = len(pwr_violations) + len(nc_violations)
+    result.total_violations = len(pwr_violations) + len(nc_violations) + len(wire_violations)
     result.skipped_unknown = len(unknown_violations)
 
     if result.total_violations == 0:
@@ -276,6 +285,36 @@ def _apply_fixes(sch_path: Path, report, *, dry_run: bool, quiet: bool) -> FixER
             )
         )
 
+    # Fix wire_dangling / unconnected_wire_endpoint: remove dangling wire at violation pos
+    wire_remove_positions: set[tuple[float, float]] = set()
+    for v in wire_violations:
+        wx = v.pos_x
+        wy = v.pos_y
+        pos_key = (round(wx, 2), round(wy, 2))
+
+        if pos_key in wire_remove_positions:
+            result.skipped_duplicate += 1
+            continue
+
+        wire_remove_positions.add(pos_key)
+
+        if not dry_run and sch is not None:
+            removed = sch.remove_wires_at((wx, wy))
+            if removed == 0:
+                # No wire found at exact position; skip silently
+                continue
+
+        result.wires_removed += 1
+        result.actions.append(
+            FixAction(
+                violation_type=v.type_str,
+                action="remove_wire",
+                x=wx,
+                y=wy,
+                description=v.description,
+            )
+        )
+
     # Save modified schematic
     if not dry_run and sch is not None and result.total_fixed > 0:
         sch.write(sch_path)
@@ -301,6 +340,7 @@ def _print_json(result: FixERCResult, dry_run: bool) -> None:
         "total_fixed": result.total_fixed,
         "pwr_flag_inserted": result.pwr_flag_inserted,
         "no_connect_inserted": result.no_connect_inserted,
+        "wires_removed": result.wires_removed,
         "skipped_unknown": result.skipped_unknown,
         "skipped_duplicate": result.skipped_duplicate,
         "actions": [
@@ -325,6 +365,8 @@ def _print_summary(result: FixERCResult, dry_run: bool) -> None:
         print(f"  PWR_FLAG inserted: {result.pwr_flag_inserted}")
     if result.no_connect_inserted > 0:
         print(f"  No-connect markers: {result.no_connect_inserted}")
+    if result.wires_removed > 0:
+        print(f"  Dangling wires removed: {result.wires_removed}")
     if result.skipped_unknown > 0:
         print(f"  Skipped (unknown type): {result.skipped_unknown}")
     if result.skipped_duplicate > 0:
@@ -354,6 +396,13 @@ def _print_text(result: FixERCResult, dry_run: bool) -> None:
         print(f"NO-CONNECT MARKERS: {result.no_connect_inserted}")
         for a in result.actions:
             if a.action == "insert_no_connect":
+                print(f"  at ({a.x:.2f}, {a.y:.2f}): {a.description}")
+
+    if result.wires_removed > 0:
+        print(f"\n{'-' * 60}")
+        print(f"DANGLING WIRES REMOVED: {result.wires_removed}")
+        for a in result.actions:
+            if a.action == "remove_wire":
                 print(f"  at ({a.x:.2f}, {a.y:.2f}): {a.description}")
 
     if result.skipped_unknown > 0:

--- a/src/kicad_tools/erc/violation.py
+++ b/src/kicad_tools/erc/violation.py
@@ -57,6 +57,7 @@ class ERCViolationType(Enum):
     UNANNOTATED = "unannotated"
     UNSPECIFIED = "unspecified"
     WIRE_DANGLING = "wire_dangling"
+    UNCONNECTED_WIRE_ENDPOINT = "unconnected_wire_endpoint"
 
     # Unknown
     UNKNOWN = "unknown"
@@ -117,6 +118,7 @@ ERC_TYPE_DESCRIPTIONS = {
     "unannotated": "Symbol not annotated",
     "unspecified": "Unspecified error",
     "wire_dangling": "Wire not connected at both ends",
+    "unconnected_wire_endpoint": "Unconnected wire endpoint",
     # Library/footprint checks (non-electrical)
     "lib_symbol_mismatch": "Library symbol does not match schematic symbol",
     "footprint_link_issues": "Footprint link issues",
@@ -160,6 +162,7 @@ ERC_CATEGORIES = {
         "endpoint_off_grid",
         "four_way_junction",
         "net_not_bus_member",
+        "unconnected_wire_endpoint",
         "wire_dangling",
     ],
     "Symbols": [

--- a/src/kicad_tools/feedback/suggestions.py
+++ b/src/kicad_tools/feedback/suggestions.py
@@ -95,6 +95,7 @@ class FixSuggestionGenerator:
             ERCViolationType.GLOBAL_LABEL_DANGLING: self._suggest_global_label_dangling,
             ERCViolationType.HIER_LABEL_MISMATCH: self._suggest_hier_label,
             ERCViolationType.WIRE_DANGLING: self._suggest_wire_dangling,
+            ERCViolationType.UNCONNECTED_WIRE_ENDPOINT: self._suggest_wire_dangling,
             ERCViolationType.MISSING_UNIT: self._suggest_missing_unit,
             ERCViolationType.UNANNOTATED: self._suggest_unannotated,
             ERCViolationType.SIMILAR_LABELS: self._suggest_similar_labels,

--- a/tests/test_fix_erc_cmd.py
+++ b/tests/test_fix_erc_cmd.py
@@ -652,3 +652,180 @@ class TestUnhandledTypes:
         assert result.skipped_unknown == 0
         assert result.no_connect_inserted == 1
         assert result.total_fixed == 1
+
+
+# ── Tests: unconnected_wire_endpoint and wire_dangling fixes ────────
+
+
+class TestUnconnectedWireEndpoint:
+    """unconnected_wire_endpoint violations should remove dangling wires."""
+
+    def test_unconnected_wire_endpoint_is_recognized(self):
+        """unconnected_wire_endpoint should parse to its own enum value, not UNKNOWN."""
+        vtype = ERCViolationType.from_string("unconnected_wire_endpoint")
+        assert vtype == ERCViolationType.UNCONNECTED_WIRE_ENDPOINT
+        assert vtype != ERCViolationType.UNKNOWN
+
+    def test_unconnected_wire_endpoint_dry_run(self):
+        """unconnected_wire_endpoint should be counted as fixable in dry-run."""
+        violations = [
+            _make_violation(
+                ERCViolationType.UNCONNECTED_WIRE_ENDPOINT,
+                "unconnected_wire_endpoint",
+                "Unconnected wire endpoint",
+                pos_x=80.0,
+                pos_y=40.0,
+            ),
+        ]
+        report = _make_report(violations)
+
+        result = _apply_fixes(Path("dummy.kicad_sch"), report, dry_run=True, quiet=True)
+
+        assert result.wires_removed == 1
+        assert result.total_fixed == 1
+        assert result.skipped_unknown == 0
+        assert result.total_violations == 1
+        assert len(result.actions) == 1
+        action = result.actions[0]
+        assert action.action == "remove_wire"
+        assert action.violation_type == "unconnected_wire_endpoint"
+        assert action.x == 80.0
+        assert action.y == 40.0
+
+    def test_multiple_unconnected_wire_endpoints(self):
+        """Multiple unconnected_wire_endpoint violations at different positions."""
+        violations = [
+            _make_violation(
+                ERCViolationType.UNCONNECTED_WIRE_ENDPOINT,
+                "unconnected_wire_endpoint",
+                "Unconnected wire endpoint",
+                pos_x=80.0,
+                pos_y=40.0,
+            ),
+            _make_violation(
+                ERCViolationType.UNCONNECTED_WIRE_ENDPOINT,
+                "unconnected_wire_endpoint",
+                "Unconnected wire endpoint",
+                pos_x=90.0,
+                pos_y=50.0,
+            ),
+        ]
+        report = _make_report(violations)
+
+        result = _apply_fixes(Path("dummy.kicad_sch"), report, dry_run=True, quiet=True)
+
+        assert result.wires_removed == 2
+        assert result.total_fixed == 2
+
+    def test_duplicate_unconnected_wire_endpoints(self):
+        """Duplicate unconnected_wire_endpoint at same position should be deduplicated."""
+        violations = [
+            _make_violation(
+                ERCViolationType.UNCONNECTED_WIRE_ENDPOINT,
+                "unconnected_wire_endpoint",
+                "Unconnected wire endpoint (1)",
+                pos_x=80.0,
+                pos_y=40.0,
+            ),
+            _make_violation(
+                ERCViolationType.UNCONNECTED_WIRE_ENDPOINT,
+                "unconnected_wire_endpoint",
+                "Unconnected wire endpoint (2)",
+                pos_x=80.0,
+                pos_y=40.0,
+            ),
+        ]
+        report = _make_report(violations)
+
+        result = _apply_fixes(Path("dummy.kicad_sch"), report, dry_run=True, quiet=True)
+
+        assert result.wires_removed == 1
+        assert result.skipped_duplicate == 1
+
+    def test_unconnected_wire_not_counted_as_unknown(self, capsys):
+        """unconnected_wire_endpoint should not produce UNKNOWN warning."""
+        violations = [
+            _make_violation(
+                ERCViolationType.UNCONNECTED_WIRE_ENDPOINT,
+                "unconnected_wire_endpoint",
+                "Unconnected wire endpoint",
+                pos_x=80.0,
+                pos_y=40.0,
+            ),
+        ]
+        report = _make_report(violations)
+
+        _apply_fixes(Path("dummy.kicad_sch"), report, dry_run=True, quiet=False)
+
+        captured = capsys.readouterr()
+        assert "UNKNOWN" not in captured.err
+
+
+class TestWireDangling:
+    """wire_dangling violations should also remove dangling wires."""
+
+    def test_wire_dangling_dry_run(self):
+        """wire_dangling should be counted as fixable in dry-run."""
+        violations = [
+            _make_violation(
+                ERCViolationType.WIRE_DANGLING,
+                "wire_dangling",
+                "Wire not connected at both ends",
+                pos_x=60.0,
+                pos_y=30.0,
+            ),
+        ]
+        report = _make_report(violations)
+
+        result = _apply_fixes(Path("dummy.kicad_sch"), report, dry_run=True, quiet=True)
+
+        assert result.wires_removed == 1
+        assert result.total_fixed == 1
+        assert result.skipped_unknown == 0
+        assert result.total_violations == 1
+        action = result.actions[0]
+        assert action.action == "remove_wire"
+        assert action.violation_type == "wire_dangling"
+
+    def test_mixed_wire_and_pin_violations(self):
+        """Wire violations mixed with pin violations should all be fixed."""
+        violations = [
+            _make_violation(
+                ERCViolationType.UNCONNECTED_WIRE_ENDPOINT,
+                "unconnected_wire_endpoint",
+                "Unconnected wire endpoint",
+                pos_x=80.0,
+                pos_y=40.0,
+            ),
+            _make_violation(
+                ERCViolationType.WIRE_DANGLING,
+                "wire_dangling",
+                "Wire not connected at both ends",
+                pos_x=60.0,
+                pos_y=30.0,
+            ),
+            _make_violation(
+                ERCViolationType.PIN_NOT_CONNECTED,
+                "pin_not_connected",
+                "Pin 1 not connected",
+                pos_x=100.0,
+                pos_y=50.0,
+            ),
+            _make_violation(
+                ERCViolationType.POWER_PIN_NOT_DRIVEN,
+                "power_pin_not_driven",
+                "VCC not driven",
+                pos_x=120.0,
+                pos_y=70.0,
+            ),
+        ]
+        report = _make_report(violations)
+
+        result = _apply_fixes(Path("dummy.kicad_sch"), report, dry_run=True, quiet=True)
+
+        assert result.wires_removed == 2
+        assert result.no_connect_inserted == 1
+        assert result.pwr_flag_inserted == 1
+        assert result.total_fixed == 4
+        assert result.total_violations == 4
+        assert result.skipped_unknown == 0


### PR DESCRIPTION
## Summary
Add support for auto-fixing `unconnected_wire_endpoint` and `wire_dangling` ERC violations in the `fix-erc` command. Previously these were skipped as UNKNOWN, leaving 9 warnings and 2 errors unresolved in every pipeline run.

## Changes
- Add `UNCONNECTED_WIRE_ENDPOINT` enum value to `ERCViolationType` so it parses correctly instead of falling through to UNKNOWN
- Add description and category entries for the new violation type
- Extend `fix-erc` to handle both `unconnected_wire_endpoint` and `wire_dangling` by removing the dangling wire segment at the violation position via `Schematic.remove_wires_at()`
- Add `wires_removed` counter to `FixERCResult` and include it in all output formats (JSON, summary, text)
- Register `UNCONNECTED_WIRE_ENDPOINT` in the ERC suggestion handler so it gets the same fix suggestions as `wire_dangling`
- Add 7 new tests covering enum parsing, dry-run counting, deduplication, mixed violation handling, and absence of UNKNOWN warnings

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `unconnected_wire_endpoint` recognized as known type | Pass | `ERCViolationType.from_string("unconnected_wire_endpoint")` returns `UNCONNECTED_WIRE_ENDPOINT`, not `UNKNOWN` |
| `wire_dangling` auto-fixed by removing wire | Pass | Dry-run test confirms `wires_removed == 1` for wire_dangling violation |
| `unconnected_wire_endpoint` auto-fixed by removing wire | Pass | Dry-run test confirms `wires_removed == 1` for unconnected_wire_endpoint violation |
| No UNKNOWN warning for these types | Pass | Test verifies stderr does not contain "UNKNOWN" |
| Duplicate positions deduplicated | Pass | Test verifies `skipped_duplicate == 1` when two violations share same position |
| Mixed violations all handled | Pass | Test with all 4 fixable types confirms `total_fixed == 4` |
| All 103 existing ERC tests still pass | Pass | `pytest tests/test_fix_erc_cmd.py tests/test_erc.py tests/test_erc_violation_classification.py` = 103 passed |

## Test Plan
- `python3 -m pytest tests/test_fix_erc_cmd.py -v` -- 34 tests pass (27 existing + 7 new)
- `python3 -m pytest tests/test_erc.py tests/test_erc_violation_classification.py -v` -- all pass with no regressions

Closes #2225