### PR TITLE
feat(sch): add connected field and synthetic _local_N nets to pin-map

### DIFF
--- a/src/kicad_tools/cli/sch_pin_map.py
+++ b/src/kicad_tools/cli/sch_pin_map.py
@@ -50,7 +50,14 @@ def resolve_pin_map(
         ref_filter: If provided, only include this reference designator
 
     Returns:
-        Dict mapping reference -> {"lib_id": str, "pins": {pin_num: {name, net, type, position}}}
+        Dict mapping reference -> {"lib_id": str, "pins": {pin_num: {name, net, connected, type, position}}}
+
+        The ``connected`` field is True when the pin touches at least one wire
+        in the schematic, False when the pin is truly floating (no wire at all).
+
+        Pins on unnamed local nets (wired together but no label) receive a
+        synthetic net name like ``_local_1``, ``_local_2``, etc.  Pins that are
+        truly floating have ``net: None`` and ``connected: False``.
     """
     result: dict[str, dict] = {}
 
@@ -166,9 +173,16 @@ def resolve_pin_map(
             # Trace from pin position to find net name
             net = _flood_fill_net(coord, adjacency, net_names, barrier_pins)
 
+            # Determine connectivity: a pin is "connected" if it has any
+            # neighbors in the wire adjacency graph (i.e., a wire touches it).
+            snapped = _snap_coord(coord, set(adjacency.keys()))
+            has_neighbors = bool(adjacency.get(snapped, set()))
+            connected = net is not None or has_neighbors
+
             pins_data[lib_pin.number] = {
                 "name": lib_pin.name,
                 "net": net,
+                "connected": connected,
                 "type": lib_pin.type,
                 "position": [round(pos[0], 4), round(pos[1], 4)],
             }
@@ -182,6 +196,53 @@ def resolve_pin_map(
                 "value": symbol.value,
                 "pins": pins_data,
             }
+
+    # ------------------------------------------------------------------
+    # Post-pass: assign synthetic net names to unnamed local nets.
+    #
+    # Pins with net=None but connected=True are on unnamed local nets.
+    # Group them by connected component using BFS on the adjacency graph,
+    # then assign _local_1, _local_2, etc. to each group.
+    # ------------------------------------------------------------------
+    # Collect all (ref, pin_num, coord) tuples for unresolved-but-connected pins
+    unresolved_coords: dict[Coord, list[tuple[str, str]]] = defaultdict(list)
+    for ref, entry in result.items():
+        for pin_num, pin_data in entry["pins"].items():
+            if pin_data["net"] is None and pin_data["connected"]:
+                pos = pin_data["position"]
+                coord = _to_coord(pos[0], pos[1])
+                snapped = _snap_coord(coord, set(adjacency.keys()))
+                unresolved_coords[snapped].append((ref, pin_num))
+
+    # BFS to find connected components among unresolved pin coordinates
+    visited: set[Coord] = set()
+    local_counter = 0
+
+    for start_coord in unresolved_coords:
+        if start_coord in visited:
+            continue
+
+        # BFS from this coordinate through the wire graph
+        component_coords: set[Coord] = set()
+        queue = [start_coord]
+        visited.add(start_coord)
+
+        while queue:
+            current = queue.pop(0)
+            if current in unresolved_coords:
+                component_coords.add(current)
+            for neighbor in adjacency.get(current, set()):
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    queue.append(neighbor)
+
+        # Only assign a synthetic name if there are pins in this component
+        if component_coords:
+            local_counter += 1
+            synthetic_name = f"_local_{local_counter}"
+            for coord in component_coords:
+                for ref, pin_num in unresolved_coords[coord]:
+                    result[ref]["pins"][pin_num]["net"] = synthetic_name
 
     return result
 
@@ -209,7 +270,12 @@ def output_table(pin_map: dict[str, dict]) -> None:
             key=lambda p: (not p.isdigit(), int(p) if p.isdigit() else 0, p),
         ):
             pin = pins[pin_num]
-            net_str = pin["net"] if pin["net"] else "(unconnected)"
+            if pin["net"]:
+                net_str = pin["net"]
+            elif pin.get("connected"):
+                net_str = "(unnamed)"
+            else:
+                net_str = "(floating)"
             pos = pin.get("position")
             pos_str = f"({pos[0]:.2f}, {pos[1]:.2f})" if pos else ""
             print(f"  {pin_num:<6} {pin['name']:<20} {pin['type']:<15} {pos_str:<22} {net_str}")

--- a/src/kicad_tools/cli/sch_symbol_info.py
+++ b/src/kicad_tools/cli/sch_symbol_info.py
@@ -107,6 +107,7 @@ def output_json(symbol, show_pins, show_properties, pin_map_data=None):
                 pin_entry["name"] = enriched.get("name")
                 pin_entry["type"] = enriched.get("type")
                 pin_entry["net"] = enriched.get("net")
+                pin_entry["connected"] = enriched.get("connected")
                 pin_entry["position"] = enriched.get("position")
             pins.append(pin_entry)
         data["pins"] = pins
@@ -145,7 +146,12 @@ def output_text(symbol, show_pins, show_properties, pin_map_data=None):
                 enriched = pin_map_data.get(pin.number, {})
                 name = enriched.get("name", "")
                 pin_type = enriched.get("type", "")
-                net = enriched.get("net") or "(unconnected)"
+                if enriched.get("net"):
+                    net = enriched["net"]
+                elif enriched.get("connected"):
+                    net = "(unnamed)"
+                else:
+                    net = "(floating)"
                 print(f"  {pin.number:<6} {name:<20} {pin_type:<15} {net:<20} {pin.uuid}")
         else:
             print("-" * 50)

--- a/tests/test_sch_pin_map.py
+++ b/tests/test_sch_pin_map.py
@@ -687,6 +687,10 @@ class TestResolvePinMap:
         assert pin_map["R1"]["pins"]["2"]["net"] == "GND"
         assert pin_map["R1"]["lib_id"] == "Device:R"
 
+        # All pins on named nets should be connected
+        assert pin_map["R1"]["pins"]["1"]["connected"] is True
+        assert pin_map["R1"]["pins"]["2"]["connected"] is True
+
         # Verify absolute pin positions (R1 at (100, 50), pin offsets +-3.81)
         assert pin_map["R1"]["pins"]["1"]["position"] == [100.0, 46.19]
         assert pin_map["R1"]["pins"]["2"]["position"] == [100.0, 53.81]
@@ -694,6 +698,8 @@ class TestResolvePinMap:
         # C1 follows the same pin layout (at (120, 50))
         assert pin_map["C1"]["pins"]["1"]["net"] == "VIN"
         assert pin_map["C1"]["pins"]["2"]["net"] == "GND"
+        assert pin_map["C1"]["pins"]["1"]["connected"] is True
+        assert pin_map["C1"]["pins"]["2"]["connected"] is True
         assert pin_map["C1"]["pins"]["1"]["position"] == [120.0, 46.19]
         assert pin_map["C1"]["pins"]["2"]["position"] == [120.0, 53.81]
 
@@ -723,8 +729,10 @@ class TestResolvePinMap:
         assert "R1" in pin_map
         # R1 pin 1 at (100, 46.19) connected via wire to +3.3V power symbol at (100, 40)
         assert pin_map["R1"]["pins"]["1"]["net"] == "+3.3V"
-        # R1 pin 2 at (100, 53.81) is unconnected (no wire)
+        assert pin_map["R1"]["pins"]["1"]["connected"] is True
+        # R1 pin 2 at (100, 53.81) is floating (no wire)
         assert pin_map["R1"]["pins"]["2"]["net"] is None
+        assert pin_map["R1"]["pins"]["2"]["connected"] is False
 
     def test_power_symbols_excluded(self, tmp_path):
         sch = Schematic.load(_write_sch(tmp_path, POWER_SYMBOL_SCHEMATIC))
@@ -735,12 +743,15 @@ class TestResolvePinMap:
             assert not ref.startswith("#PWR")
 
     def test_unconnected_pin(self, tmp_path):
+        """Truly floating pins (no wires) should have net=None and connected=False."""
         sch = Schematic.load(_write_sch(tmp_path, UNCONNECTED_SCHEMATIC))
         pin_map = resolve_pin_map(sch)
 
         assert "R1" in pin_map
         assert pin_map["R1"]["pins"]["1"]["net"] is None
         assert pin_map["R1"]["pins"]["2"]["net"] is None
+        assert pin_map["R1"]["pins"]["1"]["connected"] is False
+        assert pin_map["R1"]["pins"]["2"]["connected"] is False
         # Position should still be present even for unconnected pins
         assert pin_map["R1"]["pins"]["1"]["position"] == [100.0, 46.19]
         assert pin_map["R1"]["pins"]["2"]["position"] == [100.0, 53.81]
@@ -798,7 +809,7 @@ class TestBFSBarrier:
 
         Without BFS barriers, D1 cathode would incorrectly resolve to GND by
         traversing through R1's body.  With barriers, the BFS stops at R1 pin 1
-        and D1 cathode resolves to None (unnamed net at the junction).
+        and D1 cathode gets a synthetic _local_N net name (unnamed local net).
         """
         sch = Schematic.load(_write_sch(tmp_path, DIODE_RESISTOR_SCHEMATIC))
         pin_map = resolve_pin_map(sch)
@@ -806,20 +817,35 @@ class TestBFSBarrier:
         assert "D1" in pin_map
         assert "R1" in pin_map
 
-        # D1 cathode (pin 1) must NOT resolve to GND
+        # D1 cathode (pin 1) must NOT resolve to GND -- it should get a
+        # synthetic _local_N name since it is wired to R1 pin 1 (unnamed net)
         d1_pin1_net = pin_map["D1"]["pins"]["1"]["net"]
-        assert d1_pin1_net is None, (
-            f"D1 cathode should be None (unnamed net), got {d1_pin1_net!r}"
+        assert d1_pin1_net is not None, (
+            "D1 cathode should have a synthetic net name (unnamed local net)"
         )
+        assert d1_pin1_net.startswith("_local_"), (
+            f"D1 cathode should have _local_N net name, got {d1_pin1_net!r}"
+        )
+        assert d1_pin1_net != "GND", (
+            "D1 cathode must NOT resolve to GND through R1's body"
+        )
+        assert pin_map["D1"]["pins"]["1"]["connected"] is True
 
         # D1 anode (pin 2) should resolve to VBUS
         assert pin_map["D1"]["pins"]["2"]["net"] == "VBUS"
+        assert pin_map["D1"]["pins"]["2"]["connected"] is True
 
-        # R1 should still resolve correctly
-        # R1 pin 1 shares junction with D1 cathode -- unnamed net
-        assert pin_map["R1"]["pins"]["1"]["net"] is None
+        # R1 pin 1 shares junction with D1 cathode -- same unnamed local net
+        r1_pin1_net = pin_map["R1"]["pins"]["1"]["net"]
+        assert r1_pin1_net == d1_pin1_net, (
+            f"R1 pin 1 and D1 cathode should share the same local net, "
+            f"got R1={r1_pin1_net!r} vs D1={d1_pin1_net!r}"
+        )
+        assert pin_map["R1"]["pins"]["1"]["connected"] is True
+
         # R1 pin 2 connects to GND
         assert pin_map["R1"]["pins"]["2"]["net"] == "GND"
+        assert pin_map["R1"]["pins"]["2"]["connected"] is True
 
     def test_shared_junction_still_resolves(self, tmp_path):
         """Components sharing a junction (same coordinate) should both see the
@@ -873,13 +899,17 @@ class TestPullupBarrierNetPropagation:
         """Even with net propagation, BFS must not cross through a component.
 
         The diode-resistor test (DIODE_RESISTOR_SCHEMATIC) must still pass:
-        D1 cathode must NOT resolve to GND through R1's body."""
+        D1 cathode must NOT resolve to GND through R1's body. It gets a
+        synthetic _local_N name instead."""
         sch = Schematic.load(_write_sch(tmp_path, DIODE_RESISTOR_SCHEMATIC))
         pin_map = resolve_pin_map(sch)
 
         d1_pin1_net = pin_map["D1"]["pins"]["1"]["net"]
-        assert d1_pin1_net is None, (
-            f"D1 cathode should still be None, got {d1_pin1_net!r}"
+        assert d1_pin1_net != "GND", (
+            f"D1 cathode must NOT resolve to GND, got {d1_pin1_net!r}"
+        )
+        assert d1_pin1_net is not None and d1_pin1_net.startswith("_local_"), (
+            f"D1 cathode should have _local_N synthetic net, got {d1_pin1_net!r}"
         )
         assert pin_map["D1"]["pins"]["2"]["net"] == "VBUS"
         assert pin_map["R1"]["pins"]["2"]["net"] == "GND"
@@ -1000,9 +1030,13 @@ class TestRCFilterChain:
 
         assert pin_map["R1"]["pins"]["1"]["net"] == "AUDIO_L"
         assert pin_map["C1"]["pins"]["1"]["net"] == "AUDIO_L"
-        # Pin 2 of both components has no wire -- should be None
+        assert pin_map["R1"]["pins"]["1"]["connected"] is True
+        assert pin_map["C1"]["pins"]["1"]["connected"] is True
+        # Pin 2 of both components has no wire -- should be floating
         assert pin_map["R1"]["pins"]["2"]["net"] is None
         assert pin_map["C1"]["pins"]["2"]["net"] is None
+        assert pin_map["R1"]["pins"]["2"]["connected"] is False
+        assert pin_map["C1"]["pins"]["2"]["connected"] is False
 
     def test_ref_filter_with_chain(self, tmp_path):
         """Filtering by ref still resolves nets correctly in a chain."""
@@ -1262,28 +1296,230 @@ class TestNetTieTraversal:
             f"U1 pin 1 should resolve to NET_A or NET_B, got {u1_pin1_net!r}"
         )
 
-    def test_nettie_no_label_resolves_none(self, tmp_path):
-        """Net-tie with no labels on either side: pins resolve to None."""
+    def test_nettie_no_label_resolves_local(self, tmp_path):
+        """Net-tie with no labels on either side: pins get synthetic _local_N names."""
         sch = Schematic.load(_write_sch(tmp_path, NET_TIE_NO_LABEL_SCHEMATIC))
         pin_map = resolve_pin_map(sch)
 
         assert "U1" in pin_map
-        assert pin_map["U1"]["pins"]["1"]["net"] is None
+        # U1 pin 1 is wired (through net-tie) but has no label
+        u1_net = pin_map["U1"]["pins"]["1"]["net"]
+        assert u1_net is not None and u1_net.startswith("_local_"), (
+            f"U1 pin 1 should have _local_N synthetic net, got {u1_net!r}"
+        )
+        assert pin_map["U1"]["pins"]["1"]["connected"] is True
 
     def test_barrier_still_blocks_non_nettie(self, tmp_path):
         """Net-tie exemption must not weaken barriers for normal components.
 
         The diode-resistor barrier test must still pass: D1 cathode must NOT
-        resolve to GND through R1's body."""
+        resolve to GND through R1's body. It gets a _local_N name instead."""
         sch = Schematic.load(_write_sch(tmp_path, DIODE_RESISTOR_SCHEMATIC))
         pin_map = resolve_pin_map(sch)
 
         d1_pin1_net = pin_map["D1"]["pins"]["1"]["net"]
-        assert d1_pin1_net is None, (
-            f"D1 cathode should still be None with net-tie support, got {d1_pin1_net!r}"
+        assert d1_pin1_net != "GND", (
+            f"D1 cathode must NOT resolve to GND, got {d1_pin1_net!r}"
+        )
+        assert d1_pin1_net is not None and d1_pin1_net.startswith("_local_"), (
+            f"D1 cathode should have _local_N synthetic net, got {d1_pin1_net!r}"
         )
         assert pin_map["D1"]["pins"]["2"]["net"] == "VBUS"
         assert pin_map["R1"]["pins"]["2"]["net"] == "GND"
+
+
+# ---------------------------------------------------------------------------
+# Unnamed local net detection and connected field
+# ---------------------------------------------------------------------------
+
+# Two resistors wired together with NO label -- unnamed local net.
+# R1 pin 1 at (100, 46.19) wired to R2 pin 1 at (120, 46.19) via horizontal wire.
+# R1 pin 2 and R2 pin 2 are both floating (no wires).
+UNNAMED_LOCAL_NET_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000002219")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (symbol "R_1_1"
+        (pin passive line
+          (at 0 3.81 270) (length 1.27) (name "~") (number "1"))
+        (pin passive line
+          (at 0 -3.81 90) (length 1.27) (name "~") (number "2"))
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R") (at 100 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (uuid "uln-r1")
+    (property "Reference" "R1" (at 102 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "10k" (at 102 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p1")) (pin "2" (uuid "p2"))
+  )
+  (symbol
+    (lib_id "Device:R") (at 120 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (uuid "uln-r2")
+    (property "Reference" "R2" (at 122 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "10k" (at 122 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p3")) (pin "2" (uuid "p4"))
+  )
+  (wire (pts (xy 100 46.19) (xy 120 46.19))
+    (stroke (width 0) (type default)) (uuid "w-r1r2"))
+)
+"""
+
+# Mixed: some pins on named nets, some on unnamed local nets, some floating.
+# R1 pin 1 -> wire -> label "SIG"
+# R1 pin 2 -> wire -> R2 pin 1 (no label = unnamed local net)
+# R2 pin 2 -> floating (no wire)
+MIXED_CONNECTIVITY_SCHEMATIC = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000002220")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (symbol "R_1_1"
+        (pin passive line
+          (at 0 3.81 270) (length 1.27) (name "~") (number "1"))
+        (pin passive line
+          (at 0 -3.81 90) (length 1.27) (name "~") (number "2"))
+      )
+    )
+  )
+  (symbol
+    (lib_id "Device:R") (at 100 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (uuid "mix-r1")
+    (property "Reference" "R1" (at 102 48 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "10k" (at 102 50 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p1")) (pin "2" (uuid "p2"))
+  )
+  (symbol
+    (lib_id "Device:R") (at 100 70 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (uuid "mix-r2")
+    (property "Reference" "R2" (at 102 68 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (property "Value" "10k" (at 102 70 0)
+      (effects (font (size 1.27 1.27)) (justify left)))
+    (pin "1" (uuid "p3")) (pin "2" (uuid "p4"))
+  )
+  (wire (pts (xy 100 46.19) (xy 100 40))
+    (stroke (width 0) (type default)) (uuid "w-sig"))
+  (wire (pts (xy 100 53.81) (xy 100 66.19))
+    (stroke (width 0) (type default)) (uuid "w-r1r2"))
+  (label "SIG" (at 100 40 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid "lbl-sig"))
+)
+"""
+
+
+class TestUnnamedLocalNets:
+    """Verify that pins on unnamed local nets get synthetic _local_N names."""
+
+    def test_two_resistors_unnamed_net(self, tmp_path):
+        """R1 pin 1 and R2 pin 1 wired together with no label."""
+        sch = Schematic.load(_write_sch(tmp_path, UNNAMED_LOCAL_NET_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        assert "R1" in pin_map
+        assert "R2" in pin_map
+
+        # Both pin 1s should share the same _local_N net name
+        r1_net = pin_map["R1"]["pins"]["1"]["net"]
+        r2_net = pin_map["R2"]["pins"]["1"]["net"]
+        assert r1_net is not None, "R1 pin 1 should not be None (it is wired)"
+        assert r1_net.startswith("_local_"), (
+            f"R1 pin 1 should get _local_N, got {r1_net!r}"
+        )
+        assert r1_net == r2_net, (
+            f"R1 and R2 pin 1 should share the same local net, "
+            f"got R1={r1_net!r} vs R2={r2_net!r}"
+        )
+        assert pin_map["R1"]["pins"]["1"]["connected"] is True
+        assert pin_map["R2"]["pins"]["1"]["connected"] is True
+
+        # Both pin 2s are floating
+        assert pin_map["R1"]["pins"]["2"]["net"] is None
+        assert pin_map["R2"]["pins"]["2"]["net"] is None
+        assert pin_map["R1"]["pins"]["2"]["connected"] is False
+        assert pin_map["R2"]["pins"]["2"]["connected"] is False
+
+    def test_mixed_connectivity(self, tmp_path):
+        """Mixed: named net, unnamed local net, and floating pin."""
+        sch = Schematic.load(_write_sch(tmp_path, MIXED_CONNECTIVITY_SCHEMATIC))
+        pin_map = resolve_pin_map(sch)
+
+        # R1 pin 1 -> named net "SIG"
+        assert pin_map["R1"]["pins"]["1"]["net"] == "SIG"
+        assert pin_map["R1"]["pins"]["1"]["connected"] is True
+
+        # R1 pin 2 and R2 pin 1 share an unnamed local net
+        r1p2_net = pin_map["R1"]["pins"]["2"]["net"]
+        r2p1_net = pin_map["R2"]["pins"]["1"]["net"]
+        assert r1p2_net is not None
+        assert r1p2_net.startswith("_local_")
+        assert r1p2_net == r2p1_net
+        assert pin_map["R1"]["pins"]["2"]["connected"] is True
+        assert pin_map["R2"]["pins"]["1"]["connected"] is True
+
+        # R2 pin 2 is floating
+        assert pin_map["R2"]["pins"]["2"]["net"] is None
+        assert pin_map["R2"]["pins"]["2"]["connected"] is False
+
+    def test_synthetic_net_counter_resets_per_call(self, tmp_path):
+        """Each call to resolve_pin_map should reset the _local_N counter."""
+        sch = Schematic.load(_write_sch(tmp_path, UNNAMED_LOCAL_NET_SCHEMATIC))
+        pin_map1 = resolve_pin_map(sch)
+        pin_map2 = resolve_pin_map(sch)
+
+        # Both calls should produce the same synthetic net name
+        assert pin_map1["R1"]["pins"]["1"]["net"] == pin_map2["R1"]["pins"]["1"]["net"]
+
+
+class TestConnectedFieldInJSON:
+    """Verify the connected field appears in JSON output."""
+
+    def test_connected_in_json(self, tmp_path, capsys):
+        path = _write_sch(tmp_path, MIXED_CONNECTIVITY_SCHEMATIC)
+        rc = pin_map_main([str(path), "--format", "json"])
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+
+        # Named net pin: connected=True
+        assert data["R1"]["pins"]["1"]["connected"] is True
+        # Unnamed local net pin: connected=True
+        assert data["R1"]["pins"]["2"]["connected"] is True
+        # Floating pin: connected=False
+        assert data["R2"]["pins"]["2"]["connected"] is False
+
+    def test_table_shows_floating(self, tmp_path, capsys):
+        """Table output should show (floating) for truly unconnected pins."""
+        path = _write_sch(tmp_path, UNCONNECTED_SCHEMATIC)
+        rc = pin_map_main([str(path), "--format", "table"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "(floating)" in captured.out
+
+    def test_table_shows_local_net(self, tmp_path, capsys):
+        """Table output should show _local_N for unnamed local nets."""
+        path = _write_sch(tmp_path, UNNAMED_LOCAL_NET_SCHEMATIC)
+        rc = pin_map_main([str(path), "--format", "table"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "_local_" in captured.out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Distinguish unnamed local nets from truly floating pins in the pin-map command output. Pins wired together but lacking a label now receive a synthetic `_local_N` net name via connected-component analysis, and a new `connected` boolean field indicates wire connectivity.

## Changes
- Add `connected: bool` field to each pin in `resolve_pin_map()` output -- True when the pin touches at least one wire, False when truly floating
- Add post-processing pass that groups unresolved-but-connected pins into connected components via BFS on the wire adjacency graph, assigning synthetic `_local_1`, `_local_2`, etc. net names
- Update `output_table()` to show `(floating)` for disconnected pins and the synthetic name for unnamed local nets
- Update `sch_symbol_info.py` to include the `connected` field in JSON output and display `(floating)` vs `(unnamed)` in text output
- Add new test schematics and test classes: `TestUnnamedLocalNets` (two resistors on unnamed net, mixed connectivity, counter reset) and `TestConnectedFieldInJSON` (JSON/table output verification)
- Update existing regression tests (diode-resistor barrier, net-tie no-label) to expect `_local_N` names instead of `None` for wired-but-unlabeled pins

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pins on unnamed local nets get `connected: true` + synthetic net name | Pass | `test_two_resistors_unnamed_net`, `test_mixed_connectivity` |
| Truly floating pins get `connected: false` + `net: null` | Pass | `test_unconnected_pin`, floating assertions in mixed test |
| Pins sharing an unnamed wire get the same `_local_N` name | Pass | `test_two_resistors_unnamed_net` asserts `r1_net == r2_net` |
| BFS barriers still prevent cross-component traversal | Pass | `test_diode_cathode_does_not_resolve_through_resistor` |
| Synthetic counter resets per call | Pass | `test_synthetic_net_counter_resets_per_call` |
| JSON output includes `connected` field | Pass | `test_connected_in_json` |
| Table output shows `(floating)` and `_local_N` | Pass | `test_table_shows_floating`, `test_table_shows_local_net` |

## Test Plan
All 51 passing tests in `tests/test_sch_pin_map.py` (1 pre-existing failure on main: `test_rotated_symbol_positions` -- unrelated to this change).

Closes #2219