### PR TITLE
fix(router): use connectivity tiebreaker when completion ties

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -609,6 +609,7 @@ class LayerEscalationResult:
     nets_to_route: int
     completion: float
     success: bool
+    stats: dict | None = None
 
 
 @dataclass
@@ -628,6 +629,39 @@ class RuleRelaxationResult:
     completion: float
     success: bool
     layer_count: int = 2  # May be set by layer escalation integration
+    stats: dict | None = None
+
+
+def _is_better_result(
+    candidate: "LayerEscalationResult | RuleRelaxationResult",
+    best: "LayerEscalationResult | RuleRelaxationResult",
+) -> bool:
+    """Compare routing results with tiebreaking on connectivity metrics.
+
+    The cascade is: completion > segments > vias > fewer layers.
+    When completions are tied (e.g. both 0.0), secondary metrics from the
+    router statistics break the tie so that the configuration with the most
+    routing progress wins (Issue #2397).
+    """
+    if candidate.completion != best.completion:
+        return candidate.completion > best.completion
+
+    # Tie on completion -- use stats-based tiebreakers
+    c_stats = candidate.stats or {}
+    b_stats = best.stats or {}
+
+    c_segments = c_stats.get("segments", 0)
+    b_segments = b_stats.get("segments", 0)
+    if c_segments != b_segments:
+        return c_segments > b_segments
+
+    c_vias = c_stats.get("vias", 0)
+    b_vias = b_stats.get("vias", 0)
+    if c_vias != b_vias:
+        return c_vias > b_vias
+
+    # Still tied: prefer fewer layers (simpler board)
+    return candidate.layer_count < best.layer_count
 
 
 def update_pcb_layer_stackup(pcb_content: str, target_layers: int) -> str:
@@ -1049,10 +1083,11 @@ def route_with_layer_escalation(
             nets_to_route=nets_to_route,
             completion=completion,
             success=completion >= args.min_completion,
+            stats=stats,
         )
 
-        # Track best result
-        if best_result is None or completion > best_result.completion:
+        # Track best result (Issue #2397: use tiebreaker cascade)
+        if best_result is None or _is_better_result(result, best_result):
             best_result = result
 
         # Issue #2388: Record any power-net stall for the next attempt's
@@ -1508,10 +1543,11 @@ def route_with_rule_relaxation(
             completion=completion,
             success=completion >= args.min_completion,
             layer_count=layer_stack.num_layers,
+            stats=stats,
         )
 
-        # Track best result
-        if best_result is None or completion > best_result.completion:
+        # Track best result (Issue #2397: use tiebreaker cascade)
+        if best_result is None or _is_better_result(result, best_result):
             best_result = result
             # Update interrupt state so signal handler saves the best attempt
             _interrupt_state["router"] = result.router
@@ -1978,10 +2014,11 @@ def route_with_combined_escalation(
                 completion=completion,
                 success=completion >= args.min_completion,
                 layer_count=layer_count,
+                stats=stats,
             )
 
-            # Track best result
-            if best_result is None or completion > best_result.completion:
+            # Track best result (Issue #2397: use tiebreaker cascade)
+            if best_result is None or _is_better_result(result, best_result):
                 best_result = result
                 # Update interrupt state so signal handler saves the best attempt
                 _interrupt_state["router"] = result.router

--- a/tests/test_adaptive_early_stop.py
+++ b/tests/test_adaptive_early_stop.py
@@ -23,14 +23,19 @@ class FakeTier:
     via_diameter: float = 0.6
 
 
-def _make_fake_router(nets_routed: int, nets_total: int = 20):
+def _make_fake_router(nets_routed: int, nets_total: int = 20,
+                      segments: int = 0, vias: int = 0):
     """Create a mock router that reports the given routing stats."""
     router = MagicMock()
     router.nets = {i: [1, 2] for i in range(1, nets_total + 1)}
     router.grid = MagicMock(width=50, height=50)
     router.routes = []
     router._pour_nets_without_zones = set()
-    router.get_statistics.return_value = {"nets_routed": nets_routed}
+    router.get_statistics.return_value = {
+        "nets_routed": nets_routed,
+        "segments": segments,
+        "vias": vias,
+    }
     return router
 
 
@@ -347,3 +352,193 @@ class TestCombinedEscalationEarlyStop:
 
         # Only 2 attempts: 2L tier 0 + 2L tier 1 (regression detected)
         assert router_idx[0] == 2
