### PR TITLE
chore(ci): tighten board 05 DRC allowlist 17 → 15 (lock in PR #2583's floor)

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -27,9 +27,12 @@
 #   * board 03 (1 error) -- tracked separately; pre-existing pre-CI-gate state.
 
 tolerances:
-  # 15x clearance_segment_segment + 2x clearance_segment_via at JLCPCB rules.
-  # Partial progress landed in #2551 (closes #2532); full fix tracked in #2542.
-  boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb: 17
+  # Tightened from 17 → 15 to lock in the floor reached by PR #2583 (Hall
+  # sensor placement re-tune dropped 22 → 15 via R30-R32/C30-C32 spread).
+  # Per-rule: 13x clearance_segment_segment + 2x clearance_segment_via at
+  # JLCPCB rules. Partial progress landed in #2551 (closes #2532); full
+  # fix tracked in #2542.
+  boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb: 15
 
   # 1x clearance_segment_segment at JLCPCB rules. Pre-existing at the time the
   # CI gate landed (issue #2546). Should be driven to 0 in a follow-up.


### PR DESCRIPTION
## Summary

PR #2583 (Hall sensor placement re-tune) dropped board 05's routed PCB DRC from 22 → 15 errors via the R30-R32/C30-C32 spread along J3. The committed `_routed.kicad_pcb` has 15 errors; the allowlist was still 17 from the pre-PR-#2583 floor.

Per the file's own guidance:
> When a board's count IMPROVES (e.g., 17 → 12), reduce the value here in the same PR that reduces the count, so further regressions are caught against the new floor.

PR #2583 didn't do this in the same PR; the judge explicitly flagged it as a follow-up. This PR addresses that.

## Test plan

```
$ uv run python scripts/ci/check_routed_drc.py \
    boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb
OK: ... 15 errors (allowlist max 15; reduce the allowlist value in
.github/routed-drc-tolerance.yml if this count drops further).
```

## What's NOT in this PR

Board 03 was investigated for similar tightening (1 → 0) — the fresh Python-backend route can produce 0 errors but shows wide run-to-run variance (0 to 3 errors observed in 2 runs). The 1-error allowlist is preserved. The full clean state for board 03 is tracked in #2587 (Phase 1C-cont — autorouter wiring of `intra_pair_clearance`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)