### PR TITLE
fix(router): via minimizer breaks layer connectivity

### DIFF
--- a/src/kicad_tools/router/optimizer/trace.py
+++ b/src/kicad_tools/router/optimizer/trace.py
@@ -305,6 +305,24 @@ class TraceOptimizer:
         if self.config.minimize_vias:
             optimized_route = self._via_optimizer.optimize_route(optimized_route)
 
+        # Re-run the connectivity-preserving guard after via minimization
+        # so that via removals that break pad connectivity are caught and
+        # the entire route is reverted to pre-optimisation state.  The
+        # earlier guard (above) only checks segment optimisation; this one
+        # covers via-induced disconnects (issue #2402).
+        if not _endpoints_preserved(
+            pre_endpoints,
+            list(optimized_route.segments),
+            list(optimized_route.vias),
+            tolerance=self.config.tolerance,
+        ):
+            optimized_route = Route(
+                net=route.net,
+                net_name=route.net_name,
+                segments=list(route.segments),
+                vias=list(route.vias),
+            )
+
         return optimized_route
 
     def optimize_pcb(

--- a/src/kicad_tools/router/optimizer/via_optimizer.py
+++ b/src/kicad_tools/router/optimizer/via_optimizer.py
@@ -24,6 +24,96 @@ if TYPE_CHECKING:
     pass
 
 
+def _via_removal_preserves_connectivity(
+    segments: list[Segment],
+    vias: list[Via],
+    candidate_via: Via,
+    seg_before: Segment,
+    seg_after: Segment,
+    alt_path: list[Segment],
+    tolerance: float = 1e-4,
+) -> bool:
+    """Check whether removing *candidate_via* preserves pad connectivity.
+
+    Computes the degree-1 (pad-like) terminal endpoints from the
+    *current* segment+via graph, then simulates the removal (drop
+    ``candidate_via``, ``seg_before``, ``seg_after``; add ``alt_path``)
+    and verifies every original terminal is still reachable in a single
+    connected component of the hypothetical graph.
+
+    The key insight is that terminals are identified on the *pre-removal*
+    graph.  If a pad exists on B.Cu, its vertex must still be present and
+    connected after the removal even though the hypothetical graph may no
+    longer contain any B.Cu segments.
+    """
+
+    def _key(x: float, y: float, layer: Layer) -> tuple[int, int, int]:
+        if tolerance <= 0:
+            qx = int(round(x * 1e9))
+            qy = int(round(y * 1e9))
+        else:
+            qx = int(round(x / tolerance))
+            qy = int(round(y / tolerance))
+        return (qx, qy, int(layer.value))
+
+    # --- Identify terminals on the CURRENT (pre-removal) graph. ---
+    pre_counts: dict[tuple[int, int, int], int] = {}
+    for seg in segments:
+        for x, y in (seg.start, seg.end):
+            k = _key(x, y, seg.layer)
+            pre_counts[k] = pre_counts.get(k, 0) + 1
+    terminals = {k for k, c in pre_counts.items() if c == 1}
+
+    if len(terminals) < 2:
+        return True  # Nothing to disconnect
+
+    # --- Build the hypothetical segment list after the removal. ---
+    hyp_segments: list[Segment] = []
+    for seg in segments:
+        if seg is seg_before or seg is seg_after:
+            continue
+        hyp_segments.append(seg)
+    hyp_segments.extend(alt_path)
+
+    hyp_vias: list[Via] = [v for v in vias if v is not candidate_via]
+
+    # --- Build adjacency graph of the hypothetical state. ---
+    adjacency: dict[tuple[int, int, int], set[tuple[int, int, int]]] = {}
+
+    def _add(a: tuple[int, int, int], b: tuple[int, int, int]) -> None:
+        adjacency.setdefault(a, set()).add(b)
+        adjacency.setdefault(b, set()).add(a)
+
+    for seg in hyp_segments:
+        a = _key(seg.x1, seg.y1, seg.layer)
+        b = _key(seg.x2, seg.y2, seg.layer)
+        _add(a, b)
+
+    for via in hyp_vias:
+        if not via.layers or len(via.layers) < 2:
+            continue
+        a = _key(via.x, via.y, via.layers[0])
+        b = _key(via.x, via.y, via.layers[1])
+        _add(a, b)
+
+    # Every original terminal must still exist in the hypothetical graph.
+    if not terminals.issubset(adjacency.keys()):
+        return False
+
+    # All terminals must lie in the same connected component (BFS).
+    start = next(iter(terminals))
+    visited: set[tuple[int, int, int]] = {start}
+    queue = [start]
+    while queue:
+        node = queue.pop()
+        for nbr in adjacency.get(node, ()):
+            if nbr not in visited:
+                visited.add(nbr)
+                queue.append(nbr)
+
+    return terminals.issubset(visited)
+
+
 @dataclass
 class ViaContext:
     """Context for a via within a route.
@@ -380,12 +470,23 @@ class ViaOptimizer:
             )
 
             if alt_path:
-                # Apply the optimization
-                self._apply_single_via_removal(
-                    ctx, seg_before, seg_after, alt_path, segments, vias, route
-                )
-                removed += 1
-                continue
+                # Verify removing this via preserves pad connectivity
+                if _via_removal_preserves_connectivity(
+                    segments,
+                    vias,
+                    ctx.via,
+                    seg_before,
+                    seg_after,
+                    alt_path,
+                    tolerance=self.config.tolerance,
+                ):
+                    self._apply_single_via_removal(
+                        ctx, seg_before, seg_after, alt_path, segments, vias, route
+                    )
+                    removed += 1
+                    continue
+                # Connectivity would break on the 'before' layer -- fall
+                # through to try the 'after' layer instead.
 
             # Try on the 'after' layer
             alt_path = self._find_same_layer_path(
@@ -400,10 +501,19 @@ class ViaOptimizer:
             )
 
             if alt_path:
-                self._apply_single_via_removal(
-                    ctx, seg_before, seg_after, alt_path, segments, vias, route
-                )
-                removed += 1
+                if _via_removal_preserves_connectivity(
+                    segments,
+                    vias,
+                    ctx.via,
+                    seg_before,
+                    seg_after,
+                    alt_path,
+                    tolerance=self.config.tolerance,
+                ):
+                    self._apply_single_via_removal(
+                        ctx, seg_before, seg_after, alt_path, segments, vias, route
+                    )
+                    removed += 1
 
         return removed
 

--- a/tests/test_via_optimizer.py
+++ b/tests/test_via_optimizer.py
@@ -397,3 +397,109 @@ class TestOptimizationWithValidation:
         assert stats.vias_before == 1
         # Via count after depends on whether optimization was applied
         assert stats.vias_after >= 0
+
+
+class TestViaConnectivityPreservation:
+    """Test that via minimization preserves multi-layer pad connectivity."""
+
+    def test_required_via_not_removed_when_pads_on_both_layers(self):
+        """A via connecting pads on F.Cu and B.Cu must not be removed.
+
+        Scenario: pad on F.Cu at (0,0) -- seg F.Cu --> via at (5,0) -- seg B.Cu --> pad on B.Cu at (10,0).
+        The via is the only connection between layers; removing it disconnects
+        the B.Cu pad.  The optimizer must keep it.
+        """
+        optimizer = ViaOptimizer()
+
+        seg1 = Segment(x1=0, y1=0, x2=5, y2=0, width=0.2, layer=Layer.F_CU, net=1)
+        via = Via(x=5, y=0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=1)
+        seg2 = Segment(x1=5, y1=0, x2=10, y2=0, width=0.2, layer=Layer.B_CU, net=1)
+
+        route = Route(net=1, net_name="Net1", segments=[seg1, seg2], vias=[via])
+        result = optimizer.optimize_route(route)
+
+        # The via MUST be retained -- removing it would disconnect the B.Cu pad.
+        assert len(result.vias) == 1, (
+            "Required via was removed, breaking layer connectivity"
+        )
+
+    def test_redundant_via_still_removed_when_pads_on_same_layer(self):
+        """A via between same-layer pads is redundant and should be removed.
+
+        Scenario: pad on F.Cu at (0,0) -- seg F.Cu --> via at (1,0) -- seg B.Cu --> via at (2,0) -- seg F.Cu --> pad at (3,0).
+        The down-up via pair is redundant because both endpoints are on F.Cu.
+        Vias are placed within the via_pair_threshold (2.0 mm).
+        """
+        optimizer = ViaOptimizer()
+
+        seg1 = Segment(x1=0, y1=0, x2=1, y2=0, width=0.2, layer=Layer.F_CU, net=1)
+        via1 = Via(x=1, y=0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=1)
+        seg2 = Segment(x1=1, y1=0, x2=2, y2=0, width=0.2, layer=Layer.B_CU, net=1)
+        via2 = Via(x=2, y=0, drill=0.3, diameter=0.6, layers=(Layer.B_CU, Layer.F_CU), net=1)
+        seg3 = Segment(x1=2, y1=0, x2=3, y2=0, width=0.2, layer=Layer.F_CU, net=1)
+
+        route = Route(net=1, net_name="Net1", segments=[seg1, seg2, seg3], vias=[via1, via2])
+        result = optimizer.optimize_route(route)
+
+        # Both vias should be removable (via pair elimination).
+        assert len(result.vias) < 2, (
+            "Redundant via pair was not removed"
+        )
+
+    def test_partial_via_removal_with_three_vias(self):
+        """In a route with 3 vias, only redundant ones should be removed.
+
+        Scenario: F.Cu pad -> via1(F->B) -> B.Cu segment -> via2(B->F) -> F.Cu segment -> via3(F->B) -> B.Cu pad.
+        via1+via2 form a redundant pair (down-up), but via3 is required for
+        the B.Cu pad.  Only via1+via2 should be removed.
+        """
+        optimizer = ViaOptimizer()
+
+        seg1 = Segment(x1=0, y1=0, x2=2, y2=0, width=0.2, layer=Layer.F_CU, net=1)
+        via1 = Via(x=2, y=0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=1)
+        seg2 = Segment(x1=2, y1=0, x2=4, y2=0, width=0.2, layer=Layer.B_CU, net=1)
+        via2 = Via(x=4, y=0, drill=0.3, diameter=0.6, layers=(Layer.B_CU, Layer.F_CU), net=1)
+        seg3 = Segment(x1=4, y1=0, x2=8, y2=0, width=0.2, layer=Layer.F_CU, net=1)
+        via3 = Via(x=8, y=0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=1)
+        seg4 = Segment(x1=8, y1=0, x2=12, y2=0, width=0.2, layer=Layer.B_CU, net=1)
+
+        route = Route(
+            net=1,
+            net_name="Net1",
+            segments=[seg1, seg2, seg3, seg4],
+            vias=[via1, via2, via3],
+        )
+        result = optimizer.optimize_route(route)
+
+        # via3 must be kept (connects to B.Cu pad at (12,0))
+        assert len(result.vias) >= 1, "All vias removed -- B.Cu pad disconnected"
+
+        # Check layer connectivity is valid
+        errors = optimizer.validate_layer_connectivity(result)
+        assert len(errors) == 0, f"Layer connectivity errors: {errors}"
+
+
+class TestEndpointsPreservedAfterViaMinimization:
+    """Test that _endpoints_preserved guard in TraceOptimizer catches via-induced disconnects."""
+
+    def test_trace_optimizer_preserves_multi_layer_connectivity(self):
+        """TraceOptimizer.optimize_route must not break multi-layer pad connectivity.
+
+        This is the end-to-end test through TraceOptimizer, verifying that
+        the _endpoints_preserved guard runs after via minimization.
+        """
+        config = OptimizationConfig(minimize_vias=True)
+        optimizer = TraceOptimizer(config=config)
+
+        # Pad on F.Cu at (0,0), pad on B.Cu at (10,0), connected by via at (5,0)
+        seg1 = Segment(x1=0, y1=0, x2=5, y2=0, width=0.2, layer=Layer.F_CU, net=1)
+        via = Via(x=5, y=0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=1)
+        seg2 = Segment(x1=5, y1=0, x2=10, y2=0, width=0.2, layer=Layer.B_CU, net=1)
+
+        route = Route(net=1, net_name="Net1", segments=[seg1, seg2], vias=[via])
+        result = optimizer.optimize_route(route)
+
+        # The via must remain -- the B.Cu pad would be disconnected without it
+        assert len(result.vias) >= 1, (
+            "TraceOptimizer removed required via, breaking layer connectivity"
+        )


### PR DESCRIPTION
## Summary

- Add per-via connectivity check (`_via_removal_preserves_connectivity`) in `ViaOptimizer._remove_single_vias()` that builds a hypothetical segment+via graph and verifies all pad-like terminals remain in a single connected component before each via removal
- Re-run `_endpoints_preserved` guard after via minimization in `TraceOptimizer.optimize_route()` as a belt-and-suspenders safety net (the existing guard only ran before via minimization)
- Add 4 new test cases covering required via retention, redundant via pair removal, partial via removal in 3-via routes, and end-to-end TraceOptimizer connectivity preservation

Closes #2402

## Test plan

- [x] `test_required_via_not_removed_when_pads_on_both_layers` -- via connecting F.Cu and B.Cu pads is retained
- [x] `test_redundant_via_still_removed_when_pads_on_same_layer` -- redundant down-up via pair is still eliminated
- [x] `test_partial_via_removal_with_three_vias` -- only redundant vias removed in mixed route
- [x] `test_trace_optimizer_preserves_multi_layer_connectivity` -- end-to-end guard catches via-induced disconnects
- [x] All 31 via optimizer tests pass
- [x] All 79 trace optimizer tests pass
- [x] All 52 related via tests pass (via_conflict, via_impact, via_placement_regression)

Generated with [Claude Code](https://claude.com/claude-code)