### PR TITLE
fix(sexp): preserve quoted-string semantics on round-trip

### DIFF
--- a/src/kicad_tools/footprints/__init__.py
+++ b/src/kicad_tools/footprints/__init__.py
@@ -78,7 +78,14 @@ class Pad:
             )
         """
         # Build pad node: (pad "number" type shape ...)
-        pad = SExp.list("pad", self.number, self.pad_type.value, self.shape.value)
+        # Pad number is a strict-typed string in KiCad; quote it explicitly so
+        # numeric-looking numbers like "1" don't get serialized as bare ints.
+        pad = SExp.list(
+            "pad",
+            SExp.quoted_atom(self.number),
+            self.pad_type.value,
+            self.shape.value,
+        )
 
         # Position: (at x y)
         x, y = self.position

--- a/src/kicad_tools/panel/panel.py
+++ b/src/kicad_tools/panel/panel.py
@@ -846,10 +846,15 @@ def _deep_copy_sexp(node: SExp) -> SExp:
     """Create a deep copy of an S-expression tree.
 
     This avoids Python's ``copy.deepcopy`` which is slow for large
-    trees. Instead we walk the tree manually.
+    trees. Instead we walk the tree manually. Round-trip metadata
+    (_original_str for numerics, _originally_quoted for strings) is
+    propagated so the cloned subtree serializes identically.
     """
     if node.is_atom:
-        return SExp(value=node.value)
+        new_atom = SExp(value=node.value)
+        new_atom._original_str = node._original_str
+        new_atom._originally_quoted = node._originally_quoted
+        return new_atom
 
     new_node = SExp(name=node.name)
     for child in node.children:

--- a/src/kicad_tools/schema/library.py
+++ b/src/kicad_tools/schema/library.py
@@ -407,13 +407,16 @@ class LibraryPin:
         # Build effects for name and number
         font_effects = SExp.list("effects", SExp.list("font", SExp.list("size", 1.27, 1.27)))
 
+        # Pin name and number are strict-typed string fields in KiCad. Quote
+        # them explicitly so numeric-looking values (e.g. "1", "9.0") survive
+        # round-trip without being silently downgraded to bare numerics.
         children: list[SExp] = [
             SExp(value=self.type),
             SExp(value=self.shape),
             SExp.list("at", self.position[0], self.position[1], self.rotation),
             SExp.list("length", self.length),
-            SExp.list("name", self.name, font_effects),
-            SExp.list("number", self.number, font_effects),
+            SExp.list("name", SExp.quoted_atom(self.name), font_effects),
+            SExp.list("number", SExp.quoted_atom(self.number), font_effects),
         ]
 
         return SExp(name="pin", children=children)
@@ -1126,10 +1129,13 @@ class SymbolLibrary:
               (symbol ...)
             )
         """
+        # generator_version is a strict-typed string field in KiCad; emit the
+        # value as a quoted atom so kicad-cli accepts the file even though
+        # "1.0" textually parses as a number.
         children: list[SExp] = [
             SExp.list("version", 20231120),
             SExp.list("generator", "kicad_tools"),
-            SExp.list("generator_version", "1.0"),
+            SExp.list("generator_version", SExp.quoted_atom("1.0")),
         ]
 
         # Add all symbols

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1183,7 +1183,10 @@ class PCB:
         # Version and generator info
         pcb.append(SExp.list("version", 20240108))
         pcb.append(SExp.list("generator", "kicad_tools"))
