### PR TITLE
fix(router): clamp trace-width boundary check and record corridor failures

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -401,6 +401,7 @@ class NegotiatedRouter:
         present_cost_factor: float,
         mark_route_callback: callable,
         per_net_timeout: float | None = None,
+        failure_callback: callable | None = None,
     ) -> list[Route]:
         """Route a single net in negotiated mode.
 
@@ -410,6 +411,9 @@ class NegotiatedRouter:
             mark_route_callback: Callback to mark a route on the grid
             per_net_timeout: Optional wall-clock timeout in seconds for each
                 A* search within this net (Issue #1605)
+            failure_callback: Optional callback to record routing failures.
+                Called with (source_pad, target_pad) when routing fails
+                (Issue #2425).
 
         Returns:
             List of routes created
@@ -474,6 +478,8 @@ class NegotiatedRouter:
                     # Collect grid cells from the routed segments so later
                     # edges can terminate early upon reaching this tree.
                     self._collect_route_cells(route, routed_cells)
+                elif failure_callback is not None:
+                    failure_callback(source_pad, target_pad)
         else:
             # 2-pin net
             route = self.router.route(
@@ -486,6 +492,8 @@ class NegotiatedRouter:
             if route:
                 mark_route_callback(route)
                 routes.append(route)
+            elif failure_callback is not None:
+                failure_callback(pad_objs[0], pad_objs[1])
 
         return routes
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -4142,8 +4142,15 @@ class Autorouter:
         def mark_route(route: Route):
             self._mark_route(route)
 
+        def record_failure(source_pad: Pad, target_pad: Pad):
+            self._record_routing_failure(net, source_pad, target_pad)
+
         # Route with corridor-aware costs (negotiated router will pick up corridor costs)
-        new_routes = neg_router.route_net_negotiated(pad_objs, present_cost_factor, mark_route, per_net_timeout=per_net_timeout)
+        new_routes = neg_router.route_net_negotiated(
+            pad_objs, present_cost_factor, mark_route,
+            per_net_timeout=per_net_timeout,
+            failure_callback=record_failure,
+        )
         routes.extend(new_routes)
         return routes
 

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -731,9 +731,16 @@ class Router:
         x2 = gx + radius + 1
         y2 = gy + radius + 1
 
-        # Check if region extends outside grid (any out-of-bounds cell blocks)
-        if x1 < 0 or y1 < 0 or x2 > self.grid.cols or y2 > self.grid.rows:
-            return True
+        # Clamp region to grid bounds instead of rejecting out-of-bounds
+        # entirely (Issue #2425).  Pads near the board periphery previously
+        # had all neighbours rejected because the trace-width check region
+        # extended outside the grid, making them unroutable.
+        x1 = max(0, x1)
+        y1 = max(0, y1)
+        x2 = min(self.grid.cols, x2)
+        y2 = min(self.grid.rows, y2)
+        if x1 >= x2 or y1 >= y2:
+            return True  # degenerate region after clamping
 
         # Extract array slices for the region
         blocked_region = self.grid._blocked[layer, y1:y2, x1:x2]

--- a/tests/test_router_autorouter.py
+++ b/tests/test_router_autorouter.py
@@ -740,6 +740,49 @@ class TestRouterPathfinder:
         blocked = router._is_trace_blocked(10, 10, 0, net=1)
         assert blocked is False
 
+    def test_is_trace_blocked_boundary_clamp(self):
+        """Trace near grid edge should clamp, not reject (Issue #2425).
+
+        Previously _is_trace_blocked returned True unconditionally when
+        the trace clearance region extended outside the grid, making
+        pads near the board periphery unroutable.
+        """
+        rules = DesignRules(grid_resolution=0.5)
+        grid = RoutingGrid(50.0, 50.0, rules)
+        router = Router(grid, rules)
+
+        # Ensure the trace half-width is at least 1 cell so the check
+        # region extends beyond the grid edge when the cell is at (0, 0).
+        router._trace_half_width_cells = 1
+
+        # Cell at corner (0, 0) -- the check region extends to negative
+        # coordinates.  With the old code this returned True (blocked);
+        # with the clamping fix it should check only in-bounds cells.
+        blocked = router._is_trace_blocked(0, 0, 0, net=1)
+        assert blocked is False, (
+            "Cell at grid corner (0,0) should not be blocked when "
+            "in-bounds cells are clear"
+        )
+
+        # Cell at opposite corner
+        max_x = grid.cols - 1
+        max_y = grid.rows - 1
+        blocked = router._is_trace_blocked(max_x, max_y, 0, net=1)
+        assert blocked is False, (
+            "Cell at grid corner (max,max) should not be blocked when "
+            "in-bounds cells are clear"
+        )
+
+        # Block a cell adjacent to the corner -- the boundary cell
+        # should now report blocked.
+        grid.grid[0][0][1].blocked = True
+        grid.grid[0][0][1].is_obstacle = True
+        blocked = router._is_trace_blocked(0, 0, 0, net=1)
+        assert blocked is True, (
+            "Cell at grid corner should be blocked when an adjacent "
+            "in-bounds cell is an obstacle"
+        )
+
     def test_router_is_via_blocked(self):
         """Test via blocking check."""
         rules = DesignRules(grid_resolution=0.5)

--- a/tests/test_router_integration.py
+++ b/tests/test_router_integration.py
@@ -184,6 +184,15 @@ class TestRealBoardRouting:
         if hasattr(router, 'routing_failures'):
             print(f"Failures: {len(router.routing_failures)}")
 
+        # Issue #2425: Assert minimum net completion rate.
+        # Before the boundary-clamping fix only ~4 nets routed;
+        # after clamping trace-width checks to grid bounds, at least
+        # 6 nets should succeed (periphery pads are now reachable).
+        assert routed_nets >= 6, (
+            f"Expected at least 6/{total_nets} nets routed but got {routed_nets}. "
+            f"Boundary-clamping fix may have regressed."
+        )
+
     def test_no_shorts_in_output(self, voltage_divider_pcb: Path):
         """Routed output must have zero net-to-net shorts."""
         # Load and route board


### PR DESCRIPTION
## Summary
Fixes two issues causing A* pathfinding failures on the usb-joystick board: (1) `_is_trace_blocked()` unconditionally rejected trace positions when the clearance region extended outside the grid, making periphery pads unroutable; (2) `_route_net_with_corridor()` silently dropped routing failures instead of recording them for diagnosis.

## Changes
- **pathfinder.py**: Clamp trace-width check region to grid bounds instead of returning `True` (blocked) when region extends out of bounds
- **negotiated.py**: Add optional `failure_callback` parameter to `route_net_negotiated()` for recording failures
- **core.py**: Wire `_record_routing_failure` into `_route_net_with_corridor()` via the new callback
- **test_router_autorouter.py**: Add unit test for boundary clamping at grid corners
- **test_router_integration.py**: Add net completion assertion for usb-joystick board (>= 6 nets)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| _is_trace_blocked clamps to grid bounds | PASS | Unit test verifies cells at (0,0) and (max,max) are routable when in-bounds cells are clear |
| Corridor routing records failures | PASS | Integration test shows 7 RoutingFailure entries recorded (was 0 before) |
| USB-joystick net completion improves | PASS | 6/16 nets routed (up from ~4), boundary fix enables periphery pads |
| Voltage divider regression check | PASS | 2/2 nets still route at 100% |
| Charlieplex regression check | PASS | 5/10 nets (improved from 3/10 on main -- pre-existing failure) |

## Test Plan
- `pytest tests/test_router_autorouter.py::TestRouterPathfinder::test_is_trace_blocked_boundary_clamp` -- boundary clamping unit test
- `pytest tests/test_router_integration.py::TestRealBoardRouting::test_usb_joystick_valid_output` -- integration test with net completion assertion
- Existing trace-blocked and voltage-divider tests pass unchanged

Closes #2425