### PR TITLE
fix(router): use connectivity-aware counting in two-phase routing summary

### DIFF
--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -266,13 +266,36 @@ class TwoPhaseRouter:
         # Clear corridor preferences (not needed after routing)
         self.grid.clear_all_corridor_preferences()
 
-        # Summary
-        successful_nets = len({r.net for r in detailed_routes})
+        # Summary — use connectivity-aware counting so we only report
+        # nets where all pads are in the same connected component (#2352).
+        nets_with_segments = len({r.net for r in detailed_routes})
+        connected_nets = nets_with_segments  # fallback if pad data unavailable
+
+        if self.pads and self.nets:
+            from ..observability import validate_net_connectivity
+
+            net_pads: dict[int, list] = {}
+            for net_id, pad_keys in self.nets.items():
+                pad_list = [self.pads[k] for k in pad_keys if k in self.pads]
+                if pad_list:
+                    net_pads[net_id] = pad_list
+            connectivity = validate_net_connectivity(detailed_routes, net_pads)
+            connected_nets = sum(
+                1
+                for info in connectivity.values()
+                if info["connected"]
+            )
+
         total_elapsed = time.time() - start_time
         print("\n=== Two-Phase Routing Complete ===")
         print(f"  Total nets: {total_nets}")
         print(f"  Global routing: {len(corridors)} corridors assigned")
-        print(f"  Detailed routing: {successful_nets} nets routed")
+        print(f"  Detailed routing: {connected_nets} nets routed")
+        if connected_nets < nets_with_segments:
+            print(
+                f"    ({nets_with_segments - connected_nets} additional net(s) "
+                "have partial routes)"
+            )
         print(f"  Total time: {total_elapsed:.1f}s")
 
         # Print failed nets summary if any routes failed
@@ -284,7 +307,7 @@ class TwoPhaseRouter:
         if progress_callback is not None:
             progress_callback(
                 1.0,
-                f"Complete: {successful_nets}/{total_nets} nets routed in {total_elapsed:.1f}s",
+                f"Complete: {connected_nets}/{total_nets} nets routed in {total_elapsed:.1f}s",
                 False,
             )
 

