### PR TITLE
fix(router): pop stale sys.modules entry + invalidate import caches before reload

### DIFF
--- a/src/kicad_tools/cli/build_native_cmd.py
+++ b/src/kicad_tools/cli/build_native_cmd.py
@@ -357,9 +357,11 @@ def build_native(
             # ``sys.modules`` for ``kicad_tools.router.router_cpp``.  We
             # must drop that stale entry and invalidate the path-based
             # caches so the reloaded ``cpp_backend`` actually picks up
-            # the freshly-written ``.so``.
+            # the freshly-written ``.so``.  ``sys`` is already imported
+            # at module scope -- do NOT shadow it with a local import
+            # here (would trigger ``UnboundLocalError`` on the earlier
+            # ``sys.executable`` reference at the cmake configure step).
             import importlib
-            import sys
 
             sys.modules.pop("kicad_tools.router.router_cpp", None)
             importlib.invalidate_caches()

--- a/src/kicad_tools/cli/build_native_cmd.py
+++ b/src/kicad_tools/cli/build_native_cmd.py
@@ -348,7 +348,21 @@ def build_native(
         # Verify the installation
         try:
             # Clear any cached imports
+            #
+            # Issue #2594: ``importlib.reload(cpp_module)`` alone is not
+            # enough when the original ``from . import router_cpp`` failed
+            # at startup (fresh checkout with no .so on disk).  Python
+            # caches the negative result on the parent package's
+            # ``FileFinder`` and may leave a partial / ``None`` entry in
+            # ``sys.modules`` for ``kicad_tools.router.router_cpp``.  We
+            # must drop that stale entry and invalidate the path-based
+            # caches so the reloaded ``cpp_backend`` actually picks up
+            # the freshly-written ``.so``.
             import importlib
+            import sys
+
+            sys.modules.pop("kicad_tools.router.router_cpp", None)
+            importlib.invalidate_caches()
 
             import kicad_tools.router.cpp_backend as cpp_module
 

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -135,6 +135,23 @@ def _reload_cpp_backend() -> bool:
     to :func:`is_cpp_available` return ``True`` and the C++ backend is
     actually used by the routing code.
 
+    Issue #2594: ``importlib.reload(cpp_backend)`` alone is *not* enough.
+    The original ``from . import router_cpp`` failed at startup, leaving:
+
+      1. A negative/partially-initialised entry for
+         ``kicad_tools.router.router_cpp`` in :data:`sys.modules` that
+         Python re-uses on subsequent imports instead of re-running the
+         module finder.
+      2. A cached directory listing on the parent package's
+         ``FileFinder`` that does not yet contain the freshly-written
+         ``router_cpp.*.so``.
+
+    To pick up the new ``.so`` in the same process we MUST drop the
+    stale ``sys.modules`` entry AND call
+    :func:`importlib.invalidate_caches` before the reload.  This is the
+    safe case: the previous attempt never succeeded, so there is no
+    initialised native module to clash with.
+
     Returns:
         ``True`` if the backend is available after reload, ``False`` otherwise.
     """
@@ -142,6 +159,18 @@ def _reload_cpp_backend() -> bool:
 
     import importlib
     import sys as _sys
+
+    # 1. Drop any stale negative/partial entry for the C++ extension itself.
+    #    A failed ``from . import router_cpp`` at startup leaves a None or
+    #    partially-initialised module in sys.modules that Python re-uses
+    #    on subsequent imports.
+    _sys.modules.pop("kicad_tools.router.router_cpp", None)
+
+    # 2. Tell the import machinery to re-scan filesystem-based finders
+    #    for the freshly-written .so. Without this, the parent package's
+    #    FileFinder may keep its cached directory listing from before the
+    #    build wrote the new file.
+    importlib.invalidate_caches()
 
     module_name = __name__  # "kicad_tools.router.cpp_backend"
     module = _sys.modules.get(module_name)
@@ -340,11 +369,19 @@ def _attempt_auto_build(*, quiet: bool) -> bool:
     # (``_CPP_AVAILABLE``, ``router_cpp``) reflect the freshly written
     # ``.so``.  Without this, ``is_cpp_available()`` continues to return
     # ``False`` for the rest of the process.
+    #
+    # Issue #2594: ``_reload_cpp_backend`` now invalidates the import
+    # caches and pops the stale ``router_cpp`` entry from ``sys.modules``
+    # before reloading, so this is expected to succeed in the same
+    # process.  The ``not available`` branch is retained as a defensive
+    # diagnostic for genuinely pathological reload failures (e.g. a
+    # platform where dlopen of the new .so itself fails after the build
+    # wrote it to disk).
     available = _reload_cpp_backend()
     if not available and not quiet:
         print(
             "Note: C++ build succeeded but module reload did not pick it up; "
-            "falling back to Python (re-run kct to use C++).",
+            "falling back to Python.",
             flush=True,
         )
     return available

--- a/tests/test_router_cpp_auto_build.py
+++ b/tests/test_router_cpp_auto_build.py
@@ -336,3 +336,124 @@ class TestRouteCmdCallsHelper:
         assert "WARNING: C++ router backend not installed" not in text, (
             "Old inline Python-fallback warning still present in route_cmd.py"
         )
+
+
+class TestReloadCppBackend:
+    """Issue #2594: ``_reload_cpp_backend()`` must flush import caches.
+
+    The auto-build path writes a fresh ``router_cpp.*.so`` to disk and
+    then calls ``_reload_cpp_backend()``.  Before this fix,
+    ``importlib.reload(cpp_backend)`` alone did not pick up the new
+    ``.so`` because:
+
+      1. The original failed ``from . import router_cpp`` left a stale
+         entry in ``sys.modules`` for ``kicad_tools.router.router_cpp``
+         that Python re-used on subsequent imports.
+      2. The parent package's ``FileFinder`` had a cached directory
+         listing that did not contain the freshly-written ``.so``.
+
+    These tests pin the cache-flushing behavior so future regressions
+    surface as test failures rather than as the silent
+    "C++ build succeeded but module reload did not pick it up" warning.
+    """
+
+    def test_reload_pops_stale_router_cpp_from_sys_modules(self, monkeypatch):
+        """``_reload_cpp_backend()`` removes the stale router_cpp entry.
+
+        Simulates the fresh-checkout scenario: a sentinel object is
+        planted in ``sys.modules`` under ``kicad_tools.router.router_cpp``
+        to mimic Python's negative-import cache from the original failed
+        ``from . import router_cpp`` at startup.  After
+        ``_reload_cpp_backend()`` runs, that sentinel must be gone --
+        otherwise the reloaded ``cpp_backend`` would re-use it instead
+        of running the module finder against the freshly-written .so.
+        """
+        import sys
+
+        sentinel = object()
+        monkeypatch.setitem(sys.modules, "kicad_tools.router.router_cpp", sentinel)
+
+        cpp_backend._reload_cpp_backend()
+
+        # After reload, the stale sentinel MUST be gone.  Either the
+        # entry has been re-populated by a successful import (real .so
+        # on disk) or it has been removed entirely (no .so).  In either
+        # case the sentinel object itself must not survive.
+        assert sys.modules.get("kicad_tools.router.router_cpp") is not sentinel
+
+    def test_reload_calls_invalidate_caches(self, monkeypatch):
+        """``_reload_cpp_backend()`` invokes ``importlib.invalidate_caches``.
+
+        Without this call, Python's ``FileFinder`` keeps its cached
+        directory listing for ``kicad_tools/router/`` from before the
+        build wrote ``router_cpp.*.so``, so the reloaded ``cpp_backend``
+        misses the freshly-installed file.
+        """
+        import importlib
+
+        called = {"count": 0}
+        original = importlib.invalidate_caches
+
+        def _spy() -> None:
+            called["count"] += 1
+            original()
+
+        monkeypatch.setattr(importlib, "invalidate_caches", _spy)
+
+        cpp_backend._reload_cpp_backend()
+
+        assert called["count"] >= 1, (
+            "_reload_cpp_backend() must call importlib.invalidate_caches() "
+            "before reload(cpp_backend) so the freshly-written router_cpp.*.so "
+            "is visible to the parent package's FileFinder"
+        )
+
+    def test_reload_recovers_when_router_cpp_was_set_to_none(self, monkeypatch):
+        """Fresh-checkout simulation: cpp_backend.router_cpp == None, .so on disk.
+
+        This mirrors the in-process state immediately after
+        ``_attempt_auto_build`` finishes writing the .so but before
+        ``_reload_cpp_backend()`` runs.  If the C++ extension *is* on
+        disk in this test run (i.e., ``is_cpp_available()`` was True
+        before we patched it), the reload must recover it.
+
+        This is the strongest available regression test: it actually
+        exercises the import system's cache-flushing on the live tree
+        without requiring a build invocation.  The test is skipped on
+        environments that genuinely have no .so on disk.
+        """
+        if not cpp_backend.is_cpp_available():
+            import pytest
+
+            pytest.skip("C++ backend not available on this environment")
+
+        # Stash the live state so we can restore it.
+        live_router_cpp = cpp_backend.router_cpp
+        live_available = cpp_backend._CPP_AVAILABLE
+        live_error = cpp_backend._CPP_IMPORT_ERROR
+
+        try:
+            # Force the in-process flags into the "post-failed-import"
+            # state that the auto-build path would see.
+            monkeypatch.setattr(cpp_backend, "_CPP_AVAILABLE", False)
+            monkeypatch.setattr(cpp_backend, "router_cpp", None)
+            monkeypatch.setattr(
+                cpp_backend, "_CPP_IMPORT_ERROR", "stub: simulated startup failure"
+            )
+
+            recovered = cpp_backend._reload_cpp_backend()
+
+            assert recovered is True, (
+                "_reload_cpp_backend() must recover the C++ backend when the "
+                ".so is present on disk (Issue #2594). It did not -- this is "
+                "the regression that produces the 'C++ build succeeded but "
+                "module reload did not pick it up' warning."
+            )
+            assert cpp_backend.is_cpp_available() is True
+            assert cpp_backend.router_cpp is not None
+        finally:
+            # Restore live state regardless of pass/fail so subsequent
+            # tests in the session see the real backend.
+            cpp_backend._CPP_AVAILABLE = live_available
+            cpp_backend.router_cpp = live_router_cpp
+            cpp_backend._CPP_IMPORT_ERROR = live_error


### PR DESCRIPTION
## Summary

Fixes the in-process module-reload path that loads the freshly-built C++ router extension after `_attempt_auto_build()` writes a new `router_cpp.*.so` to disk. Before this PR, `kct route --backend cpp` on a fresh checkout (no `.so` present) would build the extension successfully but then print the misleading `Error: C++ backend requested but not available.` and exit with code 1, requiring the user to re-run the command.

The root cause was that `importlib.reload(cpp_backend)` alone does not pick up a newly-written native extension when the original `from . import router_cpp` failed at startup:
1. The failed import left a negative/partial entry for `kicad_tools.router.router_cpp` in `sys.modules` that Python re-uses on subsequent imports instead of re-running the module finder.
2. The parent package's `FileFinder` had a cached directory listing that did not yet include the freshly-written `.so`.

This implements the curator's recommended Option A from #2594: drop the stale `sys.modules` entry and call `importlib.invalidate_caches()` before `importlib.reload()` in both `_reload_cpp_backend()` and the verification block in `build_native()`. Option B/C (subprocess re-exec) was not needed — Option A reliably succeeds in the same process for the fresh-checkout case.

## Changes

- `src/kicad_tools/router/cpp_backend.py::_reload_cpp_backend()`: drop `sys.modules["kicad_tools.router.router_cpp"]` and call `importlib.invalidate_caches()` before `importlib.reload(cpp_backend)`. Updated the misleading "fall back to Python (re-run kct to use C++)" hint since this path is now effectively unreachable for the common case.
- `src/kicad_tools/cli/build_native_cmd.py::build_native()`: same cache-flush logic for the verification block at lines 348-380. Note: must use the module-level `sys` (already imported at line 15), not a local `import sys` shadow which would trigger `UnboundLocalError` on the earlier `sys.executable` reference at the cmake configure step.
- `tests/test_router_cpp_auto_build.py`: added `TestReloadCppBackend` with three regression tests pinning the cache-flush behavior:
  - `test_reload_pops_stale_router_cpp_from_sys_modules`: plants a sentinel in `sys.modules` and verifies it is dropped after reload.
  - `test_reload_calls_invalidate_caches`: spies on `importlib.invalidate_caches` and asserts it is called.
  - `test_reload_recovers_when_router_cpp_was_set_to_none`: integration test that forces `cpp_backend` into the post-failed-import state (router_cpp=None, _CPP_AVAILABLE=False) and asserts that `_reload_cpp_backend()` recovers the real `.so` from disk. Skipped when no `.so` is available.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fresh-checkout `kct route --backend cpp --no-cache` succeeds on first invocation | Yes | Manually verified: `rm -f router_cpp.*.so && uv run kicad-tools route ... --backend cpp --no-cache` builds and routes in a single process. C++ backend engaged (sub-second per-net routing times). |
| `is_cpp_available()` returns True after auto-build in same process | Yes | Direct repro: `_attempt_auto_build()` returns True; `is_cpp_available()` is True after; integration test in `tests/test_router_cpp_auto_build.py::test_reload_recovers_when_router_cpp_was_set_to_none` pins this. |
| No `Error: C++ backend requested but not available` when auto-build succeeded | Yes | Confirmed by manual test above; the message is now reserved for genuine build failures (toolchain missing, build error). |
| `--backend auto` behaviour unchanged: success uses C++, failure falls back to Python | Yes | Verified: with toolchain present + missing `.so`, `--backend auto` builds and engages C++. With toolchain missing, falls back to Python with existing warning (no exit code). |
| `--backend python` unchanged: never auto-builds, never reloads | Yes | No change to that code path; existing `TestBackendPython::test_python_skips_auto_build` still passes. |
| "module reload did not pick it up" message removed/unreachable | Yes | Message retained as defensive diagnostic for genuinely pathological reload failures (e.g. dlopen failure on the new .so). Removed the misleading "(re-run kct to use C++)" parenthetical. |
| Existing tests in `tests/test_router_cpp_auto_build.py` still pass | Yes | All 27 existing tests pass (the patched-stub fixture path is unchanged). |
| Option C re-exec only triggers under `--backend cpp` after in-process build whose reload still failed | N/A | Not implemented — Option A is sufficient (curator: "common case (Option A succeeds) is fast"). |

## Test Plan

Manual single-shot reproduction (the killer test):
```bash
find src/kicad_tools/router -name "router_cpp.*.so" -delete
uv run kicad-tools route boards/01-voltage-divider/output/voltage_divider.kicad_pcb \
  -o /tmp/out.kicad_pcb --backend cpp --no-cache
# Before fix: builds, then prints "Error: C++ backend requested but not available." and exits 1.
# After fix:  builds, then routes in the same process with the C++ backend engaged. Exit 0.
```

Direct verification of the in-process reload:
```bash
find src/kicad_tools/router -name "router_cpp.*.so" -delete
uv run python -c "
from kicad_tools.router.cpp_backend import is_cpp_available, _attempt_auto_build
print('Before:', is_cpp_available())  # False
ok = _attempt_auto_build(quiet=False)
print('After:', is_cpp_available(), 'Result:', ok)  # True, True
"
```

Automated tests:
```bash
uv run pytest tests/test_router_cpp_auto_build.py tests/test_route_cmd_params.py tests/test_route_exit_codes.py
# All pass (27+109 tests).
```

## Notes

- Pre-existing test failures in `tests/test_router_cpp_backend.py::TestCppPathfinderPythonFallback` (5 tests) are unrelated to this PR — they exist on `main` as well, but are normally skipped because the .so is not built in CI/dev environments. Those tests use `MagicMock` to patch a read-only C++ binding attribute (`pf._impl.route`) which fails with `AttributeError: 'kicad_tools.router.router_cpp.Pathfinder' object attribute 'route' is read-only`. Out of scope for this PR.
- The nanobind "leaked instances/types/functions" warnings printed at process exit when reloading the module are pre-existing — they happen because `importlib.reload(cpp_backend)` re-imports `router_cpp` while old type/function objects are still referenced. Addressing those would require a separate change to nanobind binding lifetime management. Not blocking.

Closes #2594