### PR TITLE
feat(loom): require incremental commits in builder/doctor role contracts (closes #2547)

### DIFF
--- a/.claude/commands/loom/builder-pr.md
+++ b/.claude/commands/loom/builder-pr.md
@@ -522,6 +522,26 @@ These patterns are **WRONG** — the shepherd will reject PRs with titles matchi
 | `feat: implement feature from issue #N` | Generic — could be any feature |
 | `<copy of issue title>` | Issue titles describe problems; commits describe solutions |
 
+### Intermediate Commits from the Incremental Commit Protocol
+
+The builder Incremental Commit Protocol (`.claude/commands/loom/builder.md` / `.loom/roles/builder.md`) requires you to make `wip:`-prefixed commits at well-defined boundaries during a single agent run. When you reach PR creation, you may have several intermediate commits on the branch in addition to the final commit.
+
+**This is fine — the diff-derivation step still works correctly.** PR title derivation uses `git diff --stat` and `git diff` against the *base ref* (typically `origin/main`), which is unaffected by the number of intermediate commits on your feature branch. The diff against `main` is the same whether you made one commit or twelve.
+
+```bash
+# Even with intermediate commits, this still gives you the full diff
+# against main for title derivation:
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+```
+
+**At PR creation time:**
+- The PR title still describes what the *whole diff* does (squashed view), not the latest individual commit
+- Champion's `merge-pr.sh` uses squash-merge, collapsing all your intermediate `wip:` commits into the single PR title commit on main
+- Your intermediate `wip:` messages are preserved on the feature branch and remain visible in `git log feature/issue-<N>` after merge if archived, but they do not pollute `git log main`
+
+**Final commit before PR creation:** if you have residual uncommitted changes when you reach the PR-creation step, write the final commit with a descriptive (not `wip:`) message that describes the *delta since the last `wip:` commit*. The PR title separately describes the *whole diff*.
+
 ---
 
 ## Creating Pull Requests: Label and Auto-Close Requirements

--- a/.claude/commands/loom/builder.md
+++ b/.claude/commands/loom/builder.md
@@ -382,6 +382,116 @@ You can read the current checkpoint:
 ./.loom/scripts/checkpoint.sh read --json  # For programmatic use
 ```
 
+## Incremental Commit Protocol
+
+**CRITICAL: You MUST commit and push at well-defined boundaries during a single agent run, not only at the end of the cycle.** A single end-of-cycle commit is insufficient for long iterative work.
+
+### Why This Exists (Concrete Failures)
+
+This protocol is not theoretical — it is a direct response to recoverable-only-by-luck failures observed in 2026-05:
+
+- **Issue #2542 (builder, 2026-05-07)**: Builder ran for **175 minutes** on board 05 placement, made real progress on `design.py` (~24 LoC of useful changes), then crashed with API 529. **Zero commits were made during the run.** The work was only recovered because the user manually inspected the worktree before it was reused. With incremental commits + push, the work would have been durable on the remote feature branch the moment the agent pushed, regardless of any session destruction.
+- **PR #2535 (doctor)**: Doctor crashed without any commits during a fix attempt; same recovery exposure.
+
+The existing recovery story (`validate-phase.sh` invoking commit/push from a still-on-disk worktree) is a **fallback**, not a guarantee. If the worktree is reused or wiped before the shepherd validates, uncommitted work is gone.
+
+### Required Commit Boundaries (MUST)
+
+You MUST make a commit AND push (`git push origin <branch>`) at every one of these boundaries. These boundaries are deliberately chosen to align with the existing checkpoint stages above — every checkpoint transition you write should also be a commit boundary.
+
+| # | Boundary | Trigger | Why this is a natural seam |
+|---|----------|---------|----------------------------|
+| 1 | **Scaffolding / infrastructure** | Adding a parameter, helper, type, stub, fixture, or import that is not yet exercised by any code path | Self-contained, well-described, low-blast-radius — easy to write a clear `wip:` message even if nothing calls it yet |
+| 2 | **Between tier attempts** | Iterative algorithm with named tiers (e.g. Tier 0 -> Tier 1 -> ... in a routing or placement search). Each tier is its own checkpoint of "approach X didn't work, trying Y" | Even a *failed* tier attempt is information worth preserving in `git log` for the next agent or human |
+| 3 | **Before any single command/operation expected to take >2 min** | Long route attempts, large test runs, slow simulations, KiCad invocations with thousands of nets | Wall-clock risk window — checkpoint the state of the world before the gamble |
+| 4 | **At every checkpoint stage transition** | Already a thing for state tracking (`planning` -> `implementing` -> `tested`); piggyback a commit on each meaningful transition | Forces git history to align with the recovery checkpoints |
+
+**Push every committed batch.** Local commits inside a worktree are still a recovery hazard — the disk can fill, the worktree can be reused, another tool can clobber it. `git push` puts the work on the remote where it is durable.
+
+### How to Commit Incrementally
+
+```bash
+# After completing scaffolding (e.g. added a no-op parameter)
+git add src/foo.py
+git commit -m "wip: add rotation parameter to generate_htssop56 (no-op)"
+git push origin "$(git branch --show-current)"
+./.loom/scripts/checkpoint.sh write --stage committed --issue <N> --commit-sha "$(git rev-parse HEAD)"
+
+# Before launching a long routing attempt for Tier 2 (the previous tier, Tier 1, just failed)
+git add boards/05-bldc-motor-controller/
+git commit -m "wip(board-05): tier 1 placement attempt — DRC still failing on U1<->U2"
+git push origin "$(git branch --show-current)"
+./.loom/scripts/checkpoint.sh write --stage committed --issue <N> --commit-sha "$(git rev-parse HEAD)"
+
+# Continue with Tier 2 — even if you crash now, Tier 1 result is durably on remote
+```
+
+### Verifying the Protocol Works (Simulated Crash)
+
+To convince yourself this actually preserves work on a hard crash, run this thought experiment:
+
+```bash
+# 1. Builder is at Tier 2 of placement search. It commits + pushes a wip:
+git commit -m "wip(board-05): tier 1 attempt"
+git push origin feature/issue-2394
+
+# 2. Builder begins Tier 2 — a long, expensive routing run
+# 3. API 529 (or OOM, or session timeout) terminates the process MID-ROUTE
+# 4. Worktree is destroyed; orchestrator picks up.
+
+# 5. The next agent or human checks:
+gh pr list --search "head:feature/issue-2394"        # branch is on remote
+git log --oneline origin/feature/issue-2394          # tier-1 commit is present
+# Tier 1 progress is preserved. Tier 2 is gone (it never committed),
+# but Tier 1 was *known to work* — that's the durable state to resume from.
+```
+
+Without incremental commits, both Tier 1 and Tier 2 progress would be on disk in the worktree only, and would be lost the moment the worktree was wiped. This is exactly what happened on issue #2542 (175 min builder, crashed, manual recovery only).
+
+### Intermediate Commit Message Style
+
+Intermediate commits will be **squashed at merge time** by the champion (this repo uses squash-merge), so the final commit on `main` is the PR title. But intermediate messages still matter for:
+- Worktree history when an agent crashes and another picks up
+- `git log --oneline` debugging during the run
+- The shepherd's recovery decision (a meaningful message tells it what was preserved)
+
+**Good intermediate messages:**
+- `wip: add rotation parameter to generate_htssop56 (no-op)`
+- `wip(board-05): tier 1 placement attempt — DRC still failing on U1<->U2`
+- `wip(router): scaffolding for CoupledPathfinder neck-down support`
+
+**Bad (avoid these for intermediates):**
+- `progress` / `wip` / `checkpoint` (no information content)
+- `working` (says nothing)
+- Final-style messages (`fix: resolve DRC violations on board 05`) — premature; save for the final commit
+
+### Relationship to the Checkpoint System
+
+The `committed` checkpoint stage and incremental commits are **complementary, not duplicative**:
+
+- An incremental `git commit` makes the work durable on remote (after push).
+- A `committed` checkpoint write tells the shepherd: "the work I just did at this stage is safely committed at SHA X."
+- **Write a `committed` checkpoint after every incremental commit**, passing the new `--commit-sha`. This keeps the recovery system aligned with git history.
+
+### When NOT to Commit Incrementally
+
+- **Untested broken code in the middle of a single coherent edit** — if you are 3 lines into a 30-line refactor and the file does not parse, finish the edit first. The boundary triggers (tier transition, >2min command, scaffolding done) all imply a coherent unit is complete.
+- **Generated artifacts that pollute the diff** — `boards/*/output/*.kicad_pcb` regenerated as a side effect should be committed deliberately, not folded into a `wip:` commit, unless they are the actual deliverable.
+
+### Recovery Now Works Even on Hard Crashes
+
+With this protocol followed, a builder that crashes mid-tier leaves a feature branch on the remote with progress visible in `git log`. The shepherd's `validate-phase.sh` recovery becomes a **fallback** for "changes since the last incremental commit," not the only mechanism keeping work alive. See `.claude/commands/loom/shepherd-lifecycle.md` Phase contracts table for the updated recovery framing.
+
+### Self-Check Before Long Operations
+
+Before any single tool call you expect to take more than ~2 minutes, ask:
+
+1. Is there work on disk since the last `git push`?
+2. If yes, is it in a coherent enough state to commit as `wip:`?
+3. If yes, **commit and push first**, then run the long operation.
+
+If the answer to (2) is "no, the file is mid-edit and broken," finish the edit before starting the long operation — do not start a >2min op while holding uncommitted broken state.
+
 ## Signaling "No Changes Needed"
 
 If after analyzing the issue you determine that **no code changes are required** (e.g. the bug is already fixed on main, the feature already exists, the issue is invalid), you **MUST** create a `.no-changes-needed` marker file in the worktree root before exiting:

--- a/.claude/commands/loom/doctor.md
+++ b/.claude/commands/loom/doctor.md
@@ -510,6 +510,110 @@ $ sleep 60 && gh pr checks 1448
 # ... 1 CI run, complete in one pass
 ```
 
+## Incremental Commit Protocol
+
+**CRITICAL: You MUST commit and push at well-defined boundaries during a single agent run, not only at the end of the cycle.** A single end-of-cycle commit is insufficient for long iterative work — and "iterative" describes most doctor sessions, where each fix attempt may or may not move the failing CI check toward green.
+
+### Why This Exists (Concrete Failure)
+
+This protocol is not theoretical — it is a direct response to **PR #2535 (doctor, 2026-05)**: doctor crashed during a fix attempt without making any commits, losing all in-progress diagnostic work. The same week, the builder on issue #2542 ran for 175 minutes and crashed with API 529 having committed nothing. **Both failures left work recoverable only via manual worktree inspection.** Doctors are particularly exposed because:
+
+- Diagnostic work (reading logs, running tests, narrowing down failures) is high-value and often discarded if not committed
+- A doctor frequently runs *multiple* fix attempts in a single session — without incremental commits, only the final attempt is durable
+
+### Required Commit Boundaries (MUST)
+
+You MUST make a commit AND push (`git push`) at every one of these boundaries:
+
+| # | Boundary | Trigger | Why this is a natural seam |
+|---|----------|---------|----------------------------|
+| 1 | **After CI assessment is complete** | Finished step 1-3 of "CI Assessment (First Step)" above — you have the full list of failures and a fix plan | The plan itself is recoverable artifact; if you crash next, the next doctor doesn't have to re-run all the log fetches |
+| 2 | **After each fix attempt that changes a file** | You modified a test, a config, or production code as part of a fix — even if you haven't yet re-run the failing check | A failed-but-informative attempt (e.g. "this assertion update didn't help, but reveals the real bug is upstream") is worth preserving |
+| 3 | **Before any single command/operation expected to take >2 min** | Long test runs (`pnpm check:ci` on this repo takes ~15-20 min locally), CI status polls, slow simulations | Wall-clock risk window — if the tool call hangs or your session is killed during the wait, a commit-then-run pattern keeps the fix in `git log` |
+| 4 | **Before any push that triggers a long CI cycle** | Even a "single push" that triggers ~60 min of GitHub Actions is a checkpoint worth committing locally first, since CI failures may require another fix iteration | Decouples local commit from remote CI fate |
+
+**Push every committed batch.** Local commits inside a worktree are still a recovery hazard — the disk can fill, the worktree can be reused, another tool can clobber it. `git push` puts the work on the remote where it is durable.
+
+### How to Commit Incrementally as a Doctor
+
+```bash
+# After completing the CI assessment in step 1-3 of "CI Assessment (First Step)"
+# Even if no code has changed yet, commit a notes file so the plan is durable:
+cat > .loom/doctor-fix-plan.md <<'EOF'
+PR #1448 fix plan:
+1. state.test.ts — update mock for useConfig (renamed in #1444)
+2. button.test.ts — refresh snapshot
+3. SC2086 in scripts/worktree.sh:45 — quote $TARGET
+EOF
+git add .loom/doctor-fix-plan.md
+git commit -m "wip(doctor): triaged CI failures — fix plan recorded"
+git push
+
+# After fix attempt #1 — even if it didn't fully resolve the CI failures
+git add src/state.test.ts
+git commit -m "wip(doctor): update useConfig mock — fixes 8/21 frontend test failures"
+git push
+
+# Before launching a long pnpm check:ci run
+git add src/button.test.ts
+git commit -m "wip(doctor): refresh button snapshot"
+git push
+# Now safe to run pnpm check:ci, even if the run dies the snapshot fix is durable
+pnpm check:ci
+```
+
+### Verifying the Protocol Works (Simulated Crash)
+
+```bash
+# 1. Doctor commits + pushes after CI triage
+git commit -m "wip(doctor): triaged CI failures — fix plan recorded"
+git push
+
+# 2. Doctor begins fix #1 — modifies test, runs pnpm test (slow)
+# 3. API 529 / OOM / session timeout terminates the process
+# 4. Worktree is destroyed; the next doctor or human picks up.
+
+# 5. The next doctor can read the plan from PR branch:
+gh pr checkout 1448
+cat .loom/doctor-fix-plan.md  # plan is durable, no re-triage needed
+git log --oneline              # know which fix attempts have been tried
+
+# Without this protocol, the entire CI assessment + any partial fixes are gone.
+```
+
+### Intermediate Commit Message Style
+
+Use `wip(doctor):` for intermediate commits during a fix session — they will be squashed at merge time by the champion.
+
+**Good intermediate messages:**
+- `wip(doctor): triaged CI failures — fix plan recorded`
+- `wip(doctor): update useConfig mock — fixes 8/21 frontend test failures`
+- `wip(doctor): SC2086 fix in scripts/worktree.sh, shellcheck still failing on SC2164`
+
+**Bad (avoid):**
+- `progress` / `wip` / `checkpoint` (no information)
+- Final-style messages (`fix: resolve all CI failures`) until you actually have
+
+### Cleanup of `.loom/doctor-fix-plan.md`
+
+If you committed a fix plan as a recoverability aid, remove it before the final commit so it doesn't ship in the merged PR:
+
+```bash
+git rm .loom/doctor-fix-plan.md
+git commit -m "chore: remove doctor fix plan (work complete)"
+```
+
+The squash-merge will collapse all of these into the single PR title commit, but having the cleanup as its own intermediate commit keeps reviewer-visible history clean if the squash is ever bypassed.
+
+### When NOT to Commit Incrementally
+
+- **Mid-edit broken code** — finish the coherent unit first
+- **Diagnostic-only work that produced no file change** — if you ran `gh run view` and `pnpm test --filter foo` but did not edit any tracked file, there is nothing to commit. (The fix-plan-as-file pattern above is the workaround if you have non-trivial findings to preserve.)
+
+### Recovery Now Works Even on Hard Crashes
+
+With this protocol followed, a doctor that crashes mid-fix leaves the PR branch with progress and a fix plan visible in `git log`. The next doctor (or human) inherits the previous attempt's diagnostic work instead of starting from scratch. See `.claude/commands/loom/shepherd-lifecycle.md` Phase contracts table for the updated recovery framing.
+
 ## Types of Feedback to Address
 
 ### Quick Fixes (Always Handle)

--- a/.claude/commands/loom/shepherd-lifecycle.md
+++ b/.claude/commands/loom/shepherd-lifecycle.md
@@ -416,12 +416,14 @@ fi
 
 **Phase contracts and recovery**:
 
-| Phase | Expected Outcome | Recovery |
-|-------|-----------------|----------|
+| Phase | Expected Outcome | Recovery (Fallback) |
+|-------|-----------------|---------------------|
 | `curator` | `loom:curated` label on issue | Apply label (curator may have enhanced but not labeled) |
-| `builder` | PR exists with `loom:review-requested` | Commit/push worktree changes, create PR |
+| `builder` | PR exists with `loom:review-requested` | Commit/push residual worktree changes since the last incremental commit, create PR |
 | `judge` | `loom:pr` or `loom:changes-requested` on PR | No recovery — mark `loom:blocked` |
-| `doctor` | `loom:review-requested` on PR | No recovery — mark `loom:blocked` |
+| `doctor` | `loom:review-requested` on PR | Commit/push residual worktree changes since the last incremental commit, then mark `loom:blocked` if PR still missing the label |
+
+**Recovery is a fallback, not a primary mechanism.** Builders and doctors are required by their role contracts (see `.claude/commands/loom/builder.md` Incremental Commit Protocol and `.claude/commands/loom/doctor.md` Incremental Commit Protocol) to commit AND push at well-defined boundaries during a single agent run. When followed, the worktree should already have committed progress at every point of failure, and the recovery step here only captures any uncommitted changes since the most recent incremental commit. This is a structural change from the previous model where recovery was the *only* path for preserving builder/doctor work on a crash — the previous model was the root cause of issue #2547 (#2542 builder lost 175 min of work, PR #2535 doctor lost diagnostic state, both because no per-boundary commit contract existed).
 
 Use `--json` for machine-readable output. Exit code 0 means contract satisfied (initially or after recovery), 1 means failed.
 

--- a/.loom/roles/builder-pr.md
+++ b/.loom/roles/builder-pr.md
@@ -522,6 +522,26 @@ These patterns are **WRONG** — the shepherd will reject PRs with titles matchi
 | `feat: implement feature from issue #N` | Generic — could be any feature |
 | `<copy of issue title>` | Issue titles describe problems; commits describe solutions |
 
+### Intermediate Commits from the Incremental Commit Protocol
+
+The builder Incremental Commit Protocol (`.claude/commands/loom/builder.md` / `.loom/roles/builder.md`) requires you to make `wip:`-prefixed commits at well-defined boundaries during a single agent run. When you reach PR creation, you may have several intermediate commits on the branch in addition to the final commit.
+
+**This is fine — the diff-derivation step still works correctly.** PR title derivation uses `git diff --stat` and `git diff` against the *base ref* (typically `origin/main`), which is unaffected by the number of intermediate commits on your feature branch. The diff against `main` is the same whether you made one commit or twelve.
+
+```bash
+# Even with intermediate commits, this still gives you the full diff
+# against main for title derivation:
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+```
+
+**At PR creation time:**
+- The PR title still describes what the *whole diff* does (squashed view), not the latest individual commit
+- Champion's `merge-pr.sh` uses squash-merge, collapsing all your intermediate `wip:` commits into the single PR title commit on main
+- Your intermediate `wip:` messages are preserved on the feature branch and remain visible in `git log feature/issue-<N>` after merge if archived, but they do not pollute `git log main`
+
+**Final commit before PR creation:** if you have residual uncommitted changes when you reach the PR-creation step, write the final commit with a descriptive (not `wip:`) message that describes the *delta since the last `wip:` commit*. The PR title separately describes the *whole diff*.
+
 ---
 
 ## Creating Pull Requests: Label and Auto-Close Requirements

--- a/.loom/roles/builder.md
+++ b/.loom/roles/builder.md
@@ -382,6 +382,116 @@ You can read the current checkpoint:
 ./.loom/scripts/checkpoint.sh read --json  # For programmatic use
 ```
 
+## Incremental Commit Protocol
+
+**CRITICAL: You MUST commit and push at well-defined boundaries during a single agent run, not only at the end of the cycle.** A single end-of-cycle commit is insufficient for long iterative work.
+
+### Why This Exists (Concrete Failures)
+
+This protocol is not theoretical — it is a direct response to recoverable-only-by-luck failures observed in 2026-05:
+
+- **Issue #2542 (builder, 2026-05-07)**: Builder ran for **175 minutes** on board 05 placement, made real progress on `design.py` (~24 LoC of useful changes), then crashed with API 529. **Zero commits were made during the run.** The work was only recovered because the user manually inspected the worktree before it was reused. With incremental commits + push, the work would have been durable on the remote feature branch the moment the agent pushed, regardless of any session destruction.
+- **PR #2535 (doctor)**: Doctor crashed without any commits during a fix attempt; same recovery exposure.
+
+The existing recovery story (`validate-phase.sh` invoking commit/push from a still-on-disk worktree) is a **fallback**, not a guarantee. If the worktree is reused or wiped before the shepherd validates, uncommitted work is gone.
+
+### Required Commit Boundaries (MUST)
+
+You MUST make a commit AND push (`git push origin <branch>`) at every one of these boundaries. These boundaries are deliberately chosen to align with the existing checkpoint stages above — every checkpoint transition you write should also be a commit boundary.
+
+| # | Boundary | Trigger | Why this is a natural seam |
+|---|----------|---------|----------------------------|
+| 1 | **Scaffolding / infrastructure** | Adding a parameter, helper, type, stub, fixture, or import that is not yet exercised by any code path | Self-contained, well-described, low-blast-radius — easy to write a clear `wip:` message even if nothing calls it yet |
+| 2 | **Between tier attempts** | Iterative algorithm with named tiers (e.g. Tier 0 -> Tier 1 -> ... in a routing or placement search). Each tier is its own checkpoint of "approach X didn't work, trying Y" | Even a *failed* tier attempt is information worth preserving in `git log` for the next agent or human |
+| 3 | **Before any single command/operation expected to take >2 min** | Long route attempts, large test runs, slow simulations, KiCad invocations with thousands of nets | Wall-clock risk window — checkpoint the state of the world before the gamble |
+| 4 | **At every checkpoint stage transition** | Already a thing for state tracking (`planning` -> `implementing` -> `tested`); piggyback a commit on each meaningful transition | Forces git history to align with the recovery checkpoints |
+
+**Push every committed batch.** Local commits inside a worktree are still a recovery hazard — the disk can fill, the worktree can be reused, another tool can clobber it. `git push` puts the work on the remote where it is durable.
+
+### How to Commit Incrementally
+
+```bash
+# After completing scaffolding (e.g. added a no-op parameter)
+git add src/foo.py
+git commit -m "wip: add rotation parameter to generate_htssop56 (no-op)"
+git push origin "$(git branch --show-current)"
+./.loom/scripts/checkpoint.sh write --stage committed --issue <N> --commit-sha "$(git rev-parse HEAD)"
+
+# Before launching a long routing attempt for Tier 2 (the previous tier, Tier 1, just failed)
+git add boards/05-bldc-motor-controller/
+git commit -m "wip(board-05): tier 1 placement attempt — DRC still failing on U1<->U2"
+git push origin "$(git branch --show-current)"
+./.loom/scripts/checkpoint.sh write --stage committed --issue <N> --commit-sha "$(git rev-parse HEAD)"
+
+# Continue with Tier 2 — even if you crash now, Tier 1 result is durably on remote
+```
+
+### Verifying the Protocol Works (Simulated Crash)
+
+To convince yourself this actually preserves work on a hard crash, run this thought experiment:
+
+```bash
+# 1. Builder is at Tier 2 of placement search. It commits + pushes a wip:
+git commit -m "wip(board-05): tier 1 attempt"
+git push origin feature/issue-2394
+
+# 2. Builder begins Tier 2 — a long, expensive routing run
+# 3. API 529 (or OOM, or session timeout) terminates the process MID-ROUTE
+# 4. Worktree is destroyed; orchestrator picks up.
+
+# 5. The next agent or human checks:
+gh pr list --search "head:feature/issue-2394"        # branch is on remote
+git log --oneline origin/feature/issue-2394          # tier-1 commit is present
+# Tier 1 progress is preserved. Tier 2 is gone (it never committed),
+# but Tier 1 was *known to work* — that's the durable state to resume from.
+```
+
+Without incremental commits, both Tier 1 and Tier 2 progress would be on disk in the worktree only, and would be lost the moment the worktree was wiped. This is exactly what happened on issue #2542 (175 min builder, crashed, manual recovery only).
+
+### Intermediate Commit Message Style
+
+Intermediate commits will be **squashed at merge time** by the champion (this repo uses squash-merge), so the final commit on `main` is the PR title. But intermediate messages still matter for:
+- Worktree history when an agent crashes and another picks up
+- `git log --oneline` debugging during the run
+- The shepherd's recovery decision (a meaningful message tells it what was preserved)
+
+**Good intermediate messages:**
+- `wip: add rotation parameter to generate_htssop56 (no-op)`
+- `wip(board-05): tier 1 placement attempt — DRC still failing on U1<->U2`
+- `wip(router): scaffolding for CoupledPathfinder neck-down support`
+
+**Bad (avoid these for intermediates):**
+- `progress` / `wip` / `checkpoint` (no information content)
+- `working` (says nothing)
+- Final-style messages (`fix: resolve DRC violations on board 05`) — premature; save for the final commit
+
+### Relationship to the Checkpoint System
+
+The `committed` checkpoint stage and incremental commits are **complementary, not duplicative**:
+
+- An incremental `git commit` makes the work durable on remote (after push).
+- A `committed` checkpoint write tells the shepherd: "the work I just did at this stage is safely committed at SHA X."
+- **Write a `committed` checkpoint after every incremental commit**, passing the new `--commit-sha`. This keeps the recovery system aligned with git history.
+
+### When NOT to Commit Incrementally
+
+- **Untested broken code in the middle of a single coherent edit** — if you are 3 lines into a 30-line refactor and the file does not parse, finish the edit first. The boundary triggers (tier transition, >2min command, scaffolding done) all imply a coherent unit is complete.
+- **Generated artifacts that pollute the diff** — `boards/*/output/*.kicad_pcb` regenerated as a side effect should be committed deliberately, not folded into a `wip:` commit, unless they are the actual deliverable.
+
+### Recovery Now Works Even on Hard Crashes
+
+With this protocol followed, a builder that crashes mid-tier leaves a feature branch on the remote with progress visible in `git log`. The shepherd's `validate-phase.sh` recovery becomes a **fallback** for "changes since the last incremental commit," not the only mechanism keeping work alive. See `.claude/commands/loom/shepherd-lifecycle.md` Phase contracts table for the updated recovery framing.
+
+### Self-Check Before Long Operations
+
+Before any single tool call you expect to take more than ~2 minutes, ask:
+
+1. Is there work on disk since the last `git push`?
+2. If yes, is it in a coherent enough state to commit as `wip:`?
+3. If yes, **commit and push first**, then run the long operation.
+
+If the answer to (2) is "no, the file is mid-edit and broken," finish the edit before starting the long operation — do not start a >2min op while holding uncommitted broken state.
+
 ## Signaling "No Changes Needed"
 
 If after analyzing the issue you determine that **no code changes are required** (e.g. the bug is already fixed on main, the feature already exists, the issue is invalid), you **MUST** create a `.no-changes-needed` marker file in the worktree root before exiting:

--- a/.loom/roles/doctor.md
+++ b/.loom/roles/doctor.md
@@ -510,6 +510,110 @@ $ sleep 60 && gh pr checks 1448
 # ... 1 CI run, complete in one pass
 ```
 
+## Incremental Commit Protocol
+
+**CRITICAL: You MUST commit and push at well-defined boundaries during a single agent run, not only at the end of the cycle.** A single end-of-cycle commit is insufficient for long iterative work — and "iterative" describes most doctor sessions, where each fix attempt may or may not move the failing CI check toward green.
+
+### Why This Exists (Concrete Failure)
+
+This protocol is not theoretical — it is a direct response to **PR #2535 (doctor, 2026-05)**: doctor crashed during a fix attempt without making any commits, losing all in-progress diagnostic work. The same week, the builder on issue #2542 ran for 175 minutes and crashed with API 529 having committed nothing. **Both failures left work recoverable only via manual worktree inspection.** Doctors are particularly exposed because:
+
+- Diagnostic work (reading logs, running tests, narrowing down failures) is high-value and often discarded if not committed
+- A doctor frequently runs *multiple* fix attempts in a single session — without incremental commits, only the final attempt is durable
+
+### Required Commit Boundaries (MUST)
+
+You MUST make a commit AND push (`git push`) at every one of these boundaries:
+
+| # | Boundary | Trigger | Why this is a natural seam |
+|---|----------|---------|----------------------------|
+| 1 | **After CI assessment is complete** | Finished step 1-3 of "CI Assessment (First Step)" above — you have the full list of failures and a fix plan | The plan itself is recoverable artifact; if you crash next, the next doctor doesn't have to re-run all the log fetches |
+| 2 | **After each fix attempt that changes a file** | You modified a test, a config, or production code as part of a fix — even if you haven't yet re-run the failing check | A failed-but-informative attempt (e.g. "this assertion update didn't help, but reveals the real bug is upstream") is worth preserving |
+| 3 | **Before any single command/operation expected to take >2 min** | Long test runs (`pnpm check:ci` on this repo takes ~15-20 min locally), CI status polls, slow simulations | Wall-clock risk window — if the tool call hangs or your session is killed during the wait, a commit-then-run pattern keeps the fix in `git log` |
+| 4 | **Before any push that triggers a long CI cycle** | Even a "single push" that triggers ~60 min of GitHub Actions is a checkpoint worth committing locally first, since CI failures may require another fix iteration | Decouples local commit from remote CI fate |
+
+**Push every committed batch.** Local commits inside a worktree are still a recovery hazard — the disk can fill, the worktree can be reused, another tool can clobber it. `git push` puts the work on the remote where it is durable.
+
+### How to Commit Incrementally as a Doctor
+
+```bash
+# After completing the CI assessment in step 1-3 of "CI Assessment (First Step)"
+# Even if no code has changed yet, commit a notes file so the plan is durable:
+cat > .loom/doctor-fix-plan.md <<'EOF'
+PR #1448 fix plan:
+1. state.test.ts — update mock for useConfig (renamed in #1444)
+2. button.test.ts — refresh snapshot
+3. SC2086 in scripts/worktree.sh:45 — quote $TARGET
+EOF
+git add .loom/doctor-fix-plan.md
+git commit -m "wip(doctor): triaged CI failures — fix plan recorded"
+git push
+
+# After fix attempt #1 — even if it didn't fully resolve the CI failures
+git add src/state.test.ts
+git commit -m "wip(doctor): update useConfig mock — fixes 8/21 frontend test failures"
+git push
+
+# Before launching a long pnpm check:ci run
+git add src/button.test.ts
+git commit -m "wip(doctor): refresh button snapshot"
+git push
+# Now safe to run pnpm check:ci, even if the run dies the snapshot fix is durable
+pnpm check:ci
+```
+
+### Verifying the Protocol Works (Simulated Crash)
+
+```bash
+# 1. Doctor commits + pushes after CI triage
+git commit -m "wip(doctor): triaged CI failures — fix plan recorded"
+git push
+
+# 2. Doctor begins fix #1 — modifies test, runs pnpm test (slow)
+# 3. API 529 / OOM / session timeout terminates the process
+# 4. Worktree is destroyed; the next doctor or human picks up.
+
+# 5. The next doctor can read the plan from PR branch:
+gh pr checkout 1448
+cat .loom/doctor-fix-plan.md  # plan is durable, no re-triage needed
+git log --oneline              # know which fix attempts have been tried
+
+# Without this protocol, the entire CI assessment + any partial fixes are gone.
+```
+
+### Intermediate Commit Message Style
+
+Use `wip(doctor):` for intermediate commits during a fix session — they will be squashed at merge time by the champion.
+
+**Good intermediate messages:**
+- `wip(doctor): triaged CI failures — fix plan recorded`
+- `wip(doctor): update useConfig mock — fixes 8/21 frontend test failures`
+- `wip(doctor): SC2086 fix in scripts/worktree.sh, shellcheck still failing on SC2164`
+
+**Bad (avoid):**
+- `progress` / `wip` / `checkpoint` (no information)
+- Final-style messages (`fix: resolve all CI failures`) until you actually have
+
+### Cleanup of `.loom/doctor-fix-plan.md`
+
+If you committed a fix plan as a recoverability aid, remove it before the final commit so it doesn't ship in the merged PR:
+
+```bash
+git rm .loom/doctor-fix-plan.md
+git commit -m "chore: remove doctor fix plan (work complete)"
+```
+
+The squash-merge will collapse all of these into the single PR title commit, but having the cleanup as its own intermediate commit keeps reviewer-visible history clean if the squash is ever bypassed.
+
+### When NOT to Commit Incrementally
+
+- **Mid-edit broken code** — finish the coherent unit first
+- **Diagnostic-only work that produced no file change** — if you ran `gh run view` and `pnpm test --filter foo` but did not edit any tracked file, there is nothing to commit. (The fix-plan-as-file pattern above is the workaround if you have non-trivial findings to preserve.)
+
+### Recovery Now Works Even on Hard Crashes
+
+With this protocol followed, a doctor that crashes mid-fix leaves the PR branch with progress and a fix plan visible in `git log`. The next doctor (or human) inherits the previous attempt's diagnostic work instead of starting from scratch. See `.claude/commands/loom/shepherd-lifecycle.md` Phase contracts table for the updated recovery framing.
+
 ## Types of Feedback to Address
 
 ### Quick Fixes (Always Handle)

--- a/.loom/roles/shepherd-lifecycle.md
+++ b/.loom/roles/shepherd-lifecycle.md
@@ -416,12 +416,14 @@ fi
 
 **Phase contracts and recovery**:
 
-| Phase | Expected Outcome | Recovery |
-|-------|-----------------|----------|
+| Phase | Expected Outcome | Recovery (Fallback) |
+|-------|-----------------|---------------------|
 | `curator` | `loom:curated` label on issue | Apply label (curator may have enhanced but not labeled) |
-| `builder` | PR exists with `loom:review-requested` | Commit/push worktree changes, create PR |
+| `builder` | PR exists with `loom:review-requested` | Commit/push residual worktree changes since the last incremental commit, create PR |
 | `judge` | `loom:pr` or `loom:changes-requested` on PR | No recovery — mark `loom:blocked` |
-| `doctor` | `loom:review-requested` on PR | No recovery — mark `loom:blocked` |
+| `doctor` | `loom:review-requested` on PR | Commit/push residual worktree changes since the last incremental commit, then mark `loom:blocked` if PR still missing the label |
+
+**Recovery is a fallback, not a primary mechanism.** Builders and doctors are required by their role contracts (see `.claude/commands/loom/builder.md` Incremental Commit Protocol and `.claude/commands/loom/doctor.md` Incremental Commit Protocol) to commit AND push at well-defined boundaries during a single agent run. When followed, the worktree should already have committed progress at every point of failure, and the recovery step here only captures any uncommitted changes since the most recent incremental commit. This is a structural change from the previous model where recovery was the *only* path for preserving builder/doctor work on a crash — the previous model was the root cause of issue #2547 (#2542 builder lost 175 min of work, PR #2535 doctor lost diagnostic state, both because no per-boundary commit contract existed).
 
 Use `--json` for machine-readable output. Exit code 0 means contract satisfied (initially or after recovery), 1 means failed.
 


### PR DESCRIPTION
## Summary

Adds an explicit Incremental Commit Protocol to the builder and doctor
role contracts so that long iterative agent runs preserve work on
crashes. Previously, both roles described a single end-of-cycle commit;
when a 175 min builder (#2542) and a doctor (PR #2535) crashed without
committing, all in-progress work was recoverable only by manual
worktree inspection.

## Changes

- `.loom/roles/builder.md` + `.claude/commands/loom/builder.md`: new
  `## Incremental Commit Protocol` section between `## Progress
  Checkpoints` and `## Signaling "No Changes Needed"`. Defines four
  required commit-and-push boundaries: scaffolding/infrastructure,
  between tier attempts, before any single command >2 min, and at
  every checkpoint stage transition. Includes worked example, `wip:`
  message style guide, simulated-crash thought experiment.
- `.loom/roles/doctor.md` + `.claude/commands/loom/doctor.md`: parallel
  `## Incremental Commit Protocol` section adapted to doctor task
  shape (after CI assessment, after each fix attempt, before long
  commands, before pushes that trigger long CI). Introduces the
  fix-plan-as-file pattern (`.loom/doctor-fix-plan.md`) for preserving
  diagnostic work even before any production code changes.
- `.loom/roles/shepherd-lifecycle.md` +
  `.claude/commands/loom/shepherd-lifecycle.md`: phase contracts table
  at lines 417-426 reframed — recovery is now a *fallback* for residual
  uncommitted changes since the most recent incremental commit, not the
  *primary* mechanism for preserving builder/doctor work. Doctor's
  recovery row also expanded to mention commit/push (mirroring builder).
- `.loom/roles/builder-pr.md` + `.claude/commands/loom/builder-pr.md`:
  new subsection in `## Commit Messages: Same Rules as PR Titles`
  confirming that diff-derivation (`git diff --stat origin/main...HEAD`)
  is unaffected by the number of intermediate `wip:` commits, since
  champion squash-merges them away.

## Decision: PostToolUse Hook (in scope vs. deferred)

**Decision: deferred to a follow-up issue.** This PR is scoped to
documentation/protocol changes only. The curator's enrichment flagged
the meta-risk that "doc-only enforcement of incremental commits may
itself be vulnerable to the Superficial Fix Anti-Pattern" (cited at
builder.md line 568, now line 587 after this change), and asked the
implementer to make an explicit decision rather than silently dropping
the question.

Reasoning for deferring the hook to a follow-up:

1. **Different change type, different risk profile.** A PostToolUse
   hook is a *structural* change (modifies tool flow, can fail and
   block agents). A protocol/contract update is a *documentation*
   change with very low blast radius. Bundling them creates a single
   PR that is harder to roll back if the hook misbehaves.
2. **The protocol is independently valuable.** Even without a hook,
   a clear contract enables (a) judges to flag PRs that obviously
   ignored it, (b) doctors recovering from a previous failed attempt
   to know what *should* have been preserved, and (c) the shepherd's
   recovery framing in `shepherd-lifecycle.md` to make sense.
3. **The hook design needs its own deliberation.** Open questions:
   warning vs. hard block, how to count "tool calls since last
   commit" reliably across resumptions, what to do during the
   `Read`-only investigation phase early in a builder run, how to
   interact with the `.no-changes-needed` marker workflow.

Concrete next step (suggested follow-up issue):

> Add `.loom/hooks/incremental-commit-warn.sh` that, after every N
> file-modifying tool calls (`Edit`/`Write` matchers) without an
> intervening `git commit`, emits a `WARNING: <N> edits since last
> commit. Commit now or justify the delay.` This is a *warning*,
> not a deny — it preserves the structural-fix property without
> the risk of blocking legitimate work. Tracking issue: TBD.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All 6 affected files updated with explicit incremental-commit boundaries | ✅ | `git log main..HEAD` shows 4 commits modifying all 6 files; `diff` confirms `.claude/commands/loom/*.md` and `.loom/roles/*.md` mirrors stay in sync |
| Each boundary cites a current concrete example (#2542, PR #2535) | ✅ | builder.md "Why This Exists (Concrete Failures)", doctor.md "Why This Exists (Concrete Failure)", shepherd-lifecycle.md prose paragraph all reference both #2542 and #2535 by number |
| Simulated-crash test/example showing committed branch with progress visible in `git log` | ✅ | builder.md "Verifying the Protocol Works (Simulated Crash)" section, doctor.md "Verifying the Protocol Works (Simulated Crash)" section — both walk through the API 529 / OOM / session-timeout case and show what `gh pr list` and `git log` return after the crash |
| PR description records the decision on PostToolUse hook scope | ✅ | "Decision: PostToolUse Hook (in scope vs. deferred)" section above |
| Pre-commit / pre-push checks pass | ✅ | `uv run ruff check .` shows 779 pre-existing errors, none introduced by this PR (verified via stash test). All changes are markdown only. |
| Commits are reviewable per role file (builder, doctor, shepherd, builder-pr separately) | ✅ | 4 commits, one per role file pair, see `git log main..HEAD` |
| Builder ate own dog food: incremental commits during this PR | ✅ | 4 logical commits + push at each role-file boundary |

## Test Plan

- [x] `diff .claude/commands/loom/builder.md .loom/roles/builder.md` (identical)
- [x] `diff .claude/commands/loom/doctor.md .loom/roles/doctor.md` (identical)
- [x] `diff .claude/commands/loom/shepherd-lifecycle.md .loom/roles/shepherd-lifecycle.md` (identical)
- [x] `diff .claude/commands/loom/builder-pr.md .loom/roles/builder-pr.md` (identical)
- [x] `uv run ruff check .` produces same error count as before (779; no new lint errors from doc changes)
- [x] All four files render as valid markdown (manual visual inspection)
- [x] Each role file's new section is reachable from a logical predecessor: builder.md after Progress Checkpoints, doctor.md after the CI Assessment anti-pattern subsection, shepherd-lifecycle.md inline in the existing phase-contracts table, builder-pr.md inline in the Commit Messages section

Closes #2547