### PR TITLE
feat(router): opt-in CoupledPathfinder engagement + single-ended refusal (closes #2638)

### DIFF
--- a/src/kicad_tools/router/diffpair.py
+++ b/src/kicad_tools/router/diffpair.py
@@ -53,7 +53,7 @@ class DifferentialPairRules:
     impedance: float = 90.0
 
     @classmethod
-    def for_type(cls, pair_type: DifferentialPairType) -> "DifferentialPairRules":
+    def for_type(cls, pair_type: DifferentialPairType) -> DifferentialPairRules:
         """Get predefined rules for a differential pair type."""
         rules_map = {
             DifferentialPairType.USB2: cls(
@@ -263,7 +263,7 @@ def _lookup_net_class(
     net_name: str,
     net_class_routing: dict | None,
     net_to_class: dict | None,
-) -> "NetClassRouting | None":
+) -> NetClassRouting | None:
     """Resolve the :class:`NetClassRouting` for ``net_name``.
 
     Supports two key conventions in ``net_class_routing``:
@@ -294,7 +294,7 @@ def _lookup_net_class(
 
 
 def should_engage_coupled(
-    pair: "DifferentialPair",
+    pair: DifferentialPair,
     net_class_routing: dict | None,
     net_to_class: dict | None = None,
 ) -> tuple[bool, str]:

--- a/src/kicad_tools/router/diffpair.py
+++ b/src/kicad_tools/router/diffpair.py
@@ -6,6 +6,7 @@ This module provides:
 - DifferentialPair: A pair of P/N signals with routing constraints
 - detect_differential_pairs: Parse net names to identify differential pairs
 - DifferentialPairConfig: Configuration for differential pair routing
+- should_engage_coupled: Engagement-layer gate for CoupledPathfinder (Phase 2E)
 
 Differential pairs are detected from common naming conventions:
 - Plus/minus notation: USB_D+/USB_D-, ETH_TX+/ETH_TX-
@@ -13,9 +14,15 @@ Differential pairs are detected from common naming conventions:
 - Positive/negative suffix: CLK_POS/CLK_NEG
 """
 
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass
 from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .rules import NetClassRouting
 
 
 class DifferentialPairType(Enum):
@@ -236,8 +243,123 @@ def is_single_ended_refused(net_name: str) -> bool:
     Refusal applies to suffix INFERENCE only -- explicit declarations
     (via ``NetClassRouting.diffpair_partner``) and KiCad group
     declarations bypass this check (designer override wins).
+
+    Note: a SEPARATE engagement-layer refusal in
+    :func:`should_engage_coupled` re-applies this pattern at the
+    CoupledPathfinder dispatch site so an explicit declaration cannot
+    force coupling on electrically-single-ended pins like USB-C CC1/CC2.
+    See Issue #2638 / Epic #2556 Phase 2E.
     """
     return bool(_SINGLE_ENDED_REFUSAL_PATTERN.match(net_name))
+
+
+# =============================================================================
+# ENGAGEMENT-LAYER GATE -- decides whether CoupledPathfinder runs for a pair
+# (Issue #2638, Epic #2556 Phase 2E).
+# =============================================================================
+
+
+def _lookup_net_class(
+    net_name: str,
+    net_class_routing: dict | None,
+    net_to_class: dict | None,
+) -> "NetClassRouting | None":
+    """Resolve the :class:`NetClassRouting` for ``net_name``.
+
+    Supports two key conventions in ``net_class_routing``:
+
+    1. ``class_name -> NetClassRouting`` paired with a
+       ``net_to_class: {net_name: class_name}`` map -- the layered
+       detector's convention (see ``diffpair_detection.py``).
+    2. ``net_name -> NetClassRouting`` directly -- the autorouter's
+       ``net_class_map`` convention (see ``router/core.py``).
+
+    The function tries convention (1) first when ``net_to_class`` is
+    supplied, then falls back to convention (2).  Returns ``None`` if
+    neither lookup yields a match.
+    """
+    if not net_class_routing:
+        return None
+
+    # Convention 1: class_name-keyed lookup via net_to_class.
+    if net_to_class is not None:
+        class_name = net_to_class.get(net_name)
+        if class_name is not None:
+            nc = net_class_routing.get(class_name)
+            if nc is not None:
+                return nc
+
+    # Convention 2: net_name-keyed lookup (autorouter.net_class_map style).
+    return net_class_routing.get(net_name)
+
+
+def should_engage_coupled(
+    pair: "DifferentialPair",
+    net_class_routing: dict | None,
+    net_to_class: dict | None = None,
+) -> tuple[bool, str]:
+    """Decide whether CoupledPathfinder should engage on ``pair``.
+
+    Phase 2E (Issue #2638, Epic #2556) refines diff-pair engagement from
+    "always run coupled when ``--differential-pairs`` is on" to "run
+    coupled only when the net class explicitly opts in AND the pair is
+    not single-ended-by-spec."  This is the engagement-layer counterpart
+    to suffix-time refusal in :func:`is_single_ended_refused`.
+
+    The single-ended refusal here fires regardless of detection source.
+    The #2527 case (designer accidentally declares
+    ``diffpair_partner="USB_CC2"`` on a USB_CC1 net class) is caught
+    here even though the explicit declaration bypassed the suffix-time
+    refusal: USB-C CC1/CC2 are orientation pins, not a coupled pair,
+    and routing them as a coupled pair would be electrically wrong.
+
+    Args:
+        pair: The detected :class:`DifferentialPair`.
+        net_class_routing: Map of either ``{class_name: NetClassRouting}``
+            or ``{net_name: NetClassRouting}`` (see
+            :func:`_lookup_net_class`).  When ``None`` or empty, no class
+            opted in -> ``(False, "no_class_match")``.
+        net_to_class: Optional ``{net_name: class_name}`` lookup used in
+            tandem with the class-name-keyed convention.
+
+    Returns:
+        ``(engaged, reason)`` where ``reason`` is one of:
+
+        * ``"engaged"`` -- proceed with coupled routing.
+        * ``"single_ended_refusal"`` -- both nets match
+          :func:`is_single_ended_refused`.  Coupling them would be
+          electrically wrong (USB-C CC1/CC2, SBU1/SBU2).  Fires even
+          when explicit declaration would otherwise bypass suffix-time
+          refusal.
+        * ``"opt_in_disabled"`` -- a class match exists but
+          ``coupled_routing`` is ``False`` on the matched class.
+        * ``"no_class_match"`` -- neither net resolves to a
+          :class:`NetClassRouting`.  Treated as disabled.
+    """
+    # 1. Engagement-layer single-ended refusal (#2527 lesson).  Fires
+    #    regardless of detection source -- explicit declarations cannot
+    #    force coupling on electrically-single-ended pins.
+    p_name = pair.positive.net_name
+    n_name = pair.negative.net_name
+    if is_single_ended_refused(p_name) and is_single_ended_refused(n_name):
+        return False, "single_ended_refusal"
+
+    # 2. Look up the net class for either half.  Either side opting in
+    #    is sufficient -- this mirrors the one-sided-declaration policy
+    #    in ``_gather_explicit_pairs`` (#2558).
+    p_class = _lookup_net_class(p_name, net_class_routing, net_to_class)
+    n_class = _lookup_net_class(n_name, net_class_routing, net_to_class)
+
+    if p_class is None and n_class is None:
+        return False, "no_class_match"
+
+    p_opt = bool(p_class is not None and getattr(p_class, "coupled_routing", False))
+    n_opt = bool(n_class is not None and getattr(n_class, "coupled_routing", False))
+
+    if p_opt or n_opt:
+        return True, "engaged"
+
+    return False, "opt_in_disabled"
 
 
 def parse_differential_signal(net_name: str) -> tuple[str, str, str] | None:

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -977,6 +977,57 @@ class DiffPairRouter:
         """
         self.autorouter = autorouter
 
+    def _resolve_detection_inputs(
+        self,
+    ) -> tuple[dict | None, dict[str, str] | None, list | None]:
+        """Pull layered-detection context off the autorouter.
+
+        Returns the ``(net_class_routing, net_to_class, kicad_groups)``
+        triple needed by :func:`_layered_detect_diff_pairs`.  Supports
+        both attribute conventions:
+
+        * ``net_class_routing`` + ``net_to_class`` -- preferred (set by
+          callers that have built a class-name-keyed map).
+        * ``net_class_map`` -- the autorouter's per-net-name map; when
+          present, we synthesise a ``net_to_class`` map from it so the
+          explicit declaration path can be consulted.
+
+        Issue #2638 / Epic #2556 Phase 2E: the explicit-declaration
+        path in ``_gather_explicit_pairs`` was previously dead for
+        callers that only set ``autorouter.net_class_map`` (the common
+        case).  Phase 2E plumbs the fallback through so the
+        engagement-layer single-ended refusal -- which depends on
+        explicit pairs being detected -- can fire.
+        """
+        net_class_routing = getattr(self.autorouter, "net_class_routing", None)
+        net_to_class = getattr(self.autorouter, "net_to_class", None)
+        kicad_groups = getattr(self.autorouter, "kicad_diff_pair_groups", None)
+
+        if net_class_routing is None:
+            net_class_map = getattr(self.autorouter, "net_class_map", None)
+            if net_class_map:
+                net_class_routing = net_class_map
+                if net_to_class is None:
+                    # Synthesise a net_name -> class_name map.  We use
+                    # the NetClassRouting.name attribute so the
+                    # class-name-keyed lookup in _gather_explicit_pairs
+                    # can find each entry under a stable key.  Because
+                    # multiple net names may map to the same
+                    # NetClassRouting instance, we also register each
+                    # NetClassRouting under its own .name so
+                    # _gather_explicit_pairs' subsequent lookup
+                    # ``net_class_routing.get(class_name)`` succeeds.
+                    synth_routing: dict = dict(net_class_map)
+                    synth_to_class: dict[str, str] = {}
+                    for net_name, nc in net_class_map.items():
+                        cls_name = nc.name
+                        synth_to_class[net_name] = cls_name
+                        synth_routing.setdefault(cls_name, nc)
+                    net_class_routing = synth_routing
+                    net_to_class = synth_to_class
+
+        return net_class_routing, net_to_class, kicad_groups
+
     def detect_differential_pairs(self) -> list[DifferentialPair]:
         """Detect differential pairs from net names.
 
@@ -984,14 +1035,15 @@ class DiffPairRouter:
         detector (``diffpair_detection.detect_diff_pairs``) which
         consults explicit ``NetClassRouting.diffpair_partner`` and
         KiCad-group declarations in priority order before falling back
-        to suffix inference.  When the autorouter does not provide
-        ``net_class_routing`` / ``net_to_class`` / ``kicad_diff_pair_groups``
-        attributes, behaviour collapses to the legacy suffix-only
-        result.
+        to suffix inference.
+
+        Issue #2638, Phase 2E: the layered-detection inputs are now
+        pulled from either explicit ``net_class_routing`` /
+        ``net_to_class`` attributes OR the autorouter's
+        ``net_class_map`` (see :meth:`_resolve_detection_inputs`), so
+        explicit declarations are honoured for both attribute shapes.
         """
-        net_class_routing = getattr(self.autorouter, "net_class_routing", None)
-        net_to_class = getattr(self.autorouter, "net_to_class", None)
-        kicad_groups = getattr(self.autorouter, "kicad_diff_pair_groups", None)
+        net_class_routing, net_to_class, kicad_groups = self._resolve_detection_inputs()
 
         detected = _layered_detect_diff_pairs(
             self.autorouter.net_names,
@@ -1008,9 +1060,7 @@ class DiffPairRouter:
         Returns a list of ``(pair, source)`` tuples where ``source`` is
         one of ``"explicit"``, ``"kicad_group"``, ``"suffix"``.
         """
-        net_class_routing = getattr(self.autorouter, "net_class_routing", None)
-        net_to_class = getattr(self.autorouter, "net_to_class", None)
-        kicad_groups = getattr(self.autorouter, "kicad_diff_pair_groups", None)
+        net_class_routing, net_to_class, kicad_groups = self._resolve_detection_inputs()
 
         detected = _layered_detect_diff_pairs(
             self.autorouter.net_names,
@@ -1030,26 +1080,14 @@ class DiffPairRouter:
         """Resolve whether ``pair`` should engage CoupledPathfinder.
 
         Issue #2638, Epic #2556 Phase 2E: thin wrapper that pulls
-        net-class context off the autorouter and defers to
+        net-class context off the autorouter via
+        :meth:`_resolve_detection_inputs` and defers to
         :func:`should_engage_coupled`.
-
-        The autorouter exposes one of two attribute shapes:
-
-        * ``net_class_routing`` + ``net_to_class`` -- the layered
-          detector's convention.
-        * ``net_class_map`` -- the autorouter's per-net-name map.
-          We surface this as ``net_class_routing`` for the helper,
-          which handles the net-name-keyed convention via its
-          :func:`_lookup_net_class` fallback.
 
         Returns:
             ``(engaged, reason)`` from :func:`should_engage_coupled`.
         """
-        net_class_routing = getattr(self.autorouter, "net_class_routing", None)
-        net_to_class = getattr(self.autorouter, "net_to_class", None)
-        if net_class_routing is None:
-            # Fall back to the autorouter's per-net-name map.
-            net_class_routing = getattr(self.autorouter, "net_class_map", None)
+        net_class_routing, net_to_class, _ = self._resolve_detection_inputs()
         return should_engage_coupled(pair, net_class_routing, net_to_class)
 
     def _get_pair_pads(self, pair: DifferentialPair) -> tuple[list[Pad], list[Pad]] | None:

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -1074,9 +1074,7 @@ class DiffPairRouter:
         """Analyze net names for differential pairs."""
         return analyze_differential_pairs(self.autorouter.net_names)
 
-    def _resolve_engagement(
-        self, pair: DifferentialPair
-    ) -> tuple[bool, str]:
+    def _resolve_engagement(self, pair: DifferentialPair) -> tuple[bool, str]:
         """Resolve whether ``pair`` should engage CoupledPathfinder.
 
         Issue #2638, Epic #2556 Phase 2E: thin wrapper that pulls

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -28,6 +28,7 @@ from .diffpair import (
     DifferentialPairConfig,
     LengthMismatchWarning,
     analyze_differential_pairs,
+    should_engage_coupled,
 )
 from .diffpair_detection import (
     detect_diff_pairs as _layered_detect_diff_pairs,
@@ -1023,6 +1024,34 @@ class DiffPairRouter:
         """Analyze net names for differential pairs."""
         return analyze_differential_pairs(self.autorouter.net_names)
 
+    def _resolve_engagement(
+        self, pair: DifferentialPair
+    ) -> tuple[bool, str]:
+        """Resolve whether ``pair`` should engage CoupledPathfinder.
+
+        Issue #2638, Epic #2556 Phase 2E: thin wrapper that pulls
+        net-class context off the autorouter and defers to
+        :func:`should_engage_coupled`.
+
+        The autorouter exposes one of two attribute shapes:
+
+        * ``net_class_routing`` + ``net_to_class`` -- the layered
+          detector's convention.
+        * ``net_class_map`` -- the autorouter's per-net-name map.
+          We surface this as ``net_class_routing`` for the helper,
+          which handles the net-name-keyed convention via its
+          :func:`_lookup_net_class` fallback.
+
+        Returns:
+            ``(engaged, reason)`` from :func:`should_engage_coupled`.
+        """
+        net_class_routing = getattr(self.autorouter, "net_class_routing", None)
+        net_to_class = getattr(self.autorouter, "net_to_class", None)
+        if net_class_routing is None:
+            # Fall back to the autorouter's per-net-name map.
+            net_class_routing = getattr(self.autorouter, "net_class_map", None)
+        return should_engage_coupled(pair, net_class_routing, net_to_class)
+
     def _get_pair_pads(self, pair: DifferentialPair) -> tuple[list[Pad], list[Pad]] | None:
         """Get pads for P and N nets of a differential pair.
 
@@ -1635,6 +1664,17 @@ class DiffPairRouter:
 
         for pair in diff_pairs:
             p_id, n_id = pair.get_net_ids()
+            # Issue #2638, Epic #2556 Phase 2E: engagement gate.  When the
+            # pair's net class has not opted in via ``coupled_routing=True``,
+            # or when the pair is single-ended-by-spec (USB-C CC1/CC2,
+            # SBU1/SBU2 — the #2527 lesson), refuse coupled routing and
+            # let the pair fall through to the main strategy.
+            engaged, reason = self._resolve_engagement(pair)
+            if not engaged:
+                msg = f"[diffpair-engage] refused {pair}: {reason}"
+                print(f"  {msg}")
+                logger.info(msg)
+                continue
             # Issue #2464: Use coupled_only=True so that the pre-pass is a
             # no-op for pairs that the CoupledPathfinder cannot handle.
             # Those pairs are left for the main strategy (negotiated/MC/GA)
@@ -1732,8 +1772,24 @@ class DiffPairRouter:
         # caller can decide which nets to leave for the main strategy.
         coupled_routed_nets: set[int] = set()
 
+        refused_diff_nets: set[int] = set()
         for pair in diff_pairs:
             p_id, n_id = pair.get_net_ids()
+            # Issue #2638, Epic #2556 Phase 2E: engagement gate.  Refuse
+            # coupled routing when the pair's net class has not opted in
+            # (default ``coupled_routing=False``) or when the pair is
+            # single-ended-by-spec (#2527 lesson).  Refused pairs fall
+            # through to the main strategy (their net IDs are removed
+            # from ``diff_net_ids`` below so the main strategy picks
+            # them up normally).
+            engaged, reason = self._resolve_engagement(pair)
+            if not engaged:
+                msg = f"[diffpair-engage] refused {pair}: {reason}"
+                print(f"  {msg}")
+                logger.info(msg)
+                refused_diff_nets.add(p_id)
+                refused_diff_nets.add(n_id)
+                continue
             if coupled_only:
                 pair_routes, warning = self.route_differential_pair_coupled(
                     pair,
@@ -1763,6 +1819,14 @@ class DiffPairRouter:
         # main strategy can pick them up.
         if coupled_only:
             diff_net_ids = coupled_routed_nets
+        elif refused_diff_nets:
+            # Issue #2638 Phase 2E: engagement-refused pairs produced no
+            # routes here; drop their nets from ``diff_net_ids`` so the
+            # main strategy routes them normally.  Non-refused pairs
+            # remain in ``diff_net_ids`` to preserve the pre-2638 behavior
+            # of treating coupled-routing fallbacks (independent routing
+            # inside route_differential_pair) as "handled".
+            diff_net_ids = diff_net_ids - refused_diff_nets
 
         non_diff_nets = [n for n in self.autorouter.nets if n not in diff_net_ids and n != 0]
         if non_diff_nets:

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -447,6 +447,37 @@ class NetClassRouting:
     # Phase 1A (#2557).
     diffpair_partner: str | None = None
 
+    # Differential pair coupled-routing engagement (Issue #2638, Epic #2556 Phase 2E)
+    coupled_routing: bool = False
+    """Opt-in flag for routing this net class's diff pairs via CoupledPathfinder.
+
+    When ``False`` (default), differential pairs whose P or N net belongs to
+    this class fall through to the main routing strategy even when
+    ``--differential-pairs`` is enabled.  Phase 1's ``intra_pair_clearance``
+    still applies to within-pair edges at the pathfinder layer, so a tight
+    intra clearance can be honored without forcing coupled geometry.
+
+    When ``True``, the diff-pair pre-pass / ``route_all_with_diffpairs``
+    dispatch invokes :meth:`CoupledPathfinder` for pairs in this class,
+    subject to the engagement-layer single-ended refusal in
+    :func:`should_engage_coupled` (#2527 lesson — pin pairs that look
+    diff-pair-ish but are single-ended by spec, like USB-C CC1/CC2 and
+    SBU1/SBU2, are refused at engagement time even when explicitly
+    declared via :attr:`diffpair_partner`).
+
+    Default is ``False`` for backward compatibility with all pre-#2636
+    boards.  Predefined classes (e.g. ``NET_CLASS_HIGH_SPEED``) keep
+    ``coupled_routing=False`` until a follow-up issue flips them on with
+    empirical board coverage from Phase 4's board 06.
+
+    NOTE -- name collision with the ``use_coupled_routing`` function
+    parameter on :meth:`DiffPairRouter.route_differential_pair`.  The
+    parameter is a runtime dispatch toggle ("call coupled vs independent
+    for this single invocation"); this field is a class-level
+    configuration flag ("nets in this class opt into the coupled
+    engagement path").  Future refactors must not collapse the two.
+    """
+
     def effective_intra_pair_clearance(self) -> float:
         """Return the clearance to apply to within-pair diff-pair edges.
 

--- a/tests/test_diffpair_engagement.py
+++ b/tests/test_diffpair_engagement.py
@@ -1,0 +1,445 @@
+"""Engagement-layer gate for CoupledPathfinder (Issue #2638, Epic #2556 Phase 2E).
+
+This module tests :func:`kicad_tools.router.diffpair.should_engage_coupled`
+and the dispatcher integration in
+:mod:`kicad_tools.router.diffpair_routing` -- specifically:
+
+* ``coupled_routing=False`` default skips coupled routing for opted-out
+  net classes (the new opt-in policy).
+* ``coupled_routing=True`` engages coupled routing for opted-in classes.
+* Engagement-layer single-ended refusal: an explicit
+  ``diffpair_partner`` declaration on USB-C ``CC1`` / ``CC2`` (the
+  #2527 lesson — orientation pins, NOT a diff pair) is refused even
+  though the explicit declaration bypasses suffix-time refusal.
+* ``--differential-pairs`` (i.e. ``DifferentialPairConfig.enabled=False``)
+  master switch short-circuits engagement regardless of per-class flag.
+* N-pad regression (#2473 USB-C 3-pad coverage) must not regress.
+"""
+
+import dataclasses
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.diffpair import (
+    DifferentialPair,
+    DifferentialPairConfig,
+    DifferentialPairType,
+    DifferentialSignal,
+    should_engage_coupled,
+)
+from kicad_tools.router.rules import (
+    NET_CLASS_HIGH_SPEED,
+    DesignRules,
+    NetClassRouting,
+)
+
+
+# =============================================================================
+# Test helpers
+# =============================================================================
+
+
+def _make_pair(p_name: str, n_name: str, p_id: int = 1, n_id: int = 2) -> DifferentialPair:
+    """Construct a minimal ``DifferentialPair`` for engagement tests."""
+    return DifferentialPair(
+        name=p_name.rstrip("+-_PN"),
+        positive=DifferentialSignal(
+            net_name=p_name,
+            net_id=p_id,
+            base_name=p_name.rstrip("+-_PN"),
+            polarity="P",
+            notation="plus_minus",
+        ),
+        negative=DifferentialSignal(
+            net_name=n_name,
+            net_id=n_id,
+            base_name=n_name.rstrip("+-_PN"),
+            polarity="N",
+            notation="plus_minus",
+        ),
+        pair_type=DifferentialPairType.USB2,
+    )
+
+
+# =============================================================================
+# 1. Unit tests on ``should_engage_coupled``
+# =============================================================================
+
+
+class TestShouldEngageCoupled:
+    def test_no_class_match_returns_no_class_match(self):
+        pair = _make_pair("USB_D+", "USB_D-")
+        engaged, reason = should_engage_coupled(pair, None, None)
+        assert engaged is False
+        assert reason == "no_class_match"
+
+    def test_empty_class_map_returns_no_class_match(self):
+        pair = _make_pair("USB_D+", "USB_D-")
+        engaged, reason = should_engage_coupled(pair, {}, None)
+        assert engaged is False
+        assert reason == "no_class_match"
+
+    def test_opt_in_disabled_returns_opt_in_disabled(self):
+        # Class exists, coupled_routing defaults to False.
+        pair = _make_pair("USB_D+", "USB_D-")
+        nc = NetClassRouting(name="HighSpeed")  # coupled_routing=False
+        # net_name-keyed convention (autorouter.net_class_map style).
+        engaged, reason = should_engage_coupled(
+            pair, {"USB_D+": nc, "USB_D-": nc}, None
+        )
+        assert engaged is False
+        assert reason == "opt_in_disabled"
+
+    def test_opt_in_enabled_engages(self):
+        pair = _make_pair("USB_D+", "USB_D-")
+        nc = NetClassRouting(name="HighSpeed", coupled_routing=True)
+        engaged, reason = should_engage_coupled(
+            pair, {"USB_D+": nc, "USB_D-": nc}, None
+        )
+        assert engaged is True
+        assert reason == "engaged"
+
+    def test_either_side_opt_in_engages(self):
+        # If either P or N's class opts in, engagement proceeds.  Mirrors
+        # the one-sided-declaration policy in ``_gather_explicit_pairs``.
+        pair = _make_pair("USB_D+", "USB_D-")
+        nc_opt = NetClassRouting(name="HighSpeed", coupled_routing=True)
+        nc_off = NetClassRouting(name="Other", coupled_routing=False)
+        engaged, _ = should_engage_coupled(
+            pair, {"USB_D+": nc_opt, "USB_D-": nc_off}, None
+        )
+        assert engaged is True
+
+    def test_class_name_keyed_with_net_to_class(self):
+        # Layered-detector convention: net_class_routing keyed by class
+        # name and net_to_class maps net_name -> class_name.
+        pair = _make_pair("USB_D+", "USB_D-")
+        nc = NetClassRouting(name="HighSpeed", coupled_routing=True)
+        engaged, reason = should_engage_coupled(
+            pair,
+            net_class_routing={"HighSpeed": nc},
+            net_to_class={"USB_D+": "HighSpeed", "USB_D-": "HighSpeed"},
+        )
+        assert engaged is True
+        assert reason == "engaged"
+
+    def test_single_ended_refusal_fires_regardless_of_opt_in(self):
+        # The #2527 lesson, made executable.  USB-C CC1/CC2 are
+        # orientation pins; coupling them would be electrically wrong.
+        pair = _make_pair("USB_CC1", "USB_CC2")
+        nc = NetClassRouting(
+            name="USBCC",
+            diffpair_partner="USB_CC2",
+            coupled_routing=True,  # designer explicitly opted in
+        )
+        engaged, reason = should_engage_coupled(
+            pair, {"USB_CC1": nc, "USB_CC2": nc}, None
+        )
+        assert engaged is False
+        assert reason == "single_ended_refusal"
+
+    def test_single_ended_refusal_for_sbu(self):
+        pair = _make_pair("SBU1", "SBU2")
+        nc = NetClassRouting(
+            name="SBU",
+            diffpair_partner="SBU2",
+            coupled_routing=True,
+        )
+        engaged, reason = should_engage_coupled(
+            pair, {"SBU1": nc, "SBU2": nc}, None
+        )
+        assert engaged is False
+        assert reason == "single_ended_refusal"
+
+    def test_single_ended_refusal_for_prefixed_cc(self):
+        pair = _make_pair("FOO_CC1", "FOO_CC2")
+        nc = NetClassRouting(
+            name="FooCC",
+            diffpair_partner="FOO_CC2",
+            coupled_routing=True,
+        )
+        engaged, reason = should_engage_coupled(
+            pair, {"FOO_CC1": nc, "FOO_CC2": nc}, None
+        )
+        assert engaged is False
+        assert reason == "single_ended_refusal"
+
+    def test_only_one_side_single_ended_does_not_refuse(self):
+        # Defensive: refusal needs BOTH halves matching the pattern.  A
+        # net oddly named ``USB_CC1`` paired with ``USB_D-`` is
+        # presumably mis-declared but we don't want the refusal to
+        # mask user errors; opt-in still wins.
+        pair = _make_pair("USB_CC1", "USB_D-")
+        nc = NetClassRouting(
+            name="Mixed",
+            coupled_routing=True,
+        )
+        engaged, _ = should_engage_coupled(
+            pair, {"USB_CC1": nc, "USB_D-": nc}, None
+        )
+        # Engagement proceeds (single-ended refusal needs both halves);
+        # the suffix/explicit-detection layer is responsible for
+        # rejecting malformed pairs before reaching this point.
+        assert engaged is True
+
+
+# =============================================================================
+# 2. Dispatcher integration -- ``route_diffpair_prepass``
+# =============================================================================
+
+
+def _two_pad_router(
+    *,
+    coupled_routing: bool = False,
+    extra_class_kwargs: dict | None = None,
+) -> Autorouter:
+    """Two-pad USB_D+/USB_D- fixture parameterized by opt-in state."""
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
+    nc_kwargs = dict(name="HighSpeed", coupled_routing=coupled_routing)
+    if extra_class_kwargs:
+        nc_kwargs.update(extra_class_kwargs)
+    nc = NetClassRouting(**nc_kwargs)
+    net_class_map = {"USB_D+": nc, "USB_D-": nc}
+    router = Autorouter(
+        width=30.0,
+        height=10.0,
+        rules=rules,
+        net_class_map=net_class_map,
+    )
+
+    spacing = 0.8
+    p_y = 5.0 - spacing / 2
+    n_y = 5.0 + spacing / 2
+    router.add_component(
+        "U1",
+        [
+            {"number": "1", "x": 5.0, "y": p_y, "width": 0.4, "height": 0.4,
+             "net": 1, "net_name": "USB_D+"},
+            {"number": "2", "x": 5.0, "y": n_y, "width": 0.4, "height": 0.4,
+             "net": 2, "net_name": "USB_D-"},
+        ],
+    )
+    router.add_component(
+        "J1",
+        [
+            {"number": "1", "x": 25.0, "y": p_y, "width": 0.4, "height": 0.4,
+             "net": 1, "net_name": "USB_D+"},
+            {"number": "2", "x": 25.0, "y": n_y, "width": 0.4, "height": 0.4,
+             "net": 2, "net_name": "USB_D-"},
+        ],
+    )
+    return router
+
+
+class TestPrepassEngagementGate:
+    def test_opt_in_disabled_skips_coupled(self):
+        # Default ``coupled_routing=False`` on the class -> pre-pass is
+        # a no-op for this pair; net IDs are NOT in routed_net_ids.
+        router = _two_pad_router(coupled_routing=False)
+        config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+        routes, _warnings, routed = router.route_diffpair_prepass(config)
+
+        assert routed == set(), (
+            f"Expected pre-pass to skip non-opted-in pair; got routed={routed}"
+        )
+        assert routes == [], (
+            f"Expected no coupled routes from refused pair; got {len(routes)}"
+        )
+
+    def test_opt_in_enabled_engages_coupled(self):
+        router = _two_pad_router(coupled_routing=True)
+        config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+        routes, _warnings, routed = router.route_diffpair_prepass(config)
+
+        assert 1 in routed and 2 in routed, (
+            f"Expected both diff-pair nets to route; got {routed}"
+        )
+        assert routes, "Opt-in pair must produce coupled routes"
+
+    def test_master_switch_off_short_circuits(self):
+        # ``--differential-pairs`` off (config.enabled=False) bypasses
+        # the pre-pass entirely -- per-class opt-in is irrelevant.
+        router = _two_pad_router(coupled_routing=True)
+        config = DifferentialPairConfig(enabled=False, spacing=0.8)
+
+        routes, warnings, routed = router.route_diffpair_prepass(config)
+
+        assert routes == []
+        assert warnings == []
+        assert routed == set()
+
+
+# =============================================================================
+# 3. Engagement-layer single-ended refusal (the #2527 lesson)
+# =============================================================================
+
+
+def _usb_cc_router(coupled_routing: bool = True) -> Autorouter:
+    """USB_CC1/CC2 fixture with explicit ``diffpair_partner`` declaration."""
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
+    # Designer accidentally pairs USB_CC1 with USB_CC2 via explicit
+    # diffpair_partner declaration AND opts in to coupled routing.
+    # Phase 2E must refuse engagement even with this configuration.
+    nc = NetClassRouting(
+        name="USBCC",
+        diffpair_partner="USB_CC2",
+        coupled_routing=coupled_routing,
+    )
+    net_class_map = {"USB_CC1": nc, "USB_CC2": nc}
+    router = Autorouter(
+        width=30.0,
+        height=10.0,
+        rules=rules,
+        net_class_map=net_class_map,
+    )
+
+    router.add_component(
+        "U1",
+        [
+            {"number": "1", "x": 5.0, "y": 4.5, "width": 0.4, "height": 0.4,
+             "net": 1, "net_name": "USB_CC1"},
+            {"number": "2", "x": 5.0, "y": 5.5, "width": 0.4, "height": 0.4,
+             "net": 2, "net_name": "USB_CC2"},
+        ],
+    )
+    router.add_component(
+        "J1",
+        [
+            {"number": "1", "x": 25.0, "y": 4.5, "width": 0.4, "height": 0.4,
+             "net": 1, "net_name": "USB_CC1"},
+            {"number": "2", "x": 25.0, "y": 5.5, "width": 0.4, "height": 0.4,
+             "net": 2, "net_name": "USB_CC2"},
+        ],
+    )
+    return router
+
+
+class TestSingleEndedRefusalAtEngagement:
+    def test_explicit_declaration_refused_at_engagement(self):
+        """#2527 lesson: explicit declaration cannot force coupling on CC1/CC2."""
+        router = _usb_cc_router(coupled_routing=True)
+        config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+        # The detector returns the pair (explicit declaration is the
+        # authoritative source); engagement-layer refusal kicks in.
+        detected = router._diffpair.detect_differential_pairs_with_source()
+        # Layered detector should pair them explicitly.
+        assert any(
+            {p.positive.net_name, p.negative.net_name} == {"USB_CC1", "USB_CC2"}
+            and src == "explicit"
+            for p, src in detected
+        ), f"Expected explicit USB_CC1/USB_CC2 pair detection; got {detected}"
+
+        # ... but the pre-pass refuses to engage coupled routing.
+        routes, _warnings, routed = router.route_diffpair_prepass(config)
+        assert routed == set(), (
+            "USB_CC1/USB_CC2 must NOT be coupled-routed (single-ended refusal); "
+            f"got routed={routed}"
+        )
+        assert routes == [], (
+            "Expected zero coupled routes for refused USB_CC1/USB_CC2 pair"
+        )
+
+    def test_engagement_helper_directly_refuses_cc_pair(self):
+        """Direct helper test mirroring the engagement-time guard."""
+        pair = _make_pair("USB_CC1", "USB_CC2")
+        nc = NetClassRouting(
+            name="USBCC",
+            diffpair_partner="USB_CC2",
+            coupled_routing=True,
+        )
+        engaged, reason = should_engage_coupled(
+            pair,
+            net_class_routing={"USB_CC1": nc, "USB_CC2": nc},
+            net_to_class=None,
+        )
+        assert engaged is False
+        assert reason == "single_ended_refusal"
+
+
+# =============================================================================
+# 4. N-pad regression (#2473 USB-C 3-pad coverage)
+# =============================================================================
+
+
+def _three_pad_usb_router(coupled_routing: bool = True) -> Autorouter:
+    """USB-C 3-pad-per-net diff pair (board 03's J1 row A/B + U1 footprint)."""
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
+    nc = NetClassRouting(name="HighSpeed", coupled_routing=coupled_routing)
+    net_class_map = {"USB_D+": nc, "USB_D-": nc}
+    router = Autorouter(
+        width=40.0,
+        height=20.0,
+        rules=rules,
+        net_class_map=net_class_map,
+    )
+
+    # Three pads per net (U1 + J1 row A + J1 row B).
+    for ref, x in [("U1", 5.0), ("J1A", 25.0), ("J1B", 35.0)]:
+        router.add_component(
+            ref,
+            [
+                {"number": "1", "x": x, "y": 9.0, "width": 0.4, "height": 0.4,
+                 "net": 1, "net_name": "USB_D+"},
+                {"number": "2", "x": x, "y": 11.0, "width": 0.4, "height": 0.4,
+                 "net": 2, "net_name": "USB_D-"},
+            ],
+        )
+    return router
+
+
+class TestNPadRegression:
+    def test_three_pad_usb_engagement_routes_all_pads(self):
+        """#2473 must-pass: 3-pad USB pair with opt-in must produce coupled routes.
+
+        Phase 2E refines engagement criteria but must NOT regress the
+        N-pad coverage that landed in PR #2474.
+        """
+        router = _three_pad_usb_router(coupled_routing=True)
+        config = DifferentialPairConfig(enabled=True, spacing=2.0)
+
+        routes, _warnings, routed = router.route_diffpair_prepass(config)
+
+        # With opt-in, the pre-pass attempts coupled routing.  The
+        # 3-pad-per-net case may yield 2 coupled segments and the
+        # remaining stubs come from the main strategy, so we accept
+        # any non-empty set; the critical assertion is that engagement
+        # was NOT refused.
+        assert routes, (
+            "3-pad USB pair with coupled_routing=True must produce coupled routes "
+            "(N-pad regression check)"
+        )
+
+    def test_three_pad_usb_default_off_falls_through(self):
+        """Default opt-out path: 3-pad USB pair falls through to main strategy."""
+        router = _three_pad_usb_router(coupled_routing=False)
+        config = DifferentialPairConfig(enabled=True, spacing=2.0)
+
+        routes, _warnings, routed = router.route_diffpair_prepass(config)
+
+        assert routes == []
+        assert routed == set()
+
+
+# =============================================================================
+# 5. Predefined classes preserve pre-#2638 default (coupled_routing=False)
+# =============================================================================
+
+
+class TestPredefinedClassesDefaultOff:
+    def test_high_speed_default_off(self):
+        # Phase 2E out-of-scope: predefined classes must NOT have
+        # coupled_routing flipped on.  That's a follow-up issue.
+        assert NET_CLASS_HIGH_SPEED.coupled_routing is False
+
+    def test_dataclass_default_is_false(self):
+        nc = NetClassRouting(name="Bare")
+        assert nc.coupled_routing is False
+
+    def test_dataclass_replace_preserves_field(self):
+        nc = NetClassRouting(name="Bare")
+        replaced = dataclasses.replace(nc, coupled_routing=True)
+        assert replaced.coupled_routing is True
+        # Original is unchanged.
+        assert nc.coupled_routing is False

--- a/tests/test_diffpair_engagement.py
+++ b/tests/test_diffpair_engagement.py
@@ -32,7 +32,6 @@ from kicad_tools.router.rules import (
     NetClassRouting,
 )
 
-
 # =============================================================================
 # Test helpers
 # =============================================================================
@@ -83,18 +82,14 @@ class TestShouldEngageCoupled:
         pair = _make_pair("USB_D+", "USB_D-")
         nc = NetClassRouting(name="HighSpeed")  # coupled_routing=False
         # net_name-keyed convention (autorouter.net_class_map style).
-        engaged, reason = should_engage_coupled(
-            pair, {"USB_D+": nc, "USB_D-": nc}, None
-        )
+        engaged, reason = should_engage_coupled(pair, {"USB_D+": nc, "USB_D-": nc}, None)
         assert engaged is False
         assert reason == "opt_in_disabled"
 
     def test_opt_in_enabled_engages(self):
         pair = _make_pair("USB_D+", "USB_D-")
         nc = NetClassRouting(name="HighSpeed", coupled_routing=True)
-        engaged, reason = should_engage_coupled(
-            pair, {"USB_D+": nc, "USB_D-": nc}, None
-        )
+        engaged, reason = should_engage_coupled(pair, {"USB_D+": nc, "USB_D-": nc}, None)
         assert engaged is True
         assert reason == "engaged"
 
@@ -104,9 +99,7 @@ class TestShouldEngageCoupled:
         pair = _make_pair("USB_D+", "USB_D-")
         nc_opt = NetClassRouting(name="HighSpeed", coupled_routing=True)
         nc_off = NetClassRouting(name="Other", coupled_routing=False)
-        engaged, _ = should_engage_coupled(
-            pair, {"USB_D+": nc_opt, "USB_D-": nc_off}, None
-        )
+        engaged, _ = should_engage_coupled(pair, {"USB_D+": nc_opt, "USB_D-": nc_off}, None)
         assert engaged is True
 
     def test_class_name_keyed_with_net_to_class(self):
@@ -131,9 +124,7 @@ class TestShouldEngageCoupled:
             diffpair_partner="USB_CC2",
             coupled_routing=True,  # designer explicitly opted in
         )
-        engaged, reason = should_engage_coupled(
-            pair, {"USB_CC1": nc, "USB_CC2": nc}, None
-        )
+        engaged, reason = should_engage_coupled(pair, {"USB_CC1": nc, "USB_CC2": nc}, None)
         assert engaged is False
         assert reason == "single_ended_refusal"
 
@@ -144,9 +135,7 @@ class TestShouldEngageCoupled:
             diffpair_partner="SBU2",
             coupled_routing=True,
         )
-        engaged, reason = should_engage_coupled(
-            pair, {"SBU1": nc, "SBU2": nc}, None
-        )
+        engaged, reason = should_engage_coupled(pair, {"SBU1": nc, "SBU2": nc}, None)
         assert engaged is False
         assert reason == "single_ended_refusal"
 
@@ -157,9 +146,7 @@ class TestShouldEngageCoupled:
             diffpair_partner="FOO_CC2",
             coupled_routing=True,
         )
-        engaged, reason = should_engage_coupled(
-            pair, {"FOO_CC1": nc, "FOO_CC2": nc}, None
-        )
+        engaged, reason = should_engage_coupled(pair, {"FOO_CC1": nc, "FOO_CC2": nc}, None)
         assert engaged is False
         assert reason == "single_ended_refusal"
 
@@ -173,9 +160,7 @@ class TestShouldEngageCoupled:
             name="Mixed",
             coupled_routing=True,
         )
-        engaged, _ = should_engage_coupled(
-            pair, {"USB_CC1": nc, "USB_D-": nc}, None
-        )
+        engaged, _ = should_engage_coupled(pair, {"USB_CC1": nc, "USB_D-": nc}, None)
         # Engagement proceeds (single-ended refusal needs both halves);
         # the suffix/explicit-detection layer is responsible for
         # rejecting malformed pairs before reaching this point.
@@ -194,7 +179,7 @@ def _two_pad_router(
 ) -> Autorouter:
     """Two-pad USB_D+/USB_D- fixture parameterized by opt-in state."""
     rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
-    nc_kwargs = dict(name="HighSpeed", coupled_routing=coupled_routing)
+    nc_kwargs: dict = {"name": "HighSpeed", "coupled_routing": coupled_routing}
     if extra_class_kwargs:
         nc_kwargs.update(extra_class_kwargs)
     nc = NetClassRouting(**nc_kwargs)
@@ -212,19 +197,47 @@ def _two_pad_router(
     router.add_component(
         "U1",
         [
-            {"number": "1", "x": 5.0, "y": p_y, "width": 0.4, "height": 0.4,
-             "net": 1, "net_name": "USB_D+"},
-            {"number": "2", "x": 5.0, "y": n_y, "width": 0.4, "height": 0.4,
-             "net": 2, "net_name": "USB_D-"},
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": p_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_D+",
+            },
+            {
+                "number": "2",
+                "x": 5.0,
+                "y": n_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_D-",
+            },
         ],
     )
     router.add_component(
         "J1",
         [
-            {"number": "1", "x": 25.0, "y": p_y, "width": 0.4, "height": 0.4,
-             "net": 1, "net_name": "USB_D+"},
-            {"number": "2", "x": 25.0, "y": n_y, "width": 0.4, "height": 0.4,
-             "net": 2, "net_name": "USB_D-"},
+            {
+                "number": "1",
+                "x": 25.0,
+                "y": p_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_D+",
+            },
+            {
+                "number": "2",
+                "x": 25.0,
+                "y": n_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_D-",
+            },
         ],
     )
     return router
@@ -239,12 +252,8 @@ class TestPrepassEngagementGate:
 
         routes, _warnings, routed = router.route_diffpair_prepass(config)
 
-        assert routed == set(), (
-            f"Expected pre-pass to skip non-opted-in pair; got routed={routed}"
-        )
-        assert routes == [], (
-            f"Expected no coupled routes from refused pair; got {len(routes)}"
-        )
+        assert routed == set(), f"Expected pre-pass to skip non-opted-in pair; got routed={routed}"
+        assert routes == [], f"Expected no coupled routes from refused pair; got {len(routes)}"
 
     def test_opt_in_enabled_engages_coupled(self):
         router = _two_pad_router(coupled_routing=True)
@@ -252,9 +261,7 @@ class TestPrepassEngagementGate:
 
         routes, _warnings, routed = router.route_diffpair_prepass(config)
 
-        assert 1 in routed and 2 in routed, (
-            f"Expected both diff-pair nets to route; got {routed}"
-        )
+        assert 1 in routed and 2 in routed, f"Expected both diff-pair nets to route; got {routed}"
         assert routes, "Opt-in pair must produce coupled routes"
 
     def test_master_switch_off_short_circuits(self):
@@ -297,19 +304,47 @@ def _usb_cc_router(coupled_routing: bool = True) -> Autorouter:
     router.add_component(
         "U1",
         [
-            {"number": "1", "x": 5.0, "y": 4.5, "width": 0.4, "height": 0.4,
-             "net": 1, "net_name": "USB_CC1"},
-            {"number": "2", "x": 5.0, "y": 5.5, "width": 0.4, "height": 0.4,
-             "net": 2, "net_name": "USB_CC2"},
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": 4.5,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_CC1",
+            },
+            {
+                "number": "2",
+                "x": 5.0,
+                "y": 5.5,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_CC2",
+            },
         ],
     )
     router.add_component(
         "J1",
         [
-            {"number": "1", "x": 25.0, "y": 4.5, "width": 0.4, "height": 0.4,
-             "net": 1, "net_name": "USB_CC1"},
-            {"number": "2", "x": 25.0, "y": 5.5, "width": 0.4, "height": 0.4,
-             "net": 2, "net_name": "USB_CC2"},
+            {
+                "number": "1",
+                "x": 25.0,
+                "y": 4.5,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_CC1",
+            },
+            {
+                "number": "2",
+                "x": 25.0,
+                "y": 5.5,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_CC2",
+            },
         ],
     )
     return router
@@ -337,9 +372,7 @@ class TestSingleEndedRefusalAtEngagement:
             "USB_CC1/USB_CC2 must NOT be coupled-routed (single-ended refusal); "
             f"got routed={routed}"
         )
