### PR TITLE
perf(router): pre-compute blocked bitmap and spatial crossing index for A* search

### DIFF
--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -1977,6 +1977,86 @@ class RoutingGrid:
         # Ensure we return a plain NumPy array regardless of backend
         return to_numpy(ratios) if not isinstance(ratios, np.ndarray) else ratios
 
+    def compute_expanded_blocked(
+        self,
+        radius: int,
+        net: int,
+        allow_sharing: bool = False,
+    ) -> np.ndarray:
+        """Pre-compute an expanded blocked bitmap for trace-width clearance.
+
+        Issue #2430: Instead of extracting NumPy sub-arrays per neighbor in
+        ``_is_trace_blocked``, dilate the blocked bitmap once at the start
+        of each ``route()`` call.  The per-neighbor check then becomes a
+        single array lookup: ``expanded[layer, ny, nx]``.
+
+        The dilation uses ``scipy.ndimage.maximum_filter`` when available,
+        falling back to a pure-NumPy sliding-window maximum.
+
+        Args:
+            radius: Half-width of the trace in grid cells (``_trace_half_width_cells``).
+            net: Net ID of the route being planned.  Same-net cells are
+                 *not* treated as blocked (consistent with ``_is_trace_blocked``).
+            allow_sharing: If True (negotiated mode), only static obstacles
+                           block; shared-usage cells are passable.
+
+        Returns:
+            Boolean NumPy array of shape ``(num_layers, rows, cols)`` where
+            ``True`` means the cell is blocked for this net considering
+            trace width expansion.
+        """
+        if allow_sharing:
+            # Negotiated mode: block only static obstacles with different net
+            different_net = self._net != net
+            obstacle_blocks = self._blocked & self._is_obstacle & different_net
+            static_blocks = (
+                self._blocked & ~self._is_obstacle & different_net & (self._usage_count == 0)
+            )
+            base_blocked = obstacle_blocks | static_blocks
+        else:
+            # Standard mode: block cells that are blocked AND different net
+            base_blocked = self._blocked & (self._net != net)
+
+        if radius <= 1:
+            # No expansion needed; single-cell check is equivalent.
+            return base_blocked
+
+        # Dilate by *radius* using a square structuring element of side 2*radius+1.
+        kernel_size = 2 * radius + 1
+        try:
+            from scipy.ndimage import maximum_filter  # type: ignore[import-untyped]
+
+            # maximum_filter on bool is equivalent to dilation (any-True in window).
+            expanded = maximum_filter(
+                base_blocked.astype(np.uint8),
+                size=(1, kernel_size, kernel_size),
+            ).astype(np.bool_)
+        except ImportError:
+            # Fallback: pure-NumPy sliding-window maximum via np.lib.stride_tricks.
+            # Pad the array so that out-of-bounds cells count as blocked.
+            padded = np.ones(
+                (
+                    self.num_layers,
+                    self.rows + 2 * radius,
+                    self.cols + 2 * radius,
+                ),
+                dtype=np.bool_,
+            )
+            padded[
+                :,
+                radius : radius + self.rows,
+                radius : radius + self.cols,
+            ] = base_blocked
+
+            expanded = np.zeros_like(base_blocked)
+            for dy in range(kernel_size):
+                for dx in range(kernel_size):
+                    expanded |= padded[
+                        :, dy : dy + self.rows, dx : dx + self.cols
+                    ]
+
+        return expanded
+
     def get_total_overflow(self) -> int:
         """Get total overflow (sum of usage_count - 1 for overused cells).
 

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -192,6 +192,14 @@ class Router:
         # Each entry is (x1, y1, x2, y2, layer_index, net_id) in grid coordinates.
         self._routed_segments: list[tuple[int, int, int, int, int, int]] = []
 
+        # Issue #2430: Grid-based spatial index for crossing detection.
+        # Built lazily at the start of each route() call when segments exist.
+        # Replaces O(S) linear scan with O(B) bucket lookup.
+        self._crossing_grid: dict[int, dict[tuple[int, int], list[int]]] | None = None
+        self._crossing_bucket_size: int = 8
+        self._crossing_grid_cols: int = 0
+        self._crossing_grid_rows: int = 0
+
         # Issue #2325: Via placement diagnostic counters.
         # These track via placement attempts and rejections to help diagnose
         # zero-via routing failures on multi-layer boards.
@@ -413,6 +421,10 @@ class Router:
 
         Only counts crossings on the same layer with a different net.
 
+        Issue #2430: When a crossing grid index is available (built by
+        ``_build_crossing_grid``), uses spatial bucketing for O(B) lookup
+        instead of O(S) linear scan.
+
         Args:
             cx, cy: Current node grid coordinates (edge start).
             nx, ny: Neighbor node grid coordinates (edge end).
@@ -422,6 +434,12 @@ class Router:
         Returns:
             Number of crossing segments.
         """
