### PR TITLE
fix(placement): plumb --fixed through routing-aware path / PlaceRouteOptimizer (closes #2537)

### DIFF
--- a/src/kicad_tools/cli/placement_cmd.py
+++ b/src/kicad_tools/cli/placement_cmd.py
@@ -249,7 +249,11 @@ def cmd_fix(args) -> int:
             print("\nPer-pass progress:")
             for pr in result.pass_results:
                 resolved = pr.conflicts_before - pr.conflicts_after
-                esc_str = f" (escalation: {pr.escalation_factor:.1f}x)" if pr.escalation_factor > 1.0 else ""
+                esc_str = (
+                    f" (escalation: {pr.escalation_factor:.1f}x)"
+                    if pr.escalation_factor > 1.0
+                    else ""
+                )
                 print(
                     f"  Pass {pr.pass_number}: {pr.conflicts_before} conflicts "
                     f"-> {pr.conflicts_after} conflicts "
@@ -979,16 +983,35 @@ def _estimate_routability(pcb_path: Path, quiet: bool = False) -> tuple[float, i
         return (1.0, 0, 0)
 
 
-def _cmd_optimize_routing_aware(args, pcb_path: Path, quiet: bool, output_format: str) -> int:
+def _cmd_optimize_routing_aware(
+    args,
+    pcb_path: Path,
+    quiet: bool,
+    output_format: str,
+    fixed_refs: list[str] | None = None,
+) -> int:
     """
     Run routing-aware placement optimization.
 
     Uses PlaceRouteOptimizer to iterate between placement and routing
     for better overall results.
+
+    Args:
+        args: argparse Namespace with optimization options.
+        pcb_path: Path to the input .kicad_pcb file.
+        quiet: Suppress text output.
+        output_format: "text" or "json".
+        fixed_refs: Component references that must not move during
+            optimization (issue #2537). Passed through to the
+            ``PlaceRouteOptimizer.from_pcb`` factory so it reaches
+            both placement-conflict fixes and blocker-nudging.
     """
     from kicad_tools.cli.progress import spinner
     from kicad_tools.optim.place_route import PlaceRouteOptimizer
     from kicad_tools.schema.pcb import PCB
+
+    # Defensive: caller may not pass fixed_refs (legacy callers).
+    fixed_refs = fixed_refs or []
 
     # For JSON output, suppress text output
     if output_format == "json":
@@ -1019,6 +1042,8 @@ def _cmd_optimize_routing_aware(args, pcb_path: Path, quiet: bool, output_format
         print("=" * 50)
         print("This mode iterates between placement and routing")
         print("to find placements that are actually routable.")
+        if fixed_refs:
+            print(f"Fixed components: {', '.join(fixed_refs)}")
         print()
 
     # Load PCB
@@ -1037,6 +1062,7 @@ def _cmd_optimize_routing_aware(args, pcb_path: Path, quiet: bool, output_format
                 pcb,
                 pcb_path=pcb_path,
                 verbose=not quiet,
+                fixed_refs=set(fixed_refs),
             )
     except Exception as e:
         if output_format != "json":
@@ -1144,14 +1170,18 @@ def cmd_optimize(args) -> int:
             print(f"Error: File not found: {pcb_path}", file=sys.stderr)
         return output_result(False, f"File not found: {pcb_path}")
 
-    # Handle routing-aware optimization mode
-    if routing_aware:
-        return _cmd_optimize_routing_aware(args, pcb_path, quiet, output_format)
-
-    # Parse fixed components
+    # Parse fixed components (shared between routing-aware and default paths).
+    # IMPORTANT: parse this BEFORE dispatching to the routing-aware code path
+    # so the constraint reaches both paths (issue #2537).
     fixed_refs: list[str] = []
     if args.fixed:
         fixed_refs = [r.strip() for r in args.fixed.split(",") if r.strip()]
+
+    # Handle routing-aware optimization mode
+    if routing_aware:
+        return _cmd_optimize_routing_aware(
+            args, pcb_path, quiet, output_format, fixed_refs=fixed_refs
+        )
 
     # Load constraints if specified
     constraints = []
@@ -1976,7 +2006,9 @@ def main(argv: list[str] | None = None) -> int:
         default="text",
         help="Output format (default: text)",
     )
-    place_unplaced_parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    place_unplaced_parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Verbose output"
+    )
     place_unplaced_parser.add_argument(
         "-q", "--quiet", action="store_true", help="Suppress progress output"
     )

--- a/src/kicad_tools/optim/place_route.py
+++ b/src/kicad_tools/optim/place_route.py
@@ -98,6 +98,7 @@ class PlaceRouteOptimizer:
         verbose: bool = True,
         escape_routing: bool | None = None,
         max_fix_attempts: int = 3,
+        fixed_refs: set[str] | list[str] | None = None,
     ) -> None:
         """Initialize the optimizer.
 
@@ -117,6 +118,11 @@ class PlaceRouteOptimizer:
                 None = auto-detect dense packages (default).
             max_fix_attempts: Maximum DRC fix attempts per optimization
                 iteration before giving up and reporting failure.
+            fixed_refs: Optional set/list of component references that must
+                not move during optimization. The optimizer wires this into
+                the ``PlacementFixer.anchored`` set so that placement-conflict
+                fixes won't move these components, and filters anchored refs
+                out of the blocker-nudge phase.
         """
         self.pcb_path = Path(pcb_path)
         self.analyzer = analyzer
@@ -126,6 +132,16 @@ class PlaceRouteOptimizer:
         self.verbose = verbose
         self.escape_routing = escape_routing
         self.max_fix_attempts = max_fix_attempts
+        # Normalize to a frozen set; expose as public attribute for inspection.
+        self.fixed_refs: set[str] = set(fixed_refs or [])
+
+        # Make sure the fixer honors the same anchored set. The fixer already
+        # supports ``anchored`` in ``_choose_component_to_move``; merge any
+        # refs the caller pre-configured on the fixer with our own list so
+        # the union is anchored.
+        if self.fixed_refs:
+            existing = getattr(self.fixer, "anchored", None) or set()
+            self.fixer.anchored = set(existing) | self.fixed_refs
 
         # Track state across iterations
         self._current_routes: list[Route] = []
@@ -142,6 +158,7 @@ class PlaceRouteOptimizer:
         board_width: float | None = None,
         board_height: float | None = None,
         verbose: bool = True,
+        fixed_refs: set[str] | list[str] | None = None,
     ) -> PlaceRouteOptimizer:
         """Create optimizer from a PCB object.
 
@@ -155,6 +172,9 @@ class PlaceRouteOptimizer:
             board_width: Board width in mm (auto-detected if None)
             board_height: Board height in mm (auto-detected if None)
             verbose: Print progress messages
+            fixed_refs: Optional set/list of component references that must
+                not move during optimization. Forwarded to the constructor
+                and the underlying ``PlacementFixer.anchored`` set.
 
         Returns:
             Configured PlaceRouteOptimizer ready to run
@@ -165,6 +185,7 @@ class PlaceRouteOptimizer:
             ...     pcb,
             ...     manufacturer="jlcpcb",
             ...     layers=4,
+            ...     fixed_refs={"J1"},
             ... )
             >>> result = optimizer.optimize()
         """
