### PR TITLE
fix(router): dedupe RSMT sub-route vias and invalidate cpp stored vias on rip-up

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from ..congestion_estimator import CongestionEstimator
     from ..grid import RoutingGrid
     from ..pathfinder import Router
-    from ..primitives import Pad, Route
+    from ..primitives import Pad, Route, Via
     from ..rules import DesignRules, NetClassRouting
 
 
@@ -354,6 +354,95 @@ def calculate_congestion_tuned_params(
     return adjusted_mult, adjusted_hist
 
 
+# Resolution used when grouping vias by (x, y) for cross-route same-net
+# deduplication.  Vias whose coordinates round to the same key (to the
+# nearest micron) are treated as the same physical placement.
+_VIA_DEDUP_RESOLUTION_MM = 0.001
+
+
+def _dedupe_sibling_route_vias(
+    routes: list[Route],
+    *,
+    resolution_mm: float = _VIA_DEDUP_RESOLUTION_MM,
+) -> int:
+    """Drop duplicate same-net vias across sibling Route objects (Issue #2481).
+
+    A multi-pin net routed via RSMT decomposition emits one ``Route``
+    object per Steiner edge, each carrying its own ``vias`` list.  When
+    two RSMT edges meet at a Steiner tap and both edges require a layer
+    transition there, they each insert a via at the same (x, y).  These
+    duplicates survive into the post-route validator, where each pair of
+    sibling vias against any cross-net via produces a separate
+    via-vs-via violation -- inflating the reported defect count and, for
+    the C++ side, polluting ``stored_vias_`` with redundant entries.
+
+    This function keeps the first via per (rounded x, rounded y) across
+    *all* the supplied sibling routes, expands its layer span to cover
+    every duplicate, and removes the duplicates from their owning route.
+    Segments are not touched: they already terminate at the Steiner tap
+    coordinate, which still has a via after this dedup.
+
+    Args:
+        routes: List of sibling ``Route`` objects produced for a single
+            net.  Mutated in place.
+        resolution_mm: Coordinate rounding for the dedup key.  Defaults
+            to 1 micron, well below the routing grid resolution.
+
+    Returns:
+        The number of duplicate vias removed across all routes.
+    """
+    if len(routes) < 2:
+        return 0
+
+    from ..layers import Layer
+
+    inv_res = 1.0 / resolution_mm
+    seen: dict[tuple[int, int], Via] = {}
+    removed = 0
+
+    for route in routes:
+        if not route.vias:
+            continue
+        keep_indices: list[int] = []
+        for idx, via in enumerate(route.vias):
+            key = (
+                int(round(via.x * inv_res)),
+                int(round(via.y * inv_res)),
+            )
+            existing = seen.get(key)
+            if existing is None:
+                seen[key] = via
+                keep_indices.append(idx)
+            else:
+                # Expand the surviving via's layer range to cover this
+                # duplicate's layer range, in case the two edges had
+                # different layer pairs at the same tap (mid-layer
+                # buried via on one edge, full-stack on the other).
+                min_layer = min(
+                    existing.layers[0].value,
+                    existing.layers[1].value,
+                    via.layers[0].value,
+                    via.layers[1].value,
+                )
+                max_layer = max(
+                    existing.layers[0].value,
+                    existing.layers[1].value,
+                    via.layers[0].value,
+                    via.layers[1].value,
+                )
+                if (
+                    min_layer != existing.layers[0].value
+                    or max_layer != existing.layers[1].value
+                ):
+                    existing.layers = (Layer(min_layer), Layer(max_layer))
+                removed += 1
+
+        if len(keep_indices) != len(route.vias):
+            route.vias = [route.vias[k] for k in keep_indices]
+
+    return removed
+
+
 class NegotiatedRouter:
     """PathFinder-style negotiated congestion router.
 
@@ -504,6 +593,15 @@ class NegotiatedRouter:
                     self._record_via_blocked_failure(source_pad.net)
                     if failure_callback is not None:
                         failure_callback(source_pad, target_pad)
+
+            # Issue #2481: Dedupe vias at the same (x, y) location across
+            # the multi-edge RSMT sub-routes for this net.  Two RSMT edges
+            # that meet at a Steiner tap on the same layer pair would each
+            # insert a via at that tap, producing duplicate same-net vias
+            # that the post-route DRC counts as triple-pair violations.
+            # We keep the first occurrence per (rounded) (x, y) and drop
+            # the rest from sibling sub-routes.
+            _dedupe_sibling_route_vias(routes)
         else:
             # 2-pin net
             route = self.router.route(

--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -116,6 +116,18 @@ public:
     // Clear all stored validation data (pads, segments, vias).
     void clear_validation_data();
 
+    // Clear only stored routes (segments + vias), keeping pads.
+    // Issue #2481: Used by CppGrid.invalidate_stored_routes() after a
+    // rip-up on the Python side.  ``Pathfinder::is_via_blocked_diag``
+    // (Issue #2466) consults ``stored_vias_`` to refuse via placements
+    // that would violate cross-net clearance with already-placed routes.
+    // Without this clearing path, those entries remain even when the
+    // owning route has been ripped up, leading to false rejections (and,
+    // when the surviving routes are later re-synced, double-counted
+    // vias).  Pads are intentionally left untouched: they are intrinsic
+    // board geometry and never change between sync points.
+    void clear_stored_routes();
+
     // Validate a candidate route against all stored pads, segments, and vias.
     // Ports the 4 Python validation methods from grid.py lines 905-1317:
     //   - validate_segment_clearance (seg vs pads + stored segs + stored vias)

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -177,6 +177,10 @@ NB_MODULE(router_cpp, m) {
         .def("add_stored_via", &Grid3D::add_stored_via,
              "x"_a, "y"_a, "drill"_a, "diameter"_a, "net"_a)
         .def("clear_validation_data", &Grid3D::clear_validation_data)
+        .def("clear_stored_routes", &Grid3D::clear_stored_routes,
+             "Issue #2481: Drop only stored route data (segments + vias), "
+             "keeping pads.  Used after rip-up to invalidate the cached "
+             "snapshot consulted by Pathfinder::is_via_blocked_diag.")
         .def("validate_route", &Grid3D::validate_route,
              "segments"_a, "vias"_a, "exclude_net"_a,
              "exclude_ref_hashes"_a, "trace_clearance"_a,

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -304,6 +304,14 @@ void Grid3D::clear_validation_data() {
     stored_vias_.clear();
 }
 
+void Grid3D::clear_stored_routes() {
+    // Issue #2481: Drop only stored route data (segments + vias).
+    // Pads represent board geometry registered once at grid build time
+    // and must survive rip-up cycles.
+    stored_segments_.clear();
+    stored_vias_.clear();
+}
+
 ValidationResult Grid3D::validate_route(
     const std::vector<Segment>& segments,
     const std::vector<Via>& vias,

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -242,6 +242,15 @@ class CppGrid:
         # Store reference to original Python grid for post-route validation
         cpp_grid._py_grid = grid
 
+        # Issue #2481: Establish the back-reference from the Python grid
+        # to this CppGrid so ``RoutingGrid.unmark_route`` can invalidate
+        # the C++ stored-via/segment snapshot whenever a route is ripped
+        # up.  Without this, ``Pathfinder::is_via_blocked_diag`` would
+        # consult stale ``stored_vias_`` entries and either reject
+        # legitimate via candidates or silently allow placements that
+        # collide with newly-placed sibling vias the cpp side never saw.
+        grid._cpp_grid = cpp_grid
+
         # Copy layer index mappings for layer conversion
         cpp_grid._index_to_layer = dict(grid._index_to_layer)
         cpp_grid._layer_to_index = dict(grid._layer_to_index)
@@ -342,6 +351,30 @@ class CppGrid:
             "blocked_cells": self._impl.count_blocked(),
             "memory_mb": self._impl.memory_mb(),
         }
+
+    def invalidate_stored_routes(self) -> None:
+        """Drop the cached stored-routes snapshot used by validation.
+
+        Issue #2481: ``CppPathfinder._sync_stored_routes`` is append-only
+        and tracks ``self._synced_route_count`` to skip already-copied
+        routes.  When the Python side rips up a route via
+        :meth:`RoutingGrid.unmark_route`, the C++ ``stored_vias_`` /
+        ``stored_segments_`` vectors retain the ripped-up route's
+        entries, and the next call to ``_sync_stored_routes`` would
+        early-return because ``len(py_grid.routes)`` may have decreased.
+
+        This method clears the C++ side's stored routes and resets the
+        sync watermark to 0 so the *next* call to ``_sync_stored_routes``
+        rebuilds the full snapshot from the surviving
+        ``py_grid.routes``.  It is intentionally cheap: clearing two
+        vectors and resetting a counter; the actual rebuild only happens
+        the next time the cpp pathfinder needs to validate a candidate.
+
+        This is called from ``RoutingGrid.unmark_route`` via the
+        ``_cpp_grid`` back-reference established by ``from_routing_grid``.
+        """
+        self._impl.clear_stored_routes()
+        self._synced_route_count = 0
 
 
 class CppPathfinder:

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -385,6 +385,15 @@ class RoutingGrid:
         # Track placed routes for net assignment
         self.routes: list[Route] = []
 
+        # Issue #2481: Optional back-reference to a paired C++ grid.  When
+        # set (by ``CppGrid.from_routing_grid``), rip-up paths invalidate
+        # the C++ side's ``stored_vias_``/``stored_segments_`` snapshots so
+        # the next geometric pre-search check (Issue #2466) does not
+        # consult stale data from a route that was just ripped up.  The
+        # attribute is loosely typed (``Any``) so this module does not
+        # need to import the optional cpp backend.
+        self._cpp_grid: object | None = None
+
         # Alias for backward compatibility
         self.layers = self.num_layers
 
@@ -1795,11 +1804,19 @@ class RoutingGrid:
         Issue #1674: Computes clearance per-segment from ``seg.width``
         to match the per-segment marking done by ``mark_route()``.
 
+        Issue #2481: When a paired C++ grid exists (``_cpp_grid``), this
+        method also invalidates the C++ stored-via / stored-segment
+        snapshot.  Without the invalidation,
+        ``Pathfinder::is_via_blocked_diag`` would continue to consult
+        already-ripped-up via positions and reject legitimate placements,
+        and the post-route validator would compare against stale data.
+
         Args:
             route: The route to unmark.
             max_trace_width: Must match the value used in ``mark_route()``
                 so via cells are cleared symmetrically (Issue #1692).
         """
+        removed = False
         with self._acquire_lock():
             for seg in route.segments:
                 total_clearance = seg.width / 2 + self.rules.trace_clearance
@@ -1814,6 +1831,19 @@ class RoutingGrid:
                 # Remove from R-tree index before removing from list (Issue #1249)
                 self._rtree_remove_route(route)
                 self.routes.remove(route)
+                removed = True
+
+        # Issue #2481: After releasing the grid lock, propagate the rip-up
+        # to the paired C++ grid (if any) so its ``stored_vias_`` /
+        # ``stored_segments_`` no longer reference this route.  We only
+        # invalidate when the route was actually in ``self.routes`` --
+        # otherwise the snapshot is unaffected by this call.
+        if removed:
+            cpp_grid = self._cpp_grid
+            if cpp_grid is not None:
+                invalidate = getattr(cpp_grid, "invalidate_stored_routes", None)
+                if invalidate is not None:
+                    invalidate()
 
     def _unmark_segment(self, seg: Segment, clearance_cells: int = 1) -> None:
         """Unmark cells along a segment (clear blocked status and net)."""

--- a/tests/test_router_cpp_via_blocked_failure.py
+++ b/tests/test_router_cpp_via_blocked_failure.py
@@ -474,3 +474,277 @@ class TestNegotiatedRouterViaBlockedRetry:
         )
         assert resolved == 0
         assert attempted == 0