+        # Fast path: use spatial grid index when available
+        if self._crossing_grid is not None:
+            return self._count_edge_crossings_indexed(
+                cx, cy, nx, ny, nlayer, current_net
+            )
+
         count = 0
         for sx1, sy1, sx2, sy2, seg_layer, seg_net in self._routed_segments:
             # Only same layer, different net
@@ -429,6 +447,101 @@ class Router:
                 continue
             if self._segments_intersect(cx, cy, nx, ny, sx1, sy1, sx2, sy2):
                 count += 1
+        return count
+
+    # ------------------------------------------------------------------
+    # Crossing grid spatial index (Issue #2430)
+    # ------------------------------------------------------------------
+
+    def _build_crossing_grid(self, bucket_size: int = 8) -> None:
+        """Build a grid-based spatial index for routed segments.
+
+        Partitions the grid into square buckets and stores segment indices
+        per bucket per layer.  ``_count_edge_crossings_indexed`` then only
+        checks segments whose buckets overlap the query edge's bounding box.
+
+        Args:
+            bucket_size: Side length of each bucket in grid cells.
+        """
+        self._crossing_bucket_size = bucket_size
+        cols_b = (self.grid.cols + bucket_size - 1) // bucket_size
+        rows_b = (self.grid.rows + bucket_size - 1) // bucket_size
+
+        # Dict[layer, Dict[(bx, by), List[int]]] where int = index into
+        # _routed_segments.
+        grid_idx: dict[int, dict[tuple[int, int], list[int]]] = {}
+
+        for seg_i, (sx1, sy1, sx2, sy2, seg_layer, _seg_net) in enumerate(
+            self._routed_segments
+        ):
+            bx1 = min(sx1, sx2) // bucket_size
+            by1 = min(sy1, sy2) // bucket_size
+            bx2 = max(sx1, sx2) // bucket_size
+            by2 = max(sy1, sy2) // bucket_size
+
+            bx1 = max(0, min(bx1, cols_b - 1))
+            by1 = max(0, min(by1, rows_b - 1))
+            bx2 = max(0, min(bx2, cols_b - 1))
+            by2 = max(0, min(by2, rows_b - 1))
+
+            layer_grid = grid_idx.setdefault(seg_layer, {})
+            for by in range(by1, by2 + 1):
+                for bx in range(bx1, bx2 + 1):
+                    layer_grid.setdefault((bx, by), []).append(seg_i)
+
+        self._crossing_grid = grid_idx
+        self._crossing_grid_cols = cols_b
+        self._crossing_grid_rows = rows_b
+
+    def _count_edge_crossings_indexed(
+        self,
+        cx: int,
+        cy: int,
+        nx: int,
+        ny: int,
+        nlayer: int,
+        current_net: int,
+    ) -> int:
+        """Count edge crossings using the spatial grid index.
+
+        Same semantics as ``_count_edge_crossings`` but O(B) where B is the
+        number of segments in overlapping buckets, instead of O(S) total.
+        """
+        assert self._crossing_grid is not None
+        bs = self._crossing_bucket_size
+
+        layer_grid = self._crossing_grid.get(nlayer)
+        if layer_grid is None:
+            return 0
+
+        # Compute bounding box of the edge in bucket coordinates
+        bx1 = min(cx, nx) // bs
+        by1 = min(cy, ny) // bs
+        bx2 = max(cx, nx) // bs
+        by2 = max(cy, ny) // bs
+
+        bx1 = max(0, bx1)
+        by1 = max(0, by1)
+        bx2 = min(bx2, self._crossing_grid_cols - 1)
+        by2 = min(by2, self._crossing_grid_rows - 1)
+
+        # Collect unique segment indices from overlapping buckets
+        seen: set[int] = set()
+        count = 0
+        for by in range(by1, by2 + 1):
+            for bx in range(bx1, bx2 + 1):
+                bucket = layer_grid.get((bx, by))
+                if bucket is None:
+                    continue
+                for seg_i in bucket:
+                    if seg_i in seen:
+                        continue
+                    seen.add(seg_i)
+                    sx1, sy1, sx2, sy2, _seg_layer, seg_net = self._routed_segments[seg_i]
+                    if seg_net == current_net:
+                        continue
+                    if self._segments_intersect(cx, cy, nx, ny, sx1, sy1, sx2, sy2):
+                        count += 1
         return count
 
     def _init_via_impact_scoring(self) -> None:
@@ -1438,8 +1551,45 @@ class Router:
 
         # A* setup
         open_set: list[AStarNode] = []
-        closed_set: set[tuple[int, int, int]] = set()
-        g_scores: dict[tuple[int, int, int], float] = {}
+
+        # Issue #2430: Use NumPy arrays for closed_set and g_scores to avoid
+        # Python dict/set overhead with 480K+ tuple keys.  Array indexing
+        # (closed_arr[layer, y, x]) is significantly faster than dict hashing.
+        closed_arr = np.zeros(
+            (self.grid.num_layers, self.grid.rows, self.grid.cols), dtype=np.bool_
+        )
+        g_scores_arr = np.full(
+            (self.grid.num_layers, self.grid.rows, self.grid.cols),
+            np.inf,
+            dtype=np.float64,
+        )
+
+        # Issue #2430: Pre-compute expanded blocked bitmap so that
+        # _is_trace_blocked becomes a single array lookup per neighbor.
+        expanded_blocked = self.grid.compute_expanded_blocked(
+            net_trace_half_width_cells, start.net, allow_sharing
+        )
+
+        # Issue #2430: Build crossing grid index if routed segments exist.
+        if self.rules.crossing_penalty > 0.0 and self._routed_segments:
+            self._build_crossing_grid()
+        else:
+            self._crossing_grid = None
+
+        # Issue #2430: Pre-compute zone blocking and zone cost arrays.
+        # Zone cells with a different net are blocked; same-net zones get
+        # a cost discount.  This replaces per-neighbor Python object access
+        # with direct NumPy lookups.
+        zone_blocked_arr = self.grid._is_zone & (self.grid._net != start.net) & (self.grid._net != 0)
+        zone_cost_arr = np.where(
+            self.grid._is_zone & (self.grid._net == start.net),
+            self.rules.cost_zone_same_net - 1.0,
+            np.where(
+                zone_blocked_arr,
+                100.0,
+                0.0,
+            ),
+        )
 
         # Create heuristic context - for PTH end pads, use closest routable layer
         # for heuristic estimation (the actual goal check will accept any)
@@ -1465,7 +1615,7 @@ class Router:
                     start_h = self.heuristic.estimate(sgx, sgy, sl, (0, 0), heuristic_context)
                     start_node = AStarNode(start_h, 0, sgx, sgy, sl)
                     heapq.heappush(open_set, start_node)
-                    g_scores[(sgx, sgy, sl)] = 0
+                    g_scores_arr[sl, sgy, sgx] = 0
 
         # Issue #2330: Waypoint injection for off-grid start pad.
         # Inject the exact pad world position as a waypoint node with edges
@@ -1481,9 +1631,8 @@ class Router:
                     wp_g = edge_cost * self.rules.cost_straight
                     wp_h = self.heuristic.estimate(gx, gy, sl, (0, 0), heuristic_context)
                     wp_node = AStarNode(wp_g + weight * wp_h, wp_g, gx, gy, sl)
-                    neighbor_key = (gx, gy, sl)
-                    if neighbor_key not in g_scores or wp_g < g_scores[neighbor_key]:
-                        g_scores[neighbor_key] = wp_g
+                    if wp_g < g_scores_arr[sl, gy, gx]:
+                        g_scores_arr[sl, gy, gx] = wp_g
                         heapq.heappush(open_set, wp_node)
 
         # Issue #2330: Waypoint for off-grid end pad — used in goal check.