+
+
+class TestIsBetterResult:
+    """Unit tests for _is_better_result tiebreaker helper (Issue #2397)."""
+
+    def test_higher_completion_wins(self):
+        """When completions differ, higher completion wins regardless of segments."""
+        from kicad_tools.cli.route_cmd import (
+            RuleRelaxationResult,
+            _is_better_result,
+        )
+
+        better = RuleRelaxationResult(
+            tier=0, trace_width=0.2, clearance=0.15, via_drill=0.3,
+            via_diameter=0.6, tier_description="user", router=None,
+            net_map={}, nets_routed=10, nets_to_route=20,
+            completion=0.5, success=False, layer_count=2,
+            stats={"segments": 5, "vias": 0},
+        )
+        worse = RuleRelaxationResult(
+            tier=1, trace_width=0.15, clearance=0.127, via_drill=0.3,
+            via_diameter=0.6, tier_description="moderate", router=None,
+            net_map={}, nets_routed=5, nets_to_route=20,
+            completion=0.25, success=False, layer_count=2,
+            stats={"segments": 100, "vias": 20},
+        )
+
+        assert _is_better_result(better, worse) is True
+        assert _is_better_result(worse, better) is False
+
+    def test_tied_completion_more_segments_wins(self):
+        """When completion ties, result with more segments wins."""
+        from kicad_tools.cli.route_cmd import (
+            RuleRelaxationResult,
+            _is_better_result,
+        )
+
+        more_segments = RuleRelaxationResult(
+            tier=1, trace_width=0.15, clearance=0.127, via_drill=0.3,
+            via_diameter=0.6, tier_description="moderate", router=None,
+            net_map={}, nets_routed=0, nets_to_route=20,
+            completion=0.0, success=False, layer_count=2,
+            stats={"segments": 50, "vias": 3},
+        )
+        fewer_segments = RuleRelaxationResult(
+            tier=0, trace_width=0.2, clearance=0.15, via_drill=0.3,
+            via_diameter=0.6, tier_description="user", router=None,
+            net_map={}, nets_routed=0, nets_to_route=20,
+            completion=0.0, success=False, layer_count=2,
+            stats={"segments": 10, "vias": 1},
+        )
+
+        assert _is_better_result(more_segments, fewer_segments) is True
+        assert _is_better_result(fewer_segments, more_segments) is False
+
+    def test_tied_completion_and_segments_more_vias_wins(self):
+        """When completion and segments tie, result with more vias wins."""
+        from kicad_tools.cli.route_cmd import (
+            RuleRelaxationResult,
+            _is_better_result,
+        )
+
+        more_vias = RuleRelaxationResult(
+            tier=1, trace_width=0.15, clearance=0.127, via_drill=0.3,
+            via_diameter=0.6, tier_description="moderate", router=None,
+            net_map={}, nets_routed=0, nets_to_route=20,
+            completion=0.0, success=False, layer_count=2,
+            stats={"segments": 50, "vias": 10},
+        )
+        fewer_vias = RuleRelaxationResult(
+            tier=0, trace_width=0.2, clearance=0.15, via_drill=0.3,
+            via_diameter=0.6, tier_description="user", router=None,
+            net_map={}, nets_routed=0, nets_to_route=20,
+            completion=0.0, success=False, layer_count=2,
+            stats={"segments": 50, "vias": 2},
+        )
+
+        assert _is_better_result(more_vias, fewer_vias) is True
+        assert _is_better_result(fewer_vias, more_vias) is False
+
+    def test_full_cascade_fewer_layers_wins(self):
+        """When completion, segments, and vias all tie, fewer layers wins."""
+        from kicad_tools.cli.route_cmd import (
+            RuleRelaxationResult,
+            _is_better_result,
+        )
+
+        fewer_layers = RuleRelaxationResult(
+            tier=0, trace_width=0.2, clearance=0.15, via_drill=0.3,
+            via_diameter=0.6, tier_description="user", router=None,
+            net_map={}, nets_routed=0, nets_to_route=20,
+            completion=0.0, success=False, layer_count=2,
+            stats={"segments": 50, "vias": 5},
+        )
+        more_layers = RuleRelaxationResult(
+            tier=0, trace_width=0.2, clearance=0.15, via_drill=0.3,
+            via_diameter=0.6, tier_description="user", router=None,
+            net_map={}, nets_routed=0, nets_to_route=20,
+            completion=0.0, success=False, layer_count=4,
+            stats={"segments": 50, "vias": 5},
+        )
+
+        assert _is_better_result(fewer_layers, more_layers) is True
+        assert _is_better_result(more_layers, fewer_layers) is False
+
+    def test_none_stats_handled_gracefully(self):
+        """Results with None stats use 0 defaults for tiebreaker fields."""
+        from kicad_tools.cli.route_cmd import (
+            RuleRelaxationResult,
+            _is_better_result,
+        )
+
+        with_stats = RuleRelaxationResult(
+            tier=0, trace_width=0.2, clearance=0.15, via_drill=0.3,
+            via_diameter=0.6, tier_description="user", router=None,
+            net_map={}, nets_routed=0, nets_to_route=20,
+            completion=0.0, success=False, layer_count=2,
+            stats={"segments": 10, "vias": 1},
+        )
+        no_stats = RuleRelaxationResult(
+            tier=0, trace_width=0.2, clearance=0.15, via_drill=0.3,
+            via_diameter=0.6, tier_description="user", router=None,
+            net_map={}, nets_routed=0, nets_to_route=20,
+            completion=0.0, success=False, layer_count=2,
+            stats=None,
+        )
+
+        assert _is_better_result(with_stats, no_stats) is True
+        assert _is_better_result(no_stats, with_stats) is False
+
+    def test_layer_escalation_result_works(self):
+        """_is_better_result works with LayerEscalationResult too."""
+        from kicad_tools.cli.route_cmd import (
+            LayerEscalationResult,
+            _is_better_result,
+        )
+
+        better = LayerEscalationResult(
+            layer_count=2, layer_stack=None, router=None, net_map={},
+            nets_routed=0, nets_to_route=20, completion=0.0, success=False,
+            stats={"segments": 30, "vias": 5},
+        )
+        worse = LayerEscalationResult(
+            layer_count=4, layer_stack=None, router=None, net_map={},
+            nets_routed=0, nets_to_route=20, completion=0.0, success=False,
+            stats={"segments": 10, "vias": 1},
+        )
+
+        assert _is_better_result(better, worse) is True
+        assert _is_better_result(worse, better) is False
+
+
+class TestTiebreakerInRuleRelaxation:
+    """Integration: verify tiebreaker selects best result in rule relaxation."""
+
+    def test_early_stop_does_not_trigger_on_tied_completion(self):
+        """When all completions are 0.0, early-stop should not trigger."""
+        from kicad_tools.cli.route_cmd import route_with_rule_relaxation
+
+        tiers = [
+            FakeTier(0, "user", 0.2, 0.15),
+            FakeTier(1, "moderate", 0.15, 0.127),
+            FakeTier(2, "aggressive", 0.127, 0.1),
+        ]
+
+        # All tie at 0% completion
+        routers = [
+            _make_fake_router(0, 20, segments=10),
+            _make_fake_router(0, 20, segments=20),
+            _make_fake_router(0, 20, segments=30),
+        ]
+        router_idx = [0]
+
+        def fake_load_pcb(*args, **kwargs):
+            r = routers[router_idx[0]]
+            router_idx[0] += 1
+            return r, {"net1": 1}
+
+        args = _make_args()  # early_stop enabled (default)
+
+        with _patches_for_relaxation(tiers, fake_load_pcb):
+            route_with_rule_relaxation(
+                pcb_path=MagicMock(),
+                output_path=MagicMock(),
+                args=args,
+                quiet=True,
+            )
+
+        # All 3 tiers should run (no regression in completion, all 0.0)
+        assert router_idx[0] == 3


### PR DESCRIPTION
## Summary

- Add shared `_is_better_result()` helper with tiebreaker cascade: completion > segments > vias > fewer layers
- Apply to all three escalation functions: `route_with_layer_escalation`, `route_with_adaptive_rules`, `route_with_combined_escalation`
- Store `stats` dict on `LayerEscalationResult` and `RuleRelaxationResult` dataclasses for zero-cost access to secondary metrics

Closes #2397

## Test plan

- [x] Unit tests for `_is_better_result`: higher completion wins, segment tiebreaker, via tiebreaker, layer count tiebreaker, None stats handled
- [x] Integration test: early-stop does not trigger when completions are tied at 0.0
- [x] LayerEscalationResult works with the helper
- [x] All 24 existing tests pass unchanged (31 total with new tests)
- [x] `pytest tests/test_adaptive_early_stop.py tests/test_layer_escalation.py` -- 31 passed

Generated with [Claude Code](https://claude.com/claude-code)