### PR TITLE
feat(report): add interactive HTML reports with Canvas 2D PCB viewer

### DIFF
--- a/src/kicad_tools/cli/report_cmd.py
+++ b/src/kicad_tools/cli/report_cmd.py
@@ -82,6 +82,27 @@ def main(argv: list[str] | None = None) -> int:
         help="Skip auto-collection; generate skeleton report (legacy behavior)",
     )
 
+    # --- Interactive DRC report sub-command ---
+    int_parser = sub.add_parser(
+        "interactive",
+        help="Generate an interactive HTML DRC report with PCB visualization",
+    )
+    int_parser.add_argument(
+        "input",
+        help="Path to .kicad_pcb file",
+    )
+    int_parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Output HTML file path (default: <input_stem>_interactive.html)",
+    )
+    int_parser.add_argument(
+        "--project-name",
+        default=None,
+        help="Project display name (default: PCB filename stem)",
+    )
+
     args = parser.parse_args(argv)
 
     if not args.report_subcommand:
@@ -90,6 +111,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.report_subcommand == "generate":
         return _run_generate(args)
+
+    if args.report_subcommand == "interactive":
+        return _run_interactive(args)
 
     return 0
 
@@ -416,3 +440,46 @@ def _load_data_dir(data_dir_str: str) -> dict:
                 result["git_hash"] = meta["git_hash"]
 
     return result
+
+
+def _run_interactive(args: argparse.Namespace) -> int:
+    """Execute the ``interactive`` sub-command."""
+    input_path = Path(args.input)
+
+    # Resolve .kicad_pro to .kicad_pcb
+    if input_path.suffix == ".kicad_pro":
+        input_path = input_path.with_suffix(".kicad_pcb")
+
+    if not input_path.exists():
+        print(f"Error: PCB file not found: {input_path}", file=sys.stderr)
+        return 1
+
+    if input_path.suffix != ".kicad_pcb":
+        print(
+            f"Error: expected .kicad_pcb file, got {input_path.suffix}",
+            file=sys.stderr,
+        )
+        return 1
+
+    output_path = (
+        Path(args.output) if args.output else input_path.with_name(
+            f"{input_path.stem}_interactive.html"
+        )
+    )
+
+    try:
+        from kicad_tools.report.interactive import render_interactive_html
+
+        print(f"Generating interactive report for {input_path} ...")
+        html = render_interactive_html(
+            pcb_path=input_path,
+            project_name=args.project_name,
+        )
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(html, encoding="utf-8")
+        print(f"Interactive report written to {output_path}")
+        return 0
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1

--- a/src/kicad_tools/report/__init__.py
+++ b/src/kicad_tools/report/__init__.py
@@ -17,13 +17,14 @@ from __future__ import annotations
 
 from kicad_tools.report.collector import ReportDataCollector
 from kicad_tools.report.figures import FigureEntry, ReportFigureGenerator
-from kicad_tools.report.renderers import render_html, render_pdf
+from kicad_tools.report.renderers import render_html, render_interactive_html, render_pdf
 
 __all__ = [
     "FigureEntry",
     "ReportDataCollector",
     "ReportFigureGenerator",
     "render_html",
+    "render_interactive_html",
     "render_pdf",
 ]
 

--- a/src/kicad_tools/report/interactive.py
+++ b/src/kicad_tools/report/interactive.py
@@ -1,0 +1,162 @@
+"""Interactive HTML report generator with embedded PCB visualization.
+
+Generates single-file HTML reports with an interactive Canvas 2D board
+viewer and a DRC violation browser. All CSS and JavaScript are inlined
+so the output has no external dependencies.
+
+Example:
+    >>> from kicad_tools.report.interactive import render_interactive_html
+    >>> html = render_interactive_html(pcb_path=Path("board.kicad_pcb"))
+    >>> Path("report.html").write_text(html)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+
+def render_interactive_html(
+    pcb_path: Path,
+    drc_violations: list[dict[str, Any]] | None = None,
+    project_name: str | None = None,
+    date: str | None = None,
+) -> str:
+    """Generate a self-contained interactive HTML report.
+
+    The output is a single HTML file with inlined CSS and JavaScript.
+    It includes a Canvas 2D PCB viewer with pan/zoom and a DRC violation
+    table. Clicking a violation in the table pans the viewer to its
+    location on the board.
+
+    Args:
+        pcb_path: Path to ``.kicad_pcb`` file.
+        drc_violations: Optional list of DRC violation dicts (from
+            ``DRCViolation.to_dict()``). When None, DRC is run
+            automatically if available.
+        project_name: Project display name. Defaults to the PCB
+            filename stem.
+        date: Report date string. Defaults to today's date.
+
+    Returns:
+        Complete HTML document string.
+    """
+    from kicad_tools.report.pcb_data import extract_pcb_data_from_path
+
+    pcb_path = Path(pcb_path)
+
+    if project_name is None:
+        project_name = pcb_path.stem
+
+    if date is None:
+        from datetime import date as dt_date
+
+        date = dt_date.today().isoformat()
+
+    # Extract PCB geometry
+    pcb_data = extract_pcb_data_from_path(pcb_path)
+
+    # Gather DRC violations
+    drc_data = _gather_drc_data(pcb_path, drc_violations)
+
+    # Build the HTML from template
+    title = f"{project_name} - Interactive DRC Report"
+    return _build_html(title, pcb_data, drc_data, project_name, date)
+
+
+def _gather_drc_data(
+    pcb_path: Path,
+    drc_violations: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Gather DRC data, either from provided violations or by running DRC.
+
+    Args:
+        pcb_path: Path to PCB file.
+        drc_violations: Pre-computed violations or None.
+
+    Returns:
+        Dictionary with ``violations``, ``error_count``, ``warning_count``.
+    """
+    if drc_violations is not None:
+        violations = drc_violations
+    else:
+        violations = _try_auto_drc(pcb_path)
+
+    error_count = sum(
+        1 for v in violations if v.get("severity", "error") == "error"
+    )
+    warning_count = sum(
+        1 for v in violations if v.get("severity", "error") == "warning"
+    )
+
+    return {
+        "violations": violations,
+        "error_count": error_count,
+        "warning_count": warning_count,
+    }
+
+
+def _try_auto_drc(pcb_path: Path) -> list[dict[str, Any]]:
+    """Attempt to run DRC and return violations as dicts.
+
+    Returns an empty list on failure.
+    """
+    try:
+        from kicad_tools.drc.runner import run_drc
+
+        report = run_drc(pcb_path)
+        return [v.to_dict() for v in report.violations]
+    except Exception:
+        logger.debug("Auto-DRC failed; producing report with no violations", exc_info=True)
+        return []
+
+
+def _build_html(
+    title: str,
+    pcb_data: dict[str, Any],
+    drc_data: dict[str, Any],
+    project_name: str,
+    date: str,
+) -> str:
+    """Assemble the HTML document from template and data.
+
+    Loads CSS and JS from the templates directory and injects them
+    along with JSON data payloads into the HTML template.
+    """
+    css = (_TEMPLATES_DIR / "interactive.css").read_text(encoding="utf-8")
+    js = (_TEMPLATES_DIR / "interactive.js").read_text(encoding="utf-8")
+    template_str = (_TEMPLATES_DIR / "interactive.html").read_text(encoding="utf-8")
+
+    # Build data injection scripts
+    pcb_json = json.dumps(pcb_data, separators=(",", ":"))
+    drc_json = json.dumps(drc_data, separators=(",", ":"))
+    meta_json = json.dumps(
+        {"project_name": project_name, "date": date},
+        separators=(",", ":"),
+    )
+
+    pcb_data_script = f"window.PCB_DATA = {pcb_json};"
+    drc_data_script = f"window.DRC_DATA = {drc_json};"
+    report_meta_script = f"window.REPORT_META = {meta_json};"
+
+    # Simple template substitution (avoiding Jinja2 dependency for this)
+    html = template_str
+    html = html.replace("{{ title }}", _escape_html(title))
+    html = html.replace("{{ css }}", css)
+    html = html.replace("{{ js }}", js)
+    html = html.replace("{{ pcb_data_script }}", pcb_data_script)
+    html = html.replace("{{ drc_data_script }}", drc_data_script)
+    html = html.replace("{{ report_meta_script }}", report_meta_script)
+
+    return html
+
+
+def _escape_html(s: str) -> str:
+    """Minimal HTML escaping for template values."""
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")

