### PR TITLE
fix(router): add find_blocking_nets_relaxed to CppPathfinder

### DIFF
--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -24,6 +24,8 @@ import math
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import numpy as np
+
     from .grid import RoutingGrid
     from .primitives import Pad, Route
     from .rules import DesignRules, NetClassRouting
@@ -215,6 +217,10 @@ class CppGrid:
         self._layer_to_index: dict[int, int] = {i: i for i in range(layers)}
         # Routable layer indices (all layers by default, refined by from_routing_grid)
         self._routable_layers: list[int] = list(range(layers))
+        # Reference to original Python grid (set by from_routing_grid for
+        # post-route validation and pad_blocked lookups during relaxed
+        # blocker identification, see find_blocking_nets_relaxed).
+        self._py_grid: RoutingGrid | None = None
 
     @classmethod
     def from_routing_grid(cls, grid: RoutingGrid) -> CppGrid:
@@ -251,6 +257,15 @@ class CppGrid:
     def index_to_layer(self, index: int) -> int:
         """Convert grid index to Layer enum value."""
         return self._index_to_layer.get(index, index)
+
+    def layer_to_index(self, layer_enum_value: int) -> int:
+        """Map Layer enum value to grid index.
+
+        Mirrors :meth:`RoutingGrid.layer_to_index` for parity. Falls back
+        to identity mapping when the enum value is not in the mapping
+        (e.g. a CppGrid built without ``from_routing_grid``).
+        """
+        return self._layer_to_index.get(layer_enum_value, layer_enum_value)
 
     def get_routable_indices(self) -> list[int]:
         """Get indices of routable layers (matching RoutingGrid interface)."""
@@ -630,6 +645,137 @@ class CppPathfinder:
                 gy += sy
 
         return blocking_nets
