### PR TITLE
feat(router): per-pair diff-pair length-match (skew) tracker

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -47,6 +47,7 @@ from .cache import (
 from .bus_routing import BusRouter
 from .cpp_backend import CppGrid, CppPathfinder, create_hybrid_router, get_backend_info
 from .diffpair import DifferentialPair, DifferentialPairConfig, LengthMismatchWarning
+from .diffpair_length import DiffPairLengthTracker
 from .diffpair_routing import DiffPairRouter
 from .escape import EscapeRouter, PackageInfo, is_dense_package
 from .adaptive_grid import AdaptiveGridResult, AdaptiveGridRouter
@@ -433,6 +434,12 @@ class Autorouter:
 
         # Length constraint tracking (Issue #630)
         self._length_tracker: LengthTracker = LengthTracker()
+
+        # Per-pair diff-pair skew tracking (Issue #2647, Epic #2556 Phase 3H).
+        # Sibling to ``_length_tracker`` -- the existing tracker handles
+        # generic match-group / min/max constraints; this one is keyed on
+        # detected diff pairs and exposes ``|L_p - L_n|`` for Phase 3I/J.
+        self._diffpair_length_tracker: DiffPairLengthTracker = DiffPairLengthTracker()
 
         # Sub-problem pattern cache (Issue #2336)
         # When set, enables cross-board reuse of routing solutions for
@@ -6915,6 +6922,62 @@ class Autorouter:
         """Update the length tracker with current route lengths."""
         for route in self.routes:
             self._length_tracker.record_route(route.net, route)
+
+    def update_diffpair_skew(
+        self,
+        detected_pairs: list,
+        board_thickness_mm: float | None = None,
+        num_copper_layers: int | None = None,
+    ) -> DiffPairLengthTracker:
+        """Populate the diff-pair length tracker with current route skews.
+
+        Sibling to :meth:`_update_length_tracker` (Issue #2647, Epic #2556
+        Phase 3H).  Measures the routed length of each half of each
+        detected pair and exposes per-pair skew via
+        :attr:`_diffpair_length_tracker`.
+
+        Args:
+            detected_pairs: List of
+                :class:`~kicad_tools.router.diffpair_detection.DetectedPair`
+                objects from
+                :func:`~kicad_tools.router.diffpair_detection.detect_diff_pairs`.
+            board_thickness_mm: Total stackup thickness in mm.  When
+                ``None``, vias contribute ``0.0`` to the length
+                (documented zero-via-length default).
+            num_copper_layers: Number of copper layers in the stack.
+                Defaults to the layer-stack count when ``None`` (or 2
+                when no stack has been configured).
+
+        Returns:
+            The internal :class:`DiffPairLengthTracker` instance (also
+            accessible via :attr:`diffpair_length_tracker` for inspection).
+        """
+        if num_copper_layers is None:
+            # Best-effort default: pull the count from the configured
+            # layer stack when available; otherwise fall back to 2.
+            if self.layer_stack is not None:
+                num_copper_layers = len(self.layer_stack.layers)
+            else:
+                num_copper_layers = 2
+
+        self._diffpair_length_tracker.record_routes(
+            routes=self.routes,
+            detected_pairs=detected_pairs,
+            board_thickness_mm=board_thickness_mm,
+            num_copper_layers=num_copper_layers,
+        )
+        return self._diffpair_length_tracker
+
+    @property
+    def diffpair_length_tracker(self) -> DiffPairLengthTracker:
+        """Per-pair diff-pair skew tracker (Issue #2647, Epic #2556 Phase 3H).
+
+        Returns the :class:`DiffPairLengthTracker` instance populated by
+        :meth:`update_diffpair_skew`.  The tracker exposes per-pair
+        ``(L_p, L_n)`` lengths and ``|L_p - L_n|`` skew for Phase 3I
+        (serpentine insertion) and Phase 3J (DRC rule) consumers.
+        """
+        return self._diffpair_length_tracker
 
     def apply_length_tuning(
         self,

--- a/src/kicad_tools/router/diffpair_length.py
+++ b/src/kicad_tools/router/diffpair_length.py
@@ -1,0 +1,304 @@
+"""Per-pair length-match (skew) computation (Issue #2647, Epic #2556 Phase 3H).
+
+This module provides :class:`DiffPairLengthTracker`, a thin measurement-only
+layer on top of the existing :class:`~kicad_tools.router.length.LengthTracker`
+geometry primitive (specifically the
+:meth:`~kicad_tools.router.length.LengthTracker.calculate_route_length`
+staticmethod) that records the routed length of each half of a detected
+differential pair and exposes per-pair skew (``|L_p - L_n|``).
+
+Design notes
+============
+
+* **Why a separate class rather than extending** :mod:`router.length`? The
+  existing :class:`LengthTracker` is keyed on net id and uses an explicit
+  :class:`LengthConstraint.match_group` mechanism (a `str` field set by the
+  user).  Diff pairs are *detected* (see
+  :class:`~kicad_tools.router.diffpair_detection.DetectedPair`) and need a
+  ``(P, N)`` keying with both halves attributed separately -- the
+  match-group violation type is keyed on the group name, not the pair.
+  Trying to overload `length.py` would break DDR / wide-bus tuning that
+  legitimately uses match groups.  Phase 3H keeps the match-group code
+  paths untouched.
+* **Why not populate** :attr:`DifferentialPair.routed_length_p`/`routed_length_n`?
+  Those fields exist on :class:`~kicad_tools.router.diffpair.DifferentialPair`
+  (`router/diffpair.py:131-132`) but are stale pre-Phase-1 legacy state.
+  The Phase 3H tracker is the authoritative store; populating the legacy
+  fields would risk drift between two sources of truth.  A follow-up issue
+  can remove the legacy fields once they are confirmed unreferenced.
+* **Via-length policy.**  When a route traverses a via, the via contributes
+  a geometric drilled length equal to::
+
+      board_thickness_mm * |layer_index_delta| / (num_copper_layers - 1)
+
+  where ``layer_index_delta`` is computed from the via's
+  :attr:`~kicad_tools.router.primitives.Via.layers` tuple of two
+  :class:`~kicad_tools.core.types.CopperLayer` enums.  When the caller does
+  not supply ``board_thickness_mm`` the via contributes **0.0 mm** to the
+  length (with a documented caveat) rather than a guessed default -- this
+  policy mirrors the curator's spec on #2647 and ensures Phase 3I sizes
+  serpentines off explicit values.
+* **Per-class skew tolerance** lives on
+  :attr:`~kicad_tools.router.rules.NetClassRouting.skew_tolerance_mm`
+  (added in this issue) with accessor
+  :meth:`~kicad_tools.router.rules.NetClassRouting.effective_skew_tolerance`.
+  The tracker itself measures unconditionally; the DRC rule (Phase 3J /
+  Issue J) consumes the accessor to decide whether to fire.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .length import LengthTracker
+
+if TYPE_CHECKING:
+    from .diffpair_detection import DetectedPair
+    from .primitives import Route, Via
+
+
+@dataclass
+class DiffPairLengthTracker:
+    """Tracks per-pair routed length and skew for detected differential pairs.
+
+    The tracker stores route lengths keyed on net id (matching the
+    :class:`Route.net` attribute) and exposes per-pair query methods that
+    look up both halves of a :class:`~kicad_tools.router.diffpair_detection.DetectedPair`
+    and return their lengths or skew.
+
+    Attributes:
+        lengths: Mapping ``{net_id: routed_length_mm}`` for every net
+            recorded so far.  Populated by :meth:`record_routes`.
+    """
+
+    lengths: dict[int, float] = field(default_factory=dict)
+
+    # =========================================================================
+    # Recording
+    # =========================================================================
+
+    def record_routes(
+        self,
+        routes: list[Route],
+        detected_pairs: list[DetectedPair],
+        board_thickness_mm: float | None = None,
+        num_copper_layers: int = 2,
+    ) -> None:
+        """Measure and record the routed length of each half of each detected pair.
+
+        Args:
+            routes: All routed nets from the autorouter pass.
+            detected_pairs: Pairs from
+                :func:`~kicad_tools.router.diffpair_detection.detect_diff_pairs`.
+                Each pair's ``pair.positive.net_id`` and
+                ``pair.negative.net_id`` are looked up in ``routes`` to
+                measure each half independently.
+            board_thickness_mm: Total stackup thickness in mm.  When
+                ``None`` (the default), vias contribute ``0.0`` to the
+                length (documented behavior -- see module docstring).
+                When supplied, each via on a recorded route contributes
+                ``board_thickness_mm * |Δlayer_index| / (num_copper_layers - 1)``.
+            num_copper_layers: Number of copper layers in the stack (used
+                to compute per-via drilled length when ``board_thickness_mm``
+                is supplied).  Defaults to ``2`` (typical 2-layer stack).
+
+        Notes:
+            * Routes whose ``net`` is not the P or N of any detected pair
+              are ignored (this is a per-pair tracker; non-pair nets are
+              invisible to it by design).
+            * If a pair's P or N is not present in ``routes`` (unrouted),
+              the missing side simply doesn't get recorded; :meth:`get_skew`
+              returns ``None`` for such pairs.
+            * This method may be called multiple times; subsequent calls
+              overwrite previously-recorded lengths for the same net ids.
+        """
+        # Collect the set of net ids that belong to a detected pair so we
+        # can skip non-pair routes cheaply.
+        pair_net_ids: set[int] = set()
+        for dp in detected_pairs:
+            pair_net_ids.add(dp.pair.positive.net_id)
+            pair_net_ids.add(dp.pair.negative.net_id)
+
+        # Build a {net_id -> Route} lookup for O(1) access (a board can
+        # have hundreds of routes; linear scans per pair would be O(n*m)).
+        routes_by_net: dict[int, Route] = {}
+        for route in routes:
+            if route.net in pair_net_ids:
+                routes_by_net[route.net] = route
+
+        # Measure each side of each detected pair, and refresh the
+        # name-keyed skew cache used by :meth:`get_all_skews`.
+        self._skew_map.clear()
+        for dp in detected_pairs:
+            p_id = dp.pair.positive.net_id
+            n_id = dp.pair.negative.net_id
+
+            p_route = routes_by_net.get(p_id)
+            if p_route is not None:
+                self.lengths[p_id] = self._measure_route(
+                    p_route, board_thickness_mm, num_copper_layers
+                )
+
+            n_route = routes_by_net.get(n_id)
+            if n_route is not None:
+                self.lengths[n_id] = self._measure_route(
+                    n_route, board_thickness_mm, num_copper_layers
+                )
+
+            # Populate the name-keyed cache only when BOTH halves are
+            # routed; an unrouted half yields ``None`` from get_skew and
+            # is intentionally omitted from get_all_skews.
+            l_p = self.lengths.get(p_id)
+            l_n = self.lengths.get(n_id)
+            if l_p is not None and l_n is not None:
+                self._skew_map[(dp.pair.positive.net_name, dp.pair.negative.net_name)] = abs(
+                    l_p - l_n
+                )
+
+    @staticmethod
+    def _measure_route(
+        route: Route,
+        board_thickness_mm: float | None,
+        num_copper_layers: int,
+    ) -> float:
+        """Return the geometric length of a route in mm, including via drill.
+
+        Segment length is computed via
+        :meth:`LengthTracker.calculate_route_length` (single source of truth
+        for segment summation -- see `length.py:138-153`).  Via length is
+        computed from the via's ``layers`` tuple and the supplied
+        ``board_thickness_mm`` / ``num_copper_layers``; when
+        ``board_thickness_mm`` is ``None`` each via contributes ``0.0``.
+        """
+        # Segment portion (reuses the existing primitive -- no duplication).
+        total = LengthTracker.calculate_route_length(route)
+
+        # Via portion.  When the caller did not supply board_thickness_mm
+        # (or the stack has fewer than 2 layers) we cannot compute a
+        # drilled length and document that vias contribute 0.0.
+        if board_thickness_mm is None or num_copper_layers <= 1:
+            return total
+
+        for via in route.vias:
+            total += DiffPairLengthTracker._via_length(via, board_thickness_mm, num_copper_layers)
+        return total
+
+    @staticmethod
+    def _via_length(
+        via: Via,
+        board_thickness_mm: float,
+        num_copper_layers: int,
+    ) -> float:
+        """Return the geometric drilled length of ``via`` in mm.
+
+        Computed as ``board_thickness_mm * |stack_index_delta| / (num_copper_layers - 1)``
+        where ``stack_index_delta`` is the difference between the via's
+        two layers' **stack positions** in an ``num_copper_layers``-deep
+        stack (NOT the raw KiCad layer enum values).  The stack positions
+        are the natural ordering of populated copper layers; for example:
+
+        * 2-layer stack populates ``[F.Cu, B.Cu]`` -> stack indices ``[0, 1]``.
+          A F.Cu->B.Cu via gives ``1.6 * 1 / 1 = 1.6`` mm.
+        * 4-layer stack populates ``[F.Cu, In1.Cu, In2.Cu, B.Cu]`` ->
+          stack indices ``[0, 1, 2, 3]``.  A F.Cu->In1.Cu blind via
+          gives ``1.6 * 1 / 3 ≈ 0.533`` mm; a F.Cu->B.Cu through-via
+          gives ``1.6 * 3 / 3 = 1.6`` mm.
+        * 6-layer stack populates ``[F.Cu, In1..In4, B.Cu]`` -> stack
+          indices ``[0, 1, 2, 3, 4, 5]``.
+
+        Using stack positions (rather than the raw 0/1/2/3/4/5 enum
+        values, which always treat F.Cu->B.Cu as a "5-layer span" even
+        on a 2-layer board) is correct because the via's physical
+        drilled length depends on how many dielectric layers it actually
+        crosses, not on KiCad's nominal layer numbering.
+        """
+        layer_start, layer_end = via.layers
+        idx_start = DiffPairLengthTracker._stack_position(layer_start, num_copper_layers)
+        idx_end = DiffPairLengthTracker._stack_position(layer_end, num_copper_layers)
+        delta = abs(idx_start - idx_end)
+        return board_thickness_mm * delta / (num_copper_layers - 1)
+
+    @staticmethod
+    def _stack_position(layer, num_copper_layers: int) -> int:
+        """Map a :class:`CopperLayer` to its stack-position index for an N-layer stack.
+
+        Populated copper layers in a KiCad N-layer stack are always
+        ``[F.Cu, In1.Cu, In2.Cu, ..., In(N-2).Cu, B.Cu]``.  ``F.Cu`` is
+        always position 0; ``B.Cu`` is always position ``num_copper_layers - 1``;
+        inner layers map by their enum order (``IN1_CU`` -> 1, ``IN2_CU`` -> 2,
+        and so on).
+
+        This is intentionally robust to an unusual stack (e.g. a board
+        that only populates F.Cu and In1.Cu): the function still returns
+        sensible indices for those two layers.
+        """
+        # F.Cu and B.Cu are anchored at the ends of any populated stack.
+        from kicad_tools.core.types import CopperLayer
+
+        if layer == CopperLayer.F_CU:
+            return 0
+        if layer == CopperLayer.B_CU:
+            return num_copper_layers - 1
+        # Inner layers: IN1_CU=1, IN2_CU=2, etc.  Their enum values
+        # happen to match their stack positions for typical 4- and 6-layer
+        # stacks because the enum was designed that way (see core/types.py).
+        return layer.value
+
+    # =========================================================================
+    # Per-pair queries
+    # =========================================================================
+
+    def get_pair_lengths(self, pair: DetectedPair) -> tuple[float, float] | None:
+        """Return ``(L_p, L_n)`` in mm for ``pair``, or ``None`` if either half is unrouted.
+
+        Args:
+            pair: A detected pair (the ``DetectedPair.pair`` attribute is
+                a :class:`DifferentialPair` whose ``.positive.net_id`` and
+                ``.negative.net_id`` are looked up in the recorded lengths).
+
+        Returns:
+            ``(L_p, L_n)`` if both halves have been recorded, else ``None``.
+        """
+        p_id = pair.pair.positive.net_id
+        n_id = pair.pair.negative.net_id
+        l_p = self.lengths.get(p_id)
+        l_n = self.lengths.get(n_id)
+        if l_p is None or l_n is None:
+            return None
+        return (l_p, l_n)
+
+    def get_skew(self, pair: DetectedPair) -> float | None:
+        """Return ``|L_p - L_n|`` in mm for ``pair``, or ``None`` if either half is unrouted.
+
+        This is the per-pair skew that Phase 3I uses as a serpentine
+        target and Phase 3J fires DRC violations on.
+        """
+        lengths = self.get_pair_lengths(pair)
+        if lengths is None:
+            return None
+        l_p, l_n = lengths
+        return abs(l_p - l_n)
+
+    def get_all_skews(self) -> dict[tuple[str, str], float]:
+        """Return ``{(p_net_name, n_net_name): skew_mm}`` for all recorded pairs.
+
+        Pairs whose P or N is unrouted are omitted.  The dictionary is
+        keyed on ``(p_net_name, n_net_name)`` (not net ids) so callers
+        can render skew reports without back-references.  Insertion order
+        follows ``p_net_name`` alphabetically for deterministic iteration.
+        """
+        # The tracker stores only net ids and lengths; the public
+        # ``(p_net_name, n_net_name)`` keying requires DetectedPair data
+        # to be available at query time.  Since record_routes stores
+        # lengths by net id, get_all_skews relies on the caller to also
+        # call record_routes with the detected_pairs list (which is the
+        # normal call shape).  To make this method usable in isolation
+        # we cache the pair name mapping when record_routes runs.
+        return dict(sorted(self._skew_map.items(), key=lambda kv: kv[0][0]))
+
+    # =========================================================================
+    # Internal name cache (populated by record_routes; used by get_all_skews)
+    # =========================================================================
+
+    _skew_map: dict[tuple[str, str], float] = field(default_factory=dict, init=False, repr=False)

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -502,6 +502,29 @@ class NetClassRouting:
     via the ``threshold_map`` constructor argument.
     """
 
+    # Differential pair length-match skew tolerance (Issue #2647, Epic #2556 Phase 3H)
+    skew_tolerance_mm: float | None = None
+    """Maximum allowed length skew (|L_p - L_n|, in mm) for differential pairs
+    in this class.
+
+    ``None`` (the default) means "use the rule's module-level default of
+    0.5 mm" -- a conservative value covering USB 3.0 / PCIe Gen 2+ (~0.5-1 mm),
+    MIPI D-PHY (~1 mm), and DDR4 DQ-strobe (~0.5 mm) headroom while still
+    permitting the looser USB 2.0 HS budget (~3 mm) to be set explicitly.
+    Setting ``0.3`` is appropriate for tight HSDI lanes; setting ``3.0``
+    accommodates USB 2.0 full-/high-speed pairs.
+
+    The :class:`~kicad_tools.router.diffpair_length.DiffPairLengthTracker`
+    measures skew per pair unconditionally (no per-class gate); this field
+    only controls the DRC rule's firing threshold (Phase 3J / Issue J).
+    Phase 3I (serpentine insertion) consumes the accessor to choose which
+    side to lengthen.
+
+    Orthogonal to :attr:`length_critical`, which is a routing-priority hint
+    rather than a skew gate (`length_critical=False` pairs still get
+    measured).
+    """
+
     def effective_intra_pair_clearance(self) -> float:
         """Return the clearance to apply to within-pair diff-pair edges.
 
@@ -532,6 +555,30 @@ class NetClassRouting:
         """
         if self.coupled_continuity_threshold is not None:
             return self.coupled_continuity_threshold
+        return default
+
+    def effective_skew_tolerance(self, default: float = 0.5) -> float:
+        """Return the length-match skew tolerance for diff pairs in this class.
+
+        Backward-compatible accessor (Issue #2647 / Epic #2556 Phase 3H):
+        returns ``default`` when :attr:`skew_tolerance_mm` is unset
+        (``None``).  ``default`` mirrors the (Phase 3J / Issue J) DRC rule's
+        module-level ``DEFAULT_SKEW_TOLERANCE_MM`` so callers can override
+        the floor consistently without re-importing it.
+
+        Args:
+            default: Fallback value (in mm) when no per-class skew
+                tolerance is set.  Defaults to ``0.5`` -- a conservative
+                value that covers USB 3.0 / PCIe Gen 2+ (~0.5-1 mm),
+                MIPI D-PHY (~1 mm), and DDR4 DQ-strobe (~0.5 mm) while
+                still permitting the looser USB 2.0 HS budget (~3 mm) to
+                be set explicitly per class.
+
+        Returns:
+            The per-class skew tolerance in mm if set, else ``default``.
+        """
+        if self.skew_tolerance_mm is not None:
+            return self.skew_tolerance_mm
         return default
 
 

--- a/tests/test_diffpair_length.py
+++ b/tests/test_diffpair_length.py
@@ -1,0 +1,581 @@
+"""Per-pair diff-pair length-match (skew) tests (Issue #2647, Epic #2556 Phase 3H).
+
+This module tests:
+
+* :class:`kicad_tools.router.diffpair_length.DiffPairLengthTracker` for
+  symmetric / asymmetric / via-traversing / unrouted scenarios.
+* :meth:`kicad_tools.router.rules.NetClassRouting.effective_skew_tolerance`
+  per-class round-trip + default-fallback semantics.
+* The Phase 3I-facing :meth:`Autorouter.update_diffpair_skew` production
+  path -- the dormant-signal gate (Issue #2587 lesson).
+"""
+
+from __future__ import annotations
+
+from kicad_tools.core.types import CopperLayer
+from kicad_tools.router.diffpair import (
+    DifferentialPair,
+    DifferentialPairType,
+    DifferentialSignal,
+)
+from kicad_tools.router.diffpair_detection import DetectedPair, DetectionSource
+from kicad_tools.router.diffpair_length import DiffPairLengthTracker
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Route, Segment, Via
+from kicad_tools.router.rules import NetClassRouting
+
+# =============================================================================
+# Test helpers
+# =============================================================================
+
+
+def _make_signal(name: str, net_id: int, polarity: str) -> DifferentialSignal:
+    """Construct a :class:`DifferentialSignal` with sensible defaults."""
+    return DifferentialSignal(
+        net_name=name,
+        net_id=net_id,
+        base_name=name.rstrip("+-_PN"),
+        polarity=polarity,
+        notation="plus_minus",
+    )
+
+
+def _make_detected_pair(
+    base_name: str = "USB_D",
+    p_name: str = "USB_D+",
+    n_name: str = "USB_D-",
+    p_id: int = 1,
+    n_id: int = 2,
+) -> DetectedPair:
+    """Construct a :class:`DetectedPair` for skew measurement."""
+    return DetectedPair(
+        pair=DifferentialPair(
+            name=base_name,
+            positive=_make_signal(p_name, p_id, "P"),
+            negative=_make_signal(n_name, n_id, "N"),
+            pair_type=DifferentialPairType.USB2,
+        ),
+        source=DetectionSource.EXPLICIT,
+    )
+
+
+def _make_straight_route(
+    net_id: int, net_name: str, length_mm: float, layer: Layer = Layer.F_CU
+) -> Route:
+    """Construct a single-segment horizontal route of the given length."""
+    return Route(
+        net=net_id,
+        net_name=net_name,
+        segments=[
+            Segment(
+                x1=0.0,
+                y1=0.0,
+                x2=length_mm,
+                y2=0.0,
+                width=0.2,
+                layer=layer,
+                net=net_id,
+                net_name=net_name,
+            )
+        ],
+    )
+
+
+def _make_two_segment_route(
+    net_id: int,
+    net_name: str,
+    leg1_mm: float,
+    leg2_mm: float,
+    layer: Layer = Layer.F_CU,
+) -> Route:
+    """Construct a 2-segment L-shaped route with total length leg1+leg2."""
+    return Route(
+        net=net_id,
+        net_name=net_name,
+        segments=[
+            Segment(
+                x1=0.0,
+                y1=0.0,
+                x2=leg1_mm,
+                y2=0.0,
+                width=0.2,
+                layer=layer,
+                net=net_id,
+                net_name=net_name,
+            ),
+            Segment(
+                x1=leg1_mm,
+                y1=0.0,
+                x2=leg1_mm,
+                y2=leg2_mm,
+                width=0.2,
+                layer=layer,
+                net=net_id,
+                net_name=net_name,
+            ),
+        ],
+    )
+
+
+# =============================================================================
+# 1. DiffPairLengthTracker -- basic record / query
+# =============================================================================
+
+
+class TestDiffPairLengthTrackerBasic:
+    """Symmetric and asymmetric pair length / skew measurement."""
+
+    def test_symmetric_pair_zero_skew(self):
+        # L_p == L_n == 10mm -> skew = 0.0
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        p_route = _make_two_segment_route(1, "USB_D+", 5.0, 5.0)
+        n_route = _make_two_segment_route(2, "USB_D-", 5.0, 5.0)
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes([p_route, n_route], [dp])
+
+        lengths = tracker.get_pair_lengths(dp)
+        assert lengths is not None
+        l_p, l_n = lengths
+        assert abs(l_p - 10.0) < 1e-9
+        assert abs(l_n - 10.0) < 1e-9
+        assert tracker.get_skew(dp) == 0.0
+
+    def test_asymmetric_pair_skew_two_mm(self):
+        # L_p = 10mm, L_n = 12mm -> skew = 2.0
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        p_route = _make_straight_route(1, "USB_D+", 10.0)
+        n_route = _make_straight_route(2, "USB_D-", 12.0)
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes([p_route, n_route], [dp])
+
+        assert tracker.get_pair_lengths(dp) == (10.0, 12.0)
+        assert tracker.get_skew(dp) == 2.0
+
+    def test_unrouted_p_side_returns_none(self):
+        # Only the negative half has a Route -- positive is unrouted.
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        n_route = _make_straight_route(2, "USB_D-", 12.0)
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes([n_route], [dp])
+
+        assert tracker.get_pair_lengths(dp) is None
+        assert tracker.get_skew(dp) is None
+
+    def test_unrouted_n_side_returns_none(self):
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        p_route = _make_straight_route(1, "USB_D+", 10.0)
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes([p_route], [dp])
+
+        assert tracker.get_pair_lengths(dp) is None
+        assert tracker.get_skew(dp) is None
+
+    def test_non_pair_routes_ignored(self):
+        # A net id that is not part of any detected pair must NOT
+        # appear in the recorded lengths -- the tracker is per-pair.
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        unrelated = _make_straight_route(99, "VCC", 100.0)
+        p_route = _make_straight_route(1, "USB_D+", 5.0)
+        n_route = _make_straight_route(2, "USB_D-", 5.0)
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes([unrelated, p_route, n_route], [dp])
+
+        assert 99 not in tracker.lengths
+        assert tracker.get_skew(dp) == 0.0
+
+
+# =============================================================================
+# 2. Via-length policy
+# =============================================================================
+
+
+class TestViaLengthPolicy:
+    """Vias contribute to length only when board_thickness_mm is supplied."""
+
+    def test_via_traversal_includes_drilled_length_when_thickness_supplied(self):
+        # 2-layer 1.6 mm board, P traverses F.Cu -> B.Cu via.
+        # Expected via length = 1.6 * |5 - 0| / (2 - 1) = 1.6 mm.
+        # Two F.Cu segments totalling 10 mm + 1.6 mm via = 11.6 mm.
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        p_route = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[
+                Segment(0.0, 0.0, 5.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+"),
+                Segment(5.0, 0.0, 10.0, 0.0, 0.2, Layer.B_CU, net=1, net_name="USB_D+"),
+            ],
+            vias=[
+                Via(
+                    x=5.0,
+                    y=0.0,
+                    drill=0.3,
+                    diameter=0.6,
+                    layers=(CopperLayer.F_CU, CopperLayer.B_CU),
+                    net=1,
+                    net_name="USB_D+",
+                )
+            ],
+        )
+        n_route = _make_straight_route(2, "USB_D-", 11.6)
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes([p_route, n_route], [dp], board_thickness_mm=1.6, num_copper_layers=2)
+
+        lengths = tracker.get_pair_lengths(dp)
+        assert lengths is not None
+        l_p, l_n = lengths
+        assert abs(l_p - 11.6) < 1e-9
+        assert abs(l_n - 11.6) < 1e-9
+        # Skew should be ~0 because we sized n_route to match.
+        assert abs(tracker.get_skew(dp)) < 1e-9
+
+    def test_via_returns_zero_length_when_thickness_is_none(self):
+        # When board_thickness_mm is None, vias contribute 0.0 mm.
+        # P_segments = 10 mm + via -> 10 mm total when no thickness.
+        # N is 10 mm -> skew should be 0, not 1.6.
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        p_route = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[
+                Segment(0.0, 0.0, 5.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+"),
+                Segment(5.0, 0.0, 10.0, 0.0, 0.2, Layer.B_CU, net=1, net_name="USB_D+"),
+            ],
+            vias=[
+                Via(
+                    x=5.0,
+                    y=0.0,
+                    drill=0.3,
+                    diameter=0.6,
+                    layers=(CopperLayer.F_CU, CopperLayer.B_CU),
+                    net=1,
+                    net_name="USB_D+",
+                )
+            ],
+        )
+        n_route = _make_straight_route(2, "USB_D-", 10.0)
+
+        tracker = DiffPairLengthTracker()
+        # board_thickness_mm defaults to None.
+        tracker.record_routes([p_route, n_route], [dp])
+
+        lengths = tracker.get_pair_lengths(dp)
+        assert lengths is not None
+        l_p, l_n = lengths
+        assert abs(l_p - 10.0) < 1e-9
+        assert abs(l_n - 10.0) < 1e-9
+        assert tracker.get_skew(dp) == 0.0
+
+    def test_blind_via_partial_thickness_on_four_layer_stack(self):
+        # 4-layer 1.6 mm board with a F.Cu -> In1.Cu blind via.
+        # Layer index delta = 1; divisor = (4 - 1) = 3.
+        # Per-via length = 1.6 * 1 / 3 ~= 0.5333 mm.
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        p_route = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[
+                Segment(0.0, 0.0, 5.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+"),
+                Segment(5.0, 0.0, 10.0, 0.0, 0.2, Layer.IN1_CU, net=1, net_name="USB_D+"),
+            ],
+            vias=[
+                Via(
+                    x=5.0,
+                    y=0.0,
+                    drill=0.2,
+                    diameter=0.45,
+                    layers=(CopperLayer.F_CU, CopperLayer.IN1_CU),
+                    net=1,
+                    net_name="USB_D+",
+                )
+            ],
+        )
+        # N is segments only, same total: 10 mm + via_length.
+        expected_via_mm = 1.6 * 1 / 3  # ~0.5333
+        n_route = _make_straight_route(2, "USB_D-", 10.0 + expected_via_mm)
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes([p_route, n_route], [dp], board_thickness_mm=1.6, num_copper_layers=4)
+
+        lengths = tracker.get_pair_lengths(dp)
+        assert lengths is not None
+        l_p, l_n = lengths
+        assert abs(l_p - (10.0 + expected_via_mm)) < 1e-9
+        assert abs(l_n - (10.0 + expected_via_mm)) < 1e-9
+        # Skew should be ~0 because we sized n_route to match P + via.
+        assert tracker.get_skew(dp) < 1e-9
+
+
+# =============================================================================
+# 3. get_all_skews -- ordering + omission of unrouted pairs
+# =============================================================================
+
+
+class TestGetAllSkews:
+    """Bulk skew query returns deterministic ordering and skips unrouted pairs."""
+
+    def test_returns_skew_for_all_routed_pairs(self):
+        dp1 = _make_detected_pair("USB_D", "USB_D+", "USB_D-", p_id=1, n_id=2)
+        dp2 = _make_detected_pair("PCIE_TX", "PCIE_TX_P", "PCIE_TX_N", p_id=3, n_id=4)
+
+        routes = [
+            _make_straight_route(1, "USB_D+", 10.0),
+            _make_straight_route(2, "USB_D-", 12.0),
+            _make_straight_route(3, "PCIE_TX_P", 7.0),
+            _make_straight_route(4, "PCIE_TX_N", 7.0),
+        ]
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes(routes, [dp1, dp2])
+
+        skews = tracker.get_all_skews()
+        assert skews[("PCIE_TX_P", "PCIE_TX_N")] == 0.0
+        assert skews[("USB_D+", "USB_D-")] == 2.0
+
+    def test_omits_pairs_with_unrouted_halves(self):
+        # dp1 is fully routed; dp2 is missing its P half.
+        dp1 = _make_detected_pair("USB_D", "USB_D+", "USB_D-", p_id=1, n_id=2)
+        dp2 = _make_detected_pair("PCIE_TX", "PCIE_TX_P", "PCIE_TX_N", p_id=3, n_id=4)
+
+        routes = [
+            _make_straight_route(1, "USB_D+", 10.0),
+            _make_straight_route(2, "USB_D-", 12.0),
+            _make_straight_route(4, "PCIE_TX_N", 7.0),
+        ]
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes(routes, [dp1, dp2])
+
+        skews = tracker.get_all_skews()
+        assert ("USB_D+", "USB_D-") in skews
+        assert ("PCIE_TX_P", "PCIE_TX_N") not in skews
+
+    def test_ordering_is_deterministic_by_p_net_name(self):
+        # Build pairs whose P names sort to a known order.
+        dp_b = _make_detected_pair("BUS_B", "B+", "B-", p_id=1, n_id=2)
+        dp_a = _make_detected_pair("BUS_A", "A+", "A-", p_id=3, n_id=4)
+
+        routes = [
+            _make_straight_route(1, "B+", 10.0),
+            _make_straight_route(2, "B-", 10.0),
+            _make_straight_route(3, "A+", 10.0),
+            _make_straight_route(4, "A-", 10.0),
+        ]
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes(routes, [dp_b, dp_a])
+
+        # The detected_pairs list was [dp_b, dp_a]; insertion would put
+        # B+ before A+.  get_all_skews must sort by p_net_name so A+
+        # comes first.
+        skews = tracker.get_all_skews()
+        keys = list(skews.keys())
+        assert keys == [("A+", "A-"), ("B+", "B-")]
+
+    def test_record_routes_resets_skew_map(self):
+        # Calling record_routes twice with different detected_pairs lists
+        # must not retain stale (p, n) entries from the previous call.
+        dp1 = _make_detected_pair("USB_D", "USB_D+", "USB_D-", p_id=1, n_id=2)
+        dp2 = _make_detected_pair("PCIE_TX", "PCIE_TX_P", "PCIE_TX_N", p_id=3, n_id=4)
+
+        routes1 = [
+            _make_straight_route(1, "USB_D+", 10.0),
+            _make_straight_route(2, "USB_D-", 11.0),
+        ]
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes(routes1, [dp1])
+        assert ("USB_D+", "USB_D-") in tracker.get_all_skews()
+
+        routes2 = [
+            _make_straight_route(3, "PCIE_TX_P", 7.0),
+            _make_straight_route(4, "PCIE_TX_N", 8.0),
+        ]
+        tracker.record_routes(routes2, [dp2])
+        skews = tracker.get_all_skews()
+        assert ("PCIE_TX_P", "PCIE_TX_N") in skews
+        assert ("USB_D+", "USB_D-") not in skews
+
+
+# =============================================================================
+# 4. NetClassRouting.effective_skew_tolerance round-trip
+# =============================================================================
+
+
+class TestEffectiveSkewTolerance:
+    """Per-class override semantics for the skew tolerance accessor."""
+
+    def test_default_unset_returns_half_mm(self):
+        # The literal default arg is 0.5; this anchors the drift-prevention
+        # cross-check with Issue J's DEFAULT_SKEW_TOLERANCE_MM (which must
+        # equal 0.5 byte-for-byte once the J-side module exists).
+        nc = NetClassRouting(name="Default")
+        assert nc.effective_skew_tolerance() == 0.5
+
+    def test_override_returns_explicit_value(self):
+        nc = NetClassRouting(name="USB_HS", skew_tolerance_mm=0.3)
+        assert nc.effective_skew_tolerance() == 0.3
+        # The explicit default arg must be ignored when the field is set.
+        assert nc.effective_skew_tolerance(default=99.0) == 0.3
+
+    def test_default_arg_overrides_module_default_when_field_unset(self):
+        # Mirrors :meth:`effective_coupled_continuity_threshold` semantics:
+        # the default arg is the fallback when the field is None.
+        nc = NetClassRouting(name="Default")
+        assert nc.effective_skew_tolerance(default=1.0) == 1.0
+
+    def test_field_round_trip_via_dataclass_construction(self):
+        # Plain dataclass construction with the field must round-trip
+        # through repr() and equality.
+        nc1 = NetClassRouting(name="HS", skew_tolerance_mm=0.25)
+        nc2 = NetClassRouting(name="HS", skew_tolerance_mm=0.25)
+        assert nc1 == nc2
+        assert nc1.skew_tolerance_mm == 0.25
+        assert "skew_tolerance_mm=0.25" in repr(nc1)
+
+
+# =============================================================================
+# 5. Drift-prevention test (anticipating Issue J's DEFAULT_SKEW_TOLERANCE_MM)
+# =============================================================================
+
+
+class TestDriftPrevention:
+    """The H accessor default must equal Issue J's DRC-rule constant byte-for-byte.
+
+    Until Issue J lands the J-side module does not exist; the H-side test
+    asserts the accessor returns ``0.5``.  The J-side PR will add the
+    import-and-cross-check.  This mirrors the #2521 / #2640 alias-drift
+    failure mode where two literal copies of the same threshold drifted.
+    """
+
+    def test_accessor_default_is_half_mm(self):
+        # The literal 0.5 must appear in exactly two places per repo:
+        # router/rules.py (accessor default arg, this assertion) and
+        # validate/rules/diffpair_length_skew.py (DEFAULT_SKEW_TOLERANCE_MM,
+        # added in Issue J).  Any third copy is drift.
+        nc = NetClassRouting(name="Default")
+        assert nc.effective_skew_tolerance() == 0.5
+
+    def test_accessor_default_matches_issue_j_constant_when_available(self):
+        # Best-effort cross-check: if Issue J has already landed,
+        # import the constant and assert byte-for-byte equality.
+        try:
+            from kicad_tools.validate.rules.diffpair_length_skew import (
+                DEFAULT_SKEW_TOLERANCE_MM,
+            )
+        except ImportError:
+            # Issue J not yet merged -- the H-side test (above) anchors
+            # the 0.5 default unilaterally.
+            return
+        nc = NetClassRouting(name="Default")
+        assert nc.effective_skew_tolerance() == DEFAULT_SKEW_TOLERANCE_MM
+
+
+# =============================================================================
+# 6. Length-critical flag does NOT gate measurement (acceptance criterion)
+# =============================================================================
+
+
+class TestLengthCriticalFlagDoesNotGate:
+    """Pairs whose net class has length_critical=False still get measured."""
+
+    def test_length_critical_false_pair_still_measured(self):
+        # length_critical defaults to False on most net classes; the
+        # tracker must measure unconditionally (the flag is a routing
+        # priority hint, not a skew-tracking gate).  The DRC rule (Issue J)
+        # is responsible for deciding whether to fire.
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        nc = NetClassRouting(name="Generic", length_critical=False)
+        assert nc.length_critical is False
+
+        p_route = _make_straight_route(1, "USB_D+", 10.0)
+        n_route = _make_straight_route(2, "USB_D-", 12.0)
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes([p_route, n_route], [dp])
+
+        # The tracker doesn't know about net classes -- it always
+        # measures.  This test documents the policy.
+        assert tracker.get_skew(dp) == 2.0
+
+
+# =============================================================================
+# 7. Dormant-signal gate -- Autorouter.update_diffpair_skew (Issue #2587 lesson)
+# =============================================================================
+
+
+class TestUpdateDiffpairSkewProductionPath:
+    """The production-code path that calls record_routes must be reachable.
+
+    The #2587 lesson: a feature whose record-routes call is reached from
+    no production code path is dormant and silently regresses.  This
+    test invokes :meth:`Autorouter.update_diffpair_skew` and asserts the
+    tracker is non-empty after the call.
+    """
+
+    def test_update_diffpair_skew_populates_tracker(self):
+        from kicad_tools.router.core import Autorouter
+        from kicad_tools.router.rules import DesignRules
+
+        # Build a minimal Autorouter and inject synthetic routes.  We
+        # don't actually invoke the routing engine -- this test isolates
+        # the production-path wiring that update_diffpair_skew exercises.
+        router = Autorouter(
+            width=20.0,
+            height=20.0,
+            rules=DesignRules(),
+        )
+        router.routes = [
+            _make_straight_route(1, "USB_D+", 10.0),
+            _make_straight_route(2, "USB_D-", 12.0),
+        ]
+
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        tracker = router.update_diffpair_skew([dp])
+
+        # Production path is reached and produces a non-empty tracker.
+        assert tracker is router.diffpair_length_tracker
+        assert tracker.lengths  # non-empty
+        assert tracker.get_skew(dp) == 2.0
+
+    def test_update_diffpair_skew_with_board_thickness(self):
+        from kicad_tools.router.core import Autorouter
+        from kicad_tools.router.rules import DesignRules
+
+        router = Autorouter(
+            width=20.0,
+            height=20.0,
+            rules=DesignRules(),
+        )
+
+        # P has a F.Cu -> B.Cu via on a 2-layer 1.6 mm board.
+        p_route = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[
+                Segment(0.0, 0.0, 5.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+"),
+                Segment(5.0, 0.0, 10.0, 0.0, 0.2, Layer.B_CU, net=1, net_name="USB_D+"),
+            ],
+            vias=[
+                Via(
+                    x=5.0,
+                    y=0.0,
+                    drill=0.3,
+                    diameter=0.6,
+                    layers=(CopperLayer.F_CU, CopperLayer.B_CU),
+                    net=1,
+                    net_name="USB_D+",
+                )
+            ],
+        )
+        n_route = _make_straight_route(2, "USB_D-", 10.0)
+        router.routes = [p_route, n_route]
+
+        dp = _make_detected_pair(p_id=1, n_id=2)
+        tracker = router.update_diffpair_skew([dp], board_thickness_mm=1.6, num_copper_layers=2)
+
+        # P = 10 mm segments + 1.6 mm via = 11.6 mm; N = 10 mm.
+        # Skew = 1.6 mm.
+        assert abs(tracker.get_skew(dp) - 1.6) < 1e-9


### PR DESCRIPTION
## Summary

Implements Phase 3H of Epic #2556 (first-class differential pair support):
the **measurement foundation** for protocols that care about timing skew
(USB 2.0/3.0 HS, PCIe, MIPI, DDR).  Phase 3I (serpentine insertion) and
Phase 3J (DRC rule) depend on this tracker for their target skew quantity.

This PR is measurement-only — it does not change routes (Phase 3I) and
does not fire DRC violations (Phase 3J).

## Changes

- **New** `src/kicad_tools/router/diffpair_length.py` — `DiffPairLengthTracker`
  class measures per-pair routed length and exposes:
  - `record_routes(routes, detected_pairs, board_thickness_mm=None, num_copper_layers=2)`
  - `get_pair_lengths(pair) -> tuple[float, float] | None`
  - `get_skew(pair) -> float | None`
  - `get_all_skews() -> dict[tuple[str, str], float]` (sorted by p_net_name)
  - Reuses `LengthTracker.calculate_route_length` for the segment-summation
    primitive (no duplicated math).
- **New** via-length policy: when `board_thickness_mm` is supplied each via
  contributes `thickness * |stack_position_delta| / (num_copper_layers - 1)`.
  When `board_thickness_mm` is `None` vias contribute `0.0 mm` (documented
  conservative default rather than a guessed value).
- **New field** `NetClassRouting.skew_tolerance_mm: float | None = None`
  in `src/kicad_tools/router/rules.py`, placed immediately after
  `coupled_continuity_threshold` (the PR #2646 pattern).
- **New accessor** `NetClassRouting.effective_skew_tolerance(default=0.5)`
  mirroring PR #2646's `effective_coupled_continuity_threshold`.  Anchors
  the literal `0.5` in exactly one router-side location.
- **New production-path method** `Autorouter.update_diffpair_skew(
  detected_pairs, board_thickness_mm=None, num_copper_layers=None)` in
  `router/core.py` — sibling to `_update_length_tracker`, populates the
  per-pair tracker from `self.routes`.  Plus `Autorouter.diffpair_length_tracker`
  property for callers to inspect the tracker.  Closes the #2587 dormant-signal
  failure mode (tracker is reachable from a production path AND covered by
  a test).
- **New** `tests/test_diffpair_length.py` (21 tests across 7 classes).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `DiffPairLengthTracker` with `record_routes` reusing `calculate_route_length` | Pass | `_measure_route` calls `LengthTracker.calculate_route_length` then adds via length |
| `get_pair_lengths(pair) -> tuple | None` looking up via `pair.pair.positive.net_id` | Pass | `TestDiffPairLengthTrackerBasic::test_symmetric_pair_zero_skew`, `test_asymmetric_pair_skew_two_mm` |
| `get_skew(pair) -> float | None` | Pass | All `TestDiffPairLengthTrackerBasic` tests |
| `get_all_skews() -> dict[(p, n), float]` sorted by `p_net_name` | Pass | `TestGetAllSkews::test_ordering_is_deterministic_by_p_net_name` |
| `NetClassRouting.skew_tolerance_mm: float | None = None` after `coupled_continuity_threshold` | Pass | Field placed at `rules.py:506` (immediately after `coupled_continuity_threshold`); docstring references Phase 3H #2647 |
| `effective_skew_tolerance(default=0.5) -> float` mirroring `effective_coupled_continuity_threshold` | Pass | Implemented at `rules.py:559` with same default-arg shape |
| Layer-aware-by-summation via length using stack position | Pass | `TestViaLengthPolicy::test_via_traversal_includes_drilled_length_when_thickness_supplied` (2-layer F.Cu->B.Cu = 1.6 mm; 4-layer F.Cu->In1.Cu = 0.533 mm) |
| Zero via length when `board_thickness_mm` is `None` (documented) | Pass | `TestViaLengthPolicy::test_via_returns_zero_length_when_thickness_is_none` |
| `DesignRules` decoupling — explicit `board_thickness_mm` parameter | Pass | `record_routes` signature accepts `board_thickness_mm: float | None = None` independent of `DesignRules` |
| Dormant-signal gate — production path + test coverage | Pass | `Autorouter.update_diffpair_skew` calls `record_routes`; `TestUpdateDiffpairSkewProductionPath` exercises it |
| `length_critical=False` pairs still measured | Pass | `TestLengthCriticalFlagDoesNotGate::test_length_critical_false_pair_still_measured` |
| Drift-prevention test for the `0.5` default | Pass | `TestDriftPrevention::test_accessor_default_is_half_mm` + the conditional Issue-J cross-check stub |
| Existing tests pass (`test_length_matching`, `test_trace_length`, `test_diffpair_*`) | Pass | 413 passed, 9 skipped (pre-existing) across the full diffpair test suite |
| Legacy `DifferentialPair.routed_length_p/n` NOT populated | Pass | Tracker stores lengths in its own `lengths` dict; legacy fields untouched (verified by grep) |

## Test Plan

Ran the new test module plus the regression suite mandated by the issue's
"existing tests pass" acceptance criterion:

```
uv run pytest tests/test_diffpair_length.py tests/test_length_matching.py \
  tests/test_trace_length.py tests/test_diffpair.py \
  tests/test_diffpair_detection.py tests/test_diffpair_engagement.py \
  tests/test_diffpair_partner_wiring.py tests/test_net_class.py \
  tests/test_validate_diffpair_routing_continuity.py \
  tests/test_net_class_trace_width.py tests/test_diffpair_routing_integration.py \
  tests/test_diffpair_npad.py tests/test_escape_diffpair.py \
  tests/test_cli_check_diffpair_clearance_intra.py \
  tests/test_cli_check_diffpair_routing_continuity.py \
  tests/test_validate_diffpair_clearance_intra.py
# => 413 passed, 9 skipped
```

The 21 new `tests/test_diffpair_length.py` tests cover:
- Symmetric (skew=0), asymmetric (skew=2.0), unrouted-P, unrouted-N, non-pair-net-ignored
- Via-traversal with explicit `board_thickness_mm` (2-layer + 4-layer cases)
- Via with `board_thickness_mm=None` (documented zero contribution)
- `get_all_skews` ordering by `p_net_name` + omission of unrouted pairs
- `NetClassRouting.effective_skew_tolerance` default + override round-trip
- Drift-prevention: H-side anchor + conditional Issue-J cross-check
- `length_critical=False` does not gate measurement
- Production path: `Autorouter.update_diffpair_skew` (dormant-signal gate)

`ruff check` passes on all four files; pre-existing core.py lint issues
are unchanged and out of scope per builder discipline.

Closes #2647