### PR TITLE
feat(pcb): run pad net assignment unconditionally in sync-netlist

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -617,6 +617,7 @@ def _run_sync_netlist_command(args, pcb_path: Path) -> int:
     remove_orphans = getattr(args, "remove_orphans", False)
     force = getattr(args, "force", False)
     auto_rename = getattr(args, "auto_rename", False)
+    remove_orphan_nets = getattr(args, "remove_orphan_nets", False)
 
     return run_sync_netlist(
         schematic_path=schematic_path,
@@ -627,6 +628,7 @@ def _run_sync_netlist_command(args, pcb_path: Path) -> int:
         remove_orphans=remove_orphans,
         force=force,
         auto_rename=auto_rename,
+        remove_orphan_nets=remove_orphan_nets,
     )
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1392,6 +1392,11 @@ def _add_pcb_parser(subparsers) -> None:
         action="store_true",
         help="Apply reference renames without interactive confirmation",
     )
+    pcb_sync_netlist.add_argument(
+        "--remove-orphan-nets",
+        action="store_true",
+        help="Remove nets with no pad references after net assignment",
+    )
 
     # pcb zones
     pcb_zones = pcb_subparsers.add_parser("zones", help="List copper pour zones")

--- a/src/kicad_tools/cli/pcb_sync_netlist.py
+++ b/src/kicad_tools/cli/pcb_sync_netlist.py
@@ -53,6 +53,7 @@ class SyncResult:
     orphaned: list[SyncAction] = field(default_factory=list)
     removed: list[SyncAction] = field(default_factory=list)
     pin_mismatches: list[PinMismatch] = field(default_factory=list)
+    net_updated: list[SyncAction] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
@@ -61,6 +62,7 @@ class SyncResult:
         return bool(
             self.added or self.renamed or self.orphaned
             or self.removed or self.pin_mismatches
+            or self.net_updated
         )
 
 
