### PR TITLE
feat(check): diffpair_clearance_intra DRC rule (closes #2560, Epic #2556 Phase 1D)

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -59,6 +59,7 @@ def _find_pcb_file(directory: Path) -> Path | None:
 
 CHECK_CATEGORIES = [
     "clearance",
+    "diffpair_clearance_intra",
     "dimensions",
     "edge",
     "netlist",
@@ -269,6 +270,7 @@ def run_selected_checks(
     # Map of category to check method
     check_methods = {
         "clearance": checker.check_clearances,
+        "diffpair_clearance_intra": checker.check_diffpair_clearance_intra,
         "dimensions": checker.check_dimensions,
         "edge": checker.check_edge_clearances,
         "netlist": checker.check_netlist,

--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -45,6 +45,9 @@ def _init_type_category_map() -> None:
             ViolationType.CLEARANCE_PAD_VIA: ViolationCategory.ROUTING,
             ViolationType.CLEARANCE_SEGMENT_SEGMENT: ViolationCategory.ROUTING,
             ViolationType.CLEARANCE_VIA_VIA: ViolationCategory.ROUTING,
+            # Differential-pair within-pair clearance (Issue #2560, Epic #2556 Phase 1D).
+            # Same category as other clearance subtypes -- fixable by rerouting.
+            ViolationType.DIFFPAIR_CLEARANCE_INTRA: ViolationCategory.ROUTING,
             ViolationType.TRACK_WIDTH: ViolationCategory.ROUTING,
             ViolationType.TRACK_ANGLE: ViolationCategory.ROUTING,
             ViolationType.DIMENSION_TRACE_WIDTH: ViolationCategory.ROUTING,
@@ -110,6 +113,11 @@ class ViolationType(Enum):
     CLEARANCE_PAD_PAD = "clearance_pad_pad"
     CLEARANCE_SEGMENT_SEGMENT = "clearance_segment_segment"
     CLEARANCE_VIA_VIA = "clearance_via_via"
+    # Differential-pair within-pair clearance (Issue #2560, Epic #2556 Phase 1D).
+    # Distinct from the generic CLEARANCE family because it validates the
+    # *intra-pair* gap (allowed to be tighter than the manufacturer's inter-pair
+    # ``min_clearance_mm``) against the per-class ``intra_pair_clearance``.
+    DIFFPAIR_CLEARANCE_INTRA = "diffpair_clearance_intra"
     COPPER_EDGE_CLEARANCE = "copper_edge_clearance"
     EDGE_CLEARANCE_TRACE = "edge_clearance_trace"
     EDGE_CLEARANCE_PAD = "edge_clearance_pad"
@@ -212,6 +220,13 @@ class ViolationType(Enum):
             "clearance_pad_trace": cls.CLEARANCE_PAD_SEGMENT,
             "clearance_trace_trace": cls.CLEARANCE_SEGMENT_SEGMENT,
             "clearance_trace_via": cls.CLEARANCE_SEGMENT_VIA,
+            # Differential-pair within-pair clearance (Issue #2560).
+            # MUST be in the alias table -- without this entry the fuzzy
+            # fallback at the bottom of from_string() silently matches
+            # ``"clearance"`` and miscategorizes this rule_id as the
+            # generic CLEARANCE type, masking the new violation type from
+            # downstream consumers that filter by exact ``type`` value.
+            "diffpair_clearance_intra": cls.DIFFPAIR_CLEARANCE_INTRA,
             # edge clearance subtypes
             "edge_clearance_trace": cls.EDGE_CLEARANCE_TRACE,
             "edge_clearance_pad": cls.EDGE_CLEARANCE_PAD,

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from kicad_tools.manufacturers import DesignRules, get_profile
 
 from .rules.clearance import ClearanceRule
+from .rules.diffpair_clearance_intra import DiffPairClearanceIntraRule
 from .rules.edge import EdgeClearanceRule
 from .rules.placement import FootprintOutsideBoardRule
 from .rules.silkscreen import check_all_silkscreen
@@ -99,6 +100,7 @@ class DRCChecker:
 
         # Run each category of checks
         results.merge(self.check_clearances())
+        results.merge(self.check_diffpair_clearance_intra())
         results.merge(self.check_dimensions())
         results.merge(self.check_edge_clearances())
         results.merge(self.check_silkscreen())
@@ -129,6 +131,35 @@ class DRCChecker:
             DRCResults containing clearance violations
         """
         rule = ClearanceRule()
+        return rule.check(self.pcb, self.design_rules)
+
+    def check_diffpair_clearance_intra(self) -> DRCResults:
+        """Check within-pair clearance for differential pairs.
+
+        Validates that segments belonging to a detected differential pair
+        maintain at least the per-class ``intra_pair_clearance`` edge-to-edge
+        spacing.  Within-pair edges are *allowed* to be tighter than the
+        inter-pair manufacturer minimum (that's the whole point of diff-pair
+        coupling), but they must still respect the intra threshold.
+
+        Diff-pair detection uses the suffix-inference matcher in
+        ``router/diffpair`` (USB_D+/USB_D-, HDMI_D0_P/HDMI_D0_N, etc.).
+        Single-ended refusal patterns (``USB_CC1``/``USB_CC2``,
+        ``SBU1``/``SBU2``) are correctly excluded per #2558.
+
+        See Issue #2560 / Epic #2556 Phase 1D.  When the upstream router
+        gains the per-pair clearance map (#2559), this method may be
+        extended to accept it via constructor injection on
+        :class:`DRCChecker`; today the rule falls back to the manufacturer's
+        ``min_clearance_mm``, which makes it a no-op duplicate of the
+        generic clearance rule for any pair without an explicit threshold.
+
+        Returns:
+            DRCResults containing intra-pair clearance violations.
+        """
+        from .rules.diffpair_clearance_intra import DiffPairClearanceIntraRule
+
+        rule = DiffPairClearanceIntraRule()
         return rule.check(self.pcb, self.design_rules)
 
     def check_dimensions(self) -> DRCResults:

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -157,7 +157,6 @@ class DRCChecker:
         Returns:
             DRCResults containing intra-pair clearance violations.
         """
-        from .rules.diffpair_clearance_intra import DiffPairClearanceIntraRule
 
         rule = DiffPairClearanceIntraRule()
         return rule.check(self.pcb, self.design_rules)

--- a/src/kicad_tools/validate/rules/__init__.py
+++ b/src/kicad_tools/validate/rules/__init__.py
@@ -6,6 +6,7 @@ implementations for the pure Python DRC checker.
 
 from .base import DRC_TOLERANCE, DRCRule
 from .clearance import ClearanceRule
+from .diffpair_clearance_intra import DiffPairClearanceIntraRule
 from .dimensions import DimensionRules
 from .edge import EdgeClearanceRule
 from .impedance import ImpedanceRule, NetImpedanceSpec
@@ -23,6 +24,7 @@ __all__ = [
     "DRC_TOLERANCE",
     "DRCRule",
     "ClearanceRule",
+    "DiffPairClearanceIntraRule",
     "DimensionRules",
     "EdgeClearanceRule",
     "ImpedanceRule",

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING
 
 from kicad_tools.core.geometry import (
     point_to_segment_distance as _point_to_segment_distance,
+)
+from kicad_tools.core.geometry import (
     segment_to_segment_distance as _segment_to_segment_distance,
 )
 
@@ -154,7 +156,6 @@ def _transform_pad_dimensions(pad: Pad, footprint: Footprint) -> tuple[float, fl
     new_height = width * sin_a + height * cos_a
 
     return new_width, new_height
-
 
 
 # _point_to_segment_distance and _segment_to_segment_distance are imported

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -161,6 +161,36 @@ def _transform_pad_dimensions(pad: Pad, footprint: Footprint) -> tuple[float, fl
 # from kicad_tools.core.geometry (consolidated in #2349).
 
 
+def _build_diff_pair_set(pcb: PCB) -> set[tuple[int, int]]:
+    """Return ``{(min_net_id, max_net_id)}`` for every detected diff pair.
+
+    Used by :class:`ClearanceRule` to skip same-pair segment-segment edges
+    that are instead validated by ``DiffPairClearanceIntraRule`` against
+    the per-class ``intra_pair_clearance`` threshold (see Issue #2560 /
+    Epic #2556 Phase 1D).
+
+    Detection currently uses the suffix-inference matcher in
+    ``router/diffpair`` -- this matches what the autorouter sees when no
+    explicit declarations or KiCad-group sources are present, and the
+    refusal patterns (``USB_CC1``/``USB_CC2``, ``SBU1``/``SBU2``) are
+    correctly excluded.  When the upstream rule consumer (the autorouter
+    in #2559) gains the explicit-declaration plumbing, this helper can be
+    extended to honor those sources too without a public API change.
+    """
+    from kicad_tools.router.diffpair import detect_differential_pairs
+
+    pairs: set[tuple[int, int]] = set()
+    net_names = {net.number: net.name for net in pcb.nets.values()}
+    for diff_pair in detect_differential_pairs(net_names):
+        p_id = diff_pair.positive.net_id
+        n_id = diff_pair.negative.net_id
+        if p_id == 0 or n_id == 0:
+            continue
+        key = (p_id, n_id) if p_id <= n_id else (n_id, p_id)
+        pairs.add(key)
+    return pairs
+
+
 def _calculate_clearance(elem1: CopperElement, elem2: CopperElement) -> tuple[float, float, float]:
     """Calculate the clearance between two copper elements.
 
@@ -341,6 +371,20 @@ class ClearanceRule(DRCRule):
     Validates that spacing between traces, pads, and vias on the same
     layer but different nets meets the manufacturer's minimum clearance
     requirement.
+
+    Differential-pair within-pair edges (segment-to-segment edges where
+    both segments belong to the P/N halves of a detected diff pair) are
+    skipped here -- they are validated by
+    :class:`~kicad_tools.validate.rules.diffpair_clearance_intra.DiffPairClearanceIntraRule`
+    against the per-class ``intra_pair_clearance`` (which is allowed to
+    be tighter than the manufacturer's ``min_clearance_mm``).  Without
+    this skip users would see double violations on every diff-pair edge
+    that's tighter than inter-pair clearance, making the new rule
+    actively unhelpful.  See Issue #2560 / Epic #2556 Phase 1D.
+
+    The skip is segment-to-segment only -- pad and via clearances are
+    enforced inter-pair regardless of diff-pair membership, matching the
+    scope of the new rule (segments only).
     """
 
     rule_id = "clearance"
@@ -364,10 +408,17 @@ class ClearanceRule(DRCRule):
         results = DRCResults()
         min_clearance = design_rules.min_clearance_mm
 
+        # Build the diff-pair set once for the whole board (suffix
+        # inference is cheap; we scan the net table once).  Used to
+        # skip same-pair segment-segment edges that the new
+        # DiffPairClearanceIntraRule validates against a tighter
+        # per-class threshold.  See Issue #2560.
+        diff_pair_set = _build_diff_pair_set(pcb)
+
         # Process each copper layer
         for layer in pcb.copper_layers:
             layer_name = layer.name
-            violations = self._check_layer(pcb, layer_name, min_clearance)
+            violations = self._check_layer(pcb, layer_name, min_clearance, diff_pair_set)
             for v in violations:
                 results.add(v)
 
@@ -381,9 +432,23 @@ class ClearanceRule(DRCRule):
         pcb: PCB,
         layer_name: str,
         min_clearance: float,
+        diff_pair_set: set[tuple[int, int]] | None = None,
     ) -> list[DRCViolation]:
-        """Check clearance on a single copper layer."""
+        """Check clearance on a single copper layer.
+
+        Args:
+            pcb: The PCB being checked.
+            layer_name: Layer to scan.
+            min_clearance: Manufacturer's minimum inter-pair clearance.
+            diff_pair_set: Optional set of ``(min_net_id, max_net_id)``
+                tuples identifying detected differential pairs.  When
+                provided, segment-to-segment edges between the two
+                halves of a pair are skipped (delegated to
+                ``DiffPairClearanceIntraRule``).  See Issue #2560.
+        """
         violations: list[DRCViolation] = []
+        if diff_pair_set is None:
+            diff_pair_set = set()
 
         # Collect all copper elements on this layer
         elements = self._collect_elements(pcb, layer_name)
@@ -398,6 +463,24 @@ class ClearanceRule(DRCRule):
                 # Skip net 0 (unconnected) elements
                 if elem1.net_number == 0 or elem2.net_number == 0:
                     continue
+
+                # Skip same-pair segment-to-segment edges -- they are
+                # validated by DiffPairClearanceIntraRule against a
+                # tighter per-class threshold.  Pad/via combinations
+                # remain in scope here (issue #2560 scopes the new
+                # rule to segments only).
+                if (
+                    elem1.element_type == "segment"
+                    and elem2.element_type == "segment"
+                    and diff_pair_set
+                ):
+                    key = (
+                        (elem1.net_number, elem2.net_number)
+                        if elem1.net_number <= elem2.net_number
+                        else (elem2.net_number, elem1.net_number)
+                    )
+                    if key in diff_pair_set:
+                        continue
 
                 # Calculate clearance
                 clearance, loc_x, loc_y = _calculate_clearance(elem1, elem2)

--- a/src/kicad_tools/validate/rules/diffpair_clearance_intra.py
+++ b/src/kicad_tools/validate/rules/diffpair_clearance_intra.py
@@ -1,0 +1,300 @@
+"""Differential-pair within-pair clearance DRC rule.
+
+Validates that segments belonging to a detected differential pair maintain
+at least the per-class :attr:`~kicad_tools.router.rules.NetClassRouting.intra_pair_clearance`
+edge-to-edge spacing.
+
+Distinct from the generic :class:`~kicad_tools.validate.rules.clearance.ClearanceRule`,
+which validates inter-pair (different-net) clearance against the manufacturer's
+``min_clearance_mm``.  Within-pair edges are *allowed* to be tighter than the
+inter-pair clearance (that's the whole point of the diff-pair geometry --
+controlled coupling needs the two traces close), but they must still respect
+the per-class intra threshold.
+
+This rule is part of Epic #2556 Phase 1D (Issue #2560):
+
+- Phase 1A (#2557) added :attr:`NetClassRouting.intra_pair_clearance`.
+- Phase 1B (#2558) added layered diff-pair detection.
+- Phase 1C (#2559, in flight) threads the value into the router.
+- Phase 1D (this rule) validates the produced layout against the threshold.
+
+Scope:
+
+- Segment-to-segment only.  Pads and vias are out of scope -- their spacing
+  is enforced by the generic ``clearance`` rule using the inter-pair
+  ``min_clearance_mm`` threshold (a tighter intra-pair threshold for V-V or
+  P-P would be a reasonable extension but is not part of this issue).
+- Same-pair edges only (the two nets must be detected as the P/N halves of
+  the same differential pair).  Cross-net edges that are NOT part of the
+  same diff pair are validated by the generic clearance rule.
+
+Diff-pair detection:
+
+The rule reuses :func:`kicad_tools.router.diffpair.detect_differential_pairs`
+to identify P/N pairs from net names, mirroring the suffix-inference behavior
+that the router uses.  Explicit declarations and KiCad-group sources from
+#2558 are honored when the caller pre-builds a ``diff_pair_map`` and passes
+it to the constructor; otherwise the rule falls back to suffix detection
+(matching the legacy router behavior, sufficient for the common USB/HDMI/
+Ethernet cases).
+
+The ``intra_pair_clearance`` value used for comparison defaults to a
+caller-supplied per-pair map (``intra_pair_clearance_map``).  When omitted
+or when a particular pair is not in the map, the rule falls back to the
+manufacturer's ``min_clearance_mm`` -- which makes the rule equivalent to
+the generic clearance rule (no extra constraint).  The intended call site
+(the autorouter consumer in #2559) computes the per-pair map from
+:meth:`NetClassRouting.effective_intra_pair_clearance` and passes it in.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..violations import DRCResults, DRCViolation
+from .base import DRC_TOLERANCE, DRCRule
+from .clearance import CopperElement, _segment_segment_clearance
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers import DesignRules
+    from kicad_tools.schema.pcb import PCB
+
+
+class DiffPairClearanceIntraRule(DRCRule):
+    """Validate within-pair separation of differential-pair segments.
+
+    Iterates segment pairs on each copper layer; emits a violation when
+    two segments are detected as belonging to the same differential pair
+    AND their edge-to-edge separation is less than the pair's
+    ``intra_pair_clearance`` threshold (after :data:`DRC_TOLERANCE`).
+
+    The rule does NOT fire when:
+      - The two segments are on different (unrelated) nets.
+      - The two segments are on the same net (continuity is allowed to
+        touch).
+      - The two segments belong to a pair, but their separation is within
+        the threshold (the structural correctness case -- tighter coupling
+        is allowed).
+      - The two nets match a single-ended refusal pattern such as
+        ``USB_CC1``/``USB_CC2`` (per #2558 -- these are not diff pairs).
+
+    Attributes:
+        rule_id: ``"diffpair_clearance_intra"`` (must be the EXACT
+            string the alias table in ``drc/violation.py`` keys on).
+        intra_pair_clearance_map: Optional ``{(net_a, net_b) -> threshold_mm}``
+            map.  Keys are stored as ``(min, max)`` net-number tuples so the
+            order of the pair members doesn't matter.  When a detected pair
+            is not in the map, the rule falls back to ``design_rules.min_clearance_mm``,
+            which makes the rule equivalent to the generic clearance rule
+            for that pair.
+        diff_pair_overrides: Optional list of ``(net_a_name, net_b_name)`` pairs
+            that should be treated as diff pairs even if suffix inference
+            doesn't recognize them (mirrors the explicit-declaration source
+            from #2558).  Net names are looked up against ``pcb.nets`` to
+            resolve to net numbers at check time.
+    """
+
+    rule_id = "diffpair_clearance_intra"
+    name = "Differential-Pair Within-Pair Clearance"
+    description = (
+        "Validates that within-pair separation of detected differential pairs "
+        "respects the per-class intra_pair_clearance threshold."
+    )
+
+    def __init__(
+        self,
+        intra_pair_clearance_map: dict[tuple[int, int], float] | None = None,
+        diff_pair_overrides: list[tuple[str, str]] | None = None,
+    ) -> None:
+        """Initialize the rule.
+
+        Args:
+            intra_pair_clearance_map: Optional ``{(net_a, net_b) -> threshold_mm}``
+                map of explicit per-pair thresholds.  Keys are normalized to
+                ``(min, max)`` net-number ordering.  Missing pairs fall back
+                to ``design_rules.min_clearance_mm`` (equivalent to no extra
+                constraint -- the generic clearance rule handles them).
+            diff_pair_overrides: Optional ``[(p_name, n_name), ...]`` list to
+                augment suffix inference (see #2558).  Useful when a board
+                explicitly declares pairs via ``diffpair_partner`` or KiCad's
+                ``diff_pair_template``.
+        """
+        # Normalize keys to (min, max) ordering so callers don't have to.
+        self._intra_map: dict[tuple[int, int], float] = {}
+        if intra_pair_clearance_map:
+            for (a, b), thr in intra_pair_clearance_map.items():
+                key = (a, b) if a <= b else (b, a)
+                self._intra_map[key] = thr
+
+        self._overrides: list[tuple[str, str]] = list(diff_pair_overrides or [])
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Check intra-pair clearance on all copper layers.
+
+        Args:
+            pcb: The PCB to check.
+            design_rules: Design rules (used as fallback threshold when a
+                pair is not in ``intra_pair_clearance_map``).
+
+        Returns:
+            DRCResults containing intra-pair clearance violations.
+        """
+        results = DRCResults()
+
+        # Build the diff-pair set: { (min_net_id, max_net_id) }
+        diff_pair_set = self._build_diff_pair_set(pcb)
+
+        # Process each copper layer
+        for layer in pcb.copper_layers:
+            layer_name = layer.name
+            violations = self._check_layer(
+                pcb,
+                layer_name,
+                diff_pair_set,
+                design_rules.min_clearance_mm,
+            )
+            for v in violations:
+                results.add(v)
+
+        # One rule check per layer (matches ClearanceRule convention).
+        results.rules_checked = len(pcb.copper_layers)
+
+        return results
+
+    def _build_diff_pair_set(self, pcb: PCB) -> set[tuple[int, int]]:
+        """Build the set of ``(min_net_id, max_net_id)`` diff-pair tuples.
+
+        Combines:
+          - ``diff_pair_overrides`` from the constructor (explicit pairs,
+            net names resolved via the PCB net table).
+          - Suffix inference via ``router/diffpair.detect_differential_pairs``.
+
+        Net IDs of zero (unconnected) are filtered out.
+        """
+        from kicad_tools.router.diffpair import detect_differential_pairs
+
+        pairs: set[tuple[int, int]] = set()
+
+        # Explicit overrides: resolve names -> ids via pcb.nets.
+        if self._overrides:
+            name_to_id = {net.name: net.number for net in pcb.nets.values()}
+            for p_name, n_name in self._overrides:
+                p_id = name_to_id.get(p_name)
+                n_id = name_to_id.get(n_name)
+                if p_id is None or n_id is None:
+                    continue
+                if p_id == 0 or n_id == 0:
+                    continue
+                key = (p_id, n_id) if p_id <= n_id else (n_id, p_id)
+                pairs.add(key)
+
+        # Suffix inference from net names.
+        net_names = {net.number: net.name for net in pcb.nets.values()}
+        for diff_pair in detect_differential_pairs(net_names):
+            p_id = diff_pair.positive.net_id
+            n_id = diff_pair.negative.net_id
+            if p_id == 0 or n_id == 0:
+                continue
+            key = (p_id, n_id) if p_id <= n_id else (n_id, p_id)
+            pairs.add(key)
+
+        return pairs
+
+    def _threshold_for(
+        self,
+        net_a: int,
+        net_b: int,
+        fallback: float,
+    ) -> float:
+        """Look up the intra_pair_clearance threshold for a pair, with fallback."""
+        key = (net_a, net_b) if net_a <= net_b else (net_b, net_a)
+        return self._intra_map.get(key, fallback)
+
+    def _check_layer(
+        self,
+        pcb: PCB,
+        layer_name: str,
+        diff_pair_set: set[tuple[int, int]],
+        fallback_clearance: float,
+    ) -> list[DRCViolation]:
+        """Check intra-pair clearance on a single copper layer.
+
+        Iterates segment-to-segment pairs (pads/vias intentionally out of
+        scope -- inter-pair clearance for circular elements is enforced by
+        the generic clearance rule).  A violation fires when both segments
+        are on nets that form a detected diff pair AND the edge-to-edge
+        separation is below the pair's intra threshold.
+        """
+        violations: list[DRCViolation] = []
+
+        # Segments only (segment-to-segment scope per Issue #2560).
+        segments: list[CopperElement] = [
+            CopperElement.from_segment(seg) for seg in pcb.segments_on_layer(layer_name)
+        ]
+
+        for i, elem1 in enumerate(segments):
+            for elem2 in segments[i + 1 :]:
+                # Skip same-net (continuity) and unconnected.
+                if elem1.net_number == elem2.net_number:
+                    continue
+                if elem1.net_number == 0 or elem2.net_number == 0:
+                    continue
+
+                # Only fire on segments belonging to the same detected pair.
+                key = (
+                    (elem1.net_number, elem2.net_number)
+                    if elem1.net_number <= elem2.net_number
+                    else (elem2.net_number, elem1.net_number)
+                )
+                if key not in diff_pair_set:
+                    continue
+
+                threshold = self._threshold_for(
+                    elem1.net_number, elem2.net_number, fallback_clearance
+                )
+
+                # Compute edge-to-edge clearance (reuses the same math the
+                # generic ClearanceRule uses; do NOT duplicate).
+                clearance, loc_x, loc_y = _segment_segment_clearance(elem1, elem2)
+
+                if clearance + DRC_TOLERANCE < threshold:
+                    violations.append(
+                        self._create_violation(
+                            elem1, elem2, clearance, threshold, layer_name, loc_x, loc_y
+                        )
+                    )
+
+        return violations
+
+    def _create_violation(
+        self,
+        elem1: CopperElement,
+        elem2: CopperElement,
+        actual: float,
+        required: float,
+        layer: str,
+        loc_x: float,
+        loc_y: float,
+    ) -> DRCViolation:
+        """Create a DRC violation for an intra-pair clearance issue."""
+        # Stable net-name ordering in the message so test assertions and
+        # diff'd reports don't flap when the iteration order changes.
+        net_a, net_b = sorted([elem1.net_name, elem2.net_name])
+        return DRCViolation(
+            rule_id=self.rule_id,
+            severity="error",
+            message=(
+                f"Within-pair clearance for diff pair {net_a}/{net_b}: "
+                f"{actual:.3f}mm < intra_pair_clearance {required:.3f}mm"
+            ),
+            location=(round(loc_x, 3), round(loc_y, 3)),
+            layer=layer,
+            actual_value=round(actual, 4),
+            required_value=required,
+            items=(elem1.reference, elem2.reference),
+            nets=(elem1.net_name, elem2.net_name),
+        )

--- a/tests/test_cli_check_diffpair_clearance_intra.py
+++ b/tests/test_cli_check_diffpair_clearance_intra.py
@@ -1,0 +1,148 @@
+"""CLI tests for ``kct check --only/--skip diffpair_clearance_intra``.
+
+Verifies the new category id is wired into ``CHECK_CATEGORIES`` and the
+``check_methods`` dispatch dict at ``cli/check_cmd.py``.
+
+Exit-code expectations:
+
+- Exit 2 (errors found) when the rule fires.  Default severity is
+  ``error``, so this happens automatically once a violation is emitted.
+- Exit 0 when ``--skip diffpair_clearance_intra`` removes the only
+  violation source AND the same-pair skip in ``ClearanceRule`` already
+  drops the corresponding inter-pair clearance violation.
+
+The fixture stages two ``USB_D+`` / ``USB_D-`` segments separated by 0.07 mm
+edge-to-edge.  The default JLCPCB inter-pair ``min_clearance_mm`` is
+0.1 mm (above 0.07), so without the new rule the ``ClearanceRule``
+would fire here.  With the new rule installed:
+
+  - ``ClearanceRule`` is suppressed because the two nets are a detected
+    diff pair (same-pair skip).
+  - ``DiffPairClearanceIntraRule`` fires using the manufacturer's
+    ``min_clearance_mm`` as its fallback threshold (no per-pair map is
+    plumbed at the CLI yet -- that will follow in #2559).
+
+So the net effect is the same exit code (2), but the violation now
+reports against ``rule_id == "diffpair_clearance_intra"`` instead of
+``"clearance_segment_segment"``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# A board with two USB_D+/USB_D- segments at a tight 0.07 mm edge-to-edge
+# gap.  Default JLCPCB min_clearance_mm is 0.1 mm, so this fires.
+DIFFPAIR_TIGHT_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "USB_D+")
+  (net 2 "USB_D-")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (segment (start 110 120) (end 140 120) (width 0.2) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000020"))
+  (segment (start 110 120.27) (end 140 120.27) (width 0.2) (layer "F.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-000000000021"))
+)
+"""
+
+
+@pytest.fixture
+def diffpair_tight_pcb(tmp_path: Path) -> Path:
+    """A PCB with USB_D+/USB_D- segments at a tighter-than-min_clearance gap."""
+    pcb_file = tmp_path / "diffpair_tight.kicad_pcb"
+    pcb_file.write_text(DIFFPAIR_TIGHT_PCB)
+    return pcb_file
+
+
+class TestDiffPairClearanceIntraCLI:
+    """CLI-level wiring tests for the new check category."""
+
+    def test_only_diffpair_returns_exit_2(self, diffpair_tight_pcb: Path, capsys):
+        """``--only diffpair_clearance_intra`` -> exit 2 when the rule fires."""
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(diffpair_tight_pcb), "--only", "diffpair_clearance_intra"])
+        assert result == 2  # errors found
+
+        captured = capsys.readouterr()
+        assert "diffpair_clearance_intra" in captured.out
+
+    def test_skip_diffpair_returns_exit_0(self, diffpair_tight_pcb: Path, capsys):
+        """``--skip diffpair_clearance_intra`` -> exit 0.
+
+        With the new rule skipped, ClearanceRule's same-pair skip means
+        the inter-pair clearance violation is also suppressed, so the
+        run is clean.
+        """
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(diffpair_tight_pcb), "--skip", "diffpair_clearance_intra"])
+        # No violations reach the user.
+        assert result == 0
+
+    def test_only_diffpair_json_carries_correct_type(self, diffpair_tight_pcb: Path, capsys):
+        """JSON ``type`` field round-trips to ``diffpair_clearance_intra``.
+
+        This is the cross-check for the to_dict() round-trip trap at the
+        CLI level: if the alias entry in drc/violation.py were missing,
+        the fuzzy fallback would silently miscategorize the type as
+        ``"clearance"`` (because the rule_id contains the substring).
+        """
+        from kicad_tools.cli.check_cmd import main
+
+        result = main(
+            [
+                str(diffpair_tight_pcb),
+                "--only",
+                "diffpair_clearance_intra",
+                "--format",
+                "json",
+            ]
+        )
+        assert result == 2
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["summary"]["passed"] is False
+        assert data["summary"]["errors"] >= 1
+        # At least one violation has the EXACT type string.
+        types = {v["type"] for v in data["violations"]}
+        assert "diffpair_clearance_intra" in types
+
+    def test_errors_only_with_diffpair_returns_exit_2(self, diffpair_tight_pcb: Path, capsys):
+        """``--errors-only`` with the new rule firing returns exit 2.
+
+        Default severity is ``error`` so ``--errors-only`` keeps the
+        violations and the exit code is 2.
+        """
+        from kicad_tools.cli.check_cmd import main
+
+        result = main(
+            [
+                str(diffpair_tight_pcb),
+                "--only",
+                "diffpair_clearance_intra",
+                "--errors-only",
+            ]
+        )
+        assert result == 2

--- a/tests/test_validate_diffpair_clearance_intra.py
+++ b/tests/test_validate_diffpair_clearance_intra.py
@@ -1,0 +1,453 @@
+"""Tests for the differential-pair within-pair clearance DRC rule.
+
+Mirrors the stub-PCB pattern from tests/test_validate_single_pad_net.py.
+Covers:
+
+- The structural-correctness no-fire case (within-pair separation tighter
+  than the manufacturer's inter-pair clearance but >= intra threshold).
+- The fire case (within-pair separation < intra threshold).
+- Cross-rule no-fire: ClearanceRule must NOT fire on the same edge that
+  DiffPairClearanceIntraRule is OK with (the double-violation guard).
+- Single-ended exclusion (USB_CC1/USB_CC2): not detected as a pair, so
+  the new rule does NOT fire.
+- Pads-out-of-scope: a segment-vs-pad gap below intra threshold does not
+  fire (the new rule is segment-segment only).
+- The to_dict() round-trip trap test that catches the fuzzy-fallback
+  miscategorization (Issue #2521 / #2560 critical risk).
+- Per-pair threshold lookup (different pairs may carry different
+  intra_pair_clearance values).
+- Empty-PCB / no-segment edge cases.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from kicad_tools.manufacturers import DesignRules
+from kicad_tools.validate.rules.clearance import ClearanceRule
+from kicad_tools.validate.rules.diffpair_clearance_intra import (
+    DiffPairClearanceIntraRule,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubLayer:
+    name: str
+    type: str = "signal"
+
+
+@dataclass
+class _StubNet:
+    number: int
+    name: str
+
+
+@dataclass
+class _StubSegment:
+    start: tuple[float, float]
+    end: tuple[float, float]
+    width: float = 0.2
+    layer: str = "F.Cu"
+    net_number: int = 0
+    net_name: str = ""
+    uuid: str = ""
+
+
+@dataclass
+class _StubPad:
+    number: str
+    net_number: int = 0
+    net_name: str = ""
+    position: tuple[float, float] = (0.0, 0.0)
+    size: tuple[float, float] = (1.0, 1.0)
+    layers: list[str] = field(default_factory=lambda: ["F.Cu"])
+    type: str = "smd"
+    shape: str = "rect"
+    drill: float = 0.0
+
+
+@dataclass
+class _StubFootprint:
+    reference: str = "U1"
+    name: str = ""
+    position: tuple[float, float] = (0.0, 0.0)
+    rotation: float = 0.0
+    pads: list[_StubPad] = field(default_factory=list)
+
+
+@dataclass
+class _StubPCB:
+    """Minimal PCB stub implementing the subset used by the rule."""
+
+    _nets: dict[int, _StubNet] = field(default_factory=dict)
+    _segments: list[_StubSegment] = field(default_factory=list)
+    _vias: list[object] = field(default_factory=list)
+    _footprints: list[_StubFootprint] = field(default_factory=list)
+    _layers: list[_StubLayer] = field(default_factory=lambda: [_StubLayer("F.Cu")])
+
+    @property
+    def nets(self) -> dict[int, _StubNet]:
+        return self._nets
+
+    @property
+    def copper_layers(self) -> list[_StubLayer]:
+        return self._layers
+
+    @property
+    def vias(self) -> list[object]:
+        return self._vias
+
+    @property
+    def footprints(self) -> list[_StubFootprint]:
+        return self._footprints
+
+    def segments_on_layer(self, layer: str):
+        for seg in self._segments:
+            if seg.layer == layer:
+                yield seg
+
+
+def _design_rules(min_clearance_mm: float = 0.127) -> DesignRules:
+    """Build a real DesignRules with a configurable inter-pair clearance.
+
+    Default 0.127 mm matches the JLCPCB 4-layer min for the regression
+    scenarios in the issue's test plan.
+    """
+    return DesignRules(
+        min_trace_width_mm=0.1,
+        min_clearance_mm=min_clearance_mm,
+        min_via_drill_mm=0.3,
+        min_via_diameter_mm=0.6,
+        min_annular_ring_mm=0.075,
+    )
+
+
+def _parallel_segments(
+    *,
+    net_a: int,
+    name_a: str,
+    net_b: int,
+    name_b: str,
+    gap_mm: float,
+    width_mm: float = 0.2,
+) -> list[_StubSegment]:
+    """Build two parallel horizontal segments with the requested edge gap.
+
+    Both segments are 2 mm long along the X axis, centered at y=0 and
+    y=(width_mm + gap_mm), so the edge-to-edge separation is exactly
+    ``gap_mm``.
+    """
+    y_b = (width_mm / 2) + gap_mm + (width_mm / 2)
+    return [
+        _StubSegment(
+            start=(0.0, 0.0),
+            end=(2.0, 0.0),
+            width=width_mm,
+            net_number=net_a,
+            net_name=name_a,
+            uuid=f"seg-{name_a}",
+        ),
+        _StubSegment(
+            start=(0.0, y_b),
+            end=(2.0, y_b),
+            width=width_mm,
+            net_number=net_b,
+            net_name=name_b,
+            uuid=f"seg-{name_b}",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiffPairClearanceIntraRule:
+    """Tests for DiffPairClearanceIntraRule.check()."""
+
+    def test_no_diffpair_no_violation(self):
+        """Two unrelated signal nets -- diff-pair detection returns empty."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                1: _StubNet(1, "DATA"),
+                2: _StubNet(2, "CLK"),
+            },
+            _segments=_parallel_segments(
+                net_a=1, name_a="DATA", net_b=2, name_b="CLK", gap_mm=0.05
+            ),
+        )
+        rule = DiffPairClearanceIntraRule(intra_pair_clearance_map={(1, 2): 0.075})
+        results = rule.check(pcb, _design_rules())
+        # Even though the explicit map names them, suffix detection does
+        # not see them as a pair, so the rule must not fire.
+        assert len(results.violations) == 0
+
+    def test_diffpair_within_intra_threshold(self):
+        """Within-pair gap >= intra_pair_clearance: NO violation.
+
+        This is the structural correctness case: the gap is tighter than
+        the manufacturer's ``min_clearance_mm`` (0.127 mm), but >= the
+        diff-pair's ``intra_pair_clearance`` (0.075 mm).  Allowed.
+        """
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                3: _StubNet(3, "USB_D+"),
+                4: _StubNet(4, "USB_D-"),
+            },
+            _segments=_parallel_segments(
+                net_a=3, name_a="USB_D+", net_b=4, name_b="USB_D-", gap_mm=0.090
+            ),
+        )
+        rule = DiffPairClearanceIntraRule(intra_pair_clearance_map={(3, 4): 0.075})
+        results = rule.check(pcb, _design_rules(min_clearance_mm=0.127))
+        assert len(results.violations) == 0
+
+    def test_diffpair_below_intra_threshold(self):
+        """Within-pair gap < intra_pair_clearance: ONE violation."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                3: _StubNet(3, "USB_D+"),
+                4: _StubNet(4, "USB_D-"),
+            },
+            _segments=_parallel_segments(
+                net_a=3, name_a="USB_D+", net_b=4, name_b="USB_D-", gap_mm=0.060
+            ),
+        )
+        rule = DiffPairClearanceIntraRule(intra_pair_clearance_map={(3, 4): 0.075})
+        results = rule.check(pcb, _design_rules())
+        assert len(results.violations) == 1
+
+        v = results.violations[0]
+        assert v.rule_id == "diffpair_clearance_intra"
+        assert v.severity == "error"
+        # Both nets in the violation.
+        assert "USB_D+" in v.nets
+        assert "USB_D-" in v.nets
+        # Both nets in the message.
+        assert "USB_D+" in v.message
+        assert "USB_D-" in v.message
+        # Gap and threshold present in the message.
+        assert "0.060" in v.message or "0.06" in v.message
+        assert "0.075" in v.message
+        # Numeric fields populated.
+        assert v.required_value == 0.075
+        assert v.actual_value is not None
+        assert abs(v.actual_value - 0.060) < 1e-3
+
+    def test_clearance_rule_skips_same_pair(self):
+        """Cross-rule: ClearanceRule must NOT fire on a same-pair edge.
+
+        Without the same-pair skip in ClearanceRule._check_layer the user
+        would see a clearance_segment_segment violation AND the new rule
+        either fires or stays silent depending on the threshold -- which
+        defeats the whole point of the diff-pair rule.
+
+        Setup: gap = 0.090, inter-pair clearance = 0.127 -> would normally
+        fire ClearanceRule.  But the two segments are USB_D+/USB_D-, a
+        suffix-detected diff pair, so the skip kicks in.
+        """
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                3: _StubNet(3, "USB_D+"),
+                4: _StubNet(4, "USB_D-"),
+            },
+            _segments=_parallel_segments(
+                net_a=3, name_a="USB_D+", net_b=4, name_b="USB_D-", gap_mm=0.090
+            ),
+        )
+        # Both rules see a 0.090 mm gap with min_clearance_mm = 0.127.
+        rules = _design_rules(min_clearance_mm=0.127)
+
+        # New rule: gap 0.090 >= intra threshold 0.075 -> no violation.
+        diff_rule = DiffPairClearanceIntraRule(intra_pair_clearance_map={(3, 4): 0.075})
+        diff_results = diff_rule.check(pcb, rules)
+        assert len(diff_results.violations) == 0
+
+        # Existing clearance rule: would normally fire (0.090 < 0.127),
+        # but the same-pair skip suppresses it.
+        clearance_rule = ClearanceRule()
+        clearance_results = clearance_rule.check(pcb, rules)
+        assert len(clearance_results.violations) == 0, (
+            "ClearanceRule should skip same-pair segment edges when both "
+            "segments are halves of a detected diff pair."
+        )
+
+    def test_single_ended_pair_excluded(self):
+        """USB_CC1 / USB_CC2 are NOT a diff pair (per #2558 refusal list)."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                5: _StubNet(5, "USB_CC1"),
+                6: _StubNet(6, "USB_CC2"),
+            },
+            _segments=_parallel_segments(
+                net_a=5, name_a="USB_CC1", net_b=6, name_b="USB_CC2", gap_mm=0.060
+            ),
+        )
+        # Even with an explicit intra map entry, suffix detection refuses
+        # CC1/CC2 -- they're not in the diff-pair set.
+        rule = DiffPairClearanceIntraRule(intra_pair_clearance_map={(5, 6): 0.075})
+        results = rule.check(pcb, _design_rules())
+        assert len(results.violations) == 0
+
+    def test_segment_vs_pad_out_of_scope(self):
+        """Segment-vs-pad edges are out of scope -- the new rule is segments-only."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                3: _StubNet(3, "USB_D+"),
+                4: _StubNet(4, "USB_D-"),
+            },
+            _segments=[
+                _StubSegment(
+                    start=(0.0, 0.0),
+                    end=(2.0, 0.0),
+                    width=0.2,
+                    net_number=3,
+                    net_name="USB_D+",
+                    uuid="seg-usbdp",
+                ),
+            ],
+            _footprints=[
+                _StubFootprint(
+                    reference="J1",
+                    pads=[
+                        _StubPad(
+                            number="1",
+                            net_number=4,
+                            net_name="USB_D-",
+                            position=(1.0, 0.16),
+                            size=(0.8, 0.2),
+                            layers=["F.Cu"],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        rule = DiffPairClearanceIntraRule(
+            intra_pair_clearance_map={(3, 4): 0.5}  # Aggressive, would fire if scoped wide.
+        )
+        results = rule.check(pcb, _design_rules())
+        # No violation -- pads are intentionally not iterated.
+        assert len(results.violations) == 0
+
+    def test_to_dict_resolves_violation_type(self):
+        """The fuzzy-fallback miscategorization trap (Issue #2521 / #2560).
+
+        ``"diffpair_clearance_intra"`` contains the substring
+        ``"clearance"``.  Without the alias entry in
+        ``drc/violation.py::ViolationType._ALIASES`` the keyword fuzzy
+        fallback would silently match generic ``CLEARANCE`` -- not
+        ``UNKNOWN`` like the single-pad-net case.  This test asserts the
+        EXACT type string round-trips, which is the only defense.
+        """
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                3: _StubNet(3, "USB_D+"),
+                4: _StubNet(4, "USB_D-"),
+            },
+            _segments=_parallel_segments(
+                net_a=3, name_a="USB_D+", net_b=4, name_b="USB_D-", gap_mm=0.060
+            ),
+        )
+        rule = DiffPairClearanceIntraRule(intra_pair_clearance_map={(3, 4): 0.075})
+        results = rule.check(pcb, _design_rules())
+        assert len(results.violations) == 1
+
+        d = results.violations[0].to_dict()
+        assert d["rule_id"] == "diffpair_clearance_intra"
+        # The trap: substring "clearance" would match the fuzzy fallback
+        # and resolve to "clearance" without the alias entry.  The test
+        # asserts the EXACT new type string.
+        assert d["type"] == "diffpair_clearance_intra", (
+            "type field must round-trip to 'diffpair_clearance_intra' "
+            "(alias entry in drc/violation.py is missing or wrong)"
+        )
+        assert d["severity"] == "error"
+
+    def test_per_pair_threshold(self):
+        """Two diff pairs on the same board, each with its own threshold.
+
+        Pair A (USB_D+/USB_D-) at 0.090 mm with intra=0.075 -> NO fire.
+        Pair B (HDMI_TX0_P/HDMI_TX0_N) at 0.090 mm with intra=0.100 -> FIRE.
+        """
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                10: _StubNet(10, "USB_D+"),
+                11: _StubNet(11, "USB_D-"),
+                12: _StubNet(12, "HDMI_TX0_P"),
+                13: _StubNet(13, "HDMI_TX0_N"),
+            },
+            _segments=[
+                # Pair A at y=0 / y=0.290 (gap 0.090, width 0.2 each)
+                *_parallel_segments(
+                    net_a=10, name_a="USB_D+", net_b=11, name_b="USB_D-", gap_mm=0.090
+                ),
+                # Pair B at y=10 / y=10.290 (offset by +10 in Y to keep
+                # the two pairs spatially separate)
+                _StubSegment(
+                    start=(0.0, 10.0),
+                    end=(2.0, 10.0),
+                    width=0.2,
+                    net_number=12,
+                    net_name="HDMI_TX0_P",
+                    uuid="seg-hdmip",
+                ),
+                _StubSegment(
+                    start=(0.0, 10.290),
+                    end=(2.0, 10.290),
+                    width=0.2,
+                    net_number=13,
+                    net_name="HDMI_TX0_N",
+                    uuid="seg-hdmin",
+                ),
+            ],
+        )
+        rule = DiffPairClearanceIntraRule(
+            intra_pair_clearance_map={
+                (10, 11): 0.075,  # USB: pair A passes
+                (12, 13): 0.100,  # HDMI: pair B fails
+            }
+        )
+        results = rule.check(pcb, _design_rules())
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        # Only the HDMI pair fires.
+        assert "HDMI_TX0_P" in v.nets
+        assert "HDMI_TX0_N" in v.nets
+        assert "USB_D+" not in v.nets
+        assert "USB_D-" not in v.nets
+
+    def test_rules_checked_count(self):
+        """rules_checked increments per layer (matches ClearanceRule)."""
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                3: _StubNet(3, "USB_D+"),
+                4: _StubNet(4, "USB_D-"),
+            },
+            _segments=[],
+            _layers=[_StubLayer("F.Cu"), _StubLayer("B.Cu")],
+        )
+        rule = DiffPairClearanceIntraRule()
+        results = rule.check(pcb, _design_rules())
+        assert results.rules_checked == 2
+
+    def test_passes_with_no_segments(self):
+        """Empty PCB -> zero violations and no crashes."""
+        pcb = _StubPCB(_nets={0: _StubNet(0, "")})
+        rule = DiffPairClearanceIntraRule()
+        results = rule.check(pcb, _design_rules())
+        assert len(results.violations) == 0
+        assert results.rules_checked == 1


### PR DESCRIPTION
## Summary

Adds the new `diffpair_clearance_intra` DRC rule that validates within-pair separation against `NetClassRouting.intra_pair_clearance` (introduced in Phase 1A / #2557). Distinct from the generic `clearance` rule: within-pair edges are *allowed* to be tighter than the manufacturer's inter-pair `min_clearance_mm`, but must respect the per-class intra threshold.

Closes #2560 (Epic #2556 Phase 1D). Builds on:
- #2557 (closed) — `NetClass.intra_pair_clearance` field.
- #2558 (closed) — layered diff-pair detection.
- #2559 (open) — router-side wiring (this PR works against today's layouts and rebases cleanly when #2559 lands).

## Changes (incremental commits per #2547)

1. **`drc(violation)`**: register `DIFFPAIR_CLEARANCE_INTRA` enum + `_ALIASES` entry + `_TYPE_CATEGORY_MAP` entry. The alias is load-bearing because `"diffpair_clearance_intra"` contains `"clearance"` as a substring — the fuzzy fallback would otherwise silently miscategorize it as `CLEARANCE`.
2. **`validate`**: add `DiffPairClearanceIntraRule` (segment-segment only, reuses `_segment_segment_clearance` from `clearance.py`, applies `DRC_TOLERANCE`) and wire it into `DRCChecker.check_all()` + `check_diffpair_clearance_intra()`.
3. **`validate/cli`**: export from `validate.rules.__all__`; add `"diffpair_clearance_intra"` to `CHECK_CATEGORIES` and `check_methods` (id matches rule_id, mirroring #2525's `single_pad_net` convention).
4. **`clearance`**: `ClearanceRule` now skips same-pair segment-segment edges (the cross-rule fix called out in the issue) so users don't see double violations on every diff-pair edge tighter than `min_clearance_mm`.
5. **`tests`**: 10 unit tests (stub-PCB pattern from `test_validate_single_pad_net.py`) + 4 CLI tests, including the **MANDATORY** `to_dict()` round-trip trap test that catches the fuzzy-fallback miscategorization.

## Test plan

- [x] 10 unit tests pass: `tests/test_validate_diffpair_clearance_intra.py`
  - Structural correctness (within-pair gap < `min_clearance` but >= `intra` -> no fire)
  - Fire case (within-pair gap < `intra` -> one error, both nets in nets/message)
  - Cross-rule no-fire (`ClearanceRule` skips same-pair edges)
  - Single-ended exclusion (`USB_CC1`/`USB_CC2` not detected as a pair)
  - Pads-out-of-scope (segment-vs-pad gap below intra -> no fire)
  - `to_dict()` exact-equality round-trip (`d["type"] == "diffpair_clearance_intra"`)
  - Per-pair threshold (two pairs, different thresholds, only failing one fires)
  - rules_checked count, empty-PCB no-crash
- [x] 4 CLI tests pass: `tests/test_cli_check_diffpair_clearance_intra.py`
  - `--only diffpair_clearance_intra` -> exit 2 when fire case is staged
  - `--skip diffpair_clearance_intra` -> exit 0
  - JSON output `type` field round-trips exactly
  - `--errors-only` -> exit 2
- [x] 343 prior validate/clearance/intra-pair tests pass
- [x] 107 diff-pair detection/routing tests pass
- [x] `ruff check` and `ruff format --check` clean on all touched files
- [x] `kct check --help` shows the new category in `--only`/`--skip`

Generated with Claude Code