### PR TITLE
feat(erc): re-attribute symbol and label violations to correct sheets

### DIFF
--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -32,6 +32,7 @@ from kicad_tools.erc.cross_sheet import (
     filter_cross_sheet_global_labels,
     filter_cross_sheet_power_violations,
     filter_phantom_wire_violations,
+    reattribute_symbol_violations,
     reattribute_wire_dangling_violations,
 )
 from kicad_tools.schema import Schematic
@@ -162,6 +163,13 @@ def run_erc(schematic_path: str) -> list[ValidationIssue]:
                         # violations from root sheet to the correct child
                         # sheet based on position coordinates.
                         raw_violations = reattribute_wire_dangling_violations(
+                            raw_violations, schematic_path
+                        )
+
+                        # Re-attribute symbol-based and label-based
+                        # violations from root sheet to the correct child
+                        # sheet based on component UUID / reference lookup.
+                        raw_violations = reattribute_symbol_violations(
                             raw_violations, schematic_path
                         )
 

--- a/src/kicad_tools/erc/cross_sheet.py
+++ b/src/kicad_tools/erc/cross_sheet.py
@@ -857,3 +857,185 @@ def filter_phantom_wire_violations(
             )
 
     return filtered
+
+
+# ---------------------------------------------------------------------------
+# Symbol-based violation sheet re-attribution
+# ---------------------------------------------------------------------------
+
+# Violation types that reference specific symbols (via UUID or reference
+# designator in the items array) and may be mis-attributed to the root
+# sheet in hierarchical designs.
+_SYMBOL_VIOLATION_TYPES: frozenset[str] = frozenset(
+    {
+        "pin_not_connected",
+        "pin_not_driven",
+        "power_pin_not_driven",
+        "different_unit_value",
+        "different_unit_footprint",
+        "unresolved_variable",
+        "extra_units",
+        "missing_units",
+    }
+)
+
+# Label-based violation types that can also be re-attributed using the
+# label's UUID from the items array.
+_LABEL_VIOLATION_TYPES: frozenset[str] = frozenset(
+    {
+        "global_label_dangling",
+        "label_dangling",
+        "single_global_label",
+        "isolated_pin_label",
+    }
+)
+
+
+def _build_symbol_sheet_map(root_schematic: str) -> dict[str, str]:
+    """Build a mapping of symbol UUID and reference to sheet path.
+
+    Traverses the full schematic hierarchy, collecting each symbol's
+    UUID and reference designator, and mapping them to the sheet path
+    string (e.g. ``"/DAC"``, ``"/Power"``).
+
+    Args:
+        root_schematic: Path to the root ``.kicad_sch`` file.
+
+    Returns:
+        A dict mapping UUID strings and reference designator strings
+        to their containing sheet path.  If a reference appears on
+        multiple sheets only the first occurrence is recorded (the
+        cross-sheet duplicate checker handles that separately).
+    """
+    from kicad_tools.schema.hierarchy import build_hierarchy
+    from kicad_tools.schema.schematic import Schematic
+
+    hierarchy = build_hierarchy(root_schematic)
+    mapping: dict[str, str] = {}
+
+    for node in hierarchy.all_nodes():
+        try:
+            sch = Schematic.load(node.path)
+        except Exception:
+            continue
+
+        sheet_path = node.get_path_string()
+
+        for sym in sch.symbols:
+            if sym.uuid:
+                mapping[sym.uuid] = sheet_path
+            ref = sym.reference
+            if ref and ref not in mapping:
+                mapping[ref] = sheet_path
+
+        # Also index labels by UUID for label-type violations.
+        for gl in sch.global_labels:
+            if hasattr(gl, "uuid") and gl.uuid:
+                mapping[gl.uuid] = sheet_path
+        for lbl in sch.labels:
+            if hasattr(lbl, "uuid") and lbl.uuid:
+                mapping[lbl.uuid] = sheet_path
+
+    return mapping
+
+
+def _extract_identifiers_from_items(items: list[dict]) -> list[str]:
+    """Extract UUIDs and component references from a violation's items array.
+
+    KiCad's ERC JSON ``items`` entries may contain:
+    - A ``"uuid"`` key with a UUID string
+    - A ``"description"`` containing a reference like ``"Pin VCC of U3"``
+
+    Args:
+        items: List of item dicts from a KiCad ERC violation.
+
+    Returns:
+        A list of identifier strings (UUIDs and/or references) that
+        can be looked up in the symbol-sheet mapping.
+    """
+    identifiers: list[str] = []
+
+    for item in items:
+        # Direct UUID field
+        uuid = item.get("uuid", "")
+        if uuid:
+            identifiers.append(uuid)
+
+        # Extract reference from description patterns like:
+        # "Pin VCC (power_in) of U3"
+        # "Symbol U3"
+        desc = item.get("description", "")
+        if desc:
+            # Match "of <reference>" at end of description
+            m = re.search(r"\bof\s+([A-Za-z]+\d+)\b", desc)
+            if m:
+                identifiers.append(m.group(1))
+            # Match "Symbol <reference>" at start
+            m = re.search(r"\bSymbol\s+([A-Za-z]+\d+)\b", desc)
+            if m:
+                identifiers.append(m.group(1))
+
+    return identifiers
+
+
+def reattribute_symbol_violations(
+    violations: list[dict],
+    root_schematic: str,
+) -> list[dict]:
+    """Re-attribute symbol-based ERC violations from the root sheet to the
+    correct child sheet based on component reference or UUID lookup.
+
+    KiCad's ERC JSON sometimes attributes violations to the root sheet
+    (``"/"``) even when the offending symbol lives in a child sheet.
+    This affects symbol-based violation types (``pin_not_connected``,
+    ``pin_not_driven``, etc.) and label-based types whose items contain
+    identifiable UUIDs or references.
+
+    This function builds a symbol-to-sheet mapping from the hierarchy
+    and updates ``_sheet_path`` for violations that can be matched to
+    a specific child sheet.
+
+    Args:
+        violations: List of raw violation dicts (must already have
+            ``_sheet_path`` injected by the caller).
+        root_schematic: Path to the root ``.kicad_sch`` file.
+
+    Returns:
+        The same list (mutated in place for efficiency) with updated
+        ``_sheet_path`` values where re-attribution was possible.
+    """
+    target_types = _SYMBOL_VIOLATION_TYPES | _LABEL_VIOLATION_TYPES
+
+    # Quick check: skip expensive hierarchy traversal when unnecessary.
+    has_target = any(
+        v.get("type", "") in target_types and v.get("_sheet_path", "") == "/"
+        for v in violations
+    )
+    if not has_target:
+        return violations
+
+    symbol_map = _build_symbol_sheet_map(root_schematic)
+
+    for v in violations:
+        vtype = v.get("type", "")
+        if vtype not in target_types:
+            continue
+
+        if v.get("_sheet_path", "") != "/":
+            continue
+
+        items = v.get("items", [])
+        if not items:
+            continue
+
+        identifiers = _extract_identifiers_from_items(items)
+
+        # Try each identifier against the map; use the first match
+        # that points to a non-root sheet.
+        for ident in identifiers:
+            sheet_path = symbol_map.get(ident)
+            if sheet_path and sheet_path != "/":
+                v["_sheet_path"] = sheet_path
+                break
+
+    return violations

