### PR TITLE
fix(router): align C++ via blocking with validator geometric clearance (#2466)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -624,10 +624,19 @@ class Autorouter:
         # Mark all vias on C++ grid
         for via in route.vias:
             gx, gy = self.grid.world_to_grid(via.x, via.y)
-            # Via radius includes via_clearance + trace half-width (same as Python)
-            radius_cells = int(
-                (via.diameter / 2 + self.rules.via_clearance + self.rules.trace_width / 2)
-                / self.grid.resolution
+            # Issue #2466: Use ``ceil`` (not ``int``) for the via blocking
+            # radius so that grid-cell blocking matches the validator's
+            # geometric ``via_diameter/2 + via_clearance`` keepout.  The
+            # previous ``int(...)`` truncation under-blocked by up to one
+            # grid cell, allowing the search to place a via that the post-
+            # route validator would later flag.  Mirrors the +1 safety
+            # margin in ``RoutingGrid._mark_via`` (Issue #1797).
+            radius_cells = (
+                math.ceil(
+                    (via.diameter / 2 + self.rules.via_clearance + self.rules.trace_width / 2)
+                    / self.grid.resolution
+                )
+                + 1
             )
             cpp_grid.mark_via(gx, gy, via.net, radius_cells)
 

--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -143,6 +143,12 @@ public:
     size_t stored_segment_count() const { return stored_segments_.size(); }
     size_t stored_via_count() const { return stored_vias_.size(); }
 
+    // Accessor for stored vias (Issue #2466).
+    // Used by Pathfinder::is_via_blocked to perform a geometric via-vs-via
+    // clearance check that mirrors validate_route() exactly, so the search
+    // refuses placements the post-route validator would later reject.
+    const std::vector<StoredVia>& stored_vias() const { return stored_vias_; }
+
 private:
     inline size_t index(int x, int y, int layer) const {
         return static_cast<size_t>(layer) * rows_ * cols_ +

--- a/src/kicad_tools/router/cpp/include/pathfinder.hpp
+++ b/src/kicad_tools/router/cpp/include/pathfinder.hpp
@@ -84,6 +84,16 @@ public:
     int get_iterations() const { return last_iterations_; }
     int get_nodes_explored() const { return last_nodes_explored_; }
 
+    // Check if via placement is blocked on all layers.
+    // radius_override: if > 0, use this instead of via_half_cells_.
+    //
+    // Public to allow direct exercise from regression tests.  See
+    // tests/test_router_cpp_via_clearance.py (Issue #2466) which verifies
+    // that the search refuses placements the post-route validator would
+    // later reject.
+    bool is_via_blocked(int x, int y, int net, bool allow_sharing,
+                        int radius_override = 0) const;
+
 private:
     // Check if trace placement is blocked (accounts for trace width)
     // radius_override: if > 0, use this instead of trace_half_width_cells_
@@ -93,11 +103,6 @@ private:
     // Check if diagonal move cuts through obstacles
     bool is_diagonal_blocked(int x, int y, int dx, int dy, int layer, int net,
                              bool allow_sharing) const;
-
-    // Check if via placement is blocked on all layers
-    // radius_override: if > 0, use this instead of via_half_cells_
-    bool is_via_blocked(int x, int y, int net, bool allow_sharing,
-                        int radius_override = 0) const;
 
     // Heuristic: Manhattan distance with layer change cost
     float heuristic(int x, int y, int layer, int goal_x, int goal_y, int goal_layer) const;

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -205,6 +205,11 @@ NB_MODULE(router_cpp, m) {
              "reject_x"_a, "reject_y"_a, "reject_layer"_a)
         .def("clear_search_state", &Pathfinder::clear_search_state)
         .def("set_routable_layers", &Pathfinder::set_routable_layers, "layers"_a)
+        .def("is_via_blocked", &Pathfinder::is_via_blocked,
+             "x"_a, "y"_a, "net"_a, "allow_sharing"_a, "radius_override"_a = 0,
+             "Check if a via placement at (x, y) is blocked. "
+             "Includes both grid-cell blocking and geometric via-vs-via "
+             "clearance against stored_vias_ (Issue #2466).")
         .def_prop_ro("iterations", &Pathfinder::get_iterations)
         .def_prop_ro("nodes_explored", &Pathfinder::get_nodes_explored);
 

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -153,6 +153,31 @@ bool Pathfinder::is_via_blocked(int x, int y, int net, bool allow_sharing,
             }
         }
     }
+
+    // Issue #2466: Also check via-vs-via geometric clearance against
+    // ``stored_vias_``.  The grid-cell blocking heuristic above can miss
+    // conflicts in negotiated mode (where ``allow_sharing`` lets cells with
+    // ``usage_count > 0`` be passed through), but two vias can never
+    // physically overlap regardless of routing mode.  This mirrors the
+    // post-route validator (Grid3D::validate_route) so the search refuses
+    // placements that the validator would later reject.
+    auto candidate_world = grid_.grid_to_world(x, y);
+    float candidate_x = candidate_world.first;
+    float candidate_y = candidate_world.second;
+    float candidate_radius = rules_.via_diameter / 2.0f;
+    float clearance_required = rules_.via_clearance;
+
+    for (const auto& sv : grid_.stored_vias()) {
+        if (sv.net == net) continue;  // same-net spacing handled elsewhere
+        float dxw = candidate_x - sv.x;
+        float dyw = candidate_y - sv.y;
+        float distance = std::sqrt(dxw * dxw + dyw * dyw);
+        float clearance = distance - candidate_radius - sv.diameter / 2.0f;
+        if (clearance < clearance_required) {
+            return true;
+        }
+    }
+
     return false;
 }
 

