### PR TITLE
fix(router): detect charlieplex matrix topology and assign alternating layer preferences

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -472,6 +472,11 @@ class Autorouter:
         # Cache for component pitches, computed lazily on first access
         self._component_pitches: dict[str, float] | None = None
 
+        # Issue #2432: Matrix-conflicting net IDs (charlieplex topology).
+        # Populated by _detect_and_apply_matrix_preferences() before the
+        # routing loop so _calculate_constraint_score() can boost priority.
+        self._matrix_conflict_nets: set[int] = set()
+
         # Pre-route congestion estimator (Issue #2278)
         # Computed lazily before net ordering; provides RUDY-based
         # congestion scores used as a 6th tiebreaker in _get_net_priority().
@@ -1764,6 +1769,14 @@ class Autorouter:
                 score += fine_pitch_weight
                 break  # One off-grid pad is enough to boost the whole net
 
+        # Issue #2432: Matrix-conflicting nets (charlieplex topology) are
+        # heavily constrained because they share pads with other nets in
+        # the same conflict group.  Boost their priority so they route
+        # before non-matrix nets, giving the layer preference assignment
+        # maximum effect.
+        if net_id in self._matrix_conflict_nets:
+            score += fine_pitch_weight * 2
+
         return score
 
     def _net_has_off_grid_pads(self, net_id: int) -> bool:
@@ -1891,6 +1904,205 @@ class Autorouter:
             f"  Skipping {len(pour_nets)} pour net(s) (use zone fill instead): {pour_names}"
         )
         return [n for n in net_order if not self._is_pour_net(n)]
