### PR TITLE
feat(router): thread intra_pair_clearance through pathfinder + cpp bindings (closes #2559, Epic #2556 Phase 1C)

### DIFF
--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -141,6 +141,12 @@ public:
     // trace_clearance: default clearance for segments
     // via_clearance: default clearance for vias
     // min_drill_clearance: minimum drill-to-drill spacing (same-net)
+    // partner_net: Issue #2559 / Phase 1C -- diff-pair partner net id, or
+    //              -1 to disable the partner branch (default).  When set,
+    //              segment-vs-segment / segment-vs-via comparisons against
+    //              partner_net use intra_pair_clearance instead of
+    //              trace_clearance.  Defaults preserve pre-#2559 behavior.
+    // intra_pair_clearance: tighter clearance applied only to the partner.
     ValidationResult validate_route(
         const std::vector<Segment>& segments,
         const std::vector<Via>& vias,
@@ -148,7 +154,9 @@ public:
         const std::vector<uint32_t>& exclude_ref_hashes,
         float trace_clearance,
         float via_clearance,
-        float min_drill_clearance) const;
+        float min_drill_clearance,
+        int partner_net = -1,
+        float intra_pair_clearance = 0.0f) const;
 
     // Accessors for validation data sizes (for testing/debugging)
     size_t pad_count() const { return pads_.size(); }

--- a/src/kicad_tools/router/cpp/include/pathfinder.hpp
+++ b/src/kicad_tools/router/cpp/include/pathfinder.hpp
@@ -47,7 +47,13 @@ public:
         int trace_radius_cells = 0,  // Per-net trace clearance radius (0 = use default)
         int via_radius_cells = 0,    // Per-net via clearance radius (0 = use default)
         const PadBounds& start_pad_bounds = {},  // Start pad metal/approach bounds
-        const PadBounds& end_pad_bounds = {}     // End pad metal/approach bounds
+        const PadBounds& end_pad_bounds = {},    // End pad metal/approach bounds
+        // Issue #2559 / Epic #2556 Phase 1C: diff-pair within-pair clearance.
+        // partner_net = -1 disables the partner branch (default; pre-#2559 behavior).
+        // intra_pair_radius_cells = 0 means "no tighter radius" -- the partner
+        // (when set) is treated with the wider trace_radius_cells.
+        int partner_net = -1,
+        int intra_pair_radius_cells = 0
     );
 
     // Resumable A* routing: initializes search state and runs to first goal.
@@ -65,7 +71,11 @@ public:
         int trace_radius_cells = 0,
         int via_radius_cells = 0,
         const PadBounds& start_pad_bounds = {},
-        const PadBounds& end_pad_bounds = {}
+        const PadBounds& end_pad_bounds = {},
+        // Issue #2559 / Epic #2556 Phase 1C: diff-pair within-pair clearance.
+        // See comment on route() above; defaults preserve pre-#2559 behavior.
+        int partner_net = -1,
+        int intra_pair_radius_cells = 0
     );
 
     // Resume A* search after rejecting a goal cell.
@@ -116,8 +126,16 @@ public:
 private:
     // Check if trace placement is blocked (accounts for trace width)
     // radius_override: if > 0, use this instead of trace_half_width_cells_
