### PR TITLE
feat(blocks): create_bootstrap_capacitor_array — N-phase bootstrap cap network (closes #2565)

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -39,6 +39,7 @@ from kicad_tools.schematic.blocks import (
     LEDIndicator,
     ThreePhaseInverter,
     create_5v_buck,
+    create_bootstrap_capacitor_array,
     create_gate_drive_resistor_array,
 )
 from kicad_tools.schematic.models.schematic import Schematic
@@ -438,12 +439,14 @@ def create_bldc_controller(output_dir: Path) -> Path:
                       validate_connection=False)
 
     # =========================================================================
-    # Section 6: Gate Driver (using GateDriverBlock)
+    # Section 6: Gate Driver (using GateDriverBlock + BootstrapCapacitorArray)
     # =========================================================================
     print("\n6. Adding gate driver...")
 
-    # 3-phase gate driver with bootstrap capacitors
-    # Note: C10-C11 are used by CrystalOscillator, so start at C12
+    # 3-phase gate driver IC (no internal bootstrap cap composition --
+    # we instantiate BootstrapCapacitorArray explicitly below to demonstrate
+    # the new factory's composability).
+    # Note: C10-C11 are used by CrystalOscillator, so start at C15 for bypass
     gate_driver = GateDriverBlock(
         sch,
         x=X_GATE_DRV,
@@ -451,13 +454,27 @@ def create_bldc_controller(output_dir: Path) -> Path:
         driver_type="3-phase",
         ref="U3",
         value="DRV8301",
-        bootstrap_caps="100nF",
+        bootstrap_caps=None,  # bootstrap caps created externally below
         bypass_caps=["100nF", "10uF"],
-        cap_ref_start=12,  # C12-C14 for bootstrap, C15-C16 for bypass
+        cap_ref_start=15,  # C15-C16 for bypass (C12-C14 reserved for bootstrap)
     )
     gate_driver.connect_to_rails(vcc_rail_y=RAIL_5V, gnd_rail_y=RAIL_GND)
+
+    # External 3-phase bootstrap cap network (BST_x to PHASE_x).
+    # Uses C12-C14 to preserve existing PCB-side ref numbering and layout.
+    create_bootstrap_capacitor_array(
+        sch,
+        x=X_GATE_DRV - 20,
+        y=80,
+        phases=3,
+        value="100nF",
+        cap_ref_start=12,
+        high_nets=["BST_A", "BST_B", "BST_C"],
+        phase_nets=["PHASE_A", "PHASE_B", "PHASE_C"],
+    )
+
     print("   Gate driver: DRV8301 (GateDriverBlock)")
-    print("   Bootstrap caps: C12, C13, C14")
+    print("   Bootstrap caps: C12, C13, C14 (BootstrapCapacitorArray)")
     print("   Bypass caps: C15, C16")
 
     # Series gate-drive (slew-rate) resistors between DRV8301 outputs and the

