### PR TITLE
fix(net_class): classify +3V3-style no-decimal voltage names as POWER (closes #2528)

### DIFF
--- a/src/kicad_tools/router/net_class.py
+++ b/src/kicad_tools/router/net_class.py
@@ -118,6 +118,7 @@ NET_CLASS_PATTERNS: dict[NetClass, list[str]] = {
     NetClass.POWER: [
         r"^(VCC|VDD|VBUS|VIN|VOUT|PWR|POWER|AVDD|DVDD)",
         r"^[+-]?\d+\.?\d*V[ADPS]?$",  # +3.3V, -5V, 1.8VA, 3.3VD
+        r"^[+-]?\d+V\d+[ADPS]?$",  # +3V3, +5V0, +1V8, +12V0, -5V0 (no-decimal)
         r"^(PVDD|PVCC|VBAT|VCORE|VCAP|VIO)$",
         r"_VCC$|_VDD$|_PWR$",
         r"^V\d+",  # V5, V3.3, etc.

--- a/tests/test_net_class.py
+++ b/tests/test_net_class.py
@@ -98,6 +98,21 @@ class TestNamePatternClassification:
         assert classify_from_name("VBUS") == NetClass.POWER
         assert classify_from_name("AVDD") == NetClass.POWER
         assert classify_from_name("DVDD") == NetClass.POWER
+        # No-decimal voltage forms (European-style, KiCad templates)
+        assert classify_from_name("+3V3") == NetClass.POWER
+        assert classify_from_name("+5V0") == NetClass.POWER
+        assert classify_from_name("+1V8") == NetClass.POWER
+        assert classify_from_name("+1V2") == NetClass.POWER
+        assert classify_from_name("+12V0") == NetClass.POWER
+        assert classify_from_name("+24V0") == NetClass.POWER
+        assert classify_from_name("-5V0") == NetClass.POWER
+        assert classify_from_name("-12V0") == NetClass.POWER
+        assert classify_from_name("3V3") == NetClass.POWER  # bare, no leading sign
+        assert classify_from_name("1V8") == NetClass.POWER
+        # Regression guards: digit+V containing names that must NOT classify
+        # as POWER (priority ordering protects HIGH_CURRENT_SIGNAL).
+        assert classify_from_name("MOTOR_A") != NetClass.POWER
+        assert classify_from_name("PHASE_5V0") == NetClass.HIGH_CURRENT_SIGNAL
 
     def test_ground_net_patterns(self):
         """Test ground net name detection."""

--- a/tests/test_validate_single_pad_net.py
+++ b/tests/test_validate_single_pad_net.py
@@ -173,6 +173,30 @@ class TestSinglePadNetRule:
         results = SinglePadNetRule().check(pcb, RULES)
         assert len(results.violations) == 0
 
+    def test_single_pad_3v3_no_decimal_marker_allowed(self):
+        """A single-pad +3V3 (no-decimal) marker is silently allowed.
+
+        Mirrors test_single_pad_power_suppressed but uses the European-style
+        no-decimal voltage name (+3V3) that PR for issue #2528 added support
+        for in NET_CLASS_PATTERNS.
+        """
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                4: _StubNet(4, "+3V3"),
+            },
+            _footprints=[
+                _StubFootprint(
+                    reference="TP4",
+                    pads=[
+                        _StubPad(number="1", net_number=4, net_name="+3V3"),
+                    ],
+                ),
+            ],
+        )
+        results = SinglePadNetRule().check(pcb, RULES)
+        assert len(results.violations) == 0
+
     def test_single_pad_vcc_suppressed(self):
         """A single-pad VCC net is silently allowed (pour-net pattern)."""
         pcb = _StubPCB(


### PR DESCRIPTION
## Summary

- Add one regex line to `NET_CLASS_PATTERNS[POWER]` so European-style no-decimal voltage names (`+3V3`, `+5V0`, `+1V8`, `+1V2`, `+12V0`, `+24V0`, `-5V0`, `-12V0`, plus bare `3V3`/`1V8`) classify as `NetClass.POWER`.
- Restores correct behavior for `SinglePadNetRule` pour-net suppression and the router's `_is_power_net_by_class` early-abort heuristic on boards using KiCad's stock no-decimal templates.
- Anchored regex (`^[+-]?\d+V\d+[ADPS]?$`) does not regress any existing classification; priority ordering still routes `MOTOR_*` / `PHASE_*` nets to `HIGH_CURRENT_SIGNAL`.

## Test plan

- [x] `tests/test_net_class.py::test_power_net_patterns` extended with 10 positive cases (no-decimal forms) and 2 regression guards (`MOTOR_A`, `PHASE_5V0`)
- [x] New `tests/test_validate_single_pad_net.py::test_single_pad_3v3_no_decimal_marker_allowed` mirrors the existing `+3.3V` suppression test
- [x] `pytest tests/test_net_class.py tests/test_validate_single_pad_net.py tests/test_single_pad_net_count.py tests/test_single_pad_net_integration.py tests/test_cli_check_single_pad_net.py tests/test_route_single_pad_warning.py` -> 101 passed, 7 skipped (KiCad-runner-only)
- [x] Broader sweep `pytest -k "net_class or pour_net or power_net or _is_power"` -> 249 passed, 5 skipped, 0 regressions
- [x] `ruff check` clean on modified files; `mypy` clean on `net_class.py`
- [x] No source changes outside `net_class.py`; consumers (`single_pad_net.py`, `router/core.py::_is_power_net_by_class`) inherit the fix automatically

Closes #2528.

Out of scope (per curator): parallel power-name heuristics in `explain/mistakes.py`, `optim/signal_integrity.py`, `schema/pcb.py`, `optim/placement.py`, `placement/priors.py`, `cli/sch_reconnect_pin.py` already accept `+3V3` and are intentionally not touched here.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>