@@ -83,6 +85,7 @@ def sync_netlist(
     remove_orphans: bool = False,
     force: bool = False,
     auto_rename: bool = False,
+    remove_orphan_nets: bool = False,
 ) -> SyncResult:
     """Sync PCB footprints from schematic.
 
@@ -97,6 +100,8 @@ def sync_netlist(
             When False (default) and not dry_run, the caller is responsible
             for confirming renames before applying.  The ``run_sync_netlist``
             wrapper handles the interactive prompt.
+        remove_orphan_nets: If True, remove nets with no pad references after
+            net assignment.
 
     Returns:
         SyncResult describing all actions taken or planned.
@@ -306,69 +311,202 @@ def sync_netlist(
     # When auto_rename is False and there are renames, the caller must confirm
     # before calling with auto_rename=True.  dry_run always skips application.
     skip_apply = dry_run or (result.renamed and not auto_rename)
-    if not skip_apply and result.has_changes:
-        # Apply renames using collision-safe rename plan
-        if result.renamed:
-            _apply_renames_safe(pcb, rename_map, pcb_ref_set, result)
+    if not skip_apply:
+        # Apply footprint-level changes (renames, adds, removes)
+        if result.has_changes:
+            # Apply renames using collision-safe rename plan
+            if result.renamed:
+                _apply_renames_safe(pcb, rename_map, pcb_ref_set, result)
 
-        # Add missing footprints at board edge
-        placement_x, placement_y = _get_board_edge_position(pcb)
-        x_offset = 0.0
-        for action in result.added:
+            # Add missing footprints at board edge
+            placement_x, placement_y = _get_board_edge_position(pcb)
+            x_offset = 0.0
+            for action in result.added:
+                try:
+                    pcb.add_footprint(
+                        library_id=action.footprint,
+                        reference=action.reference,
+                        x=placement_x + x_offset,
+                        y=placement_y,
+                        value=action.value,
+                    )
+                    x_offset += 5.0  # Space footprints horizontally
+                except Exception as e:
+                    result.errors.append(
+                        f"Failed to add footprint for {action.reference}: {e}"
+                    )
+
+            # Remove orphaned footprints
+            for action in result.removed:
+                if not pcb.remove_footprint(action.reference):
+                    result.errors.append(
+                        f"Failed to remove footprint {action.reference}"
+                    )
+
+        # Update net assignments from schematic netlist unconditionally.
+        # This catches stale pad-net assignments even when no footprints are
+        # added or renamed (e.g. when pad nets drifted from the schematic).
+        net_actions, net_errors = _assign_nets_from_schematic(
+            pcb, schematic_path
+        )
+        result.net_updated.extend(net_actions)
+        result.errors.extend(net_errors)
+
+        # Optionally remove nets that have no pad references
+        if remove_orphan_nets:
+            _remove_unused_nets(pcb, result)
+
+        # Save if anything changed (footprints or nets)
+        if result.has_changes:
+            save_path = output_path or pcb_path
             try:
-                pcb.add_footprint(
-                    library_id=action.footprint,
-                    reference=action.reference,
-                    x=placement_x + x_offset,
-                    y=placement_y,
-                    value=action.value,
-                )
-                x_offset += 5.0  # Space footprints horizontally
+                pcb.save(save_path)
             except Exception as e:
-                result.errors.append(
-                    f"Failed to add footprint for {action.reference}: {e}"
-                )
+                result.errors.append(f"Failed to save PCB: {e}")
 
-        # Remove orphaned footprints
-        for action in result.removed:
-            if not pcb.remove_footprint(action.reference):
-                result.errors.append(
-                    f"Failed to remove footprint {action.reference}"
-                )
-
-        # Update net assignments from schematic netlist (covers renamed refs
-        # and newly added footprints)
-        if result.renamed or result.added:
-            _assign_nets_from_schematic(pcb, schematic_path)
-
-        # Save
-        save_path = output_path or pcb_path
-        try:
-            pcb.save(save_path)
-        except Exception as e:
-            result.errors.append(f"Failed to save PCB: {e}")
+    elif dry_run:
+        # Compute net diff for dry-run reporting (no PCB changes applied).
+        # Note: this mutates the in-memory PCB to compute the diff but
+        # never saves, so the file on disk is unchanged.
+        net_actions, net_errors = _assign_nets_from_schematic(
+            pcb, schematic_path
+        )
+        result.net_updated.extend(net_actions)
+        result.errors.extend(net_errors)
 
     return result
 
 
-def _assign_nets_from_schematic(pcb, schematic_path: Path) -> None:
+def _get_pad_net_snapshot(pcb) -> dict[tuple[str, str], str]:
+    """Snapshot current pad-to-net assignments from all footprints.
+
+    Returns a dict mapping ``(reference, pad_number)`` to ``net_name``.
+    """
+    snapshot: dict[tuple[str, str], str] = {}
+    for fp in pcb.footprints:
+        if not fp.reference or fp.reference.startswith("#"):
+            continue
+        for pad in fp.pads:
+            snapshot[(fp.reference, pad.number)] = pad.net_name
+    return snapshot
+
+
+def _assign_nets_from_schematic(
+    pcb, schematic_path: Path
+) -> tuple[list[SyncAction], list[str]]:
     """Export netlist from schematic and assign nets to PCB pads.
 
