### PR TITLE
fix(router): exclude PWR_FLAG ERC-marker nets from auto-pour (closes #2592)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1015,6 +1015,7 @@ def _auto_skip_pour_nets(
     try:
         import re as _re
 
+        from kicad_tools.router.auto_pour import _is_erc_marker_net
         from kicad_tools.router.net_class import classify_and_apply_rules
 
         pcb_text = pcb_path.read_text()
@@ -1042,10 +1043,19 @@ def _auto_skip_pour_nets(
                 nets_with_zones.add(zm.group(1))
             del pcb_text  # free memory
 
+            # ERC-marker nets (PWR_FLAG and friends) are misclassified as
+            # pour nets by the name pattern but carry no copper and have
+            # no zone -- exclude them from both the auto-skip and the
+            # "pour nets without zones" warning so the user does not see
+            # a misleading "use zone fill" log line for a non-existent
+            # zone.  See router/auto_pour.py for the filter.
             auto_skip = [
                 name
                 for name, routing in net_class_map.items()
-                if routing.is_pour_net and name not in skip_nets and name in nets_with_zones
+                if routing.is_pour_net
+                and name not in skip_nets
+                and name in nets_with_zones
+                and not _is_erc_marker_net(name)
             ]
             if auto_skip:
                 skip_nets.extend(auto_skip)
@@ -1053,11 +1063,15 @@ def _auto_skip_pour_nets(
                     print(
                         f"Auto-skip: {', '.join(sorted(auto_skip))} (pour nets \u2014 use zone fill)"
                     )
-            # Warn about pour nets without zones
+            # Warn about pour nets without zones (excluding ERC markers
+            # which never get zones by design).
             no_zone = [
                 name
                 for name, routing in net_class_map.items()
-                if routing.is_pour_net and name not in skip_nets and name not in nets_with_zones
+                if routing.is_pour_net
+                and name not in skip_nets
+                and name not in nets_with_zones
+                and not _is_erc_marker_net(name)
             ]
             if no_zone and not quiet:
                 print(f"Routing: {', '.join(sorted(no_zone))} (power nets without zones)")

--- a/src/kicad_tools/router/auto_pour.py
+++ b/src/kicad_tools/router/auto_pour.py
@@ -11,12 +11,55 @@ voltage divider whose only nets are VIN, VOUT, GND) from being
 inadvertently drained of routable nets: auto-pour is only applied when
 the board has at least one signal (non-power/ground) net, indicating
 that the power nets are infrastructure rather than the entire design.
+
+ERC-marker net exclusion
+------------------------
+
+KiCad's netlister exports the ``PWR_FLAG`` virtual symbol as if it were
+an ordinary net, even though the symbol carries no electrical
+connection -- its sole purpose is to silence the *Input Power pin not
+driven by any Output Power pin* ERC error.  Because the resulting net
+name starts with ``PWR``, the name-based classifier in
+:mod:`kicad_tools.router.net_class` matches it as :class:`NetClass.POWER`
+and would otherwise produce a spurious zone.  See
+:func:`_is_erc_marker_net` and the ``ERC_MARKER_NET_PATTERNS`` constant
+below for the filter that excludes such names from the pour-net set.
+The schematic-side analogue lives in
+``src/kicad_tools/cli/sch_connectivity.py`` (``"PWR_FLAG is an ERC
+annotation, not a real net name"``).
 """
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
+
+# ERC-only marker nets that must never be poured.  These are synthetic
+# net names emitted by KiCad's netlister for symbols whose sole purpose
+# is to silence ERC, not to carry copper.  The schematic-side connectivity
+# walker has the equivalent carve-out in
+# ``src/kicad_tools/cli/sch_connectivity.py`` (search for
+# ``"PWR_FLAG is an ERC annotation"``).
+#
+# Patterns are anchored regular expressions; ``_is_erc_marker_net`` uses
+# ``re.match`` (anchors at the start) so each entry is tested against
+# the full net name.
+ERC_MARKER_NET_PATTERNS: tuple[str, ...] = (
+    r"^PWR_FLAG$",  # KiCad's stock power:PWR_FLAG symbol
+    r"^#FLG(?:\d*|_.*|$)",  # Reference-designator spelling (#FLG, #FLG01, #FLG_VBUS)
+    r".*_FLAG$",  # User-named flag variants (e.g., +3V3_FLAG, VBUS_FLAG)
+)
+
+
+def _is_erc_marker_net(name: str) -> bool:
+    """Return True when *name* is an ERC-only marker, not a real net.
+
+    See module docstring for context.  Used by :func:`auto_pour_if_missing`
+    to skip such nets when building the pour-net set, and by the
+    ``kct route`` skip-pour-nets path to avoid the misleading
+    ``Auto-skip: PWR_FLAG (pour nets — use zone fill)`` log line.
+    """
+    return any(re.match(p, name) for p in ERC_MARKER_NET_PATTERNS)
 
 
 def _detect_uninset_zones(
@@ -216,8 +259,16 @@ def auto_pour_if_missing(
     pour_nets: list[tuple[str, NetClass]] = []
     signal_net_count = 0
     for net_id, classification in classifications.items():
+        net_name = net_names[net_id]
+        # ERC-marker nets (PWR_FLAG and friends) carry no copper; the
+        # name-based classifier reports them as POWER but they must not
+        # be poured.  Treat them as if they did not exist for the
+        # all-power guard below -- a board whose only "power" net is
+        # PWR_FLAG should not be mistaken for a power-only design.
+        if _is_erc_marker_net(net_name):
+            continue
         if classification.net_class in (NetClass.POWER, NetClass.GROUND):
-            pour_nets.append((net_names[net_id], classification.net_class))
+            pour_nets.append((net_name, classification.net_class))
         else:
             signal_net_count += 1
 

--- a/tests/test_auto_pour.py
+++ b/tests/test_auto_pour.py
@@ -453,3 +453,123 @@ class TestAutoPourIfMissing:
         # VCC's original inset polygon must still be present verbatim.
         assert "(xy 0.3 0.3)" in text
         assert "(xy 49.7 0.3)" in text
+
+
+class TestErcMarkerNetExclusion:
+    """Tests for the ERC-marker (PWR_FLAG) exclusion filter (#2592).
+
+    KiCad's netlister emits ``PWR_FLAG`` (and user-named flag variants)
+    as ordinary net names, even though those symbols have no electrical
+    connection -- they exist purely to silence the *Input Power pin not
+    driven by any Output Power pin* ERC error.  The name-based classifier
+    in ``router/net_class.py`` matches them as ``NetClass.POWER`` because
+    they start with ``PWR``, so without a dedicated filter they would
+    end up as poured zones that starve legitimate power rails of copper.
+    """
+
+    def test_pwr_flag_excluded_from_pour_nets(self, tmp_path: Path):
+        """``PWR_FLAG`` must not produce a zone even when classified POWER."""
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        pcb = _make_pcb(
+            net_defs=[(1, "+3.3V"), (2, "GND"), (3, "PWR_FLAG"), (4, "SIG1")],
+            pad_nets=[(1, "+3.3V"), (2, "GND"), (3, "PWR_FLAG"), (4, "SIG1")],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(pcb_path)
+
+        # Exactly two zones: +3.3V and GND.  PWR_FLAG must not appear.
+        assert count == 2
+        assert set(names) == {"+3.3V", "GND"}
+        assert "PWR_FLAG" not in names
+
+        # And the file must not contain a PWR_FLAG zone definition.
+        text = pcb_path.read_text()
+        assert '(net_name "PWR_FLAG")' not in text
+        assert '(net "PWR_FLAG")' not in text
+
+    def test_user_named_flag_variant_excluded(self, tmp_path: Path):
+        """User-named flag nets (e.g., ``+3V3_FLAG``) are also filtered."""
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        pcb = _make_pcb(
+            net_defs=[(1, "+3.3V"), (2, "GND"), (3, "+3V3_FLAG"), (4, "SIG1")],
+            pad_nets=[(1, "+3.3V"), (2, "GND"), (3, "+3V3_FLAG"), (4, "SIG1")],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(pcb_path)
+
+        # +3V3_FLAG must not be poured even though it would otherwise
+        # match both the POWER pattern and the per-rail naming idiom.
+        assert "+3V3_FLAG" not in names
+        assert set(names) == {"+3.3V", "GND"}
+        assert count == 2
+
+    def test_pwr_flag_only_does_not_count_as_power_only_board(
+        self, tmp_path: Path
+    ):
+        """A board whose only power-classified net is ``PWR_FLAG`` runs normally.
+
+        Without the filter, the all-power-board guard would treat the
+        board as having one power net (``PWR_FLAG``) and one signal net
+        (``SIG1``), and produce a spurious zone for ``PWR_FLAG``.  With
+        the filter, ``PWR_FLAG`` is invisible to the pour stage entirely:
+        no zones are created and the function returns cleanly without
+        triggering the all-power early return.
+        """
+        from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+        pcb = _make_pcb(
+            net_defs=[(1, "PWR_FLAG"), (2, "SIG1")],
+            pad_nets=[(1, "PWR_FLAG"), (2, "SIG1")],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        count, names = auto_pour_if_missing(pcb_path)
+
+        # No zones -- no real pour nets -- and no all-power guard hit.
+        assert count == 0
+        assert names == []
+        text = pcb_path.read_text()
+        assert "(zone" not in text
+
+    def test_pwr_flag_classifier_unchanged(self):
+        """``classify_from_name`` may still tag PWR_FLAG as POWER.
+
+        The fix lives in the *pour-net selection* layer, not the
+        classifier.  Other consumers (e.g., trace-width selection in
+        ``apply_net_class_rules``) should keep getting a POWER answer
+        for legacy reasons; the auto-pour filter is what excludes the
+        net from zones.  This test pins down that design decision so a
+        future refactor does not silently move the carve-out.
+        """
+        from kicad_tools.router.net_class import NetClass, classify_from_name
+
+        # The classifier is allowed to return POWER here -- this is the
+        # *expected* behaviour given the ``^PWR`` pattern.  What matters
+        # is that auto_pour_if_missing filters it out (covered above).
+        result = classify_from_name("PWR_FLAG")
+        assert result == NetClass.POWER
+
+    def test_is_erc_marker_net_helper(self):
+        """The internal helper recognises canonical and variant spellings."""
+        from kicad_tools.router.auto_pour import _is_erc_marker_net
+
+        # Canonical ERC markers
+        assert _is_erc_marker_net("PWR_FLAG")
+        assert _is_erc_marker_net("+3V3_FLAG")
+        assert _is_erc_marker_net("VBUS_FLAG")
+        assert _is_erc_marker_net("#FLG01")
+        assert _is_erc_marker_net("#FLG")
+
+        # Real net names that must NOT be treated as ERC markers
+        assert not _is_erc_marker_net("PWR_5V")  # legitimate per-rail name
+        assert not _is_erc_marker_net("+3.3V")
+        assert not _is_erc_marker_net("GND")
+        assert not _is_erc_marker_net("SIG1")
+        assert not _is_erc_marker_net("FLAG_OUT")  # _FLAG anchored at end only

--- a/tests/test_pour_net_auto_skip.py
+++ b/tests/test_pour_net_auto_skip.py
@@ -995,3 +995,97 @@ class TestPourNetsWithoutZonesSerialization:
         config2 = {}
         result2 = set(config2.get("pour_nets_without_zones", []))
         assert result2 == set()
+
+
+# ===========================================================================
+# Tests for ERC-marker net exclusion (#2592)
+# ===========================================================================
+
+# Minimal PCB with GND, +3.3V, PWR_FLAG and a signal -- mimics what KiCad's
+# netlister produces when a schematic uses a PWR_FLAG to silence ERC.
+PWR_FLAG_PCB = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0.05))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (net 3 "PWR_FLAG")
+  (net 4 "SIG1")
+
+  (gr_line (start 0 0) (end 50 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 0) (end 50 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 40) (end 0 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 0 40) (end 0 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+
+  (footprint "R_0603"
+    (layer "F.Cu") (at 10 10) (attr smd)
+    (property "Reference" "R1") (property "Value" "10k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "+3.3V"))
+  )
+  (footprint "R_0603"
+    (layer "F.Cu") (at 30 10) (attr smd)
+    (property "Reference" "R2") (property "Value" "10k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 3 "PWR_FLAG"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 4 "SIG1"))
+  )
+
+  (zone (net 1) (net_name "GND") (layer "B.Cu") (hatch edge 0.5)
+    (connect_pads (clearance 0.25))
+    (fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5))
+    (polygon (pts (xy 0 0) (xy 50 0) (xy 50 40) (xy 0 40))))
+)
+"""
+
+
+class TestAutoSkipExcludesErcMarkers:
+    """Verify ``_auto_skip_pour_nets`` does not list PWR_FLAG (#2592).
+
+    ``classify_from_name`` matches ``PWR_FLAG`` against ``^PWR`` and so
+    reports it as a pour-classified power net.  But because PWR_FLAG is
+    purely an ERC annotation it will never have an associated zone, and
+    listing it under ``Auto-skip: ... (pour nets — use zone fill)`` or
+    ``Routing: ... (power nets without zones)`` would be misleading.
+    """
+
+    @pytest.fixture
+    def pcb_with_pwr_flag(self, tmp_path: Path) -> Path:
+        p = tmp_path / "board_pwr_flag.kicad_pcb"
+        p.write_text(PWR_FLAG_PCB)
+        return p
+
+    def test_pwr_flag_not_in_auto_skip(self, pcb_with_pwr_flag: Path) -> None:
+        """PWR_FLAG must not be added to ``skip_nets`` even if classified POWER."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        auto_skipped, no_zone = _auto_skip_pour_nets(
+            pcb_with_pwr_flag, skip_nets, quiet=True
+        )
+
+        # GND has a zone -> auto-skipped.  +3.3V is a pour net without
+        # zone -> reported in no_zone.  PWR_FLAG must appear in NEITHER.
+        assert "GND" in auto_skipped
+        assert "PWR_FLAG" not in auto_skipped
+        assert "PWR_FLAG" not in skip_nets
+        assert "PWR_FLAG" not in no_zone
+
+    def test_pwr_flag_not_in_auto_skip_log(
+        self, pcb_with_pwr_flag: Path, capsys
+    ) -> None:
+        """The auto-skip / routing log lines must not mention PWR_FLAG."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        _auto_skip_pour_nets(pcb_with_pwr_flag, skip_nets, quiet=False)
+
+        out = capsys.readouterr().out
+        assert "PWR_FLAG" not in out


### PR DESCRIPTION
## Summary

- Closes #2592
- `PWR_FLAG` (and user-named variants like `+3V3_FLAG`) are ERC-only virtual symbols that carry no copper, but KiCad's netlister still emits them as ordinary net entries.  The name-based classifier in `router/net_class.py` matches the leading `PWR` against the POWER pattern, so auto-pour was creating a spurious zone for them at F.Cu priority 3, starving legitimate power rails (`+3.3VA`, `+5V`) of copper.
- Fix at the pour-net selection layer (`router/auto_pour.py`) rather than the classifier — the classifier returning POWER for `PWR_FLAG` is not strictly wrong; the bug is specifically about pouring the net.
- Added `ERC_MARKER_NET_PATTERNS` and `_is_erc_marker_net()` helper to `auto_pour.py`, filter those names out of the pour-net build loop in `auto_pour_if_missing`, and re-use the helper in `route_cmd._auto_skip_pour_nets` so the misleading `Auto-skip: PWR_FLAG (pour nets — use zone fill)` log line and the `Routing: PWR_FLAG (power nets without zones)` log line no longer appear.
- Schematic-side analogue already exists in `src/kicad_tools/cli/sch_connectivity.py:119-125` (`"PWR_FLAG is an ERC annotation, not a real net name"`); this PR is the PCB-side mirror.

## Acceptance criteria (from issue)

- `kct route` no longer produces a `PWR_FLAG` zone in routed output PCBs.
- `Zone 'PWR_FLAG' on F.Cu (priority 3) overlaps queued zone …` warnings disappear.
- `Auto-pour: created N zone(s) for …` log line no longer lists `PWR_FLAG`.
- `Auto-skip: … (pour nets — use zone fill)` log line no longer lists `PWR_FLAG`.
- Module docstring documents the ERC-marker exclusion behavior.
- Classifier behavior is unchanged (`classify_from_name("PWR_FLAG")` still returns `NetClass.POWER`) — the fix lives in the pour-net selector.

## Test plan

- [x] New `TestErcMarkerNetExclusion` class in `tests/test_auto_pour.py` (5 tests):
  - `test_pwr_flag_excluded_from_pour_nets` — PWR_FLAG never produces a zone even when classified POWER.
  - `test_user_named_flag_variant_excluded` — `+3V3_FLAG` and similar variants are also filtered.
  - `test_pwr_flag_only_does_not_count_as_power_only_board` — board with only `PWR_FLAG` + signals does not trigger the all-power early-return.
  - `test_pwr_flag_classifier_unchanged` — pins down the design decision that the classifier still returns POWER.
  - `test_is_erc_marker_net_helper` — covers the helper's positive and negative cases (e.g. legitimate `PWR_5V` is *not* filtered).
- [x] New `TestAutoSkipExcludesErcMarkers` class in `tests/test_pour_net_auto_skip.py` (2 tests):
  - `test_pwr_flag_not_in_auto_skip` — `_auto_skip_pour_nets` returns no PWR_FLAG entry.
  - `test_pwr_flag_not_in_auto_skip_log` — `Auto-skip:` and `Routing:` log lines no longer mention `PWR_FLAG`.
- [x] All 17 `tests/test_auto_pour.py` tests pass (12 existing + 5 new).
- [x] All 41 `tests/test_pour_net_auto_skip.py` tests pass (39 existing + 2 new).
- [x] All 75 existing `tests/test_net_class.py` tests still pass (no classifier regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)