### PR TITLE
fix(router): rip up neighbors when failures have overflow=0; clearer C++ backend diagnostic (closes #2514)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3671,6 +3671,16 @@ class Autorouter:
         neighborhood_stall_count = 0
         prev_routed_count = 0
         full_reorder_used_this_iter = False
+        # Issue #2514: Identify single-pad nets up front so the recovery
+        # loop can distinguish "structurally unroutable" from "failed but
+        # retry-able".  A net with <2 routable pads has no edges in its
+        # MST and ``_route_net_negotiated`` returns ``[]`` immediately --
+        # if we don't filter these out explicitly the rip-up loop counts
+        # them in the "X net(s) failed to route" diagnostic and then
+        # silently exits at iteration 1 because the recovery filter at
+        # ``failed_nets_to_recover`` excludes them via the implicit
+        # ``n in pads_by_net`` clause.
+        single_pad_nets: set[int] = set()
         for net in net_order:
             if net in self.nets:
                 pads_for_routing = self.nets[net]
@@ -3681,6 +3691,13 @@ class Autorouter:
                         self._escape_pad_overrides.get(p, self.pads[p])
                         for p in pads_for_routing
                     ]
+                else:
+                    single_pad_nets.add(net)
+            else:
+                # Net referenced by net_order but absent from self.nets --
+                # treat as structurally unroutable so the recovery loop
+                # does not spin trying to route it.
+                single_pad_nets.add(net)
 
         def check_timeout() -> bool:
             """Check if timeout has been reached."""
@@ -3755,17 +3772,38 @@ class Autorouter:
             f"  Routed {len(net_routes)}/{total_nets} nets, overflow: {overflow} ({elapsed_str()})"
         )
 
+        # Issue #2514: Surface structurally unroutable nets (single-pad)
+        # before the rip-up loop so the user understands why some nets in
+        # ``net_order`` will never enter ``net_routes``.
+        if single_pad_nets:
+            single_pad_names = [self.net_names.get(n, f"Net {n}") for n in sorted(single_pad_nets)]
+            flush_print(
+                f"  Excluding {len(single_pad_nets)} structurally unroutable "
+                f"single-pad net(s): {', '.join(single_pad_names)}"
+            )
+
         if timed_out:
             print("  ⚠ Returning partial result due to timeout")
-        elif overflow == 0 and len(net_routes) == total_nets:
-            # Only declare complete if ALL nets were routed AND no conflicts
-            print("  No conflicts - routing complete!")
+        elif overflow == 0 and len(net_routes) == total_nets - len(single_pad_nets):
+            # Only declare complete if all routable nets were routed AND no conflicts.
+            # Single-pad nets cannot be routed (no MST edges) so they don't
+            # contribute to the "complete" check.
+            if single_pad_nets:
+                print(
+                    f"  No conflicts - routing complete! "
+                    f"({len(net_routes)} routable net(s) routed; "
+                    f"{len(single_pad_nets)} single-pad net(s) skipped)"
+                )
+            else:
+                print("  No conflicts - routing complete!")
             if progress_callback is not None:
                 progress_callback(1.0, "Routing complete - no conflicts", False)
             return list(self.routes)
-        elif overflow == 0 and len(net_routes) < total_nets:
-            # Some nets failed to route but no overflow - need rip-up
-            failed_count = total_nets - len(net_routes)
+        elif overflow == 0 and len(net_routes) < total_nets - len(single_pad_nets):
+            # Some routable nets failed to route but no overflow - need rip-up.
+            # Exclude single-pad nets from the failed count: they have no
+            # edges and cannot be "failed" in any meaningful sense.
+            failed_count = total_nets - len(net_routes) - len(single_pad_nets)
             print(f"  ⚠ {failed_count} net(s) failed to route - attempting recovery")
 
         # Issue #1605: Collect nets that are structurally unroutable (off-grid pads)
@@ -3877,10 +3915,17 @@ class Autorouter:
                 # Issue #858: Also include nets that completely failed to route
                 # (not in net_routes) - these need recovery via targeted rip-up
                 # Issue #1605: Exclude structurally unroutable nets (PADS_OFF_GRID)
+                # Issue #2514: Exclude single-pad nets explicitly.  The previous
+                # ``n in pads_by_net`` clause silently dropped them but also
+                # masked legitimate failures whose pads were not yet in the
+                # ``pads_by_net`` cache.  We now make the structural-unroutable
+                # filter explicit via the ``single_pad_nets`` set built up front.
                 failed_nets_to_recover = [
                     n
                     for n in net_order
-                    if n not in net_routes and n in pads_by_net and n not in off_grid_nets
+                    if n not in net_routes
+                    and n not in single_pad_nets
+                    and n not in off_grid_nets
                 ]
                 if failed_nets_to_recover:
                     # Add failed nets to reroute list if not already present
