### PR TITLE
feat(optim): add RoutingEvaluator to replace spacing proxy in placement fitness

### DIFF
--- a/src/kicad_tools/optim/evolutionary.py
+++ b/src/kicad_tools/optim/evolutionary.py
@@ -29,9 +29,9 @@ from __future__ import annotations
 import math
 import os
 import random
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Protocol
 
 import numpy as np
 
@@ -58,7 +58,54 @@ __all__ = [
     "EvolutionaryPlacementOptimizer",
     "EvolutionaryConfig",
     "Individual",
+    "RoutingEvaluator",
 ]
+
+
+class RoutingEvaluator(Protocol):
+    """Protocol for routing-based routability evaluation.
+
+    Implementations receive the current component positions and return
+    a routing completion rate (0.0--1.0).  The evolutionary optimizer
+    calls this instead of the spacing proxy when a routing evaluator
+    is provided.
+
+    The evaluator is called with the components already moved to the
+    candidate positions, so implementations can read component state
+    directly from the optimizer's component list or use the provided
+    position dict.
+
+    Example::
+
+        class SimpleRoutingEvaluator:
+            def __init__(self, router_factory, pcb):
+                self._router_factory = router_factory
+                self._pcb = pcb
+
+            def evaluate_routability(self, positions, rotations):
+                router = self._router_factory()
+                routes = router.route_all()
+                total = len(router.nets) - 1  # exclude net 0
+                routed = len({r.net for r in routes if r.net != 0})
+                return routed / total if total > 0 else 1.0
+    """
+
+    def evaluate_routability(
+        self,
+        positions: dict[str, tuple[float, float]],
+        rotations: dict[str, float],
+    ) -> float:
+        """Evaluate routability of a candidate placement.
+
+        Args:
+            positions: Component reference to (x, y) position mapping.
+            rotations: Component reference to rotation (degrees) mapping.
+
+        Returns:
+            Routing completion rate from 0.0 (nothing routes) to 1.0
+            (all nets routed).
+        """
+        ...  # pragma: no cover
 
 
 @dataclass
@@ -411,6 +458,7 @@ class EvolutionaryPlacementOptimizer:
         self,
         board_outline: Polygon,
         config: EvolutionaryConfig | None = None,
+        routing_evaluator: RoutingEvaluator | None = None,
     ):
         """
         Initialize the evolutionary optimizer.
@@ -418,9 +466,18 @@ class EvolutionaryPlacementOptimizer:
         Args:
             board_outline: Polygon defining the board boundary
             config: Optimization parameters
+            routing_evaluator: Optional routing evaluator that replaces
+                the spacing-based routability proxy with actual routing
+                completion rate.  When provided, ``_estimate_routability``
+                calls the evaluator instead of computing average pairwise
+                spacing.  The evaluator is not picklable, so parallel
+                evaluation uses ``ThreadPoolExecutor`` instead of
+                ``ProcessPoolExecutor`` (the GIL is released during C++
+                routing calls, so threads still provide useful concurrency).
         """
         self.board_outline = board_outline
         self.config = config or EvolutionaryConfig()
+        self.routing_evaluator = routing_evaluator
         self.components: list[Component] = []
         self.springs: list[Spring] = []
         self.clusters: list[FunctionalCluster] = []
@@ -454,6 +511,7 @@ class EvolutionaryPlacementOptimizer:
         config: EvolutionaryConfig | None = None,
         fixed_refs: list[str] | None = None,
         enable_clustering: bool = False,
+        routing_evaluator: RoutingEvaluator | None = None,
     ) -> EvolutionaryPlacementOptimizer:
         """
         Create optimizer from a loaded PCB.
@@ -466,13 +524,17 @@ class EvolutionaryPlacementOptimizer:
             config: Optimization parameters
             fixed_refs: List of reference designators for fixed components
             enable_clustering: If True, detect and preserve functional clusters
+            routing_evaluator: Optional routing evaluator for actual
+                routability scoring (replaces spacing proxy)
         """
         # Use PlacementOptimizer to extract components and nets
         physics_opt = PlacementOptimizer.from_pcb(
             pcb, fixed_refs=fixed_refs, enable_clustering=enable_clustering
         )
 
