### PR TITLE
fix(router): match full layers block in stackup update regex

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -711,39 +711,52 @@ def update_pcb_layer_stackup(pcb_content: str, target_layers: int) -> str:
     if target_layers not in layer_defs:
         return pcb_content
 
-    # Find and replace the layers section
-    # KiCad format: (layers (0 "F.Cu" signal) ... )
-    layers_pattern = re.compile(
-        r'(\(layers\s+)([^)]*"(?:F\.Cu|B\.Cu|In\d+\.Cu)"[^)]*\s*)+(\))',
-        re.DOTALL,
-    )
-
-    def replace_layers(match):
-        # Build new layers content
-        new_layers = "\n    ".join(layer_defs[target_layers])
-        return f"(layers\n    {new_layers}\n  )"
-
     # Check if we need to update — count ALL copper layers regardless of type
     # (signal, power, mixed, etc.) not just those marked "signal"
     current_layers = len(re.findall(r'\(\d+\s+"[^"]*\.Cu"\s+\w+', pcb_content))
     if current_layers >= target_layers:
         return pcb_content
 
-    # Try to find and replace the layers section
+    # Match the entire (layers ...) block including all inner entries.
+    # Each inner entry is e.g. (0 "F.Cu" signal) or (44 "Edge.Cuts" user "Edge.Cuts").
+    # The pattern matches from "(layers" through each "(...)" entry to the
+    # block-closing ")".
+    layers_pattern = re.compile(
+        r'\(layers\s*\n(\s+\(\d+\s+"[^"]+"\s+\w+[^)]*\)\s*\n)+\s*\)',
+        re.MULTILINE,
+    )
+
+    # Non-copper layer entry pattern (e.g. B.SilkS, Edge.Cuts, F.Fab)
+    non_copper_re = re.compile(
+        r'(\s*\(\d+\s+"(?!.*\.Cu")[^"]+"\s+\w+[^)]*\))',
+    )
+
+    def replace_layers(match):
+        matched_text = match.group(0)
+        # Extract non-copper layer entries from the original block
+        non_copper_entries = non_copper_re.findall(matched_text)
+        # Build new layers content with copper layers
+        new_layers = "\n    ".join(layer_defs[target_layers])
+        # Append non-copper layers after copper layers
+        if non_copper_entries:
+            non_copper_lines = "\n".join(
+                entry.strip() for entry in non_copper_entries
+            )
+            return f"(layers\n    {new_layers}\n    {non_copper_lines}\n  )"
+        return f"(layers\n    {new_layers}\n  )"
+
     new_content = layers_pattern.sub(replace_layers, pcb_content)
 
