### PR TITLE
fix(router): guard escape strategies against zero-overflow triggering

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -101,6 +101,11 @@ def detect_oscillation(overflow_history: list[int], window: int = 4) -> bool:
 
     recent = overflow_history[-window:]
 
+    # Issue #2262: If the most recent overflow is zero the router has
+    # converged -- never report oscillation in this state.
+    if recent[-1] == 0:
+        return False
+
     # Issue #1823: If the recent window contains a new global minimum,
     # the router is still making progress -- do not declare oscillation.
     # For example, [21, 21, 8, 21] has overflow 8 as a new best, which
@@ -119,7 +124,8 @@ def detect_oscillation(overflow_history: list[int], window: int = 4) -> bool:
         return True
 
     # Check for complete stagnation (all same value)
-    if len(set(recent)) == 1:
+    # Zero-overflow stagnation is convergence, not oscillation (#2262)
+    if len(set(recent)) == 1 and recent[0] > 0:
         return True
 
     # Check for bounded oscillation (values stay within small range)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2614,7 +2614,8 @@ class Autorouter:
                         break
 
                     # Adaptive oscillation detection for targeted mode (Issue #633)
-                    if adaptive and detect_oscillation(overflow_history):
+                    # Guard: skip escape strategies when overflow is already 0 (#2262)
+                    if adaptive and overflow > 0 and detect_oscillation(overflow_history):
                         print(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
                         print(f"    Attempting escape strategies starting from {escape_strategy_index + 1}...")
 
@@ -2725,7 +2726,8 @@ class Autorouter:
                     break
 
                 # Adaptive oscillation detection and escape (Issue #633)
-                if adaptive and detect_oscillation(overflow_history):
+                # Guard: skip escape strategies when overflow is already 0 (#2262)
+                if adaptive and overflow > 0 and detect_oscillation(overflow_history):
                     print(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
                     print(f"    Attempting escape strategies starting from {escape_strategy_index + 1}...")
 

--- a/tests/test_negotiated_adaptive.py
+++ b/tests/test_negotiated_adaptive.py
@@ -77,16 +77,13 @@ class TestDetectOscillation:
         assert detect_oscillation([20, 15, 10, 5], window=4) is False
 
     def test_no_oscillation_when_converged(self):
-        """Should not detect oscillation when at zero (converged)."""
-        # Stagnant at 0 is not oscillation, it's convergence
-        # The function checks if min(recent) > 0 for bounded oscillation
-        # But complete stagnation check happens first
-        # Actually, stagnation at 0 would trigger the len(set(recent)) == 1 check
-        # Let me verify the actual behavior
-        result = detect_oscillation([0, 0, 0, 0], window=4)
-        # This would return True for stagnation, but at 0 it's actually good
-        # The function doesn't distinguish - that's handled by the caller
-        assert result is True  # Technically stagnation, but caller handles this
+        """Should not detect oscillation when at zero (converged).
+
+        Issue #2262: Zero-overflow stagnation is convergence, not oscillation.
+        detect_oscillation must return False so that escape strategies are not
+        triggered on a fully-converged solution.
+        """
+        assert detect_oscillation([0, 0, 0, 0], window=4) is False
 
     def test_no_oscillation_when_window_has_new_minimum(self):
         """Issue #1823: Should NOT detect oscillation when window contains new best.


### PR DESCRIPTION
## Summary
Fixes three interacting bugs where escape strategies were triggered on converged (zero-overflow) solutions, worsening them.

## Changes
- `detect_oscillation` now returns False early when the latest overflow is 0
- `detect_oscillation` stagnation check (`len(set(recent)) == 1`) now requires `recent[0] > 0`
- Both escape strategy trigger sites in `core.py` (lines 2617 and 2728) add an `overflow > 0` guard before calling `detect_oscillation`
- Updated test `test_no_oscillation_when_converged` to assert `detect_oscillation([0, 0, 0, 0])` returns False

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| detect_oscillation returns False for [0,0,0,0] | Done | Test updated and passing |
| Escape strategies not triggered at overflow 0 | Done | overflow > 0 guard at both call sites |
| Existing oscillation detection unaffected | Done | All 45 tests in test_negotiated_adaptive.py pass |

## Test Plan
Ran `uv run python -m pytest tests/test_negotiated_adaptive.py -v` -- all 45 tests pass.

Closes #2262