### PR TITLE
fix(sexp): add x, y, xy to unquoted keywords for bare mirror values

### DIFF
--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -610,6 +610,10 @@ class SExp:
             "local",
             # Symbol types
             "symbols",
+            # Mirror/axis values
+            "x",
+            "y",
+            "xy",
             # Other
             "allow_missing_courtyard",
             "allow_soldermask_bridges",

--- a/tests/test_sexp.py
+++ b/tests/test_sexp.py
@@ -437,6 +437,21 @@ class TestSExpSerialization:
             assert f'"{keyword}"' not in result, f"{keyword} should not be quoted"
             assert keyword in result
 
+    def test_mirror_values_unquoted(self):
+        """Mirror axis values x, y, xy must be bare symbols, not quoted strings.
+
+        KiCad 10 expects (mirror x) not (mirror "x"). The serializer must
+        treat these single-letter axis identifiers as unquoted keywords.
+        Regression test for issue #2385.
+        """
+        for axis in ["x", "y", "xy"]:
+            mirror_node = SExp.list("mirror", axis)
+            result = serialize_sexp(mirror_node)
+            assert f'"{axis}"' not in result, (
+                f"mirror value '{axis}' should not be quoted, got: {result}"
+            )
+            assert f"(mirror {axis})" == result
+
 
 class TestSExpFileIO:
     """Tests for file I/O functions."""


### PR DESCRIPTION
## Summary
The S-expression serializer quoted mirror axis values like `(mirror "x")` instead of the bare `(mirror x)` that KiCad 10 expects. This adds `x`, `y`, and `xy` to the `unquoted_keywords` set in `_needs_quoting()`.

## Changes
- Added `"x"`, `"y"`, and `"xy"` to the `unquoted_keywords` frozenset in `SExp._needs_quoting()` in `src/kicad_tools/sexp/parser.py`
- Added regression test `test_mirror_values_unquoted` in `tests/test_sexp.py` verifying `(mirror x)`, `(mirror y)`, and `(mirror xy)` serialize as bare symbols

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SExp.list("mirror", "x").to_string()` produces `(mirror x)` | Pass | Test asserts exact output for x, y, xy |
| `SExp.list("mirror", "y").to_string()` produces `(mirror y)` | Pass | Covered by parametric loop in test |
| `SExp.list("mirror", "xy").to_string()` produces `(mirror xy)` | Pass | Covered by parametric loop in test |
| Regression test added | Pass | `test_mirror_values_unquoted` in `tests/test_sexp.py` |
| Existing sexp tests still pass | Pass | All 80 tests in `test_sexp.py` pass |

## Test Plan
- Ran `uv run pytest tests/test_sexp.py -v` -- all 80 tests pass including the new regression test.

Closes #2385