### PR TITLE
feat(router): inject off-grid pad positions as waypoint nodes in A* search

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -358,6 +358,12 @@ class Autorouter:
         self._escape_router: EscapeRouter | None = None
         self._subgrid_router: SubGridRouter | None = None
 
+        # Issue #2330: Waypoint injection replaces the sub-grid escape pre-pass.
+        # When True, the pathfinder injects off-grid pad positions directly into
+        # the A* search graph, eliminating the need for escape segments.
+        # The sub-grid pre-pass is retained as a fallback when this is False.
+        self.use_waypoint_injection: bool = True
+
         # Fine zones for multi-resolution escape routing (Issue #1828)
         # Set externally (e.g., from CLI's MultiResolutionGridPlan) before
         # routing so the SubGridRouter uses fine grid resolution for pads
@@ -1256,7 +1262,8 @@ class Autorouter:
         routes.extend(new_routes)
 
         # Issue #1603: Retry with sub-grid escape on PIN_ACCESS failure
-        if not _subgrid_retry and not new_routes:
+        # Issue #2330: Skip sub-grid retry when waypoint injection is active
+        if not _subgrid_retry and not new_routes and not self.use_waypoint_injection:
             # Check if this net has a PIN_ACCESS failure
             has_pin_access_failure = any(
                 f.net == net and f.failure_cause == FailureCause.PIN_ACCESS
@@ -4959,11 +4966,19 @@ class Autorouter:
         between main grid points, and unblocks grid cells at escape
         endpoints. This is a no-op for boards with no off-grid pads.
 
+        Issue #2330: When waypoint injection is enabled, the pathfinder
+        handles off-grid pads directly via injected waypoint nodes in the
+        A* search graph.  The sub-grid pre-pass is skipped entirely.
+
         Returns:
             List of escape Route objects (empty if no off-grid pads)
 
         Issue #1603: Wire sub-grid routing into default route_all pipeline.
         """
+        # Issue #2330: Skip sub-grid pre-pass when waypoint injection is active
+        if self.use_waypoint_injection:
+            return []
+
         subgrid_result = self.prepare_subgrid_escapes()
 
         if not (subgrid_result.analysis and subgrid_result.analysis.has_off_grid_pads):

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -200,6 +200,123 @@ class Router:
         self._via_diag_exclusion_blocked: int = 0
         self._via_diag_eligible: int = 0
 
+        # Issue #2330: Waypoint injection for off-grid pad routing.
+        # Maps virtual (negative) grid indices to exact world coordinates.
+        # Populated per-route call; cleared at the start of each route.
+        self._waypoint_world_coords: dict[tuple[int, int], tuple[float, float]] = {}
+        # Counter for assigning unique negative waypoint indices.
+        self._waypoint_id_counter: int = 0
+
+    # ------------------------------------------------------------------
+    # Waypoint helpers (Issue #2330)
+    # ------------------------------------------------------------------
+
+    def _is_pad_off_grid(self, pad: Pad) -> bool:
+        """Check whether a pad's center falls off the routing grid.
+
+        A pad is considered off-grid when the distance from its center to
+        the nearest grid point exceeds ``resolution / 4`` in either axis.
+        """
+        gx, gy = self.grid.world_to_grid(pad.x, pad.y)
+        snap_x, snap_y = self.grid.grid_to_world(gx, gy)
+        tolerance = self.grid.resolution / 4
+        return abs(pad.x - snap_x) > tolerance or abs(pad.y - snap_y) > tolerance
+
+    def _create_waypoint(self, pad: Pad) -> tuple[int, int]:
+        """Allocate a unique virtual grid index pair for *pad*.
+
+        The returned ``(wx, wy)`` are negative integers that will never
+        collide with real grid indices (which are >= 0).  The mapping
+        from ``(wx, wy)`` to the pad's world coordinates is stored in
+        ``self._waypoint_world_coords``.
+        """
+        self._waypoint_id_counter -= 1
+        wp_id = self._waypoint_id_counter
+        # Use the same negative value for both axes — uniqueness comes
+        # from the single counter, and the pair is used as a dict key.
+        key = (wp_id, wp_id)
+        self._waypoint_world_coords[key] = (pad.x, pad.y)
+        return key
+
+    def _waypoint_grid_edges(
+        self, wp_key: tuple[int, int], pad: Pad, net: int, allow_sharing: bool = False,
+    ) -> list[tuple[int, int, float]]:
+        """Return grid-cell neighbors reachable from a waypoint node.
+
+        For each of the nearest grid cells (within a 3-cell radius of the
+        pad's grid-snapped position), compute the Euclidean edge cost from
+        the waypoint's world position to the grid cell's world position.
+        Cells that are blocked by other nets are skipped unless they fall
+        within the pad's metal area.
+
+        Returns:
+            List of ``(gx, gy, edge_cost)`` tuples.
+        """
+        wx, wy = self._waypoint_world_coords[wp_key]
+        center_gx, center_gy = self.grid.world_to_grid(wx, wy)
+        radius = 3  # search radius in grid cells
+        edges: list[tuple[int, int, float]] = []
+
+        # Precompute pad metal bounds for same-net passability check.
+        metal_bounds = self._get_pad_metal_bounds(pad)
+        mgx1, mgy1, mgx2, mgy2 = metal_bounds
+
+        for dy in range(-radius, radius + 1):
+            for dx in range(-radius, radius + 1):
+                gx = center_gx + dx
+                gy = center_gy + dy
+                if not (0 <= gx < self.grid.cols and 0 <= gy < self.grid.rows):
+                    continue
+
+                # Check accessibility on any layer the pad can use
+                if pad.through_hole:
+                    check_layers = self.grid.get_routable_indices()
+                else:
+                    check_layers = [self.grid.layer_to_index(pad.layer.value)]
+
+                accessible = False
+                for li in check_layers:
+                    cell = self.grid.grid[li][gy][gx]
+                    # Inside pad metal — always accessible
+                    if mgx1 <= gx <= mgx2 and mgy1 <= gy <= mgy2:
+                        accessible = True
+                        break
+                    if not cell.blocked:
+                        accessible = True
+                        break
+                    if cell.net == net:
+                        accessible = True
+                        break
+                    # Clearance-zone cell (not actual copper) — accessible
+                    if not cell.pad_blocked:
+                        accessible = True
+                        break
+                if not accessible:
+                    continue
+
+                # Euclidean distance in world units
+                gw_x, gw_y = self.grid.grid_to_world(gx, gy)
+                dist = math.sqrt((wx - gw_x) ** 2 + (wy - gw_y) ** 2)
+                # Convert to grid-cell cost units
+                edge_cost = dist / self.grid.resolution
+                edges.append((gx, gy, edge_cost))
+
+        return edges
+
+    def _waypoint_to_world(self, x: int, y: int) -> tuple[float, float] | None:
+        """Resolve a node's grid indices to world coordinates.
+
+        If ``(x, y)`` is a waypoint (negative indices), return the stored
+        world position.  Otherwise return ``None`` (caller should use
+        ``grid_to_world``).
+        """
+        key = (x, y)
+        return self._waypoint_world_coords.get(key)
+
+    def _is_waypoint(self, x: int, y: int) -> bool:
+        """Return True if ``(x, y)`` represents a waypoint node."""
+        return x < 0 and y < 0 and (x, y) in self._waypoint_world_coords
+
     def add_routed_segments(self, segments: list[Segment]) -> None:
         """Add committed route segments for crossing detection.
 
@@ -1240,6 +1357,10 @@ class Router:
         # Keep cache valid within this route call for same-position checks
         self.clear_via_cache()
 
+        # Issue #2330: Reset waypoint state for this route call
+        self._waypoint_world_coords.clear()
+        self._waypoint_id_counter = 0
+
         # Get net class if not provided
         if net_class is None:
             net_class = self._get_net_class(start.net_name)
@@ -1357,6 +1478,39 @@ class Router:
                     heapq.heappush(open_set, start_node)
                     g_scores[(sgx, sgy, sl)] = 0
 
+        # Issue #2330: Waypoint injection for off-grid start pad.
+        # Inject the exact pad world position as a waypoint node with edges
+        # to nearby grid cells so A* can route from the precise pad location.
+        start_wp_key: tuple[int, int] | None = None
+        if self._is_pad_off_grid(start):
+            start_wp_key = self._create_waypoint(start)
+            wp_edges = self._waypoint_grid_edges(
+                start_wp_key, start, start.net, allow_sharing,
+            )
+            for gx, gy, edge_cost in wp_edges:
+                for sl in start_layers:
+                    wp_g = edge_cost * self.rules.cost_straight
+                    wp_h = self.heuristic.estimate(gx, gy, sl, (0, 0), heuristic_context)
+                    wp_node = AStarNode(wp_g + weight * wp_h, wp_g, gx, gy, sl)
+                    neighbor_key = (gx, gy, sl)
+                    if neighbor_key not in g_scores or wp_g < g_scores[neighbor_key]:
+                        g_scores[neighbor_key] = wp_g
+                        heapq.heappush(open_set, wp_node)
+
+        # Issue #2330: Waypoint for off-grid end pad — used in goal check.
+        end_wp_key: tuple[int, int] | None = None
+        if self._is_pad_off_grid(end):
+            end_wp_key = self._create_waypoint(end)
+            end_wp_grid_edges = self._waypoint_grid_edges(
+                end_wp_key, end, start.net, allow_sharing,
+            )
+            # Build set of grid cells reachable from end waypoint for goal check
+            end_wp_goal_cells: set[tuple[int, int]] = {
+                (gx, gy) for gx, gy, _cost in end_wp_grid_edges
+            }
+        else:
+            end_wp_goal_cells = set()
+
         iterations = 0
         max_iterations = self.grid.cols * self.grid.rows * 4  # Prevent infinite loops
 
@@ -1382,11 +1536,18 @@ class Router:
 
             # Goal check - accept any cell within end pad's metal area (Issue #956)
             # This handles off-grid pads where the center doesn't align with routing grid
-            if (
+            # Issue #2330: Also accept cells reachable from the end pad's waypoint
+            is_in_end_metal = (
                 end_metal_gx1 <= current.x <= end_metal_gx2
                 and end_metal_gy1 <= current.y <= end_metal_gy2
                 and current.layer in end_layers
-            ):
+            )
+            is_end_waypoint_reachable = (
+                end_wp_goal_cells
+                and (current.x, current.y) in end_wp_goal_cells
+                and current.layer in end_layers
+            )
+            if is_in_end_metal or is_end_waypoint_reachable:
                 route = self._reconstruct_route(current, start, end)
                 if route is not None:
                     return route
@@ -2347,6 +2508,10 @@ class Router:
         # Issue #966: Clear via cache at start of route (grid state may have changed)
         self.clear_via_cache()
 
+        # Issue #2330: Reset waypoint state for this route call
+        self._waypoint_world_coords.clear()
+        self._waypoint_id_counter = 0
+
         # Get net class if not provided
         if net_class is None:
             net_class = self._get_net_class(start.net_name)
@@ -2443,6 +2608,22 @@ class Router:
                     forward_g[key] = 0
                     forward_nodes[key] = node
 
+        # Issue #2330: Waypoint injection for off-grid start pad (bidirectional)
+        if self._is_pad_off_grid(start):
+            bidir_start_wp = self._create_waypoint(start)
+            for gx, gy, edge_cost in self._waypoint_grid_edges(
+                bidir_start_wp, start, start.net, allow_sharing,
+            ):
+                for sl in start_layers:
+                    wp_g = edge_cost * self.rules.cost_straight
+                    wp_h = self.heuristic.estimate(gx, gy, sl, (0, 0), forward_context)
+                    wp_node = AStarNode(wp_g + weight * wp_h, wp_g, gx, gy, sl)
+                    fkey = (gx, gy, sl)
+                    if fkey not in forward_g or wp_g < forward_g[fkey]:
+                        forward_g[fkey] = wp_g
+                        forward_nodes[fkey] = wp_node
+                        heapq.heappush(forward_open, wp_node)
+
         # Initialize backward search (end -> start)
         # Issue #977: Initialize from ALL cells within end pad's metal area
         backward_open: list[AStarNode] = []
@@ -2459,6 +2640,22 @@ class Router:
                     key = (egx, egy, el)
                     backward_g[key] = 0
                     backward_nodes[key] = node
+
+        # Issue #2330: Waypoint injection for off-grid end pad (bidirectional)
+        if self._is_pad_off_grid(end):
+            bidir_end_wp = self._create_waypoint(end)
+            for gx, gy, edge_cost in self._waypoint_grid_edges(
+                bidir_end_wp, end, end.net, allow_sharing,
+            ):
+                for el in end_layers:
+                    wp_g = edge_cost * self.rules.cost_straight
+                    wp_h = self.heuristic.estimate(gx, gy, el, (0, 0), backward_context)
+                    wp_node = AStarNode(wp_g + weight * wp_h, wp_g, gx, gy, el)
+                    bkey = (gx, gy, el)
+                    if bkey not in backward_g or wp_g < backward_g[bkey]:
+                        backward_g[bkey] = wp_g
+                        backward_nodes[bkey] = wp_node
+                        heapq.heappush(backward_open, wp_node)
 
         # Best meeting point tracking
         best_path_cost = float("inf")

--- a/tests/test_waypoint_injection.py
+++ b/tests/test_waypoint_injection.py
@@ -1,0 +1,395 @@
+"""Tests for waypoint injection in A* pathfinding (Issue #2330).
+
+Validates that off-grid pad positions are injected as waypoint nodes
+into the A* search graph, enabling the pathfinder to route to/from
+pads whose centers do not align with the routing grid.
+"""
+
+import math
+
+import pytest
+
+from kicad_tools.router import DesignRules, RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.pathfinder import Router
+from kicad_tools.router.primitives import Pad
+
+
+def _make_grid(
+    width: float = 10.0,
+    height: float = 10.0,
+    resolution: float = 0.1,
+    origin_x: float = 0.0,
+    origin_y: float = 0.0,
+    num_layers: int = 1,
+) -> RoutingGrid:
+    """Create a simple routing grid for testing."""
+    from kicad_tools.router.layers import LayerStack
+
+    rules = DesignRules(
+        grid_resolution=resolution,
+        trace_width=0.1,
+        trace_clearance=0.1,
+    )
+    layer_stack = LayerStack.two_layer() if num_layers <= 2 else LayerStack.four_layer()
+    grid = RoutingGrid(
+        width=width,
+        height=height,
+        rules=rules,
+        origin_x=origin_x,
+        origin_y=origin_y,
+        layer_stack=layer_stack,
+    )
+    return grid
+
+
+def _make_pad(
+    x: float,
+    y: float,
+    net: int = 1,
+    net_name: str = "NET1",
+    layer: Layer = Layer.F_CU,
+    width: float = 0.5,
+    height: float = 0.5,
+    through_hole: bool = False,
+    ref: str = "U1",
+    pin: str = "1",
+) -> Pad:
+    """Helper to create a Pad with sensible defaults."""
+    return Pad(
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+        net=net,
+        net_name=net_name,
+        layer=layer,
+        through_hole=through_hole,
+        drill=0,
+        ref=ref,
+        pin=pin,
+    )
+
+
+class TestWaypointDetection:
+    """Tests for _is_pad_off_grid detection."""
+
+    def test_on_grid_pad(self):
+        """Pad exactly on a grid point is not off-grid."""
+        grid = _make_grid(resolution=0.1)
+        rules = DesignRules(grid_resolution=0.1)
+        router = Router(grid, rules)
+
+        # 1.0 is exactly on the 0.1mm grid
+        pad = _make_pad(x=1.0, y=2.0)
+        assert not router._is_pad_off_grid(pad)
+
+    def test_off_grid_pad(self):
+        """Pad between grid points is detected as off-grid."""
+        grid = _make_grid(resolution=0.1)
+        rules = DesignRules(grid_resolution=0.1)
+        router = Router(grid, rules)
+
+        # 1.037 is 0.037mm from nearest grid point (1.0 or 1.1)
+        # Tolerance is resolution/4 = 0.025mm, so this is off-grid.
+        pad = _make_pad(x=1.037, y=2.0)
+        assert router._is_pad_off_grid(pad)
+
+    def test_near_grid_pad(self):
+        """Pad very close to a grid point (within tolerance) is on-grid."""
+        grid = _make_grid(resolution=0.1)
+        rules = DesignRules(grid_resolution=0.1)
+        router = Router(grid, rules)
+
+        # 1.02 is 0.02mm from nearest grid point (1.0)
+        # Tolerance is resolution/4 = 0.025mm, so within tolerance.
+        pad = _make_pad(x=1.02, y=2.0)
+        assert not router._is_pad_off_grid(pad)
+
+
+class TestWaypointCreation:
+    """Tests for waypoint node creation and coordinate mapping."""
+
+    def test_create_waypoint_returns_negative_indices(self):
+        """Waypoint indices are negative to avoid grid cell collisions."""
+        grid = _make_grid(resolution=0.1)
+        rules = DesignRules(grid_resolution=0.1)
+        router = Router(grid, rules)
+
+        pad = _make_pad(x=1.037, y=2.065)
+        wp_key = router._create_waypoint(pad)
+
+        assert wp_key[0] < 0
+        assert wp_key[1] < 0
+
+    def test_waypoint_stores_exact_coordinates(self):
+        """Waypoint maps to exact pad world coordinates."""
+        grid = _make_grid(resolution=0.1)
+        rules = DesignRules(grid_resolution=0.1)
+        router = Router(grid, rules)
+
+        pad = _make_pad(x=1.037, y=2.065)
+        wp_key = router._create_waypoint(pad)
+
+        world = router._waypoint_to_world(wp_key[0], wp_key[1])
+        assert world is not None
+        assert abs(world[0] - 1.037) < 1e-9
+        assert abs(world[1] - 2.065) < 1e-9
+
+    def test_multiple_waypoints_unique(self):
+        """Each waypoint gets a unique key."""
+        grid = _make_grid(resolution=0.1)
+        rules = DesignRules(grid_resolution=0.1)
+        router = Router(grid, rules)
+
+        pad1 = _make_pad(x=1.037, y=2.065)
+        pad2 = _make_pad(x=3.043, y=4.078)
+
+        wp1 = router._create_waypoint(pad1)
+        wp2 = router._create_waypoint(pad2)
+
+        assert wp1 != wp2
+
+    def test_is_waypoint(self):
+        """_is_waypoint correctly identifies waypoint nodes."""
+        grid = _make_grid(resolution=0.1)
+        rules = DesignRules(grid_resolution=0.1)
+        router = Router(grid, rules)
+
+        pad = _make_pad(x=1.037, y=2.065)
+        wp_key = router._create_waypoint(pad)
+
+        assert router._is_waypoint(wp_key[0], wp_key[1])
+        assert not router._is_waypoint(5, 10)
+        assert not router._is_waypoint(0, 0)
+
+
+class TestWaypointGridEdges:
+    """Tests for waypoint-to-grid-cell edge generation."""
+
+    def test_edges_generated(self):
+        """Waypoint produces edges to nearby grid cells."""
+        grid = _make_grid(resolution=0.1)
+        rules = DesignRules(grid_resolution=0.1)
+        router = Router(grid, rules)
+
+        pad = _make_pad(x=1.037, y=2.065, net=1)
+        # Add pad to grid so cells are accessible
+        grid.add_pad(pad)
+
+        wp_key = router._create_waypoint(pad)
+        edges = router._waypoint_grid_edges(wp_key, pad, net=1)
+
+        assert len(edges) > 0, "Expected at least one edge from waypoint"
+
+    def test_edge_costs_are_euclidean(self):
+        """Edge costs correspond to Euclidean distance in grid-cell units."""
+        grid = _make_grid(resolution=0.1)
+        rules = DesignRules(grid_resolution=0.1)
+        router = Router(grid, rules)
+
+        pad = _make_pad(x=1.037, y=2.065, net=1)
+        grid.add_pad(pad)
+
+        wp_key = router._create_waypoint(pad)
+        edges = router._waypoint_grid_edges(wp_key, pad, net=1)
+
+        for gx, gy, cost in edges:
+            gw_x, gw_y = grid.grid_to_world(gx, gy)
+            expected_dist = math.sqrt(
+                (1.037 - gw_x) ** 2 + (2.065 - gw_y) ** 2
+            )
+            expected_cost = expected_dist / grid.resolution
+            assert abs(cost - expected_cost) < 1e-6, (
+                f"Edge to ({gx},{gy}) cost {cost} != expected {expected_cost}"
+            )
+
+    def test_nearest_grid_cell_included(self):
+        """The nearest grid cell to the pad is always included."""
+        grid = _make_grid(resolution=0.1)
+        rules = DesignRules(grid_resolution=0.1)
+        router = Router(grid, rules)
+
+        pad = _make_pad(x=1.037, y=2.065, net=1)
+        grid.add_pad(pad)
+
+        wp_key = router._create_waypoint(pad)
+        edges = router._waypoint_grid_edges(wp_key, pad, net=1)
+
+        nearest_gx, nearest_gy = grid.world_to_grid(1.037, 2.065)
+        edge_cells = {(gx, gy) for gx, gy, _ in edges}
+        assert (nearest_gx, nearest_gy) in edge_cells
+
+
+class TestWaypointRouting:
+    """Tests for end-to-end routing with waypoint injection."""
+
+    def test_route_off_grid_start_pad(self):
+        """Route from an off-grid start pad to an on-grid end pad."""
+        grid = _make_grid(width=5.0, height=5.0, resolution=0.1)
+        rules = DesignRules(
+            grid_resolution=0.1,
+            trace_width=0.1,
+            trace_clearance=0.1,
+        )
+        router = Router(grid, rules)
+
+        # Off-grid start pad at (1.037, 2.065)
+        start = _make_pad(x=1.037, y=2.065, net=1, ref="U1", pin="1")
+        # On-grid end pad at (3.0, 2.0)
+        end = _make_pad(x=3.0, y=2.0, net=1, ref="R1", pin="1")
+
+        grid.add_pad(start)
+        grid.add_pad(end)
+
+        route = router.route(start, end)
+        assert route is not None, "Expected route to succeed with waypoint injection"
+        assert len(route.segments) > 0
+
+    def test_route_off_grid_end_pad(self):
+        """Route from an on-grid start pad to an off-grid end pad."""
+        grid = _make_grid(width=5.0, height=5.0, resolution=0.1)
+        rules = DesignRules(
+            grid_resolution=0.1,
+            trace_width=0.1,
+            trace_clearance=0.1,
+        )
+        router = Router(grid, rules)
+
+        # On-grid start pad
+        start = _make_pad(x=1.0, y=2.0, net=1, ref="U1", pin="1")
+        # Off-grid end pad
+        end = _make_pad(x=3.043, y=2.078, net=1, ref="R1", pin="1")
+
+        grid.add_pad(start)
+        grid.add_pad(end)
+
+        route = router.route(start, end)
+        assert route is not None, "Expected route to succeed with off-grid end pad"
+        assert len(route.segments) > 0
+
+    def test_route_both_pads_off_grid(self):
+        """Route between two off-grid pads."""
+        grid = _make_grid(width=5.0, height=5.0, resolution=0.1)
+        rules = DesignRules(
+            grid_resolution=0.1,
+            trace_width=0.1,
+            trace_clearance=0.1,
+        )
+        router = Router(grid, rules)
+
+        start = _make_pad(x=1.037, y=2.065, net=1, ref="U1", pin="1")
+        end = _make_pad(x=3.043, y=2.078, net=1, ref="R1", pin="1")
+
+        grid.add_pad(start)
+        grid.add_pad(end)
+
+        route = router.route(start, end)
+        assert route is not None, "Expected route between two off-grid pads"
+        assert len(route.segments) > 0
+
+    def test_route_on_grid_pads_still_works(self):
+        """On-grid pads continue working without waypoints."""
+        grid = _make_grid(width=5.0, height=5.0, resolution=0.1)
+        rules = DesignRules(
+            grid_resolution=0.1,
+            trace_width=0.1,
+            trace_clearance=0.1,
+        )
+        router = Router(grid, rules)
+
+        start = _make_pad(x=1.0, y=2.0, net=1, ref="U1", pin="1")
+        end = _make_pad(x=3.0, y=2.0, net=1, ref="R1", pin="1")
+
+        grid.add_pad(start)
+        grid.add_pad(end)
+
+        route = router.route(start, end)
+        assert route is not None, "On-grid routing should still work"
+        assert len(route.segments) > 0
+
+    def test_route_starts_at_pad_center(self):
+        """Route from off-grid pad should start at exact pad coordinates."""
+        grid = _make_grid(width=5.0, height=5.0, resolution=0.1)
+        rules = DesignRules(
+            grid_resolution=0.1,
+            trace_width=0.1,
+            trace_clearance=0.1,
+        )
+        router = Router(grid, rules)
+
+        start = _make_pad(x=1.037, y=2.065, net=1, ref="U1", pin="1")
+        end = _make_pad(x=3.0, y=2.0, net=1, ref="R1", pin="1")
+
+        grid.add_pad(start)
+        grid.add_pad(end)
+
+        route = router.route(start, end)
+        assert route is not None
+
+        # First segment should start at the pad center
+        first_seg = route.segments[0]
+        assert abs(first_seg.x1 - start.x) < 0.001, (
+            f"First segment starts at {first_seg.x1}, expected {start.x}"
+        )
+        assert abs(first_seg.y1 - start.y) < 0.001, (
+            f"First segment starts at {first_seg.y1}, expected {start.y}"
+        )
+
+    def test_route_ends_at_pad_center(self):
+        """Route to off-grid pad should end at exact pad coordinates."""
+        grid = _make_grid(width=5.0, height=5.0, resolution=0.1)
+        rules = DesignRules(
+            grid_resolution=0.1,
+            trace_width=0.1,
+            trace_clearance=0.1,
+        )
+        router = Router(grid, rules)
+
+        start = _make_pad(x=1.0, y=2.0, net=1, ref="U1", pin="1")
+        end = _make_pad(x=3.043, y=2.078, net=1, ref="R1", pin="1")
+
+        grid.add_pad(start)
+        grid.add_pad(end)
+
+        route = router.route(start, end)
+        assert route is not None
+
+        # Last segment should end at the pad center
+        last_seg = route.segments[-1]
+        assert abs(last_seg.x2 - end.x) < 0.001, (
+            f"Last segment ends at {last_seg.x2}, expected {end.x}"
+        )
+        assert abs(last_seg.y2 - end.y) < 0.001, (
+            f"Last segment ends at {last_seg.y2}, expected {end.y}"
+        )
+
+
+class TestSubgridPrepassSkipped:
+    """Tests that the sub-grid pre-pass is skipped when waypoints are active."""
+
+    def test_waypoint_injection_enabled_by_default(self):
+        """Autorouter has waypoint injection enabled by default."""
+        from kicad_tools.router.core import Autorouter
+
+        ar = Autorouter(width=10.0, height=10.0)
+        assert ar.use_waypoint_injection is True
+
+    def test_subgrid_prepass_skipped_with_waypoints(self):
+        """_run_subgrid_prepass returns empty list when waypoints active."""
+        from kicad_tools.router.core import Autorouter
+
+        ar = Autorouter(width=10.0, height=10.0)
+        assert ar.use_waypoint_injection is True
+        result = ar._run_subgrid_prepass()
+        assert result == []
+
+    def test_subgrid_prepass_runs_when_disabled(self):
+        """_run_subgrid_prepass runs normally when waypoints disabled."""
+        from kicad_tools.router.core import Autorouter
+
+        ar = Autorouter(width=10.0, height=10.0)
+        ar.use_waypoint_injection = False
+        # With no pads, subgrid should return empty (no off-grid pads)
+        result = ar._run_subgrid_prepass()
+        assert result == []


### PR DESCRIPTION
## Summary

Add waypoint injection to the A* pathfinder so off-grid pad positions are seeded directly into the search graph with edges to nearby grid cells. This eliminates the need for the sub-grid escape pre-pass when routing to pads whose centers do not align with the routing grid.

## Changes

- Add `_is_pad_off_grid()`, `_create_waypoint()`, `_waypoint_grid_edges()`, `_waypoint_to_world()`, and `_is_waypoint()` helper methods to the `Router` class in `pathfinder.py`
- Seed waypoint nodes into both unidirectional (`route()`) and bidirectional (`route_bidirectional()`) A* open sets with Euclidean-distance edge costs to the nearest grid cells
- Extend the goal check in `route()` to also accept grid cells reachable from the end pad's waypoint node
- Add `use_waypoint_injection` flag to `Autorouter` (default `True`)
- Skip `_run_subgrid_prepass()` and `_retry_net_with_subgrid()` when waypoint injection is active
- Add 19 unit tests covering detection, creation, edge generation, end-to-end routing, and sub-grid bypass

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Waypoint nodes injected into A* open set with edges to nearest grid cells | Done | `_create_waypoint()` allocates negative-index virtual nodes; `_waypoint_grid_edges()` generates edges with Euclidean costs; both `route()` and `route_bidirectional()` seed these into the open set |
| Off-grid pad detection (tolerance = resolution/4) | Done | `_is_pad_off_grid()` compares pad-to-grid offset against `resolution/4`; verified by `TestWaypointDetection` (3 tests) |
| Both unidirectional and bidirectional A* updated | Done | Waypoint seeding added to both `route()` and `route_bidirectional()` |
| Sub-grid pre-pass skipped when waypoints active | Done | `_run_subgrid_prepass()` returns `[]` when `use_waypoint_injection=True`; `_retry_net_with_subgrid()` also skipped |
| subgrid.py retained as fallback | Done | No changes to `subgrid.py`; setting `use_waypoint_injection=False` re-enables the pre-pass |
| Route starts/ends at exact pad coordinates | Done | Verified by `test_route_starts_at_pad_center` and `test_route_ends_at_pad_center` |
| On-grid pads continue working | Done | Verified by `test_route_on_grid_pads_still_works` |
| No regression in existing tests | Done | 134 core tests, 138 grid tests, and voltage-divider integration test all pass |

## Test Plan

- `pytest tests/test_waypoint_injection.py` -- 19 tests all pass
- `pytest tests/test_router_core.py` -- 134 tests all pass (no regression)
- `pytest tests/test_router_grid.py` -- 138 tests all pass (no regression)
- `pytest tests/test_router_integration.py -k voltage_divider` -- passes (>= 80% completion)

Closes #2330