### PR TITLE
fix(router): preserve Y/T-junction connectivity in trace optimizer

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3687,6 +3687,12 @@ def main(argv: list[str] | None = None) -> int:
                 if not quiet:
                     print(f"  Warning: Failed to cache result: {e}")
 
+    # Get pre-optimization statistics (also used in the no-optimize path
+    # below so the segment/via summary print does not raise
+    # UnboundLocalError when --no-optimize is set).
+    pre_segments = sum(len(r.segments) for r in router.routes)
+    pre_vias = sum(len(r.vias) for r in router.routes)
+
     # Optimize traces (unless --no-optimize/--raw flag is set)
     if not args.no_optimize and router.routes:
         from kicad_tools.router.optimizer import (
@@ -3697,10 +3703,6 @@ def main(argv: list[str] | None = None) -> int:
 
         if not quiet:
             print("\n--- Optimizing traces ---")
-
-        # Get pre-optimization statistics
-        pre_segments = sum(len(r.segments) for r in router.routes)
-        pre_vias = sum(len(r.vias) for r in router.routes)
 
         # Configure and run optimizer
         opt_config = OptimizationConfig(

--- a/src/kicad_tools/router/optimizer/chain.py
+++ b/src/kicad_tools/router/optimizer/chain.py
@@ -1,72 +1,200 @@
-"""Chain sorting for connected segments."""
+"""Chain sorting for connected segments.
+
+Splits routed segments into linear sub-chains at junction nodes. A junction
+node is any endpoint shared by 3 or more segment endpoints (Y/T-junctions
+that arise on multi-pad nets). Linearizing such a graph as a single chain
+causes downstream optimisations (collinear merge, pull-tight, etc.) to drop
+or rewrite branches and silently disconnect pads (issue #2389).
+"""
 
 from __future__ import annotations
 
+from collections import defaultdict
+
 from ..primitives import Segment
-from .geometry import segments_touch
+
+
+def _quantize(value: float, tolerance: float) -> int:
+    """Quantize a coordinate so endpoints within ``tolerance`` map together."""
+    # Use a quantization grid roughly an order of magnitude finer than the
+    # tolerance so neighbouring values round to the same key.  Using ``round``
+    # at the tolerance scale keeps small floating-point drift on the same
+    # vertex without merging genuinely distinct endpoints.
+    if tolerance <= 0:
+        return int(round(value * 1e9))
+    return int(round(value / tolerance))
+
+
+def _vertex_key(x: float, y: float, tolerance: float) -> tuple[int, int]:
+    """Return a hashable key that two endpoints within ``tolerance`` share."""
+    return (_quantize(x, tolerance), _quantize(y, tolerance))
 
 
 def sort_into_chains(segments: list[Segment], tolerance: float = 1e-4) -> list[list[Segment]]:
-    """Sort segments into connected chains.
+    """Sort segments into connected linear chains.
 
-    Groups segments that form continuous paths. Segments that share
-    endpoints belong to the same chain. This prevents optimization
-    from creating shortcuts between unconnected segments.
+    Groups segments that form continuous paths and **splits each connected
+    component at junction nodes** (vertices of degree >= 3) so that every
+    returned chain is a true linear path.  This prevents the downstream
+    linear optimisation passes from merging or shortening across a Y/T
+    junction and dropping pad endpoints.
 
     Args:
         segments: List of segments to sort.
         tolerance: Tolerance for endpoint comparison.
 
     Returns:
-        List of chains, where each chain is a list of connected segments.
+        List of chains, where each chain is an ordered list of segments
+        whose endpoints meet head-to-tail.  Chains do not span junctions.
     """
     if not segments:
         return []
 
-    if len(segments) == 1:
-        return [list(segments)]
+    # Build a vertex -> list[(seg_idx, which_end)] adjacency.  ``which_end``
+    # is 0 for the (x1, y1) endpoint of the segment and 1 for (x2, y2).
+    vertex_endpoints: dict[tuple[int, int], list[tuple[int, int]]] = defaultdict(list)
+    for idx, seg in enumerate(segments):
+        vertex_endpoints[_vertex_key(seg.x1, seg.y1, tolerance)].append((idx, 0))
+        vertex_endpoints[_vertex_key(seg.x2, seg.y2, tolerance)].append((idx, 1))
 
-    # Track which segments have been assigned to a chain
-    remaining = set(range(len(segments)))
+    # A vertex is a "boundary" vertex (a sub-chain split point) if it has
+    # degree != 2 -- i.e. either a leaf (1 endpoint) or a junction (>=3).
+    def is_boundary(key: tuple[int, int]) -> bool:
+        return len(vertex_endpoints[key]) != 2
+
+    # Walk linear sub-chains from each boundary vertex.  Each segment is
+    # visited at most once via the ``visited`` set.
+    visited: set[int] = set()
     chains: list[list[Segment]] = []
 
-    while remaining:
-        # Start a new chain with an arbitrary remaining segment
-        start_idx = next(iter(remaining))
-        remaining.remove(start_idx)
+    boundary_keys = [k for k in vertex_endpoints if is_boundary(k)]
 
-        chain_indices = [start_idx]
+    for start_key in boundary_keys:
+        # Try to start a sub-chain from each unvisited segment incident
+        # to this boundary vertex.
+        for seg_idx, which_end in list(vertex_endpoints[start_key]):
+            if seg_idx in visited:
+                continue
+            chain = _walk_linear_chain(
+                segments, vertex_endpoints, seg_idx, which_end, visited, tolerance
+            )
+            if chain:
+                chains.append(chain)
 
-        # Grow the chain by finding connected segments
-        changed = True
-        while changed:
-            changed = False
-            for idx in list(remaining):
-                seg = segments[idx]
-                # Check if this segment connects to any segment in the chain
-                for chain_idx in chain_indices:
-                    if segments_touch(segments[chain_idx], seg, tolerance):
-                        chain_indices.append(idx)
-                        remaining.remove(idx)
-                        changed = True
-                        break
-
-        # Sort chain segments into path order
-        chain_segments = [segments[i] for i in chain_indices]
-        sorted_chain = sort_chain_segments(chain_segments, tolerance)
-        chains.append(sorted_chain)
+    # Any segments still unvisited belong to pure loops (all vertices
+    # degree 2).  Walk each loop as a single chain.
+    for idx in range(len(segments)):
+        if idx in visited:
+            continue
+        chain = _walk_linear_chain(segments, vertex_endpoints, idx, 0, visited, tolerance)
+        if chain:
+            chains.append(chain)
 
     return chains
 
 
-def sort_chain_segments(segments: list[Segment], tolerance: float = 1e-4) -> list[Segment]:
-    """Sort segments within a chain into connected path order.
+def _walk_linear_chain(
+    segments: list[Segment],
+    vertex_endpoints: dict[tuple[int, int], list[tuple[int, int]]],
+    start_idx: int,
+    start_which_end: int,
+    visited: set[int],
+    tolerance: float,
+) -> list[Segment]:
+    """Walk a single linear sub-chain starting from segment ``start_idx``.
 
-    Arranges segments so that each segment's end connects to the
-    next segment's start, forming a continuous path.
+    The walk begins at endpoint ``start_which_end`` of ``segments[start_idx]``
+    and proceeds away from that endpoint, following degree-2 vertices through
+    the segment graph.  It stops when:
+
+    - the next vertex has degree != 2 (leaf or junction), or
+    - the next segment has already been visited (loop closed).
 
     Args:
-        segments: List of segments belonging to the same chain.
+        segments: All segments.
+        vertex_endpoints: Vertex -> list[(seg_idx, which_end)] map.
+        start_idx: Index of the segment to start from.
+        start_which_end: 0 if walk starts at (x1, y1), 1 if at (x2, y2).
+        visited: Set of segment indices already placed in a chain. Mutated.
+        tolerance: Endpoint tolerance.
+
+    Returns:
+        Ordered list of segments forming a linear path. Segments are
+        re-oriented so each segment's end matches the next segment's start.
+    """
+    if start_idx in visited:
+        return []
+
+    chain: list[Segment] = []
+    visited.add(start_idx)
+
+    seg = segments[start_idx]
+    # Orient the first segment so that the walk-start endpoint comes first.
+    if start_which_end == 1:
+        seg = _flip_segment(seg)
+    chain.append(seg)
+
+    # Walk forward from seg's "end" vertex.
+    current_end_key = _vertex_key(seg.x2, seg.y2, tolerance)
+
+    while True:
+        incident = vertex_endpoints[current_end_key]
+        # Stop at boundaries (leaves and junctions).
+        if len(incident) != 2:
+            break
+
+        # Find the *other* incident segment at this vertex.
+        next_seg_idx: int | None = None
+        next_which_end: int | None = None
+        for cand_idx, cand_which in incident:
+            if cand_idx not in visited:
+                next_seg_idx = cand_idx
+                next_which_end = cand_which
+                break
+
+        if next_seg_idx is None:
+            # All incident segments visited (loop closed).
+            break
+
+        visited.add(next_seg_idx)
+        next_seg = segments[next_seg_idx]
+        # Orient so the matching endpoint comes first (start of next_seg).
+        if next_which_end == 1:
+            next_seg = _flip_segment(next_seg)
+        chain.append(next_seg)
+        current_end_key = _vertex_key(next_seg.x2, next_seg.y2, tolerance)
+
+    return chain
+
+
+def _flip_segment(seg: Segment) -> Segment:
+    """Return a copy of ``seg`` with its endpoints swapped."""
+    return Segment(
+        x1=seg.x2,
+        y1=seg.y2,
+        x2=seg.x1,
+        y2=seg.y1,
+        width=seg.width,
+        layer=seg.layer,
+        net=seg.net,
+        net_name=seg.net_name,
+    )
+
+
+def sort_chain_segments(segments: list[Segment], tolerance: float = 1e-4) -> list[Segment]:
+    """Sort segments within a single connected chain into path order.
+
+    .. note::
+        This is the legacy single-chain sorter.  It assumes the input is a
+        linear (non-branching) path; the new :func:`sort_into_chains`
+        already splits at junctions, so this function should only ever
+        receive linear inputs from internal callers.  External callers
+        passing a Y/T-shape will get a single linearised result with
+        branches appended in arbitrary order -- prefer
+        :func:`sort_into_chains` instead.
+
+    Args:
+        segments: List of segments belonging to the same linear chain.
         tolerance: Tolerance for endpoint comparison.
 
     Returns:
@@ -75,97 +203,11 @@ def sort_chain_segments(segments: list[Segment], tolerance: float = 1e-4) -> lis
     if len(segments) <= 1:
         return list(segments)
 
+    # If callers hand us a multi-branch shape, split it first and
+    # concatenate the branches so we still produce a valid (if not
+    # ideal) ordering rather than silently dropping branches.
+    chains = sort_into_chains(segments, tolerance)
     result: list[Segment] = []
-    remaining = list(segments)
-
-    def find_chain_tip() -> int:
-        """Find a segment at the tip of the chain (has an unshared endpoint)."""
-        for i, seg in enumerate(remaining):
-            # Check if seg's start point is shared with any other segment
-            start_shared = False
-            end_shared = False
-            for j, other in enumerate(remaining):
-                if i == j:
-                    continue
-                # Check if start of seg matches any endpoint of other
-                if (abs(seg.x1 - other.x1) < tolerance and abs(seg.y1 - other.y1) < tolerance) or (
-                    abs(seg.x1 - other.x2) < tolerance and abs(seg.y1 - other.y2) < tolerance
-                ):
-                    start_shared = True
-                # Check if end of seg matches any endpoint of other
-                if (abs(seg.x2 - other.x1) < tolerance and abs(seg.y2 - other.y1) < tolerance) or (
-                    abs(seg.x2 - other.x2) < tolerance and abs(seg.y2 - other.y2) < tolerance
-                ):
-                    end_shared = True
-
-            # If start is not shared, this is a good starting point
-            if not start_shared:
-                return i
-            # If end is not shared but start is, we can use this (will need to traverse)
-            if not end_shared:
-                return i
-
-        # All endpoints are shared (could be a loop), just pick first
-        return 0
-
-    # Start from a tip
-    start_idx = find_chain_tip()
-    current = remaining.pop(start_idx)
-
-    # Ensure segment is oriented so we're starting from an unshared endpoint
-    # Check if current.start is shared with remaining segments
-    start_shared = any(
-        (abs(current.x1 - other.x1) < tolerance and abs(current.y1 - other.y1) < tolerance)
-        or (abs(current.x1 - other.x2) < tolerance and abs(current.y1 - other.y2) < tolerance)
-        for other in remaining
-    )
-    if start_shared:
-        # Flip the segment so we start from the unshared end
-        current = Segment(
-            x1=current.x2,
-            y1=current.y2,
-            x2=current.x1,
-            y2=current.y1,
-            width=current.width,
-            layer=current.layer,
-            net=current.net,
-            net_name=current.net_name,
-        )
-
-    result.append(current)
-
-    # Traverse the chain, finding segments that connect to the current end
-    while remaining:
-        found = False
-        for i, seg in enumerate(remaining):
-            # Check if seg's start connects to current's end
-            if abs(current.x2 - seg.x1) < tolerance and abs(current.y2 - seg.y1) < tolerance:
-                current = remaining.pop(i)
-                result.append(current)
-                found = True
-                break
-            # Check if seg's end connects to current's end (need to flip seg)
-            if abs(current.x2 - seg.x2) < tolerance and abs(current.y2 - seg.y2) < tolerance:
-                seg = remaining.pop(i)
-                current = Segment(
-                    x1=seg.x2,
-                    y1=seg.y2,
-                    x2=seg.x1,
-                    y2=seg.y1,
-                    width=seg.width,
-                    layer=seg.layer,
-                    net=seg.net,
-                    net_name=seg.net_name,
-                )
-                result.append(current)
-                found = True
-                break
-
-        if not found:
-            # Remaining segments aren't connected to current chain end
-            # This shouldn't happen for a properly connected chain,
-            # but handle gracefully by just appending the rest
-            result.extend(remaining)
-            break
-
+    for chain in chains:
+        result.extend(chain)
     return result

--- a/src/kicad_tools/router/optimizer/trace.py
+++ b/src/kicad_tools/router/optimizer/trace.py
@@ -248,12 +248,25 @@ class TraceOptimizer:
         before optimization. This prevents optimization from creating
         shortcuts between unconnected parts of the route.
 
+        A connectivity-preserving guard runs after optimisation: if the
+        optimised segment graph fails to reach every pad-like endpoint of
+        the input route, the original (pre-optimisation) segments are
+        retained instead.  This protects against optimiser bugs on
+        Y/T-junction multi-pad nets (issue #2389) and serves as a safety
+        net for future optimiser changes.
+
         Args:
             route: Route to optimize.
 
         Returns:
             New Route with optimized segments and minimized vias.
         """
+        # Capture pad-like endpoints (degree-1 vertices) on the input
+        # segments so we can verify connectivity is preserved after
+        # optimisation.  We use the same per-layer grouping the optimiser
+        # uses, since vias bridge layers separately.
+        pre_endpoints = _collect_terminal_endpoints(route.segments)
+
         # Group segments by layer for optimization
         segments_by_layer: dict[Layer, list[Segment]] = {}
         for seg in route.segments:
@@ -266,6 +279,19 @@ class TraceOptimizer:
         for _layer, segs in segments_by_layer.items():
             optimized = self.optimize_segments(segs)
             optimized_segments.extend(optimized)
+
+        # Connectivity-preserving guard: if optimisation dropped any
+        # pad-like endpoint from the segment graph, revert to the
+        # pre-optimisation segments for this route.  This protects
+        # against branch-dropping bugs in chain sorting and downstream
+        # linearisation passes.
+        if not _endpoints_preserved(
+            pre_endpoints,
+            optimized_segments,
+            list(route.vias),
+            tolerance=self.config.tolerance,
+        ):
+            optimized_segments = list(route.segments)
 
         # Create route with optimized segments
         optimized_route = Route(
@@ -411,3 +437,103 @@ class TraceOptimizer:
     def reset_via_stats(self) -> None:
         """Reset via optimization statistics."""
         self._via_optimizer.reset_stats()
+
+
+# ---------------------------------------------------------------------------
+# Connectivity-preserving guard helpers (issue #2389)
+# ---------------------------------------------------------------------------
+
+
+def _vertex_key(x: float, y: float, layer: Layer, tolerance: float) -> tuple[int, int, int]:
+    """Quantise (x, y, layer) so neighbouring endpoints share a key."""
+    if tolerance <= 0:
+        qx = int(round(x * 1e9))
+        qy = int(round(y * 1e9))
+    else:
+        qx = int(round(x / tolerance))
+        qy = int(round(y / tolerance))
+    return (qx, qy, int(layer.value))
+
+
+def _collect_terminal_endpoints(
+    segments: list[Segment], tolerance: float = 1e-4
+) -> set[tuple[int, int, int]]:
+    """Return the per-layer degree-1 vertices in a segment list.
+
+    These are the "pad-like" endpoints of a route: points where exactly one
+    segment terminates.  Interior junction or chain-internal vertices have
+    degree >= 2 and are excluded.
+    """
+    counts: dict[tuple[int, int, int], int] = {}
+    for seg in segments:
+        for x, y in (seg.start, seg.end):
+            k = _vertex_key(x, y, seg.layer, tolerance)
+            counts[k] = counts.get(k, 0) + 1
+    return {k for k, c in counts.items() if c == 1}
+
+
+def _endpoints_preserved(
+    pre_endpoints: set[tuple[int, int, int]],
+    optimized_segments: list[Segment],
+    vias: list,
+    tolerance: float = 1e-4,
+) -> bool:
+    """Verify every pre-optimisation pad-like endpoint is reachable.
+
+    Builds a connectivity graph from ``optimized_segments`` (and the route's
+    vias, which bridge layers at a shared (x, y)) and confirms that every
+    vertex in ``pre_endpoints`` is present and lies in a single connected
+    component.  Returns True if connectivity is preserved, False otherwise.
+
+    The check is conservative: missing keys, or splitting endpoints across
+    multiple components, both fail.
+    """
+    if not pre_endpoints:
+        return True
+
+    # Build adjacency between vertex keys.  Each segment contributes an
+    # edge between its two endpoints on its layer.  Each via contributes
+    # edges between (x, y) on every layer it spans.
+    adjacency: dict[tuple[int, int, int], set[tuple[int, int, int]]] = {}
+
+    def add_edge(a: tuple[int, int, int], b: tuple[int, int, int]) -> None:
+        adjacency.setdefault(a, set()).add(b)
+        adjacency.setdefault(b, set()).add(a)
+
+    for seg in optimized_segments:
+        a = _vertex_key(seg.x1, seg.y1, seg.layer, tolerance)
+        b = _vertex_key(seg.x2, seg.y2, seg.layer, tolerance)
+        add_edge(a, b)
+
+    for via in vias:
+        # Vias have an (x, y) and a tuple of two layers.  A via connects
+        # the same (x, y) across both layers.
+        try:
+            via_layers = via.layers
+            via_x = via.x
+            via_y = via.y
+        except AttributeError:
+            continue
+        if not via_layers or len(via_layers) < 2:
+            continue
+        a = _vertex_key(via_x, via_y, via_layers[0], tolerance)
+        b = _vertex_key(via_x, via_y, via_layers[1], tolerance)
+        add_edge(a, b)
+
+    # Every pre-optimisation endpoint must appear in the adjacency map.
+    if not pre_endpoints.issubset(adjacency.keys()):
+        return False
+
+    # All pre-optimisation endpoints must lie in the same connected
+    # component (BFS from one of them).
+    start = next(iter(pre_endpoints))
+    visited: set[tuple[int, int, int]] = {start}
+    queue = [start]
+    while queue:
+        node = queue.pop()
+        for neighbor in adjacency.get(node, ()):
+            if neighbor not in visited:
+                visited.add(neighbor)
+                queue.append(neighbor)
+
+    return pre_endpoints.issubset(visited)

--- a/tests/test_trace_optimizer.py
+++ b/tests/test_trace_optimizer.py
@@ -7,6 +7,7 @@ from kicad_tools.router import (
     GridCollisionChecker,
     Layer,
     OptimizationConfig,
+    Route,
     RoutingGrid,
     Segment,
     TraceOptimizer,
@@ -955,8 +956,15 @@ class TestMultiChainOptimization:
             if seg.x1 > 15:
                 assert seg.x2 > 10, "Segment from chain 2 should not reach chain 1"
 
-    def test_t_junction_single_chain(self, optimizer):
-        """Test that a T-junction (3 segments meeting at a point) forms one chain."""
+    def test_t_junction_split_into_branches(self, optimizer):
+        """Test that a T-junction is split into one sub-chain per branch.
+
+        Each arm of a T/Y junction is a linear path that the downstream
+        optimisers can safely process; merging arms into a single
+        "chain" caused the optimiser to drop branches and disconnect
+        pads (issue #2389).  ``sort_into_chains`` therefore splits at
+        any vertex of degree >= 3.
+        """
         # T-junction: segments meet at (5, 0)
         segments = [
             self.make_segment(0, 0, 5, 0),  # Left arm
@@ -966,9 +974,14 @@ class TestMultiChainOptimization:
 
         chains = optimizer._sort_into_chains(segments)
 
-        # All segments are connected, should be one chain
-        assert len(chains) == 1
-        assert len(chains[0]) == 3
+        # All three arms are split off as separate sub-chains.
+        assert len(chains) == 3
+        # Total segments preserved.
+        assert sum(len(c) for c in chains) == 3
+        # Every chain is a single-segment branch (length 1) since the
+        # only branch endpoint that isn't a leaf is the junction.
+        for chain in chains:
+            assert len(chain) == 1
 
     def test_endpoints_preserved_after_optimization(self, optimizer):
         """Test that chain endpoints are preserved after optimization."""
@@ -1857,3 +1870,193 @@ class TestPullTight:
         optimizer = TraceOptimizer(config=config)
         result = optimizer.pull_tight(segments)
         assert len(result) == 2
+
+
+class TestYJunctionConnectivityPreserved:
+    """Issue #2389: optimiser must not disconnect pads on Y/T-junction nets.
+
+    Reproduces the failing scenario from board 01 (voltage divider) where a
+    3-pad VOUT net with a T-junction in the middle ended up with one pad
+    dropped from the optimised segment graph, producing a "PARTIAL: Routed
+    1/3 signal nets" warning.  The fix is two-fold:
+
+    1. ``sort_into_chains`` splits at junction vertices so each branch is
+       optimised as a true linear path.
+    2. ``TraceOptimizer.optimize_route`` runs a connectivity-preserving
+       guard and reverts to pre-optimisation segments if any pad-like
+       endpoint becomes unreachable.
+
+    These tests verify the guard upholds connectivity end-to-end, which is
+    the user-visible acceptance criterion.
+    """
+
+    @staticmethod
+    def _seg(
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        net: int = 1,
+    ) -> Segment:
+        return Segment(
+            x1=x1,
+            y1=y1,
+            x2=x2,
+            y2=y2,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=net,
+            net_name="VOUT",
+        )
+
+    @staticmethod
+    def _build_pad_graph(
+        segments: list[Segment], tolerance: float = 1e-3
+    ) -> dict[tuple[float, float], set[tuple[float, float]]]:
+        """Build an adjacency map keyed on (x, y) for connectivity checks."""
+        from collections import defaultdict
+
+        def key(x: float, y: float) -> tuple[float, float]:
+            # Snap to a tolerance-sized grid so endpoints near each other
+            # share a key.
+            return (round(x / tolerance) * tolerance, round(y / tolerance) * tolerance)
+
+        adj: dict[tuple[float, float], set[tuple[float, float]]] = defaultdict(set)
+        for seg in segments:
+            a = key(seg.x1, seg.y1)
+            b = key(seg.x2, seg.y2)
+            adj[a].add(b)
+            adj[b].add(a)
+        return adj
+
+    @classmethod
+    def _all_pads_reachable(
+        cls,
+        segments: list[Segment],
+        pads: list[tuple[float, float]],
+        tolerance: float = 1e-3,
+    ) -> bool:
+        """True if every pad is in the same connected component of segments."""
+        adj = cls._build_pad_graph(segments, tolerance)
+
+        def key(x: float, y: float) -> tuple[float, float]:
+            return (round(x / tolerance) * tolerance, round(y / tolerance) * tolerance)
+
+        pad_keys = [key(*p) for p in pads]
+        # Every pad must appear as a vertex.
+        if not all(k in adj for k in pad_keys):
+            return False
+        # BFS from first pad and ensure all others are reachable.
+        start = pad_keys[0]
+        visited = {start}
+        queue = [start]
+        while queue:
+            node = queue.pop()
+            for n in adj[node]:
+                if n not in visited:
+                    visited.add(n)
+                    queue.append(n)
+        return all(k in visited for k in pad_keys)
+
+    def test_y_junction_preserves_connectivity(self):
+        """A 3-pad Y-shaped route stays connected after full optimisation.
+
+        Geometry mirrors the failing VOUT net on board 01: three pads
+        connected through a single T-junction.  All three pads must be
+        reachable from each other in the optimised segment graph.
+        """
+        # Three pads: A (left), B (right), C (below); T-junction at (5, 0).
+        pad_a = (0.0, 0.0)
+        pad_b = (10.0, 0.0)
+        pad_c = (5.0, 5.0)
+        junction = (5.0, 0.0)
+
+        # Build a Y-shape with a couple of intermediate kinks so the
+        # collinear-merge / pull-tight passes have something to chew on
+        # (a single segment per arm would already be optimal and would
+        # not stress the optimiser).
+        segments = [
+            # Arm A: (0,0) -> (2,0) -> (5,0)
+            self._seg(*pad_a, 2.0, 0.0),
+            self._seg(2.0, 0.0, *junction),
+            # Arm B: (5,0) -> (7,0) -> (10,0)
+            self._seg(*junction, 7.0, 0.0),
+            self._seg(7.0, 0.0, *pad_b),
+            # Arm C: (5,0) -> (5,2) -> (5,5)
+            self._seg(*junction, 5.0, 2.0),
+            self._seg(5.0, 2.0, *pad_c),
+        ]
+
+        # Sanity check: pre-optimisation connectivity is sound.
+        assert self._all_pads_reachable(segments, [pad_a, pad_b, pad_c])
+
+        route = Route(net=1, net_name="VOUT", segments=segments, vias=[])
+        optimizer = TraceOptimizer()
+        result = optimizer.optimize_route(route)
+
+        assert self._all_pads_reachable(
+            result.segments, [pad_a, pad_b, pad_c]
+        ), (
+            "All three pads of a Y-shaped route must remain connected "
+            "after optimisation (issue #2389)."
+        )
+
+    def test_y_junction_chains_split_at_junction(self):
+        """Verify chains are split at the junction vertex itself."""
+        pad_a = (0.0, 0.0)
+        pad_b = (10.0, 0.0)
+        pad_c = (5.0, 5.0)
+        junction = (5.0, 0.0)
+        segments = [
+            self._seg(*pad_a, *junction),
+            self._seg(*junction, *pad_b),
+            self._seg(*junction, *pad_c),
+        ]
+
+        optimizer = TraceOptimizer()
+        chains = optimizer._sort_into_chains(segments)
+
+        # Three arms => three sub-chains.
+        assert len(chains) == 3
+        # Each sub-chain endpoints touch either a leaf or the junction.
+        leaves = {pad_a, pad_b, pad_c}
+        for chain in chains:
+            endpoints = {chain[0].start, chain[-1].end}
+            # One endpoint is a leaf, the other is the junction.
+            assert (endpoints & leaves), (
+                "Each branch should terminate at one of the pad leaves"
+            )
+            assert junction in endpoints
+
+    def test_optimizer_guard_reverts_if_branch_dropped(self):
+        """If a hostile optimiser drops a branch, the guard must revert.
+
+        Constructs a route, monkey-patches ``optimize_segments`` to return
+        only the first segment (simulating the original branch-dropping
+        bug), and checks that ``optimize_route`` still returns a fully
+        connected segment graph -- it must fall back to the original
+        segments rather than silently disconnect a pad.
+        """
+        pad_a = (0.0, 0.0)
+        pad_b = (10.0, 0.0)
+        pad_c = (5.0, 5.0)
+        junction = (5.0, 0.0)
+        segments = [
+            self._seg(*pad_a, *junction),
+            self._seg(*junction, *pad_b),
+            self._seg(*junction, *pad_c),
+        ]
+        route = Route(net=1, net_name="VOUT", segments=segments, vias=[])
+
+        optimizer = TraceOptimizer()
+        # Force optimize_segments to drop two of the three branches.
+        optimizer.optimize_segments = lambda segs: segs[:1]  # type: ignore[assignment]
+
+        result = optimizer.optimize_route(route)
+
+        # Guard must have reverted to the original three segments so all
+        # pads remain reachable from one another.
+        assert self._all_pads_reachable(
+            result.segments, [pad_a, pad_b, pad_c]
+        ), "Guard failed to revert when branches were dropped"
+        assert len(result.segments) == 3


### PR DESCRIPTION
## Summary

Closes #2389.

The trace optimiser linearised multi-pad nets through a single greedy chain walker, then ran the linear optimisation passes (collinear merge, zigzag elimination, staircase compression, pull-tight) on the result. On Y/T-shaped 3-pad nets (e.g. board 01's VOUT and GND nets, both of which have a 3-pad T-junction), branches at the junction were silently dropped or rewritten, disconnecting one pad and producing a partial routing output and `WARNING: ... disconnected pads` from the connectivity verifier.

Two layered fixes per the issue's suggested approach:

1. **Branch-aware chain sorting** -- `src/kicad_tools/router/optimizer/chain.py::sort_into_chains` now builds a vertex-indexed segment graph and splits each connected component at any vertex of degree >= 3 (a junction node).  Each branch becomes its own linear sub-chain that the downstream optimisers can safely process.  Pure loops (all vertices degree 2) are walked as a single chain.

2. **Connectivity-preserving guard** -- `TraceOptimizer.optimize_route` captures the pad-like (degree-1) endpoints of the input route, runs the optimisation, then verifies all those endpoints still lie in a single connected component of the optimised segment graph (vias bridge layers as expected).  If not, it reverts to the pre-optimisation segments for that route.  This is a defence in depth against future optimiser regressions.

Also fixes an `UnboundLocalError` on the `--no-optimize` path of `kct route` where `pre_segments` was referenced before assignment when optimisation was skipped (mentioned out of scope in the issue but the fix is one-line).

## Files

- `src/kicad_tools/router/optimizer/chain.py` -- rewritten `sort_into_chains` with junction splitting; legacy `sort_chain_segments` kept as a shim that delegates to the new implementation.
- `src/kicad_tools/router/optimizer/trace.py` -- connectivity guard in `optimize_route` plus private helpers `_collect_terminal_endpoints` and `_endpoints_preserved`.
- `src/kicad_tools/cli/route_cmd.py` -- hoist `pre_segments`/`pre_vias` calculation out of the `if not args.no_optimize` block so it's always defined.
- `tests/test_trace_optimizer.py` -- new `TestYJunctionConnectivityPreserved` class with three tests; updated existing `test_t_junction_split_into_branches` to assert the new (correct) split-at-junction behaviour.

## Test plan

- [x] `uv run pytest tests/test_trace_optimizer.py --no-cov` -- 79/79 pass (3 new + existing all green).
- [x] `uv run pytest tests/test_optimizer_pcb_segments.py tests/test_via_optimizer.py tests/test_evolutionary_optimizer.py tests/test_place_route_optimizer.py tests/test_router_core.py tests/test_router_geometry.py tests/test_router_collision.py tests/test_router_grid.py tests/test_router_cpp_backend.py --no-cov` -- 555/555 pass.
- [x] `uv run pytest tests/test_trace_optimizer.py::TestYJunctionConnectivityPreserved::test_y_junction_preserves_connectivity` fails on main (verified by reverting the chain.py and trace.py fixes), passes after fix.
- [x] `uv run kct route boards/01-voltage-divider/output/voltage_divider.kicad_pcb -o /tmp/vd.kicad_pcb --no-cache --strategy basic` -- `Nets routed: 3/3`, `All nets verified connected in written output`, `DRC PASSED`, `SUCCESS: All signal nets routed, DRC passed!`.
- [x] `uv run kct route boards/01-voltage-divider/output/voltage_divider.kicad_pcb -o /tmp/vd-raw.kicad_pcb --no-cache --no-optimize` no longer raises `UnboundLocalError`.
- [x] `uv run ruff check src/kicad_tools/router/optimizer/chain.py` clean.
- [x] `uv run ruff format src/kicad_tools/router/optimizer/trace.py` applied.

## Notes

- The default (negotiated) strategy on board 01 still produces partial connectivity in this environment because the C++ router backend is unavailable (`circular import` warning) and the negotiated MST routing only emits one MST edge instead of two for these multi-pad nets.  That is a separate router bug, not the optimiser bug this PR addresses; the optimiser changes here correctly preserve whatever the router produces (verified with `--strategy basic`, where the router emits both MST edges and routing now succeeds 3/3 with all pads connected after optimisation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)