@@ -1517,11 +1666,10 @@ class Router:
                     break
 
             current = heapq.heappop(open_set)
-            current_key = (current.x, current.y, current.layer)
 
-            if current_key in closed_set:
+            if closed_arr[current.layer, current.y, current.x]:
                 continue
-            closed_set.add(current_key)
+            closed_arr[current.layer, current.y, current.x] = True
 
             # Goal check - accept any cell within end pad's metal area (Issue #956)
             # This handles off-grid pads where the center doesn't align with routing grid
@@ -1550,7 +1698,7 @@ class Router:
             # running the full A* to the target pad when a shorter connection to
             # the existing tree exists, dramatically reducing search time for
             # high-fanout nets (e.g., GNDD with 7+ components).
-            if extra_goal_cells and current_key in extra_goal_cells:
+            if extra_goal_cells and (current.x, current.y, current.layer) in extra_goal_cells:
                 # Create a synthetic end pad at the reached grid cell so
                 # _reconstruct_route can build a valid Route object.
                 wx, wy = self.grid.grid_to_world(current.x, current.y)
@@ -1664,9 +1812,8 @@ class Router:
                         # Allow routing through it - this is key for THT routing
                         pass
                     elif cell.net == 0:
-                        # No-net blocked cell - use full check for obstacles
-                        if self._is_trace_blocked(nx, ny, nlayer, start.net, allow_sharing,
-                                                  radius=net_trace_half_width_cells):
+                        # No-net blocked cell - use pre-computed expanded bitmap
+                        if expanded_blocked[nlayer, ny, nx]:
                             continue
                     else:
                         # Different net's blocked cell
@@ -1699,16 +1846,15 @@ class Router:
                         or is_exiting_end_pad
                     )
                     if not is_pad_exit_or_approach:
-                        if self._is_trace_blocked(nx, ny, nlayer, start.net, allow_sharing,
-                                                  radius=net_trace_half_width_cells):
+                        # Issue #2430: Use pre-computed expanded blocked bitmap
+                        if expanded_blocked[nlayer, ny, nx]:
                             continue
 
-                # Check zone blocking (other-net zones block routing)
-                if self._is_zone_blocked(nx, ny, nlayer, start.net):
+                # Issue #2430: Use pre-computed zone blocking array
+                if zone_blocked_arr[nlayer, ny, nx]:
                     continue
 
-                neighbor_key = (nx, ny, nlayer)
-                if neighbor_key in closed_set:
+                if closed_arr[nlayer, ny, nx]:
                     continue
 
                 # Calculate cost - use batch pre-computed values (Issue #963)
@@ -1726,8 +1872,8 @@ class Router:
                         nx, ny, nlayer, present_cost_factor
                     )
 
-                # Add zone cost (reduced for same-net zones)
-                zone_cost = self._get_zone_cost(nx, ny, nlayer, start.net)
+                # Issue #2430: Use pre-computed zone cost array
+                zone_cost = float(zone_cost_arr[nlayer, ny, nx])
 
                 # Add layer preference cost (Issue #625)
                 layer_pref_mult = self._get_layer_preference_cost(nlayer, net_class)
@@ -1760,8 +1906,8 @@ class Router:
                     + corridor_cost
                 ) * cost_mult
 
-                if neighbor_key not in g_scores or new_g < g_scores[neighbor_key]:
-                    g_scores[neighbor_key] = new_g
+                if new_g < g_scores_arr[nlayer, ny, nx]:
+                    g_scores_arr[nlayer, ny, nx] = new_g
                     h = self.heuristic.estimate(nx, ny, nlayer, new_direction, heuristic_context)
                     f = new_g + weight * h  # Weighted A*
 
@@ -1804,8 +1950,7 @@ class Router:
 
                 self._via_diag_eligible += 1
 
-                neighbor_key = (current.x, current.y, new_layer)
-                if neighbor_key in closed_set:
+                if closed_arr[new_layer, current.y, current.x]:
                     continue
 
                 # Via cost + congestion at new layer
@@ -1866,8 +2011,8 @@ class Router:
 
                 new_g = (current.g_score + via_incremental) * cost_mult
 
