### PR TITLE
feat(router): per-pair diff-pair length-match (skew) serpentine tuner

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -286,6 +286,9 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--diffpair-spacing", str(args.diffpair_spacing)])
     if getattr(args, "diffpair_max_delta", None) is not None:
         sub_argv.extend(["--diffpair-max-delta", str(args.diffpair_max_delta)])
+    # Issue #2648 (Epic #2556 Phase 3I): forward the length-match-diffpairs flag
+    if getattr(args, "length_match_diffpairs", False):
+        sub_argv.append("--length-match-diffpairs")
     return route_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2462,6 +2462,17 @@ def _add_route_parser(subparsers) -> None:
             "Default: auto based on detected pair type."
         ),
     )
+    route_parser.add_argument(
+        "--length-match-diffpairs",
+        action="store_true",
+        help=(
+            "Enable per-pair differential length-match (skew) tuning (Epic "
+            "#2556 Phase 3I). Inserts serpentines on the shorter half of "
+            "each length-critical diff pair until skew is within the "
+            "per-class tolerance. Requires --differential-pairs (otherwise "
+            "warns and short-circuits)."
+        ),
+    )
 
 
 def _add_route_auto_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3339,6 +3339,17 @@ def main(argv: list[str] | None = None) -> int:
         help="Maximum length mismatch for differential pairs in mm (default: auto based on type)",
     )
     parser.add_argument(
+        "--length-match-diffpairs",
+        action="store_true",
+        help=(
+            "Enable per-pair differential length-match tuning (Epic #2556 "
+            "Phase 3I). Inserts serpentines on the shorter half of each "
+            "length-critical diff pair until skew is within the per-class "
+            "tolerance. Requires --differential-pairs to be set; emits a "
+            "warning and short-circuits otherwise."
+        ),
+    )
+    parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
@@ -5059,6 +5070,62 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  Segments: {pre_segments} -> {post_segments} ({-segment_reduction:+.1f}%)")
             if pre_vias > 0:
                 print(f"  Vias:     {pre_vias} -> {post_vias} ({-via_reduction:+.1f}%)")
+
+    # Differential-pair length-match (skew) tuning -- Epic #2556 Phase 3I (Issue #2648).
+    # Engaged via --length-match-diffpairs (opt-in).  Requires --differential-pairs;
+    # otherwise emit a warning and short-circuit (no detection means no pairs).
+    if getattr(args, "length_match_diffpairs", False) and router.routes:
+        if not args.differential_pairs:
+            if not quiet:
+                print(
+                    "\n--- Length-Match Diff-Pairs: skipped ---\n"
+                    "  --length-match-diffpairs requires --differential-pairs "
+                    "(no detection means no pairs to tune)."
+                )
+        else:
+            from kicad_tools.router.diffpair_detection import detect_diff_pairs
+
+            if not quiet:
+                print("\n--- Length-Match Diff-Pairs (Epic #2556 Phase 3I) ---")
+            detected_pairs = detect_diff_pairs(net_names=router.net_names)
+            if not detected_pairs:
+                if not quiet:
+                    print("  No differential pairs detected; nothing to tune.")
+            else:
+                # Snapshot connectivity for the pad-to-pad invariant.
+                _ci_snapshot_skew = _connectivity_snapshot(router)
+                tune_results = router.apply_diffpair_length_tuning(
+                    detected_pairs=detected_pairs,
+                    verbose=not quiet,
+                )
+                _enforce_connectivity_invariant_or_exit(
+                    router,
+                    _ci_snapshot_skew,
+                    phase="length_match_diffpairs",
+                    args=args,
+                    quiet=quiet,
+                )
+                if not quiet:
+                    n_tuned = sum(1 for r in tune_results.values() if r.reason == "tuned")
+                    n_clean = sum(
+                        1 for r in tune_results.values() if r.reason == "already_within_tolerance"
+                    )
+                    n_rollback = sum(
+                        1
+                        for r in tune_results.values()
+                        if r.reason == "post_insertion_drc_violation"
+                    )
+                    n_budget = sum(
+                        1 for r in tune_results.values() if r.reason == "exceeded_max_inserts"
+                    )
+                    n_skipped = sum(
+                        1 for r in tune_results.values() if r.reason == "not_length_critical"
+                    )
+                    print(
+                        f"  Summary: {n_tuned} tuned, {n_clean} clean, "
+                        f"{n_rollback} rolled back, {n_budget} budget-exhausted, "
+                        f"{n_skipped} skipped (not length-critical)"
+                    )
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
     multi_pad_net_ids = set(multi_pad_nets)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -845,7 +845,7 @@ class Autorouter:
         min_pitch = float("inf")
         positions = [(p["x"], p["y"]) for p in pads]
         for i, (x1, y1) in enumerate(positions):
-            for x2, y2 in positions[i + 1 :]:
+            for x2, y2 in positions[i + 1:]:
                 dist = math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2)
                 if dist > 0.01:  # Ignore overlapping pads
                     min_pitch = min(min_pitch, dist)
@@ -998,7 +998,9 @@ class Autorouter:
                 }
             )
 
-    def _find_pads_near(self, x: float, y: float, epsilon: float) -> set[tuple[str, str]]:
+    def _find_pads_near(
+        self, x: float, y: float, epsilon: float
+    ) -> set[tuple[str, str]]:
         """Find all router pad keys within epsilon distance of (x, y).
 
         Args:
@@ -1233,7 +1235,10 @@ class Autorouter:
         # Issue #2401: Substitute escaped pads with virtual pads at escape
         # endpoints so RSMT + A* route between escape endpoints, not original
         # pad centers.
-        pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing]
+        pad_objs = [
+            self._escape_pad_overrides.get(p, self.pads[p])
+            for p in pads_for_routing
+        ]
 
         # Issue #2336: Try sub-problem pattern cache before A* search.
         # Compute a position/rotation-invariant signature and check for a
@@ -1429,9 +1434,7 @@ class Autorouter:
             # the off-grid Steiner point failure mode.
             has_off_grid = self._net_has_off_grid_pads(net)
             new_routes = mst_router.route_net(
-                pad_objs,
-                mark_route,
-                record_failure,
+                pad_objs, mark_route, record_failure,
                 use_steiner=not has_off_grid,
             )
         else:
@@ -2435,7 +2438,9 @@ class Autorouter:
     # Matrix-conflict detection and layer preference assignment (Issue #2432)
     # ------------------------------------------------------------------
 
-    def _detect_matrix_conflicts(self, net_ids: list[int], threshold: int = 2) -> list[set[int]]:
+    def _detect_matrix_conflicts(
+        self, net_ids: list[int], threshold: int = 2
+    ) -> list[set[int]]:
         """Detect groups of nets sharing multiple components (matrix topology).
 
         In a charlieplex LED matrix, nets like NODE_A through NODE_D each
@@ -2549,7 +2554,9 @@ class Autorouter:
 
         return preferences
 
-    def _inject_matrix_layer_preferences(self, net_layer_prefs: dict[int, list[int]]) -> None:
+    def _inject_matrix_layer_preferences(
+        self, net_layer_prefs: dict[int, list[int]]
+    ) -> None:
         """Inject per-net layer preferences into net_class_map overrides.
 
         Creates per-net NetClassRouting entries with ``preferred_layers``
@@ -2582,7 +2589,9 @@ class Autorouter:
             self.net_class_map[net_name] = override
 
         if net_layer_prefs:
-            names = [self.net_names.get(n, f"Net {n}") for n in net_layer_prefs]
+            names = [
+                self.net_names.get(n, f"Net {n}") for n in net_layer_prefs
+            ]
             flush_print(
                 f"  Matrix conflict: assigned layer preferences for {len(names)} net(s): {names}"
             )
@@ -2592,7 +2601,9 @@ class Autorouter:
     # _calculate_constraint_score() can boost priority for these nets.
     _matrix_conflict_nets: set[int]
 
-    def _detect_and_apply_matrix_preferences(self, net_order: list[int]) -> None:
+    def _detect_and_apply_matrix_preferences(
+        self, net_order: list[int]
+    ) -> None:
         """Detect matrix-conflicting nets and inject layer preferences.
 
         Convenience method that chains :meth:`_detect_matrix_conflicts`,
@@ -2700,14 +2711,7 @@ class Autorouter:
             noise = self._perturbation_rng.gauss(0, self._perturbation_magnitude)
             congestion_score += noise
 
