### PR TITLE
fix(router): monte-carlo + auto-layers escalates past 2L

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1660,7 +1660,22 @@ def route_with_layer_escalation(
         # Issue #2412: Early termination — zero overflow means failures
         # are placement/topology issues, not congestion.  Adding layers
         # cannot help when there is no congestion to relieve.
-        if overflow == 0 and nets_routed < nets_to_route:
+        #
+        # Issue #2634: This heuristic was calibrated for ``route_all_negotiated``,
+        # which deliberately allows overlapping tracks and records overflow as
+        # a first-class congestion signal.  The basic A*, monte-carlo, and
+        # evolutionary strategies never plant overlaps, so ``grid.get_total_overflow()``
+        # is 0 by construction regardless of true congestion.  Reading 0 from
+        # those strategies as "no congestion" is wrong, and historically it
+        # broke after attempt #1 even with ``--auto-layers`` on (see the
+        # chorus-test-revA fixture, which negotiated escalates 2L -> 4L while
+        # MC stopped at 2L=42%).  Skip the heuristic for those strategies.
+        strategies_without_overflow_signal = {"monte-carlo", "basic", "evolutionary"}
+        if (
+            overflow == 0
+            and nets_routed < nets_to_route
+            and args.strategy not in strategies_without_overflow_signal
+        ):
             if not quiet:
                 flush_print(
                     "  Escalation stopped: failures are not congestion-related (overflow=0)"
@@ -1989,6 +2004,9 @@ def route_with_layer_escalation(
                 pcb_file=args.pcb,
                 nets_to_route_ids=_multi_pad_ids,
                 single_pad_count=getattr(final_result, "single_pad_count", 0),
+                # Issue #2634: auto-layer escalation already ran in this code
+                # path; suppress the redundant "Try --auto-layers" recommendation.
+                auto_layers_attempted=True,
             )
 
     if final_result.success:
@@ -3041,6 +3059,10 @@ def route_with_combined_escalation(
                 pcb_file=args.pcb,
                 nets_to_route_ids=_multi_pad_ids,
                 single_pad_count=getattr(final_result, "single_pad_count", 0),
+                # Issue #2634: combined escalation includes auto-layer escalation
+                # as one of its axes; suppress the redundant "Try --auto-layers"
+                # recommendation.
+                auto_layers_attempted=True,
             )
 
     if final_result.success:

--- a/src/kicad_tools/router/algorithms/monte_carlo.py
+++ b/src/kicad_tools/router/algorithms/monte_carlo.py
@@ -286,7 +286,21 @@ def run_monte_carlo(
     if verbose:
         print(f"\n  Best: Trial {best_trial + 1} (score={best_score:.2f})")
 
+    # Issue #2634: The grid state at the end of the trial loop reflects whatever
+    # the *last* trial left behind, not the *best* trial whose routes we are
+    # about to surface.  ``_reset_for_new_trial`` rebuilds the grid and re-adds
+    # pads but never re-marks routes; the parallel path skips this entirely
+    # because all trials ran in worker processes.  Downstream consumers — the
+    # layer-escalation overflow heuristic at ``route_cmd.py``, zone fills,
+    # statistics — read grid state expecting it to match ``autorouter.routes``.
+    # Rebuild the grid once more and replay the best routes onto it so that
+    # invariant holds.  Note: ``_reset_for_new_trial`` clears ``autorouter.routes``,
+    # so the assignment must happen *after* the reset.
+    autorouter._reset_for_new_trial()
     autorouter.routes = best_routes if best_routes else []
+    for route in autorouter.routes:
+        autorouter.grid.mark_route_usage(route)
+
     if progress_callback is not None:
         routed = len({r.net for r in autorouter.routes}) if autorouter.routes else 0
         progress_callback(

--- a/src/kicad_tools/router/output.py
+++ b/src/kicad_tools/router/output.py
@@ -26,6 +26,7 @@ def show_routing_summary(
     pcb_file: str | None = None,
     nets_to_route_ids: set[int] | None = None,
     single_pad_count: int = 0,
+    auto_layers_attempted: bool = False,
 ) -> None:
     """Show comprehensive routing summary with successes, failures, and suggestions.
 
@@ -50,6 +51,11 @@ def show_routing_summary(
             When ``None``, the function falls back to ``router.nets``
             (multi-pad nets only) so user-skipped power/pour nets are not
             mis-reported as failed routes (Issue #2498).
+        auto_layers_attempted: If True, the layer-escalation loop already ran
+            (i.e. ``--auto-layers`` was on, which is the default).  Recommending
+            ``--auto-layers`` again in that case is misleading — Issue #2634.
+            Callers from outside the escalation loop should leave this False so
+            users still see the suggestion.
     """
     if quiet:
         return
@@ -460,16 +466,36 @@ def show_routing_summary(
                 f"RECOMMENDATION: {failed_count}/{nets_to_route} nets "
                 f"({failure_pct:.0f}%) failed on {num_layers} layers."
             )
-            print(f"  Try: kct route{pcb_arg} --auto-layers")
-            print(f"  Or:  kct route{pcb_arg} --layers 4")
+            # Issue #2634: Do not recommend --auto-layers when it already ran.
+            # The escalation loop chose this layer count as the best result.
+            if auto_layers_attempted:
+                print(
+                    "  Auto-layer escalation already ran; this was the best layer count."
+                )
+                print(
+                    f"  Try: kct route{pcb_arg} --layers {max(num_layers + 2, 4)} "
+                    "(force more layers)"
+                )
+                print(
+                    "  Or:  review component placement (failures look like topology, "
+                    "not congestion)"
+                )
+            else:
+                print(f"  Try: kct route{pcb_arg} --auto-layers")
+                print(f"  Or:  kct route{pcb_arg} --layers 4")
         elif num_layers < 4:
             print(
                 f"\nTip: {failed_count}/{nets_to_route} nets failed on {num_layers} layers "
                 f"({failure_pct:.0f}% failure rate)."
             )
-            print(f"Try automatic layer escalation: kct route{pcb_arg} --auto-layers")
+            # Issue #2634: Same suppression for the lower-severity tip.
+            if not auto_layers_attempted:
+                print(f"Try automatic layer escalation: kct route{pcb_arg} --auto-layers")
 
-        # Strategy suggestion: surface monte-carlo when using negotiated
+        # Strategy suggestion: surface monte-carlo when using negotiated.
+        # Issue #2634: Only suggest MC if the user is not already on it.  The
+        # ``current_strategy == "negotiated"`` guard already handles this, but
+        # be explicit for clarity in case the set of strategies grows.
         if current_strategy == "negotiated":
             print("\nTip: Try randomized net ordering for better results:")
             print(f"  kct route{pcb_arg} --strategy monte-carlo --mc-trials 20")

--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -980,6 +980,152 @@ class TestEarlyTermination:
 
         assert result.overflow == 0
 
+    # Issue #2634: monte-carlo (and basic / evolutionary) strategies never
+    # accumulate a meaningful overflow signal because they don't plant
+    # overlapping tracks like the negotiated congestion router does.  Reading
+    # ``overflow == 0`` from them caused the zero-overflow heuristic above to
+    # fire after attempt 1, killing escalation even when ``--auto-layers`` was
+    # explicitly on.
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    def test_monte_carlo_skips_zero_overflow_heuristic(
+        self, _esc_flag, _esc_use, _pour, tmp_path
+    ):
+        """MC + auto-layers must escalate past 2L even with overflow=0.
+
+        Regression for Issue #2634: ``run_monte_carlo`` calls basic A* per trial,
+        which never accumulates ``grid.get_total_overflow()``.  The zero-overflow
+        early-termination heuristic (calibrated for negotiated) used to fire
+        after attempt 1 and break the loop.  After the fix, MC trials no longer
+        trigger that heuristic and the escalation loop tries at least one
+        higher layer count.
+        """
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+        out = tmp_path / "out.kicad_pcb"
+
+        # Router: 2/3 nets routed every attempt, overflow=0 (MC has no signal)
+        # and nets_routed increases just enough between attempts to defeat the
+        # *stagnation* heuristic — we want to confirm the *zero-overflow*
+        # heuristic doesn't fire on its own.
+        attempt_results = [
+            (1, 3, 0),  # 2L: 1/3 routed, overflow=0
+            (2, 3, 0),  # 4L sig_gnd_pwr_sig: 2/3, overflow=0 (improved)
+            (3, 3, 0),  # 4L all_signal: 3/3, overflow=0 (success)
+        ]
+        call_count = 0
+
+        def mock_load(*args, **kwargs):
+            nonlocal call_count
+            nets_routed, nets_to_route, overflow = attempt_results[
+                min(call_count, len(attempt_results) - 1)
+            ]
+            call_count += 1
+            return self._make_mock_router(nets_routed, nets_to_route, overflow), {}
+
+        args = self._make_args(strategy="monte-carlo")
+        with patch("kicad_tools.router.load_pcb_for_routing", mock_load):
+            with patch("kicad_tools.router.is_cpp_available", return_value=False):
+                with patch("kicad_tools.router.show_routing_summary"):
+                    with patch(
+                        "kicad_tools.cli.route_cmd.run_post_route_drc",
+                        return_value=False,
+                    ):
+                        route_with_layer_escalation(pcb, out, args, quiet=True)
+
+        # Must attempt at least 2 layer configurations.  Pre-fix this was 1 —
+        # the zero-overflow heuristic broke the loop after attempt 1.
+        assert call_count >= 2, (
+            f"Expected >=2 attempts with --strategy monte-carlo (zero-overflow "
+            f"heuristic must NOT fire on MC), got {call_count}"
+        )
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    def test_basic_strategy_skips_zero_overflow_heuristic(
+        self, _esc_flag, _esc_use, _pour, tmp_path
+    ):
+        """``--strategy basic`` also escalates past 2L despite overflow=0.
+
+        Basic A* never plants overlaps; the same heuristic exemption applies.
+        """
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+        out = tmp_path / "out.kicad_pcb"
+
+        attempt_results = [
+            (1, 3, 0),
+            (2, 3, 0),
+            (3, 3, 0),
+        ]
+        call_count = 0
+
+        def mock_load(*args, **kwargs):
+            nonlocal call_count
+            nets_routed, nets_to_route, overflow = attempt_results[
+                min(call_count, len(attempt_results) - 1)
+            ]
+            call_count += 1
+            return self._make_mock_router(nets_routed, nets_to_route, overflow), {}
+
+        args = self._make_args(strategy="basic")
+        with patch("kicad_tools.router.load_pcb_for_routing", mock_load):
+            with patch("kicad_tools.router.is_cpp_available", return_value=False):
+                with patch("kicad_tools.router.show_routing_summary"):
+                    with patch(
+                        "kicad_tools.cli.route_cmd.run_post_route_drc",
+                        return_value=False,
+                    ):
+                        route_with_layer_escalation(pcb, out, args, quiet=True)
+
+        assert call_count >= 2, (
+            f"Expected >=2 attempts with --strategy basic, got {call_count}"
+        )
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    def test_negotiated_still_uses_zero_overflow_heuristic(
+        self, _esc_flag, _esc_use, _pour, tmp_path
+    ):
+        """The zero-overflow heuristic still fires for ``--strategy negotiated``.
+
+        Regression guard: Issue #2634 must NOT change the negotiated behaviour
+        that Issue #2412 added.  Negotiated reading overflow=0 with incomplete
+        routing should still break after attempt 1.
+        """
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+        out = tmp_path / "out.kicad_pcb"
+
+        router = self._make_mock_router(nets_routed=2, nets_to_route=3, overflow=0)
+        call_count = 0
+
+        def mock_load(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return router, {}
+
+        args = self._make_args(strategy="negotiated")
+        with patch("kicad_tools.router.load_pcb_for_routing", mock_load):
+            with patch("kicad_tools.router.is_cpp_available", return_value=False):
+                route_with_layer_escalation(pcb, out, args, quiet=True)
+
+        # Negotiated: zero-overflow heuristic still fires after attempt 1
+        assert call_count == 1, (
+            f"Expected 1 attempt with --strategy negotiated (zero-overflow early "
+            f"stop preserved), got {call_count}"
+        )
+
 
 class TestPristineStatePerAttempt:
     """Tests for Issue #2396: pristine state per layer-escalation attempt.

--- a/tests/test_partial_routing_features.py
+++ b/tests/test_partial_routing_features.py
@@ -181,6 +181,63 @@ class TestAutoLayersSuggestion:
         text = output.getvalue()
         assert text == ""
 
+    def test_auto_layers_suggestion_suppressed_when_already_attempted(self):
+        """Issue #2634: ``--auto-layers`` recommendation must not appear when
+        the escalation loop has already run.
+
+        Calling ``show_routing_summary`` with ``auto_layers_attempted=True``
+        (the layer-escalation code path) should not tell the user to try
+        ``--auto-layers``, because that's the path they're already on.
+        """
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {f"Net{i}": i for i in range(1, 5)}
+        # 2 of 4 routed on 2 layers (>20% failure)
+        router = _make_mock_router(routed_nets=[1, 2], num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=4,
+                quiet=False,
+                pcb_file="board.kicad_pcb",
+                auto_layers_attempted=True,
+            )
+
+        text = output.getvalue()
+        # The recommendation block still appears...
+        assert "RECOMMENDATION" in text
+        # ...but no longer says "Try: kct route ... --auto-layers"
+        assert "kct route board.kicad_pcb --auto-layers" not in text
+        # Helpful guidance is given instead
+        assert "Auto-layer escalation already ran" in text
+
+    def test_auto_layers_low_severity_tip_suppressed_when_already_attempted(self):
+        """Lower-severity ``Try automatic layer escalation`` tip also suppressed.
+
+        Same fix at the ``elif num_layers < 4`` branch (failure_pct <= 20).
+        """
+        from kicad_tools.router.output import show_routing_summary
+
+        net_map = {f"Net{i}": i for i in range(1, 11)}
+        # 9/10 routed on 2 layers => 10% failure (low severity branch)
+        router = _make_mock_router(routed_nets=list(range(1, 10)), num_layers=2)
+
+        output = StringIO()
+        with patch("sys.stdout", output):
+            show_routing_summary(
+                router,
+                net_map,
+                nets_to_route=10,
+                quiet=False,
+                auto_layers_attempted=True,
+            )
+
+        text = output.getvalue()
+        assert "Try automatic layer escalation" not in text
+
 
 class TestExportFailedNets:
     """Tests for --export-failed-nets feature."""


### PR DESCRIPTION
## Summary

`kct route --strategy monte-carlo --auto-layers` previously stopped after the
first attempt (2 layers) even though `--strategy negotiated` correctly escalated
to 4 and 6 layers on the same board. The escalation loop's zero-overflow
early-termination heuristic from #2412 was reading `grid.get_total_overflow() == 0`
on every MC attempt and breaking the loop — but that signal is 0 by construction
for basic A* (which MC trials use), not because the board is uncongested.

A second decoupling: `run_monte_carlo` rebuilt the grid per trial and only
surfaced `autorouter.routes = best_routes` at the end without replaying those
routes onto a fresh grid. The visible grid state reflected the last trial, not
the best one. Downstream consumers (escalation overflow read, zone fills,
statistics) saw inconsistent state.

Independently, the recommendation block printed `Try: kct route ... --auto-layers`
to users who already had `--auto-layers` on by default — pointing them back at
the code path that just gave up.

## Changes

- `src/kicad_tools/cli/route_cmd.py` (escalation loop, line ~1663): skip the
  zero-overflow heuristic when `args.strategy in {"monte-carlo", "basic",
  "evolutionary"}` — those strategies never accumulate a meaningful overflow
  signal. Negotiated still uses the heuristic unchanged.
- `src/kicad_tools/router/algorithms/monte_carlo.py` (sequential + parallel paths
  converge here, line ~286): after selecting `best_routes`, call
  `autorouter._reset_for_new_trial()` and replay the best routes via
  `grid.mark_route_usage()` so the grid state matches `autorouter.routes`.
- `src/kicad_tools/router/output.py`: add `auto_layers_attempted` parameter to
  `show_routing_summary`; when True, suppress the redundant
  `Try: kct route ... --auto-layers` recommendation and surface different
  remediation (force more layers, review placement).
- `src/kicad_tools/cli/route_cmd.py` (call sites): pass
  `auto_layers_attempted=True` from `route_with_layer_escalation` and
  `route_with_combined_escalation`. The non-escalation
  `route_with_rule_relaxation` call site leaves the parameter at its False
  default so users on fixed-layer paths still see the tip.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| MC + auto-layers escalates past 2L on real boards | Verified by mock | `test_monte_carlo_skips_zero_overflow_heuristic` asserts `call_count >= 2` |
| Either MC populates overflow OR early-term skips MC | Done (latter) | `route_cmd.py` exempts `{monte-carlo, basic, evolutionary}` from the heuristic |
| Existing MC tests still pass | All 15 pass | `tests/test_router_core.py -k monte_carlo`, `test_route_exit_codes`, `test_routing_output`, `test_adaptive_grid` |
| New regression test in `TestEarlyTermination` | Added | 3 new tests using the `_make_mock_router` / `_make_args` pattern at lines 761-816 |
| MC tip in `output.py` doesn't make user worse off | Yes | Tip is only shown when `current_strategy == "negotiated"`; MC strategy now genuinely escalates |
| `--auto-layers` tip suppressed when it already ran | Yes | `auto_layers_attempted=True` from escalation call sites; new tests assert suppression |

## Test Plan

- `pytest tests/test_layer_escalation.py::TestEarlyTermination` — 9 pass (was 6, +3 new)
- `pytest tests/test_partial_routing_features.py::TestAutoLayersSuggestion` — 9 pass (was 7, +2 new)
- `pytest tests/test_router_core.py -k monte_carlo` — 8 pass (unchanged)
- `pytest tests/test_layer_escalation.py tests/test_partial_routing_features.py tests/test_router_core.py` — 224 pass
- `pytest tests/test_routing_output.py tests/test_route_exit_codes.py tests/test_adaptive_grid.py tests/test_routing_connectivity.py` — 154 pass

Pre-existing failures observed in `tests/test_adaptive_early_stop.py` (7 tests) are
unrelated to this PR — they reproduce on `main` (verified by stash + re-run) and
fail with `shutil.SameFileError` on `MagicMock` paths inside
`route_with_rule_relaxation`, which is not modified here.

Closes #2634

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>