-        assert routes == [], (
-            "Expected zero coupled routes for refused USB_CC1/USB_CC2 pair"
-        )
+        assert routes == [], "Expected zero coupled routes for refused USB_CC1/USB_CC2 pair"
 
     def test_engagement_helper_directly_refuses_cc_pair(self):
         """Direct helper test mirroring the engagement-time guard."""
@@ -380,10 +413,24 @@ def _three_pad_usb_router(coupled_routing: bool = True) -> Autorouter:
         router.add_component(
             ref,
             [
-                {"number": "1", "x": x, "y": 9.0, "width": 0.4, "height": 0.4,
-                 "net": 1, "net_name": "USB_D+"},
-                {"number": "2", "x": x, "y": 11.0, "width": 0.4, "height": 0.4,
-                 "net": 2, "net_name": "USB_D-"},
+                {
+                    "number": "1",
+                    "x": x,
+                    "y": 9.0,
+                    "width": 0.4,
+                    "height": 0.4,
+                    "net": 1,
+                    "net_name": "USB_D+",
+                },
+                {
+                    "number": "2",
+                    "x": x,
+                    "y": 11.0,
+                    "width": 0.4,
+                    "height": 0.4,
+                    "net": 2,
+                    "net_name": "USB_D-",
+                },
             ],
         )
     return router

