### PR TITLE
fix(router): pristine state per layer-escalation attempt and failed-net recovery

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -638,15 +638,25 @@ def _is_better_result(
 ) -> bool:
     """Compare routing results with tiebreaking on connectivity metrics.
 
-    The cascade is: completion > segments > vias > fewer layers.
-    When completions are tied (e.g. both 0.0), secondary metrics from the
-    router statistics break the tie so that the configuration with the most
-    routing progress wins (Issue #2397).
+    Issue #2396: The primary comparison uses **absolute nets_routed** rather
+    than completion ratio.  When ``nets_to_route`` differs across escalation
+    attempts (e.g. power nets auto-skipped on 4L but not 2L), comparing
+    ratios produces misleading results: 6/10 (0.60) vs 3/8 (0.375) looks
+    like a clear win for 2L, but the raw ratio comparison used to use
+    ``completion`` which could disagree when denominators differ.  Using
+    absolute counts ensures we always keep the attempt that routed the most
+    nets, breaking ties by completion ratio, then segments, vias, and layer
+    count.
     """
+    # Primary: absolute nets routed (cross-denominator safe)
+    if candidate.nets_routed != best.nets_routed:
+        return candidate.nets_routed > best.nets_routed
+
+    # Tied on absolute count: use completion ratio as tiebreaker
     if candidate.completion != best.completion:
         return candidate.completion > best.completion
 
-    # Tie on completion -- use stats-based tiebreakers
+    # Tie on completion -- use stats-based tiebreakers (Issue #2397)
     c_stats = candidate.stats or {}
     b_stats = best.stats or {}
 
