### PR TITLE
fix(build-cpp): use uv venv interpreter and pass Python_EXECUTABLE

### DIFF
--- a/scripts/build-cpp.sh
+++ b/scripts/build-cpp.sh
@@ -21,6 +21,17 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUILD_DIR="$PROJECT_ROOT/build"
 ROUTER_DIR="$PROJECT_ROOT/src/kicad_tools/router"
 
+# Prefer the project's uv-managed virtualenv interpreter when present so that
+# nanobind (installed via `uv sync --extra dev`) is visible to both the
+# preflight import check and the cmake configure step. Fall back to the first
+# `python3` on PATH so non-uv workflows continue to work.
+VENV_PY="$PROJECT_ROOT/.venv/bin/python3"
+if [ -x "$VENV_PY" ]; then
+    PY="$VENV_PY"
+else
+    PY="$(command -v python3)"
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -38,7 +49,7 @@ case "${1:-build}" in
 
     check)
         echo "Checking C++ router backend availability..."
-        python3 -c "
+        "$PY" -c "
 from kicad_tools.router.cpp_backend import is_cpp_available, get_backend_info
 info = get_backend_info()
 print(f'Backend: {info[\"backend\"]}')
@@ -52,7 +63,7 @@ if info['available']:
         echo -e "${YELLOW}Building C++ router extension...${NC}"
 
         # Check for nanobind
-        if ! python3 -c "import nanobind" 2>/dev/null; then
+        if ! "$PY" -c "import nanobind" 2>/dev/null; then
             echo -e "${RED}Error: nanobind not installed${NC}"
             echo "Install with: pip install nanobind"
             exit 1
@@ -69,10 +80,16 @@ if info['available']:
         mkdir -p "$BUILD_DIR"
 
         # Configure with CMake
+        # NOTE: pass `-DPython_EXECUTABLE` (the variable cmake's FindPython
+        # module actually consumes), not `-DPYTHON_EXECUTABLE`. The per-module
+        # CMakeLists only forwards `PYTHON_EXECUTABLE` -> `Python_EXECUTABLE`
+        # under `if(SKBUILD)`, which is unset on this manual path, so the
+        # uppercase form is silently dropped and find_package(Python ...)
+        # falls back to whatever python3 is first on PATH.
         echo "Configuring..."
         cmake -B "$BUILD_DIR" -S "$PROJECT_ROOT" \
             -DCMAKE_BUILD_TYPE=Release \
-            -DPYTHON_EXECUTABLE="$(which python3)"
+            -DPython_EXECUTABLE="$PY"
 
         # Build
         echo "Building..."


### PR DESCRIPTION
## Summary
`scripts/build-cpp.sh` invoked bare `python3` for the nanobind preflight, the `check` command, and `-DPYTHON_EXECUTABLE=...` passed to cmake. When the project is installed via `uv sync --extra dev`, nanobind lives in `.venv/lib/...` and is invisible to system `python3`, so the script aborted with "nanobind not installed" even after a clean install. Compounding this, the per-module `CMakeLists.txt` only honors caller-supplied `PYTHON_EXECUTABLE` under `if(SKBUILD)` — on the manual path it was silently dropped and `find_package(Python ...)` fell back to whatever `python3` was first on PATH.

This PR adopts the curator's recommended **option (a)** fix in `scripts/build-cpp.sh` only: detect `.venv/bin/python3` once, use it everywhere, and pass cmake the lowercase `Python_EXECUTABLE` variable (the one its FindPython module actually consumes). No CMakeLists are changed, so the existing `pip install .[native]` / scikit-build path is unaffected.

## Changes
- `scripts/build-cpp.sh`: pick `$PROJECT_ROOT/.venv/bin/python3` if executable, otherwise fall back to `command -v python3`.
- Replace bare `python3` invocations in the `check` action and the nanobind preflight with the resolved `"$PY"`.
- Switch the cmake configure flag from `-DPYTHON_EXECUTABLE="$(which python3)"` to `-DPython_EXECUTABLE="$PY"` so the chosen interpreter actually survives `find_package(Python ...)` on the manual (non-SKBUILD) path. Inline comment documents why the lowercase form is required.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `./scripts/build-cpp.sh` succeeds in a fresh `uv sync --extra dev` checkout with no PATH munging | Yes | Ran `clean` then `build` against the project venv; full build, install, and self-verify (`Available: True`) completed end-to-end |
| Falls back to system `python3` when `.venv/bin/python3` does not exist | Yes | Worktree without a `.venv` symlink resolves `PY` from `command -v python3`; `bash -n` clean and `check` runs through to the import (the only failure mode is the system python missing the `kicad_tools` package, which is the expected non-uv user environment) |
| `./scripts/build-cpp.sh check` uses the same interpreter as the build step | Yes | Both branches use the single `$PY` resolved at the top of the script |
| cmake's resolved `Python_EXECUTABLE` matches `$PROJECT_ROOT/.venv/bin/python3` when invoked from a uv venv | Yes | Configure log: `-- Python_EXECUTABLE: /Users/rwalters/GitHub/kicad-tools/.loom/worktrees/issue-2500/.venv/bin/python3` (matches the venv) |
| `./scripts/build-cpp.sh clean` continues to work | Yes | Ran `clean` twice during validation; removes `build/` and `router_cpp*.so` |
| Existing `pip install .[native]` / scikit-build path unchanged | Yes | No CMakeLists modified; `if(SKBUILD)` branch in the per-module CMakeLists is untouched |

## Test Plan
- `bash -n scripts/build-cpp.sh` — syntax check
- `shellcheck scripts/build-cpp.sh` — lint clean
- `./scripts/build-cpp.sh clean` — removes prior artifacts
- `./scripts/build-cpp.sh build` — configure log shows `Python_EXECUTABLE: .../.venv/bin/python3`, both `placement_cpp` and `router_cpp` link, module is copied into `src/kicad_tools/router/`
- `./scripts/build-cpp.sh check` — reports `Backend: cpp`, `Available: True`, `Version: 1.0.0`

Closes #2500