+
+
+# =====================================================================
+# Issue #2481: Cross-net stored-via removal on rip-up
+# =====================================================================
+
+
+@requires_cpp
+class TestUnmarkRouteInvalidatesStoredVias:
+    """``RoutingGrid.unmark_route`` must invalidate the cpp ``stored_vias_``
+    so the next via search at the unmarked location is no longer blocked
+    (Issue #2481)."""
+
+    def test_unmark_route_clears_cpp_stored_via(self):
+        """After unmark_route, the cpp side's stored_via_count drops to zero
+        (a single-route grid).  The Python ``unmark_route`` must call into
+        the cpp grid to clear stored validation data; without this hook,
+        stored_via_count stays at the pre-rip-up level and
+        ``Pathfinder::is_via_blocked_diag`` keeps rejecting candidates at
+        the freed location.
+        """
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Route, Via
+
+        grid, rules = _make_grid_and_rules()
+        cpp_grid = CppGrid.from_routing_grid(grid)
+
+        # Build a Python-side route with a single via at (1.0, 1.0)
+        # on net 7, and register it on the Python grid.
+        route = Route(net=7, net_name="N7")
+        route.vias.append(
+            Via(
+                x=1.0, y=1.0, drill=0.3, diameter=0.6,
+                layers=(Layer.F_CU, Layer.B_CU), net=7, net_name="N7",
+            )
+        )
+        grid.routes.append(route)
+
+        # Simulate the sync that happens after a successful route() call.
+        cpp_grid._impl.add_stored_via(1.0, 1.0, 0.3, 0.6, 7)
+        cpp_grid._synced_route_count = len(grid.routes)
+        assert cpp_grid._impl.stored_via_count == 1
+
+        # Now rip up.  Issue #2481: the C++ stored_vias_ must be cleared
+        # AND the synced-count reset so the next sync repopulates from
+        # the (now empty) grid.routes list.
+        grid.unmark_route(route)
+
+        assert cpp_grid._impl.stored_via_count == 0, (
+            "unmark_route must invalidate cpp stored_vias_; otherwise the "
+            "next is_via_blocked_diag call rejects against a stale entry."
+        )
+        assert cpp_grid._synced_route_count == 0, (
+            "_synced_route_count must reset so the next _sync_stored_routes "
+            "call rebuilds the snapshot from py_grid.routes (now empty)."
+        )
+
+    def test_unmark_route_then_via_search_unblocked(self):
+        """End-to-end: a candidate via slot rejected by is_via_blocked_diag
+        before rip-up is *not* rejected after rip-up at the same coordinate.
+        """
+        # Build a 2mm x 2mm grid and register a single stored via on net 2
+        # at (0.8, 0.8) -- close enough to (0.8, 0.8) that any candidate
+        # at that exact point on a different net is rejected.
+        rules = DesignRules(
+            trace_width=0.25,
+            trace_clearance=0.2,
+            via_diameter=0.6,
+            via_clearance=0.2,
+            grid_resolution=0.1,
+        )
+        grid = RoutingGrid(
+            width=2.0, height=2.0, rules=rules,
+            layer_stack=LayerStack.four_layer_all_signal(),
+        )
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+
+        # Build a route that holds the stored via on the Python side, and
+        # mirror it on the cpp side so the dedup-on-ripup path runs.
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Route, Via
+
+        route = Route(net=2, net_name="N2")
+        route.vias.append(
+            Via(
+                x=0.8, y=0.8, drill=0.3, diameter=0.6,
+                layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="N2",
+            )
+        )
+        grid.routes.append(route)
+        cpp_grid._impl.add_stored_via(0.8, 0.8, 0.3, 0.6, 2)
+        cpp_grid._synced_route_count = 1
+
+        # Convert (0.8, 0.8) world -> grid coords for is_via_blocked.
+        gx, gy = cpp_grid._impl.world_to_grid(0.8, 0.8)
+
+        # Sanity: the candidate is rejected by is_via_blocked because of
+        # the geometric stored-via clearance check.  This relies on the
+        # candidate net (3) being different from the stored via's net (2).
+        assert pathfinder._impl.is_via_blocked(
+            gx, gy, 3, False, 0,
+        ), "Setup expectation: stored via on net 2 blocks net 3 candidate."
+
+        # Rip up the Python-side route -- this must clear cpp stored_vias_.
+        grid.unmark_route(route)
+
+        # After rip-up: the cpp stored_via_count is zero.
+        assert cpp_grid._impl.stored_via_count == 0
+
+        # The same is_via_blocked query no longer rejects geometrically.
+        # (Grid cells around (0.8, 0.8) were never marked, so this checks
+        # the stored-via path specifically.)
+        assert not pathfinder._impl.is_via_blocked(
+            gx, gy, 3, False, 0,
+        ), "After unmark_route, is_via_blocked must not reject against the freed via."
+
+    def test_invalidate_stored_routes_method_exists_and_works(self):
+        """``CppGrid.invalidate_stored_routes`` is the public hook the
+        Python grid uses to drop the cpp snapshot.  Test it in isolation.
+        """
+        grid, rules = _make_grid_and_rules()
+        cpp_grid = CppGrid.from_routing_grid(grid)
+
+        cpp_grid._impl.add_stored_via(1.0, 1.0, 0.3, 0.6, 5)
+        cpp_grid._impl.add_stored_segment(0.0, 0.0, 1.0, 0.0, 0.25, 0, 5)
+        cpp_grid._synced_route_count = 1
+        # Pads from from_routing_grid are present, but the test grid was
+        # built with no pads, so pad_count may be 0 -- we just assert it
+        # doesn't change after invalidate_stored_routes().
+        pad_count_before = cpp_grid._impl.pad_count
+        assert cpp_grid._impl.stored_via_count == 1
+        assert cpp_grid._impl.stored_segment_count == 1
+
+        cpp_grid.invalidate_stored_routes()
+
+        assert cpp_grid._impl.stored_via_count == 0
+        assert cpp_grid._impl.stored_segment_count == 0
+        assert cpp_grid._impl.pad_count == pad_count_before, (
+            "invalidate_stored_routes must NOT clear pads -- they are "
+            "intrinsic board geometry and survive rip-up."
+        )
+        assert cpp_grid._synced_route_count == 0
+
+
+# =====================================================================
+# Issue #2481: RSMT sub-route via deduplication
+# =====================================================================
+
+
+class TestRsmtSubRouteViaDedup:
+    """Multi-edge RSMT routes that meet at a Steiner tap must produce
+    exactly one via at that tap, not one per incident edge (Issue #2481)."""
+
+    def test_dedupe_helper_collapses_duplicate_vias(self):
+        """The standalone ``_dedupe_sibling_route_vias`` helper consolidates
+        same-coordinate same-net vias across sibling routes, expanding the
+        survivor's layer span when necessary.
+        """
+        from kicad_tools.router.algorithms.negotiated import (
+            _dedupe_sibling_route_vias,
+        )
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Route, Via
+
+        # Three sibling routes that all carry a via at the same Steiner
+        # tap (1.5, 2.5).
+        r0 = Route(net=1, net_name="N1")
+        r0.vias.append(
+            Via(
+                x=1.5, y=2.5, drill=0.3, diameter=0.6,
+                layers=(Layer.F_CU, Layer.IN1_CU), net=1, net_name="N1",
+            )
+        )
+
+        r1 = Route(net=1, net_name="N1")
+        r1.vias.append(
+            Via(
+                x=1.5, y=2.5, drill=0.3, diameter=0.6,
+                layers=(Layer.F_CU, Layer.IN1_CU), net=1, net_name="N1",
+            )
+        )
+
+        r2 = Route(net=1, net_name="N1")
+        r2.vias.append(
+            Via(
+                # Different layer span -- forces a layer expansion.
+                x=1.5, y=2.5, drill=0.3, diameter=0.6,
+                layers=(Layer.IN1_CU, Layer.B_CU), net=1, net_name="N1",
+            )
+        )
+        # Plus a second via on a different coordinate -- must NOT be deduped.
+        r2.vias.append(
+            Via(
+                x=4.0, y=4.0, drill=0.3, diameter=0.6,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="N1",
+            )
+        )
+
+        removed = _dedupe_sibling_route_vias([r0, r1, r2])
+
+        assert removed == 2, (
+            "Two duplicates at (1.5, 2.5) must be collapsed; one occurrence kept."
+        )
+        # r0 keeps its via; r1 loses it; r2 loses the (1.5, 2.5) but keeps (4.0, 4.0).
+        assert len(r0.vias) == 1
+        assert len(r1.vias) == 0
+        assert len(r2.vias) == 1
+        assert r2.vias[0].x == pytest.approx(4.0)
+
+        # The surviving via on r0 must have its layer span expanded to
+        # cover the (IN1_CU, B_CU) range that was lost when r2's via at
+        # (1.5, 2.5) was dropped.
+        survivor = r0.vias[0]
+        assert survivor.layers[0].value == Layer.F_CU.value
+        assert survivor.layers[1].value == Layer.B_CU.value
+
+    def test_dedupe_helper_no_duplicates_no_change(self):
+        """When there are no duplicates the helper is a no-op and returns 0."""
+        from kicad_tools.router.algorithms.negotiated import (
+            _dedupe_sibling_route_vias,
+        )
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Route, Via
+
+        r0 = Route(net=1, net_name="N1")
+        r0.vias.append(
+            Via(
+                x=1.5, y=2.5, drill=0.3, diameter=0.6,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="N1",
+            )
+        )
+        r1 = Route(net=1, net_name="N1")
+        r1.vias.append(
+            Via(
+                x=4.5, y=2.5, drill=0.3, diameter=0.6,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="N1",
+            )
+        )
+
+        removed = _dedupe_sibling_route_vias([r0, r1])
+        assert removed == 0
+        assert len(r0.vias) == 1
+        assert len(r1.vias) == 1
+
+    def test_dedupe_helper_single_route_no_change(self):
+        """A single-route input is returned unchanged (no sibling to dedupe against)."""
+        from kicad_tools.router.algorithms.negotiated import (
+            _dedupe_sibling_route_vias,
+        )
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Route, Via
+
+        r0 = Route(net=1, net_name="N1")
+        r0.vias.append(
+            Via(
+                x=1.5, y=2.5, drill=0.3, diameter=0.6,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="N1",
+            )
+        )
+        # Two vias on the same route at the same coord -- intra-route
+        # merge is the responsibility of _merge_same_net_vias, not this
+        # helper, so the helper must leave them alone.
+        r0.vias.append(
+            Via(
+                x=1.5, y=2.5, drill=0.3, diameter=0.6,
+                layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="N1",
+            )
+        )
+
+        removed = _dedupe_sibling_route_vias([r0])
+        assert removed == 0
+        assert len(r0.vias) == 2