--- a/tests/test_erc_reattribute_symbol.py
+++ b/tests/test_erc_reattribute_symbol.py
@@ -1,0 +1,400 @@
+"""Tests for symbol-based ERC violation sheet re-attribution.
+
+Tests the ``reattribute_symbol_violations`` function that corrects
+``_sheet_path`` for violations mis-attributed to the root sheet when
+the offending symbol lives on a child sheet.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.erc.cross_sheet import (
+    _build_symbol_sheet_map,
+    _extract_identifiers_from_items,
+    reattribute_symbol_violations,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture schematic templates (same format as test_erc_cross_sheet.py)
+# ---------------------------------------------------------------------------
+
+_ROOT_TEMPLATE = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "root-uuid-001")
+  (paper "A4")
+  (lib_symbols)
+  {symbols}
+  {sheets}
+)
+"""
+
+_SUBSHEET_TEMPLATE = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "{uuid}")
+  (paper "A4")
+  (lib_symbols)
+  {symbols}
+)
+"""
+
+_SYMBOL_TEMPLATE = """\
+  (symbol
+    (lib_id "{lib_id}")
+    (at 100 100 0)
+    (unit {unit})
+    (uuid "{uuid}")
+    (property "Reference" "{reference}"
+      (at 100 90 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Value" "{value}"
+      (at 100 110 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (pin "1" (uuid "{uuid}-pin1"))
+  )
+"""
+
+_SHEET_TEMPLATE = """\
+  (sheet
+    (at 130 40) (size 40 30)
+    (uuid "{uuid}")
+    (property "Sheetname" "{name}"
+      (at 130 39 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Sheetfile" "{filename}"
+      (at 130 71 0)
+      (effects (font (size 1.27 1.27)))
+    )
+  )
+"""
+
+
+def _make_symbol(
+    reference: str,
+    value: str = "10k",
+    lib_id: str = "Device:R",
+    uuid: str = "sym-001",
+    unit: int = 1,
+) -> str:
+    return _SYMBOL_TEMPLATE.format(
+        reference=reference,
+        value=value,
+        lib_id=lib_id,
+        uuid=uuid,
+        unit=unit,
+    )
+
+
+def _make_sheet(name: str, filename: str, uuid: str = "sheet-001") -> str:
+    return _SHEET_TEMPLATE.format(name=name, filename=filename, uuid=uuid)
+
+
+def _make_hierarchy(tmp_path: Path) -> str:
+    """Create a two-level hierarchy: root with DAC and Power sub-sheets.
+
+    Root has R1, DAC sub-sheet has U3, Power sub-sheet has U5.
+    Returns path to root schematic.
+    """
+    root_symbols = _make_symbol("R1", "10k", uuid="root-r1")
+    root_sheets = (
+        _make_sheet("DAC", "dac.kicad_sch", uuid="sheet-dac")
+        + _make_sheet("Power", "power.kicad_sch", uuid="sheet-power")
+    )
+    root_content = _ROOT_TEMPLATE.format(
+        symbols=root_symbols, sheets=root_sheets
+    )
+
+    dac_symbols = _make_symbol("U3", "PCM5122", lib_id="Audio:PCM5122", uuid="dac-u3")
+    dac_content = _SUBSHEET_TEMPLATE.format(uuid="dac-uuid-001", symbols=dac_symbols)
+
+    power_symbols = _make_symbol("U5", "TPS7A47", lib_id="Regulator:TPS7A47", uuid="power-u5")
+    power_content = _SUBSHEET_TEMPLATE.format(uuid="power-uuid-001", symbols=power_symbols)
+
+    (tmp_path / "root.kicad_sch").write_text(root_content)
+    (tmp_path / "dac.kicad_sch").write_text(dac_content)
+    (tmp_path / "power.kicad_sch").write_text(power_content)
+
+    return str(tmp_path / "root.kicad_sch")
+
+
+# ---------------------------------------------------------------------------
+# Tests: _extract_identifiers_from_items
+# ---------------------------------------------------------------------------
+
+
+class TestExtractIdentifiers:
+    """Tests for _extract_identifiers_from_items."""
+
+    def test_uuid_extraction(self):
+        items = [{"uuid": "abc-123", "description": "some pin"}]
+        result = _extract_identifiers_from_items(items)
+        assert "abc-123" in result
+
+    def test_reference_from_of_pattern(self):
+        items = [{"description": "Pin VCC (power_in) of U3"}]
+        result = _extract_identifiers_from_items(items)
+        assert "U3" in result
+
+    def test_reference_from_symbol_pattern(self):
+        items = [{"description": "Symbol U5"}]
+        result = _extract_identifiers_from_items(items)
+        assert "U5" in result
+
+    def test_both_uuid_and_reference(self):
+        items = [{"uuid": "dac-u3", "description": "Pin SDA of U3"}]
+        result = _extract_identifiers_from_items(items)
+        assert "dac-u3" in result
+        assert "U3" in result
+
+    def test_empty_items(self):
+        assert _extract_identifiers_from_items([]) == []
+
+    def test_no_identifiers(self):
+        items = [{"description": "Some generic error"}]
+        result = _extract_identifiers_from_items(items)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_symbol_sheet_map
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSymbolSheetMap:
+    """Tests for _build_symbol_sheet_map."""
+
+    def test_maps_symbols_to_sheets(self, tmp_path: Path):
+        root_path = _make_hierarchy(tmp_path)
+        mapping = _build_symbol_sheet_map(root_path)
+
+        # Root symbols should map to "/"
+        assert mapping.get("root-r1") == "/"
+        # DAC symbols should map to "/DAC"
+        assert mapping.get("dac-u3") == "/DAC"
+        assert mapping.get("U3") == "/DAC"
+        # Power symbols should map to "/Power"
+        assert mapping.get("power-u5") == "/Power"
+        assert mapping.get("U5") == "/Power"
+
+    def test_flat_schematic(self, tmp_path: Path):
+        """A flat schematic with no sub-sheets maps everything to root."""
+        symbols = _make_symbol("R1", "10k", uuid="r1-uuid")
+        content = _ROOT_TEMPLATE.format(symbols=symbols, sheets="")
+        (tmp_path / "root.kicad_sch").write_text(content)
+
+        mapping = _build_symbol_sheet_map(str(tmp_path / "root.kicad_sch"))
+        assert mapping.get("r1-uuid") == "/"
+        assert mapping.get("R1") == "/"
+
+
+# ---------------------------------------------------------------------------
+# Tests: reattribute_symbol_violations
+# ---------------------------------------------------------------------------
+
+
+class TestReattributeSymbolViolations:
+    """Tests for reattribute_symbol_violations."""
+
+    def test_reattributes_by_uuid(self, tmp_path: Path):
+        """A violation with a UUID matching a child-sheet symbol gets re-attributed."""
+        root_path = _make_hierarchy(tmp_path)
+
+        violations = [
+            {
+                "type": "pin_not_connected",
+                "description": "Pin not connected",
+                "severity": "error",
+                "_sheet_path": "/",
+                "items": [{"uuid": "dac-u3", "description": "Pin SDA of U3"}],
+            }
+        ]
+
+        result = reattribute_symbol_violations(violations, root_path)
+        assert len(result) == 1
+        assert result[0]["_sheet_path"] == "/DAC"
+
+    def test_reattributes_by_reference(self, tmp_path: Path):
+        """A violation with a reference in description gets re-attributed."""
+        root_path = _make_hierarchy(tmp_path)
+
+        violations = [
+            {
+                "type": "pin_not_driven",
+                "description": "Power input pin not driven",
+                "severity": "error",
+                "_sheet_path": "/",
+                "items": [{"description": "Pin VCC (power_in) of U5"}],
+            }
+        ]
+
+        result = reattribute_symbol_violations(violations, root_path)
+        assert len(result) == 1
+        assert result[0]["_sheet_path"] == "/Power"
+
+    def test_root_sheet_violations_stay_on_root(self, tmp_path: Path):
+        """Violations for symbols actually on root should remain on root."""
+        root_path = _make_hierarchy(tmp_path)
+
+        violations = [
+            {
+                "type": "pin_not_connected",
+                "description": "Pin not connected",
+                "severity": "error",
+                "_sheet_path": "/",
+                "items": [{"uuid": "root-r1", "description": "Pin 1 of R1"}],
+            }
+        ]
+
+        result = reattribute_symbol_violations(violations, root_path)
+        assert len(result) == 1
+        # Should stay on "/" because R1 is actually on root
+        assert result[0]["_sheet_path"] == "/"
+
+    def test_non_root_violations_unchanged(self, tmp_path: Path):
+        """Violations already on a child sheet should not be changed."""
+        root_path = _make_hierarchy(tmp_path)
+
+        violations = [
+            {
+                "type": "pin_not_connected",
+                "description": "Pin not connected",
+                "severity": "error",
+                "_sheet_path": "/DAC",
+                "items": [{"uuid": "dac-u3", "description": "Pin SDA of U3"}],
+            }
+        ]
+
+        result = reattribute_symbol_violations(violations, root_path)
+        assert result[0]["_sheet_path"] == "/DAC"
+
+    def test_non_target_types_unchanged(self, tmp_path: Path):
+        """Violations of unrelated types should pass through unchanged."""
+        root_path = _make_hierarchy(tmp_path)
+
+        violations = [
+            {
+                "type": "some_other_type",
+                "description": "Something else",
+                "severity": "warning",
+                "_sheet_path": "/",
+                "items": [{"uuid": "dac-u3"}],
+            }
+        ]
+
+        result = reattribute_symbol_violations(violations, root_path)
+        assert result[0]["_sheet_path"] == "/"
+
+    def test_no_items_unchanged(self, tmp_path: Path):
+        """Violations with no items array cannot be re-attributed."""
+        root_path = _make_hierarchy(tmp_path)
+
+        violations = [
+            {
+                "type": "pin_not_connected",
+                "description": "Pin not connected",
+                "severity": "error",
+                "_sheet_path": "/",
+                "items": [],
+            }
+        ]
+
+        result = reattribute_symbol_violations(violations, root_path)
+        assert result[0]["_sheet_path"] == "/"
+
+    def test_no_target_violations_skips_traversal(self, tmp_path: Path):
+        """When no target violations exist, hierarchy is not traversed."""
+        root_path = _make_hierarchy(tmp_path)
+
+        violations = [
+            {
+                "type": "wire_dangling",
+                "description": "Wire not connected",
+                "severity": "warning",
+                "_sheet_path": "/",
+                "items": [],
+            }
+        ]
+
+        # Should return quickly without building hierarchy
+        result = reattribute_symbol_violations(violations, root_path)
+        assert result[0]["_sheet_path"] == "/"
+
+    def test_flat_schematic_no_change(self, tmp_path: Path):
+        """In a flat schematic, root violations stay on root."""
+        symbols = _make_symbol("R1", "10k", uuid="r1-uuid")
+        content = _ROOT_TEMPLATE.format(symbols=symbols, sheets="")
+        root_path = str(tmp_path / "root.kicad_sch")
+        (tmp_path / "root.kicad_sch").write_text(content)
+
+        violations = [
+            {
+                "type": "pin_not_connected",
+                "description": "Pin not connected",
+                "severity": "error",
+                "_sheet_path": "/",
+                "items": [{"uuid": "r1-uuid", "description": "Pin 1 of R1"}],
+            }
+        ]
+
+        result = reattribute_symbol_violations(violations, root_path)
+        assert result[0]["_sheet_path"] == "/"
+
+    def test_label_violation_reattributed(self, tmp_path: Path):
+        """Label-type violations should also be re-attributed by UUID."""
+        root_path = _make_hierarchy(tmp_path)
+
+        violations = [
+            {
+                "type": "global_label_dangling",
+                "description": "Global label not connected",
+                "severity": "warning",
+                "_sheet_path": "/",
+                "items": [{"uuid": "dac-u3", "description": "Global Label 'AUDIO_L'"}],
+            }
+        ]
+
+        result = reattribute_symbol_violations(violations, root_path)
+        assert result[0]["_sheet_path"] == "/DAC"
+
+    def test_multiple_violations_mixed(self, tmp_path: Path):
+        """Multiple violations with different types and sheets are handled correctly."""
+        root_path = _make_hierarchy(tmp_path)
+
+        violations = [
+            {
+                "type": "pin_not_connected",
+                "description": "Pin not connected",
+                "severity": "error",
+                "_sheet_path": "/",
+                "items": [{"uuid": "dac-u3", "description": "Pin SDA of U3"}],
+            },
+            {
+                "type": "pin_not_driven",
+                "description": "Power pin not driven",
+                "severity": "error",
+                "_sheet_path": "/",
+                "items": [{"description": "Pin VIN (power_in) of U5"}],
+            },
+            {
+                "type": "wire_dangling",
+                "description": "Wire not connected",
+                "severity": "warning",
+                "_sheet_path": "/",
+                "items": [],
+            },
+        ]
+
+        result = reattribute_symbol_violations(violations, root_path)
+        assert result[0]["_sheet_path"] == "/DAC"
+        assert result[1]["_sheet_path"] == "/Power"
+        assert result[2]["_sheet_path"] == "/"  # wire_dangling not a target type


### PR DESCRIPTION
## Summary
ERC findings in hierarchical designs were not attributed to specific sheets -- symbol-based
and label-based violations reported by KiCad were left on the root sheet ("/") even when
the offending component lived on a child sheet (e.g. "/DAC", "/Power"). This adds
re-attribution logic that matches violation items (UUID, reference designator) to the
correct child sheet via the schematic hierarchy.

## Changes
- Added `reattribute_symbol_violations()` in `erc/cross_sheet.py` following the established
  pattern from `reattribute_wire_dangling_violations()`
- Added `_build_symbol_sheet_map()` helper that traverses the hierarchy and maps symbol
  UUIDs and reference designators to their containing sheet path
- Added `_extract_identifiers_from_items()` helper that parses UUIDs and component
  references from KiCad ERC violation item descriptions
- Integrated the new re-attribution call in `sch_validate.py:run_erc()` alongside the
  existing wire re-attribution
- Added 18 unit tests covering UUID-based lookup, reference-based lookup, edge cases
  (flat schematics, root-sheet symbols, empty items), and mixed violation batches

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Symbol-based violations re-attributed to correct sheet | PASS | test_reattributes_by_uuid, test_reattributes_by_reference |
| Label-based violations re-attributed | PASS | test_label_violation_reattributed |
| Root-sheet symbols stay on root | PASS | test_root_sheet_violations_stay_on_root |
| Flat schematics unaffected | PASS | test_flat_schematic_no_change |
| Non-target types pass through | PASS | test_non_target_types_unchanged |
| Existing wire re-attribution unaffected | PASS | All 58 existing ERC tests pass |

## Test Plan
- All 18 new tests pass (`tests/test_erc_reattribute_symbol.py`)
- All 58 existing ERC tests pass (no regressions)

Closes #2227