### PR TITLE
fix(router): single-pad nets inflating 'nets routed' count

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1334,6 +1334,7 @@ def route_with_layer_escalation(
                 current_strategy=args.strategy,
                 pcb_file=args.pcb,
                 nets_to_route_ids=_multi_pad_ids,
+                single_pad_count=getattr(final_result, "single_pad_count", 0),
             )
 
     if final_result.success:
@@ -1807,6 +1808,7 @@ def route_with_rule_relaxation(
                 current_strategy=args.strategy,
                 pcb_file=args.pcb,
                 nets_to_route_ids=_multi_pad_ids,
+                single_pad_count=getattr(final_result, "single_pad_count", 0),
             )
 
     if final_result.success:
@@ -2319,6 +2321,7 @@ def route_with_combined_escalation(
                 current_strategy=args.strategy,
                 pcb_file=args.pcb,
                 nets_to_route_ids=_multi_pad_ids,
+                single_pad_count=getattr(final_result, "single_pad_count", 0),
             )
 
     if final_result.success:
@@ -4342,6 +4345,7 @@ def main(argv: list[str] | None = None) -> int:
                     nets_to_route,
                     current_strategy=args.strategy,
                     nets_to_route_ids=multi_pad_net_ids,
+                    single_pad_count=len(single_pad_nets),
                 )
             else:
                 # Verbose mode shows detailed path analysis for each failure
@@ -4355,6 +4359,7 @@ def main(argv: list[str] | None = None) -> int:
                     current_strategy=args.strategy,
                     pcb_file=args.pcb,
                     nets_to_route_ids=multi_pad_net_ids,
+                    single_pad_count=len(single_pad_nets),
                 )
 
     # Save partial results on clean partial exit (not just SIGINT)

--- a/src/kicad_tools/router/adaptive.py
+++ b/src/kicad_tools/router/adaptive.py
@@ -34,6 +34,7 @@ class RoutingResult:
     iterations_used: int
     statistics: dict
     routing_failures: list[RoutingFailure] = field(default_factory=list)
+    single_pad_count: int = 0
 
     @property
     def success_rate(self) -> float:
@@ -219,10 +220,15 @@ class AdaptiveAutorouter:
         """Check if routing has converged.
 
         Convergence criteria:
-        1. All nets routed (nets_routed == nets_requested)
+        1. All multi-pad nets routed (nets_routed == nets_requested)
         2. No overflow (no resource conflicts)
+
+        Single-pad nets are excluded because they have no endpoints to
+        connect and can never produce routes.
         """
-        nets_requested = len([n for n in router.nets if n != 0])
+        nets_requested = len(
+            [n for n, pads in router.nets.items() if n != 0 and len(pads) >= 2]
+        )
         nets_routed = len({r.net for r in router.routes if r.net != 0})
 
         return nets_routed >= nets_requested and overflow == 0
@@ -249,11 +255,18 @@ class AdaptiveAutorouter:
             # Create fresh autorouter with this layer stack
             router = self._create_autorouter(stack)
 
-            # Count nets to route
-            nets_requested = len([n for n in router.nets if n != 0])
+            # Count nets to route (exclude single-pad nets that can never be routed)
+            all_nonzero = [n for n in router.nets if n != 0]
+            single_pad_nets = [
+                n for n in all_nonzero if len(router.nets.get(n, [])) < 2
+            ]
+            nets_requested = len(all_nonzero) - len(single_pad_nets)
+            single_pad_count = len(single_pad_nets)
 
             if self.verbose:
                 print(f"  Nets to route: {nets_requested}")
+                if single_pad_count:
+                    print(f"  Single-pad nets excluded: {single_pad_count}")
                 print(f"  Routable layers: {stack.get_routable_indices()}")
 
             # Attempt routing
@@ -282,6 +295,7 @@ class AdaptiveAutorouter:
                 iterations_used=iterations,
                 statistics=router.get_statistics(),
                 routing_failures=getattr(router, "routing_failures", []),
+                single_pad_count=single_pad_count,
             )
             self._autorouter = router
 