@@ -187,9 +208,13 @@ class PlaceRouteOptimizer:
             board_width = board_width or width
             board_height = board_height or height
 
-        # Create components
+        # Normalize fixed_refs into a set early so we can pass it to the fixer.
+        anchored: set[str] = set(fixed_refs or [])
+
+        # Create components. PlacementFixer already honors ``anchored`` in
+        # ``_choose_component_to_move`` (see placement/fixer.py).
         analyzer = PlacementAnalyzer(verbose=verbose)
-        fixer = PlacementFixer(verbose=verbose)
+        fixer = PlacementFixer(verbose=verbose, anchored=anchored)
 
         # Router factory - creates fresh router for each attempt
         def router_factory() -> Autorouter:
@@ -213,6 +238,7 @@ class PlaceRouteOptimizer:
             router_factory=router_factory,
             drc_checker_factory=drc_checker_factory,
             verbose=verbose,
+            fixed_refs=anchored,
         )
 
     @staticmethod
@@ -670,7 +696,8 @@ class PlaceRouteOptimizer:
         """Move blocking components slightly to allow routing.
 
         Applies small displacements to potentially blocking components
-        to create routing channels.
+        to create routing channels. Components listed in ``self.fixed_refs``
+        are never nudged.
 
         Args:
             blockers: List of component references to nudge
@@ -678,10 +705,19 @@ class PlaceRouteOptimizer:
         from kicad_tools.placement.conflict import Point
         from kicad_tools.placement.fixer import PlacementFix
 
+        # Filter out anchored / fixed components before slicing.
+        if self.fixed_refs:
+            filtered_blockers = [b for b in blockers if b not in self.fixed_refs]
+            if self.verbose and len(filtered_blockers) != len(blockers):
+                skipped = [b for b in blockers if b in self.fixed_refs]
+                print(f"    Skipping fixed blockers: {skipped}")
+        else:
+            filtered_blockers = blockers
+
         # Create synthetic fixes to move blockers
         fixes: list[PlacementFix] = []
 
-        for ref in blockers[:3]:  # Limit to avoid too many changes
+        for ref in filtered_blockers[:3]:  # Limit to avoid too many changes
             # Try small moves in each direction
             # Pick direction based on component position relative to board center
             components = self.analyzer.get_components()
@@ -737,10 +773,7 @@ class PlaceRouteOptimizer:
         # Guard: respect per-iteration attempt limit
         if self._fix_attempts >= self.max_fix_attempts:
             if self.verbose:
-                print(
-                    f"    DRC fix: max attempts ({self.max_fix_attempts}) "
-                    f"reached, giving up"
-                )
+                print(f"    DRC fix: max attempts ({self.max_fix_attempts}) reached, giving up")
             return False
 
         self._fix_attempts += 1

--- a/tests/test_cli_placement_routing_aware.py
+++ b/tests/test_cli_placement_routing_aware.py
@@ -57,9 +57,7 @@ class TestRoutingAwareFlagExists:
 
         # Parse a minimal command line with --routing-aware
         # This should not raise an error if the flag exists
-        args = parser.parse_args(
-            ["placement", "optimize", "test.kicad_pcb", "--routing-aware"]
-        )
+        args = parser.parse_args(["placement", "optimize", "test.kicad_pcb", "--routing-aware"])
 
         assert hasattr(args, "routing_aware")
         assert args.routing_aware is True
@@ -70,9 +68,7 @@ class TestRoutingAwareFlagExists:
 
         parser = create_parser()
 
-        args = parser.parse_args(
-            ["placement", "optimize", "test.kicad_pcb", "--check-routability"]
-        )
+        args = parser.parse_args(["placement", "optimize", "test.kicad_pcb", "--check-routability"])
 
         assert hasattr(args, "check_routability")
         assert args.check_routability is True
@@ -286,3 +282,272 @@ class TestPlaceRouteOptimizer:
         assert result.has_placement_conflicts is False
         assert result.has_drc_violations is False
         assert result.routing_complete is False
+
+
+# =============================================================================
+# --fixed plumbing tests (issue #2537)
+# =============================================================================
+
+
+class TestFixedFlagWithRoutingAware:
+    """Tests that ``--fixed`` reaches the routing-aware path (issue #2537).
+
+    Before the fix, ``--fixed`` was parsed AFTER the routing-aware dispatch
+    so the constraint was silently dropped. These tests guard against that
+    regression at the CLI level.
+    """
+
+    def test_fixed_arg_parses_with_routing_aware(self):
+        """``--fixed`` and ``--routing-aware`` parse without conflict."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "placement",
+                "optimize",
+                "test.kicad_pcb",
+                "--routing-aware",
+                "--fixed",
+                "J1",
+            ]
+        )
+
+        assert args.routing_aware is True
+        assert args.fixed == "J1"
+
+    def test_fixed_arg_with_multiple_components(self):
+        """Comma-separated ``--fixed`` accumulates correctly."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "placement",
+                "optimize",
+                "test.kicad_pcb",
+                "--routing-aware",
+                "--fixed",
+                "J1,U1,H1",
+            ]
+        )
+
+        assert args.fixed == "J1,U1,H1"
+
+    def test_routing_aware_dispatch_receives_fixed_refs(self, tmp_path):
+        """``_cmd_optimize_routing_aware`` is called with parsed fixed_refs."""
+        import json
+        from unittest.mock import patch
+
+        from kicad_tools.cli import placement_cmd
+
+        # Create a tiny placeholder PCB so the path-existence check passes.
+        pcb_path = tmp_path / "fake.kicad_pcb"
+        pcb_path.write_text(
+            "(kicad_pcb (version 20240108) (generator test) "
+            "(generator_version 8.0) (general (thickness 1.6)) "
+            '(layers (0 "F.Cu" signal) (44 "Edge.Cuts" user)) '
+            "(setup (pad_to_mask_clearance 0)))\n"
+        )
+
+        captured: dict = {}
+
+        def fake_routing_aware(args, p, quiet, output_format, fixed_refs=None):
+            captured["fixed_refs"] = list(fixed_refs or [])
+            captured["pcb_path"] = p
+            print(json.dumps({"success": True, "captured": True}))
+            return 0
+
+        with patch.object(placement_cmd, "_cmd_optimize_routing_aware", fake_routing_aware):
+            placement_cmd.main(
+                [
+                    "optimize",
+                    str(pcb_path),
+                    "--routing-aware",
+                    "--fixed",
+                    "J1,U1",
+                    "--dry-run",
+                    "--quiet",
+                ]
+            )
+
+        assert captured.get("fixed_refs") == ["J1", "U1"]
+
+    def test_routing_aware_dispatch_default_fixed_refs_empty(self, tmp_path):
+        """Without ``--fixed``, the routing-aware path gets an empty list."""
+        from unittest.mock import patch
+
+        from kicad_tools.cli import placement_cmd
+
+        pcb_path = tmp_path / "fake.kicad_pcb"
+        pcb_path.write_text(
+            "(kicad_pcb (version 20240108) (generator test) "
+            "(generator_version 8.0) (general (thickness 1.6)) "
+            '(layers (0 "F.Cu" signal) (44 "Edge.Cuts" user)) '
+            "(setup (pad_to_mask_clearance 0)))\n"
+        )
+
+        captured: dict = {}
+
+        def fake_routing_aware(args, p, quiet, output_format, fixed_refs=None):
+            captured["fixed_refs"] = list(fixed_refs or [])
+            return 0
+
+        with patch.object(placement_cmd, "_cmd_optimize_routing_aware", fake_routing_aware):
+            placement_cmd.main(
+                [
+                    "optimize",
+                    str(pcb_path),
+                    "--routing-aware",
+                    "--dry-run",
+                    "--quiet",
+                ]
+            )
+
+        assert captured.get("fixed_refs") == []
+
+    def test_fixed_refs_passed_to_optimizer_from_pcb(self, tmp_path, minimal_pcb):
+        """``_cmd_optimize_routing_aware`` forwards fixed_refs to from_pcb."""
+        from unittest.mock import patch
+
+        from kicad_tools.cli import placement_cmd
+
+        captured: dict = {}
+
+        # Patch from_pcb to capture the fixed_refs kwarg without running
+        # the full optimization.
+        from kicad_tools.optim.place_route import PlaceRouteOptimizer
+
+        def fake_from_pcb(pcb, *, pcb_path=None, fixed_refs=None, **kwargs):
+            captured["fixed_refs"] = fixed_refs
+            # Build a stub optimizer that returns a successful result on
+            # ``optimize`` so the CLI saves the PCB and exits 0.
+            from unittest.mock import MagicMock
+
+            from kicad_tools.optim.workflow import OptimizationResult
+
+            stub = MagicMock(spec=PlaceRouteOptimizer)
+            stub.optimize.return_value = OptimizationResult(
+                success=True,
+                pcb_path=pcb_path,
+                routes=[],
+                iterations=1,
+                message="ok",
+            )
+            return stub
+
+        with patch.object(PlaceRouteOptimizer, "from_pcb", fake_from_pcb):
+            placement_cmd.main(
+                [
+                    "optimize",
+                    str(minimal_pcb),
+                    "--routing-aware",
+                    "--fixed",
+                    "R1,U1",
+                    "--dry-run",
+                    "--quiet",
+                ]
+            )
+
+        assert captured.get("fixed_refs") == {"R1", "U1"}
+
+
+class TestFixedRefsPositionInvariance:
+    """End-to-end tests that ``--fixed`` keeps a component's position fixed.
+
+    These tests exercise the whole optimization loop on small synthetic
+    PCBs to confirm the named component does not move regardless of
+    routing-aware / non-routing-aware dispatch.
+    """
+
+    @staticmethod
+    def _read_position(pcb_path: Path, ref: str) -> tuple[float, float]:
+        """Return ``(x, y)`` for the given component ref."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(str(pcb_path))
+        for fp in pcb.footprints:
+            if fp.reference == ref:
+                return (float(fp.position[0]), float(fp.position[1]))
+        raise AssertionError(f"Component {ref} not found in {pcb_path}")
+
+    def test_routing_aware_with_fixed_keeps_position(self, minimal_pcb, tmp_path):
+        """``--fixed R1 --routing-aware`` keeps R1's position unchanged.
+
+        The minimal PCB has a single resistor R1; fixing it should
+        guarantee its position is bit-identical post-optimization.
+        """
+        from kicad_tools.cli import placement_cmd
+
+        before_pos = self._read_position(minimal_pcb, "R1")
+        out_path = tmp_path / "out.kicad_pcb"
+
+        rc = placement_cmd.main(
+            [
+                "optimize",
+                str(minimal_pcb),
+                "--routing-aware",
+                "--fixed",
+                "R1",
+                "-o",
+                str(out_path),
+                "--quiet",
+            ]
+        )
+        assert rc in (0, 1)
+
+        # Optimization may not succeed on a single-component PCB, but the
+        # input must be preserved. The output is only saved if the run
+        # produced one; otherwise check the input file.
+        target = out_path if out_path.exists() else minimal_pcb
+        after_pos = self._read_position(target, "R1")
+
+        assert after_pos == before_pos, f"R1 moved from {before_pos} to {after_pos} despite --fixed"
+
+    def test_default_path_with_fixed_keeps_position(self, minimal_pcb, tmp_path):
+        """Non-routing-aware path also honors ``--fixed`` (regression guard)."""
+        from kicad_tools.cli import placement_cmd
+
+        before_pos = self._read_position(minimal_pcb, "R1")
+        out_path = tmp_path / "out.kicad_pcb"
+
+        placement_cmd.main(
+            [
+                "optimize",
+                str(minimal_pcb),
+                "--fixed",
+                "R1",
+                "-o",
+                str(out_path),
+                "--quiet",
+            ]
+        )
+
+        target = out_path if out_path.exists() else minimal_pcb
+        after_pos = self._read_position(target, "R1")
+
+        assert after_pos == before_pos
+
+    def test_routing_aware_unconstrained_path_unaffected(self, minimal_pcb, tmp_path):
+        """Without ``--fixed``, optimization runs as before (no regression).
+
+        We don't assert that R1 *did* move (a single-component PCB has
+        nothing to optimize) — only that the run completes cleanly.
+        """
+        from kicad_tools.cli import placement_cmd
+
+        out_path = tmp_path / "out.kicad_pcb"
+        rc = placement_cmd.main(
+            [
+                "optimize",
+                str(minimal_pcb),
+                "--routing-aware",
+                "-o",
+                str(out_path),
+                "--dry-run",
+                "--quiet",
+            ]
+        )
+
+        # Should not error out due to missing fixed_refs handling.
+        assert rc in (0, 1)

