### PR TITLE
test(router): add pad dimension rotation tests

### DIFF
--- a/tests/test_footprint_rotation.py
+++ b/tests/test_footprint_rotation.py
@@ -1,7 +1,8 @@
 """Tests for footprint rotation handling in router and validation.
 
 Verifies that pad positions are correctly transformed when footprints
-are rotated (issue #727).
+are rotated (issue #727), and that pad dimensions are swapped to PCB
+space when the total rotation is 90 or 270 degrees (issue #2400).
 """
 
 import math
@@ -138,3 +139,111 @@ class TestClearanceValidationRotation:
         # Expected: (112.5, 109.0)
         assert abs_x == pytest.approx(112.5, abs=0.001)
         assert abs_y == pytest.approx(109.0, abs=0.001)
+
+
+def _make_pcb_text(fp_rotation: float, pad_rotation: float | None = None) -> str:
+    """Build a minimal KiCad PCB S-expression for testing pad dimension rotation.
+
+    The pad has local-frame size 1.475 x 0.400 (asymmetric so we can detect swaps).
+
+    Args:
+        fp_rotation: Footprint rotation in degrees.
+        pad_rotation: Optional pad-local rotation in degrees.  When None the
+            pad ``(at ...)`` omits the rotation field.
+    """
+    fp_at = f"(at 100 100 {fp_rotation})"
+    if pad_rotation is not None:
+        pad_at = f"(at -1.0 0 {pad_rotation})"
+    else:
+        pad_at = "(at -1.0 0)"
+    return (
+        "(kicad_pcb (version 20221018)\n"
+        f'  (footprint "TestPkg" {fp_at}\n'
+        '    (fp_text reference "U1" (at 0 0))\n'
+        f'    (pad "1" smd rect {pad_at} (size 1.475 0.400)\n'
+        '      (layers "F.Cu") (net 1 "VCC"))\n'
+        "  )\n"
+        ")"
+    )
+
+
+class TestPadDimensionRotation:
+    """Tests that pad width/height are swapped to PCB space at 90/270 degrees.
+
+    The fix (commit a3122259) swaps width and height when the total rotation
+    (footprint + pad) is approximately 90 or 270 degrees.  At 0 and 180 degrees
+    the dimensions remain unchanged.
+    """
+
+    def test_0_degree_rotation_no_swap(self):
+        """At 0-degree rotation, pad dimensions stay as defined (1.475 x 0.400)."""
+        from kicad_tools.router.io import load_pads_for_analysis
+
+        pads = load_pads_for_analysis(_make_pcb_text(0))
+        assert len(pads) == 1
+        assert pads[0].width == pytest.approx(1.475, abs=0.001)
+        assert pads[0].height == pytest.approx(0.400, abs=0.001)
+
+    def test_90_degree_rotation_swaps_dimensions(self):
+        """At 90-degree rotation, width and height should be swapped."""
+        from kicad_tools.router.io import load_pads_for_analysis
+
+        pads = load_pads_for_analysis(_make_pcb_text(90))
+        assert len(pads) == 1
+        # Swapped: original 1.475 x 0.400 becomes 0.400 x 1.475
+        assert pads[0].width == pytest.approx(0.400, abs=0.001)
+        assert pads[0].height == pytest.approx(1.475, abs=0.001)
+
+    def test_180_degree_rotation_no_swap(self):
+        """At 180-degree rotation, dimensions stay unchanged."""
+        from kicad_tools.router.io import load_pads_for_analysis
+
+        pads = load_pads_for_analysis(_make_pcb_text(180))
+        assert len(pads) == 1
+        assert pads[0].width == pytest.approx(1.475, abs=0.001)
+        assert pads[0].height == pytest.approx(0.400, abs=0.001)
+
+    def test_270_degree_rotation_swaps_dimensions(self):
+        """At 270-degree rotation, width and height should be swapped."""
+        from kicad_tools.router.io import load_pads_for_analysis
+
+        pads = load_pads_for_analysis(_make_pcb_text(270))
+        assert len(pads) == 1
+        assert pads[0].width == pytest.approx(0.400, abs=0.001)
+        assert pads[0].height == pytest.approx(1.475, abs=0.001)
+
+    def test_negative_90_degree_rotation_swaps_dimensions(self):
+        """At -90-degree rotation (equivalent to 270), dimensions should swap."""
+        from kicad_tools.router.io import load_pads_for_analysis
+
+        pads = load_pads_for_analysis(_make_pcb_text(-90))
+        assert len(pads) == 1
+        assert pads[0].width == pytest.approx(0.400, abs=0.001)
+        assert pads[0].height == pytest.approx(1.475, abs=0.001)
+
+    def test_combined_fp_and_pad_rotation_totaling_90(self):
+        """When footprint (45) + pad (45) = 90 total, dimensions should swap."""
+        from kicad_tools.router.io import load_pads_for_analysis
+
+        pads = load_pads_for_analysis(_make_pcb_text(45, pad_rotation=45))
+        assert len(pads) == 1
+        assert pads[0].width == pytest.approx(0.400, abs=0.001)
+        assert pads[0].height == pytest.approx(1.475, abs=0.001)
+
+    def test_combined_fp_and_pad_rotation_totaling_270(self):
+        """When footprint (180) + pad (90) = 270 total, dimensions should swap."""
+        from kicad_tools.router.io import load_pads_for_analysis
+
+        pads = load_pads_for_analysis(_make_pcb_text(180, pad_rotation=90))
+        assert len(pads) == 1
+        assert pads[0].width == pytest.approx(0.400, abs=0.001)
+        assert pads[0].height == pytest.approx(1.475, abs=0.001)
+
+    def test_combined_fp_and_pad_rotation_totaling_180_no_swap(self):
+        """When footprint (90) + pad (90) = 180 total, dimensions stay unchanged."""
+        from kicad_tools.router.io import load_pads_for_analysis
+
+        pads = load_pads_for_analysis(_make_pcb_text(90, pad_rotation=90))
+        assert len(pads) == 1
+        assert pads[0].width == pytest.approx(1.475, abs=0.001)
+        assert pads[0].height == pytest.approx(0.400, abs=0.001)


### PR DESCRIPTION
## Summary

- Add 8 unit tests in `TestPadDimensionRotation` class covering the pad width/height swap logic in `load_pads_for_analysis()` (fix from commit a3122259)
- Tests verify dimensions swap at 90/270 degrees and remain unchanged at 0/180 degrees
- Includes combined footprint + pad rotation cases (e.g., fp=45 + pad=45 = 90 total triggers swap)

Closes #2400

## Test plan

- [x] `test_0_degree_rotation_no_swap` -- dimensions unchanged at 0 degrees
- [x] `test_90_degree_rotation_swaps_dimensions` -- width/height swapped at 90 degrees
- [x] `test_180_degree_rotation_no_swap` -- dimensions unchanged at 180 degrees
- [x] `test_270_degree_rotation_swaps_dimensions` -- width/height swapped at 270 degrees
- [x] `test_negative_90_degree_rotation_swaps_dimensions` -- -90 degrees (equivalent to 270) swaps
- [x] `test_combined_fp_and_pad_rotation_totaling_90` -- fp=45 + pad=45 triggers swap
- [x] `test_combined_fp_and_pad_rotation_totaling_270` -- fp=180 + pad=90 triggers swap
- [x] `test_combined_fp_and_pad_rotation_totaling_180_no_swap` -- fp=90 + pad=90 = 180, no swap
- [x] All 7 existing tests in `test_footprint_rotation.py` continue to pass

Generated with [Claude Code](https://claude.com/claude-code)