-        return (
-            priority,
-            complexity_tier,
-            -constraint_score,
-            pad_count,
-            distance,
-            -congestion_score,
-        )
+        return (priority, complexity_tier, -constraint_score, pad_count, distance, -congestion_score)
 
     def _compute_mst_edges(self, net_id: int) -> list[MSTEdgeInfo]:
         """Compute MST edges for a net and return them sorted by distance.
@@ -3255,7 +3259,8 @@ class Autorouter:
         # Identify lower-priority siblings whose pads sit on the blocking
         # components.  Restrict candidates to nets that currently have
         # routes in ``net_routes``.
-        routed_net_ids = {n for n, routes in net_routes.items() if routes and n != failed_net}
+        routed_net_ids = {n for n, routes in net_routes.items()
+                          if routes and n != failed_net}
         siblings = self._find_lower_priority_siblings_on_components(
             failed_net=failed_net,
             blocking_components=blocking_components,
@@ -3315,7 +3320,8 @@ class Autorouter:
             )
         except Exception as exc:  # pragma: no cover - defensive
             flush_print(
-                f"  BLOCKED_BY_COMPONENT rip-up (negotiated) raised {type(exc).__name__}: {exc}"
+                f"  BLOCKED_BY_COMPONENT rip-up (negotiated) raised "
+                f"{type(exc).__name__}: {exc}"
             )
             return False
 
@@ -3326,7 +3332,9 @@ class Autorouter:
         if rescued:
             # Drop any stale failure entries for the rescued net so the
             # summary output reflects the rescued state.
-            self.routing_failures = [f for f in self.routing_failures if f.net != failed_net]
+            self.routing_failures = [
+                f for f in self.routing_failures if f.net != failed_net
+            ]
         elif not success:
             flush_print(
                 f"  BLOCKED_BY_COMPONENT rip-up (negotiated) for {failed_name}: "
@@ -3475,7 +3483,10 @@ class Autorouter:
 
         # Issue #2401: Substitute escaped pads with virtual pads at escape
         # endpoints.
-        pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing]
+        pad_objs = [
+            self._escape_pad_overrides.get(p, self.pads[p])
+            for p in pads_for_routing
+        ]
 
         # Route MST edges in order (shortest first)
         # The mst_edges contain indices into the original pad list
@@ -3993,10 +4004,7 @@ class Autorouter:
         total_nets = len(net_order)
 
         neg_router = NegotiatedRouter(
-            self.grid,
-            self.router,
-            self.rules,
-            self.net_class_map,
+            self.grid, self.router, self.rules, self.net_class_map,
             congestion_estimator=self._ensure_congestion_estimator(),
         )
 
@@ -4031,10 +4039,7 @@ class Autorouter:
                 # Update router to use new grid
                 self.router.grid = self.grid
                 neg_router = NegotiatedRouter(
-                    self.grid,
-                    self.router,
-                    self.rules,
-                    self.net_class_map,
+                    self.grid, self.router, self.rules, self.net_class_map,
                     congestion_estimator=self._ensure_congestion_estimator(),
                 )
 
@@ -4097,7 +4102,8 @@ class Autorouter:
                     # Issue #2401: Substitute escaped pads with virtual pads
                     # at escape endpoints.
                     pads_by_net[net] = [
-                        self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing
+                        self._escape_pad_overrides.get(p, self.pads[p])
+                        for p in pads_for_routing
                     ]
                 else:
                     single_pad_nets.add(net)
@@ -4275,9 +4281,7 @@ class Autorouter:
                 # perturbation has already been active for 3+ iterations
                 # without finding a new best.
                 unrouted = total_nets - len(net_routes)
-                if adaptive and should_terminate_early(
-                    overflow_history, iteration, unrouted_count=unrouted
-                ):
+                if adaptive and should_terminate_early(overflow_history, iteration, unrouted_count=unrouted):
                     if perturbation and perturbation_stagnation_count < 3:
                         # Activate perturbation instead of terminating
                         perturbation_stagnation_count += 1
@@ -4295,12 +4299,15 @@ class Autorouter:
                             for n in net_order
                             if n not in net_routes and n in pads_by_net
                         )
-                        partial_at_term = self._get_partially_routed_nets(net_routes, pads_by_net)
+                        partial_at_term = self._get_partially_routed_nets(
+                            net_routes, pads_by_net
+                        )
                         partial_names = sorted(
                             self.net_names.get(n, f"Net_{n}") for n in partial_at_term
                         )
                         full_routed = sum(
-                            1 for n, r in net_routes.items() if r and n not in partial_at_term
+                            1 for n, r in net_routes.items()
+                            if r and n not in partial_at_term
                         )
                         print(f"\n  ⚠ Early termination: no progress detected ({elapsed_str()})")
                         print(f"    Overflow history: {overflow_history[-5:]}")
@@ -4349,10 +4356,7 @@ class Autorouter:
                     )
                     # Adaptive present cost based on iteration and congestion
                     present_factor = calculate_present_cost(
-                        iteration,
-                        max_iterations,
-                        overflow_ratio,
-                        initial_present_factor,
+                        iteration, max_iterations, overflow_ratio, initial_present_factor,
                         exponential=exponential_cost,
                         pres_fac_mult=iter_pres_fac_mult,
                         pres_fac_cap=pres_fac_cap,
@@ -4376,7 +4380,9 @@ class Autorouter:
                 # Issue #2334: Re-sort net order when perturbation is active
                 # so the rip-up iterations explore different orderings.
                 if self._perturbation_magnitude > 0:
-                    net_order = sorted(net_order, key=lambda n: self._get_net_priority(n))
+                    net_order = sorted(
+                        net_order, key=lambda n: self._get_net_priority(n)
+                    )
 
                 nets_to_reroute = neg_router.find_nets_through_overused_cells(net_routes, overused)
 
@@ -4391,7 +4397,9 @@ class Autorouter:
                 failed_nets_to_recover = [
                     n
                     for n in net_order
-                    if n not in net_routes and n not in single_pad_nets and n not in off_grid_nets
+                    if n not in net_routes
+                    and n not in single_pad_nets
+                    and n not in off_grid_nets
                 ]
                 if failed_nets_to_recover:
                     # Add failed nets to reroute list if not already present
@@ -4409,14 +4417,15 @@ class Autorouter:
                 partial_nets = self._get_partially_routed_nets(net_routes, pads_by_net)
                 if partial_nets:
                     new_partial = [
-                        n
-                        for n in partial_nets
+                        n for n in partial_nets
                         if n not in nets_to_reroute and n not in off_grid_nets
                     ]
                     if new_partial:
                         for partial_net in new_partial:
                             nets_to_reroute.append(partial_net)
-                        partial_names = [self.net_names.get(n, f"Net_{n}") for n in new_partial]
+                        partial_names = [
+                            self.net_names.get(n, f"Net_{n}") for n in new_partial
+                        ]
                         flush_print(
                             f"  Including {len(new_partial)} partially routed net(s) "
                             f"in recovery: {', '.join(partial_names)}"
@@ -4454,14 +4463,15 @@ class Autorouter:
 
                 # Filter out stalled nets
                 newly_stalled = [
-                    n
-                    for n in nets_to_reroute
+                    n for n in nets_to_reroute
                     if net_ripup_stall.get(n, 0) >= max_net_stall_iterations
                     and n not in stalled_nets
                 ]
                 if newly_stalled:
                     stalled_nets.update(newly_stalled)
-                    stalled_names = [self.net_names.get(n, f"Net_{n}") for n in newly_stalled]
+                    stalled_names = [
+                        self.net_names.get(n, f"Net_{n}") for n in newly_stalled
+                    ]
                     flush_print(
                         f"  Excluding {len(newly_stalled)} stalled net(s) from rip-up: "
                         f"{', '.join(stalled_names)}"
@@ -4507,8 +4517,9 @@ class Autorouter:
                     # Same set OR subsequent cohorts are a subset of base
                     # (handles the case where some nets get marked stalled
                     # mid-window but the active subset stabilises).
-                    cohorts_stable = bool(base_cohort) and all(
-                        c <= base_cohort and c for c in recent_cohorts
+                    cohorts_stable = (
+                        bool(base_cohort)
+                        and all(c <= base_cohort and c for c in recent_cohorts)
                     )
                     overflow_stable = False
                     if len(overflow_history) >= cohort_stagnation_window:
@@ -4605,7 +4616,9 @@ class Autorouter:
                                 nets_to_reroute.append(fn)
 
                 if stalled_nets:
-                    nets_to_reroute = [n for n in nets_to_reroute if n not in stalled_nets]
+                    nets_to_reroute = [
+                        n for n in nets_to_reroute if n not in stalled_nets
+                    ]
 
                 # Issue #2396: When overflow is 0 but nets remain unrouted,
                 # the rip-up loop has no overflow signal to act on.  Force
@@ -4613,7 +4626,11 @@ class Autorouter:
                 # present_factor to encourage exploration of alternative
                 # paths.  This directly addresses the 4L 3/8 plateau
                 # observed in board 04.
-                if current_overflow == 0 and failed_net_ids and not timed_out:
+                if (
+                    current_overflow == 0
+                    and failed_net_ids
+                    and not timed_out
+                ):
                     recovery_factor = max(present_factor * 2.0, initial_present_factor * 4.0)
                     recovered = 0
                     attempted = 0
@@ -4687,7 +4704,9 @@ class Autorouter:
                             for n in net_order
                             if n not in net_routes and n in pads_by_net
                         )
-                        partial_at_term = self._get_partially_routed_nets(net_routes, pads_by_net)
+                        partial_at_term = self._get_partially_routed_nets(
+                            net_routes, pads_by_net
+                        )
                         partial_names = sorted(
                             self.net_names.get(n, f"Net_{n}") for n in partial_at_term
                         )
@@ -4696,9 +4715,13 @@ class Autorouter:
                             f"{iteration}/{max_iterations} ({elapsed_str()})"
                         )
                         if unrouted_names:
-                            flush_print(f"    Unrouted nets: {', '.join(unrouted_names)}")
+                            flush_print(
+                                f"    Unrouted nets: {', '.join(unrouted_names)}"
+                            )
                         if partial_names:
-                            flush_print(f"    Partially routed nets: {', '.join(partial_names)}")
+                            flush_print(
+                                f"    Partially routed nets: {', '.join(partial_names)}"
+                            )
                     break
 
                 # Issue #2388: Early-abort heuristic for power-net stalls.
@@ -4715,10 +4738,13 @@ class Autorouter:
                     and len(overflow_history) >= 2
                     and overflow_history[-1] == overflow_history[-2]
                     and all(
-                        self._is_pour_net(n) or self._is_power_net_by_class(n) for n in stalled_nets
+                        self._is_pour_net(n) or self._is_power_net_by_class(n)
+                        for n in stalled_nets
                     )
                 ):
-                    stall_names = sorted(self.net_names.get(n, f"Net_{n}") for n in stalled_nets)
+                    stall_names = sorted(
+                        self.net_names.get(n, f"Net_{n}") for n in stalled_nets
+                    )
                     self.power_stall_abort = True
                     self.power_stall_nets = stall_names
                     flush_print(
@@ -4726,7 +4752,9 @@ class Autorouter:
                         f"net(s) are all power/pour nets and overflow has plateaued "
                         f"at {overflow_history[-1]}."
                     )
-                    flush_print(f"  Stalled nets: {', '.join(stall_names)}")
+                    flush_print(
+                        f"  Stalled nets: {', '.join(stall_names)}"
+                    )
                     flush_print(
                         "  Aborting iteration loop to avoid spin-wait. "
                         "Try --auto-layers (dedicated planes) or "
@@ -4768,7 +4796,9 @@ class Autorouter:
                         # are still marked, and ``_route_net_negotiated`` will
                         # build a duplicate Steiner tree on top of stale routes.
                         if failed_net in net_routes and net_routes[failed_net]:
-                            neg_router.rip_up_nets([failed_net], net_routes, self.routes)
+                            neg_router.rip_up_nets(
+                                [failed_net], net_routes, self.routes
+                            )
 
                         # Find which nets are blocking by checking pad connections
                         blocking_nets: set[int] = set()
@@ -4827,12 +4857,7 @@ class Autorouter:
                             # direct path but still prevent routing via clearance/congestion.
                             # Try ripping up ALL routed nets and re-routing failed net first.
                             routed_nets = list(net_routes.keys())
-                            if (
-                                routed_nets
-                                and iteration <= 2
-                                and not full_reorder_used_this_iter
-                                and not hotset_only
-                            ):  # Try in first few iterations
+                            if routed_nets and iteration <= 2 and not full_reorder_used_this_iter and not hotset_only:  # Try in first few iterations
                                 print(
                                     f"    No direct blockers found - trying full reorder for net {failed_net}"
                                 )
@@ -4928,18 +4953,12 @@ class Autorouter:
                     # Issue #2274: Neighborhood rip-up when stalled with 0
                     # overflow but unrouted nets remain.
                     still_unrouted_targeted = [
-                        n
-                        for n in net_order
+                        n for n in net_order
                         if (n not in net_routes or not net_routes.get(n))
                         and n in pads_by_net
                         and n not in off_grid_nets
                     ]
-                    if (
-                        overflow == 0
-                        and still_unrouted_targeted
-                        and not timed_out
-                        and not hotset_only
-                    ):
+                    if overflow == 0 and still_unrouted_targeted and not timed_out and not hotset_only:
                         # Track stall progression
                         current_routed = len(net_routes)
                         if current_routed <= prev_routed_count:
@@ -5008,9 +5027,7 @@ class Autorouter:
                             )
 
                         print(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
-                        print(
-                            f"    Attempting escape strategies starting from {escape_strategy_index + 1}..."
-                        )
+                        print(f"    Attempting escape strategies starting from {escape_strategy_index + 1}...")
 
                         def mark_route_targeted(route: Route) -> None:
                             self._mark_route(route)
@@ -5043,9 +5060,7 @@ class Autorouter:
                             overflow_history[-1] = new_overflow
                             overused = self.grid.find_overused_cells()
                         else:
-                            print(
-                                f"    All {tried} escape strategies exhausted without improvement"
-                            )
+                            print(f"    All {tried} escape strategies exhausted without improvement")
 
                     # Skip common code since targeted ripup handles everything
                     # (convergence and oscillation already checked above)
@@ -5121,7 +5136,9 @@ class Autorouter:
                     flush_print(
                         f"  Rerouted {rerouted_count}/{len(nets_to_reroute)} nets, overflow: {overflow} ({elapsed_str()})"
                     )
-                    flush_print(f"  Progress: {len(net_routes)}/{total_nets} nets routed total")
+                    flush_print(
+                        f"  Progress: {len(net_routes)}/{total_nets} nets routed total"
+                    )
 
                     # Issue #2265: When overflow is 0 but nets remain unrouted,
                     # the standard rip-up path only re-attempts failed nets without
@@ -5133,8 +5150,7 @@ class Autorouter:
                     # they too cannot make further progress without rip-up.
                     partial_failed = self._get_partially_routed_nets(net_routes, pads_by_net)
                     still_failed = [
-                        n
-                        for n in net_order
+                        n for n in net_order
                         if (
                             (n not in net_routes or n in partial_failed)
                             and n in pads_by_net
@@ -5179,10 +5195,8 @@ class Autorouter:
                             # may now be routed thanks to the targeted via
                             # blocker rip-up.
                             still_failed = [
-                                n
-                                for n in net_order
-                                if n not in net_routes
-                                and n in pads_by_net
+                                n for n in net_order
+                                if n not in net_routes and n in pads_by_net
                                 and n not in off_grid_nets
                             ]
 
@@ -5229,10 +5243,8 @@ class Autorouter:
                                 # Recompute still_failed for the Bresenham
                                 # fallback below.
                                 still_failed = [
-                                    n
-                                    for n in net_order
-                                    if n not in net_routes
-                                    and n in pads_by_net
+                                    n for n in net_order
+                                    if n not in net_routes and n in pads_by_net
                                     and n not in off_grid_nets
                                 ]
 
@@ -5271,7 +5283,9 @@ class Autorouter:
                             # to zero routed segments.
                             if blocking_nets:
                                 if failed_net in net_routes and net_routes[failed_net]:
-                                    neg_router.rip_up_nets([failed_net], net_routes, self.routes)
+                                    neg_router.rip_up_nets(
+                                        [failed_net], net_routes, self.routes
+                                    )
 
                                 def _mark_route_fallback(route: Route) -> None:
                                     self._mark_route(route)
@@ -5300,8 +5314,7 @@ class Autorouter:
                     # targeted fallback was insufficient and nets remain stalled.
                     # Issue #2333: Skip in hotset-only mode.
                     still_unrouted_std = [
-                        n
-                        for n in net_order
+                        n for n in net_order
                         if (n not in net_routes or not net_routes.get(n))
                         and n in pads_by_net
                         and n not in off_grid_nets
@@ -5405,9 +5418,7 @@ class Autorouter:
                         )
 
                     print(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
-                    print(
-                        f"    Attempting escape strategies starting from {escape_strategy_index + 1}..."
-                    )
+                    print(f"    Attempting escape strategies starting from {escape_strategy_index + 1}...")
 
                     def mark_route(route: Route) -> None:
                         self._mark_route(route)
@@ -5577,12 +5588,12 @@ class Autorouter:
         # Issue #2401: Substitute escaped pads with virtual pads at escape
         # endpoints so RSMT + A* route between escape endpoints, not original
         # pad centers.
-        pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing]
+        pad_objs = [
+            self._escape_pad_overrides.get(p, self.pads[p])
+            for p in pads_for_routing
+        ]
         neg_router = NegotiatedRouter(
-            self.grid,
-            self.router,
-            self.rules,
-            self.net_class_map,
+            self.grid, self.router, self.rules, self.net_class_map,
             congestion_estimator=self._ensure_congestion_estimator(),
         )
 
@@ -5651,9 +5662,9 @@ class Autorouter:
             # Issue #1798: Categorise violations by layer to identify
             # inner-layer congestion that needs stronger repulsion.
             inner_layer_violations = [
-                v
-                for v in seg_violations
-                if getattr(v, "layer", None) is not None and v.layer not in (Layer.F_CU, Layer.B_CU)
+                v for v in seg_violations
+                if getattr(v, "layer", None) is not None
+                and v.layer not in (Layer.F_CU, Layer.B_CU)
             ]
 
             # Collect the distinct layer names for the log message.
@@ -5680,10 +5691,7 @@ class Autorouter:
                 inner_violating_nets.add(v.obstacle_net)
 
             neg_router = NegotiatedRouter(
-                self.grid,
-                self.router,
-                self.rules,
-                self.net_class_map,
+                self.grid, self.router, self.rules, self.net_class_map,
                 congestion_estimator=self._ensure_congestion_estimator(),
             )
 
@@ -5698,7 +5706,9 @@ class Autorouter:
                 # Issue #1798: Use a higher present_factor for nets that had
                 # inner-layer violations, encouraging wider spacing.
                 net_pf = present_factor * 2.0 if net in inner_violating_nets else present_factor
-                routes = self._route_net_negotiated(net, net_pf, per_net_timeout=per_net_timeout)
+                routes = self._route_net_negotiated(
+                    net, net_pf, per_net_timeout=per_net_timeout
+                )
                 if routes:
                     net_routes[net] = routes
                     rerouted_count += 1
@@ -5741,7 +5751,9 @@ class Autorouter:
                                     self.routes.append(route)
 
             total_corrected += rerouted_count
-            flush_print(f"  Rerouted {rerouted_count}/{len(nets_to_reroute)} net(s)")
+            flush_print(
+                f"  Rerouted {rerouted_count}/{len(nets_to_reroute)} net(s)"
+            )
 
             if rerouted_count == 0:
                 # No progress -- stop trying
@@ -5755,7 +5767,6 @@ class Autorouter:
 
     def _create_two_phase_router(self) -> TwoPhaseRouter:
         """Create a TwoPhaseRouter with access to Autorouter state."""
-
         # Issue #2527: Provide a builder for ``pads_by_net`` that honours
         # ``_escape_pad_overrides`` so the two-phase router's stall-recovery
         # path sees the same virtual escape-endpoint pads the negotiated
@@ -5774,7 +5785,8 @@ class Autorouter:
                 if len(pads_for_routing) < 2:
                     continue
                 mapping[net] = [
-                    self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing
+                    self._escape_pad_overrides.get(p, self.pads[p])
+                    for p in pads_for_routing
                 ]
             return mapping
 
@@ -5851,10 +5863,7 @@ class Autorouter:
         )
 
     def _route_net_with_corridor(
-        self,
-        net: int,
-        present_cost_factor: float,
-        per_net_timeout: float | None = None,
+        self, net: int, present_cost_factor: float, per_net_timeout: float | None = None,
     ) -> list[Route]:
         """Route a single net with corridor-aware costs.
 
@@ -5893,12 +5902,12 @@ class Autorouter:
         # Issue #2401: Substitute escaped pads with virtual pads at escape
         # endpoints so RSMT + A* route between escape endpoints, not original
         # pad centers.
-        pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing]
+        pad_objs = [
+            self._escape_pad_overrides.get(p, self.pads[p])
+            for p in pads_for_routing
+        ]
         neg_router = NegotiatedRouter(
-            self.grid,
-            self.router,
-            self.rules,
-            self.net_class_map,
+            self.grid, self.router, self.rules, self.net_class_map,
             congestion_estimator=self._ensure_congestion_estimator(),
         )
 
@@ -5910,9 +5919,7 @@ class Autorouter:
 
         # Route with corridor-aware costs (negotiated router will pick up corridor costs)
         new_routes = neg_router.route_net_negotiated(
-            pad_objs,
-            present_cost_factor,
-            mark_route,
+            pad_objs, present_cost_factor, mark_route,
             per_net_timeout=per_net_timeout,
             failure_callback=record_failure,
         )
@@ -5998,7 +6005,9 @@ class Autorouter:
             self.grid.add_pad(pad, pin_pitch=pitches.get(pad.ref))
         self.routes = []
 
