### PR TITLE
feat(library): add composition-based part model with parametric search

### DIFF
--- a/src/kicad_tools/parts/__init__.py
+++ b/src/kicad_tools/parts/__init__.py
@@ -51,6 +51,14 @@ Note:
 """
 
 from .cache import PartsCache, get_default_cache_path
+from .composition import (
+    ComposedPart,
+    ComposedPartStore,
+    Entity,
+    PinDirection,
+    Unit,
+    UnitPin,
+)
 from .importer import (
     ImportOptions,
     ImportResult,
@@ -83,6 +91,13 @@ __all__ = [
     # Cache
     "PartsCache",
     "get_default_cache_path",
+    # Composition
+    "ComposedPart",
+    "ComposedPartStore",
+    "Entity",
+    "PinDirection",
+    "Unit",
+    "UnitPin",
     # Models
     "Part",
     "PartPrice",

--- a/src/kicad_tools/parts/composition.py
+++ b/src/kicad_tools/parts/composition.py
@@ -1,0 +1,673 @@
+"""
+Composition-based part model with parametric search.
+
+Provides a structured, composition-based part model that separates electrical
+definition (Unit/Entity) from physical packaging (Package) and supplier data.
+This allows parts to share definitions across packages and inherit from base
+variants.
+
+Key concepts:
+- **Unit**: A logical group of pins (e.g., one gate of a quad op-amp).
+- **Entity**: One or more Units forming a complete logical device.
+- **Package**: Physical footprint binding with pad-to-pin mapping.
+- **ComposedPart**: Top-level binding of Entity + Package + MPN + parametric data,
+  with optional single-parent inheritance for variant derivation.
+
+Example - Creating a composed part::
+
+    from kicad_tools.parts.composition import (
+        ComposedPart, Entity, PinDirection, Unit, UnitPin,
+    )
+
+    # Define a simple resistor unit with two pins
+    resistor_unit = Unit(
+        id="resistor",
+        name="Resistor",
+        pins=[
+            UnitPin(name="1", number="1", direction=PinDirection.PASSIVE),
+            UnitPin(name="2", number="2", direction=PinDirection.PASSIVE),
+        ],
+    )
+
+    # Wrap in an entity (single gate)
+    resistor_entity = Entity(
+        id="resistor",
+        name="Resistor",
+        units=[resistor_unit],
+    )
+
+    # Create a base 0402 resistor
+    base_resistor = ComposedPart(
+        id="resistor-0402-base",
+        entity=resistor_entity,
+        package="0402",
+        category="resistor",
+    )
+
+    # Derive a specific variant via inheritance
+    r10k = ComposedPart(
+        id="resistor-0402-10k-1pct",
+        entity=resistor_entity,
+        package="0402",
+        category="resistor",
+        mpn="RC0402FR-0710KL",
+        manufacturer="Yageo",
+        base_part=base_resistor,
+        params={"resistance": "10000", "tolerance": "1%"},
+    )
+
+Example - Parametric search::
+
+    from kicad_tools.parts.composition import ComposedPartStore
+
+    store = ComposedPartStore(db_path)
+    store.save(r10k)
+    results = store.find_parts(category="resistor", package="0402",
+                               params={"resistance": "10000"})
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Pin / Unit / Entity models
+# ---------------------------------------------------------------------------
+
+class PinDirection(Enum):
+    """Electrical direction of a pin."""
+
+    INPUT = "input"
+    OUTPUT = "output"
+    BIDIRECTIONAL = "bidirectional"
+    PASSIVE = "passive"
+    POWER_IN = "power_in"
+    POWER_OUT = "power_out"
+    OPEN_COLLECTOR = "open_collector"
+    OPEN_EMITTER = "open_emitter"
+    UNSPECIFIED = "unspecified"
+
+
+@dataclass
+class UnitPin:
+    """
+    A single pin within a Unit.
+
+    Attributes:
+        name: Human-readable pin name (e.g., "VCC", "IN+").
+        number: Pin number as it appears on the physical part (e.g., "1", "A3").
+        direction: Electrical direction.
+        alternate_names: Optional alternative names for the pin.
+    """
+
+    name: str
+    number: str
+    direction: PinDirection = PinDirection.UNSPECIFIED
+    alternate_names: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Unit:
+    """
+    A logical group of pins that forms one functional block.
+
+    For a quad op-amp this would be one amplifier section.  A device that
+    is not sub-divided into gates has a single Unit containing all pins.
+
+    Attributes:
+        id: Stable identifier (e.g., "opamp-gate").
+        name: Human-readable label.
+        pins: Ordered list of pins belonging to this unit.
+    """
+
+    id: str
+    name: str
+    pins: list[UnitPin] = field(default_factory=list)
+
+    @property
+    def pin_count(self) -> int:
+        """Number of pins in this unit."""
+        return len(self.pins)
+
+    def get_pin(self, number: str) -> UnitPin | None:
+        """Look up a pin by its number."""
+        for pin in self.pins:
+            if pin.number == number:
+                return pin
+        return None
+
+    def get_pins_by_name(self, name: str) -> list[UnitPin]:
+        """Get all pins matching *name*."""
+        return [p for p in self.pins if p.name == name]
+
+
+@dataclass
+class Entity:
+    """
+    A complete logical device composed of one or more Units (gates).
+
+    Attributes:
+        id: Stable identifier.
+        name: Human-readable label (e.g., "LM324 Quad Op-Amp").
+        units: Ordered list of units (gates) in this entity.
+    """
+
+    id: str
+    name: str
+    units: list[Unit] = field(default_factory=list)
+
+    @property
+    def total_pins(self) -> int:
+        """Total pins across all units."""
+        return sum(u.pin_count for u in self.units)
+
+
+# ---------------------------------------------------------------------------
+# ComposedPart (top-level binding)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ComposedPart:
+    """
+    A fully-specified part binding Entity + Package + supplier data.
+
+    Supports single-parent inheritance via ``base_part``.  When
+    ``resolve()`` is called the returned dict merges fields from the
+    inheritance chain with the most-derived value winning.
+
+    Attributes:
+        id: Unique identifier for this part variant.
+        entity: The logical device definition.
+        package: Physical package name (e.g., "0402", "SOIC-8").
+        category: Part category string (e.g., "resistor", "capacitor").
+        mpn: Manufacturer part number.
+        manufacturer: Manufacturer name.
+        description: Human-readable description.
+        base_part: Optional parent part for field inheritance.
+        params: Parametric specifications as key-value pairs.
+            Keys should be lowercase, e.g. ``resistance``, ``capacitance``,
+            ``voltage``, ``tolerance``.
+        tags: Flat list of tags for classification / search.
+        lcsc_part: Optional LCSC part number linking to supplier data.
+        datasheet_url: URL to part datasheet.
+        pad_to_pin: Mapping from physical pad name to logical pin number.
+        created_at: Timestamp when this record was created.
+    """
+
+    id: str
+    entity: Entity
+    package: str = ""
+    category: str = ""
+    mpn: str = ""
+    manufacturer: str = ""
+    description: str = ""
+    base_part: ComposedPart | None = None
+    params: dict[str, str] = field(default_factory=dict)
+    tags: list[str] = field(default_factory=list)
+    lcsc_part: str = ""
+    datasheet_url: str = ""
+    pad_to_pin: dict[str, str] = field(default_factory=dict)
+    created_at: datetime | None = None
+
+    # ------------------------------------------------------------------
+    # Inheritance helpers
+    # ------------------------------------------------------------------
+
+    def _inheritance_chain(self) -> list[ComposedPart]:
+        """
+        Walk the inheritance chain from most-derived to base.
+
+        Raises ``ValueError`` on circular inheritance.
+        """
+        chain: list[ComposedPart] = []
+        seen: set[str] = set()
+        current: ComposedPart | None = self
+        while current is not None:
+            if current.id in seen:
+                raise ValueError(
+                    f"Circular inheritance detected: {current.id} "
+                    f"appears twice in the chain"
+                )
+            seen.add(current.id)
+            chain.append(current)
+            current = current.base_part
+        return chain
+
+    def resolve(self) -> dict[str, object]:
+        """
+        Resolve the inheritance chain and return merged fields.
+
+        Fields from the most-derived part override those from ancestors.
+        ``params`` dicts are merged (most-derived wins per key).
+        ``tags`` lists are unioned.
+
+        Returns:
+            A flat dict of resolved field values.
+        """
+        chain = self._inheritance_chain()
+
+        merged_params: dict[str, str] = {}
+        merged_tags: set[str] = set()
+
+        # Start with base (last in chain) and overlay toward self
+        result: dict[str, object] = {}
+        for part in reversed(chain):
+            for attr in (
+                "id", "package", "category", "mpn", "manufacturer",
+                "description", "lcsc_part", "datasheet_url",
+            ):
+                val = getattr(part, attr)
+                if val:
+                    result[attr] = val
+            merged_params.update(part.params)
+            merged_tags.update(part.tags)
+
+        result["params"] = dict(merged_params)
+        result["tags"] = sorted(merged_tags)
+        # Entity always comes from self (not inherited)
+        result["entity"] = self.entity
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers (Unit / Entity / ComposedPart <-> dict/JSON)
+# ---------------------------------------------------------------------------
+
+def _pin_to_dict(pin: UnitPin) -> dict:
+    d: dict[str, object] = {
+        "name": pin.name,
+        "number": pin.number,
+        "direction": pin.direction.value,
+    }
+    if pin.alternate_names:
+        d["alternate_names"] = pin.alternate_names
+    return d
+
+
+def _pin_from_dict(d: dict) -> UnitPin:
+    return UnitPin(
+        name=d["name"],
+        number=d["number"],
+        direction=PinDirection(d.get("direction", "unspecified")),
+        alternate_names=d.get("alternate_names", []),
+    )
+
+
+def _unit_to_dict(unit: Unit) -> dict:
+    return {
+        "id": unit.id,
+        "name": unit.name,
+        "pins": [_pin_to_dict(p) for p in unit.pins],
+    }
+
+
+def _unit_from_dict(d: dict) -> Unit:
+    return Unit(
+        id=d["id"],
+        name=d["name"],
+        pins=[_pin_from_dict(p) for p in d.get("pins", [])],
+    )
+
+
+def _entity_to_dict(entity: Entity) -> dict:
+    return {
+        "id": entity.id,
+        "name": entity.name,
+        "units": [_unit_to_dict(u) for u in entity.units],
+    }
+
+
+def _entity_from_dict(d: dict) -> Entity:
+    return Entity(
+        id=d["id"],
+        name=d["name"],
+        units=[_unit_from_dict(u) for u in d.get("units", [])],
+    )
+
+
+# ---------------------------------------------------------------------------
+# SQLite-backed store with parametric search
+# ---------------------------------------------------------------------------
+
+class ComposedPartStore:
+    """
+    SQLite-backed store for composed parts with parametric search.
+
+    Schema uses three tables:
+    - ``composed_parts`` -- one row per part
+    - ``composed_part_params`` -- key/value parametric data (indexed)
+    - ``composed_part_tags`` -- flat tag list (indexed)
+
+    Example::
+
+        store = ComposedPartStore(Path("/tmp/parts.db"))
+        store.save(my_part)
+
+        hits = store.find_parts(category="resistor",
+                                package="0402",
+                                params={"resistance": "10000"})
+    """
+
+    SCHEMA_VERSION = 1
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # DB helpers
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS composed_meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS composed_parts (
+                    id TEXT PRIMARY KEY,
+                    entity_json TEXT NOT NULL,
+                    package TEXT NOT NULL DEFAULT '',
+                    category TEXT NOT NULL DEFAULT '',
+                    mpn TEXT NOT NULL DEFAULT '',
+                    manufacturer TEXT NOT NULL DEFAULT '',
+                    description TEXT NOT NULL DEFAULT '',
+                    base_part_id TEXT,
+                    lcsc_part TEXT NOT NULL DEFAULT '',
+                    datasheet_url TEXT NOT NULL DEFAULT '',
+                    pad_to_pin_json TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_cp_category
+                    ON composed_parts(category);
+                CREATE INDEX IF NOT EXISTS idx_cp_package
+                    ON composed_parts(package);
+                CREATE INDEX IF NOT EXISTS idx_cp_mpn
+                    ON composed_parts(mpn);
+                CREATE INDEX IF NOT EXISTS idx_cp_manufacturer
+                    ON composed_parts(manufacturer);
+                CREATE INDEX IF NOT EXISTS idx_cp_lcsc
+                    ON composed_parts(lcsc_part);
+
+                CREATE TABLE IF NOT EXISTS composed_part_params (
+                    part_id TEXT NOT NULL,
+                    key TEXT NOT NULL,
+                    value TEXT NOT NULL,
+                    PRIMARY KEY (part_id, key),
+                    FOREIGN KEY (part_id)
+                        REFERENCES composed_parts(id) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_cpp_key_value
+                    ON composed_part_params(key, value);
+
+                CREATE TABLE IF NOT EXISTS composed_part_tags (
+                    part_id TEXT NOT NULL,
+                    tag TEXT NOT NULL,
+                    PRIMARY KEY (part_id, tag),
+                    FOREIGN KEY (part_id)
+                        REFERENCES composed_parts(id) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_cpt_tag
+                    ON composed_part_tags(tag);
+            """)
+
+            cur = conn.execute(
+                "SELECT value FROM composed_meta WHERE key = 'schema_version'"
+            )
+            row = cur.fetchone()
+            if row is None:
+                conn.execute(
+                    "INSERT INTO composed_meta (key, value) VALUES ('schema_version', ?)",
+                    (str(self.SCHEMA_VERSION),),
+                )
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def save(self, part: ComposedPart) -> None:
+        """Insert or replace a composed part and its params/tags."""
+        with self._connect() as conn:
+            conn.execute("PRAGMA foreign_keys = ON")
+            # Delete existing params/tags if replacing
+            conn.execute("DELETE FROM composed_part_params WHERE part_id = ?", (part.id,))
+            conn.execute("DELETE FROM composed_part_tags WHERE part_id = ?", (part.id,))
+
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO composed_parts (
+                    id, entity_json, package, category, mpn, manufacturer,
+                    description, base_part_id, lcsc_part, datasheet_url,
+                    pad_to_pin_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    part.id,
+                    json.dumps(_entity_to_dict(part.entity)),
+                    part.package,
+                    part.category,
+                    part.mpn,
+                    part.manufacturer,
+                    part.description,
+                    part.base_part.id if part.base_part else None,
+                    part.lcsc_part,
+                    part.datasheet_url,
+                    json.dumps(part.pad_to_pin),
+                    (part.created_at or datetime.now()).isoformat(),
+                ),
+            )
+
+            if part.params:
+                conn.executemany(
+                    "INSERT INTO composed_part_params (part_id, key, value) VALUES (?, ?, ?)",
+                    [(part.id, k, v) for k, v in part.params.items()],
+                )
+
+            if part.tags:
+                conn.executemany(
+                    "INSERT INTO composed_part_tags (part_id, tag) VALUES (?, ?)",
+                    [(part.id, t) for t in part.tags],
+                )
+
+    def get(self, part_id: str) -> ComposedPart | None:
+        """Retrieve a single composed part by ID."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM composed_parts WHERE id = ?", (part_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            return self._row_to_part(conn, row)
+
+    def delete(self, part_id: str) -> bool:
+        """Delete a composed part. Returns True if it existed."""
+        with self._connect() as conn:
+            conn.execute("PRAGMA foreign_keys = ON")
+            conn.execute("DELETE FROM composed_part_params WHERE part_id = ?", (part_id,))
+            conn.execute("DELETE FROM composed_part_tags WHERE part_id = ?", (part_id,))
+            cur = conn.execute("DELETE FROM composed_parts WHERE id = ?", (part_id,))
+            return cur.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Parametric search
+    # ------------------------------------------------------------------
+
+    def find_parts(
+        self,
+        *,
+        category: str | None = None,
+        package: str | None = None,
+        manufacturer: str | None = None,
+        mpn: str | None = None,
+        tags: list[str] | None = None,
+        params: dict[str, str] | None = None,
+        limit: int = 100,
+    ) -> list[ComposedPart]:
+        """
+        Search for composed parts by parametric criteria.
+
+        All supplied filters are ANDed together.
+
+        Args:
+            category: Exact category match (e.g., "resistor").
+            package: Exact package match (e.g., "0402").
+            manufacturer: Exact manufacturer match.
+            mpn: Exact MPN match.
+            tags: Parts must have **all** listed tags.
+            params: Parts must have **all** listed param key=value pairs.
+            limit: Maximum results to return.
+
+        Returns:
+            List of matching ``ComposedPart`` objects.
+        """
+        clauses: list[str] = []
+        bindings: list[object] = []
+
+        if category is not None:
+            clauses.append("cp.category = ?")
+            bindings.append(category)
+        if package is not None:
+            clauses.append("cp.package = ?")
+            bindings.append(package)
+        if manufacturer is not None:
+            clauses.append("cp.manufacturer = ?")
+            bindings.append(manufacturer)
+        if mpn is not None:
+            clauses.append("cp.mpn = ?")
+            bindings.append(mpn)
+
+        # Tag filtering: require all tags present
+        if tags:
+            for tag in tags:
+                clauses.append(
+                    "EXISTS (SELECT 1 FROM composed_part_tags t "
+                    "WHERE t.part_id = cp.id AND t.tag = ?)"
+                )
+                bindings.append(tag)
+
+        # Param filtering: require all key=value pairs
+        if params:
+            for key, value in params.items():
+                clauses.append(
+                    "EXISTS (SELECT 1 FROM composed_part_params p "
+                    "WHERE p.part_id = cp.id AND p.key = ? AND p.value = ?)"
+                )
+                bindings.append(key)
+                bindings.append(value)
+
+        where = " AND ".join(clauses) if clauses else "1=1"
+        query = f"SELECT * FROM composed_parts cp WHERE {where} LIMIT ?"
+        bindings.append(limit)
+
+        with self._connect() as conn:
+            rows = conn.execute(query, bindings).fetchall()
+            return [self._row_to_part(conn, r) for r in rows]
+
+    def find_by_tag(self, tag: str) -> list[ComposedPart]:
+        """Convenience: find all parts with a specific tag."""
+        return self.find_parts(tags=[tag])
+
+    # ------------------------------------------------------------------
+    # Stats
+    # ------------------------------------------------------------------
+
+    def stats(self) -> dict[str, object]:
+        """Return basic statistics about the store."""
+        with self._connect() as conn:
+            total = conn.execute("SELECT COUNT(*) FROM composed_parts").fetchone()[0]
+            categories: dict[str, int] = {}
+            for row in conn.execute(
+                "SELECT category, COUNT(*) FROM composed_parts GROUP BY category"
+            ):
+                categories[row[0]] = row[1]
+            tag_count = conn.execute(
+                "SELECT COUNT(DISTINCT tag) FROM composed_part_tags"
+            ).fetchone()[0]
+        return {
+            "total": total,
+            "categories": categories,
+            "distinct_tags": tag_count,
+            "db_path": str(self.db_path),
+        }
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _row_to_part(self, conn: sqlite3.Connection, row: sqlite3.Row) -> ComposedPart:
+        """Convert a DB row (plus params/tags sub-queries) to ComposedPart."""
+        part_id: str = row["id"]
+
+        # Params
+        params: dict[str, str] = {}
+        for pr in conn.execute(
+            "SELECT key, value FROM composed_part_params WHERE part_id = ?",
+            (part_id,),
+        ):
+            params[pr["key"]] = pr["value"]
+
+        # Tags
+        tags: list[str] = []
+        for tr in conn.execute(
+            "SELECT tag FROM composed_part_tags WHERE part_id = ?",
+            (part_id,),
+        ):
+            tags.append(tr["tag"])
+
+        # Entity
+        entity = _entity_from_dict(json.loads(row["entity_json"]))
+
+        # Base part (lazy -- load only the ID, not recursively)
+        base_part: ComposedPart | None = None
+        if row["base_part_id"]:
+            base_row = conn.execute(
+                "SELECT * FROM composed_parts WHERE id = ?",
+                (row["base_part_id"],),
+            ).fetchone()
+            if base_row:
+                base_part = self._row_to_part(conn, base_row)
+
+        created_at = None
+        if row["created_at"]:
+            created_at = datetime.fromisoformat(row["created_at"])
+
+        return ComposedPart(
+            id=part_id,
+            entity=entity,
+            package=row["package"] or "",
+            category=row["category"] or "",
+            mpn=row["mpn"] or "",
+            manufacturer=row["manufacturer"] or "",
+            description=row["description"] or "",
+            base_part=base_part,
+            params=params,
+            tags=tags,
+            lcsc_part=row["lcsc_part"] or "",
+            datasheet_url=row["datasheet_url"] or "",
+            pad_to_pin=json.loads(row["pad_to_pin_json"]) if row["pad_to_pin_json"] else {},
+            created_at=created_at,
+        )

--- a/src/kicad_tools/parts/models.py
+++ b/src/kicad_tools/parts/models.py
@@ -123,6 +123,82 @@ class Part:
             return self.prices[0].unit_price if self.prices else None
         return max(applicable, key=lambda p: p.quantity).unit_price
 
+    def to_composed(self) -> "ComposedPart":
+        """
+        Project this flat supplier ``Part`` into a ``ComposedPart``.
+
+        Creates a minimal Entity with two passive pins (suitable for
+        two-terminal passives).  For ICs / multi-pin parts the caller
+        should replace the entity with a richer definition.
+
+        Returns:
+            A ``ComposedPart`` populated from this part's fields.
+        """
+        from .composition import (
+            ComposedPart,
+            Entity,
+            PinDirection,
+            Unit,
+            UnitPin,
+        )
+
+        # Build a generic two-pin unit as a default
+        unit = Unit(
+            id=f"{self.lcsc_part}-unit",
+            name=self.description or self.lcsc_part,
+            pins=[
+                UnitPin(name="1", number="1", direction=PinDirection.PASSIVE),
+                UnitPin(name="2", number="2", direction=PinDirection.PASSIVE),
+            ],
+        )
+        entity = Entity(
+            id=f"{self.lcsc_part}-entity",
+            name=self.description or self.lcsc_part,
+            units=[unit],
+        )
+
+        # Map Part fields into parametric dict
+        params: dict[str, str] = {}
+        if self.value:
+            params["value"] = self.value
+        if self.tolerance:
+            params["tolerance"] = self.tolerance
+        if self.voltage_rating:
+            params["voltage"] = self.voltage_rating
+        if self.power_rating:
+            params["power"] = self.power_rating
+        if self.temperature_range:
+            params["temperature_range"] = self.temperature_range
+        # Include any extra specs
+        params.update(self.specs)
+
+        tags: list[str] = []
+        if self.category != PartCategory.OTHER:
+            tags.append(self.category.value)
+        if self.is_basic:
+            tags.append("jlcpcb-basic")
+        if self.is_preferred:
+            tags.append("jlcpcb-preferred")
+        if self.package_type == PackageType.SMD:
+            tags.append("smd")
+        elif self.package_type == PackageType.THROUGH_HOLE:
+            tags.append("through-hole")
+
+        return ComposedPart(
+            id=self.lcsc_part,
+            entity=entity,
+            package=self.package,
+            category=self.category.value,
+            mpn=self.mfr_part,
+            manufacturer=self.manufacturer,
+            description=self.description,
+            params=params,
+            tags=tags,
+            lcsc_part=self.lcsc_part,
+            datasheet_url=self.datasheet_url,
+            created_at=self.fetched_at,
+        )
+
     def __str__(self) -> str:
         return f"{self.lcsc_part}: {self.description}"
 

--- a/tests/test_parametric_search.py
+++ b/tests/test_parametric_search.py
@@ -1,0 +1,426 @@
+"""Tests for ComposedPartStore parametric search."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from kicad_tools.parts.composition import (
+    ComposedPart,
+    ComposedPartStore,
+    Entity,
+    PinDirection,
+    Unit,
+    UnitPin,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def resistor_entity() -> Entity:
+    unit = Unit(
+        id="passive",
+        name="Passive",
+        pins=[
+            UnitPin(name="1", number="1", direction=PinDirection.PASSIVE),
+            UnitPin(name="2", number="2", direction=PinDirection.PASSIVE),
+        ],
+    )
+    return Entity(id="resistor", name="Resistor", units=[unit])
+
+
+@pytest.fixture
+def capacitor_entity() -> Entity:
+    unit = Unit(
+        id="passive",
+        name="Passive",
+        pins=[
+            UnitPin(name="1", number="1", direction=PinDirection.PASSIVE),
+            UnitPin(name="2", number="2", direction=PinDirection.PASSIVE),
+        ],
+    )
+    return Entity(id="capacitor", name="Capacitor", units=[unit])
+
+
+@pytest.fixture
+def store(tmp_path) -> ComposedPartStore:
+    return ComposedPartStore(tmp_path / "composed.db")
+
+
+@pytest.fixture
+def populated_store(
+    store: ComposedPartStore,
+    resistor_entity: Entity,
+    capacitor_entity: Entity,
+) -> ComposedPartStore:
+    """Store with a handful of test parts."""
+    parts = [
+        ComposedPart(
+            id="r-10k-0402",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            mpn="RC0402FR-0710KL",
+            manufacturer="Yageo",
+            params={"resistance": "10000", "tolerance": "1%"},
+            tags=["smd", "basic"],
+        ),
+        ComposedPart(
+            id="r-10k-0603",
+            entity=resistor_entity,
+            package="0603",
+            category="resistor",
+            mpn="RC0603FR-0710KL",
+            manufacturer="Yageo",
+            params={"resistance": "10000", "tolerance": "1%"},
+            tags=["smd", "basic"],
+        ),
+        ComposedPart(
+            id="r-4k7-0402",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            mpn="RC0402FR-074K7L",
+            manufacturer="Yageo",
+            params={"resistance": "4700", "tolerance": "1%"},
+            tags=["smd"],
+        ),
+        ComposedPart(
+            id="c-100n-0402",
+            entity=capacitor_entity,
+            package="0402",
+            category="capacitor",
+            mpn="CL05B104KO5NNNC",
+            manufacturer="Samsung",
+            params={"capacitance": "100nF", "voltage": "16V"},
+            tags=["smd", "basic", "mlcc"],
+        ),
+        ComposedPart(
+            id="c-10u-0805",
+            entity=capacitor_entity,
+            package="0805",
+            category="capacitor",
+            mpn="CL21A106KAYNNNE",
+            manufacturer="Samsung",
+            params={"capacitance": "10uF", "voltage": "25V"},
+            tags=["smd", "mlcc"],
+        ),
+    ]
+    for p in parts:
+        store.save(p)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Basic CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestComposedPartStoreCRUD:
+    def test_save_and_get(self, store: ComposedPartStore, resistor_entity: Entity):
+        part = ComposedPart(
+            id="r1",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            params={"resistance": "10000"},
+            tags=["smd"],
+        )
+        store.save(part)
+        retrieved = store.get("r1")
+
+        assert retrieved is not None
+        assert retrieved.id == "r1"
+        assert retrieved.package == "0402"
+        assert retrieved.category == "resistor"
+        assert retrieved.params == {"resistance": "10000"}
+        assert retrieved.tags == ["smd"]
+        assert retrieved.entity.id == "resistor"
+        assert retrieved.entity.total_pins == 2
+
+    def test_get_not_found(self, store: ComposedPartStore):
+        assert store.get("nonexistent") is None
+
+    def test_save_replaces(self, store: ComposedPartStore, resistor_entity: Entity):
+        part = ComposedPart(
+            id="r1",
+            entity=resistor_entity,
+            params={"resistance": "10000"},
+            tags=["old"],
+        )
+        store.save(part)
+
+        # Update
+        part.params = {"resistance": "4700"}
+        part.tags = ["new"]
+        store.save(part)
+
+        retrieved = store.get("r1")
+        assert retrieved is not None
+        assert retrieved.params == {"resistance": "4700"}
+        assert retrieved.tags == ["new"]
+
+    def test_delete(self, store: ComposedPartStore, resistor_entity: Entity):
+        part = ComposedPart(id="r1", entity=resistor_entity)
+        store.save(part)
+        assert store.delete("r1") is True
+        assert store.get("r1") is None
+
+    def test_delete_not_found(self, store: ComposedPartStore):
+        assert store.delete("nonexistent") is False
+
+    def test_save_with_base_part(
+        self, store: ComposedPartStore, resistor_entity: Entity
+    ):
+        base = ComposedPart(
+            id="base",
+            entity=resistor_entity,
+            package="0402",
+            manufacturer="Yageo",
+        )
+        store.save(base)
+
+        variant = ComposedPart(
+            id="variant",
+            entity=resistor_entity,
+            package="0402",
+            base_part=base,
+            mpn="RC0402FR-0710KL",
+        )
+        store.save(variant)
+
+        retrieved = store.get("variant")
+        assert retrieved is not None
+        assert retrieved.base_part is not None
+        assert retrieved.base_part.id == "base"
+        assert retrieved.base_part.manufacturer == "Yageo"
+
+    def test_save_with_pad_to_pin(
+        self, store: ComposedPartStore, resistor_entity: Entity
+    ):
+        part = ComposedPart(
+            id="mapped",
+            entity=resistor_entity,
+            pad_to_pin={"1": "1", "2": "2"},
+        )
+        store.save(part)
+        retrieved = store.get("mapped")
+        assert retrieved is not None
+        assert retrieved.pad_to_pin == {"1": "1", "2": "2"}
+
+    def test_created_at_preserved(
+        self, store: ComposedPartStore, resistor_entity: Entity
+    ):
+        ts = datetime(2026, 1, 15, 12, 0, 0)
+        part = ComposedPart(id="ts-test", entity=resistor_entity, created_at=ts)
+        store.save(part)
+        retrieved = store.get("ts-test")
+        assert retrieved is not None
+        assert retrieved.created_at == ts
+
+
+# ---------------------------------------------------------------------------
+# Parametric search
+# ---------------------------------------------------------------------------
+
+
+class TestParametricSearch:
+    def test_find_by_category(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(category="resistor")
+        assert len(results) == 3
+        assert all(r.category == "resistor" for r in results)
+
+    def test_find_by_package(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(package="0402")
+        assert len(results) == 3  # 2 resistors + 1 cap
+
+    def test_find_by_category_and_package(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(category="resistor", package="0402")
+        assert len(results) == 2
+
+    def test_find_by_manufacturer(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(manufacturer="Samsung")
+        assert len(results) == 2
+
+    def test_find_by_mpn(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(mpn="RC0402FR-0710KL")
+        assert len(results) == 1
+        assert results[0].id == "r-10k-0402"
+
+    def test_find_by_param(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(params={"resistance": "10000"})
+        assert len(results) == 2  # 0402 and 0603 variants
+
+    def test_find_by_multiple_params(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(
+            params={"resistance": "10000", "tolerance": "1%"}
+        )
+        assert len(results) == 2
+
+    def test_find_by_tag(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(tags=["basic"])
+        assert len(results) == 3  # 2 basic resistors + 1 basic cap
+
+    def test_find_by_multiple_tags(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(tags=["smd", "mlcc"])
+        assert len(results) == 2  # both caps
+
+    def test_find_combined_filters(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(
+            category="resistor",
+            package="0402",
+            params={"resistance": "10000"},
+            tags=["basic"],
+        )
+        assert len(results) == 1
+        assert results[0].id == "r-10k-0402"
+
+    def test_find_no_results(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(category="inductor")
+        assert results == []
+
+    def test_find_no_filters(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts()
+        assert len(results) == 5  # all parts
+
+    def test_find_with_limit(self, populated_store: ComposedPartStore):
+        results = populated_store.find_parts(limit=2)
+        assert len(results) == 2
+
+    def test_find_by_tag_convenience(self, populated_store: ComposedPartStore):
+        results = populated_store.find_by_tag("mlcc")
+        assert len(results) == 2
+
+    def test_empty_store_returns_empty(self, store: ComposedPartStore):
+        results = store.find_parts(category="resistor")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+
+class TestComposedPartStoreStats:
+    def test_stats_empty(self, store: ComposedPartStore):
+        s = store.stats()
+        assert s["total"] == 0
+        assert s["categories"] == {}
+        assert s["distinct_tags"] == 0
+
+    def test_stats_populated(self, populated_store: ComposedPartStore):
+        s = populated_store.stats()
+        assert s["total"] == 5
+        assert s["categories"]["resistor"] == 3
+        assert s["categories"]["capacitor"] == 2
+        assert s["distinct_tags"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Part.to_composed round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestPartToComposed:
+    def test_round_trip(self):
+        from kicad_tools.parts.models import PackageType, Part, PartCategory
+
+        part = Part(
+            lcsc_part="C123456",
+            mfr_part="RC0402FR-0710KL",
+            manufacturer="Yageo",
+            description="10K 1% 0402 Resistor",
+            category=PartCategory.RESISTOR,
+            package="0402",
+            package_type=PackageType.SMD,
+            value="10k",
+            tolerance="1%",
+            voltage_rating="50V",
+            is_basic=True,
+            datasheet_url="https://example.com/ds.pdf",
+        )
+        composed = part.to_composed()
+
+        assert composed.id == "C123456"
+        assert composed.mpn == "RC0402FR-0710KL"
+        assert composed.manufacturer == "Yageo"
+        assert composed.package == "0402"
+        assert composed.category == "resistor"
+        assert composed.lcsc_part == "C123456"
+        assert composed.datasheet_url == "https://example.com/ds.pdf"
+        assert composed.params["value"] == "10k"
+        assert composed.params["tolerance"] == "1%"
+        assert composed.params["voltage"] == "50V"
+        assert "smd" in composed.tags
+        assert "jlcpcb-basic" in composed.tags
+        assert "resistor" in composed.tags
+        # Entity has default two-pin passive
+        assert composed.entity.total_pins == 2
+
+    def test_round_trip_minimal(self):
+        from kicad_tools.parts.models import Part
+
+        part = Part(lcsc_part="C1")
+        composed = part.to_composed()
+        assert composed.id == "C1"
+        assert composed.params == {}
+        assert composed.entity.total_pins == 2
+
+    def test_round_trip_through_hole(self):
+        from kicad_tools.parts.models import PackageType, Part
+
+        part = Part(
+            lcsc_part="C999",
+            package_type=PackageType.THROUGH_HOLE,
+        )
+        composed = part.to_composed()
+        assert "through-hole" in composed.tags
+
+    def test_round_trip_preferred(self):
+        from kicad_tools.parts.models import Part
+
+        part = Part(lcsc_part="C888", is_preferred=True)
+        composed = part.to_composed()
+        assert "jlcpcb-preferred" in composed.tags
+
+    def test_round_trip_with_specs(self):
+        from kicad_tools.parts.models import Part
+
+        part = Part(
+            lcsc_part="C777",
+            value="100nF",
+            specs={"dielectric": "X7R", "esr": "low"},
+        )
+        composed = part.to_composed()
+        assert composed.params["value"] == "100nF"
+        assert composed.params["dielectric"] == "X7R"
+        assert composed.params["esr"] == "low"
+
+    def test_to_composed_then_store(self, tmp_path):
+        """Verify a Part can be projected and stored in ComposedPartStore."""
+        from kicad_tools.parts.models import PackageType, Part, PartCategory
+
+        part = Part(
+            lcsc_part="C123",
+            mfr_part="TEST",
+            manufacturer="TestMfr",
+            category=PartCategory.CAPACITOR,
+            package="0402",
+            package_type=PackageType.SMD,
+            value="100nF",
+        )
+        composed = part.to_composed()
+
+        store = ComposedPartStore(tmp_path / "test.db")
+        store.save(composed)
+
+        # Search for it
+        results = store.find_parts(category="capacitor", package="0402")
+        assert len(results) == 1
+        assert results[0].id == "C123"
+        assert results[0].params["value"] == "100nF"

--- a/tests/test_part_composition.py
+++ b/tests/test_part_composition.py
@@ -1,0 +1,319 @@
+"""Tests for composition-based part model (Unit, Entity, ComposedPart)."""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.parts.composition import (
+    ComposedPart,
+    Entity,
+    PinDirection,
+    Unit,
+    UnitPin,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def passive_unit() -> Unit:
+    """A two-pin passive unit (e.g., resistor)."""
+    return Unit(
+        id="passive",
+        name="Passive",
+        pins=[
+            UnitPin(name="1", number="1", direction=PinDirection.PASSIVE),
+            UnitPin(name="2", number="2", direction=PinDirection.PASSIVE),
+        ],
+    )
+
+
+@pytest.fixture
+def opamp_unit() -> Unit:
+    """A single op-amp gate unit."""
+    return Unit(
+        id="opamp-gate",
+        name="Op-Amp Gate",
+        pins=[
+            UnitPin(name="IN+", number="3", direction=PinDirection.INPUT),
+            UnitPin(name="IN-", number="2", direction=PinDirection.INPUT),
+            UnitPin(name="OUT", number="1", direction=PinDirection.OUTPUT),
+        ],
+    )
+
+
+@pytest.fixture
+def power_unit() -> Unit:
+    """A power-supply unit."""
+    return Unit(
+        id="power",
+        name="Power",
+        pins=[
+            UnitPin(name="VCC", number="8", direction=PinDirection.POWER_IN),
+            UnitPin(name="GND", number="4", direction=PinDirection.POWER_IN),
+        ],
+    )
+
+
+@pytest.fixture
+def resistor_entity(passive_unit: Unit) -> Entity:
+    return Entity(id="resistor", name="Resistor", units=[passive_unit])
+
+
+@pytest.fixture
+def quad_opamp_entity(opamp_unit: Unit, power_unit: Unit) -> Entity:
+    """Four identical op-amp gates plus one power unit."""
+    gates = [
+        Unit(id=f"opamp-gate-{i}", name=f"Gate {i}", pins=list(opamp_unit.pins))
+        for i in range(1, 5)
+    ]
+    return Entity(id="lm324", name="LM324 Quad Op-Amp", units=[*gates, power_unit])
+
+
+# ---------------------------------------------------------------------------
+# UnitPin tests
+# ---------------------------------------------------------------------------
+
+
+class TestUnitPin:
+    def test_defaults(self):
+        pin = UnitPin(name="A", number="1")
+        assert pin.direction == PinDirection.UNSPECIFIED
+        assert pin.alternate_names == []
+
+    def test_alternate_names(self):
+        pin = UnitPin(name="SDA", number="5", alternate_names=["I2C_DATA"])
+        assert "I2C_DATA" in pin.alternate_names
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestUnit:
+    def test_pin_count(self, passive_unit: Unit):
+        assert passive_unit.pin_count == 2
+
+    def test_get_pin(self, passive_unit: Unit):
+        p = passive_unit.get_pin("1")
+        assert p is not None
+        assert p.name == "1"
+
+    def test_get_pin_not_found(self, passive_unit: Unit):
+        assert passive_unit.get_pin("99") is None
+
+    def test_get_pins_by_name(self, opamp_unit: Unit):
+        ins = opamp_unit.get_pins_by_name("IN+")
+        assert len(ins) == 1
+        assert ins[0].number == "3"
+
+
+# ---------------------------------------------------------------------------
+# Entity tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntity:
+    def test_single_unit_entity(self, resistor_entity: Entity):
+        assert len(resistor_entity.units) == 1
+        assert resistor_entity.total_pins == 2
+
+    def test_multi_unit_entity(self, quad_opamp_entity: Entity):
+        # 4 gates x 3 pins + 1 power unit x 2 pins = 14
+        assert len(quad_opamp_entity.units) == 5
+        assert quad_opamp_entity.total_pins == 14
+
+
+# ---------------------------------------------------------------------------
+# ComposedPart tests
+# ---------------------------------------------------------------------------
+
+
+class TestComposedPart:
+    def test_standalone_part(self, resistor_entity: Entity):
+        part = ComposedPart(
+            id="r-10k-0402",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            mpn="RC0402FR-0710KL",
+            manufacturer="Yageo",
+            params={"resistance": "10000", "tolerance": "1%"},
+            tags=["smd", "basic"],
+        )
+        assert part.base_part is None
+        assert part.params["resistance"] == "10000"
+
+    def test_resolve_standalone(self, resistor_entity: Entity):
+        part = ComposedPart(
+            id="r-10k",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            params={"resistance": "10000"},
+            tags=["smd"],
+        )
+        resolved = part.resolve()
+        assert resolved["package"] == "0402"
+        assert resolved["category"] == "resistor"
+        assert resolved["params"] == {"resistance": "10000"}
+        assert resolved["tags"] == ["smd"]
+        assert resolved["entity"] is resistor_entity
+
+    def test_inheritance_basic(self, resistor_entity: Entity):
+        base = ComposedPart(
+            id="r-0402-base",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            manufacturer="Yageo",
+            description="0402 resistor",
+            tags=["smd"],
+        )
+        variant = ComposedPart(
+            id="r-10k-0402",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            mpn="RC0402FR-0710KL",
+            base_part=base,
+            params={"resistance": "10000", "tolerance": "1%"},
+            tags=["basic"],
+        )
+
+        resolved = variant.resolve()
+        # mpn comes from variant
+        assert resolved["mpn"] == "RC0402FR-0710KL"
+        # manufacturer inherited from base
+        assert resolved["manufacturer"] == "Yageo"
+        # tags are unioned
+        assert set(resolved["tags"]) == {"smd", "basic"}
+        # params merged
+        assert resolved["params"]["resistance"] == "10000"
+
+    def test_inheritance_override(self, resistor_entity: Entity):
+        base = ComposedPart(
+            id="base",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            description="Generic 0402",
+            params={"tolerance": "5%"},
+        )
+        variant = ComposedPart(
+            id="variant",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            description="Precision 0402",
+            base_part=base,
+            params={"tolerance": "1%"},
+        )
+
+        resolved = variant.resolve()
+        # Description overridden by variant
+        assert resolved["description"] == "Precision 0402"
+        # Param overridden by variant
+        assert resolved["params"]["tolerance"] == "1%"
+
+    def test_inheritance_chain_three_levels(self, resistor_entity: Entity):
+        grandparent = ComposedPart(
+            id="gp",
+            entity=resistor_entity,
+            category="resistor",
+            manufacturer="Yageo",
+            tags=["passive"],
+        )
+        parent = ComposedPart(
+            id="p",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            base_part=grandparent,
+            tags=["smd"],
+        )
+        child = ComposedPart(
+            id="c",
+            entity=resistor_entity,
+            package="0402",
+            category="resistor",
+            mpn="CHILD-MPN",
+            base_part=parent,
+            params={"resistance": "10000"},
+        )
+
+        resolved = child.resolve()
+        assert resolved["manufacturer"] == "Yageo"
+        assert resolved["mpn"] == "CHILD-MPN"
+        assert set(resolved["tags"]) == {"passive", "smd"}
+        assert resolved["params"]["resistance"] == "10000"
+
+    def test_circular_inheritance_detected(self, resistor_entity: Entity):
+        a = ComposedPart(id="a", entity=resistor_entity)
+        b = ComposedPart(id="b", entity=resistor_entity, base_part=a)
+        # Create cycle: a -> b -> a
+        a.base_part = b
+
+        with pytest.raises(ValueError, match="Circular inheritance"):
+            a.resolve()
+
+    def test_pad_to_pin_mapping(self, resistor_entity: Entity):
+        part = ComposedPart(
+            id="r-mapped",
+            entity=resistor_entity,
+            package="0402",
+            pad_to_pin={"1": "1", "2": "2"},
+        )
+        assert part.pad_to_pin["1"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# Serialisation round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_unit_round_trip(self):
+        from kicad_tools.parts.composition import _unit_from_dict, _unit_to_dict
+
+        unit = Unit(
+            id="test",
+            name="Test Unit",
+            pins=[
+                UnitPin(
+                    name="VCC",
+                    number="1",
+                    direction=PinDirection.POWER_IN,
+                    alternate_names=["V+"],
+                ),
+                UnitPin(name="GND", number="2", direction=PinDirection.POWER_IN),
+            ],
+        )
+        d = _unit_to_dict(unit)
+        restored = _unit_from_dict(d)
+        assert restored.id == unit.id
+        assert restored.name == unit.name
+        assert len(restored.pins) == 2
+        assert restored.pins[0].alternate_names == ["V+"]
+        assert restored.pins[0].direction == PinDirection.POWER_IN
+
+    def test_entity_round_trip(self):
+        from kicad_tools.parts.composition import _entity_from_dict, _entity_to_dict
+
+        entity = Entity(
+            id="ent",
+            name="Entity",
+            units=[
+                Unit(id="u1", name="U1", pins=[UnitPin(name="A", number="1")]),
+                Unit(id="u2", name="U2", pins=[]),
+            ],
+        )
+        d = _entity_to_dict(entity)
+        restored = _entity_from_dict(d)
+        assert restored.id == "ent"
+        assert len(restored.units) == 2
+        assert restored.units[0].pins[0].name == "A"


### PR DESCRIPTION
## Summary
Introduces a composition-based part model that separates electrical definition (Unit/Entity) from physical packaging and supplier data, with single-parent inheritance for variant derivation and SQLite-backed parametric search.

## Changes
- Add `src/kicad_tools/parts/composition.py` with `Unit`, `UnitPin`, `PinDirection`, `Entity`, `ComposedPart` dataclasses and `ComposedPartStore` (SQLite-backed store with indexed parametric search)
- Add `Part.to_composed()` projection method to `src/kicad_tools/parts/models.py` for converting flat LCSC parts into the composition model
- Export new composition types from `src/kicad_tools/parts/__init__.py`
- Add `tests/test_part_composition.py` with 18 tests covering Unit/Entity/ComposedPart creation, inheritance (basic, override, 3-level chain), circular inheritance detection, serialization round-trips
- Add `tests/test_parametric_search.py` with 30 tests covering CRUD, parametric filtering (category, package, manufacturer, MPN, params, tags, combined), stats, and Part.to_composed round-trip through the store

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Unit model with pins, directions, alternate names | Done | `UnitPin` dataclass with `PinDirection` enum and `alternate_names` field |
| Entity model with multiple Units (gates) | Done | `Entity` contains list of `Unit`; quad op-amp test uses 4 gates + power unit |
| ComposedPart binds Entity + Package + MPN + parametric data | Done | `ComposedPart` dataclass with all fields |
| Part inheritance with base_part | Done | `base_part` field, `_inheritance_chain()`, `resolve()` with field merge |
| Circular inheritance detection | Done | `_inheritance_chain()` raises `ValueError` on cycle; tested |
| Parametric search with SQLite indexing | Done | `ComposedPartStore.find_parts()` with indexed columns and junction tables |
| Tag-based search | Done | `composed_part_tags` table with index; `find_parts(tags=...)` and `find_by_tag()` |
| Part.to_composed() projection from existing flat model | Done | Converts fields, specs, and metadata; tested with round-trip through store |
| Existing PartsCache operations unchanged | Done | All 34 existing test_parts.py tests pass unchanged |

## Test Plan
- `uv run python -m pytest tests/test_part_composition.py tests/test_parametric_search.py -v` -- 48 tests pass
- `uv run python -m pytest tests/test_parts.py -v` -- all existing tests pass (no regressions)

Closes #2344