-    Updates pad-to-net mappings for all footprints, including renamed and
-    newly added ones. Failures are silently ignored since net assignment is
-    best-effort; the user can run KiCad's Update PCB from Schematic for a
-    full refresh.
+    Always applies net assignments to the in-memory *pcb* object.  The
+    caller is responsible for deciding whether to persist (save) the
+    result.
+
+    Returns:
+        A tuple of ``(net_actions, errors)`` where *net_actions* is a list
+        of :class:`SyncAction` items with ``action="net_updated"`` and
+        *errors* is a list of error strings.
     """
+    actions: list[SyncAction] = []
+    errors: list[str] = []
+
     try:
         from kicad_tools.operations.netlist import export_netlist
 
         netlist = export_netlist(str(schematic_path))
-        for net in netlist.nets:
-            if net.name:
-                pcb.add_net(net.name)
+    except Exception as exc:
+        errors.append(f"Failed to export netlist for net assignment: {exc}")
+        return actions, errors
+
+    # Snapshot before assignment
+    before = _get_pad_net_snapshot(pcb)
+
+    # Ensure all schematic nets exist in the PCB
+    for net in netlist.nets:
+        if net.name:
+            pcb.add_net(net.name)
+
+    # Apply net assignments
+    try:
         pcb.assign_nets_from_netlist(netlist)
-    except Exception:
-        pass
+    except Exception as exc:
+        errors.append(f"Failed to assign nets from netlist: {exc}")
+        return actions, errors
+
+    # Snapshot after assignment
+    after = _get_pad_net_snapshot(pcb)
+
+    # Compute diff
+    for key in sorted(set(before.keys()) | set(after.keys())):
+        old_net = before.get(key, "")
+        new_net = after.get(key, "")
+        if old_net != new_net:
+            ref, pad_num = key
+            actions.append(SyncAction(
+                action="net_updated",
+                reference=ref,
+                detail=f"{ref}.{pad_num}: \"{old_net}\" -> \"{new_net}\"",
+            ))
+
+    return actions, errors
+
+
+def _remove_unused_nets(pcb, result: SyncResult) -> None:
+    """Remove nets that have zero pad references from the PCB.
+
+    Skips the unconnected net (net 0 / empty name).  Removed net names
+    are appended as warnings on *result* for visibility.
+    """
+    # Collect nets referenced by at least one pad
+    referenced_nets: set[str] = set()
+    for fp in pcb.footprints:
+        for pad in fp.pads:
+            if pad.net_name:
+                referenced_nets.add(pad.net_name)
+
+    # Also count nets used by segments, vias, and zones
+    for seg in pcb.segments:
+        if seg.net_name:
+            referenced_nets.add(seg.net_name)
+    for via in pcb.vias:
+        if via.net_name:
+            referenced_nets.add(via.net_name)
+    for zone in pcb.zones:
+        if zone.net_name:
+            referenced_nets.add(zone.net_name)
+
+    # Find unreferenced nets
+    orphan_net_names: list[str] = []
+    for net in pcb.nets.values():
+        if not net.name:
+            continue  # skip unconnected net
+        if net.name not in referenced_nets:
+            orphan_net_names.append(net.name)
+
+    if not orphan_net_names:
+        return
+
+    # Remove from S-expression tree and internal dict
+    removed: list[str] = []
+    for name in sorted(orphan_net_names):
+        net = pcb.get_net_by_name(name)
+        if net is None:
+            continue
+        # Remove from _nets dict
+        if net.number in pcb.nets:
+            del pcb.nets[net.number]
+        # Remove from S-expression
+        for net_sexp in pcb._sexp.find_all("net"):
+            sexp_name = net_sexp.get_string(1)
+            if sexp_name is None:
+                sexp_name = net_sexp.get_string(0)
+            if sexp_name == name:
+                pcb._sexp.remove(net_sexp)
+                break
+        removed.append(name)
+
+    if removed:
+        result.warnings.append(
+            f"Removed {len(removed)} orphan net(s): {', '.join(removed)}"
+        )
 
 
 def _apply_rename(pcb, old_ref: str, new_ref: str) -> bool:
@@ -447,6 +585,12 @@ def format_text(result: SyncResult, dry_run: bool, pcb_path: Path) -> str:
         lines.append(f"  Removed footprints ({len(result.removed)}):")
         for action in result.removed:
             lines.append(f"    {action.reference}: {action.value} ({action.footprint})")
+        lines.append("")
+
+    if result.net_updated:
+        lines.append(f"  Net updates ({len(result.net_updated)}):")
+        for action in result.net_updated:
+            lines.append(f"    {action.detail}")
         lines.append("")
 
     if result.orphaned:
@@ -530,6 +674,13 @@ def format_json(result: SyncResult, dry_run: bool, pcb_path: Path) -> str:
             }
             for pm in result.pin_mismatches
         ],
+        "net_updated": [
+            {
+                "reference": a.reference,
+                "detail": a.detail,
+            }
+            for a in result.net_updated
+        ],
         "warnings": result.warnings,
         "errors": result.errors,
     }
@@ -545,6 +696,7 @@ def run_sync_netlist(
     remove_orphans: bool = False,
     force: bool = False,
     auto_rename: bool = False,
+    remove_orphan_nets: bool = False,
 ) -> int:
     """Run the sync-netlist command.
 
