### PR TITLE
feat(router): wire diff-pair partner threading from autorouter into both backends

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2215,6 +2215,136 @@ class Autorouter:
         )
         return self._congestion_estimator
 
+    # ------------------------------------------------------------------
+    # Diff-pair partner activation (Issue #2587 / Epic #2556 Phase 1C-cont)
+    # ------------------------------------------------------------------
+
+    def _prepare_routing(self) -> None:
+        """Pre-route setup: populate the partner-name reverse map.
+
+        Issue #2587 / Epic #2556 Phase 1C-cont: Phase 1C threaded
+        ``NetClassRouting.intra_pair_clearance`` through the Python pathfinder
+        (#2559 / PR #2586) and the C++ bindings, but left the *activation*
+        path dormant: ``Pathfinder.set_net_name_to_id`` was never called from
+        any ``route_all_*`` entry point, so ``_net_name_to_id`` stayed empty
+        and ``_resolve_partner_net_id`` always returned ``None``.
+
+        This helper closes the gap.  It must be invoked once per
+        ``route_all_*`` call (before the first ``route_net``) so the
+        underlying pathfinder (Python or C++) can resolve partner-id from
+        partner-name at search time.
+
+        The helper is intentionally idempotent and cheap: it rebuilds the
+        reverse map from ``self.net_names`` every call, since the autorouter
+        may have added new pads (and therefore new nets) since the last
+        invocation.  Calling it on a router that doesn't yet implement
+        ``set_net_name_to_id`` (a backwards-compatibility scenario) is a
+        no-op via ``hasattr`` guard.
+
+        Diff-pair detection is also engaged here.  When
+        :func:`detect_diff_pairs` produces a non-empty result, this helper
+        propagates each pair onto a fresh per-net ``NetClassRouting``
+        instance via ``dataclasses.replace`` so the shared net-class
+        singletons (e.g. ``NET_CLASS_HIGH_SPEED`` is one object shared by
+        many nets) are NOT mutated cross-call.  The replaced instance is
+        then stored back in ``self.net_class_map`` for *this* router, so
+        the next ``route_net()`` reads the correct partner-name.
+
+        With this single helper, the dormant Phase 1C path activates from
+        every ``route_all_*`` entry point that calls it:
+
+        * The Python pathfinder's ``_resolve_partner_net_id`` starts
+          returning non-``None`` for paired nets.
+        * The C++ backend's ``route_resumable()`` is called with
+          ``partner_net != -1`` and the tighter ``intra_pair_radius_cells``.
+        * ``find_blocking_nets`` (both backends) excludes the partner from
+          the rip-up candidate set.
+
+        Safe to call when there are no diff pairs detected -- in that case
+        the reverse map is still populated but ``_resolve_partner_net_id``
+        returns ``None`` because no ``diffpair_partner`` is set anywhere,
+        which is bit-for-bit identical to pre-Phase-1C behavior.
+        """
+        # 1. Build name -> id reverse map from self.net_names.  First
+        #    occurrence wins (matches diffpair_detection._name_to_id_map
+        #    behavior).  Skip empty names to avoid collisions.
+        name_to_id: dict[str, int] = {}
+        for nid, name in self.net_names.items():
+            if name and name not in name_to_id:
+                name_to_id[name] = nid
+
+        # 2. Engage diff-pair detection (Issue #2587 second gate).  Without
+        #    this, NET_CLASS_HIGH_SPEED.diffpair_partner stays None for the
+        #    USB_D+/USB_D- pair on board 03 and the partner branch is
+        #    silently inert even though the reverse map is populated.
+        try:
+            from .diffpair_detection import detect_diff_pairs
+        except ImportError:
+            detect_diff_pairs = None  # type: ignore[assignment]
+
+        if detect_diff_pairs is not None and self.net_names:
+            # Build net_to_class map so explicit declarations can be
+            # consulted by detection.
+            net_to_class: dict[str, str] = {}
+            for net_name, net_class in self.net_class_map.items():
+                net_to_class[net_name] = net_class.name
+
+            try:
+                pairs = detect_diff_pairs(
+                    self.net_names,
+                    net_class_routing=self.net_class_map,
+                    net_to_class=net_to_class,
+                )
+            except Exception:
+                # Defensive: detection failure must not break routing.
+                pairs = []
+
+            if pairs:
+                # Avoid singleton mutation: clone the NetClassRouting for
+                # each paired net before setting ``diffpair_partner``.  This
+                # is the structural risk the curator note flagged: many
+                # nets share the same NET_CLASS_HIGH_SPEED instance, and
+                # an in-place set would cross-contaminate unrelated nets.
+                import dataclasses
+
+                for detected in pairs:
+                    pair = detected.pair
+                    p_name = pair.positive.net_name
+                    n_name = pair.negative.net_name
+
+                    # Positive side: partner is the negative net.
+                    p_class = self.net_class_map.get(p_name)
+                    if p_class is not None and p_class.diffpair_partner != n_name:
+                        self.net_class_map[p_name] = dataclasses.replace(
+                            p_class, diffpair_partner=n_name
+                        )
+                    # Negative side: partner is the positive net.
+                    n_class = self.net_class_map.get(n_name)
+                    if n_class is not None and n_class.diffpair_partner != p_name:
+                        self.net_class_map[n_name] = dataclasses.replace(
+                            n_class, diffpair_partner=p_name
+                        )
+
+        # 3. Push the reverse map down into the pathfinder.  Guard the call
+        #    with hasattr so older Pathfinder/CppPathfinder builds (or
+        #    third-party Router subclasses without the setter) still work.
+        if hasattr(self.router, "set_net_name_to_id"):
+            self.router.set_net_name_to_id(name_to_id)
+
+        # Also propagate the updated net_class_map down to any router that
+        # caches it locally (CppPathfinder and Pathfinder both store a
+        # reference at construction).  When the autorouter's net_class_map
+        # was mutated above via dataclasses.replace, the router's cached
+        # reference may still be the original dict; ensure they stay in
+        # sync by reassigning the attribute when present.
+        if hasattr(self.router, "_net_class_map"):
+            self.router._net_class_map = self.net_class_map
+        if hasattr(self.router, "net_class_map"):
+            try:
+                self.router.net_class_map = self.net_class_map
+            except AttributeError:
+                pass
+
     def _filter_pour_nets(self, net_order: list[int]) -> list[int]:
         """Remove pour nets from a net ordering and log a warning.
 
@@ -2708,6 +2838,11 @@ class Autorouter:
         if interleaved:
             return self.route_all_interleaved(progress_callback=progress_callback)
 
+        # Issue #2587 / Epic #2556 Phase 1C-cont: Activate diff-pair partner
+        # threading by populating the reverse map + diff-pair detection on
+        # the underlying pathfinder.  No-op when there are no diff pairs.
+        self._prepare_routing()
+
         if net_order is None:
             net_order = sorted(self.nets.keys(), key=lambda n: self._get_net_priority(n))
 
@@ -3174,6 +3309,10 @@ class Autorouter:
         """
         print("\n=== Interleaved Net Routing ===")
 
