### PR TITLE
ci: warn on stale routed-drc-tolerance.yml entries (closes #2590)

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -14,9 +14,17 @@
 #     absence of the entry is the strict 0-error gate.
 #   * When a board's count IMPROVES (e.g., 17 -> 12), reduce the value here
 #     in the same PR that reduces the count, so further regressions are
-#     caught against the new floor.
+#     caught against the new floor. Issue #2590 added a CI warning annotation
+#     that nags the PR Files-changed view when the actual count is below the
+#     allowlist value (slack > 0), so reviewers see the stale entry.
 #   * Adding a new entry (loosening) requires reviewer justification and a
 #     tracking issue link in the PR description.
+#
+# Cross-PR drift (an entry going stale because a different PR improved the
+# count without tightening) is NOT detected by the per-PR warning above --
+# only files in the diff are checked. A scheduled-audit job that walks every
+# entry in this file is deferred (see the TODO in
+# scripts/ci/check_routed_drc.py::annotate_drift_warning).
 #
 # Schema:
 #   tolerances:

--- a/scripts/ci/check_routed_drc.py
+++ b/scripts/ci/check_routed_drc.py
@@ -147,13 +147,48 @@ def annotate_error(file: str, message: str) -> None:
     print(f"::error file={file}::{message}", flush=True)
 
 
-def check_file(pcb_path: Path, allowed: int) -> tuple[bool, str]:
+def annotate_drift_warning(file: str, errors: int, allowed: int) -> None:
+    """Emit a GitHub-Actions ``::warning file=...::`` for a stale allowlist entry.
+
+    Called when a routed PCB's actual error count is strictly less than the
+    allowlist value (slack > 0). The warning surfaces in the PR Files-changed
+    view alongside ``::error::`` annotations so reviewers don't miss it
+    (issue #2590).
+
+    Args:
+        file: Repo-relative path to the routed PCB (used as the annotation's
+            ``file=`` target so GitHub anchors the warning to the file).
+        errors: Actual error count returned by ``kct check``.
+        allowed: Current allowlist value from
+            ``.github/routed-drc-tolerance.yml``.
+
+    Note:
+        TODO(#2590): Cross-PR drift detection (i.e., warning on stale entries
+        for files NOT touched in the current PR) is deferred to a future
+        scheduled-audit job. v1 only inspects files in the diff so the
+        warning attaches to a file the reviewer is actively looking at, and
+        we don't pay the per-board ``kct check`` cost for every entry on
+        every PR. See the issue's "Scope question" section for the rationale.
+    """
+    slack = allowed - errors
+    print(
+        f"::warning file={file}::Allowlist for `{file}` is {allowed} but "
+        f"actual is {errors} (slack={slack}). Tighten to {errors} in this "
+        f"PR or a follow-up to lock in the new floor (see "
+        f".github/routed-drc-tolerance.yml).",
+        flush=True,
+    )
+
+
+def check_file(pcb_path: Path, allowed: int) -> tuple[bool, str, int]:
     """Check a single PCB against its allowed error count.
 
     Returns:
-        (passed, message) tuple. ``passed`` is True if errors <= allowed.
-        ``message`` is a human-readable summary suitable for both stdout
-        and GitHub annotation.
+        ``(passed, message, errors)`` tuple. ``passed`` is True if
+        ``errors <= allowed``. ``message`` is a human-readable summary
+        suitable for both stdout and GitHub annotation. ``errors`` is the
+        actual count returned by ``kct check`` so callers can compute drift
+        slack without re-running the (expensive) DRC check.
     """
     errors = count_errors(pcb_path)
     if errors <= allowed:
@@ -165,7 +200,7 @@ def check_file(pcb_path: Path, allowed: int) -> tuple[bool, str]:
                 f"reduce the allowlist value in .github/routed-drc-tolerance.yml "
                 f"if this count drops further)."
             )
-        return True, msg
+        return True, msg, errors
 
     if allowed == 0:
         msg = (
@@ -181,7 +216,7 @@ def check_file(pcb_path: Path, allowed: int) -> tuple[bool, str]:
             f"new violations, or (if intentional) raise the allowlist value "
             f"with reviewer sign-off."
         )
-    return False, msg
+    return False, msg, errors
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -241,7 +276,7 @@ def main(argv: list[str] | None = None) -> int:
         allowed = allowlist.get(lookup_key, 0)
 
         try:
-            passed, message = check_file(pcb_path, allowed)
+            passed, message, errors = check_file(pcb_path, allowed)
         except RuntimeError as e:
             annotate_error(str(pcb_path), f"kct check failed: {e}")
             overall_failed = 1
