### PR TITLE
feat(router): flip NET_CLASS_HIGH_SPEED.coupled_routing to True (Phase 2.5a)

### DIFF
--- a/src/kicad_tools/router/net_class.py
+++ b/src/kicad_tools/router/net_class.py
@@ -581,6 +581,11 @@ def apply_net_class_rules(
             clearance=0.15,
             cost_multiplier=0.85,
             length_critical=True,
+            # Issue #2651 / Epic #2556 Phase 2.5a: auto-classifier path for
+            # nets recognized as DIFFERENTIAL must engage CoupledPathfinder
+            # for semantic consistency with the explicit ``high_speed_nets=``
+            # opt-in (which routes through ``NET_CLASS_HIGH_SPEED``).
+            coupled_routing=True,
         ),
         NetClass.ANALOG: NET_CLASS_AUDIO,
         NetClass.RF: NetClassRouting(

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -466,9 +466,13 @@ class NetClassRouting:
     declared via :attr:`diffpair_partner`).
 
     Default is ``False`` for backward compatibility with all pre-#2636
-    boards.  Predefined classes (e.g. ``NET_CLASS_HIGH_SPEED``) keep
-    ``coupled_routing=False`` until a follow-up issue flips them on with
-    empirical board coverage from Phase 4's board 06.
+    boards.  ``NET_CLASS_HIGH_SPEED`` was flipped to ``True`` in #2651
+    (Epic #2556 Phase 2.5a) -- it is the canonical HSDI class that
+    consumers opt into via ``high_speed_nets=`` and is the producer-side
+    half of the Phase 2 coupled-routing pipeline.  Other predefined
+    classes (``POWER``, ``HIGH_CURRENT_SIGNAL``, ``CLOCK``, ``AUDIO``,
+    ``DIGITAL``, ``DEBUG``, ``DEFAULT``) keep ``coupled_routing=False``
+    because they carry single-ended signals.
 
     NOTE -- name collision with the ``use_coupled_routing`` function
     parameter on :meth:`DiffPairRouter.route_differential_pair`.  The
@@ -589,6 +593,7 @@ NET_CLASS_HIGH_SPEED = NetClassRouting(
     intra_pair_clearance=0.075,  # Issue #2559 / Epic #2556 Phase 1C
     cost_multiplier=0.85,
     length_critical=True,
+    coupled_routing=True,  # Issue #2651 / Epic #2556 Phase 2.5a: producer-side flip
 )
 
 NET_CLASS_AUDIO = NetClassRouting(

--- a/tests/test_diffpair_engagement.py
+++ b/tests/test_diffpair_engagement.py
@@ -470,15 +470,45 @@ class TestNPadRegression:
 
 
 # =============================================================================
-# 5. Predefined classes preserve pre-#2638 default (coupled_routing=False)
+# 5. Predefined-class opt-in policy
+#
+# After #2651 (Epic #2556 Phase 2.5a), ``NET_CLASS_HIGH_SPEED`` and the
+# auto-classifier's ``NetClass.DIFFERENTIAL``-mapped ad-hoc class are the
+# only predefined classes with ``coupled_routing=True``.  All other
+# predefined singletons must remain ``False`` because they carry
+# single-ended signals.  The bare-dataclass default is still ``False`` so
+# unrelated callers don't accidentally engage coupled routing.
 # =============================================================================
 
 
-class TestPredefinedClassesDefaultOff:
-    def test_high_speed_default_off(self):
-        # Phase 2E out-of-scope: predefined classes must NOT have
-        # coupled_routing flipped on.  That's a follow-up issue.
-        assert NET_CLASS_HIGH_SPEED.coupled_routing is False
+class TestPredefinedClassesOptIn:
+    def test_high_speed_default_on(self):
+        # Phase 2.5a / #2651: NET_CLASS_HIGH_SPEED is the canonical HSDI
+        # class and is the only predefined singleton consumers opt into
+        # via ``high_speed_nets=``.  The producer-side flip lives here.
+        assert NET_CLASS_HIGH_SPEED.coupled_routing is True
+
+    def test_other_predefined_classes_default_off(self):
+        # All other predefined classes carry single-ended signals.
+        # Flipping coupled_routing on them would be electrically wrong
+        # (e.g. motor phase outputs, single-ended clocks, generic digital).
+        from kicad_tools.router.rules import (
+            NET_CLASS_AUDIO,
+            NET_CLASS_CLOCK,
+            NET_CLASS_DEBUG,
+            NET_CLASS_DEFAULT,
+            NET_CLASS_DIGITAL,
+            NET_CLASS_HIGH_CURRENT_SIGNAL,
+            NET_CLASS_POWER,
+        )
+
+        assert NET_CLASS_POWER.coupled_routing is False
+        assert NET_CLASS_HIGH_CURRENT_SIGNAL.coupled_routing is False
+        assert NET_CLASS_CLOCK.coupled_routing is False
+        assert NET_CLASS_AUDIO.coupled_routing is False
+        assert NET_CLASS_DIGITAL.coupled_routing is False
+        assert NET_CLASS_DEBUG.coupled_routing is False
+        assert NET_CLASS_DEFAULT.coupled_routing is False
 
     def test_dataclass_default_is_false(self):
         nc = NetClassRouting(name="Bare")

--- a/tests/test_diffpair_routing_integration.py
+++ b/tests/test_diffpair_routing_integration.py
@@ -252,9 +252,10 @@ def _diffpair_with_connector_sibling_router() -> Autorouter:
         grid_resolution=0.1,
     )
     # Issue #2638 / Epic #2556 Phase 2E: opt the USB diff-pair class into
-    # coupled routing.  Phase 2E does NOT flip ``coupled_routing`` on the
-    # predefined ``NET_CLASS_HIGH_SPEED`` (that's a follow-up issue), so
-    # tests that exercise the pre-pass must opt in explicitly.
+    # coupled routing.  After #2651 (Phase 2.5a), ``NET_CLASS_HIGH_SPEED``
+    # already has ``coupled_routing=True``; the explicit ``replace`` here
+    # is retained for clarity and to keep this test stable if a future
+    # issue flips the singleton back.
     hs_coupled = dataclasses.replace(NET_CLASS_HIGH_SPEED, coupled_routing=True)
     net_class_map = {
         "USB_D+": hs_coupled,


### PR DESCRIPTION
## Summary

Producer-side flip for the Phase 2 coupled-routing pipeline. After #2645 wired CoupledPathfinder engagement via `NetClassRouting.coupled_routing`, no predefined class actually engaged. This PR flips the one class consumers opt into via `high_speed_nets=` (`NET_CLASS_HIGH_SPEED`) and the auto-classifier's `NetClass.DIFFERENTIAL`-mapped ad-hoc class.

This PR enables the engagement machinery only. Board 03's DRC improvement (driving the `diffpair_clearance_intra` count to 0) is deferred to Phase 3K/3I follow-ups under Epic #2556 -- the policy flip itself has zero impact on stored artifacts.

## Changes

- `src/kicad_tools/router/rules.py:596` -- `NET_CLASS_HIGH_SPEED.coupled_routing = True`. Updated the surrounding class docstring (`rules.py:466-474`) to reflect the new state.
- `src/kicad_tools/router/net_class.py:588` -- `NetClass.DIFFERENTIAL` ad-hoc class in `apply_net_class_rules`'s `class_to_routing` map: `coupled_routing = True` for semantic consistency with the explicit opt-in path.
- `tests/test_diffpair_engagement.py` -- Replaced `TestPredefinedClassesDefaultOff` with `TestPredefinedClassesOptIn`. New test asserts `NET_CLASS_HIGH_SPEED.coupled_routing is True` and that the other 7 predefined classes (`POWER`, `HIGH_CURRENT_SIGNAL`, `CLOCK`, `AUDIO`, `DIGITAL`, `DEBUG`, `DEFAULT`) remain `False`.
- `tests/test_diffpair_routing_integration.py` -- Updated outdated comment noting the singleton is already opted in post-#2651.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `NET_CLASS_HIGH_SPEED.coupled_routing == True` | Done | `rules.py:596`; new test `test_high_speed_default_on` passes |
| `NetClass.DIFFERENTIAL` ad-hoc class also flipped | Done | `net_class.py:588`; semantic consistency for auto-classifier path |
| Other 7 predefined classes keep `coupled_routing=False` | Done | New `test_other_predefined_classes_default_off` test asserts all 7 |
| Boards 01-05 stored artifacts unchanged | Done | This PR touches no `boards/**/output/*.kicad_pcb` files; CI Routed PCB DRC tolerance unchanged at 0/0/1/0/15 |

## Test Plan

Ran:
- `uv run pytest tests/test_diffpair_engagement.py tests/test_diffpair_routing_integration.py tests/test_diffpair_npad.py tests/test_diffpair.py tests/test_net_class.py tests/test_intra_pair_clearance.py tests/test_recovery.py tests/test_validate_diffpair_clearance_intra.py` -- 261 passed

## Scope notes

- This PR is the engagement-machinery flip only. No PCB artifacts are regenerated. The stored routed PCB for board 03 stays identical to `main`, so the CI Routed PCB DRC Check stays within its existing tolerance (board 03 = 1 error).
- Driving board 03's `diffpair_clearance_intra` to 0 requires Phase 3 work (impedance-controlled width+spacing per Epic #2556 Phase 3K) since further reducing the USB-C pad rail-out width requires a sub-0.127mm coupled-pair stackup.
- The pre-existing F841 lint error in `tests/test_diffpair_routing_integration.py:322` is also present on `main` and is out of scope here.

Closes #2651
