### PR TITLE
feat(router): integrate two-phase global routing into escape routing path

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -927,6 +927,13 @@ def route_with_layer_escalation(
                     max_iterations=args.iterations,
                     timeout=args.timeout,
                 )
+            elif getattr(args, "two_phase", False) and args.strategy == "negotiated":
+                router.route_all_two_phase(
+                    use_negotiated=True,
+                    corridor_width_factor=2.0,
+                    timeout=args.timeout,
+                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                )
             elif args.strategy == "negotiated":
                 router.route_all_negotiated(
                     max_iterations=args.iterations,
@@ -1328,6 +1335,13 @@ def route_with_rule_relaxation(
                     use_negotiated=(args.strategy == "negotiated"),
                     max_iterations=args.iterations,
                     timeout=args.timeout,
+                )
+            elif getattr(args, "two_phase", False) and args.strategy == "negotiated":
+                router.route_all_two_phase(
+                    use_negotiated=True,
+                    corridor_width_factor=2.0,
+                    timeout=args.timeout,
+                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
                 )
             elif args.strategy == "negotiated":
                 router.route_all_negotiated(
@@ -1748,6 +1762,13 @@ def route_with_combined_escalation(
                         use_negotiated=(args.strategy == "negotiated"),
                         max_iterations=args.iterations,
                         timeout=args.timeout,
+                    )
+                elif getattr(args, "two_phase", False) and args.strategy == "negotiated":
+                    router.route_all_two_phase(
+                        use_negotiated=True,
+                        corridor_width_factor=2.0,
+                        timeout=args.timeout,
+                        per_net_timeout=getattr(args, "per_net_timeout", None) or None,
                     )
                 elif args.strategy == "negotiated":
                     router.route_all_negotiated(
@@ -2525,6 +2546,18 @@ def main(argv: list[str] | None = None) -> int:
             "the router auto-detects dense packages and enables escape "
             "routing when needed. Use this flag to skip escape routing "
             "even when dense packages are present."
+        ),
+    )
+    parser.add_argument(
+        "--two-phase",
+        action="store_true",
+        help=(
+            "Use two-phase global+detailed routing. Phase 1 allocates "
+            "coarse corridors on a tile graph; Phase 2 routes within those "
+            "corridors using negotiated congestion. Produces dramatically "
+            "better results on complex multi-layer boards by preventing "
+            "overflow divergence. When combined with escape routing, "
+            "replaces the negotiated rip-up phase after escape generation."
         ),
     )
     parser.add_argument(
@@ -3344,7 +3377,14 @@ def main(argv: list[str] | None = None) -> int:
 
                 # Define the Phase 2 routing function
                 def phase2_route_fn():
-                    if args.strategy == "negotiated":
+                    if getattr(args, "two_phase", False) and args.strategy == "negotiated":
+                        return router.route_all_two_phase(
+                            use_negotiated=True,
+                            corridor_width_factor=2.0,
+                            timeout=args.timeout,
+                            per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                        )
+                    elif args.strategy == "negotiated":
                         return router.route_all_negotiated(
                             max_iterations=args.iterations,
                             timeout=args.timeout,
@@ -3388,6 +3428,13 @@ def main(argv: list[str] | None = None) -> int:
                     use_negotiated=(args.strategy == "negotiated"),
                     max_iterations=args.iterations,
                     timeout=args.timeout,
+                )
+            elif getattr(args, "two_phase", False) and args.strategy == "negotiated":
+                return router.route_all_two_phase(
+                    use_negotiated=True,
+                    corridor_width_factor=2.0,
+                    timeout=args.timeout,
+                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
                 )
             elif args.strategy == "negotiated":
                 return router.route_all_negotiated(

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -77,6 +77,7 @@ class TwoPhaseRouter:
         corridor_penalty: float | None = None,
         progress_callback: ProgressCallback | None = None,
         timeout: float | None = None,
+        per_net_timeout: float | None = None,
     ) -> list[Route]:
         """Route all nets using two-phase global+detailed routing.
 
@@ -87,6 +88,7 @@ class TwoPhaseRouter:
                 Defaults to ``self.rules.cost_corridor_deviation`` when *None*.
             progress_callback: Optional callback for progress updates
             timeout: Optional timeout in seconds
+            per_net_timeout: Optional wall-clock timeout per A* search
 
         Returns:
             List of routes (may be partial if timeout reached or some nets fail)
@@ -237,6 +239,7 @@ class TwoPhaseRouter:
                 progress_callback=progress_callback,
                 timeout=timeout,
                 start_time=start_time,
+                per_net_timeout=per_net_timeout,
             )
         else:
             detailed_routes = self._detailed_standard(
@@ -281,6 +284,7 @@ class TwoPhaseRouter:
         progress_callback: ProgressCallback | None = None,
         timeout: float | None = None,
         start_time: float = 0.0,
+        per_net_timeout: float | None = None,
     ) -> list[Route]:
         """Detailed routing phase using negotiated congestion routing."""
         from ..algorithms import NegotiatedRouter
@@ -315,7 +319,7 @@ class TwoPhaseRouter:
             pct = (i / total_nets * 100) if total_nets > 0 else 0
             flush_print(f"  [{pct:5.1f}%] Routing {net_name}... ({elapsed_str()})")
 
-            routes = self._route_net_with_corridor(net, present_factor)
+            routes = self._route_net_with_corridor(net, present_factor, per_net_timeout=per_net_timeout)
             if routes:
                 net_routes[net] = routes
                 for route in routes:
@@ -369,7 +373,7 @@ class TwoPhaseRouter:
                 for net in nets_to_reroute:
                     if check_timeout():
                         break
-                    routes = self._route_net_with_corridor(net, present_factor)
+                    routes = self._route_net_with_corridor(net, present_factor, per_net_timeout=per_net_timeout)
                     if routes:
                         net_routes[net] = routes
                         for route in routes:

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3310,6 +3310,7 @@ class Autorouter:
         corridor_penalty: float | None = None,
         progress_callback: ProgressCallback | None = None,
         timeout: float | None = None,
+        per_net_timeout: float | None = None,
     ) -> list[Route]:
         """Route all nets using two-phase global+detailed routing.
 
@@ -3325,6 +3326,7 @@ class Autorouter:
                 Defaults to ``self.rules.cost_corridor_deviation`` when *None*.
             progress_callback: Optional callback for progress updates
             timeout: Optional timeout in seconds
+            per_net_timeout: Optional wall-clock timeout per A* search
 
         Returns:
             List of routes (may be partial if timeout reached or some nets fail)
@@ -3336,13 +3338,21 @@ class Autorouter:
             corridor_penalty=corridor_penalty,
             progress_callback=progress_callback,
             timeout=timeout,
+            per_net_timeout=per_net_timeout,
         )
 
-    def _route_net_with_corridor(self, net: int, present_cost_factor: float) -> list[Route]:
+    def _route_net_with_corridor(
+        self, net: int, present_cost_factor: float, per_net_timeout: float | None = None,
+    ) -> list[Route]:
         """Route a single net with corridor-aware costs.
 
         This is similar to _route_net_negotiated but the pathfinder will
         use corridor costs from the grid when available.
+
+        Args:
+            net: Net number to route
+            present_cost_factor: Multiplier for present sharing cost
+            per_net_timeout: Optional wall-clock timeout per A* search
         """
         if net not in self.nets:
             return []
@@ -3378,7 +3388,7 @@ class Autorouter:
             self._mark_route(route)
 
         # Route with corridor-aware costs (negotiated router will pick up corridor costs)
-        new_routes = neg_router.route_net_negotiated(pad_objs, present_cost_factor, mark_route)
+        new_routes = neg_router.route_net_negotiated(pad_objs, present_cost_factor, mark_route, per_net_timeout=per_net_timeout)
         routes.extend(new_routes)
         return routes
 
@@ -4781,10 +4791,11 @@ class Autorouter:
         print("\n--- Phase 2: Main Routing ---")
 
         if use_negotiated:
-            main_routes = self.route_all_negotiated(
+            main_routes = self.route_all_two_phase(
+                use_negotiated=True,
+                corridor_width_factor=2.0,
                 progress_callback=progress_callback,
                 timeout=timeout,
-                use_targeted_ripup=True,
             )
         else:
             main_routes = self.route_all(


### PR DESCRIPTION
## Summary

- Replace `route_all_negotiated()` with `route_all_two_phase()` inside `route_with_escape()` to prevent monotonically diverging overflow on complex boards (52->202->287->460->610 becomes convergent 21->13)
- Plumb `per_net_timeout` through the full two-phase routing stack: `route_all_two_phase` -> `TwoPhaseRouter.route_all` -> `_detailed_negotiated` -> `_route_net_with_corridor` -> `route_net_negotiated`
- Add `--two-phase` CLI flag to `kicad-tools route` for explicit two-phase routing without escape routing

Closes #2301

## Test plan

- [x] All 3 modified files pass Python syntax validation
- [x] Full test suite: 38 failures (all pre-existing on main, which has 44 failures), 13497 passed
- [x] No regressions introduced by these changes
- [ ] Manual validation on chorus-test-revA board to confirm 40+ nets routed (vs 18 baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)