+        # Issue #2587 / Epic #2556 Phase 1C-cont: Activate diff-pair partner
+        # threading before routing begins.
+        self._prepare_routing()
+
         # Issue #1603: Sub-grid escape pre-pass for off-grid pads
         escape_routes = self._run_subgrid_prepass()
 
@@ -3399,6 +3538,10 @@ class Autorouter:
         """
         print("\n=== Parallel Net Routing ===")
         print(f"  Max workers: {max_workers}")
+
+        # Issue #2587 / Epic #2556 Phase 1C-cont: Activate diff-pair partner
+        # threading before routing begins.
+        self._prepare_routing()
 
         # Issue #1603: Sub-grid escape pre-pass for off-grid pads
         escape_routes = self._run_subgrid_prepass()
@@ -3665,6 +3808,13 @@ class Autorouter:
                 progress_callback=progress_callback,
                 timeout=timeout,
             )
+
+        # Issue #2587 / Epic #2556 Phase 1C-cont: Activate diff-pair partner
+        # threading before negotiated routing begins.  This is the default
+        # path for ``kct route`` (negotiated strategy is enabled by default
+        # in the CLI), so wiring here is what actually fires Phase 1C on
+        # production boards.
+        self._prepare_routing()
 
         # Issue #1603: Sub-grid escape pre-pass for off-grid pads
         escape_routes = self._run_subgrid_prepass()
@@ -5630,6 +5780,10 @@ class Autorouter:
         Returns:
             List of routes (may be partial if timeout reached or some nets fail)
         """