--- a/src/kicad_tools/schematic/blocks/__init__.py
+++ b/src/kicad_tools/schematic/blocks/__init__.py
@@ -85,12 +85,14 @@ from .mcu import (
 
 # Motor control blocks
 from .motor import (
+    BootstrapCapacitorArray,
     CurrentSenseShunt,
     GateDriverBlock,
     GateDriveResistorArray,
     HalfBridge,
     ThreePhaseInverter,
     create_3phase_inverter,
+    create_bootstrap_capacitor_array,
     create_current_sense,
     create_gate_drive_resistor_array,
     create_half_bridge,
@@ -210,10 +212,12 @@ __all__ = [
     "CurrentSenseShunt",
     "GateDriverBlock",
     "GateDriveResistorArray",
+    "BootstrapCapacitorArray",
     "create_half_bridge",
     "create_3phase_inverter",
     "create_current_sense",
     "create_gate_drive_resistor_array",
+    "create_bootstrap_capacitor_array",
     # Analog
     "ADCInputFilterBlock",
     "OpAmpBlock",

--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -640,6 +640,145 @@ class CurrentSenseShunt(CircuitBlock):
             return float(value)
 
 
+class BootstrapCapacitorArray(CircuitBlock):
+    """
+    N-phase array of bootstrap capacitors for driver-IC topologies.
+
+    Each phase has a single bootstrap capacitor between its high-side
+    bootstrap node (e.g. ``BST_A``) and the corresponding switch-node
+    return (e.g. ``PHASE_A``).  Unlike :class:`HalfBridge`'s built-in
+    bootstrap (which adds a diode for discrete-MOSFET designs), this
+    block targets driver ICs that already have an internal bootstrap
+    pin and only need the external cap.
+
+    Schematic (3-phase example):
+        BST_A ─┬─    BST_B ─┬─    BST_C ─┬─
+               │            │            │
+              [C1]         [C2]         [C3]
+               │            │            │
+        PHASE_A┴     PHASE_B┴     PHASE_C┴
+
+    Ports per phase ``i`` in ``[0, phases)``:
+        - ``HIGH_<label>``: Bootstrap node (cap pin 1).
+        - ``PHASE_<label>``: Switch-node return (cap pin 2).
+
+    Components are stored as ``self.caps`` (list[Symbol]) and keyed in
+    ``self.components`` as ``C_BOOT_<label>``.
+
+    The block does NOT call any rail-connect helper -- wiring is left
+    to the caller, consistent with :class:`DecouplingCaps`.
+
+    Example:
+        from kicad_tools.schematic.blocks import (
+            create_bootstrap_capacitor_array,
+        )
+
+        boot = create_bootstrap_capacitor_array(
+            sch, x=80, y=60,
+            phases=3,
+            value="100nF",
+            cap_ref_start=12,        # C12, C13, C14
+            high_nets=["BST_A", "BST_B", "BST_C"],
+            phase_nets=["PHASE_A", "PHASE_B", "PHASE_C"],
+        )
+    """
+
+    def __init__(
+        self,
+        sch: "Schematic",
+        x: float,
+        y: float,
+        phases: int = 3,
+        value: str = "100nF",
+        phase_labels: list[str] | None = None,
+        high_nets: list[str] | None = None,
+        phase_nets: list[str] | None = None,
+        cap_ref_start: int = 1,
+        cap_ref_prefix: str = "C",
+        cap_symbol: str = "Device:C",
+        cap_spacing: float = 10,
+    ):
+        """
+        Create an N-phase bootstrap capacitor array.
+
+        Args:
+            sch: Schematic to add to.
+            x: X coordinate of the first capacitor.
+            y: Y coordinate of all capacitors.
+            phases: Number of bootstrap capacitors (default 3).
+            value: Capacitor value, applied to every cap (default "100nF").
+            phase_labels: Per-phase labels.  Defaults to
+                ``["A", "B", "C"][:phases]`` when ``phases <= 3``,
+                otherwise ``[str(i) for i in range(phases)]``.
+            high_nets: Optional per-phase net names for the high
+                (bootstrap) side.  If provided, ``add_label`` is called
+                at each cap's pin 1.  Length must equal ``phases``.
+            phase_nets: Optional per-phase net names for the
+                switch-node return.  If provided, ``add_label`` is
+                called at each cap's pin 2.  Length must equal
+                ``phases``.
+            cap_ref_start: Reference number for the first capacitor
+                (default 1).
+            cap_ref_prefix: Reference prefix (default "C").
+            cap_symbol: KiCad symbol for capacitors (default "Device:C").
+            cap_spacing: Horizontal spacing between caps (default 10).
+
+        Raises:
+            ValueError: If ``phases`` < 1, or if ``phase_labels``,
+                ``high_nets``, or ``phase_nets`` have mismatched length.
+        """
+        super().__init__(sch, x, y)
+
+        if phases < 1:
+            raise ValueError(f"phases must be >= 1, got {phases}")
+
+        # Default labels: A/B/C for small phase counts, integers otherwise
+        if phase_labels is None:
+            if phases <= 3:
+                phase_labels = ["A", "B", "C"][:phases]
+            else:
+                phase_labels = [str(i) for i in range(phases)]
+        elif len(phase_labels) != phases:
+            raise ValueError(
+                f"phase_labels length {len(phase_labels)} != phases {phases}"
+            )
+
+        if high_nets is not None and len(high_nets) != phases:
+            raise ValueError(
+                f"high_nets length {len(high_nets)} != phases {phases}"
+            )
+        if phase_nets is not None and len(phase_nets) != phases:
+            raise ValueError(
+                f"phase_nets length {len(phase_nets)} != phases {phases}"
+            )
+
+        self.phases = phases
+        self.phase_labels = phase_labels
+        self.value = value
+        self.caps: list = []
+        self.components = {}
+        self.ports = {}
+
+        for i, label in enumerate(phase_labels):
+            cap_x = x + i * cap_spacing
+            cap_ref = f"{cap_ref_prefix}{cap_ref_start + i}"
+            cap = sch.add_symbol(cap_symbol, cap_x, y, cap_ref, value)
+            self.caps.append(cap)
+            self.components[f"C_BOOT_{label}"] = cap
+
+            high_pos = cap.pin_position("1")
+            phase_pos = cap.pin_position("2")
+
+            self.ports[f"HIGH_{label}"] = high_pos
+            self.ports[f"PHASE_{label}"] = phase_pos
+
+            # Optionally drive labels for net naming
+            if high_nets is not None:
+                sch.add_label(high_nets[i], high_pos[0], high_pos[1], rotation=0)
+            if phase_nets is not None:
+                sch.add_label(phase_nets[i], phase_pos[0], phase_pos[1], rotation=0)
+
+
 class GateDriverBlock(CircuitBlock):
     """
     Gate driver IC block with bootstrap capacitors.
@@ -697,7 +836,7 @@ class GateDriverBlock(CircuitBlock):
         ref: str = "U1",
         value: str = "DRV8301",
         driver_symbol: str | None = None,
-        bootstrap_caps: str = "100nF",
+        bootstrap_caps: str | None = "100nF",
         bypass_caps: list[str] | None = None,
         cap_ref_start: int = 1,
     ):
@@ -712,7 +851,9 @@ class GateDriverBlock(CircuitBlock):
             ref: Reference designator for driver IC
             value: Driver IC part number
             driver_symbol: KiCad symbol (auto-selected based on driver_type if None)
-            bootstrap_caps: Bootstrap capacitor value per phase
+            bootstrap_caps: Bootstrap capacitor value per phase (None to omit).
+                When non-None, an internal :class:`BootstrapCapacitorArray`
+                is composed and exposed via ``self._bootstrap_block``.
             bypass_caps: Bypass capacitor values (default: ["10uF", "100nF"])
             cap_ref_start: Starting reference number for capacitors
         """
@@ -738,15 +879,26 @@ class GateDriverBlock(CircuitBlock):
         num_phases = 3 if driver_type == "3-phase" else 1
         phase_labels = ["A", "B", "C"][:num_phases]
 
-        # Add bootstrap capacitors
-        self.bootstrap_caps = []
-        for i in range(num_phases):
-            cap_ref = f"C{cap_ref_start + i}"
-            cap_x = x - 20 + i * 10
-            cap_y = y - 15
-            cap = sch.add_symbol("Device:C", cap_x, cap_y, cap_ref, bootstrap_caps)
-            self.bootstrap_caps.append(cap)
-            self.components[f"C_BOOT_{phase_labels[i]}"] = cap
+        # Add bootstrap capacitors via BootstrapCapacitorArray composition.
+        # We expose self.bootstrap_caps as the underlying caps list for
+        # back-compat with tests that assert len(driver.bootstrap_caps) == N.
+        self._bootstrap_block: BootstrapCapacitorArray | None = None
+        if bootstrap_caps is not None:
+            self._bootstrap_block = BootstrapCapacitorArray(
+                sch,
+                x=x - 20,
+                y=y - 15,
+                phases=num_phases,
+                value=bootstrap_caps,
+                phase_labels=phase_labels,
+                cap_ref_start=cap_ref_start,
+            )
+            self.bootstrap_caps = self._bootstrap_block.caps
+            # Merge bootstrap components into our components dict
+            for name, comp in self._bootstrap_block.components.items():
+                self.components[name] = comp
+        else:
+            self.bootstrap_caps = []
 
         # Add bypass capacitors
         self.bypass_caps = []
@@ -774,6 +926,14 @@ class GateDriverBlock(CircuitBlock):
             self.ports[f"PWM_H_{label}"] = (x + offset - 30, y + 5)
             self.ports[f"PWM_L_{label}"] = (x + offset - 30, y + 10)
 
+        # Re-expose bootstrap-array ports so callers can wire HIGH_<label>
+        # / PHASE_<label> to BST_<label> / PHASE_<label> nets.
+        if self._bootstrap_block is not None:
+            for name, pos in self._bootstrap_block.ports.items():
+                # Avoid clobbering driver ports if names ever collide
+                if name not in self.ports:
+                    self.ports[name] = pos
+
     def connect_to_rails(
         self,
         vcc_rail_y: float,
@@ -796,6 +956,65 @@ class GateDriverBlock(CircuitBlock):
 
 
 # Factory functions
+
+
+def create_bootstrap_capacitor_array(
+    sch: "Schematic",
+    x: float,
+    y: float,
+    phases: int = 3,
+    value: str = "100nF",
+    phase_labels: list[str] | None = None,
+    high_nets: list[str] | None = None,
+    phase_nets: list[str] | None = None,
+    cap_ref_start: int = 1,
+    cap_ref_prefix: str = "C",
+    cap_symbol: str = "Device:C",
+    cap_spacing: float = 10,
+) -> BootstrapCapacitorArray:
+    """
+    Create an N-phase bootstrap capacitor array (driver-IC topology).
+
+    This is a thin wrapper around :class:`BootstrapCapacitorArray`
+    that provides a discoverable factory entry point alongside the
+    other ``create_*`` helpers in this module.
+
+    Args:
+        sch: Schematic to add to.
+        x: X coordinate of the first capacitor.
+        y: Y coordinate of all capacitors.
+        phases: Number of bootstrap capacitors (default 3).
+        value: Capacitor value, applied to every cap (default "100nF").
+        phase_labels: Per-phase labels.  Defaults to A/B/C for
+            ``phases <= 3``, integer strings otherwise.
+        high_nets: Optional per-phase net names for the high
+            (bootstrap) side (e.g. ``["BST_A", "BST_B", "BST_C"]``).
+            Length must equal ``phases``.
+        phase_nets: Optional per-phase net names for the switch-node
+            return.  Length must equal ``phases``.
+        cap_ref_start: Reference number for the first capacitor
+            (default 1).
+        cap_ref_prefix: Reference prefix (default "C").
+        cap_symbol: KiCad symbol for capacitors (default "Device:C").
+        cap_spacing: Horizontal spacing between caps (default 10).
+
+    Returns:
+        :class:`BootstrapCapacitorArray` instance.
+    """
+    return BootstrapCapacitorArray(
+        sch,
+        x,
+        y,
+        phases=phases,
+        value=value,
+        phase_labels=phase_labels,
+        high_nets=high_nets,
+        phase_nets=phase_nets,
+        cap_ref_start=cap_ref_start,
+        cap_ref_prefix=cap_ref_prefix,
+        cap_symbol=cap_symbol,
+        cap_spacing=cap_spacing,
+    )
 
 
 def create_half_bridge(

--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -739,18 +739,12 @@ class BootstrapCapacitorArray(CircuitBlock):
             else:
                 phase_labels = [str(i) for i in range(phases)]
         elif len(phase_labels) != phases:
-            raise ValueError(
-                f"phase_labels length {len(phase_labels)} != phases {phases}"
-            )
+            raise ValueError(f"phase_labels length {len(phase_labels)} != phases {phases}")
 
         if high_nets is not None and len(high_nets) != phases:
-            raise ValueError(
-                f"high_nets length {len(high_nets)} != phases {phases}"
-            )
+            raise ValueError(f"high_nets length {len(high_nets)} != phases {phases}")
         if phase_nets is not None and len(phase_nets) != phases:
-            raise ValueError(
-                f"phase_nets length {len(phase_nets)} != phases {phases}"
-            )
+            raise ValueError(f"phase_nets length {len(phase_nets)} != phases {phases}")
 
         self.phases = phases
         self.phase_labels = phase_labels
@@ -772,11 +766,19 @@ class BootstrapCapacitorArray(CircuitBlock):
             self.ports[f"HIGH_{label}"] = high_pos
             self.ports[f"PHASE_{label}"] = phase_pos
 
-            # Optionally drive labels for net naming
+            # Optionally drive labels for net naming.  ERC requires labels
+            # to attach to wires, so we draw a short stub from each pin
+            # to the label position (matches ThreePhaseInverter convention).
             if high_nets is not None:
-                sch.add_label(high_nets[i], high_pos[0], high_pos[1], rotation=0)
+                stub_x = high_pos[0]
+                stub_y = high_pos[1] - 2.54
+                sch.add_wire(high_pos, (stub_x, stub_y), warn_on_collision=False)
+                sch.add_label(high_nets[i], stub_x, stub_y, rotation=0)
             if phase_nets is not None:
-                sch.add_label(phase_nets[i], phase_pos[0], phase_pos[1], rotation=0)
+                stub_x = phase_pos[0]
+                stub_y = phase_pos[1] + 2.54
+                sch.add_wire(phase_pos, (stub_x, stub_y), warn_on_collision=False)
+                sch.add_label(phase_nets[i], stub_x, stub_y, rotation=0)
 
 
 class GateDriverBlock(CircuitBlock):

--- a/tests/test_blocks_bootstrap_cap_array.py
+++ b/tests/test_blocks_bootstrap_cap_array.py
@@ -1,0 +1,260 @@
+"""Tests for BootstrapCapacitorArray block and create_bootstrap_capacitor_array factory."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from kicad_tools.schematic.blocks import (
+    BootstrapCapacitorArray,
+    GateDriverBlock,
+    create_bootstrap_capacitor_array,
+)
+
+
+@pytest.fixture
+def mock_schematic():
+    """Create mock schematic for tests.
+
+    Same pattern as TestGateDriverBlockMocked in test_schematic_blocks.py.
+    """
+    sch = Mock()
+
+    def create_mock_component(symbol, x, y, ref, *args, **kwargs):
+        comp = Mock()
+        comp.ref = ref
+        comp.value = args[0] if args else kwargs.get("value")
+        comp.x = x
+        comp.y = y
+        comp.pin_position.side_effect = lambda name: {
+            "1": (x, y - 5),
+            "2": (x, y + 5),
+        }.get(name, (x, y))
+        return comp
+
+    sch.add_symbol = Mock(side_effect=create_mock_component)
+    sch.add_wire = Mock()
+    sch.add_junction = Mock()
+    sch.add_label = Mock()
+    sch.add_text = Mock()
+    sch.wire_decoupling_cap = Mock()
+    return sch
+
+
+class TestBootstrapCapacitorArrayMocked:
+    """Tests for BootstrapCapacitorArray with mocked schematic."""
+
+    def test_default_3_phase(self, mock_schematic):
+        """Default phases=3 creates 3 caps with default labels A/B/C, value 100nF."""
+        block = create_bootstrap_capacitor_array(mock_schematic, x=0, y=0)
+
+        assert block.phases == 3
+        assert block.phase_labels == ["A", "B", "C"]
+        assert len(block.caps) == 3
+        # Verify each cap got the default value
+        for cap in block.caps:
+            assert cap.value == "100nF"
+        # Verify component dict keys
+        assert "C_BOOT_A" in block.components
+        assert "C_BOOT_B" in block.components
+        assert "C_BOOT_C" in block.components
+
+    def test_phase_count_1(self, mock_schematic):
+        """phases=1 creates exactly 1 cap, label A."""
+        block = create_bootstrap_capacitor_array(mock_schematic, x=0, y=0, phases=1)
+
+        assert block.phases == 1
+        assert block.phase_labels == ["A"]
+        assert len(block.caps) == 1
+        assert "C_BOOT_A" in block.components
+
+    def test_phase_count_2(self, mock_schematic):
+        """phases=2 creates 2 caps, labels A, B."""
+        block = create_bootstrap_capacitor_array(mock_schematic, x=0, y=0, phases=2)
+
+        assert block.phases == 2
+        assert block.phase_labels == ["A", "B"]
+        assert len(block.caps) == 2
+        assert "C_BOOT_A" in block.components
+        assert "C_BOOT_B" in block.components
+
+    def test_phase_count_6(self, mock_schematic):
+        """phases=6 creates 6 caps with integer-style labels '0'..'5'."""
+        block = create_bootstrap_capacitor_array(mock_schematic, x=0, y=0, phases=6)
+
+        assert block.phases == 6
+        assert block.phase_labels == ["0", "1", "2", "3", "4", "5"]
+        assert len(block.caps) == 6
+        for label in ["0", "1", "2", "3", "4", "5"]:
+            assert f"C_BOOT_{label}" in block.components
+
+    def test_custom_phase_labels(self, mock_schematic):
+        """Custom phase_labels=['U','V','W'] yields C_BOOT_U/V/W keys."""
+        block = create_bootstrap_capacitor_array(
+            mock_schematic,
+            x=0,
+            y=0,
+            phases=3,
+            phase_labels=["U", "V", "W"],
+        )
+
+        assert block.phase_labels == ["U", "V", "W"]
+        assert "C_BOOT_U" in block.components
+        assert "C_BOOT_V" in block.components
+        assert "C_BOOT_W" in block.components
+
+    def test_custom_value(self, mock_schematic):
+        """value='220nF' applied to all caps via add_symbol."""
+        block = create_bootstrap_capacitor_array(
+            mock_schematic, x=0, y=0, phases=3, value="220nF"
+        )
+
+        assert block.value == "220nF"
+        # Verify all add_symbol calls received "220nF" as the value
+        # (positional arg 4: symbol, x, y, ref, value)
+        for call in mock_schematic.add_symbol.call_args_list:
+            args, kwargs = call
+            assert args[4] == "220nF"
+
+    def test_cap_ref_start(self, mock_schematic):
+        """cap_ref_start=12 yields refs C12, C13, C14."""
+        create_bootstrap_capacitor_array(
+            mock_schematic, x=0, y=0, phases=3, cap_ref_start=12
+        )
+
+        # Pull the ref (positional arg 3) from each add_symbol call
+        refs = [call.args[3] for call in mock_schematic.add_symbol.call_args_list]
+        assert refs == ["C12", "C13", "C14"]
+
+    def test_cap_ref_prefix(self, mock_schematic):
+        """cap_ref_prefix='CB' yields refs CB1, CB2, CB3."""
+        create_bootstrap_capacitor_array(
+            mock_schematic, x=0, y=0, phases=3, cap_ref_prefix="CB"
+        )
+
+        refs = [call.args[3] for call in mock_schematic.add_symbol.call_args_list]
+        assert refs == ["CB1", "CB2", "CB3"]
+
+    def test_ports(self, mock_schematic):
+        """Default 3-phase block exposes HIGH_A/B/C and PHASE_A/B/C ports."""
+        block = create_bootstrap_capacitor_array(mock_schematic, x=0, y=0)
+
+        for label in ["A", "B", "C"]:
+            assert f"HIGH_{label}" in block.ports
+            assert f"PHASE_{label}" in block.ports
+
+    def test_phase_nets_validation(self, mock_schematic):
+        """phase_nets length mismatch raises ValueError."""
+        with pytest.raises(ValueError, match="phase_nets"):
+            create_bootstrap_capacitor_array(
+                mock_schematic, x=0, y=0, phases=3, phase_nets=["X"]
+            )
+
+    def test_high_nets_validation(self, mock_schematic):
+        """high_nets length mismatch raises ValueError."""
+        with pytest.raises(ValueError, match="high_nets"):
+            create_bootstrap_capacitor_array(
+                mock_schematic, x=0, y=0, phases=3, high_nets=["A", "B"]
+            )
+
+    def test_phase_labels_validation(self, mock_schematic):
+        """phase_labels length mismatch raises ValueError."""
+        with pytest.raises(ValueError, match="phase_labels"):
+            create_bootstrap_capacitor_array(
+                mock_schematic, x=0, y=0, phases=3, phase_labels=["A", "B"]
+            )
+
+    def test_invalid_phases(self, mock_schematic):
+        """phases < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="phases"):
+            create_bootstrap_capacitor_array(mock_schematic, x=0, y=0, phases=0)
+
+    def test_cap_spacing(self, mock_schematic):
+        """Caps are placed at x, x+spacing, x+2*spacing."""
+        create_bootstrap_capacitor_array(
+            mock_schematic, x=100, y=50, phases=3, cap_spacing=15
+        )
+
+        # Pull positional x argument (index 1) from each add_symbol call
+        xs = [call.args[1] for call in mock_schematic.add_symbol.call_args_list]
+        assert xs == [100, 115, 130]
+
+        # All caps share the same y
+        ys = [call.args[2] for call in mock_schematic.add_symbol.call_args_list]
+        assert ys == [50, 50, 50]
+
+    def test_high_nets_creates_labels(self, mock_schematic):
+        """high_nets triggers add_label at each cap pin 1."""
+        create_bootstrap_capacitor_array(
+            mock_schematic,
+            x=0,
+            y=0,
+            phases=3,
+            high_nets=["BST_A", "BST_B", "BST_C"],
+        )
+
+        # Verify add_label was called with each net name
+        label_names = [call.args[0] for call in mock_schematic.add_label.call_args_list]
+        assert "BST_A" in label_names
+        assert "BST_B" in label_names
+        assert "BST_C" in label_names
+
+    def test_phase_nets_creates_labels(self, mock_schematic):
+        """phase_nets triggers add_label at each cap pin 2."""
+        create_bootstrap_capacitor_array(
+            mock_schematic,
+            x=0,
+            y=0,
+            phases=3,
+            phase_nets=["PHASE_A", "PHASE_B", "PHASE_C"],
+        )
+
+        label_names = [call.args[0] for call in mock_schematic.add_label.call_args_list]
+        assert "PHASE_A" in label_names
+        assert "PHASE_B" in label_names
+        assert "PHASE_C" in label_names
+
+    def test_no_labels_when_nets_none(self, mock_schematic):
+        """When neither high_nets nor phase_nets is provided, add_label is not called."""
+        create_bootstrap_capacitor_array(mock_schematic, x=0, y=0, phases=3)
+        assert mock_schematic.add_label.call_count == 0
+
+    def test_returns_bootstrap_array_instance(self, mock_schematic):
+        """Factory returns a BootstrapCapacitorArray."""
+        block = create_bootstrap_capacitor_array(mock_schematic, x=0, y=0)
+        assert isinstance(block, BootstrapCapacitorArray)
+
+
+class TestGateDriverBlockComposition:
+    """Verify GateDriverBlock composes BootstrapCapacitorArray internally."""
+
+    def test_gate_driver_uses_bootstrap_array(self, mock_schematic):
+        """GateDriverBlock(bootstrap_caps='100nF') composes a BootstrapCapacitorArray.
+
+        Back-compat: len(driver.bootstrap_caps) == 3 must still hold.
+        """
+        driver = GateDriverBlock(
+            mock_schematic,
+            x=100,
+            y=100,
+            driver_type="3-phase",
+            value="DRV8301",
+            bootstrap_caps="100nF",
+        )
+
+        # Composition: an internal _bootstrap_block attribute exists
+        assert hasattr(driver, "_bootstrap_block")
+        assert isinstance(driver._bootstrap_block, BootstrapCapacitorArray)
+
+        # Back-compat with existing tests
+        assert len(driver.bootstrap_caps) == 3
+
+    def test_gate_driver_half_bridge_composition(self, mock_schematic):
+        """Half-bridge gate driver composes a 1-phase BootstrapCapacitorArray."""
+        driver = GateDriverBlock(
+            mock_schematic, x=100, y=100, driver_type="half-bridge"
+        )
+
+        assert hasattr(driver, "_bootstrap_block")
+        assert isinstance(driver._bootstrap_block, BootstrapCapacitorArray)
+        assert driver._bootstrap_block.phases == 1
+        assert len(driver.bootstrap_caps) == 1

--- a/tests/test_blocks_bootstrap_cap_array.py
+++ b/tests/test_blocks_bootstrap_cap_array.py
@@ -104,9 +104,7 @@ class TestBootstrapCapacitorArrayMocked:
 
     def test_custom_value(self, mock_schematic):
         """value='220nF' applied to all caps via add_symbol."""
-        block = create_bootstrap_capacitor_array(
-            mock_schematic, x=0, y=0, phases=3, value="220nF"
-        )
+        block = create_bootstrap_capacitor_array(mock_schematic, x=0, y=0, phases=3, value="220nF")
 
         assert block.value == "220nF"
         # Verify all add_symbol calls received "220nF" as the value
@@ -117,9 +115,7 @@ class TestBootstrapCapacitorArrayMocked:
 
     def test_cap_ref_start(self, mock_schematic):
         """cap_ref_start=12 yields refs C12, C13, C14."""
-        create_bootstrap_capacitor_array(
-            mock_schematic, x=0, y=0, phases=3, cap_ref_start=12
-        )
+        create_bootstrap_capacitor_array(mock_schematic, x=0, y=0, phases=3, cap_ref_start=12)
 
         # Pull the ref (positional arg 3) from each add_symbol call
         refs = [call.args[3] for call in mock_schematic.add_symbol.call_args_list]
@@ -127,9 +123,7 @@ class TestBootstrapCapacitorArrayMocked:
 
     def test_cap_ref_prefix(self, mock_schematic):
         """cap_ref_prefix='CB' yields refs CB1, CB2, CB3."""
-        create_bootstrap_capacitor_array(
-            mock_schematic, x=0, y=0, phases=3, cap_ref_prefix="CB"
-        )
+        create_bootstrap_capacitor_array(mock_schematic, x=0, y=0, phases=3, cap_ref_prefix="CB")
 
         refs = [call.args[3] for call in mock_schematic.add_symbol.call_args_list]
         assert refs == ["CB1", "CB2", "CB3"]
@@ -145,9 +139,7 @@ class TestBootstrapCapacitorArrayMocked:
     def test_phase_nets_validation(self, mock_schematic):
         """phase_nets length mismatch raises ValueError."""
         with pytest.raises(ValueError, match="phase_nets"):
-            create_bootstrap_capacitor_array(
-                mock_schematic, x=0, y=0, phases=3, phase_nets=["X"]
-            )
+            create_bootstrap_capacitor_array(mock_schematic, x=0, y=0, phases=3, phase_nets=["X"])
 
     def test_high_nets_validation(self, mock_schematic):
         """high_nets length mismatch raises ValueError."""
@@ -170,9 +162,7 @@ class TestBootstrapCapacitorArrayMocked:
 
     def test_cap_spacing(self, mock_schematic):
         """Caps are placed at x, x+spacing, x+2*spacing."""
-        create_bootstrap_capacitor_array(
-            mock_schematic, x=100, y=50, phases=3, cap_spacing=15
-        )
+        create_bootstrap_capacitor_array(mock_schematic, x=100, y=50, phases=3, cap_spacing=15)
 
         # Pull positional x argument (index 1) from each add_symbol call
         xs = [call.args[1] for call in mock_schematic.add_symbol.call_args_list]
@@ -250,9 +240,7 @@ class TestGateDriverBlockComposition:
 
     def test_gate_driver_half_bridge_composition(self, mock_schematic):
         """Half-bridge gate driver composes a 1-phase BootstrapCapacitorArray."""
-        driver = GateDriverBlock(
-            mock_schematic, x=100, y=100, driver_type="half-bridge"
-        )
+        driver = GateDriverBlock(mock_schematic, x=100, y=100, driver_type="half-bridge")
 
         assert hasattr(driver, "_bootstrap_block")
         assert isinstance(driver._bootstrap_block, BootstrapCapacitorArray)


### PR DESCRIPTION
## Summary

Adds `BootstrapCapacitorArray` (CircuitBlock subclass) and the factory
`create_bootstrap_capacitor_array()` for the driver-IC bootstrap
topology (`BST_x` -> `PHASE_x` external cap). Distinct from
`HalfBridge`'s discrete-MOSFET bootstrap, which also adds a diode and
remains untouched.

`GateDriverBlock` is refactored to compose `BootstrapCapacitorArray`
internally when `bootstrap_caps` is non-None, with `self.bootstrap_caps`
re-exposed as the underlying caps list to preserve the existing test
expectations (`len(driver.bootstrap_caps) == N`).

Board 05 is refactored to use the new factory explicitly:
- `GateDriverBlock(bootstrap_caps=None, cap_ref_start=15)` — bypass
  caps move directly to C15-C16.
- `create_bootstrap_capacitor_array(cap_ref_start=12, high_nets=BST_*,
  phase_nets=PHASE_*)` — bootstrap caps remain at C12-C14, preserving
  existing PCB-side ref numbering and layout.

## Closes

Closes #2565

## API

```python
create_bootstrap_capacitor_array(
    sch, x, y,
    phases: int = 3,
    value: str = "100nF",
    phase_labels: list[str] | None = None,    # A/B/C for <=3, "0".."N-1" otherwise
    high_nets: list[str] | None = None,        # per-phase BST nets (separate, not shared)
    phase_nets: list[str] | None = None,       # per-phase switch-node nets
    cap_ref_start: int = 1,
    cap_ref_prefix: str = "C",
    cap_symbol: str = "Device:C",
    cap_spacing: float = 10,
) -> BootstrapCapacitorArray
```

Per-phase ports: `HIGH_<label>` (cap pin 1) and `PHASE_<label>` (cap pin 2).
When `high_nets` / `phase_nets` are provided, the block draws a short
2.54mm stub wire from each cap pin to the label position so that ERC
recognizes the label-to-net binding (matches `ThreePhaseInverter`'s
convention).

## Test plan

- [x] `tests/test_blocks_bootstrap_cap_array.py` — 20 new tests covering
      phase counts (1, 2, 3, 6), label defaults (A/B/C and integer fallback),
      custom labels/values, ref numbering, port exposure, validation
      errors, cap spacing, label-driven net naming, and `GateDriverBlock`
      composition back-compat (`_bootstrap_block` attribute,
      `len(bootstrap_caps) == 3` and `== 1`).
- [x] `tests/test_schematic_blocks.py::TestGateDriverBlockMocked` — all 4
      existing tests pass without modification (back-compat preserved).
- [x] All 298 tests in `tests/test_schematic_blocks.py` and
      `tests/test_blocks_bootstrap_cap_array.py` pass locally.
- [x] All 7 tests in `tests/test_kicad_cli_roundtrip.py` (PR #2507's
      smoke tests) pass — board 05 emits a valid PCB.
- [x] Board 05 schematic generation: 32 errors / 5 warnings — identical
      to pre-PR baseline. (Without the stub-wire fix, refactor would
      have introduced 6 new label-not-attached-to-wire ERC errors.)
- [x] Board 05 schematic still contains C12, C13, C14 with value 100nF
      and labels BST_A/B/C + PHASE_A/B/C as expected.
- [x] `uv run ruff check` on all modified files: clean.

## Incremental commits (per #2547)

1. `feat(blocks): create_bootstrap_capacitor_array - N-phase bootstrap
   cap network` — class + factory + `__init__` exports + 20 tests +
   GateDriverBlock refactor.
2. `feat(boards/05): use create_bootstrap_capacitor_array for C12-C14`
   — board 05 call-site refactor + stub-wire fix in
   `BootstrapCapacitorArray` (uncovered by integrating with real ERC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)