### PR TITLE
fix(router): exclude skipped pour/CC nets from routing summary failures

### DIFF
--- a/boards/02-charlieplex-led/route_demo.py
+++ b/boards/02-charlieplex-led/route_demo.py
@@ -224,7 +224,15 @@ def main():
 
     # Summary
     print("\n" + "=" * 60)
-    total_nets = len([n for n in router.nets if n > 0])
+    # Issue #2498: Restrict the routing-summary target population to multi-pad
+    # nets that are still routable post-skip.  ``router.nets`` reflects the
+    # state after ``load_pcb_for_routing`` rewrote skip-net pads to net=0, so
+    # this matches the convention used by ``cli/route_cmd.py`` and prevents
+    # skipped power nets (VCC/GND) from being mis-reported as "No path found".
+    multi_pad_net_ids = {
+        net_id for net_id, pads in router.nets.items() if net_id > 0 and len(pads) >= 2
+    }
+    total_nets = len(multi_pad_net_ids)
     all_nets_routed = stats["nets_routed"] == total_nets
 
     if all_nets_routed and drc_passed:
@@ -237,7 +245,12 @@ def main():
         if not drc_passed:
             print(f"  Additionally, {drc_errors} DRC violation(s) detected.")
         # Show comprehensive routing summary with successes, failures, and suggestions
-        show_routing_summary(router, net_map, total_nets)
+        show_routing_summary(
+            router,
+            net_map,
+            total_nets,
+            nets_to_route_ids=multi_pad_net_ids,
+        )
     print("=" * 60)
 
     # Return success only if all nets routed AND DRC passed

--- a/boards/03-usb-joystick/route_demo.py
+++ b/boards/03-usb-joystick/route_demo.py
@@ -252,7 +252,16 @@ def main():
 
     # Summary
     print("\n" + "=" * 60)
-    total_nets = len([n for n in router.nets if n > 0])
+    # Issue #2498: Restrict the routing-summary target population to multi-pad
+    # nets that are still routable post-skip.  ``router.nets`` reflects the
+    # state after ``load_pcb_for_routing`` rewrote skip-net pads to net=0, so
+    # this matches the convention used by ``cli/route_cmd.py`` and prevents
+    # skipped power nets (VCC/VBUS/GND/USB_CC1/USB_CC2) from being mis-reported
+    # as "No path found".
+    multi_pad_net_ids = {
+        net_id for net_id, pads in router.nets.items() if net_id > 0 and len(pads) >= 2
+    }
+    total_nets = len(multi_pad_net_ids)
     all_nets_routed = stats["nets_routed"] == total_nets
 
     if all_nets_routed and drc_passed:
@@ -265,7 +274,12 @@ def main():
         if not drc_passed:
             print(f"  Additionally, {drc_errors} DRC violation(s) detected.")
         # Show comprehensive routing summary with successes, failures, and suggestions
-        show_routing_summary(router, net_map, total_nets)
+        show_routing_summary(
+            router,
+            net_map,
+            total_nets,
+            nets_to_route_ids=multi_pad_net_ids,
+        )
     print("=" * 60)
 
     # Partial routing is acceptable for this board; the USB-C connector

