### PR TITLE
router: detect rip-up cohort stagnation in negotiated outer loop (closes #2597)

### DIFF
--- a/src/kicad_tools/router/algorithms/__init__.py
+++ b/src/kicad_tools/router/algorithms/__init__.py
@@ -23,6 +23,7 @@ from .negotiated import (
     calculate_history_increment,
     calculate_present_cost,
     detect_oscillation,
+    detect_ripup_stagnation,
     should_terminate_early,
 )
 from .steiner import build_rsmt
@@ -42,5 +43,6 @@ __all__ = [
     "calculate_history_increment",
     "calculate_present_cost",
     "detect_oscillation",
+    "detect_ripup_stagnation",
     "should_terminate_early",
 ]

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -270,6 +270,126 @@ def should_terminate_early(
     return False
 
 
+def detect_ripup_stagnation(
+    ripup_history: list[set[int]],
+    overflow_history: list[int],
+    *,
+    overflow_delta_threshold: float = 0.20,
+    jaccard_threshold: float = 0.8,
+) -> bool:
+    """Detect when negotiated rip-up keeps targeting the same nets without progress.
+
+    Issue #2597.  This complements :func:`should_terminate_early`, which only
+    inspects the overflow history.  On boards like chorus-test-revA the
+    overflow trajectory is *strictly decreasing* (e.g. ``[30, 12, 10]``) so
+    none of the standard stagnation checks fire — yet the rip-up cohort is
+    identical across consecutive iterations and each new iteration only
+    nibbles a few units off the overflow.  Rerouting the same six nets a
+    fourth time is overwhelmingly likely to repeat the same near-identical
+    paths and burn another ~per-net-timeout × N seconds before the wall-clock
+    timeout fires.
+
+    Stagnation is declared when **all** of the following hold:
+
+    1. There are at least two complete iterations of rip-up history
+       (``len(ripup_history) >= 2`` and ``len(overflow_history) >= 2``).
+    2. The latest two rip-up sets ``A = ripup_history[-2]`` and
+       ``B = ripup_history[-1]`` are highly similar:
+       ``B`` is a non-empty subset of ``A``, **or** the Jaccard similarity
+       ``|A ∩ B| / |A ∪ B|`` meets ``jaccard_threshold`` (default 0.8).
+    3. Overflow improved by less than ``overflow_delta_threshold`` (default
+       20 %): ``(overflow[-2] - overflow[-1]) / overflow[-2] <
+       overflow_delta_threshold``.  A regression (overflow[-1] > overflow[-2])
+       also counts as "less than threshold".
+    4. The current overflow is still positive — at ``overflow == 0`` the
+       router has converged and there is nothing to detect.
+
+    Args:
+        ripup_history: List of rip-up cohorts (one ``set[int]`` per
+            negotiated outer iteration).  ``ripup_history[k]`` is the set
+            of net IDs ripped up at the start of iteration ``k+1``.
+        overflow_history: List of total overflow values (one per iteration,
+            including the initial pass at index 0).  Must be at least the
+            same length as ``ripup_history`` minus one initial-pass entry.
+        overflow_delta_threshold: Minimum fractional improvement in overflow
+            required to *avoid* a stagnation declaration.  Default 0.20
+            (20 %).  Lower values are stricter (declare stagnation sooner).
+        jaccard_threshold: Minimum Jaccard similarity between consecutive
+            rip-up sets required to declare stagnation.  Default 0.8.  A
+            strict subset relationship also satisfies this criterion
+            regardless of the threshold.
+
+    Returns:
+        ``True`` if the negotiated outer loop should break out and let the
+        existing best-state restore in ``two_phase.py`` hand back the
+        previous (lower-overflow) iteration; ``False`` otherwise.
+
+    Examples:
+        >>> # chorus-test pattern: same 6 nets ripped up twice, overflow
+        >>> # 30 -> 12 -> 10 (16 % improvement on iter 2)
+        >>> detect_ripup_stagnation(
+        ...     ripup_history=[{1, 2, 3, 4, 5, 6}, {1, 2, 3, 4, 5, 6}],
+        ...     overflow_history=[30, 12, 10],
+        ... )
+        True
+
+        >>> # Cohort churned -- different nets, no stagnation
+        >>> detect_ripup_stagnation(
+        ...     ripup_history=[{1, 2, 3}, {7, 8, 9}],
+        ...     overflow_history=[30, 12, 10],
+        ... )
+        False
+
+        >>> # Same cohort but >= 20 % overflow improvement
+        >>> detect_ripup_stagnation(
+        ...     ripup_history=[{1, 2, 3}, {1, 2, 3}],
+        ...     overflow_history=[30, 12, 5],
+        ... )
+        False
+    """
+    # Criterion 1: need two complete rip-up + overflow iterations to compare.
+    if len(ripup_history) < 2 or len(overflow_history) < 2:
+        return False
+
+    prev_ripup = ripup_history[-2]
+    curr_ripup = ripup_history[-1]
+    prev_overflow = overflow_history[-2]
+    curr_overflow = overflow_history[-1]
+
+    # Criterion 4: skip when converged (no work left to detect).
+    if curr_overflow <= 0:
+        return False
+
+    # Empty cohorts indicate the iteration ripped up nothing -- not the
+    # stagnation pattern this detector targets.
+    if not prev_ripup or not curr_ripup:
+        return False
+
+    # Criterion 2: high overlap between consecutive rip-up cohorts.
+    # Subset relationship (curr ⊆ prev) is always sufficient; otherwise
+    # require Jaccard similarity >= threshold.
+    if curr_ripup <= prev_ripup:
+        cohort_stable = True
+    else:
+        intersection = len(curr_ripup & prev_ripup)
+        union = len(curr_ripup | prev_ripup)
+        jaccard = intersection / union if union else 0.0
+        cohort_stable = jaccard >= jaccard_threshold
+
+    if not cohort_stable:
+        return False
+
+    # Criterion 3: insufficient overflow improvement on this iteration.
+    # If overflow regressed or held steady, treat that as 0 % improvement.
+    if prev_overflow <= 0:
+        # Cannot compute a fractional delta from a non-positive baseline;
+        # fall back to "no improvement on a positive current overflow".
+        return True
+
+    improvement = (prev_overflow - curr_overflow) / prev_overflow
+    return improvement < overflow_delta_threshold
+
+
 def calculate_present_cost(
     iteration: int,
     total_iterations: int,

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -85,6 +85,18 @@ class TwoPhaseRouter:
         self._build_pads_by_net = build_pads_by_net
         self._get_partially_routed_nets = get_partially_routed_nets
 
+        # Issue #2597: Communicates the reason the negotiated outer loop in
+        # ``_detailed_negotiated()`` exited.  Read by the progress-callback
+        # status string in :class:`Autorouter` to distinguish ``"stagnated"``
+        # from ``"timeout"`` and bare ``f"overflow={N}"``.  Possible values:
+        #   - ``None`` — loop hasn't run yet, or two-phase path not taken.
+        #   - ``"stagnated"`` — rip-up cohort stagnation detector tripped.
+        #   - ``"timeout"`` — wall-clock budget exhausted.
+        #   - ``"early_stop"`` — overflow-history early termination.
+        #   - ``"converged"`` — overflow reached zero.
+        #   - ``"max_iterations"`` — outer loop ran to ``max_iterations``.
+        self.last_termination_reason: str | None = None
+
     def route_all(
         self,
         use_negotiated: bool = True,
@@ -336,9 +348,23 @@ class TwoPhaseRouter:
                 print(failure_summary)
 
         if progress_callback is not None:
+            # Issue #2597: Distinguish ``stagnated`` from ``timeout`` in the
+            # final progress message so callers (and CI) can pick the right
+            # next action — re-place vs. add budget.  Plain ``timeout`` was
+            # ambiguous: did we run out of clock or hit a local minimum?
+            status_suffix = ""
+            if self.last_termination_reason == "stagnated":
+                status_suffix = " (stagnated)"
+            elif self.last_termination_reason == "timeout":
+                status_suffix = " (timeout)"
+            elif self.last_termination_reason == "converged":
+                status_suffix = " (converged)"
             progress_callback(
                 1.0,
-                f"Complete: {connected_nets}/{total_nets} nets routed in {total_elapsed:.1f}s",
+                (
+                    f"Complete: {connected_nets}/{total_nets} nets routed "
+                    f"in {total_elapsed:.1f}s{status_suffix}"
+                ),
                 False,
             )
 
@@ -368,7 +394,10 @@ class TwoPhaseRouter:
                 ``min_iterations`` to ``should_terminate_early()``.
         """
         from ..algorithms import NegotiatedRouter
-        from ..algorithms.negotiated import should_terminate_early
+        from ..algorithms.negotiated import (
+            detect_ripup_stagnation,
+            should_terminate_early,
+        )
 
         if corridor_penalty is None:
             corridor_penalty = self.rules.cost_corridor_deviation
@@ -512,6 +541,23 @@ class TwoPhaseRouter:
         # Issue #2317: Track overflow history for early-stop detection.
         overflow_history: list[int] = [overflow]
 
+        # Issue #2597: Track per-iteration rip-up cohort for stagnation
+        # detection.  ``ripup_set_history[k]`` is the set of net IDs ripped
+        # up at the start of outer iteration ``k+1`` (the initial pass is
+        # not represented).  Combined with ``overflow_history`` this lets
+        # us detect the chorus-test pattern where consecutive iterations
+        # tear up the *same* nets and produce only marginal overflow
+        # improvement — the existing ``should_terminate_early()`` heuristic
+        # cannot see this because the overflow trajectory is strictly
+        # decreasing.
+        ripup_set_history: list[set[int]] = []
+
+        # Issue #2597: stagnation flag returned to the caller via the
+        # ``last_termination_reason`` attribute so the progress callback can
+        # distinguish ``"stagnated"`` from ``"timeout"`` and bare
+        # ``f"overflow={N}"``.
+        stagnation_detected = False
+
         # Issue #2305: Track best routing state across iterations.
         # Overflow can oscillate during rip-up-and-reroute; if timeout or
         # iteration limit is hit during a high-overflow iteration we want to
@@ -564,6 +610,11 @@ class TwoPhaseRouter:
                 flush_print(
                     f"  Iteration {iteration}: ripping up {len(nets_to_reroute)} nets ({elapsed_str()})"
                 )
+
+                # Issue #2597: Snapshot the rip-up cohort *before* mutating
+                # ``net_routes`` so the stagnation detector can compare the
+                # current iteration's targets against the previous one.
+                ripup_set_history.append(set(nets_to_reroute))
 
                 neg_router.rip_up_nets(nets_to_reroute, net_routes, self.routes)
 
@@ -632,6 +683,38 @@ class TwoPhaseRouter:
                     )
                     break
 
+                # Issue #2597: Detect rip-up cohort stagnation that
+                # ``should_terminate_early()`` cannot see.  When the same
+                # nets get torn up across consecutive iterations and the
+                # overflow needle barely moves, the next iteration is very
+                # likely to repeat the same ~per-net-timeout × N seconds of
+                # work without escaping the local minimum.  The chorus-test
+                # pattern is ``ripup=[{A..F}, {A..F}], overflow=[30, 12, 10]``
+                # — strictly decreasing overflow keeps the standard
+                # heuristic silent, but iteration 3 is doomed to burn ~100 s
+                # of wall-clock budget before producing the same six routes.
+                if detect_ripup_stagnation(
+                    ripup_set_history,
+                    overflow_history,
+                    overflow_delta_threshold=self.rules.stagnation_overflow_delta_threshold,
+                    jaccard_threshold=self.rules.stagnation_jaccard_threshold,
+                ):
+                    prev_ov = overflow_history[-2]
+                    curr_ov = overflow_history[-1]
+                    if prev_ov > 0:
+                        improvement_pct = (
+                            100.0 * (prev_ov - curr_ov) / prev_ov
+                        )
+                    else:
+                        improvement_pct = 0.0
+                    flush_print(
+                        f"  Stagnation detected: rip-up set unchanged, "
+                        f"overflow plateau ({prev_ov} → {curr_ov}, "
+                        f"{improvement_pct:.1f}%)"
+                    )
+                    stagnation_detected = True
+                    break
+
         # Issue #2305: Restore best state if the final iteration is worse
         final_overflow = self.grid.get_total_overflow()
         if best_overflow < final_overflow:
@@ -652,6 +735,26 @@ class TwoPhaseRouter:
             # Update net_routes to best state
             net_routes.clear()
             net_routes.update(best_net_routes)
+
+        # Issue #2597: Surface the iteration-loop exit reason to the caller
+        # so the progress-callback status string can distinguish between
+        # ``"stagnated"`` (rip-up cohort stuck), ``"timeout"`` (wall clock
+        # exhausted), and bare ``f"overflow={N}"`` (other early stop or
+        # ``max_iterations`` reached).  ``stagnated`` takes precedence over
+        # ``timeout`` because the stagnation detector breaks out *before*
+        # iteration N+1 has a chance to trip the wall-clock check.
+        effective_overflow = min(best_overflow, final_overflow)
+        if stagnation_detected:
+            self.last_termination_reason = "stagnated"
+        elif effective_overflow == 0:
+            self.last_termination_reason = "converged"
+        elif timed_out:
+            self.last_termination_reason = "timeout"
+        else:
+            # Loop hit ``max_iterations`` or ``should_terminate_early()``;
+            # both fall under the catch-all ``f"overflow={N}"`` status in
+            # the caller's progress message, so signal ``early_stop`` here.
+            self.last_termination_reason = "early_stop"
 
         return list(self.routes)
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -5292,11 +5292,26 @@ class Autorouter:
                 )
 
         if progress_callback is not None:
-            status = (
-                "converged"
-                if overflow == 0
-                else ("timeout" if timed_out else f"overflow={overflow}")
-            )
+            # Issue #2597: Distinguish ``stagnated`` from ``timeout`` and
+            # bare ``f"overflow={N}"`` so callers (and CI) can pick the
+            # right next action — re-place vs. add budget.  Plain
+            # ``timeout`` was ambiguous: did we run out of clock or hit a
+            # local minimum?  ``stagnation_detected`` is reserved here for
+            # the same rip-up cohort stagnation heuristic that the
+            # ``TwoPhaseRouter._detailed_negotiated()`` outer loop uses;
+            # the route-all path currently relies on ``cohort_history`` /
+            # stagnation-recovery (Issue #2515) so the flag is always
+            # ``False`` in this branch, but the branch is exposed so the
+            # status string is symmetric with the two-phase callback.
+            stagnation_detected = False
+            if overflow == 0:
+                status = "converged"
+            elif timed_out:
+                status = "timeout"
+            elif stagnation_detected:
+                status = "stagnated"
+            else:
+                status = f"overflow={overflow}"
             progress_callback(
                 1.0, f"Routing complete: {successful_nets}/{total_nets} nets ({status})", False
             )

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -130,6 +130,24 @@ class DesignRules:
     corridor_decay_rate: float = 0.05  # per-iteration linear decay
     corridor_decay_floor: float = 0.3  # minimum multiplier (never decays below this)
 
+    # Rip-up cohort stagnation detection (Issue #2597)
+    # Controls the heuristic that breaks out of the negotiated outer loop
+    # when consecutive iterations rip up the same set of nets without
+    # meaningful overflow progress (e.g. chorus-test-revA pattern
+    # ``ripup=[{A..F}, {A..F}], overflow=[30, 12, 10]`` — strictly decreasing
+    # but each iteration costs ~per-net-timeout × N seconds).
+    #   - ``stagnation_overflow_delta_threshold``: minimum fractional
+    #     overflow improvement required to *avoid* declaring stagnation.
+    #     Default 0.20 (20 %).  Lower values declare stagnation sooner.
+    #   - ``stagnation_jaccard_threshold``: minimum Jaccard similarity
+    #     between consecutive rip-up cohorts to declare stagnation.  Default
+    #     0.8.  A strict subset relationship between cohorts always
+    #     satisfies this criterion regardless of the value.
+    # See ``detect_ripup_stagnation()`` in
+    # ``router.algorithms.negotiated`` for the full heuristic.
+    stagnation_overflow_delta_threshold: float = 0.20
+    stagnation_jaccard_threshold: float = 0.8
+
     # Crossing-aware routing (Issue #1250)
     # Penalizes candidate edges that cross already-routed segments on the same layer.
     # This steers A* toward non-crossing paths while still permitting crossings when

--- a/tests/test_best_state_tracking.py
+++ b/tests/test_best_state_tracking.py
@@ -126,6 +126,10 @@ class TestBestStateTracking:
         router = MagicMock()
         rules = MagicMock()
         rules.cost_corridor_deviation = 5.0
+        # Issue #2597: Numeric defaults for stagnation thresholds so the
+        # rip-up cohort detector compares floats, not MagicMock objects.
+        rules.stagnation_overflow_delta_threshold = 0.20
+        rules.stagnation_jaccard_threshold = 0.8
 
         call_count = [0]
 
@@ -339,6 +343,10 @@ class TestEarlyStopOverflowRegression:
         rules.cost_corridor_deviation = 5.0
         rules.corridor_decay_rate = 0.1
         rules.corridor_decay_floor = 0.1
+        # Issue #2597: Numeric defaults for stagnation thresholds so the
+        # rip-up cohort detector compares floats, not MagicMock objects.
+        rules.stagnation_overflow_delta_threshold = 0.20
+        rules.stagnation_jaccard_threshold = 0.8
 
         call_count = [0]
 
@@ -385,6 +393,15 @@ class TestEarlyStopOverflowRegression:
         # iteration 10.  We provide enough overflow values for max_iterations=10.
         overflow_seq = [81, 18, 25, 30, 35, 40, 45, 50, 55, 60, 65, 65]
         two_phase, grid = self._build_two_phase(overflow_seq)
+        # Issue #2597: Disable rip-up cohort stagnation detection so this
+        # test exercises ``should_terminate_early()`` exclusively.  The
+        # FakeNegotiatedRouter always rips up the same single net, so the
+        # new detector would fire on iter 2's regression (18 → 25) before
+        # the should_terminate_early heuristic gets a chance to evaluate
+        # the longer history.  Setting an impossibly-strict delta
+        # threshold (-1.0) means only a >100 % regression would trip
+        # stagnation detection, which never happens in this fixture.
+        two_phase.rules.stagnation_overflow_delta_threshold = -1.0
 
         with patch(
             "kicad_tools.router.algorithms.NegotiatedRouter",
@@ -472,6 +489,10 @@ class TestEarlyStopOverflowRegression:
         #   [0] initial = 81, [1] = 18, [2] = 25, [3] = 30, [4] = 0
         overflow_seq = [81, 18, 25, 30, 0, 0]
         two_phase, grid = self._build_two_phase(overflow_seq)
+        # Issue #2597: Disable rip-up cohort stagnation detection so this
+        # test exercises ``patience`` exclusively.  See comment in
+        # ``test_early_stop_on_regression`` for details.
+        two_phase.rules.stagnation_overflow_delta_threshold = -1.0
 
         with patch(
             "kicad_tools.router.algorithms.NegotiatedRouter",

--- a/tests/test_negotiated_adaptive.py
+++ b/tests/test_negotiated_adaptive.py
@@ -12,6 +12,7 @@ from kicad_tools.router.algorithms.negotiated import (
     calculate_history_increment,
     calculate_present_cost,
     detect_oscillation,
+    detect_ripup_stagnation,
     should_terminate_early,
 )
 
@@ -2477,4 +2478,204 @@ class TestNegotiatedStallFallbackInvokesComponentRipup:
         assert "_attempt_blocked_component_ripup_negotiated" in source, (
             "route_all_negotiated must invoke the destination-component "
             "rip-up helper on stall (issue #2517)."
+        )
+
+
+class TestDetectRipupStagnation:
+    """Tests for detect_ripup_stagnation function (Issue #2597).
+
+    The detector flags the chorus-test-revA pattern where consecutive
+    negotiated outer iterations rip up the same set of nets but produce
+    only marginal overflow improvement.  ``should_terminate_early()`` is
+    blind to this case because the overflow trajectory ``[30, 12, 10]`` is
+    strictly decreasing and ``len(overflow_history) < 5`` short-circuits
+    its stagnation check.
+
+    Test matrix covers six cases per the acceptance criteria:
+      1. True  — chorus-test pattern: identical cohort, < 20 % delta
+      2. True  — strict subset cohort, < 20 % delta
+      3. False — cohort churn (Jaccard < 0.8)
+      4. False — same cohort, >= 20 % overflow improvement
+      5. False — overflow == 0 (converged)
+      6. False — insufficient history (iteration < 2)
+    """
+
+    # -- True cases ----------------------------------------------------
+
+    def test_chorus_test_pattern_identical_cohort_low_delta(self):
+        """True: identical 6-net cohort across two iterations, 16 % delta.
+
+        Reproduces the exact chorus-test-revA pattern from the bug report:
+        ``ripup_history=[{A..F}, {A..F}], overflow_history=[30, 12, 10]``.
+        Iteration 2 only improved overflow by 2/12 = 16.7 %, well below
+        the 20 % threshold, on the same six-net rip-up set.  The detector
+        must fire so the outer loop bails before iteration 3 burns ~100 s
+        of wall-clock budget producing the same routes.
+        """
+        ripup_history = [
+            {1, 2, 3, 4, 5, 6},  # AUDIO_L, AUDIO_R, Net-(C21-1), ...
+            {1, 2, 3, 4, 5, 6},  # same six nets again
+        ]
+        overflow_history = [30, 12, 10]
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is True
+
+    def test_strict_subset_cohort_low_delta(self):
+        """True: rip-up set shrank to a subset, but overflow barely moved.
+
+        ``{1,2,3,4} ⊂ {1,2,3,4,5,6}`` qualifies as cohort_stable regardless
+        of the Jaccard threshold.  Combined with overflow drop 12 → 11
+        (8.3 % < 20 %) and current overflow > 0, the detector should fire.
+        """
+        ripup_history = [
+            {1, 2, 3, 4, 5, 6},
+            {1, 2, 3, 4},  # subset of the previous iteration
+        ]
+        overflow_history = [30, 12, 11]
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is True
+
+    # -- False cases ---------------------------------------------------
+
+    def test_cohort_churn_low_jaccard(self):
+        """False: rip-up set churned substantially (Jaccard < 0.8).
+
+        Cohorts ``{1,2,3,4,5,6}`` and ``{4,5,6,7,8,9}`` share only
+        ``{4,5,6}`` out of a union of 9 nets — Jaccard = 3/9 ≈ 0.33.
+        Even with a small overflow improvement this is *not* stagnation;
+        the router is still exploring different topologies.
+        """
+        ripup_history = [
+            {1, 2, 3, 4, 5, 6},
+            {4, 5, 6, 7, 8, 9},  # 50 % overlap, Jaccard = 3/9 ≈ 0.33
+        ]
+        overflow_history = [30, 12, 10]
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is False
+
+    def test_same_cohort_significant_improvement(self):
+        """False: same six nets, but overflow dropped >= 20 % this iteration.
+
+        Even though the rip-up cohort is identical, a 50 % overflow
+        improvement (12 → 6) means the router is still making meaningful
+        progress on those nets.  Bailing here would discard real gains.
+        """
+        ripup_history = [
+            {1, 2, 3, 4, 5, 6},
+            {1, 2, 3, 4, 5, 6},
+        ]
+        overflow_history = [30, 12, 6]  # 50 % improvement >= 20 %
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is False
+
+    def test_converged_overflow_zero(self):
+        """False: overflow == 0 means converged regardless of cohort history.
+
+        At zero overflow the router has converged; declaring stagnation
+        would be nonsensical.  The detector must short-circuit on this
+        condition so a "stagnated" status never overrides "converged".
+        """
+        ripup_history = [
+            {1, 2, 3, 4, 5, 6},
+            {1, 2, 3, 4, 5, 6},
+        ]
+        overflow_history = [30, 12, 0]  # converged on iter 2
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is False
+
+    def test_insufficient_history_first_iteration(self):
+        """False: only one iteration of rip-up history (iteration < 2).
+
+        After the very first rip-up iteration there is nothing to compare
+        against — the previous iteration has no rip-up cohort recorded.
+        The detector must require ``len(ripup_history) >= 2`` before
+        firing so that real stagnation is distinguishable from "we just
+        started".
+        """
+        ripup_history = [{1, 2, 3, 4, 5, 6}]  # only iter 1
+        overflow_history = [30, 12]  # initial pass + iter 1
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is False
+
+    # -- Additional edge cases ----------------------------------------
+
+    def test_jaccard_exactly_at_threshold(self):
+        """True: cohorts with Jaccard exactly == 0.8 should trip detection.
+
+        Two five-element cohorts sharing four elements have
+        Jaccard = 4/6 ≈ 0.667 — below 0.8.  Use a 9/11 = 0.818 split so
+        the threshold edge is exercised.
+        """
+        # Jaccard = |A ∩ B| / |A ∪ B| = 9 / (10 + 1) = 9/11 ≈ 0.818
+        ripup_history = [
+            set(range(10)),
+            set(range(1, 11)),  # shifted by one: 9 shared, 1 new, 1 dropped
+        ]
+        overflow_history = [30, 12, 11]
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is True
+
+    def test_overflow_regression_with_stable_cohort(self):
+        """True: overflow regressed (got worse) on the same cohort.
+
+        A regression is "less than 20 % improvement" — strictly worse
+        progress than zero improvement.  The detector should fire so the
+        outer loop falls back to the best-state restore.
+        """
+        ripup_history = [
+            {1, 2, 3, 4, 5, 6},
+            {1, 2, 3, 4, 5, 6},
+        ]
+        overflow_history = [30, 10, 12]  # got worse: 10 -> 12
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is True
+
+    def test_empty_ripup_set_does_not_trigger(self):
+        """False: an empty rip-up cohort means no nets need rerouting.
+
+        Defensive guard: if ``find_nets_through_overused_cells`` returns
+        nothing, the iteration is a no-op and stagnation is meaningless.
+        """
+        ripup_history: list[set[int]] = [set(), set()]
+        overflow_history = [30, 12, 10]
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is False
+
+    def test_custom_thresholds_strict(self):
+        """A stricter delta threshold makes the detector fire sooner.
+
+        A 25 % overflow improvement (12 -> 9) does *not* trip detection
+        with the default 20 % threshold, but a custom ``0.30`` (30 %)
+        threshold should declare stagnation since 25 % < 30 %.
+        """
+        ripup_history = [
+            {1, 2, 3, 4, 5, 6},
+            {1, 2, 3, 4, 5, 6},
+        ]
+        overflow_history = [30, 12, 9]  # 25 % improvement
+        # Default 0.20 threshold: not stagnated (25 % > 20 %)
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is False
+        # Stricter 0.30 threshold: stagnated (25 % < 30 %)
+        assert (
+            detect_ripup_stagnation(
+                ripup_history,
+                overflow_history,
+                overflow_delta_threshold=0.30,
+            )
+            is True
+        )
+
+    def test_custom_jaccard_threshold(self):
+        """A stricter Jaccard threshold rejects partial cohort overlap.
+
+        Cohorts with Jaccard ≈ 0.667 (4/6) should *not* trip the default
+        0.8 threshold but should trip a relaxed 0.5 threshold.
+        """
+        # |A ∩ B| = 4, |A ∪ B| = 6, Jaccard = 4/6 ≈ 0.667
+        ripup_history = [
+            {1, 2, 3, 4, 5},
+            {2, 3, 4, 5, 6},
+        ]
+        overflow_history = [30, 12, 11]
+        # Default 0.80 threshold: cohort not stable (0.667 < 0.80)
+        assert detect_ripup_stagnation(ripup_history, overflow_history) is False
+        # Relaxed 0.50 threshold: cohort stable (0.667 >= 0.50)
+        assert (
+            detect_ripup_stagnation(
+                ripup_history,
+                overflow_history,
+                jaccard_threshold=0.5,
+            )
+            is True
         )

--- a/tests/test_negotiated_timeout_propagation.py
+++ b/tests/test_negotiated_timeout_propagation.py
@@ -145,6 +145,10 @@ class TestTwoPhaseTimeoutPropagation:
         rules.cost_corridor_deviation = 5.0
         rules.corridor_decay_rate = 0.1
         rules.corridor_decay_floor = 0.1
+        # Issue #2597: Set explicit numeric defaults for stagnation thresholds
+        # so the rip-up cohort detector can compare them against floats.
+        rules.stagnation_overflow_delta_threshold = 0.20
+        rules.stagnation_jaccard_threshold = 0.8
 
         # Track timestamps when each net is routed (after the burn).
         burn_log: list[float] = []
@@ -264,6 +268,16 @@ class TestTwoPhaseTimeoutPropagation:
         path."""
         two_phase, grid, burn_log = self._build(net_count=2, per_net_step=0.0)
         clock = two_phase._test_clock  # type: ignore[attr-defined]
+        # Issue #2597: Disable rip-up cohort stagnation detection for this
+        # test.  The fake grid pins overflow at 5 across every iteration
+        # which would naturally trip the new detector on iter 2 (same
+        # cohort, 0 % overflow improvement).  We want the test to exercise
+        # the no-timeout / max_iterations path, so set the overflow-delta
+        # threshold to ``0.0`` — only an outright regression will fire the
+        # detector, and the fake grid never regresses.  (Setting the
+        # Jaccard threshold to >1.0 would not help because the cohort is a
+        # subset of itself, which always satisfies cohort_stable.)
+        two_phase.rules.stagnation_overflow_delta_threshold = 0.0
 
         with (
             patch("kicad_tools.router.algorithms.two_phase.time.time", clock),


### PR DESCRIPTION
## Summary

Adds a per-iteration rip-up cohort stagnation detector to the negotiated outer loop in `TwoPhaseRouter._detailed_negotiated()`.  Closes #2597.

When consecutive iterations rip up the *same* set of nets and overflow barely budges, the next iteration is very likely to repeat ~per-net-timeout × N seconds of work without escaping the local minimum.  The existing `should_terminate_early()` heuristic cannot see this pattern because the chorus-test-revA overflow trajectory `[30, 12, 10]` is strictly decreasing and `len(overflow_history) < 5` short-circuits its stagnation check.

### Heuristic

`detect_ripup_stagnation(ripup_history, overflow_history, ...)` returns `True` when **all** of:

1. `iteration >= 2` (need two iterations to compare)
2. `ripup[N] ⊆ ripup[N-1]` **or** Jaccard similarity `|A ∩ B| / |A ∪ B| >= 0.8`
3. `(overflow[N-1] - overflow[N]) / overflow[N-1] < 0.20` (less than 20 % improvement)
4. `overflow[N] > 0` (not converged)

On trigger, the outer loop logs `Stagnation detected: rip-up set unchanged, overflow plateau (N → M, X%)`, breaks, and the existing best-state restore (`two_phase.py:635-654`) hands back the lower-overflow snapshot.  Status callback distinguishes `"stagnated"` from `"timeout"` and `"overflow=N"`.

### Files touched

- `src/kicad_tools/router/algorithms/negotiated.py` — new `detect_ripup_stagnation()` next to `should_terminate_early()`; pure function, no router state
- `src/kicad_tools/router/algorithms/two_phase.py` — record `ripup_set_history` per iteration, call detector after `should_terminate_early()`, expose `last_termination_reason`
- `src/kicad_tools/router/algorithms/__init__.py` — export new function
- `src/kicad_tools/router/core.py` — `route_all_negotiated` status callback gets a `"stagnated"` branch (symmetric with two-phase)
- `src/kicad_tools/router/rules.py` — `stagnation_overflow_delta_threshold` (default 0.20) and `stagnation_jaccard_threshold` (default 0.8) configuration knobs
- `tests/test_negotiated_adaptive.py` — new `TestDetectRipupStagnation` class with the required 6-case matrix plus 5 edge cases
- `tests/test_best_state_tracking.py`, `tests/test_negotiated_timeout_propagation.py` — set numeric thresholds on `MagicMock` rules so existing fixtures don't trip the detector accidentally

### Out of scope (per issue)

- Perturbation injection / shuffle-on-stagnation — separate larger change
- Solving the underlying chorus-test U5/U7/U9 cluster congestion (#2595)
- Trace optimizer segment loss (#2596)
- Changes to `should_terminate_early()` itself or to `patience` defaults

## Test plan

- [x] `tests/test_negotiated_adaptive.py::TestDetectRipupStagnation` — 11 unit tests covering the chorus-test pattern, subset cohort, cohort churn, significant improvement, converged, insufficient history, Jaccard edge, regression, empty cohort, custom delta threshold, custom Jaccard threshold (all pass)
- [x] `tests/test_negotiated_adaptive.py` — full file (120 tests) still passes; `should_terminate_early()` semantics unchanged
- [x] `tests/test_best_state_tracking.py` — 12 tests pass after threshold-disable annotation in two regression-pattern tests
- [x] `tests/test_negotiated_timeout_propagation.py` — 6 tests pass (one needed threshold-disable for the no-timeout fixture which now naturally trips stagnation)
- [x] `tests/test_two_phase_*` and other router tests run green (1329 router tests, 2 unrelated pre-existing failures on baseline `6926b47c` for `test_voltage_divider_high_completion` / `test_charlieplex_high_completion`)
- [x] `python -m doctest negotiated.py` — 3 docstring examples pass
- [ ] Re-run on chorus-test-revA: `kct route boards/external/chorus-test-revA/...kicad_pcb --backend cpp --timeout 1800 --per-net-timeout 120` should exit "stagnated" at iteration 2 instead of timing out at iteration 3, saving ~100 s wall-clock

🤖 Generated with [Claude Code](https://claude.com/claude-code)