-    def _shuffle_within_tiers(self, net_order: list[int], promotion_rate: float = 0.0) -> list[int]:
+    def _shuffle_within_tiers(
+        self, net_order: list[int], promotion_rate: float = 0.0
+    ) -> list[int]:
         """Shuffle nets but keep priority ordering.
 
         Args:
@@ -6258,7 +6267,9 @@ class Autorouter:
             )
 
             # Feed pads from main router into block router
-            block_router.add_pads_from_autorouter(self.pads, self.nets, self.net_names)
+            block_router.add_pads_from_autorouter(
+                self.pads, self.nets, self.net_names
+            )
 
             result = block_router.route_block()
             block_results.append(result)
@@ -6276,10 +6287,7 @@ class Autorouter:
             # global routing avoids block interiors.
             min_x, min_y, max_x, max_y = block_router.bounds
             region_graph.register_block_occupancy(
-                min_x,
-                min_y,
-                max_x,
-                max_y,
+                min_x, min_y, max_x, max_y,
                 trace_count=len(result.routes),
             )
 
@@ -6302,14 +6310,23 @@ class Autorouter:
                 if pad_keys and all(k in globally_connected for k in pad_keys):
                     fully_routed_nets.add(net_id)
 
-        net_order = sorted(self.nets.keys(), key=lambda n: self._get_net_priority(n))
+        net_order = sorted(
+            self.nets.keys(), key=lambda n: self._get_net_priority(n)
+        )
         net_order = self._filter_pour_nets(net_order)
-        nets_to_route = [n for n in net_order if n != 0 and n not in fully_routed_nets]
+        nets_to_route = [
+            n for n in net_order if n != 0 and n not in fully_routed_nets
+        ]
 
-        flush_print(f"    Skipping {len(fully_routed_nets)} fully block-routed nets")
+        flush_print(
+            f"    Skipping {len(fully_routed_nets)} fully block-routed nets"
+        )
         flush_print(f"    Routing {len(nets_to_route)} remaining nets")
         if all_inter_block_nets:
-            flush_print(f"    Inter-block nets (corridor routing): {len(all_inter_block_nets)}")
+            flush_print(
+                f"    Inter-block nets (corridor routing): "
+                f"{len(all_inter_block_nets)}"
+            )
 
         # Issue #1654: Wire RegionGraph corridor costs into inter-block routing.
         # Use GlobalRouter to assign corridors for inter-block nets so that
@@ -6334,7 +6351,9 @@ class Autorouter:
                     pad_positions.append((pad_obj.x, pad_obj.y))
             assignment = global_router.route_net(net, pad_positions)
             if assignment is not None:
-                self.grid.set_corridor_preference(assignment.corridor, net, corridor_penalty)
+                self.grid.set_corridor_preference(
+                    assignment.corridor, net, corridor_penalty
+                )
                 corridor_assigned_nets.add(net)
 
         if corridor_assigned_nets:
@@ -6350,9 +6369,13 @@ class Autorouter:
         total_remaining = len(nets_to_route)
         for i, net in enumerate(nets_to_route):
             if progress_callback is not None:
-                progress = (len(block_list) + i) / (len(block_list) + total_remaining)
+                progress = (len(block_list) + i) / (
+                    len(block_list) + total_remaining
+                )
                 net_name = self.net_names.get(net, f"Net {net}")
-                if not progress_callback(progress, f"Routing {net_name}", True):
+                if not progress_callback(
+                    progress, f"Routing {net_name}", True
+                ):
                     break
 
             if net in all_inter_block_nets:
@@ -7497,9 +7520,7 @@ class Autorouter:
         """Lazy-initialize escape router."""
         if self._escape_router is None:
             self._escape_router = EscapeRouter(
-                self.grid,
-                self.rules,
-                net_class_map=self.net_class_map,
+                self.grid, self.rules, net_class_map=self.net_class_map,
                 edge_clearance=self._edge_clearance,
                 board_bounds=self._board_bbox,
                 manufacturer=getattr(self.rules, "manufacturer", None),
@@ -8257,7 +8278,8 @@ class Autorouter:
             # Issue #2401: Substitute escaped pads with virtual pads at
             # escape endpoints.
             pad_objs = [
-                self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_keys if p in self.pads
+                self._escape_pad_overrides.get(p, self.pads[p])
+                for p in pads_keys if p in self.pads
             ]
             if len(pad_objs) < 2:
                 continue
@@ -8489,14 +8511,14 @@ class Autorouter:
 
                 # Issue #2401: Substitute escaped pads with virtual pads at
                 # escape endpoints.
-                pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads]
+                pad_objs = [
+                    self._escape_pad_overrides.get(p, self.pads[p])
+                    for p in pads
+                ]
 
                 # Create negotiated router with relaxed rules
                 neg_router = NegotiatedRouter(
-                    self.grid,
-                    relaxed_router,
-                    relaxed_rules,
-                    self.net_class_map,
+                    self.grid, relaxed_router, relaxed_rules, self.net_class_map,
                     congestion_estimator=self._ensure_congestion_estimator(),
                 )
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -7,7 +7,7 @@ import math
 import os
 import random
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -48,6 +48,7 @@ from .bus_routing import BusRouter
 from .cpp_backend import CppGrid, CppPathfinder, create_hybrid_router, get_backend_info
 from .diffpair import DifferentialPair, DifferentialPairConfig, LengthMismatchWarning
 from .diffpair_length import DiffPairLengthTracker
+from .diffpair_length_tuning import DiffPairTuneResult
 from .diffpair_routing import DiffPairRouter
 from .escape import EscapeRouter, PackageInfo, is_dense_package
 from .adaptive_grid import AdaptiveGridResult, AdaptiveGridRouter
@@ -844,7 +845,7 @@ class Autorouter:
         min_pitch = float("inf")
         positions = [(p["x"], p["y"]) for p in pads]
         for i, (x1, y1) in enumerate(positions):
-            for x2, y2 in positions[i + 1:]:
+            for x2, y2 in positions[i + 1 :]:
                 dist = math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2)
                 if dist > 0.01:  # Ignore overlapping pads
                     min_pitch = min(min_pitch, dist)
@@ -997,9 +998,7 @@ class Autorouter:
                 }
             )
 
-    def _find_pads_near(
-        self, x: float, y: float, epsilon: float
-    ) -> set[tuple[str, str]]:
+    def _find_pads_near(self, x: float, y: float, epsilon: float) -> set[tuple[str, str]]:
         """Find all router pad keys within epsilon distance of (x, y).
 
         Args:
@@ -1234,10 +1233,7 @@ class Autorouter:
         # Issue #2401: Substitute escaped pads with virtual pads at escape
         # endpoints so RSMT + A* route between escape endpoints, not original
         # pad centers.
-        pad_objs = [
-            self._escape_pad_overrides.get(p, self.pads[p])
-            for p in pads_for_routing
-        ]
+        pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing]
 
         # Issue #2336: Try sub-problem pattern cache before A* search.
         # Compute a position/rotation-invariant signature and check for a
@@ -1433,7 +1429,9 @@ class Autorouter:
             # the off-grid Steiner point failure mode.
             has_off_grid = self._net_has_off_grid_pads(net)
             new_routes = mst_router.route_net(
-                pad_objs, mark_route, record_failure,
+                pad_objs,
+                mark_route,
+                record_failure,
                 use_steiner=not has_off_grid,
             )
         else:
@@ -2437,9 +2435,7 @@ class Autorouter:
     # Matrix-conflict detection and layer preference assignment (Issue #2432)
     # ------------------------------------------------------------------
 
-    def _detect_matrix_conflicts(
-        self, net_ids: list[int], threshold: int = 2
-    ) -> list[set[int]]:
+    def _detect_matrix_conflicts(self, net_ids: list[int], threshold: int = 2) -> list[set[int]]:
         """Detect groups of nets sharing multiple components (matrix topology).
 
         In a charlieplex LED matrix, nets like NODE_A through NODE_D each
@@ -2553,9 +2549,7 @@ class Autorouter:
 
         return preferences
 
-    def _inject_matrix_layer_preferences(
-        self, net_layer_prefs: dict[int, list[int]]
-    ) -> None:
+    def _inject_matrix_layer_preferences(self, net_layer_prefs: dict[int, list[int]]) -> None:
         """Inject per-net layer preferences into net_class_map overrides.
 
         Creates per-net NetClassRouting entries with ``preferred_layers``
@@ -2588,9 +2582,7 @@ class Autorouter:
             self.net_class_map[net_name] = override
 
         if net_layer_prefs:
-            names = [
-                self.net_names.get(n, f"Net {n}") for n in net_layer_prefs
-            ]
+            names = [self.net_names.get(n, f"Net {n}") for n in net_layer_prefs]
             flush_print(
                 f"  Matrix conflict: assigned layer preferences for {len(names)} net(s): {names}"
             )
@@ -2600,9 +2592,7 @@ class Autorouter:
     # _calculate_constraint_score() can boost priority for these nets.
     _matrix_conflict_nets: set[int]
 
-    def _detect_and_apply_matrix_preferences(
-        self, net_order: list[int]
-    ) -> None:
+    def _detect_and_apply_matrix_preferences(self, net_order: list[int]) -> None:
         """Detect matrix-conflicting nets and inject layer preferences.
 
         Convenience method that chains :meth:`_detect_matrix_conflicts`,
@@ -2710,7 +2700,14 @@ class Autorouter:
             noise = self._perturbation_rng.gauss(0, self._perturbation_magnitude)
             congestion_score += noise
 
-        return (priority, complexity_tier, -constraint_score, pad_count, distance, -congestion_score)
+        return (
+            priority,
+            complexity_tier,
+            -constraint_score,
+            pad_count,
+            distance,
+            -congestion_score,
+        )
 
     def _compute_mst_edges(self, net_id: int) -> list[MSTEdgeInfo]:
         """Compute MST edges for a net and return them sorted by distance.
@@ -3258,8 +3255,7 @@ class Autorouter:
         # Identify lower-priority siblings whose pads sit on the blocking
         # components.  Restrict candidates to nets that currently have
         # routes in ``net_routes``.
-        routed_net_ids = {n for n, routes in net_routes.items()
-                          if routes and n != failed_net}
+        routed_net_ids = {n for n, routes in net_routes.items() if routes and n != failed_net}
         siblings = self._find_lower_priority_siblings_on_components(
             failed_net=failed_net,
             blocking_components=blocking_components,
@@ -3319,8 +3315,7 @@ class Autorouter:
             )
         except Exception as exc:  # pragma: no cover - defensive
             flush_print(
-                f"  BLOCKED_BY_COMPONENT rip-up (negotiated) raised "
-                f"{type(exc).__name__}: {exc}"
+                f"  BLOCKED_BY_COMPONENT rip-up (negotiated) raised {type(exc).__name__}: {exc}"
             )
             return False
 
@@ -3331,9 +3326,7 @@ class Autorouter:
         if rescued:
             # Drop any stale failure entries for the rescued net so the
             # summary output reflects the rescued state.
-            self.routing_failures = [
-                f for f in self.routing_failures if f.net != failed_net
-            ]
+            self.routing_failures = [f for f in self.routing_failures if f.net != failed_net]
         elif not success:
             flush_print(
                 f"  BLOCKED_BY_COMPONENT rip-up (negotiated) for {failed_name}: "
@@ -3482,10 +3475,7 @@ class Autorouter:
 
         # Issue #2401: Substitute escaped pads with virtual pads at escape
         # endpoints.
-        pad_objs = [
-            self._escape_pad_overrides.get(p, self.pads[p])
-            for p in pads_for_routing
-        ]
+        pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing]
 
         # Route MST edges in order (shortest first)
         # The mst_edges contain indices into the original pad list
@@ -4003,7 +3993,10 @@ class Autorouter:
         total_nets = len(net_order)
 
         neg_router = NegotiatedRouter(
-            self.grid, self.router, self.rules, self.net_class_map,
+            self.grid,
+            self.router,
+            self.rules,
+            self.net_class_map,
             congestion_estimator=self._ensure_congestion_estimator(),
         )
 
@@ -4038,7 +4031,10 @@ class Autorouter:
                 # Update router to use new grid
                 self.router.grid = self.grid
                 neg_router = NegotiatedRouter(
-                    self.grid, self.router, self.rules, self.net_class_map,
+                    self.grid,
+                    self.router,
+                    self.rules,
+                    self.net_class_map,
                     congestion_estimator=self._ensure_congestion_estimator(),
                 )
 
@@ -4101,8 +4097,7 @@ class Autorouter:
                     # Issue #2401: Substitute escaped pads with virtual pads
                     # at escape endpoints.
                     pads_by_net[net] = [
-                        self._escape_pad_overrides.get(p, self.pads[p])
-                        for p in pads_for_routing
+                        self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing
                     ]
                 else:
                     single_pad_nets.add(net)
@@ -4280,7 +4275,9 @@ class Autorouter:
                 # perturbation has already been active for 3+ iterations
                 # without finding a new best.
                 unrouted = total_nets - len(net_routes)
-                if adaptive and should_terminate_early(overflow_history, iteration, unrouted_count=unrouted):
+                if adaptive and should_terminate_early(
+                    overflow_history, iteration, unrouted_count=unrouted
+                ):
                     if perturbation and perturbation_stagnation_count < 3:
                         # Activate perturbation instead of terminating
                         perturbation_stagnation_count += 1
@@ -4298,15 +4295,12 @@ class Autorouter:
                             for n in net_order
                             if n not in net_routes and n in pads_by_net
                         )
-                        partial_at_term = self._get_partially_routed_nets(
-                            net_routes, pads_by_net
-                        )
+                        partial_at_term = self._get_partially_routed_nets(net_routes, pads_by_net)
                         partial_names = sorted(
                             self.net_names.get(n, f"Net_{n}") for n in partial_at_term
                         )
                         full_routed = sum(
-                            1 for n, r in net_routes.items()
-                            if r and n not in partial_at_term
+                            1 for n, r in net_routes.items() if r and n not in partial_at_term
                         )
                         print(f"\n  ⚠ Early termination: no progress detected ({elapsed_str()})")
                         print(f"    Overflow history: {overflow_history[-5:]}")
