### PR TITLE
fix(sch): cleanup-wires veto for label/pin/sheet-pin anchored stubs

### DIFF
--- a/src/kicad_tools/cli/sch_cleanup_wires.py
+++ b/src/kicad_tools/cli/sch_cleanup_wires.py
@@ -42,6 +42,15 @@ _QUANT = 1000
 # schematic wire is ever this short.
 _MICRO_STUB_FLOOR = 0.05
 
+# Tolerance (mm) used when deciding whether a wire endpoint coincides with
+# a "strong anchor" (label, pin, sheet pin, no-connect).  This matches
+# `validate/sch_orphan_label._COORD_EPS` so that files which pass the
+# orphan-label validator can never be torn apart by ``cleanup-wires``.
+# It is intentionally looser than the 1 um quantization bucket used for
+# everything else, because schematic edits / repairs frequently re-emit
+# coordinates with sub-um float drift.
+_ANCHOR_EPS = 0.01
+
 
 @dataclass
 class WireIssue:
@@ -175,29 +184,73 @@ def _build_connection_map(
 
     This excludes wire endpoints themselves -- we build those separately
     so we can check whether a given wire endpoint touches another wire.
+
+    The returned set covers all anchor kinds enumerated by
+    :func:`_collect_strong_anchors`, quantized to the 1 um bucket used for
+    fast exact lookup.  For tolerance-aware matching (e.g. against files
+    with sub-um float drift) callers should use the strong-anchor list
+    directly instead.
     """
     points: set[tuple[int, int]] = set()
+    for x, y in _collect_strong_anchors(schematic):
+        points.add((_quantize(x), _quantize(y)))
+    return points
+
+
+def _collect_strong_anchors(
+    schematic: Schematic,
+) -> list[tuple[float, float]]:
+    """Enumerate every "strong anchor" position in *schematic*.
+
+    A strong anchor is a non-wire object whose position is the canonical
+    end of a net segment in KiCad's electrical model: junctions, labels of
+    every kind (local / global / hierarchical / directive / netclass),
+    no-connect markers, symbol pins, and hierarchical sheet pins.
+
+    Wire endpoints anchored at any of these positions are by definition
+    load-bearing -- ``cleanup-wires`` must never remove them.
+    """
+    anchors: list[tuple[float, float]] = []
 
     # Junctions
     for junc in schematic.junctions:
-        points.add((_quantize(junc.position[0]), _quantize(junc.position[1])))
+        anchors.append((junc.position[0], junc.position[1]))
 
-    # Labels
+    # Local / global / hierarchical labels
     for lbl in schematic.labels:
-        points.add((_quantize(lbl.position[0]), _quantize(lbl.position[1])))
-
+        anchors.append((lbl.position[0], lbl.position[1]))
     for lbl in schematic.global_labels:
-        points.add((_quantize(lbl.position[0]), _quantize(lbl.position[1])))
-
+        anchors.append((lbl.position[0], lbl.position[1]))
     for lbl in schematic.hierarchical_labels:
-        points.add((_quantize(lbl.position[0]), _quantize(lbl.position[1])))
+        anchors.append((lbl.position[0], lbl.position[1]))
 
-    # No-connect markers count as connections for this purpose
+    # KiCad 8 introduced ``directive_label`` and ``netclass_flag`` nodes
+    # that are not exposed through :class:`Schematic` properties.  Read
+    # them directly so a wire endpoint anchored on one of them is still
+    # considered load-bearing.
+    for tag in ("directive_label", "netclass_flag"):
+        for node in schematic.sexp.find_all(tag):
+            if at := node.find("at"):
+                anchors.append(
+                    (at.get_float(0) or 0.0, at.get_float(1) or 0.0)
+                )
+
+    # No-connect markers
     for nc_node in schematic.sexp.find_all("no_connect"):
         if at := nc_node.find("at"):
-            x = at.get_float(0) or 0
-            y = at.get_float(1) or 0
-            points.add((_quantize(x), _quantize(y)))
+            anchors.append((at.get_float(0) or 0.0, at.get_float(1) or 0.0))
+
+    # Hierarchical sheet pins: each (sheet ...) block may contain
+    # (pin "NAME" SHAPE (at X Y R) ...) child nodes that mark the
+    # connection points on the sheet boundary.  These are NOT enumerated
+    # by Schematic.hierarchical_labels (those live inside the child sheet,
+    # not on the parent's sheet block).
+    for sheet_node in schematic.sexp.find_all("sheet"):
+        for pin_node in sheet_node.find_all("pin"):
+            if at := pin_node.find("at"):
+                anchors.append(
+                    (at.get_float(0) or 0.0, at.get_float(1) or 0.0)
+                )
 
     # Symbol pin positions -- use library data for accurate pin locations
     for sym in schematic.symbols:
@@ -208,15 +261,35 @@ def _build_connection_map(
                 sym.position, sym.rotation, sym.mirror
             )
             for pos in pin_positions.values():
-                points.add((_quantize(pos[0]), _quantize(pos[1])))
+                anchors.append((pos[0], pos[1]))
         else:
             # Fallback to symbol center when library data is unavailable
-            points.add((_quantize(sym.position[0]), _quantize(sym.position[1])))
+            anchors.append((sym.position[0], sym.position[1]))
         # Power symbols always connect via their position
         if sym.lib_id.startswith("power:"):
-            points.add((_quantize(sym.position[0]), _quantize(sym.position[1])))
+            anchors.append((sym.position[0], sym.position[1]))
 
-    return points
+    return anchors
+
+
+def _endpoint_at_strong_anchor(
+    point: tuple[float, float],
+    strong_anchors: list[tuple[float, float]],
+    tolerance: float = _ANCHOR_EPS,
+) -> bool:
+    """Return ``True`` if *point* is within *tolerance* mm of any anchor.
+
+    This is the tolerance-aware veto used by stub detection (Phase 3b).
+    It deliberately does NOT use the 1 um quantization bucket -- files
+    that round-trip through repair tools frequently introduce sub-um
+    float drift, which would otherwise miss a legitimate label/pin
+    anchor and let the stub heuristic remove a load-bearing wire.
+    """
+    px, py = point
+    return any(
+        abs(px - ax) <= tolerance and abs(py - ay) <= tolerance
+        for ax, ay in strong_anchors
+    )
 
 
 def _wire_endpoint_counts(
@@ -403,6 +476,7 @@ def find_cleanup_candidates(
 
     # Phase 3: dangling wires (endpoints not connected to anything else)
     connection_points = _build_connection_map(schematic, unique_wires)
+    strong_anchors = _collect_strong_anchors(schematic)
     endpoint_counts = _wire_endpoint_counts(unique_wires)
 
     for ws in unique_wires:
@@ -458,7 +532,10 @@ def find_cleanup_candidates(
                 continue
 
             # (a) Micro-stubs: unconditionally flag wires shorter than the
-            # floor -- no real schematic wire is ever this short.
+            # floor -- no real schematic wire is ever this short.  This is
+            # intentionally checked BEFORE the strong-anchor veto, because
+            # zero-area wire fragments at a label position are still
+            # invalid (KiCad treats them as ERC errors).
             if length < _MICRO_STUB_FLOOR:
                 issues.append(
                     WireIssue(
@@ -468,6 +545,19 @@ def find_cleanup_candidates(
                         end=end,
                     )
                 )
+                continue
+
+            # Hard veto: if EITHER endpoint coincides (within
+            # _ANCHOR_EPS) with any strong anchor -- a label of any kind,
+            # a symbol pin, a no-connect, or a hierarchical sheet pin --
+            # the wire is load-bearing and must never be classified as a
+            # stub.  This is the fix for the J2.24-style perpendicular
+            # L-shape into a label, where the wire endpoint is exactly on
+            # the label position but the quantization bucket misses it
+            # because of sub-um float drift introduced by repair tools.
+            if _endpoint_at_strong_anchor(
+                start, strong_anchors
+            ) or _endpoint_at_strong_anchor(end, strong_anchors):
                 continue
 
             electrically_dangling = 0

--- a/tests/test_sch_wiring_commands.py
+++ b/tests/test_sch_wiring_commands.py
@@ -513,22 +513,25 @@ SCHEMATIC_WITH_T_JUNCTION_CONNECTED = """\
 
 
 # Schematic where a sub-mm stub has one endpoint sharing a wire endpoint
-# and the other endpoint landing on the body of another wire WITHOUT a
-# junction marker.  The old detection logic treated the body-touching end
-# as "connected" (via _endpoint_touches_other_wire_body), giving
-# dangling_ends == 0, so the stub escaped detection entirely.
+# (with NO strong anchor at that point) and the other endpoint landing on
+# the body of another wire WITHOUT a junction marker.  The old detection
+# logic treated the body-touching end as "connected" (via
+# _endpoint_touches_other_wire_body), giving dangling_ends == 0, so the
+# stub escaped detection entirely.
 #
 # Layout:
 #   Wire A: (100,50) -> (200,50)  horizontal, labels at both ends
-#   Wire B: (150,50) -> (150,60)  vertical, label at far end
-#   Stub:   (150,60) -> (160,60.4) 0.4mm diagonal stub from wire B end
+#   Wire B: (150,50) -> (150,60)  vertical -- both ends touch wire bodies
+#   Stub:   (150,60) -> (150.3,60.4) 0.4mm diagonal stub from wire B end
 #
-# The stub's start (150,60) shares an endpoint with wire B and a label.
-# The stub's end (160,60.4) lands on the body of wire A' (see wire-c).
-# Wire C: (100,60.4) -> (200,60.4) runs horizontally at y=60.4.
-# The stub endpoint at (160,60.4) sits on wire C's interior but has
-# no junction, label, pin, or shared wire endpoint there.
-# ERC flags (160,60.4) as "Wire endpoint is not connected".
+# The stub's start (150,60) shares an endpoint with wire B but has no
+# label, pin, junction, or other strong anchor -- so the strong-anchor
+# veto in Phase 3b does NOT apply.
+# The stub's end (150.3,60.4) lands on the body of wire C without any
+# junction.  ERC flags it as "Wire endpoint is not connected".
+#
+# Wire C: (100,60.4) -> (200,60.4) runs horizontally at y=60.4 with
+# labels at both ends so it isn't itself flagged as dangling.
 #
 # NOTE: we use a diagonal stub (not horizontal/vertical) to ensure it
 # cannot be flagged as a collinear overlap of wire C.
@@ -563,10 +566,6 @@ SCHEMATIC_WITH_ERC_STUB_WIRE_BODY = """\
   (label "NET2" (at 200 50 0)
     (effects (font (size 1.27 1.27)))
     (uuid "label-2")
-  )
-  (label "NET3" (at 150 60 0)
-    (effects (font (size 1.27 1.27)))
-    (uuid "label-3")
   )
   (label "NET4" (at 100 60.4 0)
     (effects (font (size 1.27 1.27)))
@@ -771,6 +770,194 @@ SCHEMATIC_WITH_SHORT_BRIDGE_AT_LABEL = """\
   (label "NET3" (at 200 50 0)
     (effects (font (size 1.27 1.27)))
     (uuid "label-3")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Regression fixtures for issue #2626 (strong-anchor veto)
+# ---------------------------------------------------------------------------
+
+# Perpendicular L-shape into a label.  Matches the J2.24 incident geometry
+# from issue #2626 exactly:
+#   W1: horizontal (130, 99.06) -> (138.43, 99.06)
+#   W2: vertical   (138.43, 99.06) -> (138.43, 100.33)   -- 1.27 mm "stub"
+#   Label "SPI_NSS" at (138.43, 100.33)
+#
+# W2's far endpoint is exactly on the label, so the strong-anchor veto
+# must keep W2 from being classified as a stub.
+SCHEMATIC_WITH_PERPENDICULAR_LABEL_ANCHORED_STUB = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000002626")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 130 99.06) (xy 138.43 99.06))
+    (stroke (width 0) (type default))
+    (uuid "w1-horiz")
+  )
+  (wire (pts (xy 138.43 99.06) (xy 138.43 100.33))
+    (stroke (width 0) (type default))
+    (uuid "w2-stub")
+  )
+  (label "SPI_NSS" (at 138.43 100.33 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "lbl-spi-nss")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+# A short wire whose endpoint coincides with a label but with sub-um
+# float drift in the coordinates (138.43, 100.330001 vs label at
+# 138.43, 100.33).  The 1 um quantization bucket would miss this anchor;
+# the tolerance-aware veto (using _ANCHOR_EPS = 0.01 mm) must still
+# recognize the wire as anchored.
+SCHEMATIC_WITH_MICRON_DRIFT_LABEL = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000002628")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 130 99.06) (xy 138.43 99.06))
+    (stroke (width 0) (type default))
+    (uuid "w1-horiz")
+  )
+  (wire (pts (xy 138.43 99.06) (xy 138.43 100.330001))
+    (stroke (width 0) (type default))
+    (uuid "w2-stub-drifted")
+  )
+  (label "SPI_NSS" (at 138.43 100.33 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "lbl-spi-nss")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+# A short wire from a symbol pin to a wire endpoint.  The pin-anchored
+# endpoint must never let the wire be classified as a stub, even though
+# the other end has no label.
+#
+# Resistor R1 placed at (100, 50) with no rotation.  Pin 1 is at
+# (100, 50 - 3.81) = (100, 46.19), pin 2 is at (100, 50 + 3.81) = (100, 53.81).
+# The candidate stub runs from pin 1 (100, 46.19) down 1.0 mm to a wire
+# endpoint at (100, 45.19) which is shared with a longer wire that ends
+# at a label.
+SCHEMATIC_WITH_PIN_ANCHORED_STUB = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000002629")
+  (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (property "Reference" "R" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "R" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Footprint" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (property "Datasheet" "" (at 0 0 0) (effects (font (size 1.27 1.27)) (hide yes)))
+      (symbol "Device:R_0_1"
+        (polyline (pts (xy -1.016 -2.54) (xy -1.016 2.54)) (stroke (width 0) (type default)) (fill (type none)))
+      )
+      (symbol "Device:R_1_1"
+        (pin passive line (at 0 3.81 270) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+        (pin passive line (at 0 -3.81 90) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+      )
+    )
+  )
+  (symbol (lib_id "Device:R") (at 100 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid "sym-r1-pin-stub")
+    (property "Reference" "R1" (at 100 50 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "10k" (at 100 50 0) (effects (font (size 1.27 1.27))))
+    (pin "1" (uuid "pin-r1-1"))
+    (pin "2" (uuid "pin-r1-2"))
+    (instances (project "test" (path "/" (reference "R1") (unit 1))))
+  )
+  (wire (pts (xy 100 46.19) (xy 100 45.19))
+    (stroke (width 0) (type default))
+    (uuid "pin-anchored-stub")
+  )
+  (wire (pts (xy 100 45.19) (xy 100 30))
+    (stroke (width 0) (type default))
+    (uuid "long-trunk")
+  )
+  (label "GND" (at 100 30 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-gnd")
+  )
+  (label "VCC" (at 100 53.81 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-vcc")
+  )
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)
+"""
+
+
+# A short wire whose free endpoint coincides with a hierarchical sheet
+# pin.  Sheet pins are NOT enumerated by Schematic.hierarchical_labels
+# (those live inside the child sheet), so before this fix the cleanup
+# detector treated them as un-anchored points.
+#
+# Layout:
+#   Sheet at (130, 90)..(170, 110)  with pin "CLK" at (170, 100)
+#   Wire trunk: (150, 100) -> (168.73, 100)   ~18.7 mm horizontal
+#   Stub:       (168.73, 100) -> (170, 100)   1.27 mm into the sheet pin
+SCHEMATIC_WITH_SHEET_PIN_ANCHORED_STUB = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000002630")
+  (paper "A4")
+  (lib_symbols)
+  (wire (pts (xy 150 100) (xy 168.73 100))
+    (stroke (width 0) (type default))
+    (uuid "trunk-wire")
+  )
+  (wire (pts (xy 168.73 100) (xy 170 100))
+    (stroke (width 0) (type default))
+    (uuid "sheet-pin-stub")
+  )
+  (label "CLK" (at 150 100 0)
+    (effects (font (size 1.27 1.27)))
+    (uuid "label-clk")
+  )
+  (sheet
+    (at 130 90)
+    (size 40 20)
+    (uuid "00000000-0000-0000-0000-000000002631")
+    (property "Sheetname" "child"
+      (at 130 89 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Sheetfile" "child.kicad_sch"
+      (at 130 110.5 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (pin "CLK" input
+      (at 170 100 0)
+      (effects (font (size 1.27 1.27)) (justify left))
+      (uuid "sheet-pin-clk")
+    )
   )
   (sheet_instances
     (path "/" (page "1"))
@@ -1371,6 +1558,132 @@ class TestCleanupWires:
         removed = remove_wires(sch, stubs)
         assert removed == 1
         assert len(list(sch.sexp.find_all("wire"))) == initial_wire_count - 1
+
+    # --- issue #2626 regression tests: strong-anchor veto ----------------
+
+    def test_perpendicular_short_wire_to_label_not_flagged(self, tmp_path):
+        """A perpendicular L-shape wire ending at a label is NOT a stub.
+
+        This is the exact J2.24 incident geometry that motivated #2626:
+        the vertical 1.27 mm wire is below the default stub threshold but
+        its far endpoint coincides with the SPI_NSS label, so the
+        strong-anchor veto must keep it from being classified as a stub.
+        """
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_PERPENDICULAR_LABEL_ANCHORED_STUB)
+        sch = Schematic.load(path)
+        issues = find_cleanup_candidates(sch)
+
+        stubs = [i for i in issues if i.reason == "stub"]
+        assert len(stubs) == 0, (
+            f"Expected no stubs but found: {[(s.start, s.end) for s in stubs]}"
+        )
+
+    def test_label_at_endpoint_with_micron_drift_not_flagged(self, tmp_path):
+        """A label whose position is within _ANCHOR_EPS of a wire endpoint
+        (sub-um float drift) still anchors the wire against stub removal.
+
+        Wire endpoint is at (138.43, 100.330001) and the label is at
+        (138.43, 100.33).  The drift is well under 0.01 mm so the
+        tolerance-aware veto recognizes them as the same anchor.
+        """
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_MICRON_DRIFT_LABEL)
+        sch = Schematic.load(path)
+        issues = find_cleanup_candidates(sch)
+
+        stubs = [i for i in issues if i.reason == "stub"]
+        assert len(stubs) == 0, (
+            f"Expected no stubs but found: {[(s.start, s.end) for s in stubs]}"
+        )
+
+    def test_short_wire_to_pin_not_flagged(self, tmp_path):
+        """A short wire whose endpoint sits on a symbol pin is NOT a stub.
+
+        The 1.0 mm wire below the default stub threshold has its pin-side
+        endpoint at R1 pin 1 (100, 46.19).  The pin veto must keep it from
+        being classified as a stub.
+        """
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_PIN_ANCHORED_STUB)
+        sch = Schematic.load(path)
+        issues = find_cleanup_candidates(sch)
+
+        stubs = [i for i in issues if i.reason == "stub"]
+        assert len(stubs) == 0, (
+            f"Expected no stubs but found: {[(s.start, s.end) for s in stubs]}"
+        )
+
+    def test_short_wire_to_sheet_pin_not_flagged(self, tmp_path):
+        """A short wire whose endpoint sits on a hierarchical sheet pin is
+        NOT classified as a stub.
+
+        Sheet pins live inside ``(sheet ...)`` blocks and are not exposed
+        through ``Schematic.hierarchical_labels``; the strong-anchor
+        enumeration must reach into the sheet block to find them.
+        """
+        from kicad_tools.cli.sch_cleanup_wires import find_cleanup_candidates
+
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_SHEET_PIN_ANCHORED_STUB)
+        sch = Schematic.load(path)
+        issues = find_cleanup_candidates(sch)
+
+        stubs = [i for i in issues if i.reason == "stub"]
+        assert len(stubs) == 0, (
+            f"Expected no stubs but found: {[(s.start, s.end) for s in stubs]}"
+        )
+
+    def test_collect_strong_anchors_includes_all_kinds(self, tmp_path):
+        """The strong-anchor enumeration covers labels, no-connects, sheet
+        pins, and symbol pins -- not just the subset previously enumerated."""
+        from kicad_tools.cli.sch_cleanup_wires import _collect_strong_anchors
+
+        # Sheet-pin fixture exercises the sheet-pin enumeration
+        path = _write_sch(tmp_path, SCHEMATIC_WITH_SHEET_PIN_ANCHORED_STUB)
+        sch = Schematic.load(path)
+        anchors = _collect_strong_anchors(sch)
+
+        # Sheet pin at (170, 100) must be in the list
+        assert any(
+            abs(x - 170.0) < 1e-6 and abs(y - 100.0) < 1e-6 for x, y in anchors
+        ), f"sheet pin (170, 100) missing from anchors: {anchors}"
+        # Label at (150, 100) must be in the list
+        assert any(
+            abs(x - 150.0) < 1e-6 and abs(y - 100.0) < 1e-6 for x, y in anchors
+        ), f"label (150, 100) missing from anchors: {anchors}"
+
+    def test_perpendicular_stub_removable_after_cleanup_preserves_label(
+        self, tmp_path
+    ):
+        """After running cleanup-wires on the J2.24 fixture, the label-
+        anchored wire and the label itself both remain in the schematic.
+
+        This is the integration-level post-cleanup invariant from issue
+        #2626: cleanup-wires must not introduce a new orphan-label or
+        dangling-endpoint condition.
+        """
+        from kicad_tools.cli.sch_cleanup_wires import (
+            find_cleanup_candidates,
+            remove_wires,
+        )
+
+        path = _write_sch(
+            tmp_path, SCHEMATIC_WITH_PERPENDICULAR_LABEL_ANCHORED_STUB
+        )
+        sch = Schematic.load(path)
+
+        initial_wires = len(list(sch.sexp.find_all("wire")))
+        initial_labels = len(list(sch.sexp.find_all("label")))
+
+        issues = find_cleanup_candidates(sch)
+        remove_wires(sch, issues)
+
+        # No wires or labels were removed -- fixture started clean.
+        assert len(list(sch.sexp.find_all("wire"))) == initial_wires
+        assert len(list(sch.sexp.find_all("label"))) == initial_labels
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a hard veto in `cleanup-wires` Phase 3b: wires whose endpoints sit at any strong anchor (label of any kind, symbol pin, no-connect, hierarchical sheet pin) are never classified as stubs, regardless of length or `--stub-threshold`.
- Enumerate previously-missing anchor sources: hierarchical sheet pins (inside `(sheet ...)` blocks), `directive_label`, and `netclass_flag` nodes.
- Use tolerance-aware matching (`_ANCHOR_EPS = 0.01 mm`, aligned with `validate/sch_orphan_label._COORD_EPS`) so files round-tripped through repair tools with sub-um float drift still recognize their anchors.

Fixes the J2.24 incident where a perpendicular L-shape wire `(138.43, 99.06) -> (138.43, 100.33)` ending exactly on the `SPI_NSS` label was incorrectly removed because the 1 um quantization bucket missed the anchor.

## Behavioural smoke check (from issue body)

```
$ kct sch cleanup-wires repro_2626.kicad_sch --dry-run
No stale wires found.
```

Before the fix this reported `Wires to clean up: 1`.

## Test plan

- [x] All 43 pre-existing `TestCleanupWires` tests pass (including the called-out `test_finds_stub_wire`, `test_micro_stub_unconditionally_flagged`, `test_both_ends_connected_no_connection_point_flagged`, `test_short_bridge_at_label_not_flagged`, `test_erc_stub_one_end_on_wire_body`, `test_erc_stub_both_ends_on_wire_body`, `test_long_single_dangling_wire_not_flagged_as_stub`).
- [x] 6 new regression tests added:
  - `test_perpendicular_short_wire_to_label_not_flagged` (criterion d, exact J2.24 geometry)
  - `test_label_at_endpoint_with_micron_drift_not_flagged` (criterion f, sub-um drift)
  - `test_short_wire_to_pin_not_flagged` (criterion e, pin veto)
  - `test_short_wire_to_sheet_pin_not_flagged` (criterion g, sheet-pin veto)
  - `test_collect_strong_anchors_includes_all_kinds` (anchor enumeration coverage)
  - `test_perpendicular_stub_removable_after_cleanup_preserves_label` (criterion h, post-cleanup invariant)
- [x] `uv run pytest tests/test_sch_wiring_commands.py` -- 75/75 pass
- [x] `uv run ruff check src/kicad_tools/cli/sch_cleanup_wires.py tests/test_sch_wiring_commands.py` -- clean

## Notes

`SCHEMATIC_WITH_ERC_STUB_WIRE_BODY` had a label NET3 at the stub's anchored endpoint (150, 60); the new strong-anchor veto correctly rejects classifying this as a stub. The fixture's *intent* -- "ERC stub anchored only by a wire-body touch" -- is preserved by removing the conflicting label and updating the docstring. The test assertion is unchanged.

Closes #2626