### PR TITLE
feat(router): validate pad-to-pad connectivity and suppress false success banners

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3728,14 +3728,29 @@ class Autorouter:
             nets_to_route_ids: Optional set of net IDs that were targeted
                 for routing (multi-pad signal nets).  When provided,
                 ``nets_routed`` only counts nets in this set.
+
+        When pad information is available (``self.pads`` and ``self.nets``),
+        connectivity validation is performed so that ``nets_routed``
+        reflects actual pad-to-pad connectivity rather than mere segment
+        existence.
         """
         from .observability import compute_routing_statistics
+
+        # Build net_pads mapping when pad data is available
+        net_pads: dict[int, list] | None = None
+        if self.pads and self.nets:
+            net_pads = {}
+            for net_id, pad_keys in self.nets.items():
+                pad_list = [self.pads[k] for k in pad_keys if k in self.pads]
+                if pad_list:
+                    net_pads[net_id] = pad_list
 
         return compute_routing_statistics(
             routes=self.routes,
             grid=self.grid,
             layer_stats=self.get_layer_usage_statistics(),
             nets_to_route_ids=nets_to_route_ids,
+            net_pads=net_pads,
         )
 
     def get_layer_usage_statistics(self) -> dict:

--- a/src/kicad_tools/router/fine_pitch.py
+++ b/src/kicad_tools/router/fine_pitch.py
@@ -129,6 +129,13 @@ class FinePitchReport:
     affected_net_count: int = 0
 
     @property
+    def off_grid_percentage(self) -> float:
+        """Percentage of all analyzed pads that are off-grid."""
+        if self.total_pads == 0:
+            return 0.0
+        return self.total_off_grid / self.total_pads * 100
+
+    @property
     def has_warnings(self) -> bool:
         """True if any components have routing concerns."""
         return any(c.has_issues for c in self.components)
@@ -224,6 +231,20 @@ class FinePitchReport:
                 )
             lines.append("    • Consider enabling sub-grid routing for pad connections")
             lines.append("    • Review affected nets for manual routing")
+
+        # Warn when >50% of pads are off-grid (Issue #2254)
+        pct = self.off_grid_percentage
+        if pct > 50:
+            lines.append("")
+            lines.append(
+                f"  WARNING: {pct:.0f}% of pads ({self.total_off_grid}/{self.total_pads})"
+                f" are off-grid at {self.grid_resolution}mm resolution."
+            )
+            suggested = self.grid_resolution / 2
+            lines.append(
+                f"  Routing quality will be degraded. Consider --grid {suggested}"
+                " for better pad alignment."
+            )
 
         return "\n".join(lines)
 

--- a/src/kicad_tools/router/observability.py
+++ b/src/kicad_tools/router/observability.py
@@ -11,7 +11,168 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .grid import RoutingGrid
-    from .primitives import Route
+    from .primitives import Pad, Route
+
+
+# ---------------------------------------------------------------------------
+# Union-Find for connectivity validation
+# ---------------------------------------------------------------------------
+
+
+class _UnionFind:
+    """Lightweight union-find (disjoint set) for connectivity checks."""
+
+    def __init__(self) -> None:
+        self._parent: dict[tuple[float, float], tuple[float, float]] = {}
+        self._rank: dict[tuple[float, float], int] = {}
+
+    def _ensure(self, p: tuple[float, float]) -> None:
+        if p not in self._parent:
+            self._parent[p] = p
+            self._rank[p] = 0
+
+    def find(self, p: tuple[float, float]) -> tuple[float, float]:
+        self._ensure(p)
+        while self._parent[p] != p:
+            self._parent[p] = self._parent[self._parent[p]]
+            p = self._parent[p]
+        return p
+
+    def union(self, a: tuple[float, float], b: tuple[float, float]) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra == rb:
+            return
+        if self._rank[ra] < self._rank[rb]:
+            ra, rb = rb, ra
+        self._parent[rb] = ra
+        if self._rank[ra] == self._rank[rb]:
+            self._rank[ra] += 1
+
+
+def _snap(val: float, tolerance: float = 0.01) -> float:
+    """Round a coordinate to avoid floating-point mismatch."""
+    return round(val / tolerance) * tolerance
+
+
+def _pt(x: float, y: float, tol: float = 0.01) -> tuple[float, float]:
+    return (_snap(x, tol), _snap(y, tol))
+
+
+def validate_net_connectivity(
+    routes: list[Route],
+    net_pads: dict[int, list[Pad]],
+    tolerance: float = 0.01,
+) -> dict[int, dict]:
+    """Check whether routed segments actually connect all pads in each net.
+
+    For every net that has routes **and** pad information, this builds a
+    union-find over segment endpoints, then checks how many pads belong to the
+    same connected component.
+
+    Args:
+        routes: All routed ``Route`` objects.
+        net_pads: Mapping of net ID to the list of ``Pad`` objects that belong
+            to that net.  Only nets present in this dict are validated.
+        tolerance: Coordinate tolerance for matching endpoints (mm).
+
+    Returns:
+        Dict mapping net ID -> connectivity info dict with keys:
+
+        - ``total_pads``: number of pads in the net
+        - ``connected_pads``: number of pads reachable from the largest
+          connected component that includes at least one pad
+        - ``connected``: ``True`` when all pads are in one component
+    """
+    # Group routes by net
+    routes_by_net: dict[int, list[Route]] = {}
+    for r in routes:
+        routes_by_net.setdefault(r.net, []).append(r)
+
+    result: dict[int, dict] = {}
+
+    for net_id, pads in net_pads.items():
+        if len(pads) < 2:
+            # Single-pad nets are trivially connected
+            result[net_id] = {
+                "total_pads": len(pads),
+                "connected_pads": len(pads),
+                "connected": True,
+            }
+            continue
+
+        net_routes = routes_by_net.get(net_id, [])
+        if not net_routes:
+            # No routes at all for this net
+            result[net_id] = {
+                "total_pads": len(pads),
+                "connected_pads": 0,
+                "connected": False,
+            }
+            continue
+
+        uf = _UnionFind()
+
+        # Union segment endpoints
+        for route in net_routes:
+            for seg in route.segments:
+                p1 = _pt(seg.x1, seg.y1, tolerance)
+                p2 = _pt(seg.x2, seg.y2, tolerance)
+                uf.union(p1, p2)
+            for via in route.vias:
+                via_pt = _pt(via.x, via.y, tolerance)
+                # A via connects to any segment endpoint at the same position
+                # (already handled because the segment endpoints are unioned
+                # with each other; the via shares the same coordinate as an
+                # endpoint, so find() will merge them).
+                uf._ensure(via_pt)
+                # Explicitly union via point with nearby segment endpoints
+                for seg in route.segments:
+                    for sp in [_pt(seg.x1, seg.y1, tolerance), _pt(seg.x2, seg.y2, tolerance)]:
+                        if sp == via_pt:
+                            uf.union(via_pt, sp)
+
+        # Map each pad to its nearest segment endpoint
+        pad_points: list[tuple[float, float]] = []
+        for pad in pads:
+            pad_pt = _pt(pad.x, pad.y, tolerance)
+            # Check if this pad position is already in the union-find
+            # (i.e. a segment starts/ends at this pad).  If not, find
+            # the closest segment endpoint and union with it.
+            best_dist = float("inf")
+            best_pt = pad_pt
+            for route in net_routes:
+                for seg in route.segments:
+                    for sp in [_pt(seg.x1, seg.y1, tolerance), _pt(seg.x2, seg.y2, tolerance)]:
+                        dx = sp[0] - pad_pt[0]
+                        dy = sp[1] - pad_pt[1]
+                        d = dx * dx + dy * dy
+                        if d < best_dist:
+                            best_dist = d
+                            best_pt = sp
+            # Only link pad to segment if within a reasonable proximity
+            # (2mm -- escape stubs are typically short).
+            if best_dist <= 4.0:  # 2mm squared
+                uf.union(pad_pt, best_pt)
+            else:
+                uf._ensure(pad_pt)
+            pad_points.append(pad_pt)
+
+        # Count pads in the largest connected component
+        component_pads: dict[tuple[float, float], int] = {}
+        for pp in pad_points:
+            root = uf.find(pp)
+            component_pads[root] = component_pads.get(root, 0) + 1
+
+        max_component = max(component_pads.values()) if component_pads else 0
+        total = len(pads)
+
+        result[net_id] = {
+            "total_pads": total,
+            "connected_pads": max_component,
+            "connected": max_component == total,
+        }
+
+    return result
 
 
 def compute_routing_statistics(
@@ -19,6 +180,7 @@ def compute_routing_statistics(
     grid: RoutingGrid,
     layer_stats: dict,
     nets_to_route_ids: set[int] | None = None,
+    net_pads: dict[int, list[Pad]] | None = None,
 ) -> dict:
     """Compute routing statistics including congestion metrics.
 
