### PR TITLE
feat(router): auto-create copper pour zones for power nets before routing

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -927,6 +927,12 @@ def route_with_layer_escalation(
     if args.skip_nets:
         skip_nets = [n.strip() for n in args.skip_nets.split(",")]
 
+    # Auto-create copper pours for power nets (before skip detection)
+    if getattr(args, "auto_pour", True):
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        auto_pour_if_missing(pcb_path, quiet=quiet)
+
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
 
@@ -1373,6 +1379,12 @@ def route_with_rule_relaxation(
     skip_nets = []
     if args.skip_nets:
         skip_nets = [n.strip() for n in args.skip_nets.split(",")]
+
+    # Auto-create copper pours for power nets (before skip detection)
+    if getattr(args, "auto_pour", True):
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        auto_pour_if_missing(pcb_path, quiet=quiet)
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
@@ -1839,6 +1851,12 @@ def route_with_combined_escalation(
     skip_nets = []
     if args.skip_nets:
         skip_nets = [n.strip() for n in args.skip_nets.split(",")]
+
+    # Auto-create copper pours for power nets (before skip detection)
+    if getattr(args, "auto_pour", True):
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        auto_pour_if_missing(pcb_path, quiet=quiet)
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
@@ -2648,6 +2666,16 @@ def main(argv: list[str] | None = None) -> int:
         help="Alias for --no-optimize (keep raw grid-step segments for debugging)",
     )
     parser.add_argument(
+        "--auto-pour",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Automatically create copper pour zones for power-classified "
+            "nets (GND, VCC, etc.) when the input PCB has none "
+            "(default: enabled). Use --no-auto-pour to disable."
+        ),
+    )
+    parser.add_argument(
         "--auto-layers",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -3167,6 +3195,12 @@ def main(argv: list[str] | None = None) -> int:
     skip_nets = []
     if args.skip_nets:
         skip_nets = [n.strip() for n in args.skip_nets.split(",")]
+
+    # Auto-create copper pours for power nets (before skip detection)
+    if getattr(args, "auto_pour", True):
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        auto_pour_if_missing(pcb_path, quiet=args.quiet)
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=args.quiet)

--- a/src/kicad_tools/router/auto_pour.py
+++ b/src/kicad_tools/router/auto_pour.py
@@ -1,0 +1,120 @@
+"""Auto-create copper pour zones for power-classified nets.
+
+This module provides a helper that inspects a PCB file, classifies its
+nets, and auto-inserts zone definitions for power/ground nets when the
+file has no existing zones for them.  It is designed to be called by
+``kct route`` before routing begins so that power nets are connected via
+copper pours rather than routed as ordinary signal traces.
+
+A board-level heuristic prevents small all-power designs (e.g., a simple
+voltage divider whose only nets are VIN, VOUT, GND) from being
+inadvertently drained of routable nets: auto-pour is only applied when
+the board has at least one signal (non-power/ground) net, indicating
+that the power nets are infrastructure rather than the entire design.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def auto_pour_if_missing(
+    pcb_path: Path,
+    *,
+    quiet: bool = False,
+) -> tuple[int, list[str]]:
+    """Auto-create copper pours for power-classified nets that lack zones.
+
+    Idempotent: skips nets that already have zones.  Skips boards where
+    *every* net is power/ground-classified (small designs do not benefit
+    from pours, and skipping all nets removes them from routing entirely).
+
+    Args:
+        pcb_path: Path to .kicad_pcb file (modified **in place**).
+        quiet: Suppress informational output.
+
+    Returns:
+        Tuple of ``(zones_created, pour_net_names)`` where
+        *pour_net_names* lists the nets that received new zones.
+    """
+    from kicad_tools.router.net_class import NetClass, auto_classify_nets
+    from kicad_tools.zones.generator import auto_create_zones_for_pour_nets
+
+    pcb_path = Path(pcb_path)
+    pcb_text = pcb_path.read_text()
+
+    # ------------------------------------------------------------------
+    # 1. Build net inventory from the file header
+    # ------------------------------------------------------------------
+    net_names: dict[int, str] = {}
+    for m in re.finditer(r'\(net\s+(\d+)\s+"([^"]+)"\)', pcb_text):
+        net_num, name = int(m.group(1)), m.group(2)
+        if net_num > 0:
+            net_names[net_num] = name
+
+    if not net_names:
+        return 0, []
+
+    # ------------------------------------------------------------------
+    # 2. Classify nets
+    # ------------------------------------------------------------------
+    classifications = auto_classify_nets(net_names)
+
+    pour_nets: list[tuple[str, NetClass]] = []
+    signal_net_count = 0
+    for net_id, classification in classifications.items():
+        if classification.net_class in (NetClass.POWER, NetClass.GROUND):
+            pour_nets.append((net_names[net_id], classification.net_class))
+        else:
+            signal_net_count += 1
+
+    # Count unclassified nets (those that didn't meet confidence threshold)
+    # as signal nets -- they are certainly not power/ground.
+    unclassified = len(net_names) - len(classifications)
+    signal_net_count += unclassified
+
+    if not pour_nets:
+        return 0, []
+
+    # ------------------------------------------------------------------
+    # 3. Board-level guard: skip if ALL nets are power/ground
+    # ------------------------------------------------------------------
+    if signal_net_count == 0:
+        if not quiet:
+            print(
+                "Auto-pour: skipped (all nets are power/ground — "
+                "routing as signals instead)"
+            )
+        return 0, []
+
+    # ------------------------------------------------------------------
+    # 4. Idempotency: filter out nets that already have zones
+    # ------------------------------------------------------------------
+    nets_with_zones: set[str] = set()
+    # KiCad 7/8 format: (zone ... (net_name "GND") ...)
+    for zm in re.finditer(
+        r'\(zone\s+.*?\(net_name\s+"([^"]+)"\)', pcb_text, re.DOTALL
+    ):
+        nets_with_zones.add(zm.group(1))
+    # KiCad 9 name-only format: (zone ... (net "GND") ...)
+    for zm in re.finditer(r'\(zone\s[^)]*\(net\s+"([^"]+)"\)', pcb_text):
+        nets_with_zones.add(zm.group(1))
+
+    new_pour_nets = [
+        (name, cls) for name, cls in pour_nets if name not in nets_with_zones
+    ]
+
+    if not new_pour_nets:
+        return 0, []
+
+    # ------------------------------------------------------------------
+    # 5. Create zones via the shared generator
+    # ------------------------------------------------------------------
+    count = auto_create_zones_for_pour_nets(pcb_path, new_pour_nets)
+
+    names = [name for name, _ in new_pour_nets]
+    if not quiet and count > 0:
+        print(f"Auto-pour: created {count} zone(s) for {', '.join(sorted(names))}")
+
+    return count, names

--- a/tests/test_auto_pour.py
+++ b/tests/test_auto_pour.py
@@ -1,0 +1,208 @@
+"""Tests for auto_pour_if_missing() helper.
+
+Verifies that copper pour zones are automatically created for
+power-classified nets when the PCB has no existing zones, while
+respecting the board-level guard (all-power boards are left alone).
+"""
+
+from pathlib import Path
+
+import pytest
+
+# Minimal PCB skeleton for testing.  Footprints contain pads with net
+# references; the zone generator reads net definitions from the header.
+_PCB_HEADER = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+"""
+
+_PCB_FOOTER = """\
+  (gr_line (start 0 0) (end 50 0) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 50 0) (end 50 50) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 50 50) (end 0 50) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 0 50) (end 0 0) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
+)
+"""
+
+
+def _make_pcb(
+    net_defs: list[tuple[int, str]],
+    pad_nets: list[tuple[int, str]],
+    zones: list[str] | None = None,
+) -> str:
+    """Build a minimal PCB string.
+
+    Args:
+        net_defs: (net_id, net_name) pairs for the header.
+        pad_nets: (net_id, net_name) pairs for pad references inside a
+            dummy footprint.
+        zones: Optional list of zone S-expression strings to insert.
+    """
+    parts = [_PCB_HEADER]
+    parts.append('  (net 0 "")\n')
+    for nid, name in net_defs:
+        parts.append(f'  (net {nid} "{name}")\n')
+
+    # Single dummy footprint with pads
+    parts.append(
+        '  (footprint "TestLib:TestPkg" (layer "F.Cu") (at 10 10)\n'
+    )
+    for idx, (nid, name) in enumerate(pad_nets):
+        x_off = idx * 2.0
+        parts.append(
+            f'    (pad "{idx + 1}" smd roundrect (at {x_off} 0) '
+            f'(size 1.0 1.3) (layers "F.Cu" "F.Paste" "F.Mask") '
+            f'(roundrect_rratio 0.25) (net {nid} "{name}"))\n'
+        )
+    parts.append("  )\n")
+
+    if zones:
+        for z in zones:
+            parts.append(f"  {z}\n")
+
+    parts.append(_PCB_FOOTER)
+    return "".join(parts)
+
+
+class TestAutoPourIfMissing:
+    """Unit tests for auto_pour_if_missing."""
+
+    def test_creates_zones_for_power_nets_with_signals(self, tmp_path: Path):
+        """Zones are created when power nets coexist with signal nets."""
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        pcb = _make_pcb(
+            net_defs=[(1, "GND"), (2, "VCC"), (3, "SDA"), (4, "SCL")],
+            pad_nets=[
+                (1, "GND"),
+                (2, "VCC"),
+                (3, "SDA"),
+                (4, "SCL"),
+            ],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(pcb_path)
+
+        assert count == 2
+        assert set(names) == {"GND", "VCC"}
+        # Verify zones actually written to file
+        text = pcb_path.read_text()
+        assert "(zone" in text
+
+    def test_skips_all_power_board(self, tmp_path: Path):
+        """No zones created when every net is power/ground (board 01 guard)."""
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        pcb = _make_pcb(
+            net_defs=[(1, "VIN"), (2, "VOUT"), (3, "GND")],
+            pad_nets=[
+                (1, "VIN"),
+                (1, "VIN"),
+                (2, "VOUT"),
+                (2, "VOUT"),
+                (2, "VOUT"),
+                (3, "GND"),
+                (3, "GND"),
+                (3, "GND"),
+            ],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(pcb_path)
+
+        assert count == 0
+        assert names == []
+        text = pcb_path.read_text()
+        assert "(zone" not in text
+
+    def test_idempotent_second_call(self, tmp_path: Path):
+        """Calling twice produces the same result -- second call is a no-op."""
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        pcb = _make_pcb(
+            net_defs=[(1, "GND"), (2, "SDA")],
+            pad_nets=[(1, "GND"), (2, "SDA")],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count1, names1 = auto_pour_if_missing(pcb_path)
+        assert count1 == 1
+        assert names1 == ["GND"]
+
+        count2, names2 = auto_pour_if_missing(pcb_path)
+        assert count2 == 0
+        assert names2 == []
+
+    def test_skips_nets_with_existing_zones(self, tmp_path: Path):
+        """Nets that already have zones are not re-created."""
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        zone_gnd = (
+            '(zone (net 1) (net_name "GND") (layer "B.Cu") (hatch edge 0.5) '
+            "(connect_pads (clearance 0.25)) "
+            "(fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5)) "
+            "(polygon (pts (xy 0 0) (xy 50 0) (xy 50 50) (xy 0 50))))"
+        )
+        pcb = _make_pcb(
+            net_defs=[(1, "GND"), (2, "VCC"), (3, "SDA")],
+            pad_nets=[(1, "GND"), (2, "VCC"), (3, "SDA")],
+            zones=[zone_gnd],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(pcb_path)
+
+        # Only VCC should get a new zone; GND already has one
+        assert count == 1
+        assert names == ["VCC"]
+
+    def test_no_power_nets(self, tmp_path: Path):
+        """No zones created when there are no power-classified nets."""
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        pcb = _make_pcb(
+            net_defs=[(1, "SDA"), (2, "SCL")],
+            pad_nets=[(1, "SDA"), (2, "SCL")],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(pcb_path)
+
+        assert count == 0
+        assert names == []
+
+    def test_nonexistent_file_raises(self, tmp_path: Path):
+        """Raises FileNotFoundError for a missing PCB file."""
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        with pytest.raises(FileNotFoundError):
+            auto_pour_if_missing(tmp_path / "missing.kicad_pcb")
+
+    def test_empty_nets(self, tmp_path: Path):
+        """PCB with no nets returns 0 zones."""
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        pcb = _make_pcb(net_defs=[], pad_nets=[])
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(pcb_path)
+
+        assert count == 0
+        assert names == []


### PR DESCRIPTION
## Summary

When `kct route` is invoked on a PCB with no `(zone ...)` blocks, power-classified nets (GND, VCC, etc.) are routed as ordinary signal traces, causing stalls on multi-component boards. This PR adds automatic copper pour zone insertion for power nets before routing begins, reusing the existing `auto_create_zones_for_pour_nets` generator.

## Changes

- **New module `src/kicad_tools/router/auto_pour.py`**: `auto_pour_if_missing()` helper that classifies nets, checks for existing zones, and creates zones for power/ground nets. Includes a board-level guard: if every net is power-classified (e.g. a simple voltage divider), no zones are created to avoid draining all routable nets.
- **`src/kicad_tools/cli/route_cmd.py`**: Added `--auto-pour` / `--no-auto-pour` CLI flag (default: enabled). Wired up `auto_pour_if_missing()` at all four entry points (`main()`, `route_with_layer_escalation()`, `route_with_rule_relaxation()`, `route_with_combined_escalation()`) before `_auto_skip_pour_nets()`.
- **New test file `tests/test_auto_pour.py`**: 7 unit tests covering zone creation for mixed boards, all-power board guard, idempotency, existing zone skip, no power nets, missing file error, and empty nets.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board 02 gets zones for VCC and GND | PASS | Tested with actual board file: `auto_pour_if_missing` creates 2 zones |
| `--no-auto-pour` preserves today's behavior | PASS | Flag added with `BooleanOptionalAction`, guarded by `getattr(args, "auto_pour", True)` |
| No regression on board 01 (3/3 nets) | PASS | All-power guard correctly skips zone creation (0 zones, nets routed as signals) |
| Reuses `auto_create_zones_for_pour_nets` | PASS | Direct import and call in auto_pour.py |
| Idempotent | PASS | Unit test confirms second call returns (0, []) |

## Test Plan

- `uv run pytest tests/test_auto_pour.py -v` -- 7/7 pass
- `uv run pytest tests/test_auto_pour.py tests/test_route_cmd_params.py tests/test_zone_generator.py tests/test_net_class.py -v` -- 154/154 pass
- Manual validation against board 01 (0 zones, all-power guard) and board 02 (2 zones for GND, VCC)

Closes #2395