### PR TITLE
fix(sch): detect sub-mm dangling wire stubs in cleanup-wires

### DIFF
--- a/src/kicad_tools/cli/sch_cleanup_wires.py
+++ b/src/kicad_tools/cli/sch_cleanup_wires.py
@@ -37,6 +37,11 @@ from kicad_tools.sexp import SExp
 # resolution.
 _QUANT = 1000
 
+# Any wire shorter than this (mm) is unconditionally flagged as a stub,
+# regardless of how many endpoints appear connected.  No intentional
+# schematic wire is ever this short.
+_MICRO_STUB_FLOOR = 0.05
+
 
 @dataclass
 class WireIssue:
@@ -431,6 +436,14 @@ def find_cleanup_candidates(
     # a junction marker) is NOT considered connected, because KiCad's ERC
     # treats it the same way.  This ensures that sub-mm stubs whose only
     # "anchor" is a wire-body overlap are correctly detected.
+    #
+    # Sub-mm stubs where *both* endpoints appear electrically connected are
+    # also caught in two ways:
+    #   (a) Micro-stubs (length < _MICRO_STUB_FLOOR) are unconditionally
+    #       flagged -- no intentional wire is ever that short.
+    #   (b) Short wires where both endpoints are connected only through
+    #       shared wire endpoints (no pin, label, or junction at either
+    #       end) are likely repair artifacts and are flagged as stubs.
     if stub_threshold > 0:
         # Build a set of wires already flagged so we don't double-count
         flagged_ids = {id(issue.wire_sexp) for issue in issues}
@@ -442,6 +455,19 @@ def find_cleanup_candidates(
             start, end = _wire_start_end(ws)
             length = math.hypot(end[0] - start[0], end[1] - start[1])
             if length >= stub_threshold:
+                continue
+
+            # (a) Micro-stubs: unconditionally flag wires shorter than the
+            # floor -- no real schematic wire is ever this short.
+            if length < _MICRO_STUB_FLOOR:
+                issues.append(
+                    WireIssue(
+                        reason="stub",
+                        wire_sexp=ws,
+                        start=start,
+                        end=end,
+                    )
+                )
                 continue
 
             electrically_dangling = 0
@@ -458,6 +484,32 @@ def find_cleanup_candidates(
             # the free end dangling will show electrically_dangling == 1.
             # Both cases should be flagged.
             if electrically_dangling >= 1:
+                issues.append(
+                    WireIssue(
+                        reason="stub",
+                        wire_sexp=ws,
+                        start=start,
+                        end=end,
+                    )
+                )
+                continue
+
+            # (b) Both endpoints are electrically connected.  Check if
+            # neither endpoint touches a "strong" connection (pin, label,
+            # junction, no-connect).  A short wire that merely bridges two
+            # other wire endpoints without any component-level anchor is
+            # very likely a repair artifact (the typical chorus-test-revA
+            # pattern: 0.05-0.43mm fragments left between wire endpoints).
+            start_key = (_quantize(start[0]), _quantize(start[1]))
+            end_key = (_quantize(end[0]), _quantize(end[1]))
+
+            start_at_connection_point = start_key in connection_points
+            end_at_connection_point = end_key in connection_points
+
+            if not start_at_connection_point and not end_at_connection_point:
+                # Neither end touches a pin, label, junction, or no-connect.
+                # Both ends are connected only via shared wire endpoints.
+                # Flag as a stub -- it is a redundant bridge fragment.
                 issues.append(
                     WireIssue(
                         reason="stub",

--- a/tests/test_sch_wiring_commands.py
+++ b/tests/test_sch_wiring_commands.py
@@ -637,6 +637,148 @@ SCHEMATIC_WITH_BOTH_ENDS_ON_WIRE_BODY = """\
 """
 
 
+# Schematic with a micro-stub (0.025mm) shorter than _MICRO_STUB_FLOOR (0.05mm).
+# The micro-stub floor should catch it unconditionally regardless of
+# endpoint connectivity.
+#
+# Layout:
+#   Wire A: (100,50) -> (150,50)      label at (100,50)
+#   Wire B: (150,50) -> (150,100)     label at (150,100)
+#   Stub:   (150,50) -> (150.025,50)  0.025mm micro-stub
+SCHEMATIC_WITH_MICRO_STUB = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000060")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 100 50) (xy 150 50))
+    (stroke (width 0) (type default))
+    (uuid "wire-a")
+  )
+  (wire (pts (xy 150 50) (xy 150 100))
+    (stroke (width 0) (type default))
+    (uuid "wire-b")
+  )
+  (wire (pts (xy 150 50) (xy 150.025 50))
+    (stroke (width 0) (type default))
+    (uuid "micro-stub")
+  )
+  (label "NET1" (at 100 50 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-1")
+  )
+  (label "NET2" (at 150 100 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-2")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+# Schematic with a short 0.43mm stub where both endpoints are connected
+# only through shared wire endpoints (no pins, labels, or junctions at
+# either stub endpoint).  This is the chorus-test-revA pattern: a repair
+# operation left a tiny bridge between two wire endpoints.
+#
+# Layout:
+#   Wire A: (100,50) -> (150,50)        label at (100,50)
+#   Wire B: (150,50) -> (150.43,50)     the 0.43mm stub
+#   Wire C: (150.43,50) -> (200,50)     label at (200,50)
+#
+# The stub's start at (150,50) is shared with wire A (endpoint_counts > 1)
+# but (150,50) is NOT at any label, pin, or junction.  Likewise the
+# stub's end at (150.43,50) is shared with wire C but has no connection
+# point.  Both ends pass _is_endpoint_electrically_connected(), so the
+# old code had electrically_dangling == 0 and skipped it.
+# The new heuristic (b) detects that neither endpoint touches a strong
+# connection point and flags the wire as a stub.
+SCHEMATIC_WITH_BOTH_ENDS_CONNECTED_STUB = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000061")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 100 50) (xy 150 50))
+    (stroke (width 0) (type default))
+    (uuid "wire-a")
+  )
+  (wire (pts (xy 150 50) (xy 150.43 50))
+    (stroke (width 0) (type default))
+    (uuid "both-ends-stub")
+  )
+  (wire (pts (xy 150.43 50) (xy 200 50))
+    (stroke (width 0) (type default))
+    (uuid "wire-c")
+  )
+  (label "NET1" (at 100 50 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-1")
+  )
+  (label "NET2" (at 200 50 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-2")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+# Schematic with a short 0.43mm wire where one endpoint IS at a label.
+# This is a legitimate short bridge -- it should NOT be flagged, because
+# the label anchors it to a meaningful connection point.
+#
+# Layout:
+#   Wire A: (100,50) -> (150,50)        label at (100,50) and (150,50)
+#   Bridge: (150,50) -> (150.43,50)     0.43mm, start at label
+#   Wire C: (150.43,50) -> (200,50)     label at (200,50)
+SCHEMATIC_WITH_SHORT_BRIDGE_AT_LABEL = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000063")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 100 50) (xy 150 50))
+    (stroke (width 0) (type default))
+    (uuid "wire-a")
+  )
+  (wire (pts (xy 150 50) (xy 150.43 50))
+    (stroke (width 0) (type default))
+    (uuid "short-bridge")
+  )
+  (wire (pts (xy 150.43 50) (xy 200 50))
+    (stroke (width 0) (type default))
+    (uuid "wire-c")
+  )
+  (label "NET1" (at 100 50 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-1")
+  )
+  (label "NET2" (at 150 50 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-2")
+  )
+  (label "NET3" (at 200 50 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-3")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
 SCHEMATIC_WITH_NO_CONNECT = """\
 (kicad_sch
   (version 20231120)
@@ -1169,6 +1311,65 @@ class TestCleanupWires:
 
         assert removed == 1
         # 4 wires initially (wire-a, wire-b, wire-c, stub) -> 3 remaining
+        assert len(list(sch.sexp.find_all("wire"))) == initial_wire_count - 1
+
+    # --- sub-mm dangling wire stub detection tests ---
+
+    def test_micro_stub_unconditionally_flagged(self, tmp_path):
+        """A wire shorter than _MICRO_STUB_FLOOR is always flagged as a stub."""
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_MICRO_STUB)
+        sch = Schematic.load(path)
+        issues = find_cleanup_candidates(sch)
+
+        stubs = [i for i in issues if i.reason == "stub"]
+        assert len(stubs) == 1
+        # The micro-stub is (150,50) -> (150.025,50), length 0.025mm
+        assert stubs[0].start == (150.0, 50.0)
+        assert stubs[0].end == (150.025, 50.0)
+
+    def test_both_ends_connected_no_connection_point_flagged(self, tmp_path):
+        """A short wire with both ends at shared wire endpoints but no label/pin/junction is flagged."""
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_BOTH_ENDS_CONNECTED_STUB)
+        sch = Schematic.load(path)
+        issues = find_cleanup_candidates(sch)
+
+        stubs = [i for i in issues if i.reason == "stub"]
+        assert len(stubs) == 1
+        # The stub is the 0.43mm wire from (150,50) to (150.43,50)
+        assert stubs[0].start == (150.0, 50.0)
+        assert stubs[0].end == (150.43, 50.0)
+
+    def test_short_bridge_at_label_not_flagged(self, tmp_path):
+        """A short wire with one endpoint at a label is NOT flagged as a stub."""
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_SHORT_BRIDGE_AT_LABEL)
+        sch = Schematic.load(path)
+        issues = find_cleanup_candidates(sch)
+
+        stubs = [i for i in issues if i.reason == "stub"]
+        assert len(stubs) == 0, (
+            f"Expected no stubs but found: {[(s.start, s.end) for s in stubs]}"
+        )
+
+    def test_micro_stub_removal(self, tmp_path):
+        """Micro-stub-flagged wires are removed and wire count decreases."""
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates, remove_wires
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_MICRO_STUB)
+        sch = Schematic.load(path)
+
+        initial_wire_count = len(list(sch.sexp.find_all("wire")))
+        issues = find_cleanup_candidates(sch)
+        stubs = [i for i in issues if i.reason == "stub"]
+        assert len(stubs) == 1
+
+        removed = remove_wires(sch, stubs)
+        assert removed == 1
         assert len(list(sch.sexp.find_all("wire"))) == initial_wire_count - 1
 
 


### PR DESCRIPTION
## Summary
Adds two new detection mechanisms for sub-mm wire stubs that previously escaped Phase 3b stub detection in `sch cleanup-wires`. Short stubs (0.025-0.43mm) from repair operations were missed because both endpoints passed the `_is_endpoint_electrically_connected()` check.

## Changes
- Add micro-stub floor (0.05mm): wires shorter than this are unconditionally flagged as stubs regardless of endpoint connectivity
- Use the already-defined `_MICRO_STUB_FLOOR` constant in Phase 3b detection logic
- Add both-ends-connected heuristic: short wires where neither endpoint touches a pin, label, junction, or no-connect (only shared wire endpoints) are flagged as repair artifacts
- Add test fixtures for micro-stubs, both-ends-connected stubs, and short bridges at labels
- Add 4 new tests covering the new detection paths and false-positive prevention

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Micro-stubs (< 0.05mm) unconditionally detected | Pass | `test_micro_stub_unconditionally_flagged` passes |
| Both-ends-connected short stubs without strong anchors detected | Pass | `test_both_ends_connected_no_connection_point_flagged` passes |
| Short bridges at labels NOT false-positive flagged | Pass | `test_short_bridge_at_label_not_flagged` passes |
| Micro-stub removal works correctly | Pass | `test_micro_stub_removal` passes |
| Existing stub tests still pass | Pass | All 14 stub-related tests pass |
| Full test suite passes | Pass | All 69 tests pass |

## Test Plan
- Ran `python3 -m pytest tests/test_sch_wiring_commands.py -x -v` -- 69/69 tests pass
- Verified all existing stub detection tests still pass (threshold=0 disables, long wires not flagged, T-junction preservation, etc.)
- New tests cover: micro-stub floor, both-ends-connected heuristic, false-positive prevention for label-anchored short bridges

Closes #2239