### PR TITLE
fix(router): aggregate sub-grid escape failures per-package at WARNING level

### DIFF
--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1425,9 +1425,9 @@ class EscapeRouter:
                 )
 
         if skipped_count:
-            logger.info(
+            logger.warning(
                 "Escape routing for %s: %d of %d pins deferred to main router "
-                "due to segment-to-pad clearance violations",
+                "(clearance violation)",
                 ref, skipped_count, len(pads),
             )
 

--- a/src/kicad_tools/router/subgrid.py
+++ b/src/kicad_tools/router/subgrid.py
@@ -166,12 +166,14 @@ class SubGridResult:
         analysis: The analysis that produced these escapes
         unblocked_count: Number of pad grid cells that were unblocked
         failed_pads: Pads where escape routing could not find a valid path
+        failure_reasons: Per-pad failure reason, keyed by (ref, pin)
     """
 
     escapes: list[SubGridEscape] = field(default_factory=list)
     analysis: SubGridAnalysis | None = None
     unblocked_count: int = 0
     failed_pads: list[Pad] = field(default_factory=list)
+    failure_reasons: dict[tuple[str, str], str] = field(default_factory=dict)
 
     @property
     def success_count(self) -> int:
@@ -183,6 +185,23 @@ class SubGridResult:
         """Total pads attempted."""
         return self.success_count + len(self.failed_pads)
 
+    def failures_by_component(self) -> dict[str, dict[str, int]]:
+        """Aggregate failure counts per component, grouped by reason.
+
+        Returns:
+            ``{ref: {reason: count}}`` sorted by ref.
+        """
+        by_ref: dict[str, dict[str, int]] = {}
+        for pad in self.failed_pads:
+            ref = pad.ref or "<unknown>"
+            reason = self.failure_reasons.get(
+                (pad.ref, pad.pin), "unknown",
+            )
+            if ref not in by_ref:
+                by_ref[ref] = {}
+            by_ref[ref][reason] = by_ref[ref].get(reason, 0) + 1
+        return dict(sorted(by_ref.items()))
+
     def format_summary(self) -> str:
         """Format a summary of escape results."""
         lines = [
@@ -191,8 +210,25 @@ class SubGridResult:
         if self.unblocked_count > 0:
             lines.append(f"  Grid cells unblocked: {self.unblocked_count}")
         if self.failed_pads:
-            failed_refs = sorted({p.ref for p in self.failed_pads})
-            lines.append(f"  Failed components: {', '.join(failed_refs)}")
+            # Per-component breakdown with reasons
+            by_ref = self.failures_by_component()
+            # Count total attempted per component from analysis
+            attempted_by_ref: dict[str, int] = {}
+            if self.analysis is not None:
+                for sgp in self.analysis.off_grid_pads:
+                    ref = sgp.pad.ref or "<unknown>"
+                    attempted_by_ref[ref] = attempted_by_ref.get(ref, 0) + 1
+            for ref, reasons in by_ref.items():
+                total_failed = sum(reasons.values())
+                total_attempted = attempted_by_ref.get(ref, total_failed)
+                escaped = total_attempted - total_failed
+                reason_parts = [
+                    f"{reason}: {cnt}" for reason, cnt in sorted(reasons.items())
+                ]
+                lines.append(
+                    f"  {ref}: {escaped}/{total_attempted} pads escaped "
+                    f"({', '.join(reason_parts)})"
+                )
         return "\n".join(lines)
 
 
@@ -346,17 +382,19 @@ class SubGridRouter:
         result = SubGridResult(analysis=analysis)
 
         for sgp in analysis.off_grid_pads:
-            escape = self._find_escape_for_pad(sgp)
+            escape, reason = self._find_escape_for_pad(sgp)
             if escape is not None:
                 result.escapes.append(escape)
             else:
                 result.failed_pads.append(sgp.pad)
+                result.failure_reasons[(sgp.pad.ref, sgp.pad.pin)] = reason
                 logger.debug(
-                    "Sub-grid escape failed for %s.%s at (%.3f, %.3f)",
+                    "Sub-grid escape failed for %s.%s at (%.3f, %.3f): %s",
                     sgp.pad.ref,
                     sgp.pad.pin,
                     sgp.pad.x,
                     sgp.pad.y,
+                    reason,
                 )
 
         logger.info(
@@ -364,6 +402,26 @@ class SubGridRouter:
             result.success_count,
             result.total_attempted,
         )
+
+        # Per-package failure summary at WARNING level
+        if result.failed_pads:
+            by_ref = result.failures_by_component()
+            # Count attempted per component
+            attempted_by_ref: dict[str, int] = {}
+            for sgp in analysis.off_grid_pads:
+                ref = sgp.pad.ref or "<unknown>"
+                attempted_by_ref[ref] = attempted_by_ref.get(ref, 0) + 1
+            for ref, reasons in by_ref.items():
+                total_failed = sum(reasons.values())
+                total_attempted = attempted_by_ref.get(ref, total_failed)
+                escaped = total_attempted - total_failed
+                reason_parts = [
+                    f"{reason}: {cnt}" for reason, cnt in sorted(reasons.items())
+                ]
+                logger.warning(
+                    "%s: %d/%d pads escaped (%s)",
+                    ref, escaped, total_attempted, ", ".join(reason_parts),
+                )
 
         return result
 
@@ -927,7 +985,9 @@ class SubGridRouter:
 
         return True
 
-    def _find_escape_for_pad(self, sgp: SubGridPad) -> SubGridEscape | None:
+    def _find_escape_for_pad(
+        self, sgp: SubGridPad,
+    ) -> tuple[SubGridEscape | None, str]:
         """Find the best escape point for a single off-grid pad.
 
         Searches nearby grid points for the best escape target, considering
@@ -953,7 +1013,9 @@ class SubGridRouter:
             sgp: SubGridPad to find escape for
 
         Returns:
-            SubGridEscape if found, None if no valid escape point exists
+            Tuple of (SubGridEscape, reason). On success reason is "ok".
+            On failure, SubGridEscape is None and reason describes the
+            failure (e.g. "no grid point reachable", "clearance violation").
         """
         pad = sgp.pad
 
@@ -1012,7 +1074,7 @@ class SubGridRouter:
                 sgp, candidates, width, layer, component_pitches,
             )
             if escape is not None:
-                return escape
+                return escape, "ok"
 
         # --- Phase 2: Expanded search radius (2x) ---
         # The initial radius may be too small for pads surrounded by
@@ -1040,7 +1102,7 @@ class SubGridRouter:
                     "Escape for %s.%s succeeded with expanded radius %d",
                     pad.ref, pad.pin, expanded_radius,
                 )
-                return escape
+                return escape, "ok"
 
         # --- Phase 3: Relaxed clearance mode ---
         # For escape segments specifically, reduce the clearance requirement
@@ -1080,7 +1142,7 @@ class SubGridRouter:
                     pad.ref, pad.pin,
                     relaxed_clearance, self.rules.trace_clearance,
                 )
-                return escape
+                return escape, "ok"
 
         # --- Phase 4: Multi-hop escape ---
         # When direct escape fails, try routing through an intermediate
@@ -1096,15 +1158,23 @@ class SubGridRouter:
                 "Escape for %s.%s succeeded via multi-hop",
                 pad.ref, pad.pin,
             )
-            return escape
+            return escape, "ok"
 
-        # All strategies exhausted
+        # All strategies exhausted -- determine the dominant failure reason.
+        # If we never found any candidates at any radius, no grid point was
+        # reachable.  Otherwise candidates existed but all violated clearance.
+        had_any_candidates = bool(candidates or expanded_candidates or relaxed_candidates)
+        if had_any_candidates:
+            reason = "clearance violation"
+        else:
+            reason = "no grid point reachable"
+
         logger.debug(
             "All escape strategies failed for %s.%s "
-            "(normal, expanded, relaxed, multi-hop)",
-            pad.ref, pad.pin,
+            "(normal, expanded, relaxed, multi-hop): %s",
+            pad.ref, pad.pin, reason,
         )
-        return None
+        return None, reason
 
     def _try_multi_hop_escape(
         self,

--- a/tests/test_subgrid.py
+++ b/tests/test_subgrid.py
@@ -9,7 +9,7 @@ import pytest
 
 from kicad_tools.router.grid import RoutingGrid
 from kicad_tools.router.layers import Layer, LayerStack
-from kicad_tools.router.primitives import Pad
+from kicad_tools.router.primitives import Pad, Segment
 from kicad_tools.router.rules import DesignRules
 from kicad_tools.router.subgrid import (
     SubGridAnalysis,
@@ -2161,3 +2161,205 @@ class TestEscapeFallbackStrategies:
                 f"Escape for {escape.pad.ref}.{escape.pad.pin} violates "
                 f"clearance={clearance:.4f}mm"
             )
+
+
+class TestSubGridResultFailureTracking:
+    """Tests for per-component failure aggregation (issue #2351)."""
+
+    def test_failures_by_component_empty(self):
+        """No failures should produce empty dict."""
+        result = SubGridResult(escapes=[], failed_pads=[])
+        assert result.failures_by_component() == {}
+
+    def test_failures_by_component_single(self):
+        """Single failure should appear in aggregation."""
+        pad = make_pad(x=1.0, y=1.0, net=1, ref="U1", pin="1")
+        result = SubGridResult(
+            escapes=[],
+            failed_pads=[pad],
+            failure_reasons={("U1", "1"): "clearance violation"},
+        )
+        by_ref = result.failures_by_component()
+        assert by_ref == {"U1": {"clearance violation": 1}}
+
+    def test_failures_by_component_multiple_refs(self):
+        """Failures across multiple components should be grouped."""
+        p1 = make_pad(x=1.0, y=1.0, net=1, ref="U1", pin="1")
+        p2 = make_pad(x=2.0, y=1.0, net=2, ref="U1", pin="2")
+        p3 = make_pad(x=3.0, y=1.0, net=3, ref="U2", pin="1")
+        result = SubGridResult(
+            escapes=[],
+            failed_pads=[p1, p2, p3],
+            failure_reasons={
+                ("U1", "1"): "clearance violation",
+                ("U1", "2"): "no grid point reachable",
+                ("U2", "1"): "clearance violation",
+            },
+        )
+        by_ref = result.failures_by_component()
+        assert by_ref == {
+            "U1": {"clearance violation": 1, "no grid point reachable": 1},
+            "U2": {"clearance violation": 1},
+        }
+
+    def test_failures_by_component_unknown_reason(self):
+        """Pad with no recorded reason should show 'unknown'."""
+        pad = make_pad(x=1.0, y=1.0, net=1, ref="U1", pin="1")
+        result = SubGridResult(
+            escapes=[],
+            failed_pads=[pad],
+            failure_reasons={},  # no reason recorded
+        )
+        by_ref = result.failures_by_component()
+        assert by_ref == {"U1": {"unknown": 1}}
+
+    def test_format_summary_with_failure_reasons(self):
+        """format_summary should include per-component breakdown."""
+        p1 = make_pad(x=1.0, y=1.0, net=1, ref="U1", pin="1")
+        p2 = make_pad(x=2.0, y=1.0, net=2, ref="U1", pin="2")
+        # Create a minimal analysis to track attempted counts
+        analysis = SubGridAnalysis(
+            off_grid_pads=[
+                SubGridPad(pad=p1, grid_x=10, grid_y=10,
+                           offset_x=0.05, offset_y=0.0,
+                           snap_x=1.0, snap_y=1.0),
+                SubGridPad(pad=p2, grid_x=20, grid_y=10,
+                           offset_x=0.05, offset_y=0.0,
+                           snap_x=2.0, snap_y=1.0),
+            ],
+        )
+        result = SubGridResult(
+            escapes=[],
+            failed_pads=[p1, p2],
+            failure_reasons={
+                ("U1", "1"): "clearance violation",
+                ("U1", "2"): "clearance violation",
+            },
+            analysis=analysis,
+        )
+        summary = result.format_summary()
+        assert "0/2 pads escaped" in summary
+        assert "U1:" in summary
+        assert "clearance violation: 2" in summary
+
+    def test_format_summary_mixed_success_failure(self):
+        """format_summary with some escapes and some failures."""
+        p_ok = make_pad(x=1.0, y=1.0, net=1, ref="U1", pin="1")
+        p_fail = make_pad(x=2.0, y=1.0, net=2, ref="U1", pin="2")
+        escape = SubGridEscape(
+            pad=p_ok,
+            segment=Segment(
+                x1=1.0, y1=1.0, x2=1.1, y2=1.0,
+                width=0.2, layer=Layer.F_CU, net=1,
+            ),
+            grid_point=(11, 10),
+            snap_point=(1.1, 1.0),
+        )
+        analysis = SubGridAnalysis(
+            off_grid_pads=[
+                SubGridPad(pad=p_ok, grid_x=10, grid_y=10,
+                           offset_x=0.05, offset_y=0.0,
+                           snap_x=1.0, snap_y=1.0),
+                SubGridPad(pad=p_fail, grid_x=20, grid_y=10,
+                           offset_x=0.05, offset_y=0.0,
+                           snap_x=2.0, snap_y=1.0),
+            ],
+        )
+        result = SubGridResult(
+            escapes=[escape],
+            failed_pads=[p_fail],
+            failure_reasons={("U1", "2"): "no grid point reachable"},
+            analysis=analysis,
+        )
+        summary = result.format_summary()
+        assert "1/2 pads escaped" in summary
+        assert "U1: 1/2 pads escaped" in summary
+        assert "no grid point reachable" in summary
+
+
+class TestSubGridEscapeFailureLogging:
+    """Tests for WARNING-level logging on escape failures (issue #2351)."""
+
+    def test_generate_escape_segments_logs_warning_on_failure(self, caplog):
+        """generate_escape_segments should log WARNING per failed component."""
+        import logging
+
+        grid, rules = make_grid_and_rules(
+            width=20.0,
+            height=20.0,
+            resolution=0.1,
+            trace_width=0.2,
+            trace_clearance=0.15,
+        )
+        # Very small search radius to force failure
+        subgrid = SubGridRouter(grid, rules, escape_search_radius=1)
+
+        # Off-grid pad surrounded by other-net pads on all sides
+        off_grid_pad = make_pad(
+            x=5.05, y=5.0, net=1, ref="U1", pin="1",
+            width=0.3, height=0.3,
+        )
+
+        # Surround with large pads from different nets
+        blockers = []
+        for bx, by, bnet in [
+            (4.8, 5.0, 10), (5.3, 5.0, 11),
+            (5.05, 4.7, 12), (5.05, 5.3, 13),
+            (4.8, 4.7, 14), (5.3, 4.7, 15),
+            (4.8, 5.3, 16), (5.3, 5.3, 17),
+        ]:
+            blockers.append(make_pad(
+                x=bx, y=by, net=bnet, ref="U2", pin=str(bnet),
+                width=0.4, height=0.4,
+            ))
+
+        all_pads = [off_grid_pad] + blockers
+        for p in all_pads:
+            grid.add_pad(p)
+
+        analysis = subgrid.analyze_pads(all_pads)
+
+        with caplog.at_level(logging.WARNING, logger="kicad_tools.router.subgrid"):
+            result = subgrid.generate_escape_segments(analysis)
+
+        if result.failed_pads:
+            # Should have WARNING logs with per-component info
+            warning_msgs = [
+                r.message for r in caplog.records if r.levelno == logging.WARNING
+            ]
+            assert any("U1:" in msg for msg in warning_msgs), (
+                f"Expected WARNING with 'U1:' but got: {warning_msgs}"
+            )
+            # Failure reasons should be populated
+            assert len(result.failure_reasons) == len(result.failed_pads)
+
+    def test_generate_escape_segments_no_warning_on_success(self, caplog):
+        """generate_escape_segments should not warn when all pads escape."""
+        import logging
+
+        grid, rules = make_grid_and_rules(
+            resolution=0.1,
+            trace_width=0.15,
+            trace_clearance=0.1,
+        )
+
+        # Single off-grid pad with lots of room -- should succeed
+        pads = [
+            make_pad(x=1.05, y=1.0, net=1, ref="U1", pin="1",
+                     width=0.3, height=0.45),
+        ]
+        for p in pads:
+            grid.add_pad(p)
+
+        subgrid = SubGridRouter(grid, rules)
+        analysis = subgrid.analyze_pads(pads)
+
+        with caplog.at_level(logging.WARNING, logger="kicad_tools.router.subgrid"):
+            result = subgrid.generate_escape_segments(analysis)
+
+        warning_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert not warning_msgs, (
+            f"Expected no WARNING on success but got: {warning_msgs}"
+        )


### PR DESCRIPTION
## Summary
- Track failure reasons (clearance violation, no grid point reachable) per-pad in `SubGridResult.failure_reasons`
- Add `failures_by_component()` method to aggregate failure counts per component by reason
- Emit per-package WARNING logs in `generate_escape_segments()` when pads fail escape
- Upgrade escape.py deferred-pad summary from INFO to WARNING for consistency
- Enhance `format_summary()` to include per-component breakdown with reasons

Closes #2351

## Test plan
- [x] 6 new unit tests for `SubGridResult.failures_by_component()` and `format_summary()` with reasons
- [x] 2 new integration tests verifying WARNING log emission on failure and absence on success
- [x] All 76 existing+new subgrid tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)