### PR TITLE
feat(router): cache solved routing sub-problems for recurring patterns

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -28,10 +28,14 @@ from .congestion_estimator import CongestionEstimator, NetBBox, TileGrid
 from .cache import (
     CachedNetRoute,
     CachedRoutingResult,
+    CachedSubProblem,
     CacheKey,
     RoutingCache,
+    SubProblemSignature,
     compute_pad_positions_hash,
     get_default_cache_path,
+    normalize_routes_to_origin,
+    transform_routes,
 )
 from .analysis import (
     BlockingObstacle,

--- a/src/kicad_tools/router/cache.py
+++ b/src/kicad_tools/router/cache.py
@@ -9,6 +9,7 @@ Key features:
 - Content-addressable caching using SHA-256 hashes
 - Full routing result caching for exact PCB configurations
 - Per-net partial route caching for incremental routing
+- Sub-problem pattern caching for recurring pad geometries (Issue #2336)
 - Automatic cache invalidation based on kicad-tools version
 - Configurable TTL and max size limits
 """
@@ -18,18 +19,19 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import os
 import sqlite3
 import zlib
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .primitives import Route
+    from .primitives import Pad, Route
     from .rules import DesignRules
 
 logger = logging.getLogger(__name__)
@@ -173,13 +175,292 @@ class CachedNetRoute:
     created_at: datetime
 
 
+@dataclass
+class SubProblemSignature:
+    """Position- and rotation-invariant signature for a routing sub-problem.
+
+    Issue #2336: Captures the relative pad geometry and connectivity of a
+    net, normalized so that the same physical pattern at different positions
+    and rotations produces the same hash.  This allows solved routing
+    sub-problems (e.g. bypass cap connections) to be reused across the board
+    and even across different boards.
+
+    Signature components:
+    1. Relative pad positions (centroid at origin, first vector along +X)
+    2. Pad dimensions and types (width, height, through-hole, drill)
+    3. Layer assignment for each pad
+    4. Design rules (clearance, trace width, via size)
+    """
+
+    signature_hash: str
+    centroid_x: float
+    centroid_y: float
+    rotation_angle: float  # radians, used to un-rotate cached solution
+    pad_count: int
+    rules_hash: str
+
+    @classmethod
+    def compute(
+        cls,
+        pads: list[Pad],
+        rules: DesignRules,
+    ) -> SubProblemSignature:
+        """Compute a position/rotation-invariant signature from pad geometry.
+
+        Args:
+            pads: List of Pad objects belonging to the net.
+            rules: Design rules that affect routing solutions.
+
+        Returns:
+            SubProblemSignature with a deterministic hash.
+        """
+        if not pads:
+            return cls(
+                signature_hash="empty",
+                centroid_x=0.0,
+                centroid_y=0.0,
+                rotation_angle=0.0,
+                pad_count=0,
+                rules_hash="",
+            )
+
+        # 1. Compute centroid
+        cx = sum(p.x for p in pads) / len(pads)
+        cy = sum(p.y for p in pads) / len(pads)
+
+        # 2. Translate pads so centroid is at origin
+        relative = [(p.x - cx, p.y - cy) for p in pads]
+
+        # 3. Compute rotation angle: rotate so first pad (by angle from
+        #    centroid) aligns with +X axis.  For single-pad nets or pads
+        #    all at the centroid, rotation is 0.
+        angles = [(math.atan2(ry, rx), i) for i, (rx, ry) in enumerate(relative)
+                  if abs(rx) > 1e-6 or abs(ry) > 1e-6]
+
+        if angles:
+            angles.sort()
+            rotation = angles[0][0]
+        else:
+            rotation = 0.0
+
+        cos_r = math.cos(-rotation)
+        sin_r = math.sin(-rotation)
+
+        # 4. Rotate all relative positions and round for hashing stability.
+        #    Adding 0.0 converts -0.0 to 0.0 so JSON serialization is stable.
+        rotated = []
+        for rx, ry in relative:
+            nx = round(rx * cos_r - ry * sin_r, 4) + 0.0
+            ny = round(rx * sin_r + ry * cos_r, 4) + 0.0
+            rotated.append((nx, ny))
+
+        # 5. Sort rotated positions for order independence, pairing with
+        #    pad metadata
+        pad_entries = []
+        for i, (nx, ny) in enumerate(rotated):
+            p = pads[i]
+            pad_entries.append((
+                nx, ny,
+                round(p.width, 4),
+                round(p.height, 4),
+                p.through_hole,
+                round(p.drill, 4),
+                p.layer.value,
+            ))
+        pad_entries.sort()
+
+        # 6. Build rules hash (only routing-relevant fields)
+        rules_data = {
+            "trace_width": rules.trace_width,
+            "trace_clearance": rules.trace_clearance,
+            "via_drill": rules.via_drill,
+            "via_diameter": rules.via_diameter,
+            "grid_resolution": rules.grid_resolution,
+        }
+        rules_json = json.dumps(rules_data, sort_keys=True)
+        rules_hash = hashlib.sha256(rules_json.encode()).hexdigest()
+
+        # 7. Combine everything into a signature hash
+        sig_data = {
+            "pads": pad_entries,
+            "rules": rules_hash,
+            "version": CACHE_VERSION,
+        }
+        sig_json = json.dumps(sig_data, sort_keys=True)
+        signature_hash = hashlib.sha256(sig_json.encode()).hexdigest()
+
+        return cls(
+            signature_hash=signature_hash,
+            centroid_x=cx,
+            centroid_y=cy,
+            rotation_angle=rotation,
+            pad_count=len(pads),
+            rules_hash=rules_hash,
+        )
+
+
+@dataclass
+class CachedSubProblem:
+    """A cached solution for a routing sub-problem.
+
+    Stores the route segments/vias in centroid-relative, rotation-normalized
+    coordinates.  On cache hit the caller applies an affine transform
+    (rotate + translate) to place the solution at the current location.
+    """
+
+    signature_hash: str
+    route_data: bytes  # Compressed JSON of relative route
+    segment_count: int
+    via_count: int
+    hit_count: int
+    created_at: datetime
+    last_accessed: datetime
+
+
+def transform_routes(
+    routes: list[Route],
+    dx: float,
+    dy: float,
+    angle: float,
+    target_net: int,
+    target_net_name: str,
+) -> list[Route]:
+    """Apply affine transform (rotate then translate) to route geometry.
+
+    Args:
+        routes: Routes in centroid-relative, rotation-normalized coordinates.
+        dx: Translation in X (centroid of target pads).
+        dy: Translation in Y (centroid of target pads).
+        angle: Rotation angle in radians to apply.
+        target_net: Net ID to assign to the transformed routes.
+        target_net_name: Net name to assign.
+
+    Returns:
+        New list of Route objects with transformed coordinates.
+    """
+    from .layers import Layer
+    from .primitives import Route as RouteClass
+    from .primitives import Segment, Via
+
+    cos_a = math.cos(angle)
+    sin_a = math.sin(angle)
+
+    def _transform(x: float, y: float) -> tuple[float, float]:
+        rx = round(x * cos_a - y * sin_a + dx, 4)
+        ry = round(x * sin_a + y * cos_a + dy, 4)
+        return rx, ry
+
+    transformed = []
+    for route in routes:
+        new_segs = []
+        for seg in route.segments:
+            x1, y1 = _transform(seg.x1, seg.y1)
+            x2, y2 = _transform(seg.x2, seg.y2)
+            new_segs.append(Segment(
+                x1=x1, y1=y1, x2=x2, y2=y2,
+                width=seg.width,
+                layer=seg.layer,
+                net=target_net,
+                net_name=target_net_name,
+            ))
+        new_vias = []
+        for via in route.vias:
+            vx, vy = _transform(via.x, via.y)
+            new_vias.append(Via(
+                x=vx, y=vy,
+                drill=via.drill,
+                diameter=via.diameter,
+                layers=via.layers,
+                net=target_net,
+                net_name=target_net_name,
+            ))
+        transformed.append(RouteClass(
+            net=target_net,
+            net_name=target_net_name,
+            segments=new_segs,
+            vias=new_vias,
+        ))
+
+    return transformed
+
+
+def normalize_routes_to_origin(
+    routes: list[Route],
+    centroid_x: float,
+    centroid_y: float,
+    rotation_angle: float,
+) -> list[Route]:
+    """Transform routes into centroid-relative, rotation-normalized coordinates.
+
+    This is the inverse of ``transform_routes``: first translate so that the
+    centroid is at the origin, then rotate by ``-rotation_angle`` to align
+    with the canonical orientation.
+
+    Args:
+        routes: Routes in world coordinates.
+        centroid_x: X centroid of the pad configuration.
+        centroid_y: Y centroid of the pad configuration.
+        rotation_angle: Rotation angle that was applied to normalize pads.
+
+    Returns:
+        New list of Route objects in normalized coordinates.
+    """
+    from .primitives import Route as RouteClass
+    from .primitives import Segment, Via
+
+    # Inverse: translate by -centroid, then rotate by -angle
+    cos_a = math.cos(-rotation_angle)
+    sin_a = math.sin(-rotation_angle)
+
+    def _inv_transform(x: float, y: float) -> tuple[float, float]:
+        tx = x - centroid_x
+        ty = y - centroid_y
+        rx = round(tx * cos_a - ty * sin_a, 4)
+        ry = round(tx * sin_a + ty * cos_a, 4)
+        return rx, ry
+
+    normalized = []
+    for route in routes:
+        new_segs = []
+        for seg in route.segments:
+            x1, y1 = _inv_transform(seg.x1, seg.y1)
+            x2, y2 = _inv_transform(seg.x2, seg.y2)
+            new_segs.append(Segment(
+                x1=x1, y1=y1, x2=x2, y2=y2,
+                width=seg.width,
+                layer=seg.layer,
+                net=0,
+                net_name="",
+            ))
+        new_vias = []
+        for via in route.vias:
+            vx, vy = _inv_transform(via.x, via.y)
+            new_vias.append(Via(
+                x=vx, y=vy,
+                drill=via.drill,
+                diameter=via.diameter,
+                layers=via.layers,
+                net=0,
+                net_name="",
+            ))
+        normalized.append(RouteClass(
+            net=0,
+            net_name="",
+            segments=new_segs,
+            vias=new_vias,
+        ))
+
+    return normalized
+
+
 class RoutingCache:
     """
     SQLite-backed cache for routing results.
 
     Stores routing results locally to reduce computation time for
     iterative PCB design workflows. Supports both full routing result
-    caching and per-net partial route caching for incremental updates.
+    caching, per-net partial route caching for incremental updates,
+    and sub-problem pattern caching for recurring pad geometries.
 
     Example::
 
@@ -198,9 +479,17 @@ class RoutingCache:
 
         # Incremental routing
         unchanged_nets = cache.get_unchanged_net_routes(pcb_hash, net_pad_hashes)
+
+        # Sub-problem pattern reuse (Issue #2336)
+        sig = SubProblemSignature.compute(pads, rules)
+        cached_sub = cache.get_sub_problem(sig)
+        if cached_sub:
+            routes = cache.deserialize_routes(cached_sub.route_data)
+            transformed = transform_routes(routes, sig.centroid_x, sig.centroid_y,
+                                           sig.rotation_angle, net_id, net_name)
     """
 
-    SCHEMA_VERSION = 2
+    SCHEMA_VERSION = 3
     DEFAULT_TTL_DAYS = 30
     DEFAULT_MAX_SIZE_MB = 500
 
@@ -262,12 +551,28 @@ class RoutingCache:
                     PRIMARY KEY (pcb_hash, net_id)
                 );
 
+                CREATE TABLE IF NOT EXISTS sub_problem_solutions (
+                    signature_hash TEXT PRIMARY KEY,
+                    route_data BLOB NOT NULL,
+                    segment_count INTEGER NOT NULL,
+                    via_count INTEGER NOT NULL,
+                    pad_count INTEGER NOT NULL,
+                    rules_hash TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    hit_count INTEGER NOT NULL DEFAULT 0,
+                    data_size INTEGER NOT NULL,
+                    created_at TEXT NOT NULL,
+                    last_accessed TEXT NOT NULL
+                );
+
                 CREATE INDEX IF NOT EXISTS idx_routing_results_pcb
                     ON routing_results(pcb_hash);
                 CREATE INDEX IF NOT EXISTS idx_routing_results_accessed
                     ON routing_results(last_accessed);
                 CREATE INDEX IF NOT EXISTS idx_partial_routes_hash
                     ON partial_routes(pad_positions_hash);
+                CREATE INDEX IF NOT EXISTS idx_sub_problem_accessed
+                    ON sub_problem_solutions(last_accessed);
             """)
 
             # Check schema version
@@ -294,6 +599,31 @@ class RoutingCache:
             conn.execute("ALTER TABLE partial_routes ADD COLUMN version TEXT NOT NULL DEFAULT ''")
             logger.info(
                 "Migrated cache schema from v1 to v2: added version column to partial_routes"
+            )
+
+        if from_version < 3:
+            # Schema v3 (Issue #2336): add sub_problem_solutions table for
+            # pattern-level caching of recurring pad geometries.
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS sub_problem_solutions (
+                    signature_hash TEXT PRIMARY KEY,
+                    route_data BLOB NOT NULL,
+                    segment_count INTEGER NOT NULL,
+                    via_count INTEGER NOT NULL,
+                    pad_count INTEGER NOT NULL,
+                    rules_hash TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    hit_count INTEGER NOT NULL DEFAULT 0,
+                    data_size INTEGER NOT NULL,
+                    created_at TEXT NOT NULL,
+                    last_accessed TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_sub_problem_accessed
+                    ON sub_problem_solutions(last_accessed);
+            """)
+            logger.info(
+                "Migrated cache schema to v3: added sub_problem_solutions table"
             )
 
         conn.execute(
@@ -635,6 +965,120 @@ class RoutingCache:
         logger.info(f"Found {len(unchanged_routes)}/{len(net_pad_hashes)} unchanged net routes")
         return unchanged_routes
 
+    # ------------------------------------------------------------------
+    # Sub-problem pattern cache (Issue #2336)
+    # ------------------------------------------------------------------
+
+    def put_sub_problem(
+        self,
+        signature: SubProblemSignature,
+        routes: list[Route],
+    ) -> None:
+        """Store a solved routing sub-problem in the cache.
+
+        The routes must already be in centroid-relative, rotation-normalized
+        coordinates (use ``normalize_routes_to_origin`` before calling).
+
+        Args:
+            signature: Sub-problem signature computed from pad geometry.
+            routes: Route objects in normalized coordinates.
+        """
+        route_data = self.serialize_routes(routes)
+        data_size = len(route_data)
+        now = datetime.now().isoformat()
+        pkg_version = _get_kicad_tools_version()
+        version = f"{pkg_version}+cache.{CACHE_VERSION}"
+
+        seg_count = sum(len(r.segments) for r in routes)
+        via_count = sum(len(r.vias) for r in routes)
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO sub_problem_solutions (
+                    signature_hash, route_data, segment_count, via_count,
+                    pad_count, rules_hash, version, hit_count,
+                    data_size, created_at, last_accessed
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)
+                """,
+                (
+                    signature.signature_hash,
+                    route_data,
+                    seg_count,
+                    via_count,
+                    signature.pad_count,
+                    signature.rules_hash,
+                    version,
+                    data_size,
+                    now,
+                    now,
+                ),
+            )
+
+        logger.debug(
+            "Cached sub-problem %s (%d segs, %d vias, %d bytes)",
+            signature.signature_hash[:12],
+            seg_count,
+            via_count,
+            data_size,
+        )
+
+    def get_sub_problem(
+        self,
+        signature: SubProblemSignature,
+    ) -> CachedSubProblem | None:
+        """Look up a cached sub-problem solution by geometry signature.
+
+        Args:
+            signature: Sub-problem signature to look up.
+
+        Returns:
+            CachedSubProblem if found and not expired, None otherwise.
+        """
+        pkg_version = _get_kicad_tools_version()
+        version = f"{pkg_version}+cache.{CACHE_VERSION}"
+
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT * FROM sub_problem_solutions
+                WHERE signature_hash = ? AND version = ?
+                """,
+                (signature.signature_hash, version),
+            )
+            row = cursor.fetchone()
+
+            if row is None:
+                return None
+
+            if self._is_expired(row["created_at"]):
+                return None
+
+            # Update access time and hit count
+            conn.execute(
+                """
+                UPDATE sub_problem_solutions
+                SET last_accessed = ?, hit_count = hit_count + 1
+                WHERE signature_hash = ?
+                """,
+                (datetime.now().isoformat(), signature.signature_hash),
+            )
+
+            logger.debug(
+                "Sub-problem cache hit: %s (hits: %d)",
+                signature.signature_hash[:12],
+                row["hit_count"] + 1,
+            )
+            return CachedSubProblem(
+                signature_hash=row["signature_hash"],
+                route_data=row["route_data"],
+                segment_count=row["segment_count"],
+                via_count=row["via_count"],
+                hit_count=row["hit_count"] + 1,
+                created_at=datetime.fromisoformat(row["created_at"]),
+                last_accessed=datetime.fromisoformat(row["last_accessed"]),
+            )
+
     def _enforce_size_limit(self, new_data_size: int) -> None:
         """Evict oldest entries if cache exceeds size limit."""
         with self._connect() as conn:
@@ -680,10 +1124,14 @@ class RoutingCache:
             cursor = conn.execute("SELECT COUNT(*) FROM partial_routes")
             partial_count = cursor.fetchone()[0]
 
+            cursor = conn.execute("SELECT COUNT(*) FROM sub_problem_solutions")
+            sub_count = cursor.fetchone()[0]
+
             conn.execute("DELETE FROM routing_results")
             conn.execute("DELETE FROM partial_routes")
+            conn.execute("DELETE FROM sub_problem_solutions")
 
-            return result_count + partial_count
+            return result_count + partial_count + sub_count
 
     def clear_expired(self) -> int:
         """
@@ -704,6 +1152,12 @@ class RoutingCache:
 
             cursor = conn.execute(
                 "DELETE FROM partial_routes WHERE created_at < ?",
+                (cutoff,),
+            )
+            removed += cursor.rowcount
+
+            cursor = conn.execute(
+                "DELETE FROM sub_problem_solutions WHERE created_at < ?",
                 (cutoff,),
             )
             removed += cursor.rowcount
@@ -743,12 +1197,28 @@ class RoutingCache:
 
             newest = conn.execute("SELECT MAX(created_at) FROM routing_results").fetchone()[0]
 
-        total_size = result_size + partial_size
+            # Sub-problem stats (Issue #2336)
+            sub_count = conn.execute(
+                "SELECT COUNT(*) FROM sub_problem_solutions"
+            ).fetchone()[0]
+
+            sub_size = conn.execute(
+                "SELECT COALESCE(SUM(data_size), 0) FROM sub_problem_solutions"
+            ).fetchone()[0]
+
+            sub_total_hits = conn.execute(
+                "SELECT COALESCE(SUM(hit_count), 0) FROM sub_problem_solutions"
+            ).fetchone()[0]
+
+        total_size = result_size + partial_size + sub_size
         return {
             "routing_results_count": result_count,
             "routing_results_size_bytes": result_size,
             "partial_routes_count": partial_count,
             "partial_routes_size_bytes": partial_size,
+            "sub_problem_count": sub_count,
+            "sub_problem_size_bytes": sub_size,
+            "sub_problem_total_hits": sub_total_hits,
             "total_size_bytes": total_size,
             "total_size_mb": total_size / (1024 * 1024),
             "valid_results": valid_results,

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import os
 import random
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
 
 from kicad_tools.cli.progress import flush_print
 
+logger = logging.getLogger(__name__)
+
 from .adaptive import AdaptiveAutorouter, RoutingResult
 from .algorithms import (
     HierarchicalRouter,
@@ -34,6 +37,12 @@ from .algorithms import (
     should_terminate_early,
 )
 from .bus import BusGroup, BusRoutingConfig, BusRoutingMode
+from .cache import (
+    RoutingCache,
+    SubProblemSignature,
+    normalize_routes_to_origin,
+    transform_routes,
+)
 from .bus_routing import BusRouter
 from .cpp_backend import CppGrid, CppPathfinder, create_hybrid_router, get_backend_info
 from .diffpair import DifferentialPair, DifferentialPairConfig, LengthMismatchWarning
@@ -405,6 +414,14 @@ class Autorouter:
         # Length constraint tracking (Issue #630)
         self._length_tracker: LengthTracker = LengthTracker()
 
+        # Sub-problem pattern cache (Issue #2336)
+        # When set, enables cross-board reuse of routing solutions for
+        # recurring pad geometries (e.g. bypass caps, pull-up networks).
+        self._sub_problem_cache: RoutingCache | None = None
+        self._sub_problem_hits: int = 0
+        self._sub_problem_misses: int = 0
+        self._sub_problem_collisions: int = 0
+
         # Routing failure tracking (Issue #688)
         self.routing_failures: list[RoutingFailure] = []
 
@@ -436,6 +453,27 @@ class Autorouter:
         # Populated by register_block() when blocks have internal traces.
         # (Issue #1587)
         self._block_internal_connections: dict[str, list[dict]] = {}
+
+    def enable_sub_problem_cache(
+        self,
+        cache: RoutingCache | None = None,
+    ) -> None:
+        """Enable sub-problem pattern caching for recurring pad geometries.
+
+        Issue #2336: When enabled, the router computes a position/rotation-
+        invariant signature for each net's pad configuration before routing.
+        If a matching solution exists in the cache, it is transformed to the
+        current location and validated against the grid. On cache miss, the
+        freshly routed solution is stored for future reuse.
+
+        Args:
+            cache: RoutingCache instance to use. If None, creates a default
+                   cache using the standard cache directory.
+        """
+        if cache is None:
+            cache = RoutingCache()
+        self._sub_problem_cache = cache
+        logger.info("Sub-problem pattern cache enabled")
 
     def _init_physics(self) -> None:
         """Initialize physics module if available and enabled."""
@@ -1109,6 +1147,25 @@ class Autorouter:
             return routes
 
         pad_objs = [self.pads[p] for p in pads_for_routing]
+
+        # Issue #2336: Try sub-problem pattern cache before A* search.
+        # Compute a position/rotation-invariant signature and check for a
+        # cached solution that can be transformed to the current location.
+        sub_sig = None
+        if self._sub_problem_cache is not None:
+            cached_routes = self._try_sub_problem_cache(net, pad_objs)
+            if cached_routes is not None:
+                for route in cached_routes:
+                    self._mark_route(route)
+                    routes.append(route)
+                    self.routes.append(route)
+                # Record decision if enabled
+                if self.record_decisions and cached_routes:
+                    self._record_routing_decision(net, cached_routes)
+                return routes
+            # Signature was computed; we'll store the solution after routing
+            sub_sig = SubProblemSignature.compute(pad_objs, self.rules)
+
         mst_router = MSTRouter(self.grid, self.router, self.rules, self.net_class_map)
 
         def mark_route(route: Route):
@@ -1306,11 +1363,128 @@ class Autorouter:
                 if retry_routes:
                     routes.extend(retry_routes)
 
+        # Issue #2336: Store freshly routed solution in sub-problem cache
+        if sub_sig is not None and new_routes and self._sub_problem_cache is not None:
+            self._store_sub_problem(sub_sig, new_routes)
+
         # Record routing decision if enabled
         if self.record_decisions and routes:
             self._record_routing_decision(net, routes)
 
         return routes
+
+    def _try_sub_problem_cache(
+        self,
+        net: int,
+        pad_objs: list[Pad],
+    ) -> list[Route] | None:
+        """Attempt to reuse a cached sub-problem solution.
+
+        Issue #2336: Computes a position/rotation-invariant signature from
+        the pad geometry, looks up the cache, transforms a hit to the
+        current position, and validates against the current grid state.
+
+        Args:
+            net: Net ID being routed.
+            pad_objs: Pad objects for this net.
+
+        Returns:
+            Transformed routes if cache hit and validation passes, else None.
+        """
+        assert self._sub_problem_cache is not None
+
+        sig = SubProblemSignature.compute(pad_objs, self.rules)
+        cached = self._sub_problem_cache.get_sub_problem(sig)
+
+        if cached is None:
+            self._sub_problem_misses += 1
+            return None
+
+        # Deserialize and transform to current position
+        raw_routes = self._sub_problem_cache.deserialize_routes(cached.route_data)
+        net_name = self.net_names.get(net, f"Net_{net}")
+        transformed = transform_routes(
+            raw_routes,
+            dx=sig.centroid_x,
+            dy=sig.centroid_y,
+            angle=sig.rotation_angle,
+            target_net=net,
+            target_net_name=net_name,
+        )
+
+        # Validate: ensure no segment overlaps an occupied grid cell
+        # belonging to a different net
+        if not self._validate_transformed_routes(transformed, net):
+            self._sub_problem_collisions += 1
+            logger.debug(
+                "Sub-problem cache hit rejected (collision): net %d sig %s",
+                net,
+                sig.signature_hash[:12],
+            )
+            return None
+
+        self._sub_problem_hits += 1
+        logger.debug(
+            "Sub-problem cache hit accepted: net %d sig %s (%d segs, %d vias)",
+            net,
+            sig.signature_hash[:12],
+            sum(len(r.segments) for r in transformed),
+            sum(len(r.vias) for r in transformed),
+        )
+        return transformed
+
+    def _validate_transformed_routes(
+        self,
+        routes: list[Route],
+        net: int,
+    ) -> bool:
+        """Check that transformed routes do not collide with existing routes.
+
+        Walks every segment endpoint and via location, converting to grid
+        coordinates and checking that the cell is not blocked by another net.
+
+        Args:
+            routes: Transformed routes to validate.
+            net: Net ID (same-net cells are allowed).
+
+        Returns:
+            True if all cells are available or belong to this net.
+        """
+        from .layers import Layer
+
+        for route in routes:
+            for seg in route.segments:
+                for wx, wy in [(seg.x1, seg.y1), (seg.x2, seg.y2)]:
+                    gx, gy = self.grid.world_to_grid(wx, wy)
+                    if self.grid.is_blocked(gx, gy, seg.layer, net):
+                        return False
+            for via in route.vias:
+                gx, gy = self.grid.world_to_grid(via.x, via.y)
+                for layer in [via.layers[0], via.layers[1]]:
+                    if self.grid.is_blocked(gx, gy, layer, net):
+                        return False
+        return True
+
+    def _store_sub_problem(
+        self,
+        sig: SubProblemSignature,
+        routes: list[Route],
+    ) -> None:
+        """Store a freshly routed solution in the sub-problem cache.
+
+        Args:
+            sig: Sub-problem signature for the pad configuration.
+            routes: Successfully routed solution in world coordinates.
+        """
+        assert self._sub_problem_cache is not None
+
+        normalized = normalize_routes_to_origin(
+            routes,
+            sig.centroid_x,
+            sig.centroid_y,
+            sig.rotation_angle,
+        )
+        self._sub_problem_cache.put_sub_problem(sig, normalized)
 
     def _record_routing_decision(self, net: int, routes: list[Route]) -> None:
         """Record a routing decision for a net."""

--- a/tests/test_router_cache.py
+++ b/tests/test_router_cache.py
@@ -1,5 +1,6 @@
 """Tests for routing result cache."""
 
+import math
 import sqlite3
 from pathlib import Path
 from unittest import mock
@@ -12,11 +13,15 @@ from kicad_tools.router import (
     Route,
     RoutingCache,
     Segment,
+    SubProblemSignature,
     Via,
     compute_pad_positions_hash,
+    normalize_routes_to_origin,
+    transform_routes,
 )
 from kicad_tools.router.cache import CACHE_VERSION
 from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
 
 
 class TestCacheKey:
@@ -658,4 +663,402 @@ class TestSchemaMigration:
         conn = sqlite3.connect(str(db_path))
         version = conn.execute("SELECT value FROM meta WHERE key = 'schema_version'").fetchone()[0]
         conn.close()
-        assert version == "2"
+        assert version == "3"
+
+
+class TestSubProblemSignature:
+    """Tests for SubProblemSignature computation (Issue #2336)."""
+
+    def _make_pads(self, positions, layer=Layer.F_CU, width=0.6, height=0.6):
+        """Helper to create Pad objects from (x, y) positions."""
+        return [
+            Pad(x=x, y=y, width=width, height=height, net=1, net_name="N",
+                layer=layer)
+            for x, y in positions
+        ]
+
+    def test_same_pads_same_signature(self):
+        """Identical pad configs produce the same signature hash."""
+        rules = DesignRules()
+        pads1 = self._make_pads([(0, 0), (10, 0)])
+        pads2 = self._make_pads([(0, 0), (10, 0)])
+
+        sig1 = SubProblemSignature.compute(pads1, rules)
+        sig2 = SubProblemSignature.compute(pads2, rules)
+
+        assert sig1.signature_hash == sig2.signature_hash
+
+    def test_translated_pads_same_signature(self):
+        """Pads translated by a constant offset produce the same signature."""
+        rules = DesignRules()
+        pads1 = self._make_pads([(0, 0), (10, 0)])
+        pads2 = self._make_pads([(50, 30), (60, 30)])
+
+        sig1 = SubProblemSignature.compute(pads1, rules)
+        sig2 = SubProblemSignature.compute(pads2, rules)
+
+        assert sig1.signature_hash == sig2.signature_hash
+
+    def test_rotated_pads_same_signature(self):
+        """Pads rotated 90 degrees produce the same signature."""
+        rules = DesignRules()
+        # Horizontal pair
+        pads1 = self._make_pads([(0, 0), (10, 0)])
+        # Vertical pair (90-degree rotation around midpoint)
+        pads2 = self._make_pads([(5, -5), (5, 5)])
+
+        sig1 = SubProblemSignature.compute(pads1, rules)
+        sig2 = SubProblemSignature.compute(pads2, rules)
+
+        assert sig1.signature_hash == sig2.signature_hash
+
+    def test_different_geometry_different_signature(self):
+        """Different pad geometry produces different signatures."""
+        rules = DesignRules()
+        pads1 = self._make_pads([(0, 0), (10, 0)])
+        pads2 = self._make_pads([(0, 0), (20, 0)])
+
+        sig1 = SubProblemSignature.compute(pads1, rules)
+        sig2 = SubProblemSignature.compute(pads2, rules)
+
+        assert sig1.signature_hash != sig2.signature_hash
+
+    def test_different_pad_dimensions_different_signature(self):
+        """Different pad sizes produce different signatures."""
+        rules = DesignRules()
+        pads1 = self._make_pads([(0, 0), (10, 0)], width=0.6, height=0.6)
+        pads2 = self._make_pads([(0, 0), (10, 0)], width=1.0, height=1.0)
+
+        sig1 = SubProblemSignature.compute(pads1, rules)
+        sig2 = SubProblemSignature.compute(pads2, rules)
+
+        assert sig1.signature_hash != sig2.signature_hash
+
+    def test_different_rules_different_signature(self):
+        """Different design rules produce different signatures."""
+        rules1 = DesignRules(trace_width=0.2)
+        rules2 = DesignRules(trace_width=0.3)
+        pads = self._make_pads([(0, 0), (10, 0)])
+
+        sig1 = SubProblemSignature.compute(pads, rules1)
+        sig2 = SubProblemSignature.compute(pads, rules2)
+
+        assert sig1.signature_hash != sig2.signature_hash
+
+    def test_empty_pads(self):
+        """Empty pad list produces a deterministic signature."""
+        rules = DesignRules()
+        sig = SubProblemSignature.compute([], rules)
+        assert sig.signature_hash == "empty"
+        assert sig.pad_count == 0
+
+    def test_centroid_computed_correctly(self):
+        """Centroid is at the average position of all pads."""
+        rules = DesignRules()
+        pads = self._make_pads([(0, 0), (10, 0), (10, 10), (0, 10)])
+        sig = SubProblemSignature.compute(pads, rules)
+        assert sig.centroid_x == pytest.approx(5.0)
+        assert sig.centroid_y == pytest.approx(5.0)
+
+    def test_cache_version_change_invalidates_signature(self):
+        """Changing CACHE_VERSION produces a different signature hash."""
+        rules = DesignRules()
+        pads = self._make_pads([(0, 0), (10, 0)])
+
+        sig1 = SubProblemSignature.compute(pads, rules)
+        with mock.patch("kicad_tools.router.cache.CACHE_VERSION", "99.0.0"):
+            sig2 = SubProblemSignature.compute(pads, rules)
+
+        assert sig1.signature_hash != sig2.signature_hash
+
+
+class TestSubProblemTransform:
+    """Tests for route transform functions (Issue #2336)."""
+
+    def test_transform_identity(self):
+        """Zero translation and rotation preserves coordinates."""
+        routes = [Route(
+            net=0, net_name="",
+            segments=[Segment(x1=0, y1=0, x2=5, y2=0, width=0.2,
+                              layer=Layer.F_CU, net=0)],
+            vias=[],
+        )]
+        result = transform_routes(routes, dx=0, dy=0, angle=0,
+                                  target_net=1, target_net_name="N1")
+        assert result[0].segments[0].x1 == pytest.approx(0)
+        assert result[0].segments[0].y1 == pytest.approx(0)
+        assert result[0].segments[0].x2 == pytest.approx(5)
+        assert result[0].net == 1
+        assert result[0].net_name == "N1"
+
+    def test_transform_translation(self):
+        """Translation shifts all coordinates."""
+        routes = [Route(
+            net=0, net_name="",
+            segments=[Segment(x1=0, y1=0, x2=5, y2=0, width=0.2,
+                              layer=Layer.F_CU, net=0)],
+            vias=[Via(x=2.5, y=0, drill=0.3, diameter=0.6,
+                      layers=(Layer.F_CU, Layer.B_CU), net=0)],
+        )]
+        result = transform_routes(routes, dx=10, dy=20, angle=0,
+                                  target_net=5, target_net_name="NET5")
+        seg = result[0].segments[0]
+        assert seg.x1 == pytest.approx(10)
+        assert seg.y1 == pytest.approx(20)
+        assert seg.x2 == pytest.approx(15)
+        via = result[0].vias[0]
+        assert via.x == pytest.approx(12.5)
+        assert via.y == pytest.approx(20)
+
+    def test_transform_rotation_90(self):
+        """90-degree rotation transforms correctly."""
+        routes = [Route(
+            net=0, net_name="",
+            segments=[Segment(x1=5, y1=0, x2=0, y2=0, width=0.2,
+                              layer=Layer.F_CU, net=0)],
+            vias=[],
+        )]
+        result = transform_routes(routes, dx=0, dy=0, angle=math.pi / 2,
+                                  target_net=1, target_net_name="N")
+        seg = result[0].segments[0]
+        assert seg.x1 == pytest.approx(0, abs=1e-3)
+        assert seg.y1 == pytest.approx(5, abs=1e-3)
+        assert seg.x2 == pytest.approx(0, abs=1e-3)
+        assert seg.y2 == pytest.approx(0, abs=1e-3)
+
+    def test_normalize_then_transform_roundtrip(self):
+        """Normalizing then transforming recovers original coordinates."""
+        original = [Route(
+            net=1, net_name="NET1",
+            segments=[Segment(x1=10, y1=20, x2=15, y2=20, width=0.2,
+                              layer=Layer.F_CU, net=1)],
+            vias=[],
+        )]
+
+        pads = [
+            Pad(x=10, y=20, width=0.6, height=0.6, net=1, net_name="NET1",
+                layer=Layer.F_CU),
+            Pad(x=15, y=20, width=0.6, height=0.6, net=1, net_name="NET1",
+                layer=Layer.F_CU),
+        ]
+        sig = SubProblemSignature.compute(pads, DesignRules())
+
+        normalized = normalize_routes_to_origin(
+            original, sig.centroid_x, sig.centroid_y, sig.rotation_angle
+        )
+        restored = transform_routes(
+            normalized,
+            dx=sig.centroid_x,
+            dy=sig.centroid_y,
+            angle=sig.rotation_angle,
+            target_net=1,
+            target_net_name="NET1",
+        )
+
+        orig_seg = original[0].segments[0]
+        rest_seg = restored[0].segments[0]
+        assert rest_seg.x1 == pytest.approx(orig_seg.x1, abs=1e-3)
+        assert rest_seg.y1 == pytest.approx(orig_seg.y1, abs=1e-3)
+        assert rest_seg.x2 == pytest.approx(orig_seg.x2, abs=1e-3)
+        assert rest_seg.y2 == pytest.approx(orig_seg.y2, abs=1e-3)
+
+
+class TestSubProblemCache:
+    """Tests for sub-problem cache store/retrieve (Issue #2336)."""
+
+    @pytest.fixture
+    def temp_cache(self, tmp_path):
+        """Create a temporary cache for testing."""
+        cache_dir = tmp_path / "sub_cache"
+        return RoutingCache(cache_dir=cache_dir, ttl_days=30)
+
+    @pytest.fixture
+    def sample_sig(self):
+        """Create a sample sub-problem signature."""
+        pads = [
+            Pad(x=0, y=0, width=0.6, height=0.6, net=1, net_name="N",
+                layer=Layer.F_CU),
+            Pad(x=10, y=0, width=0.6, height=0.6, net=1, net_name="N",
+                layer=Layer.F_CU),
+        ]
+        return SubProblemSignature.compute(pads, DesignRules())
+
+    @pytest.fixture
+    def sample_normalized_routes(self):
+        """Create sample routes in normalized (centroid-relative) coords."""
+        return [Route(
+            net=0, net_name="",
+            segments=[Segment(x1=-5, y1=0, x2=5, y2=0, width=0.2,
+                              layer=Layer.F_CU, net=0)],
+            vias=[],
+        )]
+
+    def test_put_and_get(self, temp_cache, sample_sig, sample_normalized_routes):
+        """Store and retrieve a sub-problem solution."""
+        temp_cache.put_sub_problem(sample_sig, sample_normalized_routes)
+
+        result = temp_cache.get_sub_problem(sample_sig)
+
+        assert result is not None
+        assert result.signature_hash == sample_sig.signature_hash
+        assert result.segment_count == 1
+        assert result.via_count == 0
+
+    def test_get_miss(self, temp_cache, sample_sig):
+        """Cache miss returns None."""
+        result = temp_cache.get_sub_problem(sample_sig)
+        assert result is None
+
+    def test_hit_count_increments(self, temp_cache, sample_sig,
+                                  sample_normalized_routes):
+        """Hit count increases on each get."""
+        temp_cache.put_sub_problem(sample_sig, sample_normalized_routes)
+
+        r1 = temp_cache.get_sub_problem(sample_sig)
+        assert r1 is not None
+        assert r1.hit_count == 1
+
+        r2 = temp_cache.get_sub_problem(sample_sig)
+        assert r2 is not None
+        assert r2.hit_count == 2
+
+    def test_version_mismatch_miss(self, temp_cache, sample_sig,
+                                   sample_normalized_routes):
+        """Different CACHE_VERSION causes cache miss."""
+        temp_cache.put_sub_problem(sample_sig, sample_normalized_routes)
+
+        with mock.patch("kicad_tools.router.cache.CACHE_VERSION", "99.0.0"):
+            result = temp_cache.get_sub_problem(sample_sig)
+
+        assert result is None
+
+    def test_deserialized_routes_match(self, temp_cache, sample_sig,
+                                      sample_normalized_routes):
+        """Deserialized routes from cache match the originals."""
+        temp_cache.put_sub_problem(sample_sig, sample_normalized_routes)
+
+        result = temp_cache.get_sub_problem(sample_sig)
+        routes = temp_cache.deserialize_routes(result.route_data)
+
+        assert len(routes) == 1
+        seg = routes[0].segments[0]
+        assert seg.x1 == pytest.approx(-5)
+        assert seg.x2 == pytest.approx(5)
+
+    def test_clear_includes_sub_problems(self, temp_cache, sample_sig,
+                                         sample_normalized_routes):
+        """clear() removes sub-problem entries."""
+        temp_cache.put_sub_problem(sample_sig, sample_normalized_routes)
+        count = temp_cache.clear()
+        assert count >= 1
+
+        result = temp_cache.get_sub_problem(sample_sig)
+        assert result is None
+
+    def test_stats_include_sub_problems(self, temp_cache, sample_sig,
+                                        sample_normalized_routes):
+        """stats() includes sub-problem counts."""
+        temp_cache.put_sub_problem(sample_sig, sample_normalized_routes)
+        stats = temp_cache.stats()
+
+        assert stats["sub_problem_count"] == 1
+        assert stats["sub_problem_size_bytes"] > 0
+
+    def test_expired_sub_problem_not_returned(self, tmp_path, sample_sig,
+                                              sample_normalized_routes):
+        """Sub-problems respect TTL expiry."""
+        cache = RoutingCache(cache_dir=tmp_path / "exp_cache", ttl_days=0)
+        cache.put_sub_problem(sample_sig, sample_normalized_routes)
+
+        result = cache.get_sub_problem(sample_sig)
+        assert result is None
+
+
+class TestSchemaMigrationV2toV3:
+    """Tests for database schema migration from v2 to v3 (Issue #2336)."""
+
+    def _create_v2_database(self, db_path: Path) -> None:
+        """Manually create a v2 schema database."""
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE meta (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+
+            CREATE TABLE routing_results (
+                cache_key TEXT PRIMARY KEY,
+                pcb_hash TEXT NOT NULL,
+                rules_hash TEXT NOT NULL,
+                version TEXT NOT NULL,
+                routes_data BLOB NOT NULL,
+                success_count INTEGER NOT NULL,
+                failure_count INTEGER NOT NULL,
+                total_segments INTEGER NOT NULL,
+                total_vias INTEGER NOT NULL,
+                compute_time_ms INTEGER NOT NULL,
+                data_size INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                last_accessed TEXT NOT NULL
+            );
+
+            CREATE TABLE partial_routes (
+                pcb_hash TEXT NOT NULL,
+                net_id INTEGER NOT NULL,
+                net_name TEXT NOT NULL,
+                route_data BLOB NOT NULL,
+                pad_positions_hash TEXT NOT NULL,
+                version TEXT NOT NULL DEFAULT '',
+                data_size INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (pcb_hash, net_id)
+            );
+
+            INSERT INTO meta (key, value) VALUES ('schema_version', '2');
+            INSERT INTO meta (key, value) VALUES ('cache_version', '2.0.0');
+        """)
+        conn.commit()
+        conn.close()
+
+    def test_migration_creates_sub_problem_table(self, tmp_path):
+        """Migration from v2 creates the sub_problem_solutions table."""
+        cache_dir = tmp_path / "migrate_v2_cache"
+        cache_dir.mkdir()
+        db_path = cache_dir / "routing.db"
+        self._create_v2_database(db_path)
+
+        cache = RoutingCache(cache_dir=cache_dir)
+
+        # Verify sub_problem_solutions table exists and is usable
+        pads = [
+            Pad(x=0, y=0, width=0.6, height=0.6, net=1, net_name="N",
+                layer=Layer.F_CU),
+            Pad(x=10, y=0, width=0.6, height=0.6, net=1, net_name="N",
+                layer=Layer.F_CU),
+        ]
+        sig = SubProblemSignature.compute(pads, DesignRules())
+        routes = [Route(
+            net=0, net_name="",
+            segments=[Segment(x1=-5, y1=0, x2=5, y2=0, width=0.2,
+                              layer=Layer.F_CU, net=0)],
+            vias=[],
+        )]
+        cache.put_sub_problem(sig, routes)
+        result = cache.get_sub_problem(sig)
+        assert result is not None
+
+    def test_migration_updates_schema_version_to_3(self, tmp_path):
+        """Migration updates schema_version to 3."""
+        cache_dir = tmp_path / "migrate_v2_ver"
+        cache_dir.mkdir()
+        db_path = cache_dir / "routing.db"
+        self._create_v2_database(db_path)
+
+        RoutingCache(cache_dir=cache_dir)
+
+        conn = sqlite3.connect(str(db_path))
+        version = conn.execute(
+            "SELECT value FROM meta WHERE key = 'schema_version'"
+        ).fetchone()[0]
+        conn.close()
+        assert version == "3"


### PR DESCRIPTION
## Summary

- Add `SubProblemSignature` dataclass that computes position/rotation-invariant SHA-256 signatures from pad geometry, enabling pattern reuse across nets and boards
- Add `sub_problem_solutions` SQLite table with `put_sub_problem()` / `get_sub_problem()` methods, including hit counting, TTL expiry, and schema migration from v2 to v3
- Integrate sub-problem cache lookup in `Autorouter.route_net()`: on cache hit, transform cached solution via affine transform and validate against grid; on miss, store the freshly routed solution
- Add `transform_routes()` and `normalize_routes_to_origin()` utilities for affine coordinate transforms

Closes #2336

## Test plan

- [x] 57 cache tests pass (all existing + 21 new tests)
- [x] Signature invariance: translated pads produce identical hash, rotated pads produce identical hash, different geometry produces different hash
- [x] Transform roundtrip: normalize-then-transform recovers original coordinates
- [x] Cache store/retrieve: put + get roundtrip, hit count increment, version mismatch miss, TTL expiry
- [x] Schema migration: v1->v3 and v2->v3 migrations create sub_problem_solutions table
- [x] Full test suite: 679 passed, 1 skipped, 1 pre-existing failure (unrelated test_build_cmd_errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)