### PR TITLE
test: add chorus-test placement-feedback nightly regression gate (closes #2612)

### DIFF
--- a/src/kicad_tools/recovery/strategy.py
+++ b/src/kicad_tools/recovery/strategy.py
@@ -48,12 +48,22 @@ class StrategyGenerator:
     BYPASS_CAP_DISTANCE_THRESHOLD = 5.0
     CLUSTER_DISTANCE_THRESHOLD = 10.0
 
-    def generate_strategies(self, pcb: PCB, failure: FailureAnalysis) -> list[ResolutionStrategy]:
+    def generate_strategies(
+        self,
+        pcb: PCB,
+        failure: FailureAnalysis,
+        max_movement: float | None = None,
+    ) -> list[ResolutionStrategy]:
         """Generate ranked strategies to resolve failure.
 
         Args:
             pcb: The PCB being analyzed.
             failure: Detailed failure analysis.
+            max_movement: Optional cap on per-component movement distance,
+                in mm.  When provided, the move-strategy candidate generator
+                produces offsets within this budget (sweeping multiple
+                angles) instead of using the corridor-derived offsets that
+                routinely exceed the loop's movement cap.  See Issue #2604.
 
         Returns:
             List of resolution strategies, ranked by (difficulty, confidence).
@@ -62,7 +72,7 @@ class StrategyGenerator:
 
         # Strategy 1: Move blocking components
         if failure.has_movable_blockers:
-            strategies.extend(self._generate_move_strategies(pcb, failure))
+            strategies.extend(self._generate_move_strategies(pcb, failure, max_movement))
 
         # Strategy 2: Add vias to change layers
         if failure.root_cause in [FailureCause.CONGESTION, FailureCause.BLOCKED_PATH]:
@@ -92,7 +102,10 @@ class StrategyGenerator:
         return self._rank_strategies(strategies)
 
     def _generate_move_strategies(
-        self, pcb: PCB, failure: FailureAnalysis
+        self,
+        pcb: PCB,
+        failure: FailureAnalysis,
+        max_movement: float | None = None,
     ) -> list[ResolutionStrategy]:
         """Generate component move strategies.
 
@@ -109,7 +122,9 @@ class StrategyGenerator:
                 continue
 
             # Find good positions for this component
-            candidates = self._find_move_candidates(pcb, blocker, failure.failure_area)
+            candidates = self._find_move_candidates(
+                pcb, blocker, failure.failure_area, max_movement=max_movement
+            )
 
             for candidate in candidates[:3]:  # Top 3 positions
                 # Analyze side effects
@@ -417,7 +432,11 @@ class StrategyGenerator:
         )
 
     def _find_move_candidates(
-        self, pcb: PCB, blocker: BlockingElement, failure_area: Rectangle
+        self,
+        pcb: PCB,
+        blocker: BlockingElement,
+        failure_area: Rectangle,
+        max_movement: float | None = None,
     ) -> list[dict[str, Any]]:
         """Find candidate positions for moving a component.
 
@@ -425,6 +444,13 @@ class StrategyGenerator:
         1. Clear the failure area
         2. Don't create new conflicts
         3. Maintain functional groupings
+        4. Stay within ``max_movement`` of the current position when set
+
+        When ``max_movement`` is provided, generates candidates by sweeping
+        a fixed set of angles at radii up to the cap, which keeps every
+        emitted position inside the loop's movement budget.  Without a cap
+        we fall back to the legacy corridor-derived offsets (preserved for
+        backwards compatibility with non-feedback callers).
         """
         candidates: list[dict[str, Any]] = []
 
@@ -439,33 +465,81 @@ class StrategyGenerator:
         comp_width = blocker.bounds.width
         comp_height = blocker.bounds.height
 
-        # Generate candidate positions around the failure area
-        offsets = [
-            (failure_area.width + comp_width, 0),  # Right
-            (-(failure_area.width + comp_width), 0),  # Left
-            (0, failure_area.height + comp_height),  # Below
-            (0, -(failure_area.height + comp_height)),  # Above
-            (failure_area.width + comp_width, failure_area.height + comp_height),  # Diagonal
-        ]
+        offsets: list[tuple[float, float]]
+        if max_movement is not None and max_movement > 0:
+            # Budget-aware: sweep 8 compass directions at two radii within
+            # the cap.  This produces candidates the feedback loop's
+            # ``_strategy_within_movement_budget`` filter will accept by
+            # construction, fixing the secondary half of Issue #2604.
+            radii: list[float] = []
+            # Try a "small nudge" first (typically enough to clear a single
+            # routing channel) and then push to the budget edge.
+            small = max(0.5, max_movement * 0.5)
+            if small < max_movement:
+                radii.append(small)
+            radii.append(max_movement)
+
+            offsets = []
+            angles_deg = (0, 45, 90, 135, 180, 225, 270, 315)
+            for radius in radii:
+                for ang in angles_deg:
+                    rad = math.radians(ang)
+                    offsets.append(
+                        (radius * math.cos(rad), radius * math.sin(rad))
+                    )
+        else:
+            # Legacy corridor-derived offsets -- preserved for callers that
+            # do not pass a movement budget (e.g. CLI explain mode).
+            offsets = [
+                (failure_area.width + comp_width, 0),  # Right
+                (-(failure_area.width + comp_width), 0),  # Left
+                (0, failure_area.height + comp_height),  # Below
+                (0, -(failure_area.height + comp_height)),  # Above
+                (
+                    failure_area.width + comp_width,
+                    failure_area.height + comp_height,
+                ),  # Diagonal
+            ]
+
+        budget = max_movement if max_movement is not None else float("inf")
+        # ``failure_area`` may come from either ``recovery.types.Rectangle``
+        # (which exposes ``contains_point``) or the router's analyzer
+        # ``Rectangle`` (which exposes ``contains``).  Pick the right
+        # method once so each iteration stays cheap.
+        if hasattr(failure_area, "contains_point"):
+            in_area = failure_area.contains_point  # type: ignore[attr-defined]
+        elif hasattr(failure_area, "contains"):
+            in_area = failure_area.contains  # type: ignore[attr-defined]
+        else:
+            in_area = lambda _x, _y: False  # noqa: E731
 
         for dx, dy in offsets:
             new_x = fp.position[0] + dx
             new_y = fp.position[1] + dy
 
-            # Check if position is valid (simple bounds check)
-            confidence = 0.85 if abs(dx) + abs(dy) < 10 else 0.7
-            improvement = 0.9 if not failure_area.contains_point(new_x, new_y) else 0.5
+            distance = math.hypot(dx, dy)
+            # Confidence drops with distance and when the candidate would
+            # still land inside the failure area.
+            if budget != float("inf"):
+                # Closer moves are preferred -- they're cheaper to apply
+                # and are less likely to create new conflicts.
+                confidence = 0.85 if distance <= budget * 0.6 else 0.7
+            else:
+                confidence = 0.85 if distance < 10 else 0.7
+            improvement = 0.9 if not in_area(new_x, new_y) else 0.5
 
             candidates.append(
                 {
                     "position": (new_x, new_y),
                     "confidence": confidence,
                     "improvement": improvement,
+                    "distance": distance,
                 }
             )
 
-        # Sort by improvement
-        candidates.sort(key=lambda c: c["improvement"], reverse=True)
+        # Sort by improvement first, then by distance ascending so close
+        # moves win ties.
+        candidates.sort(key=lambda c: (-c["improvement"], c.get("distance", 0.0)))
         return candidates
 
     def _find_via_positions(

--- a/src/kicad_tools/recovery/strategy.py
+++ b/src/kicad_tools/recovery/strategy.py
@@ -484,9 +484,16 @@ class StrategyGenerator:
             for radius in radii:
                 for ang in angles_deg:
                     rad = math.radians(ang)
-                    offsets.append(
-                        (radius * math.cos(rad), radius * math.sin(rad))
-                    )
+                    offsets.append((radius * math.cos(rad), radius * math.sin(rad)))
+
+            # Track the (radius_index, angle_index) so we can promote
+            # diversity later -- otherwise the post-sort `[:3]` slice in
+            # ``_generate_move_strategies`` always falls into the first
+            # angles of the smallest radius, dropping the cap-radius and
+            # South/West/SE/SW candidates entirely (Issue #2604 follow-up).
+            offset_meta = [
+                (r_idx, a_idx) for r_idx in range(len(radii)) for a_idx in range(len(angles_deg))
+            ]
         else:
             # Legacy corridor-derived offsets -- preserved for callers that
             # do not pass a movement budget (e.g. CLI explain mode).
@@ -500,6 +507,9 @@ class StrategyGenerator:
                     failure_area.height + comp_height,
                 ),  # Diagonal
             ]
+            # No (radius, angle) structure for the legacy path -- mark all
+            # entries the same so the diversity sort is a no-op.
+            offset_meta = [(0, i) for i in range(len(offsets))]
 
         budget = max_movement if max_movement is not None else float("inf")
         # ``failure_area`` may come from either ``recovery.types.Rectangle``
@@ -513,7 +523,7 @@ class StrategyGenerator:
         else:
             in_area = lambda _x, _y: False  # noqa: E731
 
-        for dx, dy in offsets:
+        for (dx, dy), (r_idx, a_idx) in zip(offsets, offset_meta, strict=False):
             new_x = fp.position[0] + dx
             new_y = fp.position[1] + dy
 
@@ -534,12 +544,51 @@ class StrategyGenerator:
                     "confidence": confidence,
                     "improvement": improvement,
                     "distance": distance,
+                    "_radius_idx": r_idx,
+                    "_angle_idx": a_idx,
                 }
             )
 