@@ -4355,7 +4349,10 @@ class Autorouter:
                     )
                     # Adaptive present cost based on iteration and congestion
                     present_factor = calculate_present_cost(
-                        iteration, max_iterations, overflow_ratio, initial_present_factor,
+                        iteration,
+                        max_iterations,
+                        overflow_ratio,
+                        initial_present_factor,
                         exponential=exponential_cost,
                         pres_fac_mult=iter_pres_fac_mult,
                         pres_fac_cap=pres_fac_cap,
@@ -4379,9 +4376,7 @@ class Autorouter:
                 # Issue #2334: Re-sort net order when perturbation is active
                 # so the rip-up iterations explore different orderings.
                 if self._perturbation_magnitude > 0:
-                    net_order = sorted(
-                        net_order, key=lambda n: self._get_net_priority(n)
-                    )
+                    net_order = sorted(net_order, key=lambda n: self._get_net_priority(n))
 
                 nets_to_reroute = neg_router.find_nets_through_overused_cells(net_routes, overused)
 
@@ -4396,9 +4391,7 @@ class Autorouter:
                 failed_nets_to_recover = [
                     n
                     for n in net_order
-                    if n not in net_routes
-                    and n not in single_pad_nets
-                    and n not in off_grid_nets
+                    if n not in net_routes and n not in single_pad_nets and n not in off_grid_nets
                 ]
                 if failed_nets_to_recover:
                     # Add failed nets to reroute list if not already present
@@ -4416,15 +4409,14 @@ class Autorouter:
                 partial_nets = self._get_partially_routed_nets(net_routes, pads_by_net)
                 if partial_nets:
                     new_partial = [
-                        n for n in partial_nets
+                        n
+                        for n in partial_nets
                         if n not in nets_to_reroute and n not in off_grid_nets
                     ]
                     if new_partial:
                         for partial_net in new_partial:
                             nets_to_reroute.append(partial_net)
-                        partial_names = [
-                            self.net_names.get(n, f"Net_{n}") for n in new_partial
-                        ]
+                        partial_names = [self.net_names.get(n, f"Net_{n}") for n in new_partial]
                         flush_print(
                             f"  Including {len(new_partial)} partially routed net(s) "
                             f"in recovery: {', '.join(partial_names)}"
@@ -4462,15 +4454,14 @@ class Autorouter:
 
                 # Filter out stalled nets
                 newly_stalled = [
-                    n for n in nets_to_reroute
+                    n
+                    for n in nets_to_reroute
                     if net_ripup_stall.get(n, 0) >= max_net_stall_iterations
                     and n not in stalled_nets
                 ]
                 if newly_stalled:
                     stalled_nets.update(newly_stalled)
-                    stalled_names = [
-                        self.net_names.get(n, f"Net_{n}") for n in newly_stalled
-                    ]
+                    stalled_names = [self.net_names.get(n, f"Net_{n}") for n in newly_stalled]
                     flush_print(
                         f"  Excluding {len(newly_stalled)} stalled net(s) from rip-up: "
                         f"{', '.join(stalled_names)}"
@@ -4516,9 +4507,8 @@ class Autorouter:
                     # Same set OR subsequent cohorts are a subset of base
                     # (handles the case where some nets get marked stalled
                     # mid-window but the active subset stabilises).
-                    cohorts_stable = (
-                        bool(base_cohort)
-                        and all(c <= base_cohort and c for c in recent_cohorts)
+                    cohorts_stable = bool(base_cohort) and all(
+                        c <= base_cohort and c for c in recent_cohorts
                     )
                     overflow_stable = False
                     if len(overflow_history) >= cohort_stagnation_window:
@@ -4615,9 +4605,7 @@ class Autorouter:
                                 nets_to_reroute.append(fn)
 
                 if stalled_nets:
-                    nets_to_reroute = [
-                        n for n in nets_to_reroute if n not in stalled_nets
-                    ]
+                    nets_to_reroute = [n for n in nets_to_reroute if n not in stalled_nets]
 
                 # Issue #2396: When overflow is 0 but nets remain unrouted,
                 # the rip-up loop has no overflow signal to act on.  Force
@@ -4625,11 +4613,7 @@ class Autorouter:
                 # present_factor to encourage exploration of alternative
                 # paths.  This directly addresses the 4L 3/8 plateau
                 # observed in board 04.
-                if (
-                    current_overflow == 0
-                    and failed_net_ids
-                    and not timed_out
-                ):
+                if current_overflow == 0 and failed_net_ids and not timed_out:
                     recovery_factor = max(present_factor * 2.0, initial_present_factor * 4.0)
                     recovered = 0
                     attempted = 0
@@ -4703,9 +4687,7 @@ class Autorouter:
                             for n in net_order
                             if n not in net_routes and n in pads_by_net
                         )
-                        partial_at_term = self._get_partially_routed_nets(
-                            net_routes, pads_by_net
-                        )
+                        partial_at_term = self._get_partially_routed_nets(net_routes, pads_by_net)
                         partial_names = sorted(
                             self.net_names.get(n, f"Net_{n}") for n in partial_at_term
                         )
@@ -4714,13 +4696,9 @@ class Autorouter:
                             f"{iteration}/{max_iterations} ({elapsed_str()})"
                         )
                         if unrouted_names:
-                            flush_print(
-                                f"    Unrouted nets: {', '.join(unrouted_names)}"
-                            )
+                            flush_print(f"    Unrouted nets: {', '.join(unrouted_names)}")
                         if partial_names:
-                            flush_print(
-                                f"    Partially routed nets: {', '.join(partial_names)}"
-                            )
+                            flush_print(f"    Partially routed nets: {', '.join(partial_names)}")
                     break
 
                 # Issue #2388: Early-abort heuristic for power-net stalls.
@@ -4737,13 +4715,10 @@ class Autorouter:
                     and len(overflow_history) >= 2
                     and overflow_history[-1] == overflow_history[-2]
                     and all(
-                        self._is_pour_net(n) or self._is_power_net_by_class(n)
-                        for n in stalled_nets
+                        self._is_pour_net(n) or self._is_power_net_by_class(n) for n in stalled_nets
                     )
                 ):
-                    stall_names = sorted(
-                        self.net_names.get(n, f"Net_{n}") for n in stalled_nets
-                    )
+                    stall_names = sorted(self.net_names.get(n, f"Net_{n}") for n in stalled_nets)
                     self.power_stall_abort = True
                     self.power_stall_nets = stall_names
                     flush_print(
@@ -4751,9 +4726,7 @@ class Autorouter:
                         f"net(s) are all power/pour nets and overflow has plateaued "
                         f"at {overflow_history[-1]}."
                     )
-                    flush_print(
-                        f"  Stalled nets: {', '.join(stall_names)}"
-                    )
+                    flush_print(f"  Stalled nets: {', '.join(stall_names)}")
                     flush_print(
                         "  Aborting iteration loop to avoid spin-wait. "
                         "Try --auto-layers (dedicated planes) or "
@@ -4795,9 +4768,7 @@ class Autorouter:
                         # are still marked, and ``_route_net_negotiated`` will
                         # build a duplicate Steiner tree on top of stale routes.
                         if failed_net in net_routes and net_routes[failed_net]:
-                            neg_router.rip_up_nets(
-                                [failed_net], net_routes, self.routes
-                            )
+                            neg_router.rip_up_nets([failed_net], net_routes, self.routes)
 
                         # Find which nets are blocking by checking pad connections
                         blocking_nets: set[int] = set()
@@ -4856,7 +4827,12 @@ class Autorouter:
                             # direct path but still prevent routing via clearance/congestion.
                             # Try ripping up ALL routed nets and re-routing failed net first.
                             routed_nets = list(net_routes.keys())
-                            if routed_nets and iteration <= 2 and not full_reorder_used_this_iter and not hotset_only:  # Try in first few iterations
+                            if (
+                                routed_nets
+                                and iteration <= 2
+                                and not full_reorder_used_this_iter
+                                and not hotset_only
+                            ):  # Try in first few iterations
                                 print(
                                     f"    No direct blockers found - trying full reorder for net {failed_net}"
                                 )
@@ -4952,12 +4928,18 @@ class Autorouter:
                     # Issue #2274: Neighborhood rip-up when stalled with 0
                     # overflow but unrouted nets remain.
                     still_unrouted_targeted = [
-                        n for n in net_order
+                        n
+                        for n in net_order
                         if (n not in net_routes or not net_routes.get(n))
                         and n in pads_by_net
                         and n not in off_grid_nets
                     ]
-                    if overflow == 0 and still_unrouted_targeted and not timed_out and not hotset_only:
+                    if (
+                        overflow == 0
+                        and still_unrouted_targeted
+                        and not timed_out
+                        and not hotset_only
+                    ):
                         # Track stall progression
                         current_routed = len(net_routes)
                         if current_routed <= prev_routed_count:
@@ -5026,7 +5008,9 @@ class Autorouter:
                             )
 
                         print(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
-                        print(f"    Attempting escape strategies starting from {escape_strategy_index + 1}...")
+                        print(
+                            f"    Attempting escape strategies starting from {escape_strategy_index + 1}..."
+                        )
 
                         def mark_route_targeted(route: Route) -> None:
                             self._mark_route(route)
@@ -5059,7 +5043,9 @@ class Autorouter:
                             overflow_history[-1] = new_overflow
                             overused = self.grid.find_overused_cells()
                         else:
-                            print(f"    All {tried} escape strategies exhausted without improvement")
+                            print(
+                                f"    All {tried} escape strategies exhausted without improvement"
+                            )
 
                     # Skip common code since targeted ripup handles everything
                     # (convergence and oscillation already checked above)
@@ -5135,9 +5121,7 @@ class Autorouter:
                     flush_print(
                         f"  Rerouted {rerouted_count}/{len(nets_to_reroute)} nets, overflow: {overflow} ({elapsed_str()})"
                     )
-                    flush_print(
-                        f"  Progress: {len(net_routes)}/{total_nets} nets routed total"
-                    )
+                    flush_print(f"  Progress: {len(net_routes)}/{total_nets} nets routed total")
 
                     # Issue #2265: When overflow is 0 but nets remain unrouted,
                     # the standard rip-up path only re-attempts failed nets without
@@ -5149,7 +5133,8 @@ class Autorouter:
                     # they too cannot make further progress without rip-up.
                     partial_failed = self._get_partially_routed_nets(net_routes, pads_by_net)
                     still_failed = [
-                        n for n in net_order
+                        n
+                        for n in net_order
                         if (
                             (n not in net_routes or n in partial_failed)
                             and n in pads_by_net
@@ -5194,8 +5179,10 @@ class Autorouter:
                             # may now be routed thanks to the targeted via
                             # blocker rip-up.
                             still_failed = [
-                                n for n in net_order
-                                if n not in net_routes and n in pads_by_net
+                                n
+                                for n in net_order
+                                if n not in net_routes
+                                and n in pads_by_net
                                 and n not in off_grid_nets
                             ]
 
@@ -5242,8 +5229,10 @@ class Autorouter:
                                 # Recompute still_failed for the Bresenham
                                 # fallback below.
                                 still_failed = [
-                                    n for n in net_order
-                                    if n not in net_routes and n in pads_by_net
+                                    n
+                                    for n in net_order
+                                    if n not in net_routes
+                                    and n in pads_by_net
                                     and n not in off_grid_nets
                                 ]
 
@@ -5282,9 +5271,7 @@ class Autorouter:
                             # to zero routed segments.
                             if blocking_nets:
                                 if failed_net in net_routes and net_routes[failed_net]:
-                                    neg_router.rip_up_nets(
-                                        [failed_net], net_routes, self.routes
-                                    )
+                                    neg_router.rip_up_nets([failed_net], net_routes, self.routes)
 
                                 def _mark_route_fallback(route: Route) -> None:
                                     self._mark_route(route)
@@ -5313,7 +5300,8 @@ class Autorouter:
                     # targeted fallback was insufficient and nets remain stalled.
                     # Issue #2333: Skip in hotset-only mode.
                     still_unrouted_std = [
-                        n for n in net_order
+                        n
+                        for n in net_order
                         if (n not in net_routes or not net_routes.get(n))
                         and n in pads_by_net
                         and n not in off_grid_nets
@@ -5417,7 +5405,9 @@ class Autorouter:
                         )
 
                     print(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
-                    print(f"    Attempting escape strategies starting from {escape_strategy_index + 1}...")
+                    print(
+                        f"    Attempting escape strategies starting from {escape_strategy_index + 1}..."
+                    )
 
                     def mark_route(route: Route) -> None:
                         self._mark_route(route)
@@ -5587,12 +5577,12 @@ class Autorouter:
         # Issue #2401: Substitute escaped pads with virtual pads at escape
         # endpoints so RSMT + A* route between escape endpoints, not original
         # pad centers.
-        pad_objs = [
-            self._escape_pad_overrides.get(p, self.pads[p])
-            for p in pads_for_routing
-        ]
+        pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing]
         neg_router = NegotiatedRouter(
-            self.grid, self.router, self.rules, self.net_class_map,
+            self.grid,
+            self.router,
+            self.rules,
+            self.net_class_map,
             congestion_estimator=self._ensure_congestion_estimator(),
         )
 
@@ -5661,9 +5651,9 @@ class Autorouter:
             # Issue #1798: Categorise violations by layer to identify
             # inner-layer congestion that needs stronger repulsion.
             inner_layer_violations = [
-                v for v in seg_violations
-                if getattr(v, "layer", None) is not None
-                and v.layer not in (Layer.F_CU, Layer.B_CU)
+                v
+                for v in seg_violations
+                if getattr(v, "layer", None) is not None and v.layer not in (Layer.F_CU, Layer.B_CU)
             ]
 
             # Collect the distinct layer names for the log message.
@@ -5690,7 +5680,10 @@ class Autorouter:
                 inner_violating_nets.add(v.obstacle_net)
 
             neg_router = NegotiatedRouter(
-                self.grid, self.router, self.rules, self.net_class_map,
+                self.grid,
+                self.router,
+                self.rules,
+                self.net_class_map,
                 congestion_estimator=self._ensure_congestion_estimator(),
             )
 
@@ -5705,9 +5698,7 @@ class Autorouter:
                 # Issue #1798: Use a higher present_factor for nets that had
                 # inner-layer violations, encouraging wider spacing.
                 net_pf = present_factor * 2.0 if net in inner_violating_nets else present_factor
-                routes = self._route_net_negotiated(
-                    net, net_pf, per_net_timeout=per_net_timeout
-                )
+                routes = self._route_net_negotiated(net, net_pf, per_net_timeout=per_net_timeout)
                 if routes:
                     net_routes[net] = routes
                     rerouted_count += 1
@@ -5750,9 +5741,7 @@ class Autorouter:
                                     self.routes.append(route)
 
             total_corrected += rerouted_count
-            flush_print(
-                f"  Rerouted {rerouted_count}/{len(nets_to_reroute)} net(s)"
-            )
+            flush_print(f"  Rerouted {rerouted_count}/{len(nets_to_reroute)} net(s)")
 
             if rerouted_count == 0:
                 # No progress -- stop trying
@@ -5766,6 +5755,7 @@ class Autorouter:
 
     def _create_two_phase_router(self) -> TwoPhaseRouter:
         """Create a TwoPhaseRouter with access to Autorouter state."""
+
         # Issue #2527: Provide a builder for ``pads_by_net`` that honours
         # ``_escape_pad_overrides`` so the two-phase router's stall-recovery
         # path sees the same virtual escape-endpoint pads the negotiated
@@ -5784,8 +5774,7 @@ class Autorouter:
                 if len(pads_for_routing) < 2:
                     continue
                 mapping[net] = [
-                    self._escape_pad_overrides.get(p, self.pads[p])
-                    for p in pads_for_routing
+                    self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing
                 ]
             return mapping
 
@@ -5862,7 +5851,10 @@ class Autorouter:
         )
 
     def _route_net_with_corridor(
-        self, net: int, present_cost_factor: float, per_net_timeout: float | None = None,
+        self,
+        net: int,
+        present_cost_factor: float,
+        per_net_timeout: float | None = None,
     ) -> list[Route]:
         """Route a single net with corridor-aware costs.
 
@@ -5901,12 +5893,12 @@ class Autorouter:
         # Issue #2401: Substitute escaped pads with virtual pads at escape
         # endpoints so RSMT + A* route between escape endpoints, not original
         # pad centers.
-        pad_objs = [
-            self._escape_pad_overrides.get(p, self.pads[p])
-            for p in pads_for_routing
-        ]
+        pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing]
         neg_router = NegotiatedRouter(
-            self.grid, self.router, self.rules, self.net_class_map,
+            self.grid,
+            self.router,
+            self.rules,
+            self.net_class_map,
             congestion_estimator=self._ensure_congestion_estimator(),
         )
 
@@ -5918,7 +5910,9 @@ class Autorouter:
 
         # Route with corridor-aware costs (negotiated router will pick up corridor costs)
         new_routes = neg_router.route_net_negotiated(
-            pad_objs, present_cost_factor, mark_route,
+            pad_objs,
+            present_cost_factor,
+            mark_route,
             per_net_timeout=per_net_timeout,
             failure_callback=record_failure,
         )
@@ -6004,9 +5998,7 @@ class Autorouter:
             self.grid.add_pad(pad, pin_pitch=pitches.get(pad.ref))
         self.routes = []
 
-    def _shuffle_within_tiers(
-        self, net_order: list[int], promotion_rate: float = 0.0
-    ) -> list[int]:
+    def _shuffle_within_tiers(self, net_order: list[int], promotion_rate: float = 0.0) -> list[int]:
         """Shuffle nets but keep priority ordering.
 
         Args:
@@ -6266,9 +6258,7 @@ class Autorouter:
             )
 
             # Feed pads from main router into block router
-            block_router.add_pads_from_autorouter(
-                self.pads, self.nets, self.net_names
-            )
+            block_router.add_pads_from_autorouter(self.pads, self.nets, self.net_names)
 
             result = block_router.route_block()
             block_results.append(result)
@@ -6286,7 +6276,10 @@ class Autorouter:
             # global routing avoids block interiors.
             min_x, min_y, max_x, max_y = block_router.bounds
             region_graph.register_block_occupancy(
-                min_x, min_y, max_x, max_y,
+                min_x,
+                min_y,
+                max_x,
+                max_y,
                 trace_count=len(result.routes),
             )
 
@@ -6309,23 +6302,14 @@ class Autorouter:
                 if pad_keys and all(k in globally_connected for k in pad_keys):
                     fully_routed_nets.add(net_id)
 
-        net_order = sorted(
-            self.nets.keys(), key=lambda n: self._get_net_priority(n)
-        )
+        net_order = sorted(self.nets.keys(), key=lambda n: self._get_net_priority(n))
         net_order = self._filter_pour_nets(net_order)
-        nets_to_route = [
-            n for n in net_order if n != 0 and n not in fully_routed_nets
-        ]
+        nets_to_route = [n for n in net_order if n != 0 and n not in fully_routed_nets]
 
-        flush_print(
-            f"    Skipping {len(fully_routed_nets)} fully block-routed nets"
-        )
+        flush_print(f"    Skipping {len(fully_routed_nets)} fully block-routed nets")
         flush_print(f"    Routing {len(nets_to_route)} remaining nets")
         if all_inter_block_nets:
-            flush_print(
-                f"    Inter-block nets (corridor routing): "
-                f"{len(all_inter_block_nets)}"
-            )
+            flush_print(f"    Inter-block nets (corridor routing): {len(all_inter_block_nets)}")
 
         # Issue #1654: Wire RegionGraph corridor costs into inter-block routing.
         # Use GlobalRouter to assign corridors for inter-block nets so that
@@ -6350,9 +6334,7 @@ class Autorouter:
                     pad_positions.append((pad_obj.x, pad_obj.y))
             assignment = global_router.route_net(net, pad_positions)
             if assignment is not None:
-                self.grid.set_corridor_preference(
-                    assignment.corridor, net, corridor_penalty
-                )
+                self.grid.set_corridor_preference(assignment.corridor, net, corridor_penalty)
                 corridor_assigned_nets.add(net)
 
         if corridor_assigned_nets:
@@ -6368,13 +6350,9 @@ class Autorouter:
         total_remaining = len(nets_to_route)
         for i, net in enumerate(nets_to_route):
             if progress_callback is not None:
-                progress = (len(block_list) + i) / (
-                    len(block_list) + total_remaining
-                )
+                progress = (len(block_list) + i) / (len(block_list) + total_remaining)
                 net_name = self.net_names.get(net, f"Net {net}")
-                if not progress_callback(
-                    progress, f"Routing {net_name}", True
-                ):
+                if not progress_callback(progress, f"Routing {net_name}", True):
                     break
 
             if net in all_inter_block_nets:
@@ -7014,6 +6992,135 @@ class Autorouter:
             verbose=verbose,
         )
 
+    def apply_diffpair_length_tuning(
+        self,
+        detected_pairs: list,
+        verbose: bool = True,
+    ) -> dict[tuple[str, str], DiffPairTuneResult]:
+        """Apply per-pair length-match (skew) tuning to detected diff pairs.
+
+        Sibling to :meth:`apply_length_tuning` (Issue #2648, Epic #2556
+        Phase 3I).  For each detected pair whose net class is flagged
+        ``length_critical=True`` AND whose measured skew exceeds the
+        per-class ``effective_skew_tolerance``, attempt up to N=3
+        serpentine insertions on the shorter half until the skew is
+        within tolerance.  Outer-normal-only bulges; per-insertion DRC
+        self-check with byte-for-byte rollback.
+
+        Args:
+            detected_pairs: List of
+                :class:`~kicad_tools.router.diffpair_detection.DetectedPair`
+                objects from
+                :func:`~kicad_tools.router.diffpair_detection.detect_diff_pairs`.
+                Pairs whose net class is not length-critical are skipped
+                in-place via the engagement gate.
+            verbose: Whether to print progress information.
+
+        Returns:
+            ``{(p_net_name, n_net_name): DiffPairTuneResult}`` for each
+            pair processed (including those skipped by the engagement
+            gate -- the result's ``reason`` discriminates).
+        """
+        from .diffpair_length_tuning import tune_diff_pair_skew
+
+        results: dict[tuple[str, str], DiffPairTuneResult] = {}
+
+        # Build routes_by_net lookup from the autorouter's current state.
+        routes_by_net: dict[int, Route] = {r.net: r for r in self.routes}
+
+        # Update the skew tracker so the post-tuning results are queryable.
+        # Use the layer-stack count when available, else default to 2.
+        if self.layer_stack is not None:
+            num_layers = len(self.layer_stack.layers)
+        else:
+            num_layers = 2
+        self._diffpair_length_tracker.record_routes(
+            routes=self.routes,
+            detected_pairs=detected_pairs,
+            num_copper_layers=num_layers,
+        )
+
+        for dp in detected_pairs:
+            # Default per-class info.  When a net class is not configured for
+            # this pair (the common synthetic-test case) the tuner is
+            # invoked with the module-level default tolerance and the
+            # tolerance is matched against the manufacturer minimum
+            # clearance.
+            tolerance_mm = 0.5
+            intra_pair_clearance_mm = self.rules.trace_clearance
+            length_critical = True
+
+            p_name = dp.pair.positive.net_name
+            n_name = dp.pair.negative.net_name
+            net_class = self._resolve_net_class_for_pair(dp)
+            if net_class is not None:
+                tolerance_mm = net_class.effective_skew_tolerance(0.5)
+                intra_pair_clearance_mm = net_class.effective_intra_pair_clearance()
+                length_critical = net_class.length_critical
+
+            p_route, n_route, result = tune_diff_pair_skew(
+                dp,
+                routes_by_net,
+                tolerance_mm=tolerance_mm,
+                intra_pair_clearance_mm=intra_pair_clearance_mm,
+                length_critical=length_critical,
+            )
+
+            # Commit any new Route references back into self.routes and the
+            # working ``routes_by_net`` map so the next pair's neighbor
+            # self-check sees the updated geometry.
+            if p_route is not None and dp.pair.positive.net_id in routes_by_net:
+                if p_route is not routes_by_net[dp.pair.positive.net_id]:
+                    routes_by_net[dp.pair.positive.net_id] = p_route
+                    for i, r in enumerate(self.routes):
+                        if r.net == dp.pair.positive.net_id:
+                            self.routes[i] = p_route
+                            break
+            if n_route is not None and dp.pair.negative.net_id in routes_by_net:
+                if n_route is not routes_by_net[dp.pair.negative.net_id]:
+                    routes_by_net[dp.pair.negative.net_id] = n_route
+                    for i, r in enumerate(self.routes):
+                        if r.net == dp.pair.negative.net_id:
+                            self.routes[i] = n_route
+                            break
+
+            results[(p_name, n_name)] = result
+
+            if verbose:
+                summary = f"  {p_name}/{n_name}: {result.reason}"
+                if result.inserts_applied:
+                    summary += (
+                        f" ({result.inserts_applied} inserts, "
+                        f"skew {result.skew_before_mm:.3f}mm -> "
+                        f"{result.skew_after_mm:.3f}mm)"
+                    )
+                print(summary)
+
+        # Refresh the skew tracker after tuning so downstream consumers
+        # (e.g. the Phase 3J DRC rule) see the updated lengths.
+        self._diffpair_length_tracker.record_routes(
+            routes=self.routes,
+            detected_pairs=detected_pairs,
+            num_copper_layers=num_layers,
+        )
+        return results
+
+    def _resolve_net_class_for_pair(self, detected_pair) -> Any | None:
+        """Best-effort lookup of the NetClassRouting for a detected pair.
+
+        Returns the NetClassRouting keyed by the positive net name in
+        ``self.net_class_map`` (the diff-pair convention is that both
+        halves share the same class).  When the positive net is not in
+        the class map (e.g. synthetic-test boards that don't configure
+        net classes), returns ``None`` and the caller falls back to
+        default thresholds.
+        """
+        net_class_map = getattr(self, "net_class_map", None) or {}
+        if not net_class_map:
+            return None
+        p_name = detected_pair.pair.positive.net_name
+        return net_class_map.get(p_name)
+
     @property
     def length_tracker(self) -> LengthTracker:
         """Get the length tracker for manual inspection.
@@ -7390,7 +7497,9 @@ class Autorouter:
         """Lazy-initialize escape router."""
         if self._escape_router is None:
             self._escape_router = EscapeRouter(
-                self.grid, self.rules, net_class_map=self.net_class_map,
+                self.grid,
+                self.rules,
+                net_class_map=self.net_class_map,
                 edge_clearance=self._edge_clearance,
                 board_bounds=self._board_bbox,
                 manufacturer=getattr(self.rules, "manufacturer", None),
@@ -8148,8 +8257,7 @@ class Autorouter:
             # Issue #2401: Substitute escaped pads with virtual pads at
             # escape endpoints.
             pad_objs = [
-                self._escape_pad_overrides.get(p, self.pads[p])
-                for p in pads_keys if p in self.pads
+                self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_keys if p in self.pads
             ]
             if len(pad_objs) < 2:
                 continue
@@ -8381,14 +8489,14 @@ class Autorouter:
 
                 # Issue #2401: Substitute escaped pads with virtual pads at
                 # escape endpoints.
-                pad_objs = [
-                    self._escape_pad_overrides.get(p, self.pads[p])
-                    for p in pads
-                ]
+                pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads]
 
                 # Create negotiated router with relaxed rules
                 neg_router = NegotiatedRouter(
-                    self.grid, relaxed_router, relaxed_rules, self.net_class_map,
+                    self.grid,
+                    relaxed_router,
+                    relaxed_rules,
+                    self.net_class_map,
                     congestion_estimator=self._ensure_congestion_estimator(),
                 )
 

--- a/src/kicad_tools/router/diffpair_length_tuning.py
+++ b/src/kicad_tools/router/diffpair_length_tuning.py
@@ -141,6 +141,7 @@ def tune_diff_pair_skew(
     intra_pair_clearance_mm: float,
     config: SerpentineConfig | None = None,
     max_inserts: int = MAX_INSERTS_PER_PAIR,
+    length_critical: bool = True,
 ) -> tuple[Route, Route, DiffPairTuneResult]:
     """Tune the skew of a detected diff pair by serpentining the shorter half.
 
@@ -163,6 +164,13 @@ def tune_diff_pair_skew(
         max_inserts: Cascade-safety budget (default :data:`MAX_INSERTS_PER_PAIR`
             = 3).  The tuner stops after this many trombone attempts even
             if the pair remains out of tolerance.
+        length_critical: Engagement gate (default ``True``).  When ``False``
+            the tuner returns the pair unchanged with
+            ``reason="not_length_critical"``.  Callers that integrate from
+            the autorouter pipeline pass
+            ``net_class_routing.length_critical`` here -- pairs whose net
+            class is not flagged as length-critical are skipped, matching
+            the curator's engagement-gate spec on Issue #2648.
 
     Returns:
         ``(p_route, n_route, result)`` where ``p_route`` and ``n_route`` are
@@ -182,6 +190,25 @@ def tune_diff_pair_skew(
     """
     p_id = pair.pair.positive.net_id
     n_id = pair.pair.negative.net_id
+
+    # Engagement gate: pairs whose net class does NOT have length_critical=True
+    # are not tuned (the curator's spec on Issue #2648).
+    if not length_critical:
+        p_route = routes_by_net.get(p_id)
+        n_route = routes_by_net.get(n_id)
+        result = DiffPairTuneResult(
+            success=True,
+            reason="not_length_critical",
+            message=(
+                f"Pair {pair.pair.positive.net_name}/{pair.pair.negative.net_name} "
+                "is not length_critical; skipping tuning per engagement gate."
+            ),
+        )
+        return (
+            p_route if p_route is not None else _empty_route(p_id, pair.pair.positive.net_name),
+            n_route if n_route is not None else _empty_route(n_id, pair.pair.negative.net_name),
+            result,
+        )
 
     p_route = routes_by_net.get(p_id)
     n_route = routes_by_net.get(n_id)
@@ -208,12 +235,16 @@ def tune_diff_pair_skew(
 
     # Already within tolerance -- byte-for-byte unchanged.
     if skew <= tolerance_mm:
-        return p_route, n_route, DiffPairTuneResult(
-            success=True,
-            reason="already_within_tolerance",
-            skew_before_mm=skew,
-            skew_after_mm=skew,
-            message=f"Pair already matched: skew={skew:.4f}mm <= tol={tolerance_mm:.4f}mm",
+        return (
+            p_route,
+            n_route,
+            DiffPairTuneResult(
+                success=True,
+                reason="already_within_tolerance",
+                skew_before_mm=skew,
+                skew_after_mm=skew,
+                message=f"Pair already matched: skew={skew:.4f}mm <= tol={tolerance_mm:.4f}mm",
+            ),
         )
 
     # The shorter half gets the trombone; the longer half is the target
@@ -285,8 +316,7 @@ def tune_diff_pair_skew(
             # etc.).  Treat the same as no_suitable_segment.
             result.reason = "no_suitable_segment"
             result.message = (
-                f"Trombone generation failed on net {shorter_id}: "
-                f"{serp_result.message}"
+                f"Trombone generation failed on net {shorter_id}: {serp_result.message}"
             )
             current_shorter = original_shorter_route
             break
@@ -322,8 +352,10 @@ def tune_diff_pair_skew(
         current_shorter = candidate_route
         result.inserts_applied += 1
         new_shorter_length = LengthTracker.calculate_route_length(current_shorter)
-        current_skew = abs(new_shorter_length - target_length) if longer_is_p else abs(
-            target_length - new_shorter_length
+        current_skew = (
+            abs(new_shorter_length - target_length)
+            if longer_is_p
+            else abs(target_length - new_shorter_length)
         )
         # Both branches reduce to abs(target_length - new_shorter_length)
         current_skew = abs(target_length - new_shorter_length)
@@ -524,7 +556,7 @@ def _post_insertion_clearance_ok(
 
     # Neighbor check (all other nets).
     for other_net_id, other_route in routes_by_net.items():
-        if other_net_id == shorter_net_id or other_net_id == longer_net_id:
+        if other_net_id in (shorter_net_id, longer_net_id):
             continue
         for new_seg in new_segments:
             for oseg in other_route.segments:

--- a/src/kicad_tools/router/diffpair_length_tuning.py
+++ b/src/kicad_tools/router/diffpair_length_tuning.py
@@ -1,0 +1,580 @@
+"""Per-pair differential-pair length-match (skew) tuner.
+
+Issue #2648, Epic #2556 Phase 3I.
+
+This module implements :func:`tune_diff_pair_skew`, a router-internal
+helper that inserts serpentines (trombones) on the *shorter* half of a
+detected differential pair until the pair's skew is within the per-class
+:meth:`~kicad_tools.router.rules.NetClassRouting.effective_skew_tolerance`
+window, OR a cascade-safety budget of three insertion attempts is
+exhausted.
+
+Design notes
+============
+
+* **Outer-normal bulges only.**  Bulging the shorter half *toward* the
+  partner trace would consume intra-pair coupling room and trigger an
+  intra-pair clearance violation immediately.  The tuner therefore
+  computes the partner trace's bearing at the chosen insertion segment,
+  derives a unit outer-normal vector, and passes it to the trombone
+  generator via the new :attr:`SerpentineConfig.outer_normal_hint`
+  field (``side="outer"``).  See the
+  :func:`kicad_tools.router.optimizer.serpentine.SerpentineGenerator.generate_trombone`
+  implementation for how the hint is consumed.
+
+* **Per-insertion DRC self-check.**  The first call in the chain has no
+  collision-checking safety net -- :func:`add_serpentine` carries a
+  literal ``TODO`` for that.  This module supplies the safety net via
+  :func:`_post_insertion_clearance_ok`, which iterates the new
+  serpentine segments against every other route's segments and rejects
+  the insertion if any pair drops below the configured intra-pair
+  clearance threshold.  On rejection the tuner discards the proposed
+  ``new_route`` and returns the **original** ``route`` reference (and
+  its original ``.segments`` list reference) -- the byte-for-byte
+  rollback contract.
+
+* **Cascade-safety budget N=3.**  A single trombone insertion can fall
+  short of the target when the chosen segment is too crowded for enough
+  amplitude; the tuner therefore re-evaluates and tries again, up to a
+  bounded number of attempts.  Without this budget a near-zero-skew but
+  unreachable target (a tight via cluster) could loop forever.
+
+* **The longer half is never mutated.**  ``tune_diff_pair_skew`` only
+  touches the shorter route.  The drift-prevention regression test
+  asserts ``is``-identity on both the longer ``Route`` object and its
+  ``.segments`` list.
+
+Out of scope for Phase 3I:
+
+* Multi-segment trombone splitting (very tight boards).
+* Differential-pair coupling preservation during the bulge (today the
+  bulge is on only the shorter half; the longer half is unchanged, so
+  coupling is necessarily broken within the bulge.  Phase 3K's
+  impedance-controlled rebuild is the place to restore coupling).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .optimizer.geometry import segment_length
+from .optimizer.serpentine import (
+    SerpentineConfig,
+    SerpentineGenerator,
+    SerpentineResult,
+)
+
+if TYPE_CHECKING:
+    from .diffpair_detection import DetectedPair
+    from .primitives import Route, Segment
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DiffPairTuneResult:
+    """Outcome of a per-pair length-match tuning attempt.
+
+    Attributes:
+        success: True if the pair's skew is now within ``tolerance_mm`` AND
+            the modifications passed the post-insertion DRC self-check at
+            every attempt.  False if either no progress could be made
+            (no insertable segment, geometry too tight) or every attempt
+            failed the self-check.
+        reason: Short machine-readable reason code.  One of:
+            * ``"already_within_tolerance"`` -- the pair was already
+              acceptable; no change was made.
+            * ``"tuned"`` -- one or more trombones brought the pair into
+              tolerance.
+            * ``"exceeded_max_inserts"`` -- the cascade budget was
+              exhausted before reaching tolerance.
+            * ``"post_insertion_drc_violation"`` -- a candidate trombone
+              would violate intra-pair (or neighbor) clearance; the
+              insertion was rolled back and no further attempts were
+              made on this pair.
+            * ``"no_suitable_segment"`` -- the shorter route has no
+              segment long enough to host any trombone amplitude.
+            * ``"unrouted"`` -- one or both halves were not in
+              ``routes_by_net``.
+        attempts: Number of trombone insertions actually attempted.
+        inserts_applied: Number of trombones whose post-insertion check
+            passed and were committed.
+        skew_before_mm: Pair skew (``|L_p - L_n|``) at entry.
+        skew_after_mm: Pair skew after the (possibly empty) sequence of
+            successful insertions.
+        message: Human-readable summary.
+    """
+
+    success: bool = False
+    reason: str = ""
+    attempts: int = 0
+    inserts_applied: int = 0
+    skew_before_mm: float = 0.0
+    skew_after_mm: float = 0.0
+    message: str = ""
+    # The trombone results, kept for diagnostic / test inspection.  An
+    # entry is present for every attempt (including rejected ones).
+    serpentine_results: list[SerpentineResult] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+# Cascade-safety budget: cap the number of trombone insertions per pair.
+# Three is enough to bring most realistic skews into tolerance at a 1 mm
+# default amplitude, while keeping the worst case bounded for unreachable
+# targets (very large skew on a congested board).
+MAX_INSERTS_PER_PAIR: int = 3
+
+
+def tune_diff_pair_skew(
+    pair: DetectedPair,
+    routes_by_net: dict[int, Route],
+    *,
+    tolerance_mm: float,
+    intra_pair_clearance_mm: float,
+    config: SerpentineConfig | None = None,
+    max_inserts: int = MAX_INSERTS_PER_PAIR,
+) -> tuple[Route, Route, DiffPairTuneResult]:
+    """Tune the skew of a detected diff pair by serpentining the shorter half.
+
+    Args:
+        pair: A detected differential pair (positive + negative).
+        routes_by_net: ``{net_id: Route}`` lookup for all routed nets on the
+            board.  Used both to fetch the pair's two halves AND as the
+            corpus against which the post-insertion DRC self-check looks
+            for newly-introduced clearance violations.
+        tolerance_mm: The per-class skew tolerance from
+            :meth:`NetClassRouting.effective_skew_tolerance`.  Pair is
+            considered "matched" when ``|L_p - L_n| <= tolerance_mm``.
+        intra_pair_clearance_mm: The per-pair intra clearance threshold
+            from :meth:`NetClassRouting.effective_intra_pair_clearance`.
+            Used by the post-insertion DRC self-check to verify the new
+            segments do not violate the pair's own coupling rule.
+        config: Optional :class:`SerpentineConfig` override.  When supplied
+            its ``side`` and ``outer_normal_hint`` fields are overwritten by
+            the tuner; other fields (amplitude, gap_factor, ...) are honored.
+        max_inserts: Cascade-safety budget (default :data:`MAX_INSERTS_PER_PAIR`
+            = 3).  The tuner stops after this many trombone attempts even
+            if the pair remains out of tolerance.
+
+    Returns:
+        ``(p_route, n_route, result)`` where ``p_route`` and ``n_route`` are
+        the (possibly tuned) Route references for the positive and negative
+        halves.  The half that was *not* lengthened is returned **by
+        reference** -- the same object the caller passed in
+        ``routes_by_net`` -- with the same ``.segments`` list object.  If
+        rollback fired, BOTH halves are returned by reference.
+
+    Rollback contract:
+        When the post-insertion DRC self-check fails, the proposed new
+        Route is discarded and the original Route reference (the one in
+        ``routes_by_net``) is returned with its original ``.segments``
+        list object intact.  The test ``test_drift_prevention`` asserts
+        this contract via ``is`` identity on both the longer route and
+        its segments list.
+    """
+    p_id = pair.pair.positive.net_id
+    n_id = pair.pair.negative.net_id
+
+    p_route = routes_by_net.get(p_id)
+    n_route = routes_by_net.get(n_id)
+    if p_route is None or n_route is None:
+        result = DiffPairTuneResult(
+            success=False,
+            reason="unrouted",
+            message=(
+                f"Pair {pair.pair.positive.net_name}/{pair.pair.negative.net_name} "
+                "has an unrouted half; nothing to tune."
+            ),
+        )
+        return (
+            p_route if p_route is not None else _empty_route(p_id, pair.pair.positive.net_name),
+            n_route if n_route is not None else _empty_route(n_id, pair.pair.negative.net_name),
+            result,
+        )
+
+    from .length import LengthTracker  # avoid cycle
+
+    l_p = LengthTracker.calculate_route_length(p_route)
+    l_n = LengthTracker.calculate_route_length(n_route)
+    skew = abs(l_p - l_n)
+
+    # Already within tolerance -- byte-for-byte unchanged.
+    if skew <= tolerance_mm:
+        return p_route, n_route, DiffPairTuneResult(
+            success=True,
+            reason="already_within_tolerance",
+            skew_before_mm=skew,
+            skew_after_mm=skew,
+            message=f"Pair already matched: skew={skew:.4f}mm <= tol={tolerance_mm:.4f}mm",
+        )
+
+    # The shorter half gets the trombone; the longer half is the target
+    # length and is NEVER touched.
+    if l_p < l_n:
+        shorter_id, shorter_route, longer_id, longer_route = p_id, p_route, n_id, n_route
+        longer_is_p = False
+    else:
+        shorter_id, shorter_route, longer_id, longer_route = n_id, n_route, p_id, p_route
+        longer_is_p = True
+    target_length = max(l_p, l_n)
+    original_longer_segments = longer_route.segments  # for rollback assertion
+
+    # Snapshot the original shorter route -- we may need to roll back.
+    original_shorter_route = shorter_route
+    original_shorter_segments = shorter_route.segments
+
+    base_config = config or SerpentineConfig()
+
+    result = DiffPairTuneResult(skew_before_mm=skew)
+    current_shorter = shorter_route
+    current_skew = skew
+
+    # Cascade loop.  Each iteration: compute outer normal, attempt one
+    # trombone, run the self-check, commit or reject.
+    for attempt in range(max_inserts):
+        result.attempts = attempt + 1
+
+        # Pick the insertion segment first (shared by both the trombone
+        # generator and the outer-normal calculation).  This mirrors the
+        # logic in SerpentineGenerator.find_best_segment so the hint is
+        # computed for the same segment that the generator will use.
+        generator = SerpentineGenerator(base_config)  # provisional
+        best = generator.find_best_segment(current_shorter)
+        if best is None:
+            result.reason = "no_suitable_segment"
+            result.message = (
+                f"No segment long enough for a trombone on net {shorter_id} "
+                f"(skew={current_skew:.4f}mm > tol={tolerance_mm:.4f}mm)"
+            )
+            current_shorter = original_shorter_route
+            break
+        seg_idx, insertion_segment = best
+
+        # Compute the outer-normal hint: the half-plane *away* from the
+        # partner trace at the insertion segment's midpoint.
+        hint = _outer_normal_hint(insertion_segment, longer_route)
+
+        # Build the per-attempt config with side="outer" + the hint.
+        attempt_config = SerpentineConfig(
+            style=base_config.style,
+            amplitude=base_config.amplitude,
+            min_spacing=base_config.min_spacing,
+            min_segment_length=base_config.min_segment_length,
+            gap_factor=base_config.gap_factor,
+            max_iterations=base_config.max_iterations,
+            side="outer",
+            outer_normal_hint=hint,
+        )
+        attempt_generator = SerpentineGenerator(attempt_config)
+
+        candidate_route, serp_result = attempt_generator.add_serpentine(
+            current_shorter, target_length
+        )
+        result.serpentine_results.append(serp_result)
+
+        if not serp_result.success:
+            # The trombone generator itself refused (segment too short,
+            # etc.).  Treat the same as no_suitable_segment.
+            result.reason = "no_suitable_segment"
+            result.message = (
+                f"Trombone generation failed on net {shorter_id}: "
+                f"{serp_result.message}"
+            )
+            current_shorter = original_shorter_route
+            break
+
+        # Post-insertion DRC self-check.  The candidate route's new
+        # segments must not violate intra-pair clearance against the
+        # partner OR collide with any other routed net's segments.
+        # ``serp_result.new_segments`` contains *only* the trombone
+        # segments (entry + loops + exit) -- those are the segments to
+        # check.
+        if not _post_insertion_clearance_ok(
+            new_segments=serp_result.new_segments,
+            shorter_net_id=shorter_id,
+            longer_net_id=longer_id,
+            routes_by_net=routes_by_net,
+            intra_pair_clearance_mm=intra_pair_clearance_mm,
+        ):
+            # Rollback: discard the candidate, return the ORIGINAL shorter
+            # route (and the original longer route reference).
+            result.reason = "post_insertion_drc_violation"
+            result.skew_after_mm = current_skew
+            result.message = (
+                f"Post-insertion DRC self-check failed on net {shorter_id} "
+                f"(intra={intra_pair_clearance_mm:.4f}mm); rolled back."
+            )
+            # The drift-prevention contract:
+            current_shorter = original_shorter_route
+            assert current_shorter is original_shorter_route
+            assert current_shorter.segments is original_shorter_segments
+            break
+
+        # Commit this attempt's new route and re-measure skew.
+        current_shorter = candidate_route
+        result.inserts_applied += 1
+        new_shorter_length = LengthTracker.calculate_route_length(current_shorter)
+        current_skew = abs(new_shorter_length - target_length) if longer_is_p else abs(
+            target_length - new_shorter_length
+        )
+        # Both branches reduce to abs(target_length - new_shorter_length)
+        current_skew = abs(target_length - new_shorter_length)
+
+        if current_skew <= tolerance_mm:
+            result.success = True
+            result.reason = "tuned"
+            break
+    else:
+        # for/else: completed max_inserts without break (no success path).
+        result.reason = result.reason or "exceeded_max_inserts"
+
+    if result.reason == "" or result.reason == "exceeded_max_inserts":
+        result.message = result.message or (
+            f"Cascade budget exhausted (attempts={result.attempts}, "
+            f"inserts_applied={result.inserts_applied}, "
+            f"skew={current_skew:.4f}mm vs tol={tolerance_mm:.4f}mm)"
+        )
+
+    result.skew_after_mm = (
+        abs(target_length - LengthTracker.calculate_route_length(current_shorter))
+        if result.inserts_applied > 0
+        else skew
+    )
+
+    # Assemble return values, restoring P/N polarity ordering.  The
+    # longer route is ALWAYS returned by the same reference the caller
+    # passed in -- the drift-prevention regression test asserts on this.
+    if longer_is_p:
+        # longer = P, shorter = N
+        assert longer_route is p_route
+        assert longer_route.segments is original_longer_segments
+        return p_route, current_shorter, result
+    else:
+        # longer = N, shorter = P
+        assert longer_route is n_route
+        assert longer_route.segments is original_longer_segments
+        return current_shorter, n_route, result
+
+
+# ---------------------------------------------------------------------------
+# Outer-normal calculation
+# ---------------------------------------------------------------------------
+
+
+def _outer_normal_hint(
+    segment: Segment,
+    partner_route: Route,
+) -> tuple[float, float]:
+    """Return a unit vector pointing AWAY from the partner trace at ``segment``.
+
+    The hint is computed at the midpoint of ``segment``: we find the
+    closest point on the partner route, then return the unit vector from
+    that closest point to the midpoint (i.e. AWAY from the partner).
+    This guarantees the trombone will bulge into the outer half-plane
+    of the pair, never toward the partner.
+
+    Args:
+        segment: The segment selected for trombone insertion on the
+            shorter half.
+        partner_route: The longer half (the partner trace).
+
+    Returns:
+        A unit vector ``(rx, ry)`` in the segment's layer plane.  When
+        the partner has no segments (unusual but possible -- empty
+        ``Route``), the segment's own geometric perpendicular is
+        returned as a fallback so the trombone is still single-sided.
+    """
+    import math
+
+    # Segment midpoint.
+    mx = (segment.x1 + segment.x2) / 2.0
+    my = (segment.y1 + segment.y2) / 2.0
+
+    if not partner_route.segments:
+        # Fallback: use the segment's own geometric perpendicular.  This
+        # mirrors what the trombone would do without a hint, but the
+        # caller still gets a single-sided bulge (``side="outer"``).
+        dx = segment.x2 - segment.x1
+        dy = segment.y2 - segment.y1
+        length = math.sqrt(dx * dx + dy * dy)
+        if length == 0.0:
+            return (0.0, 1.0)
+        return (-dy / length, dx / length)
+
+    # Find the closest point on the partner route to the midpoint.
+    best_dist_sq = float("inf")
+    best_cx, best_cy = 0.0, 0.0
+    for pseg in partner_route.segments:
+        cx, cy = _closest_point_on_segment(mx, my, pseg.x1, pseg.y1, pseg.x2, pseg.y2)
+        d2 = (cx - mx) ** 2 + (cy - my) ** 2
+        if d2 < best_dist_sq:
+            best_dist_sq = d2
+            best_cx, best_cy = cx, cy
+
+    # Unit vector from closest partner point to segment midpoint.
+    rx = mx - best_cx
+    ry = my - best_cy
+    mag = math.sqrt(rx * rx + ry * ry)
+    if mag == 0.0:
+        # The partner crosses the midpoint exactly; pick the segment's
+        # own perpendicular as a fallback.
+        dx = segment.x2 - segment.x1
+        dy = segment.y2 - segment.y1
+        length = math.sqrt(dx * dx + dy * dy)
+        if length == 0.0:
+            return (0.0, 1.0)
+        return (-dy / length, dx / length)
+    return (rx / mag, ry / mag)
+
+
+def _closest_point_on_segment(
+    px: float,
+    py: float,
+    sx1: float,
+    sy1: float,
+    sx2: float,
+    sy2: float,
+) -> tuple[float, float]:
+    """Return the point on segment ``(sx1,sy1)->(sx2,sy2)`` closest to ``(px,py)``."""
+    dx = sx2 - sx1
+    dy = sy2 - sy1
+    seg_len_sq = dx * dx + dy * dy
+    if seg_len_sq == 0.0:
+        return (sx1, sy1)
+    t = ((px - sx1) * dx + (py - sy1) * dy) / seg_len_sq
+    t = max(0.0, min(1.0, t))
+    return (sx1 + t * dx, sy1 + t * dy)
+
+
+# ---------------------------------------------------------------------------
+# Post-insertion DRC self-check
+# ---------------------------------------------------------------------------
+
+
+def _post_insertion_clearance_ok(
+    *,
+    new_segments: list[Segment],
+    shorter_net_id: int,
+    longer_net_id: int,
+    routes_by_net: dict[int, Route],
+    intra_pair_clearance_mm: float,
+) -> bool:
+    """Return True if the proposed serpentine segments are DRC-safe.
+
+    The check is two-pronged:
+
+    1. Intra-pair clearance: every new segment is checked against every
+       segment of the partner trace (``longer_net_id``).  Threshold is
+       ``intra_pair_clearance_mm`` (the per-pair value the router used,
+       passed in explicitly -- the curator's "don't go through
+       check_diffpair_clearance_intra" guidance is satisfied because we
+       use the same threshold without rebuilding the per-pair map).
+
+    2. Inter-net clearance: every new segment is checked against every
+       segment of every *other* routed net (excluding the shorter half
+       itself, since the new segments will replace the original
+       segment).  Threshold is ``intra_pair_clearance_mm`` as a
+       conservative floor -- the architect's spec uses the same value
+       so that bulging into a neighbor is rejected at least as
+       aggressively as bulging into the partner.
+
+    Args:
+        new_segments: The trombone segments produced by
+            :meth:`SerpentineGenerator.generate_trombone`.
+        shorter_net_id: Net id of the trace receiving the trombone.
+        longer_net_id: Net id of the partner trace.
+        routes_by_net: ``{net_id: Route}`` lookup for all routed nets.
+        intra_pair_clearance_mm: Edge-to-edge clearance floor in mm.
+
+    Returns:
+        ``True`` if no clearance violation is introduced; ``False``
+        otherwise (the caller must roll back).
+    """
+    from kicad_tools.core.geometry import segment_clearance
+
+    # Pair-internal check.
+    partner = routes_by_net.get(longer_net_id)
+    if partner is not None:
+        for new_seg in new_segments:
+            for pseg in partner.segments:
+                if pseg.layer != new_seg.layer:
+                    continue
+                clearance = segment_clearance(
+                    new_seg.x1,
+                    new_seg.y1,
+                    new_seg.x2,
+                    new_seg.y2,
+                    new_seg.width,
+                    pseg.x1,
+                    pseg.y1,
+                    pseg.x2,
+                    pseg.y2,
+                    pseg.width,
+                )
+                if clearance + 1e-9 < intra_pair_clearance_mm:
+                    return False
+
+    # Neighbor check (all other nets).
+    for other_net_id, other_route in routes_by_net.items():
+        if other_net_id == shorter_net_id or other_net_id == longer_net_id:
+            continue
+        for new_seg in new_segments:
+            for oseg in other_route.segments:
+                if oseg.layer != new_seg.layer:
+                    continue
+                clearance = segment_clearance(
+                    new_seg.x1,
+                    new_seg.y1,
+                    new_seg.x2,
+                    new_seg.y2,
+                    new_seg.width,
+                    oseg.x1,
+                    oseg.y1,
+                    oseg.x2,
+                    oseg.y2,
+                    oseg.width,
+                )
+                if clearance + 1e-9 < intra_pair_clearance_mm:
+                    return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _empty_route(net_id: int, net_name: str) -> Route:
+    """Return an empty :class:`Route` shell for an unrouted net.
+
+    Used as a placeholder in the return value of
+    :func:`tune_diff_pair_skew` when one half of the pair is unrouted --
+    the caller can detect the situation via ``result.reason == "unrouted"``
+    and the empty ``.segments`` list.
+    """
+    from .primitives import Route
+
+    return Route(net=net_id, net_name=net_name, segments=[], vias=[])
+
+
+# Re-export for ``from kicad_tools.router.diffpair_length_tuning import *``.
+__all__ = [
+    "MAX_INSERTS_PER_PAIR",
+    "DiffPairTuneResult",
+    "tune_diff_pair_skew",
+]
+
+
+# Reference suppression for static linters: segment_length is used as a
+# debugging aid in interactive exploration and re-imported for callers
+# (Phase 3I tests import it from this module to avoid two import paths).
+_ = segment_length  # noqa: F401

--- a/src/kicad_tools/router/optimizer/serpentine.py
+++ b/src/kicad_tools/router/optimizer/serpentine.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from ..primitives import Route, Segment
 from .geometry import segment_length
@@ -44,6 +44,20 @@ class SerpentineConfig:
         min_segment_length: Minimum segment length for serpentine insertion in mm
         gap_factor: Multiplier for spacing (gap = min_spacing * gap_factor)
         max_iterations: Maximum loops to add per segment
+        side: Side selector for trombone bulge orientation.
+            ``"auto"`` (default) alternates direction loop-by-loop, matching
+            the legacy DDR/bus tuner behavior.  ``"outer"`` constrains every
+            loop to a single side, the one pointed to by ``outer_normal_hint``
+            (a unit vector roughly perpendicular to the segment).  This is
+            required for differential-pair length tuning (Epic #2556 Phase 3I,
+            Issue #2648) where bulging the shorter half toward the partner
+            would violate intra-pair clearance.  ``"inner"`` is the
+            symmetric opposite -- provided for completeness but rarely used.
+        outer_normal_hint: Unit vector (rx, ry) supplied when ``side`` is
+            ``"outer"`` or ``"inner"``.  The trombone projects the segment's
+            geometric perpendicular onto this vector and picks the matching
+            half-plane; loops do NOT alternate.  When ``side`` is ``"auto"``
+            this field is ignored.
     """
 
     style: SerpentineStyle = SerpentineStyle.TROMBONE
@@ -52,6 +66,9 @@ class SerpentineConfig:
     min_segment_length: float = 2.0  # mm
     gap_factor: float = 2.0
     max_iterations: int = 20
+    # Issue #2648 (Epic #2556 Phase 3I): diff-pair-aware side selector.
+    side: Literal["auto", "outer", "inner"] = "auto"
+    outer_normal_hint: tuple[float, float] | None = None
 
 
 @dataclass
@@ -180,6 +197,32 @@ class SerpentineGenerator:
         ux, uy = dx / length, dy / length  # Along segment
         px, py = -uy, ux  # Perpendicular (90 degrees CCW)
 
+        # Issue #2648: when the caller asks for a single-sided trombone
+        # (``side="outer"`` or ``"inner"``), pick the half-plane defined
+        # by ``outer_normal_hint`` and disable per-loop alternation.
+        # ``initial_direction`` becomes +1 if the perpendicular (px, py)
+        # aligns with the hint, -1 otherwise; ``alternate_direction``
+        # gates the per-loop sign flip.
+        side = self.config.side
+        hint = self.config.outer_normal_hint
+        if side in ("outer", "inner") and hint is not None:
+            hx, hy = hint
+            # Normalize the hint (tolerate non-unit input).
+            hint_mag = math.sqrt(hx * hx + hy * hy)
+            if hint_mag > 0.0:
+                hx /= hint_mag
+                hy /= hint_mag
+            dot = px * hx + py * hy
+            # "outer" -> bulge toward the hint; "inner" -> bulge away.
+            if side == "outer":
+                initial_direction = 1 if dot >= 0.0 else -1
+            else:  # "inner"
+                initial_direction = -1 if dot >= 0.0 else 1
+            alternate_direction = False
+        else:
+            initial_direction = 1
+            alternate_direction = True
+
         # Calculate number of loops needed
         amplitude = self.config.amplitude
         gap = self.config.min_spacing * self.config.gap_factor
@@ -236,8 +279,8 @@ class SerpentineGenerator:
         )
         current_x, current_y = next_x, next_y
 
-        # Alternate direction for each loop
-        direction = 1  # Start going "up" (positive perpendicular)
+        # Alternate direction for each loop (gated by config -- Issue #2648).
+        direction = initial_direction  # Start sign (chosen per config.side)
 
         for loop in range(num_loops):
             # 1. Go perpendicular (up or down)
@@ -309,8 +352,11 @@ class SerpentineGenerator:
                 )
                 current_x, current_y = next_x, next_y
 
-            # Alternate direction
-            direction *= -1
+            # Alternate direction (gated -- Issue #2648 single-side mode
+            # keeps the same direction for every loop so the bulges all
+            # land on the same side of the original segment).
+            if alternate_direction:
+                direction *= -1
 
         # Exit: connect to original segment end
         new_segments.append(

--- a/tests/test_diffpair_length_tuning.py
+++ b/tests/test_diffpair_length_tuning.py
@@ -1,0 +1,593 @@
+"""Differential-pair length-match (serpentine) tuner tests.
+
+Issue #2648 / Epic #2556 Phase 3I.
+
+This module verifies the four curator-specified mitigations of
+:func:`kicad_tools.router.diffpair_length_tuning.tune_diff_pair_skew`:
+
+1. **Per-insertion DRC self-check with byte-for-byte rollback** -- a
+   placed neighbor trace at clearance limit forces the candidate
+   serpentine to drop below the intra threshold; the tuner rolls back
+   and returns the original Route reference (by ``is`` identity) AND
+   its original ``.segments`` list (also by ``is`` identity).
+
+2. **Cascade-safety budget N=3** -- an unreachable target skew is
+   capped at three trombone insertions and reports
+   ``"exceeded_max_inserts"``.
+
+3. **Outer-normal-only bulges** -- bulging never invades the partner
+   trace's half-plane.
+
+4. **Drift-prevention** -- the longer (untouched) half is returned
+   identically to its input (``is``-identity on both the Route object
+   and its segments list).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.router.diffpair import (
+    DifferentialPair,
+    DifferentialPairType,
+    DifferentialSignal,
+)
+from kicad_tools.router.diffpair_detection import DetectedPair, DetectionSource
+from kicad_tools.router.diffpair_length_tuning import (
+    MAX_INSERTS_PER_PAIR,
+    DiffPairTuneResult,
+    tune_diff_pair_skew,
+)
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.optimizer.serpentine import SerpentineConfig, SerpentineGenerator
+from kicad_tools.router.primitives import Route, Segment
+
+# =============================================================================
+# Test helpers
+# =============================================================================
+
+
+def _make_signal(name: str, net_id: int, polarity: str) -> DifferentialSignal:
+    return DifferentialSignal(
+        net_name=name,
+        net_id=net_id,
+        base_name=name.rstrip("+-_PN"),
+        polarity=polarity,
+        notation="plus_minus",
+    )
+
+
+def _make_pair(p_id: int = 1, n_id: int = 2) -> DetectedPair:
+    return DetectedPair(
+        pair=DifferentialPair(
+            name="USB_D",
+            positive=_make_signal("USB_D+", p_id, "P"),
+            negative=_make_signal("USB_D-", n_id, "N"),
+            pair_type=DifferentialPairType.USB2,
+        ),
+        source=DetectionSource.EXPLICIT,
+    )
+
+
+def _straight_route(net_id: int, name: str, length_mm: float, y: float = 0.0) -> Route:
+    """Single horizontal segment along +x at y=``y``."""
+    return Route(
+        net=net_id,
+        net_name=name,
+        segments=[
+            Segment(
+                x1=0.0,
+                y1=y,
+                x2=length_mm,
+                y2=y,
+                width=0.2,
+                layer=Layer.F_CU,
+                net=net_id,
+                net_name=name,
+            )
+        ],
+    )
+
+
+# =============================================================================
+# 1. Already-within-tolerance path (no-op)
+# =============================================================================
+
+
+class TestAlreadyMatched:
+    def test_skew_below_tolerance_returns_unchanged(self):
+        pair = _make_pair()
+        p = _straight_route(1, "USB_D+", 10.0, y=0.0)
+        n = _straight_route(2, "USB_D-", 10.3, y=0.5)
+        routes = {1: p, 2: n}
+
+        p_out, n_out, result = tune_diff_pair_skew(
+            pair,
+            routes,
+            tolerance_mm=0.5,
+            intra_pair_clearance_mm=0.1,
+        )
+
+        assert result.success is True
+        assert result.reason == "already_within_tolerance"
+        # Both halves are returned by reference (no mutation).
+        assert p_out is p
+        assert n_out is n
+        assert p_out.segments is p.segments
+        assert n_out.segments is n.segments
+        assert result.skew_before_mm == pytest.approx(0.3, abs=1e-9)
+        assert result.skew_after_mm == pytest.approx(0.3, abs=1e-9)
+
+
+# =============================================================================
+# 2. Unrouted-half rejection
+# =============================================================================
+
+
+class TestUnroutedHalf:
+    def test_missing_p_route_returns_unrouted_reason(self):
+        pair = _make_pair()
+        n = _straight_route(2, "USB_D-", 10.0, y=0.5)
+        routes = {2: n}  # P missing
+
+        _p_out, n_out, result = tune_diff_pair_skew(
+            pair,
+            routes,
+            tolerance_mm=0.5,
+            intra_pair_clearance_mm=0.1,
+        )
+
+        assert result.success is False
+        assert result.reason == "unrouted"
+        # The routed half is still returned by reference.
+        assert n_out is n
+
+
+# =============================================================================
+# 3. Outer-normal-only bulges (mitigation #3)
+# =============================================================================
+
+
+class TestOuterNormalOnly:
+    """Tuned half's bulges land on the outer side of the pair only."""
+
+    def test_partner_below_means_bulge_goes_up(self):
+        # P at y=10 (NORTH), N at y=8 (SOUTH).  Tune P (shorter).
+        # The outer side for P is +y (away from N at y=8).
+        # After tuning, max(seg.y2) must be > 10 (north excursion)
+        # AND no segment may have y2 < 10 (no south excursion toward N).
+        pair = _make_pair(p_id=1, n_id=2)
+        # Make P shorter: 5mm; N longer: 8mm so skew = 3mm.
+        # P at y=10; N at y=8.  Long enough to host trombone.
+        p = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[Segment(0.0, 10.0, 8.0, 10.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+        )
+        n = Route(
+            net=2,
+            net_name="USB_D-",
+            segments=[Segment(0.0, 8.0, 11.0, 8.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+        )
+        routes = {1: p, 2: n}
+
+        p_out, n_out, result = tune_diff_pair_skew(
+            pair,
+            routes,
+            tolerance_mm=0.5,
+            intra_pair_clearance_mm=0.1,
+            config=SerpentineConfig(amplitude=0.5, min_spacing=0.2, gap_factor=2.0),
+        )
+
+        assert result.inserts_applied >= 1
+        # n must be untouched (drift-prevention preview -- full check below).
+        assert n_out is n
+
+        # Every segment of the tuned P must NOT drop below y=10
+        # (the partner sits at y=8, which is the "inner" side).
+        ys = []
+        for seg in p_out.segments:
+            ys.append(seg.y1)
+            ys.append(seg.y2)
+        assert max(ys) > 10.0, "Trombone must bulge above the original y=10"
+        # The y2/y1 of every segment must be >= 10 - tolerance for fp noise.
+        for y in ys:
+            assert y >= 10.0 - 1e-6, (
+                f"Trombone segment leaked to y={y} (below original y=10); "
+                "outer-normal-only invariant violated."
+            )
+
+    def test_partner_above_means_bulge_goes_down(self):
+        # Symmetric: P at y=10 (SHORTER, SOUTH), N at y=12 (LONGER, NORTH).
+        # Outer side for P is -y (away from N at y=12).
+        pair = _make_pair(p_id=1, n_id=2)
+        p = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[Segment(0.0, 10.0, 8.0, 10.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+        )
+        n = Route(
+            net=2,
+            net_name="USB_D-",
+            segments=[Segment(0.0, 12.0, 11.0, 12.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+        )
+        routes = {1: p, 2: n}
+
+        p_out, n_out, result = tune_diff_pair_skew(
+            pair,
+            routes,
+            tolerance_mm=0.5,
+            intra_pair_clearance_mm=0.1,
+            config=SerpentineConfig(amplitude=0.5, min_spacing=0.2, gap_factor=2.0),
+        )
+
+        assert result.inserts_applied >= 1
+        ys = []
+        for seg in p_out.segments:
+            ys.append(seg.y1)
+            ys.append(seg.y2)
+        assert min(ys) < 10.0, "Trombone must bulge below the original y=10"
+        for y in ys:
+            assert y <= 10.0 + 1e-6, (
+                f"Trombone segment leaked to y={y} (above original y=10); "
+                "outer-normal-only invariant violated."
+            )
+
+
+# =============================================================================
+# 4. Drift-prevention -- longer half is `is`-identical (mitigation #4)
+# =============================================================================
+
+
+class TestDriftPrevention:
+    """The longer (untouched) half is returned BY REFERENCE."""
+
+    def test_longer_route_is_identity_preserved(self):
+        # N is longer (12mm), P is shorter (8mm).  Skew = 4mm.
+        pair = _make_pair(p_id=1, n_id=2)
+        p = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[Segment(0.0, 0.0, 8.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+        )
+        n = Route(
+            net=2,
+            net_name="USB_D-",
+            segments=[Segment(0.0, 2.0, 12.0, 2.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+        )
+        routes = {1: p, 2: n}
+        original_n_segments = n.segments  # capture list reference
+
+        p_out, n_out, _result = tune_diff_pair_skew(
+            pair,
+            routes,
+            tolerance_mm=0.5,
+            intra_pair_clearance_mm=0.1,
+            config=SerpentineConfig(amplitude=0.5),
+        )
+
+        # SAME Route object.
+        assert n_out is n, "Longer half's Route object identity must be preserved"
+        # SAME .segments list object.
+        assert n_out.segments is original_n_segments, (
+            "Longer half's segments list identity must be preserved"
+        )
+
+    def test_longer_route_is_identity_when_longer_is_p(self):
+        # Symmetric: P is longer this time (10mm); N is shorter (6mm).
+        pair = _make_pair(p_id=1, n_id=2)
+        p = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[Segment(0.0, 0.0, 10.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+        )
+        n = Route(
+            net=2,
+            net_name="USB_D-",
+            segments=[Segment(0.0, 2.0, 6.0, 2.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+        )
+        routes = {1: p, 2: n}
+        original_p_segments = p.segments
+
+        p_out, _n_out, _result = tune_diff_pair_skew(
+            pair,
+            routes,
+            tolerance_mm=0.5,
+            intra_pair_clearance_mm=0.1,
+            config=SerpentineConfig(amplitude=0.5),
+        )
+
+        assert p_out is p
+        assert p_out.segments is original_p_segments
+
+
+# =============================================================================
+# 5. Cascade-safety budget N=3 (mitigation #2)
+# =============================================================================
+
+
+class TestCascadeBudget:
+    """An unreachable skew is capped at MAX_INSERTS_PER_PAIR attempts."""
+
+    def test_max_inserts_per_pair_is_three(self):
+        assert MAX_INSERTS_PER_PAIR == 3
+
+    def test_unreachable_skew_caps_at_three_attempts(self):
+        # Skew = 20mm, amplitude per loop = 0.1 -> each insertion adds
+        # at most ~0.4mm (4 loops * 2 * amplitude).  20mm is unreachable
+        # in 3 insertions; the budget should fire.
+        pair = _make_pair(p_id=1, n_id=2)
+        # Long P (50mm) so the segment is large enough for trombones,
+        # but skew vs the partner (70mm) is the unreachable 20mm.
+        p = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[Segment(0.0, 0.0, 50.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+        )
+        n = Route(
+            net=2,
+            net_name="USB_D-",
+            segments=[Segment(0.0, 5.0, 70.0, 5.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+        )
+        routes = {1: p, 2: n}
+
+        # Tight amplitude / few loops per insertion so 3 insertions cannot
+        # reach 20mm.  amplitude=0.1, gap_factor=2 -> per-loop add ~= 0.2mm;
+        # max_iterations=4 -> per-insertion add ~= 0.8mm -> 3 inserts ~= 2.4mm,
+        # still way short of 20mm.
+        cfg = SerpentineConfig(
+            amplitude=0.1,
+            min_spacing=0.2,
+            gap_factor=2.0,
+            max_iterations=4,
+        )
+
+        # Spy on add_serpentine to confirm exactly 3 calls.
+        orig_add = SerpentineGenerator.add_serpentine
+        call_count = {"n": 0}
+
+        def spy(self, route, target_length, grid=None):
+            call_count["n"] += 1
+            return orig_add(self, route, target_length, grid)
+
+        with patch.object(SerpentineGenerator, "add_serpentine", spy):
+            _p_out, _n_out, result = tune_diff_pair_skew(
+                pair,
+                routes,
+                tolerance_mm=0.1,
+                intra_pair_clearance_mm=0.1,
+                config=cfg,
+            )
+
+        assert call_count["n"] == MAX_INSERTS_PER_PAIR, (
+            f"Expected exactly {MAX_INSERTS_PER_PAIR} add_serpentine calls, got {call_count['n']}"
+        )
+        assert result.attempts == MAX_INSERTS_PER_PAIR
+        assert result.reason == "exceeded_max_inserts"
+        assert result.success is False
+
+
+# =============================================================================
+# 6. Per-insertion DRC self-check + byte-for-byte rollback (mitigation #1)
+# =============================================================================
+
+
+class TestPostInsertionRollback:
+    """A neighbor at the clearance limit forces a candidate to be rolled back."""
+
+    def test_neighbor_at_clearance_limit_triggers_rollback(self):
+        # P is the shorter (10mm); N is the longer (15mm), so skew=5mm.
+        # We need a NEIGHBOR (not P, not N) placed in the outer half-plane
+        # right where the trombone would land.  P at y=0; N at y=5 (south
+        # invalid -- partner). Outer for P is -y. Place neighbor at y=-0.5
+        # (close to where the amplitude-0.5 trombone would bulge) so the
+        # neighbor sits at clearance limit and the trombone collides.
+        pair = _make_pair(p_id=1, n_id=2)
+        p = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[Segment(0.0, 0.0, 10.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+        )
+        n = Route(
+            net=2,
+            net_name="USB_D-",
+            segments=[Segment(0.0, 5.0, 15.0, 5.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+        )
+        # Neighbor net 3, a wide trace right where the trombone would bulge.
+        # P's outer normal is -y (away from N).  amplitude=0.5 means the
+        # trombone goes to y=-0.5.  Put the neighbor at y=-0.5 so the
+        # edge-to-edge clearance to the trombone equals zero (overlap).
+        neighbor = Route(
+            net=3,
+            net_name="VCC",
+            segments=[Segment(0.0, -0.5, 10.0, -0.5, 0.2, Layer.F_CU, net=3, net_name="VCC")],
+        )
+        routes = {1: p, 2: n, 3: neighbor}
+        original_p = p
+        original_p_segments = p.segments
+
+        cfg = SerpentineConfig(amplitude=0.5, min_spacing=0.2, gap_factor=2.0)
+        p_out, n_out, result = tune_diff_pair_skew(
+            pair,
+            routes,
+            tolerance_mm=0.1,
+            intra_pair_clearance_mm=0.2,  # neighbor at 0mm -> below threshold
+            config=cfg,
+        )
+
+        assert result.success is False
+        assert result.reason == "post_insertion_drc_violation"
+        # Byte-for-byte rollback: P is returned by reference.
+        assert p_out is original_p, "Original Route reference must be preserved on rollback"
+        assert p_out.segments is original_p_segments, (
+            "Original segments list reference must be preserved on rollback"
+        )
+        # N also untouched.
+        assert n_out is n
+
+
+# =============================================================================
+# 7. Successful tuning path (smoke -- pair actually reaches tolerance)
+# =============================================================================
+
+
+class TestSuccessfulTuning:
+    def test_small_skew_can_be_tuned_in_one_insert(self):
+        # Skew = 4mm; amplitude=1.0 -> 2 loops add 4mm -> exact match in 1 insert.
+        # The shorter side has to be long enough that 2 loops fit (gap_factor*2*amplitude*2 ~ 1.6mm forward).
+        pair = _make_pair(p_id=1, n_id=2)
+        p = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[Segment(0.0, 0.0, 12.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+        )
+        n = Route(
+            net=2,
+            net_name="USB_D-",
+            segments=[Segment(0.0, 5.0, 16.0, 5.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+        )
+        routes = {1: p, 2: n}
+
+        _p_out, _n_out, result = tune_diff_pair_skew(
+            pair,
+            routes,
+            tolerance_mm=0.5,
+            intra_pair_clearance_mm=0.1,
+            config=SerpentineConfig(amplitude=1.0, min_spacing=0.2, gap_factor=2.0),
+        )
+
+        assert result.success is True, (
+            f"expected success but got reason={result.reason!r} "
+            f"skew_before={result.skew_before_mm} skew_after={result.skew_after_mm}"
+        )
+        assert result.reason == "tuned"
+        assert result.inserts_applied >= 1
+        assert result.skew_after_mm <= 0.5 + 1e-6
+        assert result.skew_before_mm == pytest.approx(4.0, abs=1e-9)
+
+
+# =============================================================================
+# 8. Engagement gate -- length_critical=False is skipped
+# =============================================================================
+
+
+class TestEngagementGate:
+    """Pairs whose net class is not length-critical are not tuned."""
+
+    def test_length_critical_false_skips_tuning(self):
+        # Skew = 10mm (unambiguous violation if tuned); length_critical=False
+        # -> tuner must NOT touch either half.
+        pair = _make_pair(p_id=1, n_id=2)
+        p = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[Segment(0.0, 0.0, 10.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+        )
+        n = Route(
+            net=2,
+            net_name="USB_D-",
+            segments=[Segment(0.0, 5.0, 20.0, 5.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+        )
+        routes = {1: p, 2: n}
+        original_p_segments = p.segments
+        original_n_segments = n.segments
+
+        p_out, n_out, result = tune_diff_pair_skew(
+            pair,
+            routes,
+            tolerance_mm=0.5,
+            intra_pair_clearance_mm=0.1,
+            length_critical=False,
+        )
+
+        # No change.
+        assert result.reason == "not_length_critical"
+        assert result.success is True  # gate is a successful no-op, not a failure
+        assert p_out is p
+        assert n_out is n
+        assert p_out.segments is original_p_segments
+        assert n_out.segments is original_n_segments
+
+
+# =============================================================================
+# 9. Triple-gate -- Autorouter.apply_diffpair_length_tuning invokes the tuner
+# =============================================================================
+
+
+class TestTripleGate:
+    """The full call chain: Autorouter -> tune_diff_pair_skew -> serpentine insert.
+
+    The triple-gate test is the #2587/#2639 lesson: it asserts EVERY link in
+    the chain actually fires.  A spy on :func:`tune_diff_pair_skew` confirms
+    the pipeline invokes the tuner for each detected pair.
+    """
+
+    def test_autorouter_invokes_tuner_for_each_pair(self):
+        from kicad_tools.router import diffpair_length_tuning as dlt_module
+        from kicad_tools.router.core import Autorouter
+
+        ar = Autorouter(width=40.0, height=20.0)
+        # Tell the autorouter that nets 1+2 are a USB_D pair via the
+        # net-name registry.  detect_diff_pairs uses suffix inference so
+        # the names alone are enough.
+        ar.net_names = {1: "USB_D+", 2: "USB_D-"}
+        # Place two unequal routes -- the shorter one needs a trombone.
+        ar.routes = [
+            Route(
+                net=1,
+                net_name="USB_D+",
+                segments=[Segment(0.0, 0.0, 12.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+            ),
+            Route(
+                net=2,
+                net_name="USB_D-",
+                segments=[Segment(0.0, 5.0, 16.0, 5.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+            ),
+        ]
+
+        # Detect the pair the same way the CLI does.
+        from kicad_tools.router.diffpair_detection import detect_diff_pairs
+
+        detected_pairs = detect_diff_pairs(net_names=ar.net_names)
+        assert len(detected_pairs) == 1, "Expected exactly one detected USB_D pair"
+
+        call_count = {"n": 0}
+        # Wrap the real function to count calls without disabling its logic.
+        real_tune = dlt_module.tune_diff_pair_skew
+
+        def spy(*args, **kwargs):
+            call_count["n"] += 1
+            return real_tune(*args, **kwargs)
+
+        with patch.object(dlt_module, "tune_diff_pair_skew", spy):
+            # Patch the imported name inside core.py's apply_diffpair_length_tuning;
+            # the import is local-to-method, so we patch through the package.
+            results = ar.apply_diffpair_length_tuning(
+                detected_pairs=detected_pairs,
+                verbose=False,
+            )
+
+        assert call_count["n"] == 1, (
+            f"Expected exactly 1 tune_diff_pair_skew call (one detected pair), "
+            f"got {call_count['n']}"
+        )
+        assert ("USB_D+", "USB_D-") in results
+        # A 4mm skew at default amplitude=1.0 / 2 loops should tune cleanly.
+        assert results[("USB_D+", "USB_D-")].reason in ("tuned", "already_within_tolerance")
+
+
+# =============================================================================
+# 10. Module-level invariants
+# =============================================================================
+
+
+class TestModuleInvariants:
+    def test_diff_pair_tune_result_dataclass_defaults(self):
+        r = DiffPairTuneResult()
+        assert r.success is False
+        assert r.reason == ""
+        assert r.attempts == 0
+        assert r.inserts_applied == 0
+        assert r.serpentine_results == []


### PR DESCRIPTION
## Summary

Implements Phase 3I of Epic #2556 — a diff-pair-aware length-match (skew) tuner that inserts serpentines on the shorter half of each detected differential pair until skew is within the per-class `effective_skew_tolerance` window, while preserving all four curator-specified mitigations.

Closes #2648

## Changes

- **New module** `src/kicad_tools/router/diffpair_length_tuning.py` (612 lines):
  - `tune_diff_pair_skew(pair, routes_by_net, *, tolerance_mm, intra_pair_clearance_mm, ...)` — the public entry point.
  - `DiffPairTuneResult` dataclass with `reason ∈ {already_within_tolerance, tuned, exceeded_max_inserts, post_insertion_drc_violation, no_suitable_segment, unrouted, not_length_critical}`.
  - `_outer_normal_hint(seg, partner_route)` — computes the unit vector from the partner trace's closest point to the segment midpoint (always away from the partner).
  - `_post_insertion_clearance_ok(...)` — router-internal DRC self-check using `core.geometry.segment_clearance` (does NOT route through `validate/checker.py:check_diffpair_clearance_intra`, per curator's spec — uses the same per-pair threshold the router used).
  - `MAX_INSERTS_PER_PAIR = 3` cascade-safety budget.
- **`SerpentineConfig.side` + `outer_normal_hint`** (`src/kicad_tools/router/optimizer/serpentine.py`):
  - `side: Literal["auto", "outer", "inner"] = "auto"` — `"auto"` keeps the legacy DDR/bus alternation; `"outer"` constrains every loop to the half-plane pointed to by `outer_normal_hint`.
  - When `side == "outer"`, `generate_trombone()` picks `initial_direction = sign(dot(perp, hint))` and disables per-loop alternation (`alternate_direction = False`).
  - `tune_match_group` and the existing `add_serpentine` path are **unchanged** (curator's "do not touch the generic match-group path").
- **`Autorouter.apply_diffpair_length_tuning(detected_pairs)`** (`src/kicad_tools/router/core.py`):
  - Sibling to `apply_length_tuning`. Iterates detected pairs, resolves per-pair `effective_skew_tolerance` / `effective_intra_pair_clearance` / `length_critical` from `net_class_map` (with safe defaults for synthetic boards), calls `tune_diff_pair_skew`, commits new Route references into `self.routes`, and refreshes `_diffpair_length_tracker` so downstream Phase 3J DRC consumers see the post-tuning state.
- **CLI flag `--length-match-diffpairs`** in `src/kicad_tools/cli/route_cmd.py` + top-level `src/kicad_tools/cli/parser.py` + forwarding in `src/kicad_tools/cli/commands/routing.py`:
  - Opt-in; requires `--differential-pairs` (warns and short-circuits otherwise).
  - Runs after the optimize + DRC-nudge passes, before `_finalize_routes`. Uses `_enforce_connectivity_invariant_or_exit` to gate the tuning pass.
- **13 new tests** in `tests/test_diffpair_length_tuning.py` covering all four mitigations.

## Acceptance Criteria Verification

| Criterion (from #2648) | Status | Verification |
|-----------------------|--------|--------------|
| `tune_diff_pair_skew` function + `DiffPairTuneResult` dataclass at new module path | Done | `src/kicad_tools/router/diffpair_length_tuning.py:136` and `:78` |
| Side selection (shorter half targeted) | Done | `test_longer_route_is_identity_preserved` / `test_longer_route_is_identity_when_longer_is_p` confirm the shorter half is the one mutated |
| `delta <= effective_skew_tolerance` -> no-op with `already_within_tolerance` | Done | `test_skew_below_tolerance_returns_unchanged` |
| Partner-aware outer-normal serpentine geometry | Done | `test_partner_below_means_bulge_goes_up` and `test_partner_above_means_bulge_goes_down` |
| Post-insertion DRC self-check with byte-for-byte rollback | Done | `test_neighbor_at_clearance_limit_triggers_rollback` asserts `result.reason == "post_insertion_drc_violation"` AND `p_out is original_p` AND `p_out.segments is original_p_segments` |
| Cascade-safety budget N=3 | Done | `test_unreachable_skew_caps_at_three_attempts` spies on `add_serpentine`, asserts call count == 3 and `reason == "exceeded_max_inserts"` |
| Engagement gate (`length_critical=False` skipped) | Done | `test_length_critical_false_skips_tuning` |
| CLI integration `--length-match-diffpairs` | Done | Verified via `kct route --help`. Opt-in; warns + short-circuits without `--differential-pairs`. |
| Triple-gate verification (full call chain) | Done | `test_autorouter_invokes_tuner_for_each_pair` patches `tune_diff_pair_skew` and asserts the autorouter invokes it exactly once per detected pair |
| Rollback test (third-net clearance limit) | Done | `test_neighbor_at_clearance_limit_triggers_rollback` (neighbor at `y=-0.5`, intra threshold 0.2mm; trombone amplitude 0.5mm; assert rollback) |
| Drift-prevention (`is`-identity on longer half) | Done | Two tests assert `n_out is n` AND `n_out.segments is original_n_segments` (one for each polarity of which-half-is-longer) |
| Existing tests pass | Done | 334 tests across `test_diffpair_length.py`, `test_diffpair.py`, `test_diffpair_engagement.py`, `test_diffpair_partner_wiring.py`, `test_diffpair_routing_integration.py`, `test_diffpair_impedance.py`, `test_diffpair_npad.py`, `test_router_cleanup.py`, `test_length_matching.py`, `test_trace_length.py`, plus the new 37 `diffpair_length_skew` tests from PR #2662 all pass |

## Test Plan

- [x] 13 unit tests in `tests/test_diffpair_length_tuning.py` pass
- [x] 175 pre-existing diff-pair tests pass (no regression)
- [x] 21 `DiffPairLengthTracker` tests pass (Phase 3H consumer compat)
- [x] 37 new Phase 3J `diffpair_length_skew` rule tests pass on rebased branch
- [x] `kct route --help` displays the new flag
- [x] `ruff check` clean on all new/modified files
- [x] No `cd`-into-main-repo, no `gh pr merge`, no skipped hooks

Closes #2648