### PR TITLE
feat(footprint): compressed footprint DSL for LLM-friendly generation

### DIFF
--- a/src/kicad_tools/cli/footprint_generate.py
+++ b/src/kicad_tools/cli/footprint_generate.py
@@ -301,8 +301,72 @@ def _output_footprint(fp, args) -> int:
         return 0
 
 
+def _try_dsl_generate(argv: list[str]) -> int | None:
+    """Try to interpret the first positional argument as a DSL spec string.
+
+    Returns exit code if handled, None if not a DSL string.
+    """
+    from kicad_tools.library.dsl import parse_footprint_dsl
+
+    # Known subcommands that should NOT be treated as DSL strings
+    known_subcommands = {"soic", "qfp", "qfn", "chip", "sot", "dip", "pin-header"}
+
+    # Find the first positional argument (skip flags)
+    dsl_spec = None
+    remaining = []
+    found_positional = False
+    for arg in argv:
+        if not found_positional and not arg.startswith("-") and arg not in known_subcommands:
+            dsl_spec = arg
+            found_positional = True
+        else:
+            remaining.append(arg)
+
+    if dsl_spec is None:
+        return None
+
+    # Parse remaining flags for output options
+    dsl_parser = argparse.ArgumentParser(prog="kct footprint generate <dsl-spec>")
+    dsl_parser.add_argument("-o", "--output", help="Output file path")
+    dsl_parser.add_argument(
+        "--json", action="store_true", help="Output as JSON"
+    )
+    dsl_parser.add_argument("--prefix", help="Component prefix (R, C, L)")
+    dsl_parser.add_argument("--name", help="Custom footprint name")
+
+    try:
+        dsl_args = dsl_parser.parse_args(remaining)
+    except SystemExit:
+        return 1
+
+    try:
+        fp = parse_footprint_dsl(dsl_spec)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    # Use a namespace compatible with _output_footprint
+    dsl_args.json = dsl_args.json
+    return _output_footprint(fp, dsl_args)
+
+
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for footprint generate command."""
+    # Try DSL shorthand first (e.g., "kct footprint generate soic8")
+    if argv is not None and argv:
+        dsl_result = _try_dsl_generate(argv)
+        if dsl_result is not None:
+            return dsl_result
+    elif argv is None:
+        # When called from sys.argv, check sys.argv[1:]
+        import sys as _sys
+
+        real_argv = _sys.argv[1:]
+        if real_argv:
+            dsl_result = _try_dsl_generate(real_argv)
+            if dsl_result is not None:
+                return dsl_result
+
     parser = argparse.ArgumentParser(
         prog="kct footprint generate",
         description="Generate parametric KiCad footprints",

--- a/src/kicad_tools/library/__init__.py
+++ b/src/kicad_tools/library/__init__.py
@@ -17,6 +17,7 @@ Usage:
 """
 
 from .footprint import Footprint, GraphicArc, GraphicCircle, GraphicLine, GraphicRect, Pad