--- a/src/kicad_tools/router/output.py
+++ b/src/kicad_tools/router/output.py
@@ -25,6 +25,7 @@ def show_routing_summary(
     current_strategy: str = "basic",
     pcb_file: str | None = None,
     nets_to_route_ids: set[int] | None = None,
+    single_pad_count: int = 0,
 ) -> None:
     """Show comprehensive routing summary with successes, failures, and suggestions.
 
@@ -123,7 +124,10 @@ def show_routing_summary(
         print(f"Routing Incomplete{connectivity_pct}")
     else:
         print("Routing Complete!")
-    print(f"  Nets routed: {len(routed_net_ids)}/{nets_to_route} ({success_rate:.0f}%)")
+    routed_line = f"  Nets routed: {len(routed_net_ids)}/{nets_to_route} ({success_rate:.0f}%)"
+    if single_pad_count:
+        routed_line += f" -- {single_pad_count} single-pad net(s) excluded"
+    print(routed_line)
 
     # Show partially-connected nets (have segments but not all pads connected)
     if partially_connected_nets:
@@ -481,6 +485,7 @@ def get_routing_diagnostics_json(
     nets_to_route: int,
     current_strategy: str = "basic",
     nets_to_route_ids: set[int] | None = None,
+    single_pad_count: int = 0,
 ) -> dict:
     """Get routing diagnostics as a JSON-serializable dictionary.
 
@@ -495,6 +500,8 @@ def get_routing_diagnostics_json(
         nets_to_route_ids: Optional set of net IDs targeted for routing
             (multi-pad signal nets).  When provided, ``routed_net_ids`` is
             filtered to this set so numerator and denominator are consistent.
+        single_pad_count: Number of single-pad nets excluded from routing.
+            Shown in the summary for diagnostic clarity.
 
     Returns:
         Dictionary with routing diagnostics in JSON-serializable format
@@ -717,8 +724,7 @@ def get_routing_diagnostics_json(
             }
         )
 
