### PR TITLE
feat(ipc): KiCad IPC API client for live instance interaction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,10 @@ datasheet = [
 placement = [
     "cmaes>=0.12.0",
 ]
+# KiCad IPC API client (live instance interaction, KiCad 9.0+)
+ipc = [
+    "pynng>=0.8.0",
+]
 # MCP server for AI agent integration
 mcp = [
     "fastmcp>=2.0,<3",

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -64,6 +64,7 @@ from .commands import (
     run_impedance_command,
     run_init_command,
     run_interactive_command,
+    run_ipc_command,
     run_lib_command,
     run_mcp_command,
     run_mfr_command,
@@ -412,6 +413,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "mcp":
         return run_mcp_command(args)
+
+    elif args.command == "ipc":
+        return run_ipc_command(args)
 
     elif args.command == "init":
         return run_init_command(args)

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -25,6 +25,7 @@ from .decisions import run_decisions_command
 from .estimate import run_estimate_command
 from .footprint import run_footprint_command
 from .impedance import run_impedance_command
+from .ipc import run_ipc_command
 from .library import run_lib_command
 from .manufacturer import run_mfr_command
 from .mcp import run_mcp_command
@@ -123,6 +124,8 @@ __all__ = [
     "run_spec_command",
     # Impedance
     "run_impedance_command",
+    # IPC
+    "run_ipc_command",
     # MCP
     "run_mcp_command",
     # Native build

--- a/src/kicad_tools/cli/commands/ipc.py
+++ b/src/kicad_tools/cli/commands/ipc.py
@@ -1,0 +1,266 @@
+"""IPC command handlers for live KiCad instance interaction."""
+
+from __future__ import annotations
+
+__all__ = ["run_ipc_command"]
+
+
+def run_ipc_command(args) -> int:
+    """Handle ipc command.
+
+    Args:
+        args: Parsed command line arguments
+
+    Returns:
+        Exit code (0 for success)
+    """
+    ipc_subcommand = getattr(args, "ipc_command", None)
+
+    if ipc_subcommand == "status":
+        return _run_status(args)
+    elif ipc_subcommand == "connect":
+        return _run_connect(args)
+    elif ipc_subcommand == "push-routes":
+        return _run_push_routes(args)
+    else:
+        print("Usage: kct ipc <command> [OPTIONS]")
+        print()
+        print("Commands:")
+        print("  status       Show KiCad IPC connection status")
+        print("  connect      Test connection to a running KiCad instance")
+        print("  push-routes  Push routed tracks from a PCB file to KiCad")
+        return 0
+
+
+def _run_status(args) -> int:
+    """Report KiCad IPC connection status.
+
+    Discovers running KiCad instances and reports their status.
+    """
+    try:
+        from kicad_tools.ipc.discovery import discover_instances, discover_socket
+    except ImportError:
+        print("Error: IPC dependencies not installed.")
+        print("Install with: pip install 'kicad-tools[ipc]'")
+        return 1
+
+    socket_path = getattr(args, "socket", None)
+
+    if socket_path:
+        resolved = discover_socket(explicit_path=socket_path)
+        if resolved:
+            print(f"Socket found: {resolved}")
+            return _try_connect_and_report(str(resolved))
+        else:
+            print(f"Socket not found at: {socket_path}")
+            return 1
+
+    # Auto-discover
+    instances = discover_instances()
+    if not instances:
+        auto_socket = discover_socket()
+        if auto_socket:
+            print(f"Socket found: {auto_socket}")
+            return _try_connect_and_report(str(auto_socket))
+        print("No running KiCad instances found.")
+        print()
+        print("To start KiCad with IPC enabled:")
+        print("  kicad-cli api-server --socket /tmp/kicad/kicad.sock")
+        print()
+        print("Or specify a socket path:")
+        print("  kct ipc status --socket /path/to/socket")
+        return 1
+
+    print(f"Found {len(instances)} KiCad instance(s):")
+    for inst in instances:
+        print(f"  {inst}")
+    print()
+
+    # Try connecting to the first instance
+    return _try_connect_and_report(str(instances[0].socket_path))
+
+
+def _try_connect_and_report(socket_path: str) -> int:
+    """Try connecting to KiCad and report status."""
+    try:
+        from kicad_tools.ipc.client import IPCClient, IPCError
+    except ImportError:
+        print("Error: pynng not installed.")
+        print("Install with: pip install 'kicad-tools[ipc]'")
+        return 1
+
+    print(f"Connecting to {socket_path}...")
+    try:
+        with IPCClient(socket_path) as client:
+            if client.ping():
+                version = client.get_version()
+                print(f"Connected to KiCad {version}")
+                docs = client.get_open_documents()
+                if docs:
+                    print(f"Open documents: {len(docs)}")
+                    for doc in docs:
+                        print(f"  {doc.get('path', 'unknown')}")
+                return 0
+            else:
+                print("Connected but KiCad is not responding to health checks.")
+                return 1
+    except IPCError as exc:
+        print(f"Connection failed: {exc}")
+        return 1
+    except ImportError:
+        print("Error: pynng not installed.")
+        print("Install with: pip install 'kicad-tools[ipc]'")
+        return 1
+
+
+def _run_connect(args) -> int:
+    """Test connection to a running KiCad instance."""
+    socket_path = getattr(args, "socket", None)
+
+    try:
+        from kicad_tools.ipc.client import IPCClient, IPCError
+        from kicad_tools.ipc.discovery import discover_socket
+    except ImportError:
+        print("Error: IPC dependencies not installed.")
+        print("Install with: pip install 'kicad-tools[ipc]'")
+        return 1
+
+    resolved = discover_socket(explicit_path=socket_path)
+    if not resolved:
+        print("No KiCad IPC socket found.")
+        if socket_path:
+            print(f"  Checked: {socket_path}")
+        print("  Set KICAD_IPC_SOCKET or use --socket")
+        return 1
+
+    try:
+        with IPCClient(str(resolved)) as client:
+            version = client.get_version()
+            print(f"Successfully connected to KiCad {version}")
+            print(f"Socket: {resolved}")
+            return 0
+    except IPCError as exc:
+        print(f"Connection failed: {exc}")
+        return 1
+
+
+def _run_push_routes(args) -> int:
+    """Push routed tracks from a PCB file to a running KiCad instance."""
+    pcb_path = getattr(args, "pcb", None)
+    socket_path = getattr(args, "socket", None)
+    net_filter = getattr(args, "net", None)
+    dry_run = getattr(args, "dry_run", False)
+
+    if not pcb_path:
+        print("Error: PCB file path required.")
+        print("Usage: kct ipc push-routes <pcb_file> [--socket PATH] [--net NAME]")
+        return 1
+
+    try:
+        from kicad_tools.ipc.client import IPCClient, IPCError
+        from kicad_tools.ipc.discovery import discover_socket
+    except ImportError:
+        print("Error: IPC dependencies not installed.")
+        print("Install with: pip install 'kicad-tools[ipc]'")
+        return 1
+
+    from pathlib import Path
+
+    pcb_file = Path(pcb_path)
+    if not pcb_file.exists():
+        print(f"Error: PCB file not found: {pcb_file}")
+        return 1
+
+    # Read tracks from the PCB file using existing kicad-tools parsing
+    try:
+        from kicad_tools.pcb.parser import parse_pcb
+    except ImportError:
+        print("Error: PCB parser not available.")
+        return 1
+
+    board = parse_pcb(pcb_file)
+    tracks = board.tracks if hasattr(board, "tracks") else []
+    vias = board.vias if hasattr(board, "vias") else []
+
+    if net_filter:
+        # Filter to specific net
+        net_code = None
+        for net in board.nets if hasattr(board, "nets") else []:
+            if hasattr(net, "name") and net.name == net_filter:
+                net_code = net.number if hasattr(net, "number") else None
+                break
+        if net_code is not None:
+            tracks = [t for t in tracks if hasattr(t, "net") and t.net == net_code]
+            vias = [v for v in vias if hasattr(v, "net") and v.net == net_code]
+
+    print(f"Found {len(tracks)} tracks and {len(vias)} vias in {pcb_file.name}")
+
+    if net_filter:
+        print(f"  Filtered to net: {net_filter}")
+
+    if dry_run:
+        print("Dry run -- no changes pushed to KiCad.")
+        return 0
+
+    if not tracks and not vias:
+        print("No tracks or vias to push.")
+        return 0
+
+    resolved = discover_socket(explicit_path=socket_path)
+    if not resolved:
+        print("No KiCad IPC socket found.")
+        return 1
+
+    try:
+        from kicad_tools.ipc.board import BoardOperations
+        from kicad_tools.ipc.proto.messages import TrackSegment as IPCTrack
+        from kicad_tools.ipc.proto.messages import Vector2
+        from kicad_tools.ipc.proto.messages import Via as IPCVia
+
+        with IPCClient(str(resolved)) as client:
+            board_ops = BoardOperations(client)
+
+            # Convert kicad-tools track format to IPC format
+            ipc_tracks = []
+            for t in tracks:
+                ipc_tracks.append(
+                    IPCTrack(
+                        start=Vector2(
+                            x_nm=int(getattr(t, "start_x", 0) * 1e6),
+                            y_nm=int(getattr(t, "start_y", 0) * 1e6),
+                        ),
+                        end=Vector2(
+                            x_nm=int(getattr(t, "end_x", 0) * 1e6),
+                            y_nm=int(getattr(t, "end_y", 0) * 1e6),
+                        ),
+                        width_nm=int(getattr(t, "width", 0.25) * 1e6),
+                        layer=getattr(t, "layer", "F.Cu"),
+                        net=getattr(t, "net", 0),
+                    )
+                )
+
+            ipc_vias = []
+            for v in vias:
+                ipc_vias.append(
+                    IPCVia(
+                        position=Vector2(
+                            x_nm=int(getattr(v, "x", 0) * 1e6),
+                            y_nm=int(getattr(v, "y", 0) * 1e6),
+                        ),
+                        diameter_nm=int(getattr(v, "size", 0.8) * 1e6),
+                        drill_nm=int(getattr(v, "drill", 0.4) * 1e6),
+                        net=getattr(v, "net", 0),
+                    )
+                )
+
+            created = board_ops.push_routes(
+                tracks=ipc_tracks,
+                vias=ipc_vias,
+                description=f"Push routes from {pcb_file.name}",
+            )
+            print(f"Pushed {len(created)} items to KiCad.")
+            return 0
+
+    except IPCError as exc:
+        print(f"Error: {exc}")
+        return 1

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -175,6 +175,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_clean_parser(subparsers)
     _add_impedance_parser(subparsers)
     _add_mcp_parser(subparsers)
+    _add_ipc_parser(subparsers)
     _add_init_parser(subparsers)
     _add_pipeline_parser(subparsers)
     _add_create_pcb_parser(subparsers)
@@ -4236,6 +4237,73 @@ def _add_mcp_parser(subparsers) -> None:
         "-n",
         action="store_true",
         help="Show what would be written without making changes",
+    )
+
+
+def _add_ipc_parser(subparsers) -> None:
+    """Add IPC subcommand parser for live KiCad instance interaction."""
+    ipc_parser = subparsers.add_parser(
+        "ipc",
+        help="Interact with a running KiCad instance via IPC API (KiCad 9.0+)",
+        description=(
+            "Connect to a running KiCad instance via its IPC API (protobuf over NNG). "
+            "Requires KiCad 9.0+ and the ipc optional dependency: pip install 'kicad-tools[ipc]'"
+        ),
+    )
+    ipc_subparsers = ipc_parser.add_subparsers(dest="ipc_command", help="IPC subcommands")
+
+    # ipc status subcommand
+    status_parser = ipc_subparsers.add_parser(
+        "status",
+        help="Show KiCad IPC connection status",
+        description="Discover running KiCad instances and report their IPC status.",
+    )
+    status_parser.add_argument(
+        "--socket",
+        "-s",
+        help="Explicit path to KiCad IPC socket (auto-discovered if not provided)",
+    )
+
+    # ipc connect subcommand
+    connect_parser = ipc_subparsers.add_parser(
+        "connect",
+        help="Test connection to a running KiCad instance",
+        description="Attempt to connect to a running KiCad instance and report the result.",
+    )
+    connect_parser.add_argument(
+        "--socket",
+        "-s",
+        help="Explicit path to KiCad IPC socket (auto-discovered if not provided)",
+    )
+
+    # ipc push-routes subcommand
+    push_parser = ipc_subparsers.add_parser(
+        "push-routes",
+        help="Push routed tracks from a PCB file to a running KiCad instance",
+        description=(
+            "Read tracks and vias from a .kicad_pcb file and push them to "
+            "a running KiCad instance via IPC. All items are created in a "
+            "single undo transaction."
+        ),
+    )
+    push_parser.add_argument(
+        "pcb",
+        help="Path to .kicad_pcb file containing the routing solution",
+    )
+    push_parser.add_argument(
+        "--socket",
+        "-s",
+        help="Explicit path to KiCad IPC socket (auto-discovered if not provided)",
+    )
+    push_parser.add_argument(
+        "--net",
+        "-n",
+        help="Only push tracks/vias for a specific net name",
+    )
+    push_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be pushed without actually connecting to KiCad",
     )
 
 

--- a/src/kicad_tools/ipc/__init__.py
+++ b/src/kicad_tools/ipc/__init__.py
@@ -13,8 +13,8 @@ Example usage::
     from kicad_tools.ipc import IPCClient, discover_socket
 
     socket_path = discover_socket()
-    async with IPCClient(socket_path) as client:
-        version = await client.get_version()
+    with IPCClient(socket_path) as client:
+        version = client.get_version()
         print(f"Connected to KiCad {version}")
 
 The IPC client is separate from the MCP server (``kicad_tools.mcp``).

--- a/src/kicad_tools/ipc/__init__.py
+++ b/src/kicad_tools/ipc/__init__.py
@@ -1,0 +1,41 @@
+"""KiCad IPC API client for live instance interaction.
+
+This module provides a Python client for KiCad's IPC API (protobuf over NNG),
+enabling two-phase workflows: compute offline with kicad-tools, then push
+results into a running KiCad instance via IPC.
+
+Requires KiCad 9.0+ and the optional ``ipc`` dependency group::
+
+    pip install 'kicad-tools[ipc]'
+
+Example usage::
+
+    from kicad_tools.ipc import IPCClient, discover_socket
+
+    socket_path = discover_socket()
+    async with IPCClient(socket_path) as client:
+        version = await client.get_version()
+        print(f"Connected to KiCad {version}")
+
+The IPC client is separate from the MCP server (``kicad_tools.mcp``).
+The MCP server provides tools for AI agents; the IPC client communicates
+with KiCad itself.
+"""
+
+from kicad_tools.ipc.board import BoardOperations
+from kicad_tools.ipc.client import IPCClient
+from kicad_tools.ipc.discovery import (
+    KiCadInstance,
+    discover_instances,
+    discover_socket,
+)
+from kicad_tools.ipc.transactions import Transaction
+
+__all__ = [
+    "BoardOperations",
+    "IPCClient",
+    "KiCadInstance",
+    "Transaction",
+    "discover_instances",
+    "discover_socket",
+]

--- a/src/kicad_tools/ipc/board.py
+++ b/src/kicad_tools/ipc/board.py
@@ -1,0 +1,202 @@
+"""High-level board operations over KiCad IPC.
+
+This module provides a convenient interface for common PCB board operations,
+building on the low-level :class:`IPCClient` and :class:`Transaction` classes.
+
+Operations include:
+- Pushing routing solutions (tracks + vias)
+- Reading design rules from the running board
+- Querying board items by net or type
+- Highlighting items in the KiCad GUI
+
+Example::
+
+    from kicad_tools.ipc import IPCClient, BoardOperations
+
+    with IPCClient(socket_path) as client:
+        board = BoardOperations(client)
+        rules = board.get_design_rules()
+        print(f"Min track width: {rules['min_track_width_nm']}nm")
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from kicad_tools.ipc.proto.messages import TrackSegment, Via
+from kicad_tools.ipc.transactions import Transaction
+
+if TYPE_CHECKING:
+    from kicad_tools.ipc.client import IPCClient
+
+logger = logging.getLogger(__name__)
+
+
+class BoardOperations:
+    """High-level board operations using KiCad IPC API.
+
+    Args:
+        client: Connected IPCClient instance.
+    """
+
+    def __init__(self, client: IPCClient) -> None:
+        self._client = client
+
+    def push_routes(
+        self,
+        tracks: list[TrackSegment],
+        vias: list[Via] | None = None,
+        description: str = "Push routes from kicad-tools",
+    ) -> list[str]:
+        """Push a routing solution to the running KiCad board.
+
+        All tracks and vias are created in a single transaction so they
+        appear as one undo step in KiCad.
+
+        Args:
+            tracks: List of track segments to create.
+            vias: Optional list of vias to create.
+            description: Description for the undo stack entry.
+
+        Returns:
+            List of created item IDs (KIIDs).
+        """
+        items: list[dict[str, Any]] = []
+        for track in tracks:
+            item = track.to_dict()
+            item["type"] = "track"
+            items.append(item)
+
+        if vias:
+            for via in vias:
+                item = via.to_dict()
+                item["type"] = "via"
+                items.append(item)
+
+        logger.info(
+            "Pushing %d tracks and %d vias",
+            len(tracks),
+            len(vias) if vias else 0,
+        )
+
+        with Transaction(self._client, description=description) as txn:
+            created_ids = txn.create_items(items)
+
+        return created_ids
+
+    def get_design_rules(self) -> dict[str, Any]:
+        """Read the active design rules from the running board.
+
+        Returns:
+            Dict with design rule values, e.g.::
+
+                {
+                    "min_track_width_nm": 150000,
+                    "min_clearance_nm": 150000,
+                    "min_via_diameter_nm": 600000,
+                    "min_via_drill_nm": 300000,
+                    ...
+                }
+        """
+        response = self._client.send_command("GetDesignRules")
+        return response.result
+
+    def get_nets(self) -> list[dict[str, Any]]:
+        """List all nets in the board.
+
+        Returns:
+            List of net info dicts with keys like ``name``, ``code``.
+        """
+        response = self._client.send_command("GetNets")
+        return response.result.get("nets", [])
+
+    def get_items(
+        self,
+        item_type: str | None = None,
+        net: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Query board items by type and/or net.
+
+        Args:
+            item_type: Filter by item type (e.g., ``"track"``, ``"via"``).
+            net: Filter by net code.
+
+        Returns:
+            List of item dicts.
+        """
+        params: dict[str, Any] = {}
+        if item_type is not None:
+            params["type"] = item_type
+        if net is not None:
+            params["net"] = net
+
+        response = self._client.send_command("GetItems", params=params)
+        return response.result.get("items", [])
+
+    def highlight_net(self, net_code: int) -> None:
+        """Highlight a net in the KiCad GUI.
+
+        Args:
+            net_code: The net code to highlight.
+        """
+        self._client.send_command(
+            "HighlightNet",
+            params={"net": net_code},
+        )
+
+    def clear_highlight(self) -> None:
+        """Clear all highlights in the KiCad GUI."""
+        self._client.send_command("ClearHighlight")
+
+    def refresh_board(self) -> None:
+        """Request KiCad to refresh/redraw the board view."""
+        self._client.send_command("RefreshBoard")
+
+    def get_board_bounding_box(self) -> dict[str, Any]:
+        """Get the bounding box of the entire board.
+
+        Returns:
+            Dict with ``min_x``, ``min_y``, ``max_x``, ``max_y`` in nm.
+        """
+        response = self._client.send_command("GetBoardBoundingBox")
+        return response.result
+
+    def get_stackup(self) -> list[dict[str, Any]]:
+        """Get the board layer stackup configuration.
+
+        Returns:
+            List of layer dicts with ``name``, ``type``, ``thickness_nm``, etc.
+        """
+        response = self._client.send_command("GetStackup")
+        return response.result.get("layers", [])
+
+    def delete_tracks_on_net(
+        self,
+        net_code: int,
+        description: str = "Delete tracks from kicad-tools",
+    ) -> int:
+        """Delete all tracks on a given net.
+
+        Args:
+            net_code: The net code whose tracks to delete.
+            description: Description for the undo stack entry.
+
+        Returns:
+            Number of deleted tracks.
+        """
+        items = self.get_items(item_type="track", net=net_code)
+        if not items:
+            return 0
+
+        item_ids = [item["id"] for item in items if "id" in item]
+        if not item_ids:
+            return 0
+
+        with Transaction(self._client, description=description) as txn:
+            txn.delete_items(item_ids)
+
+        return len(item_ids)
+
+    def __repr__(self) -> str:
+        return f"BoardOperations({self._client!r})"

--- a/src/kicad_tools/ipc/client.py
+++ b/src/kicad_tools/ipc/client.py
@@ -1,0 +1,313 @@
+"""NNG connection management for KiCad IPC API.
+
+This module provides the low-level transport layer for communicating with
+KiCad over NNG (nanomsg next generation) sockets. It handles:
+
+- Connection lifecycle (connect, disconnect, reconnect)
+- Request/response serialization (JSON over NNG)
+- Health checks and keepalive
+- Timeout and error handling
+
+The client uses the NNG ``Req0`` (request) socket pattern, which matches
+KiCad's ``Rep0`` (reply) server pattern.
+
+Requires ``pynng`` package::
+
+    pip install 'kicad-tools[ipc]'
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from kicad_tools.ipc.proto.messages import ApiRequest, ApiResponse, StatusCode
+
+logger = logging.getLogger(__name__)
+
+# Default timeout for NNG operations in milliseconds
+DEFAULT_TIMEOUT_MS = 5000
+
+# Timeout for health check operations (shorter than normal requests)
+HEALTH_CHECK_TIMEOUT_MS = 2000
+
+
+class IPCError(Exception):
+    """Base exception for IPC communication errors."""
+
+
+class IPCConnectionError(IPCError):
+    """Raised when connection to KiCad cannot be established."""
+
+
+class IPCTimeoutError(IPCError):
+    """Raised when a request times out waiting for a response."""
+
+
+class IPCProtocolError(IPCError):
+    """Raised when KiCad returns an unexpected response format."""
+
+
+class IPCApiError(IPCError):
+    """Raised when KiCad returns an API-level error.
+
+    Attributes:
+        status: The KiCad API status code.
+        api_message: The error message from KiCad.
+    """
+
+    def __init__(self, status: StatusCode, api_message: str) -> None:
+        self.status = status
+        self.api_message = api_message
+        super().__init__(f"KiCad API error ({status.name}): {api_message}")
+
+
+class IPCClient:
+    """Client for KiCad's IPC API over NNG.
+
+    This client manages a single NNG request socket connected to a
+    running KiCad instance. KiCad's IPC API is single-client, so only
+    one ``IPCClient`` can be connected at a time.
+
+    Usage::
+
+        client = IPCClient("/tmp/kicad/kicad.sock")
+        client.connect()
+        try:
+            response = client.send_command("GetVersion")
+            print(response.result)
+        finally:
+            client.disconnect()
+
+    Or as a context manager::
+
+        with IPCClient("/tmp/kicad/kicad.sock") as client:
+            response = client.send_command("GetVersion")
+
+    Args:
+        socket_path: Path to the KiCad NNG socket.
+        timeout_ms: Default timeout for requests in milliseconds.
+    """
+
+    def __init__(
+        self,
+        socket_path: str | Path,
+        timeout_ms: int = DEFAULT_TIMEOUT_MS,
+    ) -> None:
+        self._socket_path = Path(socket_path)
+        self._timeout_ms = timeout_ms
+        self._socket: Any = None  # pynng.Req0 when connected
+        self._connected = False
+        self._token: str = ""
+
+    @property
+    def socket_path(self) -> Path:
+        """The NNG socket path this client connects to."""
+        return self._socket_path
+
+    @property
+    def connected(self) -> bool:
+        """Whether the client is currently connected."""
+        return self._connected
+
+    @property
+    def token(self) -> str:
+        """The API token from the last successful connection."""
+        return self._token
+
+    def connect(self) -> None:
+        """Establish connection to KiCad IPC socket.
+
+        Raises:
+            IPCConnectionError: If the socket cannot be reached.
+            ImportError: If ``pynng`` is not installed.
+        """
+        if self._connected:
+            logger.debug("Already connected to %s", self._socket_path)
+            return
+
+        try:
+            import pynng
+        except ImportError as exc:
+            raise ImportError(
+                "pynng is required for KiCad IPC communication. "
+                "Install it with: pip install 'kicad-tools[ipc]'"
+            ) from exc
+
+        address = f"ipc://{self._socket_path}"
+        logger.info("Connecting to KiCad IPC at %s", address)
+
+        try:
+            self._socket = pynng.Req0(
+                dial=address,
+                recv_timeout=self._timeout_ms,
+                send_timeout=self._timeout_ms,
+            )
+            self._connected = True
+            logger.info("Connected to KiCad IPC at %s", address)
+        except pynng.exceptions.ConnectionRefused:
+            raise IPCConnectionError(
+                f"Connection refused at {address}. "
+                "Is KiCad running with IPC enabled?"
+            )
+        except pynng.exceptions.AddressInUse:
+            raise IPCConnectionError(
+                f"Socket at {address} is already in use. "
+                "KiCad's IPC API supports only one client at a time."
+            )
+        except Exception as exc:
+            raise IPCConnectionError(
+                f"Failed to connect to {address}: {exc}"
+            ) from exc
+
+    def disconnect(self) -> None:
+        """Close the NNG socket connection."""
+        if self._socket is not None:
+            try:
+                self._socket.close()
+            except Exception:
+                logger.debug("Error closing socket", exc_info=True)
+            finally:
+                self._socket = None
+                self._connected = False
+                self._token = ""
+                logger.info("Disconnected from KiCad IPC")
+
+    def reconnect(self) -> None:
+        """Disconnect and reconnect to the KiCad IPC socket."""
+        self.disconnect()
+        self.connect()
+
+    def send_command(
+        self,
+        command: str,
+        params: dict[str, Any] | None = None,
+        timeout_ms: int | None = None,
+    ) -> ApiResponse:
+        """Send a command to KiCad and wait for the response.
+
+        Args:
+            command: The API command name (e.g., ``"GetVersion"``).
+            params: Optional command parameters.
+            timeout_ms: Override the default timeout for this request.
+
+        Returns:
+            The parsed API response.
+
+        Raises:
+            IPCConnectionError: If not connected.
+            IPCTimeoutError: If the request times out.
+            IPCProtocolError: If the response cannot be parsed.
+            IPCApiError: If KiCad returns a non-OK status.
+        """
+        if not self._connected or self._socket is None:
+            raise IPCConnectionError("Not connected. Call connect() first.")
+
+        request = ApiRequest(
+            command=command,
+            token=self._token,
+            params=params or {},
+        )
+
+        request_bytes = json.dumps(request.to_dict()).encode("utf-8")
+        logger.debug("Sending command: %s", command)
+
+        try:
+            # Apply per-request timeout if specified
+            if timeout_ms is not None:
+                self._socket.recv_timeout = timeout_ms
+
+            self._socket.send(request_bytes)
+            response_bytes = self._socket.recv()
+
+            # Restore default timeout
+            if timeout_ms is not None:
+                self._socket.recv_timeout = self._timeout_ms
+
+        except Exception as exc:
+            exc_name = type(exc).__name__
+            # Check for timeout specifically
+            if "Timeout" in exc_name or "TimedOut" in exc_name:
+                raise IPCTimeoutError(
+                    f"Request '{command}' timed out after "
+                    f"{timeout_ms or self._timeout_ms}ms. "
+                    "KiCad may be busy with user interaction."
+                ) from exc
+            raise IPCConnectionError(
+                f"Communication error during '{command}': {exc}"
+            ) from exc
+
+        try:
+            response_data = json.loads(response_bytes.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise IPCProtocolError(
+                f"Invalid response from KiCad for '{command}': {exc}"
+            ) from exc
+
+        response = ApiResponse.from_dict(response_data)
+
+        if not response.ok:
+            raise IPCApiError(response.status, response.message)
+
+        # Capture token from initial handshake if present
+        if "token" in response.result:
+            self._token = response.result["token"]
+            logger.debug("Received API token")
+
+        return response
+
+    def ping(self) -> bool:
+        """Check if KiCad is responsive.
+
+        Sends a lightweight health check command.
+
+        Returns:
+            True if KiCad responded successfully, False otherwise.
+        """
+        if not self._connected:
+            return False
+
+        try:
+            self.send_command("Ping", timeout_ms=HEALTH_CHECK_TIMEOUT_MS)
+            return True
+        except IPCError:
+            return False
+
+    def get_version(self) -> str:
+        """Query the KiCad version string.
+
+        Returns:
+            Version string (e.g., ``"9.0.1"``).
+
+        Raises:
+            IPCError: If the request fails.
+        """
+        response = self.send_command("GetVersion")
+        return response.result.get("version", "unknown")
+
+    def get_open_documents(self) -> list[dict[str, Any]]:
+        """List currently open documents in KiCad.
+
+        Returns:
+            List of document info dicts with keys like ``path``, ``type``.
+
+        Raises:
+            IPCError: If the request fails.
+        """
+        response = self.send_command("GetOpenDocuments")
+        return response.result.get("documents", [])
+
+    def __enter__(self) -> IPCClient:
+        """Connect on context manager entry."""
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Disconnect on context manager exit."""
+        self.disconnect()
+
+    def __repr__(self) -> str:
+        state = "connected" if self._connected else "disconnected"
+        return f"IPCClient({self._socket_path!s}, {state})"

--- a/src/kicad_tools/ipc/discovery.py
+++ b/src/kicad_tools/ipc/discovery.py
@@ -1,0 +1,166 @@
+"""Auto-discover running KiCad instances and their IPC socket paths.
+
+KiCad 9.0+ writes its NNG socket path to a well-known location. This module
+searches those locations to find running KiCad instances.
+
+Discovery strategy:
+1. Check ``KICAD_IPC_SOCKET`` environment variable (explicit override)
+2. Search platform-specific runtime directories for socket files
+3. Fall back to explicit socket path argument
+
+Supported platforms:
+- macOS: ``$TMPDIR/kicad/`` or ``/tmp/kicad/``
+- Linux: ``$XDG_RUNTIME_DIR/kicad/`` or ``/tmp/kicad/``
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class KiCadInstance:
+    """Represents a discovered running KiCad instance.
+
+    Attributes:
+        socket_path: Path to the NNG IPC socket.
+        pid: Process ID of the KiCad instance, if known.
+        version: KiCad version string, if known.
+    """
+
+    socket_path: Path
+    pid: int | None = None
+    version: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        parts = [f"KiCad@{self.socket_path}"]
+        if self.pid:
+            parts.append(f"pid={self.pid}")
+        if self.version:
+            parts.append(f"v{self.version}")
+        return " ".join(parts)
+
+
+def _get_search_dirs() -> list[Path]:
+    """Return platform-specific directories to search for KiCad sockets.
+
+    Returns:
+        List of directories to search, in priority order.
+    """
+    dirs: list[Path] = []
+
+    if sys.platform == "darwin":
+        # macOS: $TMPDIR is per-user (e.g., /var/folders/.../T/)
+        tmpdir = os.environ.get("TMPDIR", "/tmp")
+        dirs.append(Path(tmpdir) / "kicad")
+        dirs.append(Path("/tmp") / "kicad")
+    elif sys.platform == "win32":
+        # Windows: %LOCALAPPDATA%\kicad or %TEMP%\kicad
+        local_appdata = os.environ.get("LOCALAPPDATA", "")
+        if local_appdata:
+            dirs.append(Path(local_appdata) / "kicad")
+        temp = os.environ.get("TEMP", os.environ.get("TMP", ""))
+        if temp:
+            dirs.append(Path(temp) / "kicad")
+    else:
+        # Linux: XDG_RUNTIME_DIR is the standard location
+        xdg_runtime = os.environ.get("XDG_RUNTIME_DIR", "")
+        if xdg_runtime:
+            dirs.append(Path(xdg_runtime) / "kicad")
+        dirs.append(Path("/tmp") / "kicad")
+
+    return dirs
+
+
+def discover_socket(explicit_path: str | Path | None = None) -> Path | None:
+    """Find the socket path for a running KiCad instance.
+
+    Args:
+        explicit_path: If provided, use this path directly instead of
+            auto-discovering. The path is validated to exist.
+
+    Returns:
+        Path to the NNG socket if found, None otherwise.
+    """
+    # 1. Explicit path takes priority
+    if explicit_path is not None:
+        path = Path(explicit_path)
+        if path.exists():
+            return path
+        return None
+
+    # 2. Environment variable override
+    env_socket = os.environ.get("KICAD_IPC_SOCKET")
+    if env_socket:
+        path = Path(env_socket)
+        if path.exists():
+            return path
+
+    # 3. Search platform-specific directories
+    for search_dir in _get_search_dirs():
+        if not search_dir.is_dir():
+            continue
+        # KiCad creates socket files with .sock extension
+        for sock_file in sorted(search_dir.glob("*.sock")):
+            return sock_file
+        # Also check for plain socket files (no extension)
+        for entry in sorted(search_dir.iterdir()):
+            if _is_socket(entry):
+                return entry
+
+    return None
+
+
+def discover_instances() -> list[KiCadInstance]:
+    """Find all running KiCad instances with active IPC sockets.
+
+    Returns:
+        List of discovered KiCad instances, possibly empty.
+    """
+    instances: list[KiCadInstance] = []
+    seen_paths: set[Path] = set()
+
+    # Check environment variable first
+    env_socket = os.environ.get("KICAD_IPC_SOCKET")
+    if env_socket:
+        path = Path(env_socket)
+        if path.exists():
+            instances.append(KiCadInstance(socket_path=path))
+            seen_paths.add(path.resolve())
+
+    # Search platform directories
+    for search_dir in _get_search_dirs():
+        if not search_dir.is_dir():
+            continue
+
+        for entry in sorted(search_dir.iterdir()):
+            resolved = entry.resolve()
+            if resolved in seen_paths:
+                continue
+
+            if entry.suffix == ".sock" or _is_socket(entry):
+                instances.append(KiCadInstance(socket_path=entry))
+                seen_paths.add(resolved)
+
+    return instances
+
+
+def _is_socket(path: Path) -> bool:
+    """Check if a path is a Unix domain socket.
+
+    Args:
+        path: Path to check.
+
+    Returns:
+        True if the path is a socket file.
+    """
+    try:
+        import stat
+
+        return stat.S_ISSOCK(path.stat().st_mode)
+    except (OSError, ValueError):
+        return False

--- a/src/kicad_tools/ipc/proto/__init__.py
+++ b/src/kicad_tools/ipc/proto/__init__.py
@@ -1,0 +1,20 @@
+"""Generated protobuf stubs for KiCad IPC API.
+
+This package contains lightweight message classes that mirror the KiCad IPC
+protobuf schema. Rather than depending on generated protobuf code (which
+requires matching the exact KiCad proto version), we use simple dataclasses
+that serialize to the same JSON wire format that KiCad's IPC API accepts.
+
+To regenerate from upstream KiCad protos::
+
+    # Clone KiCad source
+    git clone https://gitlab.com/kicad/code/kicad.git
+    cd kicad/api/proto
+
+    # Generate Python stubs
+    protoc --python_out=<output_dir> \\
+        kicad/common/types/*.proto \\
+        kicad/api/*.proto
+
+The current message definitions target KiCad 9.0 API compatibility.
+"""

--- a/src/kicad_tools/ipc/proto/messages.py
+++ b/src/kicad_tools/ipc/proto/messages.py
@@ -1,0 +1,186 @@
+"""Lightweight message types for KiCad IPC API wire format.
+
+These dataclasses mirror the KiCad protobuf message structure but use
+plain JSON serialization rather than protobuf binary encoding. KiCad's
+IPC API accepts both protobuf and JSON-encoded messages over NNG.
+
+Message structure follows the KiCad 9.0 API specification:
+- Each request is an ``ApiRequest`` envelope containing a typed command
+- Each response is an ``ApiResponse`` envelope with status and typed result
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Any
+
+
+class StatusCode(IntEnum):
+    """API response status codes matching KiCad's ApiStatusCode enum."""
+
+    AS_OK = 0
+    AS_TIMEOUT = 1
+    AS_BUSY = 2
+    AS_ERROR = 3
+    AS_INVALID_REQUEST = 4
+    AS_UNHANDLED = 5
+    AS_TOKEN_MISMATCH = 6
+    AS_NOT_READY = 7
+
+
+class ItemType(IntEnum):
+    """Board item types matching KiCad's KiCadObjectType enum."""
+
+    IT_TRACK = 0
+    IT_VIA = 1
+    IT_ZONE = 2
+    IT_PAD = 3
+    IT_FOOTPRINT = 4
+    IT_TEXT = 5
+    IT_ARC = 6
+
+
+@dataclass
+class Vector2(dict):
+    """2D coordinate in KiCad internal units (nanometers)."""
+
+    x_nm: int = 0
+    y_nm: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        return {"x": self.x_nm, "y": self.y_nm}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Vector2:
+        return cls(x_nm=d.get("x", 0), y_nm=d.get("y", 0))
+
+
+@dataclass
+class KIID:
+    """KiCad unique item identifier."""
+
+    value: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {"value": self.value}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> KIID:
+        return cls(value=d.get("value", ""))
+
+
+@dataclass
+class TrackSegment:
+    """A PCB track segment."""
+
+    start: Vector2 = field(default_factory=Vector2)
+    end: Vector2 = field(default_factory=Vector2)
+    width_nm: int = 250000  # 0.25mm default
+    layer: str = "F.Cu"
+    net: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "start": self.start.to_dict(),
+            "end": self.end.to_dict(),
+            "width": self.width_nm,
+            "layer": self.layer,
+            "net": self.net,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> TrackSegment:
+        return cls(
+            start=Vector2.from_dict(d.get("start", {})),
+            end=Vector2.from_dict(d.get("end", {})),
+            width_nm=d.get("width", 250000),
+            layer=d.get("layer", "F.Cu"),
+            net=d.get("net", 0),
+        )
+
+
+@dataclass
+class Via:
+    """A PCB via."""
+
+    position: Vector2 = field(default_factory=Vector2)
+    diameter_nm: int = 800000  # 0.8mm default
+    drill_nm: int = 400000  # 0.4mm default
+    net: int = 0
+    start_layer: str = "F.Cu"
+    end_layer: str = "B.Cu"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "position": self.position.to_dict(),
+            "diameter": self.diameter_nm,
+            "drill": self.drill_nm,
+            "net": self.net,
+            "start_layer": self.start_layer,
+            "end_layer": self.end_layer,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Via:
+        return cls(
+            position=Vector2.from_dict(d.get("position", {})),
+            diameter_nm=d.get("diameter", 800000),
+            drill_nm=d.get("drill", 400000),
+            net=d.get("net", 0),
+            start_layer=d.get("start_layer", "F.Cu"),
+            end_layer=d.get("end_layer", "B.Cu"),
+        )
+
+
+# --- API Envelope Messages ---
+
+
+@dataclass
+class ApiRequest:
+    """Top-level API request envelope.
+
+    Each request contains a ``command`` field identifying the operation
+    and a ``params`` dict with command-specific parameters.
+    """
+
+    command: str = ""
+    token: str = ""
+    params: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        msg: dict[str, Any] = {
+            "command": self.command,
+        }
+        if self.token:
+            msg["token"] = self.token
+        if self.params:
+            msg["params"] = self.params
+        return msg
+
+
+@dataclass
+class ApiResponse:
+    """Top-level API response envelope."""
+
+    status: StatusCode = StatusCode.AS_OK
+    message: str = ""
+    result: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ApiResponse:
+        status_val = d.get("status", 0)
+        if isinstance(status_val, int):
+            status = StatusCode(status_val)
+        else:
+            status = StatusCode.AS_OK
+        return cls(
+            status=status,
+            message=d.get("message", ""),
+            result=d.get("result", {}),
+        )
+
+    @property
+    def ok(self) -> bool:
+        """Check if the response indicates success."""
+        return self.status == StatusCode.AS_OK

--- a/src/kicad_tools/ipc/transactions.py
+++ b/src/kicad_tools/ipc/transactions.py
@@ -1,0 +1,218 @@
+"""Transaction support for atomic KiCad IPC operations.
+
+Wraps multi-step operations in ``begin_commit()`` / ``push_commit()`` /
+``drop_commit()`` to ensure atomic undo. When pushing a full routing
+solution (potentially hundreds of tracks and vias), transactions ensure
+that either all items are applied or none are.
+
+Usage as a context manager::
+
+    from kicad_tools.ipc import IPCClient, Transaction
+
+    with IPCClient(socket_path) as client:
+        with Transaction(client) as txn:
+            # All operations in this block are grouped
+            txn.create_items([track1, track2, via1])
+            # On success: push_commit() is called automatically
+            # On exception: drop_commit() reverts all changes
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from kicad_tools.ipc.client import IPCClient
+
+logger = logging.getLogger(__name__)
+
+
+class TransactionError(Exception):
+    """Raised when a transaction operation fails."""
+
+
+class Transaction:
+    """Context manager for atomic KiCad board modifications.
+
+    A transaction groups multiple board modifications into a single
+    undoable operation. If any step fails, the entire transaction
+    is rolled back.
+
+    Args:
+        client: Connected IPCClient instance.
+        description: Optional human-readable description for the undo stack.
+    """
+
+    def __init__(
+        self,
+        client: IPCClient,
+        description: str = "kicad-tools operation",
+    ) -> None:
+        self._client = client
+        self._description = description
+        self._active = False
+        self._committed = False
+
+    @property
+    def active(self) -> bool:
+        """Whether this transaction is currently open."""
+        return self._active
+
+    @property
+    def committed(self) -> bool:
+        """Whether this transaction was successfully committed."""
+        return self._committed
+
+    def begin(self) -> None:
+        """Start the transaction.
+
+        Sends ``BeginCommit`` to KiCad to open an undo group.
+
+        Raises:
+            TransactionError: If a transaction is already active.
+        """
+        if self._active:
+            raise TransactionError("Transaction already active")
+
+        from kicad_tools.ipc.client import IPCError
+
+        try:
+            self._client.send_command(
+                "BeginCommit",
+                params={"description": self._description},
+            )
+            self._active = True
+            logger.info("Transaction started: %s", self._description)
+        except IPCError as exc:
+            raise TransactionError(f"Failed to begin transaction: {exc}") from exc
+
+    def commit(self) -> None:
+        """Commit the transaction.
+
+        Sends ``PushCommit`` to KiCad to finalize all changes as a
+        single undo step.
+
+        Raises:
+            TransactionError: If no transaction is active.
+        """
+        if not self._active:
+            raise TransactionError("No active transaction to commit")
+
+        from kicad_tools.ipc.client import IPCError
+
+        try:
+            self._client.send_command("PushCommit")
+            self._active = False
+            self._committed = True
+            logger.info("Transaction committed: %s", self._description)
+        except IPCError as exc:
+            # Try to roll back on commit failure
+            logger.error("Commit failed, attempting rollback: %s", exc)
+            self.rollback()
+            raise TransactionError(f"Failed to commit transaction: {exc}") from exc
+
+    def rollback(self) -> None:
+        """Roll back the transaction.
+
+        Sends ``DropCommit`` to KiCad to discard all changes made
+        since ``begin()``.
+
+        Raises:
+            TransactionError: If no transaction is active.
+        """
+        if not self._active:
+            raise TransactionError("No active transaction to rollback")
+
+        from kicad_tools.ipc.client import IPCError
+
+        try:
+            self._client.send_command("DropCommit")
+            logger.info("Transaction rolled back: %s", self._description)
+        except IPCError as exc:
+            logger.error("Rollback failed: %s", exc)
+            raise TransactionError(f"Failed to rollback transaction: {exc}") from exc
+        finally:
+            self._active = False
+
+    def create_items(self, items: list[dict[str, Any]]) -> list[str]:
+        """Create board items within this transaction.
+
+        Args:
+            items: List of item dicts (tracks, vias, etc.) in KiCad
+                API format.
+
+        Returns:
+            List of created item IDs (KIIDs).
+
+        Raises:
+            TransactionError: If no transaction is active.
+        """
+        if not self._active:
+            raise TransactionError("No active transaction")
+
+        from kicad_tools.ipc.client import IPCError
+
+        try:
+            response = self._client.send_command(
+                "CreateItems",
+                params={"items": items},
+            )
+            created_ids = response.result.get("created_ids", [])
+            logger.debug("Created %d items", len(created_ids))
+            return created_ids
+        except IPCError as exc:
+            raise TransactionError(f"Failed to create items: {exc}") from exc
+
+    def delete_items(self, item_ids: list[str]) -> None:
+        """Delete board items within this transaction.
+
+        Args:
+            item_ids: List of KIIDs to delete.
+
+        Raises:
+            TransactionError: If no transaction is active.
+        """
+        if not self._active:
+            raise TransactionError("No active transaction")
+
+        from kicad_tools.ipc.client import IPCError
+
+        try:
+            self._client.send_command(
+                "DeleteItems",
+                params={"item_ids": item_ids},
+            )
+            logger.debug("Deleted %d items", len(item_ids))
+        except IPCError as exc:
+            raise TransactionError(f"Failed to delete items: {exc}") from exc
+
+    def __enter__(self) -> Transaction:
+        """Begin transaction on context manager entry."""
+        self.begin()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Commit or rollback on context manager exit.
+
+        If an exception occurred, the transaction is rolled back.
+        Otherwise, it is committed.
+        """
+        if not self._active:
+            return
+
+        if exc_type is not None:
+            logger.info(
+                "Exception during transaction, rolling back: %s",
+                exc_val,
+            )
+            try:
+                self.rollback()
+            except TransactionError:
+                logger.error("Rollback failed after exception", exc_info=True)
+        else:
+            self.commit()
+
+    def __repr__(self) -> str:
+        state = "active" if self._active else "committed" if self._committed else "inactive"
+        return f"Transaction({self._description!r}, {state})"

--- a/tests/test_ipc_client.py
+++ b/tests/test_ipc_client.py
@@ -1,0 +1,295 @@
+"""Tests for KiCad IPC client with mocked NNG transport."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.ipc.client import (
+    IPCApiError,
+    IPCClient,
+    IPCConnectionError,
+    IPCProtocolError,
+)
+from kicad_tools.ipc.proto.messages import StatusCode
+
+
+@pytest.fixture
+def mock_pynng():
+    """Provide a mocked pynng module."""
+    mock_module = MagicMock()
+    mock_socket = MagicMock()
+    mock_module.Req0.return_value = mock_socket
+    mock_module.exceptions = MagicMock()
+    mock_module.exceptions.ConnectionRefused = type("ConnectionRefused", (Exception,), {})
+    mock_module.exceptions.AddressInUse = type("AddressInUse", (Exception,), {})
+    return mock_module, mock_socket
+
+
+class TestIPCClientInit:
+    """Tests for IPCClient initialization."""
+
+    def test_init_defaults(self):
+        client = IPCClient("/tmp/kicad/test.sock")
+        assert not client.connected
+        assert client.socket_path.name == "test.sock"
+        assert client.token == ""
+
+    def test_init_custom_timeout(self):
+        client = IPCClient("/tmp/test.sock", timeout_ms=10000)
+        assert not client.connected
+
+    def test_repr_disconnected(self):
+        client = IPCClient("/tmp/test.sock")
+        assert "disconnected" in repr(client)
+
+
+class TestIPCClientConnect:
+    """Tests for connection lifecycle."""
+
+    def test_connect_success(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        client = IPCClient("/tmp/kicad/test.sock")
+
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+
+        assert client.connected
+        mock_module.Req0.assert_called_once()
+
+    def test_connect_already_connected(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        client = IPCClient("/tmp/kicad/test.sock")
+
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            # Second connect should be a no-op
+            client.connect()
+
+        # Req0 should only be called once
+        assert mock_module.Req0.call_count == 1
+
+    def test_connect_refused(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        mock_module.Req0.side_effect = mock_module.exceptions.ConnectionRefused()
+        client = IPCClient("/tmp/kicad/test.sock")
+
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            with pytest.raises(IPCConnectionError, match="Connection refused"):
+                client.connect()
+
+    def test_connect_address_in_use(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        mock_module.Req0.side_effect = mock_module.exceptions.AddressInUse()
+        client = IPCClient("/tmp/kicad/test.sock")
+
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            with pytest.raises(IPCConnectionError, match="already in use"):
+                client.connect()
+
+    def test_connect_import_error(self):
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": None}):
+            with pytest.raises(ImportError, match="pynng"):
+                client.connect()
+
+    def test_disconnect(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        client = IPCClient("/tmp/kicad/test.sock")
+
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            client.disconnect()
+
+        assert not client.connected
+        mock_socket.close.assert_called_once()
+
+    def test_disconnect_when_not_connected(self):
+        client = IPCClient("/tmp/kicad/test.sock")
+        # Should not raise
+        client.disconnect()
+        assert not client.connected
+
+    def test_reconnect(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        client = IPCClient("/tmp/kicad/test.sock")
+
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            client.reconnect()
+
+        assert client.connected
+        assert mock_module.Req0.call_count == 2
+
+
+class TestIPCClientSendCommand:
+    """Tests for command send/receive."""
+
+    def test_send_command_success(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        response_data = {"status": 0, "message": "", "result": {"version": "9.0.1"}}
+        mock_socket.recv.return_value = json.dumps(response_data).encode()
+
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            response = client.send_command("GetVersion")
+
+        assert response.ok
+        assert response.result["version"] == "9.0.1"
+
+    def test_send_command_with_params(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        response_data = {"status": 0, "message": "", "result": {}}
+        mock_socket.recv.return_value = json.dumps(response_data).encode()
+
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            client.send_command("CreateItems", params={"items": [{"type": "track"}]})
+
+        sent_bytes = mock_socket.send.call_args[0][0]
+        sent_data = json.loads(sent_bytes)
+        assert sent_data["command"] == "CreateItems"
+        assert sent_data["params"]["items"] == [{"type": "track"}]
+
+    def test_send_command_not_connected(self):
+        client = IPCClient("/tmp/kicad/test.sock")
+        with pytest.raises(IPCConnectionError, match="Not connected"):
+            client.send_command("GetVersion")
+
+    def test_send_command_api_error(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        response_data = {"status": 3, "message": "Board not loaded", "result": {}}
+        mock_socket.recv.return_value = json.dumps(response_data).encode()
+
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            with pytest.raises(IPCApiError) as exc_info:
+                client.send_command("GetNets")
+
+        assert exc_info.value.status == StatusCode.AS_ERROR
+        assert "Board not loaded" in exc_info.value.api_message
+
+    def test_send_command_invalid_json_response(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        mock_socket.recv.return_value = b"not json"
+
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            with pytest.raises(IPCProtocolError, match="Invalid response"):
+                client.send_command("GetVersion")
+
+    def test_send_command_captures_token(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        response_data = {"status": 0, "message": "", "result": {"token": "abc123"}}
+        mock_socket.recv.return_value = json.dumps(response_data).encode()
+
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            client.send_command("Connect")
+
+        assert client.token == "abc123"
+
+    def test_send_command_includes_token(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        # First response sets token
+        response_with_token = {"status": 0, "result": {"token": "tok123"}}
+        # Second response is normal
+        response_normal = {"status": 0, "result": {"version": "9.0"}}
+        mock_socket.recv.side_effect = [
+            json.dumps(response_with_token).encode(),
+            json.dumps(response_normal).encode(),
+        ]
+
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            client.send_command("Connect")
+            client.send_command("GetVersion")
+
+        # Second call should include the token
+        second_call_bytes = mock_socket.send.call_args_list[1][0][0]
+        second_call_data = json.loads(second_call_bytes)
+        assert second_call_data["token"] == "tok123"
+
+
+class TestIPCClientPing:
+    """Tests for health check."""
+
+    def test_ping_success(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        response_data = {"status": 0, "result": {}}
+        mock_socket.recv.return_value = json.dumps(response_data).encode()
+
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            assert client.ping() is True
+
+    def test_ping_not_connected(self):
+        client = IPCClient("/tmp/kicad/test.sock")
+        assert client.ping() is False
+
+    def test_ping_failure(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        mock_socket.recv.side_effect = Exception("timeout")
+
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            assert client.ping() is False
+
+
+class TestIPCClientContextManager:
+    """Tests for context manager usage."""
+
+    def test_context_manager(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            with IPCClient("/tmp/kicad/test.sock") as client:
+                assert client.connected
+
+        assert not client.connected
+        mock_socket.close.assert_called_once()
+
+    def test_context_manager_exception(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            with pytest.raises(ValueError):
+                with IPCClient("/tmp/kicad/test.sock"):
+                    raise ValueError("test error")
+
+        # Socket should still be closed
+        mock_socket.close.assert_called_once()
+
+
+class TestIPCClientGetVersion:
+    """Tests for get_version helper."""
+
+    def test_get_version(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        response_data = {"status": 0, "result": {"version": "9.0.2"}}
+        mock_socket.recv.return_value = json.dumps(response_data).encode()
+
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            assert client.get_version() == "9.0.2"
+
+    def test_get_version_missing_key(self, mock_pynng):
+        mock_module, mock_socket = mock_pynng
+        response_data = {"status": 0, "result": {}}
+        mock_socket.recv.return_value = json.dumps(response_data).encode()
+
+        client = IPCClient("/tmp/kicad/test.sock")
+        with patch.dict("sys.modules", {"pynng": mock_module}):
+            client.connect()
+            assert client.get_version() == "unknown"

--- a/tests/test_ipc_discovery.py
+++ b/tests/test_ipc_discovery.py
@@ -1,0 +1,194 @@
+"""Tests for KiCad IPC socket discovery."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from kicad_tools.ipc.discovery import (
+    KiCadInstance,
+    _get_search_dirs,
+    _is_socket,
+    discover_instances,
+    discover_socket,
+)
+
+
+class TestKiCadInstance:
+    """Tests for KiCadInstance dataclass."""
+
+    def test_basic_instance(self):
+        inst = KiCadInstance(socket_path=Path("/tmp/kicad/kicad.sock"))
+        assert inst.socket_path == Path("/tmp/kicad/kicad.sock")
+        assert inst.pid is None
+        assert inst.version is None
+        assert "KiCad@" in str(inst)
+
+    def test_instance_with_metadata(self):
+        inst = KiCadInstance(
+            socket_path=Path("/tmp/kicad/kicad.sock"),
+            pid=12345,
+            version="9.0.1",
+        )
+        assert "pid=12345" in str(inst)
+        assert "v9.0.1" in str(inst)
+
+
+class TestGetSearchDirs:
+    """Tests for platform-specific search directory logic."""
+
+    def test_linux_with_xdg(self):
+        with patch("sys.platform", "linux"), patch.dict(
+            os.environ, {"XDG_RUNTIME_DIR": "/run/user/1000"}, clear=False
+        ):
+            dirs = _get_search_dirs()
+            assert Path("/run/user/1000/kicad") in dirs
+            assert Path("/tmp/kicad") in dirs
+
+    def test_linux_without_xdg(self):
+        env = dict(os.environ)
+        env.pop("XDG_RUNTIME_DIR", None)
+        with patch("sys.platform", "linux"), patch.dict(os.environ, env, clear=True):
+            dirs = _get_search_dirs()
+            assert Path("/tmp/kicad") in dirs
+
+    def test_macos(self):
+        with patch("sys.platform", "darwin"), patch.dict(
+            os.environ, {"TMPDIR": "/var/folders/xx/T/"}, clear=False
+        ):
+            dirs = _get_search_dirs()
+            assert Path("/var/folders/xx/T/kicad") in dirs
+            assert Path("/tmp/kicad") in dirs
+
+    def test_windows(self):
+        with patch("sys.platform", "win32"), patch.dict(
+            os.environ,
+            {"LOCALAPPDATA": "C:\\Users\\test\\AppData\\Local", "TEMP": "C:\\Temp"},
+            clear=False,
+        ):
+            dirs = _get_search_dirs()
+            assert any("kicad" in str(d) for d in dirs)
+
+
+class TestDiscoverSocket:
+    """Tests for socket discovery."""
+
+    def test_explicit_path_exists(self, tmp_path):
+        sock = tmp_path / "test.sock"
+        sock.touch()
+        result = discover_socket(explicit_path=str(sock))
+        assert result == sock
+
+    def test_explicit_path_not_exists(self, tmp_path):
+        result = discover_socket(explicit_path=str(tmp_path / "nonexistent.sock"))
+        assert result is None
+
+    def test_env_variable(self, tmp_path):
+        sock = tmp_path / "kicad.sock"
+        sock.touch()
+        with patch.dict(os.environ, {"KICAD_IPC_SOCKET": str(sock)}):
+            result = discover_socket()
+        assert result == sock
+
+    def test_env_variable_missing_file(self):
+        with patch.dict(os.environ, {"KICAD_IPC_SOCKET": "/nonexistent/socket"}):
+            # Should fall through to directory search
+            with patch(
+                "kicad_tools.ipc.discovery._get_search_dirs", return_value=[]
+            ):
+                result = discover_socket()
+        assert result is None
+
+    def test_directory_search_finds_sock(self, tmp_path):
+        kicad_dir = tmp_path / "kicad"
+        kicad_dir.mkdir()
+        sock = kicad_dir / "kicad.sock"
+        sock.touch()
+
+        env = dict(os.environ)
+        env.pop("KICAD_IPC_SOCKET", None)
+        with patch.dict(os.environ, env, clear=True), patch(
+            "kicad_tools.ipc.discovery._get_search_dirs",
+            return_value=[kicad_dir],
+        ):
+            result = discover_socket()
+        assert result == sock
+
+    def test_no_sockets_found(self):
+        env = dict(os.environ)
+        env.pop("KICAD_IPC_SOCKET", None)
+        with patch.dict(os.environ, env, clear=True), patch(
+            "kicad_tools.ipc.discovery._get_search_dirs",
+            return_value=[],
+        ):
+            result = discover_socket()
+        assert result is None
+
+
+class TestDiscoverInstances:
+    """Tests for discovering multiple instances."""
+
+    def test_no_instances(self):
+        env = dict(os.environ)
+        env.pop("KICAD_IPC_SOCKET", None)
+        with patch.dict(os.environ, env, clear=True), patch(
+            "kicad_tools.ipc.discovery._get_search_dirs",
+            return_value=[],
+        ):
+            instances = discover_instances()
+        assert instances == []
+
+    def test_env_instance(self, tmp_path):
+        sock = tmp_path / "kicad.sock"
+        sock.touch()
+        with patch.dict(os.environ, {"KICAD_IPC_SOCKET": str(sock)}), patch(
+            "kicad_tools.ipc.discovery._get_search_dirs",
+            return_value=[],
+        ):
+            instances = discover_instances()
+        assert len(instances) == 1
+        assert instances[0].socket_path == sock
+
+    def test_multiple_instances(self, tmp_path):
+        kicad_dir = tmp_path / "kicad"
+        kicad_dir.mkdir()
+        sock1 = kicad_dir / "instance1.sock"
+        sock2 = kicad_dir / "instance2.sock"
+        sock1.touch()
+        sock2.touch()
+
+        env = dict(os.environ)
+        env.pop("KICAD_IPC_SOCKET", None)
+        with patch.dict(os.environ, env, clear=True), patch(
+            "kicad_tools.ipc.discovery._get_search_dirs",
+            return_value=[kicad_dir],
+        ):
+            instances = discover_instances()
+        assert len(instances) == 2
+
+    def test_deduplication(self, tmp_path):
+        sock = tmp_path / "kicad.sock"
+        sock.touch()
+        with patch.dict(os.environ, {"KICAD_IPC_SOCKET": str(sock)}), patch(
+            "kicad_tools.ipc.discovery._get_search_dirs",
+            return_value=[tmp_path],
+        ):
+            instances = discover_instances()
+        # Same socket found via env and dir search should be deduplicated
+        assert len(instances) == 1
+
+
+class TestIsSocket:
+    """Tests for socket file detection."""
+
+    def test_regular_file(self, tmp_path):
+        f = tmp_path / "regular.txt"
+        f.touch()
+        assert _is_socket(f) is False
+
+    def test_nonexistent(self, tmp_path):
+        assert _is_socket(tmp_path / "nope") is False
+
+    def test_directory(self, tmp_path):
+        assert _is_socket(tmp_path) is False

--- a/tests/test_ipc_transactions.py
+++ b/tests/test_ipc_transactions.py
@@ -1,0 +1,182 @@
+"""Tests for KiCad IPC transaction lifecycle."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kicad_tools.ipc.client import IPCClient
+from kicad_tools.ipc.transactions import Transaction, TransactionError
+
+
+@pytest.fixture
+def mock_client():
+    """Provide a mocked IPCClient that returns success responses."""
+    client = MagicMock(spec=IPCClient)
+    client.connected = True
+
+    # Default: all commands succeed
+    response = MagicMock()
+    response.ok = True
+    response.result = {}
+    client.send_command.return_value = response
+    return client
+
+
+class TestTransactionInit:
+    """Tests for Transaction initialization."""
+
+    def test_init_defaults(self, mock_client):
+        txn = Transaction(mock_client)
+        assert not txn.active
+        assert not txn.committed
+        assert "inactive" in repr(txn)
+
+    def test_init_custom_description(self, mock_client):
+        txn = Transaction(mock_client, description="test op")
+        assert "test op" in repr(txn)
+
+
+class TestTransactionLifecycle:
+    """Tests for begin/commit/rollback sequence."""
+
+    def test_begin(self, mock_client):
+        txn = Transaction(mock_client)
+        txn.begin()
+        assert txn.active
+        mock_client.send_command.assert_called_once_with(
+            "BeginCommit",
+            params={"description": "kicad-tools operation"},
+        )
+
+    def test_begin_already_active(self, mock_client):
+        txn = Transaction(mock_client)
+        txn.begin()
+        with pytest.raises(TransactionError, match="already active"):
+            txn.begin()
+
+    def test_commit(self, mock_client):
+        txn = Transaction(mock_client)
+        txn.begin()
+        txn.commit()
+        assert not txn.active
+        assert txn.committed
+
+        calls = [c[0][0] for c in mock_client.send_command.call_args_list]
+        assert "BeginCommit" in calls
+        assert "PushCommit" in calls
+
+    def test_commit_not_active(self, mock_client):
+        txn = Transaction(mock_client)
+        with pytest.raises(TransactionError, match="No active transaction"):
+            txn.commit()
+
+    def test_rollback(self, mock_client):
+        txn = Transaction(mock_client)
+        txn.begin()
+        txn.rollback()
+        assert not txn.active
+        assert not txn.committed
+
+        calls = [c[0][0] for c in mock_client.send_command.call_args_list]
+        assert "DropCommit" in calls
+
+    def test_rollback_not_active(self, mock_client):
+        txn = Transaction(mock_client)
+        with pytest.raises(TransactionError, match="No active transaction"):
+            txn.rollback()
+
+    def test_begin_fails(self, mock_client):
+        from kicad_tools.ipc.client import IPCError
+
+        mock_client.send_command.side_effect = IPCError("failed")
+        txn = Transaction(mock_client)
+        with pytest.raises(TransactionError, match="Failed to begin"):
+            txn.begin()
+        assert not txn.active
+
+
+class TestTransactionContextManager:
+    """Tests for context manager usage."""
+
+    def test_success_auto_commits(self, mock_client):
+        with Transaction(mock_client) as txn:
+            pass
+
+        assert txn.committed
+        calls = [c[0][0] for c in mock_client.send_command.call_args_list]
+        assert "BeginCommit" in calls
+        assert "PushCommit" in calls
+
+    def test_exception_auto_rollbacks(self, mock_client):
+        with pytest.raises(ValueError):
+            with Transaction(mock_client) as txn:
+                raise ValueError("boom")
+
+        assert not txn.committed
+        calls = [c[0][0] for c in mock_client.send_command.call_args_list]
+        assert "BeginCommit" in calls
+        assert "DropCommit" in calls
+
+    def test_context_manager_repr(self, mock_client):
+        with Transaction(mock_client, description="test") as txn:
+            assert "active" in repr(txn)
+        assert "committed" in repr(txn)
+
+
+class TestTransactionCreateItems:
+    """Tests for item creation within transactions."""
+
+    def test_create_items(self, mock_client):
+        response = MagicMock()
+        response.ok = True
+        response.result = {"created_ids": ["id1", "id2"]}
+        mock_client.send_command.return_value = response
+
+        txn = Transaction(mock_client)
+        txn.begin()
+        ids = txn.create_items([{"type": "track"}, {"type": "via"}])
+        assert ids == ["id1", "id2"]
+
+    def test_create_items_not_active(self, mock_client):
+        txn = Transaction(mock_client)
+        with pytest.raises(TransactionError, match="No active transaction"):
+            txn.create_items([{"type": "track"}])
+
+    def test_create_items_fails(self, mock_client):
+        from kicad_tools.ipc.client import IPCError
+
+        # begin succeeds, CreateItems fails
+        responses = [MagicMock(ok=True, result={})]
+        mock_client.send_command.side_effect = [
+            responses[0],
+            IPCError("create failed"),
+        ]
+
+        txn = Transaction(mock_client)
+        txn.begin()
+        with pytest.raises(TransactionError, match="Failed to create"):
+            txn.create_items([{"type": "track"}])
+
+
+class TestTransactionDeleteItems:
+    """Tests for item deletion within transactions."""
+
+    def test_delete_items(self, mock_client):
+        txn = Transaction(mock_client)
+        txn.begin()
+        txn.delete_items(["id1", "id2"])
+
+        # Should have called DeleteItems
+        delete_calls = [
+            c for c in mock_client.send_command.call_args_list
+            if c[0][0] == "DeleteItems"
+        ]
+        assert len(delete_calls) == 1
+        assert delete_calls[0][1]["params"]["item_ids"] == ["id1", "id2"]
+
+    def test_delete_items_not_active(self, mock_client):
+        txn = Transaction(mock_client)
+        with pytest.raises(TransactionError, match="No active transaction"):
+            txn.delete_items(["id1"])


### PR DESCRIPTION
## Summary

- Add `kicad_tools.ipc` module with NNG-based client for KiCad 9.0+ IPC API, enabling live interaction with running KiCad instances
- Implement connection lifecycle (connect/disconnect/reconnect), auto-discovery of KiCad sockets across macOS/Linux/Windows, and transaction context manager for atomic board modifications
- Add `kct ipc status|connect|push-routes` CLI subcommands and 61 unit tests covering client, discovery, and transaction behavior

Closes #2342

## Test plan

- [x] Unit tests pass (61 tests): client lifecycle, send/receive with mocked NNG, discovery with mocked filesystem, transaction begin/commit/rollback
- [x] Ruff linter passes on all new files
- [x] Module imports verified (`from kicad_tools.ipc import IPCClient, ...`)
- [x] CLI parser verified (`kct ipc` subcommand group)
- [ ] Integration tests require a running KiCad 9.0+ instance (marked as manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)