### PR TITLE
fix(router): propagate per_net_timeout and escape_budget to escape strategies

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -13,6 +13,7 @@ Adaptive parameter tuning (Issue #633) improves convergence by:
 from __future__ import annotations
 
 import random
+import time
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -934,6 +935,8 @@ class NegotiatedRouter:
         present_cost_factor: float,
         mark_route_callback: callable,
         strategy_index: int = 0,
+        per_net_timeout: float | None = None,
+        escape_budget: float | None = None,
     ) -> tuple[bool, int, int]:
         """Try escape strategies when router is stuck oscillating.
 
@@ -951,6 +954,10 @@ class NegotiatedRouter:
             present_cost_factor: Current congestion cost factor
             mark_route_callback: Callback to mark routes on the grid
             strategy_index: Index of strategy to start from (cycles through available)
+            per_net_timeout: Wall-clock timeout in seconds for each per-net A*
+                search within escape strategies (Issue #2415)
+            escape_budget: Wall-clock budget in seconds for the entire escape
+                attempt across all strategies (Issue #2415). None means no limit.
 
         Returns:
             Tuple of (success, overflow, strategies_tried) where success indicates
@@ -965,8 +972,14 @@ class NegotiatedRouter:
 
         num_strategies = len(strategies)
         strategies_tried = 0
+        escape_start = time.time()
 
         for i in range(num_strategies):
+            # Check escape budget before starting each strategy
+            if escape_budget is not None:
+                if time.time() - escape_start >= escape_budget:
+                    break
+
             idx = (strategy_index + i) % num_strategies
             strategy = strategies[idx]
             strategies_tried += 1
@@ -979,12 +992,15 @@ class NegotiatedRouter:
                 net_order=net_order,
                 present_cost_factor=present_cost_factor,
                 mark_route_callback=mark_route_callback,
+                per_net_timeout=per_net_timeout,
+                escape_budget_start=escape_start,
+                escape_budget=escape_budget,
             )
 
             if success:
                 return True, new_overflow, strategies_tried
 
-        # All strategies exhausted without success
+        # All strategies exhausted (or budget expired) without success
         current_overflow = overflow_history[-1] if overflow_history else 0
         return False, current_overflow, strategies_tried
 
@@ -997,6 +1013,9 @@ class NegotiatedRouter:
         net_order: list[int],
         present_cost_factor: float,
         mark_route_callback: callable,
+        per_net_timeout: float | None = None,
+        escape_budget_start: float | None = None,
+        escape_budget: float | None = None,
     ) -> tuple[bool, int]:
         """Escape strategy: shuffle the net order randomly.
 
@@ -1023,10 +1042,17 @@ class NegotiatedRouter:
         rerouted_count = 0
         expected_count = 0
         for net in shuffled:
+            # Check escape budget before each net (Issue #2415)
+            if escape_budget is not None and escape_budget_start is not None:
+                if time.time() - escape_budget_start >= escape_budget:
+                    break
             net_pads = pads_by_net.get(net, [])
             if net_pads and len(net_pads) >= 2:
                 expected_count += 1
-                routes = self.route_net_negotiated(net_pads, boosted_cost, mark_route_callback)
+                routes = self.route_net_negotiated(
+                    net_pads, boosted_cost, mark_route_callback,
+                    per_net_timeout=per_net_timeout,
+                )
                 if routes:
                     net_routes[net] = routes
                     rerouted_count += 1
@@ -1051,6 +1077,9 @@ class NegotiatedRouter:
         net_order: list[int],
         present_cost_factor: float,
         mark_route_callback: callable,