--- a/src/kicad_tools/report/models.py
+++ b/src/kicad_tools/report/models.py
@@ -88,6 +88,11 @@ class ReportData:
     """Layer stackup: [{name, type, thickness_mm, material}].
     Filtered to copper, dielectric, and mask layers."""
 
+    pcb_geometry: dict | None = None
+    """PCB geometry data for interactive reports: {board_outline, bounds,
+    footprints, segments, vias, layers}.  Populated by
+    :func:`~kicad_tools.report.pcb_data.extract_pcb_data`."""
+
     notes: str = ""
     """Free-form notes section content."""
 

--- a/src/kicad_tools/report/pcb_data.py
+++ b/src/kicad_tools/report/pcb_data.py
@@ -1,0 +1,212 @@
+"""PCB geometry data extraction for interactive HTML reports.
+
+Extracts board outline, footprints, pads, tracks, vias, and zone outlines
+from a parsed PCB into a JSON-serializable dictionary suitable for rendering
+in a Canvas 2D viewer.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _natsort_key(s: str) -> list[int | str]:
+    """Natural sort key: splits text into (str, int, str, int, ...) chunks.
+
+    Ensures R1, R2, R10 sort correctly instead of R1, R10, R2.
+    """
+    parts: list[int | str] = []
+    for chunk in re.split(r"(\d+)", s):
+        if chunk.isdigit():
+            parts.append(int(chunk))
+        else:
+            parts.append(chunk.lower())
+    return parts
+
+
+def natsort_refs(refs: list[str]) -> list[str]:
+    """Sort reference designators using natural alphanumeric order.
+
+    Args:
+        refs: List of reference designator strings (e.g. ["R1", "R10", "R2"]).
+
+    Returns:
+        Naturally sorted list (e.g. ["R1", "R2", "R10"]).
+    """
+    return sorted(refs, key=_natsort_key)
+
+
+def extract_pcb_data(pcb: Any) -> dict[str, Any]:
+    """Extract PCB geometry data from a parsed PCB object.
+
+    Returns a JSON-serializable dictionary with the following top-level keys:
+
+    - ``board_outline``: list of (x, y) points forming the board edge
+    - ``bounds``: ``{min_x, min_y, max_x, max_y}`` bounding box in mm
+    - ``footprints``: list of footprint dicts with position, pads, reference
+    - ``segments``: list of trace segment dicts with start, end, layer, width
+    - ``vias``: list of via dicts with position, size, drill, layers
+    - ``layers``: list of layer name strings (copper only)
+
+    Args:
+        pcb: Loaded PCB object (``kicad_tools.schema.pcb.PCB``).
+
+    Returns:
+        Dictionary of PCB geometry data.
+    """
+    result: dict[str, Any] = {}
+
+    # Board outline
+    outline = _extract_outline(pcb)
+    result["board_outline"] = outline
+
+    # Bounding box
+    result["bounds"] = _compute_bounds(outline, pcb)
+
+    # Copper layers
+    copper_layers = pcb.copper_layers
+    result["layers"] = [layer.name for layer in copper_layers]
+
+    # Footprints
+    result["footprints"] = _extract_footprints(pcb)
+
+    # Segments (traces)
+    result["segments"] = _extract_segments(pcb)
+
+    # Vias
+    result["vias"] = _extract_vias(pcb)
+
+    return result
+
+
+def _extract_outline(pcb: Any) -> list[list[float]]:
+    """Extract board outline as a list of [x, y] coordinate pairs."""
+    try:
+        points = pcb.get_board_outline()
+        return [[round(p[0], 3), round(p[1], 3)] for p in points]
+    except Exception:
+        logger.debug("Could not extract board outline", exc_info=True)
+        return []
+
+
+def _compute_bounds(
+    outline: list[list[float]], pcb: Any
+) -> dict[str, float]:
+    """Compute bounding box from outline or fallback to all geometry."""
+    if outline:
+        xs = [p[0] for p in outline]
+        ys = [p[1] for p in outline]
+        return {
+            "min_x": min(xs),
+            "min_y": min(ys),
+            "max_x": max(xs),
+            "max_y": max(ys),
+        }
+
+    # Fallback: compute from footprint positions
+    min_x = min_y = float("inf")
+    max_x = max_y = float("-inf")
+    for fp in pcb.footprints:
+        x, y = fp.position
+        min_x = min(min_x, x)
+        min_y = min(min_y, y)
+        max_x = max(max_x, x)
+        max_y = max(max_y, y)
+
+    if min_x == float("inf"):
+        return {"min_x": 0, "min_y": 0, "max_x": 100, "max_y": 100}
+
+    # Add margin
+    margin = 5.0
+    return {
+        "min_x": min_x - margin,
+        "min_y": min_y - margin,
+        "max_x": max_x + margin,
+        "max_y": max_y + margin,
+    }
+
+
+def _extract_footprints(pcb: Any) -> list[dict[str, Any]]:
+    """Extract footprint data including pads."""
+    footprints = []
+    for fp in pcb.footprints:
+        fp_data: dict[str, Any] = {
+            "reference": fp.reference or "",
+            "value": fp.value or "",
+            "position": [round(fp.position[0], 3), round(fp.position[1], 3)],
+            "rotation": fp.rotation,
+            "layer": fp.layer,
+            "attr": fp.attr or "",
+            "pads": [],
+        }
+        for pad in fp.pads:
+            pad_data = {
+                "number": pad.number,
+                "type": pad.type,
+                "shape": pad.shape,
+                "position": [
+                    round(pad.position[0], 3),
+                    round(pad.position[1], 3),
+                ],
+                "size": [round(pad.size[0], 3), round(pad.size[1], 3)],
+                "layers": pad.layers,
+                "net_name": pad.net_name,
+            }
+            fp_data["pads"].append(pad_data)
+        footprints.append(fp_data)
+
+    return footprints
+
+
+def _extract_segments(pcb: Any) -> list[dict[str, Any]]:
+    """Extract trace segments."""
+    segments = []
+    for seg in pcb.segments:
+        segments.append({
+            "start": [round(seg.start[0], 3), round(seg.start[1], 3)],
+            "end": [round(seg.end[0], 3), round(seg.end[1], 3)],
+            "width": round(seg.width, 3),
+            "layer": seg.layer,
+            "net": seg.net_name or str(seg.net_number),
+        })
+    return segments
+
+
+def _extract_vias(pcb: Any) -> list[dict[str, Any]]:
+    """Extract vias."""
+    vias = []
+    for via in pcb.vias:
+        vias.append({
+            "position": [
+                round(via.position[0], 3),
+                round(via.position[1], 3),
+            ],
+            "size": round(via.size, 3),
+            "drill": round(via.drill, 3),
+            "layers": via.layers,
+            "net": via.net_name or str(via.net_number),
+        })
+    return vias
+
+
+def extract_pcb_data_from_path(pcb_path: Path) -> dict[str, Any]:
+    """Load a .kicad_pcb file and extract geometry data.
+
+    Convenience wrapper around :func:`extract_pcb_data` that handles
+    loading the PCB file.
+
+    Args:
+        pcb_path: Path to ``.kicad_pcb`` file.
+
+    Returns:
+        Dictionary of PCB geometry data.
+    """
+    from kicad_tools.schema.pcb import PCB
+
+    pcb = PCB.load(pcb_path)
+    return extract_pcb_data(pcb)

--- a/src/kicad_tools/report/renderers.py
+++ b/src/kicad_tools/report/renderers.py
@@ -2,7 +2,8 @@
 
 Provides functions to render Markdown content (from ReportGenerator) into
 self-contained HTML documents with embedded CSS and base64-encoded images,
-and optionally to PDF via weasyprint.
+and optionally to PDF via weasyprint.  Also provides interactive HTML
+reports with embedded PCB visualization via :func:`render_interactive_html`.
 """
 
 from __future__ import annotations