-        # Sort by improvement first, then by distance ascending so close
-        # moves win ties.
-        candidates.sort(key=lambda c: (-c["improvement"], c.get("distance", 0.0)))
+        # Promote diversity across the (radius, angle) sweep so the
+        # downstream ``[:3]`` slice in ``_generate_move_strategies`` does
+        # not collapse to a single radius band or three adjacent angles.
+        # Strategy:
+        #   1. Primary key: improvement (descending) -- correctness first.
+        #   2. Secondary key: a "spread + round-robin" rank that
+        #      interleaves radii and spaces angles across the 8 compass
+        #      directions, so the first 3 picks span both radii and
+        #      cover non-adjacent quadrants (e.g. East / West / North
+        #      instead of East / NE / North).
+        #   3. Tertiary tie-breaker: distance ascending.
+        # This addresses the Issue #2604 follow-up where the 8-direction
+        # x 2-radius sweep degenerated to "first 3 small-radius candidates
+        # at 0/45/90 degrees" -- South/West/SE/SW and the cap-radius band
+        # were never tried.
+        radius_band_count = max(len({c["_radius_idx"] for c in candidates}), 1)
+        # Compass spread: opposites first (E, W), then poles (N, S),
+        # then diagonals -- so the first 4 unique angles span all
+        # quadrants.  Indices follow ``angles_deg``: 0=E, 1=NE, 2=N,
+        # 3=NW, 4=W, 5=SW, 6=S, 7=SE.
+        spread_rank = {0: 0, 4: 1, 2: 2, 6: 3, 1: 4, 5: 5, 3: 6, 7: 7}
+
+        def _diversity_key(c: dict[str, Any]) -> tuple[float, int, int, float]:
+            imp = -c["improvement"]
+            a_idx = c.get("_angle_idx", 0)
+            r_idx = c.get("_radius_idx", 0)
+            a_spread = spread_rank.get(a_idx, a_idx)
+            # Interleave radii within each angle slot so the [:3] slice
+            # always includes both small-radius and cap-radius candidates.
+            rr = a_spread * radius_band_count + r_idx
+            return (imp, rr, a_idx, c.get("distance", 0.0))
+
+        candidates.sort(key=_diversity_key)
+
+        # Strip private metadata before returning -- callers expect the
+        # legacy {"position", "confidence", "improvement", "distance"}
+        # shape.
+        for c in candidates:
+            c.pop("_radius_idx", None)
+            c.pop("_angle_idx", None)
         return candidates
 
     def _find_via_positions(

--- a/src/kicad_tools/router/failure_analysis.py
+++ b/src/kicad_tools/router/failure_analysis.py
@@ -925,6 +925,31 @@ class RootCauseAnalyzer:
 
         return Rectangle(min_x, min_y, max_x, max_y)
 
+    def _lookup_blocking_ref(
+        self,
+        grid: RoutingGrid,
+        wx: float,
+        wy: float,
+        layer_idx: int,
+    ) -> str | None:
+        """Look up the component reference owning a blocked grid cell.
+
+        Wraps ``RoutingGrid.find_pad_ref_at`` with a defensive fallback
+        for grids/test fixtures that don't expose the helper.
+
+        This is the fix for Issue #2604 -- ``GridCell`` has no ``ref``
+        field, so the analyzer recovers ownership via a spatial lookup
+        against the grid's pad list every time it sees a component
+        blocker.
+        """
+        finder = getattr(grid, "find_pad_ref_at", None)
+        if finder is None:
+            return None
+        try:
+            return finder(wx, wy, layer_idx=layer_idx)
+        except Exception:
+            return None
+
     def _find_blocking_elements(
         self,
         grid: RoutingGrid,
@@ -983,7 +1008,11 @@ class RootCauseAnalyzer:
                     movable = True  # Traces can be ripped up
                 else:
                     element_type = "component"
-                    ref = cell.ref if hasattr(cell, "ref") else None
+                    # GridCell does not carry a ``ref`` field (would cost
+                    # ~16-32B per cell across millions of cells).  Recover
+                    # the owning component via spatial lookup against the
+                    # grid's pad list.  See ``RoutingGrid.find_pad_ref_at``.
+                    ref = self._lookup_blocking_ref(grid, wx, wy, layer)
                     movable = True
 
                 # Skip if same net
@@ -1045,11 +1074,17 @@ class RootCauseAnalyzer:
                     if not cell.blocked:
                         continue
 
-                    cell_ref = cell.ref if hasattr(cell, "ref") else None
+                    wx, wy = grid.grid_to_world(gx, gy)
+                    # Recover ref via spatial lookup -- ``GridCell`` has
+                    # no per-cell ``ref`` field.  Skip cells owned by the
+                    # component being placed (no self-conflict).
+                    if cell.is_zone:
+                        cell_ref: str | None = None
+                    else:
+                        cell_ref = self._lookup_blocking_ref(grid, wx, wy, layer_idx)
                     if cell_ref == ref:
                         continue  # Don't conflict with self
 
-                    wx, wy = grid.grid_to_world(gx, gy)
                     cell_bounds = Rectangle(
                         wx - grid.resolution / 2,
                         wy - grid.resolution / 2,

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -2067,6 +2067,93 @@ class RoutingGrid:
             cells.add((gx, gy, layer_idx))
         return cells
 
+    def find_pad_ref_at(
+        self,
+        wx: float,
+        wy: float,
+        layer_idx: int | None = None,
+        max_distance: float | None = None,
+    ) -> str | None:
+        """Find the component reference whose pad/clearance envelope covers
+        the given world coordinate.
+
+        Used by failure analysis to recover the owner of a component-blocked
+        grid cell without storing a per-cell ``ref`` field (which would cost
+        ~16-32B per cell for millions of cells).
+
+        Args:
+            wx: World x-coordinate (mm).
+            wy: World y-coordinate (mm).
+            layer_idx: Optional layer index to filter SMD pads.  PTH pads
+                ignore the layer filter (they block all layers).
+            max_distance: Optional bounded search radius from (wx, wy).
+                When None, searches the full pad list (O(n)).  Set to
+                ``rules.trace_clearance + rules.trace_width`` for fast
+                proximity matching.
+
+        Returns:
+            The owning component reference, or None if no pad envelope
+            (including the clearance halo) covers the point.
+        """
+        if not self._pads:
+            return None
+
+        # Use the same clearance envelope used at add_pad time so we
+        # match the cells that were actually blocked.
+        clearance = self.rules.trace_clearance + self.rules.trace_width / 2
+
+        best_ref: str | None = None
+        best_dist = float("inf")
+
+        for pad in self._pads:
+            if not pad.ref:
+                continue
+
+            # Layer filter: PTH pads block all layers, SMD pads only their own.
+            if layer_idx is not None and not pad.through_hole:
+                pad_layer_idx = self.layer_to_index(pad.layer.value)
+                if pad_layer_idx != layer_idx:
+                    continue
+
+            # Compute effective pad bounds (mirrors _add_pad_unsafe logic)
+            if pad.through_hole:
+                if pad.width > 0 and pad.height > 0:
+                    ew, eh = pad.width, pad.height
+                elif pad.drill > 0:
+                    ew = pad.drill + 0.7
+                    eh = ew
+                else:
+                    ew = 1.7
+                    eh = 1.7
+            else:
+                ew = pad.width
+                eh = pad.height
+
+            x1 = pad.x - ew / 2 - clearance
+            y1 = pad.y - eh / 2 - clearance
+            x2 = pad.x + ew / 2 + clearance
+            y2 = pad.y + eh / 2 + clearance
+
+            # Quick bounded-distance prune
+            if max_distance is not None:
+                dx = max(x1 - wx, 0.0, wx - x2)
+                dy = max(y1 - wy, 0.0, wy - y2)
+                if dx * dx + dy * dy > max_distance * max_distance:
+                    continue
+
+            # Inside the envelope: pick the pad whose center is closest to
+            # the query point (handles overlapping clearance envelopes from
+            # neighbouring components on the same layer).
+            if x1 <= wx <= x2 and y1 <= wy <= y2:
+                cdx = wx - pad.x
+                cdy = wy - pad.y
+                d2 = cdx * cdx + cdy * cdy
+                if d2 < best_dist:
+                    best_dist = d2
+                    best_ref = pad.ref
+
+        return best_ref
+
     def find_overused_cells(self) -> list[tuple[int, int, int, int]]:
         """Find cells with usage_count > 1 (resource conflicts).
 

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -98,11 +98,7 @@ class RoutedNetsUnblocker:
 
         # Build mask: cells that are blocked by routed nets (not by pads/obstacles)
         # A routed-net cell has: blocked=True, pad_blocked=False, net != 0
-        routed_mask = (
-            self._grid._blocked
-            & ~self._grid._pad_blocked
-            & (self._grid._net != 0)
-        )
+        routed_mask = self._grid._blocked & ~self._grid._pad_blocked & (self._grid._net != 0)
 
         # Clear those cells
         self._grid._blocked[routed_mask] = False
@@ -422,6 +418,16 @@ class RoutingGrid:
         # manufacturability at that pitch.
         self._component_pads: dict[str, list[Pad]] = {}
 
+        # Issue #2604 follow-up: track per-pad pin_pitch so reverse lookups
+        # (``find_pad_ref_at``) can mirror the reduced clearance envelope
+        # ``_add_pad_unsafe`` applies for fine-pitch pads.  Without this the
+        # query side would use the standard envelope and risk attributing a
+        # cell blocked by a *neighbour* (e.g. a passive on chorus-test near
+        # U5/U7/U9 BGAs) to the fine-pitch pad whose smaller real envelope
+        # never actually covered that cell.  Keyed by ``id(pad)`` so we can
+        # store None entries for pads with no recorded pitch.
+        self._pad_pin_pitch: dict[int, float | None] = {}
+
         # R-tree spatial index for segment clearance queries (Issue #1249).
         # Per-layer rtree.index.Index for fast envelope-based candidate pruning
         # in validate_segment_clearance, replacing O(R*S) brute-force iteration.
@@ -453,9 +459,7 @@ class RoutingGrid:
         # Check if GPU should be used based on grid size
         grid_cells = self.cols * self.rows * self.num_layers
         if not should_use_gpu(self._config, grid_cells, "grid"):
-            logger.debug(
-                f"Grid size {grid_cells} below threshold, using CPU backend"
-            )
+            logger.debug(f"Grid size {grid_cells} below threshold, using CPU backend")
             return BackendType.CPU, np
 
         # Check memory availability
@@ -500,7 +504,9 @@ class RoutingGrid:
         self._net = xp.zeros(grid_shape, dtype=np.int32)
         self._usage_count = xp.zeros(grid_shape, dtype=np.int16)
         self._history_cost = xp.zeros(grid_shape, dtype=np.float32)
-        self._present_cost_ema: np.ndarray | None = None  # Lazy; allocated on first use (Issue #2333)
+        self._present_cost_ema: np.ndarray | None = (
+            None  # Lazy; allocated on first use (Issue #2333)
+        )
         self._is_obstacle = xp.zeros(grid_shape, dtype=np.bool_)
         self._is_zone = xp.zeros(grid_shape, dtype=np.bool_)
         self._pad_blocked = xp.zeros(grid_shape, dtype=np.bool_)
@@ -746,6 +752,38 @@ class RoutingGrid:
                     if 0 <= gx < self.cols and 0 <= gy < self.rows:
                         self.grid[layer_idx][gy][gx].blocked = True
 
+    def _clearance_for_pin_pitch(self, pin_pitch: float | None) -> float:
+        """Return the grid-level clearance halo to apply around a pad.
+
+        Mirrors the per-call logic in ``_add_pad_unsafe`` so callers that
+        need to *reproduce* the envelope (notably ``find_pad_ref_at``) get
+        the exact same value.  This factoring fixes an asymmetry flagged
+        in Issue #2604 review: previously the lookup side always used the
+        standard envelope, which on chorus-test U5/U7/U9 (fine-pitch BGAs
+        surrounded by standard-pitch passives) could mistakenly attribute
+        a passive's clearance halo to the BGA pad whose *real* envelope
+        was the smaller fine-pitch one.
+
+        Args:
+            pin_pitch: The component pin pitch in mm, or None when not
+                available.  When below ``rules.fine_pitch_threshold``
+                (and ``rules.min_trace_width`` is configured) the envelope
+                shrinks to ``min_trace_width / 2`` -- the minimum needed
+                to keep a necked-down trace from overlapping pad copper.
+                Full manufacturer clearance is validated in post-routing
+                DRC.
+
+        Returns:
+            Clearance distance in mm to pad outside the pad's metal.
+        """
+        if (
+            pin_pitch is not None
+            and pin_pitch < self.rules.fine_pitch_threshold
+            and self.rules.min_trace_width is not None
+        ):
+            return self.rules.min_trace_width / 2
+        return self.rules.trace_clearance + self.rules.trace_width / 2
+
     def add_pad(self, pad: Pad, pin_pitch: float | None = None) -> None:
         """Add a pad as an obstacle (except for its own net).
 
@@ -771,6 +809,12 @@ class RoutingGrid:
         if pad.ref:
             self._component_pads.setdefault(pad.ref, []).append(pad)
 
+        # Issue #2604 follow-up: remember the pin_pitch this pad was added
+        # with so ``find_pad_ref_at`` can reproduce the reduced fine-pitch
+        # clearance envelope and avoid false-positive ref attribution near
+        # BGA / fine-pitch clusters.
+        self._pad_pin_pitch[id(pad)] = pin_pitch
+
         # Clearance model: trace clearance + trace half-width from pad edge.
         # The pathfinder checks if the trace CENTER can be placed at a cell,
         # so we must block cells where the trace edge would violate clearance.
@@ -792,17 +836,7 @@ class RoutingGrid:
         # needed for grid-level blocking -- the actual manufacturer clearance is
         # validated during DRC after routing. This ensures at least 1-3 passable
         # grid cells between adjacent fine-pitch pads for A* to find paths.
-        if (
-            pin_pitch is not None
-            and pin_pitch < self.rules.fine_pitch_threshold
-            and self.rules.min_trace_width is not None
-        ):
-            # Use min_trace_width/2 as clearance: ensures the necked-down trace
-            # edge doesn't physically overlap pad copper. The full manufacturer
-            # clearance (0.127mm) is validated in post-routing DRC.
-            clearance = self.rules.min_trace_width / 2
-        else:
-            clearance = self.rules.trace_clearance + self.rules.trace_width / 2
+        clearance = self._clearance_for_pin_pitch(pin_pitch)
 
         if pad.through_hole:
             if pad.width > 0 and pad.height > 0:
@@ -1208,9 +1242,7 @@ class RoutingGrid:
                 max(seg.x1, seg.x2) + search_margin,
                 max(seg.y1, seg.y2) + search_margin,
             )
-            candidate_ids = list(
-                self._seg_rtree[seg_layer_idx].intersection(query_envelope)
-            )
+            candidate_ids = list(self._seg_rtree[seg_layer_idx].intersection(query_envelope))
             layer_items = self._seg_rtree_items.get(seg_layer_idx, {})
 
             for cand_id in candidate_ids:
@@ -1377,9 +1409,7 @@ class RoutingGrid:
                 seg_half_width = seg.width / 2
 
                 # Point-to-segment distance from via center to segment
-                dist = self._point_to_segment_distance(
-                    via.x, via.y, seg.x1, seg.y1, seg.x2, seg.y2
-                )
+                dist = self._point_to_segment_distance(via.x, via.y, seg.x1, seg.y1, seg.x2, seg.y2)
 
                 # Edge-to-edge clearance: center distance minus radii
                 clearance = dist - via_radius - seg_half_width
@@ -1437,9 +1467,7 @@ class RoutingGrid:
                 continue
 
             for existing_via in route.vias:
-                distance = math.sqrt(
-                    (via.x - existing_via.x) ** 2 + (via.y - existing_via.y) ** 2
-                )
+                distance = math.sqrt((via.x - existing_via.x) ** 2 + (via.y - existing_via.y) ** 2)
                 existing_via_radius = existing_via.diameter / 2
                 clearance = distance - via_radius - existing_via_radius
 
@@ -1497,15 +1525,10 @@ class RoutingGrid:
 
             for existing_via in route.vias:
                 # Skip checking against self (exact same position and drill)
-                if (
-                    abs(via.x - existing_via.x) < 1e-6
-                    and abs(via.y - existing_via.y) < 1e-6
-                ):
+                if abs(via.x - existing_via.x) < 1e-6 and abs(via.y - existing_via.y) < 1e-6:
                     continue
 
-                distance = math.sqrt(
-                    (via.x - existing_via.x) ** 2 + (via.y - existing_via.y) ** 2
-                )
+                distance = math.sqrt((via.x - existing_via.x) ** 2 + (via.y - existing_via.y) ** 2)
                 existing_drill_radius = existing_via.drill / 2
                 clearance = distance - drill_radius - existing_drill_radius
 
@@ -1814,10 +1837,7 @@ class RoutingGrid:
         # Issue #1692: Use the maximum trace width (across all net classes)
         # so that wide-trace nets routed later still clear this via.
         trace_w = max_trace_width if max_trace_width is not None else self.rules.trace_width
-        radius = int(
-            (via.diameter / 2 + self.rules.via_clearance + trace_w / 2)
-            / self.resolution
-        )
+        radius = int((via.diameter / 2 + self.rules.via_clearance + trace_w / 2) / self.resolution)
         # Issue #1797: Add safety margin to prevent grid-quantization
         # clearance violations between traces and vias (mirrors the +1
         # applied in mark_route() for segments, see Issue #1666).
@@ -1940,10 +1960,7 @@ class RoutingGrid:
         # Include trace half-width to match _mark_via calculation
         # Issue #1692: Use the same max_trace_width as _mark_via
         trace_w = max_trace_width if max_trace_width is not None else self.rules.trace_width
-        radius = int(
-            (via.diameter / 2 + self.rules.via_clearance + trace_w / 2)
-            / self.resolution
-        )
+        radius = int((via.diameter / 2 + self.rules.via_clearance + trace_w / 2) / self.resolution)
         # Issue #1797: Must match _mark_via safety margin so the same
         # cells are cleared during rip-up.
         radius += 1
@@ -2098,10 +2115,6 @@ class RoutingGrid:
         if not self._pads:
             return None
 
-        # Use the same clearance envelope used at add_pad time so we
-        # match the cells that were actually blocked.
-        clearance = self.rules.trace_clearance + self.rules.trace_width / 2
-
         best_ref: str | None = None
         best_dist = float("inf")
 
@@ -2114,6 +2127,15 @@ class RoutingGrid:
                 pad_layer_idx = self.layer_to_index(pad.layer.value)
                 if pad_layer_idx != layer_idx:
                     continue
+
+            # Issue #2604 follow-up: mirror ``_add_pad_unsafe``'s reduced
+            # clearance envelope for fine-pitch pads.  Without this, pads
+            # added with ``pin_pitch < fine_pitch_threshold`` would be
+            # queried with the larger standard envelope and could
+            # false-positive on cells actually blocked by neighbouring
+            # standard-pitch pads (relevant on chorus-test U5/U7/U9).
+            pad_pitch = self._pad_pin_pitch.get(id(pad))
+            clearance = self._clearance_for_pin_pitch(pad_pitch)
 
             # Compute effective pad bounds (mirrors _add_pad_unsafe logic)
             if pad.through_hole:
@@ -2235,9 +2257,7 @@ class RoutingGrid:
             # First call: initialise to the current present cost
             self._present_cost_ema = new_present.copy()
         else:
-            self._present_cost_ema = (
-                alpha * new_present + (1.0 - alpha) * self._present_cost_ema
-            )
+            self._present_cost_ema = alpha * new_present + (1.0 - alpha) * self._present_cost_ema
 
     def get_negotiated_cost(
         self, gx: int, gy: int, layer: int, present_cost_factor: float = 1.0
@@ -2408,9 +2428,7 @@ class RoutingGrid:
             expanded = np.zeros_like(base_blocked)
             for dy in range(kernel_size):
                 for dx in range(kernel_size):
-                    expanded |= padded[
-                        :, dy : dy + self.rows, dx : dx + self.cols
-                    ]
+                    expanded |= padded[:, dy : dy + self.rows, dx : dx + self.cols]
 
         return expanded
 

--- a/src/kicad_tools/router/placement_feedback.py
+++ b/src/kicad_tools/router/placement_feedback.py
@@ -438,8 +438,10 @@ class PlacementFeedbackLoop:
             strategy = self._find_best_placement_strategy(failed_nets, min_confidence)
 
             if strategy is None:
-                if self.verbose:
-                    print("  No suitable placement strategy found")
+                # The detailed rejection breakdown is already printed by
+                # ``_find_best_placement_strategy`` when verbose -- avoid
+                # duplicating the generic "No suitable placement strategy
+                # found" message here.
                 break
 
             # Apply the strategy
@@ -521,13 +523,34 @@ class PlacementFeedbackLoop:
 
         all_strategies: list[ResolutionStrategy] = []
 
+        # Diagnostic counters (Issue #2604 acceptance criterion #4):
+        # when no strategy survives filtering, log a structured breakdown
+        # of WHY each candidate was rejected so silent failure becomes loud.
+        analyses_seen = 0
+        analyses_with_movable_blockers = 0
+        candidates_total = 0
+        rejected_low_confidence = 0
+        rejected_anchored = 0
+        rejected_over_budget = 0
+        rejected_unsafe = 0
+        accepted = 0
+
         # Analyze each failed net and collect strategies
         for net_id in failed_nets[:5]:  # Limit analysis to first 5 failures
             analysis = self.router.analyze_routing_failure(net_id)
             if analysis is None:
                 continue
+            analyses_seen += 1
 
-            strategies = self._strategy_generator.generate_strategies(self.pcb, analysis)
+            # Track whether the analyzer reported movable blockers at all
+            # so we can distinguish "ref-population bug" from
+            # "all candidates filtered out".
+            if getattr(analysis, "has_movable_blockers", False):
+                analyses_with_movable_blockers += 1
+
+            strategies = self._strategy_generator.generate_strategies(
+                self.pcb, analysis, max_movement=self.max_movement
+            )
 
             # Filter to placement-related strategies
             for strategy in strategies:
@@ -536,25 +559,103 @@ class PlacementFeedbackLoop:
                     StrategyType.MOVE_MULTIPLE,
                 ]:
                     continue
+                candidates_total += 1
                 if strategy.confidence < min_confidence:
+                    rejected_low_confidence += 1
                     continue
                 # Reject strategies that touch any anchored ref.
                 if self._strategy_touches_fixed_refs(strategy):
+                    rejected_anchored += 1
                     continue
                 # Reject strategies that exceed the max movement budget.
                 if not self._strategy_within_movement_budget(strategy):
+                    rejected_over_budget += 1
                     continue
                 # Check if safe to apply (board bounds, etc.)
                 if not self._strategy_applicator.is_safe_to_apply(strategy, self.pcb):
+                    rejected_unsafe += 1
                     continue
+                accepted += 1
                 all_strategies.append(strategy)
 
         if not all_strategies:
+            if self.verbose:
+                self._log_strategy_rejection_breakdown(
+                    analyses_seen=analyses_seen,
+                    analyses_with_movable_blockers=analyses_with_movable_blockers,
+                    candidates_total=candidates_total,
+                    rejected_low_confidence=rejected_low_confidence,
+                    rejected_anchored=rejected_anchored,
+                    rejected_over_budget=rejected_over_budget,
+                    rejected_unsafe=rejected_unsafe,
+                )
             return None
 
         # Sort by confidence (highest first) and pick the best
         all_strategies.sort(key=lambda s: -s.confidence)
         return all_strategies[0]
+
+    def _log_strategy_rejection_breakdown(
+        self,
+        *,
+        analyses_seen: int,
+        analyses_with_movable_blockers: int,
+        candidates_total: int,
+        rejected_low_confidence: int,
+        rejected_anchored: int,
+        rejected_over_budget: int,
+        rejected_unsafe: int,
+    ) -> None:
+        """Print a structured diagnostic when no strategy survives filtering.
+
+        Issue #2604 acceptance criterion #4: distinguish between
+        "no candidates generated" (ref-population bug),
+        "all anchored" (fixed_refs too aggressive),
+        "all over budget" (max_movement too tight),
+        and "all unsafe" (board-bounds reject).
+        """
+        if candidates_total == 0:
+            if analyses_seen == 0:
+                print(
+                    "  No suitable placement strategy: 0 failure analyses "
+                    "produced (router returned None for all failed nets)."
+                )
+            elif analyses_with_movable_blockers == 0:
+                print(
+                    f"  No suitable placement strategy: {analyses_seen} "
+                    f"analyses produced 0 movable blockers "
+                    f"(component refs unresolved -- see Issue #2604)."
+                )
+            else:
+                print(
+                    f"  No suitable placement strategy: {analyses_seen} "
+                    f"analyses, {analyses_with_movable_blockers} with "
+                    f"movable blockers, but 0 MOVE_COMPONENT candidates "
+                    f"generated (strategy generator may have rejected "
+                    f"every blocker)."
+                )
+            return
+
+        breakdown: list[str] = []
+        if rejected_low_confidence:
+            breakdown.append(f"{rejected_low_confidence} below confidence threshold")
+        if rejected_anchored:
+            breakdown.append(f"{rejected_anchored} anchored")
+        if rejected_over_budget:
+            cap = (
+                f"{self.max_movement:.2f}mm"
+                if self.max_movement is not None
+                else "n/a"
+            )
+            breakdown.append(f"{rejected_over_budget} over budget ({cap})")
+        if rejected_unsafe:
+            breakdown.append(f"{rejected_unsafe} unsafe (board bounds)")
+        breakdown_str = "; ".join(breakdown) if breakdown else "no reason recorded"
+        print(
+            f"  No suitable placement strategy: rejected "
+            f"{candidates_total} MOVE_COMPONENT candidates "
+            f"({breakdown_str})."
+        )
 
     def _strategy_touches_fixed_refs(self, strategy: ResolutionStrategy) -> bool:
         """Return True if any affected component is in ``fixed_refs``."""

--- a/src/kicad_tools/router/placement_feedback.py
+++ b/src/kicad_tools/router/placement_feedback.py
@@ -75,7 +75,7 @@ def detect_pf_stagnation(
         return False
     if len(routed_history) < patience + 1:
         return False
-    last_window = routed_history[-(patience + 1):]
+    last_window = routed_history[-(patience + 1) :]
     return len(set(last_window)) == 1
 
 
@@ -354,10 +354,7 @@ class PlacementFeedbackLoop:
             # top of each iteration so we can bail out before kicking
             # off another (potentially multi-minute) negotiated-router
             # run.
-            if (
-                self.outer_timeout is not None
-                and time.time() - start_time > self.outer_timeout
-            ):
+            if self.outer_timeout is not None and time.time() - start_time > self.outer_timeout:
                 if self.verbose:
                     elapsed = time.time() - start_time
                     print(
@@ -579,6 +576,13 @@ class PlacementFeedbackLoop:
                 all_strategies.append(strategy)
 
         if not all_strategies:
+            # Issue #2604 follow-up: previously we only emitted the full
+            # breakdown when ``verbose`` was set, which left default
+            # (non-verbose) runs *more* silent than before -- the prior
+            # "No suitable placement strategy found" line had been removed
+            # entirely.  Restore a one-line summary in non-verbose mode so
+            # operators always see *something* when the loop bails out,
+            # while verbose users still get the full structured breakdown.
             if self.verbose:
                 self._log_strategy_rejection_breakdown(
                     analyses_seen=analyses_seen,
@@ -589,11 +593,70 @@ class PlacementFeedbackLoop:
                     rejected_over_budget=rejected_over_budget,
                     rejected_unsafe=rejected_unsafe,
                 )
+            else:
+                print(
+                    self._format_strategy_rejection_summary(
+                        analyses_seen=analyses_seen,
+                        analyses_with_movable_blockers=analyses_with_movable_blockers,
+                        candidates_total=candidates_total,
+                        rejected_low_confidence=rejected_low_confidence,
+                        rejected_anchored=rejected_anchored,
+                        rejected_over_budget=rejected_over_budget,
+                        rejected_unsafe=rejected_unsafe,
+                    )
+                )
             return None
 
         # Sort by confidence (highest first) and pick the best
         all_strategies.sort(key=lambda s: -s.confidence)
         return all_strategies[0]
+
+    def _format_strategy_rejection_summary(
+        self,
+        *,
+        analyses_seen: int,
+        analyses_with_movable_blockers: int,
+        candidates_total: int,
+        rejected_low_confidence: int,
+        rejected_anchored: int,
+        rejected_over_budget: int,
+        rejected_unsafe: int,
+    ) -> str:
+        """Return a single-line summary of why no strategy survived filtering.
+
+        Used in non-verbose mode to keep default runs from being silently
+        unhelpful (see Issue #2604 review feedback).  Verbose mode still
+        gets the full structured breakdown via
+        ``_log_strategy_rejection_breakdown``.
+        """
+        if candidates_total == 0:
+            if analyses_seen == 0:
+                cause = "0 failure analyses produced by router"
+            elif analyses_with_movable_blockers == 0:
+                cause = f"{analyses_seen} analyses, 0 movable blockers (refs unresolved)"
+            else:
+                cause = (
+                    f"{analyses_with_movable_blockers}/{analyses_seen} "
+                    f"analyses with movable blockers, 0 MOVE_COMPONENT "
+                    f"candidates generated"
+                )
+            return f"  No suitable placement strategy: {cause}."
+
+        parts: list[str] = []
+        if rejected_low_confidence:
+            parts.append(f"{rejected_low_confidence} low-confidence")
+        if rejected_anchored:
+            parts.append(f"{rejected_anchored} anchored")
+        if rejected_over_budget:
+            cap = f"{self.max_movement:.2f}mm" if self.max_movement is not None else "n/a"
+            parts.append(f"{rejected_over_budget} over-budget({cap})")
+        if rejected_unsafe:
+            parts.append(f"{rejected_unsafe} unsafe")
+        breakdown = ", ".join(parts) if parts else "no reason recorded"
+        return (
+            f"  No suitable placement strategy: rejected {candidates_total} "
+            f"candidates ({breakdown}). Re-run with --verbose for details."
+        )
 
     def _log_strategy_rejection_breakdown(
         self,
@@ -642,11 +705,7 @@ class PlacementFeedbackLoop:
         if rejected_anchored:
             breakdown.append(f"{rejected_anchored} anchored")
         if rejected_over_budget:
-            cap = (
-                f"{self.max_movement:.2f}mm"
-                if self.max_movement is not None
-                else "n/a"
-            )
+            cap = f"{self.max_movement:.2f}mm" if self.max_movement is not None else "n/a"
             breakdown.append(f"{rejected_over_budget} over budget ({cap})")
         if rejected_unsafe:
             breakdown.append(f"{rejected_unsafe} unsafe (board bounds)")

--- a/tests/test_chorus_test_placement_feedback.py
+++ b/tests/test_chorus_test_placement_feedback.py
@@ -1,0 +1,593 @@
+"""Integration regression test for the chorus-test placement-feedback pipeline.
+
+This module is the nightly-CI safety net for Issue #2604 / PR #2609,
+which fixed two latent bugs in the closed-loop placement-routing
+feedback path:
+
+1. ``BlockingElement.ref`` was always ``None`` because ``GridCell`` had
+   no ``ref`` field.  ``RoutingGrid.find_pad_ref_at`` (added by #2609)
+   recovers the owning component reference via a spatial lookup so the
+   strategy generator's ``if blocker.ref is None: continue`` short-circuit
+   no longer drops every candidate.
+
+2. ``StrategyGenerator._find_move_candidates`` ignored the ``max_movement``
+   budget and emitted corridor-derived offsets (often 20-30mm) that the
+   loop's ``_strategy_within_movement_budget`` filter then rejected
+   wholesale.  PR #2609 threads ``max_movement`` through so candidates
+   are inside the loop's budget by construction.
+
+A pure-mock test (see ``tests/test_placement_feedback.py``) cannot
+exercise either fix because it does not populate a real
+``RoutingGrid``.  The synthetic miniature here uses a real
+``Autorouter`` with hand-placed ``Pad`` objects forming a deliberate
+``BLOCKED_PATH`` topology so the analyzer -> generator -> filter ->
+applicator path runs end-to-end.
+
+Two test classes are provided:
+
+* ``TestPlacementFeedbackOnSyntheticBlockedPath`` (always runs nightly):
+  builds a 30 x 30mm board with three SSOP-pad clusters arranged so a
+  signal net's pad-pair can only route by displacing the middle
+  cluster.  Asserts that the feedback loop fires a
+  ``MOVE_COMPONENT``/``MOVE_MULTIPLE`` strategy, records at least one
+  ``PlacementDiffEntry``, and emits the verbose "Applying strategy:
+  move_component" log line that proves the pipeline reached the
+  applicator stage.  Each assertion carries a dedicated message that
+  distinguishes the four pre-#2604 failure modes -- ref-population,
+  candidate-generation, movement-budget filter, board-bounds filter --
+  so a regression is loudly attributable.
+
+* ``TestPlacementFeedbackOnRealChorusTest`` (skip-if-missing):
+  drives the ``kct route --placement-feedback`` CLI against the real
+  chorus-test-revA fixture under ``boards/external/``.  The fixture
+  is not vendored into the repo (size + license); the test skips
+  cleanly when absent so the slow-tests CI runner just records a
+  skip while a developer/self-hosted runner that has vendored the
+  board files exercises the full board-scale gate.
+
+Both classes are marked ``@pytest.mark.slow`` so PR-time CI excludes
+them (``-m "not slow"``) and the nightly workflow at
+``.github/workflows/slow-tests.yml`` (``-m slow``) picks them up
+automatically.  No workflow change is required.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.recovery import StrategyType
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.rules import DesignRules
+
+# ---------------------------------------------------------------------------
+# Minimal PCB stand-in.
+#
+# ``StrategyApplicator`` and ``StrategyGenerator`` iterate ``pcb.footprints``
+# looking for ``reference`` and ``position`` attributes and a
+# ``pcb.graphic_items`` list for board-bounds detection.  A trivial pair of
+# dataclass-ish stand-ins is enough; see the ``MockPCB`` pattern in
+# ``tests/test_placement_feedback.py``.
+# ---------------------------------------------------------------------------
+
+
+class _StubFootprint:
+    """Footprint stand-in: just ``reference`` and a mutable ``position``."""
+
+    def __init__(self, reference: str, x: float, y: float):
+        self.reference = reference
+        self.position = (x, y)
+        self.rotation = 0.0
+        self.locked = False
+        # The strategy applicator reads .pads on the footprint when
+        # repositioning groups; an empty list keeps it inert.
+        self.pads: list = []
+
+
+class _StubEdgeCut:
+    """Edge-cut graphic item used by ``_get_board_bounds``."""
+
+    def __init__(self, start: tuple[float, float], end: tuple[float, float]):
+        # ``_get_board_bounds`` matches ``"Edge"`` in ``str(item.layer)``.
+        self.layer = "Edge.Cuts"
+        self.start = start
+        self.end = end
+
+
+class _StubPCB:
+    """PCB stand-in: ``footprints`` + ``graphic_items`` are all that
+    ``StrategyApplicator`` / ``StrategyGenerator`` read on this code path.
+    """
+
+    def __init__(
+        self,
+        footprints: list[_StubFootprint],
+        edge_cuts: list[_StubEdgeCut],
+    ):
+        self.footprints = list(footprints)
+        self.graphic_items = list(edge_cuts)
+        # The remaining fields are touched only by the broader CLI path,
+        # not by ``PlacementFeedbackLoop`` -- leave them empty.
+        self.segments: list = []
+        self.vias: list = []
+        self.zones: list = []
+        self.layers: dict = {}
+        self.nets: dict = {}
+
+
+# ---------------------------------------------------------------------------
+# Synthetic miniature -- always runs.
+# ---------------------------------------------------------------------------
+
+
+def _build_blocked_path_scenario() -> tuple[Autorouter, _StubPCB]:
+    """Build a 30 x 30mm board with a deliberately BLOCKED_PATH topology.
+
+    Layout (all on F.Cu):
+
+        U1 .......... U2     <- signal net SIG1 needs U1.1 -> U2.1
+                |
+                U3
+                (obstructing cluster)
+
+    U3 is a small SMD package planted directly in the routing corridor
+    between U1 and U2 with pads that completely span the corridor on
+    BOTH copper layers (so via-escape can't bypass it).  U1 and U2 are
+    on the edges of the board.
+
+    The analyzer must:
+    * detect U3 (the cluster of SMD pads) as a movable BLOCKED_PATH
+      blocker,
+    * via ``find_pad_ref_at`` recover ``blocker.ref == "U3"``,
+    * pass U3 through the generator's ``max_movement``-aware
+      ``_find_move_candidates`` to produce in-budget move offsets,
+    * survive the loop's ``_strategy_within_movement_budget`` filter
+      so a MOVE_COMPONENT strategy reaches the applicator.
+
+    Returns:
+        Tuple of (router, pcb) ready to drive ``route_with_placement_feedback``.
+    """
+    rules = DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        grid_resolution=0.1,
+    )
+    router = Autorouter(
+        width=30.0,
+        height=30.0,
+        rules=rules,
+        layer_stack=LayerStack.two_layer(),
+    )
+
+    # U1 -- single pad at left edge of corridor.
+    router.add_component(
+        "U1",
+        [
+            {
+                "number": "1",
+                "x": 4.0,
+                "y": 15.0,
+                "width": 0.8,
+                "height": 0.8,
+                "net": 1,
+                "net_name": "SIG1",
+                "layer": Layer.F_CU,
+            },
+        ],
+    )
+
+    # U2 -- single pad at right edge of corridor (same net).
+    router.add_component(
+        "U2",
+        [
+            {
+                "number": "1",
+                "x": 26.0,
+                "y": 15.0,
+                "width": 0.8,
+                "height": 0.8,
+                "net": 1,
+                "net_name": "SIG1",
+                "layer": Layer.F_CU,
+            },
+        ],
+    )
+
+    # U3 -- obstructing cluster in the middle of the corridor.  A dense
+    # column of SMD pads at x=15 spanning the FULL y-extent of the
+    # board (1.5 to 28.5) on BOTH copper layers so the corridor is
+    # blocked on F.Cu AND B.Cu and the router cannot escape via the
+    # top/bottom rails either.  Pad pitch is 1.5mm centre-to-centre
+    # with 1.4mm pad width so consecutive clearance envelopes overlap
+    # and the column is one continuous wall.
+    u3_pads: list[dict] = []
+    pin = 1
+    y_positions = [1.5 + 1.5 * i for i in range(19)]  # 1.5, 3.0, ..., 28.5
+    for y in y_positions:
+        for layer in (Layer.F_CU, Layer.B_CU):
+            u3_pads.append(
+                {
+                    "number": str(pin),
+                    "x": 15.0,  # dead-centre of the U1->U2 corridor
+                    "y": y,
+                    "width": 1.4,
+                    "height": 1.4,
+                    # Distinct (non-SIG1) net so these pads aren't
+                    # treated as connection endpoints.
+                    "net": 2,
+                    "net_name": "U3_BLOCK",
+                    "layer": layer,
+                }
+            )
+            pin += 1
+    router.add_component("U3", u3_pads)
+
+    # Build a stub PCB so the feedback loop has something to mutate.
+    footprints = [
+        _StubFootprint("U1", 4.0, 15.0),
+        _StubFootprint("U2", 26.0, 15.0),
+        _StubFootprint("U3", 15.0, 15.0),
+    ]
+    edge_cuts = [
+        _StubEdgeCut(start=(0.0, 0.0), end=(30.0, 0.0)),
+        _StubEdgeCut(start=(30.0, 0.0), end=(30.0, 30.0)),
+        _StubEdgeCut(start=(30.0, 30.0), end=(0.0, 30.0)),
+        _StubEdgeCut(start=(0.0, 30.0), end=(0.0, 0.0)),
+    ]
+    pcb = _StubPCB(footprints=footprints, edge_cuts=edge_cuts)
+
+    return router, pcb
+
+
+@pytest.mark.slow
+class TestPlacementFeedbackOnSyntheticBlockedPath:
+    """Regression gate for Issue #2604 on a synthetic miniature.
+
+    The synthetic exercises the full analyzer -> generator -> filter ->
+    applicator path the chorus-test repro produced and which a pure-mock
+    test cannot reach (because no real ``RoutingGrid`` is populated).
+    """
+
+    def test_pre_feedback_route_all_leaves_sig1_unrouted(self) -> None:
+        """Sanity check: with U3 in the corridor, SIG1 must fail to route.
+
+        If this assertion fails the scenario is no longer a reliable
+        regression gate -- something changed about routing capability
+        that lets the corridor be threaded without moving U3.  Investigate
+        before relaxing.
+        """
+        router, _pcb = _build_blocked_path_scenario()
+        router.route_all()
+        failed = router.get_failed_nets()
+        assert failed, (
+            "Synthetic scenario produced no routing failures; the "
+            "corridor between U1/U2 must be blocked by U3 to make this "
+            "a regression gate for Issue #2604.  Adjust U3 geometry."
+        )
+
+    def test_placement_feedback_fires_move_component_strategy(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """End-to-end: feedback loop must produce a MOVE_COMPONENT adjustment.
+
+        Each assertion carries a dedicated message identifying which of
+        the four pre-#2604 failure modes broke (ref-population,
+        candidate-generation, movement-budget, board-bounds) so the
+        rejection is loudly attributable.  See
+        ``_log_strategy_rejection_breakdown`` at
+        ``src/kicad_tools/router/placement_feedback.py:447``.
+        """
+        router, pcb = _build_blocked_path_scenario()
+
+        result = router.route_with_placement_feedback(
+            pcb=pcb,
+            max_adjustments=3,
+            use_negotiated=False,  # synthetic doesn't need negotiated
+            min_confidence=0.5,
+            verbose=True,
+            max_movement=5.0,
+        )
+
+        log = capsys.readouterr().out
+
+        # ----------------------------------------------------------------
+        # Assertion 1: total_components_moved -- proves the applicator
+        # actually ran (covers fix #1: ref-population) AND that strategies
+        # survived the movement-budget filter (covers fix #2).
+        # ----------------------------------------------------------------
+        assert result.total_components_moved >= 1, (
+            "PlacementFeedbackResult.total_components_moved == 0 "
+            "(Issue #2604 regression): the feedback loop reached the "
+            "applicator zero times.  Diagnose by checking which stage "
+            "broke:\n"
+            "  (a) zero failure analyses produced => router.analyze_routing_failure returned None\n"
+            "  (b) zero movable blockers => find_pad_ref_at didn't populate BlockingElement.ref (PR #2609 grid.py:2070)\n"
+            "  (c) zero MOVE_COMPONENT candidates => StrategyGenerator._find_move_candidates dropped them (PR #2609 strategy.py:434)\n"
+            "  (d) all candidates over-budget => _strategy_within_movement_budget filtered them (max_movement plumbing)\n"
+            f"Loop log:\n{log}"
+        )
+
+        # ----------------------------------------------------------------
+        # Assertion 2: placement_diff is populated -- proves the
+        # PlacementDiffEntry collector saw the move and the loop is
+        # emitting a useful diff artifact.
+        # ----------------------------------------------------------------
+        assert len(result.placement_diff) >= 1, (
+            "PlacementFeedbackResult.placement_diff is empty even though "
+            f"total_components_moved={result.total_components_moved}.  "
+            "The loop applied a strategy but did NOT collect a "
+            "PlacementDiffEntry -- check _build_placement_diff / "
+            "_snapshot_positions wiring in placement_feedback.py.\n"
+            f"Loop log:\n{log}"
+        )
+
+        # ----------------------------------------------------------------
+        # Assertion 3: at least one adjustment is a MOVE_COMPONENT /
+        # MOVE_MULTIPLE strategy.  Catches the case where the loop fired
+        # but the strategy was a degenerate fallback (e.g. manual
+        # intervention) instead of an actual component move.
+        # ----------------------------------------------------------------
+        move_adjustments = [
+            adj
+            for adj in result.adjustments
+            if adj.strategy.type in {StrategyType.MOVE_COMPONENT, StrategyType.MOVE_MULTIPLE}
+        ]
+        assert move_adjustments, (
+            "PlacementFeedbackResult.adjustments contains zero "
+            "MOVE_COMPONENT or MOVE_MULTIPLE strategies (Issue #2604 "
+            "acceptance criterion #2.c).  "
+            f"adjustments={[a.strategy.type.value for a in result.adjustments]}.\n"
+            f"Loop log:\n{log}"
+        )
+
+        # ----------------------------------------------------------------
+        # Assertion 4: the verbose log line that announces strategy
+        # application appears in stdout.  Mirrors the issue's repro
+        # criterion: ``grep "Re-placing"`` (and the in-code analogue
+        # ``Applying strategy: move_component`` at line 446 of
+        # placement_feedback.py).
+        # ----------------------------------------------------------------
+        assert (
+            "Applying strategy: move_component" in log or "Applying strategy: move_multiple" in log
+        ), (
+            "Verbose log does NOT contain 'Applying strategy: "
+            "move_component' / 'move_multiple' even though "
+            f"total_components_moved={result.total_components_moved}.  "
+            "The loop bypassed the verbose announcement path -- check "
+            "placement_feedback.py:444-448.\n"
+            f"Loop log:\n{log}"
+        )
+
+        # ----------------------------------------------------------------
+        # Assertion 5: the diff artifact is dict-serializable with the
+        # expected schema.  ``kct route --placement-feedback`` persists
+        # this as ``<output>_placement_diff.json`` (route_cmd.py:796),
+        # so a malformed entry would silently corrupt the CI artifact.
+        # ----------------------------------------------------------------
+        first_entry_dict = result.placement_diff[0].to_dict()
+        assert set(first_entry_dict.keys()) == {
+            "ref",
+            "old_xy",
+            "new_xy",
+            "rotation_delta",
+            "distance_mm",
+        }, (
+            f"PlacementDiffEntry.to_dict() returned unexpected keys: "
+            f"{set(first_entry_dict.keys())}.  The CLI persists this "
+            "verbatim as placement_diff.json; a schema drift breaks the "
+            "downstream tooling."
+        )
+        assert first_entry_dict["distance_mm"] >= 0.0
+
+    def test_each_adjustment_respects_max_movement_budget(self) -> None:
+        """Every per-iteration adjustment must satisfy distance <= max_movement.
+
+        This is the budget-aware guarantee from PR #2609's second fix:
+        ``_find_move_candidates`` now generates candidates inside the
+        loop's ``max_movement`` cap.  If a regression re-introduces
+        out-of-budget candidates the filter might still drop them
+        (good), but if the filter and generator drift apart this guard
+        catches it.
+
+        Note: ``placement_diff`` records the CUMULATIVE displacement
+        across all iterations and CAN exceed ``max_movement`` (the
+        budget is per-move, not cumulative).  This test checks the
+        per-step ``adjustments`` instead.
+        """
+        router, pcb = _build_blocked_path_scenario()
+
+        max_movement = 5.0
+        result = router.route_with_placement_feedback(
+            pcb=pcb,
+            max_adjustments=3,
+            use_negotiated=False,
+            min_confidence=0.5,
+            verbose=False,
+            max_movement=max_movement,
+        )
+
+        # Skip if no moves happened -- the main test already asserts
+        # at least one move; this test is purely about the budget.
+        if not result.adjustments:
+            pytest.skip("No adjustments to budget-check.")
+
+        # For each per-iteration adjustment, inspect every ``move``
+        # action in the strategy and confirm the proposed new position
+        # is within ``max_movement`` of the position the loop saw at
+        # decision time (i.e. the original-or-previously-applied
+        # position).  Since the test's PCB state mutates between
+        # iterations and the loop's adjustments record the strategy
+        # state at decision time, we re-derive the per-step pre-move
+        # position from the strategy's affected components by tracing
+        # adjustments in order.
+        positions: dict[str, tuple[float, float]] = {
+            fp.reference: fp.position for fp in pcb.footprints
+        }
+        # Walk adjustments backwards to restore the original positions
+        # the loop saw before applying any of them.  ``placement_diff``
+        # records (old_xy, new_xy) for each ref; ``old_xy`` is the
+        # original position before the FIRST move.
+        diff_old: dict[str, tuple[float, float]] = {
+            entry.ref: entry.old_xy for entry in result.placement_diff
+        }
+        for ref, old_xy in diff_old.items():
+            positions[ref] = old_xy
+
+        for adjustment in result.adjustments:
+            for action in adjustment.strategy.actions:
+                if action.type != "move":
+                    continue
+                ref = action.target
+                new_x = action.params.get("x")
+                new_y = action.params.get("y")
+                if new_x is None or new_y is None:
+                    continue
+                if ref not in positions:
+                    continue
+                old_x, old_y = positions[ref]
+                step_distance = math.hypot(new_x - old_x, new_y - old_y)
+                assert step_distance <= max_movement + 1e-6, (
+                    f"Per-iteration adjustment for {ref} (iter "
+                    f"{adjustment.iteration}) moved {step_distance:.4f}mm "
+                    f"which exceeds the per-step max_movement budget of "
+                    f"{max_movement}mm (Issue #2604: "
+                    "budget-aware _find_move_candidates must not emit "
+                    f"out-of-budget candidates).  pre=({old_x}, {old_y}), "
+                    f"new=({new_x}, {new_y})"
+                )
+                # Advance the tracked position so the next adjustment
+                # for the same ref is measured against the post-move
+                # state, mirroring the loop's per-step semantics.
+                positions[ref] = (new_x, new_y)
+
+
+# ---------------------------------------------------------------------------
+# Real chorus-test-revA gate -- skipped if the board fixture is absent.
+# ---------------------------------------------------------------------------
+
+
+def _chorus_test_pcb_path() -> Path:
+    """Return the expected path to the chorus-test-revA PCB fixture.
+
+    Mirrors the path baked into the benchmark suite at
+    ``src/kicad_tools/benchmark/cases.py:103``.  We resolve relative to
+    the repository root (this file is two levels under it).
+    """
+    return (
+        Path(__file__).resolve().parent.parent
+        / "boards"
+        / "external"
+        / "chorus-test-revA"
+        / "kicad"
+        / "chorus-test-revA_v9_grid50.kicad_pcb"
+    )
+
+
+@pytest.mark.slow
+class TestPlacementFeedbackOnRealChorusTest:
+    """Real-board placement-feedback gate.
+
+    Skipped when ``boards/external/chorus-test-revA`` is not vendored
+    locally (the typical state on CI runners).  When the fixture IS
+    present, drives the ``kct route --placement-feedback`` CLI
+    end-to-end and asserts the emitted ``*_placement_diff.json`` is
+    populated.
+    """
+
+    @pytest.fixture
+    def chorus_test_pcb(self) -> Path:
+        """Resolve the chorus-test-revA PCB path or skip the test cleanly."""
+        path = _chorus_test_pcb_path()
+        if not path.exists():
+            pytest.skip(
+                f"chorus-test-revA fixture not vendored at {path}; "
+                "skipping real-board placement-feedback gate.  Set up "
+                "the board files locally (or on a self-hosted runner) "
+                "to exercise this test."
+            )
+        return path
+
+    def test_placement_diff_artifact_is_populated(
+        self,
+        chorus_test_pcb: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Driving the CLI with --placement-feedback emits a non-empty diff.
+
+        Runs the route command as if a human had invoked it from the
+        shell -- via ``route_cmd.main`` so the helper layer (anchor
+        resolution, ``_placement_diff_path``, JSON serialization) is
+        all exercised.
+
+        Asserts:
+        * The diff file exists at the expected path beside the routed PCB.
+        * The diff list contains at least one entry with non-zero
+          ``distance_mm`` (proves an actual move, not an empty file
+          written-to-signal-feedback-ran).
+        """
+        from kicad_tools.cli import route_cmd
+
+        output_pcb = tmp_path / "chorus_test_routed.kicad_pcb"
+        # 1800s timeout matches the issue's repro command.  This test
+        # runs only on nightly CI / dev workstations that have the
+        # fixture vendored, never on the default-CI runner.
+        argv = [
+            str(chorus_test_pcb),
+            "-o",
+            str(output_pcb),
+            "--strategy",
+            "negotiated",
+            "--layers",
+            "4",
+            "--manufacturer",
+            "jlcpcb-tier1",
+            "--no-cache",
+            "--timeout",
+            "1800",
+            "--per-net-timeout",
+            "120",
+            "--placement-feedback",
+        ]
+
+        rc = route_cmd.main(argv)
+        # We do not assert rc == 0: the placement-feedback path may
+        # still leave some nets unrouted, which returns a non-zero exit
+        # code.  We only care that the diff artifact was emitted.
+        assert rc in (0, 2, 3), (
+            f"route_cmd.main returned unexpected exit code {rc}; "
+            "expected 0/2/3 (success or partial)."
+        )
+
+        diff_path = output_pcb.with_suffix("").with_name(output_pcb.stem + "_placement_diff.json")
+        assert diff_path.exists(), (
+            f"--placement-feedback did not emit {diff_path}; check "
+            "route_cmd._run_placement_feedback / _placement_diff_path."
+        )
+
+        diff_data = json.loads(diff_path.read_text())
+        assert isinstance(diff_data, list), (
+            f"placement_diff.json must be a JSON array; got {type(diff_data).__name__}"
+        )
+
+        non_trivial = [entry for entry in diff_data if entry.get("distance_mm", 0.0) > 1e-6]
+        assert non_trivial, (
+            "placement_diff.json contains zero entries with non-zero "
+            "distance_mm.  Either the feedback loop did not fire (no "
+            "blocker classified as movable -- Issue #2604 regression) "
+            "or every emitted diff is a no-op move.  Diff contents: "
+            f"{diff_data!r}"
+        )
+
+        # Also verify the schema on at least one entry so a future
+        # CLI refactor that drops a field is caught here.
+        sample = non_trivial[0]
+        for key in ("ref", "old_xy", "new_xy", "distance_mm"):
+            assert key in sample, f"placement_diff.json entry missing key {key!r}: {sample!r}"
+
+        # And the move distance must be finite (NaN/inf would slip
+        # through json.loads but break downstream tooling).
+        assert math.isfinite(sample["distance_mm"])

--- a/tests/test_failure_analysis_blocking_ref.py
+++ b/tests/test_failure_analysis_blocking_ref.py
@@ -1,0 +1,260 @@
+"""Tests for Issue #2604: BlockingElement.ref population.
+
+The PlacementFeedbackLoop never produces MOVE_COMPONENT strategies because
+``BlockingElement.ref`` was always None for component blockers (GridCell
+has no ``ref`` field).  This module verifies the spatial-lookup fix in
+``RootCauseAnalyzer._find_blocking_elements`` correctly recovers the
+owning component reference via ``RoutingGrid.find_pad_ref_at``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.failure_analysis import (
+    BlockingElement,
+    Rectangle,
+    RootCauseAnalyzer,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+
+@pytest.fixture
+def design_rules() -> DesignRules:
+    """Standard design rules for these tests."""
+    return DesignRules(
+        grid_resolution=0.1,
+        trace_width=0.2,
+        trace_clearance=0.15,
+    )
+
+
+@pytest.fixture
+def two_layer_stack() -> LayerStack:
+    """Two-layer stack for these tests."""
+    return LayerStack.two_layer()
+
+
+@pytest.fixture
+def routing_grid(design_rules: DesignRules, two_layer_stack: LayerStack) -> RoutingGrid:
+    """Routing grid sized for two components on a small board."""
+    return RoutingGrid(
+        width=50.0,
+        height=50.0,
+        rules=design_rules,
+        origin_x=0.0,
+        origin_y=0.0,
+        layer_stack=two_layer_stack,
+    )
+
+
+def _add_block_at(
+    grid: RoutingGrid,
+    ref: str,
+    cx: float,
+    cy: float,
+    width: float,
+    height: float,
+    net: int = 0,
+    net_name: str = "",
+) -> Pad:
+    """Add a single SMD pad to ``grid`` representing a component obstacle."""
+    pad = Pad(
+        x=cx,
+        y=cy,
+        width=width,
+        height=height,
+        net=net,
+        net_name=net_name,
+        layer=Layer.F_CU,
+        ref=ref,
+        pin="1",
+    )
+    grid.add_pad(pad)
+    return pad
+
+
+class TestFindPadRefAt:
+    """Tests for the new ``RoutingGrid.find_pad_ref_at`` helper."""
+
+    def test_returns_none_for_empty_grid(self, routing_grid: RoutingGrid):
+        assert routing_grid.find_pad_ref_at(10.0, 10.0, layer_idx=0) is None
+
+    def test_finds_ref_at_pad_center(self, routing_grid: RoutingGrid):
+        _add_block_at(routing_grid, "U1", 10.0, 10.0, 2.0, 2.0)
+        assert routing_grid.find_pad_ref_at(10.0, 10.0, layer_idx=0) == "U1"
+
+    def test_finds_ref_within_clearance_envelope(self, routing_grid: RoutingGrid):
+        # Pad center at (10,10), 2x2mm => metal extends to (9..11, 9..11),
+        # plus clearance + trace_width/2 ~= 0.25mm.  A point at (11.2, 10)
+        # should still resolve to U1 because grid blocking extends through
+        # the clearance halo.
+        _add_block_at(routing_grid, "U1", 10.0, 10.0, 2.0, 2.0)
+        assert routing_grid.find_pad_ref_at(11.2, 10.0, layer_idx=0) == "U1"
+
+    def test_returns_none_outside_envelope(self, routing_grid: RoutingGrid):
+        _add_block_at(routing_grid, "U1", 10.0, 10.0, 2.0, 2.0)
+        assert routing_grid.find_pad_ref_at(20.0, 20.0, layer_idx=0) is None
+
+    def test_picks_nearest_when_envelopes_overlap(
+        self, routing_grid: RoutingGrid
+    ):
+        _add_block_at(routing_grid, "U1", 10.0, 10.0, 2.0, 2.0)
+        _add_block_at(routing_grid, "U2", 12.0, 10.0, 2.0, 2.0)
+        # Point closer to U1 should resolve to U1
+        assert routing_grid.find_pad_ref_at(10.5, 10.0, layer_idx=0) == "U1"
+        # Point closer to U2 should resolve to U2
+        assert routing_grid.find_pad_ref_at(11.5, 10.0, layer_idx=0) == "U2"
+
+    def test_layer_filter_smd(
+        self, routing_grid: RoutingGrid, two_layer_stack: LayerStack
+    ):
+        """SMD pads only affect their own layer."""
+        # Manually add an SMD pad on B_CU and confirm it isn't found on F_CU
+        pad = Pad(
+            x=10.0,
+            y=10.0,
+            width=2.0,
+            height=2.0,
+            net=0,
+            net_name="",
+            layer=Layer.B_CU,
+            ref="U1",
+            pin="1",
+        )
+        routing_grid.add_pad(pad)
+        b_cu_idx = routing_grid.layer_to_index(Layer.B_CU.value)
+        f_cu_idx = routing_grid.layer_to_index(Layer.F_CU.value)
+        assert routing_grid.find_pad_ref_at(10.0, 10.0, layer_idx=b_cu_idx) == "U1"
+        assert routing_grid.find_pad_ref_at(10.0, 10.0, layer_idx=f_cu_idx) is None
+
+    def test_pth_pads_block_all_layers(self, routing_grid: RoutingGrid):
+        """PTH pads ignore the layer filter -- they block both F_CU and B_CU."""
+        pad = Pad(
+            x=10.0,
+            y=10.0,
+            width=2.0,
+            height=2.0,
+            net=0,
+            net_name="",
+            layer=Layer.F_CU,
+            ref="J1",
+            pin="1",
+            through_hole=True,
+            drill=1.0,
+        )
+        routing_grid.add_pad(pad)
+        b_cu_idx = routing_grid.layer_to_index(Layer.B_CU.value)
+        f_cu_idx = routing_grid.layer_to_index(Layer.F_CU.value)
+        assert routing_grid.find_pad_ref_at(10.0, 10.0, layer_idx=f_cu_idx) == "J1"
+        assert routing_grid.find_pad_ref_at(10.0, 10.0, layer_idx=b_cu_idx) == "J1"
+
+
+class TestBlockingElementRefPopulation:
+    """Tests that ``_find_blocking_elements`` populates ``ref`` correctly."""
+
+    def test_component_blocker_has_populated_ref(
+        self, routing_grid: RoutingGrid
+    ):
+        """The fix for Issue #2604: ref must NOT be None for component blockers."""
+        # Place U1 directly between the start and end points so it lands
+        # inside the routing corridor.
+        _add_block_at(routing_grid, "U1", 25.0, 25.0, 4.0, 4.0)
+
+        analyzer = RootCauseAnalyzer()
+        analysis = analyzer.analyze_routing_failure(
+            grid=routing_grid,
+            start=(5.0, 25.0),
+            end=(45.0, 25.0),
+            net="DAC_CLK",
+            layer=0,
+        )
+
+        component_blockers = [
+            b for b in analysis.blocking_elements if b.type == "component"
+        ]
+        assert component_blockers, "Expected at least one component blocker"
+        # Every component blocker must have a non-None ref now.
+        for b in component_blockers:
+            assert b.ref is not None, (
+                f"Component blocker has ref=None (Issue #2604 regression): {b}"
+            )
+            assert b.movable is True
+        # And the ref of the inserted U1 must be present.
+        refs = {b.ref for b in component_blockers}
+        assert "U1" in refs
+
+    def test_has_movable_blockers_implies_refs_present(
+        self, routing_grid: RoutingGrid
+    ):
+        """If has_movable_blockers is True, at least one blocker must have a ref.
+
+        This is the invariant the strategy generator relies on.  If an
+        analyzer returns has_movable_blockers=True but every blocker has
+        ref=None (the pre-fix behavior), every move strategy gets dropped
+        in ``_generate_move_strategies``.
+        """
+        _add_block_at(routing_grid, "U1", 25.0, 25.0, 4.0, 4.0)
+
+        analyzer = RootCauseAnalyzer()
+        analysis = analyzer.analyze_routing_failure(
+            grid=routing_grid,
+            start=(5.0, 25.0),
+            end=(45.0, 25.0),
+            net="DAC_CLK",
+            layer=0,
+        )
+        if not analysis.has_movable_blockers:
+            pytest.skip("Analyzer didn't detect movable blockers in this fixture")
+        ref_present = [
+            b.ref
+            for b in analysis.blocking_elements
+            if b.type == "component" and b.movable and b.ref
+        ]
+        assert ref_present, (
+            "has_movable_blockers=True but no component blocker has a ref "
+            "(Issue #2604 regression -- strategy generator will drop "
+            "every candidate)"
+        )
+
+    def test_nearby_component_populated(self, routing_grid: RoutingGrid):
+        """``nearby_component`` is gated on ``b.ref`` -- verify it populates.
+
+        See ``failure_analysis.py:759``: ``component_blockers = [b for b
+        in blocking if b.ref]``.  Pre-fix this was always empty.
+        """
+        _add_block_at(routing_grid, "U1", 25.0, 25.0, 4.0, 4.0)
+
+        analyzer = RootCauseAnalyzer()
+        analysis = analyzer.analyze_routing_failure(
+            grid=routing_grid,
+            start=(5.0, 25.0),
+            end=(45.0, 25.0),
+            net="DAC_CLK",
+            layer=0,
+        )
+        if not [b for b in analysis.blocking_elements if b.type == "component"]:
+            pytest.skip("No component blockers detected in this fixture")
+        assert analysis.nearby_component is not None
+
+    def test_zone_blockers_still_have_none_ref(
+        self, routing_grid: RoutingGrid
+    ):
+        """Zones legitimately have ref=None -- verify we didn't break that."""
+        # Build a synthetic zone-blocker test by directly checking the
+        # element-type classification: a zone cell must remain ref=None.
+        # We can't easily add a real zone here, so we just assert the
+        # API contract via a constructed BlockingElement.
+        zone = BlockingElement(
+            type="zone",
+            ref=None,
+            net=None,
+            bounds=Rectangle(0, 0, 1, 1),
+            movable=False,
+            layer=0,
+        )
+        assert zone.ref is None
+        assert zone.movable is False

--- a/tests/test_placement_feedback.py
+++ b/tests/test_placement_feedback.py
@@ -468,9 +468,7 @@ class TestDetectPfStagnation:
 
     def test_improvement_followed_by_three_flat(self):
         """[40, 46, 46, 46, 46] -- the trailing 4 entries are flat => stagnated."""
-        assert (
-            detect_pf_stagnation([40, 46, 46, 46, 46], patience=3) is True
-        )
+        assert detect_pf_stagnation([40, 46, 46, 46, 46], patience=3) is True
 
     def test_still_improving(self):
         """Monotonically increasing history is never stagnated."""
@@ -487,9 +485,7 @@ class TestDetectPfStagnation:
         even though the most-recent three entries are flat, the inclusion
         of the patience+1th entry differing keeps stagnation off.
         """
-        assert (
-            detect_pf_stagnation([46, 47, 46, 46, 46], patience=3) is False
-        )
+        assert detect_pf_stagnation([46, 47, 46, 46, 46], patience=3) is False
 
     def test_configurable_patience_short(self):
         """patience=2 fires on three flat entries."""
@@ -501,12 +497,7 @@ class TestDetectPfStagnation:
 
     def test_configurable_patience_long_satisfied(self):
         """patience=5 satisfied by six flat entries."""
-        assert (
-            detect_pf_stagnation(
-                [46, 46, 46, 46, 46, 46], patience=5
-            )
-            is True
-        )
+        assert detect_pf_stagnation([46, 46, 46, 46, 46, 46], patience=5) is True
 
     def test_zero_patience_disabled(self):
         """patience<1 disables the detector."""
@@ -553,6 +544,7 @@ class _FakeAutorouter:
         self.route_all_negotiated_calls += 1
         if self._per_call_delay > 0:
             import time as _t
+
             _t.sleep(self._per_call_delay)
         self._call_index += 1
         return self.routes
@@ -561,6 +553,7 @@ class _FakeAutorouter:
         self.route_all_calls += 1
         if self._per_call_delay > 0:
             import time as _t
+
             _t.sleep(self._per_call_delay)
         self._call_index += 1
         return self.routes
@@ -602,9 +595,7 @@ class _AlwaysApplyLoop:
             type=StrategyType.MOVE_COMPONENT,
             difficulty=Difficulty.EASY,
             confidence=0.99,
-            actions=[
-                Action(type="move", target="C1", params={"x": 0.0, "y": 0.0})
-            ],
+            actions=[Action(type="move", target="C1", params={"x": 0.0, "y": 0.0})],
         )
 
         def _dummy_strategy(_failed, _conf):
@@ -648,9 +639,7 @@ class TestPlacementFeedbackLoopExitReasons:
         from kicad_tools.router import PlacementFeedbackLoop
 
         router = _FakeAutorouter(total_nets=10, failed_nets_constant=[])
-        loop = PlacementFeedbackLoop(
-            router=router, pcb=None, verbose=False, stagnation_patience=3
-        )
+        loop = PlacementFeedbackLoop(router=router, pcb=None, verbose=False, stagnation_patience=3)
         result = loop.run(max_adjustments=5)
         assert result.exit_reason == "pf_converged"
         assert result.success is True
@@ -671,13 +660,9 @@ class TestPlacementFeedbackLoopExitReasons:
         # 5 nets always failing => routed_count = 5 (constant).
         # total_nets in the loop = len(nets)-1 = 10, failed = 5,
         # so routed_count = 5 every iteration.
-        router = _FakeAutorouter(
-            total_nets=10, failed_nets_constant=[1, 2, 3, 4, 5]
-        )
+        router = _FakeAutorouter(total_nets=10, failed_nets_constant=[1, 2, 3, 4, 5])
         pcb = MockPCB()
-        loop = PlacementFeedbackLoop(
-            router=router, pcb=pcb, verbose=False, stagnation_patience=3
-        )
+        loop = PlacementFeedbackLoop(router=router, pcb=pcb, verbose=False, stagnation_patience=3)
         _AlwaysApplyLoop.patch(loop)
         result = loop.run(max_adjustments=10)
         assert result.exit_reason == "pf_stagnated"
@@ -696,13 +681,9 @@ class TestPlacementFeedbackLoopExitReasons:
         """
         from kicad_tools.router import PlacementFeedbackLoop
 
-        router = _FakeAutorouter(
-            total_nets=10, failed_nets_constant=[1, 2, 3]
-        )
+        router = _FakeAutorouter(total_nets=10, failed_nets_constant=[1, 2, 3])
         pcb = MockPCB()
-        loop = PlacementFeedbackLoop(
-            router=router, pcb=pcb, verbose=False, stagnation_patience=0
-        )
+        loop = PlacementFeedbackLoop(router=router, pcb=pcb, verbose=False, stagnation_patience=0)
         _AlwaysApplyLoop.patch(loop)
         result = loop.run(max_adjustments=3)
         assert result.exit_reason == "pf_max_iter"
@@ -721,18 +702,14 @@ class TestPlacementFeedbackLoopExitReasons:
 
         # Sequence so routed_count = 6, 7, 8, 9 across 4 iterations.
         failed_sequence = [
-            [1, 2, 3, 4],   # routed=6
-            [1, 2, 3],      # routed=7
-            [1, 2],         # routed=8
-            [1],            # routed=9 (still not converged)
+            [1, 2, 3, 4],  # routed=6
+            [1, 2, 3],  # routed=7
+            [1, 2],  # routed=8
+            [1],  # routed=9 (still not converged)
         ]
-        router = _FakeAutorouter(
-            total_nets=10, failed_nets_sequence=failed_sequence
-        )
+        router = _FakeAutorouter(total_nets=10, failed_nets_sequence=failed_sequence)
         pcb = MockPCB()
-        loop = PlacementFeedbackLoop(
-            router=router, pcb=pcb, verbose=False, stagnation_patience=3
-        )
+        loop = PlacementFeedbackLoop(router=router, pcb=pcb, verbose=False, stagnation_patience=3)
         _AlwaysApplyLoop.patch(loop)
         # max_adjustments=3 => 4 total iterations.  Progress every step
         # means stagnation must NOT fire.
@@ -748,12 +725,8 @@ class TestPlacementFeedbackLoopExitReasons:
         """Legacy behaviour preserved: pcb=None => single iteration, pf_max_iter."""
         from kicad_tools.router import PlacementFeedbackLoop
 
-        router = _FakeAutorouter(
-            total_nets=10, failed_nets_constant=[1, 2, 3]
-        )
-        loop = PlacementFeedbackLoop(
-            router=router, pcb=None, verbose=False, stagnation_patience=10
-        )
+        router = _FakeAutorouter(total_nets=10, failed_nets_constant=[1, 2, 3])
+        loop = PlacementFeedbackLoop(router=router, pcb=None, verbose=False, stagnation_patience=10)
         result = loop.run(max_adjustments=3)
         assert result.exit_reason == "pf_max_iter"
         assert result.iterations == 1
@@ -792,13 +765,9 @@ class TestPlacementFeedbackLoopExitReasons:
         """Issue #2606: summary() surfaces exit_reason for stagnated runs."""
         from kicad_tools.router import PlacementFeedbackLoop
 
-        router = _FakeAutorouter(
-            total_nets=10, failed_nets_constant=[1, 2]
-        )
+        router = _FakeAutorouter(total_nets=10, failed_nets_constant=[1, 2])
         pcb = MockPCB()
-        loop = PlacementFeedbackLoop(
-            router=router, pcb=pcb, verbose=False, stagnation_patience=2
-        )
+        loop = PlacementFeedbackLoop(router=router, pcb=pcb, verbose=False, stagnation_patience=2)
         _AlwaysApplyLoop.patch(loop)
         result = loop.run(max_adjustments=10)
         assert result.exit_reason == "pf_stagnated"
@@ -819,12 +788,8 @@ class TestPlacementFeedbackLoopBuilderHandoff:
         pcb.footprints.append(MockFootprint(ref, x, y))
         # Add a generous board outline so is_safe_to_apply doesn't reject.
         pcb.graphic_items.append(MockGraphicItem("Edge.Cuts", (0.0, 0.0), (200.0, 0.0)))
-        pcb.graphic_items.append(
-            MockGraphicItem("Edge.Cuts", (200.0, 0.0), (200.0, 200.0))
-        )
-        pcb.graphic_items.append(
-            MockGraphicItem("Edge.Cuts", (200.0, 200.0), (0.0, 200.0))
-        )
+        pcb.graphic_items.append(MockGraphicItem("Edge.Cuts", (200.0, 0.0), (200.0, 200.0)))
+        pcb.graphic_items.append(MockGraphicItem("Edge.Cuts", (200.0, 200.0), (0.0, 200.0)))
         pcb.graphic_items.append(MockGraphicItem("Edge.Cuts", (0.0, 200.0), (0.0, 0.0)))
         return pcb
 
@@ -899,9 +864,7 @@ class TestPlacementFeedbackLoopBuilderHandoff:
             verbose=True,
             max_movement=5.0,
         )
-        strategy = loop._find_best_placement_strategy(
-            failed_nets=[1], min_confidence=0.5
-        )
+        strategy = loop._find_best_placement_strategy(failed_nets=[1], min_confidence=0.5)
 
         assert strategy is not None, (
             "Issue #2604 regression: loop returned no strategy when "
@@ -925,12 +888,8 @@ class TestPlacementFeedbackLoopBuilderHandoff:
         analysis = self._make_analysis_with_blocker(ref=None)
         router = self._make_router(analysis)
 
-        loop = PlacementFeedbackLoop(
-            router=router, pcb=pcb, verbose=True, max_movement=5.0
-        )
-        strategy = loop._find_best_placement_strategy(
-            failed_nets=[1], min_confidence=0.5
-        )
+        loop = PlacementFeedbackLoop(router=router, pcb=pcb, verbose=True, max_movement=5.0)
+        strategy = loop._find_best_placement_strategy(failed_nets=[1], min_confidence=0.5)
         assert strategy is None
         captured = capsys.readouterr()
         # Acceptance criterion #4: when no candidates are generated we must
@@ -939,10 +898,31 @@ class TestPlacementFeedbackLoopBuilderHandoff:
         assert "No suitable placement strategy" in captured.out
         # Either "0 movable blockers" or "0 MOVE_COMPONENT candidates" must
         # appear so an operator can tell ref-population is the failure mode.
-        assert (
-            "0 movable blockers" in captured.out
-            or "0 MOVE_COMPONENT candidates" in captured.out
-        )
+        assert "0 movable blockers" in captured.out or "0 MOVE_COMPONENT candidates" in captured.out
+
+    def test_loop_emits_summary_in_non_verbose_mode(self, capsys):
+        """Issue #2604 follow-up: default (non-verbose) mode is not silent.
+
+        Before this fix the structured rejection breakdown only printed
+        ``if self.verbose`` and the prior ``"No suitable placement
+        strategy found"`` line had been removed entirely, so default
+        runs were *more* silent than before.  This test pins the
+        single-line summary that must appear in non-verbose mode.
+        """
+        from kicad_tools.router.placement_feedback import PlacementFeedbackLoop
+
+        pcb = self._make_pcb_with_footprint("U1", 50.0, 50.0)
+        analysis = self._make_analysis_with_blocker(ref=None)
+        router = self._make_router(analysis)
+
+        loop = PlacementFeedbackLoop(router=router, pcb=pcb, verbose=False, max_movement=5.0)
+        strategy = loop._find_best_placement_strategy(failed_nets=[1], min_confidence=0.5)
+        assert strategy is None
+        captured = capsys.readouterr()
+        # The non-verbose summary must surface at least the headline
+        # diagnostic so default users aren't left guessing why the loop
+        # bailed out.
+        assert "No suitable placement strategy" in captured.out
 
     def test_loop_logs_filter_breakdown_when_all_candidates_rejected(self, capsys):
         """Acceptance criterion #4: when all candidates are anchored, say so."""
@@ -959,9 +939,7 @@ class TestPlacementFeedbackLoopBuilderHandoff:
             max_movement=5.0,
             fixed_refs={"U1"},  # Anchor the only candidate.
         )
-        strategy = loop._find_best_placement_strategy(
-            failed_nets=[1], min_confidence=0.5
-        )
+        strategy = loop._find_best_placement_strategy(failed_nets=[1], min_confidence=0.5)
         assert strategy is None
         captured = capsys.readouterr()
         assert "anchored" in captured.out
@@ -987,9 +965,7 @@ class TestPlacementFeedbackLoopBuilderHandoff:
         analysis = self._make_analysis_with_blocker(ref="U1")
         router = self._make_router(analysis)
 
-        loop = PlacementFeedbackLoop(
-            router=router, pcb=pcb, verbose=True, max_movement=2.0
-        )
+        loop = PlacementFeedbackLoop(router=router, pcb=pcb, verbose=True, max_movement=2.0)
 
         # Stub the strategy generator to return an over-budget move so we
         # can exercise the filter deterministically.
@@ -1013,9 +989,7 @@ class TestPlacementFeedbackLoopBuilderHandoff:
                 ]
 
         loop._strategy_generator = _StubGenerator()
-        strategy = loop._find_best_placement_strategy(
-            failed_nets=[1], min_confidence=0.5
-        )
+        strategy = loop._find_best_placement_strategy(failed_nets=[1], min_confidence=0.5)
         assert strategy is None
         captured = capsys.readouterr()
         assert "over budget" in captured.out
@@ -1041,9 +1015,7 @@ class TestPlacementFeedbackLoopBuilderHandoff:
             verbose=False,
             max_movement=3.0,
         )
-        strategy = loop._find_best_placement_strategy(
-            failed_nets=[1], min_confidence=0.5
-        )
+        strategy = loop._find_best_placement_strategy(failed_nets=[1], min_confidence=0.5)
         assert strategy is not None
 
         import math
@@ -1116,6 +1088,141 @@ class TestPlacementFeedbackLoopBuilderHandoff:
                     continue
                 d = math.hypot(action.params["x"] - 50.0, action.params["y"] - 50.0)
                 assert d <= 2.0 + 1e-9, (
-                    f"Generator emitted candidate at {d:.3f}mm, "
-                    f"exceeds max_movement=2.0mm"
+                    f"Generator emitted candidate at {d:.3f}mm, exceeds max_movement=2.0mm"
                 )
+
+    def test_move_candidate_sweep_spans_both_radii_and_diverse_directions(self):
+        """Issue #2604 follow-up: cap-radius candidates must reach the strategy slice.
+
+        Before the fix, the 16-candidate sweep (8 angles x 2 radii) was
+        sorted purely by ``(-improvement, distance)`` -- with all 16
+        candidates landing outside the failure area they shared the same
+        ``improvement=0.9`` and the 8 small-radius (closer) candidates
+        always sorted ahead of the 8 cap-radius ones.  The downstream
+        ``_generate_move_strategies`` slice ``candidates[:3]`` then only
+        ever surfaced 3 small-radius candidates at angles 0/45/90 deg
+        (East / NE / North), so South / West / SE / SW directions and
+        the cap-radius band were effectively dead code.
+
+        This test pins the new "diversity" sort: across the strategies
+        emitted for a single blocker we must see candidates spanning
+        *both* radius bands AND covering at least 3 distinct quadrants.
+        """
+        import math
+
+        from kicad_tools.recovery.strategy import StrategyGenerator
+        from kicad_tools.recovery.types import (
+            BlockingElement as RecoveryBlockingElement,
+        )
+        from kicad_tools.recovery.types import (
+            FailureAnalysis as RecoveryFailureAnalysis,
+        )
+        from kicad_tools.recovery.types import (
+            FailureCause as RecoveryFailureCause,
+        )
+        from kicad_tools.recovery.types import (
+            Rectangle as RecoveryRectangle,
+        )
+
+        pcb = MockPCB()
+        pcb.footprints.append(MockFootprint("U1", 50.0, 50.0))
+
+        # Failure area is a tiny square at the component centre, so all
+        # 16 sweep candidates land outside it and tie on ``improvement``.
+        # max_movement = 4.0 produces radii [2.0, 4.0] (small + cap).
+        analysis = RecoveryFailureAnalysis(
+            root_cause=RecoveryFailureCause.BLOCKED_PATH,
+            confidence=0.85,
+            failure_location=(50.0, 50.0),
+            failure_area=RecoveryRectangle(49.5, 49.5, 50.5, 50.5),
+            blocking_elements=[
+                RecoveryBlockingElement(
+                    type="component",
+                    ref="U1",
+                    net=None,
+                    bounds=RecoveryRectangle(49.0, 49.0, 51.0, 51.0),
+                    movable=True,
+                )
+            ],
+        )
+
+        generator = StrategyGenerator()
+        strategies = generator.generate_strategies(pcb, analysis, max_movement=4.0)
+        move_strategies = [
+            s for s in strategies if s.type.value in ("move_component", "move_multiple")
+        ]
+        assert move_strategies, "expected at least one MOVE_COMPONENT strategy"
+
+        radii_seen: set[int] = set()
+        quadrants_seen: set[str] = set()
+        for s in move_strategies:
+            for action in s.actions:
+                if action.type != "move":
+                    continue
+                dx = action.params["x"] - 50.0
+                dy = action.params["y"] - 50.0
+                # Bucket distance into "small" (~2mm) vs "cap" (~4mm).
+                d = math.hypot(dx, dy)
+                if d < 3.0:
+                    radii_seen.add(0)  # small
+                else:
+                    radii_seen.add(1)  # cap
+                # Bucket into quadrants by sign of dx, dy.
+                qx = "E" if dx > 1e-6 else ("W" if dx < -1e-6 else "0")
+                qy = "N" if dy > 1e-6 else ("S" if dy < -1e-6 else "0")
+                quadrants_seen.add(f"{qx}{qy}")
+
+        assert len(radii_seen) >= 2, (
+            f"Issue #2604 follow-up: cap-radius candidates dropped -- only saw radii {radii_seen}"
+        )
+        # With the [:3] slice and strict (radius, opposite-angle)
+        # interleaving the first 3 picks land on East-small, East-cap,
+        # West-small.  That covers two opposing quadrants -- the key
+        # regression we are pinning is "both radius bands appear" rather
+        # than the slice-degenerate single-band case.  We separately
+        # verify the *underlying* candidate list (before the slice) is
+        # diverse via a direct generator inspection below.
+        assert len(quadrants_seen) >= 2, (
+            f"Issue #2604 follow-up: direction sweep collapsed to "
+            f"{quadrants_seen}; expected >=2 distinct quadrants"
+        )
+
+        # Direct inspection of the candidate list (pre-slice) confirms
+        # the sweep is producing the full 8-direction x 2-radius set so
+        # downstream consumers that look beyond the [:3] slice see all
+        # of them.
+        from kicad_tools.recovery.types import (
+            BlockingElement as _BlockingElement,
+        )
+        from kicad_tools.recovery.types import (
+            Rectangle as _Rect,
+        )
+
+        blocker = _BlockingElement(
+            type="component",
+            ref="U1",
+            net=None,
+            bounds=_Rect(49.0, 49.0, 51.0, 51.0),
+            movable=True,
+        )
+        candidates = generator._find_move_candidates(
+            pcb,
+            blocker,
+            _Rect(49.5, 49.5, 50.5, 50.5),
+            max_movement=4.0,
+        )
+        # 8 angles x 2 radii = 16 candidates expected.
+        assert len(candidates) == 16, (
+            f"expected 16 sweep candidates (8 angles x 2 radii), got {len(candidates)}"
+        )
+        all_quadrants: set[str] = set()
+        for c in candidates:
+            cdx = c["position"][0] - 50.0
+            cdy = c["position"][1] - 50.0
+            qx = "E" if cdx > 1e-6 else ("W" if cdx < -1e-6 else "0")
+            qy = "N" if cdy > 1e-6 else ("S" if cdy < -1e-6 else "0")
+            all_quadrants.add(f"{qx}{qy}")
+        # 8-direction sweep => 8 distinct (qx,qy) buckets including
+        # the diagonals.  South / West / SE / SW must all appear.
+        assert "W0" in all_quadrants and "0S" in all_quadrants
+        assert "WS" in all_quadrants and "ES" in all_quadrants

--- a/tests/test_placement_feedback.py
+++ b/tests/test_placement_feedback.py
@@ -803,3 +803,319 @@ class TestPlacementFeedbackLoopExitReasons:
         result = loop.run(max_adjustments=10)
         assert result.exit_reason == "pf_stagnated"
         assert "Exit reason: pf_stagnated" in result.summary()
+
+
+class TestPlacementFeedbackLoopBuilderHandoff:
+    """Issue #2604: integration tests for the analyzer -> generator -> loop pipeline.
+
+    The pre-existing tests in this file synthesize ``ResolutionStrategy``
+    objects directly, which bypasses the broken handoff between
+    ``RootCauseAnalyzer`` and ``StrategyGenerator``.  These tests exercise
+    the full path on a synthetic router so the bug stays caught.
+    """
+
+    def _make_pcb_with_footprint(self, ref: str, x: float, y: float):
+        pcb = MockPCB()
+        pcb.footprints.append(MockFootprint(ref, x, y))
+        # Add a generous board outline so is_safe_to_apply doesn't reject.
+        pcb.graphic_items.append(MockGraphicItem("Edge.Cuts", (0.0, 0.0), (200.0, 0.0)))
+        pcb.graphic_items.append(
+            MockGraphicItem("Edge.Cuts", (200.0, 0.0), (200.0, 200.0))
+        )
+        pcb.graphic_items.append(
+            MockGraphicItem("Edge.Cuts", (200.0, 200.0), (0.0, 200.0))
+        )
+        pcb.graphic_items.append(MockGraphicItem("Edge.Cuts", (0.0, 200.0), (0.0, 0.0)))
+        return pcb
+
+    def _make_analysis_with_blocker(self, ref: str | None):
+        """Build a router-style FailureAnalysis with a single component blocker."""
+        from kicad_tools.router.failure_analysis import (
+            BlockingElement,
+            FailureAnalysis,
+            FailureCause,
+            Rectangle,
+        )
+
+        return FailureAnalysis(
+            root_cause=FailureCause.BLOCKED_PATH,
+            confidence=0.85,
+            failure_location=(50.0, 50.0),
+            failure_area=Rectangle(45.0, 45.0, 55.0, 55.0),
+            blocking_elements=[
+                BlockingElement(
+                    type="component",
+                    ref=ref,
+                    net=None,
+                    bounds=Rectangle(48.0, 48.0, 52.0, 52.0),
+                    movable=True,
+                    layer=0,
+                )
+            ],
+        )
+
+    def _make_router(self, analysis, failed_nets=(1,)):
+        class FakeRouter:
+            def __init__(self, analysis):
+                self._analysis = analysis
+                self._failed = list(failed_nets)
+                self.nets = {0: [], 1: []}
+                self.routes = []
+
+            def get_failed_nets(self):
+                return list(self._failed)
+
+            def analyze_routing_failure(self, net_id):
+                return self._analysis
+
+            def route_all_negotiated(self, **kwargs):
+                return []
+
+            def route_all(self):
+                return []
+
+            def _reset_for_new_trial(self):
+                return None
+
+        return FakeRouter(analysis)
+
+    def test_loop_invokes_move_component_when_blockers_have_refs(self, capsys):
+        """Issue #2604 primary fix: with refs populated the loop emits MOVE_COMPONENT.
+
+        Before the fix, ``BlockingElement.ref`` was always None and the
+        strategy generator dropped every candidate, so the loop logged
+        "No suitable placement strategy found" without ever calling the
+        applicator.
+        """
+        from kicad_tools.router.placement_feedback import PlacementFeedbackLoop
+
+        pcb = self._make_pcb_with_footprint("U1", 50.0, 50.0)
+        analysis = self._make_analysis_with_blocker(ref="U1")
+        router = self._make_router(analysis)
+
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=True,
+            max_movement=5.0,
+        )
+        strategy = loop._find_best_placement_strategy(
+            failed_nets=[1], min_confidence=0.5
+        )
+
+        assert strategy is not None, (
+            "Issue #2604 regression: loop returned no strategy when "
+            "BlockingElement.ref is populated"
+        )
+        assert strategy.type.value in ("move_component", "move_multiple")
+        # The strategy must target U1 (the populated ref).
+        assert "U1" in strategy.affected_components
+
+    def test_loop_emits_no_strategy_when_blocker_ref_is_none(self, capsys):
+        """Pre-fix behavior: ref=None drops every candidate.
+
+        This test pins the *current* fix: when the analyzer fails to
+        populate the ref (e.g. on a grid with no pad data, like the chorus
+        test pre-fix), the loop now emits a structured diagnostic instead
+        of the silent "No suitable placement strategy found".
+        """
+        from kicad_tools.router.placement_feedback import PlacementFeedbackLoop
+
+        pcb = self._make_pcb_with_footprint("U1", 50.0, 50.0)
+        analysis = self._make_analysis_with_blocker(ref=None)
+        router = self._make_router(analysis)
+
+        loop = PlacementFeedbackLoop(
+            router=router, pcb=pcb, verbose=True, max_movement=5.0
+        )
+        strategy = loop._find_best_placement_strategy(
+            failed_nets=[1], min_confidence=0.5
+        )
+        assert strategy is None
+        captured = capsys.readouterr()
+        # Acceptance criterion #4: when no candidates are generated we must
+        # log a diagnostic that distinguishes the population bug from the
+        # filter rejections.
+        assert "No suitable placement strategy" in captured.out
+        # Either "0 movable blockers" or "0 MOVE_COMPONENT candidates" must
+        # appear so an operator can tell ref-population is the failure mode.
+        assert (
+            "0 movable blockers" in captured.out
+            or "0 MOVE_COMPONENT candidates" in captured.out
+        )
+
+    def test_loop_logs_filter_breakdown_when_all_candidates_rejected(self, capsys):
+        """Acceptance criterion #4: when all candidates are anchored, say so."""
+        from kicad_tools.router.placement_feedback import PlacementFeedbackLoop
+
+        pcb = self._make_pcb_with_footprint("U1", 50.0, 50.0)
+        analysis = self._make_analysis_with_blocker(ref="U1")
+        router = self._make_router(analysis)
+
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=True,
+            max_movement=5.0,
+            fixed_refs={"U1"},  # Anchor the only candidate.
+        )
+        strategy = loop._find_best_placement_strategy(
+            failed_nets=[1], min_confidence=0.5
+        )
+        assert strategy is None
+        captured = capsys.readouterr()
+        assert "anchored" in captured.out
+        assert "rejected" in captured.out.lower()
+
+    def test_loop_logs_over_budget_breakdown(self, capsys):
+        """Acceptance criterion #4: when all candidates exceed the cap, say so.
+
+        Force the over-budget filter by stubbing the strategy generator
+        to return a strategy whose move action targets a position far
+        outside the loop's movement budget.  The loop must report ``over
+        budget`` in its rejection breakdown.
+        """
+        from kicad_tools.recovery import (
+            Action,
+            Difficulty,
+            ResolutionStrategy,
+            StrategyType,
+        )
+        from kicad_tools.router.placement_feedback import PlacementFeedbackLoop
+
+        pcb = self._make_pcb_with_footprint("U1", 50.0, 50.0)
+        analysis = self._make_analysis_with_blocker(ref="U1")
+        router = self._make_router(analysis)
+
+        loop = PlacementFeedbackLoop(
+            router=router, pcb=pcb, verbose=True, max_movement=2.0
+        )
+
+        # Stub the strategy generator to return an over-budget move so we
+        # can exercise the filter deterministically.
+        class _StubGenerator:
+            def generate_strategies(self, _pcb, _failure, max_movement=None):
+                return [
+                    ResolutionStrategy(
+                        type=StrategyType.MOVE_COMPONENT,
+                        difficulty=Difficulty.EASY,
+                        confidence=0.85,
+                        # 50,50 -> 100,100 = 70.7mm, way over the 2mm cap.
+                        actions=[
+                            Action(
+                                type="move",
+                                target="U1",
+                                params={"x": 100.0, "y": 100.0},
+                            )
+                        ],
+                        affected_components=["U1"],
+                    )
+                ]
+
+        loop._strategy_generator = _StubGenerator()
+        strategy = loop._find_best_placement_strategy(
+            failed_nets=[1], min_confidence=0.5
+        )
+        assert strategy is None
+        captured = capsys.readouterr()
+        assert "over budget" in captured.out
+        assert "rejected" in captured.out.lower()
+
+    def test_loop_passes_max_movement_to_strategy_generator(self):
+        """Issue #2604 secondary fix: budget is plumbed to the generator.
+
+        Verify candidates respect the cap by ensuring the resulting
+        strategy targets a position within ``max_movement`` of the
+        original.  Pre-fix the candidate offsets were corridor-derived
+        and routinely exceeded the cap.
+        """
+        from kicad_tools.router.placement_feedback import PlacementFeedbackLoop
+
+        pcb = self._make_pcb_with_footprint("U1", 50.0, 50.0)
+        analysis = self._make_analysis_with_blocker(ref="U1")
+        router = self._make_router(analysis)
+
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            max_movement=3.0,
+        )
+        strategy = loop._find_best_placement_strategy(
+            failed_nets=[1], min_confidence=0.5
+        )
+        assert strategy is not None
+
+        import math
+
+        for action in strategy.actions:
+            if action.type != "move":
+                continue
+            new_x = action.params["x"]
+            new_y = action.params["y"]
+            distance = math.hypot(new_x - 50.0, new_y - 50.0)
+            assert distance <= 3.0 + 1e-9, (
+                f"Move candidate of {distance:.3f}mm exceeds max_movement=3.0mm"
+            )
+
+    def test_strategy_generator_respects_max_movement_directly(self):
+        """Direct test of the generator-level budget plumbing.
+
+        Even outside the feedback loop, calling
+        ``StrategyGenerator.generate_strategies(..., max_movement=...)``
+        produces only candidates inside the cap.
+        """
+        import math
+
+        from kicad_tools.recovery.strategy import StrategyGenerator
+        from kicad_tools.recovery.types import (
+            BlockingElement as RecoveryBlockingElement,
+        )
+        from kicad_tools.recovery.types import (
+            FailureAnalysis as RecoveryFailureAnalysis,
+        )
+        from kicad_tools.recovery.types import (
+            FailureCause as RecoveryFailureCause,
+        )
+        from kicad_tools.recovery.types import (
+            Rectangle as RecoveryRectangle,
+        )
+
+        pcb = MockPCB()
+        pcb.footprints.append(MockFootprint("U1", 50.0, 50.0))
+
+        analysis = RecoveryFailureAnalysis(
+            root_cause=RecoveryFailureCause.BLOCKED_PATH,
+            confidence=0.85,
+            failure_location=(50.0, 50.0),
+            failure_area=RecoveryRectangle(45.0, 45.0, 55.0, 55.0),
+            blocking_elements=[
+                RecoveryBlockingElement(
+                    type="component",
+                    ref="U1",
+                    net=None,
+                    bounds=RecoveryRectangle(48.0, 48.0, 52.0, 52.0),
+                    movable=True,
+                )
+            ],
+        )
+
+        generator = StrategyGenerator()
+        strategies = generator.generate_strategies(pcb, analysis, max_movement=2.0)
+        move_strategies = [
+            s for s in strategies if s.type.value in ("move_component", "move_multiple")
+        ]
+        assert move_strategies, (
+            "Issue #2604 regression: generator dropped all move strategies "
+            "even though blocker.ref is populated"
+        )
+        # Every candidate must respect the budget.
+        for s in move_strategies:
+            for action in s.actions:
+                if action.type != "move":
+                    continue
+                d = math.hypot(action.params["x"] - 50.0, action.params["y"] - 50.0)
+                assert d <= 2.0 + 1e-9, (
+                    f"Generator emitted candidate at {d:.3f}mm, "
+                    f"exceeds max_movement=2.0mm"
+                )

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -719,6 +719,123 @@ class TestStrategyGenerator:
             assert isinstance(strategy.affected_nets, list)
             assert 0 <= strategy.estimated_improvement <= 1
 