-        optimizer = cls(physics_opt.board_outline, config)
+        optimizer = cls(
+            physics_opt.board_outline, config, routing_evaluator=routing_evaluator
+        )
         optimizer.components = physics_opt.components
         optimizer.springs = physics_opt.springs
         optimizer.clusters = physics_opt.clusters
@@ -486,13 +548,22 @@ class EvolutionaryPlacementOptimizer:
         cls,
         physics_optimizer: PlacementOptimizer,
         config: EvolutionaryConfig | None = None,
+        routing_evaluator: RoutingEvaluator | None = None,
     ) -> EvolutionaryPlacementOptimizer:
         """
         Create evolutionary optimizer from an existing PlacementOptimizer.
 
         Useful for hybrid optimization workflows.
+
+        Args:
+            physics_optimizer: Existing placement optimizer to copy data from
+            config: Optimization parameters
+            routing_evaluator: Optional routing evaluator for actual
+                routability scoring (replaces spacing proxy)
         """
-        optimizer = cls(physics_optimizer.board_outline, config)
+        optimizer = cls(
+            physics_optimizer.board_outline, config, routing_evaluator=routing_evaluator
+        )
         optimizer.components = physics_optimizer.components
         optimizer.springs = physics_optimizer.springs
         optimizer.clusters = physics_optimizer.clusters
@@ -809,14 +880,68 @@ class EvolutionaryPlacementOptimizer:
 
     def _estimate_routability(self) -> float:
         """
-        Estimate routability based on component spacing and wire congestion.
+        Estimate routability based on routing evaluation or component spacing.
+
+        When a ``routing_evaluator`` is configured, delegates to it for
+        actual routing completion rate (scaled to 0--100).  Otherwise
+        falls back to the spacing-based proxy.
+
+        This method is called from ``_evaluate_fitness`` while components
+        are temporarily positioned at the candidate placement, so the
+        routing evaluator can read positions directly from the components.
 
         Returns a score from 0-100 where higher is better.
         """
         if not self.components:
             return 100.0
 
-        # Calculate average spacing between components
+        n = len(self.components)
+        if n < 2:
+            return 100.0
+
+        # Use routing evaluator when available
+        if self.routing_evaluator is not None:
+            return self._evaluate_routability_via_router()
+
+        return self._estimate_routability_spacing()
+
+    def _evaluate_routability_via_router(self) -> float:
+        """Evaluate routability using the configured routing evaluator.
+
+        Builds position/rotation dicts from current component state and
+        delegates to the routing evaluator.  The result (0.0--1.0
+        completion rate) is scaled to 0--100 to match the fitness
+        function's expected range.
+
+        Returns:
+            Routability score from 0 to 100.
+        """
+        positions: dict[str, tuple[float, float]] = {}
+        rotations: dict[str, float] = {}
+        for comp in self.components:
+            positions[comp.ref] = (comp.x, comp.y)
+            rotations[comp.ref] = comp.rotation
+
+        try:
+            completion_rate = self.routing_evaluator.evaluate_routability(
+                positions, rotations
+            )
+            # Clamp to [0, 1] and scale to [0, 100]
+            return max(0.0, min(1.0, completion_rate)) * 100.0
+        except Exception:
+            # Fall back to spacing proxy on routing failure
+            return self._estimate_routability_spacing()
+
+    def _estimate_routability_spacing(self) -> float:
+        """Spacing-based routability proxy (original implementation).
+
+        Computes average pairwise Euclidean distance between components
+        and scales linearly.  Used as fallback when no routing evaluator
+        is configured.
+
+        Returns:
+            Routability score from 0 to 100.
+        """
         n = len(self.components)
         if n < 2:
             return 100.0
@@ -1077,32 +1202,57 @@ class EvolutionaryPlacementOptimizer:
 
         Uses GPU acceleration when available and population is large enough.
         Falls back to ProcessPoolExecutor or sequential evaluation.
