### PR TITLE
feat(mfr): model via_in_pad_supported in DesignRules (closes #2635)

### DIFF
--- a/src/kicad_tools/cli/fab_rules_cmd.py
+++ b/src/kicad_tools/cli/fab_rules_cmd.py
@@ -226,6 +226,9 @@ def cmd_show(args):
     print(f"  Min via drill:      {fmt.format(rules.min_via_drill_mm)}")
     print(f"  Min via diameter:   {fmt.format(rules.min_via_diameter_mm)}")
     print(f"  Min annular ring:   {fmt.format(rules.min_annular_ring_mm)}")
+    # Capability flag: surface via-in-pad support so users see the
+    # tier-1 vs base difference at a glance (issue #2635).
+    print(f"  Via-in-pad support: {'yes' if rules.via_in_pad_supported else 'no'}")
 
     print(f"\n{'Holes':─^40}")
     print(f"  Min hole diameter:  {fmt.format(rules.min_hole_diameter_mm)}")

--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -66,6 +66,10 @@ def _init_type_category_map() -> None:
             ViolationType.VIA_HOLE_LARGER_THAN_PAD: ViolationCategory.MANUFACTURING,
             ViolationType.VIA_ANNULAR_WIDTH: ViolationCategory.MANUFACTURING,
             ViolationType.MICRO_VIA_HOLE_TOO_SMALL: ViolationCategory.MANUFACTURING,
+            # Via-in-pad is a manufacturer-capability question (filled and
+            # plated-over via processing) -- categorize with the other
+            # via/fab capabilities.
+            ViolationType.VIA_IN_PAD: ViolationCategory.MANUFACTURING,
             ViolationType.DRILL_HOLE_TOO_SMALL: ViolationCategory.MANUFACTURING,
             ViolationType.DRILL_CLEARANCE: ViolationCategory.MANUFACTURING,
             ViolationType.NPTH_HOLE_TOO_SMALL: ViolationCategory.MANUFACTURING,
@@ -134,6 +138,10 @@ class ViolationType(Enum):
     VIA_HOLE_LARGER_THAN_PAD = "via_hole_larger_than_pad"
     VIA_ANNULAR_WIDTH = "via_annular_width"
     MICRO_VIA_HOLE_TOO_SMALL = "micro_via_hole_too_small"
+    # Via placed inside SMD pad on a manufacturer profile that does not
+    # support via-in-pad processing.  See issue #2635 and
+    # ``validate/rules/via_in_pad.py``.
+    VIA_IN_PAD = "via_in_pad"
 
     # Track/trace dimension issues
     TRACK_WIDTH = "track_width"
@@ -258,6 +266,10 @@ class ViolationType(Enum):
             "zone_unfilled": cls.ZONE_UNFILLED,
             "zone_fill_disabled": cls.ZONE_FILL_DISABLED,
             "zone_no_net": cls.ZONE_NO_NET,
+            # via-in-pad rule from validate via_in_pad checker (issue #2635).
+            # MUST be aliased explicitly -- the fuzzy fallback below would
+            # otherwise match "via" and miscategorize this rule_id.
+            "via_in_pad": cls.VIA_IN_PAD,
         }
 
         alias_match = _ALIASES.get(s_lower)

--- a/src/kicad_tools/manufacturers/base.py
+++ b/src/kicad_tools/manufacturers/base.py
@@ -147,6 +147,22 @@ class DesignRules:
     max_board_width_mm: float = 400.0
     max_board_height_mm: float = 500.0
 
+    # Capability flags
+    #
+    # ``via_in_pad_supported`` mirrors the router's
+    # ``MfrLimits.via_in_pad_supported`` (see
+    # ``src/kicad_tools/router/mfr_limits.py``).  When ``False``, the
+    # validate-side ``via_in_pad`` DRC rule flags any via whose drill
+    # circle is fully contained within an SMD pad on the same net.
+    # When ``True``, the manufacturer offers epoxy-filled and plated-over
+    # via-in-pad processing (e.g., JLCPCB Capability Plus / Tier 1,
+    # PCBWay), so the rule is suppressed.
+    #
+    # NOTE: KiCad's ``.kicad_dru`` format has no native via-in-pad rule,
+    # so ``dru_generator.py`` does NOT translate this field.  Enforcement
+    # lives entirely in the pure-Python ``DRCChecker.check_via_in_pad``.
+    via_in_pad_supported: bool = False
+
     @property
     def min_trace_width_mil(self) -> float:
         """Trace width in mils (thousandths of an inch)."""
@@ -179,6 +195,7 @@ class DesignRules:
             "inner_copper_oz": self.inner_copper_oz,
             "max_board_width_mm": self.max_board_width_mm,
             "max_board_height_mm": self.max_board_height_mm,
+            "via_in_pad_supported": self.via_in_pad_supported,
         }
 
 

--- a/src/kicad_tools/manufacturers/data/jlcpcb_tier1.yaml
+++ b/src/kicad_tools/manufacturers/data/jlcpcb_tier1.yaml
@@ -4,10 +4,10 @@
 # additional capabilities such as via-in-pad (epoxy-filled, plated-over),
 # typically at a per-order surcharge. The scalar DRC limits (trace width,
 # clearance, via drill, annular ring, edge clearance) for Capability Plus