@@ -249,6 +284,16 @@ def main(argv: list[str] | None = None) -> int:
 
         if passed:
             print(message, flush=True)
+            # Issue #2590: surface stale allowlist entries (slack > 0) as a
+            # GitHub-Actions warning annotation so reviewers see them in the
+            # PR Files-changed view, not buried in stdout. The ``allowed > 0``
+            # guard avoids noise on the common case of an unlisted board with
+            # 0 errors (allowed defaults to 0 -> slack=0 anyway, but be
+            # explicit). The gate's exit code is unchanged: warnings are
+            # advisory, matching the precedent at the deleted-file branch
+            # above.
+            if allowed > 0 and errors < allowed:
+                annotate_drift_warning(lookup_key, errors, allowed)
         else:
             annotate_error(str(pcb_path), message)
             overall_failed = 2

--- a/tests/test_ci_routed_drc_workflow.py
+++ b/tests/test_ci_routed_drc_workflow.py
@@ -288,35 +288,39 @@ class TestHelperCheckFile:
 
     def test_zero_errors_zero_allowed_passes(self) -> None:
         with patch.object(self.helper, "count_errors", return_value=0):
-            passed, msg = self.helper.check_file(Path("foo.kicad_pcb"), allowed=0)
+            passed, msg, errors = self.helper.check_file(Path("foo.kicad_pcb"), allowed=0)
         assert passed
         assert "0 errors" in msg
+        assert errors == 0
 
     def test_under_allowed_passes(self) -> None:
         """A board grandfathered at 17 errors that drops to 5 must pass --
         the gate is "allowed minus epsilon", not "exact match"."""
         with patch.object(self.helper, "count_errors", return_value=5):
-            passed, msg = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
+            passed, msg, errors = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
         assert passed
         assert "5 errors" in msg
         # The pass message should nudge the contributor to lower the
         # allowlist if the count drops -- this prevents stale tolerances.
         assert "reduce the allowlist value" in msg
+        assert errors == 5
 
     def test_at_allowed_passes(self) -> None:
         """Equal-to-allowed is the steady state for a grandfathered board."""
         with patch.object(self.helper, "count_errors", return_value=17):
-            passed, _ = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
+            passed, _, errors = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
         assert passed
+        assert errors == 17
 
     def test_over_allowed_fails_grandfathered(self) -> None:
         """Regression on a grandfathered board: 17 -> 22. Must fail."""
         with patch.object(self.helper, "count_errors", return_value=22):
-            passed, msg = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
+            passed, msg, errors = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
         assert not passed
         assert "regression" in msg.lower()
         assert "17" in msg
         assert "22" in msg
+        assert errors == 22
 
     def test_nonzero_with_zero_allowed_fails(self) -> None:
         """Default case: a board not in the allowlist (allowed=0) must
@@ -324,7 +328,7 @@ class TestHelperCheckFile:
         critical assertion that PR #2538's merge state would have
         triggered (board 04 with 5 errors)."""
         with patch.object(self.helper, "count_errors", return_value=5):
