### PR TITLE
feat(router): wire placement-feedback into layer-escalation PARTIAL path

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1760,6 +1760,57 @@ def route_with_layer_escalation(
                 )
         return 1
 
+    # Issue #2621: placement-routing feedback for partial layer-escalation
+    # results.  The main single-pass entry point hooks ``_run_placement_feedback``
+    # at the end of routing (route_cmd.py around line 4802), but the
+    # auto-layers escalation path never reached that hook -- so
+    # ``--placement-feedback`` on a board that exhausts layer escalation
+    # with PARTIAL completion silently did nothing.  Engage the feedback
+    # loop here, mirroring the main-path trigger:
+    #   * only when escalation didn't already succeed,
+    #   * only when --placement-feedback is set,
+    #   * only when there are still failed nets to address.
+    # The loop mutates ``final_result.router.routes`` in place, so we
+    # refresh ``final_result``'s stats afterwards before optimize/save.
+    if (
+        successful_result is None
+        and getattr(args, "placement_feedback", False)
+        and final_result.router.routes is not None
+        and final_result.router.get_failed_nets()
+    ):
+        if not quiet:
+            print(
+                f"\n--- Engaging placement-routing feedback "
+                f"(escalation stalled at {final_result.completion * 100:.0f}%) ---"
+            )
+        _run_placement_feedback(
+            router=final_result.router,
+            pcb_path=pcb_path,
+            args=args,
+            quiet=quiet,
+        )
+        # Refresh completion stats from the post-feedback router state so
+        # optimize/save/summary all see the correct numbers.
+        _refreshed_multi_pad_ids = {
+            n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2
+        }
+        _refreshed = final_result.router.get_statistics(
+            nets_to_route_ids=_refreshed_multi_pad_ids
+        )
+        final_result.nets_routed = _refreshed["nets_routed"]
+        final_result.completion = (
+            final_result.nets_routed / final_result.nets_to_route
+            if final_result.nets_to_route > 0
+            else 1.0
+        )
+        final_result.success = final_result.completion >= args.min_completion
+        if not quiet:
+            print(
+                f"  Post-feedback: {final_result.nets_routed}/"
+                f"{final_result.nets_to_route} "
+                f"({final_result.completion * 100:.0f}%)"
+            )
+
     # Optimize traces
     if not args.no_optimize and final_result.router.routes:
         from kicad_tools.router.optimizer import (

--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -1180,3 +1180,182 @@ class TestCleanupBeforeStatistics:
         assert stats1 == stats2, (
             f"cleanup_artifacts is not idempotent: first={stats1}, second={stats2}"
         )
+
+
+class TestPlacementFeedbackOnPartial:
+    """Issue #2621: placement-feedback engages after a PARTIAL layer escalation.
+
+    Before the fix, ``route_with_layer_escalation`` finished its layer
+    sweep and went directly to optimize/save without ever consulting
+    ``_run_placement_feedback`` — so ``--placement-feedback`` was a no-op
+    whenever ``--auto-layers`` was on (the default).  The chorus-test
+    repro routed 30/48 nets (62%) and exited PARTIAL with the feedback
+    flag set but the loop never invoked.
+    """
+
+    def _make_mock_router(self, nets_routed, nets_to_route, overflow):
+        """Reuse the mock router pattern from TestEarlyTermination."""
+        from unittest.mock import MagicMock
+
+        router = MagicMock()
+        router.nets = {i: [f"pad{j}" for j in range(2)] for i in range(1, nets_to_route + 1)}
+        router.grid.width = 50.0
+        router.grid.height = 40.0
+        router.grid.get_total_overflow.return_value = overflow
+        router.get_statistics.return_value = {
+            "nets_routed": nets_routed,
+            "segments": 10,
+            "vias": 2,
+        }
+        router.routes = []  # truthy-list path: non-None but empty
+        router.get_failed_nets.return_value = list(range(1, nets_to_route - nets_routed + 1))
+        router.power_stall_abort = False
+        router._pour_nets_without_zones = set()
+        router.rules.via_diameter = 0.6
+        router.rules.min_drill_clearance = 0.0
+        router.rules.trace_width = 0.2
+        router.rules.trace_clearance = 0.15
+        return router
+
+    def _make_args(self, **overrides):
+        """Minimal args that exercise the placement-feedback branch."""
+        defaults = dict(
+            backend="python",
+            grid=0.25,
+            trace_width=0.2,
+            clearance=0.15,
+            via_drill=0.3,
+            via_diameter=0.6,
+            fine_pitch_clearance=None,
+            skip_nets=None,
+            auto_pour=False,
+            max_layers=2,  # Single attempt — keeps the test fast.
+            min_completion=0.95,
+            strategy="negotiated",
+            verbose=False,
+            force=False,
+            timeout=60,
+            iterations=3,
+            per_net_timeout=None,
+            batch_routing=False,
+            high_performance=False,
+            hierarchical=False,
+            perturbation=True,
+            two_phase=False,
+            multi_resolution=False,
+            edge_clearance=0.25,
+            escape_routing=None,
+            no_optimize=True,
+            dry_run=True,
+            # placement-feedback flags (CLI defaults except where overridden)
+            placement_feedback=False,
+            placement_feedback_budget=3,
+            placement_feedback_max_movement=5.0,
+            placement_feedback_anchor=None,
+            placement_feedback_no_anchor=None,
+            placement_feedback_stagnation_patience=3,
+            placement_feedback_outer_timeout=None,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    @patch("kicad_tools.cli.route_cmd._run_placement_feedback")
+    def test_partial_invokes_feedback_when_flag_set(
+        self, mock_feedback, _esc_flag, _esc_use, _pour, tmp_path
+    ):
+        """PARTIAL + --placement-feedback => loop is invoked exactly once."""
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+        out = tmp_path / "out.kicad_pcb"
+
+        # PARTIAL: 2/3 nets routed, some overflow.
+        router = self._make_mock_router(nets_routed=2, nets_to_route=3, overflow=5)
+
+        def mock_load(*args, **kwargs):
+            return router, {}
+
+        with patch("kicad_tools.router.load_pcb_for_routing", mock_load):
+            with patch("kicad_tools.router.is_cpp_available", return_value=False):
+                route_with_layer_escalation(
+                    pcb, out, self._make_args(placement_feedback=True), quiet=True
+                )
+
+        assert mock_feedback.call_count == 1, (
+            f"Expected placement-feedback to be invoked once on PARTIAL, got "
+            f"{mock_feedback.call_count}"
+        )
+        # And it must have been called with the final_result's router.
+        kwargs = mock_feedback.call_args.kwargs
+        assert kwargs["router"] is router
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    @patch("kicad_tools.cli.route_cmd._run_placement_feedback")
+    def test_partial_skips_feedback_when_flag_unset(
+        self, mock_feedback, _esc_flag, _esc_use, _pour, tmp_path
+    ):
+        """PARTIAL without --placement-feedback => loop is not invoked."""
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+        out = tmp_path / "out.kicad_pcb"
+
+        router = self._make_mock_router(nets_routed=2, nets_to_route=3, overflow=5)
+
+        def mock_load(*args, **kwargs):
+            return router, {}
+
+        with patch("kicad_tools.router.load_pcb_for_routing", mock_load):
+            with patch("kicad_tools.router.is_cpp_available", return_value=False):
+                route_with_layer_escalation(
+                    pcb, out, self._make_args(placement_feedback=False), quiet=True
+                )
+
+        assert mock_feedback.call_count == 0, (
+            f"Placement-feedback should be skipped without --placement-feedback, "
+            f"got {mock_feedback.call_count} invocations"
+        )
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    @patch("kicad_tools.cli.route_cmd._run_placement_feedback")
+    def test_success_skips_feedback_even_with_flag(
+        self, mock_feedback, _esc_flag, _esc_use, _pour, tmp_path
+    ):
+        """SUCCESS + --placement-feedback => loop is not invoked.
+
+        Placement-feedback is purely remedial — nothing to do when the
+        route already meets ``min_completion``.
+        """
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+        out = tmp_path / "out.kicad_pcb"
+
+        # 3/3 nets routed — meets default min_completion=0.95.
+        router = self._make_mock_router(nets_routed=3, nets_to_route=3, overflow=0)
+        # No failed nets when fully routed.
+        router.get_failed_nets.return_value = []
+
+        def mock_load(*args, **kwargs):
+            return router, {}
+
+        with patch("kicad_tools.router.load_pcb_for_routing", mock_load):
+            with patch("kicad_tools.router.is_cpp_available", return_value=False):
+                route_with_layer_escalation(
+                    pcb, out, self._make_args(placement_feedback=True), quiet=True
+                )
+
+        assert mock_feedback.call_count == 0, (
+            f"Placement-feedback should not run on SUCCESS, got "
+            f"{mock_feedback.call_count} invocations"
+        )


### PR DESCRIPTION
## Summary

\`--placement-feedback\` was silently a no-op for the most common routing entry point.  The hook only existed on the single-layer-attempt branch in \`route_cmd.py\` (around line 4802).  When \`--auto-layers\` was active (the default), routing went through \`route_with_layer_escalation\`, which never consulted the feedback loop — even with PARTIAL completion and the flag set.  Chorus-test v19 hit exactly this: 30/48 nets routed (62%), \`--placement-feedback\` set, loop never invoked.

This wires the trigger into the escalation path with the same gating as the single-attempt branch.

## Changes

- **\`src/kicad_tools/cli/route_cmd.py\`** (\`route_with_layer_escalation\`): after the escalation summary block selects \`final_result\` from \`best_result\` (PARTIAL case) and before \`Optimize traces\`, engage \`_run_placement_feedback\` when:
  - \`successful_result is None\` (the loop didn't already converge), AND
  - \`getattr(args, "placement_feedback", False)\` is set, AND
  - \`final_result.router.get_failed_nets()\` is non-empty.

  After the loop returns (it mutates \`router.routes\` in place), refresh \`final_result.nets_routed\`, \`.completion\`, \`.success\` from \`router.get_statistics\` so downstream optimize/save/summary all see post-feedback numbers.

- **\`tests/test_layer_escalation.py\`** (new \`TestPlacementFeedbackOnPartial\`): three regression tests covering the gating logic.
  1. PARTIAL + flag → \`_run_placement_feedback\` invoked exactly once, with the final_result's router.
  2. PARTIAL without flag → not invoked.
  3. SUCCESS + flag → not invoked (purely remedial; nothing to do when min_completion is met).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Placement-feedback engages for BLOCKED_PATH failures | ✅ | The CLI trigger is cause-agnostic (filters on \`get_failed_nets()\` only). The actual gap was that the trigger wasn't called from the escalation path; now it is, regardless of failure cause. |
| When the route also has BLOCKED_BY_COMPONENT failures, both cause types are addressed | ✅ | Same — the loop processes every failed net via \`analyze_routing_failure\`; the strategy generator already handles both BLOCKED_PATH and CONGESTION causes (\`recovery/strategy.py:78\`). |
| chorus-test-revA_v19_stripped.kicad_pcb: placement-feedback now activates and improves above 62% | ⚠️ Partial | Activation verified via the 3 new tests. End-to-end improvement on the chorus fixture requires a live route (long-running, OS-dependent) — not part of this PR's CI loop. The trigger is wired; whether it produces strategies depends on the analyzer surfacing movable blockers, which is downstream of this fix. Filed sibling considerations below. |
| Existing placement-feedback tests still pass | ✅ | \`pytest tests/test_layer_escalation.py tests/test_route_cmd_placement_feedback.py tests/test_placement_feedback.py --no-cov\` → 136 passed |

## Out of scope (sibling considerations for follow-ups)

- The sibling escalation paths \`route_with_combined_escalation\` (--auto-layers + --adaptive-rules) and \`route_with_rule_relaxation\` (--adaptive-rules) likely have the same gap.  Not touched in this PR; can be a follow-up.
- If the analyzer reports no movable blockers for a BLOCKED_PATH failure (path blocked by a trace, not a component), the loop will engage but produce 0 strategies and exit.  Improving the analyzer's blocker detection is a separate concern; this PR is strictly about wiring up the trigger.
- Pre-existing failures in \`tests/test_chorus_test_placement_feedback.py\` (synthetic-fixture geometry no longer reliably blocks SIG1) are unrelated and present on \`main\`.

## Test Plan

- [x] \`uv run pytest tests/test_layer_escalation.py::TestPlacementFeedbackOnPartial --no-cov\` → 3 passed
- [x] \`uv run pytest tests/test_layer_escalation.py tests/test_route_cmd_placement_feedback.py tests/test_placement_feedback.py --no-cov\` → 136 passed
- [x] \`uv run ruff check\` on changed files: 1 new C408 in \`tests/test_layer_escalation.py\` (style nit consistent with sibling \`_make_args\` at line 786; pre-existing C408 stays out of scope per builder discipline)
- [x] Import smoke: \`python3 -c "from kicad_tools.cli.route_cmd import route_with_layer_escalation; print('OK')"\` → OK

Closes #2621