+        # Issue #2587 / Epic #2556 Phase 1C-cont: Activate diff-pair partner
+        # threading before two-phase routing begins.
+        self._prepare_routing()
+
         tp_router = self._create_two_phase_router()
         return tp_router.route_all(
             use_negotiated=use_negotiated,

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -755,6 +755,60 @@ class CppPathfinder:
         # } or ``None`` if no diagnostic was captured.
         self._last_failure_info: dict | None = None
 
+        # Issue #2587 / Epic #2556 Phase 1C-cont: Reverse map for diff-pair
+        # partner resolution.  The autorouter populates this via
+        # :meth:`set_net_name_to_id` before routing begins so that
+        # ``NetClassRouting.diffpair_partner`` (a *name*) can be resolved to
+        # the partner *id* required by the C++ ``partner_net`` plumbing.
+        #
+        # When the map is empty (the default) or the source net has no
+        # ``diffpair_partner`` declaration, :meth:`_resolve_partner_net_id`
+        # returns ``None`` and the C++ search uses the wider inter-pair
+        # ``clearance`` for every other net (the pre-Phase-1C contract).
+        self._net_name_to_id: dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Diff-pair partner resolution (Issue #2587 / Epic #2556 Phase 1C-cont)
+    # ------------------------------------------------------------------
+
+    def set_net_name_to_id(self, mapping: dict[str, int]) -> None:
+        """Inject a net-name -> net-id reverse map for partner resolution.
+
+        Mirrors :meth:`Pathfinder.set_net_name_to_id`.  Phase 1C threads
+        ``NetClassRouting.intra_pair_clearance`` through the C++ A* search
+        via the ``partner_net`` parameter on ``route_resumable()`` and
+        ``validate_route()``.  The clearance is configured per-source-net
+        but applies only when the *other* net is the named partner.
+        Resolving partner-name to partner-id requires this reverse map,
+        which the ``Autorouter`` builds from its ``net_names`` dict.
+
+        Idempotent and may be called multiple times.  Passing an empty
+        dict disables partner detection (the C++ search falls back to
+        ``clearance`` for every other net).
+        """
+        self._net_name_to_id = dict(mapping)
+
+    def _resolve_partner_net_id(self, net_name: str) -> int | None:
+        """Look up the integer net id of the diff-pair partner of *net_name*.
+
+        Reads :attr:`NetClassRouting.diffpair_partner` and resolves the
+        partner-name to a partner-id via :attr:`_net_name_to_id`.  Returns
+        ``None`` when:
+
+        * the source net has no net class (or the class has no
+          ``diffpair_partner`` set), or
+        * the partner-name is missing from :attr:`_net_name_to_id` (e.g.
+          the autorouter has not populated the reverse map yet).
+
+        ``None`` is the dormant signal for the C++ wiring sites: when
+        partner is unknown, the search uses the wider ``clearance`` for
+        every other net, matching pre-#2559 / pre-#2587 behavior.
+        """
+        net_class = self._net_class_map.get(net_name)
+        if net_class is None or net_class.diffpair_partner is None:
+            return None
+        return self._net_name_to_id.get(net_class.diffpair_partner)
+
     def set_routable_layers(self, layers: list[int]) -> None:
         """Set which layers are routable (skip plane layers)."""
         self._impl.set_routable_layers(layers)
@@ -915,6 +969,29 @@ class CppPathfinder:
             math.ceil((net_via_size / 2 + self._rules.via_clearance) / self._grid.resolution),
         )
 
+        # Issue #2587 / Epic #2556 Phase 1C-cont: Resolve the diff-pair partner
+        # net id and compute a tighter within-pair search radius.  When the
+        # source net's ``NetClassRouting`` declares a ``diffpair_partner`` AND
+        # the partner-id is known (via ``set_net_name_to_id`` populated by the
+        # autorouter), the C++ search uses ``intra_pair_radius_cells`` for
+        # cells belonging to the partner net only.  All other foreign nets
+        # continue to see the wider ``trace_radius_cells`` radius.  When
+        # ``partner_net == -1`` (the dormant default) the C++ side preserves
+        # pre-#2559 behavior identically.
+        partner_net_id = -1
+        intra_pair_radius_cells = 0
+        if net_class is not None and net_class.diffpair_partner is not None:
+            partner_id = self._net_name_to_id.get(net_class.diffpair_partner)
+            if partner_id is not None:
+                partner_net_id = int(partner_id)
+                intra_pair_clearance = net_class.effective_intra_pair_clearance()
+                intra_pair_radius_cells = max(
+                    1,
+                    math.ceil(
+                        (net_trace_width / 2 + intra_pair_clearance) / self._grid.resolution
+                    ),
+                )
+
         # Issue #2427: Compute pad metal bounds and approach zones.
         # This mirrors the Python pathfinder's _get_pad_metal_bounds() logic
         # so the C++ A* search can use expanded goal/start regions and
@@ -963,9 +1040,14 @@ class CppPathfinder:
                 via_radius_cells,
                 start_pad_bounds,
                 end_pad_bounds,
-                # Issue #2559 / Epic #2556 Phase 1C: defaults preserve pre-#2559 behavior.
-                -1,  # partner_net (diff-pair plumbing not used here)
-                0,   # intra_pair_radius_cells
+                # Issue #2559 / Epic #2556 Phase 1C: diff-pair within-pair
+                # clearance.  When ``partner_net == -1`` (the dormant default
+                # before #2587 wired in the partner map), the C++ search uses
+                # ``trace_radius_cells`` for every other net.  When set, cells
+                # belonging to ``partner_net`` are checked against
+                # ``intra_pair_radius_cells`` (the tighter within-pair radius).
+                partner_net_id,
+                intra_pair_radius_cells,
                 # Issue #2610: per-net wall-clock deadline + iteration override.
                 timeout_seconds,
                 self._max_search_iterations,
@@ -994,9 +1076,16 @@ class CppPathfinder:
                 route = self._convert_result_to_route(result, start, net_class)
 
                 # Issue #1702 Gap 3 + Issue #2439: Post-route geometric
-                # clearance validation via C++ validate_route().
+                # clearance validation via C++ validate_route().  Issue #2587
+                # threads the partner net id + intra-pair clearance so the
+                # validator does not reject diff-pair routes that legitimately
+                # sit at the tighter within-pair distance.
                 violation_location = self._validate_route_clearance(
-                    route, start, end, trace_radius_cells
+                    route,
+                    start,
+                    end,
+                    trace_radius_cells,
+                    net_class=net_class,
                 )
 
                 if violation_location is None:
@@ -1189,6 +1278,7 @@ class CppPathfinder:
         start: "Pad",
         end: "Pad",
         trace_radius_cells: int,
+        net_class: "NetClassRouting | None" = None,
     ) -> tuple[float, float] | None:
         """Validate post-route geometric clearance using C++ validation.
 
@@ -1197,11 +1287,22 @@ class CppPathfinder:
         via-via, same-net drill spacing) in a single C++ call, eliminating
         Python callback overhead.
 
+        Issue #2587 / Epic #2556 Phase 1C-cont: When ``net_class`` declares a
+        ``diffpair_partner`` AND the partner-id is resolvable via the reverse
+        map populated by :meth:`set_net_name_to_id`, the C++ validator is
+        instructed to compare against ``intra_pair_clearance`` (instead of
+        ``trace_clearance``) for cells belonging to the partner net.  This is
+        the post-route geometric companion to the search-time
+        ``intra_pair_radius_cells`` plumbing in :meth:`route`.
+
         Args:
             route: Route to validate.
             start: Source pad (for component reference exclusion).
             end: Destination pad (for component reference exclusion).
             trace_radius_cells: Trace half-width in grid cells (for avoidance).
+            net_class: Optional net class for the source net.  When set with a
+                resolvable ``diffpair_partner``, supplies the tighter
+                within-pair clearance to the C++ validator.
 
         Returns:
             (x, y) world coordinates of violation, or None if route is valid.
@@ -1240,6 +1341,18 @@ class CppPathfinder:
             cv.net = via.net
             cpp_vias.append(cv)
 
+        # Issue #2587 / Phase 1C-cont: Resolve partner net id for the source
+        # net so the C++ validator does not reject within-pair edges of a
+        # legitimate diff pair.  Defaults preserve pre-#2559 behavior
+        # identically (partner_net == -1 -> no relaxation).
+        partner_net_id = -1
+        intra_pair_clearance = 0.0
+        if net_class is not None and net_class.diffpair_partner is not None:
+            partner_id = self._net_name_to_id.get(net_class.diffpair_partner)
+            if partner_id is not None:
+                partner_net_id = int(partner_id)
+                intra_pair_clearance = float(net_class.effective_intra_pair_clearance())
+
         vresult = self._grid._impl.validate_route(
             cpp_segs,
             cpp_vias,
@@ -1248,6 +1361,8 @@ class CppPathfinder:
             self._rules.trace_clearance,
             self._rules.via_clearance,
             self._rules.min_drill_clearance,
+            partner_net_id,
+            intra_pair_clearance,
         )
 
         if not vresult.valid:
@@ -1445,6 +1560,15 @@ class CppPathfinder:
         then identifies which net IDs are blocking cells along that path.
         This is used for targeted rip-up in negotiated routing.
 
+        Issue #2587 / Epic #2556 Phase 1C-cont: When the source net has a
+        diff-pair partner (resolvable via :meth:`_resolve_partner_net_id`),
+        the partner net is excluded from the blocker set.  The partner's
+        copper is *expected* to sit close to this route at the within-pair
+        clearance; treating it as a blocker would trigger spurious rip-up
+        of the partner during negotiated routing.  Unlike the search-time
+        plumbing, this filter does not need a tighter radius -- the
+        partner is simply not a candidate for rip-up.
+
         Args:
             start: Source pad
             end: Destination pad
@@ -1452,10 +1576,16 @@ class CppPathfinder:
             net_class: Optional net class for per-net trace width (Issue #1692).
 
         Returns:
-            Set of net IDs that block the path (excluding net 0 and the source net)
+            Set of net IDs that block the path (excluding net 0, the source
+            net, and -- when configured -- the diff-pair partner net).
         """
         blocking_nets: set[int] = set()
         source_net = start.net
