### PR TITLE
feat(pcb): add --check-connectivity flag to pcb nets command

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -85,6 +85,8 @@ def run_pcb_command(args) -> int:
             sub_argv.extend(["--filter", args.pattern])
         if args.sorted:
             sub_argv.append("--sorted")
+        if getattr(args, "check_connectivity", False):
+            sub_argv.append("--check-connectivity")
         return pcb_main(sub_argv) or 0
 
     elif args.pcb_command == "traces":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1241,6 +1241,12 @@ def _add_pcb_parser(subparsers) -> None:
     pcb_nets.add_argument("--format", choices=["text", "json"], default="text")
     pcb_nets.add_argument("--filter", dest="pattern", help="Filter by net pattern")
     pcb_nets.add_argument("--sorted", action="store_true", help="Sort output")
+    pcb_nets.add_argument(
+        "--check-connectivity",
+        action="store_true",
+        default=False,
+        help="Run island detection to find disconnected segments within each net",
+    )
 
     # pcb traces
     pcb_traces = pcb_subparsers.add_parser("traces", help="Show trace statistics")

--- a/src/kicad_tools/cli/pcb_query.py
+++ b/src/kicad_tools/cli/pcb_query.py
@@ -199,7 +199,6 @@ def cmd_nets(pcb: PCB, args):
     island_map: dict[int, list[list[str]]] = {}
     if check_connectivity:
         analyzer = NetStatusAnalyzer(pcb)
-        result = analyzer.analyze()
         # Build a lookup from net_number -> islands for quick access
         # We need to re-run island detection per net since NetStatusAnalyzer
         # only exposes connected/unconnected classification, not raw islands.

--- a/src/kicad_tools/cli/pcb_query.py
+++ b/src/kicad_tools/cli/pcb_query.py
@@ -34,7 +34,7 @@ import json
 import sys
 from pathlib import Path
 
-from kicad_tools.analysis.net_status import build_zone_net_map
+from kicad_tools.analysis.net_status import NetStatusAnalyzer, build_zone_net_map
 from kicad_tools.schema import PCB
 
 
@@ -194,36 +194,87 @@ def cmd_nets(pcb: PCB, args):
     # Build zone-to-net lookup once for all nets
     zone_net_map = build_zone_net_map(pcb)
 
+    # Run connectivity analysis if requested
+    check_connectivity = getattr(args, "check_connectivity", False)
+    island_map: dict[int, list[list[str]]] = {}
+    if check_connectivity:
+        analyzer = NetStatusAnalyzer(pcb)
+        result = analyzer.analyze()
+        # Build a lookup from net_number -> islands for quick access
+        # We need to re-run island detection per net since NetStatusAnalyzer
+        # only exposes connected/unconnected classification, not raw islands.
+        for net in nets:
+            pad_infos = analyzer._get_net_pads_with_positions(net.number)
+            if len(pad_infos) < 2:
+                # Single-pad or zero-pad nets: 1 island if pads exist, else 0
+                if pad_infos:
+                    island_map[net.number] = [[p.full_name for p in pad_infos]]
+                else:
+                    island_map[net.number] = []
+            else:
+                graph = analyzer._build_connectivity_graph(net.number, pad_infos)
+                islands = analyzer._find_islands(
+                    graph, [p.full_name for p in pad_infos]
+                )
+                island_map[net.number] = islands
+
     if args.format == "json":
         net_stats = []
         for net in nets:
             segments = list(pcb.segments_in_net(net.number))
             vias = list(pcb.vias_in_net(net.number))
             zone_layers = zone_net_map.get(net.number, [])
-            net_stats.append(
-                {
-                    "number": net.number,
-                    "name": net.name,
-                    "segments": len(segments),
-                    "vias": len(vias),
-                    "zone_connected": bool(zone_layers),
-                    "zone_layers": zone_layers,
-                }
-            )
+            entry = {
+                "number": net.number,
+                "name": net.name,
+                "segments": len(segments),
+                "vias": len(vias),
+                "zone_connected": bool(zone_layers),
+                "zone_layers": zone_layers,
+            }
+            if check_connectivity:
+                islands = island_map.get(net.number, [])
+                entry["island_count"] = len(islands)
+                entry["islands"] = islands
+                entry["is_complete"] = len(islands) <= 1
+            net_stats.append(entry)
         print(json.dumps(net_stats, indent=2))
         return
 