@@ -30,9 +192,21 @@ def compute_routing_statistics(
             routing (multi-pad signal nets).  When provided, ``nets_routed``
             only counts nets present in this set so the numerator and
             denominator use the same population.
+        net_pads: Optional mapping of net ID to list of Pad objects.
+            When provided, connectivity validation is performed and
+            ``nets_routed`` reflects actual pad-to-pad connectivity
+            rather than mere segment existence.
 
     Returns:
-        Dictionary with routing statistics
+        Dictionary with routing statistics.  When *net_pads* is supplied
+        the result also contains:
+
+        - ``connectivity``: per-net connectivity dict from
+          :func:`validate_net_connectivity`
+        - ``nets_fully_connected``: count of nets where all pads are in
+          one connected component
+        - ``has_disconnected_islands``: ``True`` when any targeted net
+          has pads that are not connected
     """
     total_length = sum(
         math.sqrt((s.x2 - s.x1) ** 2 + (s.y2 - s.y1) ** 2)
@@ -42,12 +216,37 @@ def compute_routing_statistics(
     congestion_stats = grid.get_congestion_map()
 
     all_routed_nets = {r.net for r in routes}
-    if nets_to_route_ids is not None:
-        nets_routed = len(all_routed_nets & nets_to_route_ids)
-    else:
-        nets_routed = len(all_routed_nets)
 
-    return {
+    # --- Connectivity-aware routing count ---
+    connectivity: dict[int, dict] | None = None
+    nets_fully_connected = 0
+    has_disconnected_islands = False
+
+    if net_pads is not None:
+        # Validate actual connectivity
+        target_pads = (
+            {nid: pads for nid, pads in net_pads.items() if nid in nets_to_route_ids}
+            if nets_to_route_ids is not None
+            else net_pads
+        )
+        connectivity = validate_net_connectivity(routes, target_pads)
+        nets_fully_connected = sum(
+            1 for info in connectivity.values() if info["connected"]
+        )
+        has_disconnected_islands = any(
+            not info["connected"] for info in connectivity.values()
+            if info["total_pads"] >= 2
+        )
+        # nets_routed = only nets that are fully connected
+        nets_routed = nets_fully_connected
+    else:
+        # Legacy path: count any net with at least one route
+        if nets_to_route_ids is not None:
+            nets_routed = len(all_routed_nets & nets_to_route_ids)
+        else:
+            nets_routed = len(all_routed_nets)
+
+    result = {
         "routes": len(routes),
         "segments": sum(len(r.segments) for r in routes),
         "vias": sum(len(r.vias) for r in routes),
@@ -58,6 +257,13 @@ def compute_routing_statistics(
         "congested_regions": congestion_stats["congested_regions"],
         "layer_usage": layer_stats,
     }
+
+    if connectivity is not None:
+        result["connectivity"] = connectivity
+        result["nets_fully_connected"] = nets_fully_connected
+        result["has_disconnected_islands"] = has_disconnected_islands
+
+    return result
 
 
 def compute_layer_usage_statistics(

--- a/src/kicad_tools/router/output.py
+++ b/src/kicad_tools/router/output.py
@@ -85,12 +85,55 @@ def show_routing_summary(
             failures_by_net[failure.net] = []
         failures_by_net[failure.net].append(failure)
 
+    # --- Connectivity validation (Issue #2254) ---
+    # When pad data is available, check actual pad-to-pad connectivity
+    # so we don't report SUCCESS for nets that only have escape stubs.
+    connectivity: dict[int, dict] | None = None
+    partially_connected_nets: dict[int, dict] = {}
+    has_disconnected_islands = False
+    if hasattr(router, "pads") and hasattr(router, "nets") and router.pads and router.nets:
+        from .observability import validate_net_connectivity
+
+        net_pads: dict[int, list] = {}
+        for net_id, pad_keys in router.nets.items():
+            pad_list = [router.pads[k] for k in pad_keys if k in router.pads]
+            if pad_list:
+                net_pads[net_id] = pad_list
+        target_pads = (
+            {nid: pads for nid, pads in net_pads.items() if nid in nets_to_route_ids}
+            if nets_to_route_ids is not None
+            else net_pads
+        )
+        connectivity = validate_net_connectivity(router.routes, target_pads)
+        for net_id, info in connectivity.items():
+            if info["total_pads"] >= 2 and not info["connected"]:
+                has_disconnected_islands = True
+                # A net that has routes but is not fully connected
+                if net_id in routed_net_ids:
+                    partially_connected_nets[net_id] = info
+        # Adjust routed count: remove partially-connected nets
+        routed_net_ids = routed_net_ids - set(partially_connected_nets.keys())
+
     # Calculate success percentage
     success_rate = len(routed_net_ids) / nets_to_route * 100 if nets_to_route > 0 else 0
 
     print(f"\n{'=' * 60}")
-    print("Routing Complete!")
+    if has_disconnected_islands or unrouted_ids or partially_connected_nets:
+        connectivity_pct = f" ({success_rate:.0f}% connected)"
+        print(f"Routing Incomplete{connectivity_pct}")
+    else:
+        print("Routing Complete!")
     print(f"  Nets routed: {len(routed_net_ids)}/{nets_to_route} ({success_rate:.0f}%)")
+
+    # Show partially-connected nets (have segments but not all pads connected)
+    if partially_connected_nets:
+        print(f"\n  Partially connected nets ({len(partially_connected_nets)}):")
+        for net_id in sorted(partially_connected_nets):
+            info = partially_connected_nets[net_id]
+            net_name = reverse_net.get(net_id, f"Net_{net_id}")
+            print(
+                f"    {net_name}: {info['connected_pads']}/{info['total_pads']} pads connected"
+            )
 
     # Show cleanup statistics if any artifacts were removed
     cleanup_stats = getattr(router, "_cleanup_stats", None)
@@ -482,6 +525,36 @@ def get_routing_diagnostics_json(
         all_net_ids = {v for k, v in net_map.items() if v > 0}
         unrouted_ids = all_net_ids - all_routed_net_ids
 
+    # --- Connectivity validation (Issue #2254) ---
+    connectivity: dict[int, dict] | None = None
+    partially_connected: list[dict] = []
+    has_disconnected_islands = False
+    if hasattr(router, "pads") and hasattr(router, "nets") and router.pads and router.nets:
+        from .observability import validate_net_connectivity
+
+        net_pads_map: dict[int, list] = {}
+        for net_id_iter, pad_keys in router.nets.items():
+            pad_list = [router.pads[k] for k in pad_keys if k in router.pads]
+            if pad_list:
+                net_pads_map[net_id_iter] = pad_list
+        target_pads = (
+            {nid: pads for nid, pads in net_pads_map.items() if nid in nets_to_route_ids}
+            if nets_to_route_ids is not None
+            else net_pads_map
+        )
+        connectivity = validate_net_connectivity(router.routes, target_pads)
+        for nid, info in connectivity.items():
+            if info["total_pads"] >= 2 and not info["connected"]:
+                has_disconnected_islands = True
+                if nid in routed_net_ids:
+                    partially_connected.append({
+                        "net_id": nid,
+                        "net_name": reverse_net.get(nid, f"Net_{nid}"),
+                        "connected_pads": info["connected_pads"],
+                        "total_pads": info["total_pads"],
+                    })
+                    routed_net_ids = routed_net_ids - {nid}
+
     # Build successful routes list
     successful_routes = []
     for net_id in sorted(routed_net_ids):
@@ -644,7 +717,7 @@ def get_routing_diagnostics_json(
             }
         )
 
-    return {
+    result_dict: dict = {
         "summary": {
             "nets_requested": nets_to_route,
             "nets_routed": len(routed_net_ids),
@@ -652,12 +725,16 @@ def get_routing_diagnostics_json(
             "success_rate": round(len(routed_net_ids) / nets_to_route * 100, 1)
             if nets_to_route > 0
             else 0,
+            "has_disconnected_islands": has_disconnected_islands,
         },
         "failure_breakdown": dict(failures_by_cause),
         "successful_routes": successful_routes,
         "failed_routes": failed_routes,
         "suggestions": suggestions,
     }
+    if partially_connected:
+        result_dict["partially_connected"] = partially_connected
+    return result_dict
 
 
 def print_routing_diagnostics_json(

--- a/tests/test_routing_connectivity.py
+++ b/tests/test_routing_connectivity.py
@@ -1,0 +1,370 @@
+"""Tests for routing connectivity validation (Issue #2254).
+
+Verifies that the router correctly reports actual pad-to-pad connectivity
+rather than inflated counts based on segment existence alone.
+"""
+
+from kicad_tools.router.fine_pitch import (
+    FinePitchReport,
+    FinePitchSeverity,
+    analyze_fine_pitch_components,
+)
+from kicad_tools.router.observability import validate_net_connectivity
+from kicad_tools.router.primitives import Layer, Pad, Route, Segment
+
+
+def _pad(x: float, y: float, net: int, ref: str = "U1", pin: str = "1") -> Pad:
+    """Create a minimal Pad for testing."""
+    return Pad(
+        x=x, y=y, width=0.5, height=0.5,
+        net=net, net_name=f"NET{net}", ref=ref, pin=pin,
+    )
+
+
+def _seg(x1: float, y1: float, x2: float, y2: float) -> Segment:
+    """Create a minimal Segment for testing."""
+    return Segment(
+        x1=x1, y1=y1, x2=x2, y2=y2,
+        width=0.2, layer=Layer.F_CU,
+    )
+
+
+class TestValidateNetConnectivity:
+    """Tests for validate_net_connectivity()."""
+
+    def test_fully_connected_two_pad_net(self):
+        """A net with two pads connected by a single segment is fully connected."""
+        pads = [_pad(0.0, 0.0, 1, "U1", "1"), _pad(5.0, 0.0, 1, "U1", "2")]
+        routes = [Route(net=1, net_name="NET1", segments=[_seg(0.0, 0.0, 5.0, 0.0)])]
+
+        result = validate_net_connectivity(routes, {1: pads})
+
+        assert result[1]["total_pads"] == 2
+        assert result[1]["connected_pads"] == 2
+        assert result[1]["connected"] is True
+
+    def test_disconnected_escape_stubs(self):
+        """Two escape stubs that don't connect produce disconnected islands."""
+        pads = [
+            _pad(0.0, 0.0, 1, "U1", "1"),
+            _pad(10.0, 0.0, 1, "U1", "2"),
+            _pad(20.0, 0.0, 1, "U1", "3"),
+        ]
+        # Two short escape stubs near pad 1 and pad 2, but no connection between
+        routes = [
+            Route(net=1, net_name="NET1", segments=[_seg(0.0, 0.0, 1.0, 0.0)]),
+            Route(net=1, net_name="NET1", segments=[_seg(10.0, 0.0, 11.0, 0.0)]),
+        ]
+
+        result = validate_net_connectivity(routes, {1: pads})
+
+        assert result[1]["total_pads"] == 3
+        assert result[1]["connected_pads"] < 3
+        assert result[1]["connected"] is False
+
+    def test_no_routes_for_net(self):
+        """A net with no routes at all reports 0 connected pads."""
+        pads = [_pad(0.0, 0.0, 1), _pad(5.0, 0.0, 1)]
+
+        result = validate_net_connectivity([], {1: pads})
+
+        assert result[1]["total_pads"] == 2
+        assert result[1]["connected_pads"] == 0
+        assert result[1]["connected"] is False
+
+    def test_single_pad_net_is_trivially_connected(self):
+        """A single-pad net is always connected."""
+        pads = [_pad(0.0, 0.0, 1)]
+
+        result = validate_net_connectivity([], {1: pads})
+
+        assert result[1]["total_pads"] == 1
+        assert result[1]["connected_pads"] == 1
+        assert result[1]["connected"] is True
+
+    def test_chain_of_segments_connects_all_pads(self):
+        """Three pads connected by a chain of segments are fully connected."""
+        pads = [
+            _pad(0.0, 0.0, 1, "U1", "1"),
+            _pad(5.0, 0.0, 1, "U1", "2"),
+            _pad(10.0, 0.0, 1, "U1", "3"),
+        ]
+        routes = [
+            Route(
+                net=1, net_name="NET1",
+                segments=[_seg(0.0, 0.0, 5.0, 0.0), _seg(5.0, 0.0, 10.0, 0.0)],
+            ),
+        ]
+
+        result = validate_net_connectivity(routes, {1: pads})
+
+        assert result[1]["total_pads"] == 3
+        assert result[1]["connected_pads"] == 3
+        assert result[1]["connected"] is True
+
+    def test_multiple_nets_independent(self):
+        """Connectivity is validated per-net independently."""
+        net1_pads = [_pad(0.0, 0.0, 1, "U1", "1"), _pad(5.0, 0.0, 1, "U1", "2")]
+        net2_pads = [_pad(0.0, 5.0, 2, "U1", "3"), _pad(5.0, 5.0, 2, "U1", "4")]
+
+        routes = [
+            Route(net=1, net_name="NET1", segments=[_seg(0.0, 0.0, 5.0, 0.0)]),
+            # Net 2 has no routes
+        ]
+
+        result = validate_net_connectivity(routes, {1: net1_pads, 2: net2_pads})
+
+        assert result[1]["connected"] is True
+        assert result[2]["connected"] is False
+
+    def test_pad_near_segment_endpoint_linked(self):
+        """A pad close to (but not exactly at) a segment endpoint is linked."""
+        # Pad at 0.005mm offset from segment endpoint (within default tolerance)
+        pads = [_pad(0.005, 0.005, 1, "U1", "1"), _pad(5.0, 0.0, 1, "U1", "2")]
+        routes = [Route(net=1, net_name="NET1", segments=[_seg(0.0, 0.0, 5.0, 0.0)])]
+
+        result = validate_net_connectivity(routes, {1: pads})
+
+        assert result[1]["connected_pads"] == 2
+        assert result[1]["connected"] is True
+
+
+class TestComputeRoutingStatisticsConnectivity:
+    """Tests for connectivity-aware compute_routing_statistics()."""
+
+    def test_nets_routed_reflects_connectivity(self):
+        """nets_routed should only count nets where all pads are connected."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.observability import compute_routing_statistics
+
+        grid = MagicMock()
+        grid.get_congestion_map.return_value = {
+            "max_congestion": 0,
+            "avg_congestion": 0,
+            "congested_regions": 0,
+        }
+
+        pads_net1 = [_pad(0.0, 0.0, 1, "U1", "1"), _pad(5.0, 0.0, 1, "U1", "2")]
+        pads_net2 = [_pad(0.0, 5.0, 2, "U1", "3"), _pad(5.0, 5.0, 2, "U1", "4")]
+
+        routes = [
+            # Net 1: fully connected
+            Route(net=1, net_name="NET1", segments=[_seg(0.0, 0.0, 5.0, 0.0)]),
+            # Net 2: only an escape stub (not connected to pad 4)
+            Route(net=2, net_name="NET2", segments=[_seg(0.0, 5.0, 1.0, 5.0)]),
+        ]
+
+        stats = compute_routing_statistics(
+            routes=routes,
+            grid=grid,
+            layer_stats={},
+            net_pads={1: pads_net1, 2: pads_net2},
+        )
+
+        # Net 1 is fully connected, net 2 is not
+        assert stats["nets_routed"] == 1
+        assert stats["has_disconnected_islands"] is True
+        assert stats["nets_fully_connected"] == 1
+
+    def test_legacy_path_without_net_pads(self):
+        """Without net_pads, nets_routed counts any net with a route."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.observability import compute_routing_statistics
+
+        grid = MagicMock()
+        grid.get_congestion_map.return_value = {
+            "max_congestion": 0,
+            "avg_congestion": 0,
+            "congested_regions": 0,
+        }
+
+        routes = [
+            Route(net=1, net_name="NET1", segments=[_seg(0.0, 0.0, 1.0, 0.0)]),
+            Route(net=2, net_name="NET2", segments=[_seg(0.0, 5.0, 1.0, 5.0)]),
+        ]
+
+        stats = compute_routing_statistics(
+            routes=routes,
+            grid=grid,
+            layer_stats={},
+            net_pads=None,
+        )
+
+        # Legacy: counts any net with a route
+        assert stats["nets_routed"] == 2
+        assert "connectivity" not in stats
+
+
+class TestOffGridWarning:
+    """Tests for the >50% off-grid warning (acceptance criterion 3)."""
+
+    def test_no_warning_below_threshold(self):
+        """No off-grid warning when percentage is below 50%."""
+        report = FinePitchReport(
+            total_pads=10,
+            total_off_grid=4,
+            grid_resolution=0.065,
+        )
+        # 40% off-grid -- below threshold
+        assert report.off_grid_percentage == 40.0
+        # has_warnings is False because no components have issues
+        text = report.format_warnings()
+        assert "WARNING" not in text
+
+    def test_warning_above_threshold(self):
+        """Warning emitted when >50% of pads are off-grid."""
+        from kicad_tools.router.fine_pitch import ComponentGridAnalysis, OffGridPad
+
+        comp = ComponentGridAnalysis(
+            ref="U1",
+            package_type="TSSOP-20",
+            pin_count=20,
+            pin_pitch=0.65,
+            off_grid_count=18,
+            off_grid_percentage=90.0,
+            severity=FinePitchSeverity.CRITICAL,
+            recommendations=["Use 0.025mm grid"],
+        )
+        report = FinePitchReport(
+            components=[comp],
+            total_pads=20,
+            total_off_grid=18,
+            grid_resolution=0.065,
+        )
+
+        assert report.off_grid_percentage == 90.0
+        text = report.format_warnings()
+        assert "WARNING" in text
+        assert "90%" in text
+        assert "off-grid" in text
+
+    def test_off_grid_percentage_property(self):
+        """off_grid_percentage computed correctly."""
+        report = FinePitchReport(total_pads=100, total_off_grid=87)
+        assert report.off_grid_percentage == 87.0
+
+    def test_off_grid_percentage_zero_pads(self):
+        """off_grid_percentage is 0 when no pads exist."""
+        report = FinePitchReport(total_pads=0, total_off_grid=0)
+        assert report.off_grid_percentage == 0.0
+
+    def test_analyze_off_grid_board_warns(self):
+        """End-to-end: analyzing a mostly off-grid board produces a warning."""
+        # Create 10 pads at 0.65mm pitch on a 0.5mm grid
+        pads = {}
+        for i in range(10):
+            x = i * 0.65
+            pads[("U1", str(i + 1))] = Pad(
+                x=x, y=0.0, width=0.3, height=0.8,
+                net=i + 1, net_name=f"NET{i + 1}", ref="U1", pin=str(i + 1),
+            )
+
+        report = analyze_fine_pitch_components(
+            pads=pads, grid_resolution=0.5, trace_width=0.2, clearance=0.2,
+        )
+
+        # Most pads should be off-grid at 0.5mm resolution
+        assert report.off_grid_percentage > 50
+        text = report.format_warnings()
+        assert "WARNING" in text
+
+
+class TestShowRoutingSummaryHonesty:
+    """Tests that the routing summary does not mislead when islands exist."""
+
+    def test_incomplete_banner_with_islands(self, capsys):
+        """show_routing_summary prints 'Routing Incomplete' when islands exist."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.output import show_routing_summary
+
+        router = MagicMock()
+        # Net 1 has routes but pads are disconnected
+        router.routes = [
+            Route(net=1, net_name="NET1", segments=[_seg(0.0, 0.0, 1.0, 0.0)]),
+        ]
+        router.routing_failures = []
+        router.pads = {
+            ("U1", "1"): _pad(0.0, 0.0, 1, "U1", "1"),
+            ("U1", "2"): _pad(10.0, 0.0, 1, "U1", "2"),
+        }
+        router.nets = {1: [("U1", "1"), ("U1", "2")]}
+
+        net_map = {"NET1": 1}
+
+        show_routing_summary(
+            router=router,
+            net_map=net_map,
+            nets_to_route=1,
+            nets_to_route_ids={1},
+        )
+
+        captured = capsys.readouterr()
+        assert "Routing Incomplete" in captured.out
+        assert "Routing Complete!" not in captured.out
+
+    def test_complete_banner_when_fully_connected(self, capsys):
+        """show_routing_summary prints 'Routing Complete!' when all nets connected."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.output import show_routing_summary
+
+        router = MagicMock()
+        router.routes = [
+            Route(net=1, net_name="NET1", segments=[_seg(0.0, 0.0, 5.0, 0.0)]),
+        ]
+        router.routing_failures = []
+        router.pads = {
+            ("U1", "1"): _pad(0.0, 0.0, 1, "U1", "1"),
+            ("U1", "2"): _pad(5.0, 0.0, 1, "U1", "2"),
+        }
+        router.nets = {1: [("U1", "1"), ("U1", "2")]}
+        router._cleanup_stats = None
+
+        net_map = {"NET1": 1}
+
+        show_routing_summary(
+            router=router,
+            net_map=net_map,
+            nets_to_route=1,
+            nets_to_route_ids={1},
+        )
+
+        captured = capsys.readouterr()
+        assert "Routing Complete!" in captured.out
+
+    def test_partially_connected_nets_listed(self, capsys):
+        """show_routing_summary lists partially-connected nets with pad counts."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.output import show_routing_summary
+
+        router = MagicMock()
+        # Net 1: segment near pad 1 only (escape stub)
+        router.routes = [
+            Route(net=1, net_name="SCL", segments=[_seg(0.0, 0.0, 1.0, 0.0)]),
+        ]
+        router.routing_failures = []
+        router.pads = {
+            ("U1", "1"): _pad(0.0, 0.0, 1, "U1", "1"),
+            ("U2", "3"): _pad(20.0, 0.0, 1, "U2", "3"),
+            ("U3", "5"): _pad(40.0, 0.0, 1, "U3", "5"),
+        }
+        router.nets = {1: [("U1", "1"), ("U2", "3"), ("U3", "5")]}
+        router._cleanup_stats = None
+
+        net_map = {"SCL": 1}
+
+        show_routing_summary(
+            router=router,
+            net_map=net_map,
+            nets_to_route=1,
+            nets_to_route_ids={1},
+        )
+
+        captured = capsys.readouterr()
+        # Should show per-net pad connectivity
+        assert "1/3 pads connected" in captured.out
+        assert "SCL" in captured.out


### PR DESCRIPTION
## Summary
- Add union-find connectivity validation so `nets_routed` reflects actual pad-to-pad connections, not just segment existence
- Show "Routing Incomplete (X% connected)" instead of "Routing Complete!" when disconnected islands exist
- Warn when >50% of pads are off-grid, suggesting finer grid resolution

## Changes
- `src/kicad_tools/router/observability.py` -- Added `validate_net_connectivity()` using union-find over segment endpoints and pad positions; updated `compute_routing_statistics()` to accept `net_pads` and return connectivity-aware `nets_routed` count
- `src/kicad_tools/router/core.py` -- Updated `get_statistics()` to build `net_pads` mapping from `self.pads`/`self.nets` and pass it to `compute_routing_statistics()`
- `src/kicad_tools/router/output.py` -- Updated `show_routing_summary()` and `get_routing_diagnostics_json()` to perform connectivity validation, show partially-connected nets with pad counts, and use "Routing Incomplete" banner when islands exist
- `src/kicad_tools/router/fine_pitch.py` -- Added `off_grid_percentage` property and >50% off-grid warning in `format_warnings()`
- `tests/test_routing_connectivity.py` -- 17 new tests covering connectivity validation, statistics integration, off-grid warnings, and summary output honesty

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Router reports actual connectivity percentage (e.g., "SCL: 1/3 pads connected") | PASS | `show_routing_summary()` lists partially-connected nets with `X/Y pads connected`; test `test_partially_connected_nets_listed` verifies |
| Router does not report SUCCESS when nets have disconnected islands | PASS | Banner changes from "Routing Complete!" to "Routing Incomplete (X% connected)"; test `test_incomplete_banner_with_islands` verifies |
| Boards with >50% off-grid pads get a warning suggesting finer grid | PASS | `format_warnings()` emits WARNING with percentage and grid suggestion; tests `test_warning_above_threshold` and `test_analyze_off_grid_board_warns` verify |

## Test Plan
- 17 new tests in `tests/test_routing_connectivity.py` all pass
- 147 existing tests in `test_fine_pitch.py` and `test_router_core.py` pass with no regressions

Closes #2254