### PR TITLE
feat(router): add net ordering tier promotion for long-span nets

### DIFF
--- a/src/kicad_tools/router/algorithms/evolutionary.py
+++ b/src/kicad_tools/router/algorithms/evolutionary.py
@@ -343,10 +343,13 @@ class EvolutionaryRoutingOptimizer:
             base_chrom.strategy_flags[net] = False
         population.append(base_chrom)
 
-        # Remaining: random shuffles
+        # Remaining: random shuffles with cross-tier promotions
         for i in range(1, self.pop_size):
             random.seed(seed + i)
-            order = mc.shuffle_within_tiers(base_order, get_priority)
+            promotion_rate = min(0.1 + 0.05 * i, 0.5)
+            order = mc.shuffle_with_promotions(
+                base_order, get_priority, promotion_rate=promotion_rate
+            )
             chrom = RoutingChromosome(net_order=order)
             for net in base_order:
                 chrom.astar_weights[net] = max(0.5, min(3.0, random.gauss(1.0, 0.3)))

--- a/src/kicad_tools/router/algorithms/monte_carlo.py
+++ b/src/kicad_tools/router/algorithms/monte_carlo.py
@@ -42,30 +42,95 @@ class MonteCarloRouter:
     ) -> list[int]:
         """Shuffle nets but preserve priority tier ordering.
 
+        Groups by (net_class_priority, complexity_tier) so that simple 2-pin
+        short nets and complex multi-pin/long-span nets within the same net
+        class are not mixed together.
+
         Args:
             net_order: Original net order
             get_priority: Function that takes net_id and returns priority tuple
-                (e.g., (priority, pad_count, distance))
+                where element 0 is net class priority and element 1 is
+                complexity tier.
 
         Returns:
             New net order with shuffled tiers
         """
-        # Group by priority tier (use first element of priority tuple)
-        tiers: dict[int, list[int]] = {}
+        # Group by (net_class_priority, complexity_tier)
+        tiers: dict[tuple[int, int], list[int]] = {}
         for net in net_order:
             priority_tuple = get_priority(net)
-            tier = priority_tuple[0]  # First element is the net class priority
-            if tier not in tiers:
-                tiers[tier] = []
-            tiers[tier].append(net)
+            key = (priority_tuple[0], priority_tuple[1])
+            if key not in tiers:
+                tiers[key] = []
+            tiers[key].append(net)
 
-        # Shuffle within each tier and reassemble
+        # Shuffle within each tier and reassemble in sorted key order
         result: list[int] = []
-        for priority in sorted(tiers.keys()):
-            tier_nets = tiers[priority].copy()
+        for key in sorted(tiers.keys()):
+            tier_nets = tiers[key].copy()
             random.shuffle(tier_nets)
             result.extend(tier_nets)
 
+        return result
+
+    def shuffle_with_promotions(
+        self,
+        net_order: list[int],
+        get_priority: callable,
+        promotion_rate: float = 0.2,
+    ) -> list[int]:
+        """Shuffle within (priority, complexity_tier) groups with cross-tier promotions.
+
+        Occasionally promotes tier-1 (complex/long-span) nets to tier-0
+        (simple/short) position within the same net class priority, biasing
+        exploration toward orderings where long-span nets get early corridor
+        access.
+
+        Cross-tier promotions never cross net class priority boundaries -- a
+        debug net (priority 5) is never promoted ahead of a clock net
+        (priority 2).
+
+        Args:
+            net_order: Original net order
+            get_priority: Function that takes net_id and returns priority tuple
+            promotion_rate: Probability of promoting each tier-1 net to tier 0
+                within the same net class priority (0.0 = no promotions,
+                1.0 = always promote)
+
+        Returns:
+            New net order with shuffled tiers and cross-tier promotions
+        """
+        # Group by (net_class_priority, complexity_tier)
+        groups: dict[tuple[int, int], list[int]] = {}
+        for net in net_order:
+            pt = get_priority(net)
+            key = (pt[0], pt[1])
+            groups.setdefault(key, []).append(net)
+
+        # Promote: move some tier-1 nets to tier-0 within same net class priority
+        priorities = {k[0] for k in groups}
+        for p in priorities:
+            src_key = (p, 1)
+            dst_key = (p, 0)
+            if src_key not in groups:
+                continue
+            promoted = []
+            remaining = []
+            for net in groups[src_key]:
+                if random.random() < promotion_rate:
+                    promoted.append(net)
+                else:
+                    remaining.append(net)
+            if promoted:
+                groups.setdefault(dst_key, []).extend(promoted)
+                groups[src_key] = remaining
+
+        # Shuffle within each group and reassemble in sorted key order
+        result: list[int] = []
+        for key in sorted(groups.keys()):
+            nets = groups[key].copy()
+            random.shuffle(nets)
+            result.extend(nets)
         return result
 
     def evaluate_solution(self, routes: list[Route]) -> float:
@@ -178,11 +243,14 @@ def run_monte_carlo(
 
             random.seed(base_seed + trial)
             autorouter._reset_for_new_trial()
-            net_order = (
-                base_order.copy()
-                if trial == 0
-                else autorouter._shuffle_within_tiers(base_order)
-            )
+            if trial == 0:
+                net_order = base_order.copy()
+            else:
+                # Increasing promotion rate over trials to broaden exploration
+                promotion_rate = min(0.1 + 0.05 * trial, 0.5)
+                net_order = autorouter._shuffle_within_tiers(
+                    base_order, promotion_rate=promotion_rate
+                )
             routes = (
                 autorouter.route_all_negotiated()
                 if use_negotiated

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -303,7 +303,9 @@ def _run_monte_carlo_trial(config: dict) -> tuple[list, float, int]:
     if trial_num == 0:
         net_order = base_order.copy()
     else:
-        net_order = router._shuffle_within_tiers(base_order)
+        # Increasing promotion rate over trials to broaden exploration
+        promotion_rate = min(0.1 + 0.05 * trial_num, 0.5)
+        net_order = router._shuffle_within_tiers(base_order, promotion_rate=promotion_rate)
 
     # Run routing
     if use_negotiated:
@@ -4463,9 +4465,22 @@ class Autorouter:
             self.grid.add_pad(pad, pin_pitch=pitches.get(pad.ref))
         self.routes = []
 
-    def _shuffle_within_tiers(self, net_order: list[int]) -> list[int]:
-        """Shuffle nets but keep priority ordering."""
+    def _shuffle_within_tiers(
+        self, net_order: list[int], promotion_rate: float = 0.0
+    ) -> list[int]:
+        """Shuffle nets but keep priority ordering.
+
+        Args:
+            net_order: Original net order
+            promotion_rate: If > 0, use cross-tier promotions that move
+                complex/long-span nets into simple-tier positions within
+                the same net class priority. 0.0 uses standard shuffle.
+        """
         mc_router = MonteCarloRouter(len([n for n in self.nets if n != 0]))
+        if promotion_rate > 0.0:
+            return mc_router.shuffle_with_promotions(
+                net_order, self._get_net_priority, promotion_rate=promotion_rate
+            )
         return mc_router.shuffle_within_tiers(net_order, self._get_net_priority)
 
     def _evaluate_solution(self, routes: list[Route]) -> float:

--- a/tests/test_router_autorouter.py
+++ b/tests/test_router_autorouter.py
@@ -1,6 +1,7 @@
 """Tests for router autorouter, pathfinder, and adaptive autorouter."""
 
 import math
+import random
 
 import pytest
 
@@ -413,6 +414,107 @@ class TestAutorouter:
         # Clock nets should come before signal nets
         assert set(shuffled[:2]) == {1, 2}  # Clock nets first
         assert shuffled[2] == 3  # Signal net last
+
+    def test_shuffle_within_tiers_preserves_complexity_tier(self):
+        """Test that shuffle groups by (priority, complexity_tier), not just priority."""
+        from kicad_tools.router.algorithms.monte_carlo import MonteCarloRouter
+
+        mc = MonteCarloRouter(total_nets=4)
+
+        # Mock priority tuples: (net_class_priority, complexity_tier, ...)
+        # Net 1: clock, simple (tier 0)
+        # Net 2: clock, complex (tier 1)
+        # Net 3: default, simple (tier 0)
+        # Net 4: default, complex (tier 1)
+        priorities = {
+            1: (2, 0, 0.0, 2, 5.0, 0.0),
+            2: (2, 1, 0.0, 4, 20.0, 0.0),
+            3: (10, 0, 0.0, 2, 5.0, 0.0),
+            4: (10, 1, 0.0, 4, 20.0, 0.0),
+        }
+
+        random.seed(42)
+        shuffled = mc.shuffle_within_tiers([1, 2, 3, 4], lambda n: priorities[n])
+
+        # Groups should be: (2,0)=[1], (2,1)=[2], (10,0)=[3], (10,1)=[4]
+        # Clock simple before clock complex before default simple before default complex
+        assert shuffled.index(1) < shuffled.index(2)  # clock simple < clock complex
+        assert shuffled.index(2) < shuffled.index(3)  # clock complex < default simple
+        assert shuffled.index(3) < shuffled.index(4)  # default simple < default complex
+
+    def test_shuffle_with_promotions_moves_tier1_to_tier0(self):
+        """Test that promotion_rate=1.0 moves all tier-1 nets into tier-0 position."""
+        from kicad_tools.router.algorithms.monte_carlo import MonteCarloRouter
+
+        mc = MonteCarloRouter(total_nets=4)
+
+        priorities = {
+            1: (10, 0, 0.0, 2, 5.0, 0.0),   # default, simple
+            2: (10, 0, 0.0, 2, 6.0, 0.0),   # default, simple
+            3: (10, 1, 0.0, 4, 20.0, 0.0),  # default, complex
+            4: (10, 1, 0.0, 4, 25.0, 0.0),  # default, complex
+        }
+
+        random.seed(42)
+        result = mc.shuffle_with_promotions(
+            [1, 2, 3, 4], lambda n: priorities[n], promotion_rate=1.0
+        )
+
+        # With promotion_rate=1.0, all tier-1 nets should be promoted to tier 0
+        # All nets should be in a single group (10, 0), so order is just a shuffle
+        assert set(result) == {1, 2, 3, 4}
+        assert len(result) == 4
+
+    def test_shuffle_with_promotions_zero_rate_matches_shuffle_within_tiers(self):
+        """Test that promotion_rate=0.0 produces same grouping as shuffle_within_tiers."""
+        from kicad_tools.router.algorithms.monte_carlo import MonteCarloRouter
+
+        mc = MonteCarloRouter(total_nets=4)
+
+        priorities = {
+            1: (2, 0, 0.0, 2, 5.0, 0.0),
+            2: (2, 1, 0.0, 4, 20.0, 0.0),
+            3: (10, 0, 0.0, 2, 5.0, 0.0),
+            4: (10, 1, 0.0, 4, 20.0, 0.0),
+        }
+
+        get_priority = lambda n: priorities[n]  # noqa: E731
+
+        # Both methods with same seed should produce same ordering
+        random.seed(99)
+        shuffled = mc.shuffle_within_tiers([1, 2, 3, 4], get_priority)
+        random.seed(99)
+        promoted = mc.shuffle_with_promotions(
+            [1, 2, 3, 4], get_priority, promotion_rate=0.0
+        )
+
+        assert shuffled == promoted
+
+    def test_shuffle_with_promotions_never_crosses_net_class(self):
+        """Test that promotions never mix nets across net class priority boundaries."""
+        from kicad_tools.router.algorithms.monte_carlo import MonteCarloRouter
+
+        mc = MonteCarloRouter(total_nets=4)
+
+        priorities = {
+            1: (2, 0, 0.0, 2, 5.0, 0.0),   # clock, simple
+            2: (2, 1, 0.0, 4, 20.0, 0.0),  # clock, complex
+            3: (10, 0, 0.0, 2, 5.0, 0.0),  # default, simple
+            4: (10, 1, 0.0, 4, 20.0, 0.0), # default, complex
+        }
+
+        # Run many times with full promotion to verify no cross-class mixing
+        for seed in range(50):
+            random.seed(seed)
+            result = mc.shuffle_with_promotions(
+                [1, 2, 3, 4], lambda n: priorities[n], promotion_rate=1.0
+            )
+            # Clock nets (1, 2) must always come before default nets (3, 4)
+            clock_indices = {result.index(1), result.index(2)}
+            default_indices = {result.index(3), result.index(4)}
+            assert max(clock_indices) < min(default_indices), (
+                f"Clock nets appeared after default nets with seed {seed}: {result}"
+            )
 
     def test_create_intra_ic_routes(self):
         """Test intra-IC route creation for same-component pins."""


### PR DESCRIPTION
## Summary
- Adds `shuffle_with_promotions()` to `MonteCarloRouter` that promotes complex/long-span nets from tier-1 to tier-0 within the same net class priority
- Updates `shuffle_within_tiers()` to group by `(net_class_priority, complexity_tier)` instead of just priority
- Integrates promotions into both Monte Carlo trials and evolutionary population seeding with increasing promotion rates

Closes #2451

## Test plan
- [x] `test_shuffle_within_tiers_preserves_complexity_tier` — verifies (priority, tier) grouping
- [x] `test_shuffle_with_promotions_moves_tier1_to_tier0` — verifies full promotion
- [x] `test_shuffle_with_promotions_zero_rate_matches_shuffle_within_tiers` — verifies no-op at rate 0
- [x] `test_shuffle_with_promotions_never_crosses_net_class` — verifies no cross-class mixing (50 seeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)