### PR TITLE
fix(tests): repair pre-existing TestIncrementalSteinerRouting and TestNegotiatedRouterCongestionEstimator failures (closes #2530)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -4576,13 +4576,9 @@ class Autorouter:
                             if len(pads_for_net) < 2:
                                 continue
 
-                            # Issue #2475: Rip up partially routed net's
-                            # existing routes before re-attempting.
-                            if failed_net in net_routes and net_routes[failed_net]:
-                                neg_router.rip_up_nets(
-                                    [failed_net], net_routes, self.routes
-                                )
-
+                            # Identify blockers BEFORE rip-up so we don't
+                            # destroy a partial route when targeted_ripup
+                            # would not run anyway (Issue #2530).
                             blocking_nets: set[int] = set()
                             for j in range(len(pads_for_net) - 1):
                                 blockers = neg_router.find_blocking_nets_for_connection(
@@ -4597,7 +4593,19 @@ class Autorouter:
                             )
                             blocking_nets |= sibling_blockers
 
+                            # Issue #2475/#2530: Rip up the partially-routed
+                            # net's existing routes only when we have blockers
+                            # to displace; otherwise targeted_ripup would skip
+                            # and we'd permanently lose the partial route on
+                            # single-net boards (or any board where no blockers
+                            # exist), regressing the prior partial connectivity
+                            # to zero routed segments.
                             if blocking_nets:
+                                if failed_net in net_routes and net_routes[failed_net]:
+                                    neg_router.rip_up_nets(
+                                        [failed_net], net_routes, self.routes
+                                    )
+
                                 def _mark_route_fallback(route: Route) -> None:
                                     self._mark_route(route)
 

--- a/tests/test_negotiated_adaptive.py
+++ b/tests/test_negotiated_adaptive.py
@@ -652,10 +652,19 @@ class TestNegotiatedRouterCongestionEstimator:
         mock_est.grid = mock_grid
         mock_est.get_tile_demand.return_value = 3.0
 
-        # Build a NegotiatedRouter with the mock estimator
+        # Build a NegotiatedRouter with the mock estimator.
+        # Issue #2530: Provide a MagicMock grid that satisfies the
+        # interface used by `_collect_route_cells` (introduced by
+        # PR #2315 after these tests were added in PR #2290).
+        nr_grid = MagicMock()
+        nr_grid.world_to_grid.return_value = (0, 0)
+        nr_grid.layer_to_index.return_value = 0
+        nr_grid.get_routable_indices.return_value = []
+
         nr = NegotiatedRouter.__new__(NegotiatedRouter)
-        nr.grid = None
+        nr.grid = nr_grid
         nr.router = MagicMock()
+        nr.router.route.return_value = None  # Avoid _collect_route_cells path
         nr.rules = None
         nr.net_class_map = {}
         nr.congestion_estimator = mock_est
@@ -699,9 +708,18 @@ class TestNegotiatedRouterCongestionEstimator:
         from kicad_tools.router.layers import Layer
         from kicad_tools.router.primitives import Pad
 
+        # Issue #2530: Provide a MagicMock grid that satisfies the
+        # interface used by `_collect_route_cells` (introduced by
+        # PR #2315 after these tests were added in PR #2290).
+        nr_grid = MagicMock()
+        nr_grid.world_to_grid.return_value = (0, 0)
+        nr_grid.layer_to_index.return_value = 0
+        nr_grid.get_routable_indices.return_value = []
+
         nr = NegotiatedRouter.__new__(NegotiatedRouter)
-        nr.grid = None
+        nr.grid = nr_grid
         nr.router = MagicMock()
+        nr.router.route.return_value = None  # Avoid _collect_route_cells path
         nr.rules = None
         nr.net_class_map = {}
         nr.congestion_estimator = None
@@ -735,9 +753,18 @@ class TestNegotiatedRouterCongestionEstimator:
 
         mock_est = MagicMock()
 
+        # Issue #2530: Provide a MagicMock grid that satisfies the
+        # interface used by `_collect_route_cells` (introduced by
+        # PR #2315 after these tests were added in PR #2290).
+        nr_grid = MagicMock()
+        nr_grid.world_to_grid.return_value = (0, 0)
+        nr_grid.layer_to_index.return_value = 0
+        nr_grid.get_routable_indices.return_value = []
+
         nr = NegotiatedRouter.__new__(NegotiatedRouter)
-        nr.grid = None
+        nr.grid = nr_grid
         nr.router = MagicMock()
+        nr.router.route.return_value = None  # Avoid _collect_route_cells path
         nr.rules = None
         nr.net_class_map = {}
         nr.congestion_estimator = mock_est

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -3510,7 +3510,14 @@ class TestIncrementalSteinerRouting:
     """Tests for Issue #2306: incremental Steiner target-set expansion."""
 
     def test_multi_terminal_net_routes_successfully(self):
-        """A multi-terminal net (>2 pads) should route via incremental Steiner."""
+        """A multi-terminal net (>2 pads) should route via incremental Steiner.
+
+        Issue #2530: This test guards against the targeted rip-up
+        fallback (added in PR #2479) destroying a partial RSMT route
+        when there are no blockers to displace.  Even on a single-net
+        board the partial route should be preserved when ``targeted_ripup``
+        cannot run, ensuring ``len(routes) > 0`` after a single iteration.
+        """
         router = Autorouter(width=50.0, height=40.0)
 
         # Create a high-fanout net with 5 pads spread across the board.


### PR DESCRIPTION
## Summary

Closes #2530. Repairs two pre-existing test failures on main that were flagged by 7 PR judges (#2519, #2520, #2522, #2523, #2524, #2525, #2526) as pre-existing on main, not introduced by those PRs.

### Failure 1 — `TestNegotiatedRouterCongestionEstimator::*` (3 tests)
**Root cause:** test fixture drift. PR #2290 added the tests with `nr.grid = None`; PR #2315 (one day later) added `_collect_route_cells` in `negotiated.py:684-715` which unconditionally dereferences `self.grid`.

**Fix:** updated the three test fixtures to provide a `MagicMock` grid implementing `world_to_grid`, `layer_to_index`, and `get_routable_indices` (Option 2 from the curator's enrichment). The tests still focus on `congestion_fn` capture; `nr.router.route.return_value = None` short-circuits before `_collect_route_cells` is invoked, but the safety net is in place if the path were ever exercised.

### Failure 2 — `TestIncrementalSteinerRouting::test_multi_terminal_net_routes_successfully`
**Root cause:** router behaviour regression introduced by PR #2479 (`cd9823c8`, "preserve chain connectivity in DRC nudge"). The targeted rip-up fallback in `core.py:4570-4617` ripped up partial RSMT routes **before** checking whether any blockers existed. On a single-net board (or any net with no blockers) `targeted_ripup` is then skipped and the partial route is permanently lost — `targeted fallback resolved 0/1 nets`, then convergence triggers because `len(net_routes) == total_nets` (the empty route entry still occupies the dict).

**Fix:** reordered the logic in `core.py` so blockers are identified first; the partial-route rip-up only happens when `blocking_nets` is non-empty (i.e., when `targeted_ripup` will actually run). On boards with no blockers we now preserve the prior partial connectivity, which is strictly better than destroying it.

This also addresses the curator's recommended Fix (b): a real router behaviour bug rather than papering over with `max_iterations`.

### Verification

- All 4 originally-failing tests + 2 already-passing peers in `TestNegotiatedRouterCongestionEstimator`: 6/6 pass.
- `tests/test_router_core.py` (158 tests): all pass.
- `tests/test_negotiated_adaptive.py` (99 tests): all pass.
- Wider router-area sweep (666 tests across 13 files including `test_router_negotiated_high_current.py`, `test_partial_routing_features.py`, `test_routing_connectivity.py`, `test_steiner.py`, `test_router_autorouter.py`): all pass.
- Pre-existing `test_router_integration.py` voltage_divider/charlieplex failures and `cmaes` import errors are unaffected (verified pre-existing on main via stash + checkout).
- No new ruff or format errors introduced (28 lint errors and 3 format-needed files, identical to main).

## Test plan

- [x] `uv run pytest tests/test_router_core.py::TestIncrementalSteinerRouting::test_multi_terminal_net_routes_successfully tests/test_negotiated_adaptive.py::TestNegotiatedRouterCongestionEstimator -v --no-cov` -> 6 passed, 0 failed
- [x] `uv run pytest tests/test_router_core.py tests/test_negotiated_adaptive.py --no-cov` -> 257 passed
- [x] Wider router test sweep (666 tests across 13 files): 666 passed, 4 skipped
- [x] Confirmed no new lint/format regressions vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)