### PR TITLE
feat(router): add EMA smoothing, exponential cost escalation, congestion auto-tune, and hotset-only mode

### DIFF
--- a/src/kicad_tools/router/algorithms/__init__.py
+++ b/src/kicad_tools/router/algorithms/__init__.py
@@ -17,6 +17,7 @@ from .monte_carlo import MonteCarloRouter
 from .mst import MSTRouter
 from .negotiated import (
     NegotiatedRouter,
+    calculate_congestion_tuned_params,
     calculate_history_increment,
     calculate_present_cost,
     detect_oscillation,
@@ -32,7 +33,8 @@ __all__ = [
     "MonteCarloRouter",
     "TwoPhaseRouter",
     "build_rsmt",
-    # Adaptive parameter functions (Issue #633)
+    # Adaptive parameter functions (Issue #633, #2333)
+    "calculate_congestion_tuned_params",
     "calculate_history_increment",
     "calculate_present_cost",
     "detect_oscillation",

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -274,6 +274,10 @@ def calculate_present_cost(
     total_iterations: int,
     overflow_ratio: float,
     base_cost: float = 0.5,
+    *,
+    exponential: bool = False,
+    pres_fac_mult: float = 1.3,
+    pres_fac_cap: float = 50.0,
 ) -> float:
     """Calculate adaptive present cost factor based on iteration and congestion.
 
@@ -282,6 +286,14 @@ def calculate_present_cost(
         total_iterations: Maximum number of iterations
         overflow_ratio: Current overflow / total cells (congestion metric)
         base_cost: Base present cost value (default: 0.5)
+        exponential: If True, use exponential escalation (OrthoRoute-style)
+            instead of linear ramp.  Exponential pressure more aggressively
+            forces nets away from congested areas in later iterations.
+            Issue #2333.
+        pres_fac_mult: Multiplicative factor applied per iteration in
+            exponential mode.  Default 1.3 (30% increase per iteration).
+        pres_fac_cap: Maximum present cost factor in exponential mode
+            to prevent overshooting.  Default 50.0.
 
     Returns:
         Adjusted present cost factor
@@ -290,6 +302,12 @@ def calculate_present_cost(
     - As iterations progress (more pressure over time)
     - When congestion is high (need to discourage contested resources)
     """
+    if exponential:
+        # OrthoRoute-style: base * mult^iteration, capped to prevent runaway
+        raw = base_cost * (pres_fac_mult ** iteration)
+        return min(raw, pres_fac_cap)
+
+    # Linear mode (original behaviour)
     # Increase pressure as iterations progress (gradual ramp)
     progress_factor = 1.0 + (iteration / max(total_iterations, 1))
 
@@ -297,6 +315,42 @@ def calculate_present_cost(
     congestion_factor = 1.0 + min(overflow_ratio * 2, 2.0)  # Cap at 3x
 
     return base_cost * progress_factor * congestion_factor
+
+
+def calculate_congestion_tuned_params(
+    overflow_ratio: float,
+    base_pres_fac_mult: float = 1.3,
+    base_history_increment: float = 0.5,
+) -> tuple[float, float]:
+    """Derive present-cost multiplier and history increment from congestion ratio.
+
+    OrthoRoute-inspired auto-tuning: instead of using fixed parameters,
+    scale them based on the actual congestion level so that convergence
+    is less dependent on board characteristics.
+
+    Args:
+        overflow_ratio: Fraction of overused edges (overused / total cells).
+        base_pres_fac_mult: Base exponential multiplier (default: 1.3).
+        base_history_increment: Base history increment (default: 0.5).
+
+    Returns:
+        Tuple of (adjusted_pres_fac_mult, adjusted_history_increment).
+
+    Issue #2333.
+    """
+    # When congestion is high (>10%), escalate more aggressively
+    # When congestion is low (<1%), reduce escalation to fine-tune
+    if overflow_ratio > 0.10:
+        scale = 1.0 + min(overflow_ratio, 0.5)  # cap at 1.5x
+    elif overflow_ratio < 0.01:
+        scale = 0.7
+    else:
+        scale = 1.0
+
+    adjusted_mult = 1.0 + (base_pres_fac_mult - 1.0) * scale
+    adjusted_hist = base_history_increment * scale
+
+    return adjusted_mult, adjusted_hist
 
 
 class NegotiatedRouter:

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -28,6 +28,7 @@ from .algorithms import (
     MSTRouter,
     NegotiatedRouter,
     TwoPhaseRouter,
+    calculate_congestion_tuned_params,
     calculate_history_increment,
     calculate_present_cost,
     detect_oscillation,
@@ -2340,6 +2341,13 @@ class Autorouter:
         neighborhood_max_attempts: int = 3,
         neighborhood_initial_radius: float = 1.0,
         neighborhood_escalation_factor: float = 2.0,
+        ema_smoothing: bool = False,
+        ema_alpha: float = 0.6,
+        exponential_cost: bool = False,
+        pres_fac_mult: float = 1.3,
+        pres_fac_cap: float = 50.0,
+        congestion_auto_tune: bool = False,
+        hotset_only: bool = False,
     ) -> list[Route]:
         """Route all nets using PathFinder-style negotiated congestion.
 
@@ -2387,6 +2395,31 @@ class Autorouter:
                 for neighborhood rip-up (Issue #2274). Default: 1.0.
             neighborhood_escalation_factor: Multiplier applied to radius on
                 each consecutive stall (Issue #2274). Default: 2.0.
+            ema_smoothing: If True, use EMA-smoothed per-cell present cost
+                instead of raw ``factor * usage_count``.  Prevents bang-bang
+                oscillation by smoothing cost transitions across iterations
+                (Issue #2333). Default: False.
+            ema_alpha: Weight of the new value in the EMA update
+                (Issue #2333).  Default: 0.6 (60% new, 40% previous).
+            exponential_cost: If True, use exponential present cost
+                escalation (OrthoRoute-style) instead of the default
+                linear ramp.  More aggressively forces nets away from
+                congested areas in later iterations (Issue #2333).
+                Default: False.
+            pres_fac_mult: Multiplicative factor per iteration in
+                exponential cost mode (Issue #2333). Default: 1.3.
+            pres_fac_cap: Maximum present cost factor in exponential
+                mode (Issue #2333). Default: 50.0.
+            congestion_auto_tune: If True, dynamically adjust
+                ``pres_fac_mult`` and ``history_increment`` based on the
+                actual congestion ratio each iteration (Issue #2333).
+                Default: False.
+            hotset_only: If True, each rip-up iteration only reroutes
+                nets identified by ``find_nets_through_overused_cells``,
+                skipping neighborhood rip-up and full-reorder fallbacks.
+                Produces faster, more predictable iterations at the cost
+                of potentially slower convergence (Issue #2333).
+                Default: False.
 
         Returns:
             List of routes (may be partial if timeout reached)
@@ -2424,6 +2457,14 @@ class Autorouter:
             )
         if batch_routing:
             print("  Batch routing: enabled (GPU-accelerated)")
+        if ema_smoothing:
+            print(f"  EMA smoothing: enabled (alpha={ema_alpha})")
+        if exponential_cost:
+            print(f"  Exponential cost: enabled (mult={pres_fac_mult}, cap={pres_fac_cap})")
+        if congestion_auto_tune:
+            print("  Congestion auto-tune: enabled")
+        if hotset_only:
+            print("  Hotset-only reroute: enabled")
         if timeout:
             print(f"  Timeout: {timeout}s")
         if per_net_timeout:
@@ -2645,21 +2686,42 @@ class Autorouter:
                     total_cells = self.grid.cols * self.grid.rows * self.grid.num_layers
                     overflow_ratio = overflow / max(total_cells, 1)
 
+                    # Issue #2333: Congestion-ratio-based auto-tuning
+                    iter_pres_fac_mult = pres_fac_mult
+                    iter_history_increment = history_increment
+                    if congestion_auto_tune:
+                        iter_pres_fac_mult, iter_history_increment = (
+                            calculate_congestion_tuned_params(
+                                overflow_ratio, pres_fac_mult, history_increment
+                            )
+                        )
+
                     # Adaptive history increment based on convergence progress
                     adaptive_history = calculate_history_increment(
-                        iteration, overflow_history, history_increment
+                        iteration, overflow_history, iter_history_increment
                     )
                     # Adaptive present cost based on iteration and congestion
                     present_factor = calculate_present_cost(
-                        iteration, max_iterations, overflow_ratio, initial_present_factor
+                        iteration, max_iterations, overflow_ratio, initial_present_factor,
+                        exponential=exponential_cost,
+                        pres_fac_mult=iter_pres_fac_mult,
+                        pres_fac_cap=pres_fac_cap,
                     )
                     print(
                         f"  Adaptive params: history={adaptive_history:.2f}, present={present_factor:.2f}"
                     )
                     self.grid.update_history_costs(adaptive_history)
+
+                    # Issue #2333: EMA smoothing of per-cell present cost
+                    if ema_smoothing:
+                        self.grid.update_present_cost_ema(present_factor, alpha=ema_alpha)
                 else:
                     present_factor += present_factor_increment
                     self.grid.update_history_costs(history_increment)
+
+                    # Issue #2333: EMA smoothing in non-adaptive mode
+                    if ema_smoothing:
+                        self.grid.update_present_cost_ema(present_factor, alpha=ema_alpha)
 
                 nets_to_reroute = neg_router.find_nets_through_overused_cells(net_routes, overused)
 
@@ -2793,7 +2855,7 @@ class Autorouter:
                             # direct path but still prevent routing via clearance/congestion.
                             # Try ripping up ALL routed nets and re-routing failed net first.
                             routed_nets = list(net_routes.keys())
-                            if routed_nets and iteration <= 2 and not full_reorder_used_this_iter:  # Try in first few iterations
+                            if routed_nets and iteration <= 2 and not full_reorder_used_this_iter and not hotset_only:  # Try in first few iterations
                                 print(
                                     f"    No direct blockers found - trying full reorder for net {failed_net}"
                                 )
@@ -2875,7 +2937,7 @@ class Autorouter:
                         and n in pads_by_net
                         and n not in off_grid_nets
                     ]
-                    if overflow == 0 and still_unrouted_targeted and not timed_out:
+                    if overflow == 0 and still_unrouted_targeted and not timed_out and not hotset_only:
                         # Track stall progression
                         current_routed = len(net_routes)
                         if current_routed <= prev_routed_count:
@@ -3041,11 +3103,12 @@ class Autorouter:
                     # the standard rip-up path only re-attempts failed nets without
                     # clearing the routed nets that block them. Fall back to
                     # targeted rip-up to identify and displace blockers.
+                    # Issue #2333: Skip fallbacks in hotset-only mode.
                     still_failed = [
                         n for n in net_order
                         if n not in net_routes and n in pads_by_net and n not in off_grid_nets
                     ]
-                    if overflow == 0 and still_failed and not timed_out:
+                    if overflow == 0 and still_failed and not timed_out and not hotset_only:
                         flush_print(
                             f"  Stall detected: {len(still_failed)} net(s) unrouted with 0 overflow"
                             f" - engaging targeted rip-up fallback ({elapsed_str()})"
@@ -3090,13 +3153,14 @@ class Autorouter:
 
                     # Issue #2297: Neighborhood rip-up for standard path when
                     # targeted fallback was insufficient and nets remain stalled.
+                    # Issue #2333: Skip in hotset-only mode.
                     still_unrouted_std = [
                         n for n in net_order
                         if (n not in net_routes or not net_routes.get(n))
                         and n in pads_by_net
                         and n not in off_grid_nets
                     ]
-                    if overflow == 0 and still_unrouted_std and not timed_out:
+                    if overflow == 0 and still_unrouted_std and not timed_out and not hotset_only:
                         # Track stall progression
                         current_routed = len(net_routes)
                         if current_routed <= prev_routed_count:

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -472,6 +472,7 @@ class RoutingGrid:
         self._net = xp.zeros(grid_shape, dtype=np.int32)
         self._usage_count = xp.zeros(grid_shape, dtype=np.int16)
         self._history_cost = xp.zeros(grid_shape, dtype=np.float32)
+        self._present_cost_ema: np.ndarray | None = None  # Lazy; allocated on first use (Issue #2333)
         self._is_obstacle = xp.zeros(grid_shape, dtype=np.bool_)
         self._is_zone = xp.zeros(grid_shape, dtype=np.bool_)
         self._pad_blocked = xp.zeros(grid_shape, dtype=np.bool_)
@@ -495,6 +496,8 @@ class RoutingGrid:
         self._net = to_numpy(self._net)
         self._usage_count = to_numpy(self._usage_count)
         self._history_cost = to_numpy(self._history_cost)
+        if self._present_cost_ema is not None:
+            self._present_cost_ema = to_numpy(self._present_cost_ema)
         self._is_obstacle = to_numpy(self._is_obstacle)
         self._is_zone = to_numpy(self._is_zone)
         self._pad_blocked = to_numpy(self._pad_blocked)
@@ -534,6 +537,8 @@ class RoutingGrid:
             self._net = backend.asarray(self._net)
             self._usage_count = backend.asarray(self._usage_count)
             self._history_cost = backend.asarray(self._history_cost)
+            if self._present_cost_ema is not None:
+                self._present_cost_ema = backend.asarray(self._present_cost_ema)
             self._is_obstacle = backend.asarray(self._is_obstacle)
             self._is_zone = backend.asarray(self._is_zone)
             self._pad_blocked = backend.asarray(self._pad_blocked)
@@ -1843,6 +1848,44 @@ class RoutingGrid:
             if self._backend_type != BackendType.CPU:
                 self._gpu_dirty = True
 
+    def update_present_cost_ema(
+        self,
+        present_cost_factor: float,
+        alpha: float = 0.6,
+    ) -> None:
+        """Update the per-cell present-cost EMA (Issue #2333).
+
+        Smooths the per-cell present cost using an exponential moving
+        average to prevent bang-bang oscillation in the PathFinder cost
+        model.  The EMA tracks ``present_cost_factor * usage_count``
+        for each cell.
+
+        The EMA array is allocated lazily on first call so there is zero
+        memory overhead when EMA smoothing is not used.
+
+        Args:
+            present_cost_factor: Current present cost multiplier.
+            alpha: Weight of the new value (default 0.6).
+                ``ema = alpha * new + (1 - alpha) * ema``.
+        """
+        xp = self._backend
+
+        # Compute current per-cell present cost
+        if self._backend_type == BackendType.CPU:
+            usage_float = self._usage_count.astype(np.float32)
+        else:
+            usage_float = xp.asarray(self._usage_count, dtype=np.float32)
+
+        new_present = present_cost_factor * usage_float
+
+        if self._present_cost_ema is None:
+            # First call: initialise to the current present cost
+            self._present_cost_ema = new_present.copy()
+        else:
+            self._present_cost_ema = (
+                alpha * new_present + (1.0 - alpha) * self._present_cost_ema
+            )
+
     def get_negotiated_cost(
         self, gx: int, gy: int, layer: int, present_cost_factor: float = 1.0
     ) -> float:
@@ -1855,7 +1898,11 @@ class RoutingGrid:
         if cell.is_obstacle:
             return float("inf")
 
-        present_cost = present_cost_factor * cell.usage_count
+        # Issue #2333: Use EMA-smoothed present cost when available
+        if self._present_cost_ema is not None:
+            present_cost = float(self._present_cost_ema[layer, gy, gx])
+        else:
+            present_cost = present_cost_factor * cell.usage_count
         history_cost = cell.history_cost
 
         return present_cost + history_cost

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -1179,7 +1179,12 @@ class Router:
         history_costs = self.grid._history_cost[layer, ny_arr[valid_indices], nx_arr[valid_indices]]
 
         # Compute present cost + history cost
-        present_costs = present_cost_factor * usage_counts
+        # Issue #2333: When EMA smoothing is active, use the smoothed
+        # per-cell present cost instead of the raw usage * factor.
+        if self.grid._present_cost_ema is not None:
+            present_costs = self.grid._present_cost_ema[layer, ny_arr[valid_indices], nx_arr[valid_indices]]
+        else:
+            present_costs = present_cost_factor * usage_counts
         costs[valid_indices] = present_costs + history_costs
 
         return costs

--- a/tests/test_negotiated_congestion_model.py
+++ b/tests/test_negotiated_congestion_model.py
@@ -1,0 +1,328 @@
+"""Tests for PathFinder negotiated congestion cost model (Issue #2333).
+
+Covers:
+- EMA smoothing of per-cell present cost
+- Exponential present cost escalation
+- Congestion-ratio-based parameter auto-tuning
+- Hotset-only rerouting mode
+"""
+
+import numpy as np
+import pytest
+
+from kicad_tools.router.algorithms.negotiated import (
+    calculate_congestion_tuned_params,
+    calculate_present_cost,
+)
+
+
+# =========================================================================
+# Exponential present cost escalation
+# =========================================================================
+
+
+class TestExponentialPresentCost:
+    """Tests for exponential present cost escalation mode."""
+
+    def test_exponential_grows_faster_than_linear(self):
+        """Exponential mode should produce higher costs at later iterations."""
+        linear = calculate_present_cost(
+            iteration=5, total_iterations=10, overflow_ratio=0.05, base_cost=0.5,
+            exponential=False,
+        )
+        exp = calculate_present_cost(
+            iteration=5, total_iterations=10, overflow_ratio=0.05, base_cost=0.5,
+            exponential=True, pres_fac_mult=1.3,
+        )
+        # At iteration 5 with mult 1.3: 0.5 * 1.3^5 = 0.5 * 3.71 = 1.856
+        assert exp > linear
+
+    def test_exponential_at_iteration_zero(self):
+        """At iteration 0, exponential should equal base cost (1.3^0 = 1)."""
+        result = calculate_present_cost(
+            iteration=0, total_iterations=10, overflow_ratio=0.0, base_cost=0.5,
+            exponential=True, pres_fac_mult=1.3,
+        )
+        assert result == pytest.approx(0.5)
+
+    def test_exponential_respects_cap(self):
+        """Exponential cost should be capped at pres_fac_cap."""
+        result = calculate_present_cost(
+            iteration=100, total_iterations=100, overflow_ratio=0.0, base_cost=0.5,
+            exponential=True, pres_fac_mult=1.3, pres_fac_cap=10.0,
+        )
+        assert result == pytest.approx(10.0)
+
+    def test_exponential_formula(self):
+        """Verify exact exponential formula: base * mult^iteration."""
+        result = calculate_present_cost(
+            iteration=3, total_iterations=10, overflow_ratio=0.0, base_cost=1.0,
+            exponential=True, pres_fac_mult=2.0, pres_fac_cap=100.0,
+        )
+        # 1.0 * 2.0^3 = 8.0
+        assert result == pytest.approx(8.0)
+
+    def test_backward_compatible_linear_default(self):
+        """Default (exponential=False) should produce same results as before."""
+        result = calculate_present_cost(
+            iteration=3, total_iterations=10, overflow_ratio=0.1, base_cost=0.5,
+        )
+        # progress_factor = 1 + 3/10 = 1.3
+        # congestion_factor = 1 + min(0.2, 2.0) = 1.2
+        # 0.5 * 1.3 * 1.2 = 0.78
+        assert result == pytest.approx(0.78)
+
+
+# =========================================================================
+# Congestion-ratio-based auto-tuning
+# =========================================================================
+
+
+class TestCongestionAutoTune:
+    """Tests for calculate_congestion_tuned_params."""
+
+    def test_high_congestion_increases_params(self):
+        """High congestion (>10%) should increase both parameters."""
+        mult, hist = calculate_congestion_tuned_params(
+            overflow_ratio=0.15, base_pres_fac_mult=1.3, base_history_increment=0.5,
+        )
+        # scale = 1 + min(0.15, 0.5) = 1.15
+        # mult = 1 + (1.3 - 1) * 1.15 = 1 + 0.345 = 1.345
+        assert mult == pytest.approx(1.345)
+        # hist = 0.5 * 1.15 = 0.575
+        assert hist == pytest.approx(0.575)
+
+    def test_low_congestion_reduces_params(self):
+        """Low congestion (<1%) should reduce both parameters."""
+        mult, hist = calculate_congestion_tuned_params(
+            overflow_ratio=0.005, base_pres_fac_mult=1.3, base_history_increment=0.5,
+        )
+        # scale = 0.7
+        # mult = 1 + 0.3 * 0.7 = 1.21
+        assert mult == pytest.approx(1.21)
+        # hist = 0.5 * 0.7 = 0.35
+        assert hist == pytest.approx(0.35)
+
+    def test_moderate_congestion_unchanged(self):
+        """Moderate congestion (1-10%) should use base parameters."""
+        mult, hist = calculate_congestion_tuned_params(
+            overflow_ratio=0.05, base_pres_fac_mult=1.3, base_history_increment=0.5,
+        )
+        assert mult == pytest.approx(1.3)
+        assert hist == pytest.approx(0.5)
+
+    def test_very_high_congestion_capped(self):
+        """Very high congestion should cap the scale factor."""
+        mult, hist = calculate_congestion_tuned_params(
+            overflow_ratio=0.8, base_pres_fac_mult=1.3, base_history_increment=0.5,
+        )
+        # scale = 1 + min(0.8, 0.5) = 1.5
+        assert mult == pytest.approx(1.0 + 0.3 * 1.5)
+        assert hist == pytest.approx(0.5 * 1.5)
+
+    def test_zero_congestion(self):
+        """Zero congestion should use the low-congestion scale."""
+        mult, hist = calculate_congestion_tuned_params(
+            overflow_ratio=0.0, base_pres_fac_mult=1.3, base_history_increment=0.5,
+        )
+        # 0.0 < 0.01 -> scale = 0.7
+        assert mult == pytest.approx(1.21)
+        assert hist == pytest.approx(0.35)
+
+
+# =========================================================================
+# EMA smoothing of per-cell present cost
+# =========================================================================
+
+
+class TestEMASmoothing:
+    """Tests for grid EMA present cost smoothing."""
+
+    def _make_grid(self):
+        """Create a minimal RoutingGrid for EMA testing."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.grid import RoutingGrid
+
+        grid = RoutingGrid.__new__(RoutingGrid)
+        grid._backend = np
+        grid._backend_type = MagicMock()
+        grid._backend_type.name = "CPU"
+        # Use a property check that works
+        from kicad_tools.router.grid import BackendType
+        grid._backend_type = BackendType.CPU
+        grid._usage_count = np.array([[[0, 1, 2]]], dtype=np.int16)
+        grid._present_cost_ema = None
+        return grid
+
+    def test_first_call_initializes_ema(self):
+        """First EMA update should set EMA to current present cost."""
+        grid = self._make_grid()
+        grid.update_present_cost_ema(present_cost_factor=2.0, alpha=0.6)
+
+        assert grid._present_cost_ema is not None
+        # Should equal present_cost_factor * usage_count
+        expected = np.array([[[0.0, 2.0, 4.0]]], dtype=np.float32)
+        np.testing.assert_array_almost_equal(grid._present_cost_ema, expected)
+
+    def test_ema_smooths_between_old_and_new(self):
+        """Subsequent EMA updates should blend old and new values."""
+        grid = self._make_grid()
+        # Initialize with factor=2.0 -> [0, 2, 4]
+        grid.update_present_cost_ema(present_cost_factor=2.0, alpha=0.6)
+
+        # Update with factor=10.0 -> new = [0, 10, 20]
+        # EMA = 0.6 * [0, 10, 20] + 0.4 * [0, 2, 4] = [0, 6.8, 13.6]
+        grid.update_present_cost_ema(present_cost_factor=10.0, alpha=0.6)
+
+        expected = np.array([[[0.0, 6.8, 13.6]]], dtype=np.float32)
+        np.testing.assert_array_almost_equal(grid._present_cost_ema, expected)
+
+    def test_ema_with_alpha_one_uses_new_value(self):
+        """alpha=1.0 should completely replace with new value."""
+        grid = self._make_grid()
+        grid.update_present_cost_ema(present_cost_factor=2.0, alpha=1.0)
+        grid.update_present_cost_ema(present_cost_factor=5.0, alpha=1.0)
+
+        expected = np.array([[[0.0, 5.0, 10.0]]], dtype=np.float32)
+        np.testing.assert_array_almost_equal(grid._present_cost_ema, expected)
+
+    def test_ema_with_alpha_zero_keeps_old_value(self):
+        """alpha=0.0 should keep the previous EMA value."""
+        grid = self._make_grid()
+        grid.update_present_cost_ema(present_cost_factor=2.0, alpha=0.0)
+        # First call initializes to [0, 2, 4] (copy, not blend)
+        # Second call: 0 * new + 1.0 * old
+        grid.update_present_cost_ema(present_cost_factor=100.0, alpha=0.0)
+
+        expected = np.array([[[0.0, 2.0, 4.0]]], dtype=np.float32)
+        np.testing.assert_array_almost_equal(grid._present_cost_ema, expected)
+
+    def test_ema_not_allocated_by_default(self):
+        """EMA array should be None until first update."""
+        grid = self._make_grid()
+        assert grid._present_cost_ema is None
+
+
+# =========================================================================
+# Hotset-only mode
+# =========================================================================
+
+
+class TestHotsetOnlyMode:
+    """Tests for hotset_only flag skipping fallback strategies."""
+
+    def test_hotset_only_parameter_accepted(self):
+        """route_all_negotiated should accept hotset_only parameter."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.core import Autorouter
+
+        # Just verify the parameter is accepted without TypeError
+        router = Autorouter.__new__(Autorouter)
+        # We can't easily call route_all_negotiated without full setup,
+        # so just verify the method signature accepts the parameter
+        import inspect
+        sig = inspect.signature(router.route_all_negotiated)
+        assert "hotset_only" in sig.parameters
+        assert sig.parameters["hotset_only"].default is False
+
+    def test_ema_smoothing_parameter_accepted(self):
+        """route_all_negotiated should accept ema_smoothing parameter."""
+        from kicad_tools.router.core import Autorouter
+        import inspect
+        sig = inspect.signature(Autorouter.route_all_negotiated)
+        assert "ema_smoothing" in sig.parameters
+        assert sig.parameters["ema_smoothing"].default is False
+
+    def test_exponential_cost_parameter_accepted(self):
+        """route_all_negotiated should accept exponential_cost parameter."""
+        from kicad_tools.router.core import Autorouter
+        import inspect
+        sig = inspect.signature(Autorouter.route_all_negotiated)
+        assert "exponential_cost" in sig.parameters
+        assert sig.parameters["exponential_cost"].default is False
+
+    def test_congestion_auto_tune_parameter_accepted(self):
+        """route_all_negotiated should accept congestion_auto_tune parameter."""
+        from kicad_tools.router.core import Autorouter
+        import inspect
+        sig = inspect.signature(Autorouter.route_all_negotiated)
+        assert "congestion_auto_tune" in sig.parameters
+        assert sig.parameters["congestion_auto_tune"].default is False
+
+
+# =========================================================================
+# A* cost lookup with EMA
+# =========================================================================
+
+
+class TestAStarEMAIntegration:
+    """Tests for A* cost lookup using EMA present cost."""
+
+    def test_negotiated_cost_uses_ema_when_available(self):
+        """get_negotiated_cost should use EMA values when present."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.grid import RoutingGrid
+
+        grid = RoutingGrid.__new__(RoutingGrid)
+        grid._backend = np
+        grid._backend_type = MagicMock()
+
+        # Set up a 1-layer, 1x3 grid
+        from kicad_tools.router.grid import BackendType
+        grid._backend_type = BackendType.CPU
+        grid.cols = 3
+        grid.rows = 1
+        grid.num_layers = 1
+        grid._usage_count = np.array([[[0, 2, 1]]], dtype=np.int16)
+        grid._history_cost = np.array([[[0.0, 1.0, 0.5]]], dtype=np.float32)
+        grid._present_cost_ema = np.array([[[0.0, 5.0, 3.0]]], dtype=np.float32)
+        grid._is_obstacle = np.array([[[False, False, False]]])
+        grid._blocked = np.array([[[False, False, False]]])
+
+        # Create minimal Cell mocks
+        cell1 = MagicMock()
+        cell1.is_obstacle = False
+        cell1.usage_count = 2
+        cell1.history_cost = 1.0
+
+        cell2 = MagicMock()
+        cell2.is_obstacle = False
+        cell2.usage_count = 1
+        cell2.history_cost = 0.5
+
+        grid.grid = [[
+            [MagicMock(is_obstacle=False), cell1, cell2],
+        ]]
+
+        # With EMA, present cost should use EMA value, not factor * usage
+        cost = grid.get_negotiated_cost(1, 0, 0, present_cost_factor=100.0)
+        # Should use EMA value (5.0) + history (1.0) = 6.0
+        # NOT 100.0 * 2 + 1.0 = 201.0
+        assert cost == pytest.approx(6.0)
+
+    def test_negotiated_cost_without_ema(self):
+        """get_negotiated_cost should use factor * usage when no EMA."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.grid import RoutingGrid, BackendType
+
+        grid = RoutingGrid.__new__(RoutingGrid)
+        grid._backend = np
+        grid._backend_type = BackendType.CPU
+        grid.cols = 3
+        grid.rows = 1
+        grid.num_layers = 1
+        grid._present_cost_ema = None  # No EMA
+
+        cell = MagicMock()
+        cell.is_obstacle = False
+        cell.usage_count = 2
+        cell.history_cost = 1.0
+        grid.grid = [[[MagicMock(), cell, MagicMock()]]]
+
+        cost = grid.get_negotiated_cost(1, 0, 0, present_cost_factor=3.0)
+        # factor * usage + history = 3.0 * 2 + 1.0 = 7.0
+        assert cost == pytest.approx(7.0)


### PR DESCRIPTION
## Summary

Implements four PathFinder negotiated congestion cost model enhancements to improve routing convergence quality and speed. All features are opt-in via new parameters on `route_all_negotiated`, preserving full backward compatibility.

## Changes

- **EMA smoothing** (`ema_smoothing`, `ema_alpha`): Added `_present_cost_ema` array to `RoutingGrid` (lazy-allocated) and `update_present_cost_ema()` method. The A* cost lookup in `pathfinder.py` and `grid.get_negotiated_cost()` use smoothed values when available, preventing bang-bang oscillation.
- **Exponential present cost escalation** (`exponential_cost`, `pres_fac_mult`, `pres_fac_cap`): Extended `calculate_present_cost()` with OrthoRoute-style `base * mult^iteration` mode, capped to prevent runaway.
- **Congestion-ratio-based auto-tuning** (`congestion_auto_tune`): Added `calculate_congestion_tuned_params()` that derives `pres_fac_mult` and `history_increment` from the actual overuse ratio each iteration.
- **Hotset-only rerouting** (`hotset_only`): When enabled, rip-up iterations only reroute nets from `find_nets_through_overused_cells`, skipping neighborhood rip-up and full-reorder fallbacks for faster iterations.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| EMA smoothing for present cost | Done | `_present_cost_ema` array added to grid, update method implemented, A* uses EMA when available |
| Exponential present cost escalation | Done | `calculate_present_cost(exponential=True)` with configurable mult and cap |
| Congestion-ratio-based auto-tuning | Done | `calculate_congestion_tuned_params()` scales params by overflow ratio |
| Hotset-only rerouting mode | Done | Guards added to skip targeted fallback, neighborhood rip-up, and full-reorder when `hotset_only=True` |
| All features opt-in, backward compatible | Done | All new params default to `False`, existing tests pass unchanged |

## Test Plan

- 21 new unit tests in `tests/test_negotiated_congestion_model.py` covering all four features
- All 56 existing tests in `tests/test_negotiated_adaptive.py` continue to pass (3 pre-existing failures on main unrelated to this change)

Closes #2333