### PR TITLE
feat(router): make corridor penalty decay rate and floor configurable

### DIFF
--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -352,10 +352,12 @@ class TwoPhaseRouter:
 
                 # Issue #2288: Relax corridor constraint as iterations progress
                 # so the detailed router can escape suboptimal global corridors.
-                # Floor of 0.2 keeps a mild preference even in late iterations.
+                # Issue #2308: Decay rate and floor are now configurable via
+                # DesignRules.corridor_decay_rate / corridor_decay_floor.
                 if corridors:
                     effective_penalty = corridor_penalty * max(
-                        0.2, 1.0 - 0.1 * iteration
+                        self.rules.corridor_decay_floor,
+                        1.0 - self.rules.corridor_decay_rate * iteration,
                     )
                     for net, corridor in corridors.items():
                         self.grid.set_corridor_preference(

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -110,6 +110,15 @@ class DesignRules:
     # to disable corridor guidance.
     cost_corridor_deviation: float = 5.0
 
+    # Corridor penalty decay parameters (Issue #2308)
+    # Controls how quickly the corridor penalty relaxes during negotiated
+    # rip-up iterations, allowing the detailed router to escape suboptimal
+    # global corridors over time.
+    #   effective_penalty = corridor_penalty * max(floor, 1.0 - rate * iteration)
+    # With defaults (rate=0.05, floor=0.3) the floor is reached at iteration 14.
+    corridor_decay_rate: float = 0.05   # per-iteration linear decay
+    corridor_decay_floor: float = 0.3   # minimum multiplier (never decays below this)
+
     # Crossing-aware routing (Issue #1250)
     # Penalizes candidate edges that cross already-routed segments on the same layer.
     # This steers A* toward non-crossing paths while still permitting crossings when

--- a/tests/test_corridor_integration.py
+++ b/tests/test_corridor_integration.py
@@ -234,12 +234,37 @@ class TestCorridorCostInAStar:
 class TestCorridorPenaltyDecay:
     """Verify penalty decay formula used in two_phase._detailed_negotiated."""
 
-    def test_decay_formula(self):
-        """Effective penalty decays by 10% per iteration, floor at 20%."""
+    def test_decay_formula_default(self):
+        """With default decay (rate=0.05, floor=0.3), floor is reached at iteration 14."""
+        rules = DesignRules()
+        base_penalty = 5.0
+        results = []
+        for iteration in range(1, 20):
+            effective = base_penalty * max(
+                rules.corridor_decay_floor,
+                1.0 - rules.corridor_decay_rate * iteration,
+            )
+            results.append(effective)
+
+        # Iteration 1: 5.0 * (1.0 - 0.05) = 5.0 * 0.95 = 4.75
+        assert abs(results[0] - 4.75) < 1e-6
+        # Iteration 7: 5.0 * (1.0 - 0.35) = 5.0 * 0.65 = 3.25 (still above floor)
+        assert abs(results[6] - 3.25) < 1e-6
+        # Iteration 14: 5.0 * max(0.3, 1.0 - 0.7) = 5.0 * 0.3 = 1.5 (at floor)
+        assert abs(results[13] - 1.5) < 1e-6
+        # Iteration 16: still at floor
+        assert abs(results[15] - 1.5) < 1e-6
+
+    def test_decay_formula_old_behaviour(self):
+        """Custom rate=0.1, floor=0.2 reproduces the old behaviour (floor at iteration 8)."""
+        rules = DesignRules(corridor_decay_rate=0.1, corridor_decay_floor=0.2)
         base_penalty = 5.0
         results = []
         for iteration in range(1, 12):
-            effective = base_penalty * max(0.2, 1.0 - 0.1 * iteration)
+            effective = base_penalty * max(
+                rules.corridor_decay_floor,
+                1.0 - rules.corridor_decay_rate * iteration,
+            )
             results.append(effective)
 
         # Iteration 1: 5.0 * 0.9 = 4.5
@@ -250,6 +275,40 @@ class TestCorridorPenaltyDecay:
         assert abs(results[7] - 1.0) < 1e-6
         # Iteration 10: 5.0 * 0.2 = 1.0 (still at floor)
         assert abs(results[9] - 1.0) < 1e-6
+
+    def test_zero_decay_rate_constant_penalty(self):
+        """corridor_decay_rate=0.0 means penalty never decays."""
+        rules = DesignRules(corridor_decay_rate=0.0, corridor_decay_floor=0.3)
+        base_penalty = 5.0
+        for iteration in range(1, 20):
+            effective = base_penalty * max(
+                rules.corridor_decay_floor,
+                1.0 - rules.corridor_decay_rate * iteration,
+            )
+            assert abs(effective - base_penalty) < 1e-6
+
+    def test_floor_one_constant_penalty(self):
+        """corridor_decay_floor=1.0 means penalty never decays (different parameterisation)."""
+        rules = DesignRules(corridor_decay_rate=0.05, corridor_decay_floor=1.0)
+        base_penalty = 5.0
+        for iteration in range(1, 20):
+            effective = base_penalty * max(
+                rules.corridor_decay_floor,
+                1.0 - rules.corridor_decay_rate * iteration,
+            )
+            assert abs(effective - base_penalty) < 1e-6
+
+    def test_design_rules_defaults(self):
+        """DesignRules exposes corridor_decay_rate and corridor_decay_floor with correct defaults."""
+        rules = DesignRules()
+        assert rules.corridor_decay_rate == 0.05
+        assert rules.corridor_decay_floor == 0.3
+
+    def test_design_rules_custom(self):
+        """DesignRules accepts custom corridor decay parameters."""
+        rules = DesignRules(corridor_decay_rate=0.08, corridor_decay_floor=0.15)
+        assert rules.corridor_decay_rate == 0.08
+        assert rules.corridor_decay_floor == 0.15
 
     def test_set_corridor_preference_updates_penalty(self, grid, horizontal_corridor):
         """Calling set_corridor_preference with new penalty updates it."""


### PR DESCRIPTION
## Summary

Adds configurable `corridor_decay_rate` and `corridor_decay_floor` parameters to `DesignRules`, replacing the hardcoded `0.1` rate and `0.2` floor in the two-phase detailed negotiated routing loop. The new defaults (`0.05` rate, `0.3` floor) keep corridor guidance effective through iteration 14 instead of hitting the floor at iteration 8.

## Changes

- Added `corridor_decay_rate` (default `0.05`) and `corridor_decay_floor` (default `0.3`) fields to `DesignRules` in `rules.py`
- Updated `_detailed_negotiated()` in `two_phase.py` to read decay parameters from `self.rules` instead of using hardcoded constants
- Replaced the single `test_decay_formula` test with six focused tests covering: default decay behaviour, backward-compatible old behaviour (`rate=0.1, floor=0.2`), zero-rate constant penalty, floor=1.0 constant penalty, default field values, and custom field values

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `DesignRules` exposes `corridor_decay_rate` (default 0.05) and `corridor_decay_floor` (default 0.3) | PASS | `test_design_rules_defaults` |
| With defaults, floor reached at iteration 14 (not 8) | PASS | `test_decay_formula_default` |
| With defaults, iteration 7 penalty still above floor | PASS | `test_decay_formula_default` checks iteration 7 = 3.25 > 1.5 |
| Custom `rate=0.1` reproduces old behaviour (floor at iter 8) | PASS | `test_decay_formula_old_behaviour` |
| `corridor_decay_rate=0.0` means penalty never decays | PASS | `test_zero_decay_rate_constant_penalty` |
| `corridor_decay_floor=1.0` means penalty never decays | PASS | `test_floor_one_constant_penalty` |

## Test Plan

All 17 tests in `tests/test_corridor_integration.py` pass (including the 6 new/updated decay tests).

Closes #2308