### PR TITLE
feat(router): add --two-phase-iterations CLI flag for configurable rip-up loops

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1782,6 +1782,7 @@ def route_with_combined_escalation(
                         corridor_width_factor=2.0,
                         timeout=args.timeout,
                         per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                        max_iterations=getattr(args, "two_phase_iterations", 20),
                     )
                 elif args.strategy == "negotiated":
                     router.route_all_negotiated(
@@ -3412,6 +3413,7 @@ def main(argv: list[str] | None = None) -> int:
                             corridor_width_factor=2.0,
                             timeout=args.timeout,
                             per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                            max_iterations=getattr(args, "two_phase_iterations", 20),
                         )
                     elif args.strategy == "negotiated":
                         return router.route_all_negotiated(
@@ -3464,6 +3466,7 @@ def main(argv: list[str] | None = None) -> int:
                     corridor_width_factor=2.0,
                     timeout=args.timeout,
                     per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                    max_iterations=getattr(args, "two_phase_iterations", 20),
                 )
             elif args.strategy == "negotiated":
                 return router.route_all_negotiated(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -933,6 +933,7 @@ def route_with_layer_escalation(
                     corridor_width_factor=2.0,
                     timeout=args.timeout,
                     per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                    max_iterations=getattr(args, "two_phase_iterations", 20),
                 )
             elif args.strategy == "negotiated":
                 router.route_all_negotiated(
@@ -1348,6 +1349,7 @@ def route_with_rule_relaxation(
                     corridor_width_factor=2.0,
                     timeout=args.timeout,
                     per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                    max_iterations=getattr(args, "two_phase_iterations", 20),
                 )
             elif args.strategy == "negotiated":
                 router.route_all_negotiated(
@@ -2574,6 +2576,17 @@ def main(argv: list[str] | None = None) -> int:
             "better results on complex multi-layer boards by preventing "
             "overflow divergence. When combined with escape routing, "
             "replaces the negotiated rip-up phase after escape generation."
+        ),
+    )
+    parser.add_argument(
+        "--two-phase-iterations",
+        type=int,
+        default=20,
+        help=(
+            "Max rip-up-and-reroute iterations for the Phase 2 detailed "
+            "negotiated routing loop in two-phase mode (default: 20). "
+            "Higher values allow more convergence attempts at the cost of "
+            "longer runtime. Only effective with --two-phase."
         ),
     )
     parser.add_argument(

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -80,6 +80,7 @@ class TwoPhaseRouter:
         timeout: float | None = None,
         per_net_timeout: float | None = None,
         initial_routes: list[Route] | None = None,
+        max_iterations: int = 20,
     ) -> list[Route]:
         """Route all nets using two-phase global+detailed routing.
 
@@ -94,6 +95,8 @@ class TwoPhaseRouter:
             initial_routes: Pre-existing routes (e.g. escape routes) that
                 should be seeded into the negotiated router's tracking dict
                 so they participate in rip-up/reroute (Issue #2294).
+            max_iterations: Maximum rip-up-and-reroute iterations for the
+                Phase 2 detailed negotiated routing loop (default: 20).
 
         Returns:
             List of routes (may be partial if timeout reached or some nets fail)
@@ -246,6 +249,7 @@ class TwoPhaseRouter:
                 start_time=start_time,
                 per_net_timeout=per_net_timeout,
                 initial_routes=initial_routes,
+                max_iterations=max_iterations,
             )
         else:
             detailed_routes = self._detailed_standard(
@@ -292,6 +296,7 @@ class TwoPhaseRouter:
         start_time: float = 0.0,
         per_net_timeout: float | None = None,
         initial_routes: list[Route] | None = None,
+        max_iterations: int = 20,
     ) -> list[Route]:
         """Detailed routing phase using negotiated congestion routing.
 
@@ -365,9 +370,6 @@ class TwoPhaseRouter:
 
         # Rip-up and reroute iterations if needed
         if overflow > 0:
-            import copy
-
-            max_iterations = 10
             history_increment = 1.0
             present_factor_increment = 0.5
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3376,6 +3376,7 @@ class Autorouter:
         timeout: float | None = None,
         per_net_timeout: float | None = None,
         initial_routes: list[Route] | None = None,
+        max_iterations: int = 20,
     ) -> list[Route]:
         """Route all nets using two-phase global+detailed routing.
 
@@ -3396,6 +3397,8 @@ class Autorouter:
                 into the negotiated router's tracking dict.  These routes
                 participate in rip-up/reroute so they are not permanently
                 reserved on the grid (Issue #2294).
+            max_iterations: Maximum rip-up-and-reroute iterations for the
+                Phase 2 detailed negotiated routing loop (default: 20).
 
         Returns:
             List of routes (may be partial if timeout reached or some nets fail)
@@ -3409,6 +3412,7 @@ class Autorouter:
             timeout=timeout,
             per_net_timeout=per_net_timeout,
             initial_routes=initial_routes,
+            max_iterations=max_iterations,
         )
 
     def _route_net_with_corridor(

--- a/tests/test_global_router.py
+++ b/tests/test_global_router.py
@@ -1544,3 +1544,93 @@ class TestEscapeRouteRipupEligibility:
 
         # Verify mark_route_usage was called for the escape route
         grid.mark_route_usage.assert_called_with(escape_route)
+
+
+# =============================================================================
+# Two-Phase max_iterations Configurability Tests (Issue #2304)
+# =============================================================================
+
+
+class TestTwoPhaseMaxIterations:
+    """Verify max_iterations parameter threads through two-phase routing."""
+
+    @pytest.fixture
+    def autorouter(self):
+        """Simple two-net autorouter for testing parameter forwarding."""
+        router = Autorouter(
+            width=20.0,
+            height=20.0,
+            rules=DesignRules(
+                trace_width=0.2,
+                trace_clearance=0.2,
+                via_drill=0.35,
+                via_diameter=0.7,
+                grid_resolution=0.1,
+            ),
+            force_python=True,
+        )
+        router.add_component(
+            ref="R1",
+            pads=[
+                {"number": "1", "x": 3.0, "y": 10.0, "net": 1, "net_name": "SIG_A"},
+                {"number": "2", "x": 17.0, "y": 10.0, "net": 1, "net_name": "SIG_A"},
+            ],
+        )
+        router.add_component(
+            ref="R2",
+            pads=[
+                {"number": "1", "x": 10.0, "y": 3.0, "net": 2, "net_name": "SIG_B"},
+                {"number": "2", "x": 10.0, "y": 17.0, "net": 2, "net_name": "SIG_B"},
+            ],
+        )
+        return router
+
+    def test_default_max_iterations_is_20(self):
+        """TwoPhaseRouter.route_all() defaults max_iterations to 20."""
+        import inspect
+
+        from kicad_tools.router.algorithms.two_phase import TwoPhaseRouter
+
+        sig = inspect.signature(TwoPhaseRouter.route_all)
+        default = sig.parameters["max_iterations"].default
+        assert default == 20, f"Expected default 20, got {default}"
+
+    def test_max_iterations_forwarded_to_detailed(self, autorouter):
+        """max_iterations parameter is forwarded through route_all_two_phase."""
+        from unittest.mock import patch
+
+        from kicad_tools.router.algorithms.two_phase import TwoPhaseRouter
+
+        calls = []
+        original = TwoPhaseRouter._detailed_negotiated
+
+        def spy(self_inner, *args, **kwargs):
+            calls.append(kwargs.get("max_iterations"))
+            return original(self_inner, *args, **kwargs)
+
+        with patch.object(TwoPhaseRouter, "_detailed_negotiated", spy):
+            autorouter.route_all_two_phase(
+                use_negotiated=True,
+                max_iterations=7,
+            )
+
+        assert len(calls) == 1
+        assert calls[0] == 7, f"Expected max_iterations=7, got {calls[0]}"
+
+    def test_route_all_two_phase_accepts_max_iterations(self, autorouter):
+        """route_all_two_phase completes with a custom max_iterations value."""
+        routes = autorouter.route_all_two_phase(
+            use_negotiated=False,
+            max_iterations=3,
+        )
+        assert isinstance(routes, list)
+
+    def test_core_default_max_iterations_is_20(self):
+        """Autorouter.route_all_two_phase() defaults max_iterations to 20."""
+        import inspect
+
+        from kicad_tools.router.core import Autorouter
+
+        sig = inspect.signature(Autorouter.route_all_two_phase)
+        default = sig.parameters["max_iterations"].default
+        assert default == 20, f"Expected default 20, got {default}"


### PR DESCRIPTION
## Summary
Replace the hardcoded `max_iterations=10` in `TwoPhaseRouter._detailed_negotiated()` with a configurable parameter (default: 20) threaded from CLI through core to the two-phase algorithm. The new `--two-phase-iterations` flag controls Phase 2 detailed negotiated routing iterations independently of the existing `--iterations` flag.

## Changes
- Add `max_iterations` parameter (default 20) to `TwoPhaseRouter.route_all()` and `_detailed_negotiated()`; remove hardcoded `max_iterations = 10`
- Add `max_iterations` parameter to `Autorouter.route_all_two_phase()` in `core.py`, forwarded to `TwoPhaseRouter`
- Add `--two-phase-iterations` CLI argument in `route_cmd.py`; pass value at all 5 `route_all_two_phase()` call sites
- Add 4 tests verifying default value, parameter forwarding, and end-to-end acceptance

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Hardcoded 10 replaced with parameter | Done | `max_iterations=10` line removed from `_detailed_negotiated`, parameter added with default 20 |
| Parameter threaded through three layers | Done | `_detailed_negotiated` -> `route_all` -> `route_all_two_phase` (core) -> CLI |
| New `--two-phase-iterations` CLI flag | Done | Added to argument parser, passed at all 5 call sites |
| Default changed from 10 to 20 | Done | Verified via `inspect.signature` test |
| Existing `--iterations` flag unaffected | Done | Separate flag, no changes to non-two-phase paths |
| Progress callback adapts to new value | Done | Progress calculation on line 344 already uses the `max_iterations` variable |
| Tests pass | Done | 4 new tests + 5 existing corridor penalty tests all pass |

## Test Plan
- `test_default_max_iterations_is_20`: Verifies default via signature inspection
- `test_max_iterations_forwarded_to_detailed`: Spy confirms value=7 reaches `_detailed_negotiated`
- `test_route_all_two_phase_accepts_max_iterations`: End-to-end run with `max_iterations=3`
- `test_core_default_max_iterations_is_20`: Verifies `Autorouter.route_all_two_phase` default

Closes #2304