+    def test_emits_move_strategy_when_blocker_has_ref(self):
+        """Issue #2604: ``MOVE_COMPONENT`` strategies must be emitted.
+
+        Pre-fix the strategy generator dropped every blocker because
+        ``BlockingElement.ref`` was always None.  With ref populated the
+        generator must emit at least one move strategy targeting that
+        component.
+        """
+
+        class MockFootprint:
+            def __init__(self, ref, x, y):
+                self.reference = ref
+                self.position = (x, y)
+                self.pads = []
+
+        class MockPCB:
+            def __init__(self):
+                self.footprints = [MockFootprint("U1", 50.0, 50.0)]
+                self.segments = []
+                self.vias = []
+                self.zones = []
+                self.layers = {}
+                self.nets = {}
+
+        bounds = Rectangle(min_x=48.0, min_y=48.0, max_x=52.0, max_y=52.0)
+        failure_area = Rectangle(min_x=45.0, min_y=45.0, max_x=55.0, max_y=55.0)
+        analysis = FailureAnalysis(
+            root_cause=FailureCause.BLOCKED_PATH,
+            confidence=0.85,
+            failure_location=(50.0, 50.0),
+            failure_area=failure_area,
+            blocking_elements=[
+                BlockingElement(
+                    type="component",
+                    ref="U1",
+                    net=None,
+                    bounds=bounds,
+                    movable=True,
+                )
+            ],
+            net="DAC_CLK",
+        )
+        generator = StrategyGenerator()
+        strategies = generator.generate_strategies(MockPCB(), analysis)
+        move_strategies = [
+            s
+            for s in strategies
+            if s.type == StrategyType.MOVE_COMPONENT
+            or s.type == StrategyType.MOVE_MULTIPLE
+        ]
+        assert move_strategies, (
+            "Issue #2604 regression: generator dropped every move strategy "
+            "even though blocker.ref is populated"
+        )
+        # Strategy must target U1.
+        assert any("U1" in s.affected_components for s in move_strategies)
+
+    def test_max_movement_caps_candidate_offsets(self):
+        """Issue #2604 secondary fix: max_movement clamps generator output."""
+        import math
+
+        class MockFootprint:
+            def __init__(self, ref, x, y):
+                self.reference = ref
+                self.position = (x, y)
+                self.pads = []
+
+        class MockPCB:
+            def __init__(self):
+                self.footprints = [MockFootprint("U1", 50.0, 50.0)]
+                self.segments = []
+                self.vias = []
+                self.zones = []
+                self.layers = {}
+                self.nets = {}
+
+        bounds = Rectangle(min_x=48.0, min_y=48.0, max_x=52.0, max_y=52.0)
+        # Use a wide failure area -- pre-fix this would have produced
+        # candidates ~14mm away.
+        failure_area = Rectangle(min_x=40.0, min_y=40.0, max_x=60.0, max_y=60.0)
+        analysis = FailureAnalysis(
+            root_cause=FailureCause.BLOCKED_PATH,
+            confidence=0.85,
+            failure_location=(50.0, 50.0),
+            failure_area=failure_area,
+            blocking_elements=[
+                BlockingElement(
+                    type="component",
+                    ref="U1",
+                    net=None,
+                    bounds=bounds,
+                    movable=True,
+                )
+            ],
+            net="DAC_CLK",
+        )
+        generator = StrategyGenerator()
+        strategies = generator.generate_strategies(
+            MockPCB(), analysis, max_movement=3.0
+        )
+        move_strategies = [
+            s
+            for s in strategies
+            if s.type == StrategyType.MOVE_COMPONENT
+        ]
+        assert move_strategies
+        for s in move_strategies:
+            for action in s.actions:
+                if action.type != "move":
+                    continue
+                d = math.hypot(
+                    action.params["x"] - 50.0, action.params["y"] - 50.0
+                )
+                assert d <= 3.0 + 1e-6, (
+                    f"Candidate at {d:.3f}mm exceeds max_movement=3.0mm"
+                )
+
 
 class TestModuleExports:
     """Tests for module exports."""


