### PR TITLE
feat(validate): add value_consistency check for mixed capacitor voltage formatting

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -3167,6 +3167,133 @@ def check_bom_variety(schematic_path: str) -> list[ValidationIssue]:
     return issues
 
 
+# ---------------------------------------------------------------------------
+# Value consistency check (mixed voltage-rating formatting in capacitors)
+# ---------------------------------------------------------------------------
+
+_VALUE_VOLTAGE_RE = re.compile(
+    r"^(\d+(?:\.\d+)?\s*(?:p|n|u|\xb5|m)?F)\s+(.+)$",
+    re.IGNORECASE,
+)
+
+
+def _split_cap_value(value: str) -> tuple[str, str | None]:
+    """Return (base_value, voltage_qualifier_or_None).
+
+    Examples:
+        "100nF 25V" -> ("100nF", "25V")
+        "10uF 16V"  -> ("10uF", "16V")
+        "100nF"     -> ("100nF", None)
+    """
+    m = _VALUE_VOLTAGE_RE.match(value.strip())
+    if m:
+        return m.group(1).strip(), m.group(2).strip()
+    return value.strip(), None
+
+
+def check_value_consistency(schematic_path: str) -> list[ValidationIssue]:
+    """Detect capacitors with the same base value but mixed voltage-rating formatting.
+
+    Groups capacitors by their base capacitance value (e.g. "100nF") and flags
+    groups where some components include a voltage qualifier (e.g. "100nF 25V")
+    and others do not.  This catches inconsistent BOM formatting that
+    check_bom_variety() cannot detect because it groups by full value string.
+
+    Only flags groups with a mix of qualified and unqualified values.  Groups
+    where ALL values include voltage qualifiers (even different ones) are not
+    flagged.
+    """
+    issues: list[ValidationIssue] = []
+
+    try:
+        hierarchy = build_hierarchy(schematic_path)
+
+        # Mapping: base_value -> {"with_voltage": [(ref, full_value)], "without_voltage": [ref]}
+        groups: dict[str, dict[str, list]] = {}
+
+        for node in hierarchy.all_nodes():
+            try:
+                sch = Schematic.load(node.path)
+                for sym in sch.symbols:
+                    # Skip power symbols
+                    if sym.lib_id.startswith("power:"):
+                        continue
+
+                    # Skip DNP
+                    if sym.dnp:
+                        continue
+
+                    # Only capacitors (ref prefix C)
+                    if not _is_capacitor(sym.lib_id):
+                        continue
+
+                    # Must have a value
+                    if not sym.value or sym.value in ("~", "?"):
+                        continue
+
+                    # Must have a footprint (to be a real placed component)
+                    if not sym.footprint or sym.footprint == "~":
+                        continue
+
+                    ref = sym.reference or ""
+                    if not ref:
+                        continue
+
+                    base_value, voltage = _split_cap_value(sym.value)
+
+                    if base_value not in groups:
+                        groups[base_value] = {"with_voltage": [], "without_voltage": []}
+
+                    if voltage is not None:
+                        groups[base_value]["with_voltage"].append((ref, sym.value))
+                    else:
+                        groups[base_value]["without_voltage"].append(ref)
+
+            except Exception:
+                pass  # Skip sheets that fail to load
+
+        # Emit warnings for groups with mixed formatting
+        for base_value, subsets in sorted(groups.items()):
+            with_v = subsets["with_voltage"]
+            without_v = subsets["without_voltage"]
+
+            if not with_v or not without_v:
+                continue  # All consistent (all have or all lack voltage)
+
+            # Sort references for stable output
+            with_parts = sorted(with_v, key=lambda t: t[0])
+            without_parts = sorted(without_v)
+
+            with_str = ", ".join(f"{ref} ({val})" for ref, val in with_parts)
+            without_str = ", ".join(without_parts)
+
+            issues.append(
+                ValidationIssue(
+                    severity="warning",
+                    category="value_consistency",
+                    message=(
+                        f"Value consistency: capacitors with base value '{base_value}' "
+                        f"have mixed voltage-rating formatting -- "
+                        f"with voltage: {with_str}; "
+                        f"without voltage: {without_str} "
+                        f"-- consider standardizing all to include voltage or "
+                        f"moving voltage to a separate property"
+                    ),
+                )
+            )
+
+    except Exception as e:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                category="value_consistency",
+                message=f"Value consistency check failed: {e}",
+            )
+        )
+
+    return issues
+
+
 def validate_schematic(
     schematic_path: str,
     lib_paths: list[str] = None,
@@ -3200,6 +3327,9 @@ def validate_schematic(
 
     # BOM variety (same-value passives with different footprints)
     _run("bom_variety", check_bom_variety)
+
+    # Value consistency (mixed voltage-rating formatting in capacitors)
+    _run("value_consistency", check_value_consistency)
 
     # Hierarchy
     _run("hierarchy", check_hierarchy)

--- a/tests/test_sch_validate_value_consistency.py
+++ b/tests/test_sch_validate_value_consistency.py
@@ -1,0 +1,365 @@
+"""Tests for capacitor value consistency check (mixed voltage-rating formatting)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_validate import (
+    ValidationIssue,
+    _split_cap_value,
+    check_value_consistency,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _split_cap_value helper
+# ---------------------------------------------------------------------------
+
+
+class TestSplitCapValue:
+    def test_value_with_voltage(self):
+        assert _split_cap_value("100nF 25V") == ("100nF", "25V")
+
+    def test_value_without_voltage(self):
+        assert _split_cap_value("100nF") == ("100nF", None)
+
+    def test_microfarad_with_voltage(self):
+        assert _split_cap_value("10uF 16V") == ("10uF", "16V")
+
+    def test_picofarad(self):
+        assert _split_cap_value("22pF") == ("22pF", None)
+
+    def test_decimal_value(self):
+        assert _split_cap_value("4.7uF 25V") == ("4.7uF", "25V")
+
+    def test_millifarad(self):
+        assert _split_cap_value("1mF") == ("1mF", None)
+
+    def test_mu_symbol(self):
+        assert _split_cap_value("10\u00b5F 50V") == ("10\u00b5F", "50V")
+
+    def test_plain_F(self):
+        assert _split_cap_value("1F") == ("1F", None)
+
+    def test_non_cap_value(self):
+        # Resistor value -- no match, returns as-is
+        assert _split_cap_value("10k") == ("10k", None)
+
+    def test_tilde(self):
+        assert _split_cap_value("~") == ("~", None)
+
+    def test_whitespace_stripping(self):
+        assert _split_cap_value("  100nF  25V  ") == ("100nF", "25V")
+
+    def test_case_insensitive(self):
+        assert _split_cap_value("100NF 25V") == ("100NF", "25V")
+
+    def test_complex_qualifier(self):
+        assert _split_cap_value("100nF X7R 25V") == ("100nF", "X7R 25V")
+
+
+# ---------------------------------------------------------------------------
+# Helpers to generate synthetic KiCad schematics with capacitors
+# ---------------------------------------------------------------------------
+
+
+def _cap_lib_symbol(lib_id: str = "Device:C") -> str:
+    """Generate a minimal lib_symbols entry for a capacitor."""
+    part = lib_id.split(":")[-1] if ":" in lib_id else lib_id
+    return f"""(symbol "{lib_id}"
+        (pin_names (offset 0.254))
+        (symbol "{part}_0_1"
+            (rectangle
+                (start -1.27 -1.27)
+                (end 1.27 1.27)
+                (stroke (width 0.254))
+                (fill (type background))
+            )
+        )
+        (symbol "{part}_1_1"
+            (pin passive line
+                (at 0 2.54 270)
+                (length 2.54)
+                (name "1")
+                (number "1")
+            )
+            (pin passive line
+                (at 0 -2.54 90)
+                (length 2.54)
+                (name "2")
+                (number "2")
+            )
+        )
+    )"""
+
+
+def _resistor_lib_symbol(lib_id: str = "Device:R") -> str:
+    """Generate a minimal lib_symbols entry for a resistor."""
+    part = lib_id.split(":")[-1] if ":" in lib_id else lib_id
+    return f"""(symbol "{lib_id}"
+        (pin_names (offset 0.254))
+        (symbol "{part}_0_1"
+            (rectangle
+                (start -1.27 -1.27)
+                (end 1.27 1.27)
+                (stroke (width 0.254))
+                (fill (type background))
+            )
+        )
+        (symbol "{part}_1_1"
+            (pin passive line
+                (at 0 2.54 270)
+                (length 2.54)
+                (name "1")
+                (number "1")
+            )
+            (pin passive line
+                (at 0 -2.54 90)
+                (length 2.54)
+                (name "2")
+                (number "2")
+            )
+        )
+    )"""
+
+
+def _make_symbol(
+    ref: str,
+    lib_id: str,
+    value: str,
+    footprint: str,
+    x: float,
+    dnp: bool = False,
+) -> str:
+    """Generate a symbol instance S-expression."""
+    dnp_str = "yes" if dnp else "no"
+    return f"""(symbol
+        (lib_id "{lib_id}")
+        (at {x} 50 0)
+        (unit 1)
+        (in_bom yes)
+        (on_board yes)
+        (dnp {dnp_str})
+        (uuid "uuid-{ref.lower()}")
+        (property "Reference" "{ref}"
+            (at {x + 2} 48 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Value" "{value}"
+            (at {x + 2} 50 0)
+            (effects (font (size 1.27 1.27)) (justify left))
+        )
+        (property "Footprint" "{footprint}"
+            (at {x} 50 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        (property "Datasheet" "~"
+            (at {x} 50 0)
+            (effects (font (size 1.27 1.27)) hide)
+        )
+        (pin "1" (uuid "pin-{ref.lower()}-1"))
+        (pin "2" (uuid "pin-{ref.lower()}-2"))
+    )"""
+
+
+def _make_schematic(
+    components: list[dict],
+    lib_symbols: str = "",
+) -> str:
+    """Build a minimal KiCad schematic with the given components.
+
+    Each component dict: {"ref", "lib_id", "value", "footprint", "dnp"(optional)}
+    """
+    # Collect unique lib_ids and generate lib_symbols if not provided
+    if not lib_symbols:
+        seen = set()
+        lib_parts = []
+        for comp in components:
+            lid = comp["lib_id"]
+            if lid not in seen:
+                seen.add(lid)
+                part = lid.split(":")[-1] if ":" in lid else lid
+                if part == "R" or part.startswith("R_"):
+                    lib_parts.append(_resistor_lib_symbol(lid))
+                else:
+                    lib_parts.append(_cap_lib_symbol(lid))
+        lib_symbols = "\n".join(lib_parts)
+
+    syms = []
+    for i, comp in enumerate(components):
+        syms.append(
+            _make_symbol(
+                ref=comp["ref"],
+                lib_id=comp["lib_id"],
+                value=comp["value"],
+                footprint=comp.get("footprint", "Capacitor_SMD:C_0402_1005Metric"),
+                x=100.0 + i * 20.0,
+                dnp=comp.get("dnp", False),
+            )
+        )
+
+    sym_block = "\n".join(syms)
+    return f"""(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "test-value-consistency-uuid")
+    (paper "A4")
+    (lib_symbols
+        {lib_symbols}
+    )
+    {sym_block}
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for check_value_consistency
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_sch(tmp_path):
+    """Factory fixture that writes a schematic string and returns the path."""
+
+    def _write(content: str) -> str:
+        p = tmp_path / "test.kicad_sch"
+        p.write_text(content)
+        return str(p)
+
+    return _write
+
+
+class TestCheckValueConsistency:
+    """Tests for check_value_consistency() end-to-end."""
+
+    def test_mixed_group_produces_warning(self, tmp_sch):
+        """Some caps '100nF', some '100nF 25V' -> 1 warning."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "100nF"},
+            {"ref": "C2", "lib_id": "Device:C", "value": "100nF"},
+            {"ref": "C3", "lib_id": "Device:C", "value": "100nF 25V"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 1
+        assert "100nF" in warnings[0].message
+        assert "C3" in warnings[0].message
+        assert "C1" in warnings[0].message
+        assert "value_consistency" == warnings[0].category
+
+    def test_uniform_no_voltage_no_warning(self, tmp_sch):
+        """All caps '100nF' -> 0 warnings."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "100nF"},
+            {"ref": "C2", "lib_id": "Device:C", "value": "100nF"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 0
+
+    def test_uniform_with_voltage_no_warning(self, tmp_sch):
+        """All caps '100nF 25V' -> 0 warnings."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "100nF 25V"},
+            {"ref": "C2", "lib_id": "Device:C", "value": "100nF 25V"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 0
+
+    def test_different_voltages_no_warning(self, tmp_sch):
+        """'100nF 25V' vs '100nF 50V' -> 0 warnings (both have qualifiers)."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "100nF 25V"},
+            {"ref": "C2", "lib_id": "Device:C", "value": "100nF 50V"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 0
+
+    def test_dnp_excluded(self, tmp_sch):
+        """DNP cap with voltage, active cap without -> 0 warnings."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "100nF"},
+            {"ref": "C2", "lib_id": "Device:C", "value": "100nF 25V", "dnp": True},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 0
+
+    def test_non_capacitor_ignored(self, tmp_sch):
+        """Resistors with mixed formatting -> 0 warnings."""
+        sch = _make_schematic([
+            {"ref": "R1", "lib_id": "Device:R", "value": "10k"},
+            {"ref": "R2", "lib_id": "Device:R", "value": "10k 0.25W"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 0
+
+    def test_multiple_base_values_multiple_warnings(self, tmp_sch):
+        """Both '100nF' and '10uF' have mixed groups -> 2 warnings."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "100nF"},
+            {"ref": "C2", "lib_id": "Device:C", "value": "100nF 25V"},
+            {"ref": "C3", "lib_id": "Device:C", "value": "10uF"},
+            {"ref": "C4", "lib_id": "Device:C", "value": "10uF 16V"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 2
+
+    def test_single_component_no_warning(self, tmp_sch):
+        """Single component -> 0 warnings."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "100nF"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 0
+
+    def test_tilde_value_ignored(self, tmp_sch):
+        """Value '~' is skipped."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "~"},
+            {"ref": "C2", "lib_id": "Device:C", "value": "100nF 25V"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 0
+
+    def test_missing_footprint_ignored(self, tmp_sch):
+        """Component with empty footprint is skipped."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "100nF", "footprint": ""},
+            {"ref": "C2", "lib_id": "Device:C", "value": "100nF 25V"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 0
+
+    def test_warning_message_format(self, tmp_sch):
+        """Verify the warning message contains expected substrings."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "100nF"},
+            {"ref": "C3", "lib_id": "Device:C", "value": "100nF 25V"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 1
+        msg = warnings[0].message
+        assert "with voltage: C3 (100nF 25V)" in msg
+        assert "without voltage: C1" in msg
+        assert "consider standardizing" in msg
+
+    def test_polarized_capacitor_included(self, tmp_sch):
+        """C_Polarized is also a capacitor and should be checked."""
+        sch = _make_schematic([
+            {"ref": "C1", "lib_id": "Device:C", "value": "10uF"},
+            {"ref": "C2", "lib_id": "Device:C_Polarized", "value": "10uF 25V"},
+        ])
+        issues = check_value_consistency(tmp_sch(sch))
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) == 1


### PR DESCRIPTION
## Summary
Add a new `value_consistency` validation check that detects inconsistent voltage-rating formatting in capacitor values. For example, when some 100nF caps specify "100nF 25V" and others just "100nF", the check flags this for standardization.

## Changes
- Add `_split_cap_value()` regex helper to separate base capacitance from voltage qualifier
- Add `check_value_consistency()` function that groups capacitors by base value and flags mixed formatting
- Register as `value_consistency` check in `validate_schematic()`, skippable via `--skip value_consistency`
- Add comprehensive test suite in `tests/test_sch_validate_value_consistency.py` (25 tests)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `sch validate` includes `value_consistency` check | PASS | Registered in validate_schematic() after bom_variety |
| Mixed formatting generates severity="warning" | PASS | test_mixed_group_produces_warning |
| Warning lists both subsets with values | PASS | test_warning_message_format |
| Suggests standardization in message | PASS | test_warning_message_format checks "consider standardizing" |
| All-qualified groups produce no warning | PASS | test_different_voltages_no_warning |
| DNP components excluded | PASS | test_dnp_excluded |
| Non-capacitor passives excluded | PASS | test_non_capacitor_ignored |
| Skippable via --skip value_consistency | PASS | Uses same _run() pattern as all other checks |

## Test Plan
- 25 tests passing: 14 unit tests for _split_cap_value + 11 integration tests for check_value_consistency
- Covers mixed groups, uniform groups, DNP exclusion, non-cap exclusion, multiple base values, edge cases

Closes #2222