### PR TITLE
feat(sch): adjust wire endpoints when symbol pin spacing differs on replace

### DIFF
--- a/src/kicad_tools/cli/sch_replace_symbol.py
+++ b/src/kicad_tools/cli/sch_replace_symbol.py
@@ -111,6 +111,10 @@ def main(argv=None):
         for ptc in result.pin_type_changes:
             print(f"  Pin {ptc.pin_number} ({ptc.pin_name}): {ptc.old_type} -> {ptc.new_type}")
 
+    if result.wires_adjusted > 0:
+        print()
+        print(f"Wire adjustments: {result.wires_adjusted} endpoint(s) moved to match new pin positions")
+
     if result.preserved_properties:
         print()
         print(f"Preserved properties: {', '.join(result.preserved_properties)}")

--- a/src/kicad_tools/operations/symbol_ops.py
+++ b/src/kicad_tools/operations/symbol_ops.py
@@ -36,6 +36,7 @@ class SymbolReplacement:
     changes_made: list[str]  # List of changes made
     lib_symbol_updated: bool = False  # Whether the lib_symbols entry was updated
     pin_type_changes: list[PinTypeChange] = field(default_factory=list)
+    wires_adjusted: int = 0  # Number of wire endpoints moved to match new pin positions
 
 
 def find_symbol_by_reference(sexp: SExp, reference: str) -> SExp | None:
