### PR TITLE
fix(router): surface via-vs-via failure reason for targeted rip-up (#2476)

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -395,6 +395,14 @@ class NegotiatedRouter:
         self.congestion_estimator = congestion_estimator
         self.congestion_weight = congestion_weight
 
+        # Issue #2476: Set of (failed_net_id, blocking_via_net_id) pairs
+        # collected from the C++ pathfinder's structured failure
+        # diagnostics during route_net_negotiated().  The negotiated outer
+        # loop drains this via :meth:`get_and_clear_via_blocking_nets` to
+        # target rip-up at the specific net whose stored via blocked
+        # progress, rather than blanket retry.
+        self._last_via_blocking_nets: set[tuple[int, int]] = set()
+
     def route_net_negotiated(
         self,
         pad_objs: list[Pad],
@@ -417,6 +425,17 @@ class NegotiatedRouter:
 
         Returns:
             List of routes created
+
+        Notes:
+            Issue #2476: After every failed sub-route (RSMT edge or 2-pin
+            connection), this method consults
+            ``self.router.get_last_failure_info()`` and, when the C++
+            pathfinder reports a ``FAILURE_VIA_VIA_BLOCKED`` diagnostic,
+            records the offending stored-via net in
+            ``self._last_via_blocking_nets``.  The negotiated outer loop
+            uses that list (via :meth:`get_and_clear_via_blocking_nets`) to
+            target rip-up at the specific blockers rather than blanket
+            retry.
         """
         if len(pad_objs) < 2:
             return []
@@ -478,8 +497,13 @@ class NegotiatedRouter:
                     # Collect grid cells from the routed segments so later
                     # edges can terminate early upon reaching this tree.
                     self._collect_route_cells(route, routed_cells)
-                elif failure_callback is not None:
-                    failure_callback(source_pad, target_pad)
+                else:
+                    # Issue #2476: Capture structured via-blocked failure
+                    # diagnostics from the cpp pathfinder so the negotiated
+                    # outer loop can target rip-up at the specific blocker.
+                    self._record_via_blocked_failure(source_pad.net)
+                    if failure_callback is not None:
+                        failure_callback(source_pad, target_pad)
         else:
             # 2-pin net
             route = self.router.route(
@@ -492,10 +516,72 @@ class NegotiatedRouter:
             if route:
                 mark_route_callback(route)
                 routes.append(route)
-            elif failure_callback is not None:
-                failure_callback(pad_objs[0], pad_objs[1])
+            else:
+                # Issue #2476: Capture cpp-side via-blocked diagnostic.
+                self._record_via_blocked_failure(pad_objs[0].net)
+                if failure_callback is not None:
+                    failure_callback(pad_objs[0], pad_objs[1])
 
         return routes
+
+    # =========================================================================
+    # Via-blocked failure tracking (Issue #2476)
+    # =========================================================================
+
+    # Failure-reason constant mirroring router_cpp.FAILURE_VIA_VIA_BLOCKED.
+    # Hard-coded here so the Python module imports cleanly even when the C++
+    # extension is unavailable; matches the value of ``FAILURE_VIA_VIA_BLOCKED``
+    # in ``cpp/include/types.hpp``.
+    _FAILURE_VIA_VIA_BLOCKED = 5
+
+    def _record_via_blocked_failure(self, failed_net: int) -> None:
+        """Capture a via-vs-via failure from the most recent route() call.
+
+        Issue #2476: When a sub-route fails, ask the underlying router for
+        structured failure diagnostics.  If the C++ pathfinder reports
+        ``FAILURE_VIA_VIA_BLOCKED`` along with a non-zero
+        ``blocking_via_net``, record the (failed_net, blocking_net) pair so
+        the negotiated outer loop can rip up the specific blocker rather
+        than blanket retry.
+
+        This is a no-op when:
+        - The router is the Python pathfinder (returns ``None``).
+        - The failure was an unrelated grid-cell rejection (no actionable
+          diagnostic).
+        - The blocking net id is 0 (not a stored-via geometric reject).
+
+        Args:
+            failed_net: Net id of the net whose route failed.
+        """
+        get_info = getattr(self.router, "get_last_failure_info", None)
+        if get_info is None:
+            return
+        info = get_info()
+        if not info:
+            return
+        if info.get("failure_reason") != self._FAILURE_VIA_VIA_BLOCKED:
+            return
+        blocking_net = int(info.get("blocking_via_net") or 0)
+        if blocking_net == 0 or blocking_net == failed_net:
+            return
+        self._last_via_blocking_nets.add((failed_net, blocking_net))
+
+    def get_and_clear_via_blocking_nets(self) -> set[tuple[int, int]]:
+        """Drain and return the set of (failed_net, blocking_net) pairs.
+
+        Issue #2476: Each pair indicates that ``failed_net``'s A* search
+        was rejected by ``blocking_net``'s stored via.  The negotiated
+        outer loop rips up ``blocking_net`` and then retries
+        ``failed_net``.  After draining, the internal set is cleared so
+        subsequent iterations only see fresh diagnostics.
+
+        Returns:
+            A set of ``(failed_net, blocking_net)`` tuples.  Empty if no
+            via-blocked failures have been recorded since the last drain.
+        """
+        result = self._last_via_blocking_nets
+        self._last_via_blocking_nets = set()
+        return result
 
     def _collect_route_cells(
         self,
@@ -595,6 +681,118 @@ class NegotiatedRouter:
                 if route in routes_list:
                     routes_list.remove(route)
             net_routes[net] = []
+
+    def via_blocked_ripup(
+        self,
+        net_routes: dict[int, list[Route]],
+        routes_list: list[Route],
+        pads_by_net: dict[int, list[Pad]],
+        present_cost_factor: float,
+        mark_route_callback: callable,
+        ripup_history: dict[int, int] | None = None,
+        max_ripups_per_net: int = 3,
+        per_net_timeout: float | None = None,
+    ) -> tuple[int, int]:
+        """Targeted rip-up driven by C++ via-vs-via failure diagnostics.
+
+        Issue #2476: When the C++ A* search refuses every via candidate
+        because of a stored-via clearance violation, it surfaces the
+        offending stored-via net via ``RouteResult.blocking_via_net``.
+        This method drains those (failed_net, blocking_net) pairs from
+        :meth:`get_and_clear_via_blocking_nets`, rips up each blocking
+        net, and routes the failed net first.  Displaced blockers are
+        rerouted afterwards.
+
+        Compared to :meth:`targeted_ripup`, the blocker set comes from a
+        precise geometric diagnostic rather than a Bresenham line scan or
+        relaxed A*, so we avoid the false "no direct blockers found" path
+        that previously punted to a blanket retry on board 02.
+
+        Args:
+            net_routes: Dictionary of net_id -> list of routes.
+            routes_list: Master list of all routes.
+            pads_by_net: Dictionary of net_id -> list of pads.
+            present_cost_factor: Current congestion cost factor.
+            mark_route_callback: Callback to mark routes on the grid.
+            ripup_history: Optional dict tracking per-net rip-up counts.
+            max_ripups_per_net: Maximum rip-ups per net to prevent loops.
+            per_net_timeout: Optional wall-clock timeout per A* search.
+
+        Returns:
+            Tuple of ``(resolved_count, attempted_count)`` -- how many
+            failed nets routed successfully after the rip-up, out of how
+            many distinct via-blocked failures were observed.
+        """
+        if ripup_history is None:
+            ripup_history = {}
+
+        pairs = self.get_and_clear_via_blocking_nets()
+        if not pairs:
+            return (0, 0)
+
+        # Group blockers per failed net.  A single failed net may have
+        # accumulated multiple distinct blocking-via observations across
+        # its RSMT edges.
+        blockers_by_failed: dict[int, set[int]] = {}
+        for failed_net, blocking_net in pairs:
+            blockers_by_failed.setdefault(failed_net, set()).add(blocking_net)
+
+        resolved = 0
+        attempted = 0
+
+        for failed_net, blocking_nets in blockers_by_failed.items():
+            attempted += 1
+
+            # Filter blockers by ripup budget.
+            nets_to_ripup: set[int] = set()
+            for net in blocking_nets:
+                if ripup_history.get(net, 0) < max_ripups_per_net:
+                    nets_to_ripup.add(net)
+                    ripup_history[net] = ripup_history.get(net, 0) + 1
+
+            if not nets_to_ripup:
+                # All blockers have hit their rip-up budget; skip this net
+                # so we don't churn endlessly on the same conflict.
+                continue
+
+            # Rip up the specific blockers identified by the cpp search.
+            self.rip_up_nets(list(nets_to_ripup), net_routes, routes_list)
+
+            # Route the failed net first (priority over displaced nets).
+            failed_pads = pads_by_net.get(failed_net, [])
+            failed_net_success = False
+            if failed_pads and len(failed_pads) >= 2:
+                routes = self.route_net_negotiated(
+                    failed_pads, present_cost_factor, mark_route_callback,
+                    per_net_timeout=per_net_timeout,
+                )
+                if routes:
+                    net_routes[failed_net] = routes
+                    for route in routes:
+                        self.grid.mark_route_usage(route)
+                        routes_list.append(route)
+                    failed_net_success = True
+
+            # Re-route the displaced blockers.  Their routing may now use
+            # different via positions that no longer collide with the
+            # newly-routed failed net.
+            for net in nets_to_ripup:
+                net_pads = pads_by_net.get(net, [])
+                if net_pads and len(net_pads) >= 2:
+                    routes = self.route_net_negotiated(
+                        net_pads, present_cost_factor, mark_route_callback,
+                        per_net_timeout=per_net_timeout,
+                    )
+                    if routes:
+                        net_routes[net] = routes
+                        for route in routes:
+                            self.grid.mark_route_usage(route)
+                            routes_list.append(route)
+
+            if failed_net_success:
+                resolved += 1
+
+        return (resolved, attempted)
 
     def targeted_ripup(
         self,

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3843,6 +3843,44 @@ class Autorouter:
                             f"  Stall detected: {len(still_failed)} net(s) unrouted with 0 overflow"
                             f" - engaging targeted rip-up fallback ({elapsed_str()})"
                         )
+
+                        # Issue #2476: Drive a focused via-blocked rip-up
+                        # first.  The C++ pathfinder records the offending
+                        # stored-via net when its A* expansion fails the
+                        # geometric via-vs-via clearance check.  Ripping up
+                        # that specific net is much more likely to unblock
+                        # progress than the Bresenham-based blocker scan
+                        # below, which can miss conflicts that are blocked
+                        # by clearance/congestion rather than direct-line
+                        # intersection.  Any nets still failing afterwards
+                        # fall through to the existing targeted-ripup path.
+                        def _mark_route_via_blocked(route: Route) -> None:
+                            self._mark_route(route)
+
+                        via_resolved, via_attempted = neg_router.via_blocked_ripup(
+                            net_routes=net_routes,
+                            routes_list=self.routes,
+                            pads_by_net=pads_by_net,
+                            present_cost_factor=present_factor,
+                            mark_route_callback=_mark_route_via_blocked,
+                            ripup_history=ripup_history,
+                            max_ripups_per_net=max_ripups_per_net,
+                            per_net_timeout=per_net_timeout,
+                        )
+                        if via_attempted > 0:
+                            flush_print(
+                                f"  Via-blocked rip-up resolved {via_resolved}/{via_attempted} "
+                                f"net(s) via cpp diagnostic ({elapsed_str()})"
+                            )
+                            # Recompute the still-failed list -- some nets
+                            # may now be routed thanks to the targeted via
+                            # blocker rip-up.
+                            still_failed = [
+                                n for n in net_order
+                                if n not in net_routes and n in pads_by_net
+                                and n not in off_grid_nets
+                            ]
+
                         targeted_fallback_count = 0
                         for failed_net in still_failed:
                             if check_timeout():

--- a/src/kicad_tools/router/cpp/include/pathfinder.hpp
+++ b/src/kicad_tools/router/cpp/include/pathfinder.hpp
@@ -94,6 +94,25 @@ public:
     bool is_via_blocked(int x, int y, int net, bool allow_sharing,
                         int radius_override = 0) const;
 
+    // Issue #2476: Diagnostic-aware variant of is_via_blocked.
+    //
+    // Identical semantics to the boolean overload above, but additionally
+    // records the offending stored-via net (when the geometric via-vs-via
+    // clearance rule is what caused the rejection).  When the function
+    // returns true:
+    //   * out_blocking_net != 0 indicates a geometric via-vs-via reject; the
+    //     value is the net id of the stored via that triggered the
+    //     clearance violation.  ``out_world_x``/``out_world_y`` carry the
+    //     world-coordinate location of the rejected candidate.
+    //   * out_blocking_net == 0 indicates the rejection came from the
+    //     grid-cell blocking heuristic (out-of-bounds or another net's
+    //     marked clearance), not the stored-via geometry.
+    bool is_via_blocked_diag(int x, int y, int net, bool allow_sharing,
+                             int radius_override,
+                             int& out_blocking_net,
+                             float& out_world_x,
+                             float& out_world_y) const;
+
 private:
     // Check if trace placement is blocked (accounts for trace width)
     // radius_override: if > 0, use this instead of trace_half_width_cells_
@@ -168,6 +187,16 @@ private:
     PadBounds search_start_pad_bounds_{};
     PadBounds search_end_pad_bounds_{};
     bool search_state_active_ = false;  // True when resumable state is valid
+
+    // Issue #2476: Via-vs-via failure tracking for run_astar_loop().  Reset
+    // by route_resumable() and accumulated across the search and any
+    // subsequent resume() calls so that the failure reason surfaced to
+    // Python reflects the blocker most recently observed before the open
+    // set drained.
+    int search_via_block_count_ = 0;
+    int search_last_blocking_net_ = 0;
+    float search_last_block_world_x_ = 0.0f;
+    float search_last_block_world_y_ = 0.0f;
 };
 
 }  // namespace router

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -61,12 +61,45 @@ struct Via {
     int net;
 };
 
+// Failure reason codes for RouteResult (Issue #2476).
+//
+// When ``success == false`` the search was unable to produce a route.  The
+// numbering mirrors ``ValidationResult::violation_type`` so Python callers
+// can dispatch on the same vocabulary across both search-time failures and
+// post-route validator violations.
+//
+// FAILURE_VIA_VIA_BLOCKED is set when every via candidate considered during
+// the A* expansion was refused by the geometric via-vs-via clearance check
+// in ``Pathfinder::is_via_blocked`` (the path-side mirror of the validator's
+// type-5 violation).  When set, ``RouteResult::blocking_via_net`` carries
+// the net id of the most recently observed offending stored via, and
+// ``RouteResult::failure_x``/``failure_y`` carry the world-coordinate
+// location of the candidate via that was rejected.  The negotiated strategy
+// uses these fields to target rip-up at the specific net whose stored via
+// blocked progress, rather than blanket retry.
+enum FailureReason : int {
+    FAILURE_NONE = 0,
+    FAILURE_NO_PATH = 1,            // Open set exhausted, no candidates remained.
+    FAILURE_ITERATION_LIMIT = 2,    // Reached max_iterations cap.
+    FAILURE_VIA_VIA_BLOCKED = 5,    // All via candidates refused by stored-via geometry.
+};
+
 // Complete route result
 struct RouteResult {
     std::vector<Segment> segments;
     std::vector<Via> vias;
-    int net;
-    bool success;
+    int net = 0;
+    bool success = false;
+
+    // Issue #2476: Structured failure diagnostics.
+    //
+    // Populated when ``success == false`` so the negotiated strategy can
+    // dispatch retry/rip-up intelligently (e.g. rip up the specific net
+    // whose stored via blocked our path, rather than a blanket retry).
+    int failure_reason = FAILURE_NONE;
+    int blocking_via_net = 0;       // Net of the offending stored via (if any).
+    float failure_x = 0.0f;         // World-coord of last rejected candidate.
+    float failure_y = 0.0f;
 };
 
 // Neighbor direction: dx, dy, dlayer, cost_multiplier

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -99,7 +99,21 @@ NB_MODULE(router_cpp, m) {
         .def_ro("segments", &RouteResult::segments)
         .def_ro("vias", &RouteResult::vias)
         .def_ro("net", &RouteResult::net)
-        .def_ro("success", &RouteResult::success);
+        .def_ro("success", &RouteResult::success)
+        // Issue #2476: structured failure diagnostics (mirrors
+        // ValidationResult::violation_type vocabulary).
+        .def_ro("failure_reason", &RouteResult::failure_reason)
+        .def_ro("blocking_via_net", &RouteResult::blocking_via_net)
+        .def_ro("failure_x", &RouteResult::failure_x)
+        .def_ro("failure_y", &RouteResult::failure_y);
+
+    // Issue #2476: FailureReason constants (exposed as module attributes
+    // so Python tests/strategies can dispatch on the same vocabulary the
+    // C++ search uses internally).
+    m.attr("FAILURE_NONE") = static_cast<int>(FAILURE_NONE);
+    m.attr("FAILURE_NO_PATH") = static_cast<int>(FAILURE_NO_PATH);
+    m.attr("FAILURE_ITERATION_LIMIT") = static_cast<int>(FAILURE_ITERATION_LIMIT);
+    m.attr("FAILURE_VIA_VIA_BLOCKED") = static_cast<int>(FAILURE_VIA_VIA_BLOCKED);
 
     // Grid3D class
     nb::class_<Grid3D>(m, "Grid3D")

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -126,12 +126,28 @@ bool Pathfinder::is_diagonal_blocked(int x, int y, int dx, int dy, int layer,
 
 bool Pathfinder::is_via_blocked(int x, int y, int net, bool allow_sharing,
                                 int radius_override) const {
+    int dummy_net = 0;
+    float dummy_x = 0.0f, dummy_y = 0.0f;
+    return is_via_blocked_diag(x, y, net, allow_sharing, radius_override,
+                               dummy_net, dummy_x, dummy_y);
+}
+
+bool Pathfinder::is_via_blocked_diag(int x, int y, int net, bool allow_sharing,
+                                     int radius_override,
+                                     int& out_blocking_net,
+                                     float& out_world_x,
+                                     float& out_world_y) const {
+    out_blocking_net = 0;
+    out_world_x = 0.0f;
+    out_world_y = 0.0f;
+
     int radius = (radius_override > 0) ? radius_override : via_half_cells_;
     for (int layer = 0; layer < grid_.layers(); ++layer) {
         for (int dy = -radius; dy <= radius; ++dy) {
             for (int dx = -radius; dx <= radius; ++dx) {
                 int cx = x + dx, cy = y + dy;
                 if (!grid_.is_valid(cx, cy, layer)) {
+                    // Grid-cell rejection: no specific blocking net.
                     return true;
                 }
 
@@ -154,13 +170,10 @@ bool Pathfinder::is_via_blocked(int x, int y, int net, bool allow_sharing,
         }
     }
 
-    // Issue #2466: Also check via-vs-via geometric clearance against
-    // ``stored_vias_``.  The grid-cell blocking heuristic above can miss
-    // conflicts in negotiated mode (where ``allow_sharing`` lets cells with
-    // ``usage_count > 0`` be passed through), but two vias can never
-    // physically overlap regardless of routing mode.  This mirrors the
-    // post-route validator (Grid3D::validate_route) so the search refuses
-    // placements that the validator would later reject.
+    // Issue #2466: Geometric via-vs-via clearance against ``stored_vias_``.
+    // Issue #2476: When this branch causes a rejection, record the offending
+    // stored-via net so the negotiated strategy can target the rip-up at the
+    // specific net whose via is blocking us, rather than blanket retry.
     auto candidate_world = grid_.grid_to_world(x, y);
     float candidate_x = candidate_world.first;
     float candidate_y = candidate_world.second;
@@ -174,6 +187,9 @@ bool Pathfinder::is_via_blocked(int x, int y, int net, bool allow_sharing,
         float distance = std::sqrt(dxw * dxw + dyw * dyw);
         float clearance = distance - candidate_radius - sv.diameter / 2.0f;
         if (clearance < clearance_required) {
+            out_blocking_net = sv.net;
+            out_world_x = candidate_x;
+            out_world_y = candidate_y;
             return true;
         }
     }
@@ -302,6 +318,17 @@ RouteResult Pathfinder::route(
     int max_iterations = grid_.cols() * grid_.rows() * 4;
     last_iterations_ = 0;
     last_nodes_explored_ = 0;
+
+    // Issue #2476: Track via-vs-via blocked rejections so the negotiated
+    // strategy can target rip-up at the specific net whose stored via is
+    // blocking us, rather than blanket retry.  We record the most-recently
+    // observed offending stored via along with the world-coord of the
+    // candidate slot that was rejected.  When the search ends with
+    // success=false, these are written into ``result``'s diagnostic fields.
+    int via_block_count = 0;
+    int last_blocking_net = 0;
+    float last_block_world_x = 0.0f;
+    float last_block_world_y = 0.0f;
 
     // Inline A* loop (uses local variables, no rejected goals check)
     while (!open_set.empty() && last_iterations_ < max_iterations) {
@@ -460,8 +487,20 @@ RouteResult Pathfinder::route(
         for (int new_layer : routable_layers_) {
             if (new_layer == current.layer) continue;
 
-            if (is_via_blocked(current.x, current.y, net, negotiated_mode,
-                               via_radius_cells)) {
+            // Issue #2476: Use diagnostic-aware variant so we can record the
+            // offending stored-via net when the geometric via-vs-via clearance
+            // rule is what caused the rejection.
+            int blocking_net = 0;
+            float block_wx = 0.0f, block_wy = 0.0f;
+            if (is_via_blocked_diag(current.x, current.y, net, negotiated_mode,
+                                    via_radius_cells,
+                                    blocking_net, block_wx, block_wy)) {
+                if (blocking_net != 0) {
+                    ++via_block_count;
+                    last_blocking_net = blocking_net;
+                    last_block_world_x = block_wx;
+                    last_block_world_y = block_wy;
+                }
                 continue;
             }
 
@@ -494,7 +533,21 @@ RouteResult Pathfinder::route(
         }
     }
 
-    // No path found
+    // Search ended without reaching the goal.  Populate structured failure
+    // diagnostics (Issue #2476) so the negotiated strategy can dispatch a
+    // targeted retry/rip-up rather than blanket retrying with no insight.
+    result.failure_reason = (last_iterations_ >= max_iterations)
+        ? FAILURE_ITERATION_LIMIT
+        : FAILURE_NO_PATH;
+    if (via_block_count > 0 && last_blocking_net != 0) {
+        // At least one via expansion was refused by stored-via geometry.
+        // Surface this regardless of why the open set ultimately drained --
+        // a Python caller can then choose to rip up the blocking net.
+        result.failure_reason = FAILURE_VIA_VIA_BLOCKED;
+        result.blocking_via_net = last_blocking_net;
+        result.failure_x = last_block_world_x;
+        result.failure_y = last_block_world_y;
+    }
     return result;
 }
 
@@ -564,6 +617,15 @@ RouteResult Pathfinder::route_resumable(
     last_iterations_ = 0;
     last_nodes_explored_ = 0;
     search_state_active_ = true;
+
+    // Issue #2476: Reset via-vs-via failure trackers at the start of a
+    // fresh resumable search.  resume() must NOT reset these -- a candidate
+    // observed during the original route_resumable() may still be the
+    // best diagnostic when resume() fails.
+    search_via_block_count_ = 0;
+    search_last_blocking_net_ = 0;
+    search_last_block_world_x_ = 0.0f;
+    search_last_block_world_y_ = 0.0f;
 
     return run_astar_loop();
 }
@@ -761,8 +823,20 @@ RouteResult Pathfinder::run_astar_loop() {
         for (int new_layer : routable_layers_) {
             if (new_layer == current.layer) continue;
 
-            if (is_via_blocked(current.x, current.y, search_net_,
-                               search_negotiated_mode_, search_via_radius_cells_)) {
+            // Issue #2476: Diagnostic-aware via blocking check so we can
+            // record which stored-via net rejected our candidate slot.
+            int blocking_net = 0;
+            float block_wx = 0.0f, block_wy = 0.0f;
+            if (is_via_blocked_diag(current.x, current.y, search_net_,
+                                    search_negotiated_mode_,
+                                    search_via_radius_cells_,
+                                    blocking_net, block_wx, block_wy)) {
+                if (blocking_net != 0) {
+                    ++search_via_block_count_;
+                    search_last_blocking_net_ = blocking_net;
+                    search_last_block_world_x_ = block_wx;
+                    search_last_block_world_y_ = block_wy;
+                }
                 continue;
             }
 
@@ -796,8 +870,20 @@ RouteResult Pathfinder::run_astar_loop() {
         }
     }
 
-    // Open set exhausted or iteration limit hit
+    // Open set exhausted or iteration limit hit.  Surface structured
+    // failure diagnostics (Issue #2476) -- the negotiated strategy uses
+    // ``failure_reason`` to dispatch targeted retries rather than blanket
+    // re-routing.
     search_state_active_ = false;
+    result.failure_reason = (last_iterations_ >= search_max_iterations_)
+        ? FAILURE_ITERATION_LIMIT
+        : FAILURE_NO_PATH;
+    if (search_via_block_count_ > 0 && search_last_blocking_net_ != 0) {
+        result.failure_reason = FAILURE_VIA_VIA_BLOCKED;
+        result.blocking_via_net = search_last_blocking_net_;
+        result.failure_x = search_last_block_world_x_;
+        result.failure_y = search_last_block_world_y_;
+    }
     return result;
 }
 
@@ -809,6 +895,12 @@ void Pathfinder::clear_search_state() {
     search_closed_list_.clear();
     rejected_goals_.clear();
     search_state_active_ = false;
+    // Issue #2476: Reset failure trackers as well so a stale blocker from
+    // the previous net does not leak into the next route().
+    search_via_block_count_ = 0;
+    search_last_blocking_net_ = 0;
+    search_last_block_world_x_ = 0.0f;
+    search_last_block_world_y_ = 0.0f;
 }
 
 RouteResult Pathfinder::reconstruct_path(

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -389,6 +389,19 @@ class CppPathfinder:
         self._fallback_count: int = 0
         self._fallback_nets: list[str] = []
 
+        # Issue #2476: Capture structured failure diagnostics from the most
+        # recent failed route() call so the negotiated strategy can
+        # dispatch targeted retry/rip-up.  Reset at the start of every
+        # route() invocation; populated when route() returns None.
+        #
+        # Schema: {
+        #   "failure_reason": int,           # FAILURE_* constant
+        #   "blocking_via_net": int,         # 0 if not via-blocked
+        #   "failure_x": float,              # world-coord (mm)
+        #   "failure_y": float,
+        # } or ``None`` if no diagnostic was captured.
+        self._last_failure_info: dict | None = None
+
     def set_routable_layers(self, layers: list[int]) -> None:
         """Set which layers are routable (skip plane layers)."""
         self._impl.set_routable_layers(layers)
@@ -569,6 +582,11 @@ class CppPathfinder:
         # Maximum number of resume attempts before giving up.
         max_resume_attempts = 5
 
+        # Issue #2476: Reset failure-info at the start of every route() call
+        # so the negotiated strategy never sees stale diagnostics from a
+        # previous net.
+        self._last_failure_info = None
+
         try:
             result = self._impl.route_resumable(
                 start.x,
@@ -590,6 +608,13 @@ class CppPathfinder:
             )
 
             if not result.success:
+                # Issue #2476: Capture structured failure diagnostics from
+                # the C++ pathfinder.  In particular, FAILURE_VIA_VIA_BLOCKED
+                # carries the offending stored-via net so the negotiated
+                # strategy can target rip-up at that net rather than a
+                # blanket retry.  We capture even when the Python fallback
+                # also fails, since the cpp diagnostic is still actionable.
+                self._capture_failure_info(result)
                 return self._try_python_fallback(
                     start,
                     end,
@@ -621,7 +646,11 @@ class CppPathfinder:
                 self._boost_avoidance_at(violation_location, trace_radius_cells)
 
                 if attempt >= max_resume_attempts:
-                    # Exhausted resume attempts, try Python fallback
+                    # Exhausted resume attempts, try Python fallback.
+                    # Issue #2476: Capture failure-info before falling back
+                    # so the negotiated strategy can still see the cpp-side
+                    # via-blocked diagnostic.
+                    self._capture_failure_info(result)
                     return self._try_python_fallback(
                         start,
                         end,
@@ -654,6 +683,11 @@ class CppPathfinder:
                 result = self._impl.resume(reject_gx, reject_gy, reject_layer)
 
                 if not result.success:
+                    # Issue #2476: Capture failure diagnostics; resume()
+                    # accumulates trackers from the original
+                    # route_resumable() call so the most recent via-blocker
+                    # is still reported.
+                    self._capture_failure_info(result)
                     return self._try_python_fallback(
                         start,
                         end,
@@ -669,6 +703,57 @@ class CppPathfinder:
         finally:
             # Always clear search state to release memory (Issue #2447 risk).
             self._impl.clear_search_state()
+
+    def _capture_failure_info(self, result: "router_cpp.RouteResult") -> None:
+        """Record structured failure diagnostics from a failed C++ route.
+
+        Issue #2476: When the C++ A* search fails (open set exhausted or
+        all via candidates were refused by stored-via geometry), the
+        ``RouteResult`` carries a ``failure_reason`` and -- for the
+        via-vs-via case -- the offending stored-via net.  We stash this on
+        the pathfinder so ``get_last_failure_info()`` can return it to the
+        negotiated strategy after ``route()`` returns ``None``.
+
+        Note: We capture even when we are about to fall back to the Python
+        router.  If the Python fallback also fails, the cpp-side
+        diagnostic is still actionable (the via blocker has not moved).
+
+        Args:
+            result: The failed C++ ``RouteResult`` to capture diagnostics
+                from.  ``failure_reason == FAILURE_NONE`` is silently
+                ignored (no useful info).
+        """
+        # router_cpp may be None if the import failed; guard so this method
+        # is safe to call from anywhere on the failure path.
+        if router_cpp is None:
+            return
+
+        reason = getattr(result, "failure_reason", router_cpp.FAILURE_NONE)
+        if reason == router_cpp.FAILURE_NONE:
+            return
+
+        self._last_failure_info = {
+            "failure_reason": int(reason),
+            "blocking_via_net": int(getattr(result, "blocking_via_net", 0)),
+            "failure_x": float(getattr(result, "failure_x", 0.0)),
+            "failure_y": float(getattr(result, "failure_y", 0.0)),
+        }
+
+    def get_last_failure_info(self) -> dict | None:
+        """Return structured failure diagnostics from the most recent failed route().
+
+        Issue #2476: The negotiated strategy uses this to decide between
+        blanket retry and targeted rip-up of a specific blocking net.
+        Returns ``None`` if the last route() succeeded or the failure had
+        no actionable signal (e.g. an unrelated grid-cell rejection).
+
+        Returns:
+            Dict with keys ``failure_reason``, ``blocking_via_net``,
+            ``failure_x``, ``failure_y`` -- or ``None`` if no diagnostic
+            is available.  ``failure_reason`` matches the ``FAILURE_*``
+            constants in the ``router_cpp`` module (see ``types.hpp``).
+        """
+        return self._last_failure_info
 
     def _convert_result_to_route(
         self,

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -2034,6 +2034,17 @@ class Router:
         # No path found
         return None
 
+    def get_last_failure_info(self) -> dict | None:
+        """Return structured failure diagnostics from the most recent failed route().
+
+        Issue #2476: API parity with ``CppPathfinder.get_last_failure_info``.
+        The Python pathfinder does not currently expose structured via-blocked
+        failure reasons -- callers always receive ``None`` here.  The
+        negotiated strategy treats ``None`` as "no actionable diagnostic"
+        and falls back to its existing rip-up logic.
+        """
+        return None
+
     def find_blocking_nets(
         self,
         start: Pad,

--- a/tests/test_router_cpp_via_blocked_failure.py
+++ b/tests/test_router_cpp_via_blocked_failure.py
@@ -1,0 +1,476 @@
+"""Regression tests for via-vs-via failure-reason propagation (Issue #2476).
+
+These tests verify that the C++ pathfinder surfaces a structured
+``FAILURE_VIA_VIA_BLOCKED`` reason (along with the offending stored-via
+net id) when its A* expansion is unable to place a via because of the
+geometric clearance check added in Issue #2466.  The negotiated strategy
+uses this diagnostic to dispatch a targeted rip-up at the specific
+blocker rather than blanket retry.
+
+Background
+==========
+
+PR #2472 (Issue #2466) made ``Pathfinder::is_via_blocked`` honor the
+post-route validator's via-vs-via clearance rule.  The check is correct
+(refuses placements the validator would flag), but board 02
+(charlieplex_3x3) regressed from 7/8 (DRC-failing) to 6/8 (DRC-clean):
+the negotiated strategy could not react to the new rejections because
+``RouteResult`` only carried a boolean ``success``.
+
+Fix surface area:
+
+* C++ ``RouteResult`` gains ``failure_reason``, ``blocking_via_net``,
+  ``failure_x``, ``failure_y`` (mirroring the
+  ``ValidationResult::violation_type`` numbering, value 5 = via-via).
+* C++ ``Pathfinder::is_via_blocked_diag`` overload returns the offending
+  stored via id along with the boolean rejection.
+* The two A* loops (``route()`` and ``run_astar_loop()``) accumulate
+  via-block events and write them into the result on failure.
+* Python ``CppPathfinder`` exposes the diagnostic via
+  ``get_last_failure_info()``.
+* The negotiated strategy records ``(failed_net, blocking_net)`` pairs
+  whenever a sub-route fails with the via-vs-via reason and exposes them
+  via ``get_and_clear_via_blocking_nets()``.
+* New ``via_blocked_ripup`` method on ``NegotiatedRouter`` performs a
+  targeted rip-up driven by those pairs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.cpp_backend import (
+    CppGrid,
+    CppPathfinder,
+    is_cpp_available,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+requires_cpp = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ router backend not available",
+)
+
+
+def _make_grid_and_rules(
+    width: float = 10.0,
+    height: float = 10.0,
+    resolution: float = 0.1,
+    trace_width: float = 0.25,
+    trace_clearance: float = 0.2,
+    via_diameter: float = 0.6,
+    via_clearance: float = 0.2,
+) -> tuple[RoutingGrid, DesignRules]:
+    rules = DesignRules(
+        trace_width=trace_width,
+        trace_clearance=trace_clearance,
+        via_diameter=via_diameter,
+        via_clearance=via_clearance,
+        grid_resolution=resolution,
+    )
+    grid = RoutingGrid(
+        width=width,
+        height=height,
+        rules=rules,
+        layer_stack=LayerStack.four_layer_all_signal(),
+    )
+    return grid, rules
+
+
+@requires_cpp
+class TestRouteResultFailureReason:
+    """RouteResult must carry a structured failure reason on failure (Issue #2476)."""
+
+    def test_failure_reason_constants_exposed(self):
+        """The C++ extension exposes FAILURE_* constants for Python dispatch."""
+        from kicad_tools.router import router_cpp
+
+        assert hasattr(router_cpp, "FAILURE_NONE")
+        assert hasattr(router_cpp, "FAILURE_NO_PATH")
+        assert hasattr(router_cpp, "FAILURE_VIA_VIA_BLOCKED")
+        # Mirror ValidationResult::violation_type vocabulary -- via-via = 5.
+        assert router_cpp.FAILURE_VIA_VIA_BLOCKED == 5
+        assert router_cpp.FAILURE_NONE == 0
+
+    def test_route_result_default_failure_reason_is_none(self):
+        """A default-constructed RouteResult has failure_reason == FAILURE_NONE."""
+        from kicad_tools.router import router_cpp
+
+        r = router_cpp.RouteResult()
+        assert r.failure_reason == router_cpp.FAILURE_NONE
+        assert r.blocking_via_net == 0
+        assert r.failure_x == pytest.approx(0.0)
+        assert r.failure_y == pytest.approx(0.0)
+
+    def test_via_blocked_failure_reason_propagates_to_python(self):
+        """End-to-end: when the cpp search rejects a via slot due to
+        stored-via geometry, ``get_last_failure_info()`` returns a dict
+        with ``failure_reason == FAILURE_VIA_VIA_BLOCKED`` and
+        ``blocking_via_net`` set to the offending stored-via's net.
+
+        Fixture isolates the geometric branch by:
+        - Carpeting the grid with net-2 stored vias on a tight pitch
+          (closer than ``via_diameter + via_clearance``) so any via
+          candidate is geometrically blocked by at least one of them.
+        - NOT marking any grid cells, so the grid-cell blocking check
+          inside ``is_via_blocked`` always passes -- the only rejection
+          mechanism is the geometric stored-via clearance check that
+          mirrors the post-route validator (Issue #2466).
+
+        Note: ``CppPathfinder.route()`` falls back to the pure-Python
+        pathfinder when the cpp search fails, and the fallback may still
+        find a route.  This test asserts the cpp-side diagnostic via
+        ``get_last_failure_info()`` regardless of whether the fallback
+        succeeded -- the diagnostic must be captured before any fallback
+        is attempted.
+        """
+        from kicad_tools.router import router_cpp
+
+        # Compact 2mm x 2mm grid so the carpet of stored vias densely
+        # covers every reachable via candidate.
+        rules = DesignRules(
+            trace_width=0.25,
+            trace_clearance=0.2,
+            via_diameter=0.6,
+            via_clearance=0.2,
+            grid_resolution=0.1,
+        )
+        grid = RoutingGrid(
+            width=2.0, height=2.0, rules=rules,
+            layer_stack=LayerStack.four_layer_all_signal(),
+        )
+        cpp_grid = CppGrid.from_routing_grid(grid)
+
+        # Carpet of stored vias on 0.4mm pitch -- well inside the
+        # 0.8mm geometric keepout.  We deliberately do NOT mark grid
+        # cells, so any cell-based check passes.
+        net2 = 2
+        for i in range(6):
+            for j in range(6):
+                x = i * 0.4
+                y = j * 0.4
+                cpp_grid._impl.add_stored_via(
+                    x, y, 0.3, rules.via_diameter, net2,
+                )
+
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+
+        # Force the search to attempt a via: start on F_CU, end on B_CU.
+        start = Pad(
+            x=0.2, y=0.2, width=0.2, height=0.2,
+            layer=Layer.F_CU, net=1, net_name="N1",
+        )
+        end = Pad(
+            x=1.8, y=1.8, width=0.2, height=0.2,
+            layer=Layer.B_CU, net=1, net_name="N1",
+        )
+
+        # The Python fallback may still find a path -- we don't assert on
+        # the route() return.  We DO assert that the cpp-side diagnostic
+        # was captured via _capture_failure_info before the fallback ran.
+        pathfinder.route(start, end, negotiated_mode=False)
+
+        info = pathfinder.get_last_failure_info()
+        assert info is not None, (
+            "cpp search failed but get_last_failure_info() returned None -- "
+            "_capture_failure_info should have recorded the diagnostic"
+        )
+        assert info["failure_reason"] == router_cpp.FAILURE_VIA_VIA_BLOCKED, (
+            f"Expected FAILURE_VIA_VIA_BLOCKED ({router_cpp.FAILURE_VIA_VIA_BLOCKED}), "
+            f"got {info['failure_reason']}"
+        )
+        assert info["blocking_via_net"] == net2, (
+            f"Expected blocking_via_net == {net2}, "
+            f"got {info['blocking_via_net']}"
+        )
+        # Failure coordinates should be non-zero (a real candidate was
+        # rejected somewhere on the board).
+        assert info["failure_x"] != 0.0 or info["failure_y"] != 0.0, (
+            f"failure_x/_y must record where the candidate was rejected, "
+            f"got ({info['failure_x']}, {info['failure_y']})"
+        )
+
+    def test_failure_info_cleared_on_success(self):
+        """A successful route() clears any previous failure diagnostic."""
+        grid, rules = _make_grid_and_rules()
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+
+        # Trivial 2-pad route that should succeed without vias.
+        start = Pad(
+            x=1.0, y=1.0, width=0.4, height=0.4,
+            layer=Layer.F_CU, net=1, net_name="N1",
+        )
+        end = Pad(
+            x=3.0, y=1.0, width=0.4, height=0.4,
+            layer=Layer.F_CU, net=1, net_name="N1",
+        )
+
+        route = pathfinder.route(start, end)
+        assert route is not None
+        # On success, failure-info is left at its previous value (None
+        # initially, since route() resets it at the start of every call).
+        # This guarantees stale diagnostics do not leak into the next
+        # failed route().
+        assert pathfinder.get_last_failure_info() is None
+
+    def test_failure_info_python_router_returns_none(self):
+        """The Python pathfinder's get_last_failure_info() returns None.
+
+        This is the API parity contract -- the negotiated strategy treats
+        ``None`` as "no actionable diagnostic" and falls back to its
+        existing rip-up logic, so the Python-only path is unaffected.
+        """
+        from kicad_tools.router.pathfinder import Router
+
+        grid, rules = _make_grid_and_rules()
+        py_router = Router(grid, rules)
+        assert py_router.get_last_failure_info() is None
+
+
+@requires_cpp
+class TestNegotiatedRouterViaBlockedRetry:
+    """The negotiated strategy must consume the via-blocked diagnostic
+    and dispatch a targeted rip-up of the specific blocker (Issue #2476)."""
+
+    def test_record_via_blocked_failure_captures_pair(self):
+        """``_record_via_blocked_failure`` stores (failed_net, blocking_net)
+        when the underlying router reports FAILURE_VIA_VIA_BLOCKED.
+        """
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        grid, rules = _make_grid_and_rules()
+
+        # Mock router that reports a via-vs-via failure.
+        class FakeRouter:
+            def get_last_failure_info(self):
+                return {
+                    "failure_reason": NegotiatedRouter._FAILURE_VIA_VIA_BLOCKED,
+                    "blocking_via_net": 7,
+                    "failure_x": 1.0,
+                    "failure_y": 2.0,
+                }
+
+        neg = NegotiatedRouter(grid, FakeRouter(), rules, net_class_map={})
+        neg._record_via_blocked_failure(failed_net=3)
+
+        pairs = neg.get_and_clear_via_blocking_nets()
+        assert pairs == {(3, 7)}
+
+        # Drain semantics: a second drain returns empty.
+        assert neg.get_and_clear_via_blocking_nets() == set()
+
+    def test_record_via_blocked_failure_ignores_non_via_failures(self):
+        """Failures with other reasons are NOT recorded as via-blocking.
+
+        This avoids polluting the targeted-ripup queue with rejections
+        that have nothing to do with stored-via geometry (e.g. plain
+        no-path failures, grid-cell rejections, or Python-fallback
+        failures with no diagnostic).
+        """
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        grid, rules = _make_grid_and_rules()
+
+        class FakeRouter:
+            info = None
+
+            def get_last_failure_info(self):
+                return self.info
+
+        fr = FakeRouter()
+        neg = NegotiatedRouter(grid, fr, rules, net_class_map={})
+
+        # Case 1: None
+        fr.info = None
+        neg._record_via_blocked_failure(failed_net=1)
+        assert neg.get_and_clear_via_blocking_nets() == set()
+
+        # Case 2: NO_PATH (different reason)
+        fr.info = {
+            "failure_reason": 1,  # FAILURE_NO_PATH
+            "blocking_via_net": 0,
+            "failure_x": 0.0,
+            "failure_y": 0.0,
+        }
+        neg._record_via_blocked_failure(failed_net=1)
+        assert neg.get_and_clear_via_blocking_nets() == set()
+
+        # Case 3: VIA_VIA_BLOCKED but blocking_net == 0
+        fr.info = {
+            "failure_reason": NegotiatedRouter._FAILURE_VIA_VIA_BLOCKED,
+            "blocking_via_net": 0,
+            "failure_x": 0.0,
+            "failure_y": 0.0,
+        }
+        neg._record_via_blocked_failure(failed_net=1)
+        assert neg.get_and_clear_via_blocking_nets() == set()
+
+        # Case 4: blocking_net == failed_net (same-net spacing, irrelevant)
+        fr.info = {
+            "failure_reason": NegotiatedRouter._FAILURE_VIA_VIA_BLOCKED,
+            "blocking_via_net": 1,
+            "failure_x": 0.0,
+            "failure_y": 0.0,
+        }
+        neg._record_via_blocked_failure(failed_net=1)
+        assert neg.get_and_clear_via_blocking_nets() == set()
+
+    def test_via_blocked_ripup_targets_recorded_pairs(self):
+        """``via_blocked_ripup`` rips up exactly the recorded blocking nets
+        and re-routes the failed net first.
+
+        Fixture: register two via-blocked failure pairs; verify that the
+        method drains them, calls ``rip_up_nets`` with the blockers, and
+        attempts to reroute the failed nets afterwards.
+        """
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+        from kicad_tools.router.primitives import Route
+
+        grid, rules = _make_grid_and_rules()
+
+        # Track which nets were ripped up and re-routed.
+        ripped: list[list[int]] = []
+        rerouted: list[int] = []
+
+        class FakeRouter:
+            def get_last_failure_info(self):
+                return None
+
+            def route(self, *args, **kwargs):
+                return None
+
+        # Build a real NegotiatedRouter but override the heavy methods.
+        neg = NegotiatedRouter(grid, FakeRouter(), rules, net_class_map={})
+
+        def fake_rip_up_nets(nets, net_routes, routes_list):
+            ripped.append(list(nets))
+            for n in nets:
+                net_routes.pop(n, None)
+
+        def fake_route_net_negotiated(pad_objs, *args, **kwargs):
+            net_id = pad_objs[0].net
+            rerouted.append(net_id)
+            # Net 5 (the failed net) reroutes successfully; others fail
+            # so we can verify the resolved-vs-attempted return value.
+            if net_id == 5:
+                return [Route(net=net_id, net_name=f"N{net_id}")]
+            return []
+
+        neg.rip_up_nets = fake_rip_up_nets  # type: ignore
+        neg.route_net_negotiated = fake_route_net_negotiated  # type: ignore
+
+        # Seed the via-blocked pairs.
+        neg._last_via_blocking_nets = {(5, 9)}
+
+        # Set up minimal pads_by_net so the method has something to
+        # invoke route_net_negotiated with.
+        pads_by_net: dict[int, list[Pad]] = {
+            5: [
+                Pad(x=0.5, y=0.5, width=0.4, height=0.4, layer=Layer.F_CU, net=5, net_name="N5"),
+                Pad(x=2.0, y=2.0, width=0.4, height=0.4, layer=Layer.F_CU, net=5, net_name="N5"),
+            ],
+            9: [
+                Pad(x=1.0, y=1.0, width=0.4, height=0.4, layer=Layer.F_CU, net=9, net_name="N9"),
+                Pad(x=3.0, y=3.0, width=0.4, height=0.4, layer=Layer.F_CU, net=9, net_name="N9"),
+            ],
+        }
+
+        net_routes: dict[int, list[Route]] = {9: [Route(net=9, net_name="N9")]}
+        routes_list: list[Route] = list(net_routes[9])
+
+        resolved, attempted = neg.via_blocked_ripup(
+            net_routes=net_routes,
+            routes_list=routes_list,
+            pads_by_net=pads_by_net,
+            present_cost_factor=1.0,
+            mark_route_callback=lambda r: None,
+        )
+
+        assert attempted == 1  # one distinct failed net
+        assert resolved == 1  # net 5 rerouted successfully
+
+        # The blocker was net 9 -- it must have been ripped up.
+        assert ripped == [[9]]
+
+        # Re-route was attempted for the failed net first, then the
+        # displaced blocker.
+        assert rerouted[0] == 5
+        assert 9 in rerouted
+
+        # The internal pairs set is drained (idempotent retry guard).
+        assert neg.get_and_clear_via_blocking_nets() == set()
+
+    def test_via_blocked_ripup_respects_ripup_budget(self):
+        """``via_blocked_ripup`` honors ``max_ripups_per_net`` so a blocker
+        already at its rip-up budget is skipped (prevents infinite churn).
+        """
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        grid, rules = _make_grid_and_rules()
+
+        ripped: list[list[int]] = []
+
+        class FakeRouter:
+            def get_last_failure_info(self):
+                return None
+
+            def route(self, *args, **kwargs):
+                return None
+
+        neg = NegotiatedRouter(grid, FakeRouter(), rules, net_class_map={})
+
+        def fake_rip_up_nets(nets, net_routes, routes_list):
+            ripped.append(list(nets))
+
+        neg.rip_up_nets = fake_rip_up_nets  # type: ignore
+        neg.route_net_negotiated = lambda *a, **k: []  # type: ignore
+
+        neg._last_via_blocking_nets = {(5, 9)}
+
+        # Pre-load ripup_history so net 9 has already hit its budget.
+        ripup_history = {9: 3}
+
+        resolved, attempted = neg.via_blocked_ripup(
+            net_routes={},
+            routes_list=[],
+            pads_by_net={},
+            present_cost_factor=1.0,
+            mark_route_callback=lambda r: None,
+            ripup_history=ripup_history,
+            max_ripups_per_net=3,
+        )
+
+        # The pair was attempted but no rip-up occurred (budget exhausted).
+        assert attempted == 1
+        assert resolved == 0
+        assert ripped == [], (
+            "When all blockers are over-budget no rip-up should occur"
+        )
+
+    def test_via_blocked_ripup_no_pairs_returns_zero(self):
+        """When no via-blocked pairs have been recorded, the method is a no-op."""
+        from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+        grid, rules = _make_grid_and_rules()
+
+        class FakeRouter:
+            def get_last_failure_info(self):
+                return None
+
+        neg = NegotiatedRouter(grid, FakeRouter(), rules, net_class_map={})
+
+        resolved, attempted = neg.via_blocked_ripup(
+            net_routes={},
+            routes_list=[],
+            pads_by_net={},
+            present_cost_factor=1.0,
+            mark_route_callback=lambda r: None,
+        )
+        assert resolved == 0
+        assert attempted == 0


### PR DESCRIPTION
## Summary

Restores board 02 (charlieplex_3x3) routing from 6/8 → 7/8 nets while preserving the via-vs-via DRC correctness from #2466.

After #2466 (PR #2472) made `Pathfinder::is_via_blocked` honor the geometric via-vs-via clearance rule, the negotiated strategy could not react to the new rejections because `RouteResult` only carried a boolean `success`. The fix surfaces structured failure diagnostics from C++ to Python, and adds a targeted rip-up code path that consumes them.

## Changes

### C++ pathfinder (`src/kicad_tools/router/cpp/`)
- `RouteResult` gains `failure_reason`, `blocking_via_net`, `failure_x`, `failure_y` (mirroring `ValidationResult::violation_type`, value 5 = via-via).
- New `is_via_blocked_diag` overload reports the offending stored-via net id when the geometric clearance check rejects a candidate slot.
- Both A* loops (`route()` and `run_astar_loop()`) accumulate via-block events and write them into the result on failure.
- New `FAILURE_*` constants exposed to Python via `bindings.cpp`.

### Python plumbing
- `CppPathfinder.get_last_failure_info()` returns the diagnostic from the most recent failed `route()` call. Captured before any Python fallback runs, so the cpp-side via-blocked signal is preserved.
- `Router.get_last_failure_info()` returns `None` (API parity stub).

### Negotiated strategy (`negotiated.py`, `core.py`)
- `route_net_negotiated` records `(failed_net, blocking_net)` pairs in `_last_via_blocking_nets` whenever a sub-route fails with the via-vs-via reason.
- New `via_blocked_ripup` method drains those pairs, rips up the specific blockers, and reroutes the failed nets first.
- The negotiated outer loop in `core.py` now runs `via_blocked_ripup` as the first stall fallback when overflow is 0 but nets remain unrouted, before the existing Bresenham-based blocker scan.

## Test plan

- [x] Manual end-to-end on board 02: 7/8 nets routed (was 6/8 baseline). DRC: no via-vs-via violations (4 pre-existing trace-trace / trace-via clearance violations, unrelated to this change).
- [x] 10 new unit tests in `tests/test_router_cpp_via_blocked_failure.py`:
  - `FAILURE_*` constants exposed and match `ValidationResult` numbering.
  - `RouteResult` default fields.
  - End-to-end: cpp search rejects a via slot due to stored-via geometry → `failure_reason == FAILURE_VIA_VIA_BLOCKED`, `blocking_via_net` set.
  - Failure-info reset on success / API parity for Python router.
  - `_record_via_blocked_failure` captures pairs / ignores non-via failures.
  - `via_blocked_ripup` targets recorded pairs, respects `max_ripups_per_net`, no-op when no pairs.
- [x] All 5 existing tests in `tests/test_router_cpp_via_clearance.py` still pass.
- [x] No regression on broader negotiated-routing tests (146 tests pass; 3 pre-existing failures on `TestNegotiatedRouterCongestionEstimator` are not caused by this change).

## Cross-reference

Related to #2475 (PHASE_B intra-tier rip-up). The structured-failure-reason infrastructure in this PR (`failure_reason`, `_last_via_blocking_nets` set, `via_blocked_ripup` pattern) is general enough to be reused for other constraint-driven targeted rip-up paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)