### PR TITLE
fix(validate): hierarchical extract_netlist for --consistency net checks (closes #2633)

### DIFF
--- a/src/kicad_tools/schematic/models/io_mixin.py
+++ b/src/kicad_tools/schematic/models/io_mixin.py
@@ -55,7 +55,12 @@ class SchematicIOMixin:
             raise FileNotFoundError(f"Schematic file not found: {path}")
 
         doc = parse_file(path)
-        return cls._from_sexp(doc)
+        sch = cls._from_sexp(doc)
+        # Track the source path so operations that need to walk
+        # sub-sheets (e.g., extract_netlist(hierarchical=True), run_erc)
+        # can resolve relative sheet references.
+        sch._saved_path = path
+        return sch
 
     @classmethod
     def _from_sexp(cls, doc: SExp) -> Schematic:

--- a/src/kicad_tools/schematic/models/netlist_mixin.py
+++ b/src/kicad_tools/schematic/models/netlist_mixin.py
@@ -91,9 +91,8 @@ class SchematicNetlistMixin:
         for junc in self.junctions:
             junc_pos = (round(junc.x, 2), round(junc.y, 2))
             for seg_start, seg_end in wire_segments:
-                if (
-                    junc_pos in (seg_start, seg_end)
-                    or point_on_segment(junc_pos, seg_start, seg_end)
+                if junc_pos in (seg_start, seg_end) or point_on_segment(
+                    junc_pos, seg_start, seg_end
                 ):
                     union(junc_pos, seg_start)
                     union(junc_pos, seg_end)
@@ -107,9 +106,7 @@ class SchematicNetlistMixin:
                 # Track this pin at this position
                 if pos_rounded not in point_to_pins:
                     point_to_pins[pos_rounded] = []
-                point_to_pins[pos_rounded].append(
-                    PinRef(symbol_ref=sym.reference, pin=pin.number)
-                )
+                point_to_pins[pos_rounded].append(PinRef(symbol_ref=sym.reference, pin=pin.number))
 
                 # Connect to wires
                 connect_to_wire(pos_rounded)
@@ -158,11 +155,23 @@ class SchematicNetlistMixin:
 
         return parent, point_to_net_names, point_to_pins
 
-    def extract_netlist(self) -> dict[str, list[PinRef]]:
+    def extract_netlist(self, hierarchical: bool = False) -> dict[str, list[PinRef]]:
         """Extract netlist from schematic.
 
         Analyzes schematic connectivity to build a mapping from net names
         to the pins connected to each net.
+
+        Args:
+            hierarchical: When ``True``, walk every sub-sheet referenced
+                by this schematic and return a single merged netlist
+                covering the whole hierarchy. Sheet-pin / hierarchical-
+                label connections in the parent context resolve to the
+                parent's net name. Requires the schematic to have been
+                loaded via :meth:`Schematic.load` so the source file
+                path is known. When ``False`` (default), behaviour is
+                byte-identical to previous releases: only the root
+                sheet's wires, symbols, labels, and power symbols are
+                considered.
 
         Returns:
             Dict mapping net names to list of connected pins.
@@ -173,11 +182,39 @@ class SchematicNetlistMixin:
             - Power symbols (e.g., "+3.3V", "GND")
             - Auto-generated names for unnamed nets ("Net-(R1-1)")
 
+        Raises:
+            ValueError: If ``hierarchical=True`` is passed on a Schematic
+                that was not loaded from disk (no file path is available
+                to walk sub-sheets from).
+
         Example:
             >>> netlist = sch.extract_netlist()
             >>> print(netlist["+3.3V"])
             [PinRef(symbol_ref='U1', pin='VDD'), PinRef(symbol_ref='C1', pin='1')]
         """
+        if hierarchical:
+            # Lazy import to avoid an upward dependency from
+            # schematic/models/ on the operations/ layer. The walker
+            # already implements per-sheet extract_netlist() plus
+            # sheet-pin / hierarchical-label merging across sheets.
+            from pathlib import Path
+
+            from kicad_tools.operations.netlist import (
+                _collect_hierarchy_components,
+            )
+
+            saved_path = getattr(self, "_saved_path", None)
+            if saved_path is None:
+                raise ValueError(
+                    "extract_netlist(hierarchical=True) requires the "
+                    "Schematic to have been loaded from disk via "
+                    "Schematic.load(path); no file path is available "
+                    "to walk sub-sheets."
+                )
+
+            _, net_dict = _collect_hierarchy_components(Path(saved_path), "/")
+            return net_dict
+
         parent, point_to_net_names, point_to_pins = self._build_connectivity_graph()
 
         def find(p):
@@ -190,9 +227,7 @@ class SchematicNetlistMixin:
 
         # Group all points by their root (connected component)
         root_to_points: dict[tuple, list[tuple]] = {}
-        all_points = set(parent.keys()) | set(point_to_pins.keys()) | set(
-            point_to_net_names.keys()
-        )
+        all_points = set(parent.keys()) | set(point_to_pins.keys()) | set(point_to_net_names.keys())
         for point in all_points:
             root = find(point)
             if root not in root_to_points:
@@ -319,9 +354,7 @@ class SchematicNetlistMixin:
         netlist = self.extract_netlist()
         return netlist.get(net_name, [])
 
-    def are_connected(
-        self, symbol1: str, pin1: str, symbol2: str, pin2: str
-    ) -> bool:
+    def are_connected(self, symbol1: str, pin1: str, symbol2: str, pin2: str) -> bool:
         """Check if two pins are on the same net.
 
         Args:

--- a/src/kicad_tools/validate/consistency.py
+++ b/src/kicad_tools/validate/consistency.py
@@ -845,9 +845,18 @@ class SchematicPCBChecker:
         result from ``{net_name: [PinRef]}`` into
         ``{reference: {pin_number: net_name}}``.
 
+        Walks the full sheet hierarchy via
+        ``extract_netlist(hierarchical=True)`` so sub-sheet pin nets are
+        included (issue #2633). Without this, ``_check_nets`` silently
+        skipped every sub-sheet ref because they were absent from the
+        root-only netlist.
+
         Returns:
             Mapping of reference -> {pin_number: net_name}.
-            Returns empty dict if no schematic path is available.
+            Returns empty dict if no schematic path is available
+            (hierarchical traversal requires a path; callers passing a
+            ``Schematic`` object without a path get root-only behaviour
+            and a warning is emitted upstream by ``_check_components``).
         """
         from kicad_tools.schematic.models import Schematic as ModelsSchematic
 
@@ -860,7 +869,7 @@ class SchematicPCBChecker:
             return {}
 
         models_sch = ModelsSchematic.load(sch_path)
-        netlist = models_sch.extract_netlist()
+        netlist = models_sch.extract_netlist(hierarchical=True)
 
         pin_nets: dict[str, dict[str, str]] = {}
         for net_name, pin_refs in netlist.items():

--- a/tests/test_validate_hierarchical_nets.py
+++ b/tests/test_validate_hierarchical_nets.py
@@ -1,0 +1,314 @@
+"""Regression tests for hierarchical net checks in validate --consistency.
+
+Reproduces and guards against issue #2633, where
+``SchematicPCBChecker._check_nets`` called
+``_extract_schematic_pin_nets`` which loaded the schematic via the models
+layer and invoked ``extract_netlist()`` -- a root-only walker. On a
+hierarchical design every sub-sheet pin was absent from the resulting
+pin-net map, so net-name mismatches on sub-sheet pads were silently
+skipped by the ``sch_refs & pcb_refs`` intersection.
+
+The fix is to opt ``_extract_schematic_pin_nets`` into the new
+``extract_netlist(hierarchical=True)`` mode, which delegates to the
+existing hierarchical walker in
+``kicad_tools.operations.netlist._collect_hierarchy_components`` and
+merges sub-sheet nets, with sheet-pin / hierarchical-label connections
+resolving to the parent's net name.
+
+The fixture tree under ``tests/fixtures/hierarchical/`` is reused:
+
+    root.kicad_sch
+        R1 (root)
+        + sub_a.kicad_sch  -> R2, C1
+            + nested.kicad_sch  -> C2
+        + sub_b.kicad_sch  -> R3, R4
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.schematic.models import Schematic as ModelsSchematic
+from kicad_tools.validate.consistency import SchematicPCBChecker
+
+HIERARCHICAL_ROOT_SCH = Path(__file__).parent / "fixtures" / "hierarchical" / "root.kicad_sch"
+
+
+# PCB matching the hierarchical schematic, with pad ``net_name`` values
+# chosen to AGREE with what extract_netlist(hierarchical=True) produces
+# for every component (root + every sub-sheet). On the fixtures this is
+# the auto-generated Net-(<ref>-<pin>) form for sub-sheet pins and the
+# power-symbol names ("VCC", "GND") for the root R1 pins.
+HIERARCHICAL_PCB_MATCHING_NETS = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+  (net 3 "Net-(R2-1)")
+  (net 4 "Net-(R2-2)")
+  (net 5 "Net-(C1-1)")
+  (net 6 "Net-(C1-2)")
+  (net 7 "Net-(C2-1)")
+  (net 8 "Net-(C2-2)")
+  (net 9 "Net-(R3-1)")
+  (net 10 "Net-(R3-2)")
+  (net 11 "Net-(R4-1)")
+  (net 12 "Net-(R4-2)")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r1") (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r1-ref"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r1-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "VCC"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r2") (at 110 100)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r2-ref"))
+    (property "Value" "4.7k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r2-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 3 "Net-(R2-1)"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 4 "Net-(R2-2)"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-c1") (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-c1-ref"))
+    (property "Value" "100nF" (at 0 1.5 0) (layer "F.Fab") (uuid "p-c1-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 5 "Net-(C1-1)"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 6 "Net-(C1-2)"))
+  )
+  (footprint "Capacitor_SMD:C_0603_1608Metric"
+    (layer "F.Cu") (uuid "fp-c2") (at 130 100)
+    (property "Reference" "C2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-c2-ref"))
+    (property "Value" "10uF" (at 0 1.5 0) (layer "F.Fab") (uuid "p-c2-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 7 "Net-(C2-1)"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 8 "Net-(C2-2)"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r3") (at 140 100)
+    (property "Reference" "R3" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r3-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r3-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 9 "Net-(R3-1)"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 10 "Net-(R3-2)"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r4") (at 150 100)
+    (property "Reference" "R4" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r4-ref"))
+    (property "Value" "2.2k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r4-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 11 "Net-(R4-1)"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 12 "Net-(R4-2)"))
+  )
+)
+"""
+
+
+# Same PCB as above, but R2's pad 1 has been deliberately rewired to a
+# bogus net name ("WRONG_NET"). On a hierarchical-aware checker this
+# should produce exactly one ``domain="net"`` mismatch for "R2.1".
+# Pre-fix the checker missed this entirely because R2 is in sub_a and
+# the root-only extract_netlist() never returned an R2 entry.
+HIERARCHICAL_PCB_BAD_SUBSHEET_NET = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+  (net 3 "WRONG_NET")
+  (net 4 "Net-(R2-2)")
+  (net 5 "Net-(C1-1)")
+  (net 6 "Net-(C1-2)")
+  (net 7 "Net-(C2-1)")
+  (net 8 "Net-(C2-2)")
+  (net 9 "Net-(R3-1)")
+  (net 10 "Net-(R3-2)")
+  (net 11 "Net-(R4-1)")
+  (net 12 "Net-(R4-2)")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r1") (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r1-ref"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r1-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "VCC"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r2") (at 110 100)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r2-ref"))
+    (property "Value" "4.7k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r2-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 3 "WRONG_NET"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 4 "Net-(R2-2)"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-c1") (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-c1-ref"))
+    (property "Value" "100nF" (at 0 1.5 0) (layer "F.Fab") (uuid "p-c1-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 5 "Net-(C1-1)"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 6 "Net-(C1-2)"))
+  )
+  (footprint "Capacitor_SMD:C_0603_1608Metric"
+    (layer "F.Cu") (uuid "fp-c2") (at 130 100)
+    (property "Reference" "C2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-c2-ref"))
+    (property "Value" "10uF" (at 0 1.5 0) (layer "F.Fab") (uuid "p-c2-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 7 "Net-(C2-1)"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 8 "Net-(C2-2)"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r3") (at 140 100)
+    (property "Reference" "R3" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r3-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r3-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 9 "Net-(R3-1)"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 10 "Net-(R3-2)"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu") (uuid "fp-r4") (at 150 100)
+    (property "Reference" "R4" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r4-ref"))
+    (property "Value" "2.2k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r4-val"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 11 "Net-(R4-1)"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 12 "Net-(R4-2)"))
+  )
+)
+"""
+
+
+@pytest.fixture
+def hierarchical_matching_nets_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "hierarchical_match_nets.kicad_pcb"
+    pcb_file.write_text(HIERARCHICAL_PCB_MATCHING_NETS)
+    return pcb_file
+
+
+@pytest.fixture
+def hierarchical_bad_subsheet_net_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "hierarchical_bad_subsheet_net.kicad_pcb"
+    pcb_file.write_text(HIERARCHICAL_PCB_BAD_SUBSHEET_NET)
+    return pcb_file
+
+
+class TestExtractNetlistHierarchical:
+    """Direct tests of the new hierarchical=True flag on extract_netlist()."""
+
+    def test_default_is_root_only(self) -> None:
+        """Default behaviour (no kwarg) is unchanged: root sheet only.
+
+        The fixture root contains R1 + VCC/GND power symbols and one
+        global label ("DATA_BUS"). Only R1's two pins should appear; no
+        sub-sheet refs (R2, C1, C2, R3, R4).
+        """
+        sch = ModelsSchematic.load(HIERARCHICAL_ROOT_SCH)
+        netlist = sch.extract_netlist()
+        refs = {pin.symbol_ref for pins in netlist.values() for pin in pins}
+        assert refs == {"R1"}, f"Root-only extract_netlist() returned unexpected refs: {refs}"
+
+    def test_hierarchical_walks_every_subsheet(self) -> None:
+        """``hierarchical=True`` returns pins from every sub-sheet.
+
+        Acceptance criterion from issue #2633: six components total
+        across the hierarchy -- R1 (root), R2 + C1 (sub_a), C2
+        (sub_a/nested), R3 + R4 (sub_b).
+        """
+        sch = ModelsSchematic.load(HIERARCHICAL_ROOT_SCH)
+        netlist = sch.extract_netlist(hierarchical=True)
+        refs = {pin.symbol_ref for pins in netlist.values() for pin in pins}
+        assert refs == {"R1", "R2", "C1", "C2", "R3", "R4"}, (
+            f"Hierarchical extract_netlist() missed sub-sheet pins: {refs}"
+        )
+
+    def test_hierarchical_requires_loaded_path(self) -> None:
+        """``hierarchical=True`` on an unsaved Schematic raises ValueError.
+
+        Without a source path there is no way to walk relative sheet
+        references, so the caller is told explicitly rather than
+        silently falling back to root-only.
+        """
+        sch = ModelsSchematic("Test")
+        with pytest.raises(ValueError, match=r"hierarchical=True\)? +requires"):
+            sch.extract_netlist(hierarchical=True)
+
+
+class TestExtractSchematicPinNetsHierarchical:
+    """Regression: _extract_schematic_pin_nets() must walk sub-sheets."""
+
+    def test_pin_nets_include_every_subsheet_ref(
+        self, hierarchical_matching_nets_pcb: Path
+    ) -> None:
+        """Internal helper returns entries for every component in the hierarchy.
+
+        Pre-#2633 this dict contained only R1 (the single root-sheet
+        symbol). Post-fix every sub-sheet ref is present.
+        """
+        checker = SchematicPCBChecker(HIERARCHICAL_ROOT_SCH, hierarchical_matching_nets_pcb)
+        pin_nets = checker._extract_schematic_pin_nets()
+        assert set(pin_nets.keys()) == {"R1", "R2", "C1", "C2", "R3", "R4"}, (
+            f"_extract_schematic_pin_nets() missed sub-sheet refs: {sorted(pin_nets.keys())}"
+        )
+        # Every component should have both pins represented.
+        for ref, pins in pin_nets.items():
+            assert set(pins.keys()) == {"1", "2"}, (
+                f"{ref} pin coverage incomplete: {sorted(pins.keys())}"
+            )
+
+
+class TestCheckNetsHierarchical:
+    """Regression: SchematicPCBChecker._check_nets must catch sub-sheet mismatches.
+
+    This is the end-to-end behaviour exposed via
+    ``kct validate --consistency`` and is the user-facing bug from
+    issue #2633.
+    """
+
+    def test_in_sync_hierarchical_reports_no_net_issues(
+        self, hierarchical_matching_nets_pcb: Path
+    ) -> None:
+        """A hierarchical PCB whose pad nets match the schematic emits no net issues."""
+        checker = SchematicPCBChecker(HIERARCHICAL_ROOT_SCH, hierarchical_matching_nets_pcb)
+        result = checker.check()
+        net_issues = result.net_issues
+        assert net_issues == [], (
+            "In-sync hierarchical net check reported spurious mismatches: "
+            f"{[(i.reference, i.schematic_value, i.pcb_value) for i in net_issues]}"
+        )
+
+    def test_subsheet_net_mismatch_is_detected(
+        self, hierarchical_bad_subsheet_net_pcb: Path
+    ) -> None:
+        """Deliberately wrong net on a SUB-SHEET pad must be surfaced.
+
+        This is the exact scenario the issue #2633 curator notes called
+        out: R2 lives in sub_a.kicad_sch, so pre-fix it was never even
+        considered by ``_check_nets``. After the fix the mismatch is
+        reported with ``domain="net"`` and ``reference="R2.1"``.
+        """
+        checker = SchematicPCBChecker(HIERARCHICAL_ROOT_SCH, hierarchical_bad_subsheet_net_pcb)
+        result = checker.check()
+
+        net_mismatches = [i for i in result.net_issues if i.issue_type == "mismatch"]
+        r2_pin1_mismatches = [i for i in net_mismatches if i.reference == "R2.1"]
+        assert r2_pin1_mismatches, (
+            "Pre-fix: sub-sheet net mismatch on R2.1 was silently skipped "
+            "because extract_netlist() only walked the root sheet. "
+            f"All net mismatches seen: "
+            f"{[(i.reference, i.pcb_value) for i in net_mismatches]}"
+        )
+        # The single sub-sheet pin we touched should be the only mismatch.
+        assert {i.reference for i in net_mismatches} == {"R2.1"}, (
+            "Expected exactly R2.1 net mismatch, got: "
+            f"{sorted(i.reference for i in net_mismatches)}"
+        )
+        # And it points at the wrong net name we injected.
+        assert r2_pin1_mismatches[0].pcb_value == "WRONG_NET"


### PR DESCRIPTION
## Summary

- Closes #2633.
- `SchematicPCBChecker._check_nets` called `_extract_schematic_pin_nets()`, which invoked the root-only `extract_netlist()`. Every sub-sheet pin was absent from the returned dict, so the `sch_refs & pcb_refs` intersection in `_check_nets` silently skipped every sub-sheet ref. Net-name mismatches on sub-sheet pads were therefore never reported by `kct validate --consistency`.
- Adds a `hierarchical: bool = False` flag to `SchematicNetlistMixin.extract_netlist()`. When `True`, the method delegates to the existing hierarchical walker `kicad_tools.operations.netlist._collect_hierarchy_components`, which already handles per-sheet net extraction, sheet-pin / hierarchical-label merging across sheets, and circular-reference detection.
- `_extract_schematic_pin_nets()` in `validate/consistency.py` opts in via `extract_netlist(hierarchical=True)`.
- `Schematic.load(path)` now stores the source path on `_saved_path` so the walker can resolve relative sheet references. Previously only `write()` set this attribute.

PR #2625 already fixed the component-enumeration side of the same hierarchical blind spot (`_check_components`, `_check_properties` via `extract_bom(hierarchical=True)`); `_check_nets` was the remaining victim. The curator notes on #2633 corrected the original issue title accordingly.

## Implementation notes

- Default `extract_netlist()` behaviour (no kwarg) is byte-identical to before the change: only the root sheet's wires, symbols, labels, and power symbols are considered. All other callers (`pins_on_net`, `_collect_hierarchy_components` itself, doctests) continue to use the flat path.
- The import of `operations/netlist.py` is lazy inside the `hierarchical=True` branch to avoid an upward dependency from `schematic/models/` on `operations/`.
- If `hierarchical=True` is passed on a Schematic that was never loaded from disk (no path available to walk sub-sheets from), the method raises `ValueError` with an explicit message rather than silently falling back to root-only. This mirrors the `RuntimeWarning` upstream behaviour that #2625 added to `_check_components`.

## Test plan

- [x] New `tests/test_validate_hierarchical_nets.py` (6 tests, all passing):
  - `test_default_is_root_only` — default extract_netlist still returns only root sheet refs.
  - `test_hierarchical_walks_every_subsheet` — `hierarchical=True` returns the full set `{R1, R2, C1, C2, R3, R4}` from the fixture tree.
  - `test_hierarchical_requires_loaded_path` — `ValueError` on an unsaved Schematic.
  - `test_pin_nets_include_every_subsheet_ref` — `_extract_schematic_pin_nets()` covers every sub-sheet ref with both pins.
  - `test_in_sync_hierarchical_reports_no_net_issues` — in-sync hierarchical PCB triggers zero `domain=net` issues.
  - `test_subsheet_net_mismatch_is_detected` — deliberately wrong net on R2.1 (lives in sub_a.kicad_sch) is reported as exactly one `domain=net` `ConsistencyIssue`. Pre-fix this assertion fails because the root-only walker never returned R2.
- [x] `pytest tests/test_netlist_query.py tests/test_consistency.py tests/test_hierarchical_netlist.py tests/test_validate_hierarchical_sync.py` — 86 existing tests still pass (confirms default behaviour unchanged).
- [x] `pytest tests/test_schematic_run_erc.py tests/test_schematic_helpers.py tests/test_schematic.py` — 75 tests pass (confirms `Schematic.load` setting `_saved_path` does not regress write/run_erc round-trips).
- [x] `ruff check` and `ruff format --check` clean on changed files.
- Full suite (`pytest tests/` minus pre-existing CMA-ES / router-binding failures unrelated to this PR) — 14,966 passed, same 112 pre-existing failures as `main` (verified by stashing changes and re-running the affected test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)