### PR TITLE
feat(blocks): create_gate_drive_resistor_array — N-channel slew-rate resistors (closes #2570)

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -39,6 +39,7 @@ from kicad_tools.schematic.blocks import (
     LEDIndicator,
     ThreePhaseInverter,
     create_5v_buck,
+    create_gate_drive_resistor_array,
 )
 from kicad_tools.schematic.models.schematic import Schematic
 
@@ -363,26 +364,30 @@ def create_bldc_controller(output_dir: Path) -> Path:
     _connect_mcu_pin_to_label("12", "HALL_B", dx=5, dy=0)
     _connect_mcu_pin_to_label("13", "HALL_C", dx=5, dy=0)
 
-    # High-side gate PWM: PA8/PA9/PA10 (TIM1_CH1/CH2/CH3)
-    _connect_mcu_pin_to_label("18", "GATE_AH", dx=5, dy=0)
-    _connect_mcu_pin_to_label("19", "GATE_BH", dx=5, dy=0)
-    _connect_mcu_pin_to_label("20", "GATE_CH", dx=5, dy=0)
+    # High-side gate PWM: PA8/PA9/PA10 (TIM1_CH1/CH2/CH3).  These drive the
+    # DRV8301 INH_A/B/C logic inputs (pins 17/19/21), not the MOSFET gates
+    # directly — gate output of the driver is GATE_DRV_*H, then through the
+    # R20/R21/R22 slew-rate resistors to GATE_*H on the MOSFET gates.
+    _connect_mcu_pin_to_label("18", "PWM_AH", dx=5, dy=0)
+    _connect_mcu_pin_to_label("19", "PWM_BH", dx=5, dy=0)
+    _connect_mcu_pin_to_label("20", "PWM_CH", dx=5, dy=0)
 
     # SWD debug pins
     _connect_mcu_pin_to_label("23", "SWDIO", dx=5, dy=0)
     _connect_mcu_pin_to_label("24", "SWCLK", dx=5, dy=0)
     _connect_mcu_pin_to_label("26", "SWO", dx=5, dy=0)
 
-    # Low-side gate PWM: PB6/PB7/PB8 (TIM4_CH1/CH2/CH3, sync'd with TIM1)
-    _connect_mcu_pin_to_label("29", "GATE_AL", dx=5, dy=0)
-    _connect_mcu_pin_to_label("30", "GATE_BL", dx=5, dy=0)
-    _connect_mcu_pin_to_label("31", "GATE_CL", dx=5, dy=0)
+    # Low-side gate PWM: PB6/PB7/PB8 (TIM4_CH1/CH2/CH3, sync'd with TIM1).
+    # Drives DRV8301 INL_A/B/C logic inputs (pins 18/20/22).
+    _connect_mcu_pin_to_label("29", "PWM_AL", dx=5, dy=0)
+    _connect_mcu_pin_to_label("30", "PWM_BL", dx=5, dy=0)
+    _connect_mcu_pin_to_label("31", "PWM_CL", dx=5, dy=0)
 
     # Crystal pins: PF0/PF1 -> OSC_IN/OSC_OUT
     _connect_mcu_pin_to_label("2", "OSC_IN", dx=-5, dy=0)
     _connect_mcu_pin_to_label("3", "OSC_OUT", dx=-5, dy=0)
 
-    print("   Wired 16 floating nets (6 GATE, 3 HALL, 3 ISENSE-, 4 SWD) to MCU pins")
+    print("   Wired 16 floating nets (6 PWM, 3 HALL, 3 ISENSE-, 4 SWD) to MCU pins")
 
     # Crystal oscillator (8MHz)
     xtal = CrystalOscillator(
@@ -454,6 +459,22 @@ def create_bldc_controller(output_dir: Path) -> Path:
     print("   Gate driver: DRV8301 (GateDriverBlock)")
     print("   Bootstrap caps: C12, C13, C14")
     print("   Bypass caps: C15, C16")
+
+    # Series gate-drive (slew-rate) resistors between DRV8301 outputs and the
+    # high-side MOSFET gates.  ``GATE_DRV_AH/BH/CH`` are the driver-IC outputs;
+    # ``GATE_AH/BH/CH`` are the MOSFET-gate-side nets.  The array sits in the
+    # path between them.  Low-side gates remain direct-driven for now.
+    create_gate_drive_resistor_array(
+        sch,
+        x=X_GATE_DRV + 30,
+        y=120,
+        channels=3,
+        value="22",
+        ref_start=20,  # R20-R22 (R10-R12 are the current-sense shunts)
+        input_nets=["GATE_DRV_AH", "GATE_DRV_BH", "GATE_DRV_CH"],
+        output_nets=["GATE_AH", "GATE_BH", "GATE_CH"],
+    )
+    print("   Gate-drive resistors: R20, R21, R22 (22 ohms, HS only)")
 
     # =========================================================================
     # Section 7: Power Stage (using ThreePhaseInverter and CurrentSenseShunt)
@@ -805,6 +826,20 @@ def create_bldc_pcb(output_dir: Path) -> Path:
         "PWR_LED": 29,
         "STATUS_LED": 30,
         "SW_OUT": 31,
+        # Gate-driver-side (between DRV8301 outputs and the slew-rate resistors).
+        # The MOSFET-gate-side nets remain GATE_AH/BH/CH.  Low-side gates stay
+        # direct-driven so GATE_AL/BL/CL still tie the driver IC to the MOSFETs.
+        "GATE_DRV_AH": 32,
+        "GATE_DRV_BH": 33,
+        "GATE_DRV_CH": 34,
+        # MCU-side PWM logic inputs to the DRV8301 (pins 17-22).  These are
+        # distinct from the GATE_* nets above, which are the MOSFET gates.
+        "PWM_AH": 35,
+        "PWM_AL": 36,
+        "PWM_BH": 37,
+        "PWM_BL": 38,
+        "PWM_CH": 39,
+        "PWM_CL": 40,
     }
 
     # =========================================================================
@@ -882,6 +917,14 @@ def create_bldc_pcb(output_dir: Path) -> Path:
     R10_POS = (BOARD_ORIGIN_X + 8, BOARD_ORIGIN_Y + 84)
     R11_POS = (BOARD_ORIGIN_X + 24, BOARD_ORIGIN_Y + 84)
     R12_POS = (BOARD_ORIGIN_X + 40, BOARD_ORIGIN_Y + 84)
+
+    # Gate-drive (slew-rate) resistors -- between DRV8301 HS outputs and the
+    # high-side MOSFET gates.  Sit just above each phase's HS MOSFET so the
+    # GATE_DRV_*H -> GATE_*H net runs vertically.  R20-R22 use the same 0805
+    # footprint generator as R3/R4.
+    R20_POS = (BOARD_ORIGIN_X + 8, BOARD_ORIGIN_Y + 64)  # Phase A HS
+    R21_POS = (BOARD_ORIGIN_X + 24, BOARD_ORIGIN_Y + 64)  # Phase B HS
+    R22_POS = (BOARD_ORIGIN_X + 40, BOARD_ORIGIN_Y + 64)  # Phase C HS
 
     # Motor connector (right edge, bottom -- near MOSFETs)
     J2_POS = (BOARD_ORIGIN_X + 65, BOARD_ORIGIN_Y + 76)
@@ -1066,13 +1109,13 @@ def create_bldc_pcb(output_dir: Path) -> Path:
     #    15  CP2                                   -> +5V
     #    16  EN_GATE                               -> +3.3V (always-on)
     #
-    #   PWM logic inputs (17-22):
-    #    17  INH_A                                 <- GATE_AH
-    #    18  INL_A                                 <- GATE_AL
-    #    19  INH_B                                 <- GATE_BH
-    #    20  INL_B                                 <- GATE_BL
-    #    21  INH_C                                 <- GATE_CH
-    #    22  INL_C                                 <- GATE_CL
+    #   PWM logic inputs (17-22):  driven by the MCU on PWM_* nets.
+    #    17  INH_A                                 <- PWM_AH
+    #    18  INL_A                                 <- PWM_AL
+    #    19  INH_B                                 <- PWM_BH
+    #    20  INL_B                                 <- PWM_BL
+    #    21  INH_C                                 <- PWM_CH
+    #    22  INL_C                                 <- PWM_CL
     #
     #   Analog supplies / current-sense amps (23-33):
     #    23  DVDD     (internal 3.3-V supply, cap) -> +3.3V
@@ -1091,21 +1134,21 @@ def create_bldc_pcb(output_dir: Path) -> Path:
     #    34  SL_C     (low-side source / VDS-)     -> ISENSE_C-
     #    35  GL_C                                  -> GATE_CL
     #    36  SH_C                                  -> PHASE_C
-    #    37  GH_C                                  -> GATE_CH
+    #    37  GH_C                                  -> GATE_DRV_CH (via R22 to GATE_CH)
     #    38  BST_C    (high-side bootstrap)        -> VMOTOR (via cap, DC tie)
     #
     #   Half-bridge B (39-43):
     #    39  SL_B                                  -> ISENSE_B-
     #    40  GL_B                                  -> GATE_BL
     #    41  SH_B                                  -> PHASE_B
-    #    42  GH_B                                  -> GATE_BH
+    #    42  GH_B                                  -> GATE_DRV_BH (via R21 to GATE_BH)
     #    43  BST_B                                 -> VMOTOR
     #
     #   Half-bridge A (44-48):
     #    44  SL_A                                  -> ISENSE_A-
     #    45  GL_A                                  -> GATE_AL
     #    46  SH_A                                  -> PHASE_A
-    #    47  GH_A                                  -> GATE_AH
+    #    47  GH_A                                  -> GATE_DRV_AH (via R20 to GATE_AH)
     #    48  BST_A                                 -> VMOTOR
     #
     #   SPI / buck pins (49-57):
@@ -1145,12 +1188,12 @@ def create_bldc_pcb(output_dir: Path) -> Path:
         ("14", "+5V"),           # CP1      (charge pump cap 1)
         ("15", "+5V"),           # CP2      (charge pump cap 2)
         ("16", "+3.3V"),         # EN_GATE  (always-on)
-        ("17", "GATE_AH"),       # INH_A
-        ("18", "GATE_AL"),       # INL_A
-        ("19", "GATE_BH"),       # INH_B
-        ("20", "GATE_BL"),       # INL_B
-        ("21", "GATE_CH"),       # INH_C
-        ("22", "GATE_CL"),       # INL_C
+        ("17", "PWM_AH"),        # INH_A    (PWM input from MCU)
+        ("18", "PWM_AL"),        # INL_A
+        ("19", "PWM_BH"),        # INH_B
+        ("20", "PWM_BL"),        # INL_B
+        ("21", "PWM_CH"),        # INH_C
+        ("22", "PWM_CL"),        # INL_C
         ("23", "+3.3V"),         # DVDD     (internal 3.3-V LDO output)
         ("24", "+3.3V"),         # REF      (current-sense reference)
         ("25", "ISENSE_A+"),     # SO1      (op-amp 1 output)
@@ -1165,17 +1208,17 @@ def create_bldc_pcb(output_dir: Path) -> Path:
         ("34", "ISENSE_C-"),     # SL_C     (low-side source, half-bridge C)
         ("35", "GATE_CL"),       # GL_C
         ("36", "PHASE_C"),       # SH_C
-        ("37", "GATE_CH"),       # GH_C
+        ("37", "GATE_DRV_CH"),   # GH_C     (via R22 to GATE_CH)
         ("38", "VMOTOR"),        # BST_C    (bootstrap, via cap)
         ("39", "ISENSE_B-"),     # SL_B
         ("40", "GATE_BL"),       # GL_B
         ("41", "PHASE_B"),       # SH_B
-        ("42", "GATE_BH"),       # GH_B
+        ("42", "GATE_DRV_BH"),   # GH_B     (via R21 to GATE_BH)
         ("43", "VMOTOR"),        # BST_B
         ("44", "ISENSE_A-"),     # SL_A
         ("45", "GATE_AL"),       # GL_A
         ("46", "PHASE_A"),       # SH_A
-        ("47", "GATE_AH"),       # GH_A
+        ("47", "GATE_DRV_AH"),   # GH_A     (via R20 to GATE_AH)
         ("48", "VMOTOR"),        # BST_A
         ("49", "+3.3V"),         # VDD_SPI  (SPI logic supply)
         ("50", "SW_OUT"),        # PH       (buck switch node)
@@ -1249,8 +1292,8 @@ def create_bldc_pcb(output_dir: Path) -> Path:
 
     # STM32G431K8Tx LQFP-32 pin -> net mapping.  Pin-to-port assignments come
     # from the steering decision in #2529 and the STM32G431 datasheet:
-    #   * TIM1_CH1/2/3 (PA8/PA9/PA10)  -> high-side gates AH/BH/CH
-    #   * TIM4_CH1/2/3 (PB6/PB7/PB8)   -> low-side gates AL/BL/CL
+    #   * TIM1_CH1/2/3 (PA8/PA9/PA10)  -> PWM_AH/BH/CH (DRV8301 INH_A/B/C)
+    #   * TIM4_CH1/2/3 (PB6/PB7/PB8)   -> PWM_AL/BL/CL (DRV8301 INL_A/B/C)
     #   * ADC1_IN1..IN3 (PA0/PA1/PA2)  -> ISENSE_A-/B-/C-
     #   * GPIO/TIM3 capture (PA6/PA7/PB0) -> HALL_A/B/C
     #   * SWD: PA13 SWDIO, PA14 SWCLK, PB3 SWO, PG10 NRST
@@ -1272,9 +1315,9 @@ def create_bldc_pcb(output_dir: Path) -> Path:
         ("15", "+3.3V"),       # VDDA
         ("16", "GND"),         # VSS
         ("17", "+3.3V"),       # VDD
-        ("18", "GATE_AH"),     # PA8  TIM1_CH1
-        ("19", "GATE_BH"),     # PA9  TIM1_CH2
-        ("20", "GATE_CH"),     # PA10 TIM1_CH3
+        ("18", "PWM_AH"),      # PA8  TIM1_CH1   (HS PWM -> DRV8301 INH_A)
+        ("19", "PWM_BH"),      # PA9  TIM1_CH2   (HS PWM -> DRV8301 INH_B)
+        ("20", "PWM_CH"),      # PA10 TIM1_CH3   (HS PWM -> DRV8301 INH_C)
         ("21", "GND"),         # PA11 (unused)
         ("22", "GND"),         # PA12 (unused)
         ("23", "SWDIO"),       # PA13
@@ -1283,9 +1326,9 @@ def create_bldc_pcb(output_dir: Path) -> Path:
         ("26", "SWO"),         # PB3 (SWO/TIM2_CH2)
         ("27", "GND"),         # PB4 (unused)
         ("28", "GND"),         # PB5 (unused)
-        ("29", "GATE_AL"),     # PB6  TIM4_CH1
-        ("30", "GATE_BL"),     # PB7  TIM4_CH2
-        ("31", "GATE_CL"),     # PB8  TIM4_CH3
+        ("29", "PWM_AL"),      # PB6  TIM4_CH1   (LS PWM -> DRV8301 INL_A)
+        ("30", "PWM_BL"),      # PB7  TIM4_CH2   (LS PWM -> DRV8301 INL_B)
+        ("31", "PWM_CL"),      # PB8  TIM4_CH3   (LS PWM -> DRV8301 INL_C)
         ("32", "GND"),         # VSS
     ]
 