+
+        When a routing evaluator is configured, GPU and C++ fast-paths are
+        bypassed (the routing evaluator lives in Python and is not picklable)
+        and ThreadPoolExecutor is used instead of ProcessPoolExecutor since
+        the GIL is released during C++ routing calls.
         """
         pop_size = len(population)
+        has_routing_eval = self.routing_evaluator is not None
 
-        # Try GPU path first
-        if self._should_use_gpu(pop_size):
-            try:
-                fitness_values = self._evaluate_population_gpu(population)
+        # When routing evaluator is active, skip GPU and C++ paths
+        # because they use the spacing proxy internally
+        if not has_routing_eval:
+            # Try GPU path first
+            if self._should_use_gpu(pop_size):
+                try:
+                    fitness_values = self._evaluate_population_gpu(population)
+                    for ind, fitness in zip(population, fitness_values, strict=True):
+                        ind.fitness = fitness
+                    return
+                except Exception:
+                    # Fall through to CPU path on GPU error
+                    pass
+
+            # CPU path: parallel evaluation with process pool
+            if self.config.parallel and pop_size > 4:
+                ctx = self._create_evaluation_context()
+                max_workers = self.config.max_workers or os.cpu_count()
+
+                # Prepare work items as (individual, context) tuples
+                work_items = [(ind, ctx) for ind in population]
+
+                with ProcessPoolExecutor(max_workers=max_workers) as executor:
+                    fitness_values = list(executor.map(_evaluate_fitness_worker, work_items))
+
+                # Assign fitness values back to individuals
                 for ind, fitness in zip(population, fitness_values, strict=True):
                     ind.fitness = fitness
                 return
-            except Exception:
-                # Fall through to CPU path on GPU error
-                pass
 
-        # CPU path: parallel evaluation for larger populations
-        if self.config.parallel and pop_size > 4:
-            ctx = self._create_evaluation_context()
+        # When routing evaluator is active and parallel is enabled,
+        # use ThreadPoolExecutor (routing evaluator is not picklable,
+        # but GIL is released during C++ routing calls)
+        if has_routing_eval and self.config.parallel and pop_size > 4:
             max_workers = self.config.max_workers or os.cpu_count()
 
-            # Prepare work items as (individual, context) tuples
-            work_items = [(ind, ctx) for ind in population]
+            def _eval_one(ind: Individual) -> float:
+                return self._evaluate_fitness(ind)
 
-            with ProcessPoolExecutor(max_workers=max_workers) as executor:
-                fitness_values = list(executor.map(_evaluate_fitness_worker, work_items))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                fitness_values = list(executor.map(_eval_one, population))
 
-            # Assign fitness values back to individuals
             for ind, fitness in zip(population, fitness_values, strict=True):
                 ind.fitness = fitness
         else:

--- a/src/kicad_tools/optim/evolutionary.py
+++ b/src/kicad_tools/optim/evolutionary.py
@@ -26,6 +26,7 @@ Example::
 
 from __future__ import annotations
 
+import copy
 import math
 import os
 import random
@@ -532,9 +533,7 @@ class EvolutionaryPlacementOptimizer:
             pcb, fixed_refs=fixed_refs, enable_clustering=enable_clustering
         )
 
-        optimizer = cls(
-            physics_opt.board_outline, config, routing_evaluator=routing_evaluator
-        )
+        optimizer = cls(physics_opt.board_outline, config, routing_evaluator=routing_evaluator)
         optimizer.components = physics_opt.components
         optimizer.springs = physics_opt.springs
         optimizer.clusters = physics_opt.clusters
@@ -786,6 +785,132 @@ class EvolutionaryPlacementOptimizer:
                     comp.rotation = rot
                     comp.update_pin_positions()
 
+    def _evaluate_fitness_isolated(self, ind: Individual) -> float:
+        """Thread-safe fitness evaluation using deep-copied component state.
+
+        Creates independent copies of all components so that multiple
+        threads can evaluate different individuals in parallel without
+        racing on shared mutable component objects.
+        """
+        # Deep-copy components and build an isolated component map
+        components_copy = copy.deepcopy(self.components)
+        component_map_copy: dict[str, Component] = {comp.ref: comp for comp in components_copy}
+
+        # Apply candidate positions to the copies
+        for ref, (x, y) in ind.positions.items():
+            comp = component_map_copy.get(ref)
+            if comp:
+                comp.x = x
+                comp.y = y
+                comp.rotation = ind.rotations.get(ref, comp.rotation)
+                comp.update_pin_positions()
+
+        # --- compute objectives on copies ---
+
+        # Wire length
+        wire_length = 0.0
+        for spring in self.springs:
+            comp1 = component_map_copy.get(spring.comp1_ref)
+            comp2 = component_map_copy.get(spring.comp2_ref)
+            if not comp1 or not comp2:
+                continue
+            pin1 = next((p for p in comp1.pins if p.number == spring.pin1_num), None)
+            pin2 = next((p for p in comp2.pins if p.number == spring.pin2_num), None)
+            if not pin1 or not pin2:
+                continue
+            dx = pin2.x - pin1.x
+            dy = pin2.y - pin1.y
+            wire_length += math.sqrt(dx * dx + dy * dy)
+
+        # Conflicts (AABB overlap)
+        conflicts = 0
+        n = len(components_copy)
+        for i in range(n):
+            c1 = components_copy[i]
+            hw1, hh1 = c1.width / 2, c1.height / 2
+            for j in range(i + 1, n):
+                c2 = components_copy[j]
+                hw2, hh2 = c2.width / 2, c2.height / 2
+                if abs(c1.x - c2.x) < (hw1 + hw2) and abs(c1.y - c2.y) < (hh1 + hh2):
+                    conflicts += 1
+
+        # Boundary violations
+        boundary_violations = 0
+        for comp in components_copy:
+            if not self.board_outline.contains_point(Vector2D(comp.x, comp.y)):
+                boundary_violations += 1
+
+        # Routability
+        if self.routing_evaluator is not None:
+            positions_dict: dict[str, tuple[float, float]] = {}
+            rotations_dict: dict[str, float] = {}
+            for comp in components_copy:
+                positions_dict[comp.ref] = (comp.x, comp.y)
+                rotations_dict[comp.ref] = comp.rotation
+            try:
+                completion_rate = self.routing_evaluator.evaluate_routability(
+                    positions_dict, rotations_dict
+                )
+                routability = max(0.0, min(1.0, completion_rate)) * 100.0
+            except Exception:
+                routability = self._estimate_routability_spacing_from(components_copy)
+        else:
+            routability = self._estimate_routability_spacing_from(components_copy)
+
+        # Pin alignments
+        aligned_pins = 0
+        total_pin_pairs = 0
+        tolerance = self.config.pin_alignment_tolerance
+        for spring in self.springs:
+            comp1 = component_map_copy.get(spring.comp1_ref)
+            comp2 = component_map_copy.get(spring.comp2_ref)
+            if not comp1 or not comp2:
+                continue
+            pin1 = next((p for p in comp1.pins if p.number == spring.pin1_num), None)
+            pin2 = next((p for p in comp2.pins if p.number == spring.pin2_num), None)
+            if not pin1 or not pin2:
+                continue
+            total_pin_pairs += 1
+            dx = abs(pin2.x - pin1.x)
+            dy = abs(pin2.y - pin1.y)
+            if dx < tolerance or dy < tolerance:
+                aligned_pins += 1
+        alignment = (aligned_pins / total_pin_pairs * 100.0) if total_pin_pairs > 0 else 0.0
+
+        # Weighted sum (higher = better)
+        fitness = (
+            1000.0
+            - wire_length * self.config.wire_length_weight
+            - conflicts * self.config.conflict_weight
+            - boundary_violations * self.config.boundary_violation_weight
+            + routability * self.config.routability_weight
+            + alignment * self.config.pin_alignment_weight
+        )
+
+        return fitness
+
+    @staticmethod
+    def _estimate_routability_spacing_from(components: list[Component]) -> float:
+        """Spacing-based routability proxy computed from a component list.
+
+        Thread-safe variant of ``_estimate_routability_spacing`` that
+        operates on an explicitly-provided component list rather than
+        reading from ``self.components``.
+        """
+        n = len(components)
+        if n < 2:
+            return 100.0
+        total_spacing = 0.0
+        count = 0
+        for i in range(n):
+            for j in range(i + 1, n):
+                dx = components[i].x - components[j].x
+                dy = components[i].y - components[j].y
+                total_spacing += math.sqrt(dx * dx + dy * dy)
+                count += 1
+        avg_spacing = total_spacing / count if count > 0 else 0
+        return min(100.0, avg_spacing * 5.0)
+
     def _total_wire_length(self) -> float:
         """Compute total wire length from spring connections."""
         total = 0.0
@@ -923,9 +1048,7 @@ class EvolutionaryPlacementOptimizer:
             rotations[comp.ref] = comp.rotation
 
         try:
-            completion_rate = self.routing_evaluator.evaluate_routability(
-                positions, rotations
-            )
+            completion_rate = self.routing_evaluator.evaluate_routability(positions, rotations)
             # Clamp to [0, 1] and scale to [0, 100]
             return max(0.0, min(1.0, completion_rate)) * 100.0
         except Exception:
@@ -1129,9 +1252,7 @@ class EvolutionaryPlacementOptimizer:
             )
 
         # Prepare spring data list
-        springs_list = [
-            (s.comp1_ref, s.pin1_num, s.comp2_ref, s.pin2_num) for s in self.springs
-        ]
+        springs_list = [(s.comp1_ref, s.pin1_num, s.comp2_ref, s.pin2_num) for s in self.springs]
 
         # Prepare board vertices
         board_vertices = [(v.x, v.y) for v in self.board_outline.vertices]
@@ -1142,9 +1263,7 @@ class EvolutionaryPlacementOptimizer:
             self._spring_indices,
             self._spring_pin_offsets,
             self._board_vertices_arr,
-        ) = prepare_evaluation_data(
-            components_dict, springs_list, board_vertices, self._ref_to_idx
-        )
+        ) = prepare_evaluation_data(components_dict, springs_list, board_vertices, self._ref_to_idx)
 
         self._gpu_data_prepared = True
 
@@ -1248,7 +1367,7 @@ class EvolutionaryPlacementOptimizer:
             max_workers = self.config.max_workers or os.cpu_count()
 
             def _eval_one(ind: Individual) -> float:
-                return self._evaluate_fitness(ind)
+                return self._evaluate_fitness_isolated(ind)
 
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 fitness_values = list(executor.map(_eval_one, population))

--- a/tests/test_routing_fitness.py
+++ b/tests/test_routing_fitness.py
@@ -1,0 +1,328 @@
+"""Tests for routing-based fitness evaluation in the evolutionary optimizer.
+
+Verifies that the EvolutionaryPlacementOptimizer can use a RoutingEvaluator
+to replace the spacing-based routability proxy with actual routing completion
+rate, and that the spacing proxy remains as the default fallback.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kicad_tools.optim import Component, Pin, Polygon, Spring
+from kicad_tools.optim.evolutionary import (
+    EvolutionaryConfig,
+    EvolutionaryPlacementOptimizer,
+    Individual,
+    RoutingEvaluator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_optimizer(
+    routing_evaluator=None,
+    config=None,
+):
+    """Create a small optimizer with two components and one spring."""
+    board = Polygon.rectangle(50, 50, 100, 80)
+    config = config or EvolutionaryConfig()
+    opt = EvolutionaryPlacementOptimizer(
+        board, config, routing_evaluator=routing_evaluator
+    )
+
+    comp1 = Component(
+        ref="U1",
+        x=30.0,
+        y=40.0,
+        width=5.0,
+        height=5.0,
+        pins=[Pin(number="1", x=30.0, y=40.0, net=1, net_name="NET1")],
+    )
+    comp2 = Component(
+        ref="R1",
+        x=70.0,
+        y=60.0,
+        width=3.0,
+        height=2.0,
+        pins=[Pin(number="1", x=70.0, y=60.0, net=1, net_name="NET1")],
+    )
+    opt.add_component(comp1)
+    opt.add_component(comp2)
+
+    spring = Spring(
+        comp1_ref="U1",
+        pin1_num="1",
+        comp2_ref="R1",
+        pin2_num="1",
+        stiffness=1.0,
+        net=1,
+        net_name="NET1",
+    )
+    opt.add_spring(spring)
+
+    return opt
+
+
+class _MockRoutingEvaluator:
+    """Simple mock that records calls and returns a fixed completion rate."""
+
+    def __init__(self, completion_rate: float = 0.85):
+        self.completion_rate = completion_rate
+        self.calls: list[tuple[dict, dict]] = []
+
+    def evaluate_routability(
+        self,
+        positions: dict[str, tuple[float, float]],
+        rotations: dict[str, float],
+    ) -> float:
+        self.calls.append((dict(positions), dict(rotations)))
+        return self.completion_rate
+
+
+# ---------------------------------------------------------------------------
+# Tests: RoutingEvaluator integration
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingEvaluatorFallback:
+    """Verify spacing proxy is used when no routing evaluator is provided."""
+
+    def test_default_uses_spacing_proxy(self):
+        opt = _make_optimizer(routing_evaluator=None)
+        score = opt._estimate_routability()
+        # The spacing proxy returns avg_spacing * 5.0 clamped to [0, 100].
+        # Two components at (30,40) and (70,60): dist ~ 44.7, * 5 = 223 -> clamped to 100
+        assert score == pytest.approx(100.0)
+
+    def test_spacing_proxy_with_close_components(self):
+        opt = _make_optimizer(routing_evaluator=None)
+        # Move components very close together
+        opt.components[0].x = 50.0
+        opt.components[0].y = 50.0
+        opt.components[1].x = 52.0
+        opt.components[1].y = 50.0
+        score = opt._estimate_routability()
+        # dist = 2.0, * 5.0 = 10.0
+        assert score == pytest.approx(10.0)
+
+
+class TestRoutingEvaluatorUsed:
+    """Verify routing evaluator is called when configured."""
+
+    def test_evaluator_called_during_estimate(self):
+        evaluator = _MockRoutingEvaluator(completion_rate=0.75)
+        opt = _make_optimizer(routing_evaluator=evaluator)
+        score = opt._estimate_routability()
+        assert len(evaluator.calls) == 1
+        assert score == pytest.approx(75.0)  # 0.75 * 100
+
+    def test_evaluator_receives_current_positions(self):
+        evaluator = _MockRoutingEvaluator(completion_rate=1.0)
+        opt = _make_optimizer(routing_evaluator=evaluator)
+
+        # Move components to known positions
+        opt.components[0].x = 25.0
+        opt.components[0].y = 35.0
+        opt.components[1].x = 65.0
+        opt.components[1].y = 55.0
+
+        opt._estimate_routability()
+        positions, rotations = evaluator.calls[0]
+        assert positions["U1"] == (25.0, 35.0)
+        assert positions["R1"] == (65.0, 55.0)
+
+    def test_evaluator_zero_completion(self):
+        evaluator = _MockRoutingEvaluator(completion_rate=0.0)
+        opt = _make_optimizer(routing_evaluator=evaluator)
+        score = opt._estimate_routability()
+        assert score == pytest.approx(0.0)
+
+    def test_evaluator_full_completion(self):
+        evaluator = _MockRoutingEvaluator(completion_rate=1.0)
+        opt = _make_optimizer(routing_evaluator=evaluator)
+        score = opt._estimate_routability()
+        assert score == pytest.approx(100.0)
+
+    def test_evaluator_clamped_above_one(self):
+        evaluator = _MockRoutingEvaluator(completion_rate=1.5)
+        opt = _make_optimizer(routing_evaluator=evaluator)
+        score = opt._estimate_routability()
+        assert score == pytest.approx(100.0)
+
+    def test_evaluator_clamped_below_zero(self):
+        evaluator = _MockRoutingEvaluator(completion_rate=-0.1)
+        opt = _make_optimizer(routing_evaluator=evaluator)
+        score = opt._estimate_routability()
+        assert score == pytest.approx(0.0)
+
+
+class TestRoutingEvaluatorFitnessIntegration:
+    """Verify fitness function correctly incorporates routing completion."""
+
+    def test_fitness_uses_routing_evaluator(self):
+        evaluator = _MockRoutingEvaluator(completion_rate=0.5)
+        opt = _make_optimizer(routing_evaluator=evaluator)
+        ind = opt._individual_from_current()
+        fitness = opt._evaluate_fitness(ind)
+        # Evaluator should have been called
+        assert len(evaluator.calls) >= 1
+        assert fitness != 0.0
+
+    def test_higher_completion_yields_higher_fitness(self):
+        """Better routing completion should produce higher fitness."""
+        config = EvolutionaryConfig(
+            routability_weight=50.0,
+            wire_length_weight=0.0,  # Disable wire length to isolate routability
+        )
+
+        eval_low = _MockRoutingEvaluator(completion_rate=0.2)
+        opt_low = _make_optimizer(routing_evaluator=eval_low, config=config)
+        ind = opt_low._individual_from_current()
+        fitness_low = opt_low._evaluate_fitness(ind)
+
+        eval_high = _MockRoutingEvaluator(completion_rate=0.9)
+        opt_high = _make_optimizer(routing_evaluator=eval_high, config=config)
+        ind = opt_high._individual_from_current()
+        fitness_high = opt_high._evaluate_fitness(ind)
+
+        assert fitness_high > fitness_low
+
+    def test_fitness_restores_positions_after_evaluation(self):
+        """Verify components return to original positions after evaluation."""
+        evaluator = _MockRoutingEvaluator(completion_rate=0.5)
+        opt = _make_optimizer(routing_evaluator=evaluator)
+        original_x = opt.components[0].x
+        original_y = opt.components[0].y
+
+        ind = Individual(
+            positions={"U1": (99.0, 99.0), "R1": (60.0, 60.0)},
+            rotations={"U1": 90.0, "R1": 0.0},
+        )
+        opt._evaluate_fitness(ind)
+
+        assert opt.components[0].x == original_x
+        assert opt.components[0].y == original_y
+
+
+class TestRoutingEvaluatorErrorHandling:
+    """Verify graceful fallback when routing evaluator raises."""
+
+    def test_evaluator_exception_falls_back_to_spacing(self):
+        evaluator = MagicMock(spec=RoutingEvaluator)
+        evaluator.evaluate_routability.side_effect = RuntimeError("routing failed")
+        opt = _make_optimizer(routing_evaluator=evaluator)
+
+        # Should not raise -- falls back to spacing proxy
+        score = opt._estimate_routability()
+        # The spacing proxy returns a score (we just check it's reasonable)
+        assert 0.0 <= score <= 100.0
+        assert evaluator.evaluate_routability.called
+
+
+class TestPopulationEvaluationWithRouting:
+    """Verify population evaluation respects routing evaluator."""
+
+    def test_sequential_evaluation_uses_routing(self):
+        evaluator = _MockRoutingEvaluator(completion_rate=0.6)
+        config = EvolutionaryConfig(parallel=False)
+        opt = _make_optimizer(routing_evaluator=evaluator, config=config)
+        population = opt._initialize_population(5)
+        opt._evaluate_population(population)
+
+        # Each individual should have been evaluated
+        assert all(ind.fitness != 0.0 for ind in population)
+        # The evaluator should have been called once per individual
+        assert len(evaluator.calls) == 5
+
+    def test_parallel_evaluation_uses_threads(self):
+        """When routing evaluator is active, parallel uses ThreadPoolExecutor."""
+        evaluator = _MockRoutingEvaluator(completion_rate=0.8)
+        config = EvolutionaryConfig(parallel=True, max_workers=2)
+        opt = _make_optimizer(routing_evaluator=evaluator, config=config)
+        population = opt._initialize_population(10)
+        opt._evaluate_population(population)
+
+        # All individuals should be evaluated
+        assert all(ind.fitness != 0.0 for ind in population)
+        # The evaluator should have been called for each individual
+        assert len(evaluator.calls) == 10
+
+
+class TestOptimizeWithRouting:
+    """Integration: full optimization with routing evaluator."""
+
+    def test_optimize_with_routing_evaluator(self):
+        evaluator = _MockRoutingEvaluator(completion_rate=0.9)
+        config = EvolutionaryConfig(
+            population_size=8,
+            generations=3,
+            parallel=False,
+        )
+        opt = _make_optimizer(routing_evaluator=evaluator, config=config)
+        best = opt.optimize(generations=3, population_size=8)
+        assert isinstance(best, Individual)
+        assert best.fitness != 0.0
+        # Evaluator should have been called many times
+        assert len(evaluator.calls) > 0
+
+
+class TestEdgeCases:
+    """Edge cases for routing evaluator."""
+
+    def test_zero_components(self):
+        board = Polygon.rectangle(50, 50, 100, 80)
+        evaluator = _MockRoutingEvaluator(completion_rate=0.5)
+        opt = EvolutionaryPlacementOptimizer(
+            board, routing_evaluator=evaluator
+        )
+        score = opt._estimate_routability()
+        # 0 components => 100.0 (short-circuit before evaluator)
+        assert score == pytest.approx(100.0)
+        assert len(evaluator.calls) == 0
+
+    def test_one_component(self):
+        board = Polygon.rectangle(50, 50, 100, 80)
+        evaluator = _MockRoutingEvaluator(completion_rate=0.5)
+        opt = EvolutionaryPlacementOptimizer(
+            board, routing_evaluator=evaluator
+        )
+        comp = Component(ref="U1", x=50.0, y=50.0, width=5.0, height=5.0)
+        opt.add_component(comp)
+        score = opt._estimate_routability()
+        # 1 component => 100.0 (short-circuit before evaluator)
+        assert score == pytest.approx(100.0)
+        assert len(evaluator.calls) == 0
+
+
+class TestBackwardCompatibility:
+    """Ensure existing tests pass without modification when no evaluator."""
+
+    def test_existing_fitness_unchanged(self):
+        """Without routing evaluator, fitness should match original behavior."""
+        opt = _make_optimizer(routing_evaluator=None)
+        ind = opt._individual_from_current()
+        fitness = opt._evaluate_fitness(ind)
+        # Just verify it runs and produces a reasonable value
+        assert isinstance(fitness, float)
+        assert fitness != 0.0
+
+    def test_factory_methods_accept_routing_evaluator(self):
+        """Verify from_placement_optimizer accepts routing_evaluator."""
+        from kicad_tools.optim import PlacementOptimizer
+
+        board = Polygon.rectangle(50, 50, 100, 80)
+        physics_opt = PlacementOptimizer(board)
+        comp = Component(ref="U1", x=50.0, y=50.0, width=5.0, height=5.0)
+        physics_opt.add_component(comp)
+
+        evaluator = _MockRoutingEvaluator(completion_rate=0.7)
+        evo_opt = EvolutionaryPlacementOptimizer.from_placement_optimizer(
+            physics_opt, routing_evaluator=evaluator
+        )
+        assert evo_opt.routing_evaluator is evaluator


### PR DESCRIPTION
## Summary

Replace the spacing-based routability proxy in the evolutionary placement optimizer with an optional `RoutingEvaluator` protocol that evaluates candidate placements via actual routing completion rate. This is Phase 1 of issue #2441 -- it enables single-trial route-all fitness evaluation without requiring the evolutionary routing inner loop (Phase 2, blocked on #2440).

## Changes

- Add `RoutingEvaluator` protocol with `evaluate_routability(positions, rotations) -> float` method
- Add `routing_evaluator` parameter to `EvolutionaryPlacementOptimizer.__init__`, `from_pcb`, and `from_placement_optimizer`
- Split `_estimate_routability()` into three methods:
  - `_estimate_routability()` -- dispatcher that checks for routing evaluator
  - `_evaluate_routability_via_router()` -- delegates to routing evaluator, scales 0-1 rate to 0-100
  - `_estimate_routability_spacing()` -- original spacing proxy preserved as fallback
- When routing evaluator is active, `_evaluate_population()` bypasses GPU/C++ fast-paths (they embed the spacing proxy) and uses `ThreadPoolExecutor` instead of `ProcessPoolExecutor` (routing evaluators are not picklable, GIL released during C++ routing)
- Graceful fallback to spacing proxy on evaluator exceptions
- 19 new tests covering: evaluator integration, fitness incorporation, error handling, population evaluation, edge cases, and backward compatibility

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Mock routing evaluator calls `_estimate_routability()` when available | Pass | `TestRoutingEvaluatorUsed::test_evaluator_called_during_estimate` |
| Fitness correctly incorporates routing completion rate | Pass | `TestRoutingEvaluatorFitnessIntegration::test_higher_completion_yields_higher_fitness` |
| Falls back to spacing proxy when evaluator not provided | Pass | `TestRoutingEvaluatorFallback::test_default_uses_spacing_proxy` |
| Falls back on evaluator exception | Pass | `TestRoutingEvaluatorErrorHandling::test_evaluator_exception_falls_back_to_spacing` |
| Existing tests pass without modification | Pass | All 33 `test_evolutionary_optimizer.py` tests pass |
| Edge cases (0/1 components) handled | Pass | `TestEdgeCases` |
| Completion rate clamped to [0,1] | Pass | `test_evaluator_clamped_above_one`, `test_evaluator_clamped_below_zero` |

## Test Plan

- `uv run python -m pytest tests/test_routing_fitness.py -v` -- 19/19 pass
- `uv run python -m pytest tests/test_evolutionary_optimizer.py -v` -- 33/33 pass (backward compat)

Closes #2441