+        per_net_timeout: float | None = None,
+        escape_budget_start: float | None = None,
+        escape_budget: float | None = None,
     ) -> tuple[bool, int]:
         """Escape strategy: reverse the net order.
 
@@ -1075,10 +1104,17 @@ class NegotiatedRouter:
         rerouted_count = 0
         expected_count = 0
         for net in reversed_order:
+            # Check escape budget before each net (Issue #2415)
+            if escape_budget is not None and escape_budget_start is not None:
+                if time.time() - escape_budget_start >= escape_budget:
+                    break
             net_pads = pads_by_net.get(net, [])
             if net_pads and len(net_pads) >= 2:
                 expected_count += 1
-                routes = self.route_net_negotiated(net_pads, boosted_cost, mark_route_callback)
+                routes = self.route_net_negotiated(
+                    net_pads, boosted_cost, mark_route_callback,
+                    per_net_timeout=per_net_timeout,
+                )
                 if routes:
                     net_routes[net] = routes
                     rerouted_count += 1
@@ -1103,6 +1139,9 @@ class NegotiatedRouter:
         net_order: list[int],
         present_cost_factor: float,
         mark_route_callback: callable,
+        per_net_timeout: float | None = None,
+        escape_budget_start: float | None = None,
+        escape_budget: float | None = None,
     ) -> tuple[bool, int]:
         """Escape strategy: rip up and reroute a random subset of nets.
 
@@ -1128,10 +1167,17 @@ class NegotiatedRouter:
         rerouted_count = 0
         expected_count = 0
         for net in subset:
+            # Check escape budget before each net (Issue #2415)
+            if escape_budget is not None and escape_budget_start is not None:
+                if time.time() - escape_budget_start >= escape_budget:
+                    break
             net_pads = pads_by_net.get(net, [])
             if net_pads and len(net_pads) >= 2:
                 expected_count += 1
-                routes = self.route_net_negotiated(net_pads, boosted_cost, mark_route_callback)
+                routes = self.route_net_negotiated(
+                    net_pads, boosted_cost, mark_route_callback,
+                    per_net_timeout=per_net_timeout,
+                )
                 if routes:
                     net_routes[net] = routes
                     rerouted_count += 1
@@ -1156,6 +1202,9 @@ class NegotiatedRouter:
         net_order: list[int],
         present_cost_factor: float,
         mark_route_callback: callable,
