### PR TITLE
router_cpp: detect stale .so via build version guard (closes #2501)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,13 @@ jobs:
         with:
           version: "latest"
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      # Note: deliberately NOT using actions/setup-python@v5 here. That action
+      # exports Python_ROOT_DIR=/opt/hostedtoolcache/Python/.../x64, which is
+      # sticky for cmake's find_package(Python ...) — even after activating
+      # the uv venv with `source .venv/bin/activate`, cmake locates the
+      # tool-cache Python (which has no nanobind) instead of the venv's
+      # Python with nanobind installed. We rely on uv to manage the Python
+      # version (pinned via .python-version / pyproject) and create the venv.
 
       - name: Install build dependencies
         run: |
@@ -96,7 +100,11 @@ jobs:
           sudo apt-get install -y cmake build-essential
 
       - name: Install Python dependencies
-        run: uv sync --extra dev
+        # Pin Python via uv (parity with the other jobs that use
+        # actions/setup-python with python-version: "3.12"). uv will install
+        # the requested interpreter into its managed cache and create
+        # .venv from it.
+        run: uv sync --extra dev --python 3.12
 
       - name: Install nanobind
         run: uv pip install nanobind
@@ -107,6 +115,10 @@ jobs:
       - name: Build C++ extension from source
         run: |
           source .venv/bin/activate
+          # Belt-and-suspenders: explicitly point cmake at the venv Python in
+          # case any future runner image starts setting Python_ROOT_DIR.
+          export Python_ROOT_DIR="$PWD/.venv"
+          unset Python2_ROOT_DIR Python3_ROOT_DIR
           bash scripts/build-cpp.sh build
 
       - name: Verify version-guard reports backend available

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,71 @@ jobs:
       - name: Run tests
         run: uv run pytest -n auto -o addopts= --benchmark-disable --timeout=60 -m "not slow"
         continue-on-error: true
+
+  cpp-build-check:
+    # Issue #2501: catch source/.so drift by rebuilding the C++ extension
+    # from a clean checkout and asserting the version-guard reports the
+    # backend as available. If anyone changes cpp/ source without bumping
+    # ROUTER_CPP_BUILD_VERSION (or vice versa) the import-time guard will
+    # fall back to Python and fail this check with an actionable message.
+    name: C++ Build Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential
+
+      - name: Install Python dependencies
+        run: uv sync --extra dev
+
+      - name: Install nanobind
+        run: uv pip install nanobind
+
+      - name: Clean any committed .so artifacts
+        run: bash scripts/build-cpp.sh clean
+
+      - name: Build C++ extension from source
+        run: |
+          source .venv/bin/activate
+          bash scripts/build-cpp.sh build
+
+      - name: Verify version-guard reports backend available
+        run: |
+          uv run python -c "
+          from kicad_tools.router.cpp_backend import (
+              is_cpp_available,
+              get_cpp_unavailable_reason,
+              _REQUIRED_CPP_BUILD_VERSION,
+              router_cpp,
+          )
+          if not is_cpp_available():
+              raise SystemExit(
+                  f'C++ backend unavailable after clean rebuild: '
+                  f'{get_cpp_unavailable_reason()}'
+              )
+          actual = getattr(router_cpp, 'BUILD_VERSION', None)
+          if actual != _REQUIRED_CPP_BUILD_VERSION:
+              raise SystemExit(
+                  f'BUILD_VERSION mismatch after clean rebuild: '
+                  f'compiled={actual!r} required={_REQUIRED_CPP_BUILD_VERSION!r}. '
+                  f'Did you forget to bump ROUTER_CPP_BUILD_VERSION in both '
+                  f'cpp/include/types.hpp and cpp_backend.py?'
+              )
+          print(f'C++ backend OK: BUILD_VERSION={actual}')
+          "
+
+      - name: Smoke test C++ router
+        run: |
+          uv run pytest tests/test_router_cpp_backend.py::TestCppBuildVersionGuard -v --no-cov

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -114,6 +114,57 @@ kicad-tools/
 
 ---
 
+## C++ Native Extensions
+
+The router and placement optimizer ship optional C++ acceleration modules
+(`router_cpp`, `placement_cpp`) for 10-100x speedup over the pure-Python
+implementation. They are built with nanobind + CMake and live under
+`src/kicad_tools/router/cpp/` and `src/kicad_tools/placement/cpp/`.
+
+### Building the C++ extensions
+
+```bash
+# Build (requires CMake 3.15+ and a C++20 compiler)
+bash scripts/build-cpp.sh build
+
+# Or via the CLI:
+kct build-native
+
+# Clean build artifacts:
+bash scripts/build-cpp.sh clean
+```
+
+### Build version discipline (Issue #2501)
+
+The Python side caches a compiled `.so` matching `cpython-<X>-<platform>.so`.
+If the `.cpp` source moves ahead of the compiled `.so`, the import will
+succeed but new symbols (`PadBounds`, `FAILURE_NONE`, etc.) will be missing,
+causing hard `AttributeError` crashes deep in the routing code.
+
+To prevent this, the build surface is gated by an integer constant
+`ROUTER_CPP_BUILD_VERSION`, mirrored on both sides:
+
+- `src/kicad_tools/router/cpp/include/types.hpp` (C++ source)
+- `src/kicad_tools/router/cpp_backend.py` as `_REQUIRED_CPP_BUILD_VERSION`
+  (Python side)
+
+**When you change anything under `src/kicad_tools/router/cpp/` that affects
+the binding surface (added/removed/renamed symbols, struct fields, function
+signatures), you MUST:**
+
+1. Bump `ROUTER_CPP_BUILD_VERSION` in `cpp/include/types.hpp`.
+2. Bump `_REQUIRED_CPP_BUILD_VERSION` to the same value in `cpp_backend.py`.
+3. Rebuild with `kct build-native` (or `bash scripts/build-cpp.sh build`).
+
+If the two constants disagree at import time, the C++ backend is disabled
+with a clear `kct build-native` rebuild hint and the router falls back to
+pure Python rather than crashing at routing time. The CI `cpp-build-check`
+job rebuilds from a clean checkout and asserts the guard reports the
+backend as available, so a forgotten version bump or stale `.so` will fail
+CI rather than silently regress production.
+
+---
+
 ## Running Tests
 
 ### Run All Tests

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -12,6 +12,16 @@
 
 namespace router {
 
+// Build version for the C++ binding surface (Issue #2501).
+//
+// Bump this constant in any PR that changes the bindings.cpp surface
+// (added/removed/renamed symbols, struct fields, function signatures).
+// The Python side mirrors this as ``_REQUIRED_CPP_BUILD_VERSION`` in
+// ``cpp_backend.py``; on import the two are compared and a mismatch
+// disables the C++ backend with a clear "kct build-native" error,
+// preventing silent ``AttributeError`` failures from a stale .so.
+constexpr int ROUTER_CPP_BUILD_VERSION = 2;
+
 // Grid cell state
 struct GridCell {
     bool blocked = false;

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <vector>
 #include <tuple>
 #include <optional>

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -256,4 +256,13 @@ NB_MODULE(router_cpp, m) {
     // Version info
     m.def("version", []() { return "1.0.0"; });
     m.def("is_available", []() { return true; });
+
+    // Build version (Issue #2501): exposed both as a module attribute (for cheap
+    // identity checks at import time) and a callable (for parity with version()).
+    // The Python side mirrors this as _REQUIRED_CPP_BUILD_VERSION in
+    // cpp_backend.py; mismatch indicates the compiled .so is stale relative to
+    // the cpp/ source tree and the C++ backend is disabled with an actionable
+    // "kct build-native" hint.
+    m.attr("BUILD_VERSION") = router::ROUTER_CPP_BUILD_VERSION;
+    m.def("build_version", []() { return router::ROUTER_CPP_BUILD_VERSION; });
 }

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -34,6 +34,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Required C++ binding-surface version (Issue #2501).
+#
+# This MUST match ``ROUTER_CPP_BUILD_VERSION`` in
+# ``src/kicad_tools/router/cpp/include/types.hpp``.  Bump both constants in any
+# PR that changes the bindings.cpp surface (added/removed/renamed symbols,
+# struct fields, function signatures).
+#
+# When ``router_cpp.BUILD_VERSION`` does not match this value, the compiled
+# ``.so`` is older than the source tree and would otherwise raise
+# ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
+# missing).  The guard below catches that at import time and falls back to the
+# pure-Python router with an actionable ``kct build-native`` hint.
+_REQUIRED_CPP_BUILD_VERSION = 2
+
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
 try:
@@ -63,6 +77,23 @@ except ImportError as e:
                 f"but running Python {sys.version_info.major}.{sys.version_info.minor} "
                 f"({_running_tag}). Rebuild with: kicad-tools build-native"
             )
+
+# Stale-.so guard (Issue #2501): the import succeeded, but the compiled
+# binding surface may predate the current source tree.  A mismatch here
+# means new symbols (e.g. ``PadBounds``, ``FAILURE_NONE``) referenced by
+# this module are absent from the loaded ``.so`` and would otherwise
+# raise ``AttributeError`` at routing time.  Disable the backend cleanly
+# with a clear rebuild hint that routes through the existing fallback path.
+if _CPP_AVAILABLE:
+    _actual_build_version = getattr(router_cpp, "BUILD_VERSION", None)
+    if _actual_build_version != _REQUIRED_CPP_BUILD_VERSION:
+        _CPP_AVAILABLE = False
+        _CPP_IMPORT_ERROR = (
+            f"router_cpp build version {_actual_build_version!r} does not match "
+            f"required {_REQUIRED_CPP_BUILD_VERSION}. The compiled .so is stale "
+            f"relative to the C++ source tree. Rebuild with: kct build-native"
+        )
+        router_cpp = None  # type: ignore
 
 
 def is_cpp_available() -> bool:

--- a/tests/test_router_cpp_backend.py
+++ b/tests/test_router_cpp_backend.py
@@ -1,5 +1,7 @@
 """Tests for C++ router backend fallback behavior."""
 
+import importlib
+
 from kicad_tools.router.cpp_backend import (
     LARGE_GRID_THRESHOLD,
     format_backend_status,
@@ -1163,3 +1165,108 @@ class TestCppPathfinderPythonFallback:
             pf.route(start, end)
             # Same Router instance should be reused
             assert pf._py_router is first_router
+
+
+class TestCppBuildVersionGuard:
+    """Test the stale-.so detection added in Issue #2501.
+
+    The guard compares ``router_cpp.BUILD_VERSION`` (compiled into the .so)
+    against ``_REQUIRED_CPP_BUILD_VERSION`` (mirrored in cpp_backend.py).
+    On mismatch the C++ backend is disabled with a "kct build-native" hint
+    routed through the existing fallback path, preventing downstream
+    ``AttributeError`` from missing symbols at routing time.
+    """
+
+    def test_required_build_version_constant_exists(self):
+        """The Python-side required build version is defined as an int."""
+        from kicad_tools.router import cpp_backend
+
+        assert hasattr(cpp_backend, "_REQUIRED_CPP_BUILD_VERSION")
+        assert isinstance(cpp_backend._REQUIRED_CPP_BUILD_VERSION, int)
+        assert cpp_backend._REQUIRED_CPP_BUILD_VERSION >= 1
+
+    def test_build_version_exposed_when_cpp_available(self):
+        """When C++ loads successfully, router_cpp.BUILD_VERSION matches required."""
+        if not is_cpp_available():
+            import pytest
+
+            pytest.skip("C++ backend not available")
+
+        from kicad_tools.router import cpp_backend
+
+        assert cpp_backend.router_cpp is not None
+        actual = getattr(cpp_backend.router_cpp, "BUILD_VERSION", None)
+        assert actual == cpp_backend._REQUIRED_CPP_BUILD_VERSION
+
+    def test_stale_so_disables_cpp_with_actionable_error(self, monkeypatch):
+        """A mismatched BUILD_VERSION on a fresh import disables the C++ backend.
+
+        Simulates the failure mode from Issue #2501: the .so loads cleanly but
+        is older than the cpp/ source tree, so it lacks symbols (or has the
+        wrong build version constant). The guard must short-circuit to the
+        Python fallback with a "kct build-native" hint instead of allowing
+        a downstream AttributeError.
+        """
+        import sys
+
+        # Ensure cpp_backend is freshly imported so we see the live router_cpp.
+        sys.modules.pop("kicad_tools.router.cpp_backend", None)
+        original = importlib.import_module("kicad_tools.router.cpp_backend")
+
+        # Snapshot the live router_cpp module (None if backend already disabled)
+        router_cpp_mod = original.router_cpp
+        if router_cpp_mod is None:
+            import pytest
+
+            pytest.skip("C++ backend not available - guard already engaged")
+
+        # Force BUILD_VERSION to a mismatched value before re-importing
+        monkeypatch.setattr(
+            router_cpp_mod, "BUILD_VERSION", 999_999, raising=False
+        )
+
+        # Drop the cached cpp_backend so the module-level guard re-runs
+        sys.modules.pop("kicad_tools.router.cpp_backend", None)
+        try:
+            reloaded = importlib.import_module("kicad_tools.router.cpp_backend")
+
+            assert reloaded.is_cpp_available() is False
+            reason = reloaded.get_cpp_unavailable_reason()
+            assert reason is not None
+            assert "build-native" in reason
+            assert "stale" in reason.lower() or "999999" in reason
+        finally:
+            # Restore the real cpp_backend module so subsequent tests see the
+            # true backend state (monkeypatch will restore BUILD_VERSION).
+            sys.modules.pop("kicad_tools.router.cpp_backend", None)
+            importlib.import_module("kicad_tools.router.cpp_backend")
+
+    def test_missing_build_version_attr_disables_cpp(self, monkeypatch):
+        """If router_cpp lacks BUILD_VERSION (very old .so) the guard fires."""
+        import sys
+
+        # Ensure cpp_backend is freshly imported so we see the live router_cpp.
+        sys.modules.pop("kicad_tools.router.cpp_backend", None)
+        original = importlib.import_module("kicad_tools.router.cpp_backend")
+
+        router_cpp_mod = original.router_cpp
+        if router_cpp_mod is None:
+            import pytest
+
+            pytest.skip("C++ backend not available - guard already engaged")
+
+        # Remove the attribute entirely
+        if hasattr(router_cpp_mod, "BUILD_VERSION"):
+            monkeypatch.delattr(router_cpp_mod, "BUILD_VERSION", raising=False)
+
+        sys.modules.pop("kicad_tools.router.cpp_backend", None)
+        try:
+            reloaded = importlib.import_module("kicad_tools.router.cpp_backend")
+
+            assert reloaded.is_cpp_available() is False
+            reason = reloaded.get_cpp_unavailable_reason()
+            assert reason is not None
+            assert "build-native" in reason
+        finally:
+            sys.modules.pop("kicad_tools.router.cpp_backend", None)
+            importlib.import_module("kicad_tools.router.cpp_backend")


### PR DESCRIPTION
## Summary

Closes #2501.

When the C++ source under `src/kicad_tools/router/cpp/` moves ahead of the compiled `.so`, every routing call crashes with `AttributeError` on missing symbols (e.g. `router_cpp.PadBounds`, `router_cpp.FAILURE_NONE`) deep in `cpp_backend.py` rather than at import time. This PR implements the curator's recommended hybrid Option A+C: a `ROUTER_CPP_BUILD_VERSION` integer constant mirrored on both sides of the binding boundary, plus a Python-side guard that disables the C++ backend with an actionable `kct build-native` hint when the two disagree, routing through the existing pure-Python fallback path.

## Changes

- **C++**: Added `ROUTER_CPP_BUILD_VERSION = 2` constant in `cpp/include/types.hpp`. Exposed it as both `router_cpp.BUILD_VERSION` (module attribute) and `router_cpp.build_version()` (callable) in `bindings.cpp`.
- **Python**: Added `_REQUIRED_CPP_BUILD_VERSION = 2` in `cpp_backend.py` and a post-import guard that compares `router_cpp.BUILD_VERSION` against the required value. On mismatch (or missing attribute), sets `_CPP_AVAILABLE = False` and populates `_CPP_IMPORT_ERROR` with a stale-`.so` rebuild message. Routes through the existing fallback path used today by ABI-tag mismatches.
- **Tests**: New `TestCppBuildVersionGuard` class with 4 tests covering: required constant exists, build version exposed when C++ loads, mismatched `BUILD_VERSION` disables backend with `build-native` hint, missing `BUILD_VERSION` attribute disables backend.
- **CI**: New `cpp-build-check` job that does a clean rebuild from source on Ubuntu and asserts the version guard reports the backend as available. Catches forgotten version bumps or stale `.so` artifacts before they hit `main`.
- **Docs**: Added a "C++ Native Extensions / Build version discipline" section to `docs/contributing/development.md` documenting the version-bump-and-rebuild requirement.

## Test plan

- [x] `pytest tests/test_router_cpp_backend.py::TestCppBuildVersionGuard -v` (4/4 pass locally on Python 3.13)
- [x] `pytest tests/test_router_cpp_backend.py::TestCppBackendFallback tests/test_router_cpp_backend.py::TestFormatBackendStatus` (10/10 pass; existing fallback behavior preserved)
- [x] `pytest tests/test_cpp_validation_parity.py` (33/33 pass; C++ backend still works after the guard)
- [x] `pytest tests/test_cpp_performance.py` (7/7 pass; C++ backend still hot-path on routing)
- [x] Manually verified `router_cpp.BUILD_VERSION == 2` after clean rebuild.
- [ ] CI `cpp-build-check` job passes on Ubuntu (will run on this PR).

Generated with [Claude Code](https://claude.com/claude-code)