@@ -1615,6 +1658,14 @@ def create_bldc_pcb(output_dir: Path) -> Path:
     parts.append(generate_resistor_2512("R12", R12_POS, "5mR", "ISENSE_C+", "ISENSE_C-"))
     print(f"   R10, R11, R12 (5mOhm shunts)")
 
+    print("\n9b. Adding gate-drive (slew-rate) resistors...")
+    # Series 22-ohm resistors between DRV8301 HS outputs and the MOSFET gates.
+    # Each connects GATE_DRV_*H (driver IC output) to GATE_*H (MOSFET gate).
+    parts.append(generate_resistor_0805("R20", R20_POS, "22", "GATE_DRV_AH", "GATE_AH"))
+    parts.append(generate_resistor_0805("R21", R21_POS, "22", "GATE_DRV_BH", "GATE_BH"))
+    parts.append(generate_resistor_0805("R22", R22_POS, "22", "GATE_DRV_CH", "GATE_CH"))
+    print("   R20, R21, R22 (22 ohm gate-drive, HS only)")
+
     print("\n10. Adding connectors...")
     # J2: Motor output (3-pin)
     parts.append(generate_pin_header("J2", J2_POS, 3, "Motor Output", ["PHASE_A", "PHASE_B", "PHASE_C"]))