@@ -3976,9 +4021,11 @@ class Autorouter:
                 ):
                     recovery_factor = max(present_factor * 2.0, initial_present_factor * 4.0)
                     recovered = 0
+                    attempted = 0
                     for fn in list(failed_net_ids):
                         if fn in stalled_nets or fn in net_routes:
                             continue
+                        attempted += 1
                         routes = self._route_net_negotiated(
                             fn, recovery_factor, per_net_timeout=per_net_timeout
                         )
@@ -3988,11 +4035,17 @@ class Autorouter:
                             for route in routes:
                                 self.grid.mark_route_usage(route)
                                 self.routes.append(route)
-                    if recovered > 0:
+                    # Issue #2514: Always log the attempt summary so the
+                    # operator can see that recovery ran -- previously the
+                    # log was silent on ``recovered == 0``, which made it
+                    # appear that the recovery path never executed.
+                    if attempted > 0:
                         flush_print(
-                            f"  Zero-overflow recovery: routed {recovered}/{len(failed_net_ids)} "
-                            f"previously-failed net(s) with elevated cost"
+                            f"  Zero-overflow recovery: routed {recovered}/{attempted} "
+                            f"previously-failed net(s) with elevated cost "
+                            f"(factor={recovery_factor:.2f})"
                         )
+                    if recovered > 0:
                         # Recompute overflow after recovery
                         current_overflow = self.grid.get_total_overflow()
                         overused = self.grid.find_overused_cells()
@@ -4014,10 +4067,28 @@ class Autorouter:
                 # All conflicting nets have been excluded by the stall detector,
                 # so further iterations cannot make progress.
                 if not nets_to_reroute:
-                    flush_print(
-                        f"  No nets to rip up, terminating at iteration "
-                        f"{iteration}/{max_iterations} ({elapsed_str()})"
-                    )
+                    # Issue #2514: Distinguish "genuine convergence" from
+                    # "remaining unrouted nets are all structurally
+                    # unroutable" so the operator understands why the loop
+                    # exited at iteration 1 with nets still missing.
+                    remaining_unrouted = [n for n in net_order if n not in net_routes]
+                    structurally_unroutable = [
+                        n for n in remaining_unrouted if n in single_pad_nets or n in off_grid_nets
+                    ]
+                    if remaining_unrouted and len(structurally_unroutable) == len(
+                        remaining_unrouted
+                    ):
+                        flush_print(
+                            f"  No rip-up candidates: {len(remaining_unrouted)} "
+                            f"remaining unrouted net(s) are structurally "
+                            f"unroutable (single-pad or off-grid). Terminating "
+                            f"at iteration {iteration}/{max_iterations} ({elapsed_str()})"
+                        )
+                    else:
+                        flush_print(
+                            f"  No nets to rip up, terminating at iteration "
+                            f"{iteration}/{max_iterations} ({elapsed_str()})"
+                        )
                     break
 
                 # Issue #2388: Early-abort heuristic for power-net stalls.

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -69,7 +69,21 @@ except ImportError as e:
     ) + glob.glob(
         str(pathlib.Path(__file__).parent / "router_cpp.cpython-*-linux-*.so")
     )
