### PR TITLE
feat(blocks): create_mcu_decoupling_array — multi-pin VDD decoupling factory (closes #2566)

### DIFF
--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -35,6 +35,7 @@ from kicad_tools.schematic.blocks import (
     DebugHeader,
     LEDIndicator,
     create_gpio_pull_resistor,
+    create_mcu_decoupling_array,
 )
 from kicad_tools.schematic.models.schematic import Schematic
 
@@ -239,50 +240,20 @@ def create_stm32_schematic(output_dir: Path) -> Path:
 
     print("   Wired MCU VDD/VBAT/VDDA to +3.3V and VSS/VSSA to GND")
 
-    # MCU decoupling caps (one per VDD/VBAT/VDDA pin, plus a bulk cap)
+    # MCU decoupling caps (one per VDD/VBAT/VDDA pin, plus a bulk cap).
     # Place between MCU and 3.3V rail, on the left side of the symbol.
-    c_dec1 = sch.add_symbol(
-        "Device:C_Small",
+    # Produces C12-C15 (100nF) at x=160,170,180,190 and C16 (4.7uF) at x=200.
+    mcu_decoupling = create_mcu_decoupling_array(
+        sch,
         x=160,
         y=85,
-        ref="C12",
-        value="100nF",
-        footprint="Capacitor_SMD:C_0805_2012Metric",
+        supply_pins=4,
+        ref_start=12,
+        spacing=10,
+        cap_symbol="Device:C_Small",
+        cap_footprint="Capacitor_SMD:C_0805_2012Metric",
     )
-    c_dec2 = sch.add_symbol(
-        "Device:C_Small",
-        x=170,
-        y=85,
-        ref="C13",
-        value="100nF",
-        footprint="Capacitor_SMD:C_0805_2012Metric",
-    )
-    c_dec3 = sch.add_symbol(
-        "Device:C_Small",
-        x=180,
-        y=85,
-        ref="C14",
-        value="100nF",
-        footprint="Capacitor_SMD:C_0805_2012Metric",
-    )
-    c_dec4 = sch.add_symbol(
-        "Device:C_Small",
-        x=190,
-        y=85,
-        ref="C15",
-        value="100nF",
-        footprint="Capacitor_SMD:C_0805_2012Metric",
-    )
-    c_bulk = sch.add_symbol(
-        "Device:C_Small",
-        x=200,
-        y=85,
-        ref="C16",
-        value="4.7uF",
-        footprint="Capacitor_SMD:C_0805_2012Metric",
-    )
-    for cap in (c_dec1, c_dec2, c_dec3, c_dec4, c_bulk):
-        sch.wire_decoupling_cap(cap, RAIL_3V3, RAIL_GND)
+    mcu_decoupling.connect_to_rails(RAIL_3V3, RAIL_GND)
     print("   C12-C15 (100nF) + C16 (4.7uF) bypass caps")
 
     # =========================================================================

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -40,6 +40,7 @@ from kicad_tools.schematic.blocks import (
     ThreePhaseInverter,
     create_5v_buck,
     create_gate_drive_resistor_array,
+    create_mcu_decoupling_array,
 )
 from kicad_tools.schematic.models.schematic import Schematic
 
@@ -303,14 +304,23 @@ def create_bldc_controller(output_dir: Path) -> Path:
     # =========================================================================
     print("\n5. Adding MCU section...")
 
-    # Bypass capacitors for MCU (placed first so we can wire later)
-    c_mcu1 = sch.add_symbol("Device:C", x=X_MCU, y=100, ref="C7", value="100nF", footprint="Capacitor_SMD:C_0805_2012Metric")
-    c_mcu2 = sch.add_symbol("Device:C", x=X_MCU + 10, y=100, ref="C8", value="100nF", footprint="Capacitor_SMD:C_0805_2012Metric")
-    c_mcu3 = sch.add_symbol("Device:C", x=X_MCU + 20, y=100, ref="C9", value="4.7uF", footprint="Capacitor_SMD:C_0805_2012Metric")
+    # Bypass capacitors for MCU (placed first so we can wire later).
+    # STM32G431K8Tx has 2 VDD + 1 VDDA = 3 supply pins, but historically this
+    # board uses only 2 bypass caps + 1 bulk cap (C7/C8/C9); preserve that.
+    mcu_decoupling = create_mcu_decoupling_array(
+        sch,
+        x=X_MCU,
+        y=100,
+        supply_pins=2,
+        ref_start=7,
+        spacing=10,
+        cap_symbol="Device:C",
+        cap_footprint="Capacitor_SMD:C_0805_2012Metric",
+    )
+    c_mcu1, c_mcu2, c_mcu3 = mcu_decoupling.caps
     print(f"   Bypass caps: {c_mcu1.reference}, {c_mcu2.reference}, {c_mcu3.reference}")
 
-    for cap in [c_mcu1, c_mcu2, c_mcu3]:
-        sch.wire_decoupling_cap(cap, RAIL_3V3, RAIL_GND)
+    mcu_decoupling.connect_to_rails(RAIL_3V3, RAIL_GND)
 
     # Place STM32G431K8Tx MCU (LQFP-32) below the bypass caps
     # The STM32G431K_6-8-B_Tx symbol body spans ~25mm wide x ~55mm tall.

--- a/src/kicad_tools/schematic/blocks/__init__.py
+++ b/src/kicad_tools/schematic/blocks/__init__.py
@@ -111,6 +111,7 @@ from .power import (
     create_12v_barrel_jack,
     create_12v_buck,
     create_lipo_battery,
+    create_mcu_decoupling_array,
     create_usb_power,
     create_voltage_divider,
 )
@@ -176,6 +177,7 @@ __all__ = [
     "create_12v_barrel_jack",
     "create_usb_power",
     "create_lipo_battery",
+    "create_mcu_decoupling_array",
     "create_voltage_divider",
     # Timing
     "OscillatorBlock",

--- a/src/kicad_tools/schematic/blocks/power/__init__.py
+++ b/src/kicad_tools/schematic/blocks/power/__init__.py
@@ -29,6 +29,7 @@ from .inputs import (
 from .passives import (
     DecouplingCaps,
     VoltageDivider,
+    create_mcu_decoupling_array,
     create_voltage_divider,
 )
 from .regulators import (
@@ -58,5 +59,6 @@ __all__ = [
     # Passives
     "DecouplingCaps",
     "VoltageDivider",
+    "create_mcu_decoupling_array",
     "create_voltage_divider",
 ]

--- a/src/kicad_tools/schematic/blocks/power/passives.py
+++ b/src/kicad_tools/schematic/blocks/power/passives.py
@@ -35,6 +35,7 @@ class DecouplingCaps(CircuitBlock):
         spacing: float = 15,
         cap_symbol: str = "Device:C",
         auto_footprint: bool = False,
+        cap_footprint: str | None = None,
     ):
         """
         Create a bank of decoupling capacitors.
@@ -49,6 +50,9 @@ class DecouplingCaps(CircuitBlock):
             spacing: Horizontal spacing between caps
             cap_symbol: KiCad symbol for capacitors
             auto_footprint: If True, automatically select footprint based on value
+            cap_footprint: Explicit footprint string (e.g.,
+                "Capacitor_SMD:C_0805_2012Metric"). Takes precedence over
+                auto_footprint when both are provided.
         """
         super().__init__(sch, x, y)
         self.caps = []
@@ -57,7 +61,10 @@ class DecouplingCaps(CircuitBlock):
         for i, value in enumerate(values):
             cap_x = x + i * spacing
             ref = f"{ref_prefix}{ref_start + i}"
-            cap = sch.add_symbol(cap_symbol, cap_x, y, ref, value, auto_footprint=auto_footprint)
+            add_kwargs: dict = {"auto_footprint": auto_footprint}
+            if cap_footprint is not None:
+                add_kwargs["footprint"] = cap_footprint
+            cap = sch.add_symbol(cap_symbol, cap_x, y, ref, value, **add_kwargs)
             self.caps.append(cap)
 
         self.components = {f"C{i + 1}": cap for i, cap in enumerate(self.caps)}
@@ -459,4 +466,97 @@ def create_voltage_divider(
         r_bottom=r_bottom_str,
         filter_cap="100nF" if with_filter else None,
         ref_start=ref_start,
+    )
+
+
+def create_mcu_decoupling_array(
+    sch: "Schematic",
+    x: float,
+    y: float,
+    *,
+    supply_pins: int,
+    bypass_value: str = "100nF",
+    bulk_value: str = "4.7uF",
+    ref_start: int = 1,
+    ref_prefix: str = "C",
+    spacing: float = 10,
+    cap_symbol: str = "Device:C",
+    cap_footprint: str | None = None,
+    auto_footprint: bool = False,
+) -> DecouplingCaps:
+    """
+    Create an MCU-style decoupling capacitor array (N bypass + 1 bulk).
+
+    Convenience factory that wraps :class:`DecouplingCaps` with the common
+    "one bypass cap per VDD/VBAT/VDDA pin plus a single bulk reservoir" pattern
+    used near MCUs. The first ``supply_pins`` caps share ``bypass_value`` and
+    the final cap uses ``bulk_value``.
+
+    The returned object is a regular :class:`DecouplingCaps` instance, so the
+    caller can chain ``.connect_to_rails(vcc_y, gnd_y)`` to wire each cap to
+    the power rails in the usual way.
+
+    Args:
+        sch: Schematic to add to.
+        x: X coordinate of the first capacitor.
+        y: Y coordinate (center of caps).
+        supply_pins: Number of bypass capacitors to place. Must be >= 1; the
+            total cap count is ``supply_pins + 1`` (one extra for the bulk).
+            Note that callers may legitimately use a value smaller than the
+            actual VDD pin count (e.g. board 05 uses ``supply_pins=2`` for a
+            3-VDD-pin MCU); the factory does not enforce a 1:1 ratio.
+        bypass_value: Value applied to the first ``supply_pins`` caps
+            (default ``"100nF"``).
+        bulk_value: Value applied to the final cap (default ``"4.7uF"``).
+        ref_start: Starting reference number (default 1).
+        ref_prefix: Reference designator prefix (default ``"C"``).
+        spacing: Horizontal spacing between caps in mm (default 10).
+        cap_symbol: KiCad symbol library id for capacitors (default
+            ``"Device:C"``). Boards using compact footprints typically pass
+            ``"Device:C_Small"``.
+        cap_footprint: Explicit footprint (e.g.
+            ``"Capacitor_SMD:C_0805_2012Metric"``). When ``None`` the symbol
+            footprint default is used.
+        auto_footprint: If ``True``, ``add_symbol`` will pick a footprint based
+            on the cap value and configured profile (ignored when
+            ``cap_footprint`` is provided).
+
+    Returns:
+        :class:`DecouplingCaps` instance with ``len(caps) == supply_pins + 1``.
+
+    Raises:
+        ValueError: If ``supply_pins < 1``. A zero-bypass array degenerates to
+            a single bulk cap, which almost always indicates a caller bug; use
+            :class:`DecouplingCaps` directly if you really want one cap.
+
+    Example:
+        >>> # Board 04 STM32F303 - 4 VDD/VBAT/VDDA pins + 1 bulk
+        >>> caps = create_mcu_decoupling_array(
+        ...     sch, x=160, y=85,
+        ...     supply_pins=4,
+        ...     ref_start=12,
+        ...     cap_symbol="Device:C_Small",
+        ...     cap_footprint="Capacitor_SMD:C_0805_2012Metric",
+        ... )
+        >>> caps.connect_to_rails(RAIL_3V3, RAIL_GND)
+    """
+    if supply_pins < 1:
+        raise ValueError(
+            f"supply_pins must be >= 1 (got {supply_pins}); "
+            "use DecouplingCaps directly for a bulk-only configuration"
+        )
+
+    values = [bypass_value] * supply_pins + [bulk_value]
+
+    return DecouplingCaps(
+        sch,
+        x,
+        y,
+        values=values,
+        ref_start=ref_start,
+        ref_prefix=ref_prefix,
+        spacing=spacing,
+        cap_symbol=cap_symbol,
+        auto_footprint=auto_footprint,
+        cap_footprint=cap_footprint,
     )

--- a/tests/test_schematic_blocks.py
+++ b/tests/test_schematic_blocks.py
@@ -47,6 +47,7 @@ from kicad_tools.schematic.blocks import (
     create_jtag_header,
     create_lipo_battery,
     create_mclk_oscillator,
+    create_mcu_decoupling_array,
     create_power_led,
     create_reset_button,
     create_status_led,
@@ -4456,3 +4457,222 @@ class TestPortMatchingTypeWarning:
         composed = left & right
         # Should have warnings about power-to-data mismatch
         assert len(composed.warnings) > 0
+
+
+class TestCreateMCUDecouplingArrayMocked:
+    """Tests for create_mcu_decoupling_array factory function."""
+
+    @pytest.fixture
+    def mock_schematic(self):
+        """Create mock schematic that records add_symbol calls."""
+        sch = Mock()
+
+        created_caps: list[dict] = []
+
+        def create_mock_cap(symbol, x, y, ref, value=None, *args, **kwargs):
+            cap = Mock()
+            cap.reference = ref
+            cap.value = value
+            cap.symbol = symbol
+            cap.footprint_kwarg = kwargs.get("footprint")
+            cap.auto_footprint = kwargs.get("auto_footprint", False)
+            cap.pin_position.side_effect = lambda name: {
+                "1": (x, y - 5),
+                "2": (x, y + 5),
+            }.get(name, (0, 0))
+            created_caps.append(
+                {
+                    "symbol": symbol,
+                    "x": x,
+                    "y": y,
+                    "ref": ref,
+                    "value": value,
+                    "kwargs": kwargs,
+                }
+            )
+            return cap
+
+        sch.add_symbol = Mock(side_effect=create_mock_cap)
+        sch.add_wire = Mock()
+        sch.wire_decoupling_cap = Mock()
+        sch._created_caps = created_caps
+        return sch
+
+    def test_factory_returns_decoupling_caps_instance(self, mock_schematic):
+        """Factory returns a DecouplingCaps instance."""
+        result = create_mcu_decoupling_array(
+            mock_schematic, x=160, y=85, supply_pins=4
+        )
+        assert isinstance(result, DecouplingCaps)
+
+    @pytest.mark.parametrize("supply_pins", [1, 2, 3, 4, 6, 8])
+    def test_factory_cap_count_matches_supply_plus_bulk(
+        self, mock_schematic, supply_pins
+    ):
+        """Cap count is supply_pins + 1 (one bulk)."""
+        result = create_mcu_decoupling_array(
+            mock_schematic, x=0, y=0, supply_pins=supply_pins
+        )
+        assert len(result.caps) == supply_pins + 1
+
+    def test_factory_bypass_values(self, mock_schematic):
+        """First N caps use bypass_value; last cap uses bulk_value."""
+        create_mcu_decoupling_array(
+            mock_schematic,
+            x=0,
+            y=0,
+            supply_pins=3,
+            bypass_value="100nF",
+            bulk_value="4.7uF",
+        )
+        caps = mock_schematic._created_caps
+        assert len(caps) == 4
+        # First 3 are bypass
+        assert caps[0]["value"] == "100nF"
+        assert caps[1]["value"] == "100nF"
+        assert caps[2]["value"] == "100nF"
+        # Last is bulk
+        assert caps[3]["value"] == "4.7uF"
+
+    def test_factory_default_values(self, mock_schematic):
+        """Default values are 100nF bypass and 4.7uF bulk."""
+        create_mcu_decoupling_array(
+            mock_schematic, x=0, y=0, supply_pins=2
+        )
+        caps = mock_schematic._created_caps
+        assert caps[0]["value"] == "100nF"
+        assert caps[1]["value"] == "100nF"
+        assert caps[2]["value"] == "4.7uF"
+
+    def test_factory_custom_values(self, mock_schematic):
+        """Custom bypass_value and bulk_value propagate."""
+        create_mcu_decoupling_array(
+            mock_schematic,
+            x=0,
+            y=0,
+            supply_pins=2,
+            bypass_value="10nF",
+            bulk_value="10uF",
+        )
+        caps = mock_schematic._created_caps
+        assert caps[0]["value"] == "10nF"
+        assert caps[1]["value"] == "10nF"
+        assert caps[2]["value"] == "10uF"
+
+    def test_factory_ref_start_and_prefix(self, mock_schematic):
+        """ref_start=12 and ref_prefix='C' produces C12..C16 for supply_pins=4."""
+        create_mcu_decoupling_array(
+            mock_schematic,
+            x=0,
+            y=0,
+            supply_pins=4,
+            ref_start=12,
+            ref_prefix="C",
+        )
+        caps = mock_schematic._created_caps
+        refs = [c["ref"] for c in caps]
+        assert refs == ["C12", "C13", "C14", "C15", "C16"]
+
+    def test_factory_passes_symbol_and_footprint(self, mock_schematic):
+        """cap_symbol and cap_footprint reach add_symbol."""
+        create_mcu_decoupling_array(
+            mock_schematic,
+            x=0,
+            y=0,
+            supply_pins=2,
+            cap_symbol="Device:C_Small",
+            cap_footprint="Capacitor_SMD:C_0805_2012Metric",
+        )
+        caps = mock_schematic._created_caps
+        for cap in caps:
+            assert cap["symbol"] == "Device:C_Small"
+            assert cap["kwargs"].get("footprint") == "Capacitor_SMD:C_0805_2012Metric"
+
+    def test_factory_auto_footprint_propagates(self, mock_schematic):
+        """auto_footprint=True reaches add_symbol."""
+        create_mcu_decoupling_array(
+            mock_schematic,
+            x=0,
+            y=0,
+            supply_pins=2,
+            auto_footprint=True,
+        )
+        caps = mock_schematic._created_caps
+        for cap in caps:
+            assert cap["kwargs"].get("auto_footprint") is True
+
+    def test_factory_connect_to_rails(self, mock_schematic):
+        """connect_to_rails wires every cap (supply_pins + 1 wires)."""
+        result = create_mcu_decoupling_array(
+            mock_schematic, x=0, y=0, supply_pins=4
+        )
+        result.connect_to_rails(50, 150)
+        assert mock_schematic.wire_decoupling_cap.call_count == 5
+
+    def test_supply_pins_zero_raises(self, mock_schematic):
+        """supply_pins=0 raises ValueError."""
+        with pytest.raises(ValueError, match="supply_pins must be >= 1"):
+            create_mcu_decoupling_array(
+                mock_schematic, x=0, y=0, supply_pins=0
+            )
+
+    def test_supply_pins_negative_raises(self, mock_schematic):
+        """Negative supply_pins raises ValueError."""
+        with pytest.raises(ValueError, match="supply_pins must be >= 1"):
+            create_mcu_decoupling_array(
+                mock_schematic, x=0, y=0, supply_pins=-1
+            )
+
+    def test_factory_ref_stability_board04(self, mock_schematic):
+        """Board 04 invocation produces refs C12..C16 (BOM stability)."""
+        create_mcu_decoupling_array(
+            mock_schematic,
+            x=160,
+            y=85,
+            supply_pins=4,
+            ref_start=12,
+            cap_symbol="Device:C_Small",
+            cap_footprint="Capacitor_SMD:C_0805_2012Metric",
+        )
+        caps = mock_schematic._created_caps
+        refs = [c["ref"] for c in caps]
+        values = [c["value"] for c in caps]
+        assert refs == ["C12", "C13", "C14", "C15", "C16"]
+        assert values == ["100nF", "100nF", "100nF", "100nF", "4.7uF"]
+
+    def test_factory_ref_stability_board05(self, mock_schematic):
+        """Board 05 invocation produces refs C7..C9 (BOM stability)."""
+        create_mcu_decoupling_array(
+            mock_schematic,
+            x=100,
+            y=100,
+            supply_pins=2,
+            ref_start=7,
+            cap_symbol="Device:C",
+            cap_footprint="Capacitor_SMD:C_0805_2012Metric",
+            spacing=10,
+        )
+        caps = mock_schematic._created_caps
+        refs = [c["ref"] for c in caps]
+        values = [c["value"] for c in caps]
+        assert refs == ["C7", "C8", "C9"]
+        assert values == ["100nF", "100nF", "4.7uF"]
+
+    def test_factory_spacing_default(self, mock_schematic):
+        """Default spacing of 10mm separates caps."""
+        create_mcu_decoupling_array(
+            mock_schematic, x=100, y=50, supply_pins=3
+        )
+        caps = mock_schematic._created_caps
+        # x positions should be 100, 110, 120, 130
+        xs = [c["x"] for c in caps]
+        assert xs == [100, 110, 120, 130]
+
+    def test_factory_custom_spacing(self, mock_schematic):
+        """Custom spacing is honored."""
+        create_mcu_decoupling_array(
+            mock_schematic, x=0, y=0, supply_pins=2, spacing=15
+        )
+        caps = mock_schematic._created_caps
+        xs = [c["x"] for c in caps]
+        assert xs == [0, 15, 30]

--- a/tests/test_schematic_blocks.py
+++ b/tests/test_schematic_blocks.py
@@ -2718,8 +2718,7 @@ class TestResetButtonMocked:
         jog_wire_starts = [c[0][0] for c in rail_calls]  # p1 of each call
         # One wire should go horizontal from (115, ...) to (jog_x, ...)
         has_horizontal_jog = any(
-            c[0][0][0] != c[0][1][0] and abs(c[0][1][0] - jog_x) < 0.01
-            for c in rail_calls
+            c[0][0][0] != c[0][1][0] and abs(c[0][1][0] - jog_x) < 0.01 for c in rail_calls
         )
         assert has_horizontal_jog, "Expected a horizontal jog wire to avoid X range"
 
@@ -2733,9 +2732,7 @@ class TestResetButtonMocked:
         rail_calls = mock_schematic.add_wire.call_args_list[init_wire_count:]
         # TVS cathode at x=130 is in range, should produce jog wires
         jog_x = 128 - 2.54
-        has_tvs_jog = any(
-            abs(c[0][1][0] - jog_x) < 0.01 for c in rail_calls
-        )
+        has_tvs_jog = any(abs(c[0][1][0] - jog_x) < 0.01 for c in rail_calls)
         assert has_tvs_jog, "Expected TVS cathode wire to jog around avoid X range"
 
     def test_reset_button_connect_to_rails_warn_on_collision_enabled(self, mock_schematic):
@@ -4296,12 +4293,8 @@ class TestComposedBlockPortAccess:
 
     def test_port_not_found_on_composed(self):
         """KeyError for missing port on composed block."""
-        left = _make_block(
-            {"A": Port(name="A", x=0, y=0, direction="input")}
-        )
-        right = _make_block(
-            {"B": Port(name="B", x=10, y=0, direction="input")}
-        )
+        left = _make_block({"A": Port(name="A", x=0, y=0, direction="input")})
+        right = _make_block({"B": Port(name="B", x=10, y=0, direction="input")})
         composed = left & right
         with pytest.raises(KeyError):
             composed.port("MISSING")
@@ -4340,12 +4333,8 @@ class TestComposedBlockRealize:
 
     def test_realize_parallel(self):
         """realize() for parallel updates child positions."""
-        left = _make_block(
-            {"A": Port(name="A", x=0, y=0, direction="input")}
-        )
-        right = _make_block(
-            {"A": Port(name="A", x=0, y=0, direction="input")}
-        )
+        left = _make_block({"A": Port(name="A", x=0, y=0, direction="input")})
+        right = _make_block({"A": Port(name="A", x=0, y=0, direction="input")})
         composed = left | right
 
         sch = Mock()
@@ -4500,19 +4489,13 @@ class TestCreateMCUDecouplingArrayMocked:
 
     def test_factory_returns_decoupling_caps_instance(self, mock_schematic):
         """Factory returns a DecouplingCaps instance."""
-        result = create_mcu_decoupling_array(
-            mock_schematic, x=160, y=85, supply_pins=4
-        )
+        result = create_mcu_decoupling_array(mock_schematic, x=160, y=85, supply_pins=4)
         assert isinstance(result, DecouplingCaps)
 
     @pytest.mark.parametrize("supply_pins", [1, 2, 3, 4, 6, 8])
-    def test_factory_cap_count_matches_supply_plus_bulk(
-        self, mock_schematic, supply_pins
-    ):
+    def test_factory_cap_count_matches_supply_plus_bulk(self, mock_schematic, supply_pins):
         """Cap count is supply_pins + 1 (one bulk)."""
-        result = create_mcu_decoupling_array(
-            mock_schematic, x=0, y=0, supply_pins=supply_pins
-        )
+        result = create_mcu_decoupling_array(mock_schematic, x=0, y=0, supply_pins=supply_pins)
         assert len(result.caps) == supply_pins + 1
 
     def test_factory_bypass_values(self, mock_schematic):
@@ -4536,9 +4519,7 @@ class TestCreateMCUDecouplingArrayMocked:
 
     def test_factory_default_values(self, mock_schematic):
         """Default values are 100nF bypass and 4.7uF bulk."""
-        create_mcu_decoupling_array(
-            mock_schematic, x=0, y=0, supply_pins=2
-        )
+        create_mcu_decoupling_array(mock_schematic, x=0, y=0, supply_pins=2)
         caps = mock_schematic._created_caps
         assert caps[0]["value"] == "100nF"
         assert caps[1]["value"] == "100nF"
@@ -4603,25 +4584,19 @@ class TestCreateMCUDecouplingArrayMocked:
 
     def test_factory_connect_to_rails(self, mock_schematic):
         """connect_to_rails wires every cap (supply_pins + 1 wires)."""
-        result = create_mcu_decoupling_array(
-            mock_schematic, x=0, y=0, supply_pins=4
-        )
+        result = create_mcu_decoupling_array(mock_schematic, x=0, y=0, supply_pins=4)
         result.connect_to_rails(50, 150)
         assert mock_schematic.wire_decoupling_cap.call_count == 5
 
     def test_supply_pins_zero_raises(self, mock_schematic):
         """supply_pins=0 raises ValueError."""
         with pytest.raises(ValueError, match="supply_pins must be >= 1"):
-            create_mcu_decoupling_array(
-                mock_schematic, x=0, y=0, supply_pins=0
-            )
+            create_mcu_decoupling_array(mock_schematic, x=0, y=0, supply_pins=0)
 
     def test_supply_pins_negative_raises(self, mock_schematic):
         """Negative supply_pins raises ValueError."""
         with pytest.raises(ValueError, match="supply_pins must be >= 1"):
-            create_mcu_decoupling_array(
-                mock_schematic, x=0, y=0, supply_pins=-1
-            )
+            create_mcu_decoupling_array(mock_schematic, x=0, y=0, supply_pins=-1)
 
     def test_factory_ref_stability_board04(self, mock_schematic):
         """Board 04 invocation produces refs C12..C16 (BOM stability)."""
@@ -4660,9 +4635,7 @@ class TestCreateMCUDecouplingArrayMocked:
 
     def test_factory_spacing_default(self, mock_schematic):
         """Default spacing of 10mm separates caps."""
-        create_mcu_decoupling_array(
-            mock_schematic, x=100, y=50, supply_pins=3
-        )
+        create_mcu_decoupling_array(mock_schematic, x=100, y=50, supply_pins=3)
         caps = mock_schematic._created_caps
         # x positions should be 100, 110, 120, 130
         xs = [c["x"] for c in caps]
@@ -4670,9 +4643,7 @@ class TestCreateMCUDecouplingArrayMocked:
 
     def test_factory_custom_spacing(self, mock_schematic):
         """Custom spacing is honored."""
-        create_mcu_decoupling_array(
-            mock_schematic, x=0, y=0, supply_pins=2, spacing=15
-        )
+        create_mcu_decoupling_array(mock_schematic, x=0, y=0, supply_pins=2, spacing=15)
         caps = mock_schematic._created_caps
         xs = [c["x"] for c in caps]
         assert xs == [0, 15, 30]


### PR DESCRIPTION
## Summary

- Adds `create_mcu_decoupling_array(sch, x, y, *, supply_pins, ...)` factory in `power/passives.py` (next to its returned class `DecouplingCaps`, per repo convention). Builds `values=[bypass_value]*supply_pins + [bulk_value]` and returns a `DecouplingCaps` so callers can chain `.connect_to_rails(vcc, gnd)`.
- Extends `DecouplingCaps.__init__` with an optional `cap_footprint: str | None` kwarg so the factory can forward board-specific footprint strings (e.g. `Capacitor_SMD:C_0805_2012Metric`) without resorting to `auto_footprint`.
- Re-exports the factory from `schematic/blocks/power/__init__.py` and the top-level `schematic/blocks/__init__.py`.
- Refactors **board 04** (`generate_design.py:241-285`): 5 manual `add_symbol` + wiring loop replaced with a single factory call. Refs **C12-C15** (100nF) + **C16** (4.7uF) preserved with `Device:C_Small` + 0805 footprint.
- Refactors **board 05** (`design.py:306-312`): 3 manual `add_symbol` + wiring loop replaced with a single factory call. Refs **C7/C8** (100nF) + **C9** (4.7uF) preserved with `Device:C` + 0805 footprint. Per Curator notes, intentionally keeps `supply_pins=2` (the historical bypass count) even though the STM32G431K8 has 3 supply pins; this is layout preservation, not a fix.
- Adds 20 unit tests in `tests/test_schematic_blocks.py::TestCreateMCUDecouplingArrayMocked` including parametrized supply-pin counts (1, 2, 3, 4, 6, 8), `supply_pins=0`/negative `ValueError`, BOM-stability checks for both board 04 (C12-C16) and board 05 (C7-C9), default + custom values, ref/spacing propagation, and rail-connection wire counts.

The factory is intentionally a thin wrapper (Curator Option A): both call sites diverge on symbol (`C_Small` vs `C`), bypass-to-pin ratio (4-of-4 vs 2-of-3), and placement strategy, so a more "MCU-aware" abstraction would not capture both cleanly. The wrapper documents the "N bypass + 1 bulk" intent and standardizes parameter names while leaving callers full control over symbol/footprint/placement.

Closes #2566.

## Test plan

- [x] `pytest tests/test_schematic_blocks.py::TestCreateMCUDecouplingArrayMocked` — 20/20 pass
- [x] `pytest tests/test_schematic_blocks.py` (full file) — 298/298 pass
- [x] Board 04: `python boards/04-stm32-devboard/generate_design.py` — ERC PASS, refs C12, C13, C14, C15 = 100nF and C16 = 4.7uF in generated `.kicad_sch`
- [x] Board 05: `python boards/05-bldc-motor-controller/design.py` — ERC PASS, refs C7, C8 = 100nF and C9 = 4.7uF in generated `.kicad_sch`
- [x] `ruff check` — no new lint errors introduced
- [x] `ruff format --check` — new files clean (pre-existing format issues in board 05's unrelated regions remain pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)