### PR TITLE
fix(build): pass manufacturer edge_clearance to auto-pour zone step

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -921,7 +921,24 @@ def _run_step_zones(ctx: BuildContext, console: Console) -> BuildResult:
             net_list = ", ".join(f"{name} ({cls.value})" for name, cls in new_pour_nets)
             console.print(f"  Creating zones for: {net_list}")
 
-        count = auto_create_zones_for_pour_nets(ctx.pcb_file, new_pour_nets)
+        # Look up edge_clearance from the manufacturer profile so that zone
+        # copper does not extend to the board edge.  This mirrors the
+        # auto-fill logic in route_cmd.py and prevents `edge_clearance_zone`
+        # DRC violations when `kct build` is used (which calls this step
+        # directly instead of going through `auto_pour_if_missing`).
+        from kicad_tools.router.mfr_limits import get_mfr_limits
+
+        edge_clearance: float | None = None
+        try:
+            _mfr_limits = get_mfr_limits(ctx.mfr)
+            if _mfr_limits.min_edge_clearance > 0:
+                edge_clearance = _mfr_limits.min_edge_clearance
+        except ValueError:
+            pass  # Unknown manufacturer -- edge_clearance stays None
+
+        count = auto_create_zones_for_pour_nets(
+            ctx.pcb_file, new_pour_nets, edge_clearance=edge_clearance
+        )
 
         return BuildResult(
             step="zones",

--- a/tests/test_build_zones_step.py
+++ b/tests/test_build_zones_step.py
@@ -327,3 +327,108 @@ class TestRunStepZones:
 
         pcb2 = PCB.load(str(pcb_with_power))
         assert len(pcb2.zones) == zone_count_1
+
+
+# ---------------------------------------------------------------------------
+# Edge clearance regression (issue #2496)
+# ---------------------------------------------------------------------------
+
+
+class TestRunStepZonesEdgeClearance:
+    """Verify _run_step_zones threads ``edge_clearance`` from manufacturer.
+
+    Regression for issue #2496: ``kct build`` was producing zones whose
+    polygon vertices sat exactly on the board outline (0.000 mm clearance),
+    causing ``edge_clearance_zone`` DRC violations on JLCPCB-targeted boards.
+    The fix looks up ``MfrLimits.min_edge_clearance`` from ``ctx.mfr`` and
+    forwards it to :func:`auto_create_zones_for_pour_nets`.
+    """
+
+    @staticmethod
+    def _bbox(points: list[tuple[float, float]]) -> tuple[float, float, float, float]:
+        xs = [p[0] for p in points]
+        ys = [p[1] for p in points]
+        return min(xs), min(ys), max(xs), max(ys)
+
+    @staticmethod
+    def _assert_inset(
+        polygon: list[tuple[float, float]],
+        outline_bbox: tuple[float, float, float, float],
+        clearance: float,
+        epsilon: float = 1e-3,
+    ) -> None:
+        """Every vertex must be at least ``clearance - epsilon`` from outline."""
+        x_min, y_min, x_max, y_max = outline_bbox
+        for x, y in polygon:
+            assert x - x_min >= clearance - epsilon, (
+                f"vertex x={x} too close to left edge x_min={x_min} "
+                f"(needs >= {clearance - epsilon}mm)"
+            )
+            assert x_max - x >= clearance - epsilon, (
+                f"vertex x={x} too close to right edge x_max={x_max} "
+                f"(needs >= {clearance - epsilon}mm)"
+            )
+            assert y - y_min >= clearance - epsilon, (
+                f"vertex y={y} too close to top edge y_min={y_min} "
+                f"(needs >= {clearance - epsilon}mm)"
+            )
+            assert y_max - y >= clearance - epsilon, (
+                f"vertex y={y} too close to bottom edge y_max={y_max} "
+                f"(needs >= {clearance - epsilon}mm)"
+            )
+
+    def test_jlcpcb_inset_to_min_edge_clearance(self, pcb_with_power: Path):
+        """With mfr=jlcpcb, zone polygons must be inset >= 0.3 mm from outline."""
+        ctx = _make_ctx(pcb_file=pcb_with_power, mfr="jlcpcb")
+        result = _run_step_zones(ctx, Console())
+        assert result.success is True
+
+        pcb = PCB.load(str(pcb_with_power))
+        assert len(pcb.zones) >= 1, "expected at least one zone to be created"
+
+        # Outline in MINIMAL_PCB is the rect (0,0)-(50,50).
+        outline_bbox = (0.0, 0.0, 50.0, 50.0)
+
+        for zone in pcb.zones:
+            assert zone.polygon, f"zone {zone.net_name} has no boundary polygon"
+            self._assert_inset(zone.polygon, outline_bbox, clearance=0.3)
+
+    def test_oshpark_uses_larger_clearance(self, pcb_with_power: Path):
+        """With mfr=oshpark (0.381 mm), zone polygons inset by oshpark value.
+
+        Confirms the value is plumbed from the manufacturer profile, not
+        hard-coded to JLCPCB's 0.3 mm.
+        """
+        ctx = _make_ctx(pcb_file=pcb_with_power, mfr="oshpark")
+        result = _run_step_zones(ctx, Console())
+        assert result.success is True
+
+        pcb = PCB.load(str(pcb_with_power))
+        assert len(pcb.zones) >= 1
+
+        outline_bbox = (0.0, 0.0, 50.0, 50.0)
+        for zone in pcb.zones:
+            assert zone.polygon, f"zone {zone.net_name} has no boundary polygon"
+            self._assert_inset(zone.polygon, outline_bbox, clearance=0.381)
+
+    def test_unknown_manufacturer_falls_back_to_no_inset(self, pcb_with_power: Path) -> None:
+        """Unknown manufacturer should not crash; zones still get created.
+
+        ``get_mfr_limits`` raises ``ValueError`` for unknown names; the
+        build step swallows that and proceeds with ``edge_clearance=None``,
+        matching the existing behaviour before this fix.
+        """
+        ctx = _make_ctx(pcb_file=pcb_with_power, mfr="not-a-real-manufacturer")
+        result = _run_step_zones(ctx, Console())
+        assert result.success is True
+
+        pcb = PCB.load(str(pcb_with_power))
+        assert len(pcb.zones) >= 1
+        # Vertices should sit on the outline (no inset applied)
+        for zone in pcb.zones:
+            xs = [p[0] for p in zone.polygon]
+            ys = [p[1] for p in zone.polygon]
+            assert min(xs) <= 0.01
+            assert max(xs) >= 49.99
+            assert min(ys) <= 0.01
+            assert max(ys) >= 49.99


### PR DESCRIPTION
## Summary

Fixes the `kct build` zones step so that zone copper is inset from the
board outline by the manufacturer's minimum edge clearance, eliminating
`edge_clearance_zone` DRC violations on JLCPCB-targeted boards (e.g.
board 01).

## Changes

- `src/kicad_tools/cli/build_cmd.py` — In `_run_step_zones`, look up
  `MfrLimits.min_edge_clearance` from `ctx.mfr` and forward it to
  `auto_create_zones_for_pour_nets(..., edge_clearance=...)`. Mirrors the
  auto-fill pattern at `route_cmd.py:3300-3313`. Falls back to `None` for
  unknown manufacturers (preserving prior behaviour).
- `tests/test_build_zones_step.py` — New `TestRunStepZonesEdgeClearance`
  class with three regression tests:
  - `test_jlcpcb_inset_to_min_edge_clearance` — every zone vertex is at
    least 0.3 mm from the outline.
  - `test_oshpark_uses_larger_clearance` — confirms the value is plumbed
    through (0.381 mm), not hard-coded.
  - `test_unknown_manufacturer_falls_back_to_no_inset` — unknown mfr does
    not crash and zones still get created.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct build boards/01-voltage-divider --force` produces 0 `edge_clearance_zone` errors | Verified by unit test | `test_jlcpcb_inset_to_min_edge_clearance` asserts every zone vertex is >= 0.3 mm from the outline; without the fix the test fails (vertex at 0.0). |
| Zone polygon vertices inset from outline by the manufacturer's clearance | Verified by unit test | Two parametrised tests cover jlcpcb (0.3) and oshpark (0.381). |
| New regression test in `tests/test_build_zones_step.py` | Done | `TestRunStepZonesEdgeClearance` class with 3 tests. |
| Test loads PCB via `PCB.load` and asserts zone vertex distance from outline bounding box | Done | `_assert_inset` helper compares each vertex to the outline bbox with epsilon. |
| Test parametrised over multiple manufacturers (jlcpcb, oshpark) | Done | Two separate test methods, one per mfr. |

## Test Plan

- [x] `uv run pytest tests/test_build_zones_step.py --no-cov` -> 17 passed
- [x] `uv run pytest tests/test_zone_generator_edge_clearance.py tests/test_auto_pour.py --no-cov` -> 27 passed, 3 skipped
- [x] `uv run ruff check tests/test_build_zones_step.py` -> All checks passed
- [x] `uv run ruff format tests/test_build_zones_step.py src/kicad_tools/cli/build_cmd.py --check` -> formatted
- [x] Verified failure mode: temporarily reverted `build_cmd.py` change, the two clearance tests fail with `vertex x=0.0 too close to left edge` -- proving the regression test would have caught the bug.

## Notes

- Pre-existing `F401: math imported but unused` warning in `build_cmd.py:17` was not introduced by this PR and is left in place per scope discipline.
- Existing routed PCBs (e.g. `boards/01-voltage-divider/output/voltage_divider_routed.kicad_pcb`) still contain stale un-inset zones cached on disk; users must re-run `kct build --force` after this fix to regenerate them. The curator note flagged this as a known limitation.

Closes #2496