### PR TITLE
fix(route,export): fill copper-pour zones so Gerbers contain plane copper (closes #2516)

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -854,7 +854,11 @@ def _run_step_zones(ctx: BuildContext, console: Console) -> BuildResult:
     and power nets are distributed across In2.Cu / F.Cu.
 
     Zones are *defined* here (unfilled polygons).  Filling happens later
-    after routing, typically via kicad-cli.
+    after routing -- ``kct route`` calls :func:`route_cmd._fill_zones_after_route`
+    once routing succeeds, and :func:`pipeline_cmd._run_step_zones` performs
+    the same fill via ``kct zones fill``.  ``kct export`` also runs a
+    safety-net fill if the PCB still has unfilled zones at export time
+    (see :func:`export.gerber.GerberExporter._export_gerbers`).
     """
     if not ctx.pcb_file or not ctx.pcb_file.exists():
         return BuildResult(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -597,6 +597,99 @@ def _should_auto_fix(args) -> bool:
     return True
 
 
+def _fill_zones_after_route(output_path: Path, quiet: bool = False) -> None:
+    """Fill copper-pour zones after routing completes.
+
+    Routing produces traces; copper pour zones must be filled *after* the
+    trace geometry exists so the fill polygons respect trace clearances.
+    Without this step, exported Gerbers contain ``(zone ...)`` definitions
+    but zero ``G36...G37`` polygon-fill regions, so manufactured boards have
+    no plane copper -- the bug fixed by issue #2516.
+
+    This function mirrors :func:`pipeline_cmd._run_step_zones`:
+
+    - Skips silently when ``kicad-cli`` is not installed (no-op with warning).
+    - Delegates to :func:`runner.run_fill_zones` so the existing
+      net-corruption snapshot/restore guard (``_snapshot_net_declarations`` /
+      ``_restore_net_declarations``) runs.
+    - Validates net format afterwards via :func:`runner.validate_net_format`
+      and logs a warning when corruption is detected.
+
+    The function is idempotent: filling a PCB whose zones are already filled
+    simply rewrites the same fill polygons.  When the input PCB has no
+    ``(zone ...)`` blocks at all, kicad-cli has nothing to fill and this is
+    effectively a no-op.
+
+    Args:
+        output_path: Path to the routed PCB file (modified in place).
+        quiet: Suppress informational output.
+    """
+    from kicad_tools.cli.runner import (
+        find_kicad_cli,
+        run_fill_zones,
+        validate_net_format,
+    )
+
+    kicad_cli = find_kicad_cli()
+    if kicad_cli is None:
+        if not quiet:
+            print("  Zone fill: skipped (kicad-cli not installed)")
+        return
+
+    # Quick check: does the PCB even have any zones to fill?
+    # KiCad's serializer wraps zones either as "(zone (net ...)" on one
+    # line OR as "(zone\n  (net ...)" with a newline after the opening
+    # token, so we need to detect both forms.
+    try:
+        text = output_path.read_text()
+    except OSError as exc:
+        logger.warning("Zone fill: could not read %s: %s", output_path, exc)
+        return
+    if "(zone " not in text and "(zone\n" not in text and "(zone\t" not in text:
+        # Nothing to fill -- skip silently to avoid log noise on the
+        # majority of boards that have no copper pours.
+        return
+
+    if not quiet:
+        print("\n--- Filling Copper Zones ---")
+        print(f"  Filling zones in {output_path.name}...")
+
+    result = run_fill_zones(output_path, kicad_cli=kicad_cli)
+
+    if not result.success:
+        # Non-fatal: log warning and continue.  The board may still be
+        # usable for partial inspection but the manufacturing artifacts
+        # will lack plane copper.
+        logger.warning(
+            "Zone fill failed for %s: %s",
+            output_path,
+            result.stderr or "(no stderr)",
+        )
+        if not quiet:
+            print("  Warning: zone fill failed -- Gerbers will lack plane copper")
+        return
+
+    # Validate net format after zone fill -- kicad-cli may corrupt nets.
+    report = validate_net_format(output_path)
+    if not report.valid:
+        logger.warning(
+            "Net format corruption detected after zone fill: "
+            "%d element(s) have non-canonical net format "
+            "(name_only_segments=%d, name_only_vias=%d, name_only_pads=%d, "
+            "empty_net_segments=%d, empty_net_vias=%d, empty_net_pads=%d)",
+            report.total_corrupt,
+            report.name_only_segments,
+            report.name_only_vias,
+            report.name_only_pads,
+            report.empty_net_segments,
+            report.empty_net_vias,
+            report.empty_net_pads,
+        )
+
+    if not quiet:
+        print("  Zone fill: complete")
+
+
 @dataclass
 class LayerEscalationResult:
     """Result of a layer escalation routing attempt."""
@@ -1375,6 +1468,13 @@ def route_with_layer_escalation(
         print(f"  Saved to: {output_path}")
         print(f"  Layer count: {final_result.layer_count}")
 
+    # Fill copper-pour zones now that traces exist (issue #2516).
+    # Must run BEFORE DRC so the DRC sees filled zones rather than bare
+    # zone outlines and does not flag zone-to-trace clearance against
+    # unfilled polygons.
+    if final_result.nets_routed > 0:
+        _fill_zones_after_route(output_path, quiet=quiet)
+
     # Run DRC validation unless skipped
     if not args.skip_drc and final_result.nets_routed > 0:
         drc_errors, _ = run_post_route_drc(
@@ -1858,6 +1958,10 @@ def route_with_rule_relaxation(
         print(f"  Saved to: {output_path}")
         print(f"  Final trace width: {final_result.trace_width:.3f}mm")
         print(f"  Final clearance: {final_result.clearance:.3f}mm")
+
+    # Fill copper-pour zones now that traces exist (issue #2516).
+    if final_result.nets_routed > 0:
+        _fill_zones_after_route(output_path, quiet=quiet)
 
     # Run DRC validation unless skipped
     if not args.skip_drc and final_result.nets_routed > 0:
@@ -2388,6 +2492,10 @@ def route_with_combined_escalation(
         print(f"  Layer count: {final_result.layer_count}")
         print(f"  Final trace width: {final_result.trace_width:.3f}mm")
         print(f"  Final clearance: {final_result.clearance:.3f}mm")
+
+    # Fill copper-pour zones now that traces exist (issue #2516).
+    if final_result.nets_routed > 0:
+        _fill_zones_after_route(output_path, quiet=quiet)
 
     # Run DRC validation unless skipped
     if not args.skip_drc and final_result.nets_routed > 0:
@@ -4463,6 +4571,12 @@ def main(argv: list[str] | None = None) -> int:
         else:
             if not quiet:
                 print("  No power plane nets found (no zones with assigned nets)")
+
+    # Fill copper-pour zones now that traces (and any stitching vias)
+    # are in place (issue #2516).  Must run BEFORE DRC so the DRC sees
+    # filled zones rather than bare zone outlines.
+    if not args.dry_run and stats["nets_routed"] > 0:
+        _fill_zones_after_route(output_path, quiet=quiet)
 
     # Run DRC validation unless skipped or dry-run
     drc_errors = 0

--- a/src/kicad_tools/export/gerber.py
+++ b/src/kicad_tools/export/gerber.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import tempfile
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -24,6 +25,31 @@ from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.cli.runner import find_kicad_cli
 
 logger = logging.getLogger(__name__)
+
+
+def _pcb_has_unfilled_zones(pcb_path: Path) -> bool:
+    """Return True if the PCB defines copper-pour zones with no fill data.
+
+    Cheap text scan that avoids parsing the full S-expression: a properly
+    filled zone contains ``(filled_polygon ...)`` children; an unfilled zone
+    has only the outline definition.  Used by :meth:`GerberExporter._export_gerbers`
+    to decide whether to invoke the safety-net fill pass before exporting
+    Gerbers (issue #2516).
+
+    The serializer wraps zones in two forms -- ``(zone (net ...)`` on a
+    single line, or ``(zone\\n  (net ...)`` with a newline after the
+    opening token -- so we accept either.
+    """
+    try:
+        text = pcb_path.read_text()
+    except OSError:
+        return False
+    has_zone = "(zone " in text or "(zone\n" in text or "(zone\t" in text
+    if not has_zone:
+        return False
+    # If we have zones but no filled_polygon, the zones are unfilled and
+    # the resulting Gerbers would lack G36..G37 polygon-fill regions.
+    return "filled_polygon" not in text
 
 
 @dataclass
@@ -342,12 +368,61 @@ class GerberExporter:
 
     def _export_gerbers(self, config: GerberConfig, output_dir: Path) -> None:
         """Export Gerber files using kicad-cli."""
+        # Safety-net fill (issue #2516): if the PCB has zone definitions
+        # but no fill polygons, the resulting Gerbers would contain zero
+        # G36..G37 polygon-fill regions and the manufactured board would
+        # lack plane copper.  Fill zones into a temp PCB so we never
+        # silently mutate the user's file, then export Gerbers from the
+        # temp file.
+        pcb_for_export = self.pcb_path
+        tmpdir: tempfile.TemporaryDirectory[str] | None = None
+        try:
+            if _pcb_has_unfilled_zones(self.pcb_path):
+                from kicad_tools.cli.runner import run_fill_zones
+
+                tmpdir = tempfile.TemporaryDirectory(prefix="kct_gerber_fill_")
+                # Reuse the original filename so kicad-cli's per-layer
+                # output naming is unaffected.
+                filled_pcb = Path(tmpdir.name) / self.pcb_path.name
+                logger.info(
+                    "Gerber export: PCB has unfilled zones; filling to temp file %s",
+                    filled_pcb,
+                )
+                fill_result = run_fill_zones(
+                    self.pcb_path,
+                    output_path=filled_pcb,
+                    kicad_cli=self.kicad_cli,
+                )
+                if fill_result.success and filled_pcb.exists():
+                    pcb_for_export = filled_pcb
+                else:
+                    # Non-fatal: fall back to the unfilled PCB and let the
+                    # downstream Gerber export proceed.  The user will see
+                    # missing plane copper in the Gerbers but the export
+                    # itself will still succeed.
+                    logger.warning(
+                        "Gerber export: zone fill failed (%s); Gerbers may lack plane copper",
+                        fill_result.stderr or "(no stderr)",
+                    )
+
+            self._export_gerbers_impl(config, output_dir, pcb_for_export)
+        finally:
+            if tmpdir is not None:
+                tmpdir.cleanup()
+
+    def _export_gerbers_impl(
+        self,
+        config: GerberConfig,
+        output_dir: Path,
+        pcb_path: Path,
+    ) -> None:
+        """Invoke ``kicad-cli pcb export gerbers`` against ``pcb_path``."""
         cmd = [
             str(self.kicad_cli),
             "pcb",
             "export",
             "gerbers",
-            str(self.pcb_path),
+            str(pcb_path),
             "--output",
             str(output_dir) + "/",
         ]

--- a/tests/test_gerber_zone_fill.py
+++ b/tests/test_gerber_zone_fill.py
@@ -1,0 +1,303 @@
+"""Tests for the safety-net zone-fill in Gerber export (issue #2516).
+
+When a PCB defines ``(zone ...)`` blocks but contains no ``filled_polygon``
+children, the resulting Gerbers would lack ``G36..G37`` polygon-fill regions
+and the manufactured board would have no plane copper.
+
+The fix in :meth:`GerberExporter._export_gerbers` performs a safety-net fill
+into a temp file before invoking ``kicad-cli pcb export gerbers`` so the
+source PCB is never silently mutated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.export.gerber import GerberConfig, GerberExporter, _pcb_has_unfilled_zones
+
+# ---------------------------------------------------------------------------
+# _pcb_has_unfilled_zones unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestPcbHasUnfilledZones:
+    """Verify the cheap text-scan that drives the safety-net fill."""
+
+    def test_returns_false_for_no_zones(self, tmp_path):
+        pcb = tmp_path / "no_zone.kicad_pcb"
+        pcb.write_text('(kicad_pcb (version 20240108) (net 0 ""))\n')
+        assert _pcb_has_unfilled_zones(pcb) is False
+
+    def test_returns_true_for_unfilled_zone(self, tmp_path):
+        pcb = tmp_path / "unfilled.kicad_pcb"
+        pcb.write_text(
+            "(kicad_pcb\n"
+            '  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "z1")\n'
+            "    (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10)))))\n"
+        )
+        assert _pcb_has_unfilled_zones(pcb) is True
+
+    def test_returns_true_for_multiline_zone_format(self, tmp_path):
+        """KiCad's serializer wraps zones with a newline after ``(zone``.
+
+        Regression test for the bug where the original "(zone " (with
+        trailing space) text scan missed the multi-line form actually
+        emitted by ``kct route``'s zone generator.
+        """
+        pcb = tmp_path / "multiline.kicad_pcb"
+        pcb.write_text(
+            "(kicad_pcb\n"
+            "\t(zone\n"
+            "\t\t(net 10)\n"
+            '\t\t(net_name "GND")\n'
+            '\t\t(layer "B.Cu")\n'
+            '\t\t(uuid "z1")\n'
+            "\t\t(polygon (pts (xy 0 0) (xy 10 0) (xy 10 10))))\n"
+            ")\n"
+        )
+        assert _pcb_has_unfilled_zones(pcb) is True
+
+    def test_returns_false_for_filled_zone(self, tmp_path):
+        pcb = tmp_path / "filled.kicad_pcb"
+        pcb.write_text(
+            "(kicad_pcb\n"
+            '  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "z1")\n'
+            "    (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10)))\n"
+            '    (filled_polygon (layer "B.Cu") (pts (xy 0 0) (xy 10 0)))))\n'
+        )
+        assert _pcb_has_unfilled_zones(pcb) is False
+
+    def test_returns_false_on_unreadable_file(self, tmp_path):
+        # A path that doesn't exist returns False (best-effort -- we'd
+        # rather skip the safety-net fill than crash).
+        assert _pcb_has_unfilled_zones(tmp_path / "missing.kicad_pcb") is False
+
+
+# ---------------------------------------------------------------------------
+# Safety-net fill integration with _export_gerbers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_exporter_with_unfilled(tmp_path):
+    """A GerberExporter pointing at a PCB that defines unfilled zones."""
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text(
+        "(kicad_pcb (version 20240108)\n"
+        '  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "z1")\n'
+        "    (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10)))))\n"
+    )
+
+    with patch.object(GerberExporter, "__init__", lambda self, path: None):
+        exporter = GerberExporter.__new__(GerberExporter)
+        exporter.pcb_path = pcb
+        exporter.kicad_cli = Path("/usr/bin/kicad-cli")
+        return exporter
+
+
+@pytest.fixture
+def mock_exporter_no_zones(tmp_path):
+    """A GerberExporter pointing at a PCB with no zones at all."""
+    pcb = tmp_path / "no_zone.kicad_pcb"
+    pcb.write_text("(kicad_pcb (version 20240108))\n")
+
+    with patch.object(GerberExporter, "__init__", lambda self, path: None):
+        exporter = GerberExporter.__new__(GerberExporter)
+        exporter.pcb_path = pcb
+        exporter.kicad_cli = Path("/usr/bin/kicad-cli")
+        return exporter
+
+
+@pytest.fixture
+def mock_exporter_filled(tmp_path):
+    """A GerberExporter pointing at a PCB whose zones are already filled."""
+    pcb = tmp_path / "filled.kicad_pcb"
+    pcb.write_text(
+        "(kicad_pcb (version 20240108)\n"
+        '  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "z1")\n'
+        "    (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10)))\n"
+        '    (filled_polygon (layer "B.Cu") (pts (xy 0 0)))))\n'
+    )
+
+    with patch.object(GerberExporter, "__init__", lambda self, path: None):
+        exporter = GerberExporter.__new__(GerberExporter)
+        exporter.pcb_path = pcb
+        exporter.kicad_cli = Path("/usr/bin/kicad-cli")
+        return exporter
+
+
+class TestExportGerbersSafetyFill:
+    """Verify the safety-net fill behaviour in _export_gerbers."""
+
+    def test_unfilled_pcb_triggers_run_fill_zones(self, mock_exporter_with_unfilled, tmp_path):
+        """When zones are unfilled, run_fill_zones must be invoked."""
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        config = GerberConfig()
+
+        # Mock fill: write a "filled" copy of the input to the requested path.
+        def fake_fill(pcb_path, output_path=None, kicad_cli=None):
+            if output_path is not None:
+                output_path.write_text(pcb_path.read_text() + "\n;filled\n")
+            return KiCadCLIResult(success=True, output_path=output_path, return_code=0)
+
+        impl_calls: list[Path] = []
+
+        def fake_impl(self, cfg, out, pcb_path):
+            impl_calls.append(pcb_path)
+
+        with (
+            patch(
+                "kicad_tools.cli.runner.run_fill_zones",
+                side_effect=fake_fill,
+            ) as mock_fill,
+            patch.object(GerberExporter, "_export_gerbers_impl", fake_impl),
+        ):
+            mock_exporter_with_unfilled._export_gerbers(config, out_dir)
+
+        mock_fill.assert_called_once()
+        # The PCB passed to _export_gerbers_impl must NOT be the user's
+        # original file -- it should be a temp filled copy.
+        assert len(impl_calls) == 1
+        assert impl_calls[0] != mock_exporter_with_unfilled.pcb_path
+        assert impl_calls[0].name == mock_exporter_with_unfilled.pcb_path.name
+
+    def test_no_zones_skips_fill(self, mock_exporter_no_zones, tmp_path):
+        """When the PCB has no zones, run_fill_zones must not be invoked."""
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        config = GerberConfig()
+
+        impl_calls: list[Path] = []
+
+        def fake_impl(self, cfg, out, pcb_path):
+            impl_calls.append(pcb_path)
+
+        with (
+            patch("kicad_tools.cli.runner.run_fill_zones") as mock_fill,
+            patch.object(GerberExporter, "_export_gerbers_impl", fake_impl),
+        ):
+            mock_exporter_no_zones._export_gerbers(config, out_dir)
+
+        mock_fill.assert_not_called()
+        # The original PCB is exported directly.
+        assert impl_calls == [mock_exporter_no_zones.pcb_path]
+
+    def test_already_filled_pcb_skips_fill(self, mock_exporter_filled, tmp_path):
+        """A PCB whose zones are already filled does not need re-filling."""
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        config = GerberConfig()
+
+        impl_calls: list[Path] = []
+
+        def fake_impl(self, cfg, out, pcb_path):
+            impl_calls.append(pcb_path)
+
+        with (
+            patch("kicad_tools.cli.runner.run_fill_zones") as mock_fill,
+            patch.object(GerberExporter, "_export_gerbers_impl", fake_impl),
+        ):
+            mock_exporter_filled._export_gerbers(config, out_dir)
+
+        mock_fill.assert_not_called()
+        assert impl_calls == [mock_exporter_filled.pcb_path]
+
+    def test_source_pcb_never_mutated(self, mock_exporter_with_unfilled, tmp_path):
+        """The user's source PCB file must not be written to during fill.
+
+        We capture the on-disk content before and after the export and
+        verify it is byte-identical -- the safety-net fill must use a temp
+        file.
+        """
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        original_content = mock_exporter_with_unfilled.pcb_path.read_bytes()
+
+        def fake_fill(pcb_path, output_path=None, kicad_cli=None):
+            # Simulate kicad-cli writing fill polygons into the *output*
+            # path so we can prove the input is untouched.
+            if output_path is not None:
+                output_path.write_text(
+                    pcb_path.read_text().replace("(polygon", "(filled_polygon ...) (polygon")
+                )
+            return KiCadCLIResult(success=True, output_path=output_path, return_code=0)
+
+        with (
+            patch(
+                "kicad_tools.cli.runner.run_fill_zones",
+                side_effect=fake_fill,
+            ),
+            patch.object(GerberExporter, "_export_gerbers_impl", lambda *a, **k: None),
+        ):
+            mock_exporter_with_unfilled._export_gerbers(GerberConfig(), out_dir)
+
+        # Source PCB must still match its original content.
+        assert mock_exporter_with_unfilled.pcb_path.read_bytes() == original_content
+
+    def test_fill_failure_falls_back_to_unfilled_pcb(
+        self, mock_exporter_with_unfilled, tmp_path, caplog
+    ):
+        """If the safety-net fill fails, export proceeds against the original PCB."""
+        import logging
+
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        impl_calls: list[Path] = []
+
+        def fake_impl(self, cfg, out, pcb_path):
+            impl_calls.append(pcb_path)
+
+        with (
+            patch(
+                "kicad_tools.cli.runner.run_fill_zones",
+                return_value=KiCadCLIResult(success=False, stderr="boom", return_code=1),
+            ),
+            patch.object(GerberExporter, "_export_gerbers_impl", fake_impl),
+            caplog.at_level(logging.WARNING, logger="kicad_tools.export.gerber"),
+        ):
+            mock_exporter_with_unfilled._export_gerbers(GerberConfig(), out_dir)
+
+        # Falls back to the original (unfilled) PCB.
+        assert impl_calls == [mock_exporter_with_unfilled.pcb_path]
+        # Warning logged so the user knows the Gerbers will lack plane copper.
+        assert any("zone fill failed" in r.message.lower() for r in caplog.records)
+
+    def test_temp_file_cleaned_up(self, mock_exporter_with_unfilled, tmp_path):
+        """The temp directory used for the fill must be cleaned up after export."""
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        captured_temp_path: list[Path] = []
+
+        def fake_fill(pcb_path, output_path=None, kicad_cli=None):
+            assert output_path is not None
+            captured_temp_path.append(output_path)
+            output_path.write_text("filled")
+            return KiCadCLIResult(success=True, output_path=output_path, return_code=0)
+
+        with (
+            patch(
+                "kicad_tools.cli.runner.run_fill_zones",
+                side_effect=fake_fill,
+            ),
+            patch.object(GerberExporter, "_export_gerbers_impl", lambda *a, **k: None),
+        ):
+            mock_exporter_with_unfilled._export_gerbers(GerberConfig(), out_dir)
+
+        assert len(captured_temp_path) == 1
+        # The temp file's containing directory must be gone after _export_gerbers
+        # returns (TemporaryDirectory.cleanup() removes it).
+        assert not captured_temp_path[0].parent.exists()

--- a/tests/test_route_cmd_zone_fill.py
+++ b/tests/test_route_cmd_zone_fill.py
@@ -1,0 +1,295 @@
+"""Tests for the post-route zone-fill wiring (issue #2516).
+
+The bug: ``kct route`` and ``kct export`` defined ``(zone ...)`` blocks via
+auto-pour but never filled them, so exported Gerbers contained zero
+``G36..G37`` polygon-fill regions and manufactured boards lacked plane
+copper.
+
+The fix wires :func:`runner.run_fill_zones` into:
+  - ``route_cmd._fill_zones_after_route`` (called by all four route paths)
+  - ``gerber.GerberExporter._export_gerbers`` (safety-net at export time)
+
+These tests verify the wiring at the unit level using mocks so they run
+without kicad-cli installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Patch targets -- _fill_zones_after_route imports from .runner at call time,
+# so we patch the names in the runner module itself.
+# ---------------------------------------------------------------------------
+_FIND_CLI = "kicad_tools.cli.runner.find_kicad_cli"
+_RUN_FILL = "kicad_tools.cli.runner.run_fill_zones"
+_VALIDATE_NET = "kicad_tools.cli.runner.validate_net_format"
+
+
+# ---------------------------------------------------------------------------
+# Fixture: minimal PCB with a single (zone ...) block
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pcb_with_zone(tmp_path: Path) -> Path:
+    """Write a minimal .kicad_pcb file containing one unfilled zone."""
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text(
+        '(kicad_pcb (version 20240108) (generator "test")\n'
+        "  (general (thickness 1.6))\n"
+        '  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))\n'
+        '  (net 0 "")\n'
+        '  (net 1 "GND")\n'
+        '  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "zone-test")\n'
+        "    (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10))))\n"
+        ")\n"
+    )
+    return pcb
+
+
+@pytest.fixture
+def pcb_no_zone(tmp_path: Path) -> Path:
+    """Write a minimal .kicad_pcb file with no (zone ...) blocks."""
+    pcb = tmp_path / "no_zone.kicad_pcb"
+    pcb.write_text(
+        '(kicad_pcb (version 20240108) (generator "test")\n'
+        "  (general (thickness 1.6))\n"
+        '  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))\n'
+        '  (net 0 "")\n'
+        ")\n"
+    )
+    return pcb
+
+
+# ---------------------------------------------------------------------------
+# Tests for _fill_zones_after_route
+# ---------------------------------------------------------------------------
+
+
+class TestFillZonesAfterRoute:
+    """Verify the post-route fill helper invokes run_fill_zones correctly."""
+
+    def test_skips_when_no_kicad_cli(self, pcb_with_zone, capsys):
+        """No-op (with optional warning) when kicad-cli is not available."""
+        from kicad_tools.cli.route_cmd import _fill_zones_after_route
+
+        with (
+            patch(_FIND_CLI, return_value=None),
+            patch(_RUN_FILL) as mock_fill,
+        ):
+            _fill_zones_after_route(pcb_with_zone, quiet=False)
+            mock_fill.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert "kicad-cli not installed" in captured.out
+
+    def test_skips_silently_when_no_zones(self, pcb_no_zone, capsys):
+        """Skip silently when the PCB has no zones to fill."""
+        from kicad_tools.cli.route_cmd import _fill_zones_after_route
+
+        with (
+            patch(_FIND_CLI, return_value=Path("/usr/bin/kicad-cli")),
+            patch(_RUN_FILL) as mock_fill,
+        ):
+            _fill_zones_after_route(pcb_no_zone, quiet=False)
+            mock_fill.assert_not_called()
+
+        # No output -- silent skip
+        captured = capsys.readouterr()
+        assert "Filling Copper Zones" not in captured.out
+
+    def test_detects_multiline_zone_format(self, tmp_path, capsys):
+        """The serializer wraps zones across multiple lines.
+
+        Regression: the original "(zone " (with trailing space) check missed
+        the multi-line form actually emitted by the zone generator.
+        """
+        from kicad_tools.cli.route_cmd import _fill_zones_after_route
+        from kicad_tools.cli.runner import KiCadCLIResult, NetFormatReport
+
+        pcb = tmp_path / "multiline.kicad_pcb"
+        pcb.write_text(
+            '(kicad_pcb (version 20240108) (generator "test")\n'
+            "\t(zone\n"
+            "\t\t(net 10)\n"
+            '\t\t(net_name "GND")\n'
+            '\t\t(layer "B.Cu")\n'
+            '\t\t(uuid "z1")\n'
+            "\t\t(polygon (pts (xy 0 0) (xy 10 0) (xy 10 10))))\n"
+            ")\n"
+        )
+
+        mock_result = KiCadCLIResult(success=True, return_code=0)
+        with (
+            patch(_FIND_CLI, return_value=Path("/usr/bin/kicad-cli")),
+            patch(_RUN_FILL, return_value=mock_result) as mock_fill,
+            patch(_VALIDATE_NET, return_value=NetFormatReport(valid=True)),
+        ):
+            _fill_zones_after_route(pcb, quiet=False)
+            mock_fill.assert_called_once()
+
+        captured = capsys.readouterr()
+        assert "Filling Copper Zones" in captured.out
+
+    def test_calls_run_fill_zones_when_zones_present(self, pcb_with_zone, capsys):
+        """When zones exist and kicad-cli is available, invoke run_fill_zones."""
+        from kicad_tools.cli.route_cmd import _fill_zones_after_route
+        from kicad_tools.cli.runner import KiCadCLIResult, NetFormatReport
+
+        mock_result = KiCadCLIResult(
+            success=True,
+            output_path=pcb_with_zone,
+            return_code=0,
+        )
+        with (
+            patch(_FIND_CLI, return_value=Path("/usr/bin/kicad-cli")),
+            patch(_RUN_FILL, return_value=mock_result) as mock_fill,
+            patch(_VALIDATE_NET, return_value=NetFormatReport(valid=True)),
+        ):
+            _fill_zones_after_route(pcb_with_zone, quiet=False)
+            mock_fill.assert_called_once()
+            # First positional arg is the PCB path.
+            assert mock_fill.call_args.args[0] == pcb_with_zone
+
+        captured = capsys.readouterr()
+        assert "Filling Copper Zones" in captured.out
+        assert "complete" in captured.out
+
+    def test_quiet_mode_suppresses_output(self, pcb_with_zone, capsys):
+        """quiet=True suppresses informational prints."""
+        from kicad_tools.cli.route_cmd import _fill_zones_after_route
+        from kicad_tools.cli.runner import KiCadCLIResult, NetFormatReport
+
+        mock_result = KiCadCLIResult(success=True, return_code=0)
+        with (
+            patch(_FIND_CLI, return_value=Path("/usr/bin/kicad-cli")),
+            patch(_RUN_FILL, return_value=mock_result),
+            patch(_VALIDATE_NET, return_value=NetFormatReport(valid=True)),
+        ):
+            _fill_zones_after_route(pcb_with_zone, quiet=True)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_validates_net_format_after_fill(self, pcb_with_zone):
+        """validate_net_format must be called after a successful fill."""
+        from kicad_tools.cli.route_cmd import _fill_zones_after_route
+        from kicad_tools.cli.runner import KiCadCLIResult, NetFormatReport
+
+        mock_result = KiCadCLIResult(success=True, return_code=0)
+        with (
+            patch(_FIND_CLI, return_value=Path("/usr/bin/kicad-cli")),
+            patch(_RUN_FILL, return_value=mock_result),
+            patch(_VALIDATE_NET, return_value=NetFormatReport(valid=True)) as mock_val,
+        ):
+            _fill_zones_after_route(pcb_with_zone, quiet=True)
+            mock_val.assert_called_once_with(pcb_with_zone)
+
+    def test_logs_warning_on_net_corruption(self, pcb_with_zone, caplog):
+        """When validate_net_format reports corruption, log a warning."""
+        import logging
+
+        from kicad_tools.cli.route_cmd import _fill_zones_after_route
+        from kicad_tools.cli.runner import KiCadCLIResult, NetFormatReport
+
+        bad_report = NetFormatReport(valid=False, name_only_segments=3, empty_net_vias=1)
+        mock_result = KiCadCLIResult(success=True, return_code=0)
+
+        with (
+            patch(_FIND_CLI, return_value=Path("/usr/bin/kicad-cli")),
+            patch(_RUN_FILL, return_value=mock_result),
+            patch(_VALIDATE_NET, return_value=bad_report),
+            caplog.at_level(logging.WARNING, logger="kicad_tools.cli.route_cmd"),
+        ):
+            _fill_zones_after_route(pcb_with_zone, quiet=True)
+
+        assert any("Net format corruption" in r.message for r in caplog.records)
+
+    def test_fill_failure_is_non_fatal(self, pcb_with_zone, caplog, capsys):
+        """A fill failure logs a warning but does not raise."""
+        import logging
+
+        from kicad_tools.cli.route_cmd import _fill_zones_after_route
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        bad_result = KiCadCLIResult(
+            success=False,
+            stderr="kicad-cli crashed",
+            return_code=1,
+        )
+        with (
+            patch(_FIND_CLI, return_value=Path("/usr/bin/kicad-cli")),
+            patch(_RUN_FILL, return_value=bad_result),
+            caplog.at_level(logging.WARNING, logger="kicad_tools.cli.route_cmd"),
+        ):
+            # Must not raise.
+            _fill_zones_after_route(pcb_with_zone, quiet=False)
+
+        captured = capsys.readouterr()
+        assert "zone fill failed" in captured.out.lower()
+        assert any("Zone fill failed" in r.message for r in caplog.records)
+
+    def test_idempotent_on_already_filled_pcb(self, tmp_path):
+        """Running twice on a PCB that already has filled zones is safe."""
+        from kicad_tools.cli.route_cmd import _fill_zones_after_route
+        from kicad_tools.cli.runner import KiCadCLIResult, NetFormatReport
+
+        # PCB that already contains a filled zone.
+        pcb = tmp_path / "filled.kicad_pcb"
+        pcb.write_text(
+            '(kicad_pcb (version 20240108) (generator "test")\n'
+            '  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "z1")\n'
+            "    (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10)))\n"
+            '    (filled_polygon (layer "B.Cu") (pts (xy 0 0) (xy 10 0))))\n'
+            ")\n"
+        )
+
+        mock_result = KiCadCLIResult(success=True, return_code=0)
+        with (
+            patch(_FIND_CLI, return_value=Path("/usr/bin/kicad-cli")),
+            patch(_RUN_FILL, return_value=mock_result) as mock_fill,
+            patch(_VALIDATE_NET, return_value=NetFormatReport(valid=True)),
+        ):
+            _fill_zones_after_route(pcb, quiet=True)
+            _fill_zones_after_route(pcb, quiet=True)
+
+        # Both calls should invoke fill (kicad-cli is responsible for the
+        # actual idempotency by recomputing the same fill polygons).
+        assert mock_fill.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Verify the helper is wired into all four route paths
+# ---------------------------------------------------------------------------
+
+
+class TestRouteFillWiring:
+    """Verify _fill_zones_after_route is called from all four route paths."""
+
+    def test_route_cmd_module_imports_helper(self):
+        """_fill_zones_after_route should be a top-level function."""
+        from kicad_tools.cli import route_cmd
+
+        assert hasattr(route_cmd, "_fill_zones_after_route")
+        assert callable(route_cmd._fill_zones_after_route)
+
+    def test_helper_is_invoked_from_all_route_functions(self):
+        """The four route_with_* functions must each reference the helper.
+
+        This is a simple source-level check that catches regressions where
+        a future refactor drops the call site.
+        """
+        from kicad_tools.cli import route_cmd
+
+        source = Path(route_cmd.__file__).read_text()
+        # Definition + four call sites = 5 occurrences minimum.
+        # Allow more in case of additional internal users or docstrings.
+        call_count = source.count("_fill_zones_after_route(")
+        assert call_count >= 5, (
+            f"expected >= 5 occurrences of _fill_zones_after_route( "
+            f"(1 def + 4 callers), found {call_count}"
+        )


### PR DESCRIPTION
## Summary

Wires the existing `runner.run_fill_zones` helper into `kct route` and `kct export` so that auto-poured `(zone ...)` blocks are actually filled. Without this fix, exported Gerbers contain zero `G36..G37` polygon-fill regions and manufactured boards have no GND/VCC plane copper.

The fill machinery already existed (`run_fill_zones` in `cli/runner.py:305`, wrapped as `kct zones fill` and used by `kct pipeline`). This PR closes the wiring gap in the standalone `kct route` and `kct export` commands that the example boards' Makefiles drive.

## Two layers of defense

1. **Primary fix** in `route_cmd._fill_zones_after_route()`: runs after each of the four routing paths completes successfully (`route_with_layer_escalation`, `route_with_rule_relaxation`, `route_with_combined_escalation`, and the negotiated path in `main()`). Mirrors `pipeline_cmd._run_step_zones` -- delegates to `runner.run_fill_zones` so the existing kicad-cli net-corruption snapshot/restore guard runs, and validates net format afterwards.

2. **Safety-net fix** in `gerber.GerberExporter._export_gerbers`: detects unfilled zones via a cheap text scan and fills into a temp PCB before invoking `kicad-cli pcb export gerbers`. The user's source file is never mutated (TemporaryDirectory cleanup in a finally block).

Both call sites are no-ops when the PCB has no zones, so `--no-auto-pour` and zone-less designs are unaffected.

## End-to-end verification

Verified against board 02 (charlieplex_3x3) which has signal + power nets:

- Routed PCB: 2 zones, 2 filled_polygon entries
- Gerber B.Cu: 1 G36..G37 polygon-fill region
- Gerber F.Cu: 1 G36..G37 polygon-fill region
- Safety-net path also confirmed: exporting an unfilled PCB still produces Gerbers with G36 regions, and the source PCB stays untouched.

## Notes

- Detection uses both `(zone ` and `(zone\n` because the serializer emits the multi-line form. The original v1 of this PR missed multi-line zones; a regression test was added (`test_detects_multiline_zone_format`).
- Updated outdated comment in `build_cmd._run_step_zones` docstring (the old "Filling happens later via kicad-cli" line was the breadcrumb of this bug).
- Fill is non-trivial work (seconds per board) -- adds runtime to every `kct route` invocation. CI test-suite duration may grow on the larger boards.

## Test plan

- [x] Unit tests for `_fill_zones_after_route` (all kicad-cli states, idempotency, fill failure, net-corruption logging) -- 11 tests
- [x] Unit tests for the gerber safety-net (multi-line zones, source PCB never mutated, temp file cleanup, fill-failure fallback) -- 11 tests
- [x] All 22 new tests pass
- [x] Related test suites still pass (`test_zones_cmd.py`, `test_export_extended.py`, `test_runner_net_restore.py`, `test_route_cmd_*`) -- 258 passed, 1 pre-existing failure (`test_fill_zones_on_fixture` requires kicad-cli to load the fixture board, unchanged from main)
- [x] End-to-end smoke: `kct route` on board 02 produces filled zones, `kct export` produces Gerbers with G36 polygon-fill regions
- [x] Source PCB never mutated by the safety-net fill (verified by byte-comparison test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)