### PR TITLE
feat(validate): categorize single-pad nets + add orphan-label/wire-stub ERC rules (closes #2613)

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -250,9 +250,10 @@ def main(argv: list[str] | None = None) -> int:
     # Determine exit code
     # Exit 2 = check ran successfully but found issues (errors, or warnings+strict)
     # Exit 1 = reserved for tool-level failures (file not found, parse error) above
-    # Exit 0 = no errors (warnings may be present without --strict)
+    # Exit 0 = no errors (warnings may be present without --strict; infos
+    #   never affect exit code -- they are advisory by definition).
     error_count = sum(1 for v in violations if v.is_error)
-    warning_count = len(violations) - error_count
+    warning_count = sum(1 for v in violations if v.is_warning)
 
     if error_count > 0 or (warning_count > 0 and args.strict):
         return 2
@@ -308,7 +309,8 @@ def output_table(
 ) -> None:
     """Output violations as a formatted table."""
     error_count = sum(1 for v in violations if v.is_error)
-    warning_count = len(violations) - error_count
+    warning_count = sum(1 for v in violations if v.is_warning)
+    info_count = sum(1 for v in violations if v.is_info)
 
     print(f"\n{'=' * 60}")
     print("PURE PYTHON DRC CHECK")
@@ -321,6 +323,8 @@ def output_table(
     print("\nResults:")
     print(f"  Errors:     {error_count}")
     print(f"  Warnings:   {warning_count}")
+    if info_count > 0:
+        print(f"  Infos:      {info_count}")
     if results.suppressed_count > 0:
         print(f"  Suppressed: {results.suppressed_count} (standard library footprints)")
 
@@ -333,27 +337,33 @@ def output_table(
     by_rule: dict[str, dict[str, int]] = {}
     for v in violations:
         if v.rule_id not in by_rule:
-            by_rule[v.rule_id] = {"errors": 0, "warnings": 0}
+            by_rule[v.rule_id] = {"errors": 0, "warnings": 0, "infos": 0}
         if v.is_error:
             by_rule[v.rule_id]["errors"] += 1
+        elif v.is_info:
+            by_rule[v.rule_id]["infos"] += 1
         else:
             by_rule[v.rule_id]["warnings"] += 1
 
     print(f"\n{'-' * 60}")
     print("BY RULE:")
     for rule_id, counts in sorted(
-        by_rule.items(), key=lambda x: -(x[1]["errors"] + x[1]["warnings"])
+        by_rule.items(),
+        key=lambda x: -(x[1]["errors"] + x[1]["warnings"] + x[1]["infos"]),
     ):
         parts = []
         if counts["errors"]:
             parts.append(f"{counts['errors']} error{'s' if counts['errors'] != 1 else ''}")
         if counts["warnings"]:
             parts.append(f"{counts['warnings']} warning{'s' if counts['warnings'] != 1 else ''}")
+        if counts["infos"]:
+            parts.append(f"{counts['infos']} info{'s' if counts['infos'] != 1 else ''}")
         print(f"  {rule_id}: {', '.join(parts)}")
 
     # Detailed output
     errors = [v for v in violations if v.is_error]
-    warnings = [v for v in violations if not v.is_error]
+    warnings = [v for v in violations if v.is_warning]
+    infos = [v for v in violations if v.is_info]
 
     if errors:
         print(f"\n{'-' * 60}")
@@ -370,16 +380,32 @@ def output_table(
         if len(warnings) > 10 and not verbose:
             print(f"\n  ... and {len(warnings) - 10} more warnings (use --verbose)")
 
+    if infos:
+        print(f"\n{'-' * 60}")
+        print("INFOS (advisory only):")
+        display_infos = infos if verbose else infos[:10]
+        for v in display_infos:
+            _print_violation(v, verbose)
+        if len(infos) > 10 and not verbose:
+            print(f"\n  ... and {len(infos) - 10} more infos (use --verbose)")
+
     print(f"\n{'=' * 60}")
     if errors:
         print("DRC FAILED - Fix errors before manufacturing")
-    else:
+    elif warnings:
         print("DRC WARNING - Review warnings")
+    else:
+        print("DRC PASSED - Advisory infos only")
 
 
 def _print_violation(v: DRCViolation, verbose: bool, indent: str = "  ") -> None:
     """Print a single violation."""
-    symbol = "X" if v.is_error else "!"
+    if v.is_error:
+        symbol = "X"
+    elif v.is_info:
+        symbol = "i"
+    else:
+        symbol = "!"
     print(f"\n{indent}[{symbol}] {v.rule_id}")
     print(f"{indent}    {v.message}")
 
@@ -406,11 +432,13 @@ def output_json(
 ) -> None:
     """Output violations as JSON."""
     error_count = sum(1 for v in violations if v.is_error)
-    warning_count = len(violations) - error_count
+    warning_count = sum(1 for v in violations if v.is_warning)
+    info_count = sum(1 for v in violations if v.is_info)
 
     summary_data: dict = {
         "errors": error_count,
         "warnings": warning_count,
+        "infos": info_count,
         "rules_checked": results.rules_checked,
         "passed": error_count == 0,
     }
@@ -437,11 +465,13 @@ def write_json_report(
 ) -> None:
     """Write DRC results as a JSON report file."""
     error_count = sum(1 for v in violations if v.is_error)
-    warning_count = len(violations) - error_count
+    warning_count = sum(1 for v in violations if v.is_warning)
+    info_count = sum(1 for v in violations if v.is_info)
 
     summary_data: dict = {
         "errors": error_count,
         "warnings": warning_count,
+        "infos": info_count,
         "rules_checked": results.rules_checked,
         "passed": error_count == 0,
     }
@@ -483,22 +513,30 @@ def output_summary(
     for v in violations:
         key = v.rule_id
         if key not in by_rule:
-            by_rule[key] = {"errors": 0, "warnings": 0}
+            by_rule[key] = {"errors": 0, "warnings": 0, "infos": 0}
         if v.is_error:
             by_rule[key]["errors"] += 1
+        elif v.is_info:
+            by_rule[key]["infos"] += 1
         else:
             by_rule[key]["warnings"] += 1
 
-    print(f"{'Rule ID':<30} {'Errors':<8} {'Warnings':<8}")
-    print("-" * 50)
+    print(f"{'Rule ID':<30} {'Errors':<8} {'Warnings':<10} {'Infos':<8}")
+    print("-" * 60)
 
     for rule_id, counts in sorted(by_rule.items()):
-        print(f"{rule_id:<30} {counts['errors']:<8} {counts['warnings']:<8}")
+        print(
+            f"{rule_id:<30} {counts['errors']:<8} "
+            f"{counts['warnings']:<10} {counts['infos']:<8}"
+        )
 
-    print("-" * 50)
+    print("-" * 60)
     total_errors = sum(c["errors"] for c in by_rule.values())
     total_warnings = sum(c["warnings"] for c in by_rule.values())
-    print(f"{'TOTAL':<30} {total_errors:<8} {total_warnings:<8}")
+    total_infos = sum(c["infos"] for c in by_rule.values())
+    print(
+        f"{'TOTAL':<30} {total_errors:<8} {total_warnings:<10} {total_infos:<8}"
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -82,6 +82,17 @@ def _emit_single_pad_net_warning(
     GROUND) are silently allowed because a single test point or
     pour-only net is a legitimate design pattern.
 
+    The remaining nets are categorized using the same regex rules used
+    by :class:`kicad_tools.validate.rules.SinglePadNetRule` (see issue
+    #2613).  Categorized output ensures the warning is not a firehose:
+
+    - **Genuine NCs** (KiCad-emitted ``unconnected-(REF-PIN-PadN)``):
+      reported at INFO level, no action required.
+    - **Connector NCs** (``Net-(REF-PadN)`` on a J/P prefix, typically
+      intentional GPIO no-connects): reported at INFO level.
+    - **Real defects** (everything else): reported at WARNING level
+      with a pointer to ``kct check --only single_pad_net``.
+
     See ``kct check --only single_pad_net`` for the full DRC-style
     report (this banner exists to surface the defect early in the
     pipeline; the actionable error lives in the check command).
@@ -94,6 +105,10 @@ def _emit_single_pad_net_warning(
         return
 
     from kicad_tools.cli.progress import flush_print
+    from kicad_tools.validate.rules.single_pad_net import (
+        _CONNECTOR_NET_PATTERN,
+        _KICAD_NC_PATTERN,
+    )
 
     try:
         from kicad_tools.router.net_class import classify_and_apply_rules
@@ -121,13 +136,54 @@ def _emit_single_pad_net_warning(
     if not signal_single_pad_names:
         return
 
+    # Categorize each surviving single-pad net using the same regex
+    # rules as the validate rule.  Note that this banner cannot validate
+    # the footprint-ref-prefix match (it has no Footprint handle), so
+    # connector_nc here is detected purely from the net name pattern.
+    # A net like ``Net-(J5-1)`` whose lone pad is actually on a
+    # non-connector footprint is rare in practice; the DRC-side
+    # validate rule does the stricter cross-check.
+    genuine_nc: list[str] = []
+    connector_nc: list[str] = []
+    defects: list[str] = []
+    for name in signal_single_pad_names:
+        if _KICAD_NC_PATTERN.match(name):
+            genuine_nc.append(name)
+        elif _CONNECTOR_NET_PATTERN.match(name):
+            connector_nc.append(name)
+        else:
+            defects.append(name)
+
     flush_print("")
+    # Banner header reflects categorized counts so agents see signal
+    # vs. noise at a glance.
+    parts: list[str] = []
+    if defects:
+        parts.append(f"{len(defects)} defect(s)")
+    if connector_nc:
+        parts.append(f"{len(connector_nc)} connector NC")
+    if genuine_nc:
+        parts.append(f"{len(genuine_nc)} explicit NC")
+    summary = ", ".join(parts)
     flush_print(
         f"  WARNING: {len(signal_single_pad_names)} single-pad signal "
-        "net(s) detected (likely missing footprint or schematic/PCB drift):"
+        f"net(s) detected ({summary}):"
     )
-    for name in signal_single_pad_names:
-        flush_print(f"    - {name}")
+    if defects:
+        flush_print("    DEFECTS (likely missing footprint or schematic/PCB drift):")
+        for name in defects:
+            flush_print(f"      - {name}")
+    if connector_nc:
+        flush_print(
+            "    INFO -- connector-pin NCs "
+            "(typically intentional GPIO no-connects):"
+        )
+        for name in connector_nc:
+            flush_print(f"      - {name}")
+    if genuine_nc:
+        flush_print("    INFO -- explicit NCs from symbol pin attributes:")
+        for name in genuine_nc:
+            flush_print(f"      - {name}")
     flush_print(
         "  Run 'kct check --only single_pad_net <pcb>' for details. "
         "Routing will proceed but these nets cannot be connected."

--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -3302,6 +3302,158 @@ def check_value_consistency(schematic_path: str) -> list[ValidationIssue]:
     return issues
 
 
+def _resolve_lib_symbols_for_design(
+    schematic_path: str,
+) -> tuple[list[tuple[str, Schematic]], dict[str, object]]:
+    """Build the (sheets, lib_symbols) inputs used by the new ERC rules.
+
+    Walks the schematic hierarchy starting at ``schematic_path``,
+    loads every sheet, and resolves every ``lib_id`` used to a
+    :class:`LibrarySymbol` via the schematic's embedded
+    ``lib_symbols`` section.
+
+    Returns:
+        Tuple ``(sheets, lib_symbols)`` where ``sheets`` is a list of
+        ``(sheet_path_string, Schematic)`` pairs and ``lib_symbols``
+        maps each placed ``lib_id`` to its resolved
+        :class:`LibrarySymbol`.  Returns empty values if the
+        hierarchy cannot be loaded.
+    """
+    sheets: list[tuple[str, Schematic]] = []
+    lib_symbols: dict[str, object] = {}
+
+    try:
+        hierarchy = build_hierarchy(schematic_path)
+        for node in hierarchy.all_nodes():
+            try:
+                sch = Schematic.load(node.path)
+            except Exception:
+                continue
+            sheets.append((str(node.path), sch))
+            for sym in sch.symbols:
+                if sym.lib_id and sym.lib_id not in lib_symbols:
+                    resolved = sch.get_lib_symbol_resolved(sym.lib_id)
+                    if resolved is not None:
+                        lib_symbols[sym.lib_id] = resolved
+    except Exception:
+        # Fall back to single-sheet loading.
+        try:
+            sch = Schematic.load(schematic_path)
+            sheets = [(schematic_path, sch)]
+            for sym in sch.symbols:
+                if sym.lib_id and sym.lib_id not in lib_symbols:
+                    resolved = sch.get_lib_symbol_resolved(sym.lib_id)
+                    if resolved is not None:
+                        lib_symbols[sym.lib_id] = resolved
+        except Exception:
+            return [], {}
+
+    return sheets, lib_symbols
+
+
+def check_orphan_labels(schematic_path: str) -> list[ValidationIssue]:
+    """Detect labels asserting a named signal that only reach one pin.
+
+    A label with a meaningful name (e.g., ``UART_TX``) syntactically
+    implies a multi-endpoint net.  When a global or local label is
+    attached to exactly one pin and no other pin or sheet asserts the
+    same name, the implied counterpart connection is missing -- a
+    real schematic defect that KiCad's built-in ERC does NOT catch.
+
+    See :mod:`kicad_tools.validate.sch_orphan_label` for the
+    underlying algorithm and the chorus-test-revA forensic context
+    (issue #2613).
+    """
+    issues: list[ValidationIssue] = []
+
+    try:
+        from kicad_tools.validate.sch_orphan_label import find_orphan_labels
+
+        sheets, lib_symbols = _resolve_lib_symbols_for_design(schematic_path)
+        if not sheets:
+            return issues
+        findings = find_orphan_labels(sheets, lib_symbols)
+        for f in findings:
+            issues.append(
+                ValidationIssue(
+                    severity=f.kind,
+                    category="orphan_label",
+                    message=(
+                        f"Label '{f.label_name}' asserts a named net but only "
+                        f"reaches one pin ({f.pin_ref}); the implied "
+                        f"counterpart connection is missing"
+                    ),
+                    location=f"{Path(f.sheet).name} @ "
+                    f"({f.position_mm[0]:.2f}, {f.position_mm[1]:.2f}) mm",
+                    items=[f.label_name, f.pin_ref],
+                )
+            )
+    except Exception as e:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                category="orphan_label",
+                message=f"Orphan-label check failed: {e}",
+            )
+        )
+
+    return issues
+
+
+def check_wire_stubs(schematic_path: str) -> list[ValidationIssue]:
+    """Detect wires whose free endpoint is short of a pin by N grid units.
+
+    Catches the "off-by-one-grid" defect class found in the
+    chorus-test-revA schematic (issue #2613): wires drawn on a
+    2.54 mm grid that terminate one or more grid steps short of the
+    intended pin (e.g. seven wires in ``connectors.kicad_sch``
+    terminating at ``x=81.28`` while J2 pins are at ``x=83.82``).
+
+    See :mod:`kicad_tools.validate.sch_wire_stub` for the underlying
+    algorithm.
+    """
+    issues: list[ValidationIssue] = []
+
+    try:
+        from kicad_tools.validate.sch_wire_stub import find_wire_stubs
+
+        sheets, lib_symbols = _resolve_lib_symbols_for_design(schematic_path)
+        if not sheets:
+            return issues
+        findings = find_wire_stubs(sheets, lib_symbols)
+        for f in findings:
+            issues.append(
+                ValidationIssue(
+                    severity="error",
+                    category="wire_stub",
+                    message=(
+                        f"Wire endpoint at ({f.dangling_endpoint[0]:.2f}, "
+                        f"{f.dangling_endpoint[1]:.2f}) mm is "
+                        f"{f.grid_steps_short} grid step(s) short of pin "
+                        f"{f.candidate_pin_ref} at "
+                        f"({f.candidate_pin_position[0]:.2f}, "
+                        f"{f.candidate_pin_position[1]:.2f}) mm "
+                        f"-- extend the wire by {f.grid_steps_short * 2.54:.2f} "
+                        f"mm along {f.axis} to land on the pin"
+                    ),
+                    location=f"{Path(f.sheet).name} @ "
+                    f"({f.dangling_endpoint[0]:.2f}, "
+                    f"{f.dangling_endpoint[1]:.2f}) mm",
+                    items=[f.candidate_pin_ref],
+                )
+            )
+    except Exception as e:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                category="wire_stub",
+                message=f"Wire-stub check failed: {e}",
+            )
+        )
+
+    return issues
+
+
 def validate_schematic(
     schematic_path: str,
     lib_paths: list[str] = None,
@@ -3389,6 +3541,14 @@ def validate_schematic(
 
     # Matched channel symmetry detection
     _run("matched_channel_symmetry", check_matched_channel_symmetry)
+
+    # Orphan-label detection (label asserts named signal but only
+    # reaches one pin in the design -- issue #2613).
+    _run("orphan_label", check_orphan_labels)
+
+    # Wire-stub detection (wire endpoint misses a pin by an integer
+    # multiple of the schematic grid -- issue #2613).
+    _run("wire_stub", check_wire_stubs)
 
     return result
 

--- a/src/kicad_tools/validate/rules/single_pad_net.py
+++ b/src/kicad_tools/validate/rules/single_pad_net.py
@@ -1,14 +1,33 @@
 """Single-pad-net design defect rule.
 
 Detects nets that are declared with a non-empty name but only have a
-single pad assigned to them.  Such nets are physically unroutable and
-almost always indicate one of the following design defects:
+single pad assigned to them.  Such nets fall into three distinct
+categories that this rule reports at different severities so the agent
+loop sees a meaningful signal-to-noise ratio (see issue #2613):
 
-- A footprint is missing from the PCB (the net was declared on the
-  schematic side but only one component instantiates it on the PCB).
-- The schematic was edited after the PCB was generated and the netlist
-  was not re-synced (schematic/PCB drift).
-- A part was deleted from the PCB but its associated nets remained.
+1. **Genuine NC** (``severity="info"``).  Nets named with the KiCad-emitted
+   ``unconnected-(REF-PIN-PadN)`` convention.  KiCad generates these
+   names when the schematic explicitly marks a symbol pin as no-connect
+   via the ``no_connect line`` attribute.  These are by-design and need
+   no action; surfacing them at info level lets agents acknowledge them
+   without treating them as defects.
+
+2. **Connector NC** (``severity="info"``).  Nets named with the
+   KiCad-default ``Net-(REFN-PadN)`` convention where ``REF`` matches a
+   connector prefix (``J`` or ``P``).  These are typically intentional
+   GPIO no-connects on header-style connectors (e.g., RPi 2x20 header
+   pins reserved for an M.2 E-key hat footprint).  They show up as
+   single-pad nets because no other footprint asserts a connection on
+   that header pin, but the design intent is correct.
+
+3. **Defect** (``severity="error"``).  Everything else -- single-pad
+   signal nets that look like real named signals (``UART_TX``,
+   ``I2S_BCLK``, etc.) or default-named nets on non-connector
+   footprints.  These are real design defects: the schematic asserts a
+   connection that exists on only one pad, which is structurally
+   unroutable.  Common root causes are missing footprints, schematic
+   edits not re-synced to the PCB, off-by-one wire stubs, and floating
+   labels.
 
 Power and ground nets that legitimately have a single pad (e.g., a
 single test point or a pour-only net) are silently allowed: this rule
@@ -17,12 +36,13 @@ fires only on signal nets.
 The router currently classifies these as "structurally unroutable" and
 silently skips them, which lets agents iterating on a design mistake
 "13/13 routed, DRC clean" for a successful build when 4 SWD signals are
-floating.  This rule surfaces them as DRC errors so the agent loop sees
-the problem before iterating.
+floating.  This rule surfaces them as DRC errors (or infos for the
+benign categories) so the agent loop sees the problem before iterating.
 """
 
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
@@ -33,6 +53,72 @@ from .netlist import _absolute_pad_position
 if TYPE_CHECKING:
     from kicad_tools.manufacturers import DesignRules
     from kicad_tools.schema.pcb import PCB, Footprint, Pad
+
+
+# Net-name pattern for KiCad's explicit-NC emission.  KiCad writes nets
+# of this form when a symbol pin is marked ``no_connect line`` in its
+# library definition (e.g., AP2112K-3.3 pin 4 = NC).  The pin name
+# component may include any KiCad-legal pin name characters, including
+# the literal "NC" string used in many libraries.
+#
+# Examples that should match:
+#   unconnected-(U1-NC-Pad4)
+#   unconnected-(U7-NC-Pad7)
+#   unconnected-(U2-Vbat-Pad6)
+_KICAD_NC_PATTERN = re.compile(r"^unconnected-\(.+-Pad\d+\)$")
+
+# Net-name pattern for KiCad's default-named single-pad-on-connector
+# emission.  When a connector pin has no other footprint asserting a
+# connection on its net, KiCad emits the name in the form
+# ``Net-(REFN-PadN)`` where REF is the footprint reference.  We
+# auto-downgrade to info only when the prefix is a connector designator
+# (``J`` or ``P``) -- the same letter used by the corresponding
+# footprint on the PCB.
+#
+# Examples that should match (connector-pin convention):
+#   Net-(J2-Pad11)
+#   Net-(J2-3)         <- some KiCad versions omit "Pad"
+#   Net-(P1-Pad5)
+#
+# Examples that should NOT match (these are real defects):
+#   Net-(U3-1)         <- IC pin
+#   Net-(U5-21)        <- IC pin
+#   Net-(Q1-Pad2)      <- transistor pin
+_CONNECTOR_NET_PATTERN = re.compile(r"^Net-\(([JP])\d+-(?:Pad)?\d+\)$")
+
+
+def _classify_net(net_name: str, footprint_ref: str) -> str:
+    """Classify a single-pad signal net by name and footprint context.
+
+    Args:
+        net_name: The net name (must be non-empty).
+        footprint_ref: The reference designator (e.g., ``"U1"``,
+            ``"J2"``) of the lone footprint hosting the net.
+
+    Returns:
+        One of:
+        - ``"genuine_nc"`` -- KiCad-emitted explicit-NC net.
+        - ``"connector_nc"`` -- ``Net-(REFN-PadN)`` on a connector
+          footprint (J/P prefix), typically intentional GPIO NC.
+        - ``"defect"`` -- everything else; real design defect.
+    """
+    if _KICAD_NC_PATTERN.match(net_name):
+        return "genuine_nc"
+
+    connector_match = _CONNECTOR_NET_PATTERN.match(net_name)
+    if connector_match is not None:
+        # Validate that the prefix in the net name matches the
+        # footprint's reference prefix.  This prevents a stray
+        # ``Net-(J5-1)`` from being downgraded if the matching pad is
+        # actually on a non-connector footprint (which would be a real
+        # data inconsistency).
+        net_prefix = connector_match.group(1)
+        ref_prefix = "".join(c for c in footprint_ref if c.isalpha())
+        if ref_prefix == net_prefix:
+            return "connector_nc"
+        # Falls through to defect if prefixes disagree.
+
+    return "defect"
 
 
 class SinglePadNetRule(DRCRule):
@@ -48,6 +134,11 @@ class SinglePadNetRule(DRCRule):
     are silently allowed because a single test point or pour-only net
     is a legitimate design pattern.  Only signal-class single-pad nets
     fire.
+
+    Each surviving single-pad net is then categorized into one of three
+    severities (see module docstring): info for KiCad-emitted explicit
+    NCs (``unconnected-(REF-PIN-PadN)``), info for connector-pin
+    convention nets (``Net-(JN-NN)``), and error for everything else.
     """
 
     rule_id = "single_pad_net"
@@ -74,7 +165,9 @@ class SinglePadNetRule(DRCRule):
                 by the base-class interface).
 
         Returns:
-            DRCResults containing one error per single-pad signal net.
+            DRCResults containing one entry per single-pad signal net,
+            categorized into info/error severities (see module
+            docstring).
         """
         results = DRCResults()
         results.rules_checked = 1
@@ -121,22 +214,42 @@ class SinglePadNetRule(DRCRule):
             # reported as a single-pad defect, which is recoverable.
             pour_nets = set()
 
-        # Emit one error per non-pour single-pad signal net.
+        # Emit categorized output per non-pour single-pad signal net.
         for (_net_number, net_name), (fp, pad) in single_pad:
             if net_name in pour_nets:
                 continue
 
             ref = fp.reference or fp.name
             location = _absolute_pad_position(fp, pad)
+            category = _classify_net(net_name, ref)
+
+            if category == "genuine_nc":
+                severity = "info"
+                message = (
+                    f"Net '{net_name}' has only 1 pad on {ref}-{pad.number} "
+                    f"-- KiCad-emitted explicit no-connect (symbol pin marked NC); "
+                    f"no action required"
+                )
+            elif category == "connector_nc":
+                severity = "info"
+                message = (
+                    f"Net '{net_name}' has only 1 pad on {ref}-{pad.number} "
+                    f"-- connector pin with no asserted connection "
+                    f"(typically intentional GPIO no-connect); "
+                    f"add explicit no_connect flag in schematic to silence"
+                )
+            else:
+                severity = "error"
+                message = (
+                    f"Net '{net_name}' has only 1 pad on {ref}-{pad.number} "
+                    f"-- likely missing footprint or schematic/PCB drift"
+                )
 
             results.add(
                 DRCViolation(
                     rule_id=self.rule_id,
-                    severity="error",
-                    message=(
-                        f"Net '{net_name}' has only 1 pad on {ref}-{pad.number} "
-                        f"-- likely missing footprint or schematic/PCB drift"
-                    ),
+                    severity=severity,
+                    message=message,
                     location=location,
                     items=(f"{ref}-{pad.number}",),
                     nets=(net_name,),

--- a/src/kicad_tools/validate/sch_orphan_label.py
+++ b/src/kicad_tools/validate/sch_orphan_label.py
@@ -1,0 +1,386 @@
+"""Orphan-label ERC rule (schematic-level).
+
+Detects named labels that connect to exactly one pin in the schematic.
+A label with a meaningful name (e.g., ``UART_TX``) syntactically asserts
+that the named signal exists and has at least two endpoints (one source,
+one sink).  When the label only attaches to a single pin in the entire
+design, the implied counterpart connection is missing -- a real design
+defect that KiCad's built-in ERC does NOT catch because the label itself
+syntactically resolves (it just has only one endpoint).
+
+This is one of the four tooling improvements requested by issue #2613.
+The chorus-test-revA schematic exhibits this defect: ``UART_TX``,
+``UART_RX``, ``I2S_BCLK``, ``DBG_LED2`` etc. all have global labels
+attached to a single MCU pin with no counterpart on the connector or
+the rest of the design.
+
+Algorithm
+---------
+
+Given a list of schematics (typically the root + every child sheet),
+the rule:
+
+1. Builds a mapping ``label_name -> [(x_mm, y_mm, sheet, kind)]`` over
+   local labels, hierarchical labels, and global labels (global labels
+   are cross-sheet; their occurrences are pooled across all sheets).
+2. Builds a mapping ``label_name -> set of pins reached`` by walking
+   each label's coordinate position and following any wire that
+   touches it to the pin endpoints (using a simple flood-fill via
+   `_collect_label_pin_endpoints`).
+3. Reports any label whose name does not match a benign pattern
+   (e.g., looks like a power net or a generic ``Net-...`` net), is
+   attached to only one pin in the whole design, and is not silenced
+   by an explicit ``no_connect`` flag at the lone pin.
+
+The rule is conservative by design -- it only fires on **named** labels
+(``UART_TX`` etc.).  Default-named nets (``Net-(...)``) are categorized
+by the separate single_pad_net DRC rule on the PCB side.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+# Names that look like power/ground rails should not be considered
+# "intended-signal" labels.  KiCad treats these specially (a single
+# pad connected to GND or +3V3 is a legitimate test point or pour
+# tap).  This list is intentionally short and conservative; the
+# single_pad_net DRC rule uses a richer classifier on the PCB side.
+_POWER_LIKE_PATTERN = re.compile(
+    r"^(?:GND|VCC|VDD|VSS|VBAT|VBUS|VPLUS|VMINUS|"
+    r"\+?[\d.]+V[\d.A-Z]*|-?[\d.]+V[\d.A-Z]*|"
+    r"\+[\d.A-Z]+|-[\d.A-Z]+)$",
+    re.IGNORECASE,
+)
+
+# Default-named nets (``Net-(...)``) are not "intended signal" labels.
+_DEFAULT_NET_PATTERN = re.compile(r"^Net-\(.+\)$")
+
+# Coordinates close enough to be considered identical.  Schematic
+# coordinates are stored in mm with 4-5 decimal places; pin positions
+# are rounded to the schematic grid (1.27 mm typically).
+_COORD_EPS = 0.01  # 10 micrometers -- well below any schematic grid.
+
+
+@dataclass(frozen=True)
+class OrphanLabelFinding:
+    """A single orphan-label finding.
+
+    Attributes:
+        label_name: The label's text (e.g., ``"UART_TX"``).
+        sheet: Path to the schematic sheet containing the lone pin.
+        pin_ref: Component reference + pin number (e.g., ``"U8.10"``).
+        position_mm: (x, y) coordinates of the lone pin in mm.
+        kind: Severity hint -- always ``"error"`` because an orphan
+            label is a real schematic defect.
+    """
+
+    label_name: str
+    sheet: str
+    pin_ref: str
+    position_mm: tuple[float, float]
+    kind: str = "error"
+
+
+def _approx_eq(a: float, b: float, eps: float = _COORD_EPS) -> bool:
+    """True when two floats are within ``eps``."""
+    return abs(a - b) <= eps
+
+
+def _is_intended_signal_name(label_name: str) -> bool:
+    """Filter labels that look like power/ground or default-named nets.
+
+    Args:
+        label_name: The label text.
+
+    Returns:
+        True when this looks like a real named signal (e.g.,
+        ``UART_TX``).  False for power rails (``+3V3``, ``GND``) and
+        default-named nets (``Net-(U1-Pad3)``).
+    """
+    name = label_name.strip()
+    if not name:
+        return False
+    if _POWER_LIKE_PATTERN.match(name):
+        return False
+    if _DEFAULT_NET_PATTERN.match(name):
+        return False
+    return True
+
+
+def _collect_label_positions(
+    schematic, sheet_path: str
+) -> dict[str, list[tuple[float, float, str]]]:
+    """Collect named label positions in a single schematic sheet.
+
+    Args:
+        schematic: A :class:`kicad_tools.schema.Schematic` instance.
+        sheet_path: Path string identifying the sheet (used in
+            findings, not used for processing).
+
+    Returns:
+        Mapping ``label_name -> [(x_mm, y_mm, sheet_path)]`` for every
+        label occurrence in this sheet.  Labels of all three kinds
+        (local, hierarchical, global) are pooled into one dict.
+    """
+    positions: dict[str, list[tuple[float, float, str]]] = {}
+    # Local labels (single-sheet scope, but still relevant -- a local
+    # label that connects to only one pin within its sheet is an
+    # orphan).
+    for lbl in schematic.labels:
+        text = getattr(lbl, "text", "") or ""
+        pos = getattr(lbl, "position", (0.0, 0.0))
+        if text:
+            positions.setdefault(text, []).append((pos[0], pos[1], sheet_path))
+    # Hierarchical labels -- always paired with a sheet-pin on the
+    # parent sheet.  Listed here for completeness; a single
+    # hierarchical label with a single pin counterpart is unusual but
+    # still a valid orphan signal.
+    for lbl in schematic.hierarchical_labels:
+        text = getattr(lbl, "text", "") or ""
+        pos = getattr(lbl, "position", (0.0, 0.0))
+        if text:
+            positions.setdefault(text, []).append((pos[0], pos[1], sheet_path))
+    # Global labels (cross-sheet scope).
+    for lbl in schematic.global_labels:
+        text = getattr(lbl, "text", "") or ""
+        pos = getattr(lbl, "position", (0.0, 0.0))
+        if text:
+            positions.setdefault(text, []).append((pos[0], pos[1], sheet_path))
+    return positions
+
+
+def _resolve_pin_positions(
+    schematic, lib_symbols: dict[str, object]
+) -> list[tuple[str, str, float, float]]:
+    """Resolve every pin position on every placed symbol in a sheet.
+
+    Args:
+        schematic: A :class:`kicad_tools.schema.Schematic`.
+        lib_symbols: Mapping ``lib_id -> LibrarySymbol`` (resolved).
+            Provided externally so the caller can prebuild it once for
+            a multi-sheet design.
+
+    Returns:
+        List of tuples ``(reference, pin_number, x_mm, y_mm)`` for
+        every pin on every placed (non-DNP) symbol in the sheet.
+    """
+    results: list[tuple[str, str, float, float]] = []
+    for sym in schematic.symbols:
+        if sym.dnp:
+            continue
+        lib_sym = lib_symbols.get(sym.lib_id)
+        if lib_sym is None:
+            # No library definition resolved -- skip pin position
+            # extraction for this symbol.  Tests must seed the
+            # library map.
+            continue
+        ref = sym.reference or ""
+        if not ref:
+            continue
+        try:
+            pin_positions = lib_sym.get_all_pin_positions(
+                instance_pos=sym.position,
+                instance_rot=sym.rotation,
+                mirror=sym.mirror,
+            )
+        except Exception:
+            # Library symbol shape unknown -- safest to skip than to
+            # blow up the whole validation pass.
+            continue
+        for pin_num, (x, y) in pin_positions.items():
+            results.append((ref, pin_num, x, y))
+    return results
+
+
+def _wires_at_point(
+    wires: Iterable, point: tuple[float, float]
+) -> list[object]:
+    """Return the wires that have an endpoint at ``point``."""
+    hits = []
+    px, py = point
+    for w in wires:
+        if (_approx_eq(w.start[0], px) and _approx_eq(w.start[1], py)) or (
+            _approx_eq(w.end[0], px) and _approx_eq(w.end[1], py)
+        ):
+            hits.append(w)
+    return hits
+
+
+def _collect_label_pin_endpoints(
+    label_pos: tuple[float, float],
+    wires: list,
+    pin_positions: list[tuple[str, str, float, float]],
+) -> list[tuple[str, str, float, float]]:
+    """Walk wires from a label position, collecting reached pins.
+
+    Performs a simple flood-fill: start at the label position, walk
+    every wire that has an endpoint there, hop to the opposite
+    endpoint, and continue until no new endpoints are reached.  Pins
+    coincident with any visited endpoint are returned.
+
+    Args:
+        label_pos: (x, y) of the label.
+        wires: All wires in the relevant sheet(s).
+        pin_positions: All pin positions in the relevant sheet(s).
+
+    Returns:
+        List of (ref, pin_num, x, y) pins reached from the label.
+    """
+    visited_points: set[tuple[float, float]] = set()
+    frontier: list[tuple[float, float]] = [label_pos]
+
+    def _round(p: tuple[float, float]) -> tuple[float, float]:
+        """Snap a point to micrometer precision for set hashing."""
+        return (round(p[0], 4), round(p[1], 4))
+
+    while frontier:
+        pt = frontier.pop()
+        key = _round(pt)
+        if key in visited_points:
+            continue
+        visited_points.add(key)
+        for w in _wires_at_point(wires, pt):
+            # Walk to opposite endpoint.
+            if _approx_eq(w.start[0], pt[0]) and _approx_eq(w.start[1], pt[1]):
+                other = w.end
+            else:
+                other = w.start
+            if _round(other) not in visited_points:
+                frontier.append(other)
+
+    reached: list[tuple[str, str, float, float]] = []
+    for ref, pin_num, x, y in pin_positions:
+        if _round((x, y)) in visited_points:
+            reached.append((ref, pin_num, x, y))
+    return reached
+
+
+def find_orphan_labels(
+    sheets: list[tuple[str, object]],
+    lib_symbols: dict[str, object],
+) -> list[OrphanLabelFinding]:
+    """Find orphan labels across a multi-sheet schematic design.
+
+    Args:
+        sheets: List of ``(sheet_path, Schematic)`` tuples for every
+            sheet in the design (root + children).
+        lib_symbols: Mapping ``lib_id -> LibrarySymbol`` resolved for
+            every symbol used in the design.  The caller typically
+            builds this by walking each sheet's ``lib_symbols``
+            section and resolving extends chains.
+
+    Returns:
+        List of :class:`OrphanLabelFinding`.  Empty when no orphan
+        labels are detected.
+    """
+    # Pool global-label positions across all sheets; local and
+    # hierarchical labels stay per-sheet (single-sheet scope).
+    global_positions: dict[str, list[tuple[float, float, str]]] = {}
+    per_sheet_label_positions: list[
+        tuple[str, dict[str, list[tuple[float, float, str]]]]
+    ] = []
+    per_sheet_pins: dict[str, list[tuple[str, str, float, float]]] = {}
+    per_sheet_wires: dict[str, list] = {}
+    per_sheet_no_connects: dict[str, list[tuple[float, float]]] = {}
+
+    for sheet_path, sch in sheets:
+        local_pos = _collect_label_positions(sch, sheet_path)
+        per_sheet_label_positions.append((sheet_path, local_pos))
+        for gl in sch.global_labels:
+            text = getattr(gl, "text", "") or ""
+            pos = getattr(gl, "position", (0.0, 0.0))
+            if text:
+                global_positions.setdefault(text, []).append((pos[0], pos[1], sheet_path))
+        per_sheet_pins[sheet_path] = _resolve_pin_positions(sch, lib_symbols)
+        per_sheet_wires[sheet_path] = list(sch.wires)
+        per_sheet_no_connects[sheet_path] = [
+            (nc.position[0], nc.position[1]) for nc in sch.no_connects
+        ]
+
+    findings: list[OrphanLabelFinding] = []
+
+    # Tally pins reached per global label across the whole design.
+    for label_name, occurrences in global_positions.items():
+        if not _is_intended_signal_name(label_name):
+            continue
+        reached: list[tuple[str, str, float, float, str]] = []
+        for x, y, sheet_path in occurrences:
+            pins = _collect_label_pin_endpoints(
+                (x, y),
+                per_sheet_wires[sheet_path],
+                per_sheet_pins[sheet_path],
+            )
+            for ref, pin_num, px, py in pins:
+                reached.append((ref, pin_num, px, py, sheet_path))
+        # Deduplicate by (ref, pin_num).
+        seen_pins: set[tuple[str, str]] = set()
+        unique = []
+        for ref, pin_num, px, py, sheet_path in reached:
+            key = (ref, pin_num)
+            if key in seen_pins:
+                continue
+            seen_pins.add(key)
+            unique.append((ref, pin_num, px, py, sheet_path))
+        if len(unique) == 1:
+            ref, pin_num, px, py, sheet_path = unique[0]
+            # Skip if this pin has an explicit no_connect flag.
+            no_connects = per_sheet_no_connects.get(sheet_path, [])
+            if any(_approx_eq(nx, px) and _approx_eq(ny, py) for nx, ny in no_connects):
+                continue
+            findings.append(
+                OrphanLabelFinding(
+                    label_name=label_name,
+                    sheet=sheet_path,
+                    pin_ref=f"{ref}.{pin_num}",
+                    position_mm=(px, py),
+                )
+            )
+
+    # Per-sheet check for local + hierarchical labels.  We compare
+    # within the sheet only -- a local label cannot reach pins on
+    # other sheets.
+    for sheet_path, local_pos in per_sheet_label_positions:
+        for label_name, occurrences in local_pos.items():
+            if label_name in global_positions:
+                # Already handled by the global pass.
+                continue
+            if not _is_intended_signal_name(label_name):
+                continue
+            reached_pins: list[tuple[str, str, float, float]] = []
+            for x, y, _ in occurrences:
+                reached_pins.extend(
+                    _collect_label_pin_endpoints(
+                        (x, y),
+                        per_sheet_wires[sheet_path],
+                        per_sheet_pins[sheet_path],
+                    )
+                )
+            # Deduplicate.
+            seen_pins = set()
+            unique_pins = []
+            for ref, pin_num, px, py in reached_pins:
+                key = (ref, pin_num)
+                if key in seen_pins:
+                    continue
+                seen_pins.add(key)
+                unique_pins.append((ref, pin_num, px, py))
+            if len(unique_pins) == 1:
+                ref, pin_num, px, py = unique_pins[0]
+                no_connects = per_sheet_no_connects.get(sheet_path, [])
+                if any(
+                    _approx_eq(nx, px) and _approx_eq(ny, py) for nx, ny in no_connects
+                ):
+                    continue
+                findings.append(
+                    OrphanLabelFinding(
+                        label_name=label_name,
+                        sheet=sheet_path,
+                        pin_ref=f"{ref}.{pin_num}",
+                        position_mm=(px, py),
+                    )
+                )
+
+    return findings

--- a/src/kicad_tools/validate/sch_wire_stub.py
+++ b/src/kicad_tools/validate/sch_wire_stub.py
@@ -1,0 +1,320 @@
+"""Wire-stub ERC rule (schematic-level).
+
+Detects wires whose dangling endpoint is exactly *N* grid units short
+of a real pin position.  This is the canonical "off-by-one-grid" defect
+class found in the chorus-test-revA schematic, where seven wires in
+``connectors.kicad_sch`` terminate at ``x=81.28`` while the matching
+J2 left-side pins are at ``x=83.82`` -- exactly one 2.54 mm grid step
+short.  KiCad's built-in ERC reports these as ``wire_dangling`` but
+does NOT diagnose the off-by-grid relationship to a nearby pin, so the
+agent loop receives a generic "wire not connected at both ends" with
+no actionable suggestion.
+
+Algorithm
+---------
+
+For every wire in every sheet of the design:
+
+1. Determine each endpoint's "free" status by checking whether it
+   touches any pin, junction, label, or no_connect.  An endpoint that
+   already coincides with one of those is connected and is silently
+   skipped.
+2. For each free endpoint, search for the nearest pin within
+   ``max_stub_grids * grid_mm`` mm along an axis-aligned direction
+   (horizontal or vertical).  When the offset is an integer multiple
+   of the grid (``grid_mm``, default 2.54 mm) and >= 1 grid step, the
+   endpoint is classified as a wire stub.  When the offset is below
+   one grid step but non-zero, KiCad ERC's ``endpoint_off_grid``
+   already flags it -- we skip these to avoid duplicate reporting.
+
+Grid handling
+-------------
+
+The default grid is 2.54 mm (KiCad's stock schematic grid).  Some
+projects use a 1.27 mm sub-grid; callers can override.  The detector
+only flags stubs that are an exact integer multiple of the grid -- a
+non-grid-aligned endpoint is a different defect class and is left to
+KiCad's built-in ``endpoint_off_grid`` rule.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+# Default KiCad schematic grid step in mm.
+DEFAULT_GRID_MM = 2.54
+
+# Coordinates within this distance are considered to coincide
+# (typically 10 micrometers).  Schematic positions are stored in mm
+# with at most 4-5 decimal places, so 0.01 mm is well below any
+# meaningful drift.
+_COORD_EPS = 0.01
+
+# Maximum number of grid steps to scan for a "missed-by-N-grids"
+# match.  Beyond 4 grid steps (10.16 mm) it's unlikely the user
+# intended the wire to reach the candidate pin.
+DEFAULT_MAX_STUB_GRIDS = 4
+
+
+@dataclass(frozen=True)
+class WireStubFinding:
+    """A single wire-stub finding.
+
+    Attributes:
+        sheet: Path to the schematic sheet containing the wire.
+        wire_start: (x, y) of the wire's start (mm).
+        wire_end: (x, y) of the wire's end (mm).
+        dangling_endpoint: (x, y) of the free endpoint that is short
+            of a pin (mm).
+        candidate_pin_ref: Component reference + pin number of the
+            nearest pin (e.g., ``"J2.8"``).
+        candidate_pin_position: (x, y) of the candidate pin (mm).
+        grid_steps_short: How many grid units the endpoint is short
+            of the candidate pin.  Always a positive integer.
+        axis: ``"x"`` for horizontal stub, ``"y"`` for vertical.
+    """
+
+    sheet: str
+    wire_start: tuple[float, float]
+    wire_end: tuple[float, float]
+    dangling_endpoint: tuple[float, float]
+    candidate_pin_ref: str
+    candidate_pin_position: tuple[float, float]
+    grid_steps_short: int
+    axis: str
+
+
+def _approx_eq(a: float, b: float, eps: float = _COORD_EPS) -> bool:
+    """True when two floats are within ``eps``."""
+    return abs(a - b) <= eps
+
+
+def _approx_point(
+    p: tuple[float, float], q: tuple[float, float], eps: float = _COORD_EPS
+) -> bool:
+    return _approx_eq(p[0], q[0], eps) and _approx_eq(p[1], q[1], eps)
+
+
+def _endpoint_is_connected(
+    endpoint: tuple[float, float],
+    pin_positions: Iterable[tuple[str, str, float, float]],
+    junctions: Iterable,
+    labels_pos: Iterable[tuple[float, float]],
+    no_connects: Iterable[tuple[float, float]],
+    other_wires_endpoints: Iterable[tuple[float, float]],
+) -> bool:
+    """Return True if ``endpoint`` is connected to a real anchor.
+
+    Checks for:
+    - Coincident pin position
+    - Coincident junction
+    - Coincident label of any kind
+    - Coincident no-connect flag
+    - Coincident endpoint of any other wire (T-junctions through
+      proper connections still count -- KiCad does not require a
+      junction marker when only two wires meet at a non-T point).
+    """
+    ex, ey = endpoint
+    for _ref, _pin, px, py in pin_positions:
+        if _approx_eq(px, ex) and _approx_eq(py, ey):
+            return True
+    for j in junctions:
+        jx, jy = j.position
+        if _approx_eq(jx, ex) and _approx_eq(jy, ey):
+            return True
+    for lx, ly in labels_pos:
+        if _approx_eq(lx, ex) and _approx_eq(ly, ey):
+            return True
+    for nx, ny in no_connects:
+        if _approx_eq(nx, ex) and _approx_eq(ny, ey):
+            return True
+    return any(
+        _approx_eq(ox, ex) and _approx_eq(oy, ey) for ox, oy in other_wires_endpoints
+    )
+
+
+def _find_grid_aligned_pin(
+    endpoint: tuple[float, float],
+    pin_positions: Iterable[tuple[str, str, float, float]],
+    grid_mm: float,
+    max_grids: int,
+) -> tuple[str, str, float, float, int, str] | None:
+    """Find the closest pin axis-aligned and an integer grid count away.
+
+    Args:
+        endpoint: The wire's free endpoint (x, y) in mm.
+        pin_positions: Iterable of (ref, pin_num, x, y) for every pin
+            in the design.
+        grid_mm: Grid step (typically 2.54 mm).
+        max_grids: Maximum search distance in grid units.
+
+    Returns:
+        ``(ref, pin_num, px, py, grid_steps, axis)`` for the closest
+        matching pin, or ``None`` when no match within
+        ``max_grids * grid_mm`` is found.  ``axis`` is ``"x"`` or
+        ``"y"``.  Endpoints already coincident with a pin (0 grid
+        steps) are skipped -- those are not stubs.
+    """
+    ex, ey = endpoint
+    best: tuple[str, str, float, float, int, str] | None = None
+    best_grid_steps: int | None = None
+
+    for ref, pin_num, px, py in pin_positions:
+        # Require axis-aligned alignment on the OTHER axis.
+        if _approx_eq(py, ey):
+            # Same Y -- horizontal stub.
+            dx = px - ex
+            if abs(dx) < grid_mm - _COORD_EPS:
+                # Below 1 grid step.  Could be the same point, could
+                # be sub-grid -- either way, skip.
+                continue
+            # Snap dx to integer grid count.
+            grid_count = round(dx / grid_mm)
+            if grid_count == 0:
+                continue
+            # Verify the remainder is small (i.e., dx is an integer
+            # multiple of the grid).
+            residual = abs(dx - grid_count * grid_mm)
+            if residual > _COORD_EPS:
+                continue
+            if abs(grid_count) > max_grids:
+                continue
+            steps = abs(grid_count)
+            if best_grid_steps is None or steps < best_grid_steps:
+                best = (ref, pin_num, px, py, steps, "x")
+                best_grid_steps = steps
+        elif _approx_eq(px, ex):
+            # Same X -- vertical stub.
+            dy = py - ey
+            if abs(dy) < grid_mm - _COORD_EPS:
+                continue
+            grid_count = round(dy / grid_mm)
+            if grid_count == 0:
+                continue
+            residual = abs(dy - grid_count * grid_mm)
+            if residual > _COORD_EPS:
+                continue
+            if abs(grid_count) > max_grids:
+                continue
+            steps = abs(grid_count)
+            if best_grid_steps is None or steps < best_grid_steps:
+                best = (ref, pin_num, px, py, steps, "y")
+                best_grid_steps = steps
+
+    return best
+
+
+def _resolve_pin_positions(
+    schematic, lib_symbols: dict[str, object]
+) -> list[tuple[str, str, float, float]]:
+    """Resolve every pin position on every placed symbol in a sheet.
+
+    Shared helper duplicated from sch_orphan_label to keep the two
+    modules independently testable.
+    """
+    results: list[tuple[str, str, float, float]] = []
+    for sym in schematic.symbols:
+        if sym.dnp:
+            continue
+        lib_sym = lib_symbols.get(sym.lib_id)
+        if lib_sym is None:
+            continue
+        ref = sym.reference or ""
+        if not ref:
+            continue
+        try:
+            pin_positions = lib_sym.get_all_pin_positions(
+                instance_pos=sym.position,
+                instance_rot=sym.rotation,
+                mirror=sym.mirror,
+            )
+        except Exception:
+            continue
+        for pin_num, (x, y) in pin_positions.items():
+            results.append((ref, pin_num, x, y))
+    return results
+
+
+def find_wire_stubs(
+    sheets: list[tuple[str, object]],
+    lib_symbols: dict[str, object],
+    grid_mm: float = DEFAULT_GRID_MM,
+    max_stub_grids: int = DEFAULT_MAX_STUB_GRIDS,
+) -> list[WireStubFinding]:
+    """Find wire endpoints that miss a pin by an integer multiple of grid.
+
+    Args:
+        sheets: List of ``(sheet_path, Schematic)`` tuples for every
+            sheet in the design.
+        lib_symbols: Mapping ``lib_id -> LibrarySymbol`` resolved.
+        grid_mm: KiCad schematic grid step (default 2.54 mm).
+        max_stub_grids: Maximum number of grid units to search.
+
+    Returns:
+        List of :class:`WireStubFinding`.  Empty when no stubs found.
+    """
+    findings: list[WireStubFinding] = []
+
+    for sheet_path, sch in sheets:
+        pin_positions = _resolve_pin_positions(sch, lib_symbols)
+        # Pre-compute label and no_connect positions for connection
+        # checks.
+        labels_pos: list[tuple[float, float]] = []
+        for lbl in sch.labels:
+            labels_pos.append(lbl.position)
+        for lbl in sch.hierarchical_labels:
+            labels_pos.append(lbl.position)
+        for lbl in sch.global_labels:
+            labels_pos.append(lbl.position)
+        no_connects = [(nc.position[0], nc.position[1]) for nc in sch.no_connects]
+        # Precompute every wire endpoint so we can check whether a
+        # given wire endpoint coincides with another wire (and is
+        # therefore part of a chain, not dangling).
+        all_wire_endpoints: list[tuple[float, float]] = []
+        for w in sch.wires:
+            all_wire_endpoints.append(w.start)
+            all_wire_endpoints.append(w.end)
+
+        for wire in sch.wires:
+            for endpoint in (wire.start, wire.end):
+                # Exclude this wire's other endpoint from the "other
+                # wires" set so a single isolated wire still flags
+                # both endpoints if both dangle.
+                other_endpoints = [
+                    p
+                    for p in all_wire_endpoints
+                    if not _approx_point(p, endpoint)
+                ]
+                if _endpoint_is_connected(
+                    endpoint,
+                    pin_positions,
+                    sch.junctions,
+                    labels_pos,
+                    no_connects,
+                    other_endpoints,
+                ):
+                    continue
+                match = _find_grid_aligned_pin(
+                    endpoint,
+                    pin_positions,
+                    grid_mm=grid_mm,
+                    max_grids=max_stub_grids,
+                )
+                if match is None:
+                    continue
+                ref, pin_num, px, py, steps, axis = match
+                findings.append(
+                    WireStubFinding(
+                        sheet=sheet_path,
+                        wire_start=wire.start,
+                        wire_end=wire.end,
+                        dangling_endpoint=endpoint,
+                        candidate_pin_ref=f"{ref}.{pin_num}",
+                        candidate_pin_position=(px, py),
+                        grid_steps_short=steps,
+                        axis=axis,
+                    )
+                )
+
+    return findings

--- a/src/kicad_tools/validate/violations.py
+++ b/src/kicad_tools/validate/violations.py
@@ -17,7 +17,11 @@ class DRCViolation:
 
     Attributes:
         rule_id: Unique identifier for the rule, e.g., "clearance_trace_trace"
-        severity: Either "error" or "warning"
+        severity: One of "error", "warning", or "info".  ``info`` is used
+            for advisory findings that are categorized by the rule as
+            non-actionable (e.g., a single-pad net that matches the
+            KiCad-emitted ``unconnected-(REF-PIN-PadN)`` convention for
+            explicit symbol no-connect pins).
         message: Human-readable description of the violation
         location: (x_mm, y_mm) tuple of the violation location, or None
         layer: Layer name where violation occurs, e.g., "F.Cu"
@@ -38,18 +42,25 @@ class DRCViolation:
 
     def __post_init__(self) -> None:
         """Validate severity value."""
-        if self.severity not in ("error", "warning"):
-            raise ValueError(f"severity must be 'error' or 'warning', got {self.severity!r}")
+        if self.severity not in ("error", "warning", "info"):
+            raise ValueError(
+                f"severity must be 'error', 'warning', or 'info', got {self.severity!r}"
+            )
 
     @property
     def is_error(self) -> bool:
-        """Check if this is an error (not a warning)."""
+        """Check if this is an error (not a warning or info)."""
         return self.severity == "error"
 
     @property
     def is_warning(self) -> bool:
-        """Check if this is a warning (not an error)."""
+        """Check if this is a warning (not an error or info)."""
         return self.severity == "warning"
+
+    @property
+    def is_info(self) -> bool:
+        """Check if this is an informational finding (not an error or warning)."""
+        return self.severity == "info"
 
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization.
@@ -102,8 +113,13 @@ class DRCResults:
         return sum(1 for v in self.violations if v.is_warning)
 
     @property
+    def info_count(self) -> int:
+        """Count of violations with severity='info'."""
+        return sum(1 for v in self.violations if v.is_info)
+
+    @property
     def passed(self) -> bool:
-        """True if no errors (warnings are allowed)."""
+        """True if no errors (warnings and infos are allowed)."""
         return self.error_count == 0
 
     @property
@@ -115,6 +131,11 @@ class DRCResults:
     def warnings(self) -> list[DRCViolation]:
         """List of only warning violations."""
         return [v for v in self.violations if v.is_warning]
+
+    @property
+    def infos(self) -> list[DRCViolation]:
+        """List of only informational violations."""
+        return [v for v in self.violations if v.is_info]
 
     def __iter__(self):
         """Iterate over all violations."""
@@ -152,6 +173,7 @@ class DRCResults:
             "passed": self.passed,
             "error_count": self.error_count,
             "warning_count": self.warning_count,
+            "info_count": self.info_count,
             "rules_checked": self.rules_checked,
             "violations": [v.to_dict() for v in self.violations],
         }
@@ -159,7 +181,9 @@ class DRCResults:
     def summary(self) -> str:
         """Generate a human-readable summary."""
         status = "PASSED" if self.passed else "FAILED"
+        info_part = f", {self.info_count} infos" if self.info_count else ""
         return (
             f"DRC {status}: {self.error_count} errors, "
-            f"{self.warning_count} warnings ({self.rules_checked} rules checked)"
+            f"{self.warning_count} warnings{info_part} "
+            f"({self.rules_checked} rules checked)"
         )

--- a/tests/test_cli_check_single_pad_net.py
+++ b/tests/test_cli_check_single_pad_net.py
@@ -1,10 +1,12 @@
-"""CLI tests for `kct check --only single_pad_net`.
+"""CLI tests for ``kct check --only single_pad_net``.
 
-The fixture used here is board 05 (BLDC motor controller), which still
-emits a stub PCB without its STM32G4 MCU and therefore generates the
-single-pad-net errors the rule is designed to catch.  Board 04 used to
-serve this purpose but was fixed by issue #2531 (MCU placed) -- see
-``test_single_pad_net_integration.py`` for the regression guard there.
+The original test fixture used board 05 (BLDC motor controller) which
+emitted a stub PCB without its STM32G4 MCU.  Commit ``e0459593`` placed
+a real STM32G431K8Tx on the board, eliminating its stub single-pad
+nets.  Rather than wait for a board that exhibits single-pad-net
+defects again, this test now constructs a synthetic on-disk PCB with
+exactly one named-signal singleton, then drives ``kct check`` end to
+end.
 """
 
 from __future__ import annotations
@@ -12,55 +14,94 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 
-_REPO_ROOT = Path(__file__).resolve().parent.parent
-_BOARD_05_PCB = (
-    _REPO_ROOT / "boards" / "05-bldc-motor-controller" / "output" / "bldc_controller.kicad_pcb"
+_MINIMAL_PCB = """(kicad_pcb (version 20240108) (generator "test_fixture")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (32 "B.Adhes" user "B.Adhesive")
+    (33 "F.Adhes" user "F.Adhesive")
+    (34 "B.Paste" user)
+    (35 "F.Paste" user)
+    (36 "B.SilkS" user "B.Silkscreen")
+    (37 "F.SilkS" user "F.Silkscreen")
+    (38 "B.Mask" user)
+    (39 "F.Mask" user)
+    (40 "Dwgs.User" user "User.Drawings")
+    (41 "Cmts.User" user "User.Comments")
+    (42 "Eco1.User" user "User.Eco1")
+    (43 "Eco2.User" user "User.Eco2")
+    (44 "Edge.Cuts" user)
+    (45 "Margin" user)
+    (46 "B.CrtYd" user "B.Courtyard")
+    (47 "F.CrtYd" user "F.Courtyard")
+    (48 "B.Fab" user)
+    (49 "F.Fab" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "UART_TX")
+  (footprint "Package:TEST" (layer "F.Cu")
+    (at 100 100)
+    (property "Reference" "U8" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000001"))
+    (property "Value" "TEST" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000002"))
+    (pad "10" smd rect (at 0 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "UART_TX") (uuid "00000000-0000-0000-0000-000000000003"))
+  )
 )
+"""
 
 
-@pytest.mark.skipif(
-    not _BOARD_05_PCB.exists(),
-    reason=(
-        "boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb not generated; "
-        "run 'uv run python boards/05-bldc-motor-controller/design.py' first"
-    ),
-)
+def _write_synthetic_pcb(tmp_path: Path) -> Path:
+    """Write a minimal PCB to ``tmp_path`` with one single-pad signal net."""
+    pcb_path = tmp_path / "synthetic_singleton.kicad_pcb"
+    pcb_path.write_text(_MINIMAL_PCB)
+    return pcb_path
+
+
 class TestCheckSinglePadNetCli:
-    """End-to-end CLI tests for the new rule on a stub-MCU board."""
+    """End-to-end CLI tests using a synthetic PCB."""
 
-    def test_only_single_pad_net_reports_errors(self, capsys):
-        """`kct check --only single_pad_net` exits 2 with errors."""
+    def test_only_single_pad_net_reports_errors(self, capsys, tmp_path: Path) -> None:
+        """``kct check --only single_pad_net`` exits 2 with errors."""
         from kicad_tools.cli.check_cmd import main
 
-        rc = main([str(_BOARD_05_PCB), "--only", "single_pad_net"])
+        pcb_path = _write_synthetic_pcb(tmp_path)
+        rc = main([str(pcb_path), "--only", "single_pad_net"])
         assert rc == 2  # Errors found.
 
         captured = capsys.readouterr()
-        # Some single-pad-net signal should be flagged on the stub board.
+        # Some single-pad-net signal should be flagged on the synthetic board.
         assert "single_pad_net" in captured.out
         # The output should list at least one offending net.
         assert "Net '" in captured.out
+        # UART_TX is a "real" named signal and must be reported as an error.
+        assert "UART_TX" in captured.out
 
-    def test_skip_single_pad_net_excludes_rule(self, capsys):
-        """`kct check --skip single_pad_net` does not include this rule_id."""
+    def test_skip_single_pad_net_excludes_rule(self, capsys, tmp_path: Path) -> None:
+        """``kct check --skip single_pad_net`` does not include this rule_id."""
         from kicad_tools.cli.check_cmd import main
 
+        pcb_path = _write_synthetic_pcb(tmp_path)
         # We don't care about the exit code (other rules may fire on
-        # this board); only that the single_pad_net rule is excluded.
-        main([str(_BOARD_05_PCB), "--skip", "single_pad_net"])
+        # this synthetic board); only that the single_pad_net rule is
+        # excluded.
+        main([str(pcb_path), "--skip", "single_pad_net"])
 
         captured = capsys.readouterr()
         assert "single_pad_net" not in captured.out
 
-    def test_json_output_resolves_type(self, capsys):
+    def test_json_output_resolves_type(self, capsys, tmp_path: Path) -> None:
         """JSON output round-trips rule_id -> type without 'unknown'."""
         from kicad_tools.cli.check_cmd import main
 
+        pcb_path = _write_synthetic_pcb(tmp_path)
         rc = main(
             [
-                str(_BOARD_05_PCB),
+                str(pcb_path),
                 "--only",
                 "single_pad_net",
                 "--format",
@@ -82,4 +123,43 @@ class TestCheckSinglePadNetCli:
             # Critical: must NOT resolve to 'unknown' -- verifies the
             # ViolationType enum + alias entry are wired correctly.
             assert v["type"] == "single_pad_net"
-            assert v["severity"] == "error"
+            # The synthetic fixture's UART_TX net is a "real defect",
+            # so it must be reported at error severity.
+            if v["nets"] == ["UART_TX"]:
+                assert v["severity"] == "error"
+
+    def test_info_severity_in_json_for_explicit_nc(
+        self, capsys, tmp_path: Path
+    ) -> None:
+        """An ``unconnected-(REF-PIN-PadN)`` singleton is reported at info severity.
+
+        Issue #2613: KiCad-emitted explicit NCs are advisory only.
+        """
+        from kicad_tools.cli.check_cmd import main
+
+        # Build a synthetic PCB that has exactly one ``unconnected-...``
+        # net.  The rule should classify it as info (not error) and
+        # therefore the CLI should exit 0 (no errors, infos don't
+        # affect exit code).
+        pcb_content = _MINIMAL_PCB.replace(
+            '(net 1 "UART_TX")',
+            '(net 1 "unconnected-(U8-NC-Pad10)")',
+        ).replace(
+            '(net 1 "UART_TX")',
+            '(net 1 "unconnected-(U8-NC-Pad10)")',
+            # second occurrence inside the pad definition is replaced too
+        )
+        pcb_path = tmp_path / "synthetic_nc.kicad_pcb"
+        pcb_path.write_text(pcb_content)
+
+        rc = main([str(pcb_path), "--only", "single_pad_net", "--format", "json"])
+        # Exit 0: no errors, infos do not affect exit code.
+        assert rc == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        # Confirm the violation is reported at info severity.
+        infos = [v for v in data["violations"] if v["severity"] == "info"]
+        assert len(infos) >= 1
+        assert any("explicit no-connect" in v["message"].lower() for v in infos)

--- a/tests/test_single_pad_net_categorization.py
+++ b/tests/test_single_pad_net_categorization.py
@@ -1,0 +1,254 @@
+"""Unit tests for SinglePadNetRule's three-category classification.
+
+Per issue #2613 the rule classifies single-pad signal nets into:
+
+- ``genuine_nc`` (severity=info) -- KiCad-emitted
+  ``unconnected-(REF-PIN-PadN)`` from explicit symbol NC pin
+  attributes.
+- ``connector_nc`` (severity=info) -- ``Net-(JN-NN)`` connector-pin
+  convention, typically intentional GPIO no-connects.
+- ``defect`` (severity=error) -- everything else; real schematic
+  defect that the agent loop must surface.
+
+The tests construct a minimal synthetic :class:`PCB` from raw
+:class:`Footprint` / :class:`Pad` instances (no S-expression parsing)
+to exercise the classification logic directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.schema.pcb import PCB, Footprint, Pad
+from kicad_tools.validate.rules.single_pad_net import (
+    SinglePadNetRule,
+    _classify_net,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests for the classifier helper
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyNet:
+    """The ``_classify_net`` helper covers the three categories."""
+
+    @pytest.mark.parametrize(
+        "net_name,ref,expected",
+        [
+            # KiCad-emitted explicit-NC nets (genuine_nc).
+            ("unconnected-(U1-NC-Pad4)", "U1", "genuine_nc"),
+            ("unconnected-(U7-NC-Pad7)", "U7", "genuine_nc"),
+            ("unconnected-(U2-Vbat-Pad6)", "U2", "genuine_nc"),
+            # Connector-pin convention (connector_nc).
+            ("Net-(J2-Pad11)", "J2", "connector_nc"),
+            ("Net-(J2-3)", "J2", "connector_nc"),
+            ("Net-(P1-Pad5)", "P1", "connector_nc"),
+            # Real defects: IC pins.
+            ("Net-(U3-1)", "U3", "defect"),
+            ("Net-(U5-21)", "U5", "defect"),
+            ("Net-(Q1-Pad2)", "Q1", "defect"),
+            # Real defects: named signals.
+            ("UART_TX", "U8", "defect"),
+            ("I2S_BCLK", "J2", "defect"),
+            ("DBG_LED2", "U8", "defect"),
+            # Cross-prefix mismatch: net name says J but pad is on U
+            # (data inconsistency -- fall through to defect).
+            ("Net-(J5-1)", "U8", "defect"),
+        ],
+    )
+    def test_classification(self, net_name: str, ref: str, expected: str) -> None:
+        assert _classify_net(net_name, ref) == expected
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-PCB integration tests for the full rule
+# ---------------------------------------------------------------------------
+
+
+def _pad(number: str, net_number: int, net_name: str) -> Pad:
+    """Build a minimal Pad on F.Cu."""
+    return Pad(
+        number=number,
+        type="smd",
+        shape="rect",
+        position=(0.0, 0.0),
+        size=(1.0, 1.0),
+        layers=["F.Cu"],
+        net_number=net_number,
+        net_name=net_name,
+    )
+
+
+def _footprint(reference: str, pads: list[Pad]) -> Footprint:
+    """Build a minimal Footprint at the origin."""
+    return Footprint(
+        name="Test:TEST",
+        layer="F.Cu",
+        position=(0.0, 0.0),
+        rotation=0.0,
+        reference=reference,
+        value=reference,
+        pads=pads,
+    )
+
+
+def _make_synthetic_pcb(footprints: list[Footprint]) -> PCB:
+    """Build a :class:`PCB` instance directly from in-memory footprints.
+
+    This avoids the round-trip through S-expression parsing -- the
+    rule reads ``pcb.footprints`` directly (which proxies to
+    ``_footprints``).
+    """
+    pcb = PCB.__new__(PCB)
+    # ``pcb.footprints`` is a property backed by ``_footprints``.
+    pcb._footprints = list(footprints)
+    return pcb
+
+
+class TestRuleSeverityCategorization:
+    """SinglePadNetRule emits info/error per category."""
+
+    def test_genuine_nc_emits_info(self) -> None:
+        """A KiCad-emitted ``unconnected-...`` net is reported at info level."""
+        fp = _footprint(
+            "U1",
+            [_pad("4", net_number=42, net_name="unconnected-(U1-NC-Pad4)")],
+        )
+        pcb = _make_synthetic_pcb([fp])
+
+        rule = SinglePadNetRule()
+        results = rule.check(pcb, design_rules=None)
+
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert v.is_info, f"expected info severity, got {v.severity!r}"
+        assert "explicit no-connect" in v.message.lower()
+        assert v.nets == ("unconnected-(U1-NC-Pad4)",)
+
+    def test_connector_nc_emits_info(self) -> None:
+        """``Net-(J2-Pad11)`` on a J-prefixed footprint is info."""
+        fp = _footprint(
+            "J2", [_pad("11", net_number=43, net_name="Net-(J2-Pad11)")],
+        )
+        pcb = _make_synthetic_pcb([fp])
+
+        rule = SinglePadNetRule()
+        results = rule.check(pcb, design_rules=None)
+
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert v.is_info, f"expected info severity, got {v.severity!r}"
+        assert "connector pin" in v.message.lower()
+
+    def test_connector_nc_with_p_prefix_emits_info(self) -> None:
+        """``Net-(P1-Pad5)`` on a P-prefixed footprint is info."""
+        fp = _footprint(
+            "P1", [_pad("5", net_number=44, net_name="Net-(P1-Pad5)")],
+        )
+        pcb = _make_synthetic_pcb([fp])
+
+        rule = SinglePadNetRule()
+        results = rule.check(pcb, design_rules=None)
+
+        assert len(results.violations) == 1
+        assert results.violations[0].is_info
+
+    def test_named_signal_emits_error(self) -> None:
+        """A named-signal singleton (e.g., UART_TX) is a real defect."""
+        fp = _footprint(
+            "U8", [_pad("10", net_number=45, net_name="UART_TX")],
+        )
+        pcb = _make_synthetic_pcb([fp])
+
+        rule = SinglePadNetRule()
+        results = rule.check(pcb, design_rules=None)
+
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert v.is_error, f"expected error severity, got {v.severity!r}"
+        assert "missing footprint or schematic/PCB drift" in v.message
+
+    def test_ic_pin_default_name_emits_error(self) -> None:
+        """``Net-(U3-1)`` on an IC footprint is a real defect."""
+        fp = _footprint(
+            "U3", [_pad("1", net_number=46, net_name="Net-(U3-1)")],
+        )
+        pcb = _make_synthetic_pcb([fp])
+
+        rule = SinglePadNetRule()
+        results = rule.check(pcb, design_rules=None)
+
+        assert len(results.violations) == 1
+        assert results.violations[0].is_error
+
+    def test_mixed_design_categorizes_each_net(self) -> None:
+        """All three categories surface in a mixed-defect PCB.
+
+        This is the smoke-test for the chorus-test-revA scenario: 1
+        explicit NC, 1 connector NC, 2 real defects -- the rule must
+        emit 2 infos and 2 errors.
+        """
+        u1 = _footprint(
+            "U1",
+            [
+                _pad("1", net_number=1, net_name="VCC"),
+                _pad("2", net_number=2, net_name="VCC"),
+                _pad("4", net_number=3, net_name="unconnected-(U1-NC-Pad4)"),
+            ],
+        )
+        j2 = _footprint(
+            "J2",
+            [
+                _pad("11", net_number=4, net_name="Net-(J2-Pad11)"),  # connector_nc
+            ],
+        )
+        u8 = _footprint(
+            "U8",
+            [
+                # Multi-pad net so we have an "ok" reference net.
+                _pad("1", net_number=1, net_name="VCC"),
+                _pad("10", net_number=5, net_name="UART_TX"),  # defect
+            ],
+        )
+        u3 = _footprint(
+            "U3",
+            [
+                _pad("1", net_number=6, net_name="Net-(U3-1)"),  # defect (IC pin)
+            ],
+        )
+        pcb = _make_synthetic_pcb([u1, j2, u8, u3])
+
+        rule = SinglePadNetRule()
+        results = rule.check(pcb, design_rules=None)
+
+        # Expect 4 single-pad violations: 2 info + 2 error.
+        # The multi-pad VCC net should not fire.
+        assert len(results.violations) == 4
+        infos = [v for v in results.violations if v.is_info]
+        errors = [v for v in results.violations if v.is_error]
+        assert len(infos) == 2, [v.message for v in infos]
+        assert len(errors) == 2, [v.message for v in errors]
+
+        info_nets = {v.nets[0] for v in infos}
+        assert info_nets == {"unconnected-(U1-NC-Pad4)", "Net-(J2-Pad11)"}
+
+        error_nets = {v.nets[0] for v in errors}
+        assert error_nets == {"UART_TX", "Net-(U3-1)"}
+
+
+class TestRuleExistingBehaviorPreserved:
+    """The pour-net suppression and zero-violation cases still work."""
+
+    def test_no_single_pad_returns_empty(self) -> None:
+        """When every net is multi-pad, the rule emits nothing."""
+        u1 = _footprint(
+            "U1",
+            [_pad("1", net_number=1, net_name="SIG"), _pad("2", net_number=1, net_name="SIG")],
+        )
+        pcb = _make_synthetic_pcb([u1])
+        rule = SinglePadNetRule()
+        results = rule.check(pcb, design_rules=None)
+        assert results.violations == []
+        assert results.rules_checked == 1

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -79,9 +79,22 @@ class TestDRCViolation:
         assert warning.is_warning is True
 
     def test_violation_invalid_severity(self):
-        """Test that invalid severity raises ValueError."""
+        """Test that invalid severity raises ValueError.
+
+        Note: ``"info"`` is now a valid severity (issue #2613 added it
+        for the categorized single_pad_net rule and other advisory
+        findings).  This test uses a never-valid value to assert the
+        guard still rejects unknown severities.
+        """
         with pytest.raises(ValueError, match="severity must be"):
-            DRCViolation(rule_id="test", severity="info", message="test")
+            DRCViolation(rule_id="test", severity="critical", message="test")
+
+    def test_violation_info_severity_is_valid(self):
+        """``"info"`` severity is accepted post-#2613 for advisory findings."""
+        v = DRCViolation(rule_id="test", severity="info", message="advisory")
+        assert v.is_info is True
+        assert v.is_error is False
+        assert v.is_warning is False
 
     def test_violation_to_dict(self):
         """Test converting violation to dictionary."""

--- a/tests/test_validate_sch_orphan_label.py
+++ b/tests/test_validate_sch_orphan_label.py
@@ -1,0 +1,311 @@
+"""Unit tests for the orphan-label ERC rule.
+
+The orphan-label rule detects named global / local labels that connect
+to exactly one pin in the schematic.  See
+:mod:`kicad_tools.validate.sch_orphan_label` for the algorithm
+description.
+
+These tests build synthetic in-memory "schematics" using lightweight
+namespace objects (no S-expression parsing) so the algorithm can be
+exercised in isolation from the KiCad file format.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from kicad_tools.validate.sch_orphan_label import (
+    OrphanLabelFinding,
+    _is_intended_signal_name,
+    find_orphan_labels,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building synthetic Schematic / LibrarySymbol shims.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLibSymbol:
+    """A minimal stand-in for :class:`LibrarySymbol`.
+
+    Stores pin positions in absolute schematic coordinates so the
+    rule can probe them directly via ``get_all_pin_positions``.  The
+    ``instance_pos`` and ``instance_rot`` arguments are ignored --
+    callers building this object encode the final position already.
+    """
+
+    def __init__(self, pin_positions_abs: dict[str, tuple[float, float]]):
+        self._abs = pin_positions_abs
+
+    def get_all_pin_positions(
+        self, instance_pos, instance_rot=0, mirror="", snap_to_grid=True
+    ):
+        # Translate absolute coordinates by subtracting the requested
+        # instance position so a test can place the same library
+        # symbol at multiple positions.  The synthetic library always
+        # stores absolute pin positions.
+        return dict(self._abs)
+
+
+def _label(text: str, x: float, y: float):
+    """Build a synthetic Label-like object."""
+    return SimpleNamespace(text=text, position=(x, y))
+
+
+def _wire(x1: float, y1: float, x2: float, y2: float):
+    return SimpleNamespace(start=(x1, y1), end=(x2, y2))
+
+
+def _junction(x: float, y: float):
+    return SimpleNamespace(position=(x, y))
+
+
+def _no_connect(x: float, y: float):
+    return SimpleNamespace(position=(x, y))
+
+
+def _symbol(reference: str, lib_id: str, x: float = 0.0, y: float = 0.0,
+            rotation: float = 0.0, mirror: str = "", dnp: bool = False):
+    return SimpleNamespace(
+        reference=reference,
+        lib_id=lib_id,
+        position=(x, y),
+        rotation=rotation,
+        mirror=mirror,
+        dnp=dnp,
+    )
+
+
+def _sheet(
+    symbols=None,
+    labels=None,
+    global_labels=None,
+    hierarchical_labels=None,
+    wires=None,
+    junctions=None,
+    no_connects=None,
+):
+    return SimpleNamespace(
+        symbols=symbols or [],
+        labels=labels or [],
+        global_labels=global_labels or [],
+        hierarchical_labels=hierarchical_labels or [],
+        wires=wires or [],
+        junctions=junctions or [],
+        no_connects=no_connects or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_intended_signal_name
+# ---------------------------------------------------------------------------
+
+
+class TestIntendedSignalNameFilter:
+    """The filter accepts real signal names, rejects power & default nets."""
+
+    def test_accepts_named_signal(self):
+        assert _is_intended_signal_name("UART_TX")
+        assert _is_intended_signal_name("I2S_BCLK")
+        assert _is_intended_signal_name("DBG_LED2")
+        assert _is_intended_signal_name("NRST")
+        assert _is_intended_signal_name("SCK1")
+
+    def test_rejects_power_names(self):
+        assert not _is_intended_signal_name("GND")
+        assert not _is_intended_signal_name("VCC")
+        assert not _is_intended_signal_name("VDD")
+        assert not _is_intended_signal_name("+3V3")
+        assert not _is_intended_signal_name("+5V")
+        assert not _is_intended_signal_name("-12V")
+
+    def test_rejects_default_nets(self):
+        assert not _is_intended_signal_name("Net-(U1-Pad3)")
+        assert not _is_intended_signal_name("Net-(J2-11)")
+
+
+# ---------------------------------------------------------------------------
+# find_orphan_labels
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanLabelDetection:
+    """End-to-end synthetic-schematic tests for find_orphan_labels."""
+
+    def test_single_pin_global_label_is_orphan(self):
+        """A global label ``UART_TX`` connected only to one MCU pin fires.
+
+        Setup: U8 has pin "10" at (100, 80); a wire connects (100, 80)
+        to a global label at (110, 80).  No other pin or label exists.
+        Expectation: one finding for ``UART_TX``.
+        """
+        lib = _FakeLibSymbol({"10": (100.0, 80.0)})
+        u8 = _symbol("U8", "MCU:Test")
+        wire = _wire(100.0, 80.0, 110.0, 80.0)
+        lbl = _label("UART_TX", 110.0, 80.0)
+        sheet = _sheet(symbols=[u8], global_labels=[lbl], wires=[wire])
+
+        findings = find_orphan_labels(
+            sheets=[("root.kicad_sch", sheet)],
+            lib_symbols={"MCU:Test": lib},
+        )
+
+        assert len(findings) == 1
+        assert findings[0].label_name == "UART_TX"
+        assert findings[0].pin_ref == "U8.10"
+        assert findings[0].position_mm == (100.0, 80.0)
+
+    def test_multi_pin_label_is_not_orphan(self):
+        """A label reaching two pins is a healthy net, not an orphan."""
+        lib = _FakeLibSymbol({"10": (100.0, 80.0)})
+        lib2 = _FakeLibSymbol({"8": (200.0, 80.0)})
+        u8 = _symbol("U8", "MCU:Test")
+        j2 = _symbol("J2", "Conn:Test")
+        # Wire from pin to label
+        w1 = _wire(100.0, 80.0, 110.0, 80.0)
+        # Wire from label to other pin
+        w2 = _wire(110.0, 80.0, 200.0, 80.0)
+        lbl = _label("UART_TX", 110.0, 80.0)
+        sheet = _sheet(
+            symbols=[u8, j2],
+            global_labels=[lbl],
+            wires=[w1, w2],
+        )
+
+        findings = find_orphan_labels(
+            sheets=[("root.kicad_sch", sheet)],
+            lib_symbols={"MCU:Test": lib, "Conn:Test": lib2},
+        )
+
+        assert findings == []
+
+    def test_power_label_not_flagged(self):
+        """A single-pin label named ``GND`` is silently allowed."""
+        lib = _FakeLibSymbol({"1": (50.0, 50.0)})
+        u1 = _symbol("U1", "Power:Test")
+        wire = _wire(50.0, 50.0, 60.0, 50.0)
+        lbl = _label("GND", 60.0, 50.0)
+        sheet = _sheet(symbols=[u1], global_labels=[lbl], wires=[wire])
+
+        findings = find_orphan_labels(
+            sheets=[("root.kicad_sch", sheet)],
+            lib_symbols={"Power:Test": lib},
+        )
+
+        assert findings == []
+
+    def test_no_connect_suppresses_orphan(self):
+        """An explicit no_connect at the lone pin silences the finding."""
+        lib = _FakeLibSymbol({"4": (30.0, 40.0)})
+        u1 = _symbol("U1", "Test:Test")
+        wire = _wire(30.0, 40.0, 40.0, 40.0)
+        lbl = _label("SPARE_GPIO", 40.0, 40.0)
+        nc = _no_connect(30.0, 40.0)
+        sheet = _sheet(
+            symbols=[u1], global_labels=[lbl], wires=[wire], no_connects=[nc],
+        )
+
+        findings = find_orphan_labels(
+            sheets=[("root.kicad_sch", sheet)],
+            lib_symbols={"Test:Test": lib},
+        )
+
+        assert findings == []
+
+    def test_default_named_net_not_flagged(self):
+        """A label named ``Net-(U1-Pad3)`` is silently allowed.
+
+        Default-named nets are categorized by the PCB-side
+        single_pad_net DRC rule, not the orphan-label ERC rule.
+        """
+        lib = _FakeLibSymbol({"3": (30.0, 40.0)})
+        u1 = _symbol("U1", "Test:Test")
+        wire = _wire(30.0, 40.0, 40.0, 40.0)
+        lbl = _label("Net-(U1-Pad3)", 40.0, 40.0)
+        sheet = _sheet(symbols=[u1], global_labels=[lbl], wires=[wire])
+
+        findings = find_orphan_labels(
+            sheets=[("root.kicad_sch", sheet)],
+            lib_symbols={"Test:Test": lib},
+        )
+
+        assert findings == []
+
+    def test_multiple_orphans_reported_individually(self):
+        """When multiple labels orphan-fire, each is reported."""
+        lib_mcu = _FakeLibSymbol({
+            "9": (50.0, 50.0),
+            "10": (50.0, 52.54),
+        })
+        u8 = _symbol("U8", "MCU:Test")
+        w1 = _wire(50.0, 50.0, 60.0, 50.0)
+        w2 = _wire(50.0, 52.54, 60.0, 52.54)
+        l1 = _label("UART_TX", 60.0, 50.0)
+        l2 = _label("UART_RX", 60.0, 52.54)
+        sheet = _sheet(symbols=[u8], global_labels=[l1, l2], wires=[w1, w2])
+
+        findings = find_orphan_labels(
+            sheets=[("root.kicad_sch", sheet)],
+            lib_symbols={"MCU:Test": lib_mcu},
+        )
+
+        names = sorted(f.label_name for f in findings)
+        assert names == ["UART_RX", "UART_TX"]
+
+    def test_finding_has_error_severity(self):
+        """OrphanLabelFinding.kind defaults to ``"error"``."""
+        lib = _FakeLibSymbol({"1": (10.0, 10.0)})
+        u1 = _symbol("U1", "Test:Test")
+        wire = _wire(10.0, 10.0, 20.0, 10.0)
+        lbl = _label("TEST_NET", 20.0, 10.0)
+        sheet = _sheet(symbols=[u1], global_labels=[lbl], wires=[wire])
+
+        findings = find_orphan_labels(
+            sheets=[("root.kicad_sch", sheet)],
+            lib_symbols={"Test:Test": lib},
+        )
+
+        assert len(findings) == 1
+        assert findings[0].kind == "error"
+        assert isinstance(findings[0], OrphanLabelFinding)
+
+
+class TestDnpAndMissingLibSymbol:
+    """Defensive cases: DNP symbols and missing library defs are ignored."""
+
+    def test_dnp_symbol_pins_not_counted(self):
+        """A label only attached to a DNP symbol's pin is not flagged.
+
+        (Edge case: DNP components are excluded from the active
+        design, so an orphan global label on a DNP pin is vacuously
+        ok -- there's no real pin to count.)
+        """
+        lib = _FakeLibSymbol({"1": (10.0, 10.0)})
+        u1 = _symbol("U1", "Test:Test", dnp=True)
+        wire = _wire(10.0, 10.0, 20.0, 10.0)
+        lbl = _label("DNP_SIG", 20.0, 10.0)
+        sheet = _sheet(symbols=[u1], global_labels=[lbl], wires=[wire])
+
+        findings = find_orphan_labels(
+            sheets=[("root.kicad_sch", sheet)],
+            lib_symbols={"Test:Test": lib},
+        )
+
+        # No pins resolved -> no orphan signal to report.
+        assert findings == []
+
+    def test_unresolved_lib_id_skipped(self):
+        """A symbol with no resolved lib symbol contributes no pins."""
+        u1 = _symbol("U1", "Unknown:Symbol")
+        wire = _wire(10.0, 10.0, 20.0, 10.0)
+        lbl = _label("MYSTERY_NET", 20.0, 10.0)
+        sheet = _sheet(symbols=[u1], global_labels=[lbl], wires=[wire])
+
+        findings = find_orphan_labels(
+            sheets=[("root.kicad_sch", sheet)],
+            lib_symbols={},  # empty: lib_id not resolvable
+        )
+
+        # No pins resolved -> no orphan to flag.
+        assert findings == []

--- a/tests/test_validate_sch_wire_stub.py
+++ b/tests/test_validate_sch_wire_stub.py
@@ -1,0 +1,325 @@
+"""Unit tests for the wire-stub ERC rule.
+
+The wire-stub rule detects wires whose dangling endpoint is an exact
+integer multiple of the schematic grid short of a real pin -- the
+canonical "off-by-N-grids" defect class found in the chorus-test-revA
+schematic.  See :mod:`kicad_tools.validate.sch_wire_stub` for the
+algorithm description.
+
+These tests build synthetic in-memory "schematics" using lightweight
+namespace objects (no S-expression parsing).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from kicad_tools.validate.sch_wire_stub import (
+    DEFAULT_GRID_MM,
+    WireStubFinding,
+    find_wire_stubs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic schematic helpers (parallel to the orphan-label tests)
+# ---------------------------------------------------------------------------
+
+
+class _FakeLibSymbol:
+    def __init__(self, pin_positions_abs: dict[str, tuple[float, float]]):
+        self._abs = pin_positions_abs
+
+    def get_all_pin_positions(
+        self, instance_pos, instance_rot=0, mirror="", snap_to_grid=True
+    ):
+        return dict(self._abs)
+
+
+def _wire(x1: float, y1: float, x2: float, y2: float):
+    return SimpleNamespace(start=(x1, y1), end=(x2, y2))
+
+
+def _symbol(reference: str, lib_id: str, dnp: bool = False):
+    return SimpleNamespace(
+        reference=reference,
+        lib_id=lib_id,
+        position=(0.0, 0.0),
+        rotation=0.0,
+        mirror="",
+        dnp=dnp,
+    )
+
+
+def _junction(x: float, y: float):
+    return SimpleNamespace(position=(x, y))
+
+
+def _label_at(x: float, y: float):
+    return SimpleNamespace(text="", position=(x, y))
+
+
+def _no_connect(x: float, y: float):
+    return SimpleNamespace(position=(x, y))
+
+
+def _sheet(symbols=None, wires=None, junctions=None, labels=None,
+           global_labels=None, hierarchical_labels=None, no_connects=None):
+    return SimpleNamespace(
+        symbols=symbols or [],
+        wires=wires or [],
+        junctions=junctions or [],
+        labels=labels or [],
+        global_labels=global_labels or [],
+        hierarchical_labels=hierarchical_labels or [],
+        no_connects=no_connects or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# find_wire_stubs
+# ---------------------------------------------------------------------------
+
+
+class TestWireStubDetection:
+    """End-to-end synthetic-schematic tests."""
+
+    def test_one_grid_short_horizontal_stub(self):
+        """The canonical chorus-test pattern: wire ends 2.54mm short of J2 pin.
+
+        Setup: a wire from (60.0, 80.0) to (81.28, 80.0); the target
+        pin J2.8 is at (83.82, 80.0).  Endpoint x=81.28 is exactly
+        one 2.54mm grid step short of x=83.82.
+        """
+        lib = _FakeLibSymbol({"8": (83.82, 80.0)})
+        j2 = _symbol("J2", "Conn:Test")
+        w = _wire(60.0, 80.0, 81.28, 80.0)
+        sheet = _sheet(symbols=[j2], wires=[w])
+
+        findings = find_wire_stubs(
+            sheets=[("connectors.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert len(findings) == 1
+        f = findings[0]
+        assert isinstance(f, WireStubFinding)
+        assert f.candidate_pin_ref == "J2.8"
+        assert f.grid_steps_short == 1
+        assert f.axis == "x"
+        assert f.dangling_endpoint == (81.28, 80.0)
+        assert f.candidate_pin_position == (83.82, 80.0)
+
+    def test_two_grids_short_horizontal_stub(self):
+        """A 2-grid (5.08mm) gap is still detected and reported correctly."""
+        lib = _FakeLibSymbol({"1": (88.9, 60.0)})
+        j = _symbol("J1", "Conn:Test")
+        w = _wire(60.0, 60.0, 78.74, 60.0)  # 88.9 - 78.74 = 10.16mm = 4 grids
+        sheet = _sheet(symbols=[j], wires=[w])
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert len(findings) == 1
+        assert findings[0].grid_steps_short == 4
+
+    def test_vertical_stub_detected(self):
+        """A wire ending one grid above its target pin fires the rule."""
+        lib = _FakeLibSymbol({"3": (50.0, 80.0)})
+        j = _symbol("J3", "Conn:Test")
+        # Wire ends one grid above the pin: y = 77.46 vs pin y=80.0
+        w = _wire(50.0, 70.0, 50.0, 77.46)
+        sheet = _sheet(symbols=[j], wires=[w])
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert len(findings) == 1
+        assert findings[0].axis == "y"
+        assert findings[0].grid_steps_short == 1
+
+    def test_endpoint_on_pin_not_flagged(self):
+        """A wire that already terminates on a pin is NOT flagged."""
+        lib = _FakeLibSymbol({"8": (83.82, 80.0)})
+        j2 = _symbol("J2", "Conn:Test")
+        w = _wire(60.0, 80.0, 83.82, 80.0)  # exact match -- no stub
+        sheet = _sheet(symbols=[j2], wires=[w])
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert findings == []
+
+    def test_endpoint_on_junction_not_flagged(self):
+        """A wire endpoint at a junction is connected, not a stub."""
+        lib = _FakeLibSymbol({"8": (83.82, 80.0)})
+        j2 = _symbol("J2", "Conn:Test")
+        w = _wire(60.0, 80.0, 81.28, 80.0)
+        jct = _junction(81.28, 80.0)
+        sheet = _sheet(symbols=[j2], wires=[w], junctions=[jct])
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert findings == []
+
+    def test_endpoint_on_label_not_flagged(self):
+        """A wire endpoint at a label is connected (label is a real anchor)."""
+        lib = _FakeLibSymbol({"8": (83.82, 80.0)})
+        j2 = _symbol("J2", "Conn:Test")
+        w = _wire(60.0, 80.0, 81.28, 80.0)
+        lbl = _label_at(81.28, 80.0)
+        sheet = _sheet(symbols=[j2], wires=[w], global_labels=[lbl])
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert findings == []
+
+    def test_endpoint_on_no_connect_not_flagged(self):
+        """A wire endpoint at a no_connect flag is intentional, not a stub."""
+        lib = _FakeLibSymbol({"8": (83.82, 80.0)})
+        j2 = _symbol("J2", "Conn:Test")
+        w = _wire(60.0, 80.0, 81.28, 80.0)
+        nc = _no_connect(81.28, 80.0)
+        sheet = _sheet(symbols=[j2], wires=[w], no_connects=[nc])
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert findings == []
+
+    def test_sub_grid_offset_not_flagged(self):
+        """An endpoint less than one grid step from a pin is NOT flagged.
+
+        These are caught by KiCad's built-in ``endpoint_off_grid`` rule
+        and would duplicate the report.
+        """
+        lib = _FakeLibSymbol({"8": (83.82, 80.0)})
+        j2 = _symbol("J2", "Conn:Test")
+        # 0.5mm short -- below one grid step (2.54mm).
+        w = _wire(60.0, 80.0, 83.32, 80.0)
+        sheet = _sheet(symbols=[j2], wires=[w])
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert findings == []
+
+    def test_non_integer_grid_offset_not_flagged(self):
+        """An endpoint not an integer multiple of the grid is NOT flagged.
+
+        These are also caught by ``endpoint_off_grid`` separately.
+        """
+        lib = _FakeLibSymbol({"8": (83.82, 80.0)})
+        j2 = _symbol("J2", "Conn:Test")
+        # Off-grid: 80.0 + 1.5mm = neither integer multiple of 2.54.
+        w = _wire(60.0, 80.0, 82.32, 80.0)
+        sheet = _sheet(symbols=[j2], wires=[w])
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert findings == []
+
+    def test_max_grids_limit_respected(self):
+        """Stubs beyond max_stub_grids are NOT flagged."""
+        lib = _FakeLibSymbol({"8": (100.0, 80.0)})
+        j2 = _symbol("J2", "Conn:Test")
+        # 6 grid steps away: would be flagged if we allowed it.
+        w = _wire(60.0, 80.0, 84.76, 80.0)
+        sheet = _sheet(symbols=[j2], wires=[w])
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+            max_stub_grids=4,
+        )
+
+        assert findings == []
+
+    def test_multiple_stubs_each_reported(self):
+        """Replicates the chorus-test pattern: many wires all 1 grid short."""
+        lib = _FakeLibSymbol({
+            "8": (83.82, 72.39),
+            "10": (83.82, 74.93),
+            "12": (83.82, 85.09),
+        })
+        j2 = _symbol("J2", "Conn:Test")
+        w_tx = _wire(66.04, 72.39, 81.28, 72.39)   # UART_TX
+        w_rx = _wire(66.04, 74.93, 81.28, 74.93)   # UART_RX
+        w_bclk = _wire(54.61, 85.09, 81.28, 85.09)  # I2S_BCLK
+        sheet = _sheet(symbols=[j2], wires=[w_tx, w_rx, w_bclk])
+
+        findings = find_wire_stubs(
+            sheets=[("connectors.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert len(findings) == 3
+        pins = sorted(f.candidate_pin_ref for f in findings)
+        assert pins == ["J2.10", "J2.12", "J2.8"]
+        for f in findings:
+            assert f.grid_steps_short == 1
+            assert f.axis == "x"
+
+    def test_dnp_symbol_pins_skipped(self):
+        """A DNP symbol's pins are not used as stub candidates."""
+        lib = _FakeLibSymbol({"8": (83.82, 80.0)})
+        j2 = _symbol("J2", "Conn:Test", dnp=True)
+        w = _wire(60.0, 80.0, 81.28, 80.0)
+        sheet = _sheet(symbols=[j2], wires=[w])
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Conn:Test": lib},
+        )
+
+        assert findings == []
+
+    def test_uses_custom_grid_mm(self):
+        """Caller can override the grid step (e.g., 1.27mm fine grid)."""
+        lib = _FakeLibSymbol({"1": (10.0, 10.0)})
+        u1 = _symbol("U1", "Test:Test")
+        # 1.27mm short -- one grid on a 1.27mm grid.
+        w = _wire(0.0, 10.0, 8.73, 10.0)
+        sheet = _sheet(symbols=[u1], wires=[w])
+
+        # On the default 2.54mm grid, 1.27 isn't an integer multiple.
+        findings_default = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Test:Test": lib},
+        )
+        assert findings_default == []
+
+        # On a 1.27mm grid, the stub is detected.
+        findings_fine = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Test:Test": lib},
+            grid_mm=1.27,
+        )
+        assert len(findings_fine) == 1
+        assert findings_fine[0].grid_steps_short == 1
+
+
+class TestWireStubDefaults:
+    """The module exposes documented defaults."""
+
+    def test_default_grid_is_2_54(self):
+        assert DEFAULT_GRID_MM == 2.54


### PR DESCRIPTION
## Summary

Implements four tooling improvements requested in issue #2613 to address the chorus-test 39-net single-pad firehose. Closes #2613.

- **Categorize SinglePadNetRule output** so agents see signal vs. noise: ``unconnected-(REF-PIN-PadN)`` -> info, ``Net-(JN-NN)`` connector convention -> info, everything else -> error. On ``chorus-test-revA_v18d.kicad_pcb`` this collapses 39 firehose entries into **7 errors + 11 infos** -- the curator's promised categorized output.
- **Update route-time banner** (``_emit_single_pad_net_warning``) to split into DEFECTS / connector NCs / explicit NCs sections.
- **Add orphan-label ERC rule** (``sch_orphan_label.py``): a named label that reaches only one pin is a real defect KiCad ERC misses.  Conservative: power rails and ``Net-(...)`` default-named nets are ignored; explicit ``no_connect`` flags silence the finding.
- **Add wire-stub ERC rule** (``sch_wire_stub.py``): wire endpoints an integer multiple of the schematic grid short of a pin position are flagged with the suggested grid step and pin to extend to.  Sub-grid misalignments are left to KiCad's built-in ``endpoint_off_grid`` rule.

Supporting changes:
- ``validate/violations.py`` accepts ``"info"`` severity with new ``is_info``, ``info_count``, ``infos`` accessors; infos never affect exit code.
- ``cli/check_cmd.py`` displays infos in a dedicated section and adds an ``infos`` field to JSON summaries.
- ``cli/sch_validate.py`` registers the two new check functions plus a shared ``_resolve_lib_symbols_for_design`` helper.
- Updated ``test_cli_check_single_pad_net.py`` to use a synthetic on-disk PCB (the previous fixture relied on board 05, which was fixed by commit e0459593 and stopped producing single-pad nets -- making the test silently fail before this PR).

## Test plan

- [x] Unit tests for ``_classify_net`` covering all three categories (20 tests, ``test_single_pad_net_categorization.py``)
- [x] Synthetic-fixture tests for ``find_orphan_labels`` (12 tests, ``test_validate_sch_orphan_label.py``)
- [x] Synthetic-fixture tests for ``find_wire_stubs`` (14 tests, ``test_validate_sch_wire_stub.py``)
- [x] ``DRCViolation`` now accepts ``"info"`` (regression test added)
- [x] Manual smoke test against ``/Users/rwalters/GitHub/chorus/hardware/chorus-test-revA/kicad/chorus-test-revA_v18d.kicad_pcb`` -- categorization produces 7 errors + 11 infos (was 39 in the old firehose)
- [x] All existing single-pad-net tests still pass: ``test_validate_single_pad_net.py``, ``test_single_pad_net_count.py``, ``test_single_pad_net_integration.py``, ``test_route_single_pad_warning.py``
- [x] All ``test_sch_validate_*`` tests still pass (507 tests)
- [x] ``ruff check`` clean on all modified files

## Acceptance criteria (from issue #2613)

- [x] Differentiate "NC from symbol" vs "single-pad from broken wire" in the warning (issue #2613, item 1)
- [x] Recognize ``Net-(JN-NN)`` connector-pin convention and auto-downgrade (item 2)
- [x] ERC orphan-label rule for named labels reaching only one pin (item 3)
- [x] Wire-stub detector for endpoints N×grid short of a pin (item 4)
- [x] Each new rule has unit tests on a synthetic fixture
- [x] chorus-test re-validated produces categorized output instead of 39-net firehose

Note: the curator's audit reported 7 wires terminating at ``x=81.28``; the current schematic (v18d, two months newer than the audit) has those wires properly landing on the J2 pins -- the wire-stub rule **correctly does not flag** them.  The synthetic-fixture tests in ``test_validate_sch_wire_stub.py`` exercise the canonical defect pattern so the rule will fire if the regression re-appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)