@@ -307,3 +308,35 @@ def _wrap_html(body: str, css: str, title: str = "KiCad Design Report") -> str:
 {body}
 </body>
 </html>"""
+
+
+def render_interactive_html(
+    pcb_path: "Path",
+    drc_violations: "list[dict] | None" = None,
+    project_name: str | None = None,
+    date: str | None = None,
+) -> str:
+    """Generate a self-contained interactive HTML report.
+
+    Delegates to :func:`kicad_tools.report.interactive.render_interactive_html`.
+    See that function for full documentation.
+
+    Args:
+        pcb_path: Path to ``.kicad_pcb`` file.
+        drc_violations: Optional pre-computed DRC violations.
+        project_name: Project display name.
+        date: Report date string.
+
+    Returns:
+        Complete HTML document string.
+    """
+    from kicad_tools.report.interactive import (
+        render_interactive_html as _render,
+    )
+
+    return _render(
+        pcb_path=pcb_path,
+        drc_violations=drc_violations,
+        project_name=project_name,
+        date=date,
+    )

--- a/src/kicad_tools/report/templates/interactive.css
+++ b/src/kicad_tools/report/templates/interactive.css
@@ -1,0 +1,225 @@
+/* Interactive PCB Report Styles */
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #1a1a2e;
+    color: #e0e0e0;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+header {
+    background: #16213e;
+    padding: 12px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid #0f3460;
+    flex-shrink: 0;
+}
+
+header h1 {
+    font-size: 18px;
+    font-weight: 600;
+    color: #e94560;
+}
+
+header .stats {
+    font-size: 13px;
+    color: #a0a0b0;
+}
+
+.main-container {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+/* Board Viewer Panel */
+.viewer-panel {
+    flex: 1;
+    position: relative;
+    background: #0a0a1a;
+    overflow: hidden;
+}
+
+.viewer-panel canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.viewer-controls {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    z-index: 10;
+}
+
+.viewer-controls button {
+    background: #16213e;
+    color: #e0e0e0;
+    border: 1px solid #0f3460;
+    padding: 6px 10px;
+    cursor: pointer;
+    font-size: 14px;
+    border-radius: 3px;
+}
+
+.viewer-controls button:hover {
+    background: #1a2a4e;
+}
+
+.layer-controls {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    background: rgba(22, 33, 62, 0.9);
+    border: 1px solid #0f3460;
+    border-radius: 4px;
+    padding: 8px;
+    font-size: 12px;
+    z-index: 10;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.layer-controls label {
+    display: block;
+    padding: 2px 0;
+    cursor: pointer;
+}
+
+.layer-controls input[type="checkbox"] {
+    margin-right: 6px;
+}
+
+.coord-display {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    background: rgba(22, 33, 62, 0.9);
+    border: 1px solid #0f3460;
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 11px;
+    font-family: monospace;
+    z-index: 10;
+}
+
+/* Violation Panel */
+.violation-panel {
+    width: 380px;
+    background: #16213e;
+    border-left: 1px solid #0f3460;
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+    overflow: hidden;
+}
+
+.violation-panel h2 {
+    font-size: 14px;
+    padding: 10px 14px;
+    border-bottom: 1px solid #0f3460;
+    color: #e94560;
+    flex-shrink: 0;
+}
+
+.violation-filter {
+    padding: 8px 14px;
+    border-bottom: 1px solid #0f3460;
+    flex-shrink: 0;
+}
+
+.violation-filter select {
+    width: 100%;
+    background: #1a1a2e;
+    color: #e0e0e0;
+    border: 1px solid #0f3460;
+    padding: 4px 8px;
+    font-size: 12px;
+    border-radius: 3px;
+}
+
+.violation-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0;
+}
+
+.violation-item {
+    padding: 10px 14px;
+    border-bottom: 1px solid rgba(15, 52, 96, 0.5);
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.violation-item:hover {
+    background: rgba(233, 69, 96, 0.1);
+}
+
+.violation-item.selected {
+    background: rgba(233, 69, 96, 0.2);
+    border-left: 3px solid #e94560;
+    padding-left: 11px;
+}
+
+.violation-item .v-type {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.violation-item .v-type.error {
+    color: #e94560;
+}
+
+.violation-item .v-type.warning {
+    color: #f5a623;
+}
+
+.violation-item .v-message {
+    font-size: 12px;
+    margin-top: 3px;
+    color: #c0c0d0;
+    line-height: 1.4;
+}
+
+.violation-item .v-location {
+    font-size: 11px;
+    margin-top: 3px;
+    color: #808090;
+    font-family: monospace;
+}
+
+.no-violations {
+    padding: 30px 14px;
+    text-align: center;
+    color: #808090;
+    font-size: 13px;
+}
+
+.no-violations .check-mark {
+    font-size: 36px;
+    color: #2ecc71;
+    margin-bottom: 10px;
+}
+
+/* Responsive: stack vertically on narrow screens */
+@media (max-width: 800px) {
+    .main-container {
+        flex-direction: column;
+    }
+    .violation-panel {
+        width: 100%;
+        max-height: 40vh;
+        border-left: none;
+        border-top: 1px solid #0f3460;
+    }
+}

--- a/src/kicad_tools/report/templates/interactive.html
+++ b/src/kicad_tools/report/templates/interactive.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="generator" content="kicad-tools interactive report">
+<title>{{ title }}</title>
+<style>
+{{ css }}
+</style>
+</head>
+<body>
+<header>
+    <h1>{{ title }}</h1>
+    <span class="stats" id="report-stats"></span>
+</header>
+<div class="main-container">
+    <div class="viewer-panel">
+        <canvas id="pcb-canvas"></canvas>
+        <div class="viewer-controls">
+            <button onclick="zoomIn()" title="Zoom In">+</button>
+            <button onclick="zoomOut()" title="Zoom Out">&minus;</button>
+            <button onclick="zoomFit()" title="Fit to View">&#8596;</button>
+        </div>
+        <div class="layer-controls" id="layer-controls"></div>
+        <div class="coord-display" id="coord-display">X: 0.00 mm  Y: 0.00 mm</div>
+    </div>
+    <div class="violation-panel">
+        <h2>DRC Violations</h2>
+        <div class="violation-filter">
+            <select id="violation-filter">
+                <option value="all">All Types</option>
+            </select>
+        </div>
+        <div class="violation-list" id="violation-list"></div>
+    </div>
+</div>
+<script>
+{{ pcb_data_script }}
+{{ drc_data_script }}
+{{ report_meta_script }}
+</script>
+<script>
+{{ js }}
+</script>
+</body>
+</html>

--- a/src/kicad_tools/report/templates/interactive.js
+++ b/src/kicad_tools/report/templates/interactive.js
@@ -1,0 +1,554 @@
+/* Interactive PCB Report - Canvas Renderer and UI Controller */
+(function () {
+  "use strict";
+
+  // ---- Data injected by Python template engine ----
+  // window.PCB_DATA  = { board_outline, bounds, footprints, segments, vias, layers }
+  // window.DRC_DATA  = { violations: [...], error_count, warning_count }
+  // window.REPORT_META = { project_name, date, ... }
+
+  var pcb = window.PCB_DATA || {};
+  var drc = window.DRC_DATA || { violations: [], error_count: 0, warning_count: 0 };
+
+  // ---- Layer colors ----
+  var LAYER_COLORS = {
+    "F.Cu": "#cc0000",
+    "B.Cu": "#0000cc",
+    "In1.Cu": "#cc8800",
+    "In2.Cu": "#008800",
+    "In3.Cu": "#8800cc",
+    "In4.Cu": "#00cccc",
+    "Edge.Cuts": "#cccc00",
+    "F.SilkS": "#cccccc",
+    "B.SilkS": "#666666",
+    "F.Mask": "rgba(160,0,160,0.3)",
+    "B.Mask": "rgba(0,160,160,0.3)",
+  };
+
+  function layerColor(name) {
+    return LAYER_COLORS[name] || "#888888";
+  }
+
+  // ---- Canvas state ----
+  var canvas, ctx;
+  var viewState = { offsetX: 0, offsetY: 0, scale: 1 };
+  var isDragging = false;
+  var dragStart = { x: 0, y: 0 };
+  var mouseBoard = { x: 0, y: 0 };
+  var selectedViolation = null;
+  var visibleLayers = {};
+  var highlightLocations = [];
+
+  // ---- Initialization ----
+  function init() {
+    canvas = document.getElementById("pcb-canvas");
+    ctx = canvas.getContext("2d");
+
+    // Initialize visible layers
+    (pcb.layers || []).forEach(function (l) {
+      visibleLayers[l] = true;
+    });
+    visibleLayers["Edge.Cuts"] = true;
+
+    fitBoard();
+    setupEvents();
+    buildLayerControls();
+    buildViolationList();
+    updateStats();
+    render();
+  }
+
+  function fitBoard() {
+    var b = pcb.bounds;
+    if (!b) return;
+    var rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * window.devicePixelRatio;
+    canvas.height = rect.height * window.devicePixelRatio;
+    canvas.style.width = rect.width + "px";
+    canvas.style.height = rect.height + "px";
+
+    var bw = b.max_x - b.min_x;
+    var bh = b.max_y - b.min_y;
+    if (bw === 0 || bh === 0) return;
+
+    var margin = 20 * window.devicePixelRatio;
+    var scaleX = (canvas.width - 2 * margin) / bw;
+    var scaleY = (canvas.height - 2 * margin) / bh;
+    viewState.scale = Math.min(scaleX, scaleY);
+    viewState.offsetX =
+      (canvas.width - bw * viewState.scale) / 2 - b.min_x * viewState.scale;
+    viewState.offsetY =
+      (canvas.height - bh * viewState.scale) / 2 - b.min_y * viewState.scale;
+  }
+
+  // ---- Coordinate transforms ----
+  function boardToScreen(bx, by) {
+    return {
+      x: bx * viewState.scale + viewState.offsetX,
+      y: by * viewState.scale + viewState.offsetY,
+    };
+  }
+
+  function screenToBoard(sx, sy) {
+    return {
+      x: (sx - viewState.offsetX) / viewState.scale,
+      y: (sy - viewState.offsetY) / viewState.scale,
+    };
+  }
+
+  // ---- Event handling ----
+  function setupEvents() {
+    canvas.addEventListener("mousedown", onMouseDown);
+    canvas.addEventListener("mousemove", onMouseMove);
+    canvas.addEventListener("mouseup", onMouseUp);
+    canvas.addEventListener("mouseleave", onMouseUp);
+    canvas.addEventListener("wheel", onWheel, { passive: false });
+    canvas.addEventListener("dblclick", onDblClick);
+    window.addEventListener("resize", onResize);
+  }
+
+  function onMouseDown(e) {
+    isDragging = true;
+    dragStart.x = e.clientX;
+    dragStart.y = e.clientY;
+    canvas.style.cursor = "grabbing";
+  }
+
+  function onMouseMove(e) {
+    var rect = canvas.getBoundingClientRect();
+    var sx = (e.clientX - rect.left) * window.devicePixelRatio;
+    var sy = (e.clientY - rect.top) * window.devicePixelRatio;
+    mouseBoard = screenToBoard(sx, sy);
+
+    var coordEl = document.getElementById("coord-display");
+    if (coordEl) {
+      coordEl.textContent =
+        "X: " + mouseBoard.x.toFixed(2) + " mm  Y: " + mouseBoard.y.toFixed(2) + " mm";
+    }
+
+    if (isDragging) {
+      var dx = (e.clientX - dragStart.x) * window.devicePixelRatio;
+      var dy = (e.clientY - dragStart.y) * window.devicePixelRatio;
+      viewState.offsetX += dx;
+      viewState.offsetY += dy;
+      dragStart.x = e.clientX;
+      dragStart.y = e.clientY;
+      render();
+    }
+  }
+
+  function onMouseUp() {
+    isDragging = false;
+    canvas.style.cursor = "crosshair";
+  }
+
+  function onWheel(e) {
+    e.preventDefault();
+    var rect = canvas.getBoundingClientRect();
+    var sx = (e.clientX - rect.left) * window.devicePixelRatio;
+    var sy = (e.clientY - rect.top) * window.devicePixelRatio;
+
+    var factor = e.deltaY > 0 ? 0.9 : 1.1;
+    var newScale = viewState.scale * factor;
+
+    // Zoom toward cursor position
+    viewState.offsetX = sx - (sx - viewState.offsetX) * (newScale / viewState.scale);
+    viewState.offsetY = sy - (sy - viewState.offsetY) * (newScale / viewState.scale);
+    viewState.scale = newScale;
+    render();
+  }
+
+  function onDblClick() {
+    fitBoard();
+    render();
+  }
+
+  function onResize() {
+    fitBoard();
+    render();
+  }
+
+  // ---- Rendering ----
+  function render() {
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.fillStyle = "#0a0a1a";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    // Draw board outline
+    drawOutline();
+
+    // Draw segments (traces)
+    drawSegments();
+
+    // Draw vias
+    drawVias();
+
+    // Draw footprints
+    drawFootprints();
+
+    // Draw DRC violation highlights
+    drawHighlights();
+  }
+
+  function drawOutline() {
+    var outline = pcb.board_outline;
+    if (!outline || outline.length < 2) return;
+
+    ctx.strokeStyle = layerColor("Edge.Cuts");
+    ctx.lineWidth = Math.max(1, 0.15 * viewState.scale);
+    ctx.beginPath();
+    var p0 = boardToScreen(outline[0][0], outline[0][1]);
+    ctx.moveTo(p0.x, p0.y);
+    for (var i = 1; i < outline.length; i++) {
+      var p = boardToScreen(outline[i][0], outline[i][1]);
+      ctx.lineTo(p.x, p.y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+
+    // Fill board area with subtle color
+    ctx.fillStyle = "rgba(20, 40, 20, 0.4)";
+    ctx.fill();
+  }
+
+  function drawSegments() {
+    var segs = pcb.segments || [];
+    for (var i = 0; i < segs.length; i++) {
+      var seg = segs[i];
+      if (!visibleLayers[seg.layer]) continue;
+
+      var s = boardToScreen(seg.start[0], seg.start[1]);
+      var e = boardToScreen(seg.end[0], seg.end[1]);
+      var w = Math.max(1, seg.width * viewState.scale);
+
+      ctx.strokeStyle = layerColor(seg.layer);
+      ctx.lineWidth = w;
+      ctx.lineCap = "round";
+      ctx.beginPath();
+      ctx.moveTo(s.x, s.y);
+      ctx.lineTo(e.x, e.y);
+      ctx.stroke();
+    }
+  }
+
+  function drawVias() {
+    var vias = pcb.vias || [];
+    for (var i = 0; i < vias.length; i++) {
+      var via = vias[i];
+      var p = boardToScreen(via.position[0], via.position[1]);
+      var r = Math.max(2, (via.size / 2) * viewState.scale);
+      var dr = Math.max(1, (via.drill / 2) * viewState.scale);
+
+      ctx.fillStyle = "#aaaaaa";
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, r, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Drill hole
+      ctx.fillStyle = "#0a0a1a";
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, dr, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  function drawFootprints() {
+    var fps = pcb.footprints || [];
+    for (var i = 0; i < fps.length; i++) {
+      var fp = fps[i];
+      // Draw pads
+      for (var j = 0; j < fp.pads.length; j++) {
+        var pad = fp.pads[j];
+        // Absolute position: footprint position + pad local offset
+        // (pad positions from the schema are already in absolute board coords)
+        var px = pad.position[0];
+        var py = pad.position[1];
+        var pp = boardToScreen(px, py);
+        var sw = Math.max(1, pad.size[0] * viewState.scale);
+        var sh = Math.max(1, pad.size[1] * viewState.scale);
+
+        // Check if any pad layer is visible
+        var padVisible = false;
+        for (var k = 0; k < pad.layers.length; k++) {
+          if (visibleLayers[pad.layers[k]] || pad.layers[k] === "*.Cu") {
+            padVisible = true;
+            break;
+          }
+        }
+        if (!padVisible && pad.layers.length > 0) continue;
+
+        var padColor =
+          fp.layer === "B.Cu" ? "rgba(0,0,200,0.6)" : "rgba(200,0,0,0.6)";
+        ctx.fillStyle = padColor;
+
+        if (pad.shape === "circle") {
+          ctx.beginPath();
+          ctx.arc(pp.x, pp.y, sw / 2, 0, Math.PI * 2);
+          ctx.fill();
+        } else {
+          ctx.fillRect(pp.x - sw / 2, pp.y - sh / 2, sw, sh);
+        }
+      }
+
+      // Draw reference designator text
+      if (viewState.scale > 3) {
+        var tp = boardToScreen(fp.position[0], fp.position[1]);
+        var fontSize = Math.max(8, Math.min(14, 1.2 * viewState.scale));
+        ctx.font = fontSize + "px monospace";
+        ctx.fillStyle = "#ffffff";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(fp.reference, tp.x, tp.y);
+      }
+    }
+  }
+
+  function drawHighlights() {
+    if (highlightLocations.length === 0) return;
+
+    for (var i = 0; i < highlightLocations.length; i++) {
+      var loc = highlightLocations[i];
+      var p = boardToScreen(loc.x_mm, loc.y_mm);
+
+      // Pulsing circle
+      var r = Math.max(8, 2 * viewState.scale);
+
+      // Outer ring
+      ctx.strokeStyle = "#e94560";
+      ctx.lineWidth = 3;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, r, 0, Math.PI * 2);
+      ctx.stroke();
+
+      // Inner ring
+      ctx.strokeStyle = "#ffffff";
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, r * 0.6, 0, Math.PI * 2);
+      ctx.stroke();
+
+      // Crosshair
+      var ch = r * 1.5;
+      ctx.strokeStyle = "rgba(233, 69, 96, 0.6)";
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(p.x - ch, p.y);
+      ctx.lineTo(p.x + ch, p.y);
+      ctx.moveTo(p.x, p.y - ch);
+      ctx.lineTo(p.x, p.y + ch);
+      ctx.stroke();
+    }
+  }
+
+  // ---- Hit detection ----
+  function pointToSegmentDist(px, py, x1, y1, x2, y2) {
+    var dx = x2 - x1;
+    var dy = y2 - y1;
+    var lenSq = dx * dx + dy * dy;
+    if (lenSq === 0) return Math.hypot(px - x1, py - y1);
+    var t = Math.max(0, Math.min(1, ((px - x1) * dx + (py - y1) * dy) / lenSq));
+    var projX = x1 + t * dx;
+    var projY = y1 + t * dy;
+    return Math.hypot(px - projX, py - projY);
+  }
+
+  // ---- Layer controls ----
+  function buildLayerControls() {
+    var container = document.getElementById("layer-controls");
+    if (!container) return;
+
+    var allLayers = Object.keys(visibleLayers);
+    allLayers.forEach(function (layer) {
+      var label = document.createElement("label");
+      var cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.checked = visibleLayers[layer];
+      cb.addEventListener("change", function () {
+        visibleLayers[layer] = cb.checked;
+        render();
+      });
+
+      var colorDot = document.createElement("span");
+      colorDot.style.display = "inline-block";
+      colorDot.style.width = "8px";
+      colorDot.style.height = "8px";
+      colorDot.style.borderRadius = "50%";
+      colorDot.style.backgroundColor = layerColor(layer);
+      colorDot.style.marginRight = "4px";
+      colorDot.style.verticalAlign = "middle";
+
+      label.appendChild(cb);
+      label.appendChild(colorDot);
+      label.appendChild(document.createTextNode(layer));
+      container.appendChild(label);
+    });
+  }
+
+  // ---- Violation list ----
+  function buildViolationList() {
+    var list = document.getElementById("violation-list");
+    var filter = document.getElementById("violation-filter");
+    if (!list) return;
+
+    var violations = drc.violations || [];
+
+    if (violations.length === 0) {
+      list.innerHTML =
+        '<div class="no-violations"><div class="check-mark">&#10003;</div>No DRC violations found</div>';
+      return;
+    }
+
+    // Build filter options
+    if (filter) {
+      var types = {};
+      violations.forEach(function (v) {
+        types[v.type_str || v.type] = true;
+      });
+      Object.keys(types)
+        .sort()
+        .forEach(function (t) {
+          var opt = document.createElement("option");
+          opt.value = t;
+          opt.textContent = t;
+          filter.appendChild(opt);
+        });
+      filter.addEventListener("change", function () {
+        renderViolationList(filter.value);
+      });
+    }
+
+    renderViolationList("all");
+  }
+
+  function renderViolationList(filterType) {
+    var list = document.getElementById("violation-list");
+    if (!list) return;
+    list.innerHTML = "";
+
+    var violations = drc.violations || [];
+    violations.forEach(function (v, idx) {
+      if (filterType !== "all" && (v.type_str || v.type) !== filterType) return;
+
+      var item = document.createElement("div");
+      item.className = "violation-item";
+      item.dataset.idx = idx;
+
+      var sev = (v.severity || "error").toLowerCase();
+      var typeEl = document.createElement("div");
+      typeEl.className = "v-type " + sev;
+      typeEl.textContent = (v.type_str || v.type) + " [" + sev + "]";
+
+      var msgEl = document.createElement("div");
+      msgEl.className = "v-message";
+      msgEl.textContent = v.message || "";
+
+      item.appendChild(typeEl);
+      item.appendChild(msgEl);
+
+      // Show location if available
+      if (v.locations && v.locations.length > 0) {
+        var locEl = document.createElement("div");
+        locEl.className = "v-location";
+        var loc = v.locations[0];
+        locEl.textContent =
+          "(" + loc.x_mm.toFixed(2) + ", " + loc.y_mm.toFixed(2) + ") mm" +
+          (loc.layer ? " on " + loc.layer : "");
+        item.appendChild(locEl);
+      }
+
+      item.addEventListener("click", function () {
+        selectViolation(idx);
+      });
+
+      list.appendChild(item);
+    });
+  }
+
+  function selectViolation(idx) {
+    var violations = drc.violations || [];
+    if (idx < 0 || idx >= violations.length) return;
+
+    selectedViolation = idx;
+    var v = violations[idx];
+
+    // Update selection UI
+    var items = document.querySelectorAll(".violation-item");
+    items.forEach(function (el) {
+      el.classList.toggle("selected", parseInt(el.dataset.idx) === idx);
+    });
+
+    // Scroll selected item into view
+    var selectedEl = document.querySelector('.violation-item[data-idx="' + idx + '"]');
+    if (selectedEl) {
+      selectedEl.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+
+    // Highlight locations on canvas
+    highlightLocations = v.locations || [];
+
+    // Pan to first location
+    if (highlightLocations.length > 0) {
+      var loc = highlightLocations[0];
+      panToLocation(loc.x_mm, loc.y_mm);
+    }
+
+    render();
+  }
+
+  function panToLocation(bx, by) {
+    var sp = boardToScreen(bx, by);
+    var cx = canvas.width / 2;
+    var cy = canvas.height / 2;
+    viewState.offsetX += cx - sp.x;
+    viewState.offsetY += cy - sp.y;
+  }
+
+  // ---- Stats ----
+  function updateStats() {
+    var statsEl = document.getElementById("report-stats");
+    if (!statsEl) return;
+
+    var parts = [];
+    if (drc.error_count > 0) parts.push(drc.error_count + " errors");
+    if (drc.warning_count > 0) parts.push(drc.warning_count + " warnings");
+    if (parts.length === 0) parts.push("No violations");
+    var fpCount = (pcb.footprints || []).length;
+    var segCount = (pcb.segments || []).length;
+    parts.push(fpCount + " footprints");
+    parts.push(segCount + " traces");
+    statsEl.textContent = parts.join(" | ");
+  }
+
+  // ---- Zoom controls ----
+  window.zoomIn = function () {
+    var cx = canvas.width / 2;
+    var cy = canvas.height / 2;
+    var factor = 1.3;
+    viewState.offsetX = cx - (cx - viewState.offsetX) * factor;
+    viewState.offsetY = cy - (cy - viewState.offsetY) * factor;
+    viewState.scale *= factor;
+    render();
+  };
+
+  window.zoomOut = function () {
+    var cx = canvas.width / 2;
+    var cy = canvas.height / 2;
+    var factor = 1 / 1.3;
+    viewState.offsetX = cx - (cx - viewState.offsetX) * factor;
+    viewState.offsetY = cy - (cy - viewState.offsetY) * factor;
+    viewState.scale *= factor;
+    render();
+  };
+
+  window.zoomFit = function () {
+    fitBoard();
+    render();
+  };
+
+  // ---- Start ----
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/tests/test_report_interactive.py
+++ b/tests/test_report_interactive.py
@@ -1,0 +1,406 @@
+"""Tests for interactive HTML report generation.
+
+Covers PCB data extraction, interactive HTML rendering, and
+template placeholder injection.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.report.pcb_data import (
+    extract_pcb_data,
+    natsort_refs,
+)
+
+
+# ---------------------------------------------------------------------------
+# natsort_refs
+# ---------------------------------------------------------------------------
+
+
+class TestNatsortRefs:
+    def test_simple_sort(self) -> None:
+        refs = ["R10", "R2", "R1", "R20"]
+        assert natsort_refs(refs) == ["R1", "R2", "R10", "R20"]
+
+    def test_mixed_prefixes(self) -> None:
+        refs = ["C1", "R2", "C10", "R1"]
+        result = natsort_refs(refs)
+        assert result == ["C1", "C10", "R1", "R2"]
+
+    def test_empty(self) -> None:
+        assert natsort_refs([]) == []
+
+    def test_single(self) -> None:
+        assert natsort_refs(["U1"]) == ["U1"]
+
+
+# ---------------------------------------------------------------------------
+# extract_pcb_data
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_pcb(
+    outline: list[tuple[float, float]] | None = None,
+    footprints: list | None = None,
+    segments: list | None = None,
+    vias: list | None = None,
+    copper_layers: list | None = None,
+) -> MagicMock:
+    """Build a mock PCB object with controllable geometry."""
+    pcb = MagicMock()
+
+    # Board outline
+    if outline is not None:
+        pcb.get_board_outline.return_value = outline
+    else:
+        pcb.get_board_outline.return_value = [
+            (0, 0), (50, 0), (50, 30), (0, 30),
+        ]
+
+    # Copper layers
+    if copper_layers is None:
+        layer_f = MagicMock()
+        layer_f.name = "F.Cu"
+        layer_b = MagicMock()
+        layer_b.name = "B.Cu"
+        copper_layers = [layer_f, layer_b]
+    pcb.copper_layers = copper_layers
+
+    # Footprints
+    if footprints is None:
+        fp = MagicMock()
+        fp.reference = "R1"
+        fp.value = "10k"
+        fp.position = (25.0, 15.0)
+        fp.rotation = 0.0
+        fp.layer = "F.Cu"
+        fp.attr = "smd"
+        pad = MagicMock()
+        pad.number = "1"
+        pad.type = "smd"
+        pad.shape = "roundrect"
+        pad.position = (24.0, 15.0)
+        pad.size = (1.0, 0.8)
+        pad.layers = ["F.Cu"]
+        pad.net_name = "GND"
+        fp.pads = [pad]
+        footprints = [fp]
+    pcb.footprints = footprints
+
+    # Segments
+    if segments is None:
+        seg = MagicMock()
+        seg.start = (10.0, 15.0)
+        seg.end = (25.0, 15.0)
+        seg.width = 0.25
+        seg.layer = "F.Cu"
+        seg.net_number = 1
+        seg.net_name = "GND"
+        segments = [seg]
+    pcb.segments = segments
+
+    # Vias
+    if vias is None:
+        via = MagicMock()
+        via.position = (20.0, 15.0)
+        via.size = 0.6
+        via.drill = 0.3
+        via.layers = ["F.Cu", "B.Cu"]
+        via.net_number = 1
+        via.net_name = "GND"
+        vias = [via]
+    pcb.vias = vias
+
+    return pcb
+
+
+class TestExtractPcbData:
+    def test_basic_structure(self) -> None:
+        pcb = _make_mock_pcb()
+        data = extract_pcb_data(pcb)
+
+        assert "board_outline" in data
+        assert "bounds" in data
+        assert "footprints" in data
+        assert "segments" in data
+        assert "vias" in data
+        assert "layers" in data
+
+    def test_outline_extracted(self) -> None:
+        pcb = _make_mock_pcb(outline=[(0, 0), (100, 0), (100, 50), (0, 50)])
+        data = extract_pcb_data(pcb)
+        assert len(data["board_outline"]) == 4
+        assert data["board_outline"][0] == [0.0, 0.0]
+
+    def test_bounds_from_outline(self) -> None:
+        pcb = _make_mock_pcb(outline=[(10, 20), (60, 20), (60, 50), (10, 50)])
+        data = extract_pcb_data(pcb)
+        assert data["bounds"]["min_x"] == 10.0
+        assert data["bounds"]["min_y"] == 20.0
+        assert data["bounds"]["max_x"] == 60.0
+        assert data["bounds"]["max_y"] == 50.0
+
+    def test_footprint_data(self) -> None:
+        pcb = _make_mock_pcb()
+        data = extract_pcb_data(pcb)
+        fps = data["footprints"]
+        assert len(fps) == 1
+        assert fps[0]["reference"] == "R1"
+        assert fps[0]["value"] == "10k"
+        assert len(fps[0]["pads"]) == 1
+        assert fps[0]["pads"][0]["net_name"] == "GND"
+
+    def test_segments_data(self) -> None:
+        pcb = _make_mock_pcb()
+        data = extract_pcb_data(pcb)
+        segs = data["segments"]
+        assert len(segs) == 1
+        assert segs[0]["layer"] == "F.Cu"
+        assert segs[0]["width"] == 0.25
+
+    def test_vias_data(self) -> None:
+        pcb = _make_mock_pcb()
+        data = extract_pcb_data(pcb)
+        vias = data["vias"]
+        assert len(vias) == 1
+        assert vias[0]["size"] == 0.6
+        assert vias[0]["drill"] == 0.3
+
+    def test_layers_list(self) -> None:
+        pcb = _make_mock_pcb()
+        data = extract_pcb_data(pcb)
+        assert data["layers"] == ["F.Cu", "B.Cu"]
+
+    def test_empty_board(self) -> None:
+        pcb = _make_mock_pcb(
+            outline=[],
+            footprints=[],
+            segments=[],
+            vias=[],
+        )
+        # get_board_outline returns empty list
+        pcb.get_board_outline.return_value = []
+        data = extract_pcb_data(pcb)
+        assert data["footprints"] == []
+        assert data["segments"] == []
+        assert data["vias"] == []
+        # bounds should have a fallback
+        assert "min_x" in data["bounds"]
+
+    def test_json_serializable(self) -> None:
+        pcb = _make_mock_pcb()
+        data = extract_pcb_data(pcb)
+        # Should not raise
+        json_str = json.dumps(data)
+        assert len(json_str) > 0
+
+
+# ---------------------------------------------------------------------------
+# Interactive HTML rendering
+# ---------------------------------------------------------------------------
+
+
+class TestRenderInteractiveHtml:
+    def test_single_file_output(self) -> None:
+        """Output should be a complete HTML file with no external references."""
+        from kicad_tools.report.interactive import _build_html
+
+        pcb_data = {
+            "board_outline": [[0, 0], [50, 0], [50, 30], [0, 30]],
+            "bounds": {"min_x": 0, "min_y": 0, "max_x": 50, "max_y": 30},
+            "footprints": [],
+            "segments": [],
+            "vias": [],
+            "layers": ["F.Cu", "B.Cu"],
+        }
+        drc_data = {
+            "violations": [],
+            "error_count": 0,
+            "warning_count": 0,
+        }
+
+        html = _build_html("Test Report", pcb_data, drc_data, "test", "2026-01-01")
+
+        # Single-file: must contain DOCTYPE, inline style and script
+        assert "<!DOCTYPE html>" in html
+        assert "<style>" in html
+        assert "<script>" in html
+        # No external resource links
+        assert 'href="http' not in html
+        assert 'src="http' not in html
+        assert "<link " not in html
+
+    def test_drc_violations_in_output(self) -> None:
+        """Violations should appear in both the JS data and be addressable."""
+        from kicad_tools.report.interactive import _build_html
+
+        pcb_data = {
+            "board_outline": [],
+            "bounds": {"min_x": 0, "min_y": 0, "max_x": 100, "max_y": 100},
+            "footprints": [],
+            "segments": [],
+            "vias": [],
+            "layers": [],
+        }
+        violations = [
+            {
+                "type": "clearance",
+                "type_str": "Clearance",
+                "severity": "error",
+                "message": "Pad too close to track",
+                "locations": [{"x_mm": 25.0, "y_mm": 15.0, "layer": "F.Cu"}],
+                "items": [],
+                "nets": [],
+            }
+        ]
+        drc_data = {
+            "violations": violations,
+            "error_count": 1,
+            "warning_count": 0,
+        }
+
+        html = _build_html("Test", pcb_data, drc_data, "test", "2026-01-01")
+
+        # Violation data should be embedded in the HTML
+        assert "Pad too close to track" in html
+        assert "25.0" in html
+        assert "15.0" in html
+
+    def test_zero_violations(self) -> None:
+        """Board with zero violations should still produce valid HTML."""
+        from kicad_tools.report.interactive import _build_html
+
+        pcb_data = {
+            "board_outline": [[0, 0], [50, 0], [50, 30], [0, 30]],
+            "bounds": {"min_x": 0, "min_y": 0, "max_x": 50, "max_y": 30},
+            "footprints": [],
+            "segments": [],
+            "vias": [],
+            "layers": ["F.Cu"],
+        }
+        drc_data = {
+            "violations": [],
+            "error_count": 0,
+            "warning_count": 0,
+        }
+
+        html = _build_html("No Violations", pcb_data, drc_data, "test", "2026-01-01")
+        assert "<!DOCTYPE html>" in html
+        # The JS handles empty violations gracefully
+        assert '"violations":[]' in html
+
+    def test_violations_without_location(self) -> None:
+        """Violations without location data should degrade gracefully."""
+        from kicad_tools.report.interactive import _build_html
+
+        pcb_data = {
+            "board_outline": [],
+            "bounds": {"min_x": 0, "min_y": 0, "max_x": 50, "max_y": 30},
+            "footprints": [],
+            "segments": [],
+            "vias": [],
+            "layers": [],
+        }
+        violations = [
+            {
+                "type": "unknown",
+                "type_str": "UnknownRule",
+                "severity": "warning",
+                "message": "Some warning without location",
+                "locations": [],
+                "items": [],
+                "nets": [],
+            }
+        ]
+        drc_data = {
+            "violations": violations,
+            "error_count": 0,
+            "warning_count": 1,
+        }
+
+        html = _build_html("Test", pcb_data, drc_data, "test", "2026-01-01")
+        assert "Some warning without location" in html
+
+    def test_html_escaping(self) -> None:
+        """Title with special characters should be escaped."""
+        from kicad_tools.report.interactive import _build_html
+
+        pcb_data = {
+            "board_outline": [],
+            "bounds": {"min_x": 0, "min_y": 0, "max_x": 50, "max_y": 30},
+            "footprints": [],
+            "segments": [],
+            "vias": [],
+            "layers": [],
+        }
+        drc_data = {"violations": [], "error_count": 0, "warning_count": 0}
+
+        html = _build_html(
+            "Board <script>alert(1)</script>",
+            pcb_data, drc_data, "test", "2026-01-01",
+        )
+        # Title should be escaped
+        assert "&lt;script&gt;" in html
+        assert "<script>alert(1)</script>" not in html.split("<style>")[0]
+
+
+# ---------------------------------------------------------------------------
+# Template placeholder injection
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateInjection:
+    def test_placeholders_replaced(self) -> None:
+        """All template placeholders should be replaced in the output."""
+        from kicad_tools.report.interactive import _build_html
+
+        pcb_data = {
+            "board_outline": [],
+            "bounds": {"min_x": 0, "min_y": 0, "max_x": 50, "max_y": 30},
+            "footprints": [],
+            "segments": [],
+            "vias": [],
+            "layers": [],
+        }
+        drc_data = {"violations": [], "error_count": 0, "warning_count": 0}
+
+        html = _build_html("Test", pcb_data, drc_data, "proj", "2026-01-01")
+
+        # No unreplaced placeholders
+        assert "{{ title }}" not in html
+        assert "{{ css }}" not in html
+        assert "{{ js }}" not in html
+        assert "{{ pcb_data_script }}" not in html
+        assert "{{ drc_data_script }}" not in html
+        assert "{{ report_meta_script }}" not in html
+
+    def test_valid_json_in_scripts(self) -> None:
+        """JSON data injected into scripts should be valid."""
+        from kicad_tools.report.interactive import _build_html
+
+        pcb_data = {
+            "board_outline": [[0, 0], [10, 10]],
+            "bounds": {"min_x": 0, "min_y": 0, "max_x": 10, "max_y": 10},
+            "footprints": [{"reference": "U1", "position": [5, 5]}],
+            "segments": [],
+            "vias": [],
+            "layers": ["F.Cu"],
+        }
+        drc_data = {"violations": [], "error_count": 0, "warning_count": 0}
+
+        html = _build_html("Test", pcb_data, drc_data, "proj", "2026-01-01")
+
+        # Extract the PCB_DATA JSON from the HTML
+        import re
+
+        match = re.search(r"window\.PCB_DATA\s*=\s*({.*?});", html, re.DOTALL)
+        assert match is not None
+        parsed = json.loads(match.group(1))
+        assert parsed["layers"] == ["F.Cu"]
+        assert len(parsed["board_outline"]) == 2