+
+        # Issue #2587 / Phase 1C-cont: Resolve the diff-pair partner net id
+        # (or -1 when no partner is configured).  Cells belonging to the
+        # partner are skipped below so they are not flagged for rip-up.
+        partner_net_id = self._resolve_partner_net_id(start.net_name) or -1
 
         # Convert to grid coordinates
         start_gx, start_gy = self._grid._impl.world_to_grid(start.x, start.y)
@@ -1493,7 +1623,12 @@ class CppPathfinder:
                     if 0 <= cx < self._grid.cols and 0 <= cy < self._grid.rows:
                         if self._grid._impl.is_valid(cx, cy, layer):
                             cell = self._grid._impl.at(cx, cy, layer)
-                            if cell.blocked and cell.net != source_net and cell.net != 0:
+                            if (
+                                cell.blocked
+                                and cell.net != source_net
+                                and cell.net != 0
+                                and cell.net != partner_net_id
+                            ):
                                 # This cell is blocked by another net's route
                                 if cell.usage_count > 0:
                                     blocking_nets.add(cell.net)

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -2177,16 +2177,32 @@ class Router:
         then identifies which net IDs are blocking cells along that path.
         This is used for targeted rip-up in negotiated routing.
 
+        Issue #2587 / Epic #2556 Phase 1C-cont: When the source net has a
+        diff-pair partner (resolvable via :meth:`_resolve_partner_net_id`),
+        the partner net is excluded from the blocker set.  The partner's
+        copper legitimately sits close to this route at the within-pair
+        clearance; treating it as a blocker would trigger spurious rip-up
+        of the partner during negotiated routing.  Mirror of the C++
+        backend's filter at :meth:`CppPathfinder.find_blocking_nets`.
+
         Args:
             start: Source pad
             end: Destination pad
             layer: Optional layer index (uses pad layer if not specified)
 
         Returns:
