### PR TITLE
fix(router): add early-stop to two-phase loop when overflow regresses

### DIFF
--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -81,6 +81,7 @@ class TwoPhaseRouter:
         per_net_timeout: float | None = None,
         initial_routes: list[Route] | None = None,
         max_iterations: int = 20,
+        patience: int = 2,
     ) -> list[Route]:
         """Route all nets using two-phase global+detailed routing.
 
@@ -97,6 +98,8 @@ class TwoPhaseRouter:
                 so they participate in rip-up/reroute (Issue #2294).
             max_iterations: Maximum rip-up-and-reroute iterations for the
                 Phase 2 detailed negotiated routing loop (default: 20).
+            patience: Minimum number of non-improving iterations before
+                early termination is considered (Issue #2317, default: 2).
 
         Returns:
             List of routes (may be partial if timeout reached or some nets fail)
@@ -250,6 +253,7 @@ class TwoPhaseRouter:
                 per_net_timeout=per_net_timeout,
                 initial_routes=initial_routes,
                 max_iterations=max_iterations,
+                patience=patience,
             )
         else:
             detailed_routes = self._detailed_standard(
@@ -297,6 +301,7 @@ class TwoPhaseRouter:
         per_net_timeout: float | None = None,
         initial_routes: list[Route] | None = None,
         max_iterations: int = 20,
+        patience: int = 2,
     ) -> list[Route]:
         """Detailed routing phase using negotiated congestion routing.
 
