### PR TITLE
feat(pcb): add panelization engine with tab and mousebite generation

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -70,6 +70,7 @@ from .commands import (
     run_mfr_command,
     run_optimize_command,
     run_optimize_placement_command,
+    run_panel_command,
     run_parts_command,
     run_pcb_command,
     run_pipeline_command,
@@ -419,6 +420,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "init":
         return run_init_command(args)
+
+    elif args.command == "panel":
+        return run_panel_command(args)
 
     elif args.command == "pipeline":
         return run_pipeline_command(args)

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -31,6 +31,7 @@ from .manufacturer import run_mfr_command
 from .mcp import run_mcp_command
 from .native import run_build_native_command
 from .optimize_placement import run_optimize_placement_command
+from .panel import run_panel_command
 from .parts import run_parts_command
 from .pcb import run_pcb_command
 from .pipeline import run_pipeline_command
@@ -132,6 +133,8 @@ __all__ = [
     "run_build_native_command",
     # Run
     "run_run_command",
+    # Panel
+    "run_panel_command",
     # Pipeline
     "run_pipeline_command",
     # Sync

--- a/src/kicad_tools/cli/commands/panel.py
+++ b/src/kicad_tools/cli/commands/panel.py
@@ -1,0 +1,100 @@
+"""Panel (panel) CLI command handler."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+__all__ = ["run_panel_command"]
+
+
+def run_panel_command(args) -> int:
+    """Handle the ``kct panel`` command.
+
+    Creates a manufacturing panel from a source board PCB.
+    """
+    board_path = Path(args.panel_input)
+    if not board_path.exists():
+        print(f"Error: File not found: {board_path}", file=sys.stderr)
+        return 1
+
+    output_path = args.panel_output
+    if output_path is None:
+        output_path = str(board_path.with_stem(board_path.stem + "_panel"))
+
+    try:
+        from kicad_tools.panel import CutMethod, Panel
+        from kicad_tools.panel.config import (
+            FiducialConfig,
+            FrameConfig,
+            MousebiteConfig,
+            PanelConfig,
+            TabConfig,
+            ToolingHoleConfig,
+            VCutConfig,
+        )
+    except ImportError as exc:
+        print(
+            f"Error: {exc}\n"
+            "Panelization requires Shapely. Install with: "
+            "pip install kicad-tools[geometry]",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Build config from CLI args
+    cut_method = CutMethod.MOUSEBITE
+    if hasattr(args, "panel_cut") and args.panel_cut == "vcut":
+        cut_method = CutMethod.VCUT
+
+    tabs = TabConfig(
+        width=getattr(args, "panel_tab_width", 3.0),
+        count=getattr(args, "panel_tab_count", 3),
+    )
+
+    mousebite = MousebiteConfig(
+        diameter=getattr(args, "panel_mousebite_diameter", 0.5),
+        spacing=getattr(args, "panel_mousebite_spacing", 0.8),
+    )
+
+    vcut = VCutConfig()
+
+    frame = None
+    if getattr(args, "panel_frame", False):
+        frame = FrameConfig(
+            width=getattr(args, "panel_frame_width", 5.0),
+            space=getattr(args, "panel_frame_space", 2.0),
+        )
+
+    tooling = None
+    if getattr(args, "panel_tooling_holes", False):
+        tooling = ToolingHoleConfig()
+
+    fiducials = None
+    if getattr(args, "panel_fiducials", False):
+        fiducials = FiducialConfig()
+
+    config = PanelConfig(
+        rows=getattr(args, "panel_rows", 2),
+        cols=getattr(args, "panel_cols", 2),
+        spacing=getattr(args, "panel_spacing", 2.0),
+        cut_method=cut_method,
+        tabs=tabs,
+        mousebite=mousebite,
+        vcut=vcut,
+        frame=frame,
+        tooling_holes=tooling,
+        fiducials=fiducials,
+    )
+
+    try:
+        panel = Panel.from_config(board_path, config)
+        result_path = panel.save(output_path)
+        print(f"Panel created: {result_path}")
+        print(f"  Grid: {config.rows}x{config.cols} ({panel.board_count} boards)")
+        print(f"  Tabs: {len(panel.tabs)}")
+        print(f"  Cut method: {config.cut_method.value}")
+        return 0
+    except Exception as exc:
+        print(f"Error creating panel: {exc}", file=sys.stderr)
+        return 1

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -177,6 +177,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_mcp_parser(subparsers)
     _add_ipc_parser(subparsers)
     _add_init_parser(subparsers)
+    _add_panel_parser(subparsers)
     _add_pipeline_parser(subparsers)
     _add_create_pcb_parser(subparsers)
     _add_build_parser(subparsers)
@@ -4367,6 +4368,119 @@ def _add_init_parser(subparsers) -> None:
         choices=["text", "json"],
         default="text",
         help="Output format (default: text)",
+    )
+
+
+def _add_panel_parser(subparsers) -> None:
+    """Add panel subcommand parser for board panelization."""
+    panel_parser = subparsers.add_parser(
+        "panel",
+        help="Create manufacturing panels from board PCBs",
+        description=(
+            "Panelize a board into a manufacturing panel with configurable "
+            "grid layout, breakaway tabs, mousebite/V-cut separation, "
+            "tooling holes, and fiducial marks."
+        ),
+    )
+    panel_parser.add_argument(
+        "panel_input",
+        metavar="INPUT",
+        help="Path to source .kicad_pcb file",
+    )
+    panel_parser.add_argument(
+        "-o",
+        "--output",
+        dest="panel_output",
+        default=None,
+        help="Output panel PCB file path (default: <input>_panel.kicad_pcb)",
+    )
+    panel_parser.add_argument(
+        "--rows",
+        dest="panel_rows",
+        type=int,
+        default=2,
+        help="Number of board rows (default: 2)",
+    )
+    panel_parser.add_argument(
+        "--cols",
+        dest="panel_cols",
+        type=int,
+        default=2,
+        help="Number of board columns (default: 2)",
+    )
+    panel_parser.add_argument(
+        "--spacing",
+        dest="panel_spacing",
+        type=float,
+        default=2.0,
+        help="Gap between boards in mm (default: 2.0)",
+    )
+    panel_parser.add_argument(
+        "--cut",
+        dest="panel_cut",
+        choices=["mousebite", "vcut"],
+        default="mousebite",
+        help="Separation method (default: mousebite)",
+    )
+    panel_parser.add_argument(
+        "--tab-width",
+        dest="panel_tab_width",
+        type=float,
+        default=3.0,
+        help="Tab width in mm (default: 3.0)",
+    )
+    panel_parser.add_argument(
+        "--tab-count",
+        dest="panel_tab_count",
+        type=int,
+        default=3,
+        help="Number of tabs per edge (default: 3)",
+    )
+    panel_parser.add_argument(
+        "--mousebite-diameter",
+        dest="panel_mousebite_diameter",
+        type=float,
+        default=0.5,
+        help="Mousebite hole diameter in mm (default: 0.5)",
+    )
+    panel_parser.add_argument(
+        "--mousebite-spacing",
+        dest="panel_mousebite_spacing",
+        type=float,
+        default=0.8,
+        help="Mousebite hole spacing in mm (default: 0.8)",
+    )
+    panel_parser.add_argument(
+        "--frame",
+        dest="panel_frame",
+        action="store_true",
+        help="Add a frame (rail) around the panel",
+    )
+    panel_parser.add_argument(
+        "--frame-width",
+        dest="panel_frame_width",
+        type=float,
+        default=5.0,
+        help="Frame rail width in mm (default: 5.0)",
+    )
+    panel_parser.add_argument(
+        "--frame-space",
+        dest="panel_frame_space",
+        type=float,
+        default=2.0,
+        help="Gap between board and frame in mm (default: 2.0)",
+    )
+    panel_parser.add_argument(
+        "--tooling-holes",
+        dest="panel_tooling_holes",
+        action="store_true",
+        help="Add tooling holes to the panel frame",
+    )
+    panel_parser.add_argument(
+        "--fiducials",
+        dest="panel_fiducials",
+        action="store_true",
+        help="Add fiducial marks to the panel frame",
     )
 
 

--- a/src/kicad_tools/panel/__init__.py
+++ b/src/kicad_tools/panel/__init__.py
@@ -1,0 +1,27 @@
+"""Panelization support for KiCad PCB files.
+
+Provides :class:`Panel` -- a builder-pattern API for creating
+manufacturing panels from individual board designs. Supports grid
+layout, tab generation, mousebite/V-cut separation features, and
+panel furniture (tooling holes, fiducials).
+
+Usage::
+
+    from kicad_tools.panel import Panel
+
+    panel = Panel()
+    panel.append_board("board.kicad_pcb", rows=2, cols=2)
+    panel.make_tabs(width=3.0, count=3)
+    panel.make_mousebites(diameter=0.5, spacing=0.8)
+    panel.save("panel.kicad_pcb")
+"""
+
+from .config import CutMethod, PanelConfig, TabConfig
+from .panel import Panel
+
+__all__ = [
+    "CutMethod",
+    "Panel",
+    "PanelConfig",
+    "TabConfig",
+]

--- a/src/kicad_tools/panel/config.py
+++ b/src/kicad_tools/panel/config.py
@@ -1,0 +1,137 @@
+"""Panel configuration dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class CutMethod(Enum):
+    """Separation method for panelized boards."""
+
+    MOUSEBITE = "mousebite"
+    VCUT = "vcut"
+
+
+@dataclass
+class TabConfig:
+    """Configuration for breakaway tabs between boards.
+
+    Attributes:
+        width: Tab width in mm.
+        count: Number of tabs per board edge (when using fixed count).
+        spacing: Tab spacing in mm (when using spacing-based placement).
+            If set, overrides *count*.
+        min_length: Minimum tab length along the board edge in mm.
+    """
+
+    width: float = 3.0
+    count: int = 3
+    spacing: float | None = None
+    min_length: float = 2.0
+
+
+@dataclass
+class MousebiteConfig:
+    """Configuration for mousebite perforations.
+
+    Attributes:
+        diameter: NPTH hole diameter in mm.
+        spacing: Center-to-center distance between holes in mm.
+        offset: Offset from tab edge in mm (inward).
+    """
+
+    diameter: float = 0.5
+    spacing: float = 0.8
+    offset: float = 0.0
+
+
+@dataclass
+class VCutConfig:
+    """Configuration for V-cut score lines.
+
+    V-cuts are straight horizontal or vertical score lines across the
+    full panel width/height. They are rendered as graphic lines on the
+    Edge.Cuts layer.
+
+    Attributes:
+        line_width: Width of the V-cut line on Edge.Cuts in mm.
+        layer: Layer name for V-cut lines.
+    """
+
+    line_width: float = 0.1
+    layer: str = "Edge.Cuts"
+
+
+@dataclass
+class FrameConfig:
+    """Configuration for the panel frame (rails).
+
+    Attributes:
+        width: Frame rail width in mm.
+        space: Gap between board edge and inner frame edge in mm.
+    """
+
+    width: float = 5.0
+    space: float = 2.0
+
+
+@dataclass
+class ToolingHoleConfig:
+    """Configuration for tooling holes.
+
+    Attributes:
+        diameter: Hole diameter in mm.
+        offset: Distance from frame corner to hole center in mm.
+        pattern: Number of holes -- 3 or 4.
+    """
+
+    diameter: float = 3.0
+    offset: float = 3.5
+    pattern: int = 3
+
+
+@dataclass
+class FiducialConfig:
+    """Configuration for fiducial marks.
+
+    Attributes:
+        diameter: Copper pad diameter in mm.
+        mask_margin: Solder mask opening margin in mm.
+        offset: Distance from frame corner to fiducial center in mm.
+    """
+
+    diameter: float = 1.0
+    mask_margin: float = 2.0
+    offset: float = 5.0
+
+
+@dataclass
+class PanelConfig:
+    """Top-level panel configuration.
+
+    Attributes:
+        rows: Number of board rows.
+        cols: Number of board columns.
+        spacing: Gap between board instances in mm.
+        rotation: Per-board rotation in degrees (0, 90, 180, 270).
+        cut_method: Separation method (mousebite or vcut).
+        tabs: Tab configuration.
+        mousebite: Mousebite configuration (used when cut_method is MOUSEBITE).
+        vcut: V-cut configuration (used when cut_method is VCUT).
+        frame: Frame/rail configuration. None means no frame.
+        tooling_holes: Tooling hole config. None means no tooling holes.
+        fiducials: Fiducial config. None means no fiducials.
+    """
+
+    rows: int = 2
+    cols: int = 2
+    spacing: float = 2.0
+    rotation: float = 0.0
+    cut_method: CutMethod = CutMethod.MOUSEBITE
+    tabs: TabConfig = field(default_factory=TabConfig)
+    mousebite: MousebiteConfig = field(default_factory=MousebiteConfig)
+    vcut: VCutConfig = field(default_factory=VCutConfig)
+    frame: FrameConfig | None = None
+    tooling_holes: ToolingHoleConfig | None = None
+    fiducials: FiducialConfig | None = None

--- a/src/kicad_tools/panel/cuts.py
+++ b/src/kicad_tools/panel/cuts.py
@@ -1,0 +1,201 @@
+"""Mousebite and V-cut generation for panel separation.
+
+Generates NPTH drill holes along tab center lines (mousebites) or
+full-width score lines (V-cuts) for board separation after assembly.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from dataclasses import dataclass
+
+from kicad_tools.sexp.builders import fmt, gr_line_node, uuid_node
+from kicad_tools.sexp.parser import SExp
+
+from .config import MousebiteConfig, VCutConfig
+from .tabs import Tab
+
+
+@dataclass
+class MousebiteHole:
+    """A single NPTH hole in a mousebite perforation line.
+
+    Attributes:
+        x: Hole center X in panel coordinates (mm).
+        y: Hole center Y in panel coordinates (mm).
+        diameter: Drill diameter in mm.
+    """
+
+    x: float
+    y: float
+    diameter: float
+
+
+@dataclass
+class VCutLine:
+    """A single V-cut score line.
+
+    Attributes:
+        start_x: Start X coordinate (mm).
+        start_y: Start Y coordinate (mm).
+        end_x: End X coordinate (mm).
+        end_y: End Y coordinate (mm).
+    """
+
+    start_x: float
+    start_y: float
+    end_x: float
+    end_y: float
+
+
+def generate_mousebite_holes(
+    tab: Tab,
+    config: MousebiteConfig,
+) -> list[MousebiteHole]:
+    """Generate NPTH holes along the center line of a tab.
+
+    Holes are placed along the center of the tab perpendicular to the
+    board edge, evenly spaced at the configured interval.
+
+    Args:
+        tab: The tab to perforate.
+        config: Mousebite configuration.
+
+    Returns:
+        List of MousebiteHole instances.
+    """
+    holes: list[MousebiteHole] = []
+
+    if tab.orientation == "horizontal":
+        # Tab spans horizontally -- holes along horizontal center line
+        line_y = tab.y
+        line_start = tab.min_x + config.offset
+        line_end = tab.max_x - config.offset
+    else:
+        # Tab spans vertically -- holes along vertical center line
+        line_y = None  # type: ignore[assignment]
+        line_start = tab.min_y + config.offset
+        line_end = tab.max_y - config.offset
+
+    length = line_end - line_start
+    if length <= 0:
+        return holes
+
+    n_holes = max(1, int(math.floor(length / config.spacing)) + 1)
+    actual_spacing = length / max(1, n_holes - 1) if n_holes > 1 else 0
+
+    for i in range(n_holes):
+        pos = line_start + i * actual_spacing
+        if tab.orientation == "horizontal":
+            holes.append(MousebiteHole(x=pos, y=line_y, diameter=config.diameter))
+        else:
+            holes.append(MousebiteHole(x=tab.x, y=pos, diameter=config.diameter))
+
+    return holes
+
+
+def mousebite_hole_to_sexp(hole: MousebiteHole) -> SExp:
+    """Convert a MousebiteHole to a KiCad S-expression footprint.
+
+    Generates a board-level ``footprint`` node containing a single NPTH
+    pad. This matches how KiKit and other panelizers represent
+    mousebite holes in KiCad files.
+
+    Args:
+        hole: The mousebite hole to convert.
+
+    Returns:
+        An SExp node representing the footprint.
+    """
+    hole_uuid = str(uuid.uuid4())
+    pad_uuid = str(uuid.uuid4())
+
+    # Build NPTH pad node
+    pad = SExp.list(
+        "pad",
+        "",
+        "np_thru_hole",
+        "circle",
+        SExp.list("at", 0, 0),
+        SExp.list("size", fmt(hole.diameter), fmt(hole.diameter)),
+        SExp.list("drill", fmt(hole.diameter)),
+        SExp.list("layers", "*.Cu", "*.Mask"),
+        uuid_node(pad_uuid),
+    )
+
+    # Build footprint wrapping the pad
+    fp = SExp.list(
+        "footprint",
+        "Panel:Mousebite",
+        SExp.list("layer", "F.Cu"),
+        uuid_node(hole_uuid),
+        SExp.list("at", fmt(hole.x), fmt(hole.y)),
+        SExp.list("attr", "board_only", "exclude_from_pos_files", "exclude_from_bom"),
+        pad,
+    )
+
+    return fp
+
+
+def generate_vcut_lines(
+    panel_bounds: tuple[float, float, float, float],
+    cut_positions: list[float],
+    orientation: str,
+    config: VCutConfig,
+) -> list[VCutLine]:
+    """Generate V-cut score lines across the full panel dimension.
+
+    V-cuts run the entire width or height of the panel.
+
+    Args:
+        panel_bounds: (min_x, min_y, max_x, max_y) of the panel.
+        cut_positions: List of Y positions (for horizontal cuts) or
+            X positions (for vertical cuts).
+        orientation: "horizontal" or "vertical".
+        config: V-cut configuration.
+
+    Returns:
+        List of VCutLine instances.
+    """
+    lines: list[VCutLine] = []
+    min_x, min_y, max_x, max_y = panel_bounds
+
+    for pos in cut_positions:
+        if orientation == "horizontal":
+            lines.append(VCutLine(
+                start_x=min_x,
+                start_y=pos,
+                end_x=max_x,
+                end_y=pos,
+            ))
+        else:
+            lines.append(VCutLine(
+                start_x=pos,
+                start_y=min_y,
+                end_x=pos,
+                end_y=max_y,
+            ))
+
+    return lines
+
+
+def vcut_line_to_sexp(line: VCutLine, config: VCutConfig) -> SExp:
+    """Convert a VCutLine to a KiCad gr_line S-expression.
+
+    Args:
+        line: The V-cut line to convert.
+        config: V-cut configuration for line width and layer.
+
+    Returns:
+        An SExp ``gr_line`` node.
+    """
+    return gr_line_node(
+        line.start_x,
+        line.start_y,
+        line.end_x,
+        line.end_y,
+        layer=config.layer,
+        width=config.line_width,
+        uuid_str=str(uuid.uuid4()),
+    )

--- a/src/kicad_tools/panel/furniture.py
+++ b/src/kicad_tools/panel/furniture.py
@@ -1,0 +1,225 @@
+"""Panel furniture: tooling holes and fiducial marks.
+
+Generates NPTH tooling holes and SMD fiducial pads on the panel frame
+for pick-and-place alignment and mechanical fixturing.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from kicad_tools.sexp.builders import fmt, uuid_node
+from kicad_tools.sexp.parser import SExp
+
+from .config import FiducialConfig, ToolingHoleConfig
+
+
+@dataclass
+class ToolingHole:
+    """A tooling hole position.
+
+    Attributes:
+        x: Hole center X in panel coordinates (mm).
+        y: Hole center Y in panel coordinates (mm).
+        diameter: Drill diameter in mm.
+    """
+
+    x: float
+    y: float
+    diameter: float
+
+
+@dataclass
+class Fiducial:
+    """A fiducial mark position.
+
+    Attributes:
+        x: Fiducial center X in panel coordinates (mm).
+        y: Fiducial center Y in panel coordinates (mm).
+        diameter: Copper pad diameter in mm.
+        mask_margin: Solder mask opening margin in mm.
+    """
+
+    x: float
+    y: float
+    diameter: float
+    mask_margin: float
+
+
+def compute_tooling_holes(
+    panel_bounds: tuple[float, float, float, float],
+    config: ToolingHoleConfig,
+) -> list[ToolingHole]:
+    """Compute tooling hole positions on the panel frame.
+
+    Places holes at corners of the panel according to the configured
+    pattern (3-hole or 4-hole).
+
+    Args:
+        panel_bounds: (min_x, min_y, max_x, max_y) of the panel
+            including frame.
+        config: Tooling hole configuration.
+
+    Returns:
+        List of ToolingHole instances.
+    """
+    min_x, min_y, max_x, max_y = panel_bounds
+    offset = config.offset
+    holes: list[ToolingHole] = []
+
+    # Bottom-left
+    holes.append(ToolingHole(
+        x=min_x + offset,
+        y=max_y - offset,
+        diameter=config.diameter,
+    ))
+
+    # Bottom-right
+    holes.append(ToolingHole(
+        x=max_x - offset,
+        y=max_y - offset,
+        diameter=config.diameter,
+    ))
+
+    # Top-left
+    holes.append(ToolingHole(
+        x=min_x + offset,
+        y=min_y + offset,
+        diameter=config.diameter,
+    ))
+
+    if config.pattern >= 4:
+        # Top-right
+        holes.append(ToolingHole(
+            x=max_x - offset,
+            y=min_y + offset,
+            diameter=config.diameter,
+        ))
+
+    return holes
+
+
+def tooling_hole_to_sexp(hole: ToolingHole) -> SExp:
+    """Convert a ToolingHole to a KiCad footprint S-expression.
+
+    Args:
+        hole: The tooling hole.
+
+    Returns:
+        An SExp ``footprint`` node with an NPTH pad.
+    """
+    hole_uuid = str(uuid.uuid4())
+    pad_uuid = str(uuid.uuid4())
+
+    pad = SExp.list(
+        "pad",
+        "",
+        "np_thru_hole",
+        "circle",
+        SExp.list("at", 0, 0),
+        SExp.list("size", fmt(hole.diameter), fmt(hole.diameter)),
+        SExp.list("drill", fmt(hole.diameter)),
+        SExp.list("layers", "*.Cu", "*.Mask"),
+        uuid_node(pad_uuid),
+    )
+
+    fp = SExp.list(
+        "footprint",
+        "Panel:ToolingHole",
+        SExp.list("layer", "F.Cu"),
+        uuid_node(hole_uuid),
+        SExp.list("at", fmt(hole.x), fmt(hole.y)),
+        SExp.list("attr", "board_only", "exclude_from_pos_files", "exclude_from_bom"),
+        pad,
+    )
+
+    return fp
+
+
+def compute_fiducials(
+    panel_bounds: tuple[float, float, float, float],
+    config: FiducialConfig,
+) -> list[Fiducial]:
+    """Compute fiducial mark positions on the panel frame.
+
+    Places three fiducials in an L-pattern (bottom-left, bottom-right,
+    top-left) for pick-and-place alignment.
+
+    Args:
+        panel_bounds: (min_x, min_y, max_x, max_y) of the panel
+            including frame.
+        config: Fiducial configuration.
+
+    Returns:
+        List of Fiducial instances.
+    """
+    min_x, min_y, max_x, max_y = panel_bounds
+    offset = config.offset
+    fiducials: list[Fiducial] = []
+
+    # Bottom-left
+    fiducials.append(Fiducial(
+        x=min_x + offset,
+        y=max_y - offset,
+        diameter=config.diameter,
+        mask_margin=config.mask_margin,
+    ))
+
+    # Bottom-right
+    fiducials.append(Fiducial(
+        x=max_x - offset,
+        y=max_y - offset,
+        diameter=config.diameter,
+        mask_margin=config.mask_margin,
+    ))
+
+    # Top-left
+    fiducials.append(Fiducial(
+        x=min_x + offset,
+        y=min_y + offset,
+        diameter=config.diameter,
+        mask_margin=config.mask_margin,
+    ))
+
+    return fiducials
+
+
+def fiducial_to_sexp(fiducial: Fiducial) -> SExp:
+    """Convert a Fiducial to a KiCad footprint S-expression.
+
+    Generates a footprint with an SMD copper pad and appropriate
+    solder mask opening for optical alignment.
+
+    Args:
+        fiducial: The fiducial mark.
+
+    Returns:
+        An SExp ``footprint`` node with an SMD fiducial pad.
+    """
+    fid_uuid = str(uuid.uuid4())
+    pad_uuid = str(uuid.uuid4())
+
+    pad = SExp.list(
+        "pad",
+        "1",
+        "smd",
+        "circle",
+        SExp.list("at", 0, 0),
+        SExp.list("size", fmt(fiducial.diameter), fmt(fiducial.diameter)),
+        SExp.list("layers", "F.Cu", "F.Mask"),
+        SExp.list("solder_mask_margin", fmt(fiducial.mask_margin)),
+        uuid_node(pad_uuid),
+    )
+
+    fp = SExp.list(
+        "footprint",
+        "Panel:Fiducial",
+        SExp.list("layer", "F.Cu"),
+        uuid_node(fid_uuid),
+        SExp.list("at", fmt(fiducial.x), fmt(fiducial.y)),
+        SExp.list("attr", "board_only", "exclude_from_pos_files", "exclude_from_bom"),
+        pad,
+    )
+
+    return fp

--- a/src/kicad_tools/panel/panel.py
+++ b/src/kicad_tools/panel/panel.py
@@ -1,0 +1,935 @@
+"""Panel builder -- core panelization engine.
+
+Implements the :class:`Panel` builder class that orchestrates board
+placement, tab generation, separation feature rendering, and panel
+furniture placement.  Operates entirely on S-expression trees, with
+no dependency on ``pcbnew``.
+
+Usage::
+
+    panel = Panel()
+    panel.append_board("board.kicad_pcb", rows=2, cols=2)
+    panel.make_tabs(width=3.0, count=3)
+    panel.make_mousebites(diameter=0.5, spacing=0.8)
+    panel.save("panel.kicad_pcb")
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from kicad_tools.core.sexp_file import load_pcb, save_pcb
+from kicad_tools.pcb.board_geometry import BoardGeometry, has_shapely
+from kicad_tools.sexp.builders import (
+    fmt,
+    gr_line_node,
+    gr_rect_node,
+    uuid_node,
+)
+from kicad_tools.sexp.parser import SExp
+
+from .config import (
+    CutMethod,
+    FiducialConfig,
+    FrameConfig,
+    MousebiteConfig,
+    PanelConfig,
+    TabConfig,
+    ToolingHoleConfig,
+    VCutConfig,
+)
+from .cuts import (
+    generate_mousebite_holes,
+    generate_vcut_lines,
+    mousebite_hole_to_sexp,
+    vcut_line_to_sexp,
+)
+from .furniture import (
+    compute_fiducials,
+    compute_tooling_holes,
+    fiducial_to_sexp,
+    tooling_hole_to_sexp,
+)
+from .tabs import Tab, compute_tabs_between_boards, compute_tabs_to_frame
+
+logger = logging.getLogger(__name__)
+
+
+def _require_shapely() -> None:
+    if not has_shapely():
+        raise ImportError(
+            "Shapely is required for panelization.  "
+            "Install it with:  pip install kicad-tools[geometry]"
+        )
+
+
+@dataclass
+class BoardInstance:
+    """A single copy of a board placed in the panel.
+
+    Attributes:
+        index: Board index (0-based) within the panel.
+        row: Grid row (0-based).
+        col: Grid column (0-based).
+        offset_x: X offset in panel coordinates (mm).
+        offset_y: Y offset in panel coordinates (mm).
+        rotation: Rotation in degrees.
+        bounds: (min_x, min_y, max_x, max_y) in panel coordinates.
+    """
+
+    index: int
+    row: int
+    col: int
+    offset_x: float
+    offset_y: float
+    rotation: float
+    bounds: tuple[float, float, float, float]
+
+
+class Panel:
+    """Builder-pattern API for creating manufacturing panels.
+
+    Wraps a source ``.kicad_pcb`` and provides methods for grid
+    placement, tab generation, separation feature rendering, and panel
+    furniture.
+
+    Typical usage::
+
+        panel = Panel()
+        panel.append_board("board.kicad_pcb", rows=2, cols=2, spacing=2.0)
+        panel.make_tabs(width=3.0, count=3)
+        panel.make_mousebites(diameter=0.5, spacing=0.8)
+        panel.save("panel.kicad_pcb")
+
+    Or with a full config::
+
+        cfg = PanelConfig(rows=3, cols=3, spacing=2.0)
+        panel = Panel.from_config("board.kicad_pcb", cfg)
+        panel.save("panel.kicad_pcb")
+    """
+
+    def __init__(self) -> None:
+        _require_shapely()
+
+        self._source_sexp: SExp | None = None
+        self._source_path: Path | None = None
+        self._board_bounds: tuple[float, float, float, float] = (0, 0, 0, 0)
+        self._instances: list[BoardInstance] = []
+        self._tabs: list[Tab] = []
+        self._panel_sexp: SExp | None = None
+        self._net_map: dict[int, int] = {}  # source net -> panel net
+        self._next_net: int = 1
+        self._panel_bounds: tuple[float, float, float, float] = (0, 0, 0, 0)
+        self._frame_config: FrameConfig | None = None
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_config(cls, board_path: str | Path, config: PanelConfig) -> Panel:
+        """Build a complete panel from a config in one call.
+
+        Args:
+            board_path: Path to the source ``.kicad_pcb`` file.
+            config: Full panel configuration.
+
+        Returns:
+            A fully configured Panel ready for ``save()``.
+        """
+        panel = cls()
+        panel.append_board(
+            board_path,
+            rows=config.rows,
+            cols=config.cols,
+            spacing=config.spacing,
+            rotation=config.rotation,
+        )
+
+        if config.frame is not None:
+            panel.make_frame(
+                width=config.frame.width,
+                space=config.frame.space,
+            )
+
+        panel.make_tabs(
+            width=config.tabs.width,
+            count=config.tabs.count,
+            spacing=config.tabs.spacing,
+        )
+
+        if config.cut_method == CutMethod.MOUSEBITE:
+            panel.make_mousebites(
+                diameter=config.mousebite.diameter,
+                spacing=config.mousebite.spacing,
+                offset=config.mousebite.offset,
+            )
+        elif config.cut_method == CutMethod.VCUT:
+            panel.make_vcuts(
+                line_width=config.vcut.line_width,
+            )
+
+        if config.tooling_holes is not None:
+            panel.make_tooling_holes(
+                diameter=config.tooling_holes.diameter,
+                offset=config.tooling_holes.offset,
+                pattern=config.tooling_holes.pattern,
+            )
+
+        if config.fiducials is not None:
+            panel.make_fiducials(
+                diameter=config.fiducials.diameter,
+                mask_margin=config.fiducials.mask_margin,
+                offset=config.fiducials.offset,
+            )
+
+        return panel
+
+    # ------------------------------------------------------------------
+    # Board placement
+    # ------------------------------------------------------------------
+
+    def append_board(
+        self,
+        board_path: str | Path,
+        rows: int = 1,
+        cols: int = 1,
+        spacing: float = 2.0,
+        rotation: float = 0.0,
+    ) -> Panel:
+        """Load a board and place it in a grid layout.
+
+        Each board copy is offset so that there is *spacing* mm between
+        adjacent board edges.  Net names are prefixed with the board
+        index to prevent conflicts across copies.
+
+        Args:
+            board_path: Path to the source ``.kicad_pcb``.
+            rows: Number of rows in the grid.
+            cols: Number of columns in the grid.
+            spacing: Gap between board edges in mm.
+            rotation: Per-board rotation in degrees.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+        board_path = Path(board_path)
+        self._source_sexp = load_pcb(board_path)
+        self._source_path = board_path
+
+        # Extract board bounds using BoardGeometry
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(board_path)
+        geom = BoardGeometry.from_pcb(pcb)
+        min_x, min_y, max_x, max_y = geom.bounds
+        board_w = max_x - min_x
+        board_h = max_y - min_y
+        self._board_bounds = (min_x, min_y, max_x, max_y)
+
+        # Place board copies in grid
+        self._instances.clear()
+        for row in range(rows):
+            for col in range(cols):
+                idx = row * cols + col
+                offset_x = col * (board_w + spacing)
+                offset_y = row * (board_h + spacing)
+
+                inst_bounds = (
+                    offset_x,
+                    offset_y,
+                    offset_x + board_w,
+                    offset_y + board_h,
+                )
+                self._instances.append(
+                    BoardInstance(
+                        index=idx,
+                        row=row,
+                        col=col,
+                        offset_x=offset_x,
+                        offset_y=offset_y,
+                        rotation=rotation,
+                        bounds=inst_bounds,
+                    )
+                )
+
+        # Compute panel bounds (without frame)
+        if self._instances:
+            all_min_x = min(i.bounds[0] for i in self._instances)
+            all_min_y = min(i.bounds[1] for i in self._instances)
+            all_max_x = max(i.bounds[2] for i in self._instances)
+            all_max_y = max(i.bounds[3] for i in self._instances)
+            self._panel_bounds = (all_min_x, all_min_y, all_max_x, all_max_y)
+
+        return self
+
+    # ------------------------------------------------------------------
+    # Frame
+    # ------------------------------------------------------------------
+
+    def make_frame(
+        self,
+        width: float = 5.0,
+        space: float = 2.0,
+    ) -> Panel:
+        """Add a frame (rail) around the panel.
+
+        Args:
+            width: Frame rail width in mm.
+            space: Gap between board edge and inner frame edge in mm.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+        self._frame_config = FrameConfig(width=width, space=space)
+
+        # Expand panel bounds to include frame
+        px0, py0, px1, py1 = self._panel_bounds
+        self._panel_bounds = (
+            px0 - space - width,
+            py0 - space - width,
+            px1 + space + width,
+            py1 + space + width,
+        )
+
+        return self
+
+    # ------------------------------------------------------------------
+    # Tab generation
+    # ------------------------------------------------------------------
+
+    def make_tabs(
+        self,
+        width: float = 3.0,
+        count: int = 3,
+        spacing: float | None = None,
+    ) -> Panel:
+        """Generate breakaway tabs between boards and to frame.
+
+        Args:
+            width: Tab width in mm.
+            count: Number of tabs per edge.
+            spacing: If set, compute tab count from spacing instead.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+        config = TabConfig(width=width, count=count, spacing=spacing)
+        self._tabs.clear()
+
+        # Tabs between horizontally adjacent boards
+        rows_set: dict[int, list[BoardInstance]] = {}
+        for inst in self._instances:
+            rows_set.setdefault(inst.row, []).append(inst)
+
+        for row_insts in rows_set.values():
+            row_insts.sort(key=lambda i: i.col)
+            for j in range(len(row_insts) - 1):
+                a = row_insts[j]
+                b = row_insts[j + 1]
+                tabs = compute_tabs_between_boards(
+                    a.bounds, b.bounds, config, "horizontal"
+                )
+                self._tabs.extend(tabs)
+
+        # Tabs between vertically adjacent boards
+        cols_set: dict[int, list[BoardInstance]] = {}
+        for inst in self._instances:
+            cols_set.setdefault(inst.col, []).append(inst)
+
+        for col_insts in cols_set.values():
+            col_insts.sort(key=lambda i: i.row)
+            for j in range(len(col_insts) - 1):
+                a = col_insts[j]
+                b = col_insts[j + 1]
+                tabs = compute_tabs_between_boards(
+                    a.bounds, b.bounds, config, "vertical"
+                )
+                self._tabs.extend(tabs)
+
+        # Tabs to frame (if frame is configured)
+        if self._frame_config is not None:
+            frame_inner = self._get_frame_inner_bounds()
+            for inst in self._instances:
+                tabs = compute_tabs_to_frame(
+                    inst.bounds, frame_inner, config
+                )
+                self._tabs.extend(tabs)
+
+        return self
+
+    def _get_frame_inner_bounds(self) -> tuple[float, float, float, float]:
+        """Get the inner edge of the frame."""
+        if self._frame_config is None:
+            return self._panel_bounds
+
+        px0, py0, px1, py1 = self._panel_bounds
+        w = self._frame_config.width
+        return (px0 + w, py0 + w, px1 - w, py1 - w)
+
+    # ------------------------------------------------------------------
+    # Separation features
+    # ------------------------------------------------------------------
+
+    def make_mousebites(
+        self,
+        diameter: float = 0.5,
+        spacing: float = 0.8,
+        offset: float = 0.0,
+    ) -> Panel:
+        """Generate mousebite perforations along all tabs.
+
+        Args:
+            diameter: NPTH hole diameter in mm.
+            spacing: Hole center-to-center spacing in mm.
+            offset: Inward offset from tab edges in mm.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+        self._mousebite_config = MousebiteConfig(
+            diameter=diameter, spacing=spacing, offset=offset
+        )
+        return self
+
+    def make_vcuts(
+        self,
+        line_width: float = 0.1,
+    ) -> Panel:
+        """Generate V-cut score lines between board rows/columns.
+
+        V-cuts are straight lines that span the entire panel width
+        or height.
+
+        Args:
+            line_width: Line width on Edge.Cuts in mm.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+        self._vcut_config = VCutConfig(line_width=line_width)
+        return self
+
+    # ------------------------------------------------------------------
+    # Furniture
+    # ------------------------------------------------------------------
+
+    def make_tooling_holes(
+        self,
+        diameter: float = 3.0,
+        offset: float = 3.5,
+        pattern: int = 3,
+    ) -> Panel:
+        """Add tooling holes to the panel frame.
+
+        Args:
+            diameter: Hole diameter in mm.
+            offset: Distance from panel corner in mm.
+            pattern: 3 or 4 holes.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+        self._tooling_config = ToolingHoleConfig(
+            diameter=diameter, offset=offset, pattern=pattern
+        )
+        return self
+
+    def make_fiducials(
+        self,
+        diameter: float = 1.0,
+        mask_margin: float = 2.0,
+        offset: float = 5.0,
+    ) -> Panel:
+        """Add fiducial marks to the panel frame.
+
+        Args:
+            diameter: Copper pad diameter in mm.
+            mask_margin: Solder mask margin in mm.
+            offset: Distance from panel corner in mm.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+        self._fiducial_config = FiducialConfig(
+            diameter=diameter, mask_margin=mask_margin, offset=offset
+        )
+        return self
+
+    # ------------------------------------------------------------------
+    # Save / build
+    # ------------------------------------------------------------------
+
+    def save(self, output_path: str | Path) -> Path:
+        """Build the panel S-expression tree and write to disk.
+
+        This is the terminal method that assembles all configured
+        elements into a valid ``.kicad_pcb`` file.
+
+        Args:
+            output_path: Path for the output panel PCB file.
+
+        Returns:
+            The resolved output path.
+        """
+        output_path = Path(output_path)
+        sexp = self.build()
+        save_pcb(sexp, output_path)
+        logger.info("Panel saved to %s", output_path)
+        return output_path
+
+    def build(self) -> SExp:
+        """Assemble the panel S-expression tree.
+
+        Returns:
+            A complete ``kicad_pcb`` S-expression ready for
+            serialization.
+        """
+        if self._source_sexp is None:
+            raise ValueError(
+                "No board loaded. Call append_board() before build()."
+            )
+
+        # Start with a skeleton PCB based on the source
+        panel_sexp = self._build_skeleton()
+
+        # Collect nets across all board instances
+        self._build_nets(panel_sexp)
+
+        # Place board copies
+        for inst in self._instances:
+            self._place_board_copy(panel_sexp, inst)
+
+        # Add tabs as Edge.Cuts lines
+        for tab in self._tabs:
+            self._render_tab(panel_sexp, tab)
+
+        # Add mousebite holes
+        if hasattr(self, "_mousebite_config"):
+            for tab in self._tabs:
+                holes = generate_mousebite_holes(tab, self._mousebite_config)
+                for hole in holes:
+                    panel_sexp.append(mousebite_hole_to_sexp(hole))
+
+        # Add V-cut lines
+        if hasattr(self, "_vcut_config"):
+            vcut_positions_h, vcut_positions_v = self._compute_vcut_positions()
+            lines = generate_vcut_lines(
+                self._panel_bounds, vcut_positions_h, "horizontal", self._vcut_config
+            )
+            lines.extend(
+                generate_vcut_lines(
+                    self._panel_bounds, vcut_positions_v, "vertical", self._vcut_config
+                )
+            )
+            for line in lines:
+                panel_sexp.append(vcut_line_to_sexp(line, self._vcut_config))
+
+        # Add frame outline
+        if self._frame_config is not None:
+            self._render_frame(panel_sexp)
+
+        # Add tooling holes
+        if hasattr(self, "_tooling_config"):
+            holes = compute_tooling_holes(self._panel_bounds, self._tooling_config)
+            for hole in holes:
+                panel_sexp.append(tooling_hole_to_sexp(hole))
+
+        # Add fiducials
+        if hasattr(self, "_fiducial_config"):
+            fiducials = compute_fiducials(self._panel_bounds, self._fiducial_config)
+            for fid in fiducials:
+                panel_sexp.append(fiducial_to_sexp(fid))
+
+        # Add panel-level Edge.Cuts outline
+        self._render_panel_outline(panel_sexp)
+
+        self._panel_sexp = panel_sexp
+        return panel_sexp
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_skeleton(self) -> SExp:
+        """Create a skeleton kicad_pcb from the source.
+
+        Copies the header (version, generator, general, layers, setup)
+        but not the board content (footprints, segments, zones, etc.).
+        """
+        src = self._source_sexp
+        assert src is not None
+
+        panel = SExp.list("kicad_pcb")
+
+        # Copy structural header nodes
+        header_tags = {
+            "version", "generator", "generator_version", "general",
+            "paper", "layers", "setup",
+        }
+        for child in src.children:
+            if child.name in header_tags:
+                panel.append(_deep_copy_sexp(child))
+
+        return panel
+
+    def _build_nets(self, panel_sexp: SExp) -> None:
+        """Collect and remap nets for all board instances.
+
+        Each board instance gets its own net namespace prefixed with
+        the board index to prevent conflicts.  Net 0 ("") is shared.
+        """
+        src = self._source_sexp
+        assert src is not None
+
+        # Always include net 0
+        panel_sexp.append(SExp.list("net", 0, ""))
+        self._net_map.clear()
+        self._net_map[0] = 0
+        self._next_net = 1
+
+        # Collect source nets
+        source_nets: list[tuple[int, str]] = []
+        for child in src.children:
+            if child.name == "net":
+                net_num = child.get_value(0)
+                net_name = child.get_string(1) or ""
+                if isinstance(net_num, int) and net_num != 0:
+                    source_nets.append((net_num, net_name))
+
+        # Create prefixed nets for each board instance
+        for inst in self._instances:
+            for src_num, src_name in source_nets:
+                panel_net_num = self._next_net
+                self._next_net += 1
+                panel_net_name = f"B{inst.index}/{src_name}"
+                panel_sexp.append(
+                    SExp.list("net", panel_net_num, panel_net_name)
+                )
+                # Store mapping: (instance_index, source_net) -> panel_net
+                self._net_map[(inst.index, src_num)] = panel_net_num
+
+    def _get_panel_net(self, instance_index: int, source_net: int) -> int:
+        """Look up the panel net number for a source net in a board instance."""
+        if source_net == 0:
+            return 0
+        return self._net_map.get((instance_index, source_net), 0)
+
+    def _place_board_copy(self, panel_sexp: SExp, inst: BoardInstance) -> None:
+        """Clone all board content from source and place at instance offset.
+
+        Clones footprints, segments, vias, zones, and graphic elements,
+        remapping UUIDs and net numbers.
+        """
+        src = self._source_sexp
+        assert src is not None
+
+        # Content node types to clone
+        content_tags = {
+            "footprint", "segment", "via", "zone", "gr_line", "gr_arc",
+            "gr_rect", "gr_circle", "gr_text", "gr_poly",
+        }
+
+        src_min_x, src_min_y = self._board_bounds[0], self._board_bounds[1]
+
+        for child in src.children:
+            if child.name not in content_tags:
+                continue
+
+            # Skip Edge.Cuts graphics (we generate our own panel outline)
+            if child.name in ("gr_line", "gr_arc", "gr_rect", "gr_circle", "gr_poly"):
+                layer_node = child.find_child("layer")
+                if layer_node and layer_node.get_string(0) == "Edge.Cuts":
+                    continue
+
+            cloned = _deep_copy_sexp(child)
+
+            # Remap UUIDs
+            _remap_uuids(cloned)
+
+            # Remap net numbers
+            _remap_nets(cloned, inst.index, self._get_panel_net)
+
+            # Offset positions
+            _offset_positions(cloned, inst.offset_x - src_min_x, inst.offset_y - src_min_y)
+
+            # Remap reference designators for footprints
+            if child.name == "footprint":
+                _remap_reference(cloned, inst.index)
+
+            panel_sexp.append(cloned)
+
+    def _render_tab(self, panel_sexp: SExp, tab: Tab) -> None:
+        """Render a tab as Edge.Cuts line segments.
+
+        Draws the two edge lines of the tab (the sides perpendicular
+        to the board edge).  The board-edge portion of the tab is
+        implicit -- it replaces a section of the original board outline.
+        """
+        tab_uuid1 = str(uuid.uuid4())
+        tab_uuid2 = str(uuid.uuid4())
+
+        if tab.orientation == "horizontal":
+            # Tab spans horizontally -- draw vertical side lines
+            panel_sexp.append(
+                gr_line_node(
+                    tab.min_x, tab.min_y, tab.min_x, tab.max_y,
+                    layer="Edge.Cuts", uuid_str=tab_uuid1,
+                )
+            )
+            panel_sexp.append(
+                gr_line_node(
+                    tab.max_x, tab.min_y, tab.max_x, tab.max_y,
+                    layer="Edge.Cuts", uuid_str=tab_uuid2,
+                )
+            )
+        else:
+            # Tab spans vertically -- draw horizontal side lines
+            panel_sexp.append(
+                gr_line_node(
+                    tab.min_x, tab.min_y, tab.max_x, tab.min_y,
+                    layer="Edge.Cuts", uuid_str=tab_uuid1,
+                )
+            )
+            panel_sexp.append(
+                gr_line_node(
+                    tab.min_x, tab.max_y, tab.max_x, tab.max_y,
+                    layer="Edge.Cuts", uuid_str=tab_uuid2,
+                )
+            )
+
+    def _render_frame(self, panel_sexp: SExp) -> None:
+        """Render the panel frame as Edge.Cuts lines."""
+        if self._frame_config is None:
+            return
+
+        px0, py0, px1, py1 = self._panel_bounds
+        w = self._frame_config.width
+
+        # Outer frame rectangle
+        outer = [
+            (px0, py0, px1, py0),  # top
+            (px1, py0, px1, py1),  # right
+            (px1, py1, px0, py1),  # bottom
+            (px0, py1, px0, py0),  # left
+        ]
+        for sx, sy, ex, ey in outer:
+            panel_sexp.append(
+                gr_line_node(sx, sy, ex, ey, layer="Edge.Cuts",
+                             uuid_str=str(uuid.uuid4()))
+            )
+
+        # Inner frame rectangle
+        inner = [
+            (px0 + w, py0 + w, px1 - w, py0 + w),
+            (px1 - w, py0 + w, px1 - w, py1 - w),
+            (px1 - w, py1 - w, px0 + w, py1 - w),
+            (px0 + w, py1 - w, px0 + w, py0 + w),
+        ]
+        for sx, sy, ex, ey in inner:
+            panel_sexp.append(
+                gr_line_node(sx, sy, ex, ey, layer="Edge.Cuts",
+                             uuid_str=str(uuid.uuid4()))
+            )
+
+    def _render_panel_outline(self, panel_sexp: SExp) -> None:
+        """Render per-board Edge.Cuts outlines (without frame)."""
+        if self._frame_config is not None:
+            # Frame handles the outer outline; render individual board outlines
+            for inst in self._instances:
+                bx0, by0, bx1, by1 = inst.bounds
+                edges = [
+                    (bx0, by0, bx1, by0),
+                    (bx1, by0, bx1, by1),
+                    (bx1, by1, bx0, by1),
+                    (bx0, by1, bx0, by0),
+                ]
+                for sx, sy, ex, ey in edges:
+                    panel_sexp.append(
+                        gr_line_node(sx, sy, ex, ey, layer="Edge.Cuts",
+                                     uuid_str=str(uuid.uuid4()))
+                    )
+        else:
+            # No frame -- render a simple outline around the entire panel
+            px0, py0, px1, py1 = self._panel_bounds
+            edges = [
+                (px0, py0, px1, py0),
+                (px1, py0, px1, py1),
+                (px1, py1, px0, py1),
+                (px0, py1, px0, py0),
+            ]
+            for sx, sy, ex, ey in edges:
+                panel_sexp.append(
+                    gr_line_node(sx, sy, ex, ey, layer="Edge.Cuts",
+                                 uuid_str=str(uuid.uuid4()))
+                )
+
+    def _compute_vcut_positions(
+        self,
+    ) -> tuple[list[float], list[float]]:
+        """Compute V-cut line positions from the board grid.
+
+        Returns:
+            (horizontal_positions, vertical_positions) -- lists of Y and
+            X coordinates where V-cut lines should be placed.
+        """
+        horizontal: list[float] = []
+        vertical: list[float] = []
+
+        # Group instances by row/col to find boundaries
+        rows_set: dict[int, list[BoardInstance]] = {}
+        cols_set: dict[int, list[BoardInstance]] = {}
+        for inst in self._instances:
+            rows_set.setdefault(inst.row, []).append(inst)
+            cols_set.setdefault(inst.col, []).append(inst)
+
+        # Horizontal V-cuts between rows
+        sorted_rows = sorted(rows_set.keys())
+        for i in range(len(sorted_rows) - 1):
+            top_row = rows_set[sorted_rows[i]]
+            bottom_row = rows_set[sorted_rows[i + 1]]
+            # V-cut at midpoint between rows
+            top_max_y = max(inst.bounds[3] for inst in top_row)
+            bottom_min_y = min(inst.bounds[1] for inst in bottom_row)
+            horizontal.append((top_max_y + bottom_min_y) / 2.0)
+
+        # Vertical V-cuts between columns
+        sorted_cols = sorted(cols_set.keys())
+        for i in range(len(sorted_cols) - 1):
+            left_col = cols_set[sorted_cols[i]]
+            right_col = cols_set[sorted_cols[i + 1]]
+            left_max_x = max(inst.bounds[2] for inst in left_col)
+            right_min_x = min(inst.bounds[0] for inst in right_col)
+            vertical.append((left_max_x + right_min_x) / 2.0)
+
+        return horizontal, vertical
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def instances(self) -> list[BoardInstance]:
+        """Return the list of board instances in the panel."""
+        return list(self._instances)
+
+    @property
+    def tabs(self) -> list[Tab]:
+        """Return the list of tabs in the panel."""
+        return list(self._tabs)
+
+    @property
+    def panel_bounds(self) -> tuple[float, float, float, float]:
+        """Return (min_x, min_y, max_x, max_y) of the full panel."""
+        return self._panel_bounds
+
+    @property
+    def board_count(self) -> int:
+        """Return the number of board instances."""
+        return len(self._instances)
+
+
+# ======================================================================
+# S-expression manipulation helpers
+# ======================================================================
+
+
+def _deep_copy_sexp(node: SExp) -> SExp:
+    """Create a deep copy of an S-expression tree.
+
+    This avoids Python's ``copy.deepcopy`` which is slow for large
+    trees. Instead we walk the tree manually.
+    """
+    if node.is_atom:
+        return SExp(value=node.value)
+
+    new_node = SExp(name=node.name)
+    for child in node.children:
+        new_node.children.append(_deep_copy_sexp(child))
+    return new_node
+
+
+def _remap_uuids(node: SExp) -> None:
+    """Replace all (uuid ...) nodes in the tree with fresh UUIDs."""
+    if node.name == "uuid" and node.children:
+        node.children[0] = SExp(value=str(uuid.uuid4()))
+        return
+
+    for child in node.children:
+        if not child.is_atom:
+            _remap_uuids(child)
+
+
+def _remap_nets(
+    node: SExp,
+    instance_index: int,
+    net_lookup: Any,  # Callable[[int, int], int]
+) -> None:
+    """Remap (net N) nodes using the panel net lookup function."""
+    if node.name == "net" and node.children:
+        first = node.children[0]
+        if first.is_atom and isinstance(first.value, int):
+            new_net = net_lookup(instance_index, first.value)
+            node.children[0] = SExp(value=new_net)
+            # Also remap net_name if present
+            if len(node.children) > 1 and node.children[1].is_atom:
+                # This is a net definition node, skip
+                pass
+            return
+
+    # Also handle (net_name ...) inside pads
+    if node.name == "net_name" and node.children:
+        first = node.children[0]
+        if first.is_atom and isinstance(first.value, str):
+            node.children[0] = SExp(value=f"B{instance_index}/{first.value}")
+            return
+
+    for child in node.children:
+        if not child.is_atom:
+            _remap_nets(child, instance_index, net_lookup)
+
+
+def _offset_positions(node: SExp, dx: float, dy: float) -> None:
+    """Offset all position-bearing nodes by (dx, dy).
+
+    Handles (at X Y ...), (start X Y), (end X Y), (mid X Y).
+    """
+    position_tags = {"at", "start", "end", "mid"}
+
+    if node.name in position_tags and len(node.children) >= 2:
+        x_child = node.children[0]
+        y_child = node.children[1]
+        if x_child.is_atom and isinstance(x_child.value, (int, float)):
+            if y_child.is_atom and isinstance(y_child.value, (int, float)):
+                node.children[0] = SExp(value=fmt(float(x_child.value) + dx))
+                node.children[1] = SExp(value=fmt(float(y_child.value) + dy))
+
+    for child in node.children:
+        if not child.is_atom:
+            _offset_positions(child, dx, dy)
+
+
+def _remap_reference(footprint_node: SExp, instance_index: int) -> None:
+    """Prefix footprint reference designators with board index.
+
+    Changes e.g. "R1" to "B0_R1" for board instance 0.
+    """
+    for child in footprint_node.children:
+        if child.name == "property" and len(child.children) >= 2:
+            name_child = child.children[0]
+            value_child = child.children[1]
+            if (
+                name_child.is_atom
+                and name_child.value == "Reference"
+                and value_child.is_atom
+                and isinstance(value_child.value, str)
+            ):
+                child.children[1] = SExp(
+                    value=f"B{instance_index}_{value_child.value}"
+                )
+                return

--- a/src/kicad_tools/panel/substrate.py
+++ b/src/kicad_tools/panel/substrate.py
@@ -1,0 +1,141 @@
+"""Board outline wrapper for panelization.
+
+Wraps :class:`~kicad_tools.pcb.board_geometry.BoardGeometry` to provide
+panel-specific geometric operations -- tab placement computation,
+partition line intersection, and outline boolean merging.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from kicad_tools.pcb.board_geometry import BoardGeometry, has_shapely
+
+if TYPE_CHECKING:
+    from shapely.geometry import Polygon as ShapelyPolygon
+
+
+def _require_shapely() -> None:
+    """Raise early if Shapely is not available."""
+    if not has_shapely():
+        raise ImportError(
+            "Shapely is required for panelization.  "
+            "Install it with:  pip install kicad-tools[geometry]"
+        )
+
+
+class Substrate:
+    """Board outline wrapper for panelization geometry.
+
+    Wraps a :class:`BoardGeometry` and provides helpers for computing
+    tab positions along board edges.
+
+    Attributes:
+        geometry: The underlying board geometry.
+    """
+
+    def __init__(self, geometry: BoardGeometry) -> None:
+        _require_shapely()
+        self.geometry = geometry
+
+    @classmethod
+    def from_pcb(cls, pcb: object) -> Substrate:
+        """Build a Substrate from a parsed PCB.
+
+        Args:
+            pcb: A parsed PCB instance (schema.pcb.PCB).
+        """
+        geom = BoardGeometry.from_pcb(pcb)  # type: ignore[arg-type]
+        return cls(geom)
+
+    @classmethod
+    def from_bounds(
+        cls, min_x: float, min_y: float, max_x: float, max_y: float
+    ) -> Substrate:
+        """Build a rectangular Substrate from bounding-box limits."""
+        geom = BoardGeometry.from_bounds(min_x, min_y, max_x, max_y)
+        return cls(geom)
+
+    @property
+    def bounds(self) -> tuple[float, float, float, float]:
+        """Return (min_x, min_y, max_x, max_y) bounding box."""
+        return self.geometry.bounds
+
+    @property
+    def width(self) -> float:
+        """Board width in mm."""
+        b = self.bounds
+        return b[2] - b[0]
+
+    @property
+    def height(self) -> float:
+        """Board height in mm."""
+        b = self.bounds
+        return b[3] - b[1]
+
+    def tab_positions_on_edge(
+        self,
+        edge: str,
+        count: int,
+        board_offset_x: float = 0.0,
+        board_offset_y: float = 0.0,
+    ) -> list[tuple[float, float]]:
+        """Compute evenly-spaced tab center positions along a board edge.
+
+        Args:
+            edge: One of "top", "bottom", "left", "right".
+            count: Number of tabs.
+            board_offset_x: X offset of the board instance in panel coords.
+            board_offset_y: Y offset of the board instance in panel coords.
+
+        Returns:
+            List of (x, y) tab center positions in panel coordinates.
+        """
+        min_x, min_y, max_x, max_y = self.bounds
+        positions: list[tuple[float, float]] = []
+
+        if edge in ("top", "bottom"):
+            y = min_y if edge == "top" else max_y
+            span = max_x - min_x
+            for i in range(count):
+                x = min_x + span * (i + 1) / (count + 1)
+                positions.append(
+                    (x + board_offset_x, y + board_offset_y)
+                )
+        elif edge in ("left", "right"):
+            x = min_x if edge == "left" else max_x
+            span = max_y - min_y
+            for i in range(count):
+                y = min_y + span * (i + 1) / (count + 1)
+                positions.append(
+                    (x + board_offset_x, y + board_offset_y)
+                )
+
+        return positions
+
+    def make_tab_polygon(
+        self,
+        center_x: float,
+        center_y: float,
+        width: float,
+        height: float,
+    ) -> BoardGeometry:
+        """Create a rectangular tab polygon centered at (center_x, center_y).
+
+        Args:
+            center_x: Tab center X in panel coordinates.
+            center_y: Tab center Y in panel coordinates.
+            width: Tab width (along the edge) in mm.
+            height: Tab height (perpendicular to edge) in mm.
+
+        Returns:
+            A BoardGeometry representing the tab rectangle.
+        """
+        half_w = width / 2.0
+        half_h = height / 2.0
+        return BoardGeometry.from_bounds(
+            center_x - half_w,
+            center_y - half_h,
+            center_x + half_w,
+            center_y + half_h,
+        )

--- a/src/kicad_tools/panel/tabs.py
+++ b/src/kicad_tools/panel/tabs.py
@@ -1,0 +1,226 @@
+"""Tab generation for panelized boards.
+
+Computes tab positions between board instances and between boards and
+frame, then generates Edge.Cuts line segments for the tab outlines.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .config import TabConfig
+
+
+@dataclass
+class Tab:
+    """A single breakaway tab.
+
+    Attributes:
+        x: Tab center X in panel coordinates (mm).
+        y: Tab center Y in panel coordinates (mm).
+        width: Tab width along the board edge (mm).
+        height: Tab height perpendicular to the edge (mm).
+        orientation: "horizontal" (tab spans along X) or
+            "vertical" (tab spans along Y).
+    """
+
+    x: float
+    y: float
+    width: float
+    height: float
+    orientation: str  # "horizontal" or "vertical"
+
+    @property
+    def min_x(self) -> float:
+        """Left edge of tab bounding box."""
+        if self.orientation == "horizontal":
+            return self.x - self.width / 2.0
+        return self.x - self.height / 2.0
+
+    @property
+    def max_x(self) -> float:
+        """Right edge of tab bounding box."""
+        if self.orientation == "horizontal":
+            return self.x + self.width / 2.0
+        return self.x + self.height / 2.0
+
+    @property
+    def min_y(self) -> float:
+        """Top edge of tab bounding box."""
+        if self.orientation == "horizontal":
+            return self.y - self.height / 2.0
+        return self.y - self.width / 2.0
+
+    @property
+    def max_y(self) -> float:
+        """Bottom edge of tab bounding box."""
+        if self.orientation == "horizontal":
+            return self.y + self.height / 2.0
+        return self.y + self.width / 2.0
+
+
+def compute_tabs_between_boards(
+    board_a_bounds: tuple[float, float, float, float],
+    board_b_bounds: tuple[float, float, float, float],
+    config: TabConfig,
+    orientation: str,
+) -> list[Tab]:
+    """Compute tabs connecting two adjacent boards.
+
+    Args:
+        board_a_bounds: (min_x, min_y, max_x, max_y) of the first board.
+        board_b_bounds: (min_x, min_y, max_x, max_y) of the second board.
+        config: Tab configuration.
+        orientation: "horizontal" if boards are side-by-side (tabs span
+            the vertical gap), "vertical" if boards are stacked (tabs
+            span the horizontal gap).
+
+    Returns:
+        List of Tab instances.
+    """
+    tabs: list[Tab] = []
+
+    if orientation == "horizontal":
+        # Boards are side by side (A left, B right)
+        gap_x = board_b_bounds[0] - board_a_bounds[2]
+        gap_center_x = board_a_bounds[2] + gap_x / 2.0
+        edge_min_y = max(board_a_bounds[1], board_b_bounds[1])
+        edge_max_y = min(board_a_bounds[3], board_b_bounds[3])
+        span = edge_max_y - edge_min_y
+
+        count = config.count
+        if config.spacing is not None and config.spacing > 0:
+            count = max(1, int(span / config.spacing))
+
+        for i in range(count):
+            y = edge_min_y + span * (i + 1) / (count + 1)
+            tabs.append(
+                Tab(
+                    x=gap_center_x,
+                    y=y,
+                    width=gap_x,
+                    height=config.width,
+                    orientation="vertical",
+                )
+            )
+    else:
+        # Boards are stacked (A top, B bottom)
+        gap_y = board_b_bounds[1] - board_a_bounds[3]
+        gap_center_y = board_a_bounds[3] + gap_y / 2.0
+        edge_min_x = max(board_a_bounds[0], board_b_bounds[0])
+        edge_max_x = min(board_a_bounds[2], board_b_bounds[2])
+        span = edge_max_x - edge_min_x
+
+        count = config.count
+        if config.spacing is not None and config.spacing > 0:
+            count = max(1, int(span / config.spacing))
+
+        for i in range(count):
+            x = edge_min_x + span * (i + 1) / (count + 1)
+            tabs.append(
+                Tab(
+                    x=x,
+                    y=gap_center_y,
+                    width=config.width,
+                    height=gap_y,
+                    orientation="horizontal",
+                )
+            )
+
+    return tabs
+
+
+def compute_tabs_to_frame(
+    board_bounds: tuple[float, float, float, float],
+    frame_inner_bounds: tuple[float, float, float, float],
+    config: TabConfig,
+) -> list[Tab]:
+    """Compute tabs connecting a board to the surrounding frame.
+
+    Creates tabs on all four edges where the board is adjacent to the
+    frame.
+
+    Args:
+        board_bounds: (min_x, min_y, max_x, max_y) of the board.
+        frame_inner_bounds: (min_x, min_y, max_x, max_y) of the inner
+            frame edge.
+        config: Tab configuration.
+
+    Returns:
+        List of Tab instances.
+    """
+    tabs: list[Tab] = []
+    bx0, by0, bx1, by1 = board_bounds
+    fx0, fy0, fx1, fy1 = frame_inner_bounds
+    board_w = bx1 - bx0
+    board_h = by1 - by0
+
+    count = config.count
+    if config.spacing is not None and config.spacing > 0:
+        count_h = max(1, int(board_w / config.spacing))
+        count_v = max(1, int(board_h / config.spacing))
+    else:
+        count_h = count
+        count_v = count
+
+    # Top edge (board top to frame top)
+    if abs(by0 - fy0) > 0.01:
+        gap = by0 - fy0
+        for i in range(count_h):
+            x = bx0 + board_w * (i + 1) / (count_h + 1)
+            tabs.append(
+                Tab(
+                    x=x,
+                    y=fy0 + gap / 2.0,
+                    width=config.width,
+                    height=gap,
+                    orientation="horizontal",
+                )
+            )
+
+    # Bottom edge
+    if abs(fy1 - by1) > 0.01:
+        gap = fy1 - by1
+        for i in range(count_h):
+            x = bx0 + board_w * (i + 1) / (count_h + 1)
+            tabs.append(
+                Tab(
+                    x=x,
+                    y=by1 + gap / 2.0,
+                    width=config.width,
+                    height=gap,
+                    orientation="horizontal",
+                )
+            )
+
+    # Left edge
+    if abs(bx0 - fx0) > 0.01:
+        gap = bx0 - fx0
+        for i in range(count_v):
+            y = by0 + board_h * (i + 1) / (count_v + 1)
+            tabs.append(
+                Tab(
+                    x=fx0 + gap / 2.0,
+                    y=y,
+                    width=gap,
+                    height=config.width,
+                    orientation="vertical",
+                )
+            )
+
+    # Right edge
+    if abs(fx1 - bx1) > 0.01:
+        gap = fx1 - bx1
+        for i in range(count_v):
+            y = by0 + board_h * (i + 1) / (count_v + 1)
+            tabs.append(
+                Tab(
+                    x=bx1 + gap / 2.0,
+                    y=y,
+                    width=gap,
+                    height=config.width,
+                    orientation="vertical",
+                )
+            )
+
+    return tabs

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -1,0 +1,580 @@
+"""Tests for the panel module -- panelization engine."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.sexp.parser import SExp
+
+# ---------------------------------------------------------------------------
+# Skip if Shapely is not available
+# ---------------------------------------------------------------------------
+shapely = pytest.importorskip("shapely", reason="Shapely required for panel tests")
+
+from kicad_tools.panel.config import (  # noqa: E402
+    CutMethod,
+    MousebiteConfig,
+    PanelConfig,
+    TabConfig,
+    VCutConfig,
+)
+from kicad_tools.panel.cuts import (  # noqa: E402
+    generate_mousebite_holes,
+    generate_vcut_lines,
+    mousebite_hole_to_sexp,
+    vcut_line_to_sexp,
+)
+from kicad_tools.panel.furniture import (  # noqa: E402
+    compute_fiducials,
+    compute_tooling_holes,
+    fiducial_to_sexp,
+    tooling_hole_to_sexp,
+)
+from kicad_tools.panel.panel import (  # noqa: E402
+    Panel,
+    _deep_copy_sexp,
+    _offset_positions,
+    _remap_reference,
+    _remap_uuids,
+)
+from kicad_tools.panel.tabs import (  # noqa: E402
+    Tab,
+    compute_tabs_between_boards,
+    compute_tabs_to_frame,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "projects"
+TEST_PCB = FIXTURES_DIR / "test_project.kicad_pcb"
+
+
+# ---------------------------------------------------------------------------
+# Tab computation tests
+# ---------------------------------------------------------------------------
+
+
+class TestTabComputation:
+    """Tests for tab placement algorithms."""
+
+    def test_tabs_between_horizontal_boards(self):
+        """Tabs between side-by-side boards use vertical orientation."""
+        a_bounds = (0, 0, 20, 30)
+        b_bounds = (22, 0, 42, 30)
+        config = TabConfig(width=3.0, count=3)
+
+        tabs = compute_tabs_between_boards(a_bounds, b_bounds, config, "horizontal")
+
+        assert len(tabs) == 3
+        for tab in tabs:
+            assert tab.orientation == "vertical"
+            # Tab center should be in the gap
+            assert 20 < tab.x < 22
+            # Tab Y should be within the shared edge
+            assert 0 < tab.y < 30
+
+    def test_tabs_between_vertical_boards(self):
+        """Tabs between stacked boards use horizontal orientation."""
+        a_bounds = (0, 0, 20, 30)
+        b_bounds = (0, 32, 20, 62)
+        config = TabConfig(width=3.0, count=2)
+
+        tabs = compute_tabs_between_boards(a_bounds, b_bounds, config, "vertical")
+
+        assert len(tabs) == 2
+        for tab in tabs:
+            assert tab.orientation == "horizontal"
+            assert 30 < tab.y < 32
+            assert 0 < tab.x < 20
+
+    def test_tabs_with_spacing_override(self):
+        """Tab count derived from spacing when spacing is set."""
+        a_bounds = (0, 0, 20, 30)
+        b_bounds = (22, 0, 42, 30)
+        config = TabConfig(width=3.0, count=99, spacing=10.0)
+
+        tabs = compute_tabs_between_boards(a_bounds, b_bounds, config, "horizontal")
+
+        # 30mm edge / 10mm spacing = 3 tabs
+        assert len(tabs) == 3
+
+    def test_tabs_to_frame(self):
+        """Tabs are generated on all four edges to frame."""
+        board_bounds = (10, 10, 30, 40)
+        frame_inner = (5, 5, 35, 45)
+        config = TabConfig(width=3.0, count=2)
+
+        tabs = compute_tabs_to_frame(board_bounds, frame_inner, config)
+
+        # 4 edges x 2 tabs each = 8 tabs
+        assert len(tabs) == 8
+
+
+# ---------------------------------------------------------------------------
+# Tab properties tests
+# ---------------------------------------------------------------------------
+
+
+class TestTabProperties:
+    """Tests for Tab bounding box properties."""
+
+    def test_horizontal_tab_bounds(self):
+        tab = Tab(x=10, y=20, width=6, height=2, orientation="horizontal")
+        assert tab.min_x == pytest.approx(7.0)
+        assert tab.max_x == pytest.approx(13.0)
+        assert tab.min_y == pytest.approx(19.0)
+        assert tab.max_y == pytest.approx(21.0)
+
+    def test_vertical_tab_bounds(self):
+        tab = Tab(x=10, y=20, width=6, height=2, orientation="vertical")
+        assert tab.min_x == pytest.approx(9.0)
+        assert tab.max_x == pytest.approx(11.0)
+        assert tab.min_y == pytest.approx(17.0)
+        assert tab.max_y == pytest.approx(23.0)
+
+
+# ---------------------------------------------------------------------------
+# Mousebite tests
+# ---------------------------------------------------------------------------
+
+
+class TestMousebites:
+    """Tests for mousebite hole generation."""
+
+    def test_mousebite_holes_on_horizontal_tab(self):
+        """Holes placed along horizontal center line of a horizontal tab."""
+        tab = Tab(x=10, y=5, width=6, height=2, orientation="horizontal")
+        config = MousebiteConfig(diameter=0.5, spacing=1.0, offset=0.0)
+
+        holes = generate_mousebite_holes(tab, config)
+
+        assert len(holes) >= 1
+        for hole in holes:
+            assert hole.y == pytest.approx(5.0)  # On tab center line
+            assert hole.diameter == 0.5
+            assert tab.min_x <= hole.x <= tab.max_x
+
+    def test_mousebite_holes_on_vertical_tab(self):
+        """Holes placed along vertical center line of a vertical tab."""
+        tab = Tab(x=5, y=10, width=6, height=2, orientation="vertical")
+        config = MousebiteConfig(diameter=0.5, spacing=1.0, offset=0.0)
+
+        holes = generate_mousebite_holes(tab, config)
+
+        assert len(holes) >= 1
+        for hole in holes:
+            assert hole.x == pytest.approx(5.0)
+            assert hole.diameter == 0.5
+
+    def test_mousebite_to_sexp(self):
+        """Mousebite hole S-expression has correct structure."""
+        from kicad_tools.panel.cuts import MousebiteHole
+
+        hole = MousebiteHole(x=10.5, y=20.3, diameter=0.5)
+        sexp = mousebite_hole_to_sexp(hole)
+
+        assert sexp.name == "footprint"
+        assert sexp.get_string(0) == "Panel:Mousebite"
+        # Should have a pad child
+        pad = sexp.find_child("pad")
+        assert pad is not None
+        # Should have np_thru_hole type
+        assert pad.get_string(1) == "np_thru_hole"
+
+    def test_mousebite_correct_layer(self):
+        """Mousebite holes use *.Cu and *.Mask layers."""
+        from kicad_tools.panel.cuts import MousebiteHole
+
+        hole = MousebiteHole(x=0, y=0, diameter=0.5)
+        sexp = mousebite_hole_to_sexp(hole)
+        pad = sexp.find_child("pad")
+        layers = pad.find_child("layers")
+        layer_values = [c.value for c in layers.children if c.is_atom]
+        assert "*.Cu" in layer_values
+        assert "*.Mask" in layer_values
+
+
+# ---------------------------------------------------------------------------
+# V-cut tests
+# ---------------------------------------------------------------------------
+
+
+class TestVCuts:
+    """Tests for V-cut line generation."""
+
+    def test_horizontal_vcuts(self):
+        """Horizontal V-cuts span full panel width."""
+        panel_bounds = (0, 0, 100, 80)
+        positions = [30.0, 50.0]
+        config = VCutConfig()
+
+        lines = generate_vcut_lines(panel_bounds, positions, "horizontal", config)
+
+        assert len(lines) == 2
+        for line in lines:
+            assert line.start_x == pytest.approx(0.0)
+            assert line.end_x == pytest.approx(100.0)
+
+    def test_vertical_vcuts(self):
+        """Vertical V-cuts span full panel height."""
+        panel_bounds = (0, 0, 100, 80)
+        positions = [40.0]
+        config = VCutConfig()
+
+        lines = generate_vcut_lines(panel_bounds, positions, "vertical", config)
+
+        assert len(lines) == 1
+        assert lines[0].start_y == pytest.approx(0.0)
+        assert lines[0].end_y == pytest.approx(80.0)
+
+    def test_vcut_to_sexp(self):
+        """V-cut line S-expression is a gr_line on Edge.Cuts."""
+        from kicad_tools.panel.cuts import VCutLine
+
+        line = VCutLine(start_x=0, start_y=30, end_x=100, end_y=30)
+        config = VCutConfig()
+        sexp = vcut_line_to_sexp(line, config)
+
+        assert sexp.name == "gr_line"
+        layer = sexp.find_child("layer")
+        assert layer.get_string(0) == "Edge.Cuts"
+
+
+# ---------------------------------------------------------------------------
+# Furniture tests
+# ---------------------------------------------------------------------------
+
+
+class TestFurniture:
+    """Tests for tooling holes and fiducials."""
+
+    def test_three_hole_pattern(self):
+        """3-hole pattern places holes at 3 corners."""
+        from kicad_tools.panel.config import ToolingHoleConfig
+
+        config = ToolingHoleConfig(diameter=3.0, offset=3.5, pattern=3)
+        holes = compute_tooling_holes((0, 0, 100, 80), config)
+
+        assert len(holes) == 3
+        for hole in holes:
+            assert hole.diameter == 3.0
+
+    def test_four_hole_pattern(self):
+        """4-hole pattern places holes at all 4 corners."""
+        from kicad_tools.panel.config import ToolingHoleConfig
+
+        config = ToolingHoleConfig(diameter=3.0, offset=3.5, pattern=4)
+        holes = compute_tooling_holes((0, 0, 100, 80), config)
+
+        assert len(holes) == 4
+
+    def test_tooling_hole_to_sexp(self):
+        """Tooling hole S-expression has NPTH pad."""
+        from kicad_tools.panel.furniture import ToolingHole
+
+        hole = ToolingHole(x=5, y=5, diameter=3.0)
+        sexp = tooling_hole_to_sexp(hole)
+
+        assert sexp.name == "footprint"
+        assert sexp.get_string(0) == "Panel:ToolingHole"
+
+    def test_fiducial_positions(self):
+        """Fiducials placed in L-pattern (3 marks)."""
+        from kicad_tools.panel.config import FiducialConfig
+
+        config = FiducialConfig(diameter=1.0, mask_margin=2.0, offset=5.0)
+        fiducials = compute_fiducials((0, 0, 100, 80), config)
+
+        assert len(fiducials) == 3
+
+    def test_fiducial_to_sexp(self):
+        """Fiducial S-expression has SMD pad with solder mask margin."""
+        from kicad_tools.panel.furniture import Fiducial
+
+        fid = Fiducial(x=5, y=75, diameter=1.0, mask_margin=2.0)
+        sexp = fiducial_to_sexp(fid)
+
+        assert sexp.name == "footprint"
+        assert sexp.get_string(0) == "Panel:Fiducial"
+        pad = sexp.find_child("pad")
+        assert pad.get_string(1) == "smd"
+
+
+# ---------------------------------------------------------------------------
+# S-expression helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestSExpHelpers:
+    """Tests for S-expression manipulation utilities."""
+
+    def test_deep_copy_preserves_structure(self):
+        """Deep copy creates independent tree with same structure."""
+        original = SExp.list("test",
+            SExp.list("child", "value"),
+            SExp.list("uuid", "original-uuid"),
+        )
+
+        copied = _deep_copy_sexp(original)
+
+        assert copied.name == "test"
+        assert len(copied.children) == 2
+        # Modifying copy should not affect original
+        copied.children[0].children[0] = SExp(value="modified")
+        assert original.children[0].children[0].value == "value"
+
+    def test_remap_uuids(self):
+        """UUID remapping replaces all uuid nodes with fresh values."""
+        node = SExp.list("footprint",
+            SExp.list("uuid", "old-uuid-1"),
+            SExp.list("pad",
+                SExp.list("uuid", "old-uuid-2"),
+            ),
+        )
+
+        _remap_uuids(node)
+
+        uuid1 = node.find_child("uuid").get_string(0)
+        uuid2 = node.find_child("pad").find_child("uuid").get_string(0)
+        assert uuid1 != "old-uuid-1"
+        assert uuid2 != "old-uuid-2"
+        assert uuid1 != uuid2
+
+    def test_offset_positions(self):
+        """Position offset applies to at, start, end nodes."""
+        node = SExp.list("segment",
+            SExp.list("start", 10.0, 20.0),
+            SExp.list("end", 30.0, 40.0),
+        )
+
+        _offset_positions(node, 5.0, 10.0)
+
+        start = node.find_child("start")
+        assert start.get_value(0) == pytest.approx(15.0)
+        assert start.get_value(1) == pytest.approx(30.0)
+
+        end = node.find_child("end")
+        assert end.get_value(0) == pytest.approx(35.0)
+        assert end.get_value(1) == pytest.approx(50.0)
+
+    def test_remap_reference(self):
+        """Reference designator gets board index prefix."""
+        fp = SExp.list("footprint",
+            SExp.list("property", "Reference", "R1",
+                SExp.list("at", 0, 0)),
+        )
+
+        _remap_reference(fp, 2)
+
+        prop = fp.find_child("property")
+        assert prop.get_string(1) == "B2_R1"
+
+
+# ---------------------------------------------------------------------------
+# Net remapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestNetRemapping:
+    """Tests for net renaming with board-index prefixes."""
+
+    def test_net_numbers_unique_across_instances(self):
+        """Each board instance gets unique net numbers."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        panel = Panel()
+        panel.append_board(TEST_PCB, rows=2, cols=2)
+        sexp = panel.build()
+
+        # Collect all net definitions
+        net_nodes = sexp.find_children("net")
+        net_nums = [n.get_value(0) for n in net_nodes]
+        # All net numbers should be unique
+        assert len(net_nums) == len(set(net_nums))
+
+    def test_net_names_prefixed(self):
+        """Net names include board index prefix."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        panel = Panel()
+        panel.append_board(TEST_PCB, rows=1, cols=2)
+        sexp = panel.build()
+
+        net_nodes = sexp.find_children("net")
+        prefixed = [n for n in net_nodes
+                     if n.get_string(1) and n.get_string(1).startswith("B")]
+        # Should have prefixed nets (all non-zero nets)
+        assert len(prefixed) > 0
+
+
+# ---------------------------------------------------------------------------
+# Panel integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestPanelIntegration:
+    """Integration tests for the full panel builder."""
+
+    def test_panel_grid_layout(self):
+        """Panel places N copies at correct grid positions."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        panel = Panel()
+        panel.append_board(TEST_PCB, rows=2, cols=3, spacing=2.0)
+
+        assert panel.board_count == 6
+        instances = panel.instances
+        assert len(instances) == 6
+
+        # Check grid positions
+        for inst in instances:
+            assert inst.row < 2
+            assert inst.col < 3
+
+    def test_panel_tabs_generated(self):
+        """Tabs are generated between adjacent boards."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        panel = Panel()
+        panel.append_board(TEST_PCB, rows=2, cols=2, spacing=2.0)
+        panel.make_tabs(width=3.0, count=2)
+
+        # 2x2 grid: 2 horizontal gaps + 2 vertical gaps = 4 gaps
+        # 2 tabs per gap = 8 tabs
+        assert len(panel.tabs) == 8
+
+    def test_panel_build_produces_valid_sexp(self):
+        """Built panel is a valid kicad_pcb S-expression."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        panel = Panel()
+        panel.append_board(TEST_PCB, rows=2, cols=2, spacing=2.0)
+        panel.make_tabs(width=3.0, count=2)
+        panel.make_mousebites(diameter=0.5, spacing=0.8)
+        sexp = panel.build()
+
+        assert sexp.name == "kicad_pcb"
+        # Should have version, layers, etc.
+        assert sexp.find_child("version") is not None
+        assert sexp.find_child("layers") is not None
+
+    def test_panel_round_trip(self, tmp_path):
+        """Panel can be saved and the output file exists."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        output = tmp_path / "panel_output.kicad_pcb"
+        panel = Panel()
+        panel.append_board(TEST_PCB, rows=2, cols=2, spacing=2.0)
+        panel.make_tabs(width=3.0, count=2)
+        panel.make_mousebites(diameter=0.5, spacing=0.8)
+        result = panel.save(output)
+
+        assert result == output
+        assert output.exists()
+        content = output.read_text()
+        assert content.startswith("(kicad_pcb")
+
+    def test_panel_with_vcuts(self, tmp_path):
+        """Panel with V-cuts generates gr_line on Edge.Cuts."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        panel = Panel()
+        panel.append_board(TEST_PCB, rows=2, cols=2, spacing=2.0)
+        panel.make_tabs(width=3.0, count=2)
+        panel.make_vcuts()
+        sexp = panel.build()
+
+        # Should have gr_line nodes on Edge.Cuts
+        gr_lines = sexp.find_children("gr_line")
+        edge_cuts = [
+            l for l in gr_lines
+            if l.find_child("layer") and l.find_child("layer").get_string(0) == "Edge.Cuts"
+        ]
+        assert len(edge_cuts) > 0
+
+    def test_panel_with_frame(self, tmp_path):
+        """Panel with frame generates inner and outer outline."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        panel = Panel()
+        panel.append_board(TEST_PCB, rows=2, cols=2, spacing=2.0)
+        panel.make_frame(width=5.0, space=2.0)
+        panel.make_tabs(width=3.0, count=2)
+        panel.make_mousebites()
+        sexp = panel.build()
+
+        gr_lines = sexp.find_children("gr_line")
+        edge_cuts = [
+            l for l in gr_lines
+            if l.find_child("layer") and l.find_child("layer").get_string(0) == "Edge.Cuts"
+        ]
+        # Frame adds 8 lines (4 outer + 4 inner) + board outlines + tab lines
+        assert len(edge_cuts) >= 8
+
+    def test_panel_from_config(self, tmp_path):
+        """Panel.from_config() produces same result as manual steps."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        config = PanelConfig(rows=2, cols=2, spacing=2.0)
+        panel = Panel.from_config(TEST_PCB, config)
+        output = tmp_path / "panel_config.kicad_pcb"
+        panel.save(output)
+
+        assert output.exists()
+        assert panel.board_count == 4
+
+    def test_single_board_panel(self, tmp_path):
+        """1x1 panel is a valid degenerate case."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        panel = Panel()
+        panel.append_board(TEST_PCB, rows=1, cols=1, spacing=0)
+        panel.make_tabs(width=3.0, count=0)
+        sexp = panel.build()
+
+        assert sexp.name == "kicad_pcb"
+        assert panel.board_count == 1
+
+    def test_panel_uuid_uniqueness(self):
+        """All UUIDs in the panel are unique."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        panel = Panel()
+        panel.append_board(TEST_PCB, rows=2, cols=2)
+        panel.make_tabs(width=3.0, count=2)
+        panel.make_mousebites()
+        sexp = panel.build()
+
+        uuids: list[str] = []
+        _collect_uuids(sexp, uuids)
+        assert len(uuids) == len(set(uuids)), (
+            f"Found {len(uuids) - len(set(uuids))} duplicate UUIDs"
+        )
+
+
+def _collect_uuids(node: SExp, uuids: list[str]) -> None:
+    """Recursively collect all UUID values from an S-expression tree."""
+    if node.name == "uuid" and node.children:
+        val = node.get_string(0)
+        if val:
+            uuids.append(val)
+    for child in node.children:
+        if not child.is_atom:
+            _collect_uuids(child, uuids)

--- a/tests/test_panel_cli.py
+++ b/tests/test_panel_cli.py
@@ -1,0 +1,105 @@
+"""CLI integration tests for the panel command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+shapely = pytest.importorskip("shapely", reason="Shapely required for panel CLI tests")
+
+from kicad_tools.cli.parser import create_parser  # noqa: E402
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "projects"
+TEST_PCB = FIXTURES_DIR / "test_project.kicad_pcb"
+
+
+class TestPanelCLI:
+    """Tests for the kct panel CLI command."""
+
+    @pytest.fixture
+    def parser(self):
+        return create_parser()
+
+    def test_parser_accepts_panel_command(self, parser):
+        """Parser recognizes the panel command with required args."""
+        args = parser.parse_args(["panel", str(TEST_PCB)])
+        assert args.command == "panel"
+        assert args.panel_input == str(TEST_PCB)
+        assert args.panel_rows == 2
+        assert args.panel_cols == 2
+
+    def test_parser_custom_grid(self, parser):
+        """Parser accepts custom grid size."""
+        args = parser.parse_args([
+            "panel", str(TEST_PCB),
+            "--rows", "3",
+            "--cols", "4",
+            "--spacing", "3.5",
+        ])
+        assert args.panel_rows == 3
+        assert args.panel_cols == 4
+        assert args.panel_spacing == 3.5
+
+    def test_parser_cut_method(self, parser):
+        """Parser accepts cut method selection."""
+        args = parser.parse_args([
+            "panel", str(TEST_PCB),
+            "--cut", "vcut",
+        ])
+        assert args.panel_cut == "vcut"
+
+    def test_parser_frame_options(self, parser):
+        """Parser accepts frame configuration."""
+        args = parser.parse_args([
+            "panel", str(TEST_PCB),
+            "--frame",
+            "--frame-width", "6.0",
+            "--tooling-holes",
+            "--fiducials",
+        ])
+        assert args.panel_frame is True
+        assert args.panel_frame_width == 6.0
+        assert args.panel_tooling_holes is True
+        assert args.panel_fiducials is True
+
+    def test_panel_command_runs(self, tmp_path):
+        """Panel command produces output file."""
+        if not TEST_PCB.exists():
+            pytest.skip("Test PCB fixture not found")
+
+        from kicad_tools.cli.commands.panel import run_panel_command
+
+        output = tmp_path / "test_panel.kicad_pcb"
+
+        class Args:
+            panel_input = str(TEST_PCB)
+            panel_output = str(output)
+            panel_rows = 2
+            panel_cols = 2
+            panel_spacing = 2.0
+            panel_cut = "mousebite"
+            panel_tab_width = 3.0
+            panel_tab_count = 3
+            panel_mousebite_diameter = 0.5
+            panel_mousebite_spacing = 0.8
+            panel_frame = False
+            panel_frame_width = 5.0
+            panel_frame_space = 2.0
+            panel_tooling_holes = False
+            panel_fiducials = False
+
+        result = run_panel_command(Args())
+        assert result == 0
+        assert output.exists()
+
+    def test_panel_command_missing_file(self):
+        """Panel command returns error for missing input file."""
+        from kicad_tools.cli.commands.panel import run_panel_command
+
+        class Args:
+            panel_input = "/nonexistent/board.kicad_pcb"
+            panel_output = None
+
+        result = run_panel_command(Args())
+        assert result == 1


### PR DESCRIPTION
## Summary

Add a complete panelization module that creates manufacturing panels from individual board PCBs, with grid layout, breakaway tabs, mousebite/V-cut separation, and panel furniture (tooling holes, fiducials).

## Changes

- New `src/kicad_tools/panel/` module with 7 files:
  - `panel.py` -- Panel builder class with method-chaining API and S-expression manipulation
  - `config.py` -- Dataclass configuration for all panel parameters
  - `tabs.py` -- Tab placement computation between boards and to frame
  - `cuts.py` -- Mousebite NPTH hole and V-cut line generation
  - `furniture.py` -- Tooling hole and fiducial mark placement
  - `substrate.py` -- Board outline wrapper using BoardGeometry
- New `src/kicad_tools/cli/commands/panel.py` -- `kct panel` CLI command handler
- Updated `src/kicad_tools/cli/parser.py` -- Panel subcommand with full argument set
- Updated `src/kicad_tools/cli/__init__.py` and `commands/__init__.py` -- Command registration

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Grid layout with configurable rows, columns, spacing | PASS | TestPanelIntegration.test_panel_grid_layout -- 2x3 grid produces 6 instances |
| Tab generation between boards and to frame | PASS | TestTabComputation -- 4 tests verify horizontal/vertical/spacing/frame tabs |
| Mousebite NPTH hole generation along tab center lines | PASS | TestMousebites -- holes on correct center line, correct diameter and layer |
| V-cut score line generation | PASS | TestVCuts -- horizontal/vertical lines span full panel dimension |
| Net renaming with board-index prefixes | PASS | TestNetRemapping -- unique net numbers, B0/B1 prefixed names |
| UUID remapping for duplicated items | PASS | TestPanelIntegration.test_panel_uuid_uniqueness -- all UUIDs unique |
| Tooling holes and fiducials | PASS | TestFurniture -- 3/4-hole patterns, L-pattern fiducials |
| Round-trip save/load | PASS | TestPanelIntegration.test_panel_round_trip -- output starts with (kicad_pcb |
| CLI command with preset-based configuration | PASS | TestPanelCLI -- parser, grid, cut method, frame options, full command run |
| Single board (1x1) edge case | PASS | TestPanelIntegration.test_single_board_panel |

## Test Plan

39 tests pass covering:
- Tab computation (horizontal, vertical, spacing override, frame)
- Mousebite generation (horizontal/vertical tabs, S-expression structure, layers)
- V-cut generation (horizontal/vertical, S-expression on Edge.Cuts)
- Furniture (3-hole, 4-hole, fiducials, S-expression structure)
- S-expression helpers (deep copy, UUID remapping, position offset, reference remapping)
- Net remapping (unique numbers, prefixed names)
- Full panel integration (grid layout, tabs, round-trip, V-cuts, frame, from_config, single board, UUID uniqueness)
- CLI (parser, custom grid, cut method, frame options, command execution, missing file)

Closes #2345