+
+    # ------------------------------------------------------------------
+    # Matrix-conflict detection and layer preference assignment (Issue #2432)
+    # ------------------------------------------------------------------
+
+    def _detect_matrix_conflicts(
+        self, net_ids: list[int], threshold: int = 2
+    ) -> list[set[int]]:
+        """Detect groups of nets sharing multiple components (matrix topology).
+
+        In a charlieplex LED matrix, nets like NODE_A through NODE_D each
+        connect to many of the same LEDs.  Two nets are "matrix-conflicting"
+        when they share more than *threshold* components (by reference
+        designator, e.g. "D1").  This method returns groups of mutually
+        conflicting nets that require layer separation to avoid circular
+        blocking during negotiated rip-up.
+
+        Issue #2432: Charlieplex NODE nets stall because they share
+        interleaved LED pads and cannot be ordered sequentially.
+
+        Args:
+            net_ids: Net IDs to analyse (typically the routing order,
+                already filtered of pour nets).
+            threshold: Minimum number of shared components for two nets
+                to be considered conflicting (default 2).
+
+        Returns:
+            List of sets, each set containing net IDs that are mutually
+            conflicting.  Non-conflicting nets are not included.
+        """
+        # Build per-net component sets (references only, ignore pin number)
+        net_components: dict[int, set[str]] = {}
+        for net_id in net_ids:
+            pad_keys = self.nets.get(net_id, [])
+            refs: set[str] = set()
+            for ref, _pin in pad_keys:
+                refs.add(ref)
+            if refs:
+                net_components[net_id] = refs
+
+        # Build adjacency: two nets are conflicting if they share > threshold refs
+        from collections import defaultdict
+
+        adjacency: dict[int, set[int]] = defaultdict(set)
+        net_list = list(net_components.keys())
+        for i in range(len(net_list)):
+            for j in range(i + 1, len(net_list)):
+                a, b = net_list[i], net_list[j]
+                shared = len(net_components[a] & net_components[b])
+                if shared >= threshold:
+                    adjacency[a].add(b)
+                    adjacency[b].add(a)
+
+        if not adjacency:
+            return []
+
+        # Connected-components via BFS to find groups of conflicting nets
+        visited: set[int] = set()
+        groups: list[set[int]] = []
+        for net_id in adjacency:
+            if net_id in visited:
+                continue
+            group: set[int] = set()
+            queue = [net_id]
+            while queue:
+                current = queue.pop()
+                if current in visited:
+                    continue
+                visited.add(current)
+                group.add(current)
+                for neighbor in adjacency[current]:
+                    if neighbor not in visited:
+                        queue.append(neighbor)
+            if len(group) >= 2:
+                groups.append(group)
+
+        return groups
+
+    def _assign_matrix_layer_preferences(
+        self, conflict_groups: list[set[int]]
+    ) -> dict[int, list[int]]:
+        """Assign alternating preferred layers for matrix-conflicting nets.
+
+        For each group of conflicting nets, alternates between front and
+        back copper layers so that adjacent charlieplex nets are steered
+        to different layers, breaking the circular blocking pattern.
+
+        On single-layer boards (only one routable layer), no preferences
+        are assigned so routing falls back to the normal ordering.
+
+        Issue #2432.
+
+        Args:
+            conflict_groups: Groups of mutually conflicting net IDs,
+                as returned by :meth:`_detect_matrix_conflicts`.
+
+        Returns:
+            Dict mapping net_id -> list of preferred layer indices.
+            Only nets that received a preference are included.
+        """
+        # Determine available routing layers
+        num_layers = self.grid.num_layers
+        if num_layers < 2:
+            # Single-layer board: layer separation is impossible
+            return {}
+
+        # Use the first and last layer indices (outer layers) for alternation
+        layer_a = 0
+        layer_b = num_layers - 1
+
+        preferences: dict[int, list[int]] = {}
+        for group in conflict_groups:
+            sorted_nets = sorted(group)  # Deterministic ordering
+            for idx, net_id in enumerate(sorted_nets):
+                if idx % 2 == 0:
+                    preferences[net_id] = [layer_a]
+                else:
+                    preferences[net_id] = [layer_b]
+
+        return preferences
+
+    def _inject_matrix_layer_preferences(
+        self, net_layer_prefs: dict[int, list[int]]
+    ) -> None:
+        """Inject per-net layer preferences into net_class_map overrides.
+
+        Creates per-net NetClassRouting entries with ``preferred_layers``
+        set, so the pathfinder's ``_get_layer_preference_cost()`` biases
+        A* toward the assigned layer.  If the net already has a net class
+        entry, a copy is created with the layer preference added.
+
+        Issue #2432.
+
+        Args:
+            net_layer_prefs: Dict mapping net_id -> preferred layer indices,
+                as returned by :meth:`_assign_matrix_layer_preferences`.
+        """
+        from dataclasses import replace
+
+        for net_id, layers in net_layer_prefs.items():
+            net_name = self.net_names.get(net_id, "")
+            if not net_name:
+                continue
+            existing = self.net_class_map.get(net_name)
+            if existing is not None:
+                # Copy existing net class and add layer preference
+                override = replace(existing, preferred_layers=layers)
+            else:
+                # Create a new net class entry with default values + layer pref
+                override = NetClassRouting(
+                    name=f"matrix_{net_name}",
+                    preferred_layers=layers,
+                )
+            self.net_class_map[net_name] = override
+
+        if net_layer_prefs:
+            names = [
+                self.net_names.get(n, f"Net {n}") for n in net_layer_prefs
+            ]
+            flush_print(
+                f"  Matrix conflict: assigned layer preferences for {len(names)} net(s): {names}"
+            )
+
+    # Cache of net IDs detected as matrix-conflicting (Issue #2432).
+    # Populated by _detect_and_apply_matrix_preferences() so that
+    # _calculate_constraint_score() can boost priority for these nets.
+    _matrix_conflict_nets: set[int]
+
+    def _detect_and_apply_matrix_preferences(
+        self, net_order: list[int]
+    ) -> None:
+        """Detect matrix-conflicting nets and inject layer preferences.
+
+        Convenience method that chains :meth:`_detect_matrix_conflicts`,
+        :meth:`_assign_matrix_layer_preferences`, and
+        :meth:`_inject_matrix_layer_preferences`.
+
+        Also populates :attr:`_matrix_conflict_nets` so that
+        :meth:`_calculate_constraint_score` can boost priority for
+        matrix nets.
+
+        Issue #2432.
+
+        Args:
+            net_order: Filtered net ordering (pour nets removed).
+        """
+        groups = self._detect_matrix_conflicts(net_order)
+        if not groups:
+            self._matrix_conflict_nets = set()
+            return
+
+        prefs = self._assign_matrix_layer_preferences(groups)
+        self._inject_matrix_layer_preferences(prefs)
+
+        # Cache the set of matrix-conflicting net IDs for priority boost
+        all_conflict_nets: set[int] = set()
+        for group in groups:
+            all_conflict_nets |= group
+        self._matrix_conflict_nets = all_conflict_nets
 
     def _get_net_priority(self, net_id: int) -> tuple[int, int, float, int, float, float]:
         """Get routing priority for a net (lower = higher priority).
@@ -2169,6 +2381,12 @@ class Autorouter:
         # Issue #1295: Filter out pour nets (GND, VCC, etc.) — they should be
         # connected via zone fills, not routed as individual traces.
         net_order = self._filter_pour_nets(net_order)
+
+        # Issue #2432: Detect charlieplex/matrix topology and assign
+        # alternating layer preferences to break circular blocking.
+        self._detect_and_apply_matrix_preferences(net_order)
+        # Re-sort after matrix priority boost
+        net_order = sorted(net_order, key=lambda n: self._get_net_priority(n))
 
         if parallel:
             return self.route_all_parallel(
@@ -2786,6 +3004,13 @@ class Autorouter:
         # Issue #1295: Filter out pour nets before negotiated routing
         net_order = self._filter_pour_nets(net_order)
         net_order = [n for n in net_order if n != 0]
+
+        # Issue #2432: Detect charlieplex/matrix topology and assign
+        # alternating layer preferences to break circular blocking.
+        self._detect_and_apply_matrix_preferences(net_order)
+        # Re-sort after matrix priority boost
+        net_order = sorted(net_order, key=lambda n: self._get_net_priority(n))
+
         total_nets = len(net_order)
 
         neg_router = NegotiatedRouter(

--- a/tests/test_negotiated_adaptive.py
+++ b/tests/test_negotiated_adaptive.py
@@ -2,6 +2,9 @@
 
 These tests verify the adaptive parameter tuning functions that improve
 convergence for negotiated congestion routing.
+
+Also includes tests for matrix-conflict detection and layer preference
+assignment (Issue #2432).
 """
 
 from kicad_tools.router.algorithms.negotiated import (
@@ -1083,3 +1086,282 @@ class TestEmptyNetsToRerouteTermination:
         assert nets_to_reroute == [1, 2, 3], (
             "Re-enabled nets must remain in reroute list"
         )
+
+
+# =========================================================================
+# Matrix conflict detection and layer assignment tests (Issue #2432)
+# =========================================================================
+
+
+class TestDetectMatrixConflicts:
+    """Tests for Autorouter._detect_matrix_conflicts()."""
+
+    def _make_autorouter_with_nets(self, nets_data):
+        """Create a minimal Autorouter with given nets data.
+
+        Args:
+            nets_data: dict mapping net_id -> list of (ref, pin) tuples
+        """
+        from kicad_tools.router.core import Autorouter
+
+        ar = Autorouter(width=50, height=50)
+        ar.nets = nets_data
+        ar.net_names = {n: f"NET_{n}" for n in nets_data}
+        return ar
+
+    def test_no_conflicts_disjoint_nets(self):
+        """Nets with no shared components should produce no conflict groups."""
+        ar = self._make_autorouter_with_nets({
+            1: [("R1", "1"), ("R1", "2")],
+            2: [("R2", "1"), ("R2", "2")],
+            3: [("C1", "1"), ("C1", "2")],
+        })
+        groups = ar._detect_matrix_conflicts([1, 2, 3])
+        assert groups == []
+
+    def test_no_conflicts_single_shared_component(self):
+        """Two nets sharing only 1 component should NOT conflict (threshold=2)."""
+        ar = self._make_autorouter_with_nets({
+            1: [("D1", "A"), ("D1", "K"), ("R1", "1")],
+            2: [("D1", "A"), ("D2", "K"), ("R2", "1")],
+        })
+        groups = ar._detect_matrix_conflicts([1, 2], threshold=2)
+        assert groups == []
+
+    def test_charlieplex_four_nets(self):
+        """Four nets sharing 3+ LEDs should form one conflict group."""
+        # Simulates NODE_A..NODE_D each connecting to pads on D1..D6
+        ar = self._make_autorouter_with_nets({
+            1: [("D1", "A"), ("D2", "K"), ("D3", "A"), ("D5", "K")],
+            2: [("D1", "K"), ("D2", "A"), ("D4", "A"), ("D6", "K")],
+            3: [("D3", "K"), ("D4", "K"), ("D5", "A"), ("D6", "A")],
+            4: [("D1", "A"), ("D3", "K"), ("D5", "A"), ("D6", "K")],
+        })
+        groups = ar._detect_matrix_conflicts([1, 2, 3, 4])
+        assert len(groups) == 1
+        assert groups[0] == {1, 2, 3, 4}
+
+    def test_two_independent_groups(self):
+        """Two separate matrix groups should produce two conflict sets."""
+        ar = self._make_autorouter_with_nets({
+            # Group 1: nets 1, 2 share D1, D2, D3
+            1: [("D1", "A"), ("D2", "K"), ("D3", "A")],
+            2: [("D1", "K"), ("D2", "A"), ("D3", "K")],
+            # Group 2: nets 3, 4 share U1, U2 (different components)
+            3: [("U1", "1"), ("U2", "2"), ("U3", "1")],
+            4: [("U1", "2"), ("U2", "1"), ("U3", "2")],
+            # Net 5: no conflicts
+            5: [("R1", "1"), ("R1", "2")],
+        })
+        groups = ar._detect_matrix_conflicts([1, 2, 3, 4, 5])
+        assert len(groups) == 2
+        group_sets = [frozenset(g) for g in groups]
+        assert frozenset({1, 2}) in group_sets
+        assert frozenset({3, 4}) in group_sets
+
+    def test_custom_threshold(self):
+        """Higher threshold should require more shared components."""
+        ar = self._make_autorouter_with_nets({
+            1: [("D1", "A"), ("D2", "K")],
+            2: [("D1", "K"), ("D2", "A")],
+        })
+        # threshold=2: should conflict (share D1, D2)
+        groups_t2 = ar._detect_matrix_conflicts([1, 2], threshold=2)
+        assert len(groups_t2) == 1
+
+        # threshold=3: should NOT conflict (only share 2 components)
+        groups_t3 = ar._detect_matrix_conflicts([1, 2], threshold=3)
+        assert groups_t3 == []
+
+    def test_empty_nets(self):
+        """Empty net list should produce no conflicts."""
+        ar = self._make_autorouter_with_nets({})
+        groups = ar._detect_matrix_conflicts([])
+        assert groups == []
+
+
+class TestAssignMatrixLayerPreferences:
+    """Tests for Autorouter._assign_matrix_layer_preferences()."""
+
+    def _make_autorouter(self, num_layers=2):
+        """Create a minimal Autorouter with given layer count."""
+        from kicad_tools.router.core import Autorouter
+        from kicad_tools.router.layers import LayerDefinition, LayerStack, LayerType
+
+        layers = []
+        for i in range(num_layers):
+            name = "F.Cu" if i == 0 else ("B.Cu" if i == num_layers - 1 else f"In{i}.Cu")
+            layers.append(LayerDefinition(
+                name=name,
+                index=i,
+                layer_type=LayerType.SIGNAL,
+                is_outer=(i == 0 or i == num_layers - 1),
+            ))
+        stack = LayerStack(layers=layers, name="Test")
+        ar = Autorouter(width=50, height=50, layer_stack=stack)
+        return ar
+
+    def test_alternating_layers_two_layer_board(self):
+        """Nets in a conflict group should get alternating F.Cu/B.Cu."""
+        ar = self._make_autorouter(num_layers=2)
+        groups = [{1, 2, 3, 4}]
+        prefs = ar._assign_matrix_layer_preferences(groups)
+        assert len(prefs) == 4
+        # Sorted order: 1, 2, 3, 4
+        assert prefs[1] == [0]  # F.Cu
+        assert prefs[2] == [1]  # B.Cu
+        assert prefs[3] == [0]  # F.Cu
+        assert prefs[4] == [1]  # B.Cu
+
+    def test_single_layer_board_no_preferences(self):
+        """Single-layer board should return empty preferences."""
+        ar = self._make_autorouter(num_layers=1)
+        groups = [{1, 2}]
+        prefs = ar._assign_matrix_layer_preferences(groups)
+        assert prefs == {}
+
+    def test_four_layer_board_uses_outer_layers(self):
+        """Multi-layer board should alternate between first and last layers."""
+        ar = self._make_autorouter(num_layers=4)
+        groups = [{10, 20}]
+        prefs = ar._assign_matrix_layer_preferences(groups)
+        assert prefs[10] == [0]  # F.Cu (index 0)
+        assert prefs[20] == [3]  # B.Cu (index 3)
+
+    def test_multiple_groups_independent(self):
+        """Each conflict group should be assigned independently."""
+        ar = self._make_autorouter(num_layers=2)
+        groups = [{1, 2}, {3, 4}]
+        prefs = ar._assign_matrix_layer_preferences(groups)
+        assert len(prefs) == 4
+        # Group 1: nets 1,2
+        assert prefs[1] == [0]
+        assert prefs[2] == [1]
+        # Group 2: nets 3,4
+        assert prefs[3] == [0]
+        assert prefs[4] == [1]
+
+
+class TestInjectMatrixLayerPreferences:
+    """Tests for Autorouter._inject_matrix_layer_preferences()."""
+
+    def _make_autorouter_with_nets(self, nets_data, net_names=None):
+        """Create a minimal Autorouter with given nets data."""
+        from kicad_tools.router.core import Autorouter
+
+        ar = Autorouter(width=50, height=50)
+        ar.nets = nets_data
+        if net_names:
+            ar.net_names = net_names
+        else:
+            ar.net_names = {n: f"NET_{n}" for n in nets_data}
+        return ar
+
+    def test_creates_net_class_entries(self):
+        """Should create NetClassRouting entries with preferred_layers."""
+        from kicad_tools.router.rules import NetClassRouting
+
+        ar = self._make_autorouter_with_nets(
+            {1: [], 2: []},
+            net_names={1: "NODE_A", 2: "NODE_B"},
+        )
+        prefs = {1: [0], 2: [1]}
+        ar._inject_matrix_layer_preferences(prefs)
+
+        assert "NODE_A" in ar.net_class_map
+        assert ar.net_class_map["NODE_A"].preferred_layers == [0]
+        assert "NODE_B" in ar.net_class_map
+        assert ar.net_class_map["NODE_B"].preferred_layers == [1]
+
+    def test_preserves_existing_net_class(self):
+        """Should copy existing net class and add layer preference."""
+        from kicad_tools.router.rules import NetClassRouting
+
+        ar = self._make_autorouter_with_nets(
+            {1: []},
+            net_names={1: "MCLK"},
+        )
+        # Pre-existing net class for MCLK
+        ar.net_class_map["MCLK"] = NetClassRouting(
+            name="Clock", priority=2, trace_width=0.15
+        )
+        prefs = {1: [0]}
+        ar._inject_matrix_layer_preferences(prefs)
+
+        nc = ar.net_class_map["MCLK"]
+        assert nc.priority == 2  # Preserved
+        assert nc.trace_width == 0.15  # Preserved
+        assert nc.preferred_layers == [0]  # Added
+
+    def test_skips_nets_without_names(self):
+        """Nets with no name should be skipped without error."""
+        ar = self._make_autorouter_with_nets(
+            {1: []},
+            net_names={},  # No name for net 1
+        )
+        prefs = {1: [0]}
+        ar._inject_matrix_layer_preferences(prefs)
+        # Should not crash; no new entries since no name
+
+
+class TestMatrixConstraintBoost:
+    """Tests for matrix net priority boost in _calculate_constraint_score."""
+
+    def _make_autorouter_with_matrix_nets(self, matrix_nets):
+        """Create an Autorouter with specified matrix conflict nets."""
+        from kicad_tools.router.core import Autorouter
+        from kicad_tools.router.primitives import Pad
+
+        ar = Autorouter(width=50, height=50)
+        ar._matrix_conflict_nets = set(matrix_nets)
+        # Add minimal pad data for the nets
+        for net_id in matrix_nets:
+            pad_key = (f"R{net_id}", "1")
+            ar.nets[net_id] = [pad_key]
+            ar.pads[pad_key] = Pad(
+                x=10.0, y=10.0,
+                width=1.0, height=1.0,
+                net=net_id, net_name=f"NET_{net_id}",
+                ref=f"R{net_id}", pin="1",
+            )
+            ar.net_names[net_id] = f"NET_{net_id}"
+        return ar
+
+    def test_matrix_net_gets_higher_constraint_score(self):
+        """Matrix-conflicting nets should have higher constraint score."""
+        ar = self._make_autorouter_with_matrix_nets([1])
+        # Also add a non-matrix net
+        pad_key = ("R99", "1")
+        from kicad_tools.router.primitives import Pad
+        ar.nets[99] = [pad_key]
+        ar.pads[pad_key] = Pad(
+            x=20.0, y=20.0,
+            width=1.0, height=1.0,
+            net=99, net_name="NET_99",
+            ref="R99", pin="1",
+        )
+        ar.net_names[99] = "NET_99"
+
+        matrix_score = ar._calculate_constraint_score(1)
+        normal_score = ar._calculate_constraint_score(99)
+        assert matrix_score > normal_score, (
+            "Matrix net should have higher constraint score"
+        )
+
+    def test_non_matrix_net_unaffected(self):
+        """Non-matrix nets should not get the matrix boost."""
+        ar = self._make_autorouter_with_matrix_nets([])
+        pad_key = ("R1", "1")
+        from kicad_tools.router.primitives import Pad
+        ar.nets[1] = [pad_key]
+        ar.pads[pad_key] = Pad(
+            x=10.0, y=10.0,
+            width=1.0, height=1.0,
+            net=1, net_name="NET_1",
+            ref="R1", pin="1",
+        )
+        ar.net_names[1] = "NET_1"
+
+        score = ar._calculate_constraint_score(1)
+        # Score should only contain pad_count_weight * 1 = 0.5
+        assert score < 5.0, "Non-matrix net should have low constraint score"


### PR DESCRIPTION
## Summary
Charlieplex LED matrix nets (NODE_A-D) consistently stall during negotiated rip-up because they share interleaved LED pads and create circular blocking patterns. This PR adds matrix conflict detection that identifies nets sharing 2+ components and assigns them alternating preferred layers (F.Cu/B.Cu) to break the deadlock.

## Changes
- Added `_detect_matrix_conflicts()` method to identify nets sharing multiple components in a matrix topology using connected-component BFS
- Added `_assign_matrix_layer_preferences()` to alternate preferred layers (front/back copper) across conflicting nets, with graceful fallback on single-layer boards
- Added `_inject_matrix_layer_preferences()` to create per-net `NetClassRouting` overrides that the pathfinder's existing `_get_layer_preference_cost()` respects
- Added `_detect_and_apply_matrix_preferences()` convenience method called before both `route_all()` and `route_all_negotiated()` routing loops
- Boosted constraint score for matrix-conflicting nets in `_calculate_constraint_score()` so they route first
- Added 15 unit tests covering conflict detection, layer assignment, preference injection, and constraint boosting

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Matrix conflict detection correctly identifies groups of nets sharing 2+ components | Pass | Tests verify charlieplex 4-net topology, two independent groups, threshold tuning, and edge cases |
| Alternating layer assignment for conflict groups | Pass | Tests verify F.Cu/B.Cu alternation on 2-layer and 4-layer boards |
| Single-layer board graceful fallback | Pass | Test verifies empty preferences returned when only 1 layer available |
| Non-matrix boards unaffected | Pass | Tests verify disjoint nets and single-shared-component nets produce no conflict groups |
| Matrix nets get priority boost | Pass | Test verifies matrix-conflicting net has higher constraint score than non-matrix net |
| Existing tests unaffected | Pass | All 79 previously-passing tests still pass (3 pre-existing failures in TestNegotiatedRouterCongestionEstimator unchanged) |

## Test Plan
- Ran `pytest tests/test_negotiated_adaptive.py` -- all 15 new tests pass, no regressions in existing tests
- Pre-existing failures in `TestNegotiatedRouterCongestionEstimator` (3 tests) are unchanged on main

Closes #2432