### PR DESCRIPTION
## Summary

Issue #2481: Board 02 (charlieplex_3x3) was producing via-vs-via DRC violations even after #2466/#2472 added geometric via-blocking. The curator identified three distinct bugs; this PR addresses bugs 1 and 2 (the silent-corruption ones).

**Bug 1 — RSMT sub-route via duplication.** `route_net_negotiated` in `algorithms/negotiated.py` decomposes a multi-pin net into RSMT edges and emits one `Route` per edge, each with its own `vias` list. When two edges meet at a Steiner tap and both require a layer transition, `validate_layer_transitions` runs independently per sub-route and inserts a via at the same (x, y) coord. The post-route validator then triple-counts those duplicates against any cross-net via, and the cpp `stored_vias_` snapshot ends up with redundant entries.

**Bug 2 — C++ `stored_vias_` was append-only.** `CppPathfinder._sync_stored_routes` tracks `_synced_route_count` and only forwards new routes. `RoutingGrid.unmark_route` ripped Python cells but never cleared the cpp side, so `Pathfinder::is_via_blocked_diag` kept consulting via positions from already-ripped-up nets. After enough rip-up cycles, cpp refusal logic rejected candidates against non-existent vias, and the eventual re-route could legitimately collide with a real via the cpp side never saw.

