### PR TITLE
fix(placement/fixer): respect anchored set on EDGE_CLEARANCE conflicts (closes #2541)

### DIFF
--- a/src/kicad_tools/placement/fixer.py
+++ b/src/kicad_tools/placement/fixer.py
@@ -175,8 +175,12 @@ class PlacementFixer:
         """Choose which component to move to resolve conflict."""
         c1, c2 = conflict.component1, conflict.component2
 
-        # Edge conflicts: always move the component
+        # Edge conflicts: only c1 is a real component (c2 is a board-edge sentinel
+        # like "left_edge"; see analyzer.py:533-542). If c1 is anchored, we cannot
+        # resolve this conflict by moving — return None to skip it.
         if conflict.type == ConflictType.EDGE_CLEARANCE:
+            if c1 in self.anchored:
+                return None
             return c1
 
         # If one is anchored, move the other

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -385,6 +385,65 @@ class TestPlacementFixer:
         for fix in fixes:
             assert fix.component != "R1"
 
+    # --- _choose_component_to_move with EDGE_CLEARANCE conflicts ---
+    #
+    # EDGE_CLEARANCE conflicts use component2 = "<edge>_edge" (e.g., "left_edge")
+    # as a sentinel; only component1 is a real, movable footprint.
+    # These tests guard against the regression where the EDGE_CLEARANCE branch
+    # short-circuited and bypassed the anchored set (issue #2541).
+
+    @staticmethod
+    def _make_edge_conflict(component: str = "J1", edge: str = "left_edge") -> Conflict:
+        """Build a synthetic EDGE_CLEARANCE conflict for fixer-level unit tests."""
+        return Conflict(
+            type=ConflictType.EDGE_CLEARANCE,
+            severity=ConflictSeverity.ERROR,
+            component1=component,
+            component2=edge,
+            message=f"{component} too close to {edge}",
+            location=Point(0.0, 0.0),
+            actual_clearance=0.1,
+            required_clearance=0.5,
+        )
+
+    def test_choose_component_edge_c1_anchored_returns_none(self):
+        """EDGE_CLEARANCE: when c1 is anchored, return None (cannot resolve)."""
+        fixer = PlacementFixer(anchored={"J1"})
+        conflict = self._make_edge_conflict(component="J1", edge="left_edge")
+
+        # c1 is anchored and c2 is just an edge sentinel -- no movable component
+        # remains, so the fixer must skip this conflict.
+        assert fixer._choose_component_to_move(conflict) is None
+
+    def test_choose_component_edge_c2_anchored_still_moves_c1(self):
+        """EDGE_CLEARANCE: anchoring the edge sentinel is a no-op.
+
+        Note the asymmetry vs. overlap-style conflicts: ``c2`` for an
+        EDGE_CLEARANCE conflict is a sentinel string like ``"left_edge"`` (see
+        analyzer.py:533-542), not a real component reference. Adding it to
+        ``anchored`` therefore has no meaningful effect -- the fixer should
+        still choose to move ``c1``.
+        """
+        fixer = PlacementFixer(anchored={"left_edge"})
+        conflict = self._make_edge_conflict(component="J1", edge="left_edge")
+
+        assert fixer._choose_component_to_move(conflict) == "J1"
+
+    def test_choose_component_edge_both_anchored_returns_none(self):
+        """EDGE_CLEARANCE: both anchored is the degenerate case of (a)."""
+        fixer = PlacementFixer(anchored={"J1", "left_edge"})
+        conflict = self._make_edge_conflict(component="J1", edge="left_edge")
+
+        # c1 in anchored is sufficient on its own to short-circuit to None.
+        assert fixer._choose_component_to_move(conflict) is None
+
+    def test_choose_component_edge_neither_anchored_returns_c1(self):
+        """EDGE_CLEARANCE: with no anchors, behavior is unchanged (returns c1)."""
+        fixer = PlacementFixer()
+        conflict = self._make_edge_conflict(component="J1", edge="left_edge")
+
+        assert fixer._choose_component_to_move(conflict) == "J1"
+
     def test_preview_fixes(self, overlapping_pcb: Path):
         """Test generating fix preview."""
         analyzer = PlacementAnalyzer()


### PR DESCRIPTION
## Summary

Fixes a 3-line bug in `PlacementFixer._choose_component_to_move` where `EDGE_CLEARANCE` conflicts short-circuited and returned `c1` *before* consulting the anchored set. So `--fixed J1` was silently bypassed when J1 had an edge-clearance violation.

For `EDGE_CLEARANCE` conflicts, `c2` is a board-edge sentinel string like `"left_edge"` (see `analyzer.py:533-542`), not a movable footprint. So the correct anchor-aware behavior is:

- If `c1 in self.anchored`: return `None` (skip — can't repair without moving the anchored component)
- Else: return `c1` (existing behavior)

When `_choose_component_to_move` returns `None`, `_suggest_fix_for_conflict` (`fixer.py:143-145`) already short-circuits and emits no fix, so downstream behavior in `suggest_fixes` / `iterative_fix` is automatically correct.

Closes #2541.

## Changes

- `src/kicad_tools/placement/fixer.py:174-194` — anchor-aware `EDGE_CLEARANCE` branch (3 LOC of logic + comment)
- `tests/test_placement.py` (class `TestPlacementFixer`) — four new unit tests covering all anchor permutations:
  - `test_choose_component_edge_c1_anchored_returns_none`
  - `test_choose_component_edge_c2_anchored_still_moves_c1` (documents asymmetry: c2 is the edge sentinel, not a real ref)
  - `test_choose_component_edge_both_anchored_returns_none`
  - `test_choose_component_edge_neither_anchored_returns_c1` (regression of unchanged path)

Other conflict types (`OVERLAP`, `COURTYARD_OVERLAP`, `PAD_CLEARANCE`, `HOLE_TO_HOLE`) already use the shared anchor-aware path at `fixer.py:183-188` and are unchanged.

## Test plan

- [x] `uv run pytest tests/test_placement.py` — 50 passed (incl. 4 new)
- [x] `uv run pytest tests/ -k placement` — 990 passed, 31 skipped
- [x] `uv run ruff check src/kicad_tools/placement/fixer.py tests/test_placement.py` — clean
- [x] `uv run mypy src/kicad_tools/placement/fixer.py tests/test_placement.py` — clean
- [x] Existing `test_anchored_component_not_moved` (overlap path) still passes — confirms shared anchor branch unchanged
- [x] Existing `test_find_edge_clearance_violations` still passes — confirms detection path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)