### PR TITLE
feat(blocks): create_gpio_pull_resistor — thin wrapper over BootModeSelector with generic rail/port/footprint (closes #2573)

### DIFF
--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -34,6 +34,7 @@ from kicad_tools.schematic.blocks import (
     CrystalOscillator,
     DebugHeader,
     LEDIndicator,
+    create_gpio_pull_resistor,
 )
 from kicad_tools.schematic.models.schematic import Schematic
 
@@ -408,23 +409,31 @@ def create_stm32_schematic(output_dir: Path) -> Path:
 
     # BOOT0 pull-down (left side, top half).  Tying BOOT0 low forces normal
     # flash boot at reset; this is the typical configuration for development.
+    # Refactored to use create_gpio_pull_resistor (issue #2573); previously
+    # an inline 10k vertical pull-down with a manual GND stub.
     boot0_pos = mcu.pin_position("BOOT0")
-    r_boot = sch.add_symbol(
-        "Device:R",
-        x=boot0_pos[0] - 20,
-        y=boot0_pos[1],
-        ref="R2",
+    # Place the block left of BOOT0; the block's "BOOT0" port lands at
+    # (block_x, block_y + 5) for a pull-down (resistor below center).
+    block_x = boot0_pos[0] - 20
+    block_y = boot0_pos[1] - 5
+    boot_pull = create_gpio_pull_resistor(
+        sch,
+        x=block_x,
+        y=block_y,
+        pin_name="BOOT0",
+        rail="GND",
         value="10k",
+        pull_type="down",
+        ref="R2",
         footprint="Resistor_SMD:R_0805_2012Metric",
-        rotation=270,
     )
-    # R2 pin 1 connects to BOOT0 stub, pin 2 connects down to GND rail
-    r1 = r_boot.pin_position("1")
-    r2 = r_boot.pin_position("2")
-    sch.add_wire(boot0_pos, r1, warn_on_collision=False)
-    sch.add_wire(r2, (r2[0], RAIL_GND), warn_on_collision=False)
-    sch.add_junction(r2[0], RAIL_GND)
-    print("   R2 (10k) BOOT0 pull-down to GND")
+    # Wire BOOT0 stub from MCU to the block's BOOT0 port (horizontal).
+    sch.add_wire(boot0_pos, boot_pull.port("BOOT0"), warn_on_collision=False)
+    # Drop the resistor's GND end down to the GND rail.
+    gnd_end = boot_pull.port("GND")
+    sch.add_wire(gnd_end, (gnd_end[0], RAIL_GND), warn_on_collision=False)
+    sch.add_junction(gnd_end[0], RAIL_GND)
+    print("   R2 (10k) BOOT0 pull-down to GND (via create_gpio_pull_resistor)")
 
     # =========================================================================
     # Section 7: User LED (driven by MCU PB12, active-low)

--- a/src/kicad_tools/schematic/blocks/__init__.py
+++ b/src/kicad_tools/schematic/blocks/__init__.py
@@ -71,6 +71,7 @@ from .mcu import (
     ResetButton,
     create_esp32_boot,
     create_generic_boot,
+    create_gpio_pull_resistor,
     create_reset_button,
     create_stm32_boot,
 )
@@ -188,6 +189,7 @@ __all__ = [
     "ResetButton",
     "create_esp32_boot",
     "create_generic_boot",
+    "create_gpio_pull_resistor",
     "create_reset_button",
     "create_stm32_boot",
     # Motor control

--- a/src/kicad_tools/schematic/blocks/mcu.py
+++ b/src/kicad_tools/schematic/blocks/mcu.py
@@ -783,6 +783,7 @@ class BootModeSelector(CircuitBlock):
         button_ref_prefix: str = "SW",
         resistor_symbol: str = "Device:R",
         button_symbol: str = "Switch:SW_Push",
+        footprint: str | None = None,
     ):
         """
         Create a boot mode selector circuit.
@@ -803,6 +804,9 @@ class BootModeSelector(CircuitBlock):
             button_ref_prefix: Reference designator prefix for button
             resistor_symbol: KiCad symbol for resistor
             button_symbol: KiCad symbol for push button
+            footprint: Optional footprint string for the resistor (e.g.,
+                "Resistor_SMD:R_0805_2012Metric"). Forwarded to ``add_symbol``.
+                When ``None`` (default), no explicit footprint is set.
         """
         super().__init__(sch, x, y)
         self.mode = mode.lower()
@@ -848,7 +852,21 @@ class BootModeSelector(CircuitBlock):
             resistor_y = y + component_spacing
 
         # Place resistor (always present)
-        self.resistor = sch.add_symbol(resistor_symbol, x, resistor_y, r_ref, resistor_value)
+        # Forward footprint only when caller supplied one — pass-through
+        # preserves existing behavior (no explicit footprint) when omitted.
+        if footprint is not None:
+            self.resistor = sch.add_symbol(
+                resistor_symbol,
+                x,
+                resistor_y,
+                r_ref,
+                resistor_value,
+                footprint=footprint,
+            )
+        else:
+            self.resistor = sch.add_symbol(
+                resistor_symbol, x, resistor_y, r_ref, resistor_value
+            )
         self.components["R"] = self.resistor
         self.resistors["R1"] = self.resistor
 

--- a/src/kicad_tools/schematic/blocks/mcu.py
+++ b/src/kicad_tools/schematic/blocks/mcu.py
@@ -1065,6 +1065,138 @@ def create_esp32_boot(
     )
 
 
+def create_gpio_pull_resistor(
+    sch: "Schematic",
+    x: float,
+    y: float,
+    *,
+    pin_name: str = "PIN",
+    rail: str = "GND",
+    value: str = "10k",
+    pull_type: str = "down",
+    ref: str = "R1",
+    footprint: str | None = None,
+    resistor_symbol: str = "Device:R",
+) -> BootModeSelector:
+    """
+    Create a single pull-up or pull-down resistor on a GPIO/strap pin.
+
+    Thin convenience wrapper over :class:`BootModeSelector` for the very
+    common pattern of a single pull resistor on a configuration or strap
+    pin (boot mode, I2C address select, regulator EN, mode select, etc.)
+    where the existing class' "BootModeSelector" name reads wrong.
+
+    Internally constructs a button-less ``BootModeSelector`` in
+    ``mode="generic"`` with the pull direction selected by ``pull_type``.
+    The boot port is exposed under the user-supplied ``pin_name`` (default
+    "PIN") rather than "BOOT". The opposite-end port is exposed under the
+    user-supplied ``rail`` name (default "GND") so callers can pull to
+    arbitrary rails such as "+3.3V" without coercion to VCC/GND.
+
+    Schematic (pull-down to GND, default):
+        PIN ──┬────
+              │
+             [R]   (e.g., 10k)
+              │
+        GND ──┴────
+
+    Schematic (pull-up to VCC or custom rail):
+        VCC ──┬────
+              │
+             [R]
+              │
+        PIN ──┴────
+
+    Args:
+        sch: Schematic to add to.
+        x: X coordinate of circuit center.
+        y: Y coordinate of circuit center.
+        pin_name: Port name for the GPIO/strap pin side of the resistor
+            (e.g., ``"PIN"``, ``"ADDR"``, ``"EN"``, ``"BOOT0"``).
+        rail: Port name for the rail side of the resistor (e.g., ``"GND"``,
+            ``"VCC"``, ``"+3.3V"``, ``"+5V"``). When the rail is not
+            literally ``"VCC"`` or ``"GND"``, the caller is responsible for
+            wiring the exposed port to the actual net (e.g., via
+            :func:`add_label` or :func:`add_wire`); :meth:`connect_to_rails`
+            still uses the underlying VCC/GND geometry.
+        value: Resistor value as a string (e.g., ``"10k"``, ``"4.7k"``).
+        pull_type: ``"down"`` for pull-down (resistor between pin and rail
+            assumed to be ground) or ``"up"`` for pull-up (resistor between
+            pin and rail assumed to be supply). Determines the underlying
+            ``default_state``.
+        ref: Reference designator (e.g., ``"R2"``).
+        footprint: Optional footprint string (e.g.,
+            ``"Resistor_SMD:R_0805_2012Metric"``) forwarded to ``add_symbol``.
+        resistor_symbol: KiCad symbol library id for the resistor.
+
+    Returns:
+        The underlying :class:`BootModeSelector` instance with no button.
+        ``ports[pin_name]`` is the GPIO side, ``ports[rail]`` is the rail
+        side. Standard ``ports["VCC"]`` / ``ports["GND"]`` aliases also
+        remain available for compatibility.
+
+    Raises:
+        ValueError: If ``pull_type`` is not one of ``{"up", "down"}`` or
+            ``rail`` is not a non-empty string.
+
+    Example:
+        >>> # 10k pull-down on STM32 BOOT0 to GND with explicit footprint
+        >>> r = create_gpio_pull_resistor(
+        ...     sch, x=100, y=80,
+        ...     pin_name="BOOT0", rail="GND",
+        ...     value="10k", pull_type="down", ref="R2",
+        ...     footprint="Resistor_SMD:R_0805_2012Metric",
+        ... )
+        >>> sch.add_wire(mcu.port("BOOT0"), r.port("BOOT0"))
+        >>>
+        >>> # 4.7k pull-up on I2C ADDR pin to +3.3V
+        >>> r = create_gpio_pull_resistor(
+        ...     sch, x=120, y=80,
+        ...     pin_name="ADDR", rail="+3.3V",
+        ...     value="4.7k", pull_type="up", ref="R5",
+        ... )
+    """
+    if pull_type not in ("up", "down"):
+        raise ValueError(
+            f"Invalid pull_type {pull_type!r}. Must be 'up' or 'down'."
+        )
+    if not isinstance(rail, str) or not rail:
+        raise ValueError("rail must be a non-empty string")
+
+    block = BootModeSelector(
+        sch,
+        x,
+        y,
+        mode="generic",
+        default_state="high" if pull_type == "up" else "low",
+        include_button=False,
+        resistor_value=value,
+        ref_prefix=ref,
+        resistor_symbol=resistor_symbol,
+        footprint=footprint,
+    )
+
+    # Rename the boot port ("BOOT") to caller-supplied pin_name. Keep the
+    # original alias as a fallback so existing call sites (and tests on the
+    # generic mode) continue to work.
+    if pin_name != "BOOT":
+        block.ports[pin_name] = block.ports["BOOT"]
+
+    # Expose the rail side under the caller's rail name. We don't coerce
+    # custom rail names to "VCC"/"GND" — both aliases stay populated so
+    # connect_to_rails still works for the standard cases. For non-standard
+    # rails (e.g., "+3.3V") the caller wires the port manually.
+    if pull_type == "down":
+        # Resistor's far end is at the GND rail port.
+        if rail not in ("GND",):
+            block.ports[rail] = block.ports["GND"]
+    else:  # pull_type == "up"
+        if rail not in ("VCC",):
+            block.ports[rail] = block.ports["VCC"]
+
+    return block
+
+
 def create_generic_boot(
     sch: "Schematic",
     x: float,

--- a/src/kicad_tools/schematic/blocks/mcu.py
+++ b/src/kicad_tools/schematic/blocks/mcu.py
@@ -864,9 +864,7 @@ class BootModeSelector(CircuitBlock):
                 footprint=footprint,
             )
         else:
-            self.resistor = sch.add_symbol(
-                resistor_symbol, x, resistor_y, r_ref, resistor_value
-            )
+            self.resistor = sch.add_symbol(resistor_symbol, x, resistor_y, r_ref, resistor_value)
         self.components["R"] = self.resistor
         self.resistors["R1"] = self.resistor
 
@@ -1157,9 +1155,7 @@ def create_gpio_pull_resistor(
         ... )
     """
     if pull_type not in ("up", "down"):
-        raise ValueError(
-            f"Invalid pull_type {pull_type!r}. Must be 'up' or 'down'."
-        )
+        raise ValueError(f"Invalid pull_type {pull_type!r}. Must be 'up' or 'down'.")
     if not isinstance(rail, str) or not rail:
         raise ValueError("rail must be a non-empty string")
 

--- a/tests/test_schematic_blocks.py
+++ b/tests/test_schematic_blocks.py
@@ -41,6 +41,7 @@ from kicad_tools.schematic.blocks import (
     create_current_sense,
     create_esp32_boot,
     create_generic_boot,
+    create_gpio_pull_resistor,
     create_half_bridge,
     create_i2c_pullups,
     create_jtag_header,
@@ -3143,6 +3144,140 @@ class TestBootModeSelectorFactoryFunctions:
         """Create generic boot selector with custom resistor."""
         boot = create_generic_boot(mock_schematic, x=100, y=100, ref="R1", resistor_value="100k")
         assert boot.resistor_value == "100k"
+
+
+class TestCreateGpioPullResistor:
+    """Tests for ``create_gpio_pull_resistor`` thin wrapper factory.
+
+    These tests cover the four gaps the curator analysis identified over
+    the existing ``BootModeSelector``: caller-supplied port name, custom
+    rail names (e.g. "+3.3V"), footprint pass-through, and validation of
+    pull_type. See issue #2573.
+    """
+
+    @pytest.fixture
+    def mock_schematic(self):
+        """Create mock schematic mirroring TestBootModeSelectorFactoryFunctions."""
+        sch = Mock()
+
+        def create_mock_component(symbol, x, y, ref, *args, **kwargs):
+            comp = Mock()
+            comp.pin_position.side_effect = lambda name: {
+                "1": (x, y - 5),
+                "2": (x, y + 5),
+            }.get(name, (x, y))
+            return comp
+
+        sch.add_symbol = Mock(side_effect=create_mock_component)
+        sch.add_wire = Mock()
+        sch.add_junction = Mock()
+        return sch
+
+    def test_default_pull_down_to_gnd(self, mock_schematic):
+        """Defaults give one resistor, port 'PIN', pull-down, no button."""
+        block = create_gpio_pull_resistor(mock_schematic, x=100, y=100)
+        assert isinstance(block, BootModeSelector)
+        assert block.mode == "generic"
+        assert block.default_high is False  # pull-down
+        assert block.include_button is False
+        assert "PIN" in block.ports
+        assert "GND" in block.ports
+        # No button placed
+        assert len(block.buttons) == 0
+        assert "SW" not in block.components
+        # Exactly one resistor placed
+        assert len(block.resistors) == 1
+
+    def test_pull_up_to_vcc(self, mock_schematic):
+        """pull_type='up' produces a pull-up to VCC."""
+        block = create_gpio_pull_resistor(
+            mock_schematic, x=100, y=100, pull_type="up", rail="VCC"
+        )
+        assert block.default_high is True
+        assert "PIN" in block.ports
+        assert "VCC" in block.ports
+
+    def test_custom_value(self, mock_schematic):
+        """Custom resistor value propagates."""
+        block = create_gpio_pull_resistor(mock_schematic, x=100, y=100, value="4.7k")
+        assert block.resistor_value == "4.7k"
+
+    def test_custom_rail_name_pulldown(self, mock_schematic):
+        """rail='+3.3V' is exposed as a port (not silently coerced to GND)."""
+        block = create_gpio_pull_resistor(
+            mock_schematic, x=100, y=100, pull_type="down", rail="+3.3V"
+        )
+        # Custom rail name is exposed as its own port
+        assert "+3.3V" in block.ports
+        # Standard alias remains available so connect_to_rails still works
+        assert "GND" in block.ports
+        # The custom rail port aliases the standard rail position
+        assert block.ports["+3.3V"] == block.ports["GND"]
+
+    def test_custom_rail_name_pullup(self, mock_schematic):
+        """rail='+5V' on a pull-up is exposed (not coerced to VCC)."""
+        block = create_gpio_pull_resistor(
+            mock_schematic, x=100, y=100, pull_type="up", rail="+5V"
+        )
+        assert "+5V" in block.ports
+        assert "VCC" in block.ports
+        assert block.ports["+5V"] == block.ports["VCC"]
+
+    def test_custom_pin_name(self, mock_schematic):
+        """pin_name='ADDR' exposes port 'ADDR' (not 'BOOT'/'PIN')."""
+        block = create_gpio_pull_resistor(
+            mock_schematic, x=100, y=100, pin_name="ADDR"
+        )
+        assert "ADDR" in block.ports
+
+    def test_footprint_passthrough(self, mock_schematic):
+        """footprint='...' is forwarded to sch.add_symbol."""
+        create_gpio_pull_resistor(
+            mock_schematic,
+            x=100,
+            y=100,
+            footprint="Resistor_SMD:R_0805_2012Metric",
+        )
+        # add_symbol called once for the resistor; check footprint kwarg
+        assert mock_schematic.add_symbol.called
+        call_kwargs = mock_schematic.add_symbol.call_args.kwargs
+        assert call_kwargs.get("footprint") == "Resistor_SMD:R_0805_2012Metric"
+
+    def test_no_footprint_when_omitted(self, mock_schematic):
+        """When footprint is omitted, no footprint kwarg is sent (preserves
+        existing BootModeSelector behavior for callers not using it)."""
+        create_gpio_pull_resistor(mock_schematic, x=100, y=100)
+        assert mock_schematic.add_symbol.called
+        call_kwargs = mock_schematic.add_symbol.call_args.kwargs
+        assert "footprint" not in call_kwargs
+
+    def test_invalid_pull_type_raises(self, mock_schematic):
+        """Invalid pull_type raises ValueError."""
+        with pytest.raises(ValueError, match="pull_type"):
+            create_gpio_pull_resistor(mock_schematic, x=100, y=100, pull_type="sideways")
+
+    def test_invalid_rail_raises(self, mock_schematic):
+        """Empty rail raises ValueError."""
+        with pytest.raises(ValueError, match="rail"):
+            create_gpio_pull_resistor(mock_schematic, x=100, y=100, rail="")
+
+    def test_returns_circuit_block(self, mock_schematic):
+        """Result is a CircuitBlock subclass."""
+        block = create_gpio_pull_resistor(mock_schematic, x=100, y=100)
+        assert isinstance(block, CircuitBlock)
+
+    def test_no_button_components(self, mock_schematic):
+        """No button components are added."""
+        block = create_gpio_pull_resistor(mock_schematic, x=100, y=100)
+        assert len(block.buttons) == 0
+        assert "SW" not in block.components
+
+    def test_custom_ref_designator(self, mock_schematic):
+        """Custom ref propagates to add_symbol call."""
+        create_gpio_pull_resistor(mock_schematic, x=100, y=100, ref="R42")
+        # add_symbol(symbol, x, y, ref, value, ...) — ref is positional arg 3
+        call_args = mock_schematic.add_symbol.call_args.args
+        assert call_args[3] == "R42"
 
 
 class TestCANTransceiverMocked:

--- a/tests/test_schematic_blocks.py
+++ b/tests/test_schematic_blocks.py
@@ -3190,9 +3190,7 @@ class TestCreateGpioPullResistor:
 
     def test_pull_up_to_vcc(self, mock_schematic):
         """pull_type='up' produces a pull-up to VCC."""
-        block = create_gpio_pull_resistor(
-            mock_schematic, x=100, y=100, pull_type="up", rail="VCC"
-        )
+        block = create_gpio_pull_resistor(mock_schematic, x=100, y=100, pull_type="up", rail="VCC")
         assert block.default_high is True
         assert "PIN" in block.ports
         assert "VCC" in block.ports
@@ -3216,18 +3214,14 @@ class TestCreateGpioPullResistor:
 
     def test_custom_rail_name_pullup(self, mock_schematic):
         """rail='+5V' on a pull-up is exposed (not coerced to VCC)."""
-        block = create_gpio_pull_resistor(
-            mock_schematic, x=100, y=100, pull_type="up", rail="+5V"
-        )
+        block = create_gpio_pull_resistor(mock_schematic, x=100, y=100, pull_type="up", rail="+5V")
         assert "+5V" in block.ports
         assert "VCC" in block.ports
         assert block.ports["+5V"] == block.ports["VCC"]
 
     def test_custom_pin_name(self, mock_schematic):
         """pin_name='ADDR' exposes port 'ADDR' (not 'BOOT'/'PIN')."""
-        block = create_gpio_pull_resistor(
-            mock_schematic, x=100, y=100, pin_name="ADDR"
-        )
+        block = create_gpio_pull_resistor(mock_schematic, x=100, y=100, pin_name="ADDR")
         assert "ADDR" in block.ports
 
     def test_footprint_passthrough(self, mock_schematic):


### PR DESCRIPTION
## Summary

Adds `create_gpio_pull_resistor`, a thin wrapper factory over `BootModeSelector` for the very common pattern of a single pull-up/pull-down resistor on a GPIO/strap pin (boot mode, I2C ADDR, regulator EN, mode select, etc.) where the existing class' name reads wrong.

Per curator analysis on #2573, the proposal substantially overlapped existing `BootModeSelector(mode="generic", include_button=False)`. This PR implements **Option A — wrap, don't reimplement** — fixing the four genuine gaps the original issue identified:

1. **Naming/intent** — generic name (`create_gpio_pull_resistor`) for non-boot uses
2. **`rail` kwarg** — accepts arbitrary names like `"+3.3V"` / `"+5V"` (exposed as a port; not coerced to VCC/GND)
3. **`footprint` pass-through** — added to both `BootModeSelector.__init__` and the new factory; forwarded to `add_symbol`
4. **`pin_name` kwarg** — caller-supplied port name (`"PIN"`, `"ADDR"`, `"BOOT0"`, etc.)

Refactors `boards/04-stm32-devboard/generate_design.py` (R2 inline 10k BOOT0 pull-down) to use the new factory. ERC remains clean on the regenerated schematic.

**Scope correction**: per curator, dropped board 05 from refactor scope — board 05 is a DRV8316 BLDC controller (no MCU, no inline BOOT pull resistor); the open-drain pins listed in the issue are tied directly to `+3.3V` rails (no series resistor).

Commit-incremental per #2547:
- `076e9edd` — `fix(blocks)` footprint kwarg pass-through on `BootModeSelector`
- `582ed1f3` — `feat(blocks)` add `create_gpio_pull_resistor` factory + tests + exports
- `b9dde760` — `refactor(boards/04)` migrate BOOT0 pull-down to the factory
- `8e160e6e` — `style(blocks)` ruff format on new code

## Test plan

- [x] 13 new unit tests in `tests/test_schematic_blocks.py::TestCreateGpioPullResistor` (default pull-down, pull-up, custom value, custom rail name on pull-up + pull-down, custom pin name, footprint pass-through, footprint omission preserves prior behavior, invalid pull_type raises, empty rail raises, returns CircuitBlock, no button components, custom ref designator)
- [x] Pre-existing 31 BootModeSelector + factory tests still pass (wrapper is non-breaking; `footprint=None` default preserves existing call paths)
- [x] `boards/04-stm32-devboard/generate_design.py` regenerates successfully — ERC reports `No ERC errors found!`
- [x] `ruff check` clean on all changed files (the 2 pre-existing F841/F401 errors in `tests/test_schematic_blocks.py` lines 2609/4322 are unrelated and untouched)
- [x] `ruff format --check` clean on the new code (pre-existing format issues elsewhere in `mcu.py` are unrelated and untouched)

Closes #2573

Generated with [Claude Code](https://claude.com/claude-code)