@@ -1008,6 +1018,12 @@ def route_with_layer_escalation(
                 print(f"  Error loading PCB: {e}")
             continue
 
+        # Issue #2396: Ensure pristine per-attempt state.  Today this is a
+        # no-op (load_pcb_for_routing creates a fresh Autorouter) but it
+        # documents the contract and prevents silent regression if future
+        # refactors reuse an Autorouter across attempts.
+        router.reset_attempt_state()
+
         # Issue #1841: Tell the autorouter which pour nets lack zones
         router._pour_nets_without_zones = set(_no_zone)
 
@@ -1088,9 +1104,15 @@ def route_with_layer_escalation(
             stats=stats,
         )
 
-        # Track best result (Issue #2397: use tiebreaker cascade)
+        # Track best result (Issue #2396: absolute nets_routed comparison)
         if best_result is None or _is_better_result(result, best_result):
             best_result = result
+            if not quiet:
+                flush_print(
+                    f"  Best result so far: {best_result.layer_count}L with "
+                    f"{best_result.nets_routed}/{best_result.nets_to_route} "
+                    f"({best_result.completion:.0%})"
+                )
 
         # Issue #2388: Record any power-net stall for the next attempt's
         # bias logic.  ``power_stall_nets`` is populated by
@@ -1550,7 +1572,7 @@ def route_with_rule_relaxation(
             stats=stats,
         )
 
-        # Track best result (Issue #2397: use tiebreaker cascade)
+        # Track best result (Issue #2396: absolute nets_routed comparison)
         if best_result is None or _is_better_result(result, best_result):
             best_result = result
             # Update interrupt state so signal handler saves the best attempt
@@ -2023,7 +2045,7 @@ def route_with_combined_escalation(
                 stats=stats,
             )
 
-            # Track best result (Issue #2397: use tiebreaker cascade)
+            # Track best result (Issue #2396: absolute nets_routed comparison)
             if best_result is None or _is_better_result(result, best_result):
                 best_result = result
                 # Update interrupt state so signal handler saves the best attempt

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1666,6 +1666,25 @@ class Autorouter:
         """
         self._perturbation_magnitude = 0.0
 
+    def reset_attempt_state(self) -> None:
+        """Reset per-attempt mutable state to pristine defaults (Issue #2396).
+
+        Called by the layer-escalation orchestrator at the start of each
+        attempt, immediately after ``load_pcb_for_routing()`` creates a
+        fresh ``Autorouter``.  Today this is a no-op because the
+        orchestrator already creates a new instance per attempt, but this
+        method documents the contract: *between escalation attempts, no
+        router state from the prior attempt influences the next.*
+
+        Clearing these fields defensively prevents silent regression if
+        future refactors reuse an ``Autorouter`` across attempts.
+        """
+        self.power_stall_abort = False
+        self.power_stall_nets = []
+        self.routing_failures = []
+        self._perturbation_magnitude = 0.0
+        self._congestion_estimator = None
+
     def _calculate_constraint_score(self, net_id: int) -> float:
         """Calculate a constraint score for a net based on routing difficulty.
 
@@ -3039,8 +3058,19 @@ class Autorouter:
                 # rip-up sets.  This prevents high-pad-count decoupling nets
                 # (e.g., C11-2 with 16 pads) from consuming ~200s per
                 # iteration on fruitless A* searches.
+                #
+                # Issue #2396: Nets that completely failed to route (not in
+                # net_routes) should not accumulate stall counts -- they
+                # have no overflow to improve.  Only nets that ARE routed
+                # but pass through overused cells should be stall-tracked.
                 current_overflow = self.grid.get_total_overflow()
+                failed_net_ids = set(failed_nets_to_recover)
                 for net in nets_to_reroute:
+                    if net in failed_net_ids:
+                        # Issue #2396: Skip stall tracking for unrouted nets.
+                        # They failed entirely and need fresh attempts, not
+                        # stall-based exclusion.
+                        continue
                     prev = net_prev_overflow.get(net)
                     if prev is not None:
                         if current_overflow >= prev:
@@ -3071,6 +3101,40 @@ class Autorouter:
                     nets_to_reroute = [
                         n for n in nets_to_reroute if n not in stalled_nets
                     ]
+
+                # Issue #2396: When overflow is 0 but nets remain unrouted,
+                # the rip-up loop has no overflow signal to act on.  Force
+                # a fresh A* attempt for each unrouted net with an elevated
+                # present_factor to encourage exploration of alternative
+                # paths.  This directly addresses the 4L 3/8 plateau
+                # observed in board 04.
+                if (
+                    current_overflow == 0
+                    and failed_net_ids
+                    and not timed_out
+                ):
+                    recovery_factor = max(present_factor * 2.0, initial_present_factor * 4.0)
+                    recovered = 0
+                    for fn in list(failed_net_ids):
+                        if fn in stalled_nets or fn in net_routes:
+                            continue
+                        routes = self._route_net_negotiated(
+                            fn, recovery_factor, per_net_timeout=per_net_timeout
+                        )
+                        if routes:
+                            net_routes[fn] = routes
+                            recovered += 1
+                            for route in routes:
+                                self.grid.mark_route_usage(route)
+                                self.routes.append(route)
+                    if recovered > 0:
+                        flush_print(
+                            f"  Zero-overflow recovery: routed {recovered}/{len(failed_net_ids)} "
+                            f"previously-failed net(s) with elevated cost"
+                        )
+                        # Recompute overflow after recovery
+                        current_overflow = self.grid.get_total_overflow()
+                        overused = self.grid.find_overused_cells()
 
                 # If overflow improves globally, give stalled nets another
                 # chance -- their blockage may have cleared.

--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -506,3 +506,187 @@ class TestLayerEscalationHelpText:
         assert "--max-layers" in help_text, "Help should document --max-layers"
         assert "--min-completion" in help_text, "Help should document --min-completion"
         assert "escalat" in help_text.lower(), "Help should mention escalation"
+
+
+class TestBestOfAttemptsSelection:
+    """Tests for Issue #2396: best-of-attempts uses absolute nets_routed.
+
+    When nets_to_route differs across escalation attempts (e.g. power
+    nets auto-skipped on 4L but not 2L), the comparison must use
+    absolute nets_routed count, not completion ratio.
+    """
+
+    def test_absolute_nets_routed_wins_over_ratio(self):
+        """6/10 (0.60) beats 3/8 (0.375) using absolute nets_routed."""
+        from kicad_tools.cli.route_cmd import LayerEscalationResult, _is_better_result
+        from kicad_tools.router import LayerStack
+
+        result_2l = LayerEscalationResult(
+            layer_count=2,
+            layer_stack=LayerStack.two_layer(),
+            router=None,
+            net_map={},
+            nets_routed=6,
+            nets_to_route=10,
+            completion=0.6,
+            success=False,
+        )
+
+        result_4l = LayerEscalationResult(
+            layer_count=4,
+            layer_stack=LayerStack.four_layer_sig_gnd_pwr_sig(),
+            router=None,
+            net_map={},
+            nets_routed=3,
+            nets_to_route=8,
+            completion=0.375,
+            success=False,
+        )
+
+        # 2L (6 routed) should beat 4L (3 routed)
+        assert _is_better_result(result_2l, result_4l) is True
+        assert _is_better_result(result_4l, result_2l) is False
+
+    def test_same_nets_routed_tiebreaks_on_completion(self):
+        """When nets_routed is tied, higher completion ratio wins."""
+        from kicad_tools.cli.route_cmd import LayerEscalationResult, _is_better_result
+        from kicad_tools.router import LayerStack
+
+        result_a = LayerEscalationResult(
+            layer_count=2,
+            layer_stack=LayerStack.two_layer(),
+            router=None,
+            net_map={},
+            nets_routed=5,
+            nets_to_route=10,
+            completion=0.5,
+            success=False,
+        )
+
+        result_b = LayerEscalationResult(
+            layer_count=4,
+            layer_stack=LayerStack.four_layer_sig_gnd_pwr_sig(),
+            router=None,
+            net_map={},
+            nets_routed=5,
+            nets_to_route=8,
+            completion=0.625,
+            success=False,
+        )
+
+        # Same nets_routed (5), but B has higher completion (0.625 > 0.5)
+        assert _is_better_result(result_b, result_a) is True
+        assert _is_better_result(result_a, result_b) is False
+
+    def test_same_nets_same_completion_prefers_fewer_layers(self):
+        """When everything is tied, fewer layers wins."""
+        from kicad_tools.cli.route_cmd import LayerEscalationResult, _is_better_result
+        from kicad_tools.router import LayerStack
+
+        result_2l = LayerEscalationResult(
+            layer_count=2,
+            layer_stack=LayerStack.two_layer(),
+            router=None,
+            net_map={},
+            nets_routed=5,
+            nets_to_route=10,
+            completion=0.5,
+            success=False,
+            stats={"segments": 10, "vias": 2},
+        )
+
+        result_4l = LayerEscalationResult(
+            layer_count=4,
+            layer_stack=LayerStack.four_layer_sig_gnd_pwr_sig(),
+            router=None,
+            net_map={},
+            nets_routed=5,
+            nets_to_route=10,
+            completion=0.5,
+            success=False,
+            stats={"segments": 10, "vias": 2},
+        )
+
+        # Tied on all metrics except layer count: 2L wins
+        assert _is_better_result(result_2l, result_4l) is True
+        assert _is_better_result(result_4l, result_2l) is False
+
+    def test_higher_nets_routed_wins_even_with_lower_ratio(self):
+        """A result with more absolute routed nets wins even if its
+        completion ratio is lower (cross-denominator case)."""
+        from kicad_tools.cli.route_cmd import LayerEscalationResult, _is_better_result
+        from kicad_tools.router import LayerStack
+
+        # 7/20 = 0.35 ratio but 7 absolute
+        result_many = LayerEscalationResult(
+            layer_count=4,
+            layer_stack=LayerStack.four_layer_sig_gnd_pwr_sig(),
+            router=None,
+            net_map={},
+            nets_routed=7,
+            nets_to_route=20,
+            completion=0.35,
+            success=False,
+        )
+
+        # 5/6 = 0.833 ratio but only 5 absolute
+        result_few = LayerEscalationResult(
+            layer_count=2,
+            layer_stack=LayerStack.two_layer(),
+            router=None,
+            net_map={},
+            nets_routed=5,
+            nets_to_route=6,
+            completion=5 / 6,
+            success=False,
+        )
+
+        # 7 > 5, so result_many wins despite lower ratio
+        assert _is_better_result(result_many, result_few) is True
+
+
+class TestPristineStatePerAttempt:
+    """Tests for Issue #2396: pristine state per layer-escalation attempt.
+
+    Verify that the reset_attempt_state() method is accessible and
+    that the orchestrator code path calls it.
+    """
+
+    def test_reset_attempt_state_exists(self):
+        """Autorouter has a reset_attempt_state method."""
+        from kicad_tools.router.core import Autorouter
+
+        router = Autorouter(width=50.0, height=40.0)
+        assert hasattr(router, "reset_attempt_state")
+        assert callable(router.reset_attempt_state)
+
+    def test_no_auto_layers_skips_escalation(self):
+        """When --no-auto-layers is passed, route_with_layer_escalation is
+        NOT called (C6).
+
+        This verifies the orchestrator code path is unchanged when
+        escalation is disabled -- the main() dispatcher selects the
+        fixed-layer routing path instead of the escalation path.
+        """
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation"
+        ) as mock_escalation:
+            mock_escalation.return_value = 0
+
+            # --no-auto-layers should NOT call route_with_layer_escalation.
+            # It will fail on PCB loading since we don't mock that, but the
+            # key assertion is that escalation was never invoked.
+            try:
+                route_main([
+                    "test.kicad_pcb",
+                    "--no-auto-layers",
+                    "--quiet",
+                ])
+            except (SystemExit, FileNotFoundError, Exception):
+                pass  # Expected -- PCB file doesn't exist
+
+            assert mock_escalation.call_count == 0, (
+                "route_with_layer_escalation should not be called with --no-auto-layers"
+            )

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -3736,3 +3736,77 @@ class TestPowerNetStallAbort:
         assert elapsed < 30.0, (
             f"Routing took {elapsed:.1f}s -- early-abort did not engage"
         )
+
+
+class TestEscalationStateReset:
+    """Tests for Issue #2396: Autorouter.reset_attempt_state().
+
+    The method documents the invariant that between layer-escalation
+    attempts, no router state from the prior attempt influences the
+    next.  Today this is a no-op (the orchestrator creates a fresh
+    Autorouter per attempt), but the method prevents silent regression.
+    """
+
+    def test_reset_clears_power_stall_abort(self):
+        """reset_attempt_state clears power_stall_abort to False."""
+        router = Autorouter(width=50.0, height=40.0)
+        router.power_stall_abort = True
+        router.reset_attempt_state()
+        assert router.power_stall_abort is False
+
+    def test_reset_clears_power_stall_nets(self):
+        """reset_attempt_state clears power_stall_nets to empty list."""
+        router = Autorouter(width=50.0, height=40.0)
+        router.power_stall_nets = ["+3.3V", "GND"]
+        router.reset_attempt_state()
+        assert router.power_stall_nets == []
+
+    def test_reset_clears_routing_failures(self):
+        """reset_attempt_state clears routing_failures to empty list."""
+        router = Autorouter(width=50.0, height=40.0)
+        router.routing_failures.append(
+            RoutingFailure(net=1, net_name="TEST", source_pad=("U1", "1"), target_pad=("U1", "2"), reason="TEST_FAILURE")
+        )
+        router.reset_attempt_state()
+        assert router.routing_failures == []
+
+    def test_reset_clears_perturbation_magnitude(self):
+        """reset_attempt_state zeroes _perturbation_magnitude."""
+        router = Autorouter(width=50.0, height=40.0)
+        router._perturbation_magnitude = 0.5
+        router.reset_attempt_state()
+        assert router._perturbation_magnitude == 0.0
+
+    def test_reset_clears_congestion_estimator(self):
+        """reset_attempt_state sets _congestion_estimator to None."""
+        router = Autorouter(width=50.0, height=40.0)
+        router._congestion_estimator = "sentinel"
+        router.reset_attempt_state()
+        assert router._congestion_estimator is None
+
+    def test_reset_all_fields_at_once(self):
+        """Mutate all fields, call reset, assert all back to defaults."""
+        router = Autorouter(width=50.0, height=40.0)
+        router.power_stall_abort = True
+        router.power_stall_nets = ["+3.3V", "GND"]
+        router.routing_failures.append(
+            RoutingFailure(net=1, net_name="TEST", source_pad=("U1", "1"), target_pad=("U1", "2"), reason="TEST")
+        )
+        router._perturbation_magnitude = 0.3
+        router._congestion_estimator = "sentinel"
+
+        router.reset_attempt_state()
+
+        assert router.power_stall_abort is False
+        assert router.power_stall_nets == []
+        assert router.routing_failures == []
+        assert router._perturbation_magnitude == 0.0
+        assert router._congestion_estimator is None
+
+    def test_reset_is_idempotent(self):
+        """Calling reset_attempt_state twice is safe."""
+        router = Autorouter(width=50.0, height=40.0)
+        router.power_stall_abort = True
+        router.reset_attempt_state()
+        router.reset_attempt_state()
+        assert router.power_stall_abort is False


### PR DESCRIPTION
Closes #2396

## Summary

- **Best-of-attempts comparison** now uses absolute `nets_routed` count instead of completion ratio, with ratio as tiebreaker. This fixes cross-denominator miscomparisons when `nets_to_route` differs between attempts (e.g. 6/10 vs 3/8 after power-net auto-skip).
- **`Autorouter.reset_attempt_state()`** added as a documented invariant ensuring pristine state between escalation attempts. Currently defensive (load_pcb_for_routing already creates fresh instances), but prevents silent regression.
- **Failed-net recovery at zero overflow**: unrouted nets are excluded from stall-tracking (they have no overflow to improve) and get a dedicated recovery pass with elevated present_factor to explore alternative paths.

## Acceptance criteria coverage

- C1: `_is_better_result` uses absolute `nets_routed` with ratio tiebreaker (4 unit tests)
- C2: `reset_attempt_state()` added and called from layer-escalation loop (7 unit tests)
- C6: `--no-auto-layers` skips escalation path (1 unit test)
- C7: Zero-overflow recovery pass with elevated cost for unrouted nets; stall-tracking skips failed nets

## Test plan

- [x] `TestEscalationStateReset` (7 tests) -- reset_attempt_state clears all fields
- [x] `TestBestOfAttemptsSelection` (4 tests) -- absolute nets_routed comparison
- [x] `TestPristineStatePerAttempt` (2 tests) -- method exists + no-auto-layers dispatch
- [x] All 172 existing tests in test_router_core.py and test_layer_escalation.py pass

Generated with [Claude Code](https://claude.com/claude-code)