### PR TITLE
fix(validate): walk hierarchical sub-sheets in --sync/--consistency (closes #2625)

### DIFF
--- a/src/kicad_tools/validate/consistency.py
+++ b/src/kicad_tools/validate/consistency.py
@@ -32,6 +32,7 @@ LVS Example:
 from __future__ import annotations
 
 import re
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -683,6 +684,61 @@ class SchematicPCBChecker:
             unmatched_sch.discard(sch_ref)
             unmatched_pcb.discard(pcb_ref)
 
+    def _collect_schematic_components(self) -> dict[str, dict[str, str]]:
+        """Return {reference: {value, footprint}} for every schematic symbol.
+
+        Uses :func:`kicad_tools.schema.bom.extract_bom` with
+        ``hierarchical=True`` when a schematic path is known so that
+        symbols placed inside sub-sheets are included. When the checker
+        was constructed with a loaded :class:`Schematic` object (no
+        path), falls back to root-sheet-only enumeration and emits a
+        runtime warning -- this prevents the hierarchical-blindness bug
+        where every PCB footprint was reported as "extra" / every
+        schematic symbol as "missing" (see issue #2625).
+        """
+        sch_components: dict[str, dict[str, str]] = {}
+
+        if self._schematic_path:
+            from kicad_tools.schema.bom import extract_bom
+
+            bom = extract_bom(self._schematic_path, hierarchical=True)
+            for item in bom.items:
+                if item.is_power_symbol:
+                    continue
+                if not item.on_board:
+                    continue
+                if item.reference and not item.reference.startswith("#"):
+                    sch_components[item.reference] = {
+                        "value": item.value or "",
+                        "footprint": item.footprint or "",
+                    }
+            return sch_components
+
+        # Fallback: no path -> enumerate root sheet only.
+        if self._schematic_has_sheets():
+            warnings.warn(
+                "SchematicPCBChecker was constructed with a Schematic "
+                "object instead of a path; hierarchical sub-sheets will "
+                "be skipped and PCB footprints from those sheets will "
+                "appear as extra. Pass a schematic path to enable "
+                "hierarchical traversal.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
+        for sym in self.schematic.symbols:
+            if sym.reference and not sym.reference.startswith("#"):
+                sch_components[sym.reference] = {
+                    "value": sym.value or "",
+                    "footprint": getattr(sym, "footprint", "") or "",
+                }
+        return sch_components
+
+    def _schematic_has_sheets(self) -> bool:
+        """Return True if the loaded schematic contains sub-sheet references."""
+        sheets = getattr(self.schematic, "sheets", None)
+        return bool(sheets)
+
     def _check_components(self) -> list[ConsistencyIssue]:
         """Check component consistency (missing/extra).
 
@@ -691,12 +747,11 @@ class SchematicPCBChecker:
         """
         issues: list[ConsistencyIssue] = []
 
-        # Build reference sets, excluding power symbols
-        sch_refs = {
-            sym.reference
-            for sym in self.schematic.symbols
-            if sym.reference and not sym.reference.startswith("#")
-        }
+        # Walk all sub-sheets via extract_bom() when a path is known
+        # (issue #2625) so hierarchical schematics aren't reported as
+        # having every footprint extra.
+        sch_components = self._collect_schematic_components()
+        sch_refs = set(sch_components.keys())
 
         pcb_refs = {
             fp.reference
@@ -706,9 +761,7 @@ class SchematicPCBChecker:
 
         # Find components missing from PCB
         for ref in sorted(sch_refs - pcb_refs):
-            # Get footprint from schematic if available
-            sym = next(s for s in self.schematic.symbols if s.reference == ref)
-            footprint = getattr(sym, "footprint", "") or ""
+            footprint = sch_components[ref].get("footprint", "")
             footprint_hint = f" ({footprint})" if footprint else ""
 
             issues.append(
@@ -799,7 +852,9 @@ class SchematicPCBChecker:
         from kicad_tools.schematic.models import Schematic as ModelsSchematic
 
         sch_path = self._schematic_path or (
-            str(self.schematic.path) if hasattr(self.schematic, "path") and self.schematic.path else None
+            str(self.schematic.path)
+            if hasattr(self.schematic, "path") and self.schematic.path
+            else None
         )
         if not sch_path:
             return {}
@@ -823,14 +878,9 @@ class SchematicPCBChecker:
         """
         issues: list[ConsistencyIssue] = []
 
-        # Build lookup maps
-        sch_components: dict[str, dict[str, str]] = {}
-        for sym in self.schematic.symbols:
-            if sym.reference and not sym.reference.startswith("#"):
-                sch_components[sym.reference] = {
-                    "value": sym.value or "",
-                    "footprint": sym.footprint or "",
-                }
+        # Walk all sub-sheets so values/footprints from hierarchical
+        # designs are compared (issue #2625).
+        sch_components = self._collect_schematic_components()
 
         pcb_components: dict[str, dict[str, str]] = {}
         for fp in self.pcb.footprints:

--- a/src/kicad_tools/validate/netlist.py
+++ b/src/kicad_tools/validate/netlist.py
@@ -28,6 +28,7 @@ Example:
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -223,14 +224,25 @@ class NetlistValidator:
         """Initialize the validator.
 
         Args:
-            schematic: Path to schematic file or Schematic object
+            schematic: Path to schematic file or Schematic object.
+                A path is strongly preferred -- it enables hierarchical
+                BOM extraction so sub-sheet symbols are included. Passing
+                a loaded :class:`Schematic` object falls back to root-sheet
+                enumeration and emits a runtime warning on hierarchical
+                projects (see :issue:`2625`).
             pcb: Path to PCB file or PCB object
         """
         from kicad_tools.schema.pcb import PCB as PCBClass
         from kicad_tools.schema.schematic import Schematic as SchematicClass
 
+        # Track the schematic path so _check_components can use
+        # extract_bom(..., hierarchical=True). When the caller passes a
+        # Schematic object directly we cannot walk sub-sheets.
+        self._schematic_path: str | None = None
+
         # Load schematic if path provided
         if isinstance(schematic, (str, Path)):
+            self._schematic_path = str(schematic)
             self.schematic = SchematicClass.load(schematic)
         else:
             self.schematic = schematic
@@ -257,22 +269,76 @@ class NetlistValidator:
 
         return result
 
-    def _check_components(self, result: SyncResult) -> None:
-        """Check for missing and orphaned components.
+    def _collect_schematic_refs(self) -> dict[str, dict]:
+        """Build {reference: {value, lib_id, footprint}} for the schematic.
 
-        Args:
-            result: SyncResult to add issues to
+        Uses :func:`kicad_tools.schema.bom.extract_bom` with
+        ``hierarchical=True`` when a schematic path is known so that
+        symbols placed inside sub-sheets are included. When the validator
+        was constructed with a loaded :class:`Schematic` object (no path),
+        falls back to the legacy root-sheet-only enumeration and emits a
+        runtime warning so hierarchical bugs are surfaced rather than
+        silently producing false positives (see issue #2625).
         """
-        # Build reference sets
         sch_refs: dict[str, dict] = {}
+
+        if self._schematic_path:
+            from kicad_tools.schema.bom import extract_bom
+
+            bom = extract_bom(self._schematic_path, hierarchical=True)
+            for item in bom.items:
+                # Skip power symbols (their references start with "#").
+                if item.is_power_symbol:
+                    continue
+                # Skip components that are not placed on the PCB.
+                if not item.on_board:
+                    continue
+                if item.reference and not item.reference.startswith("#"):
+                    sch_refs[item.reference] = {
+                        "value": item.value,
+                        "lib_id": item.lib_id,
+                        "footprint": item.footprint,
+                    }
+            return sch_refs
+
+        # Fallback: no path available, can only enumerate the root sheet.
+        if self._schematic_has_sheets():
+            warnings.warn(
+                "NetlistValidator was constructed with a Schematic object "
+                "instead of a path; hierarchical sub-sheets will be skipped "
+                "and PCB footprints from those sheets will appear as "
+                "orphans. Pass a schematic path to enable hierarchical "
+                "traversal.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
         for sym in self.schematic.symbols:
-            # Skip power symbols and other non-component symbols
             if sym.reference and not sym.reference.startswith("#"):
                 sch_refs[sym.reference] = {
                     "value": sym.value,
                     "lib_id": sym.lib_id,
                     "footprint": getattr(sym, "footprint", ""),
                 }
+        return sch_refs
+
+    def _schematic_has_sheets(self) -> bool:
+        """Return True if the loaded schematic contains sub-sheet references."""
+        sheets = getattr(self.schematic, "sheets", None)
+        return bool(sheets)
+
+    def _check_components(self, result: SyncResult) -> None:
+        """Check for missing and orphaned components.
+
+        Args:
+            result: SyncResult to add issues to
+        """
+        # Build reference sets from the schematic. When we have a path,
+        # walk all sub-sheets via extract_bom() so hierarchical projects
+        # don't report every footprint as orphaned (issue #2625). When
+        # constructed with a Schematic object, fall back to root-sheet
+        # enumeration and warn the caller.
+        sch_refs: dict[str, dict] = self._collect_schematic_refs()
 
         pcb_refs: dict[str, dict] = {}
         for fp in self.pcb.footprints:

--- a/tests/test_validate_hierarchical_sync.py
+++ b/tests/test_validate_hierarchical_sync.py
@@ -1,0 +1,293 @@
+"""Regression tests for hierarchical schematic support in validate --sync/--consistency.
+
+Reproduces and guards against issue #2625, where ``NetlistValidator`` and
+``SchematicPCBChecker`` enumerated only the root sheet's symbols and
+therefore reported every PCB footprint placed in a sub-sheet as an
+orphan / extra component.
+
+The fix is to use ``extract_bom(..., hierarchical=True)`` so all
+sub-sheets are walked, mirroring the behaviour of ``pcb sync-netlist``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.validate.consistency import SchematicPCBChecker
+from kicad_tools.validate.netlist import NetlistValidator
+
+# Fixture root: tests/fixtures/hierarchical/root.kicad_sch references
+#   sub_a.kicad_sch (R2, C1) -> nested.kicad_sch (C2)
+#   sub_b.kicad_sch (R3, R4)
+# and contains R1 itself at the root.
+HIERARCHICAL_ROOT_SCH = Path(__file__).parent / "fixtures" / "hierarchical" / "root.kicad_sch"
+
+# PCB with every component that lives anywhere in the hierarchical
+# schematic. Refs match: R1 (root), R2/C1 (sub_a), C2 (sub_a/nested),
+# R3/R4 (sub_b). When the validator walks hierarchically every footprint
+# below should match a schematic symbol -> 0 orphans, 0 extras.
+HIERARCHICAL_PCB_MATCHING = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r1") (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r1-ref"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r1-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r2") (at 110 100)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r2-ref"))
+    (property "Value" "4.7k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r2-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-c1") (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-c1-ref"))
+    (property "Value" "100nF" (at 0 1.5 0) (layer "F.Fab") (uuid "p-c1-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+  (footprint "Capacitor_SMD:C_0603_1608Metric"
+    (layer "F.Cu") (uuid "fp-c2") (at 130 100)
+    (property "Reference" "C2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-c2-ref"))
+    (property "Value" "10uF" (at 0 1.5 0) (layer "F.Fab") (uuid "p-c2-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r3") (at 140 100)
+    (property "Reference" "R3" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r3-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r3-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r4") (at 150 100)
+    (property "Reference" "R4" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r4-ref"))
+    (property "Value" "2.2k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r4-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+)
+"""
+
+# PCB missing one of the sub-sheet footprints (C1, which lives in
+# sub_a.kicad_sch). After the fix the validator should report exactly
+# one ``missing_on_pcb`` issue -- proving the hierarchical walker is
+# actually being exercised rather than silently disabled.
+HIERARCHICAL_PCB_MISSING_C1 = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r1") (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r1-ref"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r1-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r2") (at 110 100)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r2-ref"))
+    (property "Value" "4.7k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r2-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+  (footprint "Capacitor_SMD:C_0603_1608Metric"
+    (layer "F.Cu") (uuid "fp-c2") (at 130 100)
+    (property "Reference" "C2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-c2-ref"))
+    (property "Value" "10uF" (at 0 1.5 0) (layer "F.Fab") (uuid "p-c2-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r3") (at 140 100)
+    (property "Reference" "R3" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r3-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r3-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r4") (at 150 100)
+    (property "Reference" "R4" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r4-ref"))
+    (property "Value" "2.2k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r4-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu"))
+  )
+)
+"""
+
+
+@pytest.fixture
+def hierarchical_matching_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "hierarchical_match.kicad_pcb"
+    pcb_file.write_text(HIERARCHICAL_PCB_MATCHING)
+    return pcb_file
+
+
+@pytest.fixture
+def hierarchical_missing_c1_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "hierarchical_missing_c1.kicad_pcb"
+    pcb_file.write_text(HIERARCHICAL_PCB_MISSING_C1)
+    return pcb_file
+
+
+class TestNetlistValidatorHierarchical:
+    """Regression: NetlistValidator must walk sub-sheets (issue #2625)."""
+
+    def test_in_sync_hierarchical_reports_zero_orphans(
+        self, hierarchical_matching_pcb: Path
+    ) -> None:
+        """An in-sync hierarchical project must report 0 orphaned footprints.
+
+        Before the fix this returned every sub-sheet footprint (R2, C1,
+        C2, R3, R4 -- 5 of 6) as orphaned because ``self.schematic.symbols``
+        on a hierarchical root contained only R1.
+        """
+        validator = NetlistValidator(
+            HIERARCHICAL_ROOT_SCH,
+            hierarchical_matching_pcb,
+        )
+        result = validator.validate()
+
+        # Every footprint maps to a sub-sheet symbol -> no orphans.
+        assert result.orphaned_on_pcb == [], (
+            "Hierarchical sub-sheet footprints reported as orphans; "
+            f"saw {[i.reference for i in result.orphaned_on_pcb]}"
+        )
+        # And nothing is missing on the PCB.
+        assert result.missing_on_pcb == [], (
+            f"Unexpected missing-on-PCB: {[i.reference for i in result.missing_on_pcb]}"
+        )
+
+    def test_missing_subsheet_symbol_still_detected(
+        self, hierarchical_missing_c1_pcb: Path
+    ) -> None:
+        """Deleting one sub-sheet footprint must produce exactly one missing issue.
+
+        Proves the hierarchical walker is *actually* being exercised --
+        if it silently fell back to root-only enumeration, removing C1
+        (which lives in sub_a) would be invisible to the validator.
+        """
+        validator = NetlistValidator(
+            HIERARCHICAL_ROOT_SCH,
+            hierarchical_missing_c1_pcb,
+        )
+        result = validator.validate()
+
+        missing_refs = sorted(i.reference for i in result.missing_on_pcb)
+        assert missing_refs == ["C1"], (
+            f"Expected exactly C1 missing on PCB, got {missing_refs}. "
+            "If the list is empty the hierarchical walker is bypassed; "
+            "if R2/C2/R3/R4 also appear the matcher is broken."
+        )
+        # No spurious orphans either.
+        assert result.orphaned_on_pcb == []
+
+    def test_schematic_object_input_warns_on_hierarchical_root(
+        self, hierarchical_matching_pcb: Path
+    ) -> None:
+        """Passing a Schematic *object* on a hierarchical project warns.
+
+        We cannot walk sub-sheets without a path, so the caller must be
+        warned that they are getting the legacy root-only behaviour.
+        """
+        from kicad_tools.schema.schematic import Schematic
+
+        sch = Schematic.load(HIERARCHICAL_ROOT_SCH)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validator = NetlistValidator(sch, hierarchical_matching_pcb)
+            validator.validate()
+
+        runtime_warns = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        assert runtime_warns, (
+            "Expected a RuntimeWarning when NetlistValidator is constructed "
+            "with a Schematic object on a hierarchical schematic."
+        )
+        assert any("hierarchical" in str(w.message).lower() for w in runtime_warns)
+
+
+class TestSchematicPCBCheckerHierarchical:
+    """Regression: SchematicPCBChecker must walk sub-sheets (issue #2625)."""
+
+    def test_consistent_hierarchical_reports_no_component_issues(
+        self, hierarchical_matching_pcb: Path
+    ) -> None:
+        """An in-sync hierarchical project must show 0 component issues."""
+        checker = SchematicPCBChecker(
+            HIERARCHICAL_ROOT_SCH,
+            hierarchical_matching_pcb,
+        )
+        result = checker.check()
+
+        missing = [i for i in result.component_issues if i.issue_type == "missing"]
+        extra = [i for i in result.component_issues if i.issue_type == "extra"]
+        assert missing == [], (
+            f"Hierarchical sub-sheet symbols reported as missing: {[i.reference for i in missing]}"
+        )
+        assert extra == [], (
+            f"PCB footprints from sub-sheets reported as extra: {[i.reference for i in extra]}"
+        )
+
+    def test_missing_subsheet_symbol_still_detected(
+        self, hierarchical_missing_c1_pcb: Path
+    ) -> None:
+        """Removing one sub-sheet footprint must still surface as missing."""
+        checker = SchematicPCBChecker(
+            HIERARCHICAL_ROOT_SCH,
+            hierarchical_missing_c1_pcb,
+        )
+        result = checker.check()
+
+        missing_refs = sorted(
+            i.reference for i in result.component_issues if i.issue_type == "missing"
+        )
+        assert missing_refs == ["C1"], f"Expected exactly C1 missing, got {missing_refs}"
+        extra_refs = sorted(i.reference for i in result.component_issues if i.issue_type == "extra")
+        assert extra_refs == []
+
+    def test_schematic_object_input_warns_on_hierarchical_root(
+        self, hierarchical_matching_pcb: Path
+    ) -> None:
+        """Passing a Schematic object on a hierarchical project warns."""
+        from kicad_tools.schema.schematic import Schematic
+
+        sch = Schematic.load(HIERARCHICAL_ROOT_SCH)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            checker = SchematicPCBChecker(sch, hierarchical_matching_pcb)
+            checker.check()
+
+        runtime_warns = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        assert runtime_warns, (
+            "Expected a RuntimeWarning when SchematicPCBChecker is "
+            "constructed with a Schematic object on a hierarchical schematic."
+        )


### PR DESCRIPTION
## Summary

Closes #2625.

`NetlistValidator._check_components` and `SchematicPCBChecker._check_components` / `_check_properties` enumerated `self.schematic.symbols`, which only returns the symbols placed on the *root* sheet. On any hierarchical project this caused every PCB footprint placed in a sub-sheet to be reported as an orphan / extra component. The curator reproduced 90 false positives on chorus-test-revA v19.

Both validators now use `extract_bom(path, hierarchical=True)` -- the same primitive `pcb sync-netlist` (`src/kicad_tools/cli/pcb_sync_netlist.py:116`) already uses -- so symbols from every sub-sheet are included.

- `NetlistValidator.__init__` now stores `self._schematic_path` (mirrors `SchematicPCBChecker`).
- New `_collect_schematic_refs` / `_collect_schematic_components` helpers walk the hierarchy via `extract_bom` when a path is available, filtering power symbols and `on_board=False` items.
- When constructed with a `Schematic` *object* (no path), legacy root-only behaviour is preserved but a `RuntimeWarning` is emitted if the schematic contains sheet references, so the bug is surfaced rather than producing silent false positives.

### Audit of sibling validate flags (per curator)

| Flag | Status |
|---|---|
| `--sync` (`netlist.py:268`) | Fixed in this PR |
| `--consistency` (`consistency.py:697, 710, 828`) | Fixed in this PR |
| `--lvs` (`consistency.py:435`) | Already correct -- uses `extract_bom(..., hierarchical=True)` |
| `--placement` (`placement.py:224`) | Already correct -- `extract_bom` defaults to `hierarchical=True` |

No code change required for `--lvs` / `--placement`.

### Follow-up not in scope

The curator flagged `_extract_schematic_pin_nets` in `consistency.py:807` (uses `models_sch.extract_netlist()`) as potentially hierarchical-blind. Determining whether `ModelsSchematic.extract_netlist()` walks sub-sheets is out of scope; recommend filing a follow-up issue if confirmed.

## Test plan

- [x] New regression suite `tests/test_validate_hierarchical_sync.py` (6 tests) using existing `tests/fixtures/hierarchical/root.kicad_sch` tree:
  - in-sync hierarchical project -> `NetlistValidator.validate().orphaned_on_pcb == []` and `SchematicPCBChecker.check()` reports 0 component issues
  - removing one sub-sheet footprint -> exactly that ref is reported as missing (proves the hierarchical walker is actually being exercised, not just disabled)
  - passing a `Schematic` object on a hierarchical schematic emits a `RuntimeWarning`
- [x] Existing tests still pass: `tests/test_netlist_sync.py`, `tests/test_consistency.py`, `tests/test_lvs.py`, `tests/test_pcb_sync_netlist.py`, `tests/test_validate.py`, `tests/test_validate_netlist.py`, `tests/test_validate_placement.py`, `tests/test_netlist_query.py`, `tests/test_cli_netlist.py`, `tests/test_hierarchical_netlist.py` (430 passed, 5 skipped)
- [x] `ruff check` + `ruff format` clean on modified files

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>