--- a/tests/test_place_route_optimizer.py
+++ b/tests/test_place_route_optimizer.py
@@ -811,9 +811,7 @@ class TestFixDrcViolations:
         return optimizer
 
     @patch("kicad_tools.optim.place_route.PlaceRouteOptimizer._fix_drc_violations")
-    def test_optimize_drc_failure_exercises_fix_path(
-        self, mock_fix, tmp_path
-    ):
+    def test_optimize_drc_failure_exercises_fix_path(self, mock_fix, tmp_path):
         """DRC failure with fixable violations triggers fix attempt before failing."""
         pcb_path = tmp_path / "test.kicad_pcb"
         pcb_path.write_text(SIMPLE_PCB)
@@ -1245,3 +1243,273 @@ class TestPeriodicCheckpoint:
         optimizer.optimize(max_iterations=3, checkpoint_interval=0)
 
         assert not checkpoint_path.exists()
+
+
+# =============================================================================
+# fixed_refs plumbing tests (issue #2537)
+# =============================================================================
+
+
+class TestPlaceRouteOptimizerFixedRefs:
+    """Tests for the ``fixed_refs`` plumbing added in issue #2537.
+
+    The ``--fixed`` CLI flag was previously silently ignored when combined
+    with ``--routing-aware``. The fix adds ``fixed_refs`` plumbing through
+    ``PlaceRouteOptimizer.__init__``, ``from_pcb``, and ``_nudge_blockers``,
+    and wires it into the underlying ``PlacementFixer.anchored`` set.
+    """
+
+    def test_init_accepts_fixed_refs(self, tmp_path):
+        """``__init__`` accepts ``fixed_refs`` and stores it as a set."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        from kicad_tools.placement.fixer import PlacementFixer
+
+        fixer = PlacementFixer(verbose=False)
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(),
+            fixer=fixer,
+            router_factory=lambda: MagicMock(),
+            verbose=False,
+            fixed_refs={"J1", "U1"},
+        )
+
+        assert optimizer.fixed_refs == {"J1", "U1"}
+        # Anchored set was merged into the fixer.
+        assert "J1" in optimizer.fixer.anchored
+        assert "U1" in optimizer.fixer.anchored
+
+    def test_init_default_fixed_refs_is_empty(self, tmp_path):
+        """``fixed_refs`` defaults to an empty set."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(),
+            fixer=MagicMock(anchored=set()),
+            router_factory=lambda: MagicMock(),
+            verbose=False,
+        )
+
+        assert optimizer.fixed_refs == set()
+
+    def test_init_accepts_list_for_fixed_refs(self, tmp_path):
+        """``fixed_refs`` accepts a list (not just a set)."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        from kicad_tools.placement.fixer import PlacementFixer
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(),
+            fixer=PlacementFixer(verbose=False),
+            router_factory=lambda: MagicMock(),
+            verbose=False,
+            fixed_refs=["J1", "U1"],
+        )
+
+        assert optimizer.fixed_refs == {"J1", "U1"}
+
+    def test_init_merges_with_existing_fixer_anchored(self, tmp_path):
+        """``__init__`` merges fixed_refs with any pre-existing fixer.anchored."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        from kicad_tools.placement.fixer import PlacementFixer
+
+        fixer = PlacementFixer(verbose=False, anchored={"H1"})
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=MagicMock(),
+            fixer=fixer,
+            router_factory=lambda: MagicMock(),
+            verbose=False,
+            fixed_refs={"J1"},
+        )
+
+        # Both sets are merged.
+        assert "H1" in optimizer.fixer.anchored
+        assert "J1" in optimizer.fixer.anchored
+
+    def test_from_pcb_propagates_fixed_refs(self, tmp_path):
+        """``from_pcb`` accepts ``fixed_refs`` and forwards to the fixer."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(str(pcb_path))
+
+        optimizer = PlaceRouteOptimizer.from_pcb(
+            pcb=pcb,
+            pcb_path=pcb_path,
+            verbose=False,
+            fixed_refs={"R1"},
+        )
+
+        assert optimizer.fixed_refs == {"R1"}
+        assert "R1" in optimizer.fixer.anchored
+
+    def test_from_pcb_default_fixed_refs(self, tmp_path):
+        """``from_pcb`` defaults to no fixed refs."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(str(pcb_path))
+
+        optimizer = PlaceRouteOptimizer.from_pcb(
+            pcb=pcb,
+            pcb_path=pcb_path,
+            verbose=False,
+        )
+
+        assert optimizer.fixed_refs == set()
+
+    def test_nudge_blockers_skips_fixed_refs(self, tmp_path):
+        """``_nudge_blockers`` filters out anchored components."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        # Mock components C1 (movable) and J1 (fixed)
+        comp_c1 = MagicMock()
+        comp_c1.reference = "C1"
+        comp_c1.position = MagicMock(x=100, y=100)
+        comp_j1 = MagicMock()
+        comp_j1.reference = "J1"
+        comp_j1.position = MagicMock(x=105, y=105)
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.get_components.return_value = [comp_c1, comp_j1]
+        mock_analyzer.get_board_edge.return_value = MagicMock(
+            min_x=90, max_x=110, min_y=90, max_y=110
+        )
+
+        mock_fixer = MagicMock()
+        mock_fixer.apply_fixes.return_value = MagicMock(fixes_applied=1)
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=mock_analyzer,
+            fixer=mock_fixer,
+            router_factory=lambda: MagicMock(),
+            verbose=False,
+            fixed_refs={"J1"},
+        )
+
+        # Provide BOTH C1 and J1 as candidate blockers.
+        optimizer._nudge_blockers(["C1", "J1"])
+
+        # Only C1 should be moved; J1 must be skipped.
+        mock_fixer.apply_fixes.assert_called_once()
+        call_args = mock_fixer.apply_fixes.call_args
+        fixes = call_args[0][1]
+        assert len(fixes) == 1
+        assert fixes[0].component == "C1"
+        moved_refs = {f.component for f in fixes}
+        assert "J1" not in moved_refs
+
+    def test_nudge_blockers_no_fixes_when_all_fixed(self, tmp_path):
+        """If every blocker is in ``fixed_refs``, no fixes are applied."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.get_components.return_value = []
+        mock_analyzer.get_board_edge.return_value = MagicMock(
+            min_x=90, max_x=110, min_y=90, max_y=110
+        )
+
+        mock_fixer = MagicMock()
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=mock_analyzer,
+            fixer=mock_fixer,
+            router_factory=lambda: MagicMock(),
+            verbose=False,
+            fixed_refs={"C1", "J1"},
+        )
+
+        optimizer._nudge_blockers(["C1", "J1"])
+
+        # No movable blockers means no apply_fixes call.
+        mock_fixer.apply_fixes.assert_not_called()
+
+    def test_nudge_blockers_unconstrained_path_unchanged(self, tmp_path):
+        """Without ``fixed_refs``, ``_nudge_blockers`` behaves as before."""
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(SIMPLE_PCB)
+
+        comp = MagicMock()
+        comp.reference = "C1"
+        comp.position = MagicMock(x=100, y=100)
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.get_components.return_value = [comp]
+        mock_analyzer.get_board_edge.return_value = MagicMock(
+            min_x=90, max_x=110, min_y=90, max_y=110
+        )
+
+        mock_fixer = MagicMock()
+        mock_fixer.apply_fixes.return_value = MagicMock(fixes_applied=1)
+
+        optimizer = PlaceRouteOptimizer(
+            pcb_path=pcb_path,
+            analyzer=mock_analyzer,
+            fixer=mock_fixer,
+            router_factory=lambda: MagicMock(),
+            verbose=False,
+            # No fixed_refs at all
+        )
+
+        optimizer._nudge_blockers(["C1"])
+
+        mock_fixer.apply_fixes.assert_called_once()
+        fixes = mock_fixer.apply_fixes.call_args[0][1]
+        assert len(fixes) == 1
+        assert fixes[0].component == "C1"
+
+    def test_placement_fixer_honors_anchored_via_choose_component_to_move(self, tmp_path):
+        """End-to-end: fixer's ``_choose_component_to_move`` honors anchored.
+
+        This is a regression guard: confirms the existing ``PlacementFixer``
+        machinery is the correct landing spot for our new wiring.
+        """
+        from kicad_tools.placement.conflict import (
+            Conflict,
+            ConflictSeverity,
+            ConflictType,
+            Point,
+        )
+        from kicad_tools.placement.fixer import PlacementFixer
+
+        fixer = PlacementFixer(verbose=False, anchored={"J1"})
+
+        def make_conflict(c1: str, c2: str) -> Conflict:
+            return Conflict(
+                type=ConflictType.COURTYARD_OVERLAP,
+                severity=ConflictSeverity.ERROR,
+                component1=c1,
+                component2=c2,
+                message="test overlap",
+                location=Point(0.0, 0.0),
+                overlap_amount=0.5,
+            )
+
+        # Conflict between J1 (anchored) and R1: must move R1.
+        chosen = fixer._choose_component_to_move(make_conflict("J1", "R1"))
+        assert chosen == "R1"
+
+        # Conflict between R1 and J1 (anchored): must move R1.
+        chosen2 = fixer._choose_component_to_move(make_conflict("R1", "J1"))
+        assert chosen2 == "R1"
+
+        # Conflict between two anchored: returns None (cannot fix).
+        fixer2 = PlacementFixer(verbose=False, anchored={"J1", "U1"})
+        assert fixer2._choose_component_to_move(make_conflict("J1", "U1")) is None