### PR DESCRIPTION
## Summary
Add interactive HTML report generation with an embedded Canvas 2D PCB viewer and clickable DRC violation browser. Reports are self-contained single HTML files with all CSS and JS inlined.

## Changes
- `src/kicad_tools/report/pcb_data.py` (new): PCB geometry extraction (board outline, footprints, pads, tracks, vias) into JSON-serializable format, plus `natsort_refs()` utility for natural reference designator sorting
- `src/kicad_tools/report/interactive.py` (new): Interactive HTML report generator that assembles PCB geometry + DRC violations into a single-file HTML document
- `src/kicad_tools/report/templates/interactive.html` (new): HTML template with placeholder injection for data, CSS, and JS
- `src/kicad_tools/report/templates/interactive.css` (new): Dark-theme UI styles for the board viewer and violation panel
- `src/kicad_tools/report/templates/interactive.js` (new): Canvas 2D renderer with pan/zoom, layer toggle, and violation click-to-highlight
- `src/kicad_tools/report/renderers.py`: Added `render_interactive_html()` convenience re-export
- `src/kicad_tools/report/models.py`: Added optional `pcb_geometry` field to `ReportData`
- `src/kicad_tools/report/__init__.py`: Export `render_interactive_html`
- `src/kicad_tools/cli/report_cmd.py`: Added `kct report interactive` subcommand
- `tests/test_report_interactive.py` (new): 20 unit tests

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| PCB data JSON schema with board geometry | ✅ | `extract_pcb_data()` returns board_outline, bounds, footprints, segments, vias, layers |
| Self-contained HTML with Canvas 2D renderer | ✅ | All CSS/JS inlined; no external resource references in output |
| DRC violation browser with click-to-highlight | ✅ | Violation list with filter; clicking pans canvas to violation location |
| Pan/zoom/layer toggle in board viewer | ✅ | Mouse drag, wheel zoom, double-click fit, layer checkboxes |
| CLI subcommand `kct report interactive` | ✅ | Accepts .kicad_pcb input, optional --output and --project-name |
| Zero-violation boards render correctly | ✅ | Test `test_zero_violations` verifies valid HTML with empty table |
| Violations without location degrade gracefully | ✅ | Test `test_violations_without_location` verifies they appear in table |
| Natural sort for reference designators | ✅ | `natsort_refs()` tested with R1, R2, R10 ordering |
| Extensible for future report types | ✅ | Template + data schema pattern allows different JSON payloads |
| All existing tests pass | ✅ | 42 renderer tests + 20 new tests all pass |

## Test Plan
- `python3 -m pytest tests/test_report_interactive.py -v` -- 20 tests pass
- `python3 -m pytest tests/report/test_renderers.py -v` -- 42 existing tests pass (no regressions)

Closes #2339