-    result_dict: dict = {
-        "summary": {
+    summary_dict: dict = {
             "nets_requested": nets_to_route,
             "nets_routed": len(routed_net_ids),
             "nets_failed": len(unrouted_ids),
@@ -726,7 +732,13 @@ def get_routing_diagnostics_json(
             if nets_to_route > 0
             else 0,
             "has_disconnected_islands": has_disconnected_islands,
-        },
+    }
+    if single_pad_count:
+        summary_dict["single_pad_nets"] = single_pad_count
+        summary_dict["total_nets_on_board"] = nets_to_route + single_pad_count
+
+    result_dict: dict = {
+        "summary": summary_dict,
         "failure_breakdown": dict(failures_by_cause),
         "successful_routes": successful_routes,
         "failed_routes": failed_routes,
@@ -743,6 +755,7 @@ def print_routing_diagnostics_json(
     nets_to_route: int,
     current_strategy: str = "basic",
     nets_to_route_ids: set[int] | None = None,
+    single_pad_count: int = 0,
 ) -> None:
     """Print routing diagnostics as JSON to stdout.
 
@@ -753,10 +766,12 @@ def print_routing_diagnostics_json(
         current_strategy: The routing strategy that was used. Suggestions will
             exclude this strategy since the user already tried it.
         nets_to_route_ids: Optional set of net IDs targeted for routing.
+        single_pad_count: Number of single-pad nets excluded from routing.
     """
     diagnostics = get_routing_diagnostics_json(
         router, net_map, nets_to_route, current_strategy=current_strategy,
         nets_to_route_ids=nets_to_route_ids,
+        single_pad_count=single_pad_count,
     )
     print(json.dumps(diagnostics, indent=2))
 

--- a/tests/test_single_pad_net_count.py
+++ b/tests/test_single_pad_net_count.py
@@ -1,0 +1,286 @@
+"""Tests for single-pad net exclusion from routing counts (#2414).
+
+Verifies:
+1. AdaptiveAutorouter._check_convergence() excludes single-pad nets
+2. AdaptiveAutorouter.route() sets nets_requested excluding single-pad nets
+3. RoutingResult.single_pad_count is populated correctly
+4. show_routing_summary() reports single-pad exclusion in text output
+5. get_routing_diagnostics_json() includes single_pad_nets in JSON summary
+6. RoutingResult.success_rate returns 1.0 when only single-pad nets exist
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kicad_tools.router.adaptive import RoutingResult
+from kicad_tools.router.output import (
+    get_routing_diagnostics_json,
+    show_routing_summary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_router_mock(
+    nets: dict[int, list] | None = None,
+    routes: list | None = None,
+    routing_failures: list | None = None,
+    grid_num_layers: int = 2,
+):
+    """Build a minimal mock that satisfies show_routing_summary / get_routing_diagnostics_json."""
+    router = MagicMock()
+    router.nets = nets or {}
+    router.routes = routes or []
+    router.routing_failures = routing_failures or []
+    router.grid.num_layers = grid_num_layers
+    router.grid.resolution = 0.25
+    # pads attribute needed for connectivity validation path
+    router.pads = {}
+    return router
+
+
+# ---------------------------------------------------------------------------
+# RoutingResult unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingResultSinglePadCount:
+    """RoutingResult should correctly handle single_pad_count field."""
+
+    def test_single_pad_count_default_zero(self):
+        result = RoutingResult(
+            routes=[],
+            layer_count=2,
+            layer_stack=MagicMock(),
+            nets_requested=5,
+            nets_routed=5,
+            overflow=0,
+            converged=True,
+            iterations_used=1,
+            statistics={},
+        )
+        assert result.single_pad_count == 0
+
+    def test_single_pad_count_populated(self):
+        result = RoutingResult(
+            routes=[],
+            layer_count=2,
+            layer_stack=MagicMock(),
+            nets_requested=5,
+            nets_routed=5,
+            overflow=0,
+            converged=True,
+            iterations_used=1,
+            statistics={},
+            single_pad_count=3,
+        )
+        assert result.single_pad_count == 3
+
+    def test_success_rate_all_single_pad(self):
+        """When nets_requested is 0 (all nets are single-pad), success_rate
+        should return 1.0 (100%) not raise ZeroDivisionError."""
+        result = RoutingResult(
+            routes=[],
+            layer_count=2,
+            layer_stack=MagicMock(),
+            nets_requested=0,
+            nets_routed=0,
+            overflow=0,
+            converged=True,
+            iterations_used=1,
+            statistics={},
+            single_pad_count=5,
+        )
+        assert result.success_rate == 1.0
+
+
+# ---------------------------------------------------------------------------
+# AdaptiveAutorouter._check_convergence tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckConvergenceSinglePad:
+    """_check_convergence must exclude single-pad nets from nets_requested."""
+
+    def test_convergence_with_single_pad_nets(self):
+        """When all multi-pad nets are routed, convergence should be True
+        even if single-pad nets exist."""
+        from kicad_tools.router.adaptive import AdaptiveAutorouter
+
+        adaptive = AdaptiveAutorouter.__new__(AdaptiveAutorouter)
+
+        # Build a mock router with:
+        # - Net 1: single-pad (should be excluded)
+        # - Net 2: multi-pad, routed
+        # - Net 0: unconnected (always excluded)
+        router = MagicMock()
+        router.nets = {
+            0: [("U1", "GND")],
+            1: [("U1", "1")],           # single-pad
+            2: [("U1", "2"), ("R1", "1")],  # multi-pad
+        }
+        route = MagicMock()
+        route.net = 2
+        router.routes = [route]
+
+        result = adaptive._check_convergence(router, overflow=0)
+        assert result is True, (
+            "Convergence should be True when all multi-pad nets are routed"
+        )
+
+    def test_no_convergence_when_multi_pad_unrouted(self):
+        """When a multi-pad net is unrouted, convergence should be False."""
+        from kicad_tools.router.adaptive import AdaptiveAutorouter
+
+        adaptive = AdaptiveAutorouter.__new__(AdaptiveAutorouter)
+
+        router = MagicMock()
+        router.nets = {
+            0: [("U1", "GND")],
+            1: [("U1", "1")],                  # single-pad
+            2: [("U1", "2"), ("R1", "1")],      # multi-pad, routed
+            3: [("U1", "3"), ("R2", "1")],      # multi-pad, NOT routed
+        }
+        route = MagicMock()
+        route.net = 2
+        router.routes = [route]
+
+        result = adaptive._check_convergence(router, overflow=0)
+        assert result is False
+
+    def test_convergence_all_single_pad(self):
+        """Board with only single-pad nets should converge immediately."""
+        from kicad_tools.router.adaptive import AdaptiveAutorouter
+
+        adaptive = AdaptiveAutorouter.__new__(AdaptiveAutorouter)
+
+        router = MagicMock()
+        router.nets = {
+            0: [("U1", "GND")],
+            1: [("U1", "1")],
+            2: [("U2", "1")],
+        }
+        router.routes = []
+
+        result = adaptive._check_convergence(router, overflow=0)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# show_routing_summary single-pad reporting tests
+# ---------------------------------------------------------------------------
+
+
+class TestShowRoutingSummarySinglePad:
+    """show_routing_summary should report single-pad net exclusion."""
+
+    def test_single_pad_count_in_text_output(self, capsys):
+        """When single_pad_count > 0, the text summary should mention it."""
+        route = MagicMock()
+        route.net = 1
+        route.segments = []
+        route.vias = []
+        router = _make_router_mock(routes=[route])
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            single_pad_count=3,
+        )
+
+        output = capsys.readouterr().out
+        assert "3 single-pad net(s) excluded" in output
+
+    def test_no_single_pad_line_when_zero(self, capsys):
+        """When single_pad_count is 0, no single-pad text should appear."""
+        route = MagicMock()
+        route.net = 1
+        route.segments = []
+        route.vias = []
+        router = _make_router_mock(routes=[route])
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            single_pad_count=0,
+        )
+
+        output = capsys.readouterr().out
+        assert "single-pad" not in output
+
+
+# ---------------------------------------------------------------------------
+# get_routing_diagnostics_json single-pad reporting tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsJsonSinglePad:
+    """get_routing_diagnostics_json should include single_pad_nets in summary."""
+
+    def test_single_pad_nets_in_json(self):
+        """JSON summary should include single_pad_nets and total_nets_on_board."""
+        route = MagicMock()
+        route.net = 1
+        route.segments = []
+        route.vias = []
+        router = _make_router_mock(routes=[route])
+        net_map = {"NetA": 1}
+
+        result = get_routing_diagnostics_json(
+            router,
+            net_map,
+            nets_to_route=1,
+            single_pad_count=5,
+        )
+
+        assert result["summary"]["single_pad_nets"] == 5
+        assert result["summary"]["total_nets_on_board"] == 6  # 1 + 5
+
+    def test_no_single_pad_keys_when_zero(self):
+        """When single_pad_count is 0, the keys should not be present."""
+        route = MagicMock()
+        route.net = 1
+        route.segments = []
+        route.vias = []
+        router = _make_router_mock(routes=[route])
+        net_map = {"NetA": 1}
+
+        result = get_routing_diagnostics_json(
+            router,
+            net_map,
+            nets_to_route=1,
+            single_pad_count=0,
+        )
+
+        assert "single_pad_nets" not in result["summary"]
+        assert "total_nets_on_board" not in result["summary"]
+
+    def test_json_success_rate_excludes_single_pad(self):
+        """success_rate in JSON should be based on multi-pad nets only."""
+        route = MagicMock()
+        route.net = 1
+        route.segments = []
+        route.vias = []
+        router = _make_router_mock(routes=[route])
+        net_map = {"NetA": 1}
+
+        result = get_routing_diagnostics_json(
+            router,
+            net_map,
+            nets_to_route=1,  # only multi-pad nets
+            single_pad_count=10,
+        )
+
+        # 1 routed / 1 requested = 100%
+        assert result["summary"]["success_rate"] == 100.0
+        assert result["summary"]["nets_requested"] == 1


### PR DESCRIPTION
Closes #2414

## Summary

- **adaptive.py**: Filter `nets_requested` to only count nets with `len(pads) >= 2` in both `_check_convergence()` and `route()`, preventing single-pad nets from inflating the denominator and blocking convergence detection. Added `single_pad_count` field to `RoutingResult`.
- **output.py**: Added `single_pad_count` parameter to `show_routing_summary()`, `get_routing_diagnostics_json()`, and `print_routing_diagnostics_json()`. Text output shows "N single-pad net(s) excluded" when count > 0. JSON summary includes `single_pad_nets` and `total_nets_on_board` fields.
- **route_cmd.py**: Passed `single_pad_count` through all four call sites (main route path + three adaptive routing paths).

## Test plan

- [x] 11 new tests in `tests/test_single_pad_net_count.py` covering:
  - `RoutingResult.single_pad_count` default and population
  - `success_rate` returns 1.0 when all nets are single-pad (0/0 case)
  - `_check_convergence()` returns True when all multi-pad nets routed despite single-pad nets existing
  - `_check_convergence()` returns False when multi-pad nets remain unrouted
  - Board with only single-pad nets converges immediately
  - Text summary includes/excludes single-pad annotation correctly
  - JSON diagnostics includes `single_pad_nets` and `total_nets_on_board` when count > 0
  - JSON diagnostics omits those keys when count is 0
  - `success_rate` in JSON based on multi-pad nets only
- [x] Existing tests in `test_routing_output.py` (25 tests) and `test_two_phase_net_count.py` (7 tests) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)