### PR DESCRIPTION
## Summary

`kct placement optimize --fixed <ref> --routing-aware` silently dropped the constraint due to two compounding bugs:

1. **CLI parse-vs-dispatch ordering** in `cli/placement_cmd.py:1147`: the routing-aware dispatch happened *before* `args.fixed` was parsed at line 1153.
2. **Missing plumbing in `PlaceRouteOptimizer`** (`optim/place_route.py:91-216`): neither `__init__` nor `from_pcb` accepted a `fixed_refs` parameter.

The non-routing-aware path correctly threads `fixed_refs` via `WorkflowConfig.fixed_refs` -> `PlacementOptimizer.from_pcb` -> `is_fixed = fp.reference in fixed_refs`, so it was unaffected.

## Changes

### `src/kicad_tools/cli/placement_cmd.py`
- Move `--fixed` parsing to *before* the routing-aware dispatch; forward `fixed_refs` to `_cmd_optimize_routing_aware`.
- `_cmd_optimize_routing_aware` now accepts `fixed_refs` and passes it to `PlaceRouteOptimizer.from_pcb`.
- Banner now prints "Fixed components: ..." (was previously silent on the routing-aware path).

### `src/kicad_tools/optim/place_route.py`
- `__init__` accepts `fixed_refs: set[str] | list[str] | None`, normalizes to a set, exposes as `self.fixed_refs`, and merges into `self.fixer.anchored` so the existing `PlacementFixer._choose_component_to_move` logic refuses to move anchored refs.
- `from_pcb` accepts `fixed_refs`, builds `PlacementFixer(anchored=...)`, forwards to `__init__`.
- `_nudge_blockers` filters `self.fixed_refs` out of `blockers` before the `[:3]` slice — so the routing-failure-recovery nudge phase also honors the constraint.

