### PR TITLE
fix(router): escape coverage for TQFP-32 U1 and 2-row USB-C J1 (closes #2513)

### DIFF
--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -143,6 +143,13 @@ def is_dense_package(
     - Pin pitch < 0.5mm (when no clearance info provided), OR
     - Pin count > 48
     - Fine-pitch SSOP/TSSOP (0.65mm pitch or less) - always dense
+    - TQFP-32-class quad packages: >= 32 pins on a quad arrangement with
+      pitch <= 0.8 mm are always dense.  At common board-house defaults
+      (trace=0.2 mm, clearance=0.15 mm) the dynamic threshold of
+      2*(0.2+0.15) = 0.7 mm is JUST below the 0.8 mm pitch, so without
+      this rule TQFP-32 packages are not flagged as dense and the inner
+      pins of nets that route to them get blocked by the surrounding
+      perimeter routing.  See issue #2513.
 
     When trace_width and clearance are provided, the threshold is calculated
     dynamically: a package is dense if there's insufficient space between
@@ -186,6 +193,20 @@ def is_dense_package(
     if min_pitch <= 0.75 and _is_dual_row(pads):
         return True
 
+    # TQFP-32-class quad packages (issue #2513).
+    # A quad arrangement with >= 32 pins at <= 0.8 mm pitch is dense
+    # regardless of trace/clearance.  At common JLCPCB-style defaults
+    # (trace=0.2, clearance=0.15) the dynamic threshold below works out
+    # to 0.70 mm which is just under the 0.8 mm pitch of a TQFP-32, so
+    # the dynamic check would otherwise miss this class of MCU.  This
+    # is intentionally conservative: it requires both a quad layout AND
+    # >= 32 pins, so leaded SOIC-32 (dual row) and small QFP/QFN parts
+    # at 32 pins (e.g. QFN-32 at 0.5mm pitch) are unaffected -- the
+    # SOIC case fails the quad arrangement check and the small-pitch
+    # case is already covered by the TSSOP/dynamic threshold rules.
+    if len(pads) >= 32 and min_pitch <= 0.8 + 1e-3 and _looks_like_quad_layout(pads):
+        return True
+
     # Dynamic threshold based on design rules
     # A trace needs: trace_width + clearance on each side from adjacent pins
     # So minimum pitch to route between pins is: 2 * (trace_width/2 + clearance) + trace_width
@@ -203,6 +224,31 @@ def is_dense_package(
         return True
 
     return False
+
+
+def _looks_like_quad_layout(pads: list[Pad]) -> bool:
+    """Convenience wrapper around _is_quad_arrangement using the pads' bbox.
+
+    Used by is_dense_package() so the TQFP-32 rule does not need to
+    duplicate bbox-and-center math at the call site.
+
+    Args:
+        pads: List of pads from a single component
+
+    Returns:
+        True if pads form a QFP/QFN-style quad arrangement
+    """
+    if len(pads) < 8:
+        return False
+    xs = [p.x for p in pads]
+    ys = [p.y for p in pads]
+    width = max(xs) - min(xs)
+    height = max(ys) - min(ys)
+    if width <= 0 or height <= 0:
+        return False
+    center_x = (max(xs) + min(xs)) / 2
+    center_y = (max(ys) + min(ys)) / 2
+    return _is_quad_arrangement(pads, center_x, center_y, width, height)
 
 
 def is_fine_pitch_ssop(pads: list[Pad], pitch_threshold: float = 0.75) -> bool:
@@ -488,6 +534,17 @@ def _is_grid_pattern(pads: list[Pad], center_x: float, center_y: float) -> bool:
 
     BGA packages have pads distributed throughout the interior,
     not just on edges. This distinguishes them from QFP/QFN.
+
+    Grid (BGA) detection requires:
+    - At least 16 pads (room for at least a 4x4 grid)
+    - At least 3 substantial rows AND 3 substantial cols (BGA is at least
+      a 3x3 grid; this guards against 2-row connectors with mounting tabs
+      that produce a tiny "third row" being misclassified as BGA -- see
+      issue #2513 for USB-C with 2 SMT rows + 2 mounting tabs being
+      reported as BGA-18 with 3 unique Y values).
+    - Significant interior pads (not just edge pads, distinguishing BGA
+      from QFP/QFN)
+    - Roughly balanced quadrant distribution
     """
     if len(pads) < 16:  # Need at least 4x4 for BGA
         return False
@@ -501,6 +558,17 @@ def _is_grid_pattern(pads: list[Pad], center_x: float, center_y: float) -> bool:
     height = max_y - min_y
 
     if width < 0.1 or height < 0.1:
+        return False
+
+    # Issue #2513: A real BGA grid has many rows AND many cols, with each
+    # row and col having a substantial number of pads.  A 2-row connector
+    # (USB-C, etc.) with mounting tabs may produce a third "row" with just
+    # 2 pads in it.  Filter outlier rows/cols (those whose pad count is
+    # less than half the median) before counting -- only substantive rows
+    # and cols qualify as BGA "axes".
+    substantive_rows = _count_substantive_axis_groups(pads, axis="y")
+    substantive_cols = _count_substantive_axis_groups(pads, axis="x")
+    if substantive_rows < 3 or substantive_cols < 3:
         return False
 
     # For BGA, check that there are pads in the interior (not just on edges)
@@ -535,6 +603,49 @@ def _is_grid_pattern(pads: list[Pad], center_x: float, center_y: float) -> bool:
     # BGA should have roughly equal distribution across quadrants
     avg = len(pads) / 4
     return all(0.3 * avg <= q <= 1.7 * avg for q in quadrants if avg > 0)
+
+
+def _count_substantive_axis_groups(pads: list[Pad], axis: str) -> int:
+    """Count rows or columns that hold a substantial fraction of total pads.
+
+    Used by _is_grid_pattern (and other classifiers) to ignore outlier
+    "rows" or "cols" that are really just a few off-axis pads -- e.g.
+    USB-C mounting tabs or alignment posts that share neither a row nor
+    a column with the main signal grid.
+
+    A group is "substantive" if its pad count is at least 50% of the
+    median group count along that axis.  Singletons and tiny groups are
+    therefore filtered out.
+
+    Args:
+        pads: List of pads from a single component
+        axis: Which axis to group by - "x" counts unique X (i.e. column
+            count), "y" counts unique Y (row count).
+
+    Returns:
+        Number of substantive groups along that axis.  Returns 0 for
+        empty input.
+    """
+    if not pads:
+        return 0
+    if axis == "y":
+        coords = [round(p.y, 2) for p in pads]
+    else:
+        coords = [round(p.x, 2) for p in pads]
+    counts: dict[float, int] = {}
+    for c in coords:
+        counts[c] = counts.get(c, 0) + 1
+    if not counts:
+        return 0
+    sorted_counts = sorted(counts.values())
+    n = len(sorted_counts)
+    median = (
+        sorted_counts[n // 2]
+        if n % 2 == 1
+        else (sorted_counts[n // 2 - 1] + sorted_counts[n // 2]) / 2
+    )
+    threshold = max(1.0, median * 0.5)
+    return sum(1 for v in counts.values() if v >= threshold)
 
 
 def _is_quad_arrangement(
@@ -1036,6 +1147,15 @@ class EscapeRouter:
             if abs(pad.x - center_x) < edge_margin and abs(pad.y - center_y) < edge_margin:
                 continue
 
+            # Issue #2513: Skip pads that belong to skipped/plane nets (net=0).
+            # Plane nets (GND, VCC, etc.) are stitched via planes, not routed
+            # via escapes.  Generating escapes for them wastes perimeter
+            # routing space (a TQFP-32 MCU may have 19/32 pins on plane nets;
+            # without this filter the escape phase blocks the perimeter for
+            # the actual signal nets that need to escape).
+            if pad.net == 0:
+                continue
+
             if abs(pad.y - max_y) < edge_margin:
                 north_pads.append(pad)
             elif abs(pad.y - min_y) < edge_margin:
@@ -1051,6 +1171,16 @@ class EscapeRouter:
         east_pads.sort(key=lambda p: p.y)
         west_pads.sort(key=lambda p: p.y)
 
+        # Issue #2513: For lower-density QFP/TQFP (pitch >= 0.65 mm) the
+        # alternating perpendicular/parallel scheme blocks more perimeter
+        # space than it saves -- a TQFP-32 at 0.8 mm pitch has plenty of
+        # room between pins to fit a 0.2 mm trace with 0.15 mm clearance,
+        # so every pin can escape perpendicular and the parallel arms of
+        # the alternating pattern just consume routing real-estate.  Use
+        # the simpler perpendicular-only escape for these packages and
+        # reserve the alternating pattern for true fine-pitch QFP/QFN.
+        use_perpendicular_only = package.pin_pitch >= 0.65
+
         # Generate escapes for each edge
         for pads, primary_dir, alt_dir_cw, alt_dir_ccw in [
             (north_pads, EscapeDirection.NORTH, EscapeDirection.EAST, EscapeDirection.WEST),
@@ -1059,7 +1189,7 @@ class EscapeRouter:
             (west_pads, EscapeDirection.WEST, EscapeDirection.NORTH, EscapeDirection.SOUTH),
         ]:
             for i, pad in enumerate(pads):
-                if i % 2 == 0:
+                if use_perpendicular_only or i % 2 == 0:
                     direction = primary_dir
                 else:
                     direction = alt_dir_cw if (i // 2) % 2 == 0 else alt_dir_ccw
@@ -2043,6 +2173,11 @@ class EscapeRouter:
         center_x, center_y = package.center
 
         for pad in package.pads:
+            # Issue #2513: Skip plane-net pads (net=0) -- they are stitched
+            # via planes, not routed via escapes.
+            if pad.net == 0:
+                continue
+
             direction = self._get_quadrant_direction(pad.x, pad.y, center_x, center_y)
             dx, dy = self._direction_to_vector(direction)
 

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -149,6 +149,90 @@ def create_qfn_pads(pins_per_side: int, pitch: float = 0.5, ref: str = "U1") -> 
     return pads
 
 
+def create_usbc_smt_pads(
+    signal_pads_per_row: int = 8,
+    row_pitch: float = 1.0,
+    pad_pitch: float = 0.5,
+    mounting_tab_offset: float = 1.5,
+    ref: str = "J1",
+) -> list[Pad]:
+    """Create pads simulating a USB-C SMT receptacle (e.g. GCT USB4105).
+
+    Layout:
+      Row A (y=0):              N SMT pads, evenly spaced in X
+      Row B (y=row_pitch):      N SMT pads, evenly spaced in X
+      Tab S1 (TH, y=tab_offset, x=-half_extent - tab_clear)
+      Tab S2 (TH, y=tab_offset, x=+half_extent + tab_clear)
+
+    Real USB-C variants put A1/A12 and B1/B12 on the same row but pin spacing
+    is irregular due to the USB-C cluster pattern; this helper uses uniform
+    pitch which is sufficient for classifier tests (issue #2513).
+
+    Args:
+        signal_pads_per_row: Number of SMT pads per row (default 8 -> total 16
+            SMT + 2 tabs = 18, matching the simplified board-03 USB-C).
+        row_pitch: Vertical distance between rows A and B in mm.
+        pad_pitch: Horizontal distance between adjacent pads in mm.
+        mounting_tab_offset: Y position of the mounting tabs relative to row A.
+        ref: Component reference designator.
+
+    Returns:
+        List of Pad objects (SMT signal pads + 2 through-hole tabs).
+    """
+    pads: list[Pad] = []
+    half = (signal_pads_per_row - 1) * pad_pitch / 2
+    net = 1
+    # Row A
+    for i in range(signal_pads_per_row):
+        pads.append(
+            Pad(
+                x=-half + i * pad_pitch,
+                y=0.0,
+                width=0.25,
+                height=0.35,
+                net=net,
+                net_name=f"NET_{net}",
+                layer=Layer.F_CU,
+                ref=ref,
+                through_hole=False,
+            )
+        )
+        net += 1
+    # Row B (offset by row_pitch)
+    for i in range(signal_pads_per_row):
+        pads.append(
+            Pad(
+                x=-half + i * pad_pitch,
+                y=row_pitch,
+                width=0.25,
+                height=0.35,
+                net=net,
+                net_name=f"NET_{net}",
+                layer=Layer.F_CU,
+                ref=ref,
+                through_hole=False,
+            )
+        )
+        net += 1
+    # Mounting tabs (TH, off-row)
+    for tab_x in (-half - 1.0, half + 1.0):
+        pads.append(
+            Pad(
+                x=tab_x,
+                y=mounting_tab_offset,
+                width=1.0,
+                height=1.0,
+                net=3,  # GND
+                net_name="GND",
+                layer=Layer.F_CU,
+                ref=ref,
+                through_hole=True,
+                drill=0.6,
+            )
+        )
+    return pads
+
+
 def create_sop_pads(pins: int, pitch: float = 1.27, ref: str = "U1") -> list[Pad]:
     """Create pads simulating a SOP package with 2 rows."""
     pads = []
@@ -244,24 +328,32 @@ class TestIsDensePackage:
         assert is_dense_package([]) is False
 
     def test_tqfp32_08mm_pitch_with_clearance(self):
-        """TQFP-32 with 0.8mm pitch is dense when clearance requirements are considered.
+        """TQFP-32 with 0.8mm pitch is dense regardless of clearance.
 
-        With 0.2mm trace and 0.2mm clearance, the routing space needed between
-        pins is 2 * (0.2 + 0.2) = 0.8mm, which equals the pin pitch, meaning
-        there's no room to route between adjacent pins.
+        Issue #2513: TQFP-32-class quad packages (>= 32 pins, quad layout,
+        pitch <= 0.8 mm) are now flagged as dense unconditionally.  This
+        is because with common board-house defaults (trace=0.2 mm,
+        clearance=0.15 mm) the dynamic threshold of 2*(0.2+0.15) = 0.7 mm
+        is just below 0.8 mm, so the inner pins of the QFP would otherwise
+        get blocked at routing time even though they sit at the largest
+        pitch one of the still-needs-escape-routing tier.
 
-        Issue #795: This package was NOT being detected as dense without
-        considering clearance requirements.
+        Issue #795 (original): This package was NOT being detected as dense
+        without considering clearance requirements; we now treat it as
+        dense even without explicit clearance numbers because the failure
+        mode is reproducible at JLCPCB defaults.
         """
         pads = create_qfp_pads(8, pitch=0.8)  # 32 pins, 0.8mm pitch
         assert len(pads) == 32
 
-        # Without design rules, 0.8mm pitch is NOT dense (threshold is 0.5mm)
-        assert is_dense_package(pads) is False
+        # Issue #2513: TQFP-32 with 0.8mm pitch is dense even without
+        # design rules (the TQFP-32-class rule fires at >= 32 pads + quad
+        # layout + pitch <= 0.8mm)
+        assert is_dense_package(pads) is True
 
         # WITH design rules, 0.8mm pitch IS dense because:
         # threshold = 2 * (trace_width + clearance) = 2 * (0.2 + 0.2) = 0.8mm
-        # and 0.8mm pitch < 0.8mm threshold
+        # and 0.8mm pitch < 0.8mm threshold (also dense via TQFP-32 rule)
         assert is_dense_package(pads, trace_width=0.2, clearance=0.2) is True
 
     def test_wide_pitch_not_dense_with_clearance(self):
@@ -309,6 +401,116 @@ class TestIsDensePackage:
         # 8 pins at 2.54mm pitch, not dense
         assert is_dense_package(pads) is False
         assert is_dense_package(pads, trace_width=0.2, clearance=0.2) is False
+
+
+class TestTQFP32DenseRule:
+    """Tests for the TQFP-32-class dense-package rule (Issue #2513).
+
+    TQFP-32 (32 pins, quad layout, 0.8mm pitch) packages were previously
+    not flagged as dense at common board-house defaults (trace=0.2mm,
+    clearance=0.15mm) because the dynamic threshold of 2*(0.2+0.15)=0.7mm
+    is just below the 0.8mm pitch.  This made the inner pins of the QFP
+    unable to escape the perimeter routing, blocking USB_D+/CC1/CC2/XTAL2
+    on board 03 (USB joystick).
+    """
+
+    def test_tqfp32_at_0_8mm_pitch_is_dense_without_rules(self):
+        """TQFP-32 at 0.8mm pitch is dense even without explicit design rules."""
+        pads = create_qfp_pads(8, pitch=0.8)  # 32 pins, 0.8mm pitch
+        assert len(pads) == 32
+        # The TQFP-32-class rule fires unconditionally
+        assert is_dense_package(pads) is True
+
+    def test_tqfp32_at_jlcpcb_defaults_is_dense(self):
+        """TQFP-32 is dense at JLCPCB defaults (trace=0.2mm, clearance=0.15mm).
+
+        Without the new rule, the dynamic threshold would be
+        2*(0.2+0.15) = 0.7mm, which is < 0.8mm pitch -> NOT dense.
+        With the new rule, it is dense regardless.
+        """
+        pads = create_qfp_pads(8, pitch=0.8)
+        assert is_dense_package(pads, trace_width=0.2, clearance=0.15) is True
+
+    def test_tqfp48_is_dense(self):
+        """A larger TQFP-48 (12 pins/side, 0.5mm pitch) is dense via fine pitch."""
+        pads = create_qfp_pads(12, pitch=0.5)
+        assert len(pads) == 48
+        assert is_dense_package(pads) is True
+        assert is_dense_package(pads, trace_width=0.2, clearance=0.15) is True
+
+    def test_qfp16_at_1mm_pitch_not_dense(self):
+        """A QFP-16 (4 pins/side, 1.0mm pitch) is NOT dense -- below 32-pin gate."""
+        pads = create_qfp_pads(4, pitch=1.0)
+        assert len(pads) == 16
+        # Below 32-pin gate; pitch = 1.0 > dynamic threshold 0.7
+        assert is_dense_package(pads) is False
+        assert is_dense_package(pads, trace_width=0.2, clearance=0.15) is False
+
+    def test_sop16_at_1_27mm_not_caught_by_tqfp32_rule(self):
+        """SOIC-16 (dual-row, 1.27mm pitch) is correctly NOT dense.
+
+        Confirms the TQFP-32 rule doesn't fire for non-quad layouts.
+        SOIC has fewer than 20 pins so it doesn't trigger the existing
+        multi-row dense path either.
+        """
+        pads = create_sop_pads(16, pitch=1.27)
+        assert len(pads) == 16
+        assert is_dense_package(pads) is False
+        assert is_dense_package(pads, trace_width=0.2, clearance=0.15) is False
+
+    def test_qfn32_at_0_5mm_pitch_dense_via_fine_pitch(self):
+        """QFN-32 at 0.5mm pitch is dense (fine-pitch path), not via the new rule.
+
+        QFN-32 with thermal pad (33 total pads) at 0.5mm pitch is dense
+        because the dynamic threshold at any reasonable trace/clearance
+        catches it; this test exists to ensure the new TQFP-32 rule does
+        not regress small-pitch QFN behavior.
+        """
+        pads = create_qfn_pads(8, pitch=0.5)
+        assert is_dense_package(pads) is True
+        assert is_dense_package(pads, trace_width=0.2, clearance=0.15) is True
+
+
+class TestUSBCBGAMisclassification:
+    """Tests for the BGA-misclassification fix on 2-row connectors (Issue #2513).
+
+    USB-C SMT connectors (e.g. GCT USB4105) have 2 close SMT rows + 2 mounting
+    tabs.  The mounting tabs introduce a third unique-Y group so the previous
+    grid-pattern check would classify them as BGA, applying ring-based escape
+    routing that wastes the bottom layer for what is really a 2-row connector.
+    """
+
+    def test_usbc_smt_18pad_not_bga(self):
+        """A 2x8 SMT USB-C with 2 mounting tabs (18 pads) is NOT BGA."""
+        pads = create_usbc_smt_pads(signal_pads_per_row=8)
+        assert len(pads) == 18  # 16 SMT + 2 TH tabs
+        assert detect_package_type(pads) != PackageType.BGA
+
+    def test_usbc_smt_24pad_not_bga(self):
+        """A larger 2x12 SMT USB-C variant with mounting tabs is NOT BGA."""
+        pads = create_usbc_smt_pads(signal_pads_per_row=12)
+        assert len(pads) == 26  # 24 SMT + 2 TH tabs
+        assert detect_package_type(pads) != PackageType.BGA
+
+    def test_real_bga_still_detected(self):
+        """A real 8x8 BGA must still be detected as BGA after the fix."""
+        pads = create_bga_pads(8, 8, pitch=0.8)
+        assert detect_package_type(pads) == PackageType.BGA
+
+    def test_small_bga_4x4_still_detected(self):
+        """A 4x4 BGA-16 must still be classified as BGA after the fix."""
+        pads = create_bga_pads(4, 4, pitch=0.8)
+        assert detect_package_type(pads) == PackageType.BGA
+
+    def test_three_row_connector_with_outlier_not_bga(self):
+        """3-row connector with one short outlier row stays out of BGA path.
+
+        Confirms _count_substantive_axis_groups filters the short row.
+        """
+        pads = create_usbc_smt_pads(signal_pads_per_row=10)
+        # 20 SMT + 2 tabs; 3 unique Y values but tab row only has 2 pads
+        assert len(pads) == 22
+        assert detect_package_type(pads) != PackageType.BGA
 
 
 class TestDetectPackageType:


### PR DESCRIPTION
## Summary

Two structural fixes in `src/kicad_tools/router/escape.py` that improve board 03 USB joystick routing from 11/13 to 12/13 routed nets at jlcpcb manufacturer defaults (with C++ backend, 4-layer escalation).

### Fix A: TQFP-32-class density gate

At common JLCPCB-style defaults (trace=0.2 mm, clearance=0.15 mm) the dynamic threshold of `2*(0.2+0.15) = 0.7 mm` is just below the 0.8 mm pitch of a TQFP-32 MCU, so the previous code did not flag U1 as dense and inner-pin nets (USB_D+/CC1/CC2/XTAL2) were getting blocked by perimeter routing.

The new TQFP-32-class rule fires when the pad layout is quad AND has >= 32 pins AND the pitch is <= 0.8 mm. SOIC-32 (dual-row) and small-pitch QFN-32 are unaffected.

### Fix B: BGA misclassification on 2-row connectors

USB-C SMT receptacles have 2 close SMT rows + 2 mounting tabs, producing 3 unique-Y groups that the previous classifier interpreted as a BGA grid.

A new helper `_count_substantive_axis_groups()` filters outlier rows/cols whose pad count is less than half the median. J1 now falls through to UNKNOWN where `_escape_radial` handles its escape correctly.

### Supporting changes
- `_escape_qfp_alternating` and `_escape_radial` skip pads on plane nets (`net == 0`)
- For QFP/QFN/TQFP at >= 0.65 mm pin pitch, `_escape_qfp_alternating` uses perpendicular-only escape direction

### Verification

| Metric | Baseline | This PR |
|---|---|---|
| Board 03 nets routed (4-layer) | 11 | 12 |
| Board 03 originally-failing nets | USB_D+, USB_CC1, USB_CC2, XTAL2 (4) | USB_CC1 (1) |
| Board 01 nets routed | 3/3 | 3/3 |
| Board 01 DRC errors | 0 | 0 |

3 of the 4 originally-failing nets on board 03 (USB_D+, USB_CC2, XTAL2) now route. USB_CC1 still fails due to geometric constraints not addressed by escape changes alone.

## Test plan
- [x] tests/test_escape.py: 100 passed (11 new tests added)
- [x] tests/test_router_core.py + autorouter + layers: 342 passed
- [x] ruff check + mypy on src/kicad_tools/router/escape.py: clean
- [x] Board 03 route: 12/13 nets in ~50s
- [x] Board 01 route + DRC: 3/3 nets, 0 errors

## New unit tests
- `TestTQFP32DenseRule`: 6 cases (positive, negative, regression guards)
- `TestUSBCBGAMisclassification`: 5 cases (SMT USB-C variants + real BGA regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)