-    if _so_files:
+    # Issue #2514: Distinguish "no compiled extension" from a genuine
+    # circular import.  When ``from . import router_cpp`` runs while
+    # ``kicad_tools.router.__init__`` is still mid-import, Python's
+    # ``ImportError.__str__`` mentions "partially initialized module
+    # (most likely due to a circular import)" -- even when the actual
+    # root cause is a missing ``.so`` file (e.g. fresh checkout where
+    # ``kct build-native`` was never run).  Replace the misleading
+    # message with an actionable hint when no ``.so`` is present at all.
+    if not _so_files:
+        _CPP_IMPORT_ERROR = (
+            "C++ router extension not built (no router_cpp.*.so found in "
+            f"{pathlib.Path(__file__).parent}). "
+            "Run: kct build-native"
+        )
+    else:
         _running_tag = f"cpython-{sys.version_info.major}{sys.version_info.minor}"
         if _running_tag not in " ".join(_so_files):
             _CPP_IMPORT_ERROR = (

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -4055,3 +4055,161 @@ class TestLargeGridPerformance:
                 assert bitmap == per_cell, (
                     f"Mismatch at ({x}, {y}): bitmap={bitmap}, per_cell={per_cell}"
                 )
+
+
+class TestSinglePadNetExclusion:
+    """Tests for Issue #2514: single-pad nets must be flagged as
+    structurally unroutable so the rip-up loop does not exit at iteration 1
+    with a misleading "No nets to rip up" diagnostic.
+
+    Background: board 04 (STM32 devboard) defines an SWD header (J1) whose
+    SWDIO/SWCLK/SWO/NRST nets connect to a single pad each (the matching
+    MCU symbol is intentionally omitted from the demo).  Before this fix
+    the negotiated routing loop printed "4 net(s) failed to route -
+    attempting recovery" and then immediately exited at iteration 1
+    because the recovery filter relied on an implicit ``n in pads_by_net``
+    membership check that silently dropped single-pad nets.
+    """
+
+    def _build_router_with_single_pad_nets(self) -> Autorouter:
+        """Construct a router that has both routable and single-pad nets.
+
+        Net 1 has two pads (routable); nets 2 and 3 each have a single
+        pad on a header (unroutable).  Mirrors the board-04 topology.
+        """
+        rules = DesignRules(grid_resolution=0.5)
+        router = Autorouter(width=40.0, height=40.0, rules=rules)
+        # Two-pad net (routable)
+        router.add_component(
+            "R1",
+            [
+                {"number": "1", "x": 5.0, "y": 5.0, "net": 1, "net_name": "OK"},
+                {"number": "2", "x": 15.0, "y": 5.0, "net": 1, "net_name": "OK"},
+            ],
+        )
+        # Single-pad nets (unroutable)
+        router.add_component(
+            "J1",
+            [
+                {"number": "1", "x": 25.0, "y": 5.0, "net": 2, "net_name": "SWDIO"},
+                {"number": "2", "x": 25.0, "y": 10.0, "net": 3, "net_name": "SWCLK"},
+            ],
+        )
+        return router
+
+    def test_single_pad_nets_excluded_from_recovery_filter(self):
+        """The ``failed_nets_to_recover`` filter must exclude single-pad nets.
+
+        Replicates the filter used in ``route_all_negotiated`` (#2514)
+        with the explicit ``single_pad_nets`` set.
+        """
+        router = self._build_router_with_single_pad_nets()
+
+        # Build the same sets the production code now builds up front
+        net_order = sorted(router.nets.keys())
+        single_pad_nets = {n for n in net_order if len(router.nets.get(n, [])) < 2}
+        off_grid_nets: set[int] = set()
+
+        # Simulate iteration 0 routing only the 2-pad net
+        net_routes = {1: []}
+
+        failed_nets_to_recover = [
+            n
+            for n in net_order
+            if n not in net_routes and n not in single_pad_nets and n not in off_grid_nets
+        ]
+
+        assert single_pad_nets == {2, 3}
+        # The single-pad nets must NOT show up in recovery -- they have
+        # no MST edges and ``_route_net_negotiated`` returns ``[]``
+        # immediately.
+        assert failed_nets_to_recover == []
+
+    def test_failed_multi_pad_net_still_included_in_recovery(self):
+        """Multi-pad failures must NOT be filtered out by the new check.
+
+        Regression guard: the explicit ``single_pad_nets`` set must
+        not accidentally exclude legitimate multi-pad failures.  This
+        is the curator's primary concern -- the previous
+        ``n in pads_by_net`` clause could silently drop legitimate
+        failures whose pads were not yet in the cache.
+        """
+        rules = DesignRules(grid_resolution=0.5)
+        router = Autorouter(width=40.0, height=40.0, rules=rules)
+        router.add_component(
+            "R1",
+            [
+                {"number": "1", "x": 5.0, "y": 5.0, "net": 1, "net_name": "OK"},
+                {"number": "2", "x": 15.0, "y": 5.0, "net": 1, "net_name": "OK"},
+            ],
+        )
+        # Multi-pad net that is hypothetically failing in iteration 0
+        router.add_component(
+            "U1",
+            [
+                {"number": "1", "x": 5.0, "y": 25.0, "net": 2, "net_name": "FAILED"},
+                {"number": "2", "x": 25.0, "y": 25.0, "net": 2, "net_name": "FAILED"},
+            ],
+        )
+
+        net_order = sorted(router.nets.keys())
+        single_pad_nets = {n for n in net_order if len(router.nets.get(n, [])) < 2}
+        off_grid_nets: set[int] = set()
+
+        # Net 1 routed; net 2 (multi-pad) failed
+        net_routes = {1: []}
+
+        failed_nets_to_recover = [
+            n
+            for n in net_order
+            if n not in net_routes and n not in single_pad_nets and n not in off_grid_nets
+        ]
+
+        # Net 2 has 2 pads so it must NOT be classified as single-pad...
+        assert single_pad_nets == set()
+        # ...and it MUST appear in the recovery set so the rip-up loop
+        # has a candidate to act on.
+        assert failed_nets_to_recover == [2]
+
+    def test_route_all_negotiated_does_not_terminate_at_iter1_for_single_pad(self):
+        """End-to-end: route_all_negotiated converges cleanly on single-pad nets.
+
+        Before #2514 the loop printed "No nets to rip up, terminating at
+        iteration 1/15" because the recovery filter excluded the single-
+        pad nets (correctly) but the early-termination check did not
+        recognise that there were no genuine failures left.
+
+        With the fix, the loop should recognise that ``net_routes`` covers
+        all routable nets and return promptly with a clear diagnostic
+        rather than entering a doomed rip-up iteration.
+        """
+        router = self._build_router_with_single_pad_nets()
+
+        routes = router.route_all_negotiated(max_iterations=5)
+
+        # The 2-pad net should have been routed in iteration 0
+        routed_nets = {r.net for r in routes}
+        assert 1 in routed_nets, f"Multi-pad net should be routed; got nets {routed_nets!r}"
+        # Single-pad nets must NOT appear in the result
+        assert 2 not in routed_nets
+        assert 3 not in routed_nets
+
+    def test_iter1_diagnostic_is_actionable_when_only_single_pad_nets_remain(self, capsys):
+        """The diagnostic at the end of iteration 0 (or the early-exit
+        message at iteration 1) must clearly attribute the unrouted
+        nets to their structural single-pad cause -- not silently abort
+        the rip-up loop.
+        """
+        router = self._build_router_with_single_pad_nets()
+        router.route_all_negotiated(max_iterations=5)
+
+        captured = capsys.readouterr().out
+        # The new structural-unroutable diagnostic must fire
+        assert "structurally unroutable single-pad net" in captured, (
+            f"Expected single-pad diagnostic in output. Got:\n{captured}"
+        )
+        # The legacy misleading "No nets to rip up" message must NOT
+        # be the only thing the user sees.
+        assert "SWDIO" in captured or "SWCLK" in captured, (
+            f"Expected single-pad net names in diagnostic. Got:\n{captured}"
+        )

--- a/tests/test_router_cpp_backend.py
+++ b/tests/test_router_cpp_backend.py
@@ -1,6 +1,9 @@
 """Tests for C++ router backend fallback behavior."""
 
+import glob
 import importlib
+import pathlib
+import sys
 
 from kicad_tools.router.cpp_backend import (
     LARGE_GRID_THRESHOLD,
@@ -106,6 +109,96 @@ class TestFormatBackendStatus:
         """Test that the large grid threshold is a reasonable value."""
         assert LARGE_GRID_THRESHOLD > 10_000
         assert LARGE_GRID_THRESHOLD <= 200_000
+
+
+class TestCppBackendDiagnosticMessages:
+    """Tests for Issue #2514: when the C++ extension is missing the
+    fallback warning must blame the missing ``.so`` file (not a fictional
+    "circular import").
+
+    The actual import-time logic lives at module top of
+    ``router/cpp_backend.py``.  We re-import the module under controlled
+    conditions to verify each branch produces an actionable message.
+    """
+
+    def test_unavailable_reason_is_actionable_when_so_missing(self, monkeypatch):
+        """Re-import ``cpp_backend`` from a location with no ``.so`` and
+        verify the diagnostic mentions ``kct build-native`` and does NOT
+        blame a circular import.
+        """
+        import pytest
+
+        # Force a reload while pretending no compiled extension exists.
+        # We do this by patching ``glob.glob`` so the no-``.so`` branch
+        # is exercised regardless of whether the dev machine has built
+        # the C++ extension.
+        original_glob = glob.glob
+
+        def fake_glob(pattern, *args, **kwargs):
+            if "router_cpp.cpython" in pattern:
+                return []
+            return original_glob(pattern, *args, **kwargs)
+
+        # Drop any existing router_cpp from sys.modules so the import
+        # actually executes the try/except block.
+        sys.modules.pop("kicad_tools.router.router_cpp", None)
+        # Also evict cpp_backend so its module-level code re-runs.
+        cpp_backend_name = "kicad_tools.router.cpp_backend"
+        original_module = sys.modules.pop(cpp_backend_name, None)
+        try:
+            monkeypatch.setattr(glob, "glob", fake_glob)
+            cpp_backend = importlib.import_module(cpp_backend_name)
+            reason = cpp_backend.get_cpp_unavailable_reason()
+            if reason is None:
+                # The C++ extension was actually built and importable
+                # despite our glob patch -- skip in that case (the
+                # diagnostic branch is unreachable on this machine).
+                pytest.skip("router_cpp extension is available; cannot test missing-.so diagnostic")
+            assert "kct build-native" in reason, (
+                f"Diagnostic must mention build command. Got: {reason!r}"
+            )
+            assert "circular import" not in reason, (
+                f"Diagnostic must NOT blame circular import when .so is missing. Got: {reason!r}"
+            )
+            assert "not built" in reason or "router_cpp" in reason, (
+                f"Diagnostic must identify the missing extension. Got: {reason!r}"
+            )
+        finally:
+            # Restore original module so subsequent tests see the
+            # real backend state.
+            if original_module is not None:
+                sys.modules[cpp_backend_name] = original_module
+            else:
+                sys.modules.pop(cpp_backend_name, None)
+
+    def test_get_backend_info_python_fallback_has_clear_hint(self):
+        """When backend is unavailable, ``get_backend_info`` must include
+        a build hint that does NOT misattribute the cause to a circular
+        import.
+        """
+        info = get_backend_info()
+        if info["available"]:
+            # On machines where the .so is built, this path is
+            # unreachable -- the diagnostic-only contract is irrelevant.
+            return
+        assert "build_hint" in info
+        # The build hint itself must always be actionable (this is a
+        # fixed string, independent of the import-error branch).
+        assert "kct build-native" in info["build_hint"]
+        # The unavailable_reason is the ImportError text -- on a fresh
+        # checkout (no .so) it must NOT contain "circular import" any
+        # more.  We only enforce this when the .so is genuinely absent
+        # to avoid false failures in CI environments that build it.
+        from kicad_tools.router import cpp_backend as _cb
+
+        so_files = glob.glob(
+            str(pathlib.Path(_cb.__file__).parent / "router_cpp.cpython-*-darwin.so")
+        ) + glob.glob(str(pathlib.Path(_cb.__file__).parent / "router_cpp.cpython-*-linux-*.so"))
+        if not so_files and "unavailable_reason" in info:
+            assert "circular import" not in info["unavailable_reason"], (
+                f"Missing-.so case must not blame circular import. "
+                f"Got: {info['unavailable_reason']!r}"
+            )
 
 
 class TestCppPathfinderRouteSignature:


### PR DESCRIPTION
## Summary

Two unrelated UX bugs surfaced by the board-04 (STM32 devboard) audit (#2514):

1. **Router exited at iteration 1 with "No nets to rip up"** leaving 4/7 nets unrouted on board 04 despite overflow=0 and no errors. The four "failed" nets (SWDIO, SWCLK, SWO, NRST) are connected to a single pad each on the SWD header (the matching MCU symbol is intentionally omitted from the demo).

   **Fix:** Build an explicit `single_pad_nets` set up front in `route_all_negotiated`, route the existing structural-unroutable plumbing through it, and update the `failed_nets_to_recover` filter to use `n not in single_pad_nets` instead of the implicit `n in pads_by_net` check (which also fixes the curator's concern that legitimate multi-pad failures could be silently dropped).

2. **"C++ router backend not available -- circular import" warning is misleading** when the actual cause is no compiled extension (`kct build-native` was never run). Detect the missing-`.so` case and emit "C++ router extension not built ... Run: kct build-native" instead.

Also surfaces an attempt summary for the zero-overflow recovery loop even when `recovered == 0` (curator secondary recommendation).

## Test plan

- [x] 4 new tests in `TestSinglePadNetExclusion` covering the recovery filter, multi-pad regression guard, end-to-end convergence, and stdout diagnostic
- [x] 2 new tests in `TestCppBackendDiagnosticMessages` covering the import-error branch with `glob.glob` patched to simulate missing `.so`
- [x] Board 04 now exits cleanly: `"Routed 3/7 nets, overflow: 0 ... Excluding 4 structurally unroutable single-pad net(s) ... No conflicts - routing complete!"`
- [x] Boards 01, 02, 03 baselines unchanged
- [x] All 178 passing tests in `test_router_core.py` and `test_router_cpp_backend.py` continue to pass

Closes #2514

Generated with Claude Code