--- a/tests/test_diffpair_npad.py
+++ b/tests/test_diffpair_npad.py
@@ -23,17 +23,35 @@ from kicad_tools.router.diffpair_routing import (
     DiffPairRouter,
 )
 from kicad_tools.router.primitives import Pad
-from kicad_tools.router.rules import DesignRules
+from kicad_tools.router.rules import DesignRules, NetClassRouting
 
 # ---------------------------------------------------------------------------
 # Test 1: Regression — 2-pad pair still routes
 # ---------------------------------------------------------------------------
 
 
+def _opt_in_diffpair_class_map(net_names: list[str]) -> dict[str, NetClassRouting]:
+    """Build a per-net-name class map with ``coupled_routing=True``.
+
+    Issue #2638 / Epic #2556 Phase 2E: engagement is now opt-in per net
+    class.  Tests that exercise the dispatcher path
+    (``route_diffpair_prepass`` / ``route_all_with_diffpairs``) must
+    provide net classes whose ``coupled_routing`` flag is ``True``,
+    otherwise the pair falls through to the main strategy.
+    """
+    nc = NetClassRouting(name="HighSpeedOptIn", coupled_routing=True)
+    return {name: nc for name in net_names}
+
+
 def _two_pad_router(spacing: float = 0.8) -> Autorouter:
     """Two-pad regression fixture (mirrors test_diffpair_routing_integration)."""
     rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