-                if neighbor_key not in g_scores or new_g < g_scores[neighbor_key]:
-                    g_scores[neighbor_key] = new_g
+                if new_g < g_scores_arr[new_layer, current.y, current.x]:
+                    g_scores_arr[new_layer, current.y, current.x] = new_g
                     # Via doesn't change direction, use current direction
                     h = self.heuristic.estimate(
                         current.x, current.y, new_layer, current.direction, heuristic_context

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -3810,3 +3810,161 @@ class TestEscalationStateReset:
         router.reset_attempt_state()
         router.reset_attempt_state()
         assert router.power_stall_abort is False
+
+
+class TestLargeGridPerformance:
+    """Performance regression tests for large grid A* pathfinding (Issue #2430)."""
+
+    def test_route_400x400_completes_within_budget(self):
+        """A* on a 400x400 grid with obstacles must complete in <5s.
+
+        This exercises the optimizations added in Issue #2430:
+        - Pre-computed expanded blocked bitmap
+        - NumPy array g_scores/closed_set
+        - Pre-computed zone cost arrays
+        """
+        import time
+
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.pathfinder import Router
+        from kicad_tools.router.primitives import Pad
+
+        rules = DesignRules(
+            trace_width=0.25,
+            trace_clearance=0.15,
+            via_diameter=0.6,
+        )
+        # 400x400 grid: board ~40mm x 40mm at 0.1mm resolution
+        grid = RoutingGrid(
+            width=40.0,
+            height=40.0,
+            rules=rules,
+            resolution_override=0.1,
+        )
+
+        # Place some obstacles to make the search non-trivial
+        import numpy as np
+        for y_start in range(50, 350, 40):
+            grid._blocked[0, y_start:y_start + 20, 50:350] = True
+            grid._net[0, y_start:y_start + 20, 50:350] = 99  # different net
+            # Leave gaps for routing
+            grid._blocked[0, y_start:y_start + 20, 190:210] = False
+            grid._net[0, y_start:y_start + 20, 190:210] = 0
+
+        router = Router(grid, rules)
+
+        start_pad = Pad(
+            x=1.0, y=1.0, width=0.5, height=0.5,
+            net=1, net_name="TEST", layer=Layer.F_CU,
+            ref="U1", pin="1", through_hole=False,
+        )
+        end_pad = Pad(
+            x=39.0, y=39.0, width=0.5, height=0.5,
+            net=1, net_name="TEST", layer=Layer.F_CU,
+            ref="U2", pin="1", through_hole=False,
+        )
+
+        t0 = time.monotonic()
+        route = router.route(start_pad, end_pad, per_net_timeout=10.0)
+        elapsed = time.monotonic() - t0
+
+        # Route should complete (obstacles have gaps)
+        assert route is not None, f"Route failed on 400x400 grid (took {elapsed:.2f}s)"
+        # Performance budget: must complete in <15s on CI (generous for slow runners).
+        # Before Issue #2430 optimizations, this would timeout or take >30s.
+        assert elapsed < 15.0, (
+            f"Route took {elapsed:.2f}s on 400x400 grid (budget: 15s)"
+        )
+
+    def test_crossing_index_scales_sublinearly(self):
+        """Crossing detection with spatial index should not degrade linearly.
+
+        Adds many routed segments and verifies that _count_edge_crossings
+        with the spatial index is significantly faster than worst-case linear.
+        """
+        import time
+
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.pathfinder import Router
+
+        rules = DesignRules(
+            trace_width=0.25,
+            trace_clearance=0.15,
+            via_diameter=0.6,
+            crossing_penalty=10.0,
+        )
+        grid = RoutingGrid(
+            width=40.0,
+            height=40.0,
+            rules=rules,
+            resolution_override=0.1,
+        )
+
+        router = Router(grid, rules)
+
+        # Add 500 routed segments spread across the grid
+        import random
+        rng = random.Random(42)
+        for _ in range(500):
+            x1 = rng.randint(0, 350)
+            y1 = rng.randint(0, 350)
+            x2 = x1 + rng.randint(1, 50)
+            y2 = y1 + rng.randint(-5, 5)
+            router._routed_segments.append((x1, y1, x2, y2, 0, 99))
+
+        # Build spatial index
+        router._build_crossing_grid()
+
+        # Query crossings for many edges
+        t0 = time.monotonic()
+        total_crossings = 0
+        for i in range(1000):
+            cx, cy = i % 300 + 25, (i * 7) % 300 + 25
+            nx, ny = cx + 1, cy + 1
+            total_crossings += router._count_edge_crossings(cx, cy, nx, ny, 0, 1)
+        elapsed_indexed = time.monotonic() - t0
+
+        # Verify the index was used (should be fast)
+        assert elapsed_indexed < 2.0, (
+            f"Indexed crossing queries took {elapsed_indexed:.2f}s for 1000 queries "
+            f"with 500 segments (should be <2s)"
+        )
+
+    def test_expanded_blocked_bitmap_consistency(self):
+        """Pre-computed expanded blocked bitmap matches per-cell checks."""
+        import numpy as np
+
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.pathfinder import Router
+
+        rules = DesignRules(
+            trace_width=0.25,
+            trace_clearance=0.15,
+            via_diameter=0.6,
+        )
+        grid = RoutingGrid(
+            width=5.0,
+            height=5.0,
+            rules=rules,
+            resolution_override=0.1,
+        )
+
+        # Place some obstacles
+        grid._blocked[0, 20:25, 20:25] = True
+        grid._net[0, 20:25, 20:25] = 99
+
+        router = Router(grid, rules)
+        radius = router._trace_half_width_cells
+        net = 1
+
+        # Compute expanded bitmap
+        expanded = grid.compute_expanded_blocked(radius, net, allow_sharing=False)
+
+        # Verify against per-cell _is_trace_blocked for a sample of cells
+        for y in range(5, grid.rows - 5, 5):
+            for x in range(5, grid.cols - 5, 5):
+                per_cell = router._is_trace_blocked(x, y, 0, net, False, radius=radius)
+                bitmap = bool(expanded[0, y, x])
+                assert bitmap == per_cell, (
+                    f"Mismatch at ({x}, {y}): bitmap={bitmap}, per_cell={per_cell}"
+                )


### PR DESCRIPTION
## Summary
Optimize the Python A* pathfinder inner loop to reduce per-node overhead on large grids (>300x300 cells). The main bottlenecks were per-neighbor NumPy sub-array slicing, linear-scan crossing detection, Python dict/set overhead, and redundant zone lookups through Python objects.

## Changes
- Add `RoutingGrid.compute_expanded_blocked()` in grid.py: morphologically dilates the blocked bitmap once per `route()` call using scipy.ndimage.maximum_filter (with pure-NumPy fallback), replacing per-neighbor sub-array extraction in `_is_trace_blocked()`
- Add grid-based spatial index (`_build_crossing_grid()`) for routed segment crossing detection, replacing O(S) linear scan with O(B) bucket lookup in `_count_edge_crossings()`
- Replace Python `dict` g_scores and `set` closed_set with NumPy 3D arrays (`g_scores_arr`, `closed_arr`) for faster indexing on dense grids
- Pre-compute zone blocking and zone cost arrays from NumPy data at route start, eliminating per-neighbor `_is_zone_blocked()` and `_get_zone_cost()` Python object access
- Add performance regression tests: 400x400 grid routing, crossing index scaling, expanded bitmap consistency

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pre-computed expanded blocked bitmap | Pass | `test_expanded_blocked_bitmap_consistency` verifies bitmap matches per-cell `_is_trace_blocked` |
| Spatial index for edge crossings | Pass | `test_crossing_index_scales_sublinearly` verifies 1000 queries with 500 segments completes in <2s |
| NumPy arrays for g_scores/closed_set | Pass | Integrated into route() loop; all 151 router core tests pass |
| Pre-computed zone arrays | Pass | Zone blocking/cost arrays computed once per route(); all tests pass |
| No routing correctness regression | Pass | 148 existing + 3 new tests pass; bidirectional A* (11) and autorouter (63) tests also pass |

## Test Plan
- `uv run pytest tests/test_router_core.py` -- 151 passed (148 existing + 3 new)
- `uv run pytest tests/test_bidirectional_astar.py` -- 11 passed
- `uv run pytest tests/test_router_autorouter.py` -- 63 passed

Closes #2430