+    //
+    // Issue #2559 / Epic #2556 Phase 1C: when partner_net >= 0 and
+    // partner_radius > 0 and partner_radius < radius, cells whose net
+    // matches partner_net are checked against the smaller partner_radius
+    // instead of the wider radius.  This implements within-pair clearance
+    // for differential pairs.  Defaults preserve pre-#2559 behavior.
     bool is_trace_blocked(int x, int y, int layer, int net, bool allow_sharing,
-                          int radius_override = 0) const;
+                          int radius_override = 0,
+                          int partner_net = -1,
+                          int partner_radius = 0) const;
 
     // Check if diagonal move cuts through obstacles
     bool is_diagonal_blocked(int x, int y, int dx, int dy, int layer, int net,
@@ -187,6 +205,12 @@ private:
     PadBounds search_start_pad_bounds_{};
     PadBounds search_end_pad_bounds_{};
     bool search_state_active_ = false;  // True when resumable state is valid
+
+    // Issue #2559 / Epic #2556 Phase 1C: diff-pair within-pair clearance.
+    // Cached per-route-call so resume() and run_astar_loop() can apply
+    // the partner-aware radius branch on every neighbor expansion.
+    int search_partner_net_ = -1;
+    int search_intra_pair_radius_cells_ = 0;
 
     // Issue #2476: Via-vs-via failure tracking for run_astar_loop().  Reset
     // by route_resumable() and accumulated across the search and any

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -21,7 +21,7 @@ namespace router {
 // ``cpp_backend.py``; on import the two are compared and a mismatch
 // disables the C++ backend with a clear "kct build-native" error,
 // preventing silent ``AttributeError`` failures from a stale .so.
-constexpr int ROUTER_CPP_BUILD_VERSION = 2;
+constexpr int ROUTER_CPP_BUILD_VERSION = 3;
 
 // Grid cell state
 struct GridCell {

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -184,7 +184,13 @@ NB_MODULE(router_cpp, m) {
         .def("validate_route", &Grid3D::validate_route,
              "segments"_a, "vias"_a, "exclude_net"_a,
              "exclude_ref_hashes"_a, "trace_clearance"_a,
-             "via_clearance"_a, "min_drill_clearance"_a)
+             "via_clearance"_a, "min_drill_clearance"_a,
+             "partner_net"_a = -1,
+             "intra_pair_clearance"_a = 0.0f,
+             "Validate a candidate route against stored geometry.  Issue #2559 "
+             "/ Phase 1C: when partner_net >= 0 and intra_pair_clearance >= 0, "
+             "comparisons against partner_net use intra_pair_clearance instead "
+             "of trace_clearance (defaults preserve pre-#2559 behavior).")
         .def_prop_ro("pad_count", &Grid3D::pad_count)
         .def_prop_ro("stored_segment_count", &Grid3D::stored_segment_count)
         .def_prop_ro("stored_via_count", &Grid3D::stored_via_count);
@@ -205,7 +211,10 @@ NB_MODULE(router_cpp, m) {
              "trace_radius_cells"_a = 0,
              "via_radius_cells"_a = 0,
              "start_pad_bounds"_a = PadBounds{},
-             "end_pad_bounds"_a = PadBounds{})
+             "end_pad_bounds"_a = PadBounds{},
+             // Issue #2559 / Epic #2556 Phase 1C: diff-pair within-pair clearance.
+             "partner_net"_a = -1,
+             "intra_pair_radius_cells"_a = 0)
         .def("route_resumable", &Pathfinder::route_resumable,
              "start_x"_a, "start_y"_a, "start_layer"_a,
              "end_x"_a, "end_y"_a, "end_layer"_a,
@@ -218,7 +227,10 @@ NB_MODULE(router_cpp, m) {
              "trace_radius_cells"_a = 0,
              "via_radius_cells"_a = 0,
              "start_pad_bounds"_a = PadBounds{},
-             "end_pad_bounds"_a = PadBounds{})
+             "end_pad_bounds"_a = PadBounds{},
+             // Issue #2559 / Epic #2556 Phase 1C: diff-pair within-pair clearance.
+             "partner_net"_a = -1,
+             "intra_pair_radius_cells"_a = 0)
         .def("resume", &Pathfinder::resume,
              "reject_x"_a, "reject_y"_a, "reject_layer"_a)
         .def("clear_search_state", &Pathfinder::clear_search_state)

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -319,11 +319,20 @@ ValidationResult Grid3D::validate_route(
     const std::vector<uint32_t>& exclude_ref_hashes,
     float trace_clearance,
     float via_clearance,
-    float min_drill_clearance) const
+    float min_drill_clearance,
+    int partner_net,
+    float intra_pair_clearance) const
 {
     ValidationResult result;
     result.valid = true;
     result.min_clearance = std::numeric_limits<float>::infinity();
+
+    // Issue #2559 / Epic #2556 Phase 1C: diff-pair within-pair clearance.
+    // The partner branch is active when partner_net is a real net id (>= 0)
+    // and intra_pair_clearance is a tighter (non-negative) override.  When
+    // the branch is dormant (default), validation behaves exactly as before.
+    bool partner_active =
+        (partner_net >= 0) && (partner_net != exclude_net) && (intra_pair_clearance >= 0.0f);
 
     // Helper: check if a ref_hash is in the exclusion set
     auto is_excluded_ref = [&](uint32_t ref_hash) -> bool {
@@ -395,7 +404,14 @@ ValidationResult Grid3D::validate_route(
                 result.min_clearance = clearance;
             }
 
-            if (clearance < trace_clearance - CLEARANCE_EPSILON_MM) {
+            // Issue #2559 / Phase 1C: tighter clearance for the diff-pair
+            // partner only.  All other foreign nets keep the wider rule.
+            float effective_clearance =
+                (partner_active && other.net == partner_net)
+                ? intra_pair_clearance
+                : trace_clearance;
+
+            if (clearance < effective_clearance - CLEARANCE_EPSILON_MM) {
                 result.valid = false;
                 result.violation_x = (seg.x1 + seg.x2 + other.x1 + other.x2) / 4.0f;
                 result.violation_y = (seg.y1 + seg.y2 + other.y1 + other.y2) / 4.0f;
@@ -418,7 +434,13 @@ ValidationResult Grid3D::validate_route(
                 result.min_clearance = clearance;
             }
 
-            if (clearance < trace_clearance - CLEARANCE_EPSILON_MM) {
+            // Issue #2559 / Phase 1C: tighter clearance for the partner.
+            float effective_clearance =
+                (partner_active && sv.net == partner_net)
+                ? intra_pair_clearance
+                : trace_clearance;
+
+            if (clearance < effective_clearance - CLEARANCE_EPSILON_MM) {
                 result.valid = false;
                 result.violation_x = sv.x;
                 result.violation_y = sv.y;

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -57,8 +57,18 @@ void Pathfinder::set_routable_layers(const std::vector<int>& layers) {
 }
 
 bool Pathfinder::is_trace_blocked(int x, int y, int layer, int net,
-                                  bool allow_sharing, int radius_override) const {
+                                  bool allow_sharing, int radius_override,
+                                  int partner_net, int partner_radius) const {
     int radius = (radius_override > 0) ? radius_override : trace_half_width_cells_;
+
+    // Issue #2559 / Epic #2556 Phase 1C: when the partner branch is active
+    // (partner_net >= 0 && partner_radius > 0 && partner_radius < radius),
+    // partner-owned blocked cells in the slack ring (Chebyshev distance
+    // > partner_radius) are treated as passable.  All other cells use the
+    // wider radius as before.
+    bool partner_active =
+        (partner_net >= 0) && (partner_radius > 0) && (partner_radius < radius);
+
     for (int dy = -radius; dy <= radius; ++dy) {
         for (int dx = -radius; dx <= radius; ++dx) {
             int cx = x + dx, cy = y + dy;
@@ -68,6 +78,17 @@ bool Pathfinder::is_trace_blocked(int x, int y, int layer, int net,
 
             const auto& cell = grid_.at(cx, cy, layer);
             if (cell.blocked) {
+                // Issue #2559: relax partner cells outside the tighter
+                // intra-pair radius (Chebyshev metric matches the kernel
+                // shape used by Python compute_expanded_blocked()).
+                if (partner_active && cell.net == partner_net) {
+                    int cheb = std::max(std::abs(dx), std::abs(dy));
+                    if (cheb > partner_radius) {
+                        // Partner cell in the slack ring -- skip.
+                        continue;
+                    }
+                }
+
                 if (allow_sharing && !cell.is_obstacle) {
                     // Negotiated mode: allow sharing non-obstacle cells
                     if (cell.net == 0 && cell.usage_count == 0) {
@@ -272,7 +293,9 @@ RouteResult Pathfinder::route(
     int trace_radius_cells,
     int via_radius_cells,
     const PadBounds& start_pad_bounds,
-    const PadBounds& end_pad_bounds
+    const PadBounds& end_pad_bounds,
+    int partner_net,
+    int intra_pair_radius_cells
 ) {
     // Non-resumable route: use local A* state, no member state touched.
     // This preserves backward compatibility for callers that don't need retry.
@@ -424,7 +447,8 @@ RouteResult Pathfinder::route(
                     // Same-net blocked cell - allow
                 } else if (cell.net == 0) {
                     if (is_trace_blocked(nx, ny, nlayer, net, negotiated_mode,
-                                         trace_radius_cells)) {
+                                         trace_radius_cells,
+                                         partner_net, intra_pair_radius_cells)) {
                         continue;
                     }
                 } else {
@@ -443,7 +467,8 @@ RouteResult Pathfinder::route(
                 );
                 if (!is_pad_exit_or_approach) {
                     if (is_trace_blocked(nx, ny, nlayer, net, negotiated_mode,
-                                         trace_radius_cells)) {
+                                         trace_radius_cells,
+                                         partner_net, intra_pair_radius_cells)) {
                         continue;
                     }
                 }
@@ -563,7 +588,9 @@ RouteResult Pathfinder::route_resumable(
     int trace_radius_cells,
     int via_radius_cells,
     const PadBounds& start_pad_bounds,
-    const PadBounds& end_pad_bounds
+    const PadBounds& end_pad_bounds,
+    int partner_net,
+    int intra_pair_radius_cells
 ) {
     // Clear any previous search state
     clear_search_state();
@@ -579,6 +606,12 @@ RouteResult Pathfinder::route_resumable(
     search_weight_ = weight;
     search_trace_radius_cells_ = trace_radius_cells;
     search_via_radius_cells_ = via_radius_cells;
+
+    // Issue #2559 / Epic #2556 Phase 1C: cache diff-pair partner state so
+    // resume() and run_astar_loop() can apply the partner-aware radius
+    // branch on every neighbor expansion.
+    search_partner_net_ = partner_net;
+    search_intra_pair_radius_cells_ = intra_pair_radius_cells;
 
     auto [start_gx, start_gy] = grid_.world_to_grid(start_x, start_y);
     auto [end_gx, end_gy] = grid_.world_to_grid(end_x, end_y);
@@ -757,7 +790,9 @@ RouteResult Pathfinder::run_astar_loop() {
                 } else if (cell.net == 0) {
                     if (is_trace_blocked(nx, ny, nlayer, search_net_,
                                          search_negotiated_mode_,
-                                         search_trace_radius_cells_)) {
+                                         search_trace_radius_cells_,
+                                         search_partner_net_,
+                                         search_intra_pair_radius_cells_)) {
                         continue;
                     }
                 } else {
@@ -777,7 +812,9 @@ RouteResult Pathfinder::run_astar_loop() {
                 if (!is_pad_exit_or_approach) {
                     if (is_trace_blocked(nx, ny, nlayer, search_net_,
                                          search_negotiated_mode_,
-                                         search_trace_radius_cells_)) {
+                                         search_trace_radius_cells_,
+                                         search_partner_net_,
+                                         search_intra_pair_radius_cells_)) {
                         continue;
                     }
                 }
@@ -901,6 +938,10 @@ void Pathfinder::clear_search_state() {
     search_last_blocking_net_ = 0;
     search_last_block_world_x_ = 0.0f;
     search_last_block_world_y_ = 0.0f;
+    // Issue #2559 / Phase 1C: reset partner-net state so a stale partner
+    // from a previous net does not leak into the next route().
+    search_partner_net_ = -1;
+    search_intra_pair_radius_cells_ = 0;
 }
 
 RouteResult Pathfinder::reconstruct_path(

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 2
+_REQUIRED_CPP_BUILD_VERSION = 3
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -1073,6 +1073,8 @@ class RoutingGrid:
         min_clearance: float | None = None,
         component_pitches: dict[str, float] | None = None,
         exclude_refs: set[str] | None = None,
+        partner_net: int | None = None,
+        partner_clearance: float | None = None,
     ) -> tuple[bool, float, tuple[float, float] | None]:
         """Validate geometric clearance of a segment against all obstacles.
 
@@ -1085,6 +1087,12 @@ class RoutingGrid:
         clearance against a pad, uses the clearance for that pad's component
         (from DesignRules.component_clearances or fine_pitch_clearance).
 
+        Issue #2559 / Epic #2556 Phase 1C: Adds optional ``partner_net`` /
+        ``partner_clearance`` parameters.  When set, a segment-vs-segment
+        comparison against the partner net uses ``partner_clearance`` in
+        place of the wider ``min_clearance``.  This implements within-pair
+        clearance for differential pairs.
+
         Args:
             seg: The segment to validate
             exclude_net: Net ID to exclude (same-net elements don't violate clearance)
@@ -1092,6 +1100,12 @@ class RoutingGrid:
                           This is used when no component-specific clearance applies.
             component_pitches: Optional dict mapping component ref to pin pitch in mm.
                              Used for automatic fine-pitch clearance detection.
+            partner_net: Issue #2559 / Phase 1C -- when set, the named net id
+                         is the diff-pair partner of ``exclude_net`` and the
+                         seg-vs-seg / seg-vs-via comparisons use
+                         ``partner_clearance`` instead of ``min_clearance``.
+            partner_clearance: Tighter clearance applied only to elements
+                               whose net matches ``partner_net``.
 
         Returns:
             Tuple of (is_valid, actual_clearance, violation_location)
@@ -1103,6 +1117,15 @@ class RoutingGrid:
 
         if min_clearance is None:
             min_clearance = self.rules.trace_clearance
+
+        # Issue #2559: Tighter clearance is only applied when both arguments
+        # are present and the partner clearance is tighter than the default.
+        partner_active = (
+            partner_net is not None
+            and partner_net >= 0
+            and partner_net != exclude_net
+            and partner_clearance is not None
+        )
 
         # Segment half-width for edge-to-edge distance calculation
         seg_half_width = seg.width / 2
@@ -1213,9 +1236,17 @@ class RoutingGrid:
                 # Edge-to-edge clearance (both segment half-widths)
                 clearance = dist - seg_half_width - other_seg.width / 2
 
+                # Issue #2559 / Phase 1C: tighter clearance for the diff-pair
+                # partner only.
+                effective_clearance = (
+                    partner_clearance
+                    if partner_active and other_seg.net == partner_net
+                    else min_clearance
+                )
+
                 if clearance < min_actual_clearance:
                     min_actual_clearance = clearance
-                if clearance < min_clearance:
+                if clearance < effective_clearance:
                     has_violation = True
                     violation_loc = (
                         (seg.x1 + seg.x2 + other_seg.x1 + other_seg.x2) / 4,
@@ -1248,9 +1279,16 @@ class RoutingGrid:
                     # Edge-to-edge clearance (both segment half-widths)
                     clearance = dist - seg_half_width - other_seg.width / 2
 
+                    # Issue #2559 / Phase 1C: tighter clearance for partner.
+                    effective_clearance = (
+                        partner_clearance
+                        if partner_active and route.net == partner_net
+                        else min_clearance
+                    )
+
                     if clearance < min_actual_clearance:
                         min_actual_clearance = clearance
-                    if clearance < min_clearance:
+                    if clearance < effective_clearance:
                         # Violation location at midpoint
                         has_violation = True
                         violation_loc = (
@@ -2167,6 +2205,8 @@ class RoutingGrid:
         radius: int,
         net: int,
         allow_sharing: bool = False,
+        partner_net: int | None = None,
+        partner_radius: int | None = None,
     ) -> np.ndarray:
         """Pre-compute an expanded blocked bitmap for trace-width clearance.
 
@@ -2178,12 +2218,27 @@ class RoutingGrid:
         The dilation uses ``scipy.ndimage.maximum_filter`` when available,
         falling back to a pure-NumPy sliding-window maximum.
 
+        Issue #2559 / Epic #2556 Phase 1C: When ``partner_net`` is provided
+        with a tighter ``partner_radius`` (< ``radius``), partner-owned
+        blocked cells are dilated by the tighter radius and OR-combined
+        with the wider dilation of all other foreign-net blocked cells.
+        This implements within-pair clearance for differential pairs while
+        leaving the per-cell logic in ``_is_trace_blocked`` consistent.
+
         Args:
             radius: Half-width of the trace in grid cells (``_trace_half_width_cells``).
             net: Net ID of the route being planned.  Same-net cells are
                  *not* treated as blocked (consistent with ``_is_trace_blocked``).
             allow_sharing: If True (negotiated mode), only static obstacles
                            block; shared-usage cells are passable.
+            partner_net: Issue #2559 / Phase 1C -- when set (non-None and
+                         >= 0), cells whose net matches this id are dilated
+                         using ``partner_radius`` instead of ``radius``.
+                         When ``None``, the partner branch is dormant and
+                         behavior matches pre-#2559 (single-radius dilation).
+            partner_radius: Tighter half-width (in grid cells) for partner
+                            cells.  Ignored when ``partner_net`` is ``None``
+                            or ``partner_radius >= radius``.
 
         Returns:
             Boolean NumPy array of shape ``(num_layers, rows, cols)`` where
@@ -2202,6 +2257,36 @@ class RoutingGrid:
             # Standard mode: block cells that are blocked AND different net
             base_blocked = self._blocked & (self._net != net)
 
+        partner_active = (
+            partner_net is not None
+            and partner_net >= 0
+            and partner_radius is not None
+            and partner_radius < radius
+        )
+
+        if partner_active:
+            # Split base_blocked into "partner cells" and "non-partner cells".
+            # Partner cells get dilated by the tighter partner_radius; the
+            # rest of the foreign-net cells get the wider radius.  The
+            # final mask is the OR of the two dilations.
+            partner_mask = base_blocked & (self._net == partner_net)
+            other_mask = base_blocked & ~partner_mask
+
+            other_expanded = self._dilate_blocked(other_mask, radius)
+            partner_expanded = self._dilate_blocked(partner_mask, partner_radius)
+            return other_expanded | partner_expanded
+
+        return self._dilate_blocked(base_blocked, radius)
+
+    def _dilate_blocked(self, base_blocked: np.ndarray, radius: int) -> np.ndarray:
+        """Dilate a boolean blocked mask by ``radius`` cells (Chebyshev).
+
+        Helper extracted from :meth:`compute_expanded_blocked` so the same
+        kernel logic can be applied independently to the partner-cells
+        mask and the non-partner-cells mask (Issue #2559 / Phase 1C).
+        """
+        if radius <= 0:
+            return base_blocked.copy() if isinstance(base_blocked, np.ndarray) else base_blocked
         if radius <= 1:
             # No expansion needed; single-cell check is equivalent.
             return base_blocked

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -216,6 +216,15 @@ class Router:
         # Counter for assigning unique negative waypoint indices.
         self._waypoint_id_counter: int = 0
 
+        # Issue #2559 / Epic #2556 Phase 1C: Differential-pair within-pair
+        # clearance threading.  Net-name -> net-id reverse map populated by
+        # the autorouter (or test harness) so the pathfinder can resolve
+        # ``NetClassRouting.diffpair_partner`` (a name) to an integer net id
+        # for the per-cell partner branch in ``_is_trace_blocked``.  Empty
+        # by default -- when unset, the partner branch is dormant and
+        # behavior matches pre-#2559 (single-clearance) routing.
+        self._net_name_to_id: dict[str, int] = {}
+
     # ------------------------------------------------------------------
     # Waypoint helpers (Issue #2330)
     # ------------------------------------------------------------------
@@ -753,6 +762,46 @@ class Router:
         """Get the net class for a net name."""
         return self.net_class_map.get(net_name)
 
+    # ------------------------------------------------------------------
+    # Diff-pair partner resolution (Issue #2559 / Epic #2556 Phase 1C)
+    # ------------------------------------------------------------------
+
+    def set_net_name_to_id(self, mapping: dict[str, int]) -> None:
+        """Inject a net-name -> net-id reverse map for partner resolution.
+
+        Phase 1C threads ``NetClassRouting.intra_pair_clearance`` through the
+        A* search.  The clearance is configured by net-class on the source
+        net, but applies only when the *other* net is the named partner.
+        Resolving partner-name to partner-id requires a reverse map that the
+        ``Autorouter`` builds from its ``net_names`` dict.
+
+        The setter is idempotent and may be called multiple times (e.g. to
+        refresh the map when new pads are loaded).  Passing an empty dict
+        disables partner detection (everything falls back to ``clearance``).
+        """
+        self._net_name_to_id = dict(mapping)
+
+    def _resolve_partner_net_id(self, net_name: str) -> int | None:
+        """Look up the integer net id of the diff-pair partner of *net_name*.
+
+        Reads ``NetClassRouting.diffpair_partner`` (the authoritative
+        Phase 1B signal) and resolves the partner-name to a partner-id via
+        :attr:`_net_name_to_id`.  Returns ``None`` when:
+
+        * the source net has no net class (or the class has no
+          ``diffpair_partner`` set), or
+        * the partner-name is missing from ``_net_name_to_id`` (e.g. the
+          autorouter has not populated the reverse map yet).
+
+        ``None`` is the dormant signal for the four read sites: when partner
+        is unknown, the search uses the wider ``clearance`` for every other
+        net, matching pre-#2559 behavior.
+        """
+        net_class = self._get_net_class(net_name)
+        if net_class is None or net_class.diffpair_partner is None:
+            return None
+        return self._net_name_to_id.get(net_class.diffpair_partner)
+
     def _get_trace_width_for_net(self, net_name: str) -> float:
         """Get the trace width for a net based on its net class.
 
@@ -819,6 +868,8 @@ class Router:
     def _is_trace_blocked(
         self, gx: int, gy: int, layer: int, net: int, allow_sharing: bool = False,
         radius: int | None = None,
+        partner_net: int | None = None,
+        partner_radius: int | None = None,
     ) -> bool:
         """Check if placing a trace at this position would conflict.
 
@@ -834,6 +885,17 @@ class Router:
                           non-obstacle blocked cells (they'll get high cost instead)
             radius: Override the trace half-width in grid cells. When None,
                     uses the global ``_trace_half_width_cells`` (Issue #1674).
+            partner_net: Issue #2559 / Phase 1C -- if set (non-None and >= 0)
+                         and ``partner_radius`` is provided, cells belonging
+                         to this net are checked against the *tighter*
+                         ``partner_radius`` instead of the wider ``radius``.
+                         This implements within-pair clearance for diff pairs.
+                         When ``None``, the partner branch is dormant and
+                         behavior matches pre-#2559 routing.
+            partner_radius: Tighter half-width (in grid cells) to apply only
+                            to ``cell.net == partner_net``.  When ``None``
+                            but ``partner_net`` is set, the partner branch
+                            falls back to ``radius`` (no tightening).
         """
         if radius is None:
             radius = self._trace_half_width_cells
@@ -859,6 +921,31 @@ class Router:
         blocked_region = self.grid._blocked[layer, y1:y2, x1:x2]
         net_region = self.grid._net[layer, y1:y2, x1:x2]
 
+        # Issue #2559 / Phase 1C: Build partner-relaxation mask.
+        # When the partner branch is active, cells whose net matches
+        # partner_net are checked against partner_radius instead of radius.
+        # We OR the blocking mask with a "is partner cell outside the tight
+        # radius" suppressor so partner-blocked cells in the slack ring
+        # (>partner_radius && <=radius from gx,gy) are treated as passable.
+        partner_active = (
+            partner_net is not None
+            and partner_net >= 0
+            and partner_radius is not None
+            and partner_radius < radius
+        )
+        partner_relax_mask = None
+        if partner_active:
+            # Compute Chebyshev distance from (gx, gy) to each cell in the
+            # extracted region, then mark cells whose net == partner_net
+            # AND distance > partner_radius as "ignore for blocking".
+            ys = np.arange(y1, y2)
+            xs = np.arange(x1, x2)
+            cheb = np.maximum(
+                np.abs(ys - gy)[:, None],
+                np.abs(xs - gx)[None, :],
+            )
+            partner_relax_mask = (net_region == partner_net) & (cheb > partner_radius)
+
         if allow_sharing:
             # Negotiated mode: more complex logic
             # Block if any cell is:
@@ -876,12 +963,17 @@ class Router:
             # Case 2: Blocked non-obstacles with different net AND static (usage == 0)
             static_blocks = blocked_region & ~obstacle_region & different_net & (usage_region == 0)
 
-            return bool(np.any(obstacle_blocks | static_blocks))
+            combined = obstacle_blocks | static_blocks
+            if partner_relax_mask is not None:
+                combined = combined & ~partner_relax_mask
+            return bool(np.any(combined))
         else:
             # Standard mode: block if any cell is blocked AND has different net
             # Issue #864: Same-net cells are passable (even overlapping clearance)
             # but different-net cells and obstacles (net=0 blocked cells) must block.
             blocked_different_net = blocked_region & (net_region != net)
+            if partner_relax_mask is not None:
+                blocked_different_net = blocked_different_net & ~partner_relax_mask
             return bool(np.any(blocked_different_net))
 
     def _is_diagonal_corner_blocked(
@@ -1493,6 +1585,28 @@ class Router:
             ),
         )
 
+        # Issue #2559 / Epic #2556 Phase 1C: Resolve diff-pair partner and
+        # compute the tighter within-pair half-width radius.  When the
+        # source net's NetClassRouting declares a ``diffpair_partner`` and
+        # the partner net id is known via ``_net_name_to_id``, the search
+        # uses ``effective_intra_pair_clearance`` as the tighter radius
+        # for cells belonging to the partner net only.  All other foreign
+        # nets continue to see the wider ``net_trace_clearance`` radius.
+        partner_net_id = self._resolve_partner_net_id(start.net_name)
+        if partner_net_id is not None and net_class is not None:
+            net_intra_pair_clearance = net_class.effective_intra_pair_clearance()
+            net_partner_half_width_cells = max(
+                1,
+                math.ceil(
+                    round(
+                        (net_trace_width / 2 + net_intra_pair_clearance) / self.grid.resolution,
+                        6,
+                    )
+                ),
+            )
+        else:
+            net_partner_half_width_cells = net_trace_half_width_cells
+
         # Issue #1692: Compute per-net via clearance radius.  Net classes
         # may specify larger via_size which requires a wider blocking check.
         net_via_size = net_class.via_size if net_class else self.rules.via_diameter
@@ -1573,8 +1687,14 @@ class Router:
 
         # Issue #2430: Pre-compute expanded blocked bitmap so that
         # _is_trace_blocked becomes a single array lookup per neighbor.
+        # Issue #2559 / Phase 1C: Pass partner net id and tighter radius so
+        # within-pair edges of a diff pair get the relaxed clearance.
         expanded_blocked = self.grid.compute_expanded_blocked(
-            net_trace_half_width_cells, start.net, allow_sharing
+            net_trace_half_width_cells,
+            start.net,
+            allow_sharing,
+            partner_net=partner_net_id,
+            partner_radius=net_partner_half_width_cells,
         )
 
         # Issue #2430: Build crossing grid index if routed segments exist.
@@ -2687,6 +2807,27 @@ class Router:
             ),
         )
 
+        # Issue #2559 / Epic #2556 Phase 1C: Resolve diff-pair partner for
+        # within-pair clearance threading -- mirrors the logic in route().
+        # The bidirectional search expands neighbors via
+        # ``_expand_bidirectional_neighbors``, which now accepts a
+        # ``partner_net``/``partner_radius`` pair to forward into the
+        # ``_is_trace_blocked`` check.
+        partner_net_id = self._resolve_partner_net_id(start.net_name)
+        if partner_net_id is not None and net_class is not None:
+            net_intra_pair_clearance = net_class.effective_intra_pair_clearance()
+            net_partner_half_width_cells = max(
+                1,
+                math.ceil(
+                    round(
+                        (net_trace_width / 2 + net_intra_pair_clearance) / self.grid.resolution,
+                        6,
+                    )
+                ),
+            )
+        else:
+            net_partner_half_width_cells = net_trace_half_width_cells
+
         # Issue #1692: Compute per-net via clearance radius.
         net_via_size = net_class.via_size if net_class else self.rules.via_diameter
         net_via_half_cells = max(
@@ -2854,6 +2995,8 @@ class Router:
                         weight,
                         trace_radius=net_trace_half_width_cells,
                         via_radius=net_via_half_cells,
+                        partner_net=partner_net_id,
+                        partner_radius=net_partner_half_width_cells,
                     )
 
             # Process backward step
@@ -2890,6 +3033,8 @@ class Router:
                         weight,
                         trace_radius=net_trace_half_width_cells,
                         via_radius=net_via_half_cells,
+                        partner_net=partner_net_id,
+                        partner_radius=net_partner_half_width_cells,
                     )
 
             # Early termination: if we have a meeting point and both queues
@@ -2930,6 +3075,8 @@ class Router:
         weight: float,
         trace_radius: int | None = None,
         via_radius: int | None = None,
+        partner_net: int | None = None,
+        partner_radius: int | None = None,
     ) -> None:
         """Expand neighbors for bidirectional A* search.
 
@@ -2943,6 +3090,11 @@ class Router:
             via_radius: Per-net-class via half-width in grid cells.
                 When None, falls back to the global ``_via_half_cells``
                 (Issue #1692).
+            partner_net: Issue #2559 / Phase 1C -- diff-pair partner net id.
+                When set, ``_is_trace_blocked`` calls below pass this id and
+                ``partner_radius`` so the partner cells are treated as
+                blockers only within the tighter intra-pair radius.
+            partner_radius: Tighter half-width for partner cells.
         """
         # Extract bounds (Issue #990: also need source bounds for pad exit check)
         src_gx1, src_gy1, src_gx2, src_gy2 = source_metal_bounds
@@ -3010,7 +3162,9 @@ class Router:
                     pass  # Same net - passable
                 elif cell.net == 0:
                     if self._is_trace_blocked(nx, ny, nlayer, source_pad.net, allow_sharing,
-                                              radius=trace_radius):
+                                              radius=trace_radius,
+                                              partner_net=partner_net,
+                                              partner_radius=partner_radius):
                         continue
                 else:
                     # Different net's blocked cell
@@ -3035,7 +3189,9 @@ class Router:
                 )
                 if not is_pad_exit_or_approach:
                     if self._is_trace_blocked(nx, ny, nlayer, source_pad.net, allow_sharing,
-                                              radius=trace_radius):
+                                              radius=trace_radius,
+                                              partner_net=partner_net,
+                                              partner_radius=partner_radius):
                         continue
 
             # Check zone blocking

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -484,6 +484,7 @@ NET_CLASS_HIGH_SPEED = NetClassRouting(
     priority=2,
     trace_width=0.2,
     clearance=0.15,
+    intra_pair_clearance=0.075,  # Issue #2559 / Epic #2556 Phase 1C
     cost_multiplier=0.85,
     length_critical=True,
 )

--- a/tests/test_intra_pair_clearance.py
+++ b/tests/test_intra_pair_clearance.py
@@ -93,7 +93,9 @@ class TestDataclassesReplaceRoundTrip:
     """
 
     def test_replace_sets_only_intra_pair_clearance(self):
-        original = NET_CLASS_HIGH_SPEED
+        # Use a fresh instance — the predefined NET_CLASS_HIGH_SPEED now sets
+        # intra_pair_clearance=0.075 (Phase 1C config change).
+        original = NetClassRouting(name="TestPair", clearance=0.15)
         replaced = dataclasses.replace(original, intra_pair_clearance=0.075)
         assert replaced.intra_pair_clearance == 0.075
         assert replaced.clearance == original.clearance
@@ -135,7 +137,9 @@ class TestPredefinedInstanceDefaults:
             NET_CLASS_POWER,
             NET_CLASS_HIGH_CURRENT_SIGNAL,
             NET_CLASS_CLOCK,
-            NET_CLASS_HIGH_SPEED,
+            # NET_CLASS_HIGH_SPEED intentionally omitted — Phase 1C
+            # (issue #2559) sets intra_pair_clearance=0.075 on this class
+            # to enable tighter within-pair clearance for diff pairs.
             NET_CLASS_AUDIO,
             NET_CLASS_DIGITAL,
             NET_CLASS_DEBUG,
@@ -145,13 +149,20 @@ class TestPredefinedInstanceDefaults:
     def test_predefined_instance_intra_pair_is_none(self, net_class):
         assert net_class.intra_pair_clearance is None
 
+    def test_high_speed_has_phase1c_intra_pair_clearance(self):
+        # Phase 1C (Epic #2556) configures NET_CLASS_HIGH_SPEED with
+        # intra_pair_clearance=0.075 so USB_D+/USB_D- on board 03 fits
+        # the J1 row A 0.5mm pitch without -0.200mm overlap.
+        assert NET_CLASS_HIGH_SPEED.intra_pair_clearance == 0.075
+        assert NET_CLASS_HIGH_SPEED.effective_intra_pair_clearance() == 0.075
+
     @pytest.mark.parametrize(
         "net_class",
         [
             NET_CLASS_POWER,
             NET_CLASS_HIGH_CURRENT_SIGNAL,
             NET_CLASS_CLOCK,
-            NET_CLASS_HIGH_SPEED,
+            # NET_CLASS_HIGH_SPEED omitted (Phase 1C — see above).
             NET_CLASS_AUDIO,
             NET_CLASS_DIGITAL,
             NET_CLASS_DEBUG,


### PR DESCRIPTION
## Summary

Phase 1C of Epic #2556 (first-class differential pair support). Threads `NetClassRouting.intra_pair_clearance` (Phase 1A field) into the routing engines so within-pair edges between paired nets use the tighter clearance.

## Status: foundation + Python backend complete; C++ wiring deferred to follow-on

3 incremental commits (#2547 protocol):

1. **`08dbfddf`** — Python pathfinder threading
   - `pathfinder.py:1485` (unidirectional A*) and `:2679` (bidirectional A*) consume `intra_pair_clearance` via the new `_resolve_partner_net_id` helper and Option A precomputed two-scalar branch
   - `grid.py` extended for partner-aware passable region marking
   - Mark-route stays wide (existing behavior); search side becomes partner-aware (recommended conservative path)

2. **`d2eb4e42`** — C++ binding signature changes (backward-compatible defaults)
   - `pathfinder.hpp` / `bindings.cpp`: `route_resumable()` and `is_trace_blocked()` accept `partner_net=-1`, `partner_radius=0`
   - `grid.hpp` / `grid.cpp`: `Grid3D::validate_route()` accepts `partner_net=-1`, `intra_pair_clearance=0.0`
   - `clear_search_state()` resets the partner-net cache
   - `_REQUIRED_CPP_BUILD_VERSION` bumped 2 → 3
   - **Default-value behavior**: existing `cpp_backend.py:893` `route_resumable()` call still works unchanged (uses `partner_net=-1` default → no partner branching)

3. **`8d622fd7`** — `NET_CLASS_HIGH_SPEED.intra_pair_clearance=0.075` config + test updates
   - The empirical Phase 1C gate

## Empirical verification on board 03 (Python backend)

```
$ kct route boards/03-usb-joystick/output/usb_joystick.kicad_pcb \
    -o /tmp/x.kicad_pcb --backend python --quiet
$ kct check /tmp/x.kicad_pcb --mfr jlcpcb --errors-only
DRC PASSED - No violations found
```

Was 17 errors at allowlist baseline (the structural -0.200mm overlap on USB_D+/USB_D-).

## What's NOT in this PR (intentional follow-on)

The cpp_backend.py wiring to actually pass `partner_net` through to the new C++ binding params is **deferred to a Phase 1C-extended follow-on**. Current state:
- Python backend: full intra_pair_clearance threading; board 03 verified 0 DRC errors
- C++ backend: backward-compatible — uses default `partner_net=-1` so all existing routing behavior is unchanged

This PR was originally implemented by an autonomous builder agent that ran out of usage budget after committing 2 of the planned 6 commits. The committed work was salvaged via incremental-commit protocol (#2547). The remaining cpp_backend wiring + tests + integration verification will be filed as a follow-on issue.

## Test plan

- [x] Phase 1A tests still pass (30/30; updated `test_replace_sets_only_intra_pair_clearance` and `test_predefined_instance_intra_pair_is_none` to acknowledge Phase 1C config; new `test_high_speed_has_phase1c_intra_pair_clearance` pins the 0.075 value)
- [x] Board 03 routes 13/13 with 0 DRC errors via Python backend
- [x] Board 01 baseline preserved (3/3 routed, 0/0 DRC)
- [x] C++ backend builds cleanly with new bindings
- [ ] (follow-on) cpp_backend.py wiring of `partner_net` into `route_resumable()` / `find_blocking_nets()` calls
- [ ] (follow-on) Empirical board 03 verification via C++ backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)