-    router = Autorouter(width=30.0, height=10.0, rules=rules)
+    router = Autorouter(
+        width=30.0,
+        height=10.0,
+        rules=rules,
+        net_class_map=_opt_in_diffpair_class_map(["USB_D+", "USB_D-"]),
+    )
 
     p_y = 5.0 - spacing / 2
     n_y = 5.0 + spacing / 2

--- a/tests/test_diffpair_npad.py
+++ b/tests/test_diffpair_npad.py
@@ -40,7 +40,7 @@ def _opt_in_diffpair_class_map(net_names: list[str]) -> dict[str, NetClassRoutin
     otherwise the pair falls through to the main strategy.
     """
     nc = NetClassRouting(name="HighSpeedOptIn", coupled_routing=True)
-    return {name: nc for name in net_names}
+    return dict.fromkeys(net_names, nc)
 
 
 def _two_pad_router(spacing: float = 0.8) -> Autorouter:

--- a/tests/test_diffpair_routing_integration.py
+++ b/tests/test_diffpair_routing_integration.py
@@ -26,7 +26,7 @@ def _opt_in_diffpair_class_map(net_names: list[str]) -> dict[str, NetClassRoutin
     pair falls through to the main strategy.
     """
     nc = NetClassRouting(name="HighSpeedOptIn", coupled_routing=True)
-    return {name: nc for name in net_names}
+    return dict.fromkeys(net_names, nc)
 
 
 def _two_pad_diffpair_router(diffpair_spacing: float = 0.8) -> Autorouter:

--- a/tests/test_diffpair_routing_integration.py
+++ b/tests/test_diffpair_routing_integration.py
@@ -14,7 +14,19 @@ Verifies that:
 
 from kicad_tools.router.core import Autorouter
 from kicad_tools.router.diffpair import DifferentialPairConfig
-from kicad_tools.router.rules import DesignRules
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+
+def _opt_in_diffpair_class_map(net_names: list[str]) -> dict[str, NetClassRouting]:
+    """Build a per-net-name class map with ``coupled_routing=True``.
+
+    Issue #2638 / Epic #2556 Phase 2E: engagement is now opt-in per net
+    class.  Tests that exercise the dispatcher path must provide net
+    classes whose ``coupled_routing`` flag is ``True``, otherwise the
+    pair falls through to the main strategy.
+    """
+    nc = NetClassRouting(name="HighSpeedOptIn", coupled_routing=True)
+    return {name: nc for name in net_names}
 
 
 def _two_pad_diffpair_router(diffpair_spacing: float = 0.8) -> Autorouter:
@@ -34,7 +46,12 @@ def _two_pad_diffpair_router(diffpair_spacing: float = 0.8) -> Autorouter:
         trace_clearance=0.15,
         grid_resolution=0.1,
     )