### PR DESCRIPTION
## Summary

- Adds `tests/test_chorus_test_placement_feedback.py` (593 lines) as a nightly-CI safety net for Issue #2604 / PR #2609 (the PlacementFeedbackLoop MOVE_COMPONENT fix).
- Two test classes both marked `@pytest.mark.slow` so they are excluded from default PR-time CI and picked up automatically by `.github/workflows/slow-tests.yml`. No CI workflow changes required.
- Synthetic-miniature test exercises the full analyzer -> generator -> filter -> applicator path in-memory with a real `Autorouter` + `RoutingGrid`, so PR #2609's `find_pad_ref_at` spatial-lookup helper and `max_movement` budget plumbing are both protected.

## Dependency

**This PR depends on #2609** -- the test exercises code paths added by that fix (`RoutingGrid.find_pad_ref_at` and budget-aware `_find_move_candidates`).  The PR diff currently includes #2609's commits; once #2609 merges, the diff will be just the test file.  Please merge #2609 first.

## Design notes

Per curator findings on #2612:

* No `tests/integration/` directory exists in this repo -- the convention is flat-file `tests/`.  New file lives at `tests/test_chorus_test_placement_feedback.py`.
* No `nightly` pytest marker exists; the slow-tests workflow already filters `-m slow`.  Using `@pytest.mark.slow` automatically opts in to nightly and out of PR-time CI -- no workflow change needed.
* `boards/external/chorus-test-revA/` is NOT vendored.  The real-board test class uses `pytest.skip` when the fixture is absent (pattern mirrors `src/kicad_tools/benchmark/runner.py:69`).
* A pure-mock test (the existing `tests/test_placement_feedback.py`) cannot cover `find_pad_ref_at` -- it requires a real `RoutingGrid` populated with `Pad` objects.  This file fills that gap.

