### PR TITLE
fix(validate): wire_stub filter tracks owning-wire identity, not position

### DIFF
--- a/src/kicad_tools/validate/sch_wire_stub.py
+++ b/src/kicad_tools/validate/sch_wire_stub.py
@@ -268,24 +268,21 @@ def find_wire_stubs(
         for lbl in sch.global_labels:
             labels_pos.append(lbl.position)
         no_connects = [(nc.position[0], nc.position[1]) for nc in sch.no_connects]
-        # Precompute every wire endpoint so we can check whether a
-        # given wire endpoint coincides with another wire (and is
-        # therefore part of a chain, not dangling).
-        all_wire_endpoints: list[tuple[float, float]] = []
-        for w in sch.wires:
-            all_wire_endpoints.append(w.start)
-            all_wire_endpoints.append(w.end)
+        # Precompute every wire endpoint with its owning wire's index
+        # so we can check whether a given wire endpoint coincides with
+        # *another* wire (and is therefore part of a chain, not
+        # dangling).  Tracking the owning wire by index — not by
+        # position — keeps legitimate shared corners detectable.  A
+        # position-based filter would drop other wires that happen to
+        # share an endpoint with the wire under inspection.
+        indexed_endpoints: list[tuple[int, tuple[float, float]]] = []
+        for w_idx, w in enumerate(sch.wires):
+            indexed_endpoints.append((w_idx, w.start))
+            indexed_endpoints.append((w_idx, w.end))
 
-        for wire in sch.wires:
+        for w_idx, wire in enumerate(sch.wires):
+            other_endpoints = [pos for idx, pos in indexed_endpoints if idx != w_idx]
             for endpoint in (wire.start, wire.end):
-                # Exclude this wire's other endpoint from the "other
-                # wires" set so a single isolated wire still flags
-                # both endpoints if both dangle.
-                other_endpoints = [
-                    p
-                    for p in all_wire_endpoints
-                    if not _approx_point(p, endpoint)
-                ]
                 if _endpoint_is_connected(
                     endpoint,
                     pin_positions,

--- a/tests/test_validate_sch_wire_stub.py
+++ b/tests/test_validate_sch_wire_stub.py
@@ -20,7 +20,6 @@ from kicad_tools.validate.sch_wire_stub import (
     find_wire_stubs,
 )
 
-
 # ---------------------------------------------------------------------------
 # Synthetic schematic helpers (parallel to the orphan-label tests)
 # ---------------------------------------------------------------------------
@@ -316,6 +315,73 @@ class TestWireStubDetection:
         )
         assert len(findings_fine) == 1
         assert findings_fine[0].grid_steps_short == 1
+
+
+class TestWireStubSharedCorners:
+    """Regression: two wires meeting at a corner share an endpoint.
+
+    The original implementation filtered the "other wires' endpoints"
+    set by position, which accidentally dropped legitimate corner
+    connections from other wires.  An L-shaped path consisting of two
+    perpendicular wires meeting at the corner was therefore reported
+    as a wire stub for both endpoints of both wires.  The fix tracks
+    owning-wire identity by index instead of by position.
+    """
+
+    def test_l_shaped_path_to_pin_not_flagged(self):
+        """Two wires forming a corner: horizontal segment reaches the
+        pin, vertical segment connects elsewhere.  The shared corner
+        endpoint is connected via the vertical wire, so neither wire
+        should be flagged.
+        """
+        lib = _FakeLibSymbol({"1": (101.6, 119.38)})
+        flg = _symbol("#FLG03", "power:PWR_FLAG")
+        horiz = _wire(93.98, 119.38, 101.6, 119.38)  # reaches pin
+        vert = _wire(93.98, 107.95, 93.98, 119.38)   # joins corner
+        # The (93.98, 107.95) endpoint needs an anchor so it doesn't
+        # fire the rule on its own — give it a label.
+        lbl = _label_at(93.98, 107.95)
+        sheet = _sheet(
+            symbols=[flg], wires=[horiz, vert], global_labels=[lbl]
+        )
+
+        findings = find_wire_stubs(
+            sheets=[("power.kicad_sch", sheet)],
+            lib_symbols={"power:PWR_FLAG": lib},
+        )
+
+        assert findings == []
+
+    def test_three_wires_at_shared_corner_not_flagged(self):
+        """T-junction of three wires meeting at the corner pin.  Two
+        approach from perpendicular directions; the third reaches the
+        pin.  None should fire.
+        """
+        lib = _FakeLibSymbol({"1": (50.0, 50.0)})
+        u = _symbol("U1", "Device:Test")
+        # All three wires share the (50.0, 50.0) corner = pin position.
+        horiz = _wire(40.0, 50.0, 50.0, 50.0)  # endpoint at pin
+        vert_up = _wire(50.0, 50.0, 50.0, 60.0)  # endpoint at pin
+        # vert_down ends 1 grid short — should fire normally
+        vert_down = _wire(50.0, 50.0, 50.0, 47.46)
+        # Anchor the dangling ends with labels so they don't fire
+        lbl_left = _label_at(40.0, 50.0)
+        lbl_up = _label_at(50.0, 60.0)
+        sheet = _sheet(
+            symbols=[u],
+            wires=[horiz, vert_up, vert_down],
+            global_labels=[lbl_left, lbl_up],
+        )
+
+        findings = find_wire_stubs(
+            sheets=[("test.kicad_sch", sheet)],
+            lib_symbols={"Device:Test": lib},
+        )
+
+        # vert_down (50.0, 47.46) is 1 grid short — flagged.
+        # horiz and vert_up both reach pin (50.0, 50.0) — not flagged.
+        assert len(findings) == 1
+        assert findings[0].dangling_endpoint == (50.0, 47.46)
 
 
 class TestWireStubDefaults:


### PR DESCRIPTION
## Summary

The `wire_stub` ERC rule introduced in #2618 produced false positives on every L-shaped path where two perpendicular wires share a corner.  On chorus-test-revA v18d this caused 25 phantom findings (50 raw, dedupe-2x per wire end) for wires that already correctly reached their target pin.  The fix tracks owning-wire identity by index instead of filtering by position.

## Changes

- `src/kicad_tools/validate/sch_wire_stub.py`: replace the position-based "other-wires' endpoints" filter in `find_wire_stubs` with an index-based one.  Build a `(wire_index, position)` list once per sheet, then for each wire under inspection take the entries whose `idx != current_wire_idx`.  This preserves the original intent ("don't let this wire's own other endpoint count as an external anchor") while letting other wires that legitimately share a position still register as connections.
- `tests/test_validate_sch_wire_stub.py`: add `TestWireStubSharedCorners` with two regression cases — a basic L-shaped path to a pin, and a three-wire shared corner where one wire is genuinely a stub and must still fire.

## Root cause

```python
# Before (buggy):
all_wire_endpoints = [w.start for w in sch.wires] + [w.end for w in sch.wires]
for wire in sch.wires:
    for endpoint in (wire.start, wire.end):
        other_endpoints = [p for p in all_wire_endpoints if not _approx_point(p, endpoint)]
        # ^ also drops the *other* wire's endpoint at the same corner
```

For two wires W1=(A,B), W2=(C,A) checking W1 endpoint A:
- W1.start=A is filtered (correct — it's this wire)
- **W2.end=A is also filtered** (incorrect — it's an external anchor)

`_endpoint_is_connected` then sees no other-wire endpoint at A and reports A as dangling.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `find_wire_stubs` filter tracks wire identity, not position | ✅ | `indexed_endpoints: list[tuple[int, tuple[float, float]]]`; filter `if idx != w_idx` |
| New regression test for L-shaped corner case | ✅ | `TestWireStubSharedCorners.test_l_shaped_path_to_pin_not_flagged` |
| Existing 14 wire-stub tests still pass | ✅ | `pytest tests/test_validate_sch_wire_stub.py` → 16 passed (14 existing + 2 new) |
| Re-validating chorus-test-revA reports 0 wire_stub findings (down from 25) | ✅ | `kct sch validate /Users/rwalters/GitHub/chorus/hardware/chorus-test-revA/kicad/chorus-test-revA.kicad_sch` → `wire_stub` count = 0 |

## Test Plan

- `uv run pytest tests/test_validate_sch_wire_stub.py --no-cov` → 16 passed
- `uv run pytest tests/ -k "validate or sch_wire or orphan_label or single_pad" --no-cov` → 1043 passed, 15 skipped
- `uv run ruff check src/kicad_tools/validate/sch_wire_stub.py tests/test_validate_sch_wire_stub.py` → All checks passed
- Manual: `uv run kct sch validate <chorus-test-revA.kicad_sch>` → `wire_stub` findings dropped from 25 to 0

Closes #2619