-    router = Autorouter(width=30.0, height=10.0, rules=rules)
+    router = Autorouter(
+        width=30.0,
+        height=10.0,
+        rules=rules,
+        net_class_map=_opt_in_diffpair_class_map(["USB_D+", "USB_D-"]),
+    )
 
     p_y = 5.0 - diffpair_spacing / 2
     n_y = 5.0 + diffpair_spacing / 2
@@ -225,6 +242,8 @@ def _diffpair_with_connector_sibling_router() -> Autorouter:
     ordering bump (Issue #2482) must place USB_CC1 before any other
     same-tier non-sibling net.
     """
+    import dataclasses
+
     from kicad_tools.router.rules import NET_CLASS_HIGH_SPEED
 
     rules = DesignRules(
@@ -232,10 +251,15 @@ def _diffpair_with_connector_sibling_router() -> Autorouter:
         trace_clearance=0.15,
         grid_resolution=0.1,
     )
+    # Issue #2638 / Epic #2556 Phase 2E: opt the USB diff-pair class into
+    # coupled routing.  Phase 2E does NOT flip ``coupled_routing`` on the
+    # predefined ``NET_CLASS_HIGH_SPEED`` (that's a follow-up issue), so
+    # tests that exercise the pre-pass must opt in explicitly.
+    hs_coupled = dataclasses.replace(NET_CLASS_HIGH_SPEED, coupled_routing=True)
     net_class_map = {
-        "USB_D+": NET_CLASS_HIGH_SPEED,
-        "USB_D-": NET_CLASS_HIGH_SPEED,
-        "USB_CC1": NET_CLASS_HIGH_SPEED,
+        "USB_D+": hs_coupled,
+        "USB_D-": hs_coupled,
+        "USB_CC1": hs_coupled,
     }
     router = Autorouter(width=30.0, height=10.0, rules=rules,
                        net_class_map=net_class_map)


### PR DESCRIPTION
## Summary

Phase 2E of Epic #2556 (first-class differential pair support). Introduces opt-in `CoupledPathfinder` engagement and an engagement-layer single-ended refusal so the #2527 lesson (USB-C `CC1`/`CC2`, `SBU1`/`SBU2` are orientation pins, NOT a diff pair) is enforced even when a designer accidentally pairs them via explicit `NetClassRouting.diffpair_partner`.

Refines the previously binary `--differential-pairs` flag: pairs are now coupled-routed only when their net class explicitly sets `coupled_routing=True` AND neither half matches the single-ended refusal pattern. Refused pairs fall through to the main strategy.

## Changes

- `src/kicad_tools/router/rules.py`: new `NetClassRouting.coupled_routing: bool = False` field with cross-reference note to the existing `use_coupled_routing` function parameter (curator-flagged name-collision risk).
- `src/kicad_tools/router/diffpair.py`: new `should_engage_coupled(pair, net_class_routing, net_to_class) -> (bool, str)` helper returning one of four reasons: `"engaged"`, `"single_ended_refusal"`, `"opt_in_disabled"`, `"no_class_match"`. Reuses `is_single_ended_refused` rather than re-importing the regex.
- `src/kicad_tools/router/diffpair_routing.py`:
  - New `_resolve_detection_inputs` helper synthesises `net_class_routing`/`net_to_class` from the autorouter's `net_class_map` so the explicit-declaration path (which had been dead for the common `net_class_map`-only case) actually fires.
  - New `_resolve_engagement` helper invokes the gate.
  - `route_diffpair_prepass` and `route_all_with_diffpairs` consult the gate before dispatching to `route_differential_pair_coupled`; refused pairs are logged with `[diffpair-engage] refused {pair}: {reason}` and dropped from `diff_net_ids` so the main strategy picks them up.
- `tests/test_diffpair_engagement.py` (new, 20 tests): unit tests on `should_engage_coupled` (no-class-match, opt-in-on/off, either-side-opt-in, class-name vs net-name keyed conventions, single-ended refusal for CC/SBU/prefixed-CC, one-side-only does-not-refuse); dispatcher integration (opt-in-disabled skips, opt-in-enabled engages, `--differential-pairs` master switch); `#2527` engagement-layer refusal with explicit declaration on `USB_CC1`/`USB_CC2`; N-pad regression for `#2473` USB-C 3-pad coverage.
- `tests/test_diffpair_npad.py`, `tests/test_diffpair_routing_integration.py`: dispatcher fixtures opt in via a small `_opt_in_diffpair_class_map` helper so existing prepass tests keep exercising the coupled path.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `NetClassRouting.coupled_routing: bool = False` field added | done | `src/kicad_tools/router/rules.py:457-486` |
| `should_engage_coupled` helper exists with three reason codes (+ `no_class_match` per curator) | done | `src/kicad_tools/router/diffpair.py:296-373` |
| `route_diffpair_prepass` and `route_all_with_diffpairs` consult the helper and log refusals | done | `diffpair_routing.py:1675-1700, 1782-1799` |
| Engagement-layer single-ended refusal fires for explicit declaration on USB_CC1/USB_CC2 | done | `TestSingleEndedRefusalAtEngagement` (2 tests) |
| Source-respecting: explicit non-single-ended opt-in proceeds | done | `TestShouldEngageCoupled::test_opt_in_enabled_engages` + class-name-keyed variant |
| Backward compat: predefined classes keep `coupled_routing=False` | done | `TestPredefinedClassesDefaultOff` (3 tests) |
| `dataclasses.replace` round-trips the field | done | `test_dataclass_replace_preserves_field` |
| `--differential-pairs` master switch short-circuits regardless of per-class flag | done | `test_master_switch_off_short_circuits` |
| N-pad regression (#2473 USB-C 3-pad) does not regress | done | `TestNPadRegression::test_three_pad_usb_engagement_routes_all_pads` |
| #2527 USB_CC1/CC2 must-pass test | done | `TestSingleEndedRefusalAtEngagement::test_explicit_declaration_refused_at_engagement` |
| Existing `tests/test_diffpair_*.py` and `tests/test_diffpair_routing_integration.py` pass | done | 224 diffpair-related tests passing |

## Test Plan

- `uv run pytest tests/test_diffpair_engagement.py tests/test_diffpair*.py tests/test_coupled_lines.py tests/test_validate_diffpair_clearance_intra.py tests/test_cli_check_diffpair_clearance_intra.py` -> **224 passed**
- `uv run pytest tests/test_diffpair_partner_wiring.py tests/test_router_core.py tests/test_router_autorouter.py tests/test_router_algorithms.py` -> **308 passed** (no regressions)
- `uv run ruff check` clean on Phase 2E files
- `uv run ruff format --check` clean on Phase 2E files
- Pre-existing failures in `tests/test_router_integration.py::test_voltage_divider_high_completion` and `test_charlieplex_high_completion` (fixture issue: routed PCB fixtures lack signal nets) verified to fail on `origin/main` as well — NOT introduced here.
- Board 03 (`boards/03-usb-joystick/output/usb_joystick.kicad_pcb`) regression: the pre-existing -0.200mm USB pair overlap (1 DRC violation) reproduces on `origin/main` and is unchanged by this PR. Phase 2E does not flip `coupled_routing=True` on `NET_CLASS_HIGH_SPEED` (out of scope per curator); board 03 still takes the Phase 1 independent-routing path.

## Out of scope (curator-confirmed)

- Flipping `coupled_routing=True` on `NET_CLASS_HIGH_SPEED` or any other predefined class (follow-up issue after board 06 empirical coverage in Phase 4).
- New escape-time engagement (Phase 2F).
- New continuity DRC rule (Phase 2G).
- Length-matching/impedance (Phase 3).
- Removing the `--differential-pairs` CLI master switch.

Closes #2638