## Test classes

1. `TestPlacementFeedbackOnSyntheticBlockedPath` (always runs nightly, ~16s):
   - 30 x 30mm board, 3 components, dense U3 obstruction column at x=15 spanning the full y-extent on F.Cu AND B.Cu so via-escape cannot bypass it.
   - Asserts `total_components_moved >= 1`, `len(placement_diff) >= 1`, at least one `MOVE_COMPONENT`/`MOVE_MULTIPLE` adjustment, and the verbose `Applying strategy: move_component` log line.
   - Separate sanity test confirms the unmodified `route_all()` actually fails so the scenario remains a meaningful regression gate.
   - Separate budget test confirms each per-step adjustment respects `max_movement` (cumulative `placement_diff` may exceed it; the budget is per-move).
   - Each assertion carries a dedicated diagnostic message identifying which of the four pre-#2604 failure modes broke: ref-population (`find_pad_ref_at`), candidate-generation (`_find_move_candidates`), movement-budget filter (`_strategy_within_movement_budget`), or board-bounds filter.  Mirrors `_log_strategy_rejection_breakdown` at `src/kicad_tools/router/placement_feedback.py:447`.

2. `TestPlacementFeedbackOnRealChorusTest` (skip-if-missing):
   - Drives `kct route --placement-feedback` end-to-end via `route_cmd.main` against `boards/external/chorus-test-revA/kicad/chorus-test-revA_v9_grid50.kicad_pcb` when present.
   - Asserts the emitted `*_placement_diff.json` exists and contains at least one entry with non-zero `distance_mm`.
   - Skips cleanly on the standard CI runner (no `boards/external/`).  Self-hosted runners / developer workstations that have the fixture vendored exercise it.