--- a/tests/test_two_phase_net_count.py
+++ b/tests/test_two_phase_net_count.py
@@ -1,0 +1,101 @@
+"""Tests for connectivity-aware net counting in two-phase summary (#2352).
+
+The two-phase routing summary should only count nets as 'routed' when all
+pads in the net are connected, not just when any route segment exists.
+Disconnected escape stubs should not inflate the 'nets routed' count.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.router.observability import validate_net_connectivity
+from kicad_tools.router.primitives import Layer, Pad, Route, Segment
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pad(net: int, x: float, y: float, ref: str = "U1", pin: str = "1") -> Pad:
+    return Pad(
+        x=x, y=y, width=0.5, height=0.5,
+        net=net, net_name=f"Net{net}",
+        layer=Layer.F_CU, ref=ref, pin=pin,
+    )
+
+
+def _make_segment(net: int, x1: float, y1: float, x2: float, y2: float) -> Segment:
+    return Segment(x1=x1, y1=y1, x2=x2, y2=y2, width=0.2, layer=0, net=net)
+
+
+def _make_route(net: int, segments: list[Segment]) -> Route:
+    return Route(net=net, net_name=f"Net{net}", segments=segments)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConnectivityAwareNetCount:
+    """Verify that validate_net_connectivity correctly distinguishes
+    fully-connected nets from those with only stub/partial routes,
+    which is the mechanism used by the two-phase summary (#2352)."""
+
+    def test_connected_net_is_reported_connected(self):
+        """A net where a segment spans both pads is fully connected."""
+        pad_a = _make_pad(1, 0.0, 0.0)
+        pad_b = _make_pad(1, 10.0, 0.0, pin="2")
+        route = _make_route(1, [_make_segment(1, 0.0, 0.0, 10.0, 0.0)])
+
+        result = validate_net_connectivity([route], {1: [pad_a, pad_b]})
+        assert result[1]["connected"] is True
+        assert result[1]["connected_pads"] == 2
+
+    def test_stub_net_is_reported_disconnected(self):
+        """A net where the segment only reaches one pad is not connected."""
+        pad_a = _make_pad(1, 0.0, 0.0)
+        pad_b = _make_pad(1, 10.0, 0.0, pin="2")
+        # Stub goes away from pad_b (endpoint at 5, 5 -- far from pad_b at 10, 0)
+        stub = _make_route(1, [_make_segment(1, 0.0, 0.0, 5.0, 5.0)])
+
+        result = validate_net_connectivity([stub], {1: [pad_a, pad_b]})
+        assert result[1]["connected"] is False
+        assert result[1]["connected_pads"] == 1
+
+    def test_counting_logic_matches_issue_expectation(self):
+        """The connected-count formula from two_phase.py should exclude
+        partially routed nets."""
+        # Net 1: fully connected
+        pad_1a = _make_pad(1, 0.0, 0.0, ref="U1", pin="1")
+        pad_1b = _make_pad(1, 10.0, 0.0, ref="U1", pin="2")
+        route_1 = _make_route(1, [_make_segment(1, 0.0, 0.0, 10.0, 0.0)])
+
+        # Net 2: stub only (disconnected fragment)
+        pad_2a = _make_pad(2, 0.0, 5.0, ref="U2", pin="1")
+        pad_2b = _make_pad(2, 10.0, 5.0, ref="U2", pin="2")
+        stub_2 = _make_route(2, [_make_segment(2, 0.0, 5.0, 3.0, 7.0)])
+
+        all_routes = [route_1, stub_2]
+        net_pads = {1: [pad_1a, pad_1b], 2: [pad_2a, pad_2b]}
+        connectivity = validate_net_connectivity(all_routes, net_pads)
+
+        # This is the same formula used in the fixed two_phase.py
+        nets_with_segments = len({r.net for r in all_routes})
+        connected_nets = sum(
+            1 for info in connectivity.values() if info["connected"]
+        )
+
+        assert nets_with_segments == 2, "Both nets have segments"
+        assert connected_nets == 1, "Only one net is fully connected"
+
+    def test_no_pads_fallback(self):
+        """When net_pads is empty, validate_net_connectivity returns empty
+        and the fallback (nets_with_segments) should be used."""
+        route = _make_route(1, [_make_segment(1, 0.0, 0.0, 10.0, 0.0)])
+        result = validate_net_connectivity([route], {})
+        assert len(result) == 0


### PR DESCRIPTION
## Summary
The two-phase routing summary was counting any net with route segments as "routed", including disconnected escape stubs that never reached their target pads. This produced contradictory output (e.g. "32 nets routed" vs "5/36 nets routed" from the later connectivity check). This fix uses `validate_net_connectivity()` in the summary to only count fully-connected nets, and reports partial routes separately.

## Changes
- Replace naive `len({r.net for r in detailed_routes})` count in `two_phase.py` with connectivity-aware counting using `validate_net_connectivity()`
- When some nets have segments but are not fully connected, print the partial count separately (e.g. "2 additional net(s) have partial routes")
- Update the progress callback message to use the connectivity-aware count
- Add fallback to segment-based counting when pad data is unavailable
- Add `tests/test_two_phase_net_count.py` with 4 tests verifying the counting logic

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| "nets routed" count uses connectivity-aware validation | Pass | Uses `validate_net_connectivity()` from observability module |
| Disconnected stubs not counted as routed | Pass | Test `test_stub_net_is_reported_disconnected` confirms this |
| Partial routes reported separately | Pass | "N additional net(s) have partial routes" printed when applicable |
| Consistent with output.py connectivity count | Pass | Both use same `validate_net_connectivity()` function |

## Test Plan
- `uv run python -m pytest tests/test_two_phase_net_count.py -x -q --no-cov` -- 4 tests pass
- `uv run python -m pytest tests/test_best_state_tracking.py tests/test_two_phase_iteration_resolution.py tests/test_reroute_progress_output.py -x -q --no-cov` -- 36 existing tests pass

Closes #2352