-    print(f"{'Net':<25} {'#':<6} {'Segs':<8} {'Vias':<6} {'Zone'}")
-    print("-" * 60)
+    if check_connectivity:
+        print(
+            f"{'Net':<25} {'#':<6} {'Segs':<8} {'Vias':<6} {'Zone':<12} {'Islands'}"
+        )
+        print("-" * 80)
+    else:
+        print(f"{'Net':<25} {'#':<6} {'Segs':<8} {'Vias':<6} {'Zone'}")
+        print("-" * 60)
 
     for net in nets:
         segments = list(pcb.segments_in_net(net.number))
         vias = list(pcb.vias_in_net(net.number))
         zone_layers = zone_net_map.get(net.number, [])
         zone_col = ", ".join(zone_layers) if zone_layers else "-"
-        print(
-            f"{net.name:<25} {net.number:<6} {len(segments):<8} {len(vias):<6} {zone_col}"
-        )
+
+        if check_connectivity:
+            islands = island_map.get(net.number, [])
+            island_count = len(islands)
+            if island_count <= 1:
+                island_str = str(island_count)
+            else:
+                # Show island membership for disconnected nets
+                island_parts = []
+                for island in islands:
+                    island_parts.append(", ".join(island))
+                island_str = f"{island_count} islands [{' | '.join(island_parts)}]"
+            print(
+                f"{net.name:<25} {net.number:<6} {len(segments):<8} "
+                f"{len(vias):<6} {zone_col:<12} {island_str}"
+            )
+        else:
+            print(
+                f"{net.name:<25} {net.number:<6} {len(segments):<8} {len(vias):<6} {zone_col}"
+            )
 
     print(f"\nTotal: {len(nets)} nets")
 
@@ -480,6 +531,13 @@ def main(argv=None):
     parser.add_argument("--filter", help="Filter pattern (e.g., 'U*', 'C*')")
     parser.add_argument("--sorted", action="store_true", help="Sort output")
     parser.add_argument("--layer", help="Filter by layer (for traces)")
+    parser.add_argument(
+        "--check-connectivity",
+        action="store_true",
+        default=False,
+        dest="check_connectivity",
+        help="Run island detection to find disconnected segments within each net",
+    )
 
     args = parser.parse_args(argv)
 