--- a/tests/test_router_cpp_via_clearance.py
+++ b/tests/test_router_cpp_via_clearance.py
@@ -1,0 +1,264 @@
+"""Regression tests for via-vs-via clearance in the C++ pathfinder (Issue #2466).
+
+These tests verify that the C++ A* search refuses placements that the
+post-route validator would later flag as via-vs-via clearance violations.
+
+Background
+==========
+
+Board 02 (charlieplex_3x3) was producing routes where two vias from
+different nets were placed too close together: NODE_A and NODE_C vias
+overlapping by up to 0.317mm.  The root cause was a mismatch between
+
+* the grid-cell blocking heuristic used at search time in
+  ``Pathfinder::is_via_blocked``, and
+* the geometric ``via_diameter/2 + via_clearance`` keepout used by the
+  post-route validator (``Grid3D::validate_route``).
+
+In particular, the negotiated routing mode allowed cells with
+``usage_count > 0`` to be passed through with a cost penalty, even when
+those cells were blocked by another net's via.  Two vias can never
+physically overlap regardless of routing mode.
+
+The fix expands ``is_via_blocked`` with a geometric pass against
+``stored_vias_`` that mirrors the validator exactly, plus ``ceil``-based
+radius arithmetic in ``_mark_route_on_cpp_grid`` so the grid blocking
+matches the geometric envelope.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.router.cpp_backend import (
+    CppGrid,
+    CppPathfinder,
+    is_cpp_available,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+# Marker for tests requiring the C++ backend
+requires_cpp = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ router backend not available",
+)
+
+
+def _make_grid_and_rules(
+    width: float = 10.0,
+    height: float = 10.0,
+    resolution: float = 0.1,
+    trace_width: float = 0.25,
+    trace_clearance: float = 0.2,
+    via_diameter: float = 0.6,
+    via_clearance: float = 0.2,
+) -> tuple[RoutingGrid, DesignRules]:
+    """Create a 4-layer RoutingGrid and DesignRules for via testing."""
+    rules = DesignRules(
+        trace_width=trace_width,
+        trace_clearance=trace_clearance,
+        via_diameter=via_diameter,
+        via_clearance=via_clearance,
+        grid_resolution=resolution,
+    )
+    layer_stack = LayerStack.four_layer_all_signal()
+    grid = RoutingGrid(
+        width=width,
+        height=height,
+        rules=rules,
+        layer_stack=layer_stack,
+    )
+    return grid, rules
+
+
+@requires_cpp
+class TestViaViaClearanceRegression:
+    """Regression tests verifying that ``is_via_blocked`` mirrors
+    ``Grid3D::validate_route`` for via-vs-via clearance (Issue #2466)."""
+
+    def test_stored_via_blocks_overlapping_candidate_geometric(self):
+        """A stored via from another net must geometrically block any
+        candidate via center within ``via_diameter + via_clearance``.
+
+        This is the direct exercise of the geometric check added to
+        ``Pathfinder::is_via_blocked`` in Issue #2466.
+        """
+        grid, rules = _make_grid_and_rules()
+        cpp_grid = CppGrid.from_routing_grid(grid)
+
+        # Existing route's via belongs to net 2 at world coord (5.0, 5.0).
+        cpp_grid._impl.add_stored_via(
+            5.0,  # x_mm
+            5.0,  # y_mm
+            0.3,  # drill
+            rules.via_diameter,  # diameter
+            2,    # net
+        )
+
+        # Pathfinder must refuse a candidate via for net 1 at any point
+        # within ``via_diameter + via_clearance`` of the stored via.
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+
+        keepout_world = rules.via_diameter + rules.via_clearance  # 0.8mm
+        # Candidate exactly at the stored via -- must be refused.
+        gx, gy = grid.world_to_grid(5.0, 5.0)
+        assert pathfinder._impl.is_via_blocked(gx, gy, 1, False, 0)
+
+        # Candidate well inside the keepout (50% of required separation).
+        gx, gy = grid.world_to_grid(5.0 + 0.5 * keepout_world, 5.0)
+        assert pathfinder._impl.is_via_blocked(gx, gy, 1, False, 0)
+
+        # Negotiated mode (allow_sharing=True) must also refuse: two vias
+        # cannot physically overlap regardless of routing mode.
+        gx, gy = grid.world_to_grid(5.0 + 0.5 * keepout_world, 5.0)
+        assert pathfinder._impl.is_via_blocked(gx, gy, 1, True, 0)
+
+    def test_stored_via_does_not_block_candidate_at_safe_distance(self):
+        """A candidate via at exactly ``via_diameter + via_clearance``
+        from a stored via must NOT be refused (boundary case).
+
+        The post-route validator accepts this distance -- the search
+        must not refuse it either.
+        """
+        grid, rules = _make_grid_and_rules()
+        cpp_grid = CppGrid.from_routing_grid(grid)
+
+        # Stored via at the centre of the board.
+        cpp_grid._impl.add_stored_via(5.0, 5.0, 0.3, rules.via_diameter, 2)
+
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+
+        # Required centre-to-centre distance for clearance to be exactly
+        # ``via_clearance``.  Add a small epsilon in mm so that grid
+        # quantisation (resolution = 0.1mm) does not nudge us inside the
+        # keepout.
+        sep_mm = rules.via_diameter + rules.via_clearance + 0.05
+        gx, gy = grid.world_to_grid(5.0 + sep_mm, 5.0)
+
+        # Cells must be empty (no surrounding obstacles) for the geometric
+        # check to be the only possible blocker.
+        assert not pathfinder._impl.is_via_blocked(gx, gy, 1, False, 0)
+        assert not pathfinder._impl.is_via_blocked(gx, gy, 1, True, 0)
+
+    def test_same_net_stored_via_is_not_blocking(self):
+        """A stored via from the same net must NOT block a candidate via.
+
+        Same-net spacing is enforced by a separate drill-spacing rule;
+        the via-vs-via geometric check should only apply across nets.
+        """
+        grid, rules = _make_grid_and_rules()
+        cpp_grid = CppGrid.from_routing_grid(grid)
+
+        cpp_grid._impl.add_stored_via(5.0, 5.0, 0.3, rules.via_diameter, 1)
+
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+
+        # Candidate for the SAME net (1) overlapping the stored via.
+        gx, gy = grid.world_to_grid(5.0, 5.0)
+        # The geometric check should not flag same-net via-vs-via.
+        # (The cell-based check may still flag if the stored via has
+        # marked cells, but in this fixture we only added a stored via
+        # without calling mark_via, so cells remain unblocked.)
+        assert not pathfinder._impl.is_via_blocked(gx, gy, 1, False, 0)
+
+    def test_negotiated_mode_does_not_let_via_overlap(self):
+        """Negotiated mode (``allow_sharing=True``) must still refuse a
+        via placement that overlaps a stored via from another net.
+
+        Pre-fix behaviour: cells with ``usage_count > 0`` were allowed
+        through with a cost penalty, which let the search place a via
+        on top of another net's via.  The post-route validator then
+        flagged the overlap and the routing was rejected.
+        """
+        grid, rules = _make_grid_and_rules()
+        cpp_grid = CppGrid.from_routing_grid(grid)
+
+        # Mark cells around (5.0, 5.0) as if a route had committed a via,
+        # AND register the via in stored_vias_ as the validator sees it.
+        gx_via, gy_via = grid.world_to_grid(5.0, 5.0)
+        radius = math.ceil((rules.via_diameter / 2 + rules.via_clearance)
+                           / grid.resolution) + 1
+        cpp_grid._impl.mark_via(gx_via, gy_via, 2, radius)
+        cpp_grid._impl.add_stored_via(5.0, 5.0, 0.3, rules.via_diameter, 2)
+
+        # Pretend negotiated mode: bump usage_count on these cells so the
+        # ``allow_sharing`` branch in is_via_blocked would normally let the
+        # search pass through.  We do this via the increment_usage hook.
+        for dy in range(-radius, radius + 1):
+            for dx in range(-radius, radius + 1):
+                x, y = gx_via + dx, gy_via + dy
+                if 0 <= x < grid.cols and 0 <= y < grid.rows:
+                    for layer in range(grid.num_layers):
+                        cpp_grid._impl.increment_usage(x, y, layer)
+
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+
+        # Candidate via for net 1 directly on top of net 2's via.  Even in
+        # negotiated mode, this must be refused due to the geometric
+        # via-vs-via clearance check that mirrors the validator.
+        assert pathfinder._impl.is_via_blocked(gx_via, gy_via, 1, True, 0)
+
+    def test_two_nets_with_close_vias_get_separated(self):
+        """End-to-end: two nets that each need a layer change in close
+        proximity must NOT produce overlapping vias.
+
+        The pathfinder should either route them on different layers OR
+        shift the via location so the post-route via-vs-via clearance
+        check (``via_diameter + via_clearance``) is satisfied.
+        """
+        grid, rules = _make_grid_and_rules(width=8.0, height=8.0)
+        cpp_grid = CppGrid.from_routing_grid(grid)
+
+        # Existing route on net 2 with a via at world (4.0, 4.0).  We
+        # simulate this as if a previous route had committed:
+        #   * cells marked blocked on all layers around (4.0, 4.0);
+        #   * stored_vias_ entry for the validator to see.
+        gx_via, gy_via = grid.world_to_grid(4.0, 4.0)
+        radius = math.ceil((rules.via_diameter / 2 + rules.via_clearance)
+                           / grid.resolution) + 1
+        cpp_grid._impl.mark_via(gx_via, gy_via, 2, radius)
+        cpp_grid._impl.add_stored_via(4.0, 4.0, 0.3, rules.via_diameter, 2)
+
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+
+        # Sweep through candidate via positions inside the geometric
+        # keepout and verify that all are refused.  These are all the
+        # placements the validator would later reject.
+        keepout_mm = rules.via_diameter + rules.via_clearance  # 0.8mm
+        steps = 6
+        for i in range(steps):
+            for j in range(steps):
+                # Candidates inside a (keepout_mm * 0.9) x (...) box around
+                # the stored via -- well inside the geometric keepout.
+                offset_x = (i / (steps - 1) - 0.5) * keepout_mm * 0.9
+                offset_y = (j / (steps - 1) - 0.5) * keepout_mm * 0.9
+                cand_x, cand_y = 4.0 + offset_x, 4.0 + offset_y
+                gx, gy = grid.world_to_grid(cand_x, cand_y)
+
+                # Compute distance in mm to verify this candidate is
+                # actually inside the keepout (not a degenerate boundary
+                # case from grid quantisation).
+                dist = math.sqrt((cand_x - 4.0) ** 2 + (cand_y - 4.0) ** 2)
+                if dist >= keepout_mm:
+                    continue  # outside keepout, skip
+
+                # Both negotiated and non-negotiated modes must refuse.
+                assert pathfinder._impl.is_via_blocked(gx, gy, 1, False, 0), (
+                    f"Search must refuse via at ({cand_x:.3f}, {cand_y:.3f}) "
+                    f"-- {dist:.3f}mm from stored via, keepout={keepout_mm:.3f}mm"
+                )
+                assert pathfinder._impl.is_via_blocked(gx, gy, 1, True, 0), (
+                    f"Negotiated-mode search must refuse via at "
+                    f"({cand_x:.3f}, {cand_y:.3f}) -- {dist:.3f}mm from "
+                    f"stored via"
+                )


### PR DESCRIPTION
## Summary

- Fix C++ pathfinder via-vs-via clearance: the search now refuses any placement the post-route validator (`Grid3D::validate_route`) would later reject.
- `Pathfinder::is_via_blocked` performs a geometric pass against `stored_vias_` that mirrors the validator exactly, ignoring negotiated-mode shared-cell allowances (two vias cannot physically overlap regardless of routing mode).
- `Autorouter._mark_route_on_cpp_grid` now uses `math.ceil` (with a +1 safety margin matching `RoutingGrid._mark_via`) so grid quantisation never under-blocks the keepout zone.

## Root cause

The pre-existing search inspected a Chebyshev cube of grid cells around the candidate via center.  In negotiated mode, cells with `usage_count > 0` were passed through with a cost penalty, so the search would place a via on top of another net's via.  The validator then computed geometric clearance against `stored_vias_` and flagged the violation -- but by that point the route had already been produced.

The fix runs the validator's exact geometric check inside the search.

## Verification

Board 02 (charlieplex_3x3) re-routed with `--strategy negotiated --layers 4 --backend cpp --no-cache`:
- True via-vs-via clearance violations: 2 -> 0
- Nets routed: 5/8 -> 6/8
- Remaining `[via]` entries in the report are segment-to-via violations (have a layer set), not true via-to-via -- those are tracked separately.

## Test plan

- [x] New regression suite `tests/test_router_cpp_via_clearance.py` (5 tests, all passing) -- exercises:
  - Stored via blocks geometric overlap of candidate via center
  - Boundary distance (`via_diameter + via_clearance`) is NOT refused
  - Same-net stored via does not block (drill spacing is a separate rule)
  - Negotiated mode does not let vias overlap
  - End-to-end sweep across the keepout zone
- [x] Re-route board 02 -- 0 via-vs-via violations remain
- [x] Pre-existing test failures in `test_cpp_clearance_enforcement.py` and `test_router_cpp_backend.py` are unrelated to this change (verified by stashing changes and re-running on main).

## Coordination

Issue #2465 also touches C++ DRC code; coordinate at PR review time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)