--- a/src/kicad_tools/router/output.py
+++ b/src/kicad_tools/router/output.py
@@ -47,6 +47,9 @@ def show_routing_summary(
         nets_to_route_ids: Optional set of net IDs targeted for routing
             (multi-pad signal nets).  When provided, ``routed_net_ids`` is
             filtered to this set so numerator and denominator are consistent.
+            When ``None``, the function falls back to ``router.nets``
+            (multi-pad nets only) so user-skipped power/pour nets are not
+            mis-reported as failed routes (Issue #2498).
     """
     if quiet:
         return
@@ -76,7 +79,25 @@ def show_routing_summary(
         unrouted_ids = nets_to_route_ids - all_routed_net_ids
     else:
         routed_net_ids = all_routed_net_ids
-        all_net_ids = {v for k, v in net_map.items() if v > 0}
+        # Issue #2498: Fall back to ``router.nets`` when the caller didn't
+        # provide a target net population.  ``router.nets`` reflects the
+        # post-skip state — pads on user-skipped nets (e.g. pour nets like
+        # GND/VCC, or named nets in route_demo.py's ``skip_nets`` list) have
+        # already been rewritten to net=0 by ``load_pcb_for_routing``, so
+        # their net IDs no longer appear in ``router.nets``.  ``net_map``,
+        # by contrast, still contains those nets for diagnostics, which
+        # caused them to be reported as "No path found" failures.
+        # Restrict to multi-pad nets to mirror the convention used by
+        # ``cli/route_cmd.py`` (see ``multi_pad_nets`` there).
+        router_nets = getattr(router, "nets", None)
+        if isinstance(router_nets, dict) and router_nets:
+            all_net_ids = {
+                net_id
+                for net_id, pads in router_nets.items()
+                if isinstance(net_id, int) and net_id > 0 and len(pads) >= 2
+            }
+        else:
+            all_net_ids = {v for k, v in net_map.items() if v > 0}
         unrouted_ids = all_net_ids - all_routed_net_ids
 
     # Group recorded failures by net
@@ -135,9 +156,7 @@ def show_routing_summary(
         for net_id in sorted(partially_connected_nets):
             info = partially_connected_nets[net_id]
             net_name = reverse_net.get(net_id, f"Net_{net_id}")
-            print(
-                f"    {net_name}: {info['connected_pads']}/{info['total_pads']} pads connected"
-            )
+            print(f"    {net_name}: {info['connected_pads']}/{info['total_pads']} pads connected")
 
     # Show cleanup statistics if any artifacts were removed
     cleanup_stats = getattr(router, "_cleanup_stats", None)
@@ -146,17 +165,15 @@ def show_routing_summary(
         if total_removed > 0:
             parts = []
             if cleanup_stats.get("net0_routes_removed"):
-                parts.append(
-                    f"{cleanup_stats['net0_routes_removed']} net-0 route(s)"
-                )
-            net0_items = cleanup_stats.get(
-                "net0_segments_removed", 0
-            ) + cleanup_stats.get("net0_vias_removed", 0)
+                parts.append(f"{cleanup_stats['net0_routes_removed']} net-0 route(s)")
+            net0_items = cleanup_stats.get("net0_segments_removed", 0) + cleanup_stats.get(
+                "net0_vias_removed", 0
+            )
             if net0_items:
                 parts.append(f"{net0_items} net-0 segment/via(s)")
-            oob_items = cleanup_stats.get(
-                "oob_segments_removed", 0
-            ) + cleanup_stats.get("oob_vias_removed", 0)
+            oob_items = cleanup_stats.get("oob_segments_removed", 0) + cleanup_stats.get(
+                "oob_vias_removed", 0
+            )
             if oob_items:
                 parts.append(f"{oob_items} out-of-bounds segment/via(s)")
             print(f"  Cleanup: removed {', '.join(parts)}")
@@ -427,7 +444,9 @@ def show_routing_summary(
                     print(f"{suggestion_num}. {suggestion_text}")
             if num_layers <= 2:
                 suggestion_num += 1
-                print(f"{suggestion_num}. Consider 4-layer routing: kct route{pcb_arg} --layers 4-all")
+                print(
+                    f"{suggestion_num}. Consider 4-layer routing: kct route{pcb_arg} --layers 4-all"
+                )
 
         # Layer escalation recommendation with percentage-based threshold
         num_layers = getattr(router.grid, "num_layers", 2)
@@ -529,7 +548,25 @@ def get_routing_diagnostics_json(
         unrouted_ids = nets_to_route_ids - all_routed_net_ids
     else:
         routed_net_ids = all_routed_net_ids
-        all_net_ids = {v for k, v in net_map.items() if v > 0}
+        # Issue #2498: Fall back to ``router.nets`` when the caller didn't
+        # provide a target net population.  ``router.nets`` reflects the
+        # post-skip state — pads on user-skipped nets (e.g. pour nets like
+        # GND/VCC, or named nets in route_demo.py's ``skip_nets`` list) have
+        # already been rewritten to net=0 by ``load_pcb_for_routing``, so
+        # their net IDs no longer appear in ``router.nets``.  ``net_map``,
+        # by contrast, still contains those nets for diagnostics, which
+        # caused them to be reported as "No path found" failures.
+        # Restrict to multi-pad nets to mirror the convention used by
+        # ``cli/route_cmd.py`` (see ``multi_pad_nets`` there).
+        router_nets = getattr(router, "nets", None)
+        if isinstance(router_nets, dict) and router_nets:
+            all_net_ids = {
+                net_id
+                for net_id, pads in router_nets.items()
+                if isinstance(net_id, int) and net_id > 0 and len(pads) >= 2
+            }
+        else:
+            all_net_ids = {v for k, v in net_map.items() if v > 0}
         unrouted_ids = all_net_ids - all_routed_net_ids
 
     # --- Connectivity validation (Issue #2254) ---
@@ -554,12 +591,14 @@ def get_routing_diagnostics_json(
             if info["total_pads"] >= 2 and not info["connected"]:
                 has_disconnected_islands = True
                 if nid in routed_net_ids:
-                    partially_connected.append({
-                        "net_id": nid,
-                        "net_name": reverse_net.get(nid, f"Net_{nid}"),
-                        "connected_pads": info["connected_pads"],
-                        "total_pads": info["total_pads"],
-                    })
+                    partially_connected.append(
+                        {
+                            "net_id": nid,
+                            "net_name": reverse_net.get(nid, f"Net_{nid}"),
+                            "connected_pads": info["connected_pads"],
+                            "total_pads": info["total_pads"],
+                        }
+                    )
                     routed_net_ids = routed_net_ids - {nid}
 
     # Build successful routes list
@@ -725,13 +764,13 @@ def get_routing_diagnostics_json(
         )
 
     summary_dict: dict = {
-            "nets_requested": nets_to_route,
-            "nets_routed": len(routed_net_ids),
-            "nets_failed": len(unrouted_ids),
-            "success_rate": round(len(routed_net_ids) / nets_to_route * 100, 1)
-            if nets_to_route > 0
-            else 0,
-            "has_disconnected_islands": has_disconnected_islands,
+        "nets_requested": nets_to_route,
+        "nets_routed": len(routed_net_ids),
+        "nets_failed": len(unrouted_ids),
+        "success_rate": round(len(routed_net_ids) / nets_to_route * 100, 1)
+        if nets_to_route > 0
+        else 0,
+        "has_disconnected_islands": has_disconnected_islands,
     }
     if single_pad_count:
         summary_dict["single_pad_nets"] = single_pad_count
@@ -769,7 +808,10 @@ def print_routing_diagnostics_json(
         single_pad_count: Number of single-pad nets excluded from routing.
     """
     diagnostics = get_routing_diagnostics_json(
-        router, net_map, nets_to_route, current_strategy=current_strategy,
+        router,
+        net_map,
+        nets_to_route,
+        current_strategy=current_strategy,
         nets_to_route_ids=nets_to_route_ids,
         single_pad_count=single_pad_count,
     )

--- a/tests/test_routing_output.py
+++ b/tests/test_routing_output.py
@@ -605,3 +605,140 @@ class TestUnroutedListFiltering:
         output = capsys.readouterr().out
         # With no filter, GND should still appear as unrouted (legacy behavior)
         assert "GND" in output
+
+
+# ---------------------------------------------------------------------------
+# Issue #2498: Pour/skip nets must not be reported as failed routes
+# ---------------------------------------------------------------------------
+
+
+class TestIssue2498SkipNetFallback:
+    """The fallback branch (when ``nets_to_route_ids`` is None) must use
+    ``router.nets`` instead of ``net_map``.
+
+    ``load_pcb_for_routing`` rewrites pads on user-skipped nets (e.g. pour
+    nets like GND/VCC, named nets in route_demo.py's ``skip_nets`` list) to
+    net=0, so those net IDs no longer appear in ``router.nets``.  But they
+    *do* still appear in ``net_map`` for diagnostics, which previously caused
+    them to be reported as "No path found" failures.
+    """
+
+    def _make_route(self, net_id):
+        route = MagicMock()
+        route.net = net_id
+        route.segments = []
+        route.vias = []
+        return route
+
+    def test_skipped_pour_nets_not_reported_when_filter_omitted(self, capsys):
+        """When ``nets_to_route_ids`` is None but ``router.nets`` is a real
+        dict that excludes skipped pour nets, those nets must not show up
+        as 'No path found'.  Mirrors boards/03-usb-joystick where
+        VBUS/VCC/GND/USB_CC1/USB_CC2 are skipped via ``skip_nets``.
+        """
+        # Net 2 is a multi-pad signal net that got routed.
+        # Nets 1 (GND), 3 (VBUS) appeared in net_map (KiCad keeps them for
+        # diagnostics) but their pads were rewritten to net=0 on load, so
+        # they're absent from router.nets.
+        # Net 4 is a multi-pad signal net that genuinely failed to route.
+        router = _make_router(routes=[self._make_route(2)])
+        # Real-shape dict: keys are net IDs, values are pad-key lists.
+        router.nets = {
+            2: [("U1", "1"), ("U1", "2")],  # SIG_A, routed
+            4: [("U2", "1"), ("U2", "2")],  # SIG_B, unrouted
+        }
+        # Pads attribute set so connectivity validation block is skipped
+        # (router.pads is None here).
+        router.pads = None
+        net_map = {
+            "GND": 1,
+            "SIG_A": 2,
+            "VBUS": 3,
+            "SIG_B": 4,
+        }
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=2,
+        )
+
+        output = capsys.readouterr().out
+        # Skipped pour nets must NOT appear as 'No path found'
+        assert "GND: No path found" not in output
+        assert "VBUS: No path found" not in output
+        # Genuine signal failure must still appear
+        assert "SIG_B" in output
+
+    def test_single_pad_nets_excluded_from_fallback(self, capsys):
+        """Even when present in ``router.nets``, single-pad nets are not
+        routing candidates and must not appear as failed routes."""
+        router = _make_router(routes=[self._make_route(1)])
+        router.nets = {
+            1: [("U1", "1"), ("U1", "2")],  # SIG_A (routed)
+            2: [("TP1", "1")],  # LATCH single-pad — not routable
+        }
+        router.pads = None
+        net_map = {"SIG_A": 1, "LATCH": 2}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+        )
+
+        output = capsys.readouterr().out
+        assert "LATCH" not in output
+
+    def test_router_nets_absent_falls_back_to_net_map(self, capsys):
+        """Backward compat: when ``router.nets`` isn't a real dict (e.g. a
+        MagicMock as in older tests), fall back to ``net_map`` so legacy
+        callers see unchanged behavior."""
+        router = _make_router(routes=[self._make_route(2)])
+        # router.nets is a MagicMock attribute — not a real dict.
+        net_map = {"GND": 1, "SIG_A": 2}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=2,
+        )
+
+        output = capsys.readouterr().out
+        # Without router.nets, we keep the legacy behavior of using net_map
+        assert "GND" in output
+
+    def test_route_demo_pattern_with_explicit_filter(self, capsys):
+        """Smoke-test the route_demo.py call pattern (Option A from the
+        curator analysis): pass ``nets_to_route_ids`` derived from
+        ``router.nets``.  Skipped nets must not be reported and the
+        unrouted-list count must match (denominator - numerator).
+        """
+        # Same shape as the route_demo fix: one routed signal net, one
+        # unrouted signal net, and a skipped pour net that's absent from
+        # router.nets but present in net_map.
+        router = _make_router(routes=[self._make_route(2)])
+        router.nets = {
+            2: [("U1", "1"), ("U1", "2")],
+            3: [("U1", "3"), ("U1", "4")],
+        }
+        router.pads = None
+        net_map = {"GND": 1, "SIG_A": 2, "SIG_B": 3}
+
+        # Builder-side pattern from boards/03-usb-joystick/route_demo.py
+        multi_pad_net_ids = {
+            net_id for net_id, pads in router.nets.items() if net_id > 0 and len(pads) >= 2
+        }
+        total_nets = len(multi_pad_net_ids)
+
+        show_routing_summary(
+            router,
+            net_map,
+            total_nets,
+            nets_to_route_ids=multi_pad_net_ids,
+        )
+
+        output = capsys.readouterr().out
+        assert "GND" not in output
+        assert "SIG_B" in output  # genuine failure shown
+        assert "1/2" in output  # 1 routed of 2 candidates