+
+    def find_blocking_nets_relaxed(
+        self,
+        start: Pad,
+        end: Pad,
+        saved_blocked: np.ndarray,
+        saved_net: np.ndarray,
+        per_net_timeout: float | None = None,
+    ) -> set[int]:
+        """Find blocking nets using relaxed A* (Issue #2274 / #2386).
+
+        Python-side mirror of :meth:`Router.find_blocking_nets_relaxed` for
+        the C++ backend. Re-uses the existing C++ ``route`` path; only the
+        segment-walking and original-grid lookup happens in Python.
+
+        Runs A* with routed-net obstacles temporarily removed (the caller is
+        responsible for invoking this inside a
+        ``grid.temporarily_unblock_routed_nets()`` context manager). If a
+        path is found, examines the *original* blocked/net arrays to
+        determine which routed nets occupy cells along that path.
+
+        Args:
+            start: Source pad.
+            end: Destination pad.
+            saved_blocked: The *original* blocked array before unblocking
+                (numpy bool 3D: layers x rows x cols).
+            saved_net: The *original* net array before unblocking
+                (numpy int32 3D: layers x rows x cols).
+            per_net_timeout: Optional timeout for the relaxed A* search.
+
+        Returns:
+            Set of routed-net IDs whose cells lie along the relaxed path.
+        """
+        # 1. Run C++ A* with negotiated_mode and zero present-cost to find a
+        #    relaxed path. Grid has been unblocked by the caller's
+        #    temporarily_unblock_routed_nets() context.
+        route = self.route(
+            start,
+            end,
+            negotiated_mode=True,
+            present_cost_factor=0.0,
+            per_net_timeout=per_net_timeout,
+        )
+        if route is None:
+            return set()
+
+        blocking: set[int] = set()
+        source_net = start.net
+
+        # Compute trace half-width in cells (mirrors pathfinder.py:117).
+        # CppPathfinder doesn't currently cache _trace_half_width_cells,
+        # so compute it here on demand.
+        trace_half_width_cells = max(
+            1,
+            math.ceil(
+                round(
+                    (self._rules.trace_width / 2 + self._rules.trace_clearance)
+                    / self._grid.resolution,
+                    6,
+                )
+            ),
+        )
+
+        # _pad_blocked lookup requires the original Python RoutingGrid.
+        # CppGrid.from_routing_grid stores it on self._py_grid. If the
+        # CppGrid was built without a Python source, fall back to False
+        # (slightly looser, but safe -- at worst a few extra blockers).
+        py_grid = getattr(self._grid, "_py_grid", None)
+
+        def _pad_blocked_at(layer_idx: int, cy: int, cx: int) -> bool:
+            if py_grid is None:
+                return False
+            return bool(py_grid._pad_blocked[layer_idx, cy, cx])
+
+        # 2. Walk every cell along every segment of the relaxed path and
+        #    check the *original* (saved) blocked/net arrays to find which
+        #    routed nets occupied those cells.
+        for seg in route.segments:
+            gx1, gy1 = self._grid.world_to_grid(seg.x1, seg.y1)
+            gx2, gy2 = self._grid.world_to_grid(seg.x2, seg.y2)
+            layer_idx = self._grid.layer_to_index(seg.layer.value)
+
+            # Walk segment cells (Bresenham)
+            dx = abs(gx2 - gx1)
+            dy = abs(gy2 - gy1)
+            sx = 1 if gx1 < gx2 else -1
+            sy = 1 if gy1 < gy2 else -1
+            err = dx - dy
+            gx, gy = gx1, gy1
+            while True:
+                # Check this cell and clearance envelope
+                for cdy in range(-trace_half_width_cells, trace_half_width_cells + 1):
+                    for cdx in range(-trace_half_width_cells, trace_half_width_cells + 1):
+                        cx, cy = gx + cdx, gy + cdy
+                        if 0 <= cx < self._grid.cols and 0 <= cy < self._grid.rows:
+                            was_blocked = bool(saved_blocked[layer_idx, cy, cx])
+                            orig_net = int(saved_net[layer_idx, cy, cx])
+                            if (
+                                was_blocked
+                                and orig_net != 0
+                                and orig_net != source_net
+                                and not _pad_blocked_at(layer_idx, cy, cx)
+                            ):
+                                blocking.add(orig_net)
+
+                if gx == gx2 and gy == gy2:
+                    break
+                e2 = 2 * err
+                if e2 > -dy:
+                    err -= dy
+                    gx += sx
+                if e2 < dx:
+                    err += dx
+                    gy += sy
+
+        # 3. Also check via locations on every layer
+        for via in route.vias:
+            vgx, vgy = self._grid.world_to_grid(via.x, via.y)
+            for layer_idx in range(self._grid.num_layers):
+                if 0 <= vgx < self._grid.cols and 0 <= vgy < self._grid.rows:
+                    was_blocked = bool(saved_blocked[layer_idx, vgy, vgx])
+                    orig_net = int(saved_net[layer_idx, vgy, vgx])
+                    if (
+                        was_blocked
+                        and orig_net != 0
+                        and orig_net != source_net
+                        and not _pad_blocked_at(layer_idx, vgy, vgx)
+                    ):
+                        blocking.add(orig_net)
+
+        return blocking
 
 
 def create_hybrid_router(

--- a/tests/test_cpp_find_blocking_nets_relaxed.py
+++ b/tests/test_cpp_find_blocking_nets_relaxed.py
@@ -1,0 +1,288 @@
+"""Tests for CppPathfinder.find_blocking_nets_relaxed (Issue #2386).
+
+Regression: when neighborhood rip-up (Issue #2274) escalates and calls
+``find_blocking_nets_relaxed`` on a CppPathfinder, routing must not raise
+``AttributeError``. The C++ backend now exposes a Python-side mirror that
+re-uses the existing C++ ``route()`` and walks segments against the
+caller-provided original blocked/net arrays.
+
+These tests cover:
+
+1. Signature parity between Python and C++ implementations.
+2. Behavioral parity on a small grid.
+3. ``_py_grid is None`` fallback path.
+4. End-to-end smoke test for board 02 (charlieplex) when the C++ backend
+   is available — only verifies the AttributeError no longer fires.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import numpy as np
+import pytest
+
+from kicad_tools.router.cpp_backend import (
+    CppGrid,
+    CppPathfinder,
+    is_cpp_available,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.pathfinder import Router
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+pytestmark = pytest.mark.skipif(not is_cpp_available(), reason="C++ router backend not built")
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Signature parity / regression for the AttributeError
+# ---------------------------------------------------------------------------
+
+
+def test_cpp_pathfinder_has_find_blocking_nets_relaxed():
+    """Regression for #2386: CppPathfinder must expose find_blocking_nets_relaxed."""
+    assert hasattr(CppPathfinder, "find_blocking_nets_relaxed"), (
+        "CppPathfinder must implement find_blocking_nets_relaxed (Issue #2386)"
+    )
+
+
+def test_cpp_pathfinder_signature_matches_python():
+    """Signature parity: CppPathfinder mirrors Router.find_blocking_nets_relaxed."""
+    cpp_sig = inspect.signature(CppPathfinder.find_blocking_nets_relaxed)
+    py_sig = inspect.signature(Router.find_blocking_nets_relaxed)
+
+    cpp_params = list(cpp_sig.parameters.keys())
+    py_params = list(py_sig.parameters.keys())
+
+    assert cpp_params == [
+        "self",
+        "start",
+        "end",
+        "saved_blocked",
+        "saved_net",
+        "per_net_timeout",
+    ]
+    assert cpp_params == py_params
+
+    # per_net_timeout must default to None on both
+    assert cpp_sig.parameters["per_net_timeout"].default is None
+    assert py_sig.parameters["per_net_timeout"].default is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building a small grid scenario
+# ---------------------------------------------------------------------------
+
+
+def _make_small_grid_and_pads():
+    """Build a small grid with two pads.
+
+    The grid itself is left empty — the test passes the routed-net blocker
+    in via the ``saved_blocked`` / ``saved_net`` arrays, simulating what the
+    caller does inside ``temporarily_unblock_routed_nets()`` (the live grid
+    is unblocked, but the saved arrays preserve the original blocked
+    state).
+
+    Layout (top-down view, single layer F.Cu used for routing):
+
+        START_PAD  .................................  END_PAD
+
+    The blocker net (id=99) is recorded only in the saved arrays — it is
+    NOT marked on the live grid, so A* (Python or C++) can find a clear
+    path between the pads on the live grid. ``find_blocking_nets_relaxed``
+    then walks that path against the saved arrays and identifies net 99 as
+    a blocker.
+    """
+    rules = DesignRules()
+    # Use a coarser resolution so the small board has a manageable cell count
+    # but is still fine enough for trace_width + clearance.
+    rules.grid_resolution = 0.2
+    rules.trace_width = 0.2
+    rules.trace_clearance = 0.2
+
+    grid = RoutingGrid(
+        width=6.0,
+        height=2.0,
+        rules=rules,
+        layer_stack=LayerStack.two_layer(),
+    )
+
+    # Start pad on the left, end pad on the right.
+    start = Pad(
+        x=0.5,
+        y=1.0,
+        width=0.5,
+        height=0.5,
+        net=1,
+        net_name="N_START",
+        layer=Layer.F_CU,
+    )
+    end = Pad(
+        x=5.5,
+        y=1.0,
+        width=0.5,
+        height=0.5,
+        net=1,
+        net_name="N_START",
+        layer=Layer.F_CU,
+    )
+
+    return grid, rules, start, end
+
+
+def _make_saved_arrays_with_blocker(grid: RoutingGrid, blocker_net: int = 99):
+    """Build saved_blocked / saved_net arrays simulating a horizontal blocker.
+
+    The blocker is a vertical strip of cells in the middle of the board on
+    F.Cu — any direct path from left-pad to right-pad must cross it.
+    """
+    saved_blocked = np.zeros((grid.num_layers, grid.rows, grid.cols), dtype=np.bool_)
+    saved_net = np.zeros((grid.num_layers, grid.rows, grid.cols), dtype=np.int32)
+
+    blocker_layer = grid.layer_to_index(Layer.F_CU.value)
+    blocker_gx, _ = grid.world_to_grid(3.0, 1.0)
+    for cy in range(grid.rows):
+        for dx in (-1, 0, 1):
+            cx = blocker_gx + dx
+            if 0 <= cx < grid.cols:
+                saved_blocked[blocker_layer, cy, cx] = True
+                saved_net[blocker_layer, cy, cx] = blocker_net
+
+    return saved_blocked, saved_net
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — Behavioral parity vs. Python pathfinder
+# ---------------------------------------------------------------------------
+
+
+def test_behavioral_parity_with_python_pathfinder():
+    """CppPathfinder and Router return the same blocker set on a small grid.
+
+    Both backends share the same input arrays (``saved_blocked`` /
+    ``saved_net``) and the same empty live grid. Both run a relaxed A* and
+    walk the resulting path against the saved arrays; the result must be
+    the same set of blocker net IDs.
+    """
+    # Python run
+    py_grid, rules, start, end = _make_small_grid_and_pads()
+    saved_blocked, saved_net = _make_saved_arrays_with_blocker(py_grid, blocker_net=99)
+
+    py_router = Router(py_grid, rules)
+    py_blockers = py_router.find_blocking_nets_relaxed(start, end, saved_blocked, saved_net)
+
+    # C++ run -- same scenario, fresh grids built from the same setup.
+    cpp_py_grid, cpp_rules, cpp_start, cpp_end = _make_small_grid_and_pads()
+    cpp_saved_blocked, cpp_saved_net = _make_saved_arrays_with_blocker(cpp_py_grid, blocker_net=99)
+    cpp_grid = CppGrid.from_routing_grid(cpp_py_grid)
+    cpp_pathfinder = CppPathfinder(cpp_grid, cpp_rules)
+
+    cpp_blockers = cpp_pathfinder.find_blocking_nets_relaxed(
+        cpp_start, cpp_end, cpp_saved_blocked, cpp_saved_net
+    )
+
+    # Both backends must find the blocker (net 99). Sets must be equal.
+    assert 99 in py_blockers, (
+        f"Python pathfinder failed to identify blocker net 99; got {py_blockers}"
+    )
+    assert cpp_blockers == py_blockers, (
+        f"C++ blockers {cpp_blockers} != Python blockers {py_blockers}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — _py_grid is None fallback
+# ---------------------------------------------------------------------------
+
+
+def test_py_grid_none_fallback_does_not_raise():
+    """When CppGrid has no _py_grid backref, find_blocking_nets_relaxed must
+    still run without raising (using the safe pad_blocked=False fallback).
+    """
+    rules = DesignRules()
+    rules.grid_resolution = 0.2
+    rules.trace_width = 0.2
+    rules.trace_clearance = 0.2
+
+    # Build a CppGrid directly (no from_routing_grid) -- _py_grid will be None.
+    cpp_grid = CppGrid(cols=10, rows=10, layers=2, resolution=0.2)
+    assert cpp_grid._py_grid is None
+
+    cpp_pathfinder = CppPathfinder(cpp_grid, rules)
+
+    start = Pad(
+        x=0.2,
+        y=1.0,
+        width=0.2,
+        height=0.2,
+        net=1,
+        net_name="A",
+        layer=Layer.F_CU,
+    )
+    end = Pad(
+        x=1.8,
+        y=1.0,
+        width=0.2,
+        height=0.2,
+        net=1,
+        net_name="A",
+        layer=Layer.F_CU,
+    )
+
+    # The grid is mostly empty so there are no real blockers. Construct
+    # saved_blocked / saved_net arrays of the right shape; passing through
+    # the method must not raise.
+    saved_blocked = np.zeros((2, 10, 10), dtype=np.bool_)
+    saved_net = np.zeros((2, 10, 10), dtype=np.int32)
+
+    # Should not raise (specifically, must not raise AttributeError on
+    # _pad_blocked access).
+    blockers = cpp_pathfinder.find_blocking_nets_relaxed(start, end, saved_blocked, saved_net)
+
+    # Empty grid with empty saved_* -> no blockers expected.
+    assert blockers == set()
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — End-to-end: board 02 routes without AttributeError
+# ---------------------------------------------------------------------------
+
+
+def test_negotiated_router_can_call_relaxed_blocker_search():
+    """Issue #2386 regression: NegotiatedRouter should be able to call
+    ``find_blocking_nets_relaxed`` on a CppPathfinder without raising
+    ``AttributeError``.
+
+    This is the integration-level guard for the bug surface that the issue
+    reports. The original failure path is:
+
+        NegotiatedRouter.find_blocking_nets_relaxed (algorithms/negotiated.py)
+            -> self.router.find_blocking_nets_relaxed (CppPathfinder)
+            -> AttributeError
+
+    With the fix in place, the call resolves to the new method and either
+    returns a (possibly empty) blocker dict or completes normally.
+    """
+    from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+    py_grid, rules, start, end = _make_small_grid_and_pads()
+    cpp_grid = CppGrid.from_routing_grid(py_grid)
+    cpp_pathfinder = CppPathfinder(cpp_grid, rules)
+
+    neg = NegotiatedRouter(py_grid, cpp_pathfinder, rules, {})
+
+    pads_by_net = {start.net: [start, end]}
+
+    # If find_blocking_nets_relaxed is missing on CppPathfinder, this raises
+    # AttributeError during the negotiated router's relaxed lookup loop.
+    blocker_scores = neg.find_blocking_nets_relaxed(
+        failed_nets=[start.net],
+        pads_by_net=pads_by_net,
+        per_net_timeout=2.0,
+    )
+
+    # The shape of the result is what matters; the empty-grid scenario will
+    # naturally yield no blockers.
+    assert isinstance(blocker_scores, dict)


### PR DESCRIPTION
## Summary

Adds a Python-side mirror of `Router.find_blocking_nets_relaxed` on `CppPathfinder` that reuses the existing C++ `route()` and walks segments against the caller-provided original blocked/net arrays. No C++ binding changes required.

Without this method, neighborhood rip-up (Issue #2274) in the negotiated router crashes with `AttributeError: 'CppPathfinder' object has no attribute 'find_blocking_nets_relaxed'` whenever stall escalation fires on a moderately dense board.

Reproducer (now passes):
```bash
uv run kct route boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb -o /tmp/charlieplex_routed.kicad_pcb
```

## Changes

- `src/kicad_tools/router/cpp_backend.py`:
  - New `CppPathfinder.find_blocking_nets_relaxed(start, end, saved_blocked, saved_net, per_net_timeout=None)` mirroring the Python implementation at `pathfinder.py:1955-2053`. Computes `trace_half_width_cells` on demand (CppPathfinder doesn't cache it). Falls back to `pad_blocked=False` when `_py_grid is None`.
  - New `CppGrid.layer_to_index()` for parity with `RoutingGrid.layer_to_index()`.
  - Explicit `CppGrid._py_grid: RoutingGrid | None = None` initialization so the fallback path is well-defined.
  - Type-only `import numpy as np` under `TYPE_CHECKING`.

- `tests/test_cpp_find_blocking_nets_relaxed.py` (new file):
  - Signature parity test (`CppPathfinder.find_blocking_nets_relaxed` vs `Router.find_blocking_nets_relaxed`).
  - Behavioral parity test on a small grid: blocker recorded only in `saved_blocked` / `saved_net` so both backends find the same path on the live (empty) grid and walk it identically.
  - `_py_grid is None` fallback test (constructs `CppGrid` directly without `from_routing_grid`).
  - NegotiatedRouter integration smoke test against a `CppPathfinder` -- the exact call surface that produced the original `AttributeError`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `CppPathfinder.find_blocking_nets_relaxed` exists with correct signature | PASS | `test_cpp_pathfinder_signature_matches_python` asserts param names match Router exactly: `[self, start, end, saved_blocked, saved_net, per_net_timeout]`. |
| `kct route ...charlieplex_3x3.kicad_pcb` no longer raises AttributeError | PASS | Manually ran the reproducer; routing terminates with stuck-net diagnostics (3/9 routed) -- no AttributeError. |
| C++ and Python return identical blocker sets for same grid state | PASS | `test_behavioral_parity_with_python_pathfinder` asserts `cpp_blockers == py_blockers` (both find net 99). |
| No regression in `tests/test_neighborhood_ripup.py` | PASS | 20/20 tests pass. |
| No new C++ binding required | PASS | Only `cpp_backend.py` (Python) and tests changed; no `.cpp` or `.so` rebuild. |
| `_py_grid is None` path exercised | PASS | `test_py_grid_none_fallback_does_not_raise` constructs CppGrid without `from_routing_grid` and runs the method without raising. |

## Test Plan

- `uv run pytest tests/test_cpp_find_blocking_nets_relaxed.py tests/test_neighborhood_ripup.py tests/test_router_cpp_backend.py` -- 43 tests pass.
- Manual reproducer: `uv run kct route boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb -o /tmp/out.kicad_pcb` -- routing terminates without AttributeError (3/9 nets routed, partial result saved).
- `uv run ruff check src/kicad_tools/router/cpp_backend.py tests/test_cpp_find_blocking_nets_relaxed.py` -- only the pre-existing `UP037` warning on `find_blocking_nets` (unrelated, on `main` already).
- `uv run ruff check tests/test_cpp_find_blocking_nets_relaxed.py` -- clean.

Closes #2386