### PR TITLE
fix(auto-pour): scan full file with balanced-paren for multi-line zones

### DIFF
--- a/src/kicad_tools/router/auto_pour.py
+++ b/src/kicad_tools/router/auto_pour.py
@@ -76,43 +76,95 @@ def _detect_uninset_zones(
     return nets_needing_fix
 
 
+def _find_zone_span(text: str, start: int) -> int | None:
+    """Return the index just past the matching close paren of a ``(zone``.
+
+    *start* must point at the ``(`` of the ``(zone`` token.  Walks the
+    string counting parens (skipping over those inside double-quoted
+    strings) and returns the index immediately after the matching
+    closing paren, or ``None`` if the parens are unbalanced.
+    """
+    depth = 0
+    in_string = False
+    i = start
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if in_string:
+            if ch == "\\" and i + 1 < n:
+                # Skip escaped character inside string
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+        else:
+            if ch == '"':
+                in_string = True
+            elif ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    return i + 1
+        i += 1
+    return None
+
+
 def _remove_zones_for_nets(pcb_path: Path, net_names: set[str]) -> None:
     """Remove zone definitions for the given net names from the PCB file.
 
-    Uses a regex-based approach to strip ``(zone ...)`` blocks whose
-    ``net_name`` or ``net`` attribute matches one of *net_names*.
+    Uses a balanced-paren scan over the full file text so that zone
+    blocks spanning multiple lines (the format KiCad's writer
+    produces) are matched correctly.
     """
+    if not net_names:
+        return
+
     pcb_text = pcb_path.read_text()
 
-    for net_name in net_names:
-        escaped = re.escape(net_name)
-        # KiCad 7/8: (zone ... (net_name "GND") ... )  -- top-level node
-        # KiCad 9:   (zone ... (net "GND") ... )        -- top-level node
-        # We match the entire (zone ...) block using a balanced-paren
-        # approach: find the opening "(zone" and count parens to find
-        # the matching close.
-        new_lines: list[str] = []
-        lines = pcb_text.split("\n")
-        skip_depth = 0
-        for line in lines:
-            if skip_depth > 0:
-                skip_depth += line.count("(") - line.count(")")
-                continue
-            # Detect start of a zone block for this net
-            if re.search(
-                rf'\(zone\s.*?\(net_name\s+"{escaped}"\)',
-                line,
-                re.DOTALL,
-            ) or re.search(
-                rf'\(zone\s[^)]*\(net\s+"{escaped}"\)',
-                line,
-            ):
-                skip_depth = line.count("(") - line.count(")")
-                continue
-            new_lines.append(line)
-        pcb_text = "\n".join(new_lines)
+    # Build a single regex that matches ``(net_name "X")`` or
+    # ``(net "X")`` (KiCad 9 name-only form) for any of *net_names*.
+    escaped = "|".join(re.escape(n) for n in net_names)
+    inner_pattern = re.compile(rf'\((?:net_name|net)\s+"(?:{escaped})"\)')
 
-    pcb_path.write_text(pcb_text)
+    # Iterate every ``(zone`` opener in the file and decide whether to
+    # remove that span.  We walk forward across the text rebuilding it
+    # rather than relying on per-line state.
+    out_parts: list[str] = []
+    cursor = 0
+    zone_start_pattern = re.compile(r"\(zone\b")
+    for m in zone_start_pattern.finditer(pcb_text):
+        start = m.start()
+        if start < cursor:
+            # This opener lies inside a span we already removed (e.g. a
+            # nested ``(zone`` reference, which KiCad does not emit, but
+            # be defensive).
+            continue
+        end = _find_zone_span(pcb_text, start)
+        if end is None:
+            # Unbalanced parens -- bail out to avoid corrupting the
+            # file; leave the rest of the text untouched.
+            break
+        block = pcb_text[start:end]
+        if inner_pattern.search(block):
+            # Drop this zone block from the output.  Also strip any
+            # trailing whitespace/newline that immediately follows so
+            # we don't leave a dangling blank line.
+            out_parts.append(pcb_text[cursor:start])
+            trailing = end
+            while trailing < len(pcb_text) and pcb_text[trailing] in (
+                " ",
+                "\t",
+            ):
+                trailing += 1
+            if trailing < len(pcb_text) and pcb_text[trailing] == "\n":
+                trailing += 1
+            cursor = trailing
+        # else: keep the block; cursor unchanged so it gets emitted on
+        # the next iteration's slice.
+
+    out_parts.append(pcb_text[cursor:])
+    pcb_path.write_text("".join(out_parts))
 
 
 def auto_pour_if_missing(
@@ -182,10 +234,7 @@ def auto_pour_if_missing(
     # ------------------------------------------------------------------
     if signal_net_count == 0:
         if not quiet:
-            print(
-                "Auto-pour: skipped (all nets are power/ground — "
-                "routing as signals instead)"
-            )
+            print("Auto-pour: skipped (all nets are power/ground — routing as signals instead)")
         return 0, []
 
     # ------------------------------------------------------------------
@@ -196,9 +245,7 @@ def auto_pour_if_missing(
     # ------------------------------------------------------------------
     nets_with_zones: set[str] = set()
     # KiCad 7/8 format: (zone ... (net_name "GND") ...)
-    for zm in re.finditer(
-        r'\(zone\s+.*?\(net_name\s+"([^"]+)"\)', pcb_text, re.DOTALL
-    ):
+    for zm in re.finditer(r'\(zone\s+.*?\(net_name\s+"([^"]+)"\)', pcb_text, re.DOTALL):
         nets_with_zones.add(zm.group(1))
     # KiCad 9 name-only format: (zone ... (net "GND") ...)
     for zm in re.finditer(r'\(zone\s[^)]*\(net\s+"([^"]+)"\)', pcb_text):
@@ -209,9 +256,7 @@ def auto_pour_if_missing(
     # If so, remove those zones so they are regenerated with inset.
     nets_needing_reinset: set[str] = set()
     if edge_clearance and edge_clearance > 0 and nets_with_zones:
-        nets_needing_reinset = _detect_uninset_zones(
-            pcb_path, edge_clearance
-        )
+        nets_needing_reinset = _detect_uninset_zones(pcb_path, edge_clearance)
         if nets_needing_reinset:
             _remove_zones_for_nets(pcb_path, nets_needing_reinset)
             # Re-read the file after removal
@@ -224,9 +269,7 @@ def auto_pour_if_missing(
                     f"{', '.join(sorted(nets_needing_reinset))}"
                 )
 
-    new_pour_nets = [
-        (name, cls) for name, cls in pour_nets if name not in nets_with_zones
-    ]
+    new_pour_nets = [(name, cls) for name, cls in pour_nets if name not in nets_with_zones]
 
     if not new_pour_nets:
         return 0, []
@@ -234,9 +277,7 @@ def auto_pour_if_missing(
     # ------------------------------------------------------------------
     # 5. Create zones via the shared generator
     # ------------------------------------------------------------------
-    count = auto_create_zones_for_pour_nets(
-        pcb_path, new_pour_nets, edge_clearance=edge_clearance
-    )
+    count = auto_create_zones_for_pour_nets(pcb_path, new_pour_nets, edge_clearance=edge_clearance)
 
     names = [name for name, _ in new_pour_nets]
     if not quiet and count > 0:

--- a/tests/test_auto_pour.py
+++ b/tests/test_auto_pour.py
@@ -237,18 +237,10 @@ class TestAutoPourIfMissing:
         # at least 0.3mm inward from the edges.
         for x_str, y_str in xy_matches:
             x, y = float(x_str), float(y_str)
-            assert (
-                x >= 0.3 - 0.01
-            ), f"X coord {x} too close to left edge (expected >= 0.3)"
-            assert (
-                x <= 49.7 + 0.01
-            ), f"X coord {x} too close to right edge (expected <= 49.7)"
-            assert (
-                y >= 0.3 - 0.01
-            ), f"Y coord {y} too close to top edge (expected >= 0.3)"
-            assert (
-                y <= 49.7 + 0.01
-            ), f"Y coord {y} too close to bottom edge (expected <= 49.7)"
+            assert x >= 0.3 - 0.01, f"X coord {x} too close to left edge (expected >= 0.3)"
+            assert x <= 49.7 + 0.01, f"X coord {x} too close to right edge (expected <= 49.7)"
+            assert y >= 0.3 - 0.01, f"Y coord {y} too close to top edge (expected >= 0.3)"
+            assert y <= 49.7 + 0.01, f"Y coord {y} too close to bottom edge (expected <= 49.7)"
 
     def test_no_edge_clearance_uses_exact_outline(self, tmp_path: Path):
         """Without edge_clearance, zone boundary matches board edge exactly."""
@@ -305,9 +297,7 @@ class TestAutoPourIfMissing:
         pcb_path = tmp_path / "test.kicad_pcb"
         pcb_path.write_text(pcb)
 
-        count, names = auto_pour_if_missing(
-            pcb_path, edge_clearance=0.3
-        )
+        count, names = auto_pour_if_missing(pcb_path, edge_clearance=0.3)
 
         # GND zone should be regenerated (removed + recreated)
         assert count == 1
@@ -320,9 +310,146 @@ class TestAutoPourIfMissing:
 
         for x_str, y_str in xy_matches:
             x, y = float(x_str), float(y_str)
-            assert (
-                x >= 0.3 - 0.01
-            ), f"X coord {x} too close to left edge (expected >= 0.3)"
-            assert (
-                x <= 49.7 + 0.01
-            ), f"X coord {x} too close to right edge (expected <= 49.7)"
+            assert x >= 0.3 - 0.01, f"X coord {x} too close to left edge (expected >= 0.3)"
+            assert x <= 49.7 + 0.01, f"X coord {x} too close to right edge (expected <= 49.7)"
+
+    def test_reinsets_multiline_uninset_zone(self, tmp_path: Path):
+        """Multi-line KiCad zone blocks at the board edge are removed and reinset.
+
+        Regression test for #2462: ``_remove_zones_for_nets`` previously
+        ran a per-line regex which could not match KiCad's actual writer
+        output, where ``(zone``, ``(net …)``, ``(net_name …)``,
+        ``(layer …)`` and ``(polygon …)`` each sit on their own line.
+        The bug caused the un-inset zone to remain in the file while a
+        second inset zone was appended, producing duplicate zones and
+        ``edge_clearance_zone`` DRC violations.
+        """
+        import re
+
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        # Multi-line zone literal that mirrors KiCad's actual writer
+        # output (each sub-node on its own indented line).  The polygon
+        # sits at the exact board edge (0..50) so it should be detected
+        # as un-inset and regenerated.
+        zone_gnd_multiline = (
+            "(zone\n"
+            "    (net 1)\n"
+            '    (net_name "GND")\n'
+            '    (layer "B.Cu")\n'
+            "    (hatch edge 0.5)\n"
+            "    (connect_pads (clearance 0.25)\n"
+            "    )\n"
+            "    (min_thickness 0.25)\n"
+            "    (filled_areas_thickness no)\n"
+            "    (fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5)\n"
+            "    )\n"
+            "    (polygon (pts (xy 0 0) (xy 50 0) (xy 50 50) (xy 0 50))\n"
+            "    )\n"
+            "  )"
+        )
+
+        pcb = _make_pcb(
+            net_defs=[(1, "GND"), (2, "SDA")],
+            pad_nets=[(1, "GND"), (2, "SDA")],
+            zones=[zone_gnd_multiline],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(pcb_path, edge_clearance=0.3)
+
+        # Exactly one new zone should be created for GND (un-inset zone
+        # removed, fresh inset zone added).
+        assert count == 1
+        assert "GND" in names
+
+        text = pcb_path.read_text()
+
+        # Exactly one ``(zone`` block should remain in the file, not
+        # two -- the bug previously left the un-inset original in place.
+        zone_count = len(re.findall(r"\(zone\b", text))
+        assert zone_count == 1, (
+            f"Expected exactly 1 zone block after reinset, got "
+            f"{zone_count}.  File contents:\n{text}"
+        )
+
+        # And every polygon vertex must be inset by edge_clearance.
+        xy_matches = re.findall(r"\(xy\s+([\d.e+-]+)\s+([\d.e+-]+)\)", text)
+        assert len(xy_matches) > 0, "No zone polygon coordinates found"
+        for x_str, y_str in xy_matches:
+            x, y = float(x_str), float(y_str)
+            assert x >= 0.3 - 0.01, f"X coord {x} too close to left edge (expected >= 0.3)"
+            assert x <= 49.7 + 0.01, f"X coord {x} too close to right edge (expected <= 49.7)"
+            assert y >= 0.3 - 0.01, f"Y coord {y} too close to top edge (expected >= 0.3)"
+            assert y <= 49.7 + 0.01, f"Y coord {y} too close to bottom edge (expected <= 49.7)"
+
+    def test_reinset_preserves_other_nets_zones(self, tmp_path: Path):
+        """Reinset removes only the un-inset net's zone, not others'.
+
+        Edge case for #2462: when a file contains a mix of un-inset and
+        already-inset zones for different nets, only the un-inset one
+        should be regenerated; the inset zone for the other net must be
+        left untouched.
+        """
+        import re
+
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        # GND zone at the exact board edge (un-inset, multi-line)
+        zone_gnd_uninset = (
+            "(zone\n"
+            "    (net 1)\n"
+            '    (net_name "GND")\n'
+            '    (layer "B.Cu")\n'
+            "    (hatch edge 0.5)\n"
+            "    (connect_pads (clearance 0.25)\n"
+            "    )\n"
+            "    (fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5)\n"
+            "    )\n"
+            "    (polygon (pts (xy 0 0) (xy 50 0) (xy 50 50) (xy 0 50))\n"
+            "    )\n"
+            "  )"
+        )
+        # VCC zone already inset by 0.3mm (should be preserved)
+        zone_vcc_inset = (
+            "(zone\n"
+            "    (net 2)\n"
+            '    (net_name "VCC")\n'
+            '    (layer "F.Cu")\n'
+            "    (hatch edge 0.5)\n"
+            "    (connect_pads (clearance 0.25)\n"
+            "    )\n"
+            "    (fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5)\n"
+            "    )\n"
+            "    (polygon (pts (xy 0.3 0.3) (xy 49.7 0.3) "
+            "(xy 49.7 49.7) (xy 0.3 49.7))\n"
+            "    )\n"
+            "  )"
+        )
+
+        pcb = _make_pcb(
+            net_defs=[(1, "GND"), (2, "VCC"), (3, "SDA")],
+            pad_nets=[(1, "GND"), (2, "VCC"), (3, "SDA")],
+            zones=[zone_gnd_uninset, zone_vcc_inset],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(pcb_path, edge_clearance=0.3)
+
+        # Only GND should be regenerated; VCC's existing inset zone
+        # stays in place.
+        assert count == 1
+        assert names == ["GND"]
+
+        text = pcb_path.read_text()
+        # Two zones total: regenerated GND + preserved VCC.
+        zone_count = len(re.findall(r"\(zone\b", text))
+        assert zone_count == 2, (
+            f"Expected exactly 2 zone blocks (GND regenerated, VCC "
+            f"preserved), got {zone_count}.  File contents:\n{text}"
+        )
+        # VCC's original inset polygon must still be present verbatim.
+        assert "(xy 0.3 0.3)" in text
+        assert "(xy 49.7 0.3)" in text


### PR DESCRIPTION
## Summary

- Replace `_remove_zones_for_nets`'s per-line regex (which never matched KiCad's actual multi-line zone serialization) with a balanced-paren scan over the full file text. The bug caused un-inset zones to remain in the file while a second inset zone was appended, producing duplicate zones and `edge_clearance_zone` DRC errors on boards 01/04.
- Add two regression tests using multi-line zone literals that mirror KiCad's actual writer output.

Closes #2462

## What changed

`src/kicad_tools/router/auto_pour.py`:
- New `_find_zone_span` helper walks parens (skipping double-quoted strings) to find the matching close of any `(zone …)` block.
- Rewrote `_remove_zones_for_nets` to iterate every `(zone` opener, decide via a single regex (`(net_name "X")` or `(net "X")` against the union of target nets) whether to drop the span, and splice cleanly with no orphan blank lines.

`tests/test_auto_pour.py`:
- `test_reinsets_multiline_uninset_zone`: zone uses the line-wrapped layout KiCad emits (each `(net …)`, `(net_name …)`, `(layer …)`, `(polygon …)` on its own line). Asserts exactly one `(zone` block remains and every polygon vertex is inset.
- `test_reinset_preserves_other_nets_zones`: mixes an un-inset GND zone and an already-inset VCC zone; asserts only GND is regenerated and VCC's polygon survives verbatim.
- Existing `test_reinsets_existing_uninset_zones` (single-line variant) still passes.

## Manual verification

```
uv run kicad-tools route boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb \
  -o /tmp/b04.kicad_pcb --strategy negotiated --layers 4 --backend cpp \
  --no-cache --timeout 600
grep -c '^[[:space:]]*(zone' /tmp/b04.kicad_pcb   # -> 3 (was 6)
uv run kicad-tools check /tmp/b04.kicad_pcb --mfr jlcpcb
#   Errors:     0
#   Warnings:   3   (all zone_unfilled, unrelated to this issue)
```

All polygons in the output are at the expected inset coordinates `(100.3, 100.3) -> (149.7, 124.7)`; no un-inset duplicates remain.

## Test plan

- [x] `uv run pytest tests/test_auto_pour.py -v` (12 passed)
- [x] `uv run pytest tests -k "auto_pour or zone"` (559 passed, 8 skipped)
- [x] Board 04 re-route via CLI yields 3 zones, 0 `edge_clearance_zone` DRC errors
- [x] `uv run ruff format` applied; `ruff check` introduces no new failures (the existing `F841` on line 322 is pre-existing in `test_reinsets_existing_uninset_zones`)

## Notes

- Approach A from the curator (balanced-paren scan), as recommended; avoids touching the schema layer.
- Defensive against unbalanced parens (bails out without corrupting the file) and against `(zone` tokens nested inside another `(zone` block (skips re-entrant openers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)