@@ -304,8 +309,12 @@ class TwoPhaseRouter:
             initial_routes: Pre-existing routes (e.g. escape routes) to seed
                 into ``net_routes`` so they participate in rip-up/reroute
                 instead of being permanently reserved (Issue #2294).
+            patience: Minimum number of non-improving iterations before
+                early termination is considered (Issue #2317). Passed as
+                ``min_iterations`` to ``should_terminate_early()``.
         """
         from ..algorithms import NegotiatedRouter
+        from ..algorithms.negotiated import should_terminate_early
 
         if corridor_penalty is None:
             corridor_penalty = self.rules.cost_corridor_deviation
@@ -358,6 +367,9 @@ class TwoPhaseRouter:
 
         overflow = self.grid.get_total_overflow()
         flush_print(f"  Initial pass: {len(net_routes)}/{total_nets} nets, overflow: {overflow}")
+
+        # Issue #2317: Track overflow history for early-stop detection.
+        overflow_history: list[int] = [overflow]
 
         # Issue #2305: Track best routing state across iterations.
         # Overflow can oscillate during rip-up-and-reroute; if timeout or
@@ -423,6 +435,9 @@ class TwoPhaseRouter:
                 overflow = self.grid.get_total_overflow()
                 flush_print(f"  Iteration {iteration} complete: overflow={overflow}")
 
+                # Issue #2317: Record overflow for early-stop detection.
+                overflow_history.append(overflow)
+
                 # Issue #2305: Snapshot state when overflow improves
                 if overflow < best_overflow:
                     best_overflow = overflow
@@ -432,6 +447,19 @@ class TwoPhaseRouter:
 
                 if overflow == 0:
                     flush_print(f"  Converged at iteration {iteration}!")
+                    break
+
+                # Issue #2317: Early-stop when overflow regresses or
+                # stagnates across iterations.  Reuses the battle-tested
+                # ``should_terminate_early()`` from the negotiated router
+                # (Issues #633, #1823, #2295, #2297).
+                if should_terminate_early(
+                    overflow_history, iteration, min_iterations=patience
+                ):
+                    flush_print(
+                        f"  Early stop: overflow not improving "
+                        f"(best={best_overflow})"
+                    )
                     break
 
         # Issue #2305: Restore best state if the final iteration is worse

--- a/tests/test_best_state_tracking.py
+++ b/tests/test_best_state_tracking.py
@@ -323,3 +323,168 @@ class TestBestStateTracking:
         assert len(two_phase.routes) == len(routes)
         # Grid's _marked_routes should have the same count
         assert len(grid._marked_routes) == len(routes)
+
+
+class TestEarlyStopOverflowRegression:
+    """Verify early-stop fires when overflow regresses across iterations (Issue #2317)."""
+
+    def _build_two_phase(
+        self,
+        overflow_sequence: list[int],
+    ) -> tuple[TwoPhaseRouter, FakeGrid]:
+        """Build a TwoPhaseRouter with controlled overflow behavior."""
+        grid = FakeGrid(overflow_sequence)
+        router = MagicMock()
+        rules = MagicMock()
+        rules.cost_corridor_deviation = 5.0
+        rules.corridor_decay_rate = 0.1
+        rules.corridor_decay_floor = 0.1
+
+        call_count = [0]
+
+        def fake_route_net_with_corridor(net, present_factor, per_net_timeout=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return [_make_route(net, tag=f"iter{idx}")]
+
+        two_phase = TwoPhaseRouter(
+            grid=grid,
+            router=router,
+            rules=rules,
+            net_class_map=None,
+            nets={1: [("R1", "1"), ("R1", "2")]},
+            net_names={1: "VCC"},
+            pads={},
+            routes=[],
+            routing_failures=[],
+            get_net_priority=lambda n: n,
+            route_net=lambda n: [_make_route(n)],
+            route_net_with_corridor=fake_route_net_with_corridor,
+            mark_route=lambda r: None,
+        )
+
+        return two_phase, grid
+
+    def test_early_stop_on_regression(self, capsys):
+        """Early stop fires when overflow regresses after reaching a best.
+
+        Overflow sequence: [81, 18, 25, 30, ...].
+        With patience=2, should_terminate_early should fire after we have
+        enough history showing regression (no improvement over 18).
+        The loop should NOT run all max_iterations.
+        """
+        # Overflow sequence:
+        #   [0] initial pass = 81
+        #   [1] iteration 1  = 18  <-- best
+        #   [2] iteration 2  = 25  (regression)
+        #   [3] iteration 3  = 30  (further regression)
+        #   [4] iteration 4  = 35  (further regression)
+        #   [5] iteration 5  = 40  (would be iteration 5 if reached)
+        #   [6] post-loop check (final overflow for best-state restore)
+        # With patience=2, the early termination should fire well before
+        # iteration 10.  We provide enough overflow values for max_iterations=10.
+        overflow_seq = [81, 18, 25, 30, 35, 40, 45, 50, 55, 60, 65, 65]
+        two_phase, grid = self._build_two_phase(overflow_seq)
+
+        with patch(
+            "kicad_tools.router.algorithms.NegotiatedRouter",
+            FakeNegotiatedRouter,
+        ):
+            routes = two_phase._detailed_negotiated(
+                net_order=[1],
+                corridor_penalty=5.0,
+                max_iterations=10,
+                patience=2,
+            )
+
+        captured = capsys.readouterr()
+        # Early stop message should appear
+        assert "Early stop: overflow not improving" in captured.out
+        assert "best=18" in captured.out
+        # Best-state restore should occur since final overflow > best
+        assert "Restoring" in captured.out
+        # Should have returned routes
+        assert len(routes) > 0
+
+    def test_no_early_stop_when_converging(self, capsys):
+        """No early stop when overflow monotonically decreases to zero."""
+        # Overflow sequence:
+        #   [0] initial pass = 81
+        #   [1] iteration 1  = 18
+        #   [2] iteration 2  = 10
+        #   [3] iteration 3  = 5
+        #   [4] iteration 4  = 0  <-- converged
+        #   [5] post-loop check = 0
+        two_phase, grid = self._build_two_phase([81, 18, 10, 5, 0, 0])
+
+        with patch(
+            "kicad_tools.router.algorithms.NegotiatedRouter",
+            FakeNegotiatedRouter,
+        ):
+            routes = two_phase._detailed_negotiated(
+                net_order=[1],
+                corridor_penalty=5.0,
+                max_iterations=10,
+                patience=2,
+            )
+
+        captured = capsys.readouterr()
+        # Should converge normally, no early stop
+        assert "Converged at iteration 4" in captured.out
+        assert "Early stop" not in captured.out
+        assert len(routes) > 0
+
+    def test_best_state_restored_after_early_stop(self):
+        """Best-state restore still works correctly after early-stop fires."""
+        # Overflow sequence:
+        #   [0] initial pass = 81
+        #   [1] iteration 1  = 18  <-- best
+        #   [2] iteration 2  = 25
+        #   [3] iteration 3  = 30
+        #   [4] iteration 4  = 35
+        #   [5] iteration 5  = 40
+        #   [6] post-loop check (for best-state restore)
+        overflow_seq = [81, 18, 25, 30, 35, 40, 40]
+        two_phase, grid = self._build_two_phase(overflow_seq)
+
+        with patch(
+            "kicad_tools.router.algorithms.NegotiatedRouter",
+            FakeNegotiatedRouter,
+        ):
+            routes = two_phase._detailed_negotiated(
+                net_order=[1],
+                corridor_penalty=5.0,
+                max_iterations=10,
+                patience=2,
+            )
+
+        # Routes should be returned and grid state should be consistent
+        assert len(routes) > 0
+        assert len(two_phase.routes) == len(routes)
+        assert len(grid._marked_routes) == len(routes)
+
+    def test_patience_parameter_respected(self, capsys):
+        """Higher patience value delays early termination."""
+        # With a high patience (e.g. 8), early stop should not fire for
+        # a sequence that regresses only a few times.
+        # Overflow sequence that would trigger early stop with patience=2
+        # but should NOT trigger with patience=8:
+        #   [0] initial = 81, [1] = 18, [2] = 25, [3] = 30, [4] = 0
+        overflow_seq = [81, 18, 25, 30, 0, 0]
+        two_phase, grid = self._build_two_phase(overflow_seq)
+
+        with patch(
+            "kicad_tools.router.algorithms.NegotiatedRouter",
+            FakeNegotiatedRouter,
+        ):
+            routes = two_phase._detailed_negotiated(
+                net_order=[1],
+                corridor_penalty=5.0,
+                max_iterations=10,
+                patience=8,  # High patience -- early stop should not fire
+            )
+
+        captured = capsys.readouterr()
+        # Should converge at iteration 4 (overflow=0), not early stop
+        assert "Converged at iteration 4" in captured.out
+        assert "Early stop" not in captured.out


### PR DESCRIPTION
## Summary
Wire up the existing `should_terminate_early()` from the negotiated router into the two-phase `_detailed_negotiated()` rip-up loop. This prevents wasting iterations when overflow is regressing or stagnating after reaching a best value.

## Changes
- Build `overflow_history` list in `_detailed_negotiated()` and call `should_terminate_early()` after each iteration
- Add `patience` parameter (default=2) to `_detailed_negotiated()` and `route_all()`, threaded through as `min_iterations` to `should_terminate_early()`
- Emit "Early stop: overflow not improving (best=N)" log message when early termination fires
- Add 4 test cases in `TestEarlyStopOverflowRegression` covering regression detection, convergence (no false positive), best-state restore after early stop, and patience parameter behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Two-phase loop terminates early on overflow regression/stagnation | Pass | `test_early_stop_on_regression` verifies early stop fires on sequence [81, 18, 25, 30, ...] |
| Best-state restore (Issue #2305) still works after early termination | Pass | `test_best_state_restored_after_early_stop` verifies grid state consistency |
| Log message emitted when early stop fires | Pass | `test_early_stop_on_regression` captures stdout and asserts "Early stop: overflow not improving" |
| Default patience=2 non-improving iterations | Pass | Hardcoded as default parameter |
| No regression on converging sequences | Pass | `test_no_early_stop_when_converging` verifies no early stop on [81, 18, 10, 5, 0] |

## Test Plan
- All 12 tests in `tests/test_best_state_tracking.py` pass (8 existing + 4 new)
- Pre-existing test suite failures (missing `cmaes` package) are unrelated

Closes #2317