### PR DESCRIPTION
Closes #2498

## Summary

- Skipped pour nets (VBUS/VCC/GND) and named-skip nets (USB_CC1/USB_CC2) were appearing under "Unrouted nets:" with the generic "No path found" message on boards 02 and 03.
- Root cause: the demo route scripts called `show_routing_summary` without `nets_to_route_ids`, and the fallback branch iterated `net_map` (which retains skipped nets for diagnostics) instead of `router.nets` (which reflects post-skip state after `load_pcb_for_routing` rewrites those pads to net=0).
- Fix per curator analysis: (a) pass `nets_to_route_ids=multi_pad_net_ids` from both `route_demo.py` scripts, and (b) make the `None`-filter fallback in `show_routing_summary` / `get_routing_diagnostics_json` use `router.nets` restricted to multi-pad nets (mirroring the convention used by `cli/route_cmd.py`).

## Files changed

- `src/kicad_tools/router/output.py` — fallback now uses `router.nets` (multi-pad only), with backward-compat fallback to `net_map` when `router.nets` isn't a real dict (e.g. legacy MagicMock callers).
- `boards/03-usb-joystick/route_demo.py` — builds `multi_pad_net_ids` and threads it through `show_routing_summary`.
- `boards/02-charlieplex-led/route_demo.py` — same pattern.
- `tests/test_routing_output.py` — new `TestIssue2498SkipNetFallback` class with 4 regression tests.

## Test plan

- [x] `uv run pytest tests/test_routing_output.py tests/test_output_connectivity.py tests/test_reroute_progress_output.py` — 50 passed
- [x] `uv run pytest tests/test_route_cmd_params.py tests/test_route_cmd_power_nets.py` — 57 passed
- [x] `uv run ruff check` and `uv run ruff format --check` on touched files — all clean
- [x] `uv run --with mypy mypy --ignore-missing-imports src/kicad_tools/router/output.py` — no new errors (3 pre-existing unrelated to this change)
- [ ] Smoke test on hardware: `kct build boards/03-usb-joystick --force --verbose` should no longer print VBUS/VCC/GND/USB_CC1/USB_CC2 under "Unrouted nets:" (JOY_X may still show — separate concern, out of scope per curator).

## Notes

- The legacy MagicMock-based test in `test_legacy_no_filter_shows_all_unrouted` still passes because the fallback safely detects when `router.nets` isn't a real dict.
- This PR addresses acceptance criterion (1) from the issue; criteria (2) and (3) (better message text for pour-without-zone vs. signal failure, named-skip classifier) are deferred to a follow-up since the curator analysis flagged them as separate scope.

Generated with [Claude Code](https://claude.com/claude-code)