### PR TITLE
feat(blocks): add algebraic composition operators for circuit blocks

### DIFF
--- a/src/kicad_tools/schematic/blocks/__init__.py
+++ b/src/kicad_tools/schematic/blocks/__init__.py
@@ -39,7 +39,7 @@ from .analog import (
     create_temperature_sense,
     create_voltage_sense,
 )
-from .base import CircuitBlock, Port
+from .base import CircuitBlock, ComposedCircuitBlock, Port
 
 # Indicator blocks
 from .indicators import LEDIndicator, create_power_led, create_status_led
@@ -129,19 +129,21 @@ from .timing import (
     create_mclk_oscillator,
 )
 
-# Connection validation
-from .validator import ConnectionValidator, ConnectionWarning, WarningSeverity
+# Connection validation and port matching
+from .validator import ConnectionValidator, ConnectionWarning, WarningSeverity, match_ports
 
 __all__ = [
     # Base classes
     "Port",
     "CircuitBlock",
+    "ComposedCircuitBlock",
     # Typed ports and validation
     "PowerPort",
     "DataPort",
     "ConnectionValidator",
     "ConnectionWarning",
     "WarningSeverity",
+    "match_ports",
     # Indicators
     "LEDIndicator",
     "create_power_led",

--- a/src/kicad_tools/schematic/blocks/base.py
+++ b/src/kicad_tools/schematic/blocks/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -9,6 +10,8 @@ if TYPE_CHECKING:
     from kicad_sch_helper import Schematic, SymbolInstance
 
     from kicad_tools.intent.types import InterfaceCategory
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -118,3 +121,273 @@ class CircuitBlock:
             return Port(name=name, x=pos[0], y=pos[1])
         available = list(self.ports.keys())
         raise KeyError(f"Port '{name}' not found. Available: {available}")
+
+    # ------------------------------------------------------------------
+    # Algebraic composition operators
+    # ------------------------------------------------------------------
+
+    def _ensure_typed_ports(self) -> dict[str, Port]:
+        """Return typed ports, synthesizing from ``ports`` if needed."""
+        result: dict[str, Port] = {}
+        for name in self.ports:
+            result[name] = self.get_typed_port(name)
+        # Merge in any typed_ports that might not be in self.ports
+        for name, tp in self.typed_ports.items():
+            if name not in result:
+                result[name] = tp
+        return result
+
+    def __and__(self, other: CircuitBlock) -> ComposedCircuitBlock:
+        """Series composition: ``a & b``.
+
+        Connects output ports of *self* to input ports of *other* by
+        matching on name/alias, then direction compatibility, then
+        interface type.  The resulting block exposes the un-wired input
+        ports of *self* and un-wired output ports of *other*.
+        """
+        return ComposedCircuitBlock(
+            left=self,
+            right=other,
+            mode="series",
+        )
+
+    def __or__(self, other: CircuitBlock) -> ComposedCircuitBlock:
+        """Parallel composition: ``a | b``.
+
+        Places both blocks side-by-side (vertically) with shared input
+        ports tied together and output ports combined under
+        disambiguated names.
+        """
+        return ComposedCircuitBlock(
+            left=self,
+            right=other,
+            mode="parallel",
+        )
+
+
+class ComposedCircuitBlock(CircuitBlock):
+    """A circuit block formed by composing two child blocks.
+
+    Supports *series* (``&``) and *parallel* (``|``) composition.
+
+    Series (``a & b``):
+        - Wires output ports of *a* to input ports of *b*.
+        - Exposes un-wired input ports of *a* and un-wired output
+          ports of *b*.
+
+    Parallel (``a | b``):
+        - Ties matching input ports together (shared inputs).
+        - Combines output ports under disambiguated names.
+
+    Composition is **lazy**: child blocks may be composed before a
+    schematic is assigned.  Call :meth:`realize` to place components
+    and draw wires into a schematic.
+
+    Port matching uses :func:`~.validator.match_ports`.
+    Validation warnings are collected in :attr:`warnings` and also
+    logged at ``WARNING`` level.
+    """
+
+    # Default gap between blocks (schematic units)
+    SERIES_GAP: float = 30.0
+    PARALLEL_GAP: float = 40.0
+
+    def __init__(
+        self,
+        left: CircuitBlock,
+        right: CircuitBlock,
+        mode: str = "series",
+    ) -> None:
+        super().__init__()
+        self.left = left
+        self.right = right
+        self.mode = mode
+
+        # Lazy import to avoid circular dependency
+        from .validator import ConnectionWarning, match_ports
+
+        self.warnings: list[ConnectionWarning] = []
+        self._wired_pairs: list[tuple[Port, Port]] = []
+
+        # Resolve typed ports for both children
+        left_typed = left._ensure_typed_ports()
+        right_typed = right._ensure_typed_ports()
+
+        if mode == "series":
+            self._compose_series(left_typed, right_typed, match_ports)
+        elif mode == "parallel":
+            self._compose_parallel(left_typed, right_typed, match_ports)
+        else:
+            raise ValueError(f"Unknown composition mode: {mode!r}")
+
+    # ------------------------------------------------------------------
+    # Series composition
+    # ------------------------------------------------------------------
+
+    def _compose_series(self, left_typed, right_typed, match_ports_fn) -> None:
+        """Wire output ports of left to input ports of right."""
+        # For series, only match output-like ports of left to input-like
+        # ports of right.  Passive ports can participate on either side.
+        _OUT_DIRS = {"output", "bidirectional", "passive"}
+        _IN_DIRS = {"input", "bidirectional", "passive", "power"}
+        left_sources = {n: p for n, p in left_typed.items() if p.direction in _OUT_DIRS}
+        right_sinks = {n: p for n, p in right_typed.items() if p.direction in _IN_DIRS}
+        pairings = match_ports_fn(left_sources, right_sinks)
+
+        wired_left_names: set[str] = set()
+        wired_right_names: set[str] = set()
+
+        for src, tgt, warnings in pairings:
+            self._wired_pairs.append((src, tgt))
+            wired_left_names.add(src.name)
+            wired_right_names.add(tgt.name)
+            for w in warnings:
+                self.warnings.append(w)
+                logger.warning(
+                    "Composition warning (%s -> %s): %s",
+                    src.name,
+                    tgt.name,
+                    w.message,
+                )
+
+        # Expose un-wired ports
+        for name, tp in left_typed.items():
+            if name not in wired_left_names:
+                self.ports[name] = tp.pos()
+                self.typed_ports[name] = tp
+
+        for name, tp in right_typed.items():
+            if name not in wired_right_names:
+                # Disambiguate if name already taken
+                ext_name = name if name not in self.ports else f"{_block_label(self.right)}.{name}"
+                self.ports[ext_name] = tp.pos()
+                self.typed_ports[ext_name] = tp
+
+    # ------------------------------------------------------------------
+    # Parallel composition
+    # ------------------------------------------------------------------
+
+    def _compose_parallel(self, left_typed, right_typed, match_ports_fn) -> None:
+        """Tie matching inputs together, combine outputs."""
+        # Identify input vs output ports on each side
+        left_inputs = {
+            n: p for n, p in left_typed.items() if p.direction in ("input", "power", "passive")
+        }
+        right_inputs = {
+            n: p for n, p in right_typed.items() if p.direction in ("input", "power", "passive")
+        }
+        left_outputs = {
+            n: p for n, p in left_typed.items() if p.direction in ("output", "bidirectional")
+        }
+        right_outputs = {
+            n: p for n, p in right_typed.items() if p.direction in ("output", "bidirectional")
+        }
+
+        # Shared inputs: exact-name match
+        shared_input_names: set[str] = set()
+        for name in left_inputs:
+            if name in right_inputs:
+                shared_input_names.add(name)
+                # Expose once (use left's position as canonical)
+                tp = left_inputs[name]
+                self.ports[name] = tp.pos()
+                self.typed_ports[name] = tp
+
+        # Expose non-shared inputs
+        for name, tp in left_inputs.items():
+            if name not in shared_input_names and name not in self.ports:
+                ext_name = f"{_block_label(self.left)}.{name}"
+                self.ports[ext_name] = tp.pos()
+                self.typed_ports[ext_name] = tp
+
+        for name, tp in right_inputs.items():
+            if name not in shared_input_names and name not in self.ports:
+                ext_name = f"{_block_label(self.right)}.{name}"
+                self.ports[ext_name] = tp.pos()
+                self.typed_ports[ext_name] = tp
+
+        # Combine outputs under disambiguated names
+        for name, tp in left_outputs.items():
+            ext_name = f"{_block_label(self.left)}.{name}" if name in right_outputs else name
+            self.ports[ext_name] = tp.pos()
+            self.typed_ports[ext_name] = tp
+
+        for name, tp in right_outputs.items():
+            ext_name = f"{_block_label(self.right)}.{name}" if name in left_outputs else name
+            self.ports[ext_name] = tp.pos()
+            self.typed_ports[ext_name] = tp
+
+    # ------------------------------------------------------------------
+    # Realization
+    # ------------------------------------------------------------------
+
+    def realize(self, sch: Schematic, x: float = 0, y: float = 0) -> None:
+        """Place components and draw wires into a schematic.
+
+        Recursively realizes child blocks (if they are also
+        ``ComposedCircuitBlock`` instances) and draws wires between
+        matched port pairs.
+
+        Args:
+            sch: Target schematic.
+            x: X origin for the composed block.
+            y: Y origin for the composed block.
+        """
+        self.schematic = sch
+        self.x = x
+        self.y = y
+
+        if self.mode == "series":
+            self._realize_series(sch, x, y)
+        else:
+            self._realize_parallel(sch, x, y)
+
+    def _realize_series(self, sch: Schematic, x: float, y: float) -> None:
+        """Realize series composition: left, then right offset to the right."""
+        # Place left block
+        _realize_child(self.left, sch, x, y)
+
+        # Place right block offset to the right
+        right_x = x + self.SERIES_GAP
+        _realize_child(self.right, sch, right_x, y)
+
+        # Draw wires between matched port pairs
+        for src, tgt in self._wired_pairs:
+            sch.add_wire(src.pos(), tgt.pos())
+
+    def _realize_parallel(self, sch: Schematic, x: float, y: float) -> None:
+        """Realize parallel composition: left on top, right below."""
+        _realize_child(self.left, sch, x, y)
+        _realize_child(self.right, sch, x, y + self.PARALLEL_GAP)
+
+    @property
+    def children(self) -> tuple[CircuitBlock, CircuitBlock]:
+        """Return the two child blocks."""
+        return (self.left, self.right)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _block_label(block: CircuitBlock) -> str:
+    """Derive a short label for a block (used in disambiguated port names)."""
+    cls_name = type(block).__name__
+    # Strip common suffixes
+    for suffix in ("Block", "Circuit"):
+        if cls_name.endswith(suffix) and len(cls_name) > len(suffix):
+            cls_name = cls_name[: -len(suffix)]
+    return cls_name
+
+
+def _realize_child(child: CircuitBlock, sch: Schematic, x: float, y: float) -> None:
+    """Realize a child block, handling both composed and plain blocks."""
+    if isinstance(child, ComposedCircuitBlock):
+        child.realize(sch, x, y)
+    else:
+        # Plain CircuitBlock -- update its coordinates (it was already
+        # initialized, so we just update position attributes).
+        child.schematic = sch
+        child.x = x
+        child.y = y

--- a/src/kicad_tools/schematic/blocks/validator.py
+++ b/src/kicad_tools/schematic/blocks/validator.py
@@ -157,3 +157,106 @@ class ConnectionValidator:
             return True
         compatible = self.COMPATIBLE_PROTOCOLS.get(source_proto, set())
         return target_proto in compatible
+
+
+# ---------------------------------------------------------------------------
+# Direction compatibility matrix for port matching
+# ---------------------------------------------------------------------------
+
+_DIRECTION_COMPATIBLE: dict[str, set[str]] = {
+    "output": {"input", "passive", "bidirectional"},
+    "input": {"output", "passive", "bidirectional"},
+    "bidirectional": {"input", "output", "passive", "bidirectional"},
+    "passive": {"input", "output", "passive", "bidirectional", "power"},
+    "power": {"power", "passive"},
+}
+
+
+def _directions_compatible(a_dir: str, b_dir: str) -> bool:
+    """Return True if two port directions can be wired together."""
+    return b_dir in _DIRECTION_COMPATIBLE.get(a_dir, set())
+
+
+def match_ports(
+    source_ports: dict[str, Port],
+    target_ports: dict[str, Port],
+) -> list[tuple[Port, Port, list[ConnectionWarning]]]:
+    """Find compatible port pairings between two blocks.
+
+    Matching priority:
+      1. Exact name match (e.g. ``VOUT`` -> ``VIN`` is *not* a name match;
+         ``VOUT`` -> ``VOUT`` *is*).  Output-name aliases are also tried:
+         ``VOUT`` on the source will attempt ``VIN`` on the target.
+      2. Direction compatibility (output-to-input, etc.)
+      3. Interface type match (same ``interface`` category).
+
+    Each port participates in at most one pairing.
+
+    Args:
+        source_ports: Typed ports of the upstream (left / top) block.
+        target_ports: Typed ports of the downstream (right / bottom) block.
+
+    Returns:
+        List of ``(source_port, target_port, warnings)`` tuples.
+    """
+    validator = ConnectionValidator()
+
+    # Build a mutable pool of available target ports
+    available_targets: dict[str, Port] = dict(target_ports)
+    paired: list[tuple[Port, Port, list[ConnectionWarning]]] = []
+
+    # Common output->input name aliases
+    _ALIASES: dict[str, str] = {
+        "VOUT": "VIN",
+        "OUT": "IN",
+        "TX": "RX",
+        "DOUT": "DIN",
+        "MOSI": "MISO",
+    }
+
+    # Pass 1: exact name or alias match
+    for s_name, s_port in list(source_ports.items()):
+        # Try exact name first
+        if s_name in available_targets:
+            t_port = available_targets.pop(s_name)
+            warnings = validator.validate_connection(s_port, t_port)
+            paired.append((s_port, t_port, warnings))
+            continue
+        # Try alias
+        alias = _ALIASES.get(s_name)
+        if alias and alias in available_targets:
+            t_port = available_targets.pop(alias)
+            warnings = validator.validate_connection(s_port, t_port)
+            paired.append((s_port, t_port, warnings))
+
+    # Collect already-paired source names
+    paired_source_names = {p[0].name for p in paired}
+
+    # Pass 2: direction + interface match for remaining ports
+    for s_name, s_port in source_ports.items():
+        if s_name in paired_source_names:
+            continue
+        best: Port | None = None
+        best_score = -1
+        for t_name, t_port in list(available_targets.items()):
+            if not _directions_compatible(s_port.direction, t_port.direction):
+                continue
+            score = 0
+            # Prefer same interface category
+            if s_port.interface is not None and s_port.interface == t_port.interface:
+                score += 2
+            # Prefer same interface_type
+            if (
+                s_port.interface_type is not None
+                and s_port.interface_type == t_port.interface_type
+            ):
+                score += 1
+            if score > best_score:
+                best_score = score
+                best = t_port
+        if best is not None:
+            available_targets.pop(best.name)
+            warnings = validator.validate_connection(s_port, best)
+            paired.append((s_port, best, warnings))
+
+    return paired

--- a/tests/test_schematic_blocks.py
+++ b/tests/test_schematic_blocks.py
@@ -11,6 +11,7 @@ from kicad_tools.schematic.blocks import (
     BuckConverter,
     CANTransceiver,
     CircuitBlock,
+    ComposedCircuitBlock,
     CrystalOscillator,
     CurrentSenseShunt,
     DebugHeader,
@@ -55,6 +56,7 @@ from kicad_tools.schematic.blocks import (
     create_usb_power,
     create_usb_type_c,
     create_voltage_divider,
+    match_ports,
 )
 
 
@@ -3813,3 +3815,407 @@ class TestMotorControlFactoryFunctions:
         sense = create_current_sense(mock_schematic, x=100, y=100, with_amplifier=True, gain=50)
         assert sense.has_amplifier is True
         assert sense.gain == 50
+
+
+# ---------------------------------------------------------------------------
+# Helpers for composition tests
+# ---------------------------------------------------------------------------
+
+
+def _make_block(ports_dict: dict[str, Port]) -> CircuitBlock:
+    """Create a CircuitBlock with the given typed ports."""
+    block = CircuitBlock()
+    for name, tp in ports_dict.items():
+        block.ports[name] = tp.pos()
+        block.typed_ports[name] = tp
+    return block
+
+
+class TestSeriesComposition:
+    """Tests for the ``&`` (series) composition operator."""
+
+    def test_series_composition_basic(self):
+        """Two blocks composed with &: output wires to input, external ports exposed."""
+        left = _make_block(
+            {
+                "VIN": Port(name="VIN", x=0, y=0, direction="input"),
+                "VOUT": Port(name="VOUT", x=10, y=0, direction="output"),
+            }
+        )
+        right = _make_block(
+            {
+                "VIN": Port(name="VIN", x=20, y=0, direction="input"),
+                "VOUT": Port(name="VOUT", x=30, y=0, direction="output"),
+            }
+        )
+        composed = left & right
+        assert isinstance(composed, ComposedCircuitBlock)
+        # VOUT of left wires to VIN of right via alias match
+        assert len(composed._wired_pairs) == 1
+        src, tgt = composed._wired_pairs[0]
+        assert src.name == "VOUT"
+        assert tgt.name == "VIN"
+        # External ports: VIN from left, VOUT from right
+        assert "VIN" in composed.ports
+        assert "VOUT" in composed.ports
+
+    def test_series_port_matching_by_name(self):
+        """Output port VOUT auto-wires to input port VIN via alias."""
+        left = _make_block(
+            {
+                "VOUT": Port(name="VOUT", x=10, y=0, direction="output"),
+            }
+        )
+        right = _make_block(
+            {
+                "VIN": Port(name="VIN", x=20, y=0, direction="input"),
+            }
+        )
+        composed = left & right
+        assert len(composed._wired_pairs) == 1
+        assert composed._wired_pairs[0][0].name == "VOUT"
+        assert composed._wired_pairs[0][1].name == "VIN"
+        # No external ports (all wired)
+        assert len(composed.ports) == 0
+
+    def test_series_port_matching_by_direction(self):
+        """Output-to-input pairing works even when names differ."""
+        left = _make_block(
+            {
+                "SIG_A": Port(name="SIG_A", x=10, y=0, direction="output"),
+            }
+        )
+        right = _make_block(
+            {
+                "SIG_B": Port(name="SIG_B", x=20, y=0, direction="input"),
+            }
+        )
+        composed = left & right
+        # Should pair by direction compatibility
+        assert len(composed._wired_pairs) == 1
+
+    def test_series_no_matching_ports_raises_no_error(self):
+        """Composing blocks with no matching ports results in all ports exposed."""
+        left = _make_block(
+            {
+                "A": Port(name="A", x=0, y=0, direction="input"),
+            }
+        )
+        right = _make_block(
+            {
+                "B": Port(name="B", x=10, y=0, direction="input"),
+            }
+        )
+        composed = left & right
+        # No pairings (both are inputs)
+        assert len(composed._wired_pairs) == 0
+        # Both ports exposed
+        assert "A" in composed.ports
+        assert "B" in composed.ports
+
+    def test_series_multiple_matching_ports(self):
+        """Multiple compatible pairs are all matched."""
+        left = _make_block(
+            {
+                "VOUT": Port(name="VOUT", x=10, y=0, direction="output"),
+                "GND": Port(name="GND", x=10, y=10, direction="passive"),
+            }
+        )
+        right = _make_block(
+            {
+                "VIN": Port(name="VIN", x=20, y=0, direction="input"),
+                "GND": Port(name="GND", x=20, y=10, direction="passive"),
+            }
+        )
+        composed = left & right
+        # VOUT->VIN alias + GND->GND name match
+        assert len(composed._wired_pairs) == 2
+
+
+class TestParallelComposition:
+    """Tests for the ``|`` (parallel) composition operator."""
+
+    def test_parallel_composition_basic(self):
+        """Two blocks composed with |: shared inputs, combined outputs."""
+        left = _make_block(
+            {
+                "VIN": Port(name="VIN", x=0, y=0, direction="input"),
+                "VOUT": Port(name="VOUT", x=10, y=0, direction="output"),
+            }
+        )
+        right = _make_block(
+            {
+                "VIN": Port(name="VIN", x=0, y=20, direction="input"),
+                "VOUT": Port(name="VOUT", x=10, y=20, direction="output"),
+            }
+        )
+        composed = left | right
+        assert isinstance(composed, ComposedCircuitBlock)
+        # VIN is shared (same name, same direction)
+        assert "VIN" in composed.ports
+        # VOUT is disambiguated (both blocks have the same name)
+        # _block_label strips "Block" suffix: CircuitBlock -> Circuit
+        assert "Circuit.VOUT" in composed.ports or "VOUT" in composed.ports
+
+    def test_parallel_shared_inputs(self):
+        """Matching input port names become shared."""
+        left = _make_block(
+            {
+                "VCC": Port(name="VCC", x=0, y=0, direction="power"),
+                "SIG": Port(name="SIG", x=10, y=0, direction="output"),
+            }
+        )
+        right = _make_block(
+            {
+                "VCC": Port(name="VCC", x=0, y=20, direction="power"),
+                "SIG": Port(name="SIG", x=10, y=20, direction="output"),
+            }
+        )
+        composed = left | right
+        # VCC shared (power = input-like)
+        assert "VCC" in composed.ports
+        # Only one VCC port exposed
+        vcc_count = sum(1 for k in composed.ports if "VCC" in k)
+        assert vcc_count == 1
+
+
+class TestChainedComposition:
+    """Tests for chaining composition operators."""
+
+    def test_chained_series(self):
+        """(a & b) & c works correctly."""
+        a = _make_block(
+            {
+                "IN": Port(name="IN", x=0, y=0, direction="input"),
+                "OUT": Port(name="OUT", x=10, y=0, direction="output"),
+            }
+        )
+        b = _make_block(
+            {
+                "IN": Port(name="IN", x=20, y=0, direction="input"),
+                "OUT": Port(name="OUT", x=30, y=0, direction="output"),
+            }
+        )
+        c = _make_block(
+            {
+                "IN": Port(name="IN", x=40, y=0, direction="input"),
+                "OUT": Port(name="OUT", x=50, y=0, direction="output"),
+            }
+        )
+        composed = (a & b) & c
+        assert isinstance(composed, ComposedCircuitBlock)
+        # a & b wires OUT->IN, (a&b) & c also wires OUT->IN
+        assert "IN" in composed.ports  # from a
+        assert "OUT" in composed.ports  # from c
+
+    def test_mixed_composition(self):
+        """(a & b) | c expression produces a composed block."""
+        a = _make_block(
+            {
+                "IN": Port(name="IN", x=0, y=0, direction="input"),
+                "OUT": Port(name="OUT", x=10, y=0, direction="output"),
+            }
+        )
+        b = _make_block(
+            {
+                "IN": Port(name="IN", x=20, y=0, direction="input"),
+                "OUT": Port(name="OUT", x=30, y=0, direction="output"),
+            }
+        )
+        c = _make_block(
+            {
+                "IN": Port(name="IN", x=40, y=0, direction="input"),
+                "OUT": Port(name="OUT", x=50, y=0, direction="output"),
+            }
+        )
+        composed = (a & b) | c
+        assert isinstance(composed, ComposedCircuitBlock)
+        assert isinstance(composed.left, ComposedCircuitBlock)
+
+
+class TestComposedBlockPortAccess:
+    """Tests for port access on composed blocks."""
+
+    def test_port_lookup(self):
+        """port() and get_typed_port() work on composed blocks."""
+        left = _make_block(
+            {
+                "VIN": Port(name="VIN", x=0, y=0, direction="input"),
+                "VOUT": Port(name="VOUT", x=10, y=0, direction="output"),
+            }
+        )
+        right = _make_block(
+            {
+                "VIN": Port(name="VIN", x=20, y=0, direction="input"),
+                "VOUT": Port(name="VOUT", x=30, y=0, direction="output"),
+            }
+        )
+        composed = left & right
+        # VIN exposed from left
+        assert composed.port("VIN") == (0, 0)
+        tp = composed.get_typed_port("VIN")
+        assert tp.direction == "input"
+
+    def test_port_not_found_on_composed(self):
+        """KeyError for missing port on composed block."""
+        left = _make_block(
+            {"A": Port(name="A", x=0, y=0, direction="input")}
+        )
+        right = _make_block(
+            {"B": Port(name="B", x=10, y=0, direction="input")}
+        )
+        composed = left & right
+        with pytest.raises(KeyError):
+            composed.port("MISSING")
+
+    def test_children_property(self):
+        """children property returns the two child blocks."""
+        a = _make_block({"X": Port(name="X", x=0, y=0)})
+        b = _make_block({"Y": Port(name="Y", x=10, y=0)})
+        composed = a & b
+        assert composed.children == (a, b)
+
+
+class TestComposedBlockRealize:
+    """Tests for realize() placing components and drawing wires."""
+
+    def test_realize_series(self):
+        """realize() calls add_wire for matched pairs."""
+        left = _make_block(
+            {
+                "VOUT": Port(name="VOUT", x=10, y=0, direction="output"),
+            }
+        )
+        right = _make_block(
+            {
+                "VIN": Port(name="VIN", x=20, y=0, direction="input"),
+            }
+        )
+        composed = left & right
+
+        sch = Mock()
+        sch.add_wire = Mock()
+        composed.realize(sch, x=0, y=0)
+
+        # Should draw wire between VOUT and VIN
+        assert sch.add_wire.call_count == 1
+
+    def test_realize_parallel(self):
+        """realize() for parallel updates child positions."""
+        left = _make_block(
+            {"A": Port(name="A", x=0, y=0, direction="input")}
+        )
+        right = _make_block(
+            {"A": Port(name="A", x=0, y=0, direction="input")}
+        )
+        composed = left | right
+
+        sch = Mock()
+        composed.realize(sch, x=50, y=50)
+
+        # Right block should be offset vertically
+        assert right.y == 50 + ComposedCircuitBlock.PARALLEL_GAP
+
+    def test_realize_nested(self):
+        """realize() works for nested composed blocks."""
+        a = _make_block(
+            {
+                "OUT": Port(name="OUT", x=10, y=0, direction="output"),
+            }
+        )
+        b = _make_block(
+            {
+                "IN": Port(name="IN", x=20, y=0, direction="input"),
+                "OUT": Port(name="OUT", x=30, y=0, direction="output"),
+            }
+        )
+        c = _make_block(
+            {
+                "IN": Port(name="IN", x=40, y=0, direction="input"),
+            }
+        )
+        composed = (a & b) & c
+
+        sch = Mock()
+        sch.add_wire = Mock()
+        composed.realize(sch, x=0, y=0)
+
+        # Two wires: OUT->IN in (a&b), and OUT->IN in ((a&b)&c)
+        assert sch.add_wire.call_count == 2
+
+
+class TestMatchPorts:
+    """Tests for the match_ports() helper function."""
+
+    def test_exact_name_match(self):
+        """Ports with identical names are matched."""
+        source = {"GND": Port(name="GND", x=0, y=0, direction="passive")}
+        target = {"GND": Port(name="GND", x=10, y=0, direction="passive")}
+        pairs = match_ports(source, target)
+        assert len(pairs) == 1
+        assert pairs[0][0].name == "GND"
+        assert pairs[0][1].name == "GND"
+
+    def test_alias_match(self):
+        """VOUT on source matches VIN on target via alias."""
+        source = {"VOUT": Port(name="VOUT", x=0, y=0, direction="output")}
+        target = {"VIN": Port(name="VIN", x=10, y=0, direction="input")}
+        pairs = match_ports(source, target)
+        assert len(pairs) == 1
+
+    def test_direction_match(self):
+        """Output-to-input pairing by direction when names differ."""
+        source = {"SIG_OUT": Port(name="SIG_OUT", x=0, y=0, direction="output")}
+        target = {"SIG_IN": Port(name="SIG_IN", x=10, y=0, direction="input")}
+        pairs = match_ports(source, target)
+        assert len(pairs) == 1
+
+    def test_no_match_same_direction(self):
+        """Two input ports do not match."""
+        source = {"A": Port(name="A", x=0, y=0, direction="input")}
+        target = {"B": Port(name="B", x=10, y=0, direction="input")}
+        pairs = match_ports(source, target)
+        assert len(pairs) == 0
+
+    def test_bidirectional_matching(self):
+        """Bidirectional ports match with passive ports."""
+        source = {"SDA": Port(name="SDA", x=0, y=0, direction="bidirectional")}
+        target = {"SDA": Port(name="SDA", x=10, y=0, direction="passive")}
+        pairs = match_ports(source, target)
+        assert len(pairs) == 1
+
+
+class TestPortMatchingTypeWarning:
+    """Tests for type mismatch warnings during composition."""
+
+    def test_interface_mismatch_generates_warning(self):
+        """Composing ports with mismatched interface types produces warnings."""
+        from kicad_tools.intent.types import InterfaceCategory
+        from kicad_tools.schematic.blocks.interfaces import DataPort, PowerPort
+
+        left = _make_block(
+            {
+                "POWER": PowerPort(
+                    name="POWER",
+                    x=0,
+                    y=0,
+                    direction="output",
+                    voltage_min=3.0,
+                    voltage_max=3.6,
+                ),
+            }
+        )
+        right = _make_block(
+            {
+                "POWER": DataPort(
+                    name="POWER",
+                    x=10,
+                    y=0,
+                    direction="input",
+                    protocol="spi",
+                ),
+            }
+        )
+        composed = left & right
+        # Should have warnings about power-to-data mismatch
+        assert len(composed.warnings) > 0


### PR DESCRIPTION
## Summary

Add series (`&`) and parallel (`|`) composition operators to `CircuitBlock`, enabling algebraic circuit composition expressions like `(ldo & filter) | bypass`. Introduces `ComposedCircuitBlock` with lazy realization, automatic port matching, and validation warnings.

## Changes

- Add `__and__` (series) and `__or__` (parallel) operators to `CircuitBlock`
- Add `ComposedCircuitBlock` subclass with deferred `realize(sch, x, y)` for lazy instantiation
- Add `match_ports()` helper in `validator.py` with name/alias/direction/interface matching
- Add `_ensure_typed_ports()` to synthesize typed ports from position-only ports
- Export `ComposedCircuitBlock` and `match_ports` from `__init__.py`
- Add 21 tests covering series, parallel, chained, port access, realization, and type mismatch warnings

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `__and__` series composition wires outputs to inputs | Done | `test_series_composition_basic`, `test_series_port_matching_by_name` |
| `__or__` parallel composition shares inputs, combines outputs | Done | `test_parallel_composition_basic`, `test_parallel_shared_inputs` |
| Port matching by name, alias, direction, interface type | Done | `test_exact_name_match`, `test_alias_match`, `test_direction_match` |
| Deferred instantiation via `realize()` | Done | `test_realize_series`, `test_realize_parallel`, `test_realize_nested` |
| Chained composition `(a & b) & c` and `(a & b) | c` | Done | `test_chained_series`, `test_mixed_composition` |
| ValidationWarnings for interface type mismatches | Done | `test_interface_mismatch_generates_warning` |
| Backward compatibility with existing CircuitBlock API | Done | All 257 existing tests pass unchanged |
| Composed block port access via `port()` and `get_typed_port()` | Done | `test_port_lookup`, `test_port_not_found_on_composed` |

## Test Plan

- All 278 tests pass (257 existing + 21 new): `python3 -m pytest tests/test_schematic_blocks.py`

Closes #2343