+        per_net_timeout: float | None = None,
+        escape_budget_start: float | None = None,
+        escape_budget: float | None = None,
     ) -> tuple[bool, int]:
         """Escape strategy: rip up ALL nets and reroute in alternative order.
 
@@ -1187,10 +1236,15 @@ class NegotiatedRouter:
         boosted_cost = present_cost_factor * 1.5
         rerouted_count = 0
         for net in reorder:
+            # Check escape budget before each net (Issue #2415)
+            if escape_budget is not None and escape_budget_start is not None:
+                if time.time() - escape_budget_start >= escape_budget:
+                    break
             net_pads = pads_by_net.get(net, [])
             if net_pads and len(net_pads) >= 2:
                 routes = self.route_net_negotiated(
-                    net_pads, boosted_cost, mark_route_callback
+                    net_pads, boosted_cost, mark_route_callback,
+                    per_net_timeout=per_net_timeout,
                 )
                 if routes:
                     net_routes[net] = routes

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3448,6 +3448,14 @@ class Autorouter:
                         def mark_route_targeted(route: Route) -> None:
                             self._mark_route(route)
 
+                        # Issue #2415: Compute escape budget from remaining time
+                        escape_budget = None
+                        if timeout is not None:
+                            remaining = timeout - (time.time() - start_time)
+                            escape_budget = min(60.0, remaining * 0.25)
+                            if escape_budget <= 0:
+                                escape_budget = 0.0
+
                         success, new_overflow, tried = neg_router.escape_local_minimum(
                             overflow_history=overflow_history,
                             net_routes=net_routes,
@@ -3457,6 +3465,8 @@ class Autorouter:
                             present_cost_factor=present_factor,
                             mark_route_callback=mark_route_targeted,
                             strategy_index=escape_strategy_index,
+                            per_net_timeout=per_net_timeout,
+                            escape_budget=escape_budget,
                         )
                         escape_strategy_index += tried
 
@@ -3702,6 +3712,14 @@ class Autorouter:
                     def mark_route(route: Route) -> None:
                         self._mark_route(route)
 
+                    # Issue #2415: Compute escape budget from remaining time
+                    escape_budget = None
+                    if timeout is not None:
+                        remaining = timeout - (time.time() - start_time)
+                        escape_budget = min(60.0, remaining * 0.25)
+                        if escape_budget <= 0:
+                            escape_budget = 0.0
+
                     success, new_overflow, tried = neg_router.escape_local_minimum(
                         overflow_history=overflow_history,
                         net_routes=net_routes,
@@ -3711,6 +3729,8 @@ class Autorouter:
                         present_cost_factor=present_factor,
                         mark_route_callback=mark_route,
                         strategy_index=escape_strategy_index,
+                        per_net_timeout=per_net_timeout,
+                        escape_budget=escape_budget,
                     )
                     escape_strategy_index += tried
 

--- a/tests/test_negotiated_adaptive.py
+++ b/tests/test_negotiated_adaptive.py
@@ -821,3 +821,175 @@ class TestShouldTerminateEarlyLowOverflow:
             should_terminate_early(history, iteration=7, min_iterations=5, unrouted_count=2)
             is False
         )
+
+
+class TestEscapeBudgetEnforcement:
+    """Tests for escape strategy timeout enforcement (Issue #2415)."""
+
+    def test_escape_budget_expires_returns_early(self):
+        """escape_local_minimum with a tiny budget should return quickly."""
+        import time
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        mock_grid = MagicMock()
+        mock_router = MagicMock()
+        neg = NegotiatedRouter(mock_grid, mock_router, MagicMock(), {})
+
+        # Each strategy sleeps 0.1s to simulate work, budget is 0.001s
+        def slow_strategy(**kwargs):
+            time.sleep(0.1)
+            return False, 10
+
+        neg._escape_shuffle_order = MagicMock(side_effect=slow_strategy)
+        neg._escape_reverse_order = MagicMock(side_effect=slow_strategy)
+        neg._escape_random_subset = MagicMock(side_effect=slow_strategy)
+        neg._escape_full_reorder = MagicMock(side_effect=slow_strategy)
+
+        start = time.time()
+        success, overflow, tried = neg.escape_local_minimum(
+            overflow_history=[10, 10, 10, 10],
+            net_routes={},
+            routes_list=[],
+            pads_by_net={},
+            net_order=[],
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+            strategy_index=0,
+            per_net_timeout=1.0,
+            escape_budget=0.001,
+        )
+        elapsed = time.time() - start
+
+        assert success is False
+        # Should have tried at most 2 strategies (first runs, then budget
+        # check fires before second or shortly after)
+        assert tried <= 2
+        # Total wall time should be well under 1 second
+        assert elapsed < 1.0
+
+    def test_per_net_timeout_propagated_to_route_net_negotiated(self):
+        """per_net_timeout should be passed through to route_net_negotiated."""
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        mock_grid = MagicMock()
+        mock_grid.find_overused_cells.return_value = {(0, 0, 0)}
+        mock_grid.get_total_overflow.return_value = 5
+        mock_router = MagicMock()
+        neg = NegotiatedRouter(mock_grid, mock_router, MagicMock(), {})
+        neg.find_nets_through_overused_cells = MagicMock(return_value=[1, 2])
+        neg.rip_up_nets = MagicMock()
+
+        # Mock route_net_negotiated to capture the per_net_timeout arg
+        captured_timeouts = []
+
+        def mock_route(pad_objs, cost, callback, per_net_timeout=None):
+            captured_timeouts.append(per_net_timeout)
+            return []
+
+        neg.route_net_negotiated = mock_route
+
+        neg._escape_shuffle_order(
+            overflow_history=[10, 10],
+            net_routes={1: [], 2: []},
+            routes_list=[],
+            pads_by_net={1: [MagicMock(), MagicMock()], 2: [MagicMock(), MagicMock()]},
+            net_order=[1, 2],
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+            per_net_timeout=3.5,
+        )
+
+        # Every call should have received per_net_timeout=3.5
+        assert len(captured_timeouts) == 2
+        assert all(t == 3.5 for t in captured_timeouts)
+
+    def test_escape_budget_none_preserves_existing_behavior(self):
+        """When escape_budget=None, all 4 strategies should be tried."""
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        mock_grid = MagicMock()
+        mock_router = MagicMock()
+        neg = NegotiatedRouter(mock_grid, mock_router, MagicMock(), {})
+
+        # All strategies fail
+        neg._escape_shuffle_order = MagicMock(return_value=(False, 10))
+        neg._escape_reverse_order = MagicMock(return_value=(False, 10))
+        neg._escape_random_subset = MagicMock(return_value=(False, 10))
+        neg._escape_full_reorder = MagicMock(return_value=(False, 10))
+
+        success, overflow, tried = neg.escape_local_minimum(
+            overflow_history=[10, 10, 10, 10],
+            net_routes={},
+            routes_list=[],
+            pads_by_net={},
+            net_order=[],
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+            strategy_index=0,
+            per_net_timeout=None,
+            escape_budget=None,
+        )
+
+        assert success is False
+        assert tried == 4
+        assert neg._escape_shuffle_order.call_count == 1
+        assert neg._escape_reverse_order.call_count == 1
+        assert neg._escape_random_subset.call_count == 1
+        assert neg._escape_full_reorder.call_count == 1
+
+    def test_budget_expires_mid_strategy_returns_false(self):
+        """When budget expires during a strategy, escape returns without hanging."""
+        import time
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        mock_grid = MagicMock()
+        mock_grid.find_overused_cells.return_value = {(0, 0, 0)}
+        mock_grid.get_total_overflow.return_value = 10
+        mock_router = MagicMock()
+        neg = NegotiatedRouter(mock_grid, mock_router, MagicMock(), {})
+
+        # Create many nets so the budget expires mid-loop
+        many_nets = list(range(100))
+        neg.find_nets_through_overused_cells = MagicMock(return_value=many_nets)
+        neg.rip_up_nets = MagicMock()
+
+        call_count = 0
+
+        def slow_route(pad_objs, cost, callback, per_net_timeout=None):
+            nonlocal call_count
+            call_count += 1
+            time.sleep(0.01)  # 10ms per net
+            return []
+
+        neg.route_net_negotiated = slow_route
+
+        pads_by_net = {n: [MagicMock(), MagicMock()] for n in many_nets}
+
+        start = time.time()
+        success, overflow, tried = neg.escape_local_minimum(
+            overflow_history=[10, 10, 10, 10],
+            net_routes={n: [] for n in many_nets},
+            routes_list=[],
+            pads_by_net=pads_by_net,
+            net_order=many_nets,
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+            strategy_index=0,
+            per_net_timeout=1.0,
+            escape_budget=0.05,  # 50ms budget
+        )
+        elapsed = time.time() - start
+
+        assert success is False
+        # Should have routed far fewer than 100 nets
+        assert call_count < 100
+        # Should complete well under 2 seconds
+        assert elapsed < 2.0


### PR DESCRIPTION
## Summary
Propagates per_net_timeout to escape strategy methods and adds a wall-clock escape_budget to prevent escape_local_minimum from consuming the entire iteration budget. Previously, escape strategies called route_net_negotiated without any timeout, allowing A* searches to run unbounded and burning 900+ seconds on a single iteration.

## Changes
- Added `per_net_timeout` and `escape_budget` parameters to `escape_local_minimum` and all four `_escape_*` methods in `NegotiatedRouter`
- Each escape strategy now passes `per_net_timeout` to `route_net_negotiated` calls
- Added wall-clock budget checks before each strategy attempt and before each net re-route loop iteration
- Both call sites in `core.py` (~lines 3451 and 3715) compute `escape_budget = min(60.0, remaining_time * 0.25)`
- Added 4 new unit tests for budget enforcement, timeout propagation, backward compatibility, and mid-strategy budget expiry

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| per_net_timeout passed to route_net_negotiated in escape strategies | Pass | All four _escape_* methods now forward per_net_timeout; verified via test_per_net_timeout_propagated_to_route_net_negotiated |
| escape_local_minimum has wall-clock budget | Pass | escape_budget parameter added with checks before each strategy and each net; verified via test_escape_budget_expires_returns_early |
| Budget expiry mid-strategy returns early without hanging | Pass | Verified via test_budget_expires_mid_strategy_returns_false |
| escape_budget=None preserves existing behavior | Pass | Verified via test_escape_budget_none_preserves_existing_behavior; all 6 pre-existing escape tests still pass |

## Test Plan
- Ran `uv run pytest tests/test_negotiated_adaptive.py -k escape` -- all 10 escape tests pass (6 existing + 4 new)
- 3 pre-existing failures in TestNegotiatedRouterCongestionEstimator are unrelated to this change

Closes #2415