### PR TITLE
fix(zones): assign distinct priorities to power net zones on the same layer

### DIFF
--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -621,14 +621,14 @@ def _assign_layers_for_pour_nets(
                 if i == 0:
                     assignments.append((net_name, "In2.Cu", 0))
                 else:
-                    assignments.append((net_name, "F.Cu", i - 1))
+                    assignments.append((net_name, "F.Cu", i))
     else:
         # 2-layer board
         for net_name, _ in ground_nets:
             assignments.append((net_name, "B.Cu", 1))
 
-        for net_name, _ in power_nets:
-            assignments.append((net_name, "F.Cu", 0))
+        for i, (net_name, _) in enumerate(power_nets):
+            assignments.append((net_name, "F.Cu", len(power_nets) - i))
 
     return assignments
 
@@ -644,12 +644,15 @@ def auto_create_zones_for_pour_nets(
 
     For 2-layer boards:
     - GROUND nets get a zone on B.Cu with priority 1
-    - POWER nets get a zone on F.Cu with priority 0
+    - POWER nets get zones on F.Cu with descending priorities
+      (first power net gets highest priority) so overlapping zones
+      on the same layer coexist without undefined fill order
 
     For 4-layer boards:
     - GROUND nets get a zone on In1.Cu with priority 1
     - First POWER net gets a zone on In2.Cu with priority 0
-    - Additional POWER nets get zones on F.Cu
+    - Additional POWER nets get zones on F.Cu with distinct
+      non-zero priorities
 
     Args:
         pcb_path: Path to .kicad_pcb file (modified in place)

--- a/tests/test_zone_generator.py
+++ b/tests/test_zone_generator.py
@@ -580,7 +580,7 @@ class TestAssignLayersForPourNets:
         assert result == [("GND", "B.Cu", 1)]
 
     def test_2_layer_power_on_fcu(self):
-        """2-layer board: power nets go on F.Cu."""
+        """2-layer board: single power net goes on F.Cu with priority 1."""
         from kicad_tools.router.net_class import NetClass
 
         result = _assign_layers_for_pour_nets(
@@ -588,7 +588,29 @@ class TestAssignLayersForPourNets:
             [("GND", NetClass.GROUND), ("+3.3V", NetClass.POWER)],
         )
         assert ("GND", "B.Cu", 1) in result
-        assert ("+3.3V", "F.Cu", 0) in result
+        assert ("+3.3V", "F.Cu", 1) in result
+
+    def test_2_layer_multiple_power_nets(self):
+        """2-layer board: multiple power nets get descending priorities on F.Cu."""
+        from kicad_tools.router.net_class import NetClass
+
+        result = _assign_layers_for_pour_nets(
+            2,
+            [
+                ("GND", NetClass.GROUND),
+                ("+3.3V", NetClass.POWER),
+                ("+5V", NetClass.POWER),
+                ("+1.8V", NetClass.POWER),
+            ],
+        )
+        assert ("GND", "B.Cu", 1) in result
+        # 3 power nets get descending priorities: 3, 2, 1
+        assert ("+3.3V", "F.Cu", 3) in result
+        assert ("+5V", "F.Cu", 2) in result
+        assert ("+1.8V", "F.Cu", 1) in result
+        # All priorities must be distinct
+        fcu_priorities = [p for _, l, p in result if l == "F.Cu"]
+        assert len(fcu_priorities) == len(set(fcu_priorities))
 
     def test_4_layer_ground_on_in1cu(self):
         """4-layer board: GND goes on In1.Cu."""
@@ -625,7 +647,7 @@ class TestAssignLayersForPourNets:
         )
         assert ("GND", "In1.Cu", 1) in result
         assert ("+3.3V", "In2.Cu", 0) in result
-        assert ("+5V", "F.Cu", 0) in result
+        assert ("+5V", "F.Cu", 1) in result
 
     def test_4_layer_three_power_nets(self):
         """4-layer board: three power nets -- first on In2.Cu, rest on F.Cu."""
@@ -642,9 +664,9 @@ class TestAssignLayersForPourNets:
         )
         assert ("GND", "In1.Cu", 1) in result
         assert ("+3.3V", "In2.Cu", 0) in result
-        # Additional power nets go on F.Cu with increasing priority index
-        assert ("+5V", "F.Cu", 0) in result
-        assert ("+1.8V", "F.Cu", 1) in result
+        # Additional power nets go on F.Cu with non-zero priorities
+        assert ("+5V", "F.Cu", 1) in result
+        assert ("+1.8V", "F.Cu", 2) in result
 
 
 class TestAutoCreateZones4Layer:


### PR DESCRIPTION
## Summary
Fixes zone priority collisions on 2-layer boards with multiple power nets and on 4-layer boards with overflow power nets on F.Cu. Previously all power nets on the same layer got priority=0, causing undefined fill order and overlap warnings.

## Changes
- 2-layer path: assign descending priorities (N, N-1, ..., 1) to power nets on F.Cu instead of flat priority=0
- 4-layer overflow path: use index `i` instead of `i-1` so overflow nets on F.Cu start at priority 1 instead of 0
- Updated docstring in `auto_create_zones_for_pour_nets` to document new behavior
- Updated `test_2_layer_power_on_fcu` to expect priority=1 for single power net
- Added `test_2_layer_multiple_power_nets` verifying 3 power nets get descending distinct priorities (3, 2, 1)
- Updated `test_4_layer_multiple_power_nets` and `test_4_layer_three_power_nets` to expect non-zero F.Cu priorities

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 2-layer power nets get distinct priorities | Pass | test_2_layer_multiple_power_nets asserts priorities 3, 2, 1 and uniqueness |
| 4-layer overflow nets get non-zero priorities | Pass | test_4_layer_multiple_power_nets asserts priority=1; test_4_layer_three_power_nets asserts 1, 2 |
| Single power net still works (no regression) | Pass | test_2_layer_power_on_fcu with single net passes |
| GND-only boards unaffected | Pass | test_2_layer_ground_on_bcu passes unchanged |
| All 7 TestAssignLayersForPourNets tests pass | Pass | pytest run confirmed |

## Test Plan
Ran `uv run pytest tests/test_zone_generator.py::TestAssignLayersForPourNets -v` -- all 7 tests pass.

Closes #2410