### PR TITLE
feat(ci): validate committed _routed.kicad_pcb files via kct check (closes #2546)

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -1,0 +1,36 @@
+# Per-board DRC tolerance allowlist for the `routed-pcb-drc-check` CI job.
+#
+# This file grandfathers in known-broken routed PCB files so the CI gate can
+# land before every board reaches a 0-error state. The gate is "allowed minus
+# epsilon": if a board's committed _routed.kicad_pcb produces MORE errors than
+# the value listed here (under JLCPCB rules, --errors-only), the job fails.
+# This still catches regressions like "board 05 went from 17 -> 22 errors".
+#
+# Boards NOT listed here MUST report 0 errors. Adding a new entry should be
+# considered a regression and require explicit reviewer sign-off in the PR.
+#
+# How to update:
+#   * When a board reaches 0 errors, REMOVE its entry (do not set to 0). The
+#     absence of the entry is the strict 0-error gate.
+#   * When a board's count IMPROVES (e.g., 17 -> 12), reduce the value here
+#     in the same PR that reduces the count, so further regressions are
+#     caught against the new floor.
+#   * Adding a new entry (loosening) requires reviewer justification and a
+#     tracking issue link in the PR description.
+#
+# Schema:
+#   tolerances:
+#     <path-relative-to-repo-root>: <max_errors>
+#
+# Tracking:
+#   * board 05 (17 errors) -- tracked in #2542 (full clean state)
+#   * board 03 (1 error) -- tracked separately; pre-existing pre-CI-gate state.
+
+tolerances:
+  # 15x clearance_segment_segment + 2x clearance_segment_via at JLCPCB rules.
+  # Partial progress landed in #2551 (closes #2532); full fix tracked in #2542.
+  boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb: 17
+
+  # 1x clearance_segment_segment at JLCPCB rules. Pre-existing at the time the
+  # CI gate landed (issue #2546). Should be driven to 0 in a follow-up.
+  boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,3 +221,93 @@ jobs:
 
       - name: Run kicad-cli round-trip smoke tests
         run: uv run pytest tests/test_kicad_cli_roundtrip.py -v --no-cov
+
+  routed-pcb-drc-check:
+    # Issue #2546: validate every committed `*_routed.kicad_pcb` touched by a
+    # PR via `kct check --mfr jlcpcb --errors-only`. Closes the safety-net gap
+    # that allowed PR #2538 to ship with 5 DRC errors despite a "0 errors"
+    # claim at merge time.
+    #
+    # The check uses pure-Python DRC (no kicad-cli, no Docker container) so it
+    # piggybacks on the same cheap ubuntu-latest + uv pattern as lint/typecheck.
+    # File detection is in-job (no `paths:` filter) so the check is safe to
+    # mark as a required status check on branch protection -- it always runs
+    # and short-circuits to green on PRs that don't touch routed PCBs.
+    #
+    # A per-board allowlist (`.github/routed-drc-tolerance.yml`) grandfathers
+    # in known-broken boards (currently boards 03 and 05) at their CURRENT
+    # error counts. The gate is "allowed minus epsilon" -- regressions still
+    # fail, but the gate can land before every board reaches 0 errors.
+    name: Routed PCB DRC Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need the merge-base for `git diff origin/main...HEAD` (default
+          # fetch-depth: 1 makes the diff fail with "unknown revision").
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Identify modified routed PCBs
+        id: changed
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Push to main: diff against the previous commit.
+            base="${{ github.event.before }}"
+          else
+            # Pull request: diff against the merge-base with the target branch.
+            base="${{ github.event.pull_request.base.sha }}"
+          fi
+          # Empty `base` (e.g., very first push to a fresh branch) falls back
+          # to origin/main so the gate still has a sensible diff target.
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            base="origin/main"
+          fi
+          echo "Diffing against base: $base"
+
+          # Newline-separated list of modified routed PCBs. `|| true` keeps
+          # the pipeline green when grep finds no matches (empty result is
+          # the common case and explicitly handled below).
+          mapfile -t files < <(
+            git diff --name-only --diff-filter=AM "$base"...HEAD \
+              | grep -E '^boards/[^/]+/output/[^/]+_routed\.kicad_pcb$' || true
+          )
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No routed PCBs modified -- skipping DRC check."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Modified routed PCBs:"
+          printf '  %s\n' "${files[@]}"
+          {
+            echo 'files<<EOF'
+            printf '%s\n' "${files[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        if: steps.changed.outputs.files != ''
+        run: uv sync --extra dev
+
+      - name: Run kct check on each modified routed PCB
+        if: steps.changed.outputs.files != ''
+        run: |
+          set -euo pipefail
+          # Pass each file as a separate arg; the helper handles the
+          # allowlist comparison and emits ::error:: annotations.
+          mapfile -t files <<< "${{ steps.changed.outputs.files }}"
+          # Filter out empty lines (mapfile preserves trailing newline).
+          args=()
+          for f in "${files[@]}"; do
+            [ -n "$f" ] && args+=("$f")
+          done
+          uv run python scripts/ci/check_routed_drc.py "${args[@]}"

--- a/scripts/ci/check_routed_drc.py
+++ b/scripts/ci/check_routed_drc.py
@@ -73,9 +73,7 @@ def load_allowlist(allowlist_path: Path) -> dict[str, int]:
     result: dict[str, int] = {}
     for key, value in tolerances.items():
         if not isinstance(key, str):
-            raise ValueError(
-                f"Allowlist {allowlist_path}: key {key!r} must be a string path"
-            )
+            raise ValueError(f"Allowlist {allowlist_path}: key {key!r} must be a string path")
         if not isinstance(value, int) or isinstance(value, bool) or value < 0:
             raise ValueError(
                 f"Allowlist {allowlist_path}: value for {key!r} must be a "
@@ -137,9 +135,7 @@ def count_errors(pcb_path: Path) -> int:
     summary = data.get("summary", {})
     errors = summary.get("errors")
     if not isinstance(errors, int):
-        raise RuntimeError(
-            f"kct check JSON missing summary.errors field for {pcb_path}: {data!r}"
-        )
+        raise RuntimeError(f"kct check JSON missing summary.errors field for {pcb_path}: {data!r}")
     return errors
 
 

--- a/scripts/ci/check_routed_drc.py
+++ b/scripts/ci/check_routed_drc.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Routed-PCB DRC gate for CI (issue #2546).
+
+Runs ``kct check <file> --mfr jlcpcb --errors-only --format json`` against
+each PCB path passed on the command line, and compares the resulting error
+count against a per-board tolerance allowlist (``.github/routed-drc-tolerance.yml``).
+
+A file fails the gate if its actual error count exceeds the allowed value;
+files not listed in the allowlist must report 0 errors. This implements the
+"allowed minus epsilon" semantic: regressions (count going UP) are caught,
+even on boards that are grandfathered in with non-zero counts.
+
+Exit codes:
+    0 -- All inputs within tolerance (job passes).
+    1 -- Tool failure (allowlist parse error, kct check crash, etc.).
+    2 -- One or more inputs exceed their tolerance (job fails).
+
+GitHub-Actions annotations (``::error file=...::``) are emitted to stdout for
+each offending file so the PR Files-changed view surfaces the failure inline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_ALLOWLIST = Path(".github/routed-drc-tolerance.yml")
+
+
+def load_allowlist(allowlist_path: Path) -> dict[str, int]:
+    """Load and validate the per-board tolerance allowlist.
+
+    Args:
+        allowlist_path: Path to the YAML file. Missing file is treated as
+            an empty allowlist (every board must report 0 errors).
+
+    Returns:
+        Mapping of repo-relative PCB path -> max allowed error count.
+
+    Raises:
+        ValueError: If the file exists but is malformed.
+    """
+    if not allowlist_path.exists():
+        return {}
+
+    try:
+        data = yaml.safe_load(allowlist_path.read_text())
+    except yaml.YAMLError as e:
+        raise ValueError(f"Malformed allowlist YAML at {allowlist_path}: {e}") from e
+
+    if data is None:
+        return {}
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Allowlist {allowlist_path} must be a YAML mapping at the top level, "
+            f"got {type(data).__name__}"
+        )
+
+    tolerances = data.get("tolerances", {})
+    if not isinstance(tolerances, dict):
+        raise ValueError(
+            f"Allowlist {allowlist_path} 'tolerances' field must be a mapping, "
+            f"got {type(tolerances).__name__}"
+        )
+
+    result: dict[str, int] = {}
+    for key, value in tolerances.items():
+        if not isinstance(key, str):
+            raise ValueError(
+                f"Allowlist {allowlist_path}: key {key!r} must be a string path"
+            )
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(
+                f"Allowlist {allowlist_path}: value for {key!r} must be a "
+                f"non-negative integer, got {value!r}"
+            )
+        result[key] = value
+
+    return result
+
+
+def count_errors(pcb_path: Path) -> int:
+    """Run ``kct check`` and return the error count.
+
+    Args:
+        pcb_path: Path to a ``.kicad_pcb`` file.
+
+    Returns:
+        Number of errors reported (0 if the gate passes natively).
+
+    Raises:
+        RuntimeError: If kct check fails to run (exit code 1) or emits
+            unparseable output.
+    """
+    cmd = [
+        "uv",
+        "run",
+        "kct",
+        "check",
+        str(pcb_path),
+        "--mfr",
+        "jlcpcb",
+        "--errors-only",
+        "--format",
+        "json",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    # Exit 1 = tool-level failure (file not found, parse error). Exit 0 = no
+    # errors. Exit 2 = errors found. Both 0 and 2 produce valid JSON on stdout.
+    if proc.returncode == 1:
+        raise RuntimeError(
+            f"kct check failed on {pcb_path} (exit 1). stderr:\n{proc.stderr.strip()}"
+        )
+
+    if proc.returncode not in (0, 2):
+        raise RuntimeError(
+            f"kct check returned unexpected exit code {proc.returncode} on "
+            f"{pcb_path}. stderr:\n{proc.stderr.strip()}"
+        )
+
+    try:
+        data: dict[str, Any] = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"kct check produced invalid JSON on {pcb_path}: {e}\n"
+            f"stdout (first 500 chars):\n{proc.stdout[:500]}"
+        ) from e
+
+    summary = data.get("summary", {})
+    errors = summary.get("errors")
+    if not isinstance(errors, int):
+        raise RuntimeError(
+            f"kct check JSON missing summary.errors field for {pcb_path}: {data!r}"
+        )
+    return errors
+
+
+def annotate_error(file: str, message: str) -> None:
+    """Emit a GitHub-Actions ``::error file=...::`` annotation."""
+    # The %0A escape is not strictly required for single-line messages; we
+    # keep the message on one line so it surfaces cleanly in the Files-changed
+    # view.
+    print(f"::error file={file}::{message}", flush=True)
+
+
+def check_file(pcb_path: Path, allowed: int) -> tuple[bool, str]:
+    """Check a single PCB against its allowed error count.
+
+    Returns:
+        (passed, message) tuple. ``passed`` is True if errors <= allowed.
+        ``message`` is a human-readable summary suitable for both stdout
+        and GitHub annotation.
+    """
+    errors = count_errors(pcb_path)
+    if errors <= allowed:
+        if allowed == 0:
+            msg = f"OK: {pcb_path} -- 0 errors (strict gate)."
+        else:
+            msg = (
+                f"OK: {pcb_path} -- {errors} errors (allowlist max {allowed}; "
+                f"reduce the allowlist value in .github/routed-drc-tolerance.yml "
+                f"if this count drops further)."
+            )
+        return True, msg
+
+    if allowed == 0:
+        msg = (
+            f"DRC errors detected by `kct check --mfr jlcpcb --errors-only`: "
+            f"{errors} error(s). Boards NOT in .github/routed-drc-tolerance.yml "
+            f"must report 0 errors. Either fix the routing or, if grandfathering "
+            f"is justified, add an explicit allowlist entry with reviewer sign-off."
+        )
+    else:
+        msg = (
+            f"DRC regression: {errors} error(s) exceeds allowlist value "
+            f"{allowed} in .github/routed-drc-tolerance.yml. Either fix the "
+            f"new violations, or (if intentional) raise the allowlist value "
+            f"with reviewer sign-off."
+        )
+    return False, msg
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check_routed_drc",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Paths to *_routed.kicad_pcb files to check. If empty, the gate "
+        "is a no-op and exits 0.",
+    )
+    parser.add_argument(
+        "--allowlist",
+        default=str(DEFAULT_ALLOWLIST),
+        help=f"Path to the tolerance allowlist YAML (default: {DEFAULT_ALLOWLIST}).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.files:
+        print("No routed PCBs to check -- gate is a no-op.")
+        return 0
+
+    try:
+        allowlist = load_allowlist(Path(args.allowlist))
+    except ValueError as e:
+        print(f"::error::{e}", flush=True)
+        return 1
+
+    overall_failed = 0
+    for raw in args.files:
+        pcb_path = Path(raw)
+        if not pcb_path.is_file():
+            # GitHub Actions runs the gate after `git diff` has already
+            # reported these files as modified; a file that no longer exists
+            # was deleted in the PR (legitimate). Skip with a warning.
+            print(
+                f"::warning file={pcb_path}::file not found on disk "
+                f"(deleted in PR?) -- skipping DRC check",
+                flush=True,
+            )
+            continue
+
+        # Use the repo-relative form for allowlist lookup. The CI workflow
+        # passes paths in repo-relative form already; tolerate absolute paths
+        # by stripping the cwd if it matches.
+        lookup_key = str(pcb_path)
+        try:
+            rel = pcb_path.resolve().relative_to(Path.cwd())
+            lookup_key = str(rel)
+        except ValueError:
+            # Path is outside cwd (unlikely in CI); fall back to the raw form.
+            pass
+
+        allowed = allowlist.get(lookup_key, 0)
+
+        try:
+            passed, message = check_file(pcb_path, allowed)
+        except RuntimeError as e:
+            annotate_error(str(pcb_path), f"kct check failed: {e}")
+            overall_failed = 1
+            continue
+
+        if passed:
+            print(message, flush=True)
+        else:
+            annotate_error(str(pcb_path), message)
+            overall_failed = 2
+
+    if overall_failed:
+        print(
+            f"\nGate failed (exit {overall_failed}). See ::error:: annotations "
+            "above; offending files are also surfaced in the PR Files-changed "
+            "view.",
+            flush=True,
+        )
+    return overall_failed
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ci_routed_drc_workflow.py
+++ b/tests/test_ci_routed_drc_workflow.py
@@ -46,9 +46,7 @@ JOB_NAME = "routed-pcb-drc-check"
 
 def _load_helper_module():
     """Import scripts/ci/check_routed_drc.py as a module."""
-    spec = importlib.util.spec_from_file_location(
-        "check_routed_drc", HELPER_SCRIPT_PATH
-    )
+    spec = importlib.util.spec_from_file_location("check_routed_drc", HELPER_SCRIPT_PATH)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules["check_routed_drc"] = module
@@ -104,7 +102,11 @@ class TestWorkflowYAML:
         breaks the diff with 'unknown revision'."""
         steps = workflow["jobs"][JOB_NAME]["steps"]
         checkout = next(
-            (s for s in steps if isinstance(s, dict) and s.get("uses", "").startswith("actions/checkout")),
+            (
+                s
+                for s in steps
+                if isinstance(s, dict) and s.get("uses", "").startswith("actions/checkout")
+            ),
             None,
         )
         assert checkout is not None, "routed-pcb-drc-check must use actions/checkout"
@@ -118,11 +120,7 @@ class TestWorkflowYAML:
         the call site prevents an inadvertent refactor (e.g., to inline
         bash) from silently dropping the allowlist comparison."""
         steps = workflow["jobs"][JOB_NAME]["steps"]
-        run_blocks = [
-            s.get("run", "")
-            for s in steps
-            if isinstance(s, dict) and "run" in s
-        ]
+        run_blocks = [s.get("run", "") for s in steps if isinstance(s, dict) and "run" in s]
         joined = "\n".join(run_blocks)
         assert "scripts/ci/check_routed_drc.py" in joined, (
             "routed-pcb-drc-check must invoke scripts/ci/check_routed_drc.py "
@@ -138,10 +136,7 @@ class TestWorkflowYAML:
         ``uv sync`` + ``kct check`` cost unnecessarily."""
         steps = workflow["jobs"][JOB_NAME]["steps"]
         guarded = [
-            s for s in steps
-            if isinstance(s, dict)
-            and "if" in s
-            and "files" in str(s["if"])
+            s for s in steps if isinstance(s, dict) and "if" in s and "files" in str(s["if"])
         ]
         assert guarded, (
             "Expected at least one step guarded by `if: "
@@ -170,9 +165,7 @@ class TestAllowlist:
 
     @pytest.fixture
     def allowlist_data(self) -> dict:
-        assert ALLOWLIST_PATH.is_file(), (
-            f"Allowlist file expected at {ALLOWLIST_PATH}"
-        )
+        assert ALLOWLIST_PATH.is_file(), f"Allowlist file expected at {ALLOWLIST_PATH}"
         with ALLOWLIST_PATH.open() as f:
             return yaml.safe_load(f)
 
@@ -199,9 +192,7 @@ class TestAllowlist:
             assert isinstance(value, int) and not isinstance(value, bool), (
                 f"Allowlist value for {key!r} must be an int, got {type(value).__name__}"
             )
-            assert value >= 0, (
-                f"Allowlist value for {key!r} must be non-negative, got {value}"
-            )
+            assert value >= 0, f"Allowlist value for {key!r} must be non-negative, got {value}"
 
     def test_allowlist_files_exist_on_disk(self, allowlist_data: dict) -> None:
         """A grandfather entry pointing at a missing file is dead config --

--- a/tests/test_ci_routed_drc_workflow.py
+++ b/tests/test_ci_routed_drc_workflow.py
@@ -1,0 +1,416 @@
+"""Tests for the `routed-pcb-drc-check` CI job and its helper script.
+
+Issue #2546 added a CI gate that validates committed `*_routed.kicad_pcb`
+files via ``kct check --mfr jlcpcb --errors-only``. These tests pin the
+critical structural properties of the workflow YAML, the allowlist file,
+and the helper script's allowlist semantics so regressions in any of the
+three layers are caught immediately rather than at the next CI run.
+
+Out of scope (covered by other tests):
+    * The DRC engine itself -- ``DRCChecker`` has its own test suite.
+    * The ``kct check`` CLI surface -- ``test_check_cmd.py`` covers that.
+
+What we DO assert here:
+    * The `routed-pcb-drc-check` job exists in `.github/workflows/ci.yml`.
+    * The job uses ``fetch-depth: 0`` (required for ``git diff origin/main...HEAD``).
+    * The job invokes the helper script (so a refactor that drops the call
+      is caught).
+    * The allowlist YAML parses, has a ``tolerances`` mapping, and only
+      contains paths matching the routed-PCB pattern.
+    * The helper script's ``load_allowlist`` and ``check_file`` functions
+      enforce the documented "allowed minus epsilon" semantic.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+ALLOWLIST_PATH = REPO_ROOT / ".github" / "routed-drc-tolerance.yml"
+HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_routed_drc.py"
+
+JOB_NAME = "routed-pcb-drc-check"
+
+
+# ---------------------------------------------------------------------------
+# Helpers to load the helper script as a module without a package install.
+# ---------------------------------------------------------------------------
+
+
+def _load_helper_module():
+    """Import scripts/ci/check_routed_drc.py as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "check_routed_drc", HELPER_SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_routed_drc"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Workflow YAML structural tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowYAML:
+    """The CI gate is only useful if the YAML is well-formed and the job
+    is wired up correctly. These tests pin the load-bearing structure."""
+
+    @pytest.fixture
+    def workflow(self) -> dict:
+        assert CI_WORKFLOW_PATH.is_file(), (
+            f".github/workflows/ci.yml not found at {CI_WORKFLOW_PATH}"
+        )
+        with CI_WORKFLOW_PATH.open() as f:
+            return yaml.safe_load(f)
+
+    def test_workflow_parses(self, workflow: dict) -> None:
+        """The workflow must be valid YAML with the expected top-level shape."""
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+        assert isinstance(workflow["jobs"], dict)
+
+    def test_routed_drc_job_exists(self, workflow: dict) -> None:
+        """The `routed-pcb-drc-check` job must exist in ci.yml."""
+        assert JOB_NAME in workflow["jobs"], (
+            f"Expected job '{JOB_NAME}' in .github/workflows/ci.yml. "
+            f"Found: {sorted(workflow['jobs'].keys())}"
+        )
+
+    def test_job_runs_on_ubuntu(self, workflow: dict) -> None:
+        """Must use ubuntu-latest, NOT a kicad/kicad container -- the gate is
+        pure-Python and we don't want to pay the container-pull cost."""
+        job = workflow["jobs"][JOB_NAME]
+        assert job["runs-on"] == "ubuntu-latest"
+        # Defensive: a future refactor must not silently switch to a container.
+        assert "container" not in job, (
+            "routed-pcb-drc-check should NOT run in a container -- "
+            "kct check is pure-Python and the job piggybacks on the cheap "
+            "ubuntu-latest + uv pattern."
+        )
+
+    def test_job_uses_fetch_depth_zero(self, workflow: dict) -> None:
+        """`git diff origin/main...HEAD` requires the merge-base, which is
+        only present with fetch-depth: 0. Default fetch-depth: 1 silently
+        breaks the diff with 'unknown revision'."""
+        steps = workflow["jobs"][JOB_NAME]["steps"]
+        checkout = next(
+            (s for s in steps if isinstance(s, dict) and s.get("uses", "").startswith("actions/checkout")),
+            None,
+        )
+        assert checkout is not None, "routed-pcb-drc-check must use actions/checkout"
+        assert checkout.get("with", {}).get("fetch-depth") == 0, (
+            "actions/checkout must use fetch-depth: 0 so `git diff "
+            "origin/main...HEAD` can resolve the merge-base."
+        )
+
+    def test_job_invokes_helper_script(self, workflow: dict) -> None:
+        """Final step must invoke scripts/ci/check_routed_drc.py. Pinning
+        the call site prevents an inadvertent refactor (e.g., to inline
+        bash) from silently dropping the allowlist comparison."""
+        steps = workflow["jobs"][JOB_NAME]["steps"]
+        run_blocks = [
+            s.get("run", "")
+            for s in steps
+            if isinstance(s, dict) and "run" in s
+        ]
+        joined = "\n".join(run_blocks)
+        assert "scripts/ci/check_routed_drc.py" in joined, (
+            "routed-pcb-drc-check must invoke scripts/ci/check_routed_drc.py "
+            "(the helper that reads the per-board allowlist and emits "
+            "::error:: annotations)."
+        )
+
+    def test_job_has_short_circuit_on_no_files(self, workflow: dict) -> None:
+        """Per the issue's acceptance criteria, the job must complete in
+        <60s on PRs that don't touch routed PCBs. The implementation
+        achieves this via a step-level ``if: steps.changed.outputs.files != ''``
+        guard. Absence of that guard would cause every PR to pay the
+        ``uv sync`` + ``kct check`` cost unnecessarily."""
+        steps = workflow["jobs"][JOB_NAME]["steps"]
+        guarded = [
+            s for s in steps
+            if isinstance(s, dict)
+            and "if" in s
+            and "files" in str(s["if"])
+        ]
+        assert guarded, (
+            "Expected at least one step guarded by `if: "
+            "steps.changed.outputs.files != ''` so the job short-circuits "
+            "on PRs that don't touch routed PCBs."
+        )
+
+    def test_job_has_reasonable_timeout(self, workflow: dict) -> None:
+        """A timeout prevents a runaway DRC check from blocking the queue.
+        10 minutes is plenty for ~5 boards * <1min each."""
+        job = workflow["jobs"][JOB_NAME]
+        timeout = job.get("timeout-minutes")
+        assert isinstance(timeout, int) and 1 <= timeout <= 30, (
+            f"timeout-minutes must be set to a sane value (1-30); got {timeout!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Allowlist YAML tests
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlist:
+    """The allowlist file is the gate's "minus epsilon" floor. A malformed
+    file would silently break CI for every PR that touches a routed PCB."""
+
+    @pytest.fixture
+    def allowlist_data(self) -> dict:
+        assert ALLOWLIST_PATH.is_file(), (
+            f"Allowlist file expected at {ALLOWLIST_PATH}"
+        )
+        with ALLOWLIST_PATH.open() as f:
+            return yaml.safe_load(f)
+
+    def test_allowlist_parses(self, allowlist_data: dict) -> None:
+        assert isinstance(allowlist_data, dict)
+        assert "tolerances" in allowlist_data
+        assert isinstance(allowlist_data["tolerances"], dict)
+
+    def test_allowlist_paths_match_routed_pattern(self, allowlist_data: dict) -> None:
+        """Every key in the allowlist must be a repo-relative path to a
+        routed PCB. Catches typos like a stray space, a wrong board number,
+        or accidentally listing the unrouted PCB."""
+        import re
+
+        pattern = re.compile(r"^boards/[^/]+/output/[^/]+_routed\.kicad_pcb$")
+        for key in allowlist_data["tolerances"]:
+            assert pattern.match(key), (
+                f"Allowlist key {key!r} does not match the expected pattern "
+                f"'boards/<name>/output/<file>_routed.kicad_pcb'."
+            )
+
+    def test_allowlist_values_are_non_negative_ints(self, allowlist_data: dict) -> None:
+        for key, value in allowlist_data["tolerances"].items():
+            assert isinstance(value, int) and not isinstance(value, bool), (
+                f"Allowlist value for {key!r} must be an int, got {type(value).__name__}"
+            )
+            assert value >= 0, (
+                f"Allowlist value for {key!r} must be non-negative, got {value}"
+            )
+
+    def test_allowlist_files_exist_on_disk(self, allowlist_data: dict) -> None:
+        """A grandfather entry pointing at a missing file is dead config --
+        likely the file was renamed or deleted and the allowlist wasn't
+        updated. Keep the allowlist in sync with the tree."""
+        for key in allowlist_data["tolerances"]:
+            full_path = REPO_ROOT / key
+            assert full_path.is_file(), (
+                f"Allowlist references {key!r} but no such file exists "
+                f"at {full_path}. Either remove the stale entry or fix "
+                f"the path."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helper script unit tests (allowlist semantics)
+# ---------------------------------------------------------------------------
+
+
+class TestHelperLoadAllowlist:
+    """Unit tests for the helper's ``load_allowlist`` -- the parse layer."""
+
+    def setup_method(self) -> None:
+        self.helper = _load_helper_module()
+
+    def test_missing_file_is_empty_allowlist(self, tmp_path: Path) -> None:
+        """A missing allowlist file means strict 0-error gate for everything."""
+        missing = tmp_path / "does-not-exist.yml"
+        result = self.helper.load_allowlist(missing)
+        assert result == {}
+
+    def test_empty_file_is_empty_allowlist(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.yml"
+        f.write_text("")
+        assert self.helper.load_allowlist(f) == {}
+
+    def test_valid_allowlist_parses(self, tmp_path: Path) -> None:
+        f = tmp_path / "valid.yml"
+        f.write_text(
+            "tolerances:\n"
+            "  boards/03-x/output/x_routed.kicad_pcb: 1\n"
+            "  boards/05-y/output/y_routed.kicad_pcb: 17\n"
+        )
+        result = self.helper.load_allowlist(f)
+        assert result == {
+            "boards/03-x/output/x_routed.kicad_pcb": 1,
+            "boards/05-y/output/y_routed.kicad_pcb": 17,
+        }
+
+    def test_malformed_yaml_raises(self, tmp_path: Path) -> None:
+        f = tmp_path / "broken.yml"
+        f.write_text("tolerances:\n  -\n  bad: : :")
+        with pytest.raises(ValueError, match="Malformed allowlist YAML"):
+            self.helper.load_allowlist(f)
+
+    def test_top_level_must_be_mapping(self, tmp_path: Path) -> None:
+        f = tmp_path / "list.yml"
+        f.write_text("- foo\n- bar\n")
+        with pytest.raises(ValueError, match="must be a YAML mapping"):
+            self.helper.load_allowlist(f)
+
+    def test_tolerances_must_be_mapping(self, tmp_path: Path) -> None:
+        f = tmp_path / "wrong-type.yml"
+        f.write_text("tolerances:\n  - bad\n")
+        with pytest.raises(ValueError, match="'tolerances' field must be a mapping"):
+            self.helper.load_allowlist(f)
+
+    def test_negative_value_rejected(self, tmp_path: Path) -> None:
+        f = tmp_path / "neg.yml"
+        f.write_text("tolerances:\n  foo: -1\n")
+        with pytest.raises(ValueError, match="non-negative integer"):
+            self.helper.load_allowlist(f)
+
+    def test_bool_value_rejected(self, tmp_path: Path) -> None:
+        """YAML implicitly maps `true`/`false` to bools; bool is also an
+        int subclass in Python. The validator must reject this explicitly
+        to avoid 'True == 1' confusion."""
+        f = tmp_path / "bool.yml"
+        f.write_text("tolerances:\n  foo: true\n")
+        with pytest.raises(ValueError, match="non-negative integer"):
+            self.helper.load_allowlist(f)
+
+
+class TestHelperCheckFile:
+    """Unit tests for ``check_file`` -- the per-PCB gate logic.
+
+    These tests stub ``count_errors`` so we don't depend on the actual DRC
+    engine here; the CI integration tests cover the end-to-end path.
+    """
+
+    def setup_method(self) -> None:
+        self.helper = _load_helper_module()
+
+    def test_zero_errors_zero_allowed_passes(self) -> None:
+        with patch.object(self.helper, "count_errors", return_value=0):
+            passed, msg = self.helper.check_file(Path("foo.kicad_pcb"), allowed=0)
+        assert passed
+        assert "0 errors" in msg
+
+    def test_under_allowed_passes(self) -> None:
+        """A board grandfathered at 17 errors that drops to 5 must pass --
+        the gate is "allowed minus epsilon", not "exact match"."""
+        with patch.object(self.helper, "count_errors", return_value=5):
+            passed, msg = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
+        assert passed
+        assert "5 errors" in msg
+        # The pass message should nudge the contributor to lower the
+        # allowlist if the count drops -- this prevents stale tolerances.
+        assert "reduce the allowlist value" in msg
+
+    def test_at_allowed_passes(self) -> None:
+        """Equal-to-allowed is the steady state for a grandfathered board."""
+        with patch.object(self.helper, "count_errors", return_value=17):
+            passed, _ = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
+        assert passed
+
+    def test_over_allowed_fails_grandfathered(self) -> None:
+        """Regression on a grandfathered board: 17 -> 22. Must fail."""
+        with patch.object(self.helper, "count_errors", return_value=22):
+            passed, msg = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
+        assert not passed
+        assert "regression" in msg.lower()
+        assert "17" in msg
+        assert "22" in msg
+
+    def test_nonzero_with_zero_allowed_fails(self) -> None:
+        """Default case: a board not in the allowlist (allowed=0) must
+        report 0 errors. Any errors mean the gate fails. This is the
+        critical assertion that PR #2538's merge state would have
+        triggered (board 04 with 5 errors)."""
+        with patch.object(self.helper, "count_errors", return_value=5):
+            passed, msg = self.helper.check_file(
+                Path("boards/04-x/output/x_routed.kicad_pcb"), allowed=0
+            )
+        assert not passed
+        # Message must point the contributor at the allowlist for the
+        # grandfathering escape hatch.
+        assert "routed-drc-tolerance.yml" in msg
+        assert "5 error" in msg
+
+
+class TestHelperMain:
+    """Smoke tests for the CLI entry-point -- empty-files short-circuit
+    and end-to-end happy path."""
+
+    def setup_method(self) -> None:
+        self.helper = _load_helper_module()
+
+    def test_no_files_exits_zero(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Per acceptance criteria #5: the gate must complete in <60s and
+        exit 0 when no routed PCBs are modified."""
+        rc = self.helper.main([])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "no-op" in captured.out.lower()
+
+    def test_missing_file_is_warning_not_failure(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A file that was deleted in the PR (e.g., board removed) shows
+        up in `git diff --name-only` but won't be on disk. Must warn,
+        not fail."""
+        # Use a path that can't possibly exist.
+        rc = self.helper.main(
+            [
+                "--allowlist",
+                str(tmp_path / "missing-allowlist.yml"),
+                str(tmp_path / "nonexistent_routed.kicad_pcb"),
+            ]
+        )
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "::warning" in captured.out
+        assert "deleted in PR" in captured.out
+
+    def test_malformed_allowlist_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        bad = tmp_path / "bad.yml"
+        bad.write_text("tolerances: [oops, this, is, a, list]\n")
+        # Need at least one file argument so the allowlist is actually loaded.
+        pcb = tmp_path / "foo_routed.kicad_pcb"
+        pcb.touch()
+        rc = self.helper.main(["--allowlist", str(bad), str(pcb)])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "::error" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Allowlist self-consistency: helper must accept the real allowlist file.
+# ---------------------------------------------------------------------------
+
+
+class TestRealAllowlistRoundtrip:
+    """Sanity check: the live allowlist must load cleanly through the
+    helper. If someone introduces a malformed entry, the test suite
+    catches it before the CI run."""
+
+    def setup_method(self) -> None:
+        self.helper = _load_helper_module()
+
+    def test_live_allowlist_loads(self) -> None:
+        result = self.helper.load_allowlist(ALLOWLIST_PATH)
+        # We don't assert specific board entries -- those will change as
+        # boards reach 0 errors and entries are removed. Just assert the
+        # types are right.
+        assert isinstance(result, dict)
+        for key, value in result.items():
+            assert isinstance(key, str)
+            assert isinstance(value, int)
+            assert value >= 0


### PR DESCRIPTION
## Summary

Adds a CI gate (`routed-pcb-drc-check` job in `.github/workflows/ci.yml`) that validates committed `*_routed.kicad_pcb` files via `kct check --mfr jlcpcb --errors-only` on every PR. Closes the safety-net gap that allowed PR #2538 to ship with 5 DRC errors despite a "0 errors" claim at merge time.

The gate is a per-board "allowed minus epsilon" floor: regressions still fail even on grandfathered boards, but the gate can land before every board reaches 0 errors. Initial allowlist (`.github/routed-drc-tolerance.yml`) grandfathers the empirical state of `origin/main` today:

- board 03 (`usb_joystick_routed.kicad_pcb`): 1 error
- board 05 (`bldc_controller_routed.kicad_pcb`): 17 errors (partial #2542 progress in #2551)

Boards 01, 02, 04 are NOT listed -- they currently report 0 errors and the gate is strict for them.

## Design choices

- **Pure-Python DRC** (`kct check`) -- no kicad-cli, no Docker container. Job piggybacks on the cheap `ubuntu-latest` + `uv sync --extra dev` pattern (~30s setup) used by lint/typecheck/test.
- **In-job file detection** (no `paths:` filter) -- the job always runs and short-circuits to green on PRs that don't touch routed PCBs, so it is safe to mark as a required status check on branch protection.
- **`fetch-depth: 0`** on `actions/checkout` -- required for `git diff origin/main...HEAD` to resolve the merge-base.
- **Helper script extracted** (`scripts/ci/check_routed_drc.py`) -- the allowlist comparison logic is non-trivial and warrants extraction for testability. Keeps the inline workflow YAML readable and makes the unit-test surface explicit.
- **GitHub-Actions annotations** (`::error file=...::`) -- offending files surface inline in the PR Files-changed view.

## Files

- `.github/workflows/ci.yml` -- adds the `routed-pcb-drc-check` job (~80 lines).
- `.github/routed-drc-tolerance.yml` -- per-board allowlist (~20 lines + comments).
- `scripts/ci/check_routed_drc.py` -- helper that reads the allowlist, runs `kct check` per file, and emits annotations.
- `tests/test_ci_routed_drc_workflow.py` -- 28 tests across three layers (workflow YAML structure, allowlist YAML schema, helper-script unit tests).

## Commit history

Committed incrementally (per protocol guidance from #2547):

1. `feat(ci): add routed-pcb-drc-check job + helper script` -- the gate machinery.
2. `feat(ci): add per-board DRC tolerance allowlist` -- the tolerance floor.
3. `test(ci): add structural + unit tests` -- pins all three layers.
4. `style(ci): apply ruff format` -- pure formatting.

## Verification

- All 5 routed PCBs on `origin/main` pass with the live allowlist (verified via `uv run python scripts/ci/check_routed_drc.py boards/*/output/*_routed.kicad_pcb` -> exit 0).
- Empty allowlist (strict 0-error gate) correctly fails on boards 03 + 05 (verified locally).
- Allowlist regression case (lower the value below current count) correctly fails with a "DRC regression" annotation (verified locally).
- 28 new tests pass (`uv run pytest tests/test_ci_routed_drc_workflow.py -v`).
- Adjacent CI test still passes (`uv run pytest tests/test_kicad_cli_roundtrip.py -v` -> 7/7).
- `ruff check`/`ruff format --check` clean on new files. (Pre-existing 779 lint errors elsewhere are not introduced by this PR.)

## Sequencing note

Issue body referenced board 05 = "17 errors" -- that matches the empirical state on `origin/main` after #2551. The branch was rebased onto the latest `origin/main` (which now includes #2545 fixing board 04 and #2551 partial-progress on board 05) before the allowlist was sized. The acceptance criterion "Job would fail PR #2538's merge state (5 errors on board 04)" is verified by `tests/test_ci_routed_drc_workflow.py::TestHelperCheckFile::test_nonzero_with_zero_allowed_fails` which pins exactly that semantic.

## Test plan

- [x] `uv run pytest tests/test_ci_routed_drc_workflow.py -v` -- 28/28 pass.
- [x] `uv run ruff check scripts/ci/check_routed_drc.py tests/test_ci_routed_drc_workflow.py` -- clean.
- [x] `uv run ruff format ... --check` -- clean.
- [x] End-to-end: gate passes on all 5 routed PCBs at HEAD with live allowlist.
- [x] End-to-end: gate fails (exit 2) with empty allowlist on boards 03/05.
- [x] End-to-end: gate fails (exit 2) on regression (allowlist lowered below current count).
- [x] End-to-end: gate exits 0 with no file arguments (no-op short-circuit).
- [ ] CI: `routed-pcb-drc-check` runs and passes on this PR (no routed PCBs modified, so it short-circuits).
- [ ] Future verification: rebase a deliberately-broken routed PCB onto this branch to confirm the gate fails as expected on a real PR.

Closes #2546

🤖 Generated with [Claude Code](https://claude.com/claude-code)