-# match the standard JLCPCB advanced PCB process; the practical difference
-# is the additional via-in-pad capability, which is currently not modelled
-# as a scalar field in DesignRules. See router/mfr_limits.py
-# (MFR_JLCPCB_TIER1.via_in_pad_supported=True) for that capability.
+# match the standard JLCPCB advanced PCB process; the practical
+# differentiator is the additional via-in-pad capability, modelled here
+# by ``via_in_pad_supported: true`` (mirrors the router's
+# MFR_JLCPCB_TIER1.via_in_pad_supported in router/mfr_limits.py).
 #
 # Source: https://jlcpcb.com/capabilities/pcb-capabilities
 #         https://jlcpcb.com/capabilities/Capabilities (Capability Plus tier)
@@ -40,6 +40,7 @@ design_rules:
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0            # No inner layers
+    via_in_pad_supported: true      # Capability Plus tier offers via-in-pad
 
   2layer_2oz:
     min_trace_width_mm: 0.1524      # 6 mil (per JLCPCB published specs for 2oz copper)
@@ -59,6 +60,7 @@ design_rules:
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.0
+    via_in_pad_supported: true      # Capability Plus tier offers via-in-pad
 
   4layer_1oz:
     min_trace_width_mm: 0.1016      # 4 mil
@@ -78,6 +80,7 @@ design_rules:
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
+    via_in_pad_supported: true      # Capability Plus tier offers via-in-pad
 
   4layer_2oz:
     min_trace_width_mm: 0.1524      # 6 mil outer (per JLCPCB published specs for 2oz copper)
@@ -97,6 +100,7 @@ design_rules:
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.5
+    via_in_pad_supported: true      # Capability Plus tier offers via-in-pad
 
   6layer_1oz:
     min_trace_width_mm: 0.0889      # 3.5 mil
@@ -116,3 +120,4 @@ design_rules:
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
+    via_in_pad_supported: true      # Capability Plus tier offers via-in-pad

--- a/src/kicad_tools/manufacturers/data/pcbway.yaml
+++ b/src/kicad_tools/manufacturers/data/pcbway.yaml
@@ -1,8 +1,14 @@
 # PCBWay Design Rules Configuration
 # Source: https://www.pcbway.com/capabilities.html
-# Last verified: 2026-01-16
+# Last verified: 2026-05-10
 #
 # All measurements in millimeters unless otherwise noted.
+#
+# PCBWay offers via-in-pad (epoxy-filled, plated-over) as a standard
+# option, so ``via_in_pad_supported: true`` on every stackup block.
+# Mirrors the router's MFR_PCBWAY.via_in_pad_supported in
+# router/mfr_limits.py (drift-prevention test in
+# tests/test_manufacturer_registry_sync.py enforces parity).
 
 design_rules:
   2layer_1oz:
@@ -23,6 +29,7 @@ design_rules:
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.0
+    via_in_pad_supported: true     # PCBWay offers via-in-pad as a standard option
 
   2layer_2oz:
     min_trace_width_mm: 0.2         # 8 mil for 2oz
@@ -42,6 +49,7 @@ design_rules:
     board_thickness_mm: 1.6
     outer_copper_oz: 2.0
     inner_copper_oz: 0.0
+    via_in_pad_supported: true     # PCBWay offers via-in-pad as a standard option
 
   4layer_1oz:
     min_trace_width_mm: 0.1016      # 4 mil
@@ -61,6 +69,7 @@ design_rules:
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
+    via_in_pad_supported: true     # PCBWay offers via-in-pad as a standard option
 
   6layer_1oz:
     min_trace_width_mm: 0.0889      # 3.5 mil
@@ -80,3 +89,4 @@ design_rules:
     board_thickness_mm: 1.6
     outer_copper_oz: 1.0
     inner_copper_oz: 0.5
+    via_in_pad_supported: true     # PCBWay offers via-in-pad as a standard option

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -15,6 +15,7 @@ from .rules.diffpair_clearance_intra import DiffPairClearanceIntraRule
 from .rules.edge import EdgeClearanceRule
 from .rules.placement import FootprintOutsideBoardRule
 from .rules.silkscreen import check_all_silkscreen
+from .rules.via_in_pad import ViaInPadRule
 from .rules.zone_fill import ZoneFillRule
 from .violations import DRCResults, DRCViolation
 
@@ -108,6 +109,7 @@ class DRCChecker:
         results.merge(self.check_footprint_placement())
         results.merge(self.check_netlist())
         results.merge(self.check_single_pad_nets())
+        results.merge(self.check_via_in_pad())
         results.merge(self.check_zones())
 
         # Apply filters if provided
@@ -265,6 +267,24 @@ class DRCChecker:
         from .rules.single_pad_net import SinglePadNetRule
 
         rule = SinglePadNetRule()