## FAIL-on-revert verification

Per the curator's acceptance criteria #5, the synthetic test was verified to FAIL on the pre-#2609 baseline:

1. On `feature/issue-2612` (this branch, with PR #2609's commits included), ran the synthetic test -- PASSED.
2. Locally `git revert`ed b7e30617 and 434843ee (PR #2609's two commits), reran the test, confirmed it FAILED with:
   - `total_components_moved == 0`
   - Loop log: `No suitable placement strategy found` and `Exit reason: pf_max_iter`
   - Assertion error message identified case (b)/(c): ref-population missing or zero MOVE_COMPONENT candidates generated.
3. `git reset --hard` to restore the post-#2609 state, re-verified all 3 synthetic tests pass.

## Test plan

- [x] `uv run pytest tests/test_chorus_test_placement_feedback.py -m slow -v` -- 3 passed, 1 skipped (real-board) in ~38s
- [x] `uv run pytest tests/test_chorus_test_placement_feedback.py -m "not slow"` -- 4 deselected, 0 selected (confirms exclusion from default CI)
- [x] `uv run ruff check tests/test_chorus_test_placement_feedback.py` -- All checks passed!
- [x] `uv run ruff format --check tests/test_chorus_test_placement_feedback.py` -- already formatted
- [x] `uv run mypy tests/test_chorus_test_placement_feedback.py` -- no errors in new file (1325 pre-existing errors elsewhere are out of scope)
- [x] Adjacent tests still pass: `tests/test_placement_feedback.py`, `tests/test_failure_analysis_blocking_ref.py`, `tests/test_route_cmd_placement_feedback.py` -- 107 passed
- [x] FAIL-on-revert verification documented above

## Out of scope

- Adding a `nightly` pytest marker (not needed; `slow` already routes to the nightly workflow).
- Modifying `.github/workflows/slow-tests.yml` (test skips cleanly when fixture is missing on the runner).
- Vendoring chorus-test-revA into the repo (impractical; the synthetic variant is the regression gate).
- Sharing a fixture-loader with #2611 (future work; can be extracted to `conftest.py` when #2611 lands per the curator's recommendation).