### PR TITLE
fix(zones): add pure-Python rect inset fallback and reinset existing un-inset zones

### DIFF
--- a/src/kicad_tools/router/auto_pour.py
+++ b/src/kicad_tools/router/auto_pour.py
@@ -20,7 +20,6 @@ from pathlib import Path
 
 
 def _detect_uninset_zones(
-    pcb_text: str,
     pcb_path: Path,
     edge_clearance: float,
 ) -> set[str]:
@@ -211,7 +210,7 @@ def auto_pour_if_missing(
     nets_needing_reinset: set[str] = set()
     if edge_clearance and edge_clearance > 0 and nets_with_zones:
         nets_needing_reinset = _detect_uninset_zones(
-            pcb_text, pcb_path, edge_clearance
+            pcb_path, edge_clearance
         )
         if nets_needing_reinset:
             _remove_zones_for_nets(pcb_path, nets_needing_reinset)

--- a/src/kicad_tools/router/auto_pour.py
+++ b/src/kicad_tools/router/auto_pour.py
@@ -19,6 +19,103 @@ import re
 from pathlib import Path
 
 
+def _detect_uninset_zones(
+    pcb_text: str,
+    pcb_path: Path,
+    edge_clearance: float,
+) -> set[str]:
+    """Return net names of zones whose boundaries lack edge clearance inset.
+
+    Loads the PCB via the schema layer to get zone polygons and the board
+    outline, then checks whether any zone polygon vertex sits within
+    ``edge_clearance`` of the board edge (with a small tolerance).
+    """
+    from kicad_tools.schema.pcb import PCB
+
+    pcb = PCB.load(str(pcb_path))
+    outline = pcb.get_board_outline()
+    if not outline:
+        return set()
+
+    ox, oy = pcb.board_origin
+
+    # Build board-edge bounding box from the outline
+    outline_xs = [p[0] for p in outline]
+    outline_ys = [p[1] for p in outline]
+    edge_x_min, edge_x_max = min(outline_xs), max(outline_xs)
+    edge_y_min, edge_y_max = min(outline_ys), max(outline_ys)
+
+    # Tolerance: vertices within (edge_clearance - epsilon) of the edge
+    # are considered un-inset.  We use half the clearance as threshold
+    # so that zones that were already inset (even partially) are not
+    # unnecessarily regenerated.
+    threshold = edge_clearance * 0.5
+
+    nets_needing_fix: set[str] = set()
+    for zone in pcb.zones:
+        net_name = zone.net_name
+        if not net_name:
+            continue
+        polygon = zone.polygon
+        if not polygon:
+            continue
+
+        for px, py in polygon:
+            # Convert from sheet-absolute to board-relative
+            bx = px - ox
+            by = py - oy
+            # Check distance to each edge of the bounding box
+            dist_left = bx - edge_x_min
+            dist_right = edge_x_max - bx
+            dist_top = by - edge_y_min
+            dist_bottom = edge_y_max - by
+            min_dist = min(dist_left, dist_right, dist_top, dist_bottom)
+            if min_dist < threshold:
+                nets_needing_fix.add(net_name)
+                break  # No need to check more vertices for this zone
+
+    return nets_needing_fix
+
+
+def _remove_zones_for_nets(pcb_path: Path, net_names: set[str]) -> None:
+    """Remove zone definitions for the given net names from the PCB file.
+
+    Uses a regex-based approach to strip ``(zone ...)`` blocks whose
+    ``net_name`` or ``net`` attribute matches one of *net_names*.
+    """
+    pcb_text = pcb_path.read_text()
+
+    for net_name in net_names:
+        escaped = re.escape(net_name)
+        # KiCad 7/8: (zone ... (net_name "GND") ... )  -- top-level node
+        # KiCad 9:   (zone ... (net "GND") ... )        -- top-level node
+        # We match the entire (zone ...) block using a balanced-paren
+        # approach: find the opening "(zone" and count parens to find
+        # the matching close.
+        new_lines: list[str] = []
+        lines = pcb_text.split("\n")
+        skip_depth = 0
+        for line in lines:
+            if skip_depth > 0:
+                skip_depth += line.count("(") - line.count(")")
+                continue
+            # Detect start of a zone block for this net
+            if re.search(
+                rf'\(zone\s.*?\(net_name\s+"{escaped}"\)',
+                line,
+                re.DOTALL,
+            ) or re.search(
+                rf'\(zone\s[^)]*\(net\s+"{escaped}"\)',
+                line,
+            ):
+                skip_depth = line.count("(") - line.count(")")
+                continue
+            new_lines.append(line)
+        pcb_text = "\n".join(new_lines)
+
+    pcb_path.write_text(pcb_text)
+
+
 def auto_pour_if_missing(
     pcb_path: Path,
     *,
@@ -94,6 +191,9 @@ def auto_pour_if_missing(
 
     # ------------------------------------------------------------------
     # 4. Idempotency: filter out nets that already have zones
+    #    When edge_clearance is specified, also detect existing zones
+    #    whose boundaries match the board outline exactly (no inset)
+    #    and remove them so they can be regenerated with proper inset.
     # ------------------------------------------------------------------
     nets_with_zones: set[str] = set()
     # KiCad 7/8 format: (zone ... (net_name "GND") ...)
@@ -104,6 +204,26 @@ def auto_pour_if_missing(
     # KiCad 9 name-only format: (zone ... (net "GND") ...)
     for zm in re.finditer(r'\(zone\s[^)]*\(net\s+"([^"]+)"\)', pcb_text):
         nets_with_zones.add(zm.group(1))
+
+    # When edge_clearance is specified, check whether existing zones
+    # have boundaries that lack proper inset from the board edge.
+    # If so, remove those zones so they are regenerated with inset.
+    nets_needing_reinset: set[str] = set()
+    if edge_clearance and edge_clearance > 0 and nets_with_zones:
+        nets_needing_reinset = _detect_uninset_zones(
+            pcb_text, pcb_path, edge_clearance
+        )
+        if nets_needing_reinset:
+            _remove_zones_for_nets(pcb_path, nets_needing_reinset)
+            # Re-read the file after removal
+            pcb_text = pcb_path.read_text()
+            nets_with_zones -= nets_needing_reinset
+            if not quiet:
+                print(
+                    f"Auto-pour: removing {len(nets_needing_reinset)} zone(s) "
+                    f"with insufficient edge clearance for "
+                    f"{', '.join(sorted(nets_needing_reinset))}"
+                )
 
     new_pour_nets = [
         (name, cls) for name, cls in pour_nets if name not in nets_with_zones

--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -203,15 +203,87 @@ class ZoneGenerator:
                         self._board_outline, self._edge_clearance
                     )
                 except ImportError:
-                    import warnings
+                    # Shapely unavailable -- use pure-Python rect fallback
+                    # for axis-aligned rectangular outlines (covers the
+                    # majority of hobby/demo boards).
+                    if self._is_axis_aligned_rect(self._board_outline):
+                        self._board_outline = self._inset_rect(
+                            self._board_outline, self._edge_clearance
+                        )
+                    else:
+                        import warnings
 
-                    warnings.warn(
-                        "shapely is required for edge_clearance inset "
-                        "(install with: pip install kicad-tools[geometry]). "
-                        "Zone boundary will use exact board outline.",
-                        stacklevel=2,
-                    )
+                        warnings.warn(
+                            "shapely is required for edge_clearance inset "
+                            "on non-rectangular board outlines "
+                            "(install with: pip install kicad-tools[geometry]). "
+                            "Zone boundary will use exact board outline.",
+                            stacklevel=2,
+                        )
         return self._board_outline
+
+    @staticmethod
+    def _is_axis_aligned_rect(
+        coords: list[tuple[float, float]],
+    ) -> bool:
+        """Check whether *coords* form an axis-aligned rectangle.
+
+        Returns ``True`` when the polygon has exactly 4 unique vertices
+        whose bounding box matches the vertex coordinates (i.e. all
+        corners sit at the extremes of the bounding box).  Handles
+        closed polygons where the first point is repeated at the end.
+        """
+        # Strip closing duplicate if present
+        if len(coords) == 5 and coords[0] == coords[-1]:
+            coords = coords[:4]
+        if len(coords) != 4:
+            return False
+        xs = [c[0] for c in coords]
+        ys = [c[1] for c in coords]
+        x_min, x_max = min(xs), max(xs)
+        y_min, y_max = min(ys), max(ys)
+        # Width and height must be positive
+        if x_max - x_min < 1e-6 or y_max - y_min < 1e-6:
+            return False
+        # Every vertex must be at a corner of the bounding box
+        corners = {(x_min, y_min), (x_min, y_max), (x_max, y_min), (x_max, y_max)}
+        return all((round(x, 6), round(y, 6)) in corners for x, y in coords)
+
+    @staticmethod
+    def _inset_rect(
+        coords: list[tuple[float, float]],
+        distance: float,
+    ) -> list[tuple[float, float]]:
+        """Shrink an axis-aligned rectangle inward by *distance* mm.
+
+        Pure-Python fallback that does not require Shapely.  Returns the
+        original coordinates unchanged if the inset would collapse the
+        rectangle (width or height < 2 * distance).  Handles closed
+        polygons where the first point is repeated at the end.
+        """
+        # Strip closing duplicate if present
+        if len(coords) == 5 and coords[0] == coords[-1]:
+            coords = coords[:4]
+        xs = [c[0] for c in coords]
+        ys = [c[1] for c in coords]
+        x_min, x_max = min(xs), max(xs)
+        y_min, y_max = min(ys), max(ys)
+
+        new_x_min = x_min + distance
+        new_x_max = x_max - distance
+        new_y_min = y_min + distance
+        new_y_max = y_max - distance
+
+        # Collapsed -- fall back to original
+        if new_x_min >= new_x_max or new_y_min >= new_y_max:
+            return coords
+
+        return [
+            (round(new_x_min, 6), round(new_y_min, 6)),
+            (round(new_x_max, 6), round(new_y_min, 6)),
+            (round(new_x_max, 6), round(new_y_max, 6)),
+            (round(new_x_min, 6), round(new_y_max, 6)),
+        ]
 
     @staticmethod
     def _inset_polygon(

--- a/tests/test_auto_pour.py
+++ b/tests/test_auto_pour.py
@@ -206,10 +206,10 @@ class TestAutoPourIfMissing:
         assert names == []
 
     def test_edge_clearance_insets_zone_boundary(self, tmp_path: Path):
-        """Zone boundary is inset from board edge when edge_clearance is set."""
-        pytest.importorskip(
-            "shapely", reason="shapely required for edge clearance tests"
-        )
+        """Zone boundary is inset from board edge when edge_clearance is set.
+
+        Uses the pure-Python rect fallback so shapely is not required.
+        """
         import re
 
         from kicad_tools.router.auto_pour import auto_pour_if_missing
@@ -252,9 +252,6 @@ class TestAutoPourIfMissing:
 
     def test_no_edge_clearance_uses_exact_outline(self, tmp_path: Path):
         """Without edge_clearance, zone boundary matches board edge exactly."""
-        pytest.importorskip(
-            "shapely", reason="shapely required for edge clearance tests"
-        )
         import re
 
         from kicad_tools.router.auto_pour import auto_pour_if_missing
@@ -281,3 +278,51 @@ class TestAutoPourIfMissing:
         assert max(xs) >= 49.99, "Expected coordinate near right edge (x=50)"
         assert min(ys) <= 0.01, "Expected coordinate near top edge (y=0)"
         assert max(ys) >= 49.99, "Expected coordinate near bottom edge (y=50)"
+
+    def test_reinsets_existing_uninset_zones(self, tmp_path: Path):
+        """Existing zones at board edge are removed and recreated with inset.
+
+        When edge_clearance is specified and an existing zone's boundary
+        matches the board edge (no inset), auto_pour should remove it and
+        regenerate with proper inset.
+        """
+        import re
+
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        # Create a zone at the exact board edge (0..50)
+        zone_gnd = (
+            '(zone (net 1) (net_name "GND") (layer "B.Cu") (hatch edge 0.5) '
+            "(connect_pads (clearance 0.25)) "
+            "(fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5)) "
+            "(polygon (pts (xy 0 0) (xy 50 0) (xy 50 50) (xy 0 50))))"
+        )
+        pcb = _make_pcb(
+            net_defs=[(1, "GND"), (2, "SDA")],
+            pad_nets=[(1, "GND"), (2, "SDA")],
+            zones=[zone_gnd],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(
+            pcb_path, edge_clearance=0.3
+        )
+
+        # GND zone should be regenerated (removed + recreated)
+        assert count == 1
+        assert "GND" in names
+
+        # Verify new zone boundary is inset from the board edge
+        text = pcb_path.read_text()
+        xy_matches = re.findall(r"\(xy\s+([\d.e+-]+)\s+([\d.e+-]+)\)", text)
+        assert len(xy_matches) > 0, "No zone polygon coordinates found"
+
+        for x_str, y_str in xy_matches:
+            x, y = float(x_str), float(y_str)
+            assert (
+                x >= 0.3 - 0.01
+            ), f"X coord {x} too close to left edge (expected >= 0.3)"
+            assert (
+                x <= 49.7 + 0.01
+            ), f"X coord {x} too close to right edge (expected <= 49.7)"

--- a/tests/test_zone_generator_edge_clearance.py
+++ b/tests/test_zone_generator_edge_clearance.py
@@ -3,6 +3,9 @@
 Verifies that ``ZoneGenerator`` correctly insets the auto-derived board
 outline when ``edge_clearance`` is set, and leaves explicit boundaries
 untouched.
+
+Also tests the pure-Python rectangle inset fallback that works without
+Shapely for axis-aligned rectangular board outlines.
 """
 
 from __future__ import annotations
@@ -10,9 +13,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
-# Edge clearance inset requires shapely (optional dependency)
-shapely = pytest.importorskip("shapely", reason="shapely required for edge clearance tests")
 
 
 # ---------------------------------------------------------------------------
@@ -62,11 +62,112 @@ def _write_pcb(tmp_path: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
-class TestZoneGeneratorEdgeClearance:
-    """Tests for edge_clearance inset in ZoneGenerator."""
+class TestInsetRect:
+    """Unit tests for the pure-Python _inset_rect helper (no shapely required)."""
 
-    def test_inset_applied_to_auto_boundary(self, tmp_path: Path):
-        """board_outline is inset when edge_clearance is set."""
+    def test_square_inset(self):
+        """Insetting a square produces a smaller square."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        coords = [(0, 0), (10, 0), (10, 10), (0, 10)]
+        result = ZoneGenerator._inset_rect(coords, 1.0)
+
+        xs = [x for x, _ in result]
+        ys = [y for _, y in result]
+
+        assert min(xs) == pytest.approx(1.0, abs=0.01)
+        assert max(xs) == pytest.approx(9.0, abs=0.01)
+        assert min(ys) == pytest.approx(1.0, abs=0.01)
+        assert max(ys) == pytest.approx(9.0, abs=0.01)
+
+    def test_rectangle_inset(self):
+        """Insetting a non-square rectangle works correctly."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        coords = [(100, 100), (150, 100), (150, 155), (100, 155)]
+        result = ZoneGenerator._inset_rect(coords, 0.3)
+
+        xs = [x for x, _ in result]
+        ys = [y for _, y in result]
+
+        assert min(xs) == pytest.approx(100.3, abs=0.01)
+        assert max(xs) == pytest.approx(149.7, abs=0.01)
+        assert min(ys) == pytest.approx(100.3, abs=0.01)
+        assert max(ys) == pytest.approx(154.7, abs=0.01)
+
+    def test_collapsed_rect_returns_original(self):
+        """If inset collapses the rectangle, original coords returned."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        # Very thin rectangle that will collapse with 5mm inset
+        coords = [(0, 0), (1, 0), (1, 100), (0, 100)]
+        result = ZoneGenerator._inset_rect(coords, 5.0)
+
+        assert result == coords
+
+    def test_result_has_four_corners(self):
+        """Inset of a rectangle always has 4 corners."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        coords = [(0, 0), (50, 0), (50, 30), (0, 30)]
+        result = ZoneGenerator._inset_rect(coords, 2.0)
+
+        assert len(result) == 4
+
+
+class TestIsAxisAlignedRect:
+    """Unit tests for the _is_axis_aligned_rect helper."""
+
+    def test_standard_rect(self):
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        assert ZoneGenerator._is_axis_aligned_rect(
+            [(0, 0), (10, 0), (10, 5), (0, 5)]
+        )
+
+    def test_offset_rect(self):
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        assert ZoneGenerator._is_axis_aligned_rect(
+            [(100, 100), (150, 100), (150, 155), (100, 155)]
+        )
+
+    def test_corners_in_any_order(self):
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        # Corners listed in non-standard order
+        assert ZoneGenerator._is_axis_aligned_rect(
+            [(10, 10), (0, 0), (10, 0), (0, 10)]
+        )
+
+    def test_triangle_not_rect(self):
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        assert not ZoneGenerator._is_axis_aligned_rect(
+            [(0, 0), (10, 0), (5, 10)]
+        )
+
+    def test_five_points_not_rect(self):
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        assert not ZoneGenerator._is_axis_aligned_rect(
+            [(0, 0), (10, 0), (10, 10), (5, 10), (0, 10)]
+        )
+
+    def test_rotated_rect_not_axis_aligned(self):
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        # Diamond shape (45-degree rotated square)
+        assert not ZoneGenerator._is_axis_aligned_rect(
+            [(5, 0), (10, 5), (5, 10), (0, 5)]
+        )
+
+
+class TestEdgeClearanceWithRectFallback:
+    """Test that edge_clearance inset works on rectangular boards without shapely."""
+
+    def test_inset_applied_to_rect_board(self, tmp_path: Path):
+        """board_outline is inset on a rectangular board even without shapely."""
         from kicad_tools.zones.generator import ZoneGenerator
 
         pcb_path = _write_pcb(tmp_path)
@@ -92,7 +193,6 @@ class TestZoneGeneratorEdgeClearance:
         xs = [x for x, _ in outline]
         ys = [y for _, y in outline]
 
-        # Should reach the board edge (0 and 100)
         assert min(xs) <= 0.01
         assert max(xs) >= 99.99
         assert min(ys) <= 0.01
@@ -120,7 +220,6 @@ class TestZoneGeneratorEdgeClearance:
             net="GND", layer="B.Cu", boundary=custom_boundary
         )
 
-        # The explicit boundary should be used as-is, not inset
         assert zone.boundary == custom_boundary
 
     def test_add_zone_uses_inset_outline(self, tmp_path: Path):
@@ -132,7 +231,6 @@ class TestZoneGeneratorEdgeClearance:
 
         zone = gen.add_zone(net="GND", layer="B.Cu")
 
-        # Zone boundary should be the inset outline
         for x, y in zone.boundary:
             assert x >= 1.0 - 0.01, f"X={x} too close to left edge"
             assert x <= 99.0 + 0.01, f"X={x} too close to right edge"
@@ -140,8 +238,42 @@ class TestZoneGeneratorEdgeClearance:
             assert y <= 99.0 + 0.01, f"Y={y} too close to bottom edge"
 
 
-class TestInsetPolygon:
-    """Unit tests for the static _inset_polygon helper."""
+# ---------------------------------------------------------------------------
+# Shapely-dependent tests (skipped if shapely not installed)
+# ---------------------------------------------------------------------------
+
+
+def _has_shapely() -> bool:
+    try:
+        import shapely  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(not _has_shapely(), reason="shapely not installed")
+class TestZoneGeneratorEdgeClearanceShapely:
+    """Tests for edge_clearance inset using Shapely (non-rectangular polygons)."""
+
+    def test_inset_applied_to_auto_boundary(self, tmp_path: Path):
+        """board_outline is inset when edge_clearance is set."""
+        from kicad_tools.zones.generator import ZoneGenerator
+
+        pcb_path = _write_pcb(tmp_path)
+        gen = ZoneGenerator.from_pcb(pcb_path, edge_clearance=0.5)
+
+        outline = gen.board_outline
+
+        for x, y in outline:
+            assert x >= 0.5 - 0.01, f"X={x} too close to left edge"
+            assert x <= 99.5 + 0.01, f"X={x} too close to right edge"
+            assert y >= 0.5 - 0.01, f"Y={y} too close to top edge"
+            assert y <= 99.5 + 0.01, f"Y={y} too close to bottom edge"
+
+
+@pytest.mark.skipif(not _has_shapely(), reason="shapely not installed")
+class TestInsetPolygonShapely:
+    """Unit tests for the static _inset_polygon helper (requires shapely)."""
 
     def test_square_inset(self):
         """Insetting a square produces a smaller square."""
@@ -166,5 +298,4 @@ class TestInsetPolygon:
         coords = [(0, 0), (1, 0), (1, 100), (0, 100)]
         result = ZoneGenerator._inset_polygon(coords, 5.0)
 
-        # Should return original since inset collapses the polygon
         assert result == coords


### PR DESCRIPTION
## Summary
Zone edge clearance inset required Shapely (optional dependency). When unavailable, zones were created at the exact board outline (0mm clearance), causing DRC violations on boards 02 and 03. This adds a pure-Python fallback for rectangular boards and makes auto_pour detect and fix existing un-inset zones.

## Changes
- Added `_is_axis_aligned_rect()` and `_inset_rect()` static methods to `ZoneGenerator` for pure-Python rectangular polygon inset without Shapely
- Updated `board_outline` property to use the rect fallback when Shapely is unavailable and the board outline is a rectangle
- Added `_detect_uninset_zones()` and `_remove_zones_for_nets()` helpers in `auto_pour.py` to detect existing zones whose boundaries lack proper edge clearance inset
- Updated `auto_pour_if_missing()` to remove and regenerate un-inset zones when `edge_clearance` is specified
- Removed `pytest.importorskip("shapely")` guard from auto_pour edge clearance tests since the rect fallback now works without Shapely
- Added comprehensive tests for the rect inset fallback, axis-aligned rect detection, and zone reinset behavior

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Edge clearance inset works without Shapely for rectangular boards | Pass | TestEdgeClearanceWithRectFallback tests pass (5 tests) |
| Existing un-inset zones are detected and regenerated | Pass | test_reinsets_existing_uninset_zones passes |
| Pure-Python rect inset produces correct geometry | Pass | TestInsetRect tests pass (4 tests) |
| Axis-aligned rect detection works correctly | Pass | TestIsAxisAlignedRect tests pass (6 tests) |
| Existing zone generator tests still pass | Pass | All 50 test_zone_generator.py tests pass |
| Existing auto_pour tests still pass | Pass | All 10 test_auto_pour.py tests pass (previously 2 were skipped) |

## Test Plan
- `uv run pytest tests/test_auto_pour.py tests/test_zone_generator_edge_clearance.py tests/test_zone_generator.py` -- 75 passed, 3 skipped (shapely-only tests)

Closes #2456