@@ -1651,7 +1702,7 @@ def create_bldc_pcb(output_dir: Path) -> Path:
         + 6  # MOSFETs
         + 4  # ICs (U1 buck, U2 LDO, U3 DRV8301, U10 STM32G431K8Tx)
         + 16  # capacitors (C1-C16)
-        + 5  # resistors (R3, R4, R10-R12)
+        + 8  # resistors (R3, R4, R10-R12, R20-R22)
         + 4  # diodes (D1-D4)
         + 1  # inductor
         + 1  # fuse
@@ -1861,7 +1912,7 @@ def main() -> int:
         print("  LDO (5V->3.3V): U2, C5-C6")
         print("  MCU: C7-C9, Y1 (C10-C11)")
         print("  Gate driver: U3, C12-C16")
-        print("  Power stage: Q1-Q6, R10-R12")
+        print("  Power stage: Q1-Q6, R10-R12 (current sense), R20-R22 (gate-drive)")
         print("  Connectors: J1-J4")
         print("  LEDs: D3-D4, R3-R4")
 

--- a/src/kicad_tools/schematic/blocks/__init__.py
+++ b/src/kicad_tools/schematic/blocks/__init__.py
@@ -79,10 +79,12 @@ from .mcu import (
 from .motor import (
     CurrentSenseShunt,
     GateDriverBlock,
+    GateDriveResistorArray,
     HalfBridge,
     ThreePhaseInverter,
     create_3phase_inverter,
     create_current_sense,
+    create_gate_drive_resistor_array,
     create_half_bridge,
 )
 
@@ -195,9 +197,11 @@ __all__ = [
     "ThreePhaseInverter",
     "CurrentSenseShunt",
     "GateDriverBlock",
+    "GateDriveResistorArray",
     "create_half_bridge",
     "create_3phase_inverter",
     "create_current_sense",
+    "create_gate_drive_resistor_array",
     # Analog
     "ADCInputFilterBlock",
     "OpAmpBlock",

--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -730,9 +730,7 @@ class GateDriverBlock(CircuitBlock):
                 driver_symbol = "Driver_FET:IR2110"
 
         # Add the driver IC symbol
-        self.driver = sch.add_symbol(
-            driver_symbol, x, y, ref, value
-        )
+        self.driver = sch.add_symbol(driver_symbol, x, y, ref, value)
 
         self.components = {"DRIVER": self.driver}
 
@@ -897,4 +895,229 @@ def create_current_sense(
         ref_start=ref_start,
         amplifier=with_amplifier,
         gain=gain,
+    )
+
+
+class GateDriveResistorArray(CircuitBlock):
+    """
+    Series gate-drive (slew-rate) resistor array.
+
+    A bank of N series resistors placed in the path between a gate-driver
+    output and the gate of a power MOSFET. Each resistor controls the
+    switching slew rate for one channel:
+
+        - Too little series R causes ringing/EMI and shoot-through risk.
+        - Too much series R increases switching loss and dead-time
+          requirements.
+
+    Schematic (3-channel):
+
+        IN_1 ──[R_GATE_1]── OUT_1
+        IN_2 ──[R_GATE_2]── OUT_2
+        IN_3 ──[R_GATE_3]── OUT_3
+
+    Ports:
+        - IN_1..IN_N: Driver-side inputs.
+        - OUT_1..OUT_N: MOSFET-gate-side outputs.
+        - When ``input_nets`` / ``output_nets`` are provided, alias ports
+          named after the suffix of each net are also exposed (e.g. for
+          ``input_nets=["GATE_DRV_AH"]`` an alias ``IN_AH`` is added).
+
+    Example:
+        from kicad_tools.schematic.blocks import create_gate_drive_resistor_array
+
+        gate_r = create_gate_drive_resistor_array(
+            sch, x=300, y=120,
+            channels=3,
+            value="22",
+            ref_start=20,
+            input_nets=["GATE_DRV_AH", "GATE_DRV_BH", "GATE_DRV_CH"],
+            output_nets=["GATE_AH", "GATE_BH", "GATE_CH"],
+        )
+    """
+
+    def __init__(
+        self,
+        sch: "Schematic",
+        x: float,
+        y: float,
+        channels: int = 3,
+        value: str = "10",
+        *,
+        ref_start: int = 1,
+        ref_prefix: str = "R",
+        resistor_symbol: str = "Device:R",
+        resistor_package: str = "0805",
+        spacing: float = 10.0,
+        input_nets: list[str] | None = None,
+        output_nets: list[str] | None = None,
+    ):
+        """
+        Create a gate-drive resistor array.
+
+        Args:
+            sch: Schematic to add components to.
+            x: X coordinate of first resistor.
+            y: Y coordinate (center of the array).
+            channels: Number of resistor channels (one per gate signal).
+            value: Resistor value in ohms (e.g. ``"10"``, ``"22"``, ``"47"``).
+                Typical range is 10-47 Ω for IRLZ44N-class gates.
+            ref_start: Starting reference number for resistors.
+            ref_prefix: Reference designator prefix (default ``"R"``).
+            resistor_symbol: KiCad symbol for resistor.
+            resistor_package: Footprint package (e.g. ``"0805"``, ``"0603"``).
+            spacing: Horizontal spacing between resistors (schematic units).
+            input_nets: Optional list of input net names (length must equal
+                ``channels``). When provided, ``add_label`` is called at each
+                resistor input pin and an alias port is added.
+            output_nets: Optional list of output net names (length must equal
+                ``channels``). When provided, ``add_label`` is called at each
+                resistor output pin and an alias port is added.
+
+        Raises:
+            ValueError: If ``input_nets`` or ``output_nets`` is provided and
+                its length does not equal ``channels``.
+        """
+        super().__init__(sch, x, y)
+
+        if channels < 1:
+            raise ValueError(f"channels must be >= 1, got {channels}")
+
+        if input_nets is not None and len(input_nets) != channels:
+            raise ValueError(
+                f"input_nets length ({len(input_nets)}) must equal channels ({channels})"
+            )
+        if output_nets is not None and len(output_nets) != channels:
+            raise ValueError(
+                f"output_nets length ({len(output_nets)}) must equal channels ({channels})"
+            )
+
+        self.channels = channels
+        self.value = value
+        self.resistor_package = resistor_package
+        self.resistors = []
+        self.components = {}
+        self.ports = {}
+
+        for i in range(channels):
+            res_x = x + i * spacing
+            ref = f"{ref_prefix}{ref_start + i}"
+            resistor = sch.add_symbol(
+                resistor_symbol,
+                res_x,
+                y,
+                ref,
+                value,
+                properties={"Package": resistor_package},
+            )
+            self.resistors.append(resistor)
+            self.components[f"R_GATE_{i + 1}"] = resistor
+
+            # Pin 1 = input (driver side), Pin 2 = output (MOSFET-gate side).
+            in_pos = resistor.pin_position("1")
+            out_pos = resistor.pin_position("2")
+
+            in_port_name = f"IN_{i + 1}"
+            out_port_name = f"OUT_{i + 1}"
+            self.ports[in_port_name] = in_pos
+            self.ports[out_port_name] = out_pos
+
+            # Optional net labels — emit a label at each pin and add an
+            # alias port keyed by the net suffix (the trailing token after
+            # the last '_').
+            if input_nets is not None:
+                in_net = input_nets[i]
+                sch.add_label(in_net, in_pos[0], in_pos[1], rotation=0)
+                alias = f"IN_{_net_suffix(in_net)}"
+                self.ports[alias] = in_pos
+
+            if output_nets is not None:
+                out_net = output_nets[i]
+                sch.add_label(out_net, out_pos[0], out_pos[1], rotation=0)
+                alias = f"OUT_{_net_suffix(out_net)}"
+                self.ports[alias] = out_pos
+
+
+def _net_suffix(net_name: str) -> str:
+    """Extract the suffix used for alias port naming.
+
+    The suffix is the trailing token after the last underscore. For
+    ``"GATE_DRV_AH"`` it returns ``"AH"``; for ``"GATE_AH"`` it returns
+    ``"AH"``; for a single-token name it returns the whole name.
+    """
+    return net_name.rsplit("_", 1)[-1] if "_" in net_name else net_name
+
+
+def create_gate_drive_resistor_array(
+    sch: "Schematic",
+    x: float,
+    y: float,
+    channels: int = 3,
+    value: str = "10",
+    *,
+    ref_start: int = 1,
+    ref_prefix: str = "R",
+    resistor_symbol: str = "Device:R",
+    resistor_package: str = "0805",
+    spacing: float = 10.0,
+    input_nets: list[str] | None = None,
+    output_nets: list[str] | None = None,
+) -> GateDriveResistorArray:
+    """
+    Create an N-channel series gate-drive (slew-rate) resistor array.
+
+    A series resistor (commonly 10-47 Ω) belongs in the path from each
+    gate-driver IC output to its MOSFET gate. This factory produces an
+    array sized to ``channels``, intended to be spliced in between the
+    driver and the MOSFETs.
+
+    Args:
+        sch: Schematic to add components to.
+        x: X coordinate of first resistor.
+        y: Y coordinate (center of the array).
+        channels: Number of resistor channels (one per gate signal).
+            Common values: 1 (low-side switch), 2 (half-bridge HS+LS),
+            3 (3-phase HS only), 6 (3-phase HS+LS).
+        value: Resistor value in ohms (e.g. ``"10"``, ``"22"``, ``"47"``).
+        ref_start: Starting reference number.
+        ref_prefix: Reference designator prefix (default ``"R"``).
+        resistor_symbol: KiCad symbol for resistor.
+        resistor_package: Footprint package (e.g. ``"0805"``, ``"0603"``).
+        spacing: Horizontal spacing between resistors.
+        input_nets: Optional list of input net names (length == ``channels``).
+            Each emits an ``add_label`` call at the corresponding input pin
+            and adds an alias port (e.g. ``IN_AH``).
+        output_nets: Optional list of output net names (length == ``channels``).
+
+    Returns:
+        ``GateDriveResistorArray`` instance.
+
+    Example:
+        # 3-phase driver -> resistor array -> MOSFET gates (HS only).
+        from kicad_tools.schematic.blocks import create_gate_drive_resistor_array
+
+        gate_r = create_gate_drive_resistor_array(
+            sch, x=300, y=120,
+            channels=3, value="22", ref_start=20,
+            input_nets=["GATE_DRV_AH", "GATE_DRV_BH", "GATE_DRV_CH"],
+            output_nets=["GATE_AH", "GATE_BH", "GATE_CH"],
+        )
+
+    Raises:
+        ValueError: If ``input_nets`` or ``output_nets`` length does not
+            equal ``channels``.
+    """
+    return GateDriveResistorArray(
+        sch,
+        x,
+        y,
+        channels=channels,
+        value=value,
+        ref_start=ref_start,
+        ref_prefix=ref_prefix,
+        resistor_symbol=resistor_symbol,
+        resistor_package=resistor_package,
+        spacing=spacing,
+        input_nets=input_nets,
+        output_nets=output_nets,
     )

--- a/tests/test_blocks_gate_drive_resistor_array.py
+++ b/tests/test_blocks_gate_drive_resistor_array.py
@@ -1,0 +1,206 @@
+"""Tests for the ``create_gate_drive_resistor_array`` factory.
+
+These tests use a mocked ``Schematic`` so they exercise the factory's
+control flow without actually emitting KiCad schematic data. The shape
+mirrors ``TestCurrentSenseShuntMocked`` and ``TestGateDriverBlockMocked``
+in ``tests/test_schematic_blocks.py``.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from kicad_tools.schematic.blocks import (
+    CircuitBlock,
+    GateDriveResistorArray,
+    create_gate_drive_resistor_array,
+)
+
+
+@pytest.fixture
+def mock_schematic():
+    """Create a mock Schematic that returns mock symbols with deterministic pins.
+
+    Pin "1" is the input (driver) side; Pin "2" is the output (MOSFET-gate)
+    side. Pin coordinates are derived from the symbol's (x, y) so the
+    factory can emit add_label / add_wire calls at predictable positions.
+    """
+    sch = Mock()
+
+    def create_mock_component(symbol, x, y, ref, value, *args, **kwargs):
+        comp = Mock()
+        comp.reference = ref
+        comp.value = value
+        comp.symbol = symbol
+        comp._properties = kwargs.get("properties", {})
+
+        comp.pin_position.side_effect = lambda name, _x=x, _y=y: {
+            "1": (_x - 5, _y),
+            "2": (_x + 5, _y),
+        }.get(name, (_x, _y))
+        return comp
+
+    sch.add_symbol = Mock(side_effect=create_mock_component)
+    sch.add_wire = Mock()
+    sch.add_junction = Mock()
+    sch.add_label = Mock()
+    return sch
+
+
+class TestGateDriveResistorArray:
+    """Tests for ``create_gate_drive_resistor_array`` factory."""
+
+    def test_default_3_channels(self, mock_schematic):
+        """Default invocation creates exactly 3 resistors with default value."""
+        block = create_gate_drive_resistor_array(mock_schematic, x=100, y=100)
+
+        assert len(block.resistors) == 3
+        # Three add_symbol calls.
+        assert mock_schematic.add_symbol.call_count == 3
+        # Default refs R1..R3.
+        for i, comp in enumerate(block.resistors):
+            assert comp.reference == f"R{i + 1}"
+            assert comp.value == "10"
+
+    @pytest.mark.parametrize("channels", [1, 2, 3, 6])
+    def test_channel_count_parametrized(self, mock_schematic, channels):
+        """Number of resistors equals the ``channels`` argument."""
+        block = create_gate_drive_resistor_array(mock_schematic, x=100, y=100, channels=channels)
+
+        assert len(block.resistors) == channels
+        assert len(block.components) == channels
+        assert mock_schematic.add_symbol.call_count == channels
+        # IN_i and OUT_i ports for each channel.
+        for i in range(1, channels + 1):
+            assert f"IN_{i}" in block.ports
+            assert f"OUT_{i}" in block.ports
+
+    def test_value_propagation(self, mock_schematic):
+        """Custom value passed to every resistor."""
+        block = create_gate_drive_resistor_array(
+            mock_schematic, x=100, y=100, channels=3, value="33"
+        )
+
+        for comp in block.resistors:
+            assert comp.value == "33"
+        # Verify the value is passed to add_symbol as the 5th positional arg.
+        for call in mock_schematic.add_symbol.call_args_list:
+            args, _kwargs = call
+            assert args[4] == "33"
+
+    def test_ref_start_offset(self, mock_schematic):
+        """``ref_start=20`` produces R20, R21, R22 for 3 channels."""
+        block = create_gate_drive_resistor_array(
+            mock_schematic, x=100, y=100, channels=3, ref_start=20
+        )
+
+        refs = [comp.reference for comp in block.resistors]
+        assert refs == ["R20", "R21", "R22"]
+
+    def test_ports_present(self, mock_schematic):
+        """``IN_i`` / ``OUT_i`` ports exist with sane coordinates."""
+        block = create_gate_drive_resistor_array(
+            mock_schematic, x=100, y=100, channels=3, spacing=10
+        )
+
+        # Each resistor is at x=100 + i*10. Pin 1 is at x-5, pin 2 at x+5.
+        for i in range(3):
+            res_x = 100 + i * 10
+            in_pos = block.ports[f"IN_{i + 1}"]
+            out_pos = block.ports[f"OUT_{i + 1}"]
+            assert in_pos == (res_x - 5, 100)
+            assert out_pos == (res_x + 5, 100)
+            # Input is to the left of output (driver-side -> MOSFET-side).
+            assert in_pos[0] < out_pos[0]
+
+    def test_input_output_net_aliases(self, mock_schematic):
+        """When ``input_nets``/``output_nets`` provided, aliases and labels appear."""
+        block = create_gate_drive_resistor_array(
+            mock_schematic,
+            x=100,
+            y=100,
+            channels=1,
+            input_nets=["GATE_DRV_AH"],
+            output_nets=["GATE_AH"],
+        )
+
+        # Alias ports keyed by the suffix.
+        assert "IN_AH" in block.ports
+        assert "OUT_AH" in block.ports
+        # Numeric ports also still present.
+        assert "IN_1" in block.ports
+        assert "OUT_1" in block.ports
+
+        # Both labels emitted at the correct pin coordinates.
+        labels_called = [call.args[0] for call in mock_schematic.add_label.call_args_list]
+        assert "GATE_DRV_AH" in labels_called
+        assert "GATE_AH" in labels_called
+
+        # And each label sits at the corresponding pin position.
+        in_pos = block.ports["IN_1"]
+        out_pos = block.ports["OUT_1"]
+        for call in mock_schematic.add_label.call_args_list:
+            args, _kw = call
+            net_name, lx, ly = args[0], args[1], args[2]
+            if net_name == "GATE_DRV_AH":
+                assert (lx, ly) == in_pos
+            elif net_name == "GATE_AH":
+                assert (lx, ly) == out_pos
+
+    def test_net_list_length_validation(self, mock_schematic):
+        """Mismatched ``input_nets``/``output_nets`` length raises ValueError."""
+        # input_nets too short
+        with pytest.raises(ValueError, match="input_nets length"):
+            create_gate_drive_resistor_array(
+                mock_schematic,
+                x=100,
+                y=100,
+                channels=3,
+                input_nets=["A", "B"],  # only 2, expected 3
+            )
+
+        # output_nets too long
+        with pytest.raises(ValueError, match="output_nets length"):
+            create_gate_drive_resistor_array(
+                mock_schematic,
+                x=100,
+                y=100,
+                channels=2,
+                output_nets=["A", "B", "C"],  # 3, expected 2
+            )
+
+    def test_resistor_package_property(self, mock_schematic):
+        """Custom ``resistor_package`` is forwarded as a Package property."""
+        block = create_gate_drive_resistor_array(
+            mock_schematic, x=100, y=100, channels=2, resistor_package="0603"
+        )
+
+        assert block.resistor_package == "0603"
+        # Each add_symbol call carries properties={"Package": "0603"}.
+        for call in mock_schematic.add_symbol.call_args_list:
+            _args, kwargs = call
+            assert kwargs["properties"]["Package"] == "0603"
+
+    def test_returns_circuit_block(self, mock_schematic):
+        """Result is a CircuitBlock subclass with correct sch/x/y attrs."""
+        block = create_gate_drive_resistor_array(mock_schematic, x=42, y=84, channels=2)
+
+        assert isinstance(block, CircuitBlock)
+        assert isinstance(block, GateDriveResistorArray)
+        assert block.schematic is mock_schematic
+        assert block.x == 42
+        assert block.y == 84
+
+    def test_components_dict_keyed(self, mock_schematic):
+        """``block.components`` keyed by R_GATE_1..N."""
+        block = create_gate_drive_resistor_array(mock_schematic, x=100, y=100, channels=4)
+
+        assert set(block.components.keys()) == {
+            "R_GATE_1",
+            "R_GATE_2",
+            "R_GATE_3",
+            "R_GATE_4",
+        }
+        # Each value is the resistor symbol mock.
+        for i, comp in enumerate(block.resistors):
+            assert block.components[f"R_GATE_{i + 1}"] is comp


### PR DESCRIPTION
## Summary

- Adds ``create_gate_drive_resistor_array`` factory in
  ``src/kicad_tools/schematic/blocks/motor.py`` (and a corresponding
  ``GateDriveResistorArray`` class).  The factory produces an N-channel
  series-resistor block intended to splice in between a gate-driver IC
  output and the corresponding power-MOSFET gate to control switching
  slew rate (10-47 ohms typical).

- Re-exports the new factory and class from
  ``src/kicad_tools/schematic/blocks/__init__.py``.

- Refactors board 05 (``boards/05-bldc-motor-controller/design.py``) so
  the high-side MOSFET gates are driven through R20-R22 (22 ohms each)
  rather than direct from the DRV8301.  As part of this:
  * MCU PWM nets renamed ``GATE_*`` -> ``PWM_*`` (these are PWM logic
    inputs to the driver, not the MOSFET gates).
  * DRV8301 high-side outputs renamed ``GATE_*H`` -> ``GATE_DRV_*H``.
  * MOSFET-gate-side nets remain ``GATE_*H`` / ``GATE_*L``.
  * R20-R22 splice ``GATE_DRV_*H`` -> ``GATE_*H`` for the three phases.

- Adds 13 mocked-Schematic unit tests in
  ``tests/test_blocks_gate_drive_resistor_array.py``.

Closes #2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)