### Tests (18 new, all passing)
- `tests/test_place_route_optimizer.py` — 10 unit tests in `TestPlaceRouteOptimizerFixedRefs`:
  - `__init__` accepts set / list / None / merges with pre-existing fixer.anchored
  - `from_pcb` propagates fixed_refs / defaults to empty
  - `_nudge_blockers` filters fixed refs / no-op when all blockers fixed / unconstrained path unchanged
  - `PlacementFixer._choose_component_to_move` regression guard
- `tests/test_cli_placement_routing_aware.py` — 8 tests in `TestFixedFlagWithRoutingAware` and `TestFixedRefsPositionInvariance`:
  - argparse: `--fixed` parses with `--routing-aware`
  - argparse: comma-separated multi-component `--fixed J1,U1,H1`
  - dispatch: routing-aware path receives parsed fixed_refs (mock capture)
  - dispatch: empty default when `--fixed` absent
  - propagation: `_cmd_optimize_routing_aware` calls `from_pcb(fixed_refs={...})`
  - end-to-end: routing-aware + `--fixed R1` keeps R1 position invariant
  - end-to-end: non-routing-aware + `--fixed R1` keeps R1 position invariant (regression guard)
  - end-to-end: routing-aware without `--fixed` is unaffected (no regression)

## Verification

Issue repro from #2527 / acceptance criteria:

```
$ uv run kct placement optimize boards/03-usb-joystick/output/usb_joystick.kicad_pcb \
    --fixed J1 --routing-aware --check-routability \
    -o /tmp/test.kicad_pcb
...
Optimization converged in 1 iterations
Successfully routed 64 nets
```

J1 position before: `(30.0, 5.0, 0.0)`
J1 position after:  `(30.0, 5.0, 0.0)` — bit-identical, as required.

## Test plan

- [x] All 75 tests in `tests/test_place_route_optimizer.py` and `tests/test_cli_placement_routing_aware.py` pass (45 + 12 pre-existing + 18 new)
- [x] Repro from issue: J1 position unchanged after `--fixed J1 --routing-aware` on board 03
- [x] Board 01 baseline (`--routing-aware` without `--fixed`) still produces same outcome as before
- [x] `ruff format` clean; `ruff check` shows only 4 pre-existing errors (no new ones introduced)

## Out of scope (per curator)

- DRC-repair phase further hardening (`ClearanceRepairer` only moves traces/vias, so component-level fixed is currently a no-op there)
- `fp.locked` field integration