+        return rule.check(self.pcb, self.design_rules)
+
+    def check_via_in_pad(self) -> DRCResults:
+        """Check for vias placed inside SMD pads on unsupported profiles.
+
+        Fires only when the active manufacturer profile has
+        ``via_in_pad_supported=False`` (the default for ``jlcpcb``,
+        ``oshpark``, ``seeed``, ``flashpcb``).  The router refuses to
+        place in-pad vias for those profiles, but a hand-edited or
+        third-party-routed board could still contain them -- this rule
+        verifies the resulting board independently.
+
+        Returns:
+            DRCResults containing via_in_pad violations (one per
+            offending via/pad pair).  Empty on profiles that support
+            via-in-pad (e.g., jlcpcb-tier1, pcbway).
+        """
+        rule = ViaInPadRule()
         return rule.check(self.pcb, self.design_rules)
 
     def check_zones(self) -> DRCResults:

--- a/src/kicad_tools/validate/rules/__init__.py
+++ b/src/kicad_tools/validate/rules/__init__.py
@@ -18,6 +18,7 @@ from .silkscreen import (
 )
 from .single_pad_net import SinglePadNetRule
 from .solder_mask import SolderMaskPadRules
+from .via_in_pad import ViaInPadRule
 from .zone_fill import ZoneFillRule
 
 __all__ = [
@@ -31,6 +32,7 @@ __all__ = [
     "NetImpedanceSpec",
     "SinglePadNetRule",
     "SolderMaskPadRules",
+    "ViaInPadRule",
     "check_all_silkscreen",
     "check_silkscreen_line_width",
     "check_silkscreen_over_pads",

--- a/src/kicad_tools/validate/rules/via_in_pad.py
+++ b/src/kicad_tools/validate/rules/via_in_pad.py
@@ -1,0 +1,231 @@
+"""Via-in-pad DRC rule.
+
+Detects vias whose drill circle is fully covered by an SMD pad on the same
+net, which is only legal when the chosen manufacturer profile supports
+via-in-pad processing (epoxy-filled and plated-over vias).
+
+The router consults the same flag via the existing
+``MfrLimits.via_in_pad_supported`` field (see
+``src/kicad_tools/router/mfr_limits.py``).  When the user asks for a
+profile that does NOT support via-in-pad (default for ``jlcpcb``,
+``oshpark``, ``seeed``, ``flashpcb``), the escape router refuses to
+place an in-pad via -- but DRC must independently verify the same
+constraint, because a hand-edited or third-party-routed board could
+introduce in-pad vias that DRC would otherwise silently accept.
+
+Geometry of "via inside pad":
+
+* SMD pads are modelled as axis-aligned rectangles (post footprint
+  rotation transformation) -- mirrors the representation used by the
+  clearance rule.  For rotated footprints we use the axis-aligned
+  bounding box; pads with non-cardinal rotations are conservatively
+  reported when the BB contains the via even if the actual pad polygon
+  does not.
+* A via is "in the pad" when its drill circle is fully contained inside
+  the pad rectangle, i.e., every point on the drill circle lies on or
+  inside the pad edge.
+
+Out of scope (explicitly): blind/buried vias, microvias, and
+controlled-impedance differential pairs.  These require additional
+DesignRules fields (see issue #2635 acceptance criteria and the
+follow-up items the curator listed).
+
+NOTE: KiCad's ``.kicad_dru`` format has no native via-in-pad rule, so
+``dru_generator.py`` is intentionally not extended for this rule -- the
+check lives entirely in pure-Python ``DRCChecker.check_via_in_pad``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from ..violations import DRCResults, DRCViolation
+from .base import DRC_TOLERANCE, DRCRule
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers import DesignRules
+    from kicad_tools.schema.pcb import PCB, Footprint, Pad, Via
+
+
+def _pad_absolute_bbox(
+    pad: Pad,
+    footprint: Footprint,
+) -> tuple[float, float, float, float]:
+    """Return the axis-aligned bounding box for ``pad`` in board coords.
+
+    Mirrors the transformation used by the clearance rule: rotates the
+    pad center about the footprint origin and, for cardinal rotations,
+    swaps width/height (otherwise uses the rotated rectangle's AABB).
+
+    Returns:
+        (min_x, min_y, max_x, max_y) tuple in mm.
+    """
+    angle_rad = math.radians(footprint.rotation)
+    cos_a = math.cos(angle_rad)
+    sin_a = math.sin(angle_rad)
+
+    local_x, local_y = pad.position
+    rotated_x = local_x * cos_a - local_y * sin_a
+    rotated_y = local_x * sin_a + local_y * cos_a
+    abs_x = footprint.position[0] + rotated_x
+    abs_y = footprint.position[1] + rotated_y
+
+    width, height = pad.size
+    total_rotation = footprint.rotation % 360
+
+    # For cardinal rotations, swap dimensions.
+    if abs(total_rotation - 90) < 0.001 or abs(total_rotation - 270) < 0.001:
+        bbox_w, bbox_h = height, width
+    elif abs(total_rotation) < 0.001 or abs(total_rotation - 180) < 0.001:
+        bbox_w, bbox_h = width, height
+    else:
+        # Axis-aligned bounding box of the rotated rectangle.
+        abs_cos = abs(cos_a)
+        abs_sin = abs(sin_a)
+        bbox_w = width * abs_cos + height * abs_sin
+        bbox_h = width * abs_sin + height * abs_cos
+
+    half_w = bbox_w / 2
+    half_h = bbox_h / 2
+    return (abs_x - half_w, abs_y - half_h, abs_x + half_w, abs_y + half_h)
+
+
+def _is_smd_pad(pad: Pad) -> bool:
+    """Return True if ``pad`` is a surface-mount pad (no plated hole)."""
+    # KiCad pad types: "smd", "thru_hole", "np_thru_hole", "connect"
+    return pad.type == "smd"
+
+
+def _via_inside_pad(via: Via, pad_bbox: tuple[float, float, float, float]) -> bool:
+    """Return True if the via's drill circle is fully inside ``pad_bbox``.
+
+    Args:
+        via: The via to test.  ``via.position`` is the center, ``via.drill``
+            is the drill diameter.
+        pad_bbox: Axis-aligned (min_x, min_y, max_x, max_y) of the pad.
+
+    Returns:
+        ``True`` when every point on the drill circle is on or inside
+        the pad bounding box.  A small DRC tolerance is applied so that
+        edge-touching vias (within manufacturing rounding) are not
+        flagged.
+    """
+    cx, cy = via.position
+    radius = via.drill / 2.0
+    min_x, min_y, max_x, max_y = pad_bbox
+
+    # Every point on the drill circle lies in [cx - r, cx + r] x [cy - r, cy + r].
+    # The drill is fully inside the pad iff the circle's bounding box is.
+    # We require strict containment minus DRC_TOLERANCE so a via whose
+    # drill edge merely touches the pad edge is allowed (it would be a
+    # neckdown rather than an in-pad via).
+    return (
+        cx - radius >= min_x - DRC_TOLERANCE
+        and cx + radius <= max_x + DRC_TOLERANCE
+        and cy - radius >= min_y - DRC_TOLERANCE
+        and cy + radius <= max_y + DRC_TOLERANCE
+    )
+
+
+class ViaInPadRule(DRCRule):
+    """Check that vias are not placed inside SMD pads on unsupported profiles.
+
+    Fires only when ``design_rules.via_in_pad_supported == False`` (the
+    default for ``jlcpcb``, ``oshpark``, ``seeed``, ``flashpcb``).
+
+    For every via on the board, the rule scans SMD pads on the same net
+    and flags the via as an error if any pad's bounding box fully
+    contains the drill circle.
+
+    The same-net constraint prevents false positives where a via is
+    placed near (but not connected to) a pad on a different net -- those
+    are caught by the regular clearance rule instead.
+    """
+
+    rule_id = "via_in_pad"
+    name = "Via in Pad"
+    description = (
+        "Detects vias drilled inside SMD pads on manufacturer profiles that "
+        "do not support filled and plated-over via-in-pad processing"
+    )
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Check all vias against SMD pads on the same net.
+
+        Args:
+            pcb: The PCB to check.
+            design_rules: The active manufacturer's design rules.  This
+                rule short-circuits to no-op when
+                ``design_rules.via_in_pad_supported`` is ``True``.
+
+        Returns:
+            DRCResults containing one ``via_in_pad`` violation per
+            (via, pad) pair that violates the rule.
+        """
+        results = DRCResults()
+        results.rules_checked = 1
+
+        # Capability gate: when the manufacturer supports via-in-pad,
+        # the rule is suppressed.  The acceptance criterion in #2635
+        # requires this to be a no-op on jlcpcb-tier1 and pcbway.
+        if getattr(design_rules, "via_in_pad_supported", False):
+            return results
+
+        # Collect SMD pads grouped by net number for O(N+M) scanning
+        # rather than O(N*M) full cross product.  Net 0 is unconnected
+        # and is intentionally excluded -- vias near unconnected pads
+        # are caught by the clearance rule.
+        pads_by_net: dict[int, list[tuple[Footprint, Pad, tuple[float, float, float, float]]]] = {}
+        for fp in pcb.footprints:
+            for pad in fp.pads:
+                if not _is_smd_pad(pad):
+                    continue
+                if pad.net_number == 0:
+                    continue
+                bbox = _pad_absolute_bbox(pad, fp)
+                pads_by_net.setdefault(pad.net_number, []).append((fp, pad, bbox))
+
+        # For each via, check pads on the same net.
+        for via in pcb.vias:
+            if via.net_number == 0:
+                continue
+            candidates = pads_by_net.get(via.net_number)
+            if not candidates:
+                continue
+            for fp, pad, bbox in candidates:
+                if not _via_inside_pad(via, bbox):
+                    continue
+                results.add(self._make_violation(via, fp, pad))
+
+        return results
+
+    def _make_violation(
+        self,
+        via: Via,
+        fp: Footprint,
+        pad: Pad,
+    ) -> DRCViolation:
+        """Build a DRCViolation for a single (via, pad) pair."""
+        ref_label = f"{fp.reference}-{pad.number}"
+        via_ref = f"Via-{via.uuid[:8]}" if via.uuid else "Via"
+        net_name = via.net_name or pad.net_name or ""
+        return DRCViolation(
+            rule_id="via_in_pad",
+            severity="error",
+            message=(
+                f"Via at ({via.position[0]:.3f}, {via.position[1]:.3f}) "
+                f"drilled inside pad {ref_label} (net '{net_name}'); "
+                f"current manufacturer profile does not support via-in-pad. "
+                f"Switch to jlcpcb-tier1 or pcbway, or move the via off the pad."
+            ),
+            location=(round(via.position[0], 3), round(via.position[1], 3)),
+            actual_value=round(via.drill, 4),
+            required_value=None,
+            items=(via_ref, ref_label),
+            nets=(net_name,),
+        )

--- a/tests/test_manufacturer_registry_sync.py
+++ b/tests/test_manufacturer_registry_sync.py
@@ -106,6 +106,47 @@ class TestRouterDRCRegistrySync:
             f"  DRC:    {sorted(jlcpcb_tier1_drc_aliases)}"
         )
 
+    def test_via_in_pad_supported_parity(self):
+        """``via_in_pad_supported`` parity between router and DRC (issue #2635).
+
+        For every manufacturer name known to BOTH the router's
+        ``MFR_LIMITS`` table and the DRC profile registry, the
+        ``via_in_pad_supported`` flag must agree across all stackup
+        layer counts (2L, 4L, 6L).  If a future contributor flips this
+        flag on one side but not the other, the router would refuse to
+        place in-pad vias while DRC would silently accept them (or vice
+        versa) -- this test catches that drift.
+
+        Layer counts that the DRC profile doesn't model fall back to
+        the closest available stackup (see ``ManufacturerProfile.get_design_rules``).
+        We still assert parity per-layer to surface stackup-level
+        regressions where the capability flag is missing on a specific
+        block.
+        """
+        # Iterate the intersection: only names that exist in both
+        # registries.  Aliases on one side that resolve to a canonical
+        # name on the other are already covered by the resolver tests
+        # above; here we focus on the capability-flag value itself.
+        shared_names = set(MFR_LIMITS.keys()) & (set(DRC_PROFILES.keys()) | set(DRC_ALIASES.keys()))
+        assert shared_names, "No shared manufacturer names between router and DRC"
+
+        mismatches: list[str] = []
+        for name in sorted(shared_names):
+            router_flag = MFR_LIMITS[name].via_in_pad_supported
+            drc_profile = get_profile(name)
+            for layers in (2, 4, 6):
+                drc_rules = drc_profile.get_design_rules(layers=layers, copper_oz=1.0)
+                drc_flag = drc_rules.via_in_pad_supported
+                if router_flag != drc_flag:
+                    mismatches.append(f"{name} ({layers}L): router={router_flag}, DRC={drc_flag}")
+
+        assert not mismatches, (
+            "Router and DRC disagree on via_in_pad_supported for some "
+            "manufacturer/layer combinations. Update the corresponding "
+            "YAML stackup block (manufacturers/data/<mfr>.yaml) or the "
+            "router's MfrLimits entry to restore parity:\n  " + "\n  ".join(mismatches)
+        )
+
 
 class TestJLCPCBTier1DRCProfile:
     """Regression tests for the jlcpcb-tier1 DRC profile (issue #2622)."""

--- a/tests/test_validate_via_in_pad.py
+++ b/tests/test_validate_via_in_pad.py
@@ -1,0 +1,301 @@
+"""Tests for the via-in-pad DRC rule (validate/rules/via_in_pad.py).
+
+Covers issue #2635 acceptance criteria:
+- A board with a via fully inside an SMD pad on the same net is flagged
+  when the profile has via_in_pad_supported=False.
+- The same board produces no violation when via_in_pad_supported=True.
+- Vias on a different net than the pad they overlap are NOT flagged
+  (clearance rule handles those).
+- Vias clearly outside any pad are not flagged.
+- Through-hole pads are not treated as SMD pads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from kicad_tools.validate.rules.via_in_pad import ViaInPadRule
+
+# ---------------------------------------------------------------------------
+# Minimal stubs sufficient for the rule (mirror the schema fields it reads)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubPad:
+    number: str = "1"
+    type: str = "smd"
+    position: tuple[float, float] = (0.0, 0.0)
+    size: tuple[float, float] = (1.0, 0.5)
+    net_number: int = 1
+    net_name: str = "DATA"
+
+
+@dataclass
+class _StubFootprint:
+    reference: str = "U1"
+    position: tuple[float, float] = (10.0, 10.0)
+    rotation: float = 0.0
+    pads: list[_StubPad] = field(default_factory=list)
+
+
+@dataclass
+class _StubVia:
+    position: tuple[float, float] = (10.0, 10.0)
+    drill: float = 0.3
+    net_number: int = 1
+    net_name: str = "DATA"
+    uuid: str = "abcdef12"
+
+
+@dataclass
+class _StubPCB:
+    footprints: list[_StubFootprint] = field(default_factory=list)
+    vias: list[_StubVia] = field(default_factory=list)
+
+
+@dataclass
+class _StubDesignRules:
+    via_in_pad_supported: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestViaInPadRule:
+    """Tests for ViaInPadRule.check()."""
+
+    def test_via_inside_smd_pad_flagged_when_unsupported(self):
+        """Via at the center of an SMD pad on the same net -> violation."""
+        # Pad at footprint position (10, 10); pad local position (0,0) so
+        # absolute pad center is (10, 10).  Via also at (10, 10).
+        # Drill 0.3 fits inside a 1.0 x 0.5 pad easily.
+        pad = _StubPad(net_number=1, net_name="DATA", position=(0.0, 0.0), size=(1.0, 0.5))
+        fp = _StubFootprint(pads=[pad])
+        via = _StubVia(position=(10.0, 10.0), drill=0.3, net_number=1, net_name="DATA")
+        pcb = _StubPCB(footprints=[fp], vias=[via])
+
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=False))
+
+        violations = [v for v in results.violations if v.rule_id == "via_in_pad"]
+        assert len(violations) == 1, results.violations
+        v = violations[0]
+        assert v.severity == "error"
+        assert v.location == (10.0, 10.0)
+        assert v.items == ("Via-abcdef12", "U1-1")
+        assert v.nets == ("DATA",)
+        assert "U1-1" in v.message
+        assert "via-in-pad" in v.message.lower()
+        assert results.rules_checked == 1
+
+    def test_via_inside_smd_pad_suppressed_when_supported(self):
+        """Same board with via_in_pad_supported=True -> no violation."""
+        pad = _StubPad(net_number=1, net_name="DATA", position=(0.0, 0.0), size=(1.0, 0.5))
+        fp = _StubFootprint(pads=[pad])
+        via = _StubVia(position=(10.0, 10.0), drill=0.3, net_number=1, net_name="DATA")
+        pcb = _StubPCB(footprints=[fp], vias=[via])
+
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=True))
+
+        assert len([v for v in results.violations if v.rule_id == "via_in_pad"]) == 0
+
+    def test_via_on_different_net_not_flagged(self):
+        """Via overlapping a pad on a DIFFERENT net is out of scope.
+
+        The clearance rule handles inter-net pad-vs-via overlaps; this
+        rule is specifically about via-in-pad on the same connected net.
+        """
+        pad = _StubPad(net_number=1, net_name="DATA")
+        fp = _StubFootprint(pads=[pad])
+        via = _StubVia(net_number=2, net_name="CLK")  # different net
+        pcb = _StubPCB(footprints=[fp], vias=[via])
+
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=False))
+        assert len([v for v in results.violations if v.rule_id == "via_in_pad"]) == 0
+
+    def test_via_outside_pad_not_flagged(self):
+        """Via clearly outside the pad bounding box -> no violation."""
+        pad = _StubPad(net_number=1, net_name="DATA", position=(0.0, 0.0), size=(1.0, 0.5))
+        fp = _StubFootprint(pads=[pad])
+        # Pad spans approximately (9.5, 9.75) - (10.5, 10.25).
+        # Place via well outside that box.
+        via = _StubVia(position=(20.0, 20.0), drill=0.3, net_number=1)
+        pcb = _StubPCB(footprints=[fp], vias=[via])
+
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=False))
+        assert len([v for v in results.violations if v.rule_id == "via_in_pad"]) == 0
+
+    def test_through_hole_pad_not_considered_smd(self):
+        """Through-hole pads are not flagged -- a via "inside" them is fine."""
+        # The pad geometry overlaps, but type=thru_hole so we skip it.
+        pad = _StubPad(type="thru_hole", net_number=1, net_name="DATA", size=(1.0, 1.0))
+        fp = _StubFootprint(pads=[pad])
+        via = _StubVia(position=(10.0, 10.0), drill=0.3, net_number=1)
+        pcb = _StubPCB(footprints=[fp], vias=[via])
+
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=False))
+        assert len([v for v in results.violations if v.rule_id == "via_in_pad"]) == 0
+
+    def test_via_net_zero_not_flagged(self):
+        """Unconnected vias (net 0) cannot have via-in-pad on a same-net pad."""
+        pad = _StubPad(net_number=1, net_name="DATA")
+        fp = _StubFootprint(pads=[pad])
+        via = _StubVia(net_number=0, net_name="")
+        pcb = _StubPCB(footprints=[fp], vias=[via])
+
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=False))
+        assert len([v for v in results.violations if v.rule_id == "via_in_pad"]) == 0
+
+    def test_pad_net_zero_not_considered(self):
+        """Pads on net 0 (unconnected) are skipped.
+
+        Even if a via at net 0 sits "inside" an unconnected pad, the
+        same-net constraint excludes net 0 from both sides.
+        """
+        pad = _StubPad(net_number=0, net_name="")
+        fp = _StubFootprint(pads=[pad])
+        via = _StubVia(net_number=0, net_name="")
+        pcb = _StubPCB(footprints=[fp], vias=[via])
+
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=False))
+        assert len([v for v in results.violations if v.rule_id == "via_in_pad"]) == 0
+
+    def test_via_partially_overlapping_pad_not_flagged(self):
+        """Drill circle that pokes out of the pad edge is NOT in-pad.
+
+        The router considers a via "in-pad" only when the drill is fully
+        covered by the pad copper -- partial overlaps would be flagged
+        by the clearance rule (if any) but not here.  The DRC tolerance
+        gives a small grace zone for fabrication rounding.
+        """
+        # Pad is 1.0 wide x 0.5 tall.  Place the via at the edge so its
+        # drill circle extends well past the pad.
+        pad = _StubPad(net_number=1, net_name="DATA", position=(0.0, 0.0), size=(1.0, 0.5))
+        fp = _StubFootprint(pads=[pad])
+        # Pad spans x in [-0.5, 0.5] (relative to fp 10,10 -> [9.5, 10.5]).
+        # Via at (10.5, 10.0) with drill 0.4 -> circle in x [10.3, 10.7],
+        # which extends past the pad's max x of 10.5 by 0.2 mm (well
+        # above the DRC tolerance of 0.005 mm).
+        via = _StubVia(position=(10.5, 10.0), drill=0.4, net_number=1)
+        pcb = _StubPCB(footprints=[fp], vias=[via])
+
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=False))
+        assert len([v for v in results.violations if v.rule_id == "via_in_pad"]) == 0
+
+    def test_multiple_vias_in_same_pad_each_flagged(self):
+        """Two distinct in-pad vias on the same pad produce two violations."""
+        # Make a large pad so two vias both fit inside.
+        pad = _StubPad(net_number=1, net_name="DATA", position=(0.0, 0.0), size=(2.0, 2.0))
+        fp = _StubFootprint(pads=[pad])
+        via_a = _StubVia(position=(9.7, 10.0), drill=0.3, net_number=1, uuid="aaaa1111")
+        via_b = _StubVia(position=(10.3, 10.0), drill=0.3, net_number=1, uuid="bbbb2222")
+        pcb = _StubPCB(footprints=[fp], vias=[via_a, via_b])
+
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=False))
+        violations = [v for v in results.violations if v.rule_id == "via_in_pad"]
+        assert len(violations) == 2
+        via_refs = {v.items[0] for v in violations}
+        assert via_refs == {"Via-aaaa1111", "Via-bbbb2222"}
+
+    def test_rotated_footprint_pad_bbox_swapped(self):
+        """A footprint rotated 90 deg swaps pad width/height when computing the bbox."""
+        # Pad is 0.5 wide x 1.0 tall at local (0, 0).  Rotated 90 deg,
+        # the pad in board coords becomes 1.0 wide x 0.5 tall.
+        pad = _StubPad(net_number=1, net_name="DATA", position=(0.0, 0.0), size=(0.5, 1.0))
+        fp = _StubFootprint(pads=[pad], rotation=90.0)
+        # Pad center is still at fp.position because local (0,0) rotates to (0,0).
+        # Bbox at (10,10): x in [9.5, 10.5], y in [9.75, 10.25] after the swap.
+        # A via at (10.4, 10.0) with drill 0.2 -> x in [10.3, 10.5] (inside)
+        # and y in [9.9, 10.1] (inside).
+        via = _StubVia(position=(10.4, 10.0), drill=0.2, net_number=1)
+        pcb = _StubPCB(footprints=[fp], vias=[via])
+
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=False))
+        assert len([v for v in results.violations if v.rule_id == "via_in_pad"]) == 1
+
+    def test_rules_checked_counts_one(self):
+        """Even when there are no vias, rules_checked is 1 (the rule ran)."""
+        pcb = _StubPCB()
+        results = ViaInPadRule().check(pcb, _StubDesignRules(via_in_pad_supported=False))
+        assert results.rules_checked == 1
+
+
+class TestViaInPadIntegration:
+    """Integration tests via DRCChecker.check_via_in_pad()."""
+
+    def test_drc_checker_exposes_check_via_in_pad(self):
+        """DRCChecker should have a check_via_in_pad() method wired in."""
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb = PCB.create(width=50.0, height=50.0, layers=2)
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=4)
+        assert hasattr(checker, "check_via_in_pad")
+        # On an empty board, the check should run without errors.
+        results = checker.check_via_in_pad()
+        assert results.rules_checked == 1
+        assert len(results.violations) == 0
+
+    def test_design_rules_via_in_pad_supported_default_false(self):
+        """DesignRules default for via_in_pad_supported is False."""
+        from kicad_tools.manufacturers import DesignRules
+
+        rules = DesignRules(
+            min_trace_width_mm=0.1,
+            min_clearance_mm=0.1,
+            min_via_drill_mm=0.3,
+            min_via_diameter_mm=0.6,
+            min_annular_ring_mm=0.15,
+        )
+        assert rules.via_in_pad_supported is False
+
+    def test_design_rules_to_dict_includes_via_in_pad_supported(self):
+        """to_dict() should serialize the new field."""
+        from kicad_tools.manufacturers import DesignRules
+
+        rules = DesignRules(
+            min_trace_width_mm=0.1,
+            min_clearance_mm=0.1,
+            min_via_drill_mm=0.3,
+            min_via_diameter_mm=0.6,
+            min_annular_ring_mm=0.15,
+            via_in_pad_supported=True,
+        )
+        d = rules.to_dict()
+        assert "via_in_pad_supported" in d
+        assert d["via_in_pad_supported"] is True
+
+    def test_jlcpcb_tier1_yaml_loads_with_via_in_pad_supported(self):
+        """The jlcpcb-tier1 YAML should produce DesignRules with the flag True."""
+        from kicad_tools.manufacturers import get_profile
+
+        profile = get_profile("jlcpcb-tier1")
+        for layers in (2, 4, 6):
+            rules = profile.get_design_rules(layers=layers, copper_oz=1.0)
+            assert rules.via_in_pad_supported is True, (
+                f"jlcpcb-tier1 ({layers}L) should have via_in_pad_supported=True"
+            )
+
+    def test_base_jlcpcb_yaml_via_in_pad_unsupported(self):
+        """The base jlcpcb profile should have via_in_pad_supported=False."""
+        from kicad_tools.manufacturers import get_profile
+
+        profile = get_profile("jlcpcb")
+        for layers in (2, 4, 6):
+            rules = profile.get_design_rules(layers=layers, copper_oz=1.0)
+            assert rules.via_in_pad_supported is False, (
+                f"base jlcpcb ({layers}L) should have via_in_pad_supported=False"
+            )
+
+    def test_pcbway_yaml_via_in_pad_supported(self):
+        """PCBWay should have via_in_pad_supported=True (matches router)."""
+        from kicad_tools.manufacturers import get_profile
+
+        profile = get_profile("pcbway")
+        for layers in (2, 4, 6):
+            rules = profile.get_design_rules(layers=layers, copper_oz=1.0)
+            assert rules.via_in_pad_supported is True, (
+                f"pcbway ({layers}L) should have via_in_pad_supported=True"
+            )


### PR DESCRIPTION
## Summary

Closes #2635.

Adds `via_in_pad_supported: bool` to `DesignRules`, mirroring the router's existing `MfrLimits.via_in_pad_supported`, and a new pure-Python DRC rule (`ViaInPadRule`) that flags vias whose drill circle is fully covered by an SMD pad on the same net when the active profile does not support via-in-pad processing.

This finally lets the `jlcpcb-tier1` profile differ from base `jlcpcb` in a way DRC can actually verify: PR #2632 registered the tier1 profile but had to make its scalar limits identical to base because `DesignRules` had no field distinguishing Capability Plus from the base process. With this change, `kct fab-rules show jlcpcb-tier1` reports "Via-in-pad support: yes" and DRC will allow in-pad vias on tier1/PCBWay while rejecting them on base profiles.

### Changes

- **`DesignRules.via_in_pad_supported: bool = False`** (manufacturers/base.py). Added to `to_dict()`. Default `False` preserves backwards compatibility for every existing YAML and direct `DesignRules(...)` construction.
- **`jlcpcb_tier1.yaml`** + **`pcbway.yaml`** set `via_in_pad_supported: true` on every stackup block. `jlcpcb.yaml`, `oshpark.yaml`, `seeed.yaml`, `flashpcb.yaml` rely on the `False` default (audited and confirmed to match the router-side flag).
- **`validate/rules/via_in_pad.py`** new rule following the `ZoneFillRule` / `SinglePadNetRule` class-based pattern. Geometry: SMD pads are modelled as axis-aligned bounding boxes (post footprint rotation), and a via is "in the pad" when its drill circle is fully contained, with a small `DRC_TOLERANCE` grace zone.
- **`DRCChecker.check_all()`** wires the new rule in alongside `check_via_in_pad()`.
- **`ViolationType.VIA_IN_PAD`** added with `MANUFACTURING` category and an explicit alias-table entry so the rule_id never falls through to the fuzzy "via" match.
- **`fab-rules show`** prints "Via-in-pad support: yes/no" so users see the tier-1 vs base difference at a glance.
- **`tests/test_manufacturer_registry_sync.py`** extended with `test_via_in_pad_supported_parity` that asserts router `MfrLimits` and DRC `DesignRules` agree on the flag for every shared manufacturer across 2L/4L/6L stackups.
- **`tests/test_validate_via_in_pad.py`** new file with 17 tests covering: violation when in-pad + unsupported, no violation when supported, different-net via skipped, outside-pad via skipped, through-hole pads ignored, net-0 skipped on both sides, partially-overlapping (not in-pad) skipped, multiple in-pad vias each flagged, rotated footprint bbox correctness, and integration tests for `DRCChecker.check_via_in_pad()` + YAML loading on each profile.

### Out of Scope (per issue body)

Blind/buried vias, microvias, controlled impedance, copper-pour width, soldermask options. `dru_generator.py` is intentionally untouched — KiCad's `.kicad_dru` format has no native via-in-pad rule, so enforcement lives entirely in `DRCChecker.check_via_in_pad`. A comment in `DesignRules` documents this so future readers don't try to translate the flag into a `.kicad_dru` rule.

## Test plan

- [x] `pytest tests/test_validate_via_in_pad.py` — 17/17 pass.
- [x] `pytest tests/test_manufacturer_registry_sync.py tests/test_mfr.py tests/test_fab_rules.py` — 110/110 pass (2 pre-existing skips).
- [x] `pytest tests/test_validate_*.py` — 154/154 pass.
- [x] `ruff check` + `ruff format --check` clean on all touched Python files.
- [x] Sanity-check profile flag values: `jlcpcb=False, jlcpcb-tier1=True, pcbway=True, oshpark=False, seeed=False, flashpcb=False` (matches router `MFR_LIMITS`).
- [x] 6 failures in `tests/test_drc_tolerance.py` are pre-existing on main (`MockPCB` missing `.nets` attribute) and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)