@@ -150,7 +151,21 @@ def replace_symbol_lib_id(
         else:
             preserved.append(name)
 
+    # Extract instance position, rotation, and mirror from the symbol
+    # S-expression for wire adjustment later.
+    instance_pos = (0.0, 0.0)
+    instance_rot = 0.0
+    instance_mirror = ""
+    at_node = symbol.find("at")
+    if at_node:
+        instance_pos = (at_node.get_float(0) or 0.0, at_node.get_float(1) or 0.0)
+        instance_rot = at_node.get_float(2) or 0.0
+    mirror_node = symbol.find("mirror")
+    if mirror_node:
+        instance_mirror = mirror_node.get_string(0) or ""
+
     # Update lib_symbols entry and reconcile instance pins
+    wires_adjusted = 0
     new_pin_count = len(old_pins)
     if lib_path:
         lib_file = Path(lib_path)
@@ -265,6 +280,73 @@ def replace_symbol_lib_id(
 
         new_pin_count = len(get_symbol_pins(symbol))
 
+        # --- Wire endpoint adjustment ---
+        # When pin positions differ between old and new symbols, move wire
+        # endpoints that were connected at the old pin positions to the new
+        # positions.  This mirrors the pattern in sch_move_component.py.
+        old_lib_sym_obj = None
+        if old_lib_sym_sexp is not None:
+            old_lib_sym_obj = LibrarySymbol.from_sexp(old_lib_sym_sexp)
+            # Resolve base for old derived symbols
+            if old_lib_sym_obj.extends is not None:
+                old_base_sexp2 = _find_lib_symbol_sexp(sexp, old_lib_sym_obj.extends)
+                if old_base_sexp2 is not None:
+                    old_lib_sym_obj = LibrarySymbol.from_sexp(old_base_sexp2)
+
+        # Build the new effective LibrarySymbol for pin position resolution
+        if new_lib_sym.extends is not None and base_sym is not None:
+            new_lib_sym_for_pins = base_sym
+        else:
+            new_lib_sym_for_pins = new_lib_sym
+
+        if old_lib_sym_obj is not None:
+            old_pin_positions = old_lib_sym_obj.get_all_pin_positions(
+                instance_pos=instance_pos,
+                instance_rot=instance_rot,
+                mirror=instance_mirror,
+            )
+            new_pin_positions = new_lib_sym_for_pins.get_all_pin_positions(
+                instance_pos=instance_pos,
+                instance_rot=instance_rot,
+                mirror=instance_mirror,
+            )
+
+            adjusted_wire_ids: set[int] = set()
+            for pin_num, old_pin_pos in old_pin_positions.items():
+                new_pin_pos = new_pin_positions.get(pin_num)
+                if new_pin_pos is None:
+                    continue
+                # Skip if position unchanged
+                if (
+                    abs(new_pin_pos[0] - old_pin_pos[0]) < 0.001
+                    and abs(new_pin_pos[1] - old_pin_pos[1]) < 0.001
+                ):
+                    continue
+
+                wire_hits = _find_wires_at_point(sexp, old_pin_pos)
+                for wire_sexp, endpoint_idx in wire_hits:
+                    wire_id = id(wire_sexp)
+                    if wire_id in adjusted_wire_ids:
+                        continue
+
+                    pts_node = wire_sexp.find("pts")
+                    if not pts_node:
+                        continue
+                    xy_nodes = pts_node.find_all("xy")
+                    if endpoint_idx >= len(xy_nodes):
+                        continue
+
+                    xy_node = xy_nodes[endpoint_idx]
+                    xy_node.set_value(0, new_pin_pos[0])
+                    xy_node.set_value(1, new_pin_pos[1])
+                    adjusted_wire_ids.add(wire_id)
+                    wires_adjusted += 1
+
+            if wires_adjusted > 0:
+                changes.append(
+                    f"Adjusted {wires_adjusted} wire endpoint(s) to match new pin positions"
+                )
+
     result = SymbolReplacement(
         reference=reference,
         old_lib_id=old_lib_id,
@@ -275,6 +357,7 @@ def replace_symbol_lib_id(
         changes_made=changes,
         lib_symbol_updated=lib_symbol_updated,
         pin_type_changes=pin_type_changes,
+        wires_adjusted=wires_adjusted,
     )
 
     # Write back if not dry run
@@ -283,6 +366,47 @@ def replace_symbol_lib_id(
         path.write_text(new_text)
 
     return result
+
+
+# Tolerance for matching wire endpoints to pin positions (1/10 of standard
+# KiCad schematic grid of 1.27 mm).  Matches sch_move_component.py.
+_POINT_TOLERANCE = 0.127
+
+
+def _find_wires_at_point(
+    sexp: SExp,
+    point: tuple[float, float],
+    tolerance: float = _POINT_TOLERANCE,
+) -> list[tuple[SExp, int]]:
+    """Find all wire S-expression nodes with an endpoint at or near *point*.
+
+    Works directly on the raw schematic ``SExp`` tree (unlike the
+    ``sch_move_component`` variant that takes a ``Schematic`` wrapper).
+
+    Returns a list of ``(wire_sexp, endpoint_index)`` tuples where
+    *endpoint_index* is 0 for the start or 1 for the end of the wire.
+    """
+    target_x, target_y = point
+    matching: list[tuple[SExp, int]] = []
+
+    for wire_sexp in sexp.find_all("wire"):
+        pts_node = wire_sexp.find("pts")
+        if not pts_node:
+            continue
+
+        xy_nodes = pts_node.find_all("xy")
+        if len(xy_nodes) < 2:
+            continue
+
+        for idx, xy in enumerate(xy_nodes):
+            x = xy.get_float(0) or 0.0
+            y = xy.get_float(1) or 0.0
+
+            if abs(x - target_x) <= tolerance and abs(y - target_y) <= tolerance:
+                matching.append((wire_sexp, idx))
+                break  # Don't add the same wire twice for both endpoints
+
+    return matching
 
 
 def _find_lib_symbol_sexp(sexp: SExp, lib_id: str) -> SExp | None:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -927,6 +927,227 @@ class TestReplaceDerivedSymbol:
             )
 
 
+# ---------------------------------------------------------------------------
+# Wire adjustment fixtures
+# ---------------------------------------------------------------------------
+
+# Schematic with a 3-pin regulator and wires connected to each pin.
+# Pin positions for AP2204K-3.3 at (120, 100, 0) with no mirror:
+#   Pin 1 (VIN)  local (-5.08, 2.54) -> schematic (114.92, 97.46)
+#   Pin 2 (GND)  local (0, -5.08) -> schematic (120, 105.08)
+#   Pin 3 (VOUT) local (5.08, 2.54) -> schematic (125.08, 97.46)
+REGULATOR_SCHEMATIC_WITH_WIRES = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Regulator_Linear:AP2204K-3.3"
+      (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "AP2204K-3.3" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+      (symbol "AP2204K-3.3_1_1"
+        (pin power_in line (at -5.08 2.54 0) (length 2.54) (name "VIN") (number "1"))
+        (pin power_in line (at 0 -5.08 90) (length 2.54) (name "GND") (number "2"))
+        (pin power_out line (at 5.08 2.54 180) (length 2.54) (name "VOUT") (number "3"))
+      )
+    )
+  )
+  (wire (pts (xy 100 97.46) (xy 114.92 97.46))
+    (uuid "00000000-0000-0000-0000-000000000020"))
+  (wire (pts (xy 120 105.08) (xy 120 115))
+    (uuid "00000000-0000-0000-0000-000000000021"))
+  (wire (pts (xy 125.08 97.46) (xy 140 97.46))
+    (uuid "00000000-0000-0000-0000-000000000022"))
+  (symbol
+    (lib_id "Regulator_Linear:AP2204K-3.3")
+    (at 120 100 0)
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (property "Reference" "U1" (at 120 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "AP2204K-3.3" (at 120 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Package_TO_SOT_SMD:SOT-23-5" (at 120 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000011"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000012"))
+    (pin "3" (uuid "00000000-0000-0000-0000-000000000013"))
+    (instances
+      (project "test"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "U1")
+          (unit 1)
+        )
+      )
+    )
+  )
+)
+"""
+
+# Replacement library where pins have DIFFERENT offsets from AP2204K-3.3.
+# Pin 1 (VIN)  local offset (-2.54, 1.27)  -> schematic (117.46, 98.73)
+# Pin 2 (GND)  local offset (0, -2.54)     -> schematic (120, 102.54)
+# Pin 3 (VOUT) local offset (2.54, 1.27)   -> schematic (122.54, 98.73)
+SHIFTED_PIN_LIB = """(kicad_symbol_lib
+  (version 20231120)
+  (generator "test")
+  (symbol "Regulator_Linear:SmallReg"
+    (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "SmallReg" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+    (symbol "SmallReg_1_1"
+      (pin power_in line (at -2.54 1.27 0) (length 2.54) (name "VIN") (number "1"))
+      (pin power_in line (at 0 -2.54 90) (length 2.54) (name "GND") (number "2"))
+      (pin power_out line (at 2.54 1.27 180) (length 2.54) (name "VOUT") (number "3"))
+    )
+  )
+)
+"""
+
+# Replacement library with IDENTICAL pin positions to AP2204K-3.3.
+SAME_PIN_LIB = """(kicad_symbol_lib
+  (version 20231120)
+  (generator "test")
+  (symbol "Regulator_Linear:SameReg"
+    (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "SameReg" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+    (symbol "SameReg_1_1"
+      (pin power_in line (at -5.08 2.54 0) (length 2.54) (name "VIN") (number "1"))
+      (pin power_in line (at 0 -5.08 90) (length 2.54) (name "GND") (number "2"))
+      (pin power_out line (at 5.08 2.54 180) (length 2.54) (name "VOUT") (number "3"))
+    )
+  )
+)
+"""
+
+
+class TestWireAdjustmentOnReplace:
+    """Tests for wire endpoint adjustment when pin positions differ during symbol replace."""
+
+    def _write_schematic(self, tmp_path: Path, content: str = REGULATOR_SCHEMATIC_WITH_WIRES) -> Path:
+        sch_file = tmp_path / "regulator.kicad_sch"
+        sch_file.write_text(content)
+        return sch_file
+
+    def _write_lib(self, tmp_path: Path, content: str, name: str = "replacement.kicad_sym") -> Path:
+        lib_file = tmp_path / name
+        lib_file.write_text(content)
+        return lib_file
+
+    def test_wires_move_when_pins_shift(self, tmp_path: Path):
+        """Wire endpoints connected to old pin positions move to new positions."""
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, SHIFTED_PIN_LIB)
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "Regulator_Linear:SmallReg",
+            lib_path=str(lib_file),
+        )
+
+        assert result.wires_adjusted == 3
+        assert any("wire endpoint" in c.lower() for c in result.changes_made)
+
+        # Verify actual wire coordinates in the written file
+        sexp = parse_string(sch_file.read_text())
+        wires = sexp.find_all("wire")
+        assert len(wires) == 3
+
+        # Collect all xy endpoints
+        endpoints: list[tuple[float, float]] = []
+        for w in wires:
+            pts = w.find("pts")
+            for xy in pts.find_all("xy"):
+                endpoints.append((xy.get_float(0), xy.get_float(1)))
+
+        # The pin-connected endpoints should now match the new positions:
+        # Pin 1 -> (117.46, 98.73), Pin 2 -> (120, 102.54), Pin 3 -> (122.54, 98.73)
+        def has_point(x, y):
+            return any(abs(ex - x) < 0.01 and abs(ey - y) < 0.01 for ex, ey in endpoints)
+
+        assert has_point(117.46, 98.73), f"Pin 1 wire endpoint not found at (117.46, 98.73), got {endpoints}"
+        assert has_point(120.0, 102.54), f"Pin 2 wire endpoint not found at (120, 102.54), got {endpoints}"
+        assert has_point(122.54, 98.73), f"Pin 3 wire endpoint not found at (122.54, 98.73), got {endpoints}"
+
+        # The OTHER endpoint of each wire should be unchanged (not connected to pin)
+        assert has_point(100.0, 97.46), "Wire 1 far endpoint should not change"
+        assert has_point(120.0, 115.0), "Wire 2 far endpoint should not change"
+        assert has_point(140.0, 97.46), "Wire 3 far endpoint should not change"
+
+    def test_no_wires_adjusted_when_positions_identical(self, tmp_path: Path):
+        """No wire adjustment when old and new symbols have same pin positions."""
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, SAME_PIN_LIB)
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "Regulator_Linear:SameReg",
+            lib_path=str(lib_file),
+        )
+
+        assert result.wires_adjusted == 0
+
+    def test_dry_run_does_not_move_wires(self, tmp_path: Path):
+        """Dry run reports wire adjustments but does not modify the file."""
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, SHIFTED_PIN_LIB)
+        original_text = sch_file.read_text()
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "Regulator_Linear:SmallReg",
+            lib_path=str(lib_file),
+            dry_run=True,
+        )
+
+        assert result.wires_adjusted == 3
+        assert sch_file.read_text() == original_text
+
+    def test_wire_adjustment_only_matching_pins(self, tmp_path: Path):
+        """Only wires connected to pins present in both symbols are adjusted."""
+        # Use the DIFFERENT_PIN_COUNT_LIB which has 4 pins (same positions as
+        # AP2204K-3.3 for pins 1-3, plus pin 4).  Pin positions for 1-3
+        # happen to be the same so no wires should be adjusted.
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, DIFFERENT_PIN_COUNT_LIB)
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "AltReg:REG4PIN",
+            lib_path=str(lib_file),
+        )
+
+        # Pins 1-3 have same positions, pin 4 is new (no old wire to move)
+        assert result.wires_adjusted == 0
+
+    def test_result_dataclass_has_wires_adjusted_field(self, tmp_path: Path):
+        """SymbolReplacement result includes wires_adjusted even when 0."""
+        sch_file = self._write_schematic(tmp_path)
+        lib_file = self._write_lib(tmp_path, SAME_PIN_LIB)
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "Regulator_Linear:SameReg",
+            lib_path=str(lib_file),
+        )
+
+        assert hasattr(result, "wires_adjusted")
+        assert result.wires_adjusted == 0
+
+    def test_without_lib_path_no_wire_adjustment(self, tmp_path: Path):
+        """Soft replace (no --lib-path) does not attempt wire adjustment."""
+        sch_file = self._write_schematic(tmp_path)
+
+        result = replace_symbol_lib_id(
+            str(sch_file),
+            "U1",
+            "Regulator_Linear:NewReg",
+        )
+
+        assert result.wires_adjusted == 0
+
+
 class TestNetOpsHelpers:
     """Tests for net_ops helper functions."""
 


### PR DESCRIPTION
## Summary

When `sch replace` swaps a symbol whose pins have different offsets from the original, wire endpoints connected to old pin positions are now moved to the new positions. This prevents dangling wires after replacing symbols with different pin spacing (e.g. `Device:C` with `Device:C_Small`).

## Changes

- Added `_find_wires_at_point()` helper to `symbol_ops.py` (mirrors the pattern from `sch_move_component.py`, adapted to work with raw `SExp` instead of `Schematic` wrapper)
- Integrated wire endpoint adjustment into `replace_symbol_lib_id()` as a post-processing step after lib_symbols and instance pin reconciliation
- Added `wires_adjusted` field to `SymbolReplacement` result dataclass
- Added wire adjustment reporting to `sch_replace_symbol.py` CLI output
- Added 6 tests covering: shifted pins, identical pins, dry-run, partial pin overlap, result field existence, and soft-replace (no lib-path)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Wire endpoints move when pin positions differ | Pass | `test_wires_move_when_pins_shift` verifies all 3 wire endpoints move to new positions |
| No wires adjusted when positions identical | Pass | `test_no_wires_adjusted_when_positions_identical` |
| Dry-run reports but does not modify file | Pass | `test_dry_run_does_not_move_wires` |
| Only matching pins adjusted (new/removed pins skipped) | Pass | `test_wire_adjustment_only_matching_pins` |
| SymbolReplacement result includes wire count | Pass | `test_result_dataclass_has_wires_adjusted_field` |
| Soft replace (no --lib-path) skips wire adjustment | Pass | `test_without_lib_path_no_wire_adjustment` |

## Test Plan

```
python3 -m pytest tests/test_operations.py -x -q
# 89 passed
```

Closes #2240