### PR TITLE
fix(router): limit full-reorder fallback to once per iteration

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2395,6 +2395,7 @@ class Autorouter:
         # Issue #2274: Track consecutive stalls for neighborhood rip-up escalation
         neighborhood_stall_count = 0
         prev_routed_count = 0
+        full_reorder_used_this_iter = False
         for net in net_order:
             if net in self.nets:
                 pads_for_routing = self.nets[net]
@@ -2502,6 +2503,7 @@ class Autorouter:
         # Skip iteration loop if already timed out
         if not timed_out:
             for iteration in range(1, max_iterations + 1):
+                full_reorder_used_this_iter = False
                 if check_timeout():
                     print(f"\n  ⚠ Timeout reached at iteration {iteration} ({elapsed_str()})")
                     timed_out = True
@@ -2626,7 +2628,7 @@ class Autorouter:
                             # direct path but still prevent routing via clearance/congestion.
                             # Try ripping up ALL routed nets and re-routing failed net first.
                             routed_nets = list(net_routes.keys())
-                            if routed_nets and iteration <= 2:  # Try in first few iterations
+                            if routed_nets and iteration <= 2 and not full_reorder_used_this_iter:  # Try in first few iterations
                                 print(
                                     f"    No direct blockers found - trying full reorder for net {failed_net}"
                                 )
@@ -2664,6 +2666,7 @@ class Autorouter:
                                         # Issue #2275: Update layer fill ratios
                                         if hasattr(self.router, "update_layer_fill_ratios"):
                                             self.router.update_layer_fill_ratios()
+                                full_reorder_used_this_iter = True
                             else:
                                 # Fallback: try regular reroute
                                 routes = self._route_net_negotiated(


### PR DESCRIPTION
## Summary

- Limits the expensive full-reorder fallback in `route_all_negotiated()` to fire at most once per iteration, eliminating O(n^2) routing time when multiple failed nets have no direct blockers
- Adds a `full_reorder_used_this_iter` flag that gates the full-reorder path; subsequent failed nets fall through to the regular reroute path

Closes #2299

## Changes

4 lines changed in `src/kicad_tools/router/core.py`:
1. Initialize `full_reorder_used_this_iter = False` before iteration loop
2. Reset flag at start of each iteration
3. Add `and not full_reorder_used_this_iter` guard to the full-reorder condition
4. Set flag to `True` after full-reorder completes

## Test plan

- [x] Full test suite passes (667/668 pass, 1 pre-existing failure unrelated to this change)
- [ ] Verify chorus-test-revA iteration 1 completes in < 60s (was taking 160+ minutes)
- [ ] Confirm "No direct blockers found - trying full reorder" message appears at most once per iteration in routing output

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>