### PR TITLE
fix(router): add via-anchor guard to chain-aware DRC nudge

### DIFF
--- a/src/kicad_tools/router/drc_nudge.py
+++ b/src/kicad_tools/router/drc_nudge.py
@@ -158,6 +158,20 @@ def _nudge_segment_with_chain(
         )
         return False
 
+    # Via-anchor guard (Issue #2483).  A chain segment whose endpoint sits
+    # on a via centre is anchored to that layer transition: translating the
+    # segment slides it off the via and breaks the chain at the layer
+    # change, since the same-layer chain walk below cannot drag the via
+    # (and the via's other-layer continuation) along with it.  Decline the
+    # nudge so the original DRC violation surfaces instead of producing a
+    # silent disconnect.
+    if _segment_endpoints_anchored_to_net_vias(seg, seg.net, router):
+        logger.debug(
+            "Skipping nudge for net %s: segment is via-anchored",
+            seg.net,
+        )
+        return False
+
     # Capture pre-nudge endpoints so we can update neighbour segments.
     old_x1, old_y1 = seg.x1, seg.y1
     old_x2, old_y2 = seg.x2, seg.y2
@@ -219,6 +233,12 @@ def _nudge_segment_with_chain(
 # *actual* pad anchors, not nearby segment intersections.
 _PAD_ANCHOR_TOL = 0.02
 
+# Tolerance in mm for considering a segment endpoint anchored to a via
+# centre.  Vias also terminate segments at exact centres within float
+# rounding, so the same tolerance as ``_PAD_ANCHOR_TOL`` is appropriate
+# (Issue #2483).
+_VIA_ANCHOR_TOL = 0.02
+
 
 def _segment_endpoints_anchored_to_net_pads(
     seg: Segment,
@@ -272,6 +292,61 @@ def _segment_endpoints_anchored_to_net_pads(
             and abs(seg.y2 - pad.y) < _PAD_ANCHOR_TOL
         ):
             return True
+    return False
+
+
+def _segment_endpoints_anchored_to_net_vias(
+    seg: Segment,
+    net: int,
+    router: Autorouter,
+) -> bool:
+    """Return True when either endpoint of ``seg`` sits on a via centre of ``net``.
+
+    Companion to :func:`_segment_endpoints_anchored_to_net_pads`.  Vias are
+    layer transitions: the chain walk in :func:`_nudge_segment_with_chain`
+    intentionally restricts itself to same-layer same-net segments, which
+    means a via that links a top-layer segment to a bottom-layer segment
+    is invisible to the snap-update logic.  Translating a segment off a
+    via centre therefore disconnects the chain at the layer transition.
+
+    Issue #2483: the chain-aware nudge introduced by #2479 fixed the
+    same-layer chain disconnection case (board 05 PHASE_B) but did not
+    consider vias.  When a net routes through a via, a nudge can slide
+    the segment off the via centre, leaving the via dangling on the
+    other-layer continuation.
+
+    The conservative fix mirrors the pad-anchor guard: decline the nudge
+    when an endpoint is via-anchored.  Declining surfaces the original
+    DRC violation as a detectable signal rather than a silent disconnect.
+
+    Args:
+        seg: The segment about to be nudged.
+        net: The net the segment belongs to.
+        router: The autorouter, used to look up via positions per route.
+
+    Returns:
+        True if either endpoint of ``seg`` is within ``_VIA_ANCHOR_TOL`` of
+        any via on ``net``; False otherwise (or when route data is
+        unavailable).  Note that vias live on per-route ``Route.vias``
+        lists, not on a top-level ``router.vias`` attribute.
+    """
+    routes = getattr(router, "routes", None) or []
+    for route in routes:
+        if route.net != net:
+            continue
+        for via in route.vias:
+            # Endpoint 1
+            if (
+                abs(seg.x1 - via.x) < _VIA_ANCHOR_TOL
+                and abs(seg.y1 - via.y) < _VIA_ANCHOR_TOL
+            ):
+                return True
+            # Endpoint 2
+            if (
+                abs(seg.x2 - via.x) < _VIA_ANCHOR_TOL
+                and abs(seg.y2 - via.y) < _VIA_ANCHOR_TOL
+            ):
+                return True
     return False
 
 

--- a/tests/test_drc_nudge.py
+++ b/tests/test_drc_nudge.py
@@ -19,6 +19,7 @@ from kicad_tools.router.drc_nudge import (
     _perpendicular_unit,
     _reconnect_segments,
     _segment_endpoints_anchored_to_net_pads,
+    _segment_endpoints_anchored_to_net_vias,
     _segment_length,
     drc_verify_and_nudge,
 )
@@ -964,3 +965,220 @@ class TestNoSilentDisconnectFromNudge:
         assert not math.isclose(seg_b.x2, seg_c.x1), (
             "Legacy nudge leaves seg_c stranded -- chain breaks"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for via-anchor preservation in chain-aware nudge (Issue #2483)
+# ---------------------------------------------------------------------------
+
+
+class TestSegmentEndpointsAnchoredToNetVias:
+    """Via-anchor detection used by chain-aware nudge to preserve layer transitions."""
+
+    def test_segment_with_endpoint_on_via_is_detected(self):
+        """A segment endpoint coincident with a via centre is detected as anchored."""
+        via = Via(
+            x=10.0, y=5.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,
+        )
+        route = Route(net=1, net_name="N", segments=[], vias=[via])
+        router = _StubAutorouter(routes=[route])
+        seg = Segment(x1=10.0, y1=5.0, x2=15.0, y2=5.0, width=0.2, layer=Layer.F_CU, net=1)
+        assert _segment_endpoints_anchored_to_net_vias(seg, 1, router) is True
+
+    def test_segment_with_second_endpoint_on_via_is_detected(self):
+        """The helper checks both endpoints, not just the first."""
+        via = Via(
+            x=15.0, y=5.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,
+        )
+        route = Route(net=1, net_name="N", segments=[], vias=[via])
+        router = _StubAutorouter(routes=[route])
+        seg = Segment(x1=10.0, y1=5.0, x2=15.0, y2=5.0, width=0.2, layer=Layer.F_CU, net=1)
+        assert _segment_endpoints_anchored_to_net_vias(seg, 1, router) is True
+
+    def test_segment_close_but_not_at_via_is_not_detected(self):
+        """Endpoints outside the 0.02mm tolerance are not treated as anchored."""
+        via = Via(
+            x=10.0, y=5.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,
+        )
+        route = Route(net=1, net_name="N", segments=[], vias=[via])
+        router = _StubAutorouter(routes=[route])
+        # 0.05 mm offset -- outside the 0.02 mm via anchor tolerance.
+        seg = Segment(x1=10.05, y1=5.0, x2=15.0, y2=5.0, width=0.2, layer=Layer.F_CU, net=1)
+        assert _segment_endpoints_anchored_to_net_vias(seg, 1, router) is False
+
+    def test_segment_with_no_via_endpoint_returns_false(self):
+        """Segments far from any via on the net are not anchored."""
+        via = Via(
+            x=0.0, y=0.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,
+        )
+        route = Route(net=1, net_name="N", segments=[], vias=[via])
+        router = _StubAutorouter(routes=[route])
+        seg = Segment(x1=10.0, y1=10.0, x2=15.0, y2=10.0, width=0.2, layer=Layer.F_CU, net=1)
+        assert _segment_endpoints_anchored_to_net_vias(seg, 1, router) is False
+
+    def test_via_of_different_net_does_not_match(self):
+        """Vias on a different net should not anchor segments of this net."""
+        via = Via(
+            x=10.0, y=5.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        route = Route(net=2, net_name="Other", segments=[], vias=[via])
+        router = _StubAutorouter(routes=[route])
+        # Segment on net 1 has an endpoint at the via centre, but the via
+        # belongs to net 2 -- not an anchor for this net.
+        seg = Segment(x1=10.0, y1=5.0, x2=15.0, y2=5.0, width=0.2, layer=Layer.F_CU, net=1)
+        assert _segment_endpoints_anchored_to_net_vias(seg, 1, router) is False
+
+    def test_no_routes_returns_false(self):
+        """An empty router (no routes / no vias) returns False without error."""
+        router = _StubAutorouter()
+        seg = Segment(x1=10.0, y1=5.0, x2=15.0, y2=5.0, width=0.2, layer=Layer.F_CU, net=1)
+        assert _segment_endpoints_anchored_to_net_vias(seg, 1, router) is False
+
+    def test_via_in_different_route_same_net_is_detected(self):
+        """A via on a different route but the same net is still an anchor."""
+        # Same net, two routes -- the via lives on the second route while
+        # the segment under inspection is on the first.  We must still
+        # consider the via because it's on the same net.
+        via = Via(
+            x=10.0, y=5.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,
+        )
+        route_with_seg = Route(net=1, net_name="N", segments=[], vias=[])
+        route_with_via = Route(net=1, net_name="N", segments=[], vias=[via])
+        router = _StubAutorouter(routes=[route_with_seg, route_with_via])
+        seg = Segment(x1=10.0, y1=5.0, x2=15.0, y2=5.0, width=0.2, layer=Layer.F_CU, net=1)
+        assert _segment_endpoints_anchored_to_net_vias(seg, 1, router) is True
+
+
+class TestNudgeSegmentWithChainViaAnchor:
+    """Regression tests for Issue #2483: chain-aware nudge must respect via anchors."""
+
+    def test_via_anchored_segment_not_nudged(self):
+        """A segment whose endpoint sits on a via centre must not be translated.
+
+        Regression for #2483: chain-aware nudge must treat via centres as
+        anchors, just like pad centres.  Otherwise the segment slides off
+        the via and the layer transition breaks because the same-layer
+        chain walk cannot drag the via (and its other-layer continuation)
+        along.
+        """
+        # Build a 3-pad net: P1 (top), P2 (top), P3 (bottom).
+        # Route: P1 --seg_a(top)--> via --seg_b(bottom)--> P3
+        #        P1 --seg_c(top)--> P2
+        p1 = Pad(
+            x=0.0, y=0.0, width=1.0, height=1.0,
+            net=1, net_name="N", layer=Layer.F_CU, ref="J1", pin="1",
+        )
+        p2 = Pad(
+            x=0.0, y=10.0, width=1.0, height=1.0,
+            net=1, net_name="N", layer=Layer.F_CU, ref="J1", pin="2",
+        )
+        p3 = Pad(
+            x=10.0, y=10.0, width=1.0, height=1.0,
+            net=1, net_name="N", layer=Layer.B_CU, ref="J1", pin="3",
+        )
+        via = Via(
+            x=10.0, y=0.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,
+        )
+        # seg_a runs top-layer from P1 to the via centre
+        seg_a = Segment(x1=0.0, y1=0.0, x2=10.0, y2=0.0, width=0.2, layer=Layer.F_CU, net=1)
+        # seg_b runs bottom-layer from via centre to P3
+        seg_b = Segment(x1=10.0, y1=0.0, x2=10.0, y2=10.0, width=0.2, layer=Layer.B_CU, net=1)
+        # seg_c provides a pad-anchored stub on the top layer for P2
+        seg_c = Segment(x1=0.0, y1=0.0, x2=0.0, y2=10.0, width=0.2, layer=Layer.F_CU, net=1)
+
+        route = Route(
+            net=1, net_name="N",
+            segments=[seg_a, seg_b, seg_c],
+            vias=[via],
+        )
+        router = _StubAutorouter(
+            routes=[route],
+            pads={
+                ("J1", "1"): p1,
+                ("J1", "2"): p2,
+                ("J1", "3"): p3,
+            },
+            nets={1: [("J1", "1"), ("J1", "2"), ("J1", "3")]},
+        )
+
+        # seg_a has an endpoint at the via centre AND another at a pad centre.
+        # Capture pre-nudge state.
+        pre_x1, pre_y1, pre_x2, pre_y2 = seg_a.x1, seg_a.y1, seg_a.x2, seg_a.y2
+        via_x, via_y = via.x, via.y
+
+        # Attempt to nudge seg_a perpendicular to its run (push it +y by 0.1mm).
+        result = _nudge_segment_with_chain(seg_a, 0.0, 1.0, 0.1, router)
+
+        # The chain-aware nudge must decline this nudge.
+        assert result is False, (
+            "Nudge must be declined: seg_a is via-anchored at (10, 0) "
+            "and pad-anchored at (0, 0); translating it disconnects the chain."
+        )
+        # seg_a unchanged.
+        assert seg_a.x1 == pre_x1 and seg_a.y1 == pre_y1
+        assert seg_a.x2 == pre_x2 and seg_a.y2 == pre_y2
+        # via unchanged.
+        assert via.x == via_x and via.y == via_y
+        # The chain-walk must not have been applied: seg_b's endpoint at the
+        # via centre is still there, so the layer transition is intact.
+        assert seg_b.x1 == 10.0 and seg_b.y1 == 0.0
+
+    def test_via_anchored_segment_not_pad_anchored_still_declines(self):
+        """A segment with only a via anchor (no pad anchor) is still declined.
+
+        This isolates the via-anchor guard from the pre-existing pad-anchor
+        guard to confirm the new logic actually runs.
+        """
+        # No pads on this net at the segment endpoints; only a via.
+        via = Via(
+            x=10.0, y=5.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,
+        )
+        # seg has its x2/y2 endpoint coincident with the via centre, but its
+        # x1/y1 endpoint is in free space (not a pad and not a via).
+        seg = Segment(x1=0.0, y1=5.0, x2=10.0, y2=5.0, width=0.2, layer=Layer.F_CU, net=1)
+        route = Route(net=1, net_name="N", segments=[seg], vias=[via])
+        router = _StubAutorouter(routes=[route])
+
+        pre_x1, pre_y1, pre_x2, pre_y2 = seg.x1, seg.y1, seg.x2, seg.y2
+
+        result = _nudge_segment_with_chain(seg, 0.0, 1.0, 0.1, router)
+
+        assert result is False, "Via-anchor guard alone must decline the nudge"
+        # Segment unchanged byte-for-byte.
+        assert seg.x1 == pre_x1 and seg.y1 == pre_y1
+        assert seg.x2 == pre_x2 and seg.y2 == pre_y2
+        # Via unchanged.
+        assert via.x == 10.0 and via.y == 5.0
+
+    def test_segment_far_from_any_via_is_still_nudged(self):
+        """Vias that don't coincide with the segment do not block the nudge.
+
+        Regression guard: the via-anchor check must use the per-via
+        coordinate test, not just the presence of any via in the route.
+        """
+        # A via exists on this net but is far from the segment we'll nudge.
+        via = Via(
+            x=50.0, y=50.0, drill=0.35, diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,
+        )
+        seg = Segment(x1=0.0, y1=0.0, x2=10.0, y2=0.0, width=0.2, layer=Layer.F_CU, net=1)
+        route = Route(net=1, net_name="N", segments=[seg], vias=[via])
+        router = _StubAutorouter(routes=[route])
+
+        result = _nudge_segment_with_chain(seg, 0.0, 1.0, 0.2, router)
+
+        assert result is True, (
+            "Segments far from any via should still be nudgable -- "
+            "the guard must be position-sensitive, not route-presence-sensitive."
+        )
+        # Segment moved as expected.
+        assert math.isclose(seg.y1, 0.2)
+        assert math.isclose(seg.y2, 0.2)


### PR DESCRIPTION
## Summary

The chain-aware DRC nudge from #2479 (`_nudge_segment_with_chain` in `src/kicad_tools/router/drc_nudge.py`) walks same-net **same-layer** segments to drag adjacent endpoints along when a violating segment is translated. Vias are layer transitions and live outside that walk, so a segment endpoint coincident with a via centre cannot be tracked: translating the segment slides it off the via and disconnects the chain at the layer transition.

This PR mirrors the existing pad-anchor guard with a parallel via-anchor guard. When either endpoint of a candidate segment is within `_VIA_ANCHOR_TOL` (0.02 mm) of any via on the same net, the nudge is declined so the original DRC violation surfaces in the post-save report instead of producing a silent disconnect.

## Changes

- `src/kicad_tools/router/drc_nudge.py`:
  - Added `_VIA_ANCHOR_TOL = 0.02` mm constant alongside `_PAD_ANCHOR_TOL`.
  - Added `_segment_endpoints_anchored_to_net_vias` helper, modelled exactly on `_segment_endpoints_anchored_to_net_pads`. The only structural difference is that vias live on per-route `Route.vias` lists rather than a top-level `router.vias` attribute, so the helper iterates `router.routes` and filters by `route.net`.
  - Added a guard call in `_nudge_segment_with_chain` immediately after the pad-anchor guard.
- `tests/test_drc_nudge.py`:
  - Added `TestSegmentEndpointsAnchoredToNetVias` (7 tests) covering endpoint detection on both endpoints, tolerance bounds, net filtering, missing-data tolerance, and cross-route same-net via detection.
  - Added `TestNudgeSegmentWithChainViaAnchor` (3 tests) covering the full via-anchored decline scenario, the via-only-anchor case (isolating the via guard from the pad guard), and a regression guard ensuring segments far from any via are still nudgable.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Unit test for via-anchor preservation | PASS | `TestNudgeSegmentWithChainViaAnchor::test_via_anchored_segment_not_nudged` builds the 3-pad fixture (P1/P2 top, P3 bottom, single via) and asserts the nudge is declined and connectivity is preserved. |
| Unit test: no-op decline preserves segment byte-for-byte | PASS | `test_via_anchored_segment_not_pad_anchored_still_declines` captures pre-nudge endpoints and asserts they are unchanged after the declined nudge. |
| Boards 02 and 05 don't regress | PASS | Board 05 PHASE_B 10/10 confirmed (`SUCCESS: All signal nets routed, DRC passed!`). Board 02 8/8 confirmed (`All nets verified connected`). |
| Boards 03/04 don't regress | PASS for 03 | Board 03 10/13 matches baseline run on the same commit without the fix (same disconnects: JOY_X, USB_CC1, USB_D-). The 10/13 result is pre-existing and unrelated to this PR. |
| Board 01 returns to 3/3 (closes #2480) | NOT MET | See Note on #2480 below. The fix is correct in its own right but does not move board 01. |

## Note on #2480 (intentionally not closed)

The curator hypothesised that this fix would also close #2480 (board 01 VOUT R2:1 disconnect), but instrumented runs show that `_nudge_segment_with_chain` is **never invoked** during board 01 routing (zero nudge calls observed across the entire pipeline with both `--backend cpp` and `--backend auto`). The chain-aware nudge therefore cannot be the cause of the board 01 regression.

To verify, I:
1. Ran board 01 on the baseline (this commit's parent, `cd9823c8`) with `--backend cpp --strategy negotiated --layers 4 --no-cache --timeout 300`. Result: `VOUT: 2/3 pads connected -- disconnected: R2:1`.
2. Ran board 01 with this fix applied. Result: identical (`VOUT: 2/3 pads connected -- disconnected: R2:1`).
3. Ran with an instrumented build that counts `_nudge_segment_with_chain` calls. Result: **0 calls** for board 01.

`#2480` is left open and will need a different root-cause investigation. Likely candidates per the curator's secondary list: `optimizer/trace.py` segment collapse (94.3% reduction observed), `negotiated.py` rip-up logic from #2477, or `pathfinder.cpp` via blocking from #2472. The bisect script in #2480 should still identify the correct first-bad-commit; this PR's commit will register as `good` for that test.

## Test Plan

- [x] Unit tests: `uv run pytest tests/test_drc_nudge.py` — 66/66 PASS (10 new tests added).
- [x] Board 05: `uv run kicad-tools route boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb -o /tmp/b05.kicad_pcb --strategy negotiated --layers 4 --backend cpp --no-cache --timeout 600` — 10/10 nets, all verified connected. PHASE_B routes through the same fixture #2475/#2479 fixed.
- [x] Board 02: `uv run kicad-tools route boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb -o /tmp/b02.kicad_pcb --strategy negotiated --layers 4 --backend cpp --no-cache --timeout 600` — 8/8 nets, all verified connected.
- [x] Board 03: 10/13 — matches baseline (pre-existing, unrelated).
- [x] Board 01: 2/3 — matches baseline (#2480 has a different root cause; see note above).

Closes #2483