### PR TITLE
feat(check): detect single-pad nets as design defects (missing footprint / schematic drift) (closes #2521)

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -65,6 +65,7 @@ CHECK_CATEGORIES = [
     "pad_grid",
     "placement",
     "silkscreen",
+    "single_pad_net",
     "solder_mask",
     "zones",
 ]
@@ -274,6 +275,7 @@ def run_selected_checks(
         "pad_grid": checker.check_pad_grid_alignment,
         "placement": checker.check_footprint_placement,
         "silkscreen": checker.check_silkscreen,
+        "single_pad_net": checker.check_single_pad_nets,
         "solder_mask": checker.check_solder_mask_pads,
         "zones": checker.check_zones,
     }

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -69,6 +69,70 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _emit_single_pad_net_warning(
+    router: "Autorouter",
+    single_pad_nets: list[int],
+) -> None:
+    """Print a top-of-output warning when single-pad signal nets exist.
+
+    These nets are structurally unroutable -- the router silently skips
+    them, which makes "13/13 routed, DRC clean" look like a successful
+    build even when 4 SWD signals are floating.  Pour nets (POWER /
+    GROUND) are silently allowed because a single test point or
+    pour-only net is a legitimate design pattern.
+
+    See ``kct check --only single_pad_net`` for the full DRC-style
+    report (this banner exists to surface the defect early in the
+    pipeline; the actionable error lives in the check command).
+
+    Args:
+        router: The Autorouter (used for ``router.net_names`` lookup).
+        single_pad_nets: Net IDs that have exactly one pad assigned.
+    """
+    if not single_pad_nets:
+        return
+
+    from kicad_tools.cli.progress import flush_print
+
+    try:
+        from kicad_tools.router.net_class import classify_and_apply_rules
+
+        single_pad_name_map = {
+            net_num: router.net_names.get(net_num, "") for net_num in single_pad_nets
+        }
+        # Drop unnamed nets so we don't classify the empty string.
+        single_pad_name_map = {num: name for num, name in single_pad_name_map.items() if name}
+        pour_rules = classify_and_apply_rules(single_pad_name_map) if single_pad_name_map else {}
+        signal_single_pad_names = sorted(
+            name
+            for num, name in single_pad_name_map.items()
+            if not (pour_rules.get(name) and pour_rules[name].is_pour_net)
+        )
+    except Exception:
+        # Conservative: if classification blows up, surface every named
+        # single-pad net so we don't hide real defects.
+        signal_single_pad_names = sorted(
+            router.net_names.get(num, "")
+            for num in single_pad_nets
+            if router.net_names.get(num, "")
+        )
+
+    if not signal_single_pad_names:
+        return
+
+    flush_print("")
+    flush_print(
+        f"  WARNING: {len(signal_single_pad_names)} single-pad signal "
+        "net(s) detected (likely missing footprint or schematic/PCB drift):"
+    )
+    for name in signal_single_pad_names:
+        flush_print(f"    - {name}")
+    flush_print(
+        "  Run 'kct check --only single_pad_net <pcb>' for details. "
+        "Routing will proceed but these nets cannot be connected."
+    )
+
+
 def _insert_sexp_before_closing(pcb_content: str, sexp_fragments: str) -> str:
     """Insert S-expression fragments before the final closing parenthesis of a PCB file.
 
@@ -182,8 +246,7 @@ def _finalize_routes(
         )
         if vias_removed > 0:
             flush_print(
-                f"  Vias:     {pre_cleanup_vias} -> {post_cleanup_vias} "
-                f"({vias_removed} removed)"
+                f"  Vias:     {pre_cleanup_vias} -> {post_cleanup_vias} ({vias_removed} removed)"
             )
         if cleanup_stats.get("segments_restored", 0) > 0:
             flush_print(
@@ -740,9 +803,7 @@ def update_pcb_layer_stackup(pcb_content: str, target_layers: int) -> str:
         new_layers = "\n    ".join(layer_defs[target_layers])
         # Append non-copper layers after copper layers
         if non_copper_entries:
-            non_copper_lines = "\n".join(
-                entry.strip() for entry in non_copper_entries
-            )
+            non_copper_lines = "\n".join(entry.strip() for entry in non_copper_entries)
             return f"(layers\n    {new_layers}\n    {non_copper_lines}\n  )"
         return f"(layers\n    {new_layers}\n  )"
 
@@ -792,16 +853,11 @@ def _print_power_stall_suggestions(
     pour_arg = ",".join(pour_assignments)
 
     print()
-    print(
-        f"Routing did not complete: {nets_csv} could not be routed on "
-        f"{layer_count} layer(s)."
-    )
+    print(f"Routing did not complete: {nets_csv} could not be routed on {layer_count} layer(s).")
     print("Suggestions:")
-    print(f"  1. Add copper zones for power nets:  --power-nets \"{pour_arg}\"")
+    print(f'  1. Add copper zones for power nets:  --power-nets "{pour_arg}"')
     print("  2. Increase layer count:              --layers 4 (or --max-layers 6)")
-    print(
-        f"  3. Manual routing in KiCad for the {len(stalled_nets)} remaining net(s)"
-    )
+    print(f"  3. Manual routing in KiCad for the {len(stalled_nets)} remaining net(s)")
     print()
 
 
@@ -1007,12 +1063,11 @@ def route_with_layer_escalation(
         # this stack provides dedicated planes for them, auto-skip those
         # plane nets so the router doesn't try to route them as signals.
         attempt_skip_nets = list(skip_nets)
-        plane_nets_in_stack = {
-            lyr.plane_net for lyr in layer_stack.plane_layers if lyr.plane_net
-        }
+        plane_nets_in_stack = {lyr.plane_net for lyr in layer_stack.plane_layers if lyr.plane_net}
         if last_power_stall_nets and plane_nets_in_stack:
             auto_plane_skip = [
-                n for n in last_power_stall_nets
+                n
+                for n in last_power_stall_nets
                 if n in plane_nets_in_stack and n not in attempt_skip_nets
             ]
             if auto_plane_skip:
@@ -1059,11 +1114,15 @@ def route_with_layer_escalation(
         multi_pad_nets = [
             net_num for net_num, pads in router.nets.items() if net_num > 0 and len(pads) >= 2
         ]
+        single_pad_nets = [
+            net_num for net_num, pads in router.nets.items() if net_num > 0 and len(pads) == 1
+        ]
         nets_to_route = len(multi_pad_nets)
 
         if not quiet:
             flush_print(f"  Board size: {router.grid.width}mm x {router.grid.height}mm")
             flush_print(f"  Nets to route: {nets_to_route}")
+            _emit_single_pad_net_warning(router, single_pad_nets)
 
         # Route
         if not quiet:
@@ -1171,8 +1230,7 @@ def route_with_layer_escalation(
             # Report attempt result before breaking
             if not quiet:
                 flush_print(
-                    f"\n  Routed: {nets_routed}/{nets_to_route} nets "
-                    f"({completion * 100:.0f}%)"
+                    f"\n  Routed: {nets_routed}/{nets_to_route} nets ({completion * 100:.0f}%)"
                 )
                 flush_print("  Status: INSUFFICIENT - early stop (zero overflow)")
             break
@@ -1190,8 +1248,7 @@ def route_with_layer_escalation(
             # Report attempt result before breaking
             if not quiet:
                 flush_print(
-                    f"\n  Routed: {nets_routed}/{nets_to_route} nets "
-                    f"({completion * 100:.0f}%)"
+                    f"\n  Routed: {nets_routed}/{nets_to_route} nets ({completion * 100:.0f}%)"
                 )
                 flush_print("  Status: INSUFFICIENT - early stop (stagnation)")
             break
@@ -1206,8 +1263,7 @@ def route_with_layer_escalation(
             last_power_stall_nets = list(getattr(router, "power_stall_nets", []))
             if not quiet and last_power_stall_nets:
                 flush_print(
-                    f"  Power-net stall on this attempt: "
-                    f"{', '.join(last_power_stall_nets)}"
+                    f"  Power-net stall on this attempt: {', '.join(last_power_stall_nets)}"
                 )
         else:
             last_power_stall_nets = []
@@ -1311,9 +1367,7 @@ def route_with_layer_escalation(
             print(f"  {nudge_result.summary()}")
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
-    _final_multi_pad_ids = {
-        n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2
-    }
+    _final_multi_pad_ids = {n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2}
     route_sexp, final_stats, _cleanup_stats = _finalize_routes(
         final_result.router,
         _final_multi_pad_ids,
@@ -1590,11 +1644,15 @@ def route_with_rule_relaxation(
         multi_pad_nets = [
             net_num for net_num, pads in router.nets.items() if net_num > 0 and len(pads) >= 2
         ]
+        single_pad_nets = [
+            net_num for net_num, pads in router.nets.items() if net_num > 0 and len(pads) == 1
+        ]
         nets_to_route = len(multi_pad_nets)
 
         if not quiet:
             flush_print(f"  Board size: {router.grid.width}mm x {router.grid.height}mm")
             flush_print(f"  Nets to route: {nets_to_route}")
+            _emit_single_pad_net_warning(router, single_pad_nets)
 
         # Route
         if not quiet:
@@ -1804,9 +1862,7 @@ def route_with_rule_relaxation(
             print(f"  {nudge_result.summary()}")
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
-    _final_multi_pad_ids = {
-        n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2
-    }
+    _final_multi_pad_ids = {n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2}
     route_sexp, final_stats, _cleanup_stats = _finalize_routes(
         final_result.router,
         _final_multi_pad_ids,
@@ -2110,7 +2166,8 @@ def route_with_combined_escalation(
                         corridor_width_factor=2.0,
                         timeout=args.timeout,
                         per_net_timeout=getattr(args, "per_net_timeout", None) or None,
-                        max_iterations=getattr(args, "two_phase_iterations", None) or args.iterations,
+                        max_iterations=getattr(args, "two_phase_iterations", None)
+                        or args.iterations,
                     )
                 elif args.strategy == "negotiated":
                     router.route_all_negotiated(
@@ -2322,9 +2379,7 @@ def route_with_combined_escalation(
             print(f"  {nudge_result.summary()}")
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
-    _final_multi_pad_ids = {
-        n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2
-    }
+    _final_multi_pad_ids = {n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2}
     route_sexp, final_stats, _cleanup_stats = _finalize_routes(
         final_result.router,
         _final_multi_pad_ids,
@@ -3507,10 +3562,7 @@ def main(argv: list[str] | None = None) -> int:
     if multi_res_plan is not None and multi_res_plan.is_multi_resolution:
         router.fine_zones = list(multi_res_plan.fine_zones)
         if not quiet:
-            flush_print(
-                f"  Fine zones: {len(router.fine_zones)} "
-                f"(sub-grid escape routing enabled)"
-            )
+            flush_print(f"  Fine zones: {len(router.fine_zones)} (sub-grid escape routing enabled)")
 
     # Issue #1841: Tell the autorouter which pour nets lack zones
     router._pour_nets_without_zones = set(_no_zone)
@@ -3559,6 +3611,14 @@ def main(argv: list[str] | None = None) -> int:
                     pad_count = len(router.nets.get(net_num, []))
                     print(f"    {net_name}: {pad_count} pads")
 
+    # Surface single-pad signal nets as a top-of-output warning before
+    # routing starts.  These nets are structurally unroutable -- the router
+    # silently skips them, which makes "13/13 routed, DRC clean" look like
+    # a successful build even when 4 SWD signals are floating.  See
+    # `kct check --only single_pad_net` for the full DRC-style report.
+    if not quiet:
+        _emit_single_pad_net_warning(router, single_pad_nets)
+
     # Analyze fine-pitch components for grid compatibility warnings
     # This runs automatically to warn users about potential routing issues
     if not quiet:
@@ -3584,14 +3644,10 @@ def main(argv: list[str] | None = None) -> int:
                 # Still show full per-component detail at verbose (-v)
                 if args.verbose:
                     flush_print("\n--- Fine-Pitch Component Analysis (verbose) ---")
-                    show_fine_pitch_warnings(
-                        fine_pitch_report, quiet=quiet, verbose=True
-                    )
+                    show_fine_pitch_warnings(fine_pitch_report, quiet=quiet, verbose=True)
             else:
                 flush_print("\n--- Fine-Pitch Component Analysis ---")
-                show_fine_pitch_warnings(
-                    fine_pitch_report, quiet=quiet, verbose=args.verbose
-                )
+                show_fine_pitch_warnings(fine_pitch_report, quiet=quiet, verbose=args.verbose)
 
     # Show pre-route RUDY congestion estimation (Issue #2278)
     if getattr(args, "show_congestion", False):
@@ -3607,14 +3663,14 @@ def main(argv: list[str] | None = None) -> int:
                 print(estimator.format_ascii_heatmap())
                 # Summary stats
                 max_demand = max(
-                    (estimator.demand[r][c]
-                     for r in range(estimator.grid.rows)
-                     for c in range(estimator.grid.cols)),
+                    (
+                        estimator.demand[r][c]
+                        for r in range(estimator.grid.rows)
+                        for c in range(estimator.grid.cols)
+                    ),
                     default=0.0,
                 )
-                scored_nets = [
-                    (nid, s) for nid, s in estimator.net_scores.items() if s > 0
-                ]
+                scored_nets = [(nid, s) for nid, s in estimator.net_scores.items() if s > 0]
                 scored_nets.sort(key=lambda x: -x[1])
                 print(f"\n  Peak tile demand: {max_demand:.2f}")
                 print(f"  Nets with congestion score: {len(scored_nets)}")
@@ -3848,7 +3904,7 @@ def main(argv: list[str] | None = None) -> int:
     if cached_result is not None:
         # Skip routing - using cached result
         if not quiet:
-            flush_print(f"\n--- Using cached result (skipping routing) ---")
+            flush_print("\n--- Using cached result (skipping routing) ---")
     else:
         # Route
         if not quiet:
@@ -3900,10 +3956,8 @@ def main(argv: list[str] | None = None) -> int:
                     # The strategy then routes the remaining nets; diff-pair
                     # nets are filtered from the negotiated loop via the
                     # prerouted-net skip in route_all_negotiated.
-                    if (
-                        args.differential_pairs
-                        and args.strategy in ("negotiated", "basic")
-                    ):
+                    if args.differential_pairs and args.strategy in ("negotiated", "basic"):
+
                         def _phase2_strategy():
                             if args.strategy == "negotiated":
                                 return router.route_all_negotiated(
@@ -3947,7 +4001,8 @@ def main(argv: list[str] | None = None) -> int:
                             corridor_width_factor=2.0,
                             timeout=args.timeout,
                             per_net_timeout=getattr(args, "per_net_timeout", None) or None,
-                            max_iterations=getattr(args, "two_phase_iterations", None) or args.iterations,
+                            max_iterations=getattr(args, "two_phase_iterations", None)
+                            or args.iterations,
                         )
                     elif args.strategy == "negotiated":
                         return router.route_all_negotiated(
@@ -4124,10 +4179,7 @@ def main(argv: list[str] | None = None) -> int:
                 )
             except Exception:
                 FinePitchEscapeFailure = None  # type: ignore[assignment]
-            if (
-                FinePitchEscapeFailure is not None
-                and isinstance(e, FinePitchEscapeFailure)
-            ):
+            if FinePitchEscapeFailure is not None and isinstance(e, FinePitchEscapeFailure):
                 print(
                     f"Error during routing: {e}",
                     file=sys.stderr,
@@ -4193,9 +4245,7 @@ def main(argv: list[str] | None = None) -> int:
         # Issue #2303: Use overflow-tolerant collision checking when
         # the router finished with residual overflow.
         has_overflow = router.grid.get_total_overflow() > 0
-        collision_checker = make_collision_checker(
-            router.grid, ignore_overflow=has_overflow
-        )
+        collision_checker = make_collision_checker(router.grid, ignore_overflow=has_overflow)
         optimizer = TraceOptimizer(config=opt_config, collision_checker=collision_checker)
 
         with spinner("Optimizing traces...", quiet=quiet):
@@ -4406,14 +4456,12 @@ def main(argv: list[str] | None = None) -> int:
         if disconnected_nets:
             output_has_disconnected = True
             if not quiet:
-                print(f"\n--- Output Connectivity Verification ---")
+                print("\n--- Output Connectivity Verification ---")
                 print(
                     f"  WARNING: {len(disconnected_nets)} net(s) have disconnected "
                     f"pads in written output"
                 )
-                for nid, info in sorted(
-                    disconnected_nets.items(), key=lambda x: x[1]["net_name"]
-                ):
+                for nid, info in sorted(disconnected_nets.items(), key=lambda x: x[1]["net_name"]):
                     disc_str = ", ".join(info["disconnected_pads"][:5])
                     if len(info["disconnected_pads"]) > 5:
                         disc_str += f" (+{len(info['disconnected_pads']) - 5} more)"

--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -78,6 +78,7 @@ def _init_type_category_map() -> None:
             ViolationType.UNCONNECTED_ITEMS: ViolationCategory.CONNECTIVITY,
             ViolationType.SHORTING_ITEMS: ViolationCategory.CONNECTIVITY,
             ViolationType.NET_UNDECLARED: ViolationCategory.CONNECTIVITY,
+            ViolationType.SINGLE_PAD_NET: ViolationCategory.CONNECTIVITY,
             # Cosmetic: visual only
             ViolationType.SILK_OVER_COPPER: ViolationCategory.COSMETIC,
             ViolationType.SILK_OVERLAP: ViolationCategory.COSMETIC,
@@ -161,6 +162,7 @@ class ViolationType(Enum):
     FOOTPRINT_OUTSIDE_BOARD = "footprint_outside_board"
     # Netlist integrity
     NET_UNDECLARED = "net_undeclared"
+    SINGLE_PAD_NET = "single_pad_net"
 
     # Misc
     FOOTPRINT = "footprint"
@@ -236,6 +238,7 @@ class ViolationType(Enum):
             "footprint_outside_board": cls.FOOTPRINT_OUTSIDE_BOARD,
             # netlist integrity rule from validate netlist checker
             "net_undeclared": cls.NET_UNDECLARED,
+            "single_pad_net": cls.SINGLE_PAD_NET,
             # zone fill rules from validate zone_fill checker
             "zone_unfilled": cls.ZONE_UNFILLED,
             "zone_fill_disabled": cls.ZONE_FILL_DISABLED,

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -82,7 +82,7 @@ class DRCChecker:
 
     def check_all(
         self,
-        filters: "list[ViolationFilter] | None" = None,
+        filters: list[ViolationFilter] | None = None,
     ) -> DRCResults:
         """Run all DRC checks.
 
@@ -105,6 +105,7 @@ class DRCChecker:
         results.merge(self.check_solder_mask_pads())
         results.merge(self.check_footprint_placement())
         results.merge(self.check_netlist())
+        results.merge(self.check_single_pad_nets())
         results.merge(self.check_zones())
 
         # Apply filters if provided
@@ -217,6 +218,23 @@ class DRCChecker:
         from .rules.netlist import NetlistRule
 
         rule = NetlistRule()
+        return rule.check(self.pcb, self.design_rules)
+
+    def check_single_pad_nets(self) -> DRCResults:
+        """Check for signal nets that are connected to only one pad.
+
+        A declared signal net with exactly one pad assignment is
+        structurally unroutable and almost always indicates a missing
+        footprint or schematic/PCB drift.  Pour nets (POWER/GROUND) are
+        silently allowed because a single test point or pour-only net
+        is a legitimate design pattern.
+
+        Returns:
+            DRCResults containing single-pad-net errors.
+        """
+        from .rules.single_pad_net import SinglePadNetRule
+
+        rule = SinglePadNetRule()
         return rule.check(self.pcb, self.design_rules)
 
     def check_zones(self) -> DRCResults:

--- a/src/kicad_tools/validate/rules/__init__.py
+++ b/src/kicad_tools/validate/rules/__init__.py
@@ -9,14 +9,15 @@ from .clearance import ClearanceRule
 from .dimensions import DimensionRules
 from .edge import EdgeClearanceRule
 from .impedance import ImpedanceRule, NetImpedanceSpec
-from .solder_mask import SolderMaskPadRules
-from .zone_fill import ZoneFillRule
 from .silkscreen import (
     check_all_silkscreen,
     check_silkscreen_line_width,
     check_silkscreen_over_pads,
     check_silkscreen_text_height,
 )
+from .single_pad_net import SinglePadNetRule
+from .solder_mask import SolderMaskPadRules
+from .zone_fill import ZoneFillRule
 
 __all__ = [
     "DRC_TOLERANCE",
@@ -26,6 +27,7 @@ __all__ = [
     "EdgeClearanceRule",
     "ImpedanceRule",
     "NetImpedanceSpec",
+    "SinglePadNetRule",
     "SolderMaskPadRules",
     "check_all_silkscreen",
     "check_silkscreen_line_width",

--- a/src/kicad_tools/validate/rules/single_pad_net.py
+++ b/src/kicad_tools/validate/rules/single_pad_net.py
@@ -1,0 +1,146 @@
+"""Single-pad-net design defect rule.
+
+Detects nets that are declared with a non-empty name but only have a
+single pad assigned to them.  Such nets are physically unroutable and
+almost always indicate one of the following design defects:
+
+- A footprint is missing from the PCB (the net was declared on the
+  schematic side but only one component instantiates it on the PCB).
+- The schematic was edited after the PCB was generated and the netlist
+  was not re-synced (schematic/PCB drift).
+- A part was deleted from the PCB but its associated nets remained.
+
+Power and ground nets that legitimately have a single pad (e.g., a
+single test point or a pour-only net) are silently allowed: this rule
+fires only on signal nets.
+
+The router currently classifies these as "structurally unroutable" and
+silently skips them, which lets agents iterating on a design mistake
+"13/13 routed, DRC clean" for a successful build when 4 SWD signals are
+floating.  This rule surfaces them as DRC errors so the agent loop sees
+the problem before iterating.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from ..violations import DRCResults, DRCViolation
+from .base import DRCRule
+from .netlist import _absolute_pad_position
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers import DesignRules
+    from kicad_tools.schema.pcb import PCB, Footprint, Pad
+
+
+class SinglePadNetRule(DRCRule):
+    """Flag signal nets that have only one pad attached.
+
+    A net that has been declared in the board header but only ever
+    appears on a single footprint pad is structurally unroutable and
+    almost always a design defect (missing footprint, schematic drift,
+    or stale netlist).
+
+    Power and ground nets that are classified as ``is_pour_net=True``
+    by :func:`kicad_tools.router.net_class.classify_and_apply_rules`
+    are silently allowed because a single test point or pour-only net
+    is a legitimate design pattern.  Only signal-class single-pad nets
+    fire.
+    """
+
+    rule_id = "single_pad_net"
+    name = "Single-Pad Net"
+    description = (
+        "Detects signal nets attached to only one pad (missing footprint or schematic/PCB drift)"
+    )
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Check the PCB for signal nets with only one pad attached.
+
+        The detector walks ``pcb.footprints`` -> ``fp.pads`` (not
+        ``pcb.nets``, which only enumerates the declared net headers)
+        because the single-pad condition is defined by the count of
+        pad assignments, not the count of header entries.
+
+        Args:
+            pcb: The PCB to check.
+            design_rules: Design rules (unused by this rule but required
+                by the base-class interface).
+
+        Returns:
+            DRCResults containing one error per single-pad signal net.
+        """
+        results = DRCResults()
+        results.rules_checked = 1
+
+        # Build a map of (net_number, net_name) -> [(footprint, pad)]
+        # using the actual pad assignments (not the header).
+        net_pads: dict[
+            tuple[int, str],
+            list[tuple[Footprint, Pad]],
+        ] = defaultdict(list)
+
+        for fp in pcb.footprints:
+            for pad in fp.pads:
+                # Skip pads with no net assignment (unconnected) and
+                # the conventional (net 0, "") unconnected net.
+                if not pad.net_name:
+                    continue
+                if pad.net_number == 0 and pad.net_name == "":
+                    continue
+                net_pads[(pad.net_number, pad.net_name)].append((fp, pad))
+
+        # Identify single-pad nets.
+        single_pad: list[tuple[tuple[int, str], tuple[Footprint, Pad]]] = [
+            (key, pads_list[0]) for key, pads_list in net_pads.items() if len(pads_list) == 1
+        ]
+
+        if not single_pad:
+            return results
+
+        # Build pour-net suppression set.  Use the net-name classifier
+        # so a single-pad GND testpoint or a single-pad +3V3 marker
+        # doesn't error -- only signal-class single-pad nets fire.
+        pour_nets: set[str] = set()
+        try:
+            from kicad_tools.router.net_class import classify_and_apply_rules
+
+            net_id_by_name = {net_num: net_name for (net_num, net_name), _ in single_pad}
+            if net_id_by_name:
+                rules = classify_and_apply_rules(net_id_by_name)
+                pour_nets = {name for name, cfg in rules.items() if cfg and cfg.is_pour_net}
+        except Exception:
+            # Conservative: if the classifier blows up, don't suppress
+            # anything -- the worst case is a pour net erroneously
+            # reported as a single-pad defect, which is recoverable.
+            pour_nets = set()
+
+        # Emit one error per non-pour single-pad signal net.
+        for (_net_number, net_name), (fp, pad) in single_pad:
+            if net_name in pour_nets:
+                continue
+
+            ref = fp.reference or fp.name
+            location = _absolute_pad_position(fp, pad)
+
+            results.add(
+                DRCViolation(
+                    rule_id=self.rule_id,
+                    severity="error",
+                    message=(
+                        f"Net '{net_name}' has only 1 pad on {ref}-{pad.number} "
+                        f"-- likely missing footprint or schematic/PCB drift"
+                    ),
+                    location=location,
+                    items=(f"{ref}-{pad.number}",),
+                    nets=(net_name,),
+                )
+            )
+
+        return results

--- a/tests/test_cli_check_single_pad_net.py
+++ b/tests/test_cli_check_single_pad_net.py
@@ -1,0 +1,77 @@
+"""CLI tests for `kct check --only single_pad_net` against board 04."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_BOARD_04_PCB = _REPO_ROOT / "boards" / "04-stm32-devboard" / "output" / "stm32_devboard.kicad_pcb"
+
+
+@pytest.mark.skipif(
+    not _BOARD_04_PCB.exists(),
+    reason=(
+        "boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb not generated; "
+        "run 'uv run python boards/04-stm32-devboard/generate_design.py' first"
+    ),
+)
+class TestCheckSinglePadNetCli:
+    """End-to-end CLI tests for the new rule on board 04."""
+
+    def test_only_single_pad_net_reports_four_errors(self, capsys):
+        """`kct check --only single_pad_net` exits 2 with 4 errors."""
+        from kicad_tools.cli.check_cmd import main
+
+        rc = main([str(_BOARD_04_PCB), "--only", "single_pad_net"])
+        assert rc == 2  # Errors found.
+
+        captured = capsys.readouterr()
+        # Each of the 4 SWD signals should appear in the output.
+        for net_name in ("SWDIO", "SWCLK", "SWO", "NRST"):
+            assert net_name in captured.out, f"Expected '{net_name}' in output:\n{captured.out}"
+        # All four pads should be on J1.
+        assert "J1" in captured.out
+
+    def test_skip_single_pad_net_excludes_rule(self, capsys):
+        """`kct check --skip single_pad_net` does not include this rule_id."""
+        from kicad_tools.cli.check_cmd import main
+
+        # We don't care about the exit code (other rules may fire on
+        # this board); only that the single_pad_net rule is excluded.
+        main([str(_BOARD_04_PCB), "--skip", "single_pad_net"])
+
+        captured = capsys.readouterr()
+        assert "single_pad_net" not in captured.out
+
+    def test_json_output_resolves_type(self, capsys):
+        """JSON output round-trips rule_id -> type without 'unknown'."""
+        from kicad_tools.cli.check_cmd import main
+
+        rc = main(
+            [
+                str(_BOARD_04_PCB),
+                "--only",
+                "single_pad_net",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 2
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        assert data["summary"]["errors"] == 4
+        assert data["summary"]["passed"] is False
+
+        violations = data["violations"]
+        assert len(violations) == 4
+        for v in violations:
+            assert v["rule_id"] == "single_pad_net"
+            # Critical: must NOT resolve to 'unknown' -- verifies the
+            # ViolationType enum + alias entry are wired correctly.
+            assert v["type"] == "single_pad_net"
+            assert v["severity"] == "error"

--- a/tests/test_route_single_pad_warning.py
+++ b/tests/test_route_single_pad_warning.py
@@ -1,0 +1,63 @@
+"""Test that ``kct route`` emits a top-of-output warning for single-pad nets."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_BOARD_04_PCB = _REPO_ROOT / "boards" / "04-stm32-devboard" / "output" / "stm32_devboard.kicad_pcb"
+
+
+@pytest.mark.skipif(
+    not _BOARD_04_PCB.exists(),
+    reason=(
+        "boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb not generated; "
+        "run 'uv run python boards/04-stm32-devboard/generate_design.py' first"
+    ),
+)
+class TestRouteSinglePadWarning:
+    """`kct route` should warn about SWDIO/SWCLK/SWO/NRST on board 04."""
+
+    def test_warning_block_naming_swd_signals(self):
+        """The route command surfaces the four floating SWD signals."""
+        # Use --dry-run so we don't actually route or write output.  The
+        # banner is printed before any routing work begins, so we do not
+        # need to wait for a full route.
+        env = os.environ.copy()
+        # Avoid stale-pipx noise polluting stdout in CI environments.
+        env["KCT_NO_DEV_WARN"] = "1"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "kicad_tools.cli",
+                "route",
+                str(_BOARD_04_PCB),
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+            cwd=str(_REPO_ROOT),
+        )
+
+        # We don't care whether routing itself succeeded -- only that
+        # the banner printed.  Combine streams since output ordering
+        # varies between platforms.
+        combined = result.stdout + result.stderr
+
+        assert "single-pad signal net" in combined, (
+            f"Expected single-pad warning in route output:\n{combined[:4000]}"
+        )
+        # All four SWD signals named.
+        for net in ("SWDIO", "SWCLK", "SWO", "NRST"):
+            assert net in combined, f"Expected '{net}' in route output:\n{combined[:4000]}"
+        # The banner points users at the check command.
+        assert "kct check" in combined and "single_pad_net" in combined

--- a/tests/test_single_pad_net_integration.py
+++ b/tests/test_single_pad_net_integration.py
@@ -1,0 +1,176 @@
+"""Integration tests for the single_pad_net DRC rule using real boards.
+
+These tests load the canonical board fixtures (boards/0X-...) and verify
+that:
+
+- Board 04 (STM32 dev board, no MCU) reports exactly 4 single-pad-net
+  errors for SWDIO, SWCLK, SWO, NRST -- the four SWD signals that have
+  no MCU footprint to terminate on.
+- Boards 01, 02, 03 do not report any single-pad-net violations
+  (regression guard against the rule firing on legitimate designs).
+  Board 05 is intentionally excluded -- its STM32G4 MCU is a placeholder
+  in the schematic generator, so the gate-driver and SWD nets legitimately
+  trip the rule (a real finding, not a false positive).
+- The DRC checker's ``check_all()`` plumbing routes the violations
+  through to ``error_count`` and ``DRCStatus.blocking_count``, which
+  in turn drives ``AuditVerdict.NOT_READY`` -- exactly the behaviour
+  the issue asks for.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Repo root: tests/ is at the top of the repo, so parent of this file is
+# the tests dir, and parent of that is the repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# Board 04 stores its PCB under output/stm32_devboard.kicad_pcb (the
+# subdirectory name uses underscores, not dashes).
+_BOARD_04_PCB = _REPO_ROOT / "boards" / "04-stm32-devboard" / "output" / "stm32_devboard.kicad_pcb"
+
+
+@pytest.mark.skipif(
+    not _BOARD_04_PCB.exists(),
+    reason=(
+        "boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb not generated; "
+        "run 'uv run python boards/04-stm32-devboard/generate_design.py' first"
+    ),
+)
+class TestBoard04SwdSignals:
+    """Board 04 (no MCU) should report exactly 4 single-pad SWD nets."""
+
+    def test_check_all_includes_single_pad_errors(self):
+        """DRCChecker.check_all() emits >=4 single_pad_net errors on board 04."""
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb = PCB.load(str(_BOARD_04_PCB))
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+        results = checker.check_all()
+
+        single_pad_violations = [v for v in results.violations if v.rule_id == "single_pad_net"]
+        assert len(single_pad_violations) == 4
+
+        # All four are errors (not warnings).
+        for v in single_pad_violations:
+            assert v.severity == "error"
+
+        flagged_nets = {v.nets[0] for v in single_pad_violations}
+        assert flagged_nets == {"SWDIO", "SWCLK", "SWO", "NRST"}
+
+        # All four pads should be on J1 (the SWD header).
+        flagged_refs = {v.items[0].split("-")[0] for v in single_pad_violations}
+        assert flagged_refs == {"J1"}
+
+        # The total error count should be at least 4 (other rules may
+        # also fire on this board, hence >=, not ==).
+        assert results.error_count >= 4
+
+    def test_check_single_pad_nets_in_isolation(self):
+        """check_single_pad_nets() returns exactly 4 errors on board 04."""
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb = PCB.load(str(_BOARD_04_PCB))
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+        results = checker.check_single_pad_nets()
+
+        assert len(results.violations) == 4
+        assert all(v.rule_id == "single_pad_net" for v in results.violations)
+        assert all(v.severity == "error" for v in results.violations)
+
+    def test_audit_verdict_not_ready(self):
+        """A board with single-pad signal nets fails the audit gate.
+
+        This test exercises the same code path as ``Auditor.audit()``
+        without requiring the rest of the project structure (project
+        file, schematic, etc.).  We hand-build a DRCStatus from the
+        same ``_check_drc`` method the auditor uses internally and
+        verify the verdict mapping wires it up to NOT_READY.
+        """
+        from kicad_tools.audit.auditor import (
+            AuditResult,
+            AuditVerdict,
+            ManufacturingAudit,
+        )
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(str(_BOARD_04_PCB))
+        # ManufacturingAudit needs a path argument for project resolution
+        # but we only need its _check_drc helper for this assertion.
+        auditor = ManufacturingAudit(_BOARD_04_PCB, manufacturer="jlcpcb", layers=2)
+        drc_status = auditor._check_drc(pcb)
+
+        # The single_pad_net rule should drive blocking_count >= 4.
+        assert drc_status.blocking_count >= 4
+        # Verify the rule fires through the DRC plumbing.
+        assert drc_status.violations_by_type.get("single_pad_net", 0) == 4
+
+        result = AuditResult()
+        result.drc = drc_status
+        # Verdict is NOT_READY because drc.blocking_count > 0.
+        assert result.verdict == AuditVerdict.NOT_READY
+
+
+_REGRESSION_BOARDS = [
+    (
+        "01-voltage-divider",
+        _REPO_ROOT / "boards" / "01-voltage-divider" / "output" / "voltage_divider.kicad_pcb",
+    ),
+    (
+        "02-charlieplex-led",
+        _REPO_ROOT / "boards" / "02-charlieplex-led" / "output" / "charlieplex_3x3.kicad_pcb",
+    ),
+    (
+        "03-usb-joystick",
+        _REPO_ROOT / "boards" / "03-usb-joystick" / "output" / "usb_joystick.kicad_pcb",
+    ),
+]
+
+
+class TestRegressionBoards:
+    """Boards 01, 02, 03 (fully populated) should NOT trip the rule.
+
+    These are the canonical "good design" reference boards.  Any
+    single_pad_net violation here would indicate a false positive in
+    the rule logic.
+
+    Board 05 (BLDC motor controller) is intentionally excluded -- its
+    schematic uses a placeholder for the STM32G4 MCU, so the gate-driver
+    nets, current-sense returns, Hall sensor inputs, and SWD signals all
+    have only one pad on the PCB.  This is exactly the design defect
+    the rule is meant to catch, and would be a legitimate finding (not
+    a false positive) if the test fired against board 05.  Board 04
+    (also missing its MCU but otherwise simpler) is the canonical
+    "expected to fail" fixture covered by ``TestBoard04SwdSignals``.
+    """
+
+    @pytest.mark.parametrize(
+        "name,pcb_path",
+        _REGRESSION_BOARDS,
+        ids=[name for name, _ in _REGRESSION_BOARDS],
+    )
+    def test_no_single_pad_violations(self, name: str, pcb_path: Path):
+        """Reference boards do not produce single_pad_net errors."""
+        if not pcb_path.exists():
+            pytest.skip(
+                f"Board fixture {name} not generated at {pcb_path}; "
+                f"run 'uv run python boards/{name}/generate_design.py' first"
+            )
+
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb = PCB.load(str(pcb_path))
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+        results = checker.check_single_pad_nets()
+
+        assert len(results.violations) == 0, (
+            f"Board {name} unexpectedly produced "
+            f"{len(results.violations)} single_pad_net violations: "
+            f"{[v.message for v in results.violations]}"
+        )

--- a/tests/test_validate_single_pad_net.py
+++ b/tests/test_validate_single_pad_net.py
@@ -1,0 +1,304 @@
+"""Tests for the single-pad-net DRC rule (single_pad_net)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from kicad_tools.validate.rules.single_pad_net import SinglePadNetRule
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs that satisfy the rule without loading a real PCB file
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubNet:
+    number: int
+    name: str
+
+
+@dataclass
+class _StubPad:
+    number: str
+    net_number: int = 0
+    net_name: str = ""
+    position: tuple[float, float] = (0.0, 0.0)
+    type: str = "smd"
+
+
+@dataclass
+class _StubFootprint:
+    reference: str = "U1"
+    name: str = "Package_SO:SOIC-8"
+    position: tuple[float, float] = (100.0, 50.0)
+    rotation: float = 0.0
+    pads: list[_StubPad] = field(default_factory=list)
+
+
+@dataclass
+class _StubPCB:
+    """Minimal PCB stub implementing the subset used by SinglePadNetRule."""
+
+    _nets: dict[int, _StubNet] = field(default_factory=dict)
+    _footprints: list[_StubFootprint] = field(default_factory=list)
+
+    @property
+    def nets(self) -> dict[int, _StubNet]:
+        return self._nets
+
+    @property
+    def footprints(self) -> list[_StubFootprint]:
+        return self._footprints
+
+
+# Stub design rules -- the single-pad-net rule ignores them, but the
+# interface requires the argument.
+class _StubDesignRules:
+    pass
+
+
+RULES = _StubDesignRules()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSinglePadNetRule:
+    """Tests for SinglePadNetRule.check()."""
+
+    def test_all_multi_pad_nets_no_violations(self):
+        """No violations when every net has 2+ pads."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                1: _StubNet(1, "DATA"),
+                2: _StubNet(2, "CLK"),
+            },
+            _footprints=[
+                _StubFootprint(
+                    reference="U1",
+                    pads=[
+                        _StubPad(number="1", net_number=1, net_name="DATA"),
+                        _StubPad(number="2", net_number=2, net_name="CLK"),
+                    ],
+                ),
+                _StubFootprint(
+                    reference="U2",
+                    pads=[
+                        _StubPad(number="1", net_number=1, net_name="DATA"),
+                        _StubPad(number="2", net_number=2, net_name="CLK"),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 0
+        assert results.rules_checked == 1
+
+    def test_single_pad_signal_net_flagged(self):
+        """A signal net with only one pad produces an error."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                6: _StubNet(6, "SWDIO"),
+            },
+            _footprints=[
+                _StubFootprint(
+                    reference="J1",
+                    position=(150.0, 100.0),
+                    pads=[
+                        _StubPad(
+                            number="2",
+                            net_number=6,
+                            net_name="SWDIO",
+                            position=(0.0, -3.81),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 1
+
+        v = results.violations[0]
+        assert v.rule_id == "single_pad_net"
+        assert v.severity == "error"
+        assert "SWDIO" in v.message
+        assert "J1-2" in v.message
+        assert "missing footprint" in v.message
+        assert v.items == ("J1-2",)
+        assert v.nets == ("SWDIO",)
+        # Location should reflect footprint+pad combination.
+        assert v.location is not None
+        assert v.location[0] == 150.0
+        assert v.location[1] == 100.0 - 3.81
+
+    def test_single_pad_ground_suppressed(self):
+        """A single-pad GND net (testpoint) is silently allowed."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                3: _StubNet(3, "GND"),
+            },
+            _footprints=[
+                _StubFootprint(
+                    reference="TP1",
+                    pads=[
+                        _StubPad(number="1", net_number=3, net_name="GND"),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 0
+
+    def test_single_pad_power_suppressed(self):
+        """A single-pad +3.3V marker is silently allowed."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                4: _StubNet(4, "+3.3V"),
+            },
+            _footprints=[
+                _StubFootprint(
+                    reference="TP2",
+                    pads=[
+                        _StubPad(number="1", net_number=4, net_name="+3.3V"),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 0
+
+    def test_single_pad_vcc_suppressed(self):
+        """A single-pad VCC net is silently allowed (pour-net pattern)."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                5: _StubNet(5, "VCC"),
+            },
+            _footprints=[
+                _StubFootprint(
+                    reference="TP3",
+                    pads=[
+                        _StubPad(number="1", net_number=5, net_name="VCC"),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 0
+
+    def test_mixed_signal_and_pour_nets(self):
+        """Mix of 2 single-pad signal + 1 single-pad GND -> 2 errors."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                3: _StubNet(3, "GND"),
+                6: _StubNet(6, "SWDIO"),
+                7: _StubNet(7, "SWCLK"),
+            },
+            _footprints=[
+                _StubFootprint(
+                    reference="J1",
+                    pads=[
+                        _StubPad(number="1", net_number=3, net_name="GND"),
+                        _StubPad(number="2", net_number=6, net_name="SWDIO"),
+                        _StubPad(number="3", net_number=7, net_name="SWCLK"),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 2
+        # Both errors are signal nets, neither is GND.
+        flagged_nets = {v.nets[0] for v in results.violations}
+        assert flagged_nets == {"SWDIO", "SWCLK"}
+        for v in results.violations:
+            assert v.severity == "error"
+            assert v.rule_id == "single_pad_net"
+
+    def test_empty_net_name_skipped(self):
+        """Pads with an empty net name (unconnected) are not flagged."""
+        pcb = _StubPCB(
+            _nets={0: _StubNet(0, "")},
+            _footprints=[
+                _StubFootprint(
+                    reference="R1",
+                    pads=[
+                        _StubPad(number="1", net_number=0, net_name=""),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 0
+
+    def test_net_zero_with_empty_name_skipped(self):
+        """The conventional (net 0, '') unconnected net is not flagged."""
+        pcb = _StubPCB(
+            _nets={0: _StubNet(0, "")},
+            _footprints=[
+                _StubFootprint(
+                    reference="R1",
+                    pads=[
+                        _StubPad(number="1", net_number=0, net_name=""),
+                        _StubPad(number="2", net_number=0, net_name=""),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 0
+
+    def test_multiple_single_pad_signal_nets(self):
+        """Multiple single-pad signal nets each produce one error."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                6: _StubNet(6, "SWDIO"),
+                7: _StubNet(7, "SWCLK"),
+                8: _StubNet(8, "SWO"),
+                9: _StubNet(9, "NRST"),
+            },
+            _footprints=[
+                _StubFootprint(
+                    reference="J1",
+                    pads=[
+                        _StubPad(number="2", net_number=6, net_name="SWDIO"),
+                        _StubPad(number="3", net_number=7, net_name="SWCLK"),
+                        _StubPad(number="4", net_number=8, net_name="SWO"),
+                        _StubPad(number="5", net_number=9, net_name="NRST"),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 4
+        flagged_nets = {v.nets[0] for v in results.violations}
+        assert flagged_nets == {"SWDIO", "SWCLK", "SWO", "NRST"}
+        flagged_items = {v.items[0] for v in results.violations}
+        assert flagged_items == {"J1-2", "J1-3", "J1-4", "J1-5"}
+
+    def test_to_dict_resolves_violation_type(self):
+        """JSON output 'type' field round-trips to single_pad_net (not unknown)."""
+        pcb = _StubPCB(
+            _nets={0: _StubNet(0, ""), 6: _StubNet(6, "SWDIO")},
+            _footprints=[
+                _StubFootprint(
+                    reference="J1",
+                    pads=[
+                        _StubPad(number="2", net_number=6, net_name="SWDIO"),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 1
+        d = results.violations[0].to_dict()
+        assert d["rule_id"] == "single_pad_net"
+        assert d["type"] == "single_pad_net"
+        assert d["severity"] == "error"


### PR DESCRIPTION
## Summary

Closes #2521.

Adds a new DRC rule `single_pad_net` that flags signal nets attached to only one pad as errors. These nets are structurally unroutable and almost always indicate a missing footprint, schematic/PCB drift, or stale netlist. Three logical changes ship behind a single detector:

- **`kct check --only single_pad_net <pcb>`**: reports one error per single-pad signal net with the offending pad's `<ref>-<pad>` and a one-line diagnosis hint.
- **`kct route`**: emits a top-of-output WARNING block listing affected nets and recommending `kct check`. Fires from all three routing entry points (auto-layer escalation, max-layer try, legacy single-attempt) to cover every path.
- **`kct audit --mfr jlcpcb`**: returns `NOT_READY` automatically -- `_check_drc()` already routes errors into `DRCStatus.blocking_count`, no source change in `auditor.py` was needed.

Pour nets (POWER/GROUND) are silently allowed because a single test point or pour-only net is a legitimate design pattern. Suppression uses `kicad_tools.router.net_class.classify_and_apply_rules` -- the same name-pattern classifier `auditor._check_connectivity()` already uses for pour-net detection.

`ViolationType.SINGLE_PAD_NET` is added with a `CONNECTIVITY` category mapping and a `from_string` alias so JSON output round-trips cleanly (without the alias, `to_dict()` would resolve `type` to `"unknown"` and break downstream consumers like `drc.report._parse_kct_check_json`).

## Verified end-to-end results

| Board | Expected | Got |
|---|---|---|
| 01-voltage-divider | 0 errors | 0 |
| 02-charlieplex-led | 0 errors | 0 |
| 03-usb-joystick | 0 errors | 0 |
| 04-stm32-devboard (no MCU) | 4 errors (SWDIO/SWCLK/SWO/NRST) | 4 |
| 05-bldc-motor-controller (MCU placeholder) | (curator: 0; actual: 16) | 16 |

Board 05's MCU is a placeholder in the schematic generator (per `boards/05-bldc-motor-controller/design.py`), so its 16 single-pad nets (gate-driver outputs, current-sense returns, Hall sensor inputs, SWD) are real findings -- exactly the defect class this rule is meant to catch. The integration test excludes board 05 with an explanatory docstring noting why.

## Test plan

- [x] Unit tests in `tests/test_validate_single_pad_net.py` mirroring the `test_validate_netlist.py` stub pattern (10 cases covering all-multi-pad, single signal, pour-net suppression for GND/VCC/+3.3V, mixed signal+pour, empty/zero net edge cases, multiple signal nets, JSON type round-trip).
- [x] Integration tests in `tests/test_single_pad_net_integration.py` against board 04 (`check_all`, `check_single_pad_nets`, audit verdict NOT_READY) plus parametrized regression guard against boards 01/02/03.
- [x] CLI tests in `tests/test_cli_check_single_pad_net.py` for `kct check --only`, `--skip`, and `--format json` against board 04.
- [x] Subprocess test in `tests/test_route_single_pad_warning.py` verifying `kct route` prints the SWDIO/SWCLK/SWO/NRST banner.
- [x] All 167 existing tests in the affected modules (validate/netlist, audit, cli/check, route_cmd) still pass.
- [x] `ruff check` and `ruff format --check` clean on all 10 changed/new files.
- [x] mypy clean on the new rule file (pre-existing mypy errors in `route_cmd.py` and `validate/checker.py` are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)