-            passed, msg = self.helper.check_file(
+            passed, msg, errors = self.helper.check_file(
                 Path("boards/04-x/output/x_routed.kicad_pcb"), allowed=0
             )
         assert not passed
@@ -332,6 +336,7 @@ class TestHelperCheckFile:
         # grandfathering escape hatch.
         assert "routed-drc-tolerance.yml" in msg
         assert "5 error" in msg
+        assert errors == 5
 
 
 class TestHelperMain:

--- a/tests/test_ci_routed_drc_workflow.py
+++ b/tests/test_ci_routed_drc_workflow.py
@@ -388,6 +388,240 @@ class TestHelperMain:
 
 
 # ---------------------------------------------------------------------------
+# Drift warning tests (issue #2590)
+# ---------------------------------------------------------------------------
+
+
+class TestHelperDriftWarning:
+    """Unit tests for ``annotate_drift_warning`` -- the warning-annotation
+    helper that surfaces stale allowlist entries (slack > 0) to PR
+    reviewers via the GitHub Files-changed view (issue #2590)."""
+
+    def setup_method(self) -> None:
+        self.helper = _load_helper_module()
+
+    def test_warning_format(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """The annotation must use the ``::warning file=...::`` form so
+        GitHub anchors it to the file in the Files-changed view (matches
+        the deleted-file precedent at check_routed_drc.py's main loop)."""
+        path = "boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb"
+        self.helper.annotate_drift_warning(path, errors=15, allowed=17)
+        captured = capsys.readouterr()
+        # GitHub annotation prefix with the right file= target.
+        assert f"::warning file={path}::" in captured.out
+
+    def test_warning_includes_actual_and_allowed_counts(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The warning text must include both numbers so reviewers can
+        read the slack at a glance without opening the allowlist."""
+        path = "boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb"
+        self.helper.annotate_drift_warning(path, errors=15, allowed=17)
+        captured = capsys.readouterr()
+        assert "is 17" in captured.out  # allowlist value
+        assert "actual is 15" in captured.out  # actual count
+
+    def test_warning_includes_recommended_new_value(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Per acceptance criteria #2: the warning must tell the contributor
+        what to set the allowlist to (= the actual count). This is the
+        load-bearing 'tighten to <N>' phrasing."""
+        path = "boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb"
+        self.helper.annotate_drift_warning(path, errors=15, allowed=17)
+        captured = capsys.readouterr()
+        assert "Tighten to 15" in captured.out
+
+    def test_warning_points_at_allowlist_file(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The warning must reference the allowlist file path so the
+        reviewer can navigate to where the fix belongs."""
+        path = "boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb"
+        self.helper.annotate_drift_warning(path, errors=0, allowed=1)
+        captured = capsys.readouterr()
+        assert ".github/routed-drc-tolerance.yml" in captured.out
+
+
+class TestMainDriftWarningEmission:
+    """Integration tests for ``main()``'s drift-warning emission flow
+    (issue #2590).
+
+    These stub ``count_errors`` so we exercise the gate without invoking
+    ``kct check``. The point is to pin the conditions under which a
+    warning IS or IS NOT emitted, since the silent stdout drift was the
+    original bug.
+    """
+
+    def setup_method(self) -> None:
+        self.helper = _load_helper_module()
+
+    def _make_pcb_and_allowlist(
+        self, tmp_path: Path, allowlist_value: int | None
+    ) -> tuple[Path, Path]:
+        """Create a placeholder .kicad_pcb file in a routed-pattern path
+        and an allowlist YAML pointing at it (or empty if value is None).
+
+        Returns ``(pcb_path, allowlist_path)``.
+        """
+        # Mirror the boards/<name>/output/<file>_routed.kicad_pcb pattern
+        # so the path looks like a real routed PCB.
+        pcb_dir = tmp_path / "boards" / "99-test" / "output"
+        pcb_dir.mkdir(parents=True)
+        pcb = pcb_dir / "test_routed.kicad_pcb"
+        pcb.touch()
+
+        allowlist = tmp_path / "tolerance.yml"
+        if allowlist_value is None:
+            allowlist.write_text("tolerances: {}\n")
+        else:
+            # Use the path as passed on argv (the helper resolves it
+            # relative to cwd before lookup, but raw form works for
+            # tmp_path-rooted absolute paths too -- we set it here so the
+            # lookup_key matches what main() computes).
+            allowlist.write_text(f"tolerances:\n  '{pcb}': {allowlist_value}\n")
+        return pcb, allowlist
+
+    def test_slack_positive_emits_drift_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The PR #2583 scenario: actual=15, allowlist=17. Gate passes,
+        but a ``::warning file=...::`` MUST be emitted so the reviewer
+        sees the stale entry. This is the regression test for #2590."""
+        pcb, allowlist = self._make_pcb_and_allowlist(tmp_path, allowlist_value=17)
+        with patch.object(self.helper, "count_errors", return_value=15):
+            rc = self.helper.main(["--allowlist", str(allowlist), str(pcb)])
+        assert rc == 0  # gate still passes
+        captured = capsys.readouterr()
+        assert "::warning file=" in captured.out
+        assert "Tighten to 15" in captured.out
+        assert "actual is 15" in captured.out
+        assert "is 17" in captured.out
+
+    def test_slack_zero_no_drift_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Steady state: actual=17, allowlist=17. No warning -- the
+        floor matches reality. (The OK message still goes to stdout.)"""
+        pcb, allowlist = self._make_pcb_and_allowlist(tmp_path, allowlist_value=17)
+        with patch.object(self.helper, "count_errors", return_value=17):
+            rc = self.helper.main(["--allowlist", str(allowlist), str(pcb)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        # The "deleted in PR" warning is unrelated; we assert the drift
+        # warning specifically is absent.
+        assert "Tighten to" not in captured.out
+        assert "::warning file=" not in captured.out
+
+    def test_slack_negative_failure_no_drift_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Regression case: actual=22, allowlist=17. Gate FAILS with
+        ::error::, and we must NOT also emit a drift warning -- the
+        problem here is too many errors, not a stale floor."""
+        pcb, allowlist = self._make_pcb_and_allowlist(tmp_path, allowlist_value=17)
+        with patch.object(self.helper, "count_errors", return_value=22):
+            rc = self.helper.main(["--allowlist", str(allowlist), str(pcb)])
+        assert rc == 2  # gate fails (regression)
+        captured = capsys.readouterr()
+        assert "::error file=" in captured.out
+        assert "Tighten to" not in captured.out
+
+    def test_unlisted_board_zero_errors_no_drift_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A board not in the allowlist (allowed=0) with 0 errors is the
+        common clean-state case (boards 01/02/04). Slack is 0, but more
+        importantly the ``allowed > 0`` guard suppresses the warning so
+        every clean PR doesn't get nagged."""
+        pcb, allowlist = self._make_pcb_and_allowlist(tmp_path, allowlist_value=None)
+        with patch.object(self.helper, "count_errors", return_value=0):
+            rc = self.helper.main(["--allowlist", str(allowlist), str(pcb)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "Tighten to" not in captured.out
+        assert "::warning file=" not in captured.out
+
+    def test_drift_warning_does_not_change_exit_code(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Per acceptance criteria #3 + #5: warnings are advisory. A PR
+        that triggers the drift warning must still exit 0 so the gate
+        doesn't become accidentally blocking."""
+        pcb, allowlist = self._make_pcb_and_allowlist(tmp_path, allowlist_value=10)
+        with patch.object(self.helper, "count_errors", return_value=3):
+            rc = self.helper.main(["--allowlist", str(allowlist), str(pcb)])
+        assert rc == 0  # warning emitted, but gate still passes
+        captured = capsys.readouterr()
+        assert "::warning file=" in captured.out
+        assert "Tighten to 3" in captured.out
+
+    def test_stale_allowlist_via_subprocess(self, tmp_path: Path) -> None:
+        """End-to-end via subprocess on a real allowlist file with a stale
+        entry. Exercises the full main() path including argv parsing,
+        allowlist load, and stdout flushing -- the path the CI workflow
+        actually takes.
+
+        We mock count_errors via a small shim script that imports the
+        helper, monkey-patches count_errors, and calls main(). This avoids
+        invoking the real `kct check` (which needs KiCad and is slow).
+        """
+        import subprocess
+        import textwrap
+
+        pcb_dir = tmp_path / "boards" / "05-x" / "output"
+        pcb_dir.mkdir(parents=True)
+        pcb = pcb_dir / "x_routed.kicad_pcb"
+        pcb.touch()
+
+        allowlist = tmp_path / "tolerance.yml"
+        # The shim runs from tmp_path; use the same pcb path that argv
+        # gets so lookup_key resolves correctly.
+        rel_pcb = "boards/05-x/output/x_routed.kicad_pcb"
+        allowlist.write_text(f"tolerances:\n  {rel_pcb}: 17\n")
+
+        shim = tmp_path / "shim.py"
+        shim.write_text(
+            textwrap.dedent(
+                f"""
+                import importlib.util
+                import sys
+                from unittest.mock import patch
+
+                spec = importlib.util.spec_from_file_location(
+                    "check_routed_drc",
+                    {str(HELPER_SCRIPT_PATH)!r},
+                )
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+                with patch.object(module, "count_errors", return_value=15):
+                    sys.exit(module.main([
+                        "--allowlist", {str(allowlist)!r},
+                        {rel_pcb!r},
+                    ]))
+                """
+            )
+        )
+
+        proc = subprocess.run(
+            [sys.executable, str(shim)],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, (
+            f"subprocess exited {proc.returncode}; stderr:\n{proc.stderr}"
+        )
+        # The drift warning must appear in stdout exactly as GitHub
+        # Actions would see it.
+        assert "::warning file=" in proc.stdout
+        assert rel_pcb in proc.stdout
+        assert "Tighten to 15" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
 # Allowlist self-consistency: helper must accept the real allowlist file.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_ci_routed_drc_workflow.py
+++ b/tests/test_ci_routed_drc_workflow.py
@@ -432,9 +432,7 @@ class TestHelperDriftWarning:
         captured = capsys.readouterr()
         assert "Tighten to 15" in captured.out
 
-    def test_warning_points_at_allowlist_file(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_warning_points_at_allowlist_file(self, capsys: pytest.CaptureFixture[str]) -> None:
         """The warning must reference the allowlist file path so the
         reviewer can navigate to where the fix belongs."""
         path = "boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb"
@@ -611,9 +609,7 @@ class TestMainDriftWarningEmission:
             text=True,
             check=False,
         )
-        assert proc.returncode == 0, (
-            f"subprocess exited {proc.returncode}; stderr:\n{proc.stderr}"
-        )
+        assert proc.returncode == 0, f"subprocess exited {proc.returncode}; stderr:\n{proc.stderr}"
         # The drift warning must appear in stdout exactly as GitHub
         # Actions would see it.
         assert "::warning file=" in proc.stdout


### PR DESCRIPTION
## Summary

Closes #2590. When a routed PCB's actual DRC error count is strictly less than its allowlist value (slack > 0), emit a `::warning file=...::` GitHub-Actions annotation so the stale entry surfaces in the PR Files-changed view rather than being buried in stdout.

PR #2583 dropped board 05 from 22 to 15 errors but left the allowlist at 17. The OK message printed `"15 errors (allowlist max 17; reduce the allowlist value...)"` to the log -- it was technically there, just not visible. PR #2588 manually fixed it 24h later. This change makes the suggestion visible to reviewers in the standard place they look (Files-changed annotations).

## Implementation

- New `annotate_drift_warning(file, errors, allowed)` helper following the existing `::warning::` precedent at the deleted-file branch (line 224).
- `check_file()` now returns `(passed, message, errors)` so callers can compute drift slack without re-running the (expensive) `kct check`.
- `main()` emits the warning when `passed and allowed > 0 and errors < allowed`. The `allowed > 0` guard avoids noise on unlisted boards (every clean PR would otherwise get nagged).
- Allowlist YAML comment updated to document the new behavior + cross-PR drift caveat.
- TODO comment in the script noting that cross-PR drift detection is deferred to a future scheduled-audit job.

## Scope decision (per curator's Option A)

v1 only inspects files in the diff (matches the existing `main()` loop). Cross-PR drift -- e.g., board 03 was independently improved by a router refactor in PR B but the allowlist wasn't updated -- is rare and better solved by a weekly bot. See the TODO in `annotate_drift_warning` for the deferral pointer.

The gate's exit code is unchanged: warnings are advisory, matching the precedent at the deleted-file branch.

## Acceptance criteria (from #2590)

- [x] PRs that touch `boards/*/output/*_routed.kicad_pcb` get a `::warning file=...::` annotation per stale allowlist entry (where slack > 0).
- [x] Warning includes the recommended new value: "Allowlist for `<file>` is <allowlist> but actual is <actual>. Tighten to <actual> in this PR or a follow-up..."
- [x] Existing CI behavior unchanged (gate still enforces actual <= allowlist; exit codes 0/1/2 unchanged).
- [x] Test fixture: artificially set an allowlist to a higher value than the actual file -> the helper script's `check_file()` returns OK (gate passes) AND emits a warning annotation. Covered by `TestMainDriftWarningEmission::test_slack_positive_emits_drift_warning` and `test_stale_allowlist_via_subprocess`.
- [x] TODO-comment in the script noting cross-PR drift detection is deferred to a future scheduled-audit job.
- [x] All existing 28 tests in `tests/test_ci_routed_drc_workflow.py` still pass.

## Test plan

- [x] All 38 tests in `tests/test_ci_routed_drc_workflow.py` pass (28 original + 10 new). Run with `uv run pytest tests/test_ci_routed_drc_workflow.py`.
- [x] `uv run ruff check scripts/ci/check_routed_drc.py tests/test_ci_routed_drc_workflow.py` clean.
- [x] `uv run ruff format ... --check` clean.
- [x] Mypy on the helper script reports only the pre-existing `types-PyYAML` stubs warning -- no new errors introduced.
- [x] End-to-end subprocess test exercises the full `main()` path including argv parsing, allowlist load, and stdout flushing.

## New tests

`TestHelperDriftWarning` (4 tests) -- unit tests for the new helper:
- annotation format (`::warning file=...::`)
- includes both actual and allowed counts
- includes "Tighten to <N>" recommendation
- references `.github/routed-drc-tolerance.yml`

`TestMainDriftWarningEmission` (6 tests) -- integration tests for `main()`'s emission flow with `count_errors` stubbed:
- slack > 0 emits warning (the PR #2583 regression scenario)
- slack = 0 emits no warning (steady state)
- slack < 0 fails with `::error::`, no drift warning (regression case)
- unlisted board with 0 errors emits no warning (allowed=0 guard)
- warning does not change exit code (stays 0)
- end-to-end via subprocess on a real allowlist with a stale entry

## Commits

1. `b05d7822` ci: emit warning annotation (script changes + test signature updates)
2. `4cac8fd5` test(ci): cover stale-allowlist warning emission paths
3. `4a365980` docs(ci): explain stale-entry warning in routed-drc-tolerance.yml

Each commit leaves the tree in a working state per #2547.