--- a/tests/test_pcb_nets_connectivity.py
+++ b/tests/test_pcb_nets_connectivity.py
@@ -1,0 +1,326 @@
+"""Tests for pcb nets --check-connectivity flag."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.pcb_query import main as pcb_query_main
+
+
+# PCB with fully connected nets (all pads linked by traces)
+CONNECTED_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+
+  (gr_rect
+    (start 0 0)
+    (end 30 30)
+    (stroke (width 0.1))
+    (layer "Edge.Cuts")
+  )
+
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 10 10)
+    (property "Reference" "R1")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 20 10)
+    (property "Reference" "R2")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+
+  (segment (start 9.5 10) (end 19.5 10) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 10.5 10) (end 20.5 10) (width 0.25) (layer "F.Cu") (net 2))
+)
+"""
+
+# PCB with disconnected islands: net 1 has two pads connected, one isolated
+DISCONNECTED_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "SCL")
+
+  (gr_rect
+    (start 0 0)
+    (end 50 50)
+    (stroke (width 0.1))
+    (layer "Edge.Cuts")
+  )
+
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 10 10)
+    (property "Reference" "R1")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "SCL"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 0 ""))
+  )
+
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 20 10)
+    (property "Reference" "R2")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "SCL"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 0 ""))
+  )
+
+  (footprint "Package_SO:SOIC-8"
+    (layer "F.Cu")
+    (at 40 10)
+    (property "Reference" "U1")
+    (pad "5" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "SCL"))
+  )
+
+  (segment (start 9.5 10) (end 19.5 10) (width 0.25) (layer "F.Cu") (net 1))
+)
+"""
+
+# PCB with a single-pad net (should report 1 island)
+SINGLE_PAD_NET_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "SINGLE")
+
+  (gr_rect
+    (start 0 0)
+    (end 30 30)
+    (stroke (width 0.1))
+    (layer "Edge.Cuts")
+  )
+
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 10 10)
+    (property "Reference" "R1")
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "SINGLE"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 0 ""))
+  )
+)
+"""
+
+# PCB with unrouted net (0 pads on net = 0 islands)
+ZERO_PAD_NET_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "ORPHAN")
+
+  (gr_rect
+    (start 0 0)
+    (end 30 30)
+    (stroke (width 0.1))
+    (layer "Edge.Cuts")
+  )
+)
+"""
+
+
+@pytest.fixture
+def connected_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "connected.kicad_pcb"
+    pcb_file.write_text(CONNECTED_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def disconnected_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "disconnected.kicad_pcb"
+    pcb_file.write_text(DISCONNECTED_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def single_pad_net_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "single_pad.kicad_pcb"
+    pcb_file.write_text(SINGLE_PAD_NET_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def zero_pad_net_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "zero_pad.kicad_pcb"
+    pcb_file.write_text(ZERO_PAD_NET_PCB)
+    return pcb_file
+
+
+class TestCheckConnectivityJSON:
+    """Test --check-connectivity with JSON output."""
+
+    def test_connected_nets_report_one_island(self, connected_pcb: Path, capsys):
+        """Fully connected nets should have island_count=1 and is_complete=True."""
+        pcb_query_main([str(connected_pcb), "nets", "--check-connectivity", "--format", "json"])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        for net in data:
+            assert "island_count" in net
+            assert "islands" in net
+            assert "is_complete" in net
+            assert net["island_count"] == 1
+            assert net["is_complete"] is True
+
+    def test_disconnected_net_reports_multiple_islands(self, disconnected_pcb: Path, capsys):
+        """A net with disconnected segments should report island_count > 1."""
+        pcb_query_main(
+            [str(disconnected_pcb), "nets", "--check-connectivity", "--format", "json"]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # Find net SCL
+        scl_nets = [n for n in data if n["name"] == "SCL"]
+        assert len(scl_nets) == 1
+        scl = scl_nets[0]
+        assert scl["island_count"] == 2
+        assert scl["is_complete"] is False
+        # Verify island membership: R1.1 and R2.1 are connected, U1.5 is isolated
+        all_pads = []
+        for island in scl["islands"]:
+            all_pads.extend(island)
+        assert "U1.5" in all_pads
+        assert "R1.1" in all_pads
+        assert "R2.1" in all_pads
+
+    def test_single_pad_net_reports_one_island(self, single_pad_net_pcb: Path, capsys):
+        """A single-pad net should report island_count=1."""
+        pcb_query_main(
+            [str(single_pad_net_pcb), "nets", "--check-connectivity", "--format", "json"]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        single_nets = [n for n in data if n["name"] == "SINGLE"]
+        assert len(single_nets) == 1
+        assert single_nets[0]["island_count"] == 1
+        assert single_nets[0]["is_complete"] is True
+
+    def test_zero_pad_net_reports_zero_islands(self, zero_pad_net_pcb: Path, capsys):
+        """A net with no pads should report island_count=0."""
+        pcb_query_main(
+            [str(zero_pad_net_pcb), "nets", "--check-connectivity", "--format", "json"]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        orphan_nets = [n for n in data if n["name"] == "ORPHAN"]
+        assert len(orphan_nets) == 1
+        assert orphan_nets[0]["island_count"] == 0
+        assert orphan_nets[0]["is_complete"] is True  # 0 islands <= 1
+
+
+class TestCheckConnectivityText:
+    """Test --check-connectivity with text output."""
+
+    def test_text_output_includes_islands_column(self, connected_pcb: Path, capsys):
+        """Text output should include Islands column when flag is set."""
+        pcb_query_main([str(connected_pcb), "nets", "--check-connectivity"])
+
+        captured = capsys.readouterr()
+        assert "Islands" in captured.out
+
+    def test_text_output_shows_island_detail_for_disconnected(
+        self, disconnected_pcb: Path, capsys
+    ):
+        """Disconnected nets should show island membership in text output."""
+        pcb_query_main([str(disconnected_pcb), "nets", "--check-connectivity"])
+
+        captured = capsys.readouterr()
+        assert "2 islands" in captured.out
+        assert "U1.5" in captured.out
+
+
+class TestWithoutCheckConnectivity:
+    """Verify backward compatibility when --check-connectivity is not set."""
+
+    def test_json_output_unchanged(self, connected_pcb: Path, capsys):
+        """JSON output without --check-connectivity should not include island fields."""
+        pcb_query_main([str(connected_pcb), "nets", "--format", "json"])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        for net in data:
+            assert "island_count" not in net
+            assert "islands" not in net
+            assert "is_complete" not in net
+
+    def test_text_output_unchanged(self, connected_pcb: Path, capsys):
+        """Text output without --check-connectivity should not show Islands column."""
+        pcb_query_main([str(connected_pcb), "nets"])
+
+        captured = capsys.readouterr()
+        assert "Islands" not in captured.out
+
+
+class TestCLIFlagWiring:
+    """Test that --check-connectivity flag is properly wired through the CLI."""
+
+    def test_flag_accepted_by_pcb_query(self, connected_pcb: Path, capsys):
+        """pcb_query should accept --check-connectivity without error."""
+        # Should not raise SystemExit
+        pcb_query_main([str(connected_pcb), "nets", "--check-connectivity"])
+        captured = capsys.readouterr()
+        assert "Total:" in captured.out
+
+    def test_flag_combined_with_filter(self, disconnected_pcb: Path, capsys):
+        """--check-connectivity should work with --filter."""
+        pcb_query_main(
+            [str(disconnected_pcb), "nets", "--check-connectivity", "--filter", "SCL", "--format", "json"]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data) == 1
+        assert data[0]["name"] == "SCL"
+        assert data[0]["island_count"] == 2
+
+    def test_flag_combined_with_sorted(self, connected_pcb: Path, capsys):
+        """--check-connectivity should work with --sorted."""
+        pcb_query_main(
+            [str(connected_pcb), "nets", "--check-connectivity", "--sorted", "--format", "json"]
+        )
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        names = [n["name"] for n in data]
+        assert names == sorted(names)


### PR DESCRIPTION
## Summary
Add a --check-connectivity flag to the pcb nets command that runs NetStatusAnalyzer island detection inline, reporting disconnected copper islands per net without requiring a separate net-status command.

## Changes
- Add --check-connectivity argument to pcb nets subparser in parser.py
- Pass the flag through the CLI dispatch in commands/pcb.py
- Integrate NetStatusAnalyzer into pcb_query.py cmd_nets() to compute island counts and membership when the flag is set
- Add island_count, islands, and is_complete fields to JSON output when --check-connectivity is active
- Add Islands column to text output showing island membership for disconnected nets
- Add comprehensive test suite (11 tests) covering JSON/text output, backward compatibility, edge cases (single-pad nets, zero-pad nets), and flag combinations

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| --check-connectivity flag added to pcb nets | PASS | Added to both parser.py and pcb_query.py argparsers |
| JSON output includes island_count, islands, is_complete | PASS | Verified by test_connected_nets_report_one_island, test_disconnected_net_reports_multiple_islands |
| Text output shows Islands column with membership | PASS | Verified by test_text_output_includes_islands_column, test_text_output_shows_island_detail_for_disconnected |
| Backward compatibility (no flag = unchanged output) | PASS | Verified by test_json_output_unchanged, test_text_output_unchanged |
| Single-pad nets report 1 island | PASS | Verified by test_single_pad_net_reports_one_island |
| Zero-pad nets report 0 islands | PASS | Verified by test_zero_pad_net_reports_zero_islands |
| Works with --filter and --sorted | PASS | Verified by test_flag_combined_with_filter, test_flag_combined_with_sorted |

## Test Plan
All 11 new tests pass. All 53 existing net status tests pass unchanged.

Closes #2253