### PR TITLE
fix(router): inset auto-pour zone boundaries by edge clearance

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -941,7 +941,11 @@ def route_with_layer_escalation(
     if getattr(args, "auto_pour", True):
         from kicad_tools.router.auto_pour import auto_pour_if_missing
 
-        auto_pour_if_missing(pcb_path, quiet=quiet)
+        auto_pour_if_missing(
+            pcb_path,
+            quiet=quiet,
+            edge_clearance=getattr(args, "edge_clearance", None),
+        )
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
@@ -1406,7 +1410,11 @@ def route_with_rule_relaxation(
     if getattr(args, "auto_pour", True):
         from kicad_tools.router.auto_pour import auto_pour_if_missing
 
-        auto_pour_if_missing(pcb_path, quiet=quiet)
+        auto_pour_if_missing(
+            pcb_path,
+            quiet=quiet,
+            edge_clearance=getattr(args, "edge_clearance", None),
+        )
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
@@ -1878,7 +1886,11 @@ def route_with_combined_escalation(
     if getattr(args, "auto_pour", True):
         from kicad_tools.router.auto_pour import auto_pour_if_missing
 
-        auto_pour_if_missing(pcb_path, quiet=quiet)
+        auto_pour_if_missing(
+            pcb_path,
+            quiet=quiet,
+            edge_clearance=getattr(args, "edge_clearance", None),
+        )
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
@@ -3222,7 +3234,11 @@ def main(argv: list[str] | None = None) -> int:
     if getattr(args, "auto_pour", True):
         from kicad_tools.router.auto_pour import auto_pour_if_missing
 
-        auto_pour_if_missing(pcb_path, quiet=args.quiet)
+        auto_pour_if_missing(
+            pcb_path,
+            quiet=args.quiet,
+            edge_clearance=getattr(args, "edge_clearance", None),
+        )
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=args.quiet)

--- a/src/kicad_tools/router/auto_pour.py
+++ b/src/kicad_tools/router/auto_pour.py
@@ -23,6 +23,7 @@ def auto_pour_if_missing(
     pcb_path: Path,
     *,
     quiet: bool = False,
+    edge_clearance: float | None = None,
 ) -> tuple[int, list[str]]:
     """Auto-create copper pours for power-classified nets that lack zones.
 
@@ -33,6 +34,9 @@ def auto_pour_if_missing(
     Args:
         pcb_path: Path to .kicad_pcb file (modified **in place**).
         quiet: Suppress informational output.
+        edge_clearance: Optional edge clearance in mm.  When set, zone
+            boundaries are inset from the board edge by this distance
+            to avoid copper-to-edge DRC violations.
 
     Returns:
         Tuple of ``(zones_created, pour_net_names)`` where
@@ -111,7 +115,9 @@ def auto_pour_if_missing(
     # ------------------------------------------------------------------
     # 5. Create zones via the shared generator
     # ------------------------------------------------------------------
-    count = auto_create_zones_for_pour_nets(pcb_path, new_pour_nets)
+    count = auto_create_zones_for_pour_nets(
+        pcb_path, new_pour_nets, edge_clearance=edge_clearance
+    )
 
     names = [name for name, _ in new_pour_nets]
     if not quiet and count > 0:

--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -118,26 +118,43 @@ class ZoneGenerator:
         gen.save("board_with_zones.kicad_pcb")
     """
 
-    def __init__(self, pcb: PCB, doc: SExp | None = None):
+    def __init__(
+        self,
+        pcb: PCB,
+        doc: SExp | None = None,
+        edge_clearance: float | None = None,
+    ):
         """Initialize zone generator.
 
         Args:
             pcb: Parsed PCB object
             doc: Raw S-expression document (for modification)
+            edge_clearance: If set, inset the auto-derived board outline
+                by this many mm so zone copper does not extend to the
+                board edge.  Only affects the automatic board-outline
+                boundary; explicit ``boundary`` arguments to
+                :meth:`add_zone` are never modified.
         """
         self._pcb = pcb
         self._doc = doc
+        self._edge_clearance = edge_clearance
         self._zones: list[GeneratedZone] = []
         self._warnings: list[ZoneOverlapWarning] = []
         self._board_outline: list[tuple[float, float]] | None = None
         self._applied = False
 
     @classmethod
-    def from_pcb(cls, path: str | Path) -> ZoneGenerator:
+    def from_pcb(
+        cls,
+        path: str | Path,
+        edge_clearance: float | None = None,
+    ) -> ZoneGenerator:
         """Load PCB and create zone generator.
 
         Args:
             path: Path to .kicad_pcb file
+            edge_clearance: Optional edge clearance in mm (see
+                :meth:`__init__` for details).
 
         Returns:
             ZoneGenerator instance
@@ -145,7 +162,7 @@ class ZoneGenerator:
         path = Path(path)
         pcb = PCB.load(str(path))
         doc = parse_file(path)
-        return cls(pcb, doc)
+        return cls(pcb, doc, edge_clearance=edge_clearance)
 
     @property
     def pcb(self) -> PCB:
@@ -158,6 +175,10 @@ class ZoneGenerator:
 
         Uses cached outline if available, otherwise extracts from PCB.
         Falls back to a default rectangle if no Edge.Cuts layer found.
+
+        When *edge_clearance* was set at construction time, the outline
+        is inset by that distance using Shapely's ``buffer(-clearance)``
+        so that zone copper does not extend to the board edge.
 
         Zone boundaries written to the PCB file must be in sheet-absolute
         coordinates. ``get_board_outline()`` returns board-relative coords,
@@ -174,7 +195,58 @@ class ZoneGenerator:
             else:
                 # Fallback: create outline from board bounds
                 self._board_outline = self._estimate_board_bounds()
+
+            # Apply edge clearance inset if configured
+            if self._edge_clearance and self._edge_clearance > 0:
+                try:
+                    self._board_outline = self._inset_polygon(
+                        self._board_outline, self._edge_clearance
+                    )
+                except ImportError:
+                    import warnings
+
+                    warnings.warn(
+                        "shapely is required for edge_clearance inset "
+                        "(install with: pip install kicad-tools[geometry]). "
+                        "Zone boundary will use exact board outline.",
+                        stacklevel=2,
+                    )
         return self._board_outline
+
+    @staticmethod
+    def _inset_polygon(
+        coords: list[tuple[float, float]],
+        distance: float,
+    ) -> list[tuple[float, float]]:
+        """Shrink a polygon inward by *distance* mm using Shapely.
+
+        If the inset collapses the polygon (e.g. very thin peninsulas),
+        returns the original coordinates unchanged.
+        """
+        from shapely.geometry import Polygon
+
+        poly = Polygon(coords)
+        inset = poly.buffer(-distance)
+
+        if inset.is_empty:
+            # Collapsed polygon -- fall back to original
+            return coords
+
+        # buffer() may return a MultiPolygon if thin regions collapse;
+        # keep only the largest polygon.
+        if inset.geom_type == "MultiPolygon":
+            inset = max(inset.geoms, key=lambda g: g.area)
+
+        # Extract exterior coordinates (Shapely repeats the first point
+        # at the end; drop the duplicate).
+        exterior_coords = list(inset.exterior.coords)
+        if (
+            len(exterior_coords) > 1
+            and exterior_coords[0] == exterior_coords[-1]
+        ):
+            exterior_coords = exterior_coords[:-1]
+
+        return [(round(x, 6), round(y, 6)) for x, y in exterior_coords]
 
     def _estimate_board_bounds(self) -> list[tuple[float, float]]:
         """Estimate board bounds from component positions.
@@ -636,6 +708,7 @@ def _assign_layers_for_pour_nets(
 def auto_create_zones_for_pour_nets(
     pcb_path: str | Path,
     pour_nets: list[tuple[str, "NetClass"]],
+    edge_clearance: float | None = None,
 ) -> int:
     """Create zones for power and ground nets on a PCB.
 
@@ -655,12 +728,15 @@ def auto_create_zones_for_pour_nets(
         pcb_path: Path to .kicad_pcb file (modified in place)
         pour_nets: List of (net_name, NetClass) tuples identifying
             which nets need zones
+        edge_clearance: Optional edge clearance in mm.  When set, the
+            auto-derived board outline is inset by this distance so that
+            zone copper does not extend to the board edge.
 
     Returns:
         Number of zones created
     """
     pcb_path = Path(pcb_path)
-    gen = ZoneGenerator.from_pcb(pcb_path)
+    gen = ZoneGenerator.from_pcb(pcb_path, edge_clearance=edge_clearance)
 
     copper_layer_count = len(gen.pcb.copper_layers)
     assignments = _assign_layers_for_pour_nets(copper_layer_count, pour_nets)

--- a/tests/test_auto_pour.py
+++ b/tests/test_auto_pour.py
@@ -206,3 +206,80 @@ class TestAutoPourIfMissing:
 
         assert count == 0
         assert names == []
+
+    def test_edge_clearance_insets_zone_boundary(self, tmp_path: Path):
+        """Zone boundary is inset from board edge when edge_clearance is set."""
+        import re
+
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        pcb = _make_pcb(
+            net_defs=[(1, "GND"), (2, "SDA")],
+            pad_nets=[(1, "GND"), (2, "SDA")],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(
+            pcb_path, edge_clearance=0.3
+        )
+
+        assert count == 1
+        assert names == ["GND"]
+
+        # Parse zone polygon coordinates from the written file
+        text = pcb_path.read_text()
+        # Extract xy coordinates from the zone polygon
+        xy_matches = re.findall(
+            r"\(xy\s+([\d.e+-]+)\s+([\d.e+-]+)\)", text
+        )
+        assert len(xy_matches) > 0, "No zone polygon coordinates found"
+
+        # Board edge is 0..50 in both X and Y (from _PCB_FOOTER).
+        # With 0.3mm edge clearance, all zone coords should be
+        # at least 0.3mm inward from the edges.
+        for x_str, y_str in xy_matches:
+            x, y = float(x_str), float(y_str)
+            assert x >= 0.3 - 0.01, (
+                f"X coord {x} too close to left edge (expected >= 0.3)"
+            )
+            assert x <= 49.7 + 0.01, (
+                f"X coord {x} too close to right edge (expected <= 49.7)"
+            )
+            assert y >= 0.3 - 0.01, (
+                f"Y coord {y} too close to top edge (expected >= 0.3)"
+            )
+            assert y <= 49.7 + 0.01, (
+                f"Y coord {y} too close to bottom edge (expected <= 49.7)"
+            )
+
+    def test_no_edge_clearance_uses_exact_outline(self, tmp_path: Path):
+        """Without edge_clearance, zone boundary matches board edge exactly."""
+        import re
+
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        pcb = _make_pcb(
+            net_defs=[(1, "GND"), (2, "SDA")],
+            pad_nets=[(1, "GND"), (2, "SDA")],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, _names = auto_pour_if_missing(pcb_path)
+        assert count == 1
+
+        text = pcb_path.read_text()
+        # Zone polygon should include coordinates at or very near the
+        # board edge (0 and 50).
+        xy_matches = re.findall(
+            r"\(xy\s+([\d.e+-]+)\s+([\d.e+-]+)\)", text
+        )
+        xs = [float(x) for x, _ in xy_matches]
+        ys = [float(y) for _, y in xy_matches]
+
+        # At least one coordinate should be at (or very near) each edge
+        assert min(xs) <= 0.01, "Expected coordinate near left edge (x=0)"
+        assert max(xs) >= 49.99, "Expected coordinate near right edge (x=50)"
+        assert min(ys) <= 0.01, "Expected coordinate near top edge (y=0)"
+        assert max(ys) >= 49.99, "Expected coordinate near bottom edge (y=50)"

--- a/tests/test_auto_pour.py
+++ b/tests/test_auto_pour.py
@@ -54,9 +54,7 @@ def _make_pcb(
         parts.append(f'  (net {nid} "{name}")\n')
 
     # Single dummy footprint with pads
-    parts.append(
-        '  (footprint "TestLib:TestPkg" (layer "F.Cu") (at 10 10)\n'
-    )
+    parts.append('  (footprint "TestLib:TestPkg" (layer "F.Cu") (at 10 10)\n')
     for idx, (nid, name) in enumerate(pad_nets):
         x_off = idx * 2.0
         parts.append(
@@ -209,6 +207,9 @@ class TestAutoPourIfMissing:
 
     def test_edge_clearance_insets_zone_boundary(self, tmp_path: Path):
         """Zone boundary is inset from board edge when edge_clearance is set."""
+        pytest.importorskip(
+            "shapely", reason="shapely required for edge clearance tests"
+        )
         import re
 
         from kicad_tools.router.auto_pour import auto_pour_if_missing
@@ -220,9 +221,7 @@ class TestAutoPourIfMissing:
         pcb_path = tmp_path / "test.kicad_pcb"
         pcb_path.write_text(pcb)
 
-        count, names = auto_pour_if_missing(
-            pcb_path, edge_clearance=0.3
-        )
+        count, names = auto_pour_if_missing(pcb_path, edge_clearance=0.3)
 
         assert count == 1
         assert names == ["GND"]
@@ -230,9 +229,7 @@ class TestAutoPourIfMissing:
         # Parse zone polygon coordinates from the written file
         text = pcb_path.read_text()
         # Extract xy coordinates from the zone polygon
-        xy_matches = re.findall(
-            r"\(xy\s+([\d.e+-]+)\s+([\d.e+-]+)\)", text
-        )
+        xy_matches = re.findall(r"\(xy\s+([\d.e+-]+)\s+([\d.e+-]+)\)", text)
         assert len(xy_matches) > 0, "No zone polygon coordinates found"
 
         # Board edge is 0..50 in both X and Y (from _PCB_FOOTER).
@@ -240,21 +237,24 @@ class TestAutoPourIfMissing:
         # at least 0.3mm inward from the edges.
         for x_str, y_str in xy_matches:
             x, y = float(x_str), float(y_str)
-            assert x >= 0.3 - 0.01, (
-                f"X coord {x} too close to left edge (expected >= 0.3)"
-            )
-            assert x <= 49.7 + 0.01, (
-                f"X coord {x} too close to right edge (expected <= 49.7)"
-            )
-            assert y >= 0.3 - 0.01, (
-                f"Y coord {y} too close to top edge (expected >= 0.3)"
-            )
-            assert y <= 49.7 + 0.01, (
-                f"Y coord {y} too close to bottom edge (expected <= 49.7)"
-            )
+            assert (
+                x >= 0.3 - 0.01
+            ), f"X coord {x} too close to left edge (expected >= 0.3)"
+            assert (
+                x <= 49.7 + 0.01
+            ), f"X coord {x} too close to right edge (expected <= 49.7)"
+            assert (
+                y >= 0.3 - 0.01
+            ), f"Y coord {y} too close to top edge (expected >= 0.3)"
+            assert (
+                y <= 49.7 + 0.01
+            ), f"Y coord {y} too close to bottom edge (expected <= 49.7)"
 
     def test_no_edge_clearance_uses_exact_outline(self, tmp_path: Path):
         """Without edge_clearance, zone boundary matches board edge exactly."""
+        pytest.importorskip(
+            "shapely", reason="shapely required for edge clearance tests"
+        )
         import re
 
         from kicad_tools.router.auto_pour import auto_pour_if_missing
@@ -272,9 +272,7 @@ class TestAutoPourIfMissing:
         text = pcb_path.read_text()
         # Zone polygon should include coordinates at or very near the
         # board edge (0 and 50).
-        xy_matches = re.findall(
-            r"\(xy\s+([\d.e+-]+)\s+([\d.e+-]+)\)", text
-        )
+        xy_matches = re.findall(r"\(xy\s+([\d.e+-]+)\s+([\d.e+-]+)\)", text)
         xs = [float(x) for x, _ in xy_matches]
         ys = [float(y) for _, y in xy_matches]
 

--- a/tests/test_zone_generator_edge_clearance.py
+++ b/tests/test_zone_generator_edge_clearance.py
@@ -1,0 +1,170 @@
+"""Tests for ZoneGenerator edge clearance inset behaviour.
+
+Verifies that ``ZoneGenerator`` correctly insets the auto-derived board
+outline when ``edge_clearance`` is set, and leaves explicit boundaries
+untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Edge clearance inset requires shapely (optional dependency)
+shapely = pytest.importorskip("shapely", reason="shapely required for edge clearance tests")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PCB_TEMPLATE = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "SIG")
+  (footprint "TestLib:TestPkg" (layer "F.Cu") (at 25 25)
+    (pad "1" smd roundrect (at 0 0) (size 1.0 1.3)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 1 "GND"))
+    (pad "2" smd roundrect (at 2 0) (size 1.0 1.3)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25)
+      (net 2 "SIG"))
+  )
+  (gr_line (start 0 0) (end 100 0) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 100 0) (end 100 100) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 100 100) (end 0 100) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 0 100) (end 0 0) (stroke (width 0.05) (type default)) (layer "Edge.Cuts"))
+)
+"""
+
+
+def _write_pcb(tmp_path: Path) -> Path:
+    pcb_path = tmp_path / "test.kicad_pcb"
+    pcb_path.write_text(_PCB_TEMPLATE)
+    return pcb_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestZoneGeneratorEdgeClearance:
+    """Tests for edge_clearance inset in ZoneGenerator."""
+
+    def test_inset_applied_to_auto_boundary(self, tmp_path: Path):
+        """board_outline is inset when edge_clearance is set."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        pcb_path = _write_pcb(tmp_path)
+        gen = ZoneGenerator.from_pcb(pcb_path, edge_clearance=0.5)
+
+        outline = gen.board_outline
+
+        # All coordinates must be at least 0.5mm from 0 and 100
+        for x, y in outline:
+            assert x >= 0.5 - 0.01, f"X={x} too close to left edge"
+            assert x <= 99.5 + 0.01, f"X={x} too close to right edge"
+            assert y >= 0.5 - 0.01, f"Y={y} too close to top edge"
+            assert y <= 99.5 + 0.01, f"Y={y} too close to bottom edge"
+
+    def test_no_inset_without_edge_clearance(self, tmp_path: Path):
+        """board_outline matches board edge when no edge_clearance is set."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        pcb_path = _write_pcb(tmp_path)
+        gen = ZoneGenerator.from_pcb(pcb_path)
+
+        outline = gen.board_outline
+        xs = [x for x, _ in outline]
+        ys = [y for _, y in outline]
+
+        # Should reach the board edge (0 and 100)
+        assert min(xs) <= 0.01
+        assert max(xs) >= 99.99
+        assert min(ys) <= 0.01
+        assert max(ys) >= 99.99
+
+    def test_no_inset_with_zero_clearance(self, tmp_path: Path):
+        """edge_clearance=0 behaves like no clearance (no inset)."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        pcb_path = _write_pcb(tmp_path)
+        gen_zero = ZoneGenerator.from_pcb(pcb_path, edge_clearance=0)
+        gen_none = ZoneGenerator.from_pcb(pcb_path, edge_clearance=None)
+
+        assert gen_zero.board_outline == gen_none.board_outline
+
+    def test_explicit_boundary_not_modified(self, tmp_path: Path):
+        """Zones with explicit boundary are not affected by edge_clearance."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        pcb_path = _write_pcb(tmp_path)
+        gen = ZoneGenerator.from_pcb(pcb_path, edge_clearance=5.0)
+
+        custom_boundary = [(0, 0), (100, 0), (100, 100), (0, 100)]
+        zone = gen.add_zone(
+            net="GND", layer="B.Cu", boundary=custom_boundary
+        )
+
+        # The explicit boundary should be used as-is, not inset
+        assert zone.boundary == custom_boundary
+
+    def test_add_zone_uses_inset_outline(self, tmp_path: Path):
+        """add_zone() without boundary uses the inset board outline."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        pcb_path = _write_pcb(tmp_path)
+        gen = ZoneGenerator.from_pcb(pcb_path, edge_clearance=1.0)
+
+        zone = gen.add_zone(net="GND", layer="B.Cu")
+
+        # Zone boundary should be the inset outline
+        for x, y in zone.boundary:
+            assert x >= 1.0 - 0.01, f"X={x} too close to left edge"
+            assert x <= 99.0 + 0.01, f"X={x} too close to right edge"
+            assert y >= 1.0 - 0.01, f"Y={y} too close to top edge"
+            assert y <= 99.0 + 0.01, f"Y={y} too close to bottom edge"
+
+
+class TestInsetPolygon:
+    """Unit tests for the static _inset_polygon helper."""
+
+    def test_square_inset(self):
+        """Insetting a square produces a smaller square."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        coords = [(0, 0), (10, 0), (10, 10), (0, 10)]
+        result = ZoneGenerator._inset_polygon(coords, 1.0)
+
+        xs = [x for x, _ in result]
+        ys = [y for _, y in result]
+
+        assert min(xs) >= 1.0 - 0.01
+        assert max(xs) <= 9.0 + 0.01
+        assert min(ys) >= 1.0 - 0.01
+        assert max(ys) <= 9.0 + 0.01
+
+    def test_collapsed_polygon_returns_original(self):
+        """If inset collapses the polygon, original coords are returned."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        # Very thin rectangle that will collapse with 5mm inset
+        coords = [(0, 0), (1, 0), (1, 100), (0, 100)]
+        result = ZoneGenerator._inset_polygon(coords, 5.0)
+
+        # Should return original since inset collapses the polygon
+        assert result == coords


### PR DESCRIPTION
## Summary

Auto-pour zones now respect edge clearance by insetting the zone boundary polygon from the board edge. Previously, zones filled to the exact board outline, causing DRC copper-to-edge violations on manufactured boards.

## Changes

- Added edge_clearance parameter to ZoneGenerator.__init__() and from_pcb() to support polygon inset
- Added _inset_polygon() static method using Shapely buffer(-clearance) with graceful fallback when shapely is not installed
- Threaded edge_clearance through auto_pour_if_missing() and auto_create_zones_for_pour_nets()
- Updated all 4 auto_pour_if_missing() call sites in route_cmd.py to pass args.edge_clearance
- Added 2 integration tests in test_auto_pour.py verifying inset and exact-outline behaviour
- Added test_zone_generator_edge_clearance.py with 7 tests covering inset, zero/None clearance, explicit boundary preservation, and collapsed polygon edge case

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Zone polygon inset by edge_clearance | Pass | test_edge_clearance_insets_zone_boundary confirms all coords >= 0.3mm from edge |
| Explicit boundaries not modified | Pass | test_explicit_boundary_not_modified confirms custom boundary unchanged |
| Backward compatible (None/0 clearance) | Pass | test_no_inset_with_zero_clearance and test_no_edge_clearance_uses_exact_outline |
| Collapsed polygon handled gracefully | Pass | test_collapsed_polygon_returns_original returns original coords |
| Shapely unavailable handled gracefully | Pass | ImportError caught with warning, falls back to exact outline |

## Test Plan

All 16 tests pass (9 existing + 2 new in test_auto_pour.py + 5 new in test_zone_generator_edge_clearance.py + 2 new in TestInsetPolygon).

Closes #2411