+from .dsl import parse_footprint_dsl
 from .generators import (
     create_bga,
     create_bga_standard,
@@ -32,6 +33,8 @@ from .generators import (
 )
 
 __all__ = [
+    # DSL parser
+    "parse_footprint_dsl",
     # Core classes
     "Footprint",
     "Pad",

--- a/src/kicad_tools/library/dsl.py
+++ b/src/kicad_tools/library/dsl.py
@@ -1,0 +1,293 @@
+"""
+Compressed footprint DSL for LLM-friendly generation.
+
+Parses compact footprint specification strings and returns Footprint objects
+by delegating to the existing parametric generators.
+
+Grammar:
+    {package}[pin_count][_p{pitch}][_w{width}][_h{height}][_thermalpad]
+
+Examples:
+    - Passives: "0402", "0603", "1206"
+    - SOT: "sot23", "sot23-5", "sot223"
+    - SOIC: "soic8", "soic14", "soic8_p1.27mm"
+    - QFP: "qfp48_p0.5mm", "qfp100_p0.5mm_w14mm"
+    - QFN: "qfn16_w3mm", "qfn24_p0.5mm"
+    - BGA: "bga100_p0.8mm", "bga256_p0.8mm"
+    - DFN: "dfn8_w3mm_p0.5mm"
+    - DIP: "dip8", "dip16"
+
+Usage:
+    from kicad_tools.library.dsl import parse_footprint_dsl
+
+    fp = parse_footprint_dsl("soic8")
+    fp = parse_footprint_dsl("qfp48_p0.5mm")
+    fp = parse_footprint_dsl("0402")
+"""
+
+from __future__ import annotations
+
+import math
+import re
+
+from kicad_tools.library.footprint import Footprint
+from kicad_tools.library.generators import (
+    create_bga,
+    create_chip,
+    create_dfn,
+    create_dip,
+    create_qfn,
+    create_qfp,
+    create_soic,
+    create_sot,
+)
+from kicad_tools.library.generators.standards import (
+    CHIP_SIZES,
+    LQFP_STANDARDS,
+    QFN_STANDARDS,
+    SOT_STANDARDS,
+)
+
+# Maps DSL SOT names to SOT_STANDARDS keys
+_SOT_ALIASES: dict[str, str] = {
+    "sot23": "SOT-23",
+    "sot23-3": "SOT-23",
+    "sot23-5": "SOT-23-5",
+    "sot23-6": "SOT-23-6",
+    "sot223": "SOT-223",
+    "sot89": "SOT-89",
+}
+
+# Regex to extract optional modifiers like _p0.5mm, _w3mm, _h5mm, _thermalpad
+_MODIFIER_PITCH = re.compile(r"_p([\d.]+)(?:mm)?", re.IGNORECASE)
+_MODIFIER_WIDTH = re.compile(r"_w([\d.]+)(?:mm)?", re.IGNORECASE)
+_MODIFIER_HEIGHT = re.compile(r"_h([\d.]+)(?:mm)?", re.IGNORECASE)
+_MODIFIER_THERMALPAD = re.compile(r"_thermalpad", re.IGNORECASE)
+
+# Package prefix pattern: letters followed by digits
+_PACKAGE_PATTERN = re.compile(
+    r"^([a-z]+)([\d]+(?:-[\d]+)?)(.*)$",
+    re.IGNORECASE,
+)
+
+# Valid package prefixes recognized by the DSL
+_VALID_PREFIXES = {"soic", "qfp", "lqfp", "tqfp", "qfn", "bga", "dfn", "dip", "sot"}
+
+
+def _parse_modifiers(modifier_str: str) -> dict:
+    """Extract pitch, width, height, and thermalpad from modifier string."""
+    mods: dict = {}
+
+    m = _MODIFIER_PITCH.search(modifier_str)
+    if m:
+        mods["pitch"] = float(m.group(1))
+
+    m = _MODIFIER_WIDTH.search(modifier_str)
+    if m:
+        mods["width"] = float(m.group(1))
+
+    m = _MODIFIER_HEIGHT.search(modifier_str)
+    if m:
+        mods["height"] = float(m.group(1))
+
+    if _MODIFIER_THERMALPAD.search(modifier_str):
+        mods["thermalpad"] = True
+
+    return mods
+
+
+def _is_passive_size(spec: str) -> bool:
+    """Check if the spec is a bare passive size code (all digits, 4 chars)."""
+    # Strip any modifiers first
+    base = spec.split("_")[0]
+    return base in CHIP_SIZES
+
+
+def _build_chip(spec: str) -> Footprint:
+    """Build a chip/passive footprint from DSL spec."""
+    size = spec.split("_")[0]
+    if size not in CHIP_SIZES:
+        available = ", ".join(sorted(CHIP_SIZES.keys()))
+        raise ValueError(
+            f"Unknown chip size '{size}'. Valid sizes: {available}"
+        )
+    return create_chip(size=size)
+
+
+def _build_sot(spec_lower: str) -> Footprint:
+    """Build a SOT footprint from DSL spec."""
+    base = spec_lower.split("_")[0]
+    variant_key = _SOT_ALIASES.get(base)
+    if variant_key is None:
+        available = ", ".join(sorted(_SOT_ALIASES.keys()))
+        raise ValueError(
+            f"Unknown SOT variant '{base}'. Valid DSL names: {available}"
+        )
+    return create_sot(variant=variant_key)
+
+
+def _build_soic(pins: int, mods: dict) -> Footprint:
+    """Build a SOIC footprint from DSL spec."""
+    kwargs: dict = {"pins": pins}
+    if "pitch" in mods:
+        kwargs["pitch"] = mods["pitch"]
+    return create_soic(**kwargs)
+
+
+def _build_qfp(pins: int, mods: dict) -> Footprint:
+    """Build a QFP footprint from DSL spec."""
+    kwargs: dict = {"pins": pins}
+    if "pitch" in mods:
+        kwargs["pitch"] = mods["pitch"]
+    if "width" in mods:
+        kwargs["body_size"] = mods["width"]
+    return create_qfp(**kwargs)
+
+
+def _build_qfn(pins: int, mods: dict) -> Footprint:
+    """Build a QFN footprint from DSL spec."""
+    kwargs: dict = {"pins": pins}
+    if "pitch" in mods:
+        kwargs["pitch"] = mods["pitch"]
+    if "width" in mods:
+        kwargs["body_size"] = mods["width"]
+    return create_qfn(**kwargs)
+
+
+def _build_bga(pins: int, mods: dict) -> Footprint:
+    """Build a BGA footprint from DSL spec."""
+    # BGA needs rows and cols - assume square grid
+    side = int(math.isqrt(pins))
+    if side * side != pins:
+        raise ValueError(
+            f"BGA pin count {pins} is not a perfect square. "
+            f"BGA DSL requires a square grid (e.g., bga100 = 10x10)."
+        )
+    kwargs: dict = {"rows": side, "cols": side}
+    if "pitch" in mods:
+        kwargs["pitch"] = mods["pitch"]
+    return create_bga(**kwargs)
+
+
+def _build_dfn(pins: int, mods: dict) -> Footprint:
+    """Build a DFN footprint from DSL spec."""
+    kwargs: dict = {"pins": pins}
+    if "pitch" in mods:
+        kwargs["pitch"] = mods["pitch"]
+    if "width" in mods:
+        kwargs["body_width"] = mods["width"]
+        kwargs["body_length"] = mods["width"]  # Default square if only width given
+    if "height" in mods:
+        kwargs["body_length"] = mods["height"]
+    return create_dfn(**kwargs)
+
+
+def _build_dip(pins: int, mods: dict) -> Footprint:
+    """Build a DIP footprint from DSL spec."""
+    kwargs: dict = {"pins": pins}
+    if "pitch" in mods:
+        kwargs["pitch"] = mods["pitch"]
+    return create_dip(**kwargs)
+
+
+def parse_footprint_dsl(spec: str) -> Footprint:
+    """Parse a compact footprint DSL string and return a Footprint object.
+
+    The DSL grammar is:
+        {package}[pin_count][_p{pitch}][_w{width}][_h{height}][_thermalpad]
+
+    Args:
+        spec: A compact footprint specification string.
+
+    Returns:
+        A Footprint object ready for export.
+
+    Raises:
+        ValueError: If the spec cannot be parsed or contains invalid parameters.
+
+    Examples:
+        >>> fp = parse_footprint_dsl("0402")          # Chip passive
+        >>> fp = parse_footprint_dsl("soic8")         # SOIC-8
+        >>> fp = parse_footprint_dsl("qfp48_p0.5mm")  # LQFP-48, 0.5mm pitch
+        >>> fp = parse_footprint_dsl("sot23-5")       # SOT-23-5
+    """
+    if not spec or not isinstance(spec, str):
+        raise ValueError(
+            "Footprint DSL spec must be a non-empty string. "
+            "Examples: '0402', 'soic8', 'qfp48_p0.5mm'"
+        )
+
+    spec_stripped = spec.strip()
+    spec_lower = spec_stripped.lower()
+
+    # 1. Check for passive/chip sizes (all-digit base, e.g. "0402", "0603")
+    if _is_passive_size(spec_lower):
+        return _build_chip(spec_lower)
+
+    # 2. Check for SOT variants (sot23, sot23-5, sot223, sot89)
+    base_lower = spec_lower.split("_")[0]
+    if base_lower in _SOT_ALIASES:
+        return _build_sot(spec_lower)
+
+    # 3. Parse structured package specs: prefix + pin_count + modifiers
+    m = _PACKAGE_PATTERN.match(spec_lower)
+    if not m:
+        raise ValueError(
+            f"Cannot parse footprint DSL spec '{spec}'. "
+            f"Expected format: {{package}}{{pin_count}}[_p{{pitch}}][_w{{width}}]. "
+            f"Valid prefixes: {', '.join(sorted(_VALID_PREFIXES))}. "
+            f"Valid chip sizes: {', '.join(sorted(CHIP_SIZES.keys()))}. "
+            f"Examples: 'soic8', 'qfp48_p0.5mm', '0402', 'sot23'"
+        )
+
+    prefix = m.group(1)
+    pin_str = m.group(2)
+    modifier_str = m.group(3)
+
+    # Parse pin count (handles "23-5" style for SOT variants)
+    if "-" in pin_str:
+        # Already handled above for SOT, but catch any remaining
+        raise ValueError(
+            f"Cannot parse footprint DSL spec '{spec}'. "
+            f"Hyphenated pin counts are only valid for SOT variants."
+        )
+
+    try:
+        pins = int(pin_str)
+    except ValueError:
+        raise ValueError(
+            f"Invalid pin count '{pin_str}' in spec '{spec}'. "
+            f"Pin count must be a positive integer."
+        )
+
+    if pins <= 0:
+        raise ValueError(
+            f"Pin count must be positive, got {pins} in spec '{spec}'."
+        )
+
+    mods = _parse_modifiers(modifier_str)
+
+    # Normalize package prefix aliases
+    prefix_normalized = prefix
+    if prefix in ("lqfp", "tqfp"):
+        prefix_normalized = "qfp"
+
+    # Dispatch to the appropriate builder
+    builders = {
+        "soic": _build_soic,
+        "qfp": _build_qfp,
+        "qfn": _build_qfn,
+        "bga": _build_bga,
+        "dfn": _build_dfn,
+        "dip": _build_dip,
+    }
+
+    builder = builders.get(prefix_normalized)
+    if builder is None:
+        raise ValueError(
+            f"Unknown package prefix '{prefix}' in spec '{spec}'. "
+            f"Valid prefixes: {', '.join(sorted(_VALID_PREFIXES))}. "
+            f"Examples: 'soic8', 'qfp48_p0.5mm', 'bga100_p0.8mm'"
+        )
+
+    return builder(pins, mods)

--- a/tests/test_footprint_dsl.py
+++ b/tests/test_footprint_dsl.py
@@ -1,0 +1,291 @@
+"""Tests for the compressed footprint DSL parser."""
+
+import pytest
+
+from kicad_tools.library.dsl import parse_footprint_dsl
+from kicad_tools.library.footprint import Footprint
+from kicad_tools.library.generators import (
+    create_bga,
+    create_chip,
+    create_dfn,
+    create_dip,
+    create_qfn,
+    create_qfp,
+    create_soic,
+    create_sot,
+)
+
+
+class TestPassiveSizes:
+    """Test parsing of passive/chip component DSL strings."""
+
+    @pytest.mark.parametrize(
+        "size",
+        ["0201", "0402", "0603", "0805", "1206", "1210", "1812", "2010", "2512"],
+    )
+    def test_all_chip_sizes(self, size: str):
+        fp = parse_footprint_dsl(size)
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == 2  # Chip passives have 2 pads
+
+    def test_chip_matches_direct_generator(self):
+        """Round-trip: DSL result matches direct generator call."""
+        dsl_fp = parse_footprint_dsl("0402")
+        direct_fp = create_chip(size="0402")
+        assert dsl_fp.name == direct_fp.name
+        assert len(dsl_fp.pads) == len(direct_fp.pads)
+
+    def test_chip_0603_matches_direct(self):
+        dsl_fp = parse_footprint_dsl("0603")
+        direct_fp = create_chip(size="0603")
+        assert dsl_fp.name == direct_fp.name
+
+    def test_chip_2512_boundary(self):
+        fp = parse_footprint_dsl("2512")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == 2
+
+
+class TestSOTVariants:
+    """Test parsing of SOT DSL strings."""
+
+    @pytest.mark.parametrize(
+        "spec,expected_variant",
+        [
+            ("sot23", "SOT-23"),
+            ("sot23-5", "SOT-23-5"),
+            ("sot23-6", "SOT-23-6"),
+            ("sot223", "SOT-223"),
+            ("sot89", "SOT-89"),
+        ],
+    )
+    def test_sot_variants(self, spec: str, expected_variant: str):
+        fp = parse_footprint_dsl(spec)
+        assert isinstance(fp, Footprint)
+
+    def test_sot23_matches_direct(self):
+        dsl_fp = parse_footprint_dsl("sot23")
+        direct_fp = create_sot(variant="SOT-23")
+        assert dsl_fp.name == direct_fp.name
+        assert len(dsl_fp.pads) == len(direct_fp.pads)
+
+    def test_sot23_5_matches_direct(self):
+        dsl_fp = parse_footprint_dsl("sot23-5")
+        direct_fp = create_sot(variant="SOT-23-5")
+        assert dsl_fp.name == direct_fp.name
+
+
+class TestSOIC:
+    """Test parsing of SOIC DSL strings."""
+
+    @pytest.mark.parametrize("pins", [8, 14, 16])
+    def test_soic_pin_counts(self, pins: int):
+        fp = parse_footprint_dsl(f"soic{pins}")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == pins
+
+    def test_soic8_matches_direct(self):
+        dsl_fp = parse_footprint_dsl("soic8")
+        direct_fp = create_soic(pins=8)
+        assert dsl_fp.name == direct_fp.name
+        assert len(dsl_fp.pads) == len(direct_fp.pads)
+
+    def test_soic_with_pitch(self):
+        fp = parse_footprint_dsl("soic8_p1.27mm")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == 8
+
+    def test_soic_with_pitch_matches_direct(self):
+        dsl_fp = parse_footprint_dsl("soic8_p1.27mm")
+        direct_fp = create_soic(pins=8, pitch=1.27)
+        assert dsl_fp.name == direct_fp.name
+
+
+class TestQFP:
+    """Test parsing of QFP DSL strings."""
+
+    @pytest.mark.parametrize("pins", [32, 48, 100])
+    def test_qfp_pin_counts(self, pins: int):
+        fp = parse_footprint_dsl(f"qfp{pins}")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == pins
+
+    def test_qfp48_with_pitch(self):
+        fp = parse_footprint_dsl("qfp48_p0.5mm")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == 48
+
+    def test_qfp_with_pitch_and_width(self):
+        fp = parse_footprint_dsl("qfp100_p0.5mm_w14mm")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == 100
+
+    def test_qfp48_matches_direct(self):
+        dsl_fp = parse_footprint_dsl("qfp48_p0.5mm")
+        direct_fp = create_qfp(pins=48, pitch=0.5)
+        assert dsl_fp.name == direct_fp.name
+
+    def test_qfp144_large_pin_count(self):
+        fp = parse_footprint_dsl("qfp144")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == 144
+
+    def test_lqfp_alias(self):
+        """LQFP should route to QFP generator."""
+        fp = parse_footprint_dsl("lqfp48_p0.5mm")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == 48
+
+
+class TestQFN:
+    """Test parsing of QFN DSL strings."""
+
+    def test_qfn16_with_width(self):
+        fp = parse_footprint_dsl("qfn16_w3mm")
+        assert isinstance(fp, Footprint)
+
+    def test_qfn24_with_pitch(self):
+        fp = parse_footprint_dsl("qfn24_p0.5mm")
+        assert isinstance(fp, Footprint)
+
+    def test_qfn_matches_direct(self):
+        dsl_fp = parse_footprint_dsl("qfn16_w3mm")
+        direct_fp = create_qfn(pins=16, body_size=3.0)
+        assert dsl_fp.name == direct_fp.name
+
+
+class TestBGA:
+    """Test parsing of BGA DSL strings."""
+
+    def test_bga100(self):
+        fp = parse_footprint_dsl("bga100_p0.8mm")
+        assert isinstance(fp, Footprint)
+        # 10x10 grid = 100 pads
+        assert len(fp.pads) == 100
+
+    def test_bga256(self):
+        fp = parse_footprint_dsl("bga256_p0.8mm")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == 256
+
+    def test_bga_matches_direct(self):
+        dsl_fp = parse_footprint_dsl("bga100_p0.8mm")
+        direct_fp = create_bga(rows=10, cols=10, pitch=0.8)
+        assert dsl_fp.name == direct_fp.name
+
+    def test_bga_non_square_raises(self):
+        with pytest.raises(ValueError, match="not a perfect square"):
+            parse_footprint_dsl("bga99_p0.8mm")
+
+
+class TestDFN:
+    """Test parsing of DFN DSL strings."""
+
+    def test_dfn8_with_width_and_pitch(self):
+        fp = parse_footprint_dsl("dfn8_w3mm_p0.5mm")
+        assert isinstance(fp, Footprint)
+
+    def test_dfn_matches_direct(self):
+        dsl_fp = parse_footprint_dsl("dfn8_w3mm_p0.5mm")
+        direct_fp = create_dfn(pins=8, body_width=3.0, body_length=3.0, pitch=0.5)
+        assert dsl_fp.name == direct_fp.name
+
+
+class TestDIP:
+    """Test parsing of DIP DSL strings."""
+
+    @pytest.mark.parametrize("pins", [8, 16])
+    def test_dip_pin_counts(self, pins: int):
+        fp = parse_footprint_dsl(f"dip{pins}")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == pins
+
+    def test_dip8_matches_direct(self):
+        dsl_fp = parse_footprint_dsl("dip8")
+        direct_fp = create_dip(pins=8)
+        assert dsl_fp.name == direct_fp.name
+
+
+class TestCaseInsensitivity:
+    """Verify case-insensitive parsing."""
+
+    def test_uppercase_soic(self):
+        fp = parse_footprint_dsl("SOIC8")
+        assert isinstance(fp, Footprint)
+
+    def test_mixed_case_soic(self):
+        fp = parse_footprint_dsl("Soic8")
+        assert isinstance(fp, Footprint)
+
+    def test_all_cases_identical(self):
+        fp_lower = parse_footprint_dsl("soic8")
+        fp_upper = parse_footprint_dsl("SOIC8")
+        fp_mixed = parse_footprint_dsl("Soic8")
+        assert fp_lower.name == fp_upper.name == fp_mixed.name
+        assert len(fp_lower.pads) == len(fp_upper.pads) == len(fp_mixed.pads)
+
+    def test_uppercase_qfp(self):
+        fp = parse_footprint_dsl("QFP48")
+        assert isinstance(fp, Footprint)
+
+    def test_uppercase_sot(self):
+        fp = parse_footprint_dsl("SOT23")
+        assert isinstance(fp, Footprint)
+
+
+class TestErrorHandling:
+    """Test error handling for invalid DSL strings."""
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            parse_footprint_dsl("")
+
+    def test_none_raises(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            parse_footprint_dsl(None)  # type: ignore[arg-type]
+
+    def test_unknown_prefix_raises(self):
+        with pytest.raises(ValueError, match="Unknown package prefix"):
+            parse_footprint_dsl("xyz123")
+
+    def test_malformed_raises(self):
+        with pytest.raises(ValueError, match="Cannot parse"):
+            parse_footprint_dsl("---")
+
+    def test_helpful_error_message(self):
+        """Error messages should list valid options."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_footprint_dsl("abc16")
+        msg = str(exc_info.value)
+        assert "soic" in msg.lower() or "Valid prefixes" in msg
+
+
+class TestModifiers:
+    """Test modifier parsing (pitch, width, height)."""
+
+    def test_pitch_without_mm_suffix(self):
+        fp = parse_footprint_dsl("soic8_p1.27")
+        assert isinstance(fp, Footprint)
+
+    def test_pitch_with_mm_suffix(self):
+        fp = parse_footprint_dsl("soic8_p1.27mm")
+        assert isinstance(fp, Footprint)
+
+    def test_width_modifier(self):
+        fp = parse_footprint_dsl("qfn16_w3mm")
+        assert isinstance(fp, Footprint)
+
+    def test_multiple_modifiers(self):
+        fp = parse_footprint_dsl("qfp100_p0.5mm_w14mm")
+        assert isinstance(fp, Footprint)
+        assert len(fp.pads) == 100
+
+
+class TestImportExport:
+    """Test that parse_footprint_dsl is importable from the library package."""
+
+    def test_import_from_library(self):
+        from kicad_tools.library import parse_footprint_dsl as pfd
+
+        fp = pfd("soic8")
+        assert isinstance(fp, Footprint)


### PR DESCRIPTION
## Summary

- Add `parse_footprint_dsl()` in `src/kicad_tools/library/dsl.py` that parses compact strings (e.g., `soic8`, `qfp48_p0.5mm`, `0402`, `sot23-5`) into `Footprint` objects via existing parametric generators
- Support all package families: chip passives, SOT, SOIC, QFP/LQFP, QFN, BGA, DFN, DIP with optional pitch/width/height modifiers
- Wire DSL parsing into the CLI so `kct footprint generate "soic8" --json` works as a positional argument
- Export `parse_footprint_dsl` from `kicad_tools.library` for use by footprint_selector and datasheet/footprint_matcher modules

Closes #2348

## Test plan

- [x] 60 unit tests covering all package families, round-trip validation, case insensitivity, error handling, and modifier parsing
- [x] Verified CLI integration produces valid JSON for `0402` and `qfp48_p0.5mm` DSL strings
- [x] Existing 70 footprint generator tests still pass

Generated with [Claude Code](https://claude.com/claude-code)