**Bug 3 — `_try_nudge_via_via` dispatcher** (curator's analysis) is intentionally deferred. The two fixes here already drive board 02 to 0 cross-net via-vs-via violations. Bug 3 has overlap with the in-flight #2483 PR in `drc_nudge.py`.

## Changes

- `Grid3D::clear_stored_routes()` (cpp): clears only stored routes (segments + vias), keeps pads. Exposed via bindings.
- `CppGrid.invalidate_stored_routes()` (Python wrapper): clears cpp routes vector and resets sync watermark to 0 so next `_sync_stored_routes` rebuilds from `py_grid.routes`.
- `CppGrid.from_routing_grid()` now stores a back-reference on the Python grid (`RoutingGrid._cpp_grid`).
- `RoutingGrid.unmark_route` invokes the invalidate hook after removing the route (only when the route was actually present).
- `_dedupe_sibling_route_vias` helper in `algorithms/negotiated.py` consolidates same-coord same-net vias across per-edge sub-routes; expands the survivor's layer span when needed. Called at the end of `route_net_negotiated` for multi-pin nets.

## Verification

- **Board 02**: 8/8 nets routed; **0 cross-net via-vs-via violations** (verified by parsing the routed PCB pairwise). Previously had ~3-6 such violations.
- **Boards 01, 02, 05**: 0 same-net duplicate-position vias, 0 cross-net via-vs-via violations.
- **Board 05**: routes 9/10 nets vs 8/10 on main — slight improvement.
- **Existing tests**: 10/10 in `test_router_cpp_via_blocked_failure.py` still pass.
- **New tests**: 6 added covering the rip-up invalidation hook and the dedup helper.
- **Full router test suite**: 573 tests pass.

## Test plan

- [x] `tests/test_router_cpp_via_blocked_failure.py` — all 16 tests (10 existing + 6 new) pass
- [x] Comprehensive router test suite (573 tests) passes
- [x] Board 02 regression: 0 via-vs-via violations
- [x] Boards 01, 05 don't regress (0 via-vs-via, no duplicate vias)
- [ ] Board 03 / 04 detailed verification — board 03 routing was timeout-prone before this change too; not a regression

Closes #2481

🤖 Generated with [Claude Code](https://claude.com/claude-code)