### PR TITLE
feat(pcb): add Shapely-based BoardGeometry engine for board outline operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,10 @@ kicad-fab-rules = "kicad_tools.cli.fab_rules_cmd:main"
 kicad-project-clean = "kicad_tools.cli.clean_cmd:main"
 
 [project.optional-dependencies]
+# Shapely-based board geometry engine
+geometry = [
+    "shapely>=2.0",
+]
 # Incremental DRC with R-tree spatial indexing
 drc = [
     "rtree>=1.0",

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -254,8 +254,21 @@ def _read_board_data(
 
     pcb = SchemaPCB.load(pcb_path)
 
-    # --- Board outline from Edge.Cuts graphic lines ---
-    board_outline = _extract_board_outline(pcb)
+    # --- Board outline -- try Shapely geometry, fall back to legacy AABB ---
+    board_outline: BoardOutline | None = None
+    try:
+        from kicad_tools.pcb.board_geometry import BoardGeometry, has_shapely
+
+        if has_shapely():
+            try:
+                board_geom = BoardGeometry.from_pcb(pcb)
+                board_outline = board_geom.to_board_outline()
+            except (ValueError, Exception):
+                pass
+    except ImportError:
+        pass
+    if board_outline is None:
+        board_outline = _extract_board_outline(pcb)
 
     # --- Components from footprints ---
     components: list[ComponentDef] = []

--- a/src/kicad_tools/mcp/tools/optimize_placement.py
+++ b/src/kicad_tools/mcp/tools/optimize_placement.py
@@ -87,8 +87,21 @@ def _read_board_data(
 
     pcb = SchemaPCB.load(pcb_path)
 
-    # Board outline from Edge.Cuts graphic lines
-    board_outline = _extract_board_outline(pcb)
+    # Board outline -- try Shapely geometry first, fall back to legacy AABB
+    board_outline: BoardOutline | None = None
+    try:
+        from kicad_tools.pcb.board_geometry import BoardGeometry, has_shapely
+
+        if has_shapely():
+            try:
+                board_geom = BoardGeometry.from_pcb(pcb)
+                board_outline = board_geom.to_board_outline()
+            except (ValueError, Exception):
+                pass
+    except ImportError:
+        pass
+    if board_outline is None:
+        board_outline = _extract_board_outline(pcb)
 
     # Components from footprints
     components: list[ComponentDef] = []

--- a/src/kicad_tools/optim/keepout.py
+++ b/src/kicad_tools/optim/keepout.py
@@ -363,8 +363,20 @@ def create_keepout_from_board_edge(
 
     outline = board_outline
     if outline is None and pcb is not None:
-        # Try to extract from PCB Edge.Cuts
-        outline = _extract_board_outline(pcb)
+        # Try Shapely-based geometry first, fall back to legacy
+        try:
+            from kicad_tools.pcb.board_geometry import BoardGeometry, has_shapely
+
+            if has_shapely():
+                try:
+                    board_geom = BoardGeometry.from_pcb(pcb)
+                    outline = board_geom.to_optim_polygon()
+                except (ValueError, Exception):
+                    pass
+        except ImportError:
+            pass
+        if outline is None:
+            outline = _extract_board_outline(pcb)
 
     if outline is None:
         return None

--- a/src/kicad_tools/optim/placement.py
+++ b/src/kicad_tools/optim/placement.py
@@ -201,8 +201,23 @@ class PlacementOptimizer:
         """
         fixed_refs = set(fixed_refs or [])
 
-        # Try to extract board outline from Edge.Cuts layer
-        board = cls._extract_board_outline(pcb)
+        # Try Shapely-based geometry first, fall back to legacy parsing
+        board = None
+        try:
+            from kicad_tools.pcb.board_geometry import BoardGeometry, has_shapely
+
+            if has_shapely():
+                try:
+                    board_geom = BoardGeometry.from_pcb(pcb)
+                    board = board_geom.to_optim_polygon()
+                    logger.debug("Using Shapely-based board geometry engine")
+                except (ValueError, Exception) as exc:
+                    logger.debug("Shapely geometry failed (%s), falling back", exc)
+        except ImportError:
+            pass
+
+        if board is None:
+            board = cls._extract_board_outline(pcb)
 
         if board is None:
             # Fall back to estimating from component positions.

--- a/src/kicad_tools/pcb/__init__.py
+++ b/src/kicad_tools/pcb/__init__.py
@@ -31,9 +31,13 @@ from .footprints import (
     get_footprint_pads,
     get_library,
 )
+from .board_geometry import BoardGeometry, has_shapely
 from .layout import PCBLayout
 
 __all__ = [
+    # Board geometry
+    "BoardGeometry",
+    "has_shapely",
     # Editor
     "Point",
     "Track",

--- a/src/kicad_tools/pcb/board_geometry.py
+++ b/src/kicad_tools/pcb/board_geometry.py
@@ -22,7 +22,7 @@ Usage::
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:

--- a/src/kicad_tools/pcb/board_geometry.py
+++ b/src/kicad_tools/pcb/board_geometry.py
@@ -1,0 +1,511 @@
+"""Shapely-based board geometry engine.
+
+Provides :class:`BoardGeometry` -- a unified wrapper around Edge.Cuts
+board outline data backed by Shapely for geometric operations like
+containment checks, clearance buffers, and boolean operations.
+
+Shapely is an *optional* dependency.  When it is not installed the
+module still loads but ``BoardGeometry.from_pcb()`` will raise
+``ImportError`` with a helpful message.  Call-sites that previously used
+AABB-based logic can fall back transparently via :func:`has_shapely`.
+
+Usage::
+
+    from kicad_tools.pcb.board_geometry import BoardGeometry, has_shapely
+
+    if has_shapely():
+        geom = BoardGeometry.from_pcb(pcb)
+        inside = geom.contains_point(10.0, 15.0)
+        clearance_zone = geom.buffer(-0.3)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import PCB
+
+# ---------------------------------------------------------------------------
+# Optional Shapely import
+# ---------------------------------------------------------------------------
+
+_SHAPELY_AVAILABLE = False
+try:
+    from shapely.geometry import LineString, MultiPolygon, Point  # noqa: F811
+    from shapely.geometry import Polygon as ShapelyPolygon
+    from shapely.ops import polygonize, unary_union
+
+    _SHAPELY_AVAILABLE = True
+except ImportError:
+    pass
+
+
+def has_shapely() -> bool:
+    """Return True if Shapely is available at runtime."""
+    return _SHAPELY_AVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Arc / curve linearisation helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_ARC_SEGMENTS = 32
+
+
+def _linearize_arc(
+    sx: float,
+    sy: float,
+    mx: float,
+    my: float,
+    ex: float,
+    ey: float,
+    num_segments: int = _DEFAULT_ARC_SEGMENTS,
+) -> list[tuple[float, float]]:
+    """Approximate a KiCad three-point arc as a polyline.
+
+    KiCad ``gr_arc`` is specified by *start*, *mid*, and *end* points.
+    We recover the circumscribed circle centre and radius, then emit
+    evenly-spaced points along the arc.
+
+    Returns a list of (x, y) points *including* start and end.
+    """
+    # Circumscribed-circle of three points
+    ax, ay = sx, sy
+    bx, by = mx, my
+    cx, cy = ex, ey
+
+    D = 2.0 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by))
+    if abs(D) < 1e-12:
+        # Degenerate / collinear -- straight line
+        return [(sx, sy), (ex, ey)]
+
+    ux = (
+        (ax * ax + ay * ay) * (by - cy)
+        + (bx * bx + by * by) * (cy - ay)
+        + (cx * cx + cy * cy) * (ay - by)
+    ) / D
+    uy = (
+        (ax * ax + ay * ay) * (cx - bx)
+        + (bx * bx + by * by) * (ax - cx)
+        + (cx * cx + cy * cy) * (bx - ax)
+    ) / D
+
+    radius = math.sqrt((sx - ux) ** 2 + (sy - uy) ** 2)
+
+    angle_start = math.atan2(sy - uy, sx - ux)
+    angle_mid = math.atan2(my - uy, mx - ux)
+    angle_end = math.atan2(ey - uy, ex - ux)
+
+    def _norm(a: float) -> float:
+        while a < 0:
+            a += 2.0 * math.pi
+        while a >= 2.0 * math.pi:
+            a -= 2.0 * math.pi
+        return a
+
+    a_s = _norm(angle_start)
+    a_m = _norm(angle_mid)
+    a_e = _norm(angle_end)
+
+    sweep_ccw = _norm(a_e - a_s)
+    mid_in_ccw = _norm(a_m - a_s)
+    if mid_in_ccw <= sweep_ccw:
+        sweep = sweep_ccw
+    else:
+        sweep = -(2.0 * math.pi - sweep_ccw)
+
+    points: list[tuple[float, float]] = []
+    for i in range(num_segments + 1):
+        t = i / num_segments
+        a = angle_start + sweep * t
+        points.append((ux + radius * math.cos(a), uy + radius * math.sin(a)))
+
+    return points
+
+
+def _linearize_bezier(
+    control_points: list[tuple[float, float]],
+    num_segments: int = _DEFAULT_ARC_SEGMENTS,
+) -> list[tuple[float, float]]:
+    """Approximate a cubic or quadratic Bezier curve as a polyline.
+
+    Supports both quadratic (3 control points) and cubic (4 control
+    points) Bezier curves via De Casteljau's algorithm.
+
+    Returns a list of (x, y) points *including* start and end.
+    """
+    n = len(control_points)
+    if n < 2:
+        return list(control_points)
+
+    points: list[tuple[float, float]] = []
+    for i in range(num_segments + 1):
+        t = i / num_segments
+        # De Casteljau
+        work = list(control_points)
+        for level in range(n - 1):
+            work = [
+                (
+                    (1.0 - t) * work[j][0] + t * work[j + 1][0],
+                    (1.0 - t) * work[j][1] + t * work[j + 1][1],
+                )
+                for j in range(len(work) - 1)
+            ]
+        points.append(work[0])
+    return points
+
+
+# ---------------------------------------------------------------------------
+# BoardGeometry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BoardGeometry:
+    """Shapely-backed board outline geometry.
+
+    Wraps the Edge.Cuts layer of a KiCad PCB into a Shapely ``Polygon``
+    (or ``MultiPolygon`` for boards with cutouts) and exposes geometric
+    queries commonly needed by placement optimisation, routing edge
+    clearance, and keepout zone computation.
+
+    Attributes:
+        polygon: The Shapely polygon representing the board outline.
+        origin: The board origin ``(ox, oy)`` used to convert from
+            sheet-absolute to board-relative coordinates.
+    """
+
+    polygon: Any  # shapely.geometry.Polygon | MultiPolygon
+    origin: tuple[float, float] = (0.0, 0.0)
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_pcb(cls, pcb: PCB) -> BoardGeometry:
+        """Build a ``BoardGeometry`` from a parsed PCB.
+
+        Parses Edge.Cuts elements (``gr_line``, ``gr_arc``, ``gr_rect``,
+        ``gr_circle``, ``gr_bezier``) and constructs a Shapely polygon.
+
+        Args:
+            pcb: A parsed :class:`~kicad_tools.schema.pcb.PCB` instance.
+
+        Returns:
+            A new :class:`BoardGeometry`.
+
+        Raises:
+            ImportError: If Shapely is not installed.
+            ValueError: If no valid board outline can be constructed.
+        """
+        if not _SHAPELY_AVAILABLE:
+            raise ImportError(
+                "Shapely is required for BoardGeometry.  "
+                "Install it with:  pip install kicad-tools[geometry]"
+            )
+
+        origin = pcb.board_origin
+        ox, oy = origin
+
+        # Collect line-string segments from Edge.Cuts
+        lines: list[list[tuple[float, float]]] = []
+
+        # --- gr_line ---
+        for line in pcb.graphic_lines:
+            if line.layer == "Edge.Cuts":
+                s = (line.start[0] - ox, line.start[1] - oy)
+                e = (line.end[0] - ox, line.end[1] - oy)
+                lines.append([s, e])
+
+        # --- gr_arc ---
+        for arc in pcb.graphic_arcs:
+            if arc.layer == "Edge.Cuts":
+                sx, sy = arc.start[0] - ox, arc.start[1] - oy
+                mx, my = arc.mid[0] - ox, arc.mid[1] - oy
+                ex, ey = arc.end[0] - ox, arc.end[1] - oy
+                pts = _linearize_arc(sx, sy, mx, my, ex, ey)
+                lines.append(pts)
+
+        # --- gr_rect, gr_circle, gr_bezier from raw graphics ---
+        for g in pcb.graphics:
+            if g.layer != "Edge.Cuts":
+                continue
+
+            if g.graphic_type == "rect":
+                x1, y1 = g.start[0] - ox, g.start[1] - oy
+                x2, y2 = g.end[0] - ox, g.end[1] - oy
+                # Four edges of the rectangle
+                lines.append([(x1, y1), (x2, y1)])
+                lines.append([(x2, y1), (x2, y2)])
+                lines.append([(x2, y2), (x1, y2)])
+                lines.append([(x1, y2), (x1, y1)])
+
+            elif g.graphic_type == "circle":
+                cx_raw, cy_raw = g.start[0] - ox, g.start[1] - oy
+                ex_raw, ey_raw = g.end[0] - ox, g.end[1] - oy
+                radius = math.sqrt(
+                    (ex_raw - cx_raw) ** 2 + (ey_raw - cy_raw) ** 2
+                )
+                circle_poly = Point(cx_raw, cy_raw).buffer(
+                    radius, resolution=_DEFAULT_ARC_SEGMENTS
+                )
+                return cls(polygon=circle_poly, origin=origin)
+
+            elif g.graphic_type == "bezier":
+                # gr_bezier stores control points in pts attribute
+                if hasattr(g, "pts") and g.pts:
+                    ctrl = [(p[0] - ox, p[1] - oy) for p in g.pts]
+                    pts = _linearize_bezier(ctrl)
+                    lines.append(pts)
+
+        if not lines:
+            raise ValueError(
+                "No Edge.Cuts elements found -- cannot construct board outline."
+            )
+
+        # Build Shapely LineStrings and polygonize
+        shapely_lines = [LineString(seg) for seg in lines if len(seg) >= 2]
+        result = list(polygonize(unary_union(shapely_lines)))
+
+        if not result:
+            # Fall back: try to chain endpoints manually
+            all_coords = _chain_segments(lines)
+            if all_coords and len(all_coords) >= 3:
+                poly = ShapelyPolygon(all_coords)
+                if poly.is_valid:
+                    return cls(polygon=poly, origin=origin)
+            raise ValueError(
+                "Could not form a closed polygon from Edge.Cuts segments."
+            )
+
+        if len(result) == 1:
+            polygon = result[0]
+        else:
+            # Multiple polygons -- use the largest as the board outline
+            # (smaller ones are likely mounting-hole cutouts)
+            result.sort(key=lambda p: p.area, reverse=True)
+            polygon = result[0]
+
+        return cls(polygon=polygon, origin=origin)
+
+    @classmethod
+    def from_outline_points(
+        cls,
+        points: list[tuple[float, float]],
+        origin: tuple[float, float] = (0.0, 0.0),
+    ) -> BoardGeometry:
+        """Build from a list of polygon vertices (already board-relative).
+
+        Useful for testing or when outline points are already extracted.
+
+        Raises:
+            ImportError: If Shapely is not installed.
+            ValueError: If fewer than 3 points are provided.
+        """
+        if not _SHAPELY_AVAILABLE:
+            raise ImportError(
+                "Shapely is required for BoardGeometry.  "
+                "Install it with:  pip install kicad-tools[geometry]"
+            )
+
+        if len(points) < 3:
+            raise ValueError("Need at least 3 points for a polygon.")
+
+        poly = ShapelyPolygon(points)
+        if not poly.is_valid:
+            # Attempt to fix via buffer(0) -- common Shapely trick
+            poly = poly.buffer(0)
+        return cls(polygon=poly, origin=origin)
+
+    @classmethod
+    def from_bounds(
+        cls,
+        min_x: float,
+        min_y: float,
+        max_x: float,
+        max_y: float,
+        origin: tuple[float, float] = (0.0, 0.0),
+    ) -> BoardGeometry:
+        """Build a rectangular board geometry from bounding-box limits.
+
+        Raises:
+            ImportError: If Shapely is not installed.
+        """
+        if not _SHAPELY_AVAILABLE:
+            raise ImportError(
+                "Shapely is required for BoardGeometry.  "
+                "Install it with:  pip install kicad-tools[geometry]"
+            )
+
+        from shapely.geometry import box
+
+        return cls(polygon=box(min_x, min_y, max_x, max_y), origin=origin)
+
+    # ------------------------------------------------------------------
+    # Geometric queries
+    # ------------------------------------------------------------------
+
+    def contains_point(self, x: float, y: float) -> bool:
+        """Return True if (*x*, *y*) is inside the board outline."""
+        return self.polygon.contains(Point(x, y))
+
+    def distance_to_edge(self, x: float, y: float) -> float:
+        """Return the minimum distance from (*x*, *y*) to the board edge.
+
+        Positive values mean the point is *inside* the board; negative
+        values mean it is *outside*.  (Signed distance.)
+        """
+        pt = Point(x, y)
+        dist = self.polygon.exterior.distance(pt)
+        if self.polygon.contains(pt):
+            return dist
+        return -dist
+
+    def buffer(self, distance: float) -> BoardGeometry:
+        """Return a new geometry inset (negative) or expanded (positive).
+
+        A negative *distance* shrinks the outline inward -- useful for
+        computing edge-clearance zones.  A positive *distance* expands
+        outward.
+        """
+        new_poly = self.polygon.buffer(distance)
+        return BoardGeometry(polygon=new_poly, origin=self.origin)
+
+    def intersection(self, other: BoardGeometry) -> BoardGeometry:
+        """Return the geometric intersection with *other*."""
+        result = self.polygon.intersection(other.polygon)
+        return BoardGeometry(polygon=result, origin=self.origin)
+
+    def difference(self, other: BoardGeometry) -> BoardGeometry:
+        """Return the geometric difference (self minus *other*)."""
+        result = self.polygon.difference(other.polygon)
+        return BoardGeometry(polygon=result, origin=self.origin)
+
+    def union(self, other: BoardGeometry) -> BoardGeometry:
+        """Return the geometric union with *other*."""
+        result = self.polygon.union(other.polygon)
+        return BoardGeometry(polygon=result, origin=self.origin)
+
+    # ------------------------------------------------------------------
+    # Compatibility helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def bounds(self) -> tuple[float, float, float, float]:
+        """Return ``(min_x, min_y, max_x, max_y)`` bounding box."""
+        return self.polygon.bounds  # type: ignore[return-value]
+
+    @property
+    def area(self) -> float:
+        """Return the area of the board outline in mm^2."""
+        return float(self.polygon.area)
+
+    @property
+    def exterior_coords(self) -> list[tuple[float, float]]:
+        """Return exterior ring coordinates as ``[(x, y), ...]``."""
+        if hasattr(self.polygon, "exterior"):
+            return list(self.polygon.exterior.coords)
+        return []
+
+    def to_board_outline(self) -> Any:
+        """Convert to a ``BoardOutline`` (AABB) for backward compatibility.
+
+        Returns a ``BoardOutline`` dataclass from
+        ``kicad_tools.placement.cost``.
+        """
+        from kicad_tools.placement.cost import BoardOutline
+
+        min_x, min_y, max_x, max_y = self.bounds
+        return BoardOutline(
+            min_x=min_x, min_y=min_y, max_x=max_x, max_y=max_y
+        )
+
+    def to_optim_polygon(self) -> Any:
+        """Convert to an ``optim.geometry.Polygon`` for backward compatibility."""
+        from kicad_tools.optim.geometry import Polygon as OptimPolygon
+        from kicad_tools.optim.geometry import Vector2D
+
+        coords = self.exterior_coords
+        if coords and coords[-1] == coords[0]:
+            coords = coords[:-1]  # Remove closing duplicate
+        return OptimPolygon(vertices=[Vector2D(x, y) for x, y in coords])
+
+    def compute_boundary_violation(
+        self,
+        box_min_x: float,
+        box_min_y: float,
+        box_max_x: float,
+        box_max_y: float,
+    ) -> float:
+        """Compute out-of-bounds area for a component AABB.
+
+        Uses Shapely polygon containment for accurate non-rectangular
+        board shapes rather than simple AABB clamping.
+
+        Returns the area (mm^2) of the component box that falls outside
+        the board outline.
+        """
+        from shapely.geometry import box
+
+        comp_box = box(box_min_x, box_min_y, box_max_x, box_max_y)
+        outside = comp_box.difference(self.polygon)
+        return float(outside.area)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _chain_segments(
+    segments: list[list[tuple[float, float]]],
+    tolerance: float = 0.01,
+) -> list[tuple[float, float]]:
+    """Chain line segments into an ordered polygon vertex list.
+
+    Each segment is a list of points ``[(x1, y1), (x2, y2), ...]``.
+    We treat the first and last point of each segment as endpoints
+    and chain them by proximity.
+    """
+    if not segments:
+        return []
+
+    # Normalise to (start, end, full_points)
+    segs: list[tuple[tuple[float, float], tuple[float, float], list[tuple[float, float]]]] = []
+    for pts in segments:
+        if len(pts) < 2:
+            continue
+        segs.append((pts[0], pts[-1], pts))
+
+    if not segs:
+        return []
+
+    result = list(segs[0][2])
+    used = {0}
+
+    while len(used) < len(segs):
+        current_end = result[-1]
+        found = False
+        for i, (s, e, pts) in enumerate(segs):
+            if i in used:
+                continue
+            ds = math.sqrt((s[0] - current_end[0]) ** 2 + (s[1] - current_end[1]) ** 2)
+            de = math.sqrt((e[0] - current_end[0]) ** 2 + (e[1] - current_end[1]) ** 2)
+            if ds < tolerance:
+                result.extend(pts[1:])
+                used.add(i)
+                found = True
+                break
+            elif de < tolerance:
+                result.extend(reversed(pts[:-1]))
+                used.add(i)
+                found = True
+                break
+        if not found:
+            break
+
+    return result

--- a/src/kicad_tools/placement/geometry.py
+++ b/src/kicad_tools/placement/geometry.py
@@ -20,10 +20,13 @@ bounding boxes (AABBs).
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from .cost import BoardOutline
 from .vector import ComponentDef, PlacedComponent
+
+if TYPE_CHECKING:
+    from kicad_tools.pcb.board_geometry import BoardGeometry
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -196,6 +199,48 @@ def compute_boundary_violation(
 
         # Out-of-bounds area = total component area - area inside board
         violation = total_area - inside_area
+        if violation > 0.0:
+            total += violation
+
+    return total
+
+
+def compute_boundary_violation_shapely(
+    placements: Sequence[PlacedComponent],
+    component_defs: Sequence[ComponentDef],
+    board_geometry: BoardGeometry,
+) -> float:
+    """Compute total out-of-bounds area using Shapely polygon containment.
+
+    Like :func:`compute_boundary_violation`, but uses a Shapely-backed
+    :class:`~kicad_tools.pcb.board_geometry.BoardGeometry` for accurate
+    non-rectangular board shapes.
+
+    Args:
+        placements: Placed components with positions, rotations, and sides.
+        component_defs: Static component definitions (same order as
+            *placements*).
+        board_geometry: Shapely-based board geometry.
+
+    Returns:
+        Total out-of-bounds area in mm^2.  Returns ``0.0`` when all
+        components are fully within the board.
+
+    Raises:
+        ValueError: If *placements* and *component_defs* have different
+            lengths.
+    """
+    n = len(placements)
+    if n != len(component_defs):
+        raise ValueError(f"placements has {n} items but component_defs has {len(component_defs)}")
+
+    total = 0.0
+
+    for comp, comp_def in zip(placements, component_defs, strict=True):
+        box_min_x, box_min_y, box_max_x, box_max_y = _aabb(comp, comp_def)
+        violation = board_geometry.compute_boundary_violation(
+            box_min_x, box_min_y, box_max_x, box_max_y
+        )
         if violation > 0.0:
             total += violation
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -402,6 +402,11 @@ class Autorouter:
         # the edge clearance zone.
         self._edge_clearance: float | None = None
 
+        # Shapely-based board geometry for accurate non-rectangular edge
+        # clearance (Issue #2340).  Set by load_pcb_for_routing() when
+        # Shapely is available.
+        self._board_geometry: Any | None = None
+
         # Length constraint tracking (Issue #630)
         self._length_tracker: LengthTracker = LengthTracker()
 

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -2566,6 +2566,22 @@ def load_pcb_for_routing(
         all_ys = [p[1] for seg in edge_segments for p in seg]
         router._board_bbox = (min(all_xs), min(all_ys), max(all_xs), max(all_ys))
 
+    # Attach Shapely-based board geometry when available (Issue #2340).
+    # This enables accurate non-rectangular edge clearance checking.
+    try:
+        from kicad_tools.pcb.board_geometry import BoardGeometry, has_shapely
+
+        if has_shapely():
+            from kicad_tools.schema.pcb import PCB as SchemaPCB
+
+            _schema_pcb = SchemaPCB.load(pcb_path)
+            try:
+                router._board_geometry = BoardGeometry.from_pcb(_schema_pcb)
+            except (ValueError, Exception):
+                pass
+    except ImportError:
+        pass
+
     # Apply edge clearance if specified
     if edge_clearance is not None and edge_clearance > 0:
         # Store on router so EscapeRouter can clamp escape points (Issue #2136)

--- a/tests/test_board_geometry.py
+++ b/tests/test_board_geometry.py
@@ -1,0 +1,355 @@
+"""Tests for Shapely-based BoardGeometry engine.
+
+Tests the core geometry operations: polygon construction, containment,
+buffer, intersection, difference, and backward-compatibility helpers.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+# Guard: skip entire module if Shapely is not installed
+shapely = pytest.importorskip("shapely", reason="shapely not installed")
+
+from kicad_tools.pcb.board_geometry import (
+    BoardGeometry,
+    _chain_segments,
+    _linearize_arc,
+    _linearize_bezier,
+    has_shapely,
+)
+
+
+# -----------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------
+
+
+def _rect_geometry(
+    min_x: float = 0.0,
+    min_y: float = 0.0,
+    max_x: float = 100.0,
+    max_y: float = 80.0,
+) -> BoardGeometry:
+    """Create a simple rectangular board geometry for testing."""
+    return BoardGeometry.from_bounds(min_x, min_y, max_x, max_y)
+
+
+def _l_shape_geometry() -> BoardGeometry:
+    """Create an L-shaped board geometry for testing non-rectangular boards."""
+    # L-shape: main 100x80 body with a 40x40 notch cut from top-right
+    points = [
+        (0, 0),
+        (100, 0),
+        (100, 40),
+        (60, 40),
+        (60, 80),
+        (0, 80),
+    ]
+    return BoardGeometry.from_outline_points(points)
+
+
+# -----------------------------------------------------------------------
+# has_shapely()
+# -----------------------------------------------------------------------
+
+
+def test_has_shapely():
+    """Shapely should be available since we imported it above."""
+    assert has_shapely() is True
+
+
+# -----------------------------------------------------------------------
+# from_bounds / from_outline_points
+# -----------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_from_bounds_basic(self):
+        geom = _rect_geometry()
+        assert geom.bounds == pytest.approx((0.0, 0.0, 100.0, 80.0))
+        assert geom.area == pytest.approx(100.0 * 80.0)
+
+    def test_from_outline_points_rectangle(self):
+        geom = BoardGeometry.from_outline_points(
+            [(0, 0), (50, 0), (50, 30), (0, 30)]
+        )
+        assert geom.area == pytest.approx(50.0 * 30.0)
+
+    def test_from_outline_points_l_shape(self):
+        geom = _l_shape_geometry()
+        # Full 100x80 = 8000, minus 40x40 = 1600 notch = 6400
+        assert geom.area == pytest.approx(6400.0)
+
+    def test_from_outline_points_too_few_raises(self):
+        with pytest.raises(ValueError, match="at least 3"):
+            BoardGeometry.from_outline_points([(0, 0), (1, 1)])
+
+    def test_exterior_coords(self):
+        geom = _rect_geometry(0, 0, 10, 10)
+        coords = geom.exterior_coords
+        # Shapely closes the ring, so first == last
+        assert len(coords) == 5
+        assert coords[0] == coords[-1]
+
+
+# -----------------------------------------------------------------------
+# contains_point
+# -----------------------------------------------------------------------
+
+
+class TestContainsPoint:
+    def test_inside_rectangle(self):
+        geom = _rect_geometry()
+        assert geom.contains_point(50, 40) is True
+
+    def test_outside_rectangle(self):
+        geom = _rect_geometry()
+        assert geom.contains_point(150, 40) is False
+        assert geom.contains_point(-10, 40) is False
+
+    def test_l_shape_inside_body(self):
+        geom = _l_shape_geometry()
+        assert geom.contains_point(30, 60) is True
+
+    def test_l_shape_inside_notch(self):
+        """Point in the notch region should be outside the L-shape."""
+        geom = _l_shape_geometry()
+        assert geom.contains_point(80, 60) is False
+
+    def test_l_shape_in_arm(self):
+        """Point in the remaining arm of the L should be inside."""
+        geom = _l_shape_geometry()
+        assert geom.contains_point(80, 20) is True
+
+
+# -----------------------------------------------------------------------
+# distance_to_edge
+# -----------------------------------------------------------------------
+
+
+class TestDistanceToEdge:
+    def test_inside_distance_positive(self):
+        geom = _rect_geometry(0, 0, 100, 80)
+        dist = geom.distance_to_edge(10, 40)
+        # Closest edge is left at x=0, distance = 10
+        assert dist == pytest.approx(10.0)
+
+    def test_outside_distance_negative(self):
+        geom = _rect_geometry(0, 0, 100, 80)
+        dist = geom.distance_to_edge(-5, 40)
+        assert dist == pytest.approx(-5.0)
+
+    def test_on_edge_is_zero(self):
+        geom = _rect_geometry(0, 0, 100, 80)
+        dist = geom.distance_to_edge(0, 40)
+        assert abs(dist) < 0.001
+
+
+# -----------------------------------------------------------------------
+# buffer
+# -----------------------------------------------------------------------
+
+
+class TestBuffer:
+    def test_inset_shrinks(self):
+        geom = _rect_geometry(0, 0, 100, 80)
+        inset = geom.buffer(-5)
+        # 90 * 70 = 6300
+        assert inset.area == pytest.approx(6300.0)
+
+    def test_outset_expands(self):
+        geom = _rect_geometry(0, 0, 100, 80)
+        outset = geom.buffer(5)
+        # Expanded area > original area (corners become rounded)
+        assert outset.area > 100 * 80
+
+    def test_large_inset_collapses(self):
+        geom = _rect_geometry(0, 0, 10, 10)
+        inset = geom.buffer(-10)
+        # Should collapse to empty or near-empty
+        assert inset.area < 1.0
+
+
+# -----------------------------------------------------------------------
+# intersection / difference / union
+# -----------------------------------------------------------------------
+
+
+class TestBooleanOps:
+    def test_intersection(self):
+        a = _rect_geometry(0, 0, 100, 80)
+        b = _rect_geometry(50, 40, 150, 120)
+        result = a.intersection(b)
+        # Overlap region: x=[50,100], y=[40,80] -> 50*40 = 2000
+        assert result.area == pytest.approx(2000.0)
+
+    def test_difference(self):
+        a = _rect_geometry(0, 0, 100, 80)
+        b = _rect_geometry(50, 40, 150, 120)
+        result = a.difference(b)
+        # Original 8000 minus 2000 overlap
+        assert result.area == pytest.approx(6000.0)
+
+    def test_union(self):
+        a = _rect_geometry(0, 0, 100, 80)
+        b = _rect_geometry(50, 40, 150, 120)
+        result = a.union(b)
+        # 8000 + 8000 - 2000 = 14000
+        assert result.area == pytest.approx(14000.0)
+
+
+# -----------------------------------------------------------------------
+# compute_boundary_violation
+# -----------------------------------------------------------------------
+
+
+class TestBoundaryViolation:
+    def test_fully_inside(self):
+        geom = _rect_geometry(0, 0, 100, 80)
+        violation = geom.compute_boundary_violation(10, 10, 30, 30)
+        assert violation == pytest.approx(0.0)
+
+    def test_partially_outside(self):
+        geom = _rect_geometry(0, 0, 100, 80)
+        # Component from x=90 to x=110, y=0 to y=20
+        # Outside area: x=[100,110], y=[0,20] -> 10*20 = 200
+        violation = geom.compute_boundary_violation(90, 0, 110, 20)
+        assert violation == pytest.approx(200.0)
+
+    def test_fully_outside(self):
+        geom = _rect_geometry(0, 0, 100, 80)
+        violation = geom.compute_boundary_violation(200, 200, 210, 210)
+        assert violation == pytest.approx(100.0)
+
+    def test_l_shape_in_notch(self):
+        """Component in the notch area of an L-shape should be out of bounds."""
+        geom = _l_shape_geometry()
+        # Place component fully in the notch: x=[70,90], y=[50,70]
+        violation = geom.compute_boundary_violation(70, 50, 90, 70)
+        assert violation == pytest.approx(20.0 * 20.0)
+
+
+# -----------------------------------------------------------------------
+# to_board_outline / to_optim_polygon
+# -----------------------------------------------------------------------
+
+
+class TestCompatibility:
+    def test_to_board_outline(self):
+        geom = _rect_geometry(10, 20, 110, 100)
+        outline = geom.to_board_outline()
+        assert outline.min_x == pytest.approx(10.0)
+        assert outline.min_y == pytest.approx(20.0)
+        assert outline.max_x == pytest.approx(110.0)
+        assert outline.max_y == pytest.approx(100.0)
+
+    def test_to_optim_polygon(self):
+        geom = _rect_geometry(0, 0, 50, 30)
+        poly = geom.to_optim_polygon()
+        assert len(poly.vertices) >= 4
+
+
+# -----------------------------------------------------------------------
+# Arc linearisation
+# -----------------------------------------------------------------------
+
+
+class TestLinearizeArc:
+    def test_semicircle(self):
+        """A semicircle from (10,0) through (0,10) to (-10,0) around origin."""
+        pts = _linearize_arc(10, 0, 0, 10, -10, 0, num_segments=16)
+        assert len(pts) == 17  # 16 segments + 1
+        # First and last should be near start/end
+        assert pts[0] == pytest.approx((10, 0), abs=0.01)
+        assert pts[-1] == pytest.approx((-10, 0), abs=0.01)
+        # All points should be ~10 units from origin
+        for x, y in pts:
+            r = math.sqrt(x * x + y * y)
+            assert r == pytest.approx(10.0, abs=0.1)
+
+    def test_degenerate_collinear(self):
+        """Collinear points should degrade to a straight line."""
+        pts = _linearize_arc(0, 0, 5, 0, 10, 0)
+        assert len(pts) == 2
+        assert pts[0] == (0, 0)
+        assert pts[1] == (10, 0)
+
+
+# -----------------------------------------------------------------------
+# Bezier linearisation
+# -----------------------------------------------------------------------
+
+
+class TestLinearizeBezier:
+    def test_quadratic(self):
+        pts = _linearize_bezier([(0, 0), (5, 10), (10, 0)], num_segments=8)
+        assert len(pts) == 9
+        assert pts[0] == pytest.approx((0, 0))
+        assert pts[-1] == pytest.approx((10, 0))
+
+    def test_cubic(self):
+        pts = _linearize_bezier([(0, 0), (3, 10), (7, 10), (10, 0)], num_segments=16)
+        assert len(pts) == 17
+        assert pts[0] == pytest.approx((0, 0))
+        assert pts[-1] == pytest.approx((10, 0))
+
+    def test_single_point(self):
+        pts = _linearize_bezier([(5, 5)])
+        assert pts == [(5, 5)]
+
+
+# -----------------------------------------------------------------------
+# Segment chaining
+# -----------------------------------------------------------------------
+
+
+class TestChainSegments:
+    def test_chain_rectangle(self):
+        segments = [
+            [(0, 0), (10, 0)],
+            [(10, 0), (10, 5)],
+            [(10, 5), (0, 5)],
+            [(0, 5), (0, 0)],
+        ]
+        result = _chain_segments(segments)
+        assert len(result) >= 4
+
+    def test_chain_reversed_segment(self):
+        """Segments with reversed direction should still chain."""
+        segments = [
+            [(0, 0), (10, 0)],
+            [(10, 5), (10, 0)],  # reversed
+            [(10, 5), (0, 5)],
+            [(0, 5), (0, 0)],
+        ]
+        result = _chain_segments(segments)
+        assert len(result) >= 4
+
+    def test_empty(self):
+        assert _chain_segments([]) == []
+
+
+# -----------------------------------------------------------------------
+# Edge cases
+# -----------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_self_intersecting_outline_fixed(self):
+        """A self-intersecting polygon should be auto-fixed via buffer(0)."""
+        # Bowtie shape
+        points = [(0, 0), (10, 10), (10, 0), (0, 10)]
+        geom = BoardGeometry.from_outline_points(points)
+        # buffer(0) makes it valid
+        assert geom.area > 0
+
+    def test_bounds_property(self):
+        geom = _rect_geometry(5, 10, 50, 40)
+        min_x, min_y, max_x, max_y = geom.bounds
+        assert min_x == pytest.approx(5.0)
+        assert min_y == pytest.approx(10.0)
+        assert max_x == pytest.approx(50.0)
+        assert max_y == pytest.approx(40.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1766,7 +1766,7 @@ wheels = [
 
 [[package]]
 name = "kicad-tools"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1840,6 +1840,9 @@ dev = [
 ]
 drc = [
     { name = "rtree" },
+]
+geometry = [
+    { name = "shapely" },
 ]
 mcp = [
     { name = "fastmcp" },
@@ -1940,12 +1943,13 @@ requires-dist = [
     { name = "rtree", marker = "extra == 'drc'", specifier = ">=1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "scikit-build-core", marker = "extra == 'native'", specifier = ">=0.8" },
+    { name = "shapely", marker = "extra == 'geometry'", specifier = ">=2.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "weasyprint", marker = "extra == 'all'", specifier = ">=60.0" },
     { name = "weasyprint", marker = "extra == 'dev'", specifier = ">=60.0" },
     { name = "weasyprint", marker = "extra == 'report'", specifier = ">=60.0" },
 ]
-provides-extras = ["drc", "parts", "datasheet", "placement", "mcp", "native", "cuda", "metal", "visualization", "bayesian", "screenshot", "report", "all", "dev"]
+provides-extras = ["geometry", "drc", "parts", "datasheet", "placement", "mcp", "native", "cuda", "metal", "visualization", "bayesian", "screenshot", "report", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4727,6 +4731,74 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893, upload-time = "2026-02-08T15:08:40.206Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468, upload-time = "2026-02-08T15:08:38.723Z" },
+]
+
+[[package]]
+name = "shapely"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/89/c3548aa9b9812a5d143986764dededfa48d817714e947398bdda87c77a72/shapely-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7ae48c236c0324b4e139bea88a306a04ca630f49be66741b340729d380d8f52f", size = 1825959, upload-time = "2025-09-24T13:50:00.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8a/7ebc947080442edd614ceebe0ce2cdbd00c25e832c240e1d1de61d0e6b38/shapely-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eba6710407f1daa8e7602c347dfc94adc02205ec27ed956346190d66579eb9ea", size = 1629196, upload-time = "2025-09-24T13:50:03.447Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/86/c9c27881c20d00fc409e7e059de569d5ed0abfcec9c49548b124ebddea51/shapely-2.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef4a456cc8b7b3d50ccec29642aa4aeda959e9da2fe9540a92754770d5f0cf1f", size = 2951065, upload-time = "2025-09-24T13:50:05.266Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8a/0ab1f7433a2a85d9e9aea5b1fbb333f3b09b309e7817309250b4b7b2cc7a/shapely-2.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e38a190442aacc67ff9f75ce60aec04893041f16f97d242209106d502486a142", size = 3058666, upload-time = "2025-09-24T13:50:06.872Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c6/5a30ffac9c4f3ffd5b7113a7f5299ccec4713acd5ee44039778a7698224e/shapely-2.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:40d784101f5d06a1fd30b55fc11ea58a61be23f930d934d86f19a180909908a4", size = 3966905, upload-time = "2025-09-24T13:50:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/e92f3035ba43e53959007f928315a68fbcf2eeb4e5ededb6f0dc7ff1ecc3/shapely-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f6f6cd5819c50d9bcf921882784586aab34a4bd53e7553e175dece6db513a6f0", size = 4129260, upload-time = "2025-09-24T13:50:11.183Z" },
+    { url = "https://files.pythonhosted.org/packages/42/24/605901b73a3d9f65fa958e63c9211f4be23d584da8a1a7487382fac7fdc5/shapely-2.1.2-cp310-cp310-win32.whl", hash = "sha256:fe9627c39c59e553c90f5bc3128252cb85dc3b3be8189710666d2f8bc3a5503e", size = 1544301, upload-time = "2025-09-24T13:50:12.521Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/6db795b8dd3919851856bd2ddd13ce434a748072f6fdee42ff30cbd3afa3/shapely-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:1d0bfb4b8f661b3b4ec3565fa36c340bfb1cda82087199711f86a88647d26b2f", size = 1722074, upload-time = "2025-09-24T13:50:13.909Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/8d/1ff672dea9ec6a7b5d422eb6d095ed886e2e523733329f75fdcb14ee1149/shapely-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:91121757b0a36c9aac3427a651a7e6567110a4a67c97edf04f8d55d4765f6618", size = 1820038, upload-time = "2025-09-24T13:50:15.628Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ce/28fab8c772ce5db23a0d86bf0adaee0c4c79d5ad1db766055fa3dab442e2/shapely-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:16a9c722ba774cf50b5d4541242b4cce05aafd44a015290c82ba8a16931ff63d", size = 1626039, upload-time = "2025-09-24T13:50:16.881Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8b/868b7e3f4982f5006e9395c1e12343c66a8155c0374fdc07c0e6a1ab547d/shapely-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cc4f7397459b12c0b196c9efe1f9d7e92463cbba142632b4cc6d8bbbbd3e2b09", size = 3001519, upload-time = "2025-09-24T13:50:18.606Z" },
+    { url = "https://files.pythonhosted.org/packages/13/02/58b0b8d9c17c93ab6340edd8b7308c0c5a5b81f94ce65705819b7416dba5/shapely-2.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:136ab87b17e733e22f0961504d05e77e7be8c9b5a8184f685b4a91a84efe3c26", size = 3110842, upload-time = "2025-09-24T13:50:21.77Z" },
+    { url = "https://files.pythonhosted.org/packages/af/61/8e389c97994d5f331dcffb25e2fa761aeedfb52b3ad9bcdd7b8671f4810a/shapely-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:16c5d0fc45d3aa0a69074979f4f1928ca2734fb2e0dde8af9611e134e46774e7", size = 4021316, upload-time = "2025-09-24T13:50:23.626Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d4/9b2a9fe6039f9e42ccf2cb3e84f219fd8364b0c3b8e7bbc857b5fbe9c14c/shapely-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6ddc759f72b5b2b0f54a7e7cde44acef680a55019eb52ac63a7af2cf17cb9cd2", size = 4178586, upload-time = "2025-09-24T13:50:25.443Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f6/9840f6963ed4decf76b08fd6d7fed14f8779fb7a62cb45c5617fa8ac6eab/shapely-2.1.2-cp311-cp311-win32.whl", hash = "sha256:2fa78b49485391224755a856ed3b3bd91c8455f6121fee0db0e71cefb07d0ef6", size = 1543961, upload-time = "2025-09-24T13:50:26.968Z" },
+    { url = "https://files.pythonhosted.org/packages/38/1e/3f8ea46353c2a33c1669eb7327f9665103aa3a8dfe7f2e4ef714c210b2c2/shapely-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:c64d5c97b2f47e3cd9b712eaced3b061f2b71234b3fc263e0fcf7d889c6559dc", size = 1722856, upload-time = "2025-09-24T13:50:28.497Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c0/f3b6453cf2dfa99adc0ba6675f9aaff9e526d2224cbd7ff9c1a879238693/shapely-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fe2533caae6a91a543dec62e8360fe86ffcdc42a7c55f9dfd0128a977a896b94", size = 1833550, upload-time = "2025-09-24T13:50:30.019Z" },
+    { url = "https://files.pythonhosted.org/packages/86/07/59dee0bc4b913b7ab59ab1086225baca5b8f19865e6101db9ebb7243e132/shapely-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ba4d1333cc0bc94381d6d4308d2e4e008e0bd128bdcff5573199742ee3634359", size = 1643556, upload-time = "2025-09-24T13:50:32.291Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/a5397e75b435b9895cd53e165083faed5d12fd9626eadec15a83a2411f0f/shapely-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bd308103340030feef6c111d3eb98d50dc13feea33affc8a6f9fa549e9458a3", size = 2988308, upload-time = "2025-09-24T13:50:33.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/37/e781683abac55dde9771e086b790e554811a71ed0b2b8a1e789b7430dd44/shapely-2.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e7d4d7ad262a48bb44277ca12c7c78cb1b0f56b32c10734ec9a1d30c0b0c54b", size = 3099844, upload-time = "2025-09-24T13:50:35.459Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f3/9876b64d4a5a321b9dc482c92bb6f061f2fa42131cba643c699f39317cb9/shapely-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e9eddfe513096a71896441a7c37db72da0687b34752c4e193577a145c71736fc", size = 3988842, upload-time = "2025-09-24T13:50:37.478Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/704c7292f7014c7e74ec84eddb7b109e1fbae74a16deae9c1504b1d15565/shapely-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:980c777c612514c0cf99bc8a9de6d286f5e186dcaf9091252fcd444e5638193d", size = 4152714, upload-time = "2025-09-24T13:50:39.9Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/319c9dc788884ad0785242543cdffac0e6530e4d0deb6c4862bc4143dcf3/shapely-2.1.2-cp312-cp312-win32.whl", hash = "sha256:9111274b88e4d7b54a95218e243282709b330ef52b7b86bc6aaf4f805306f454", size = 1542745, upload-time = "2025-09-24T13:50:41.414Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bf/cb6c1c505cb31e818e900b9312d514f381fbfa5c4363edfce0fcc4f8c1a4/shapely-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:743044b4cfb34f9a67205cee9279feaf60ba7d02e69febc2afc609047cb49179", size = 1722861, upload-time = "2025-09-24T13:50:43.35Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/90/98ef257c23c46425dc4d1d31005ad7c8d649fe423a38b917db02c30f1f5a/shapely-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b510dda1a3672d6879beb319bc7c5fd302c6c354584690973c838f46ec3e0fa8", size = 1832644, upload-time = "2025-09-24T13:50:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ab/0bee5a830d209adcd3a01f2d4b70e587cdd9fd7380d5198c064091005af8/shapely-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8cff473e81017594d20ec55d86b54bc635544897e13a7cfc12e36909c5309a2a", size = 1642887, upload-time = "2025-09-24T13:50:46.735Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5e/7d7f54ba960c13302584c73704d8c4d15404a51024631adb60b126a4ae88/shapely-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe7b77dc63d707c09726b7908f575fc04ff1d1ad0f3fb92aec212396bc6cfe5e", size = 2970931, upload-time = "2025-09-24T13:50:48.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ed1a5bbfb386ee8332713bf7508bc24e32d24b74fc9a7b9f8529a55db9f4ee6", size = 3082855, upload-time = "2025-09-24T13:50:50.037Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2b/578faf235a5b09f16b5f02833c53822294d7f21b242f8e2d0cf03fb64321/shapely-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a84e0582858d841d54355246ddfcbd1fce3179f185da7470f41ce39d001ee1af", size = 3979960, upload-time = "2025-09-24T13:50:51.74Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/04/167f096386120f692cc4ca02f75a17b961858997a95e67a3cb6a7bbd6b53/shapely-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc3487447a43d42adcdf52d7ac73804f2312cbfa5d433a7d2c506dcab0033dfd", size = 4142851, upload-time = "2025-09-24T13:50:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/48/74/fb402c5a6235d1c65a97348b48cdedb75fb19eca2b1d66d04969fc1c6091/shapely-2.1.2-cp313-cp313-win32.whl", hash = "sha256:9c3a3c648aedc9f99c09263b39f2d8252f199cb3ac154fadc173283d7d111350", size = 1541890, upload-time = "2025-09-24T13:50:55.337Z" },
+    { url = "https://files.pythonhosted.org/packages/41/47/3647fe7ad990af60ad98b889657a976042c9988c2807cf322a9d6685f462/shapely-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:ca2591bff6645c216695bdf1614fca9c82ea1144d4a7591a466fef64f28f0715", size = 1722151, upload-time = "2025-09-24T13:50:57.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/49/63953754faa51ffe7d8189bfbe9ca34def29f8c0e34c67cbe2a2795f269d/shapely-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2d93d23bdd2ed9dc157b46bc2f19b7da143ca8714464249bef6771c679d5ff40", size = 1834130, upload-time = "2025-09-24T13:50:58.49Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ee/dce001c1984052970ff60eb4727164892fb2d08052c575042a47f5a9e88f/shapely-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01d0d304b25634d60bd7cf291828119ab55a3bab87dc4af1e44b07fb225f188b", size = 1642802, upload-time = "2025-09-24T13:50:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e7/fc4e9a19929522877fa602f705706b96e78376afb7fad09cad5b9af1553c/shapely-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8d8382dd120d64b03698b7298b89611a6ea6f55ada9d39942838b79c9bc89801", size = 3018460, upload-time = "2025-09-24T13:51:02.08Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/18/7519a25db21847b525696883ddc8e6a0ecaa36159ea88e0fef11466384d0/shapely-2.1.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19efa3611eef966e776183e338b2d7ea43569ae99ab34f8d17c2c054d3205cc0", size = 3095223, upload-time = "2025-09-24T13:51:04.472Z" },
+    { url = "https://files.pythonhosted.org/packages/48/de/b59a620b1f3a129c3fecc2737104a0a7e04e79335bd3b0a1f1609744cf17/shapely-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:346ec0c1a0fcd32f57f00e4134d1200e14bf3f5ae12af87ba83ca275c502498c", size = 4030760, upload-time = "2025-09-24T13:51:06.455Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/c6655ee7232b417562bae192ae0d3ceaadb1cc0ffc2088a2ddf415456cc2/shapely-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6305993a35989391bd3476ee538a5c9a845861462327efe00dd11a5c8c709a99", size = 4170078, upload-time = "2025-09-24T13:51:08.584Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8e/605c76808d73503c9333af8f6cbe7e1354d2d238bda5f88eea36bfe0f42a/shapely-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:c8876673449f3401f278c86eb33224c5764582f72b653a415d0e6672fde887bf", size = 1559178, upload-time = "2025-09-24T13:51:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/d317eb232352a1f1444d11002d477e54514a4a6045536d49d0c59783c0da/shapely-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:4a44bc62a10d84c11a7a3d7c1c4fe857f7477c3506e24c9062da0db0ae0c449c", size = 1739756, upload-time = "2025-09-24T13:51:12.105Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c4/3ce4c2d9b6aabd27d26ec988f08cb877ba9e6e96086eff81bfea93e688c7/shapely-2.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:9a522f460d28e2bf4e12396240a5fc1518788b2fcd73535166d748399ef0c223", size = 1831290, upload-time = "2025-09-24T13:51:13.56Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/f6ab8918fc15429f79cb04afa9f9913546212d7fb5e5196132a2af46676b/shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ff629e00818033b8d71139565527ced7d776c269a49bd78c9df84e8f852190c", size = 1641463, upload-time = "2025-09-24T13:51:14.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/57/91d59ae525ca641e7ac5551c04c9503aee6f29b92b392f31790fcb1a4358/shapely-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f67b34271dedc3c653eba4e3d7111aa421d5be9b4c4c7d38d30907f796cb30df", size = 2970145, upload-time = "2025-09-24T13:51:16.961Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/4948be52ee1da6927831ab59e10d4c29baa2a714f599f1f0d1bc747f5777/shapely-2.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21952dc00df38a2c28375659b07a3979d22641aeb104751e769c3ee825aadecf", size = 3073806, upload-time = "2025-09-24T13:51:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/03/83/f768a54af775eb41ef2e7bec8a0a0dbe7d2431c3e78c0a8bdba7ab17e446/shapely-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1f2f33f486777456586948e333a56ae21f35ae273be99255a191f5c1fa302eb4", size = 3980803, upload-time = "2025-09-24T13:51:20.37Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/559c7c195807c91c79d38a1f6901384a2878a76fbdf3f1048893a9b7534d/shapely-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cf831a13e0d5a7eb519e96f58ec26e049b1fad411fc6fc23b162a7ce04d9cffc", size = 4133301, upload-time = "2025-09-24T13:51:21.887Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cd/60d5ae203241c53ef3abd2ef27c6800e21afd6c94e39db5315ea0cbafb4a/shapely-2.1.2-cp314-cp314-win32.whl", hash = "sha256:61edcd8d0d17dd99075d320a1dd39c0cb9616f7572f10ef91b4b5b00c4aeb566", size = 1583247, upload-time = "2025-09-24T13:51:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d4/135684f342e909330e50d31d441ace06bf83c7dc0777e11043f99167b123/shapely-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:a444e7afccdb0999e203b976adb37ea633725333e5b119ad40b1ca291ecf311c", size = 1773019, upload-time = "2025-09-24T13:51:24.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/05/a44f3f9f695fa3ada22786dc9da33c933da1cbc4bfe876fe3a100bafe263/shapely-2.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:5ebe3f84c6112ad3d4632b1fd2290665aa75d4cef5f6c5d77c4c95b324527c6a", size = 1834137, upload-time = "2025-09-24T13:51:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/4d57db45bf314573427b0a70dfca15d912d108e6023f623947fa69f39b72/shapely-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5860eb9f00a1d49ebb14e881f5caf6c2cf472c7fd38bd7f253bbd34f934eb076", size = 1642884, upload-time = "2025-09-24T13:51:28.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/27/4e29c0a55d6d14ad7422bf86995d7ff3f54af0eba59617eb95caf84b9680/shapely-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b705c99c76695702656327b819c9660768ec33f5ce01fa32b2af62b56ba400a1", size = 3018320, upload-time = "2025-09-24T13:51:29.903Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/bb/992e6a3c463f4d29d4cd6ab8963b75b1b1040199edbd72beada4af46bde5/shapely-2.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a1fd0ea855b2cf7c9cddaf25543e914dd75af9de08785f20ca3085f2c9ca60b0", size = 3094931, upload-time = "2025-09-24T13:51:32.699Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/16/82e65e21070e473f0ed6451224ed9fa0be85033d17e0c6e7213a12f59d12/shapely-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:df90e2db118c3671a0754f38e36802db75fe0920d211a27481daf50a711fdf26", size = 4030406, upload-time = "2025-09-24T13:51:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/75/c24ed871c576d7e2b64b04b1fe3d075157f6eb54e59670d3f5ffb36e25c7/shapely-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:361b6d45030b4ac64ddd0a26046906c8202eb60d0f9f53085f5179f1d23021a0", size = 4169511, upload-time = "2025-09-24T13:51:36.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f7/b3d1d6d18ebf55236eec1c681ce5e665742aab3c0b7b232720a7d43df7b6/shapely-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:b54df60f1fbdecc8ebc2c5b11870461a6417b3d617f555e5033f1505d36e5735", size = 1602607, upload-time = "2025-09-24T13:51:37.757Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/f09272a71976dfc138129b8faf435d064a811ae2f708cb147dccdf7aacdb/shapely-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:0036ac886e0923417932c2e6369b6c52e38e0ff5d9120b90eef5cd9a5fc5cae9", size = 1796682, upload-time = "2025-09-24T13:51:39.233Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a Shapely-backed `BoardGeometry` class that provides accurate geometric operations on board outlines -- containment checks, clearance buffers, boolean operations (union/intersection/difference), and boundary violation detection for non-rectangular boards. Wire it into existing placement and routing code paths as an optional upgrade that falls back to AABB logic when Shapely is not installed.

## Changes

- Add `shapely>=2.0` as optional dependency under `[geometry]` extra in `pyproject.toml`
- Create `src/kicad_tools/pcb/board_geometry.py` with `BoardGeometry` class:
  - `from_pcb()` factory parsing Edge.Cuts (gr_line, gr_arc, gr_rect, gr_circle, gr_bezier)
  - `from_outline_points()` and `from_bounds()` constructors
  - `contains_point()`, `distance_to_edge()`, `buffer()`, `intersection()`, `difference()`, `union()`
  - `compute_boundary_violation()` for accurate non-rectangular boundary checking
  - `to_board_outline()` and `to_optim_polygon()` backward-compatibility helpers
  - Arc linearization via circumscribed-circle recovery; Bezier via De Casteljau
- Wire `BoardGeometry` into placement optimizer (`optim/placement.py`), keepout extraction (`optim/keepout.py`), CLI and MCP placement commands, and router (`router/io.py`, `router/core.py`)
- Add `compute_boundary_violation_shapely()` in `placement/geometry.py`
- Export `BoardGeometry` and `has_shapely` from `kicad_tools.pcb`
- Add 36 unit tests covering all geometry operations, arc/bezier linearization, segment chaining, edge cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Parse Edge.Cuts into Shapely polygon | PASS | `from_pcb()` handles gr_line, gr_arc, gr_rect, gr_circle, gr_bezier |
| Support lines, arcs, and bezier curves | PASS | `_linearize_arc()` and `_linearize_bezier()` with unit tests |
| Expose point-in-board and clearance buffer operations | PASS | `contains_point()`, `buffer()`, `distance_to_edge()` tested on rectangular and L-shaped boards |
| Wire into placement optimizer for boundary constraints | PASS | `optim/placement.py`, `optim/keepout.py`, `cli/optimize_placement_cmd.py`, `mcp/tools/optimize_placement.py` all try BoardGeometry first |
| Wire into router for edge clearance | PASS | `router/io.py` attaches `_board_geometry` to router; `router/core.py` declares the attribute |

## Test Plan

- 36 new tests in `tests/test_board_geometry.py` -- all pass
- Existing regression tests (`test_board_outline.py`, `test_placement_geometry.py`, `test_keepout.py`, `test_placement.py`) -- 126 tests pass, no regressions
- Optional dependency guard: module loads without Shapely; `has_shapely()` returns False; `from_pcb()` raises ImportError with install instructions

Closes #2340