-        pcb.append(SExp.list("generator_version", "9.0"))
+        # generator_version is a strict-typed string field in KiCad; emit the
+        # value as a quoted atom so kicad-cli accepts the file even though
+        # "9.0" textually parses as a number.
+        pcb.append(SExp.list("generator_version", SExp.quoted_atom("9.0")))
 
         # General settings
         pcb.append(

--- a/src/kicad_tools/schema/symbol.py
+++ b/src/kicad_tools/schema/symbol.py
@@ -24,9 +24,17 @@ class SymbolPin:
         """Convert to S-expression.
 
         Format: ``(pin "1" (uuid "..."))``
+
+        Pin number is quoted because KiCad strictly types this token as a
+        string; numeric-looking numbers like "1" must round-trip with their
+        quotes intact.
         """
         pin_uuid = self.uuid or str(uuid_mod.uuid4())
-        return SExp.list("pin", self.number, SExp.list("uuid", pin_uuid))
+        return SExp.list(
+            "pin",
+            SExp.quoted_atom(self.number),
+            SExp.list("uuid", pin_uuid),
+        )
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> SymbolPin:

--- a/src/kicad_tools/schematic/models/io_mixin.py
+++ b/src/kicad_tools/schematic/models/io_mixin.py
@@ -245,11 +245,14 @@ class SchematicIOMixin:
 
     def to_sexp_node(self) -> SExp:
         """Build complete schematic as SExp tree."""
+        # generator_version is a strict-typed string field in KiCad; emit the
+        # value as a quoted atom so kicad-cli accepts the file even though
+        # "9.0" textually parses as a number.
         root = SExp.list(
             "kicad_sch",
             SExp.list("version", 20231120),
             SExp.list("generator", "eeschema"),
-            SExp.list("generator_version", "9.0"),
+            SExp.list("generator_version", SExp.quoted_atom("9.0")),
             uuid_node(self.sheet_uuid),
             SExp.list("paper", self.paper),
         )

--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -255,8 +255,12 @@ def symbol_property_node(
 
 
 def pin_uuid_node(pin_number: str, pin_uuid: str) -> SExp:
-    """Build a pin UUID mapping node."""
-    return SExp.list("pin", pin_number, uuid_node(pin_uuid))
+    """Build a pin UUID mapping node.
+
+    Pin number is quoted explicitly since KiCad treats it as a strict-typed
+    string token; otherwise numeric-looking numbers like "1" would emit bare.
+    """
+    return SExp.list("pin", SExp.quoted_atom(pin_number), uuid_node(pin_uuid))
 
 
 def symbol_instances_node(project_name: str, sheet_path: str, reference: str, unit: int) -> SExp:

--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -62,7 +62,16 @@ class SExp:
         attributes (1-indexed) pointing to their start position in the source file.
     """
 
-    __slots__ = ("name", "children", "value", "_inline", "_original_str", "_line", "_column")
+    __slots__ = (
+        "name",
+        "children",
+        "value",
+        "_inline",
+        "_original_str",
+        "_originally_quoted",
+        "_line",
+        "_column",
+    )
 
     def __init__(
         self,
@@ -71,6 +80,7 @@ class SExp:
         value: str | int | float | None = None,
         _inline: bool = False,
         _original_str: str | None = None,
+        _originally_quoted: bool = False,
         _line: int = 0,
         _column: int = 0,
     ):
@@ -81,6 +91,13 @@ class SExp:
         self.value = value
         self._inline = _inline
         self._original_str = _original_str
+        # Tracks whether a string atom was parsed from a quoted token. When True,
+        # the serializer preserves the quoted form even if the textual value
+        # would otherwise look numeric (e.g. (generator_version "9.0")). Mirrors
+        # the role of _original_str on numeric atoms. Programmatically
+        # constructed atoms default to False so existing keyword/round-trip
+        # behavior is unchanged.
+        self._originally_quoted = _originally_quoted
         self._line = _line
         self._column = _column
 
@@ -326,25 +343,10 @@ class SExp:
         tab = "\t"
         tabs = tab * indent
 
-        # Some KiCad fields require their atom child to be a quoted string even
-        # when the value parses as a number (e.g. (generator_version "9.0")).
-        force_quote_atom_str = self.name in _FORCE_QUOTED_STRING_VALUE
-
-        def _atom_str(child: SExp) -> str:
-            if (
-                force_quote_atom_str
-                and child.is_atom
-                and isinstance(child.value, str)
-            ):
-                escaped = child.value.replace("\\", "\\\\").replace('"', '\\"')
-                escaped = escaped.replace("\n", "\\n").replace("\t", "\\t")
-                return f'"{escaped}"'
-            return child.to_string(compact=True)
-
         # Check if should render inline
         if compact or self._should_inline():
             parts = [self.name] if self.name else []
-            parts.extend(_atom_str(c) for c in self.children)
+            parts.extend(c.to_string(compact=True) for c in self.children)
             return "(" + " ".join(parts) + ")"
 
         # Multi-line formatting matching KiCad style
@@ -366,11 +368,11 @@ class SExp:
             if child.is_atom:
                 if indent == 0 or started_new_lines:
                     # Already on new lines, continue that way
-                    lines.append(f"{tabs}{tab}{_atom_str(child)}")
+                    lines.append(f"{tabs}{tab}{child.to_string(compact=True)}")
                     started_new_lines = True
                 else:
                     # Atoms go on same line as parent opener
-                    lines[-1] += " " + _atom_str(child)
+                    lines[-1] += " " + child.to_string(compact=True)
             elif child._should_inline():
                 if indent == 0:
                     # Root level: each child on own line
@@ -462,7 +464,14 @@ class SExp:
         return False
 
     def _format_value(self, value) -> str:
-        """Format a value for length calculation."""
+        """Format a value for length calculation.
+
+        Note: This is only used by _should_inline() for length budgeting on the
+        parent SExp's atom children, where the per-atom _originally_quoted flag
+        is not in scope. It produces a slight under-estimate for strings that
+        carry the quoted flag but otherwise look unquoted; that only affects
+        whether a node renders inline vs. multi-line, never the byte content.
+        """
         if value is None:
             return ""
         if isinstance(value, str):
@@ -476,8 +485,12 @@ class SExp:
         if self.value is None:
             return ""
         if isinstance(self.value, str):
-            # Check if needs quoting
-            if self._needs_quoting(self.value):
+            # Quote when the value was originally parsed quoted, or when its
+            # textual form requires quoting. The originally-quoted flag
+            # preserves the type distinction between (field "9.0") and
+            # (field 9.0) on round-trip — KiCad strict-typed string fields
+            # like generator_version would otherwise be silently downgraded.
+            if self._originally_quoted or self._needs_quoting(self.value):
                 escaped = self.value.replace("\\", "\\\\").replace('"', '\\"')
                 escaped = escaped.replace("\n", "\\n").replace("\t", "\\t")
                 return f'"{escaped}"'
@@ -795,6 +808,25 @@ class SExp:
         return cls(value=value)
 
     @classmethod
+    def quoted_atom(cls, value: str) -> SExp:
+        """Create a string atom that always serializes quoted.
+
+        Use this for KiCad strict-typed string fields whose values may
+        textually look numeric (e.g. pad numbers like "1", schematic
+        ``generator_version`` like "9.0", pin numbers, etc.). Without the
+        quoted-string flag, the serializer's textual heuristic would emit
+        these as bare numerics, which kicad-cli rejects on load.
+
+        For value strings that already need quoting under the textual
+        heuristic (containing spaces, dots, etc.) this is equivalent to
+        ``SExp.atom(value)`` -- the flag just guarantees quoting in cases
+        where the value alone would not.
+        """
+        node = cls(value=value)
+        node._originally_quoted = True
+        return node
+
+    @classmethod
     def list(cls, name: str, *children: SExp | str | int | float) -> SExp:
         """Create a list node."""
         node = cls(name=name)
@@ -917,13 +949,6 @@ _STRUCTURAL_ELEMENTS = frozenset({
 _FORCE_STRUCTURED_ON_LINES = _STRUCTURAL_ELEMENTS | frozenset({
     "gr_arc",
     "gr_poly",
-})
-
-# Fields whose string atom value must be emitted quoted even when it looks
-# numeric. KiCad's parser strictly types these as string tokens, so the bare
-# form (e.g. `(generator_version 9.0)`) is rejected by kicad-cli on load.
-_FORCE_QUOTED_STRING_VALUE = frozenset({
-    "generator_version",
 })
 
 # Elements that should never be rendered inline (used in _should_inline())
@@ -1124,8 +1149,16 @@ class Parser:
         return node
 
     def _parse_string_node(self) -> SExp:
-        """Parse a quoted string and return as SExp node."""
-        return SExp(value=self._parse_string())
+        """Parse a quoted string and return as SExp node.
+
+        The _originally_quoted flag is set so the serializer can preserve the
+        quoted form on round-trip even when the textual value parses as a
+        number (e.g. "9.0"). This keeps strict-typed KiCad fields like
+        generator_version from being silently downgraded to bare numerics.
+        """
+        node = SExp(value=self._parse_string())
+        node._originally_quoted = True
+        return node
 
     def _parse_string(self) -> str:
         """Parse a quoted string."""

--- a/tests/test_sexp_parser.py
+++ b/tests/test_sexp_parser.py
@@ -431,6 +431,92 @@ class TestSerialization:
         assert result == '"hello world"'
 
 
+class TestOriginallyQuotedFlag:
+    """Tests for the _originally_quoted flag that preserves quoted-string
+    semantics on round-trip even when the textual value parses as a number.
+
+    This protects strict-typed KiCad string fields like generator_version,
+    where the bare numeric form (e.g. (generator_version 9.0)) is rejected
+    by kicad-cli on load.
+    """
+
+    def test_default_originally_quoted_is_false(self):
+        """Programmatic atoms default to _originally_quoted=False."""
+        atom = SExp(value="9.0")
+        assert atom._originally_quoted is False
+
+    def test_parser_sets_flag_for_quoted_strings(self):
+        """Parsing a quoted string token sets _originally_quoted=True."""
+        node = parse_string('(field "9.0")')
+        atom = node.children[0]
+        assert atom.is_atom
+        assert atom.value == "9.0"
+        assert atom._originally_quoted is True
+
+    def test_parser_does_not_set_flag_for_unquoted_atoms(self):
+        """Parsing an unquoted atom leaves _originally_quoted=False."""
+        node = parse_string("(field 9.0)")
+        atom = node.children[0]
+        assert atom.is_atom
+        # Unquoted numeric tokens parse as float, not string
+        assert atom.value == 9.0
+        assert atom._originally_quoted is False
+
+    def test_roundtrip_quoted_numeric_string(self):
+        """Quoted numeric-looking strings round-trip with quotes preserved."""
+        original = '(field "9.0")'
+        result = parse_string(original).to_string(compact=True)
+        assert result == '(field "9.0")'
+
+    def test_roundtrip_unquoted_numeric_stays_unquoted(self):
+        """Unquoted numbers round-trip without quotes."""
+        original = "(field 9.0)"
+        result = parse_string(original).to_string(compact=True)
+        assert result == "(field 9.0)"
+
+    def test_roundtrip_quoted_string_atom(self):
+        """Regular quoted strings round-trip with quotes."""
+        original = '(field "abc")'
+        result = parse_string(original).to_string(compact=True)
+        assert result == '(field "abc")'
+
+    def test_roundtrip_unquoted_keyword_stays_unquoted(self):
+        """Unquoted keywords round-trip without quotes."""
+        # 'signal' is in unquoted_keywords; parser produces an unquoted str
+        original = "(layer signal)"
+        result = parse_string(original).to_string(compact=True)
+        assert result == "(layer signal)"
+
+    def test_roundtrip_generator_version_quoted(self):
+        """generator_version with quoted "9.0" round-trips quoted (the bug
+        this issue fixes — ensures kicad-cli accepts the regenerated file)."""
+        original = '(generator_version "9.0")'
+        result = parse_string(original).to_string(compact=True)
+        assert result == '(generator_version "9.0")'
+
+    def test_programmatic_atom_with_flag_emits_quoted(self):
+        """Setting _originally_quoted=True on a programmatic atom forces
+        the serializer to emit it quoted, even when the value looks numeric."""
+        atom = SExp(value="9.0")
+        atom._originally_quoted = True
+        node = SExp.list("generator_version", atom)
+        assert node.to_string(compact=True) == '(generator_version "9.0")'
+
+    def test_programmatic_numeric_string_unquoted_by_default(self):
+        """Documented behavior: SExp.list('field', '9.0') is unquoted because
+        the textual heuristic governs default emission. Programmatic callers
+        that need quoted intent must set _originally_quoted=True explicitly."""
+        node = SExp.list("field", "9.0")
+        assert node.to_string(compact=True) == "(field 9.0)"
+
+    def test_parser_does_not_set_flag_on_list_nodes(self):
+        """The flag is only meaningful for atom nodes; list nodes default
+        to _originally_quoted=False even after parsing (no behavior change)."""
+        node = parse_string('(field "9.0")')
+        # The outer list node was not parsed from a quoted string
+        assert node._originally_quoted is False
+
+
 class TestParseFile:
     """Tests for parse_file function."""
 
@@ -702,6 +788,38 @@ class TestRoundTrip:
         assert footprint is not None
         pad = footprint.find("pad")
         assert pad is not None
+
+
+    def test_roundtrip_pcb_header_quoted_generator_version(self):
+        """KiCad strict-typed string fields with numeric-looking values
+        survive round-trip with their quotes intact.
+
+        This is the regression that issue #2493 fixes: previously the
+        serializer would emit (generator_version 9.0) for the parsed
+        (generator_version "9.0"), and kicad-cli would reject the file.
+        """
+        pcb_content = (
+            "(kicad_pcb\n"
+            '\t(version 20240108)\n'
+            '\t(generator "kicad_tools")\n'
+            '\t(generator_version "9.0")\n'
+            "\t(general\n"
+            "\t\t(thickness 1.6)\n"
+            "\t)\n"
+            ")"
+        )
+        parsed = parse_string(pcb_content)
+        serialized = parsed.to_string()
+
+        # generator_version atom must be quoted on output
+        assert '(generator_version "9.0")' in serialized
+        # The bare-numeric form (the bug) must not appear
+        assert "(generator_version 9.0)" not in serialized
+        # And it must reparse cleanly
+        reparsed = parse_string(serialized)
+        gv = reparsed["generator_version"].children[0]
+        assert gv.value == "9.0"
+        assert gv._originally_quoted is True
 
 
 class TestPositionTracking:


### PR DESCRIPTION
## Summary

- Adds `_originally_quoted` flag to `SExp` atoms (set by `_parse_string_node`, defaults to `False`); `_format_atom` gates quoting on it so parsed-quoted strings round-trip with their quotes intact even when they look numeric.
- Removes the surgical `_FORCE_QUOTED_STRING_VALUE` allow-list (and the parent's `force_quote_atom_str` branch in `to_string`) introduced by 30256d40 -- replaced by a principled fix that handles any strict-typed KiCad string field.
- Adds `SExp.quoted_atom(value)` for programmatic call sites that need to force-quote a numeric-looking string (pad/pin numbers, `generator_version`); updates `schema/pcb.py`, `schema/library.py`, `schema/symbol.py`, `schematic/models/io_mixin.py`, `footprints/__init__.py`, `sexp/builders.py`.
- Fixes `panel/_deep_copy_sexp` to propagate both `_original_str` and `_originally_quoted` so cloned subtrees serialize identically.

Closes #2493

## Approach

This is approach A from the curator comment on #2493 -- the structural fix that mirrors the `_original_str` precedent for numeric atoms. The naive "always quote string atoms" pilot the curator referenced broke ~36 tests; this approach only flips behavior for atoms the parser actually saw quoted in the input, so existing keyword/round-trip tests remain green.

Programmatic callers that need quoted intent now have a clean opt-in via `SExp.quoted_atom("9.0")` rather than constructing a bare `SExp` and mutating the flag.

## Test plan

- [x] `parse_string('(field "9.0")').to_string(compact=True) == '(field "9.0")'`
- [x] `parse_string('(field 9.0)').to_string(compact=True) == '(field 9.0)'`
- [x] `parse_string('(field "abc")').to_string(compact=True) == '(field "abc")'`
- [x] `parse_string('(layer signal)').to_string(compact=True) == '(layer signal)'`
- [x] Programmatic `SExp.quoted_atom("9.0")` emits quoted; default `SExp(value="9.0")` emits unquoted (documented).
- [x] `tests/test_sexp_parser.py` -- 91 passed (12 new + 79 existing).
- [x] `tests/test_footprints.py`, `tests/test_schema.py`, `tests/test_pcb.py`, `tests/test_lvs.py`, `tests/test_consistency.py`, `tests/test_panel.py`, `tests/test_panel_cli.py`, `tests/test_incremental_drc.py`, `tests/test_collision_detection.py`, `tests/test_cli_pcb.py` -- 651 passed, 2 skipped.
- [x] `tests/test_drc*.py`, `tests/test_erc*.py`, `tests/test_stitch*.py` -- 805 passed, 6 skipped.
- [x] End-to-end: regenerated `boards/00-simple-led/output/simple_led.kicad_pcb` through the new serializer and `kicad-cli pcb export gerbers` accepts it (return code 0). The fix functionally subsumes the `_FORCE_QUOTED_STRING_VALUE` workaround.