-            Set of net IDs that block the path (excluding net 0 and the source net)
+            Set of net IDs that block the path (excluding net 0, the source
+            net, and -- when configured -- the diff-pair partner net).
         """
         blocking_nets: set[int] = set()
         source_net = start.net
+
+        # Issue #2587 / Phase 1C-cont: Resolve the diff-pair partner net id
+        # (or -1 when no partner is configured).  Cells belonging to the
+        # partner are skipped below so they are not flagged for rip-up.
+        partner_net_id = self._resolve_partner_net_id(start.net_name)
+        if partner_net_id is None:
+            partner_net_id = -1
 
         # Convert to grid coordinates
         start_gx, start_gy = self.grid.world_to_grid(start.x, start.y)
@@ -2216,7 +2232,12 @@ class Router:
                     cx, cy = gx + check_dx, gy + check_dy
                     if 0 <= cx < self.grid.cols and 0 <= cy < self.grid.rows:
                         cell = self.grid.grid[layer][cy][cx]
-                        if cell.blocked and cell.net != source_net and cell.net != 0:
+                        if (
+                            cell.blocked
+                            and cell.net != source_net
+                            and cell.net != 0
+                            and cell.net != partner_net_id
+                        ):
                             # This cell is blocked by another net's route
                             # Check usage_count to ensure it's a routed cell, not a static obstacle
                             if cell.usage_count > 0:

--- a/tests/test_diffpair_partner_wiring.py
+++ b/tests/test_diffpair_partner_wiring.py
@@ -1,0 +1,468 @@
+"""Tests for diff-pair partner-net activation wiring.
+
+Issue #2587 / Epic #2556 Phase 1C-cont: This file exercises the activation
+path that PR #2586 (Phase 1C) left dormant.  Specifically:
+
+1. ``CppPathfinder.set_net_name_to_id`` / ``_resolve_partner_net_id``
+   mirror the Python ``Router`` API.
+2. ``Autorouter._prepare_routing()`` populates the reverse map on the
+   underlying pathfinder before routing begins.
+3. Diff-pair detection runs during ``_prepare_routing()`` and mutates
+   per-net ``NetClassRouting`` copies (NEVER the shared singletons).
+4. ``find_blocking_nets`` (both backends) excludes the diff-pair partner
+   from the rip-up candidate set.
+5. Backward-compatibility: when no diff pair is present, behavior is
+   bit-for-bit identical to pre-#2559.
+
+These tests do not depend on the C++ ``.so`` being current -- the
+``CppPathfinder`` instantiation is gated by ``_CPP_AVAILABLE`` and skipped
+gracefully when the binding mismatches the source tree.  The Python-side
+wiring tests run unconditionally.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.cpp_backend import (
+    _CPP_AVAILABLE,
+    CppGrid,
+    CppPathfinder,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.pathfinder import Router
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import (
+    NET_CLASS_HIGH_SPEED,
+    DesignRules,
+    NetClassRouting,
+)
+
+
+# =============================================================================
+# Python pathfinder set_net_name_to_id / _resolve_partner_net_id
+# =============================================================================
+
+
+class TestPythonPathfinderPartnerResolution:
+    """``Router.set_net_name_to_id`` and ``_resolve_partner_net_id``."""
+
+    def _make_router(self, net_class_map=None):
+        """Build a minimal Router with a small grid for unit testing."""
+        rules = DesignRules()
+        grid = RoutingGrid(10.0, 10.0, rules)
+        return Router(grid=grid, rules=rules, net_class_map=net_class_map or {})
+
+    def test_set_net_name_to_id_stores_mapping(self):
+        router = self._make_router()
+        router.set_net_name_to_id({"USB_D+": 1, "USB_D-": 2})
+        assert router._net_name_to_id == {"USB_D+": 1, "USB_D-": 2}
+
+    def test_set_net_name_to_id_is_idempotent(self):
+        router = self._make_router()
+        router.set_net_name_to_id({"A": 1})
+        router.set_net_name_to_id({"A": 1, "B": 2})
+        assert router._net_name_to_id == {"A": 1, "B": 2}
+
+    def test_set_net_name_to_id_empty_disables_partner(self):
+        router = self._make_router()
+        router.set_net_name_to_id({"A": 1})
+        router.set_net_name_to_id({})
+        assert router._net_name_to_id == {}
+
+    def test_set_net_name_to_id_takes_a_copy(self):
+        router = self._make_router()
+        src = {"A": 1}
+        router.set_net_name_to_id(src)
+        src["B"] = 2  # outside mutation should not leak in
+        assert router._net_name_to_id == {"A": 1}
+
+    def test_resolve_partner_returns_none_when_no_class(self):
+        router = self._make_router(net_class_map={})
+        router.set_net_name_to_id({"X": 1, "Y": 2})
+        assert router._resolve_partner_net_id("X") is None
+
+    def test_resolve_partner_returns_none_when_no_partner(self):
+        nc = NetClassRouting(name="Plain")  # no diffpair_partner
+        router = self._make_router(net_class_map={"X": nc})
+        router.set_net_name_to_id({"X": 1, "Y": 2})
+        assert router._resolve_partner_net_id("X") is None
+
+    def test_resolve_partner_returns_none_when_partner_unknown(self):
+        nc = NetClassRouting(name="Plain", diffpair_partner="MISSING")
+        router = self._make_router(net_class_map={"X": nc})
+        router.set_net_name_to_id({"X": 1, "Y": 2})  # MISSING not in map
+        assert router._resolve_partner_net_id("X") is None
+
+    def test_resolve_partner_returns_id_when_resolvable(self):
+        nc = NetClassRouting(name="Diff", diffpair_partner="Y")
+        router = self._make_router(net_class_map={"X": nc})
+        router.set_net_name_to_id({"X": 1, "Y": 2})
+        assert router._resolve_partner_net_id("X") == 2
+
+    def test_resolve_partner_returns_id_for_both_halves(self):
+        """When both halves declare each other, both resolve correctly."""
+        x_class = NetClassRouting(name="Diff", diffpair_partner="Y")
+        y_class = NetClassRouting(name="Diff", diffpair_partner="X")
+        router = self._make_router(net_class_map={"X": x_class, "Y": y_class})
+        router.set_net_name_to_id({"X": 1, "Y": 2})
+        assert router._resolve_partner_net_id("X") == 2
+        assert router._resolve_partner_net_id("Y") == 1
+
+
+# =============================================================================
+# CppPathfinder set_net_name_to_id / _resolve_partner_net_id
+# =============================================================================
+
+
+@pytest.mark.skipif(not _CPP_AVAILABLE, reason="C++ router backend unavailable")
+class TestCppPathfinderPartnerResolution:
+    """Mirror of the Python tests for ``CppPathfinder``."""
+
+    def _make_cpp_pathfinder(self, net_class_map=None):
+        rules = DesignRules()
+        py_grid = RoutingGrid(10.0, 10.0, rules)
+        cpp_grid = CppGrid.from_routing_grid(py_grid)
+        return CppPathfinder(
+            grid=cpp_grid,
+            rules=rules,
+            net_class_map=net_class_map or {},
+        )
+
+    def test_setter_method_exists(self):
+        pf = self._make_cpp_pathfinder()
+        assert hasattr(pf, "set_net_name_to_id")
+        assert hasattr(pf, "_resolve_partner_net_id")
+
+    def test_set_net_name_to_id_stores_mapping(self):
+        pf = self._make_cpp_pathfinder()
+        pf.set_net_name_to_id({"USB_D+": 1, "USB_D-": 2})
+        assert pf._net_name_to_id == {"USB_D+": 1, "USB_D-": 2}
+
+    def test_set_net_name_to_id_is_idempotent(self):
+        pf = self._make_cpp_pathfinder()
+        pf.set_net_name_to_id({"A": 1})
+        pf.set_net_name_to_id({"A": 1, "B": 2})
+        assert pf._net_name_to_id == {"A": 1, "B": 2}
+
+    def test_set_net_name_to_id_empty_disables_partner(self):
+        pf = self._make_cpp_pathfinder()
+        pf.set_net_name_to_id({"A": 1})
+        pf.set_net_name_to_id({})
+        assert pf._net_name_to_id == {}
+
+    def test_resolve_partner_returns_none_when_no_class(self):
+        pf = self._make_cpp_pathfinder(net_class_map={})
+        pf.set_net_name_to_id({"X": 1, "Y": 2})
+        assert pf._resolve_partner_net_id("X") is None
+
+    def test_resolve_partner_returns_none_when_no_partner(self):
+        nc = NetClassRouting(name="Plain")
+        pf = self._make_cpp_pathfinder(net_class_map={"X": nc})
+        pf.set_net_name_to_id({"X": 1, "Y": 2})
+        assert pf._resolve_partner_net_id("X") is None
+
+    def test_resolve_partner_returns_none_when_partner_unknown(self):
+        nc = NetClassRouting(name="Plain", diffpair_partner="MISSING")
+        pf = self._make_cpp_pathfinder(net_class_map={"X": nc})
+        pf.set_net_name_to_id({"X": 1, "Y": 2})
+        assert pf._resolve_partner_net_id("X") is None
+
+    def test_resolve_partner_returns_id_when_resolvable(self):
+        nc = NetClassRouting(name="Diff", diffpair_partner="Y")
+        pf = self._make_cpp_pathfinder(net_class_map={"X": nc})
+        pf.set_net_name_to_id({"X": 1, "Y": 2})
+        assert pf._resolve_partner_net_id("X") == 2
+
+    def test_backward_compat_default_is_empty(self):
+        """A freshly-constructed CppPathfinder has no partner map."""
+        pf = self._make_cpp_pathfinder()
+        assert pf._net_name_to_id == {}
+        assert pf._resolve_partner_net_id("anything") is None
+
+
+# =============================================================================
+# Autorouter._prepare_routing
+# =============================================================================
+
+
+class TestAutorouterPrepareRouting:
+    """``Autorouter._prepare_routing`` builds the reverse map and propagates
+    diff-pair declarations from suffix detection."""
+
+    def _build_autorouter_with_usb_pair(self):
+        """Create an autorouter, add USB_D+ and USB_D- pads with the
+        ``HighSpeed`` net class, and return it ready for routing.
+
+        The pads share a component (``J1``) but are on different pins so
+        they are recognized as distinct nets by ``add_component``.
+        """
+        ar = Autorouter(width=20.0, height=20.0)
+        # Manually register the high-speed nets without going through
+        # add_component so the test stays focused on the wiring path.
+        ar.nets[1] = [("J1", "1")]
+        ar.nets[2] = [("J1", "2")]
+        ar.net_names[1] = "USB_D+"
+        ar.net_names[2] = "USB_D-"
+        ar.net_class_map["USB_D+"] = NET_CLASS_HIGH_SPEED
+        ar.net_class_map["USB_D-"] = NET_CLASS_HIGH_SPEED
+        return ar
+
+    def test_prepare_routing_populates_reverse_map(self):
+        ar = self._build_autorouter_with_usb_pair()
+        ar._prepare_routing()
+        assert hasattr(ar.router, "_net_name_to_id")
+        assert ar.router._net_name_to_id == {"USB_D+": 1, "USB_D-": 2}
+
+    def test_prepare_routing_sets_diffpair_partner_on_per_net_copies(self):
+        """Suffix detection finds USB_D+/USB_D- and sets diffpair_partner
+        on a per-net copy so the shared NET_CLASS_HIGH_SPEED singleton is
+        NOT mutated cross-call.
+        """
+        # Sanity check: predefined singleton has no partner initially
+        assert NET_CLASS_HIGH_SPEED.diffpair_partner is None
+
+        ar = self._build_autorouter_with_usb_pair()
+        # Before _prepare_routing: both nets reference the same singleton
+        assert ar.net_class_map["USB_D+"] is NET_CLASS_HIGH_SPEED
+        assert ar.net_class_map["USB_D-"] is NET_CLASS_HIGH_SPEED
+
+        ar._prepare_routing()
+
+        # After _prepare_routing: each net has its OWN NetClassRouting
+        # with the partner set; the shared singleton is unchanged.
+        assert NET_CLASS_HIGH_SPEED.diffpair_partner is None
+        assert ar.net_class_map["USB_D+"] is not NET_CLASS_HIGH_SPEED
+        assert ar.net_class_map["USB_D-"] is not NET_CLASS_HIGH_SPEED
+        # Naming convention from diff-pair detection: positive (+) gets
+        # the negative (-) as its partner.
+        assert ar.net_class_map["USB_D+"].diffpair_partner == "USB_D-"
+        assert ar.net_class_map["USB_D-"].diffpair_partner == "USB_D+"
+        # The intra_pair_clearance is preserved through dataclasses.replace.
+        assert ar.net_class_map["USB_D+"].intra_pair_clearance == 0.075
+
+    def test_prepare_routing_resolves_partner_through_router(self):
+        """After _prepare_routing, the router can resolve partners by name."""
+        ar = self._build_autorouter_with_usb_pair()
+        ar._prepare_routing()
+        # The router (whether Python or C++) now has both the map AND the
+        # per-net class with diffpair_partner set, so the partner-id
+        # resolution returns a real integer.
+        assert ar.router._resolve_partner_net_id("USB_D+") == 2
+        assert ar.router._resolve_partner_net_id("USB_D-") == 1
+
+    def test_prepare_routing_idempotent(self):
+        """Multiple calls to _prepare_routing leave net_class_map stable."""
+        ar = self._build_autorouter_with_usb_pair()
+        ar._prepare_routing()
+        first_plus = ar.net_class_map["USB_D+"]
+        ar._prepare_routing()
+        second_plus = ar.net_class_map["USB_D+"]
+        # Either the same dataclass-replaced object is reused OR an
+        # equivalent new one is produced; either way the partner stays
+        # set and the singleton remains untouched.
+        assert second_plus.diffpair_partner == "USB_D-"
+        assert NET_CLASS_HIGH_SPEED.diffpair_partner is None
+
+    def test_prepare_routing_noop_when_no_pairs(self):
+        """With no diff-pair nets, _prepare_routing still builds the
+        reverse map but leaves net_class_map untouched."""
+        ar = Autorouter(width=20.0, height=20.0)
+        ar.nets[1] = [("J1", "1")]
+        ar.net_names[1] = "SIG_A"
+        ar.net_class_map["SIG_A"] = NetClassRouting(name="Plain")
+
+        original_class = ar.net_class_map["SIG_A"]
+        ar._prepare_routing()
+
+        # Reverse map populated
+        assert ar.router._net_name_to_id == {"SIG_A": 1}
+        # Net class untouched (still the original instance, no partner)
+        assert ar.net_class_map["SIG_A"] is original_class
+        assert ar.net_class_map["SIG_A"].diffpair_partner is None
+        # Partner resolution returns None (the dormant signal)
+        assert ar.router._resolve_partner_net_id("SIG_A") is None
+
+    def test_prepare_routing_skips_empty_net_names(self):
+        """Net id 0 with empty name does not pollute the reverse map."""
+        ar = Autorouter(width=20.0, height=20.0)
+        ar.net_names[0] = ""
+        ar.net_names[1] = "REAL_NET"
+        ar.nets[1] = [("U1", "1")]
+        ar.net_class_map["REAL_NET"] = NetClassRouting(name="Plain")
+        ar._prepare_routing()
+        assert "" not in ar.router._net_name_to_id
+        assert ar.router._net_name_to_id == {"REAL_NET": 1}
+
+
+# =============================================================================
+# find_blocking_nets partner exclusion
+# =============================================================================
+
+
+class TestFindBlockingNetsPartnerExclusion:
+    """Both backends exclude the diff-pair partner from blocker set."""
+
+    def _make_router_with_pair(self):
+        """Create a Python Router whose source net is paired with net 2."""
+        rules = DesignRules()
+        grid = RoutingGrid(10.0, 10.0, rules)
+        x_class = NetClassRouting(name="Diff", diffpair_partner="Y")
+        router = Router(
+            grid=grid, rules=rules, net_class_map={"X": x_class}
+        )
+        router.set_net_name_to_id({"X": 1, "Y": 2})
+        return router, grid
+
+    def _make_pad(self, x: float, y: float, net: int, net_name: str) -> Pad:
+        return Pad(
+            x=x,
+            y=y,
+            width=0.5,
+            height=0.5,
+            net=net,
+            net_name=net_name,
+            layer=Layer.F_CU,
+            ref="R1" if net == 1 else "R2",
+            pin="1",
+        )
+
+    def test_find_blocking_nets_excludes_partner_python(self):
+        """A direct-path Bresenham scan that crosses a partner trace
+        does NOT report the partner net id as a blocker."""
+        router, grid = self._make_router_with_pair()
+
+        # Manually mark a cell on the direct path as blocked by net 2 (the
+        # partner) and net 3 (an unrelated foreign net).  find_blocking_nets
+        # should return {3} only, not {2, 3}.
+        layer_idx = grid.layer_to_index(Layer.F_CU.value)
+        mid_gx, mid_gy = grid.world_to_grid(5.0, 5.0)
+        cell_partner = grid.grid[layer_idx][mid_gy][mid_gx]
+        cell_partner.blocked = True
+        cell_partner.net = 2
+        cell_partner.usage_count = 1
+
+        offset_gx, offset_gy = grid.world_to_grid(5.0, 6.0)
+        cell_other = grid.grid[layer_idx][offset_gy][offset_gx]
+        cell_other.blocked = True
+        cell_other.net = 3
+        cell_other.usage_count = 1
+
+        # Construct pads at (1,5) and (9,5) so the Bresenham line passes
+        # straight through (5,5).  The partner trace at (5,5) is excluded.
+        start_pad = self._make_pad(1.0, 5.0, net=1, net_name="X")
+        end_pad = self._make_pad(9.0, 5.0, net=1, net_name="X")
+
+        blocking = router.find_blocking_nets(start_pad, end_pad)
+        assert 2 not in blocking, "partner net should be excluded"
+        # Net 3 may or may not be reached depending on the exact
+        # Bresenham step; we only assert the partner exclusion contract.
+
+    def test_find_blocking_nets_returns_partner_when_unpaired(self):
+        """When no partner is configured, the same blocker IS reported.
+
+        This is the dormant-signal contract: pre-Phase-1C behavior is
+        preserved when ``_net_name_to_id`` is empty (or the source net
+        has no ``diffpair_partner``).
+        """
+        rules = DesignRules()
+        grid = RoutingGrid(10.0, 10.0, rules)
+        # No partner declared on the net class.
+        router = Router(
+            grid=grid,
+            rules=rules,
+            net_class_map={"X": NetClassRouting(name="Plain")},
+        )
+        # Empty map -- no partner can resolve.
+        router.set_net_name_to_id({})
+
+        layer_idx = grid.layer_to_index(Layer.F_CU.value)
+        mid_gx, mid_gy = grid.world_to_grid(5.0, 5.0)
+        cell_blocker = grid.grid[layer_idx][mid_gy][mid_gx]
+        cell_blocker.blocked = True
+        cell_blocker.net = 2  # "partner" id, but not declared as such
+        cell_blocker.usage_count = 1
+
+        start_pad = self._make_pad(1.0, 5.0, net=1, net_name="X")
+        end_pad = self._make_pad(9.0, 5.0, net=1, net_name="X")
+
+        blocking = router.find_blocking_nets(start_pad, end_pad)
+        assert 2 in blocking, (
+            "without partner declaration, net 2 is a regular blocker"
+        )
+
+
+# =============================================================================
+# Backward compatibility: dormant-signal contract
+# =============================================================================
+
+
+class TestDormantSignalBackwardCompat:
+    """When no diff-pair declarations exist anywhere, behavior is
+    bit-for-bit identical to pre-#2559 / pre-#2587."""
+
+    def test_router_with_empty_map_has_no_partner(self):
+        """The setter accepts an empty dict and partner resolution returns
+        None for every net."""
+        rules = DesignRules()
+        grid = RoutingGrid(10.0, 10.0, rules)
+        router = Router(grid=grid, rules=rules, net_class_map={})
+        router.set_net_name_to_id({})
+        assert router._resolve_partner_net_id("anything") is None
+
+    def test_autorouter_route_all_safe_without_pairs(self):
+        """``_prepare_routing`` does not raise when there are no nets."""
+        ar = Autorouter(width=20.0, height=20.0)
+        # No pads, no nets -- the helper should still run cleanly.
+        ar._prepare_routing()
+        assert ar.router._net_name_to_id == {}
+
+    def test_high_speed_singleton_intact_after_detection(self):
+        """The shared NET_CLASS_HIGH_SPEED singleton is NEVER mutated by
+        the wiring -- only per-net copies receive the partner."""
+        baseline_partner = NET_CLASS_HIGH_SPEED.diffpair_partner
+        baseline_clearance = NET_CLASS_HIGH_SPEED.intra_pair_clearance
+
+        ar = Autorouter(width=20.0, height=20.0)
+        ar.nets[1] = [("J1", "1")]
+        ar.nets[2] = [("J1", "2")]
+        ar.net_names[1] = "USB_D+"
+        ar.net_names[2] = "USB_D-"
+        ar.net_class_map["USB_D+"] = NET_CLASS_HIGH_SPEED
+        ar.net_class_map["USB_D-"] = NET_CLASS_HIGH_SPEED
+        ar._prepare_routing()
+
+        # Critical: the singleton must be untouched so it remains usable
+        # by every other board.
+        assert NET_CLASS_HIGH_SPEED.diffpair_partner == baseline_partner
+        assert NET_CLASS_HIGH_SPEED.intra_pair_clearance == baseline_clearance
+
+
+# =============================================================================
+# Integration: route_all triggers _prepare_routing
+# =============================================================================
+
+
+class TestRouteAllTriggersPrepareRouting:
+    """End-to-end check: ``route_all()`` actually calls ``_prepare_routing``
+    so the partner map is populated when production code calls the router.
+    """
+
+    def test_route_all_populates_partner_map(self):
+        ar = Autorouter(width=20.0, height=20.0)
+        ar.nets[1] = [("J1", "1")]
+        ar.nets[2] = [("J1", "2")]
+        ar.net_names[1] = "USB_D+"
+        ar.net_names[2] = "USB_D-"
+        ar.net_class_map["USB_D+"] = NET_CLASS_HIGH_SPEED
+        ar.net_class_map["USB_D-"] = NET_CLASS_HIGH_SPEED
+
+        # No real pads added -> route_all should return [] without crashing
+        # but still run _prepare_routing.
+        ar.route_all()
+        assert ar.router._net_name_to_id == {"USB_D+": 1, "USB_D-": 2}
+        assert ar.net_class_map["USB_D+"].diffpair_partner == "USB_D-"


### PR DESCRIPTION
## Summary

Activates the Phase 1C diff-pair threading that PR #2586 left dormant in production. Before this PR, `set_net_name_to_id` was never called from any `route_all_*` entry point and `CppPathfinder` had no setter at all, so `_resolve_partner_net_id` always returned `None` and the within-pair clearance branch never fired from `kct route`.

This PR closes the triple-gated dormancy identified by the curator note on #2587:

1. **Adds `set_net_name_to_id` + `_resolve_partner_net_id` to `CppPathfinder`** (mirror of the Python `Router` API from #2586).
2. **Wires partner_net + intra_pair_radius_cells** into `CppPathfinder.route_resumable()` and `validate_route()`.
3. **Excludes the diff-pair partner from `find_blocking_nets`** in both backends so negotiated rip-up doesn't tear down the partner.
4. **Adds `Autorouter._prepare_routing()`** that populates the reverse map AND runs diff-pair detection, then propagates partners onto **per-net copies** of `NetClassRouting` (never mutating the shared singletons like `NET_CLASS_HIGH_SPEED`).
5. **Hooks `_prepare_routing()` into every `route_all_*` entry point**: `route_all`, `route_all_interleaved`, `route_all_parallel`, `route_all_negotiated`, `route_all_two_phase`. The negotiated path is what `kct route` actually runs by default, so this is where Phase 1C now fires on production boards.

## Changes

- `src/kicad_tools/router/cpp_backend.py`: Add `set_net_name_to_id`, `_resolve_partner_net_id`, wire `partner_net`/`intra_pair_radius_cells` into `route_resumable()`, wire `partner_net`/`intra_pair_clearance` into `validate_route()`, exclude partner from `find_blocking_nets()`.
- `src/kicad_tools/router/pathfinder.py`: Exclude partner from Python `find_blocking_nets()` (mirror of cpp_backend change).
- `src/kicad_tools/router/core.py`: New `Autorouter._prepare_routing()` helper that builds the reverse map and runs diff-pair detection. Mutates per-net `NetClassRouting` copies via `dataclasses.replace` to avoid singleton contamination. Hooked into `route_all`, `route_all_interleaved`, `route_all_parallel`, `route_all_negotiated`, `route_all_two_phase`.
- `tests/test_diffpair_partner_wiring.py`: New test file with 30 tests covering setters, resolution, autorouter wiring, singleton-mutation safety, partner exclusion in `find_blocking_nets`, and the dormant-signal backward-compat contract.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `Autorouter` populates partner map via `set_net_name_to_id` before routing | YES | `_prepare_routing()` called from `route_all`, `route_all_negotiated`, `route_all_two_phase`, `route_all_interleaved`, `route_all_parallel`; verified by `TestRouteAllTriggersPrepareRouting::test_route_all_populates_partner_map` |
| `Autorouter` populates `diffpair_partner` from diff-pair detection | YES | `_prepare_routing()` calls `detect_diff_pairs()` and uses `dataclasses.replace` for per-net partners; verified by `TestAutorouterPrepareRouting::test_prepare_routing_sets_diffpair_partner_on_per_net_copies` |
| `CppPathfinder.set_net_name_to_id` method added | YES | Added at `cpp_backend.py:CppPathfinder`; verified by `TestCppPathfinderPartnerResolution::test_setter_method_exists` |
| `route_resumable()` passes computed partner_net + intra_pair_radius_cells | YES | `cpp_backend.py:949-996` computes both and passes through; replaces the prior `-1, 0` placeholder at line 967-968 |
| `validate_route()` passes computed partner_net + intra_pair_clearance | YES | `_validate_route_clearance()` accepts `net_class`, resolves partner, passes both params; `route()` passes `net_class=net_class` to the validator |
| `find_blocking_nets()` excludes partner_net id (both backends) | YES | Filter at `cpp_backend.py:1564` and `pathfinder.py:2235` adds `cell.net != partner_net_id`; verified by `TestFindBlockingNetsPartnerExclusion` |
| `set_net_name_to_id` idempotent, overwrite works, empty disables | YES | `TestPythonPathfinderPartnerResolution::test_set_net_name_to_id_*` + mirror tests for `CppPathfinder` |
| `_resolve_partner_net_id` returns None for missing class / no diffpair_partner / partner not in map | YES | `TestPythonPathfinderPartnerResolution::test_resolve_partner_*` and mirror tests for `CppPathfinder` |
| Backward-compat regression: empty map / no diff pairs preserves pre-#2559 behavior | YES | `TestDormantSignalBackwardCompat`; `TestAutorouterPrepareRouting::test_prepare_routing_noop_when_no_pairs`; `test_high_speed_singleton_intact_after_detection` |

## Test Plan

- New test file `tests/test_diffpair_partner_wiring.py` with **30 tests** (21 passing, 9 skipped because the local C++ `.so` is at version 3 but the source tree expects version 4 -- the skip gate is the existing `_CPP_AVAILABLE` infrastructure, unchanged by this PR).
- Regression: all **457 router-related tests** (`test_router_*`, `test_diffpair*`, `test_intra_pair_clearance`) pass.
- Verified the helper does NOT mutate the `NET_CLASS_HIGH_SPEED` singleton -- uses `dataclasses.replace` to produce per-net copies (`test_high_speed_singleton_intact_after_detection`).
- Two pre-existing test failures in `test_router_integration.py` (board fixture loading from a worktree path) are unrelated to this PR -- they fail identically on the base commit `d74b8c8c`.

### Empirical board 03 verification (deferred)

The curator note for #2587 calls out that board 03 verification under `kct route` is genuinely useful but requires the C++ binding to be rebuilt to BUILD_VERSION=4 (the source tree value) -- the local environment has a stale `.so` at version 3, so the C++ backend falls back to Python today. The wiring is structurally complete; once a fresh `kct build-native` runs in CI or on a clean machine, the C++ partner_net path activates.

The Python-side path is fully exercised by the 21 passing unit tests and is what currently runs end-to-end via `kct route ... --backend python`.

Closes #2587

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>