-    # If the pattern didn't match, try a more permissive pattern
-    if new_content == pcb_content:
-        # Alternative pattern for different KiCad versions
-        alt_pattern = re.compile(
-            r'\(layers\s*\n(\s+\(\d+\s+"[^"]+"\s+\w+[^)]*\)\s*\n)+\s*\)',
-            re.MULTILINE,
+    # Validate output has balanced parentheses to catch regressions early
+    if not _validate_sexp_parentheses(new_content):
+        import warnings
+
+        warnings.warn(
+            "update_pcb_layer_stackup produced unbalanced parentheses; "
+            "returning original content unchanged",
+            stacklevel=2,
         )
-        new_layers_content = "\n    ".join(layer_defs[target_layers])
-        new_content = alt_pattern.sub(
-            f"(layers\n    {new_layers_content}\n  )",
-            pcb_content,
-        )
+        return pcb_content
 
     return new_content
 

--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -457,6 +457,111 @@ class TestUpdatePcbLayerStackupPowerLayers:
         assert '(0 "F.Cu"' in result
 
 
+class TestLayerStackupParenBalance:
+    """Tests for Issue #2416: S-expression syntax error from unbalanced parens.
+
+    Realistic KiCad PCB files include non-copper layers (B.SilkS, Edge.Cuts,
+    etc.) in the (layers ...) block. The old regex only matched through the
+    first inner entry's closing paren, orphaning the rest and producing
+    unbalanced parentheses.
+    """
+
+    REALISTIC_2L_PCB = """\
+(kicad_pcb
+  (version 20240101)
+  (generator "kicad")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (32 "B.Adhes" user "B.Adhesive")
+    (33 "F.Adhes" user "F.Adhesive")
+    (34 "B.Paste" user)
+    (35 "F.Paste" user)
+    (36 "B.SilkS" user "B.Silkscreen")
+    (37 "F.SilkS" user "F.Silkscreen")
+    (38 "B.Mask" user "B.Mask")
+    (39 "F.Mask" user "F.Mask")
+    (44 "Edge.Cuts" user)
+    (45 "Margin" user)
+    (46 "B.CrtYd" user "B.Courtyard")
+    (47 "F.CrtYd" user "F.Courtyard")
+    (48 "B.Fab" user)
+    (49 "F.Fab" user)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+)"""
+
+    def test_2_to_4_balanced_parens(self):
+        """Upgrading 2L to 4L with non-copper layers produces balanced parens."""
+        from kicad_tools.cli.route_cmd import (
+            _validate_sexp_parentheses,
+            update_pcb_layer_stackup,
+        )
+
+        result = update_pcb_layer_stackup(self.REALISTIC_2L_PCB, 4)
+
+        assert _validate_sexp_parentheses(result), (
+            "Output has unbalanced parentheses"
+        )
+        assert '"In1.Cu"' in result
+        assert '"In2.Cu"' in result
+        assert '"F.Cu"' in result
+        assert '"B.Cu"' in result
+
+    def test_2_to_6_balanced_parens(self):
+        """Upgrading 2L to 6L with non-copper layers produces balanced parens."""
+        from kicad_tools.cli.route_cmd import (
+            _validate_sexp_parentheses,
+            update_pcb_layer_stackup,
+        )
+
+        result = update_pcb_layer_stackup(self.REALISTIC_2L_PCB, 6)
+
+        assert _validate_sexp_parentheses(result), (
+            "Output has unbalanced parentheses"
+        )
+        assert '"In1.Cu"' in result
+        assert '"In4.Cu"' in result
+
+    def test_non_copper_layers_preserved_after_upgrade(self):
+        """Non-copper layers (SilkS, Edge.Cuts, Fab, etc.) survive the upgrade."""
+        from kicad_tools.cli.route_cmd import update_pcb_layer_stackup
+
+        result = update_pcb_layer_stackup(self.REALISTIC_2L_PCB, 4)
+
+        for layer_name in [
+            "B.Adhes", "F.Adhes", "B.Paste", "F.Paste",
+            "B.SilkS", "F.SilkS", "B.Mask", "F.Mask",
+            "Edge.Cuts", "Margin", "B.CrtYd", "F.CrtYd",
+            "B.Fab", "F.Fab",
+        ]:
+            assert layer_name in result, (
+                f"Non-copper layer {layer_name!r} was lost during upgrade"
+            )
+
+    def test_content_outside_layers_block_preserved(self):
+        """Content after the (layers ...) block is not corrupted."""
+        from kicad_tools.cli.route_cmd import update_pcb_layer_stackup
+
+        result = update_pcb_layer_stackup(self.REALISTIC_2L_PCB, 4)
+
+        assert '(net 0 "")' in result
+        assert '(net 1 "VCC")' in result
+
+    def test_non_copper_entries_with_extra_fields(self):
+        """Layer entries with extra string fields (e.g. user "B.Adhesive")
+        are preserved correctly."""
+        from kicad_tools.cli.route_cmd import update_pcb_layer_stackup
+
+        result = update_pcb_layer_stackup(self.REALISTIC_2L_PCB, 4)
+
+        # Entries with display name strings should survive
+        assert "B.Adhesive" in result
+        assert "F.Silkscreen" in result
+        assert "B.Courtyard" in result
+
+
 class TestLayerEscalationResult:
     """Tests for LayerEscalationResult dataclass."""
 


### PR DESCRIPTION
## Summary

Fix S-expression syntax error (unbalanced parentheses) when `update_pcb_layer_stackup()` fires on real KiCad PCB files that include non-copper layers (B.SilkS, Edge.Cuts, F.Fab, etc.) in their `(layers ...)` block.

## Changes

- Replace the broken primary regex (`[^)]*` stops at first inner entry's `)`) with the working alternative pattern that correctly matches the entire `(layers ...)` block
- Update the replacement function to extract and preserve non-copper layer entries from the matched block
- Add `_validate_sexp_parentheses` validation on the output, returning original content with a warning if balance check fails
- Remove the dead fallback code path (alt_pattern) since the new primary pattern handles all cases

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Regex matches full `(layers ...)` block | Pass | New pattern uses `\)` anchored per-entry + block-closing `)` |
| Non-copper layers preserved after upgrade | Pass | `test_non_copper_layers_preserved_after_upgrade` checks all 14 non-copper layers |
| Balanced parentheses in output | Pass | `test_2_to_4_balanced_parens` and `test_2_to_6_balanced_parens` validate with `_validate_sexp_parentheses` |
| Content outside layers block preserved | Pass | `test_content_outside_layers_block_preserved` checks `(net ...)` entries survive |
| All existing tests still pass | Pass | All 29 tests in `test_layer_escalation.py` pass |

## Test Plan

- All 29 tests in `tests/test_layer_escalation.py` pass (5 new tests added)
- New tests use a realistic 2-layer KiCad PCB with 14 non-copper layers to reproduce the exact failure scenario
- Tests cover 2-to-4 and 2-to-6 upgrades, non-copper preservation, paren balance, and content integrity

Closes #2416