### PR TITLE
fix(router): add pad metal area expansion and approach zone relaxation to C++ pathfinder

### DIFF
--- a/src/kicad_tools/router/cpp/include/pathfinder.hpp
+++ b/src/kicad_tools/router/cpp/include/pathfinder.hpp
@@ -35,7 +35,9 @@ public:
         float present_cost_factor = 0.0f,
         float weight = 1.0f,  // A* weight (1.0 = optimal, >1.0 = faster)
         int trace_radius_cells = 0,  // Per-net trace clearance radius (0 = use default)
-        int via_radius_cells = 0     // Per-net via clearance radius (0 = use default)
+        int via_radius_cells = 0,    // Per-net via clearance radius (0 = use default)
+        const PadBounds& start_pad_bounds = {},  // Start pad metal/approach bounds
+        const PadBounds& end_pad_bounds = {}     // End pad metal/approach bounds
     );
 
     // Configure routable layers (skip plane layers)

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -76,6 +76,18 @@ struct Neighbor {
     float cost_mult;
 };
 
+// Pad bounds in grid coordinates for metal area and approach zone
+struct PadBounds {
+    int metal_gx1 = 0;
+    int metal_gy1 = 0;
+    int metal_gx2 = 0;
+    int metal_gy2 = 0;
+    int approach_gx1 = 0;
+    int approach_gy1 = 0;
+    int approach_gx2 = 0;
+    int approach_gy2 = 0;
+};
+
 // Design rules (simplified for C++ core)
 struct DesignRules {
     float trace_width = 0.127f;

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -46,6 +46,18 @@ NB_MODULE(router_cpp, m) {
         .def_rw("cost_congestion", &DesignRules::cost_congestion)
         .def_rw("congestion_threshold", &DesignRules::congestion_threshold);
 
+    // PadBounds struct
+    nb::class_<PadBounds>(m, "PadBounds")
+        .def(nb::init<>())
+        .def_rw("metal_gx1", &PadBounds::metal_gx1)
+        .def_rw("metal_gy1", &PadBounds::metal_gy1)
+        .def_rw("metal_gx2", &PadBounds::metal_gx2)
+        .def_rw("metal_gy2", &PadBounds::metal_gy2)
+        .def_rw("approach_gx1", &PadBounds::approach_gx1)
+        .def_rw("approach_gy1", &PadBounds::approach_gy1)
+        .def_rw("approach_gx2", &PadBounds::approach_gx2)
+        .def_rw("approach_gy2", &PadBounds::approach_gy2);
+
     // Segment struct
     nb::class_<Segment>(m, "Segment")
         .def(nb::init<>())
@@ -139,7 +151,9 @@ NB_MODULE(router_cpp, m) {
              "present_cost_factor"_a = 0.0f,
              "weight"_a = 1.0f,
              "trace_radius_cells"_a = 0,
-             "via_radius_cells"_a = 0)
+             "via_radius_cells"_a = 0,
+             "start_pad_bounds"_a = PadBounds{},
+             "end_pad_bounds"_a = PadBounds{})
         .def("set_routable_layers", &Pathfinder::set_routable_layers, "layers"_a)
         .def_prop_ro("iterations", &Pathfinder::get_iterations)
         .def_prop_ro("nodes_explored", &Pathfinder::get_nodes_explored);

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -196,7 +196,9 @@ RouteResult Pathfinder::route(
     float present_cost_factor,
     float weight,
     int trace_radius_cells,
-    int via_radius_cells
+    int via_radius_cells,
+    const PadBounds& start_pad_bounds,
+    const PadBounds& end_pad_bounds
 ) {
     RouteResult result;
     result.net = net;
@@ -212,6 +214,35 @@ RouteResult Pathfinder::route(
     std::vector<int> valid_end_layers = end_layers.empty()
         ? std::vector<int>{end_layer} : end_layers;
 
+    // Issue #2427: Use pad bounds if provided, otherwise fall back to single-cell
+    // bounds matching the grid-snapped center (backward-compatible).
+    PadBounds sp = start_pad_bounds;
+    PadBounds ep = end_pad_bounds;
+    bool has_start_bounds = (sp.metal_gx1 != sp.metal_gx2 || sp.metal_gy1 != sp.metal_gy2
+                             || (sp.metal_gx1 == start_gx && sp.metal_gy1 == start_gy));
+    bool has_end_bounds = (ep.metal_gx1 != ep.metal_gx2 || ep.metal_gy1 != ep.metal_gy2
+                           || (ep.metal_gx1 == end_gx && ep.metal_gy1 == end_gy));
+    // If no bounds were passed (all zeros but not matching grid coords), create
+    // single-cell bounds at the grid-snapped position for uniform code paths.
+    if (!has_start_bounds && sp.metal_gx1 == 0 && sp.metal_gy1 == 0
+        && sp.metal_gx2 == 0 && sp.metal_gy2 == 0) {
+        sp.metal_gx1 = sp.metal_gx2 = start_gx;
+        sp.metal_gy1 = sp.metal_gy2 = start_gy;
+        sp.approach_gx1 = start_gx - 2;
+        sp.approach_gy1 = start_gy - 2;
+        sp.approach_gx2 = start_gx + 2;
+        sp.approach_gy2 = start_gy + 2;
+    }
+    if (!has_end_bounds && ep.metal_gx1 == 0 && ep.metal_gy1 == 0
+        && ep.metal_gx2 == 0 && ep.metal_gy2 == 0) {
+        ep.metal_gx1 = ep.metal_gx2 = end_gx;
+        ep.metal_gy1 = ep.metal_gy2 = end_gy;
+        ep.approach_gx1 = end_gx - 2;
+        ep.approach_gy1 = end_gy - 2;
+        ep.approach_gx2 = end_gx + 2;
+        ep.approach_gy2 = end_gy + 2;
+    }
+
     // A* data structures
     using PQ = std::priority_queue<AStarNode, std::vector<AStarNode>, std::greater<AStarNode>>;
     PQ open_set;
@@ -219,12 +250,23 @@ RouteResult Pathfinder::route(
     std::unordered_map<std::tuple<int, int, int>, float, GridPosHash> g_scores;
     std::vector<AStarNode> closed_list;  // For path reconstruction
 
-    // Initialize with start nodes (one per valid start layer)
-    for (int sl : valid_start_layers) {
-        float h = heuristic(start_gx, start_gy, sl, end_gx, end_gy, valid_end_layers[0]);
-        AStarNode start_node{h, 0.0f, start_gx, start_gy, sl, -1, false, 0, 0};
-        open_set.push(start_node);
-        g_scores[{start_gx, start_gy, sl}] = 0.0f;
+    // Issue #2427 Phase 1: Seed start nodes from ALL cells within start pad's
+    // metal area, not just the grid-snapped center. This handles off-grid pads
+    // where the center cell may be blocked by another net's clearance zone.
+    for (int sgx = sp.metal_gx1; sgx <= sp.metal_gx2; ++sgx) {
+        for (int sgy = sp.metal_gy1; sgy <= sp.metal_gy2; ++sgy) {
+            if (!grid_.is_valid(sgx, sgy, 0)) continue;
+            for (int sl : valid_start_layers) {
+                float h = heuristic(sgx, sgy, sl, end_gx, end_gy, valid_end_layers[0]);
+                AStarNode start_node{h, 0.0f, sgx, sgy, sl, -1, false, 0, 0};
+                auto key = std::make_tuple(sgx, sgy, sl);
+                auto it = g_scores.find(key);
+                if (it == g_scores.end() || 0.0f < it->second) {
+                    g_scores[key] = 0.0f;
+                    open_set.push(start_node);
+                }
+            }
+        }
     }
 
     int max_iterations = grid_.cols() * grid_.rows() * 4;
@@ -248,8 +290,15 @@ RouteResult Pathfinder::route(
         closed_list.push_back(current);
         last_nodes_explored_++;
 
-        // Goal check
-        if (current.x == end_gx && current.y == end_gy) {
+        // Issue #2427 Phase 1: Goal check - accept any cell within end pad's
+        // metal area bounds, not just the exact grid-snapped center cell.
+        // This handles off-grid pads where the center doesn't align with the
+        // routing grid (mirrors Python pathfinder behavior from Issue #956).
+        bool in_end_metal = (
+            current.x >= ep.metal_gx1 && current.x <= ep.metal_gx2 &&
+            current.y >= ep.metal_gy1 && current.y <= ep.metal_gy2
+        );
+        if (in_end_metal) {
             bool layer_ok = std::find(valid_end_layers.begin(), valid_end_layers.end(),
                                       current.layer) != valid_end_layers.end();
             if (layer_ok) {
@@ -259,6 +308,21 @@ RouteResult Pathfinder::route(
                 return result;
             }
         }
+
+        // Issue #2427 Phase 2: Pre-compute whether current node is within a
+        // pad's metal area (for pad exit relaxation, mirroring Issue #990).
+        bool is_exiting_start_pad = (
+            current.x >= sp.metal_gx1 && current.x <= sp.metal_gx2 &&
+            current.y >= sp.metal_gy1 && current.y <= sp.metal_gy2 &&
+            std::find(valid_start_layers.begin(), valid_start_layers.end(),
+                      current.layer) != valid_start_layers.end()
+        );
+        bool is_exiting_end_pad = (
+            current.x >= ep.metal_gx1 && current.x <= ep.metal_gx2 &&
+            current.y >= ep.metal_gy1 && current.y <= ep.metal_gy2 &&
+            std::find(valid_end_layers.begin(), valid_end_layers.end(),
+                      current.layer) != valid_end_layers.end()
+        );
 
         // Explore 2D neighbors
         for (const auto& [dx, dy, dlayer, cost_mult] : neighbors_2d_) {
@@ -281,21 +345,52 @@ RouteResult Pathfinder::route(
             // Check cell blocking
             const auto& cell = grid_.at(nx, ny, nlayer);
 
-            // Check if cell is near start/end pads (pad approach relaxation)
-            bool is_start = (nx == start_gx && ny == start_gy &&
-                std::find(valid_start_layers.begin(), valid_start_layers.end(), nlayer) !=
-                valid_start_layers.end());
-            bool is_end = (nx == end_gx && ny == end_gy &&
-                std::find(valid_end_layers.begin(), valid_end_layers.end(), nlayer) !=
-                valid_end_layers.end());
+            // Issue #2427 Phase 2: Geometry-derived approach zone and pad metal
+            // area checks (mirrors Python pathfinder Issues #1618, #990, #1764).
+            bool layer_in_start = std::find(valid_start_layers.begin(),
+                valid_start_layers.end(), nlayer) != valid_start_layers.end();
+            bool layer_in_end = std::find(valid_end_layers.begin(),
+                valid_end_layers.end(), nlayer) != valid_end_layers.end();
+
+            bool is_in_start_metal = (
+                nx >= sp.metal_gx1 && nx <= sp.metal_gx2 &&
+                ny >= sp.metal_gy1 && ny <= sp.metal_gy2 && layer_in_start
+            );
+            bool is_in_end_metal = (
+                nx >= ep.metal_gx1 && nx <= ep.metal_gx2 &&
+                ny >= ep.metal_gy1 && ny <= ep.metal_gy2 && layer_in_end
+            );
+
+            bool is_start_adjacent = (
+                nx >= sp.approach_gx1 && nx <= sp.approach_gx2 &&
+                ny >= sp.approach_gy1 && ny <= sp.approach_gy2 && layer_in_start
+            );
+            bool is_end_adjacent = (
+                nx >= ep.approach_gx1 && nx <= ep.approach_gx2 &&
+                ny >= ep.approach_gy1 && ny <= ep.approach_gy2 && layer_in_end
+            );
 
             if (cell.blocked) {
-                // Allow routing through start/end pad centers
-                if (is_start || is_end) {
-                    if (cell.net != net) continue;  // Wrong net
-                } else {
+                // Issue #1764: If neighbor is within pad metal area, always allow
+                if (is_in_start_metal || is_in_end_metal) {
+                    // Allow entry into own pad's metal area
+                } else if (cell.net == net) {
+                    // Same-net blocked cell (e.g., our THT pad area) - allow
+                } else if (cell.net == 0) {
+                    // No-net blocked cell - use full check
                     if (is_trace_blocked(nx, ny, nlayer, net, negotiated_mode,
                                          trace_radius_cells)) {
+                        continue;
+                    }
+                } else {
+                    // Different net's blocked cell
+                    // Issue #996/#990: When exiting a pad, allow entering clearance
+                    // zones (not actual pad copper) so A* can escape dense layouts.
+                    bool is_clearance_only = !cell.pad_blocked;
+                    bool is_pad_exit = is_exiting_start_pad || is_exiting_end_pad;
+                    if (is_clearance_only && is_pad_exit) {
+                        // Clearance zone cell while exiting pad - allow
+                    } else {
                         continue;
                     }
                 }
@@ -303,8 +398,12 @@ RouteResult Pathfinder::route(
                 // Issue #1702 Gap 1: Even when center cell is unblocked, check
                 // trace clearance. The trace has physical width and must not
                 // violate clearance to other nets within its radius. Skip this
-                // check near start/end pads to allow pad approach/exit.
-                if (!is_start && !is_end) {
+                // check near pads to allow pad approach/exit (Issue #990/#1618).
+                bool is_pad_exit_or_approach = (
+                    is_start_adjacent || is_end_adjacent ||
+                    is_exiting_start_pad || is_exiting_end_pad
+                );
+                if (!is_pad_exit_or_approach) {
                     if (is_trace_blocked(nx, ny, nlayer, net, negotiated_mode,
                                          trace_radius_cells)) {
                         continue;

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -372,6 +372,66 @@ class CppPathfinder:
         layer = Layer(layer_value)
         return layer.kicad_name in self._rules.allowed_layers
 
+    def _compute_pad_bounds(self, pad: Pad) -> "router_cpp.PadBounds":
+        """Compute pad metal area and approach zone bounds in grid coordinates.
+
+        This mirrors the Python pathfinder's ``_get_pad_metal_bounds()`` logic
+        (Issue #956/#977) so the C++ A* search can:
+        - Accept any cell within the end pad's metal area as a goal (Phase 1)
+        - Seed start nodes from all cells within the start pad's metal area
+        - Define geometry-derived approach zones for clearance relaxation (Phase 2)
+
+        Args:
+            pad: The pad to compute bounds for.
+
+        Returns:
+            A ``router_cpp.PadBounds`` struct with metal and approach grid bounds.
+        """
+        # Calculate effective pad dimensions (same logic as grid._add_pad_unsafe)
+        if getattr(pad, "through_hole", False):
+            if pad.width > 0 and pad.height > 0:
+                effective_width = pad.width
+                effective_height = pad.height
+            elif getattr(pad, "drill", 0) > 0:
+                effective_width = pad.drill + 0.7
+                effective_height = effective_width
+            else:
+                effective_width = 1.7
+                effective_height = 1.7
+        else:
+            effective_width = pad.width
+            effective_height = pad.height
+
+        # Metal area bounds in world coordinates
+        metal_x1 = pad.x - effective_width / 2
+        metal_y1 = pad.y - effective_height / 2
+        metal_x2 = pad.x + effective_width / 2
+        metal_y2 = pad.y + effective_height / 2
+
+        # Convert to grid coordinates using ceil/floor to include only cells
+        # whose CENTER is inside the metal area (Issue #996).
+        resolution = self._grid.resolution
+        origin_x = self._grid.origin_x
+        origin_y = self._grid.origin_y
+
+        gx1 = max(0, math.ceil((metal_x1 - origin_x) / resolution))
+        gy1 = max(0, math.ceil((metal_y1 - origin_y) / resolution))
+        gx2 = min(self._grid.cols - 1, math.floor((metal_x2 - origin_x) / resolution))
+        gy2 = min(self._grid.rows - 1, math.floor((metal_y2 - origin_y) / resolution))
+
+        # Approach zone: metal area + 2-cell escape margin (Issue #1618)
+        pad_escape_margin = 2
+        bounds = router_cpp.PadBounds()
+        bounds.metal_gx1 = int(gx1)
+        bounds.metal_gy1 = int(gy1)
+        bounds.metal_gx2 = int(gx2)
+        bounds.metal_gy2 = int(gy2)
+        bounds.approach_gx1 = int(gx1) - pad_escape_margin
+        bounds.approach_gy1 = int(gy1) - pad_escape_margin
+        bounds.approach_gx2 = int(gx2) + pad_escape_margin
+        bounds.approach_gy2 = int(gy2) + pad_escape_margin
+        return bounds
+
     def route(
         self,
         start: Pad,
@@ -456,6 +516,13 @@ class CppPathfinder:
             ),
         )
 
+        # Issue #2427: Compute pad metal bounds and approach zones.
+        # This mirrors the Python pathfinder's _get_pad_metal_bounds() logic
+        # so the C++ A* search can use expanded goal/start regions and
+        # geometry-derived approach zone relaxation.
+        start_pad_bounds = self._compute_pad_bounds(start)
+        end_pad_bounds = self._compute_pad_bounds(end)
+
         # Route using C++ implementation
         result = self._impl.route(
             start.x,
@@ -472,6 +539,8 @@ class CppPathfinder:
             weight,
             trace_radius_cells,
             via_radius_cells,
+            start_pad_bounds,
+            end_pad_bounds,
         )
 
         if not result.success:

--- a/tests/test_router_cpp_backend.py
+++ b/tests/test_router_cpp_backend.py
@@ -146,6 +146,156 @@ class TestCppPathfinderRouteSignature:
         assert param.default is None
 
 
+class TestCppPathfinderPadBounds:
+    """Test pad metal area expansion and approach zone relaxation (Issue #2427)."""
+
+    def test_compute_pad_bounds_smd(self):
+        """Test _compute_pad_bounds for an SMD pad returns correct metal/approach grid bounds."""
+        if not is_cpp_available():
+            import pytest
+
+            pytest.skip("C++ backend not available")
+
+        from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder
+        from kicad_tools.router.layers import Layer, LayerStack
+        from kicad_tools.router.primitives import Pad
+        from kicad_tools.router.rules import DesignRules
+
+        rules = DesignRules()
+        rules.grid_resolution = 0.127
+        from kicad_tools.router.grid import RoutingGrid
+
+        grid = RoutingGrid(
+            width=10.0,
+            height=10.0,
+            rules=rules,
+            layer_stack=LayerStack.two_layer(),
+        )
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        pf = CppPathfinder(cpp_grid, rules)
+
+        # Create an SMD pad at a known position
+        pad = Pad(
+            x=5.0,
+            y=5.0,
+            width=1.0,
+            height=0.5,
+            net=1,
+            net_name="NET1",
+            layer=Layer.F_CU,
+        )
+        bounds = pf._compute_pad_bounds(pad)
+
+        # Metal bounds should span the pad's copper area
+        assert bounds.metal_gx1 <= bounds.metal_gx2
+        assert bounds.metal_gy1 <= bounds.metal_gy2
+        # Approach bounds should be metal + 2 cells
+        assert bounds.approach_gx1 == bounds.metal_gx1 - 2
+        assert bounds.approach_gy1 == bounds.metal_gy1 - 2
+        assert bounds.approach_gx2 == bounds.metal_gx2 + 2
+        assert bounds.approach_gy2 == bounds.metal_gy2 + 2
+
+    def test_compute_pad_bounds_through_hole(self):
+        """Test _compute_pad_bounds for a through-hole pad with drill."""
+        if not is_cpp_available():
+            import pytest
+
+            pytest.skip("C++ backend not available")
+
+        from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder
+        from kicad_tools.router.layers import Layer, LayerStack
+        from kicad_tools.router.primitives import Pad
+        from kicad_tools.router.rules import DesignRules
+
+        rules = DesignRules()
+        rules.grid_resolution = 0.127
+        from kicad_tools.router.grid import RoutingGrid
+
+        grid = RoutingGrid(
+            width=10.0,
+            height=10.0,
+            rules=rules,
+            layer_stack=LayerStack.two_layer(),
+        )
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        pf = CppPathfinder(cpp_grid, rules)
+
+        # Through-hole pad with drill
+        pad = Pad(
+            x=5.0,
+            y=5.0,
+            width=1.7,
+            height=1.7,
+            net=1,
+            net_name="NET1",
+            layer=Layer.F_CU,
+            through_hole=True,
+            drill=1.0,
+        )
+        bounds = pf._compute_pad_bounds(pad)
+
+        # THT pad should have reasonable metal area
+        assert bounds.metal_gx1 <= bounds.metal_gx2
+        assert bounds.metal_gy1 <= bounds.metal_gy2
+        # Metal area should span more than 1 cell for a 1.7mm pad at 0.127mm res
+        assert bounds.metal_gx2 - bounds.metal_gx1 >= 1
+        assert bounds.metal_gy2 - bounds.metal_gy1 >= 1
+
+    def test_cpp_routes_off_grid_pad(self):
+        """Test that C++ backend routes successfully when pad is off-grid.
+
+        Creates a scenario where the pad center is offset by half a grid cell,
+        verifying the metal area expansion allows the route to succeed.
+        """
+        if not is_cpp_available():
+            import pytest
+
+            pytest.skip("C++ backend not available")
+
+        from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder
+        from kicad_tools.router.layers import Layer, LayerStack
+        from kicad_tools.router.primitives import Pad
+        from kicad_tools.router.rules import DesignRules
+
+        rules = DesignRules()
+        rules.grid_resolution = 0.254  # Coarse grid to make off-grid effect visible
+        from kicad_tools.router.grid import RoutingGrid
+
+        grid = RoutingGrid(
+            width=20.0,
+            height=20.0,
+            rules=rules,
+            layer_stack=LayerStack.two_layer(),
+        )
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        pf = CppPathfinder(cpp_grid, rules)
+
+        # Start pad on-grid
+        start = Pad(
+            x=5.0,
+            y=10.0,
+            width=1.0,
+            height=1.0,
+            net=1,
+            net_name="NET1",
+            layer=Layer.F_CU,
+        )
+        # End pad offset by half a grid cell (off-grid)
+        end = Pad(
+            x=15.0 + rules.grid_resolution * 0.5,
+            y=10.0 + rules.grid_resolution * 0.5,
+            width=1.0,
+            height=1.0,
+            net=1,
+            net_name="NET1",
+            layer=Layer.F_CU,
+        )
+
+        route = pf.route(start, end)
+        assert route is not None, "C++ backend should find route to off-grid pad"
+        assert len(route.segments) > 0
+
+
 class TestCppBackendImport:
     """Test import behavior of cpp_backend module."""
 


### PR DESCRIPTION
## Summary
The C++ pathfinder was missing three features present in the Python pathfinder, causing route failures on boards with off-grid or densely packed pads. This PR adds pad metal area expansion for goal/start checks, geometry-derived approach zone relaxation, and pad exit logic to the C++ A* search.

## Changes
- **types.hpp**: Add `PadBounds` struct with metal area and approach zone grid coordinates
- **pathfinder.hpp**: Extend `route()` signature with `start_pad_bounds` and `end_pad_bounds` parameters
- **pathfinder.cpp**: Seed start nodes from all cells within start pad metal area; accept any cell within end pad metal area as goal; skip trace clearance checks in approach zones; allow clearance-zone entry when exiting pads
- **bindings.cpp**: Expose `PadBounds` struct and updated `route()` parameters via nanobind
- **cpp_backend.py**: Add `_compute_pad_bounds()` method mirroring Python's `_get_pad_metal_bounds()` logic; pass computed bounds to C++ `route()` call
- **test_router_cpp_backend.py**: Add 3 tests for SMD/THT pad bounds computation and off-grid pad routing

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pad metal area expansion for goal check | Done | C++ goal check now uses `ep.metal_gx1..gx2` bounds instead of exact `end_gx/end_gy` match |
| Pad metal area expansion for start seeding | Done | Start nodes seeded from all cells in `sp.metal_gx1..gx2` range |
| Geometry-derived approach zone relaxation | Done | Approach bounds (metal + 2 cells) used for trace clearance skip |
| Pad exit logic for dense layouts | Done | `is_exiting_start_pad`/`is_exiting_end_pad` checks allow clearance-only cell entry |
| Backward compatibility | Done | Default `PadBounds{}` falls back to single-cell behavior at grid-snapped center |

## Test Plan
- All 21 tests in `test_router_cpp_backend.py` pass (18 existing + 3 new)
- C++ extension builds successfully with `kct build-native`
- No regressions in `test_router_core.py` or `test_router_algorithms.py` (2 pre-existing failures on main confirmed)

Closes #2427