### PR TITLE
fix(drc): register jlcpcb-tier1 manufacturer profile (closes #2622)

### DIFF
--- a/src/kicad_tools/manufacturers/__init__.py
+++ b/src/kicad_tools/manufacturers/__init__.py
@@ -6,6 +6,7 @@ and parts library information for various PCB fabrication houses.
 
 Supported manufacturers:
 - JLCPCB (jlcpcb) - Chinese fab with LCSC parts library
+- JLCPCB Capability Plus (jlcpcb-tier1) - JLCPCB advanced tier with via-in-pad
 - Seeed Fusion (seeed) - Chinese fab with OPL parts library
 - PCBWay (pcbway) - Chinese fab with global sourcing
 - OSHPark (oshpark) - US fab, PCB only, per-sq-inch pricing
@@ -36,6 +37,7 @@ from .base import (
 from .dru_generator import generate_dru
 from .flashpcb import FLASHPCB_PROFILE
 from .jlcpcb import JLCPCB_PROFILE
+from .jlcpcb_tier1 import JLCPCB_TIER1_PROFILE
 from .oshpark import OSHPARK_PROFILE
 from .pcbway import PCBWAY_PROFILE
 from .seeed import SEEED_PROFILE
@@ -58,6 +60,7 @@ __all__ = [
     # Profiles (for direct access)
     "FLASHPCB_PROFILE",
     "JLCPCB_PROFILE",
+    "JLCPCB_TIER1_PROFILE",
     "SEEED_PROFILE",
     "PCBWAY_PROFILE",
     "OSHPARK_PROFILE",
@@ -67,20 +70,33 @@ __all__ = [
 _PROFILES: dict[str, ManufacturerProfile] = {
     "flashpcb": FLASHPCB_PROFILE,
     "jlcpcb": JLCPCB_PROFILE,
+    "jlcpcb-tier1": JLCPCB_TIER1_PROFILE,
     "seeed": SEEED_PROFILE,
     "pcbway": PCBWAY_PROFILE,
     "oshpark": OSHPARK_PROFILE,
 }
 
 # Aliases for convenience
+#
+# The jlcpcb-tier1 aliases below mirror the router's
+# ``src/kicad_tools/router/mfr_limits.py:_MFR_ALIASES`` table verbatim
+# so the router and DRC registries cannot drift. See
+# ``tests/test_manufacturer_registry_sync.py`` for the invariant check.
 _ALIASES: dict[str, str] = {
     "flash": "flashpcb",
     "jlc": "jlcpcb",
     "lcsc": "jlcpcb",
     "seeed_fusion": "seeed",
+    "seeed-fusion": "seeed",  # mirror router/mfr_limits.MFR_LIMITS canonical key
+    "seeedfusion": "seeed",  # mirror router/mfr_limits._MFR_ALIASES
     "seeedstudio": "seeed",
     "osh": "oshpark",
     "osh_park": "oshpark",
+    # JLCPCB Capability Plus (tier 1) - mirror router's _MFR_ALIASES
+    "jlcpcb_tier1": "jlcpcb-tier1",
+    "jlcpcb-capabilityplus": "jlcpcb-tier1",
+    "jlcpcb_capabilityplus": "jlcpcb-tier1",
+    "jlcpcb-capability-plus": "jlcpcb-tier1",
 }
 
 

--- a/src/kicad_tools/manufacturers/data/jlcpcb_tier1.yaml
+++ b/src/kicad_tools/manufacturers/data/jlcpcb_tier1.yaml
@@ -1,0 +1,118 @@
+# JLCPCB Capability Plus (tier 1) Design Rules Configuration
+#
+# JLCPCB Capability Plus is an advanced manufacturing tier that offers
+# additional capabilities such as via-in-pad (epoxy-filled, plated-over),
+# typically at a per-order surcharge. The scalar DRC limits (trace width,
+# clearance, via drill, annular ring, edge clearance) for Capability Plus
+# match the standard JLCPCB advanced PCB process; the practical difference
+# is the additional via-in-pad capability, which is currently not modelled
+# as a scalar field in DesignRules. See router/mfr_limits.py
+# (MFR_JLCPCB_TIER1.via_in_pad_supported=True) for that capability.
+#
+# Source: https://jlcpcb.com/capabilities/pcb-capabilities
+#         https://jlcpcb.com/capabilities/Capabilities (Capability Plus tier)
+# Last verified: 2026-05-10
+#
+# All measurements in millimeters unless otherwise noted.
+#
+# NOTE: Values mirror jlcpcb.yaml. Any time JLCPCB publishes tighter
+# Capability Plus numbers, update this file (do NOT relax values below
+# the base jlcpcb profile - DRC rules for tier1 must be at least as
+# strict as the base profile to avoid regressions for users who specify
+# the tier1 profile).
+
+design_rules:
+  2layer_1oz:
+    min_trace_width_mm: 0.127       # 5 mil
+    min_clearance_mm: 0.127         # 5 mil
+    min_via_drill_mm: 0.3
+    min_via_diameter_mm: 0.6
+    min_annular_ring_mm: 0.15
+    min_hole_diameter_mm: 0.3
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.3
+    min_hole_to_edge_mm: 0.5
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
+    min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.0            # No inner layers
+
+  2layer_2oz:
+    min_trace_width_mm: 0.1524      # 6 mil (per JLCPCB published specs for 2oz copper)
+    min_clearance_mm: 0.1524        # 6 mil (per JLCPCB published specs for 2oz copper)
+    min_via_drill_mm: 0.3
+    min_via_diameter_mm: 0.6
+    min_annular_ring_mm: 0.15
+    min_hole_diameter_mm: 0.3
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.3
+    min_hole_to_edge_mm: 0.5
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
+    min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0
+    inner_copper_oz: 0.0
+
+  4layer_1oz:
+    min_trace_width_mm: 0.1016      # 4 mil
+    min_clearance_mm: 0.1016        # 4 mil
+    min_via_drill_mm: 0.2
+    min_via_diameter_mm: 0.45
+    min_annular_ring_mm: 0.10       # 4 mil (JLCPCB advanced PCB capability for 4+ layers)
+    min_hole_diameter_mm: 0.2
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.3
+    min_hole_to_edge_mm: 0.4
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
+    min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.5
+
+  4layer_2oz:
+    min_trace_width_mm: 0.1524      # 6 mil outer (per JLCPCB published specs for 2oz copper)
+    min_clearance_mm: 0.1016        # 4 mil
+    min_via_drill_mm: 0.2
+    min_via_diameter_mm: 0.45
+    min_annular_ring_mm: 0.10       # 4 mil (JLCPCB advanced PCB capability for 4+ layers)
+    min_hole_diameter_mm: 0.2
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.3
+    min_hole_to_edge_mm: 0.4
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
+    min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
+    board_thickness_mm: 1.6
+    outer_copper_oz: 2.0
+    inner_copper_oz: 0.5
+
+  6layer_1oz:
+    min_trace_width_mm: 0.0889      # 3.5 mil
+    min_clearance_mm: 0.0889        # 3.5 mil
+    min_via_drill_mm: 0.2
+    min_via_diameter_mm: 0.45
+    min_annular_ring_mm: 0.15       # 6 mil (per JLCPCB specs)
+    min_hole_diameter_mm: 0.2
+    max_hole_diameter_mm: 6.3
+    min_copper_to_edge_mm: 0.3
+    min_hole_to_edge_mm: 0.4
+    min_silkscreen_width_mm: 0.15
+    min_silkscreen_height_mm: 1.0   # 40 mil (per JLCPCB specs)
+    min_solder_mask_dam_mm: 0.1
+    min_solder_mask_clearance_mm: 0.05
+    min_pad_size_mm: 0.25
+    board_thickness_mm: 1.6
+    outer_copper_oz: 1.0
+    inner_copper_oz: 0.5

--- a/src/kicad_tools/manufacturers/jlcpcb_tier1.py
+++ b/src/kicad_tools/manufacturers/jlcpcb_tier1.py
@@ -1,0 +1,56 @@
+"""
+JLCPCB Capability Plus (tier 1) manufacturer profile.
+
+This profile represents JLCPCB's advanced "Capability Plus" tier, which
+supports via-in-pad with epoxy fill plus plating over (typically a
+per-order surcharge of ~$30 in 2026). The scalar DRC limits otherwise
+mirror the standard JLCPCB advanced PCB process.
+
+Assembly capability and parts library are identical to standard JLCPCB
+and are reused via imports from :mod:`kicad_tools.manufacturers.jlcpcb`.
+
+The router-side equivalent is
+:data:`kicad_tools.router.mfr_limits.MFR_JLCPCB_TIER1`, which carries
+``via_in_pad_supported=True``. The two registries (router and DRC) are
+kept in sync via tests; see ``tests/test_manufacturer_registry_sync.py``.
+
+Source: https://jlcpcb.com/capabilities/pcb-capabilities
+        https://jlcpcb.com/capabilities/Capabilities (Capability Plus tier)
+"""
+
+from .base import (
+    ManufacturerProfile,
+    load_design_rules_from_yaml,
+)
+from .jlcpcb import _ROTATION_CORRECTIONS, JLCPCB_ASSEMBLY, LCSC_LIBRARY
+
+# Load design rules from YAML configuration
+_DESIGN_RULES = load_design_rules_from_yaml("jlcpcb_tier1")
+
+# Complete JLCPCB Capability Plus (tier 1) Profile
+JLCPCB_TIER1_PROFILE = ManufacturerProfile(
+    id="jlcpcb-tier1",
+    name="JLCPCB Capability Plus",
+    website="https://jlcpcb.com",
+    design_rules=_DESIGN_RULES,
+    assembly=JLCPCB_ASSEMBLY,
+    parts_library=LCSC_LIBRARY,
+    lead_times={
+        "pcb_standard": 5,
+        "pcb_expedited": 2,
+        "pcba_basic": 7,
+        "pcba_extended": 14,
+        "pcba_global": 21,
+    },
+    bom_format="jlcpcb",
+    supported_layers=[1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
+    pricing_model="per_pcb",
+    rotation_corrections=_ROTATION_CORRECTIONS,
+    pnp_format_id="jlcpcb",
+    gerber_preset_id="jlcpcb",
+)
+
+
+def get_profile() -> ManufacturerProfile:
+    """Get the JLCPCB Capability Plus (tier 1) manufacturer profile."""
+    return JLCPCB_TIER1_PROFILE

--- a/tests/test_fab_rules.py
+++ b/tests/test_fab_rules.py
@@ -180,10 +180,12 @@ class TestCmdList:
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)
-        assert len(data) == 5  # jlcpcb, oshpark, seeed, pcbway, flashpcb
+        # jlcpcb, jlcpcb-tier1, oshpark, seeed, pcbway, flashpcb
+        assert len(data) == 6
 
         ids = {p["id"] for p in data}
         assert "jlcpcb" in ids
+        assert "jlcpcb-tier1" in ids
         assert "oshpark" in ids
         assert "flashpcb" in ids
 

--- a/tests/test_manufacturer_registry_sync.py
+++ b/tests/test_manufacturer_registry_sync.py
@@ -1,0 +1,226 @@
+"""Tests that the router and DRC manufacturer registries stay in sync.
+
+The router (``kicad_tools.router.mfr_limits``) and the DRC manufacturer
+profile registry (``kicad_tools.manufacturers``) each maintain their own
+list of supported manufacturer names and aliases.  Historically these
+could (and did) drift apart - see issue #2622, where ``jlcpcb-tier1``
+was accepted by the router but rejected by DRC with
+``Unknown manufacturer: 'jlcpcb-tier1'``.
+
+This module enforces the invariant that **every canonical manufacturer
+name and every alias known to the router resolves to a valid DRC
+profile**.  If you add a manufacturer or alias to one registry you must
+add it to the other, or this test will fail.
+
+The DRC registry is allowed to contain additional names that the router
+does not know about (e.g. ``flashpcb`` which is not currently a router
+target), so the relationship is a subset, not equality.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+from kicad_tools.manufacturers import (
+    _ALIASES as DRC_ALIASES,
+)
+from kicad_tools.manufacturers import (
+    _PROFILES as DRC_PROFILES,
+)
+from kicad_tools.manufacturers import (
+    get_profile,
+)
+from kicad_tools.router.mfr_limits import (
+    _MFR_ALIASES,
+    MFR_LIMITS,
+)
+
+
+class TestRouterDRCRegistrySync:
+    """Drift-prevention invariants between router and DRC registries."""
+
+    def test_router_canonical_names_resolve_in_drc(self):
+        """Every canonical MFR_LIMITS key resolves to a DRC profile."""
+        router_names = set(MFR_LIMITS.keys())
+        drc_known = set(DRC_PROFILES.keys()) | set(DRC_ALIASES.keys())
+
+        missing = router_names - drc_known
+        assert not missing, (
+            f"Router knows manufacturer names that DRC does not: {sorted(missing)}. "
+            f"Add them to kicad_tools.manufacturers._PROFILES or _ALIASES."
+        )
+
+    def test_router_aliases_resolve_in_drc(self):
+        """Every router alias resolves to a DRC profile or alias."""
+        router_aliases = set(_MFR_ALIASES.keys())
+        drc_known = set(DRC_PROFILES.keys()) | set(DRC_ALIASES.keys())
+
+        missing = router_aliases - drc_known
+        assert not missing, (
+            f"Router aliases are not recognised by DRC: {sorted(missing)}. "
+            f"Add them to kicad_tools.manufacturers._ALIASES (mirroring the router)."
+        )
+
+    def test_all_router_names_construct_drc_profile(self):
+        """get_profile() never raises for any router-known name or alias."""
+        all_router_names = set(MFR_LIMITS.keys()) | set(_MFR_ALIASES.keys())
+
+        for name in sorted(all_router_names):
+            # Should not raise ValueError("Unknown manufacturer: ...")
+            profile = get_profile(name)
+            assert profile is not None, f"get_profile({name!r}) returned None"
+
+    def test_jlcpcb_tier1_canonical_and_aliases(self):
+        """All four router aliases for jlcpcb-tier1 resolve to the tier1 profile."""
+        canonical = get_profile("jlcpcb-tier1")
+        assert canonical.id == "jlcpcb-tier1"
+
+        for alias in [
+            "jlcpcb_tier1",
+            "jlcpcb-capabilityplus",
+            "jlcpcb_capabilityplus",
+            "jlcpcb-capability-plus",
+        ]:
+            profile = get_profile(alias)
+            assert profile is canonical, (
+                f"Alias {alias!r} resolved to {profile.id!r}, expected 'jlcpcb-tier1'"
+            )
+
+    def test_jlcpcb_tier1_router_alias_table_matches_drc(self):
+        """The router and DRC alias targets for jlcpcb-tier1 are identical.
+
+        This guards against silent drift where one registry remaps an
+        alias to a different canonical name than the other.
+        """
+        jlcpcb_tier1_router_aliases = {
+            alias for alias, target in _MFR_ALIASES.items() if target == "jlcpcb-tier1"
+        }
+        jlcpcb_tier1_drc_aliases = {
+            alias for alias, target in DRC_ALIASES.items() if target == "jlcpcb-tier1"
+        }
+
+        assert jlcpcb_tier1_router_aliases == jlcpcb_tier1_drc_aliases, (
+            f"Router and DRC alias tables for jlcpcb-tier1 disagree.\n"
+            f"  Router: {sorted(jlcpcb_tier1_router_aliases)}\n"
+            f"  DRC:    {sorted(jlcpcb_tier1_drc_aliases)}"
+        )
+
+
+class TestJLCPCBTier1DRCProfile:
+    """Regression tests for the jlcpcb-tier1 DRC profile (issue #2622)."""
+
+    def test_drc_checker_accepts_jlcpcb_tier1(self):
+        """DRCChecker constructs without raising for manufacturer='jlcpcb-tier1'."""
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb = PCB.create(width=50.0, height=50.0, layers=2)
+        # Should not raise ValueError: Unknown manufacturer ...
+        checker = DRCChecker(pcb, manufacturer="jlcpcb-tier1", layers=4)
+        assert checker.design_rules is not None
+        assert checker.manufacturer == "jlcpcb-tier1"
+
+    def test_drc_checker_accepts_all_jlcpcb_tier1_aliases(self):
+        """Every router alias for jlcpcb-tier1 also works in DRCChecker."""
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb = PCB.create(width=50.0, height=50.0, layers=2)
+        for alias in [
+            "jlcpcb-tier1",
+            "jlcpcb_tier1",
+            "jlcpcb-capabilityplus",
+            "jlcpcb_capabilityplus",
+            "jlcpcb-capability-plus",
+        ]:
+            checker = DRCChecker(pcb, manufacturer=alias, layers=4)
+            assert checker.design_rules is not None, (
+                f"DRCChecker(manufacturer={alias!r}) produced no design_rules"
+            )
+
+    def test_tier1_rules_at_least_as_strict_as_base_jlcpcb(self):
+        """tier1 rules must never be looser than the base jlcpcb profile.
+
+        DRC must surface at least as many violations on jlcpcb-tier1 as on
+        plain jlcpcb so users opting into the tier1 profile do not get a
+        silent regression.
+        """
+        base = get_profile("jlcpcb")
+        tier1 = get_profile("jlcpcb-tier1")
+
+        for layers in (2, 4, 6):
+            base_rules = base.get_design_rules(layers=layers, copper_oz=1.0)
+            tier1_rules = tier1.get_design_rules(layers=layers, copper_oz=1.0)
+
+            # Fields where larger = looser (tier1 must be <=)
+            for field in (
+                "min_trace_width_mm",
+                "min_clearance_mm",
+                "min_via_drill_mm",
+                "min_via_diameter_mm",
+                "min_annular_ring_mm",
+                "min_hole_diameter_mm",
+                "min_copper_to_edge_mm",
+                "min_hole_to_edge_mm",
+                "min_silkscreen_width_mm",
+                "min_silkscreen_height_mm",
+                "min_solder_mask_dam_mm",
+                "min_solder_mask_clearance_mm",
+                "min_pad_size_mm",
+            ):
+                base_val = getattr(base_rules, field)
+                tier1_val = getattr(tier1_rules, field)
+                assert tier1_val <= base_val, (
+                    f"{layers}-layer {field}: tier1={tier1_val} looser than "
+                    f"base jlcpcb={base_val} (would be a DRC regression)"
+                )
+
+    def test_run_post_route_drc_no_unknown_manufacturer_message(self, tmp_path):
+        """Running the post-route DRC step does not emit the regression message.
+
+        Issue #2622: when the router calls ``run_post_route_drc`` with
+        ``manufacturer='jlcpcb-tier1'``, stdout must NOT contain the
+        ``Unknown manufacturer`` warning that was the original user-visible
+        symptom of the broken DRC registry.
+        """
+        from kicad_tools.cli.route_cmd import run_post_route_drc
+        from kicad_tools.schema.pcb import PCB
+
+        # Create a minimal but valid PCB on disk so run_post_route_drc can
+        # PCB.load() it.  Any small board is sufficient - DRC only runs
+        # manufacturer-rule checks against whatever is present.
+        pcb = PCB.create(width=50.0, height=50.0, layers=2)
+        test_pcb = tmp_path / "tier1_regression.kicad_pcb"
+        pcb.save(str(test_pcb))
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            run_post_route_drc(
+                output_path=test_pcb,
+                manufacturer="jlcpcb-tier1",
+                layers=4,
+                quiet=False,
+            )
+
+        output = buf.getvalue()
+        assert "Unknown manufacturer" not in output, (
+            f"Regression of issue #2622: 'Unknown manufacturer' surfaced "
+            f"in stdout for jlcpcb-tier1:\n{output}"
+        )
+        # And the positive assertion: the DRC validation block ran.
+        assert "DRC Validation" in output, (
+            f"Expected DRC validation header in output, got:\n{output}"
+        )
+
+    def test_tier1_profile_has_via_in_pad_capability_documented(self):
+        """The tier1 profile exists specifically for via-in-pad support.
+
+        Until DesignRules grows a via_in_pad_supported field (follow-up
+        scoped out of #2622), we at minimum require that the profile's
+        name documents the Capability Plus tier so users can identify it.
+        """
+        profile = get_profile("jlcpcb-tier1")
+        assert "Capability" in profile.name or "Plus" in profile.name, (
+            f"jlcpcb-tier1 profile name should reference Capability Plus, got {profile.name!r}"
+        )

--- a/tests/test_mfr.py
+++ b/tests/test_mfr.py
@@ -18,10 +18,11 @@ class TestManufacturerProfiles:
     def test_list_manufacturers(self):
         """Test listing all manufacturers."""
         manufacturers = list_manufacturers()
-        assert len(manufacturers) == 5
+        assert len(manufacturers) == 6
 
         names = {m.name for m in manufacturers}
         assert "JLCPCB" in names
+        assert "JLCPCB Capability Plus" in names
         assert "Seeed Fusion" in names
         assert "PCBWay" in names
         assert "OSHPark" in names


### PR DESCRIPTION
## Summary

Closes #2622.

- Adds the `jlcpcb-tier1` profile to the DRC manufacturer registry so it stops raising `Unknown manufacturer` when the router uses it.
- Mirrors the four router aliases (`jlcpcb_tier1`, `jlcpcb-capabilityplus`, `jlcpcb_capabilityplus`, `jlcpcb-capability-plus`) verbatim in `manufacturers/_ALIASES`, plus the previously-orphaned `seeed-fusion` / `seeedfusion`.
- New drift-prevention test (`tests/test_manufacturer_registry_sync.py`) enforces the invariant that every router-known canonical name and alias resolves to a DRC profile, so a future router-only addition cannot silently regress DRC again.

The scalar DRC limits for tier1 mirror the standard `jlcpcb` profile (same trace/clearance/via/edge values across 2/4/6-layer stackups). The practical Capability Plus differentiator is via-in-pad, which `DesignRules` does not currently model as a scalar field; the curator notes call that out as an explicit follow-up.

## Files

- `src/kicad_tools/manufacturers/data/jlcpcb_tier1.yaml` (new)
- `src/kicad_tools/manufacturers/jlcpcb_tier1.py` (new)
- `src/kicad_tools/manufacturers/__init__.py` (register profile + aliases)
- `tests/test_manufacturer_registry_sync.py` (new — drift + regression)
- `tests/test_mfr.py`, `tests/test_fab_rules.py` (bump profile-count assertions 5 -> 6)

## Test plan

- [x] `pytest tests/test_manufacturer_registry_sync.py` — 10/10 pass
- [x] `pytest tests/test_mfr.py tests/test_mfr_limits.py tests/test_fab_rules.py tests/test_cli_check.py tests/test_ci_routed_drc_workflow.py tests/test_route_auto_fix.py tests/test_drc_mfr_hint.py` — 235 passed, 2 skipped, 0 failed
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] End-to-end: `DRCChecker(pcb, manufacturer='jlcpcb-tier1', layers=4)` no longer raises; `fab-rules show jlcpcb-tier1` prints the JLCPCB Capability Plus rules block

Two pre-existing failing tests are unrelated to this change: `test_pcb_manufacturing_export.py::TestGenerateReport::test_generate_report_produces_markdown` (PDF/MD renderer issue) and three router-randomness tests in `test_drc_regression.py` (no manufacturer references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)