@@ -559,6 +711,8 @@ def run_sync_netlist(
         auto_rename: If True, apply renames without interactive confirmation.
             When False (default) and not dry_run, shows a confirmation prompt
             before applying renames.
+        remove_orphan_nets: If True, remove nets with no pad references after
+            net assignment.
 
     Returns:
         Exit code (0 for success, 1 for errors).
@@ -572,6 +726,7 @@ def run_sync_netlist(
         remove_orphans=remove_orphans,
         force=force,
         auto_rename=auto_rename,
+        remove_orphan_nets=remove_orphan_nets,
     )
 
     if output_format == "json":
@@ -600,6 +755,7 @@ def run_sync_netlist(
                 remove_orphans=remove_orphans,
                 force=force,
                 auto_rename=True,
+                remove_orphan_nets=remove_orphan_nets,
             )
             print("Renames applied.")
         else:

--- a/tests/test_pcb_sync_netlist.py
+++ b/tests/test_pcb_sync_netlist.py
@@ -266,8 +266,8 @@ class TestSyncResult:
 class TestSyncNetlist:
     """Tests for the core sync_netlist function."""
 
-    def test_in_sync_returns_no_changes(self, tmp_path):
-        """Matching schematic and PCB produce no changes."""
+    def test_in_sync_returns_no_footprint_changes(self, tmp_path):
+        """Matching schematic and PCB produce no footprint-level changes."""
         from kicad_tools.cli.pcb_sync_netlist import sync_netlist
 
         sch = tmp_path / "test.kicad_sch"
@@ -281,7 +281,6 @@ class TestSyncNetlist:
         assert not result.renamed
         assert not result.orphaned
         assert not result.errors
-        assert not result.has_changes
 
     def test_detects_missing_footprint(self, tmp_path):
         """R1 missing from PCB is detected as needing to be added."""
@@ -1862,6 +1861,40 @@ PCB_PASSIVE_2PAD = """(kicad_pcb
 """
 
 
+# --- PCB with stale net assignments for net update tests ---
+
+# R1 pad 1 is assigned to "old_net" but schematic says GND.
+# R1 pad 2 has no net (empty) but schematic generates Net-(R1-2).
+PCB_STALE_NETS = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "old_net")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "old_net"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (uuid "fp-c1")
+    (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
 class TestPinMismatch:
     """Tests for PinMismatch dataclass."""
 
@@ -2009,7 +2042,12 @@ class TestPinMismatchDetection:
         result = sync_netlist(sch, pcb, dry_run=True)
 
         assert len(result.pin_mismatches) == 0
-        assert not result.has_changes
+        # No footprint-level changes (net_updated may be non-empty because
+        # the unconditional net assignment pass assigns nets to bare pads).
+        assert not result.added
+        assert not result.renamed
+        assert not result.orphaned
+        assert not result.removed
 
     def test_dry_run_does_not_modify_pcb(self, tmp_path):
         """Dry run with mismatches does not modify the PCB file."""
@@ -2110,3 +2148,295 @@ class TestPinMismatchFormatJson:
         output = json.loads(format_json(result, dry_run=True, pcb_path=Path("test.kicad_pcb")))
 
         assert output["pin_mismatches"] == []
+
+
+# PCB with an orphan net that is not assigned to any pad
+PCB_WITH_ORPHAN_NET = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "stale_net")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (uuid "fp-c1")
+    (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+
+class TestNetUpdates:
+    """Tests for unconditional pad net assignment updates."""
+
+    def test_stale_nets_detected_in_dry_run(self, tmp_path):
+        """Dry run detects stale pad-net assignments."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(SCHEMATIC_R1_ONLY)
+        pcb.write_text(PCB_STALE_NETS)
+
+        result = sync_netlist(sch, pcb, dry_run=True)
+
+        # R1 pad 1 was "old_net", should change
+        assert len(result.net_updated) > 0
+        details = [a.detail for a in result.net_updated]
+        assert any("R1" in d and "old_net" in d for d in details)
+
+    def test_stale_nets_corrected_on_apply(self, tmp_path):
+        """Non-dry-run corrects stale pad-net assignments in the PCB."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(SCHEMATIC_R1_ONLY)
+        pcb.write_text(PCB_STALE_NETS)
+
+        result = sync_netlist(sch, pcb, dry_run=False, remove_orphans=True)
+
+        assert len(result.net_updated) > 0
+        assert not result.errors
+
+        # Reload and verify R1 pad 1 no longer has "old_net"
+        board = PCB.load(pcb)
+        r1 = board.get_footprint("R1")
+        assert r1 is not None
+        pad1_nets = [p.net_name for p in r1.pads if p.number == "1"]
+        assert pad1_nets
+        assert pad1_nets[0] != "old_net"
+
+    def test_net_update_runs_even_without_footprint_changes(self, tmp_path):
+        """Net assignment runs even when no footprints are added/renamed/removed."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_STALE_NETS)
+
+        result = sync_netlist(sch, pcb, dry_run=True)
+
+        # No footprint-level changes (both R1 and C1 exist)
+        assert not result.added
+        assert not result.renamed
+        # But net updates should be detected
+        assert len(result.net_updated) > 0
+
+    def test_correct_nets_produce_no_net_updates(self, tmp_path):
+        """PCB already matching schematic nets produces empty net_updated."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(SCHEMATIC_R1_ONLY)
+
+        # First, sync to correct the nets
+        pcb.write_text(PCB_STALE_NETS)
+        sync_netlist(sch, pcb, dry_run=False, remove_orphans=True)
+
+        # Now sync again -- should produce no net updates
+        result = sync_netlist(sch, pcb, dry_run=True)
+        # Filter net_updated to only R1 (C1 was removed as orphan)
+        r1_updates = [a for a in result.net_updated if a.reference == "R1"]
+        assert not r1_updates
+
+    def test_dry_run_does_not_modify_pcb_with_net_updates(self, tmp_path):
+        """Dry run with net updates does not change the PCB file."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_STALE_NETS)
+        original = pcb.read_text()
+
+        result = sync_netlist(sch, pcb, dry_run=True)
+
+        assert len(result.net_updated) > 0
+        assert pcb.read_text() == original
+
+    def test_net_updated_in_text_output(self, tmp_path):
+        """Net updates appear in text format output."""
+        from kicad_tools.cli.pcb_sync_netlist import SyncAction, SyncResult, format_text
+
+        result = SyncResult(
+            net_updated=[SyncAction(
+                action="net_updated",
+                reference="R1",
+                detail='R1.1: "old_net" -> "GND"',
+            )]
+        )
+        pcb = tmp_path / "test.kicad_pcb"
+        output = format_text(result, dry_run=True, pcb_path=pcb)
+
+        assert "Net updates" in output
+        assert "R1.1" in output
+        assert "old_net" in output
+        assert "GND" in output
+
+    def test_net_updated_in_json_output(self, tmp_path):
+        """Net updates appear in JSON format output."""
+        from kicad_tools.cli.pcb_sync_netlist import SyncAction, SyncResult, format_json
+
+        result = SyncResult(
+            net_updated=[SyncAction(
+                action="net_updated",
+                reference="R1",
+                detail='R1.1: "old_net" -> "GND"',
+            )]
+        )
+        pcb = tmp_path / "test.kicad_pcb"
+        output = format_json(result, dry_run=False, pcb_path=pcb)
+
+        data = json.loads(output)
+        assert "net_updated" in data
+        assert len(data["net_updated"]) == 1
+        assert data["net_updated"][0]["reference"] == "R1"
+        assert "old_net" in data["net_updated"][0]["detail"]
+
+    def test_has_changes_with_net_updated(self):
+        """SyncResult.has_changes is True when only net_updated has entries."""
+        from kicad_tools.cli.pcb_sync_netlist import SyncAction, SyncResult
+
+        result = SyncResult(
+            net_updated=[SyncAction(action="net_updated", reference="R1")]
+        )
+        assert result.has_changes is True
+
+
+class TestNetAssignmentErrorSurfacing:
+    """Tests for error surfacing from _assign_nets_from_schematic."""
+
+    def test_export_netlist_error_surfaced(self, tmp_path, monkeypatch):
+        """Failure in export_netlist produces an error in result."""
+        from kicad_tools.cli.pcb_sync_netlist import _assign_nets_from_schematic
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(MINIMAL_PCB_MATCHING)
+        board = PCB.load(pcb_path)
+
+        # Mock export_netlist to raise
+        import kicad_tools.cli.pcb_sync_netlist as mod
+        original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
+
+        def mock_export_netlist(path):
+            raise RuntimeError("kicad-cli not found")
+
+        monkeypatch.setattr(
+            "kicad_tools.operations.netlist.export_netlist",
+            mock_export_netlist,
+        )
+
+        actions, errors = _assign_nets_from_schematic(
+            board, tmp_path / "nonexistent.kicad_sch"
+        )
+
+        assert len(errors) > 0
+        assert "Failed to export netlist" in errors[0]
+        assert not actions
+
+
+class TestRemoveOrphanNets:
+    """Tests for --remove-orphan-nets functionality."""
+
+    def test_parser_accepts_remove_orphan_nets(self):
+        """Parser supports --remove-orphan-nets flag."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "sync-netlist",
+            "--schematic", "test.kicad_sch",
+            "--remove-orphan-nets",
+            "test.kicad_pcb",
+        ])
+        assert args.remove_orphan_nets is True
+
+    def test_parser_remove_orphan_nets_default_false(self):
+        """--remove-orphan-nets defaults to False."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "sync-netlist",
+            "--schematic", "test.kicad_sch",
+            "test.kicad_pcb",
+        ])
+        assert args.remove_orphan_nets is False
+
+    def test_orphan_net_removed(self, tmp_path):
+        """Net with no pad references is removed when flag is set."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_WITH_ORPHAN_NET)
+
+        result = sync_netlist(sch, pcb, dry_run=False, remove_orphan_nets=True)
+
+        # stale_net had no pad references and should be removed
+        board = PCB.load(pcb)
+        assert board.get_net_by_name("stale_net") is None
+        # Warning should mention removal
+        assert any("stale_net" in w for w in result.warnings)
+
+    def test_orphan_net_not_removed_without_flag(self, tmp_path):
+        """Net with no pad references is preserved when flag is not set."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_WITH_ORPHAN_NET)
+
+        sync_netlist(sch, pcb, dry_run=False, remove_orphan_nets=False)
+
+        board = PCB.load(pcb)
+        assert board.get_net_by_name("stale_net") is not None
+
+    def test_dispatcher_passes_remove_orphan_nets(self, tmp_path):
+        """Dispatcher passes remove_orphan_nets to run_sync_netlist."""
+        from kicad_tools.cli.commands.pcb import _run_sync_netlist_command
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+
+        class Args:
+            schematic = str(sch)
+            output = None
+            dry_run = True
+            format = "text"
+            remove_orphans = False
+            force = False
+            auto_rename = False
+            remove_orphan_nets = False
+
+        rc = _run_sync_netlist_command(Args(), pcb)
+        assert rc == 0


### PR DESCRIPTION
## Summary
Makes `sync-netlist` always update pad-to-net assignments from the schematic, not only when footprints are added or renamed. Also adds net diff reporting, `--remove-orphan-nets` flag, and surfaces errors from `export_netlist()` that were previously silently swallowed.

## Changes
- Restructured `sync_netlist()` so `_assign_nets_from_schematic()` runs unconditionally (outside the `if result.has_changes:` guard)
- Rewrote `_assign_nets_from_schematic()` to compute a before/after pad-net diff and return `(list[SyncAction], list[str])` instead of silently swallowing errors
- Added `_get_pad_net_snapshot()` helper for diffing pad-net assignments
- Added `_remove_unused_nets()` helper and `--remove-orphan-nets` CLI flag
- Added `net_updated` field to `SyncResult` and included it in `has_changes`, `format_text`, and `format_json`
- Updated CLI parser and dispatcher to pass through `remove_orphan_nets`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Net assignment runs unconditionally (not gated behind renamed/added) | PASS | Restructured conditional; net assignment now runs in all non-skip paths |
| `net_updated` action category in SyncResult | PASS | New field with `SyncAction` entries tracking per-pad changes |
| Dry-run reports net changes without persisting | PASS | Test `test_dry_run_does_not_modify_pcb_with_net_updates` verifies file unchanged |
| `--remove-orphan-nets` flag removes unreferenced nets | PASS | Test `test_orphan_net_removed` verifies stale_net removed |
| Errors from export_netlist surfaced (not swallowed) | PASS | Test `test_export_netlist_error_surfaced` verifies errors list populated |
| Net updates appear in text and JSON formatters | PASS | Tests for both format_text and format_json verify net_updated output |

## Test Plan
All 90 tests in `test_pcb_sync_netlist.py` pass (14 new tests added). Also verified 140 tests pass across `test_pcb_sync_netlist.py` + `test_cli.py`.

Closes #2244