### PR TITLE
docs(diff-pairs): per-protocol user guides + delete stale routing API (Phase 4M)

### DIFF
--- a/docs/guides/diff-pairs/01-declaring-pairs.md
+++ b/docs/guides/diff-pairs/01-declaring-pairs.md
@@ -1,0 +1,72 @@
+# 01 — Declaring a Differential Pair
+
+A pair is declared by configuring the **net class**, not by an imperative
+`router.add_diff_pair(...)` call (no such method exists).
+
+## Three detection paths (priority order)
+
+### 1. Explicit `diffpair_partner` (authoritative)
+
+The strongest declaration. A one-sided declaration (only one of the two nets
+has `diffpair_partner` set) is sufficient.
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+usb_p = NetClassRouting(
+    name="USB_DP",
+    trace_width=0.2,
+    clearance=0.15,
+    intra_pair_clearance=0.075,
+    diffpair_partner="USB_DM",   # names the other half
+    coupled_routing=True,
+)
+```
+
+Defined at `src/kicad_tools/router/rules.py:448`. This overrides KiCad group
+declarations and suffix inference.
+
+### 2. KiCad schematic DiffPair group
+
+Pairs declared in the schematic via KiCad's DiffPair grouping are honored.
+Use this when the schematic is the source of truth and you don't want to
+duplicate the pair-name list in Python.
+
+### 3. Suffix inference (fallback)
+
+Net names with matching `_P`/`_N` or `+`/`-` suffixes are detected
+automatically by `parse_differential_signal` in
+`src/kicad_tools/router/diffpair.py:365`. Examples that auto-detect:
+
+- `USB_D+` / `USB_D-`
+- `PCIE_TX_P` / `PCIE_TX_N`
+- `MIPI_CLK_P` / `MIPI_CLK_N`
+
+## Single-ended refusal (USB_CC1/CC2 lesson)
+
+USB-C `CC1`/`CC2` and `SBU1`/`SBU2` *look* like a diff pair but are
+electrically single-ended orientation/sideband pins. `is_single_ended_refused`
+in `src/kicad_tools/router/diffpair.py:240` refuses them at suffix-inference
+time, and `should_engage_coupled` in `diffpair.py:296` re-applies the refusal
+at the engagement layer — so even an explicit `diffpair_partner="USB_CC2"`
+declaration **cannot** force coupled routing on these pins (Issue #2527
+curator lesson).
+
+```python
+from kicad_tools.router.diffpair import is_single_ended_refused
+
+assert is_single_ended_refused("USB_CC1")    # True — refused
+assert is_single_ended_refused("USB_SBU1")   # True — refused
+assert not is_single_ended_refused("USB_D+") # False — real diff pair
+```
+
+If you genuinely need tight clearance on `CC1`/`CC2` for ESD-trace reasons,
+configure `intra_pair_clearance` on the class — they will still be routed as
+two independent single-ended nets, not as a coupled pair.
+
+## See also
+
+- [02-clearance-and-classes.md](02-clearance-and-classes.md) — once you have a
+  pair, configure its clearances.
+- [05-protocol-recipes.md](05-protocol-recipes.md) — copy-pasteable
+  `NetClassRouting` blocks for USB / PCIe / MIPI.

--- a/docs/guides/diff-pairs/02-clearance-and-classes.md
+++ b/docs/guides/diff-pairs/02-clearance-and-classes.md
@@ -1,0 +1,76 @@
+# 02 — Clearance and Net Classes
+
+A differential pair has **two** clearances: the gap between the two halves of
+the pair (intra-pair) and the gap between the pair and everything else
+(inter-pair).
+
+## Two fields, one effective accessor
+
+`NetClassRouting` (`src/kicad_tools/router/rules.py`) exposes both:
+
+| Field | Line | Meaning |
+|---|---|---|
+| `clearance` | 405 | Inter-net clearance, applied between this class's nets and everything else. |
+| `intra_pair_clearance` | 425 | Within-pair clearance, applied only to the two halves of a declared pair. `None` → falls back to `clearance`. |
+
+Read `intra_pair_clearance` via the accessor, never the field directly:
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+nc = NetClassRouting(name="USB", clearance=0.15, intra_pair_clearance=0.075)
+assert nc.effective_intra_pair_clearance() == 0.075   # explicit override
+
+nc2 = NetClassRouting(name="USB", clearance=0.15)
+assert nc2.effective_intra_pair_clearance() == 0.15   # fallback to clearance
+```
+
+The `None` sentinel encodes "fall back to `clearance`" — it is NOT a literal
+zero clearance. This preserves backward compatibility with pre-#2557 configs
+that only set `clearance`.
+
+## Opt-in coupled routing
+
+A pair is detected (guide 01) but is **not** routed as a coupled pair unless
+the net class opts in:
+
+```python
+NetClassRouting(
+    name="HighSpeed",
+    intra_pair_clearance=0.075,
+    coupled_routing=True,   # opt-in to CoupledPathfinder
+)
+```
+
+`coupled_routing` (`rules.py:451`) defaults to `False`. When `False`, the
+pair's halves are still routed *as a pair* by the diff-pair dispatch — the
+intra-pair clearance is honored at the pathfinder layer — but the
+`CoupledPathfinder` geometric coupling is bypassed. Use this for hobby
+boards where tight clearance suffices without forcing coupled geometry.
+
+### Canonical opt-in: `NET_CLASS_HIGH_SPEED`
+
+The pre-configured `NET_CLASS_HIGH_SPEED` in `rules.py:675` already has
+`coupled_routing=True` and `intra_pair_clearance=0.075`. Opt nets into it via
+`Autorouter(..., high_speed_nets=[...])` instead of redeclaring the class.
+
+## Manufacturer profiles
+
+The manufacturer profile (e.g. `--mfr jlcpcb`) supplies a *minimum* inter-pair
+clearance. `intra_pair_clearance` is allowed to be **tighter** than that
+floor — the validation rule `diffpair_clearance_intra` (guide 06) checks the
+intra-pair gap against the per-class field, not against the manufacturer
+floor.
+
+## Via-in-pad coverage
+
+Via-in-pad (BGA escape, fine-pitch SSOP) interacts with intra-pair clearance
+when the via lands inside a coupled launch. See `ViaInPadRule` and Issue
+#2637 for the full coverage matrix — not duplicated here.
+
+## See also
+
+- [03-impedance-and-sizing.md](03-impedance-and-sizing.md) — letting
+  `target_diff_impedance` drive `intra_pair_clearance` automatically.
+- [06-drc-rules.md](06-drc-rules.md) — `diffpair_clearance_intra` checks the
+  routed gap against `effective_intra_pair_clearance()`.

--- a/docs/guides/diff-pairs/03-impedance-and-sizing.md
+++ b/docs/guides/diff-pairs/03-impedance-and-sizing.md
@@ -1,0 +1,73 @@
+# 03 — Impedance-Driven Sizing
+
+Set a target impedance and the router derives `(trace_width,
+intra_pair_clearance)` from the PCB stackup. From Epic #2556 Phase 3K
+(#2655).
+
+## Fields
+
+`NetClassRouting` (`src/kicad_tools/router/rules.py`):
+
+| Field | Line | Use |
+|---|---|---|
+| `target_diff_impedance` | 486 | Differential impedance in Ω (e.g. 90 for USB 2.0, 100 for USB 3.0 / PCIe / MIPI). |
+| `target_single_impedance` | 504 | Single-ended impedance in Ω (50 for clocks; 75 for video/coax). |
+| `impedance_tolerance_percent` | 515 | DRC firing threshold, default 10.0 %. |
+
+When `target_diff_impedance` is set, the router calls
+`kicad_tools.router.diffpair_impedance.apply_impedance_driven_sizing` to
+compute the width/spacing pair from the stackup via
+`kicad_tools.physics.CoupledLines`. When `None` (default), the per-class
+`trace_width` / `intra_pair_clearance` literals are used unchanged.
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+usb3 = NetClassRouting(
+    name="USB3_SS",
+    target_diff_impedance=90.0,
+    impedance_tolerance_percent=10.0,
+    coupled_routing=True,
+)
+```
+
+A class may set `target_diff_impedance`, `target_single_impedance`, both, or
+neither. When both are set, diff-pair nets consume the diff value; single-
+ended nets in the same class consume the single value.
+
+## Stackup awareness
+
+The impedance solver reads the board's stackup (dielectric thickness, εr,
+copper thickness). When the actual stackup deviates from the JLCPCB tier-1
+calibration baseline (FR-4, εr=4.5, 35 µm Cu) the solver emits a
+`StackupMismatchWarning` from
+`src/kicad_tools/router/diffpair_impedance.py:76`. The warning is included
+in the route result so consumers can flag the discrepancy at CI time.
+
+When the stackup is unknown, the solver falls back to the JLCPCB tier-1
+baseline. Boards without an explicit stackup will still route, but the
+computed width may not actually achieve the target impedance — set the
+stackup explicitly for HSDI work.
+
+## CLI: `kct impedance`
+
+The `impedance` CLI command exposes the underlying solver outside the
+router:
+
+| Subcommand | What it does |
+|---|---|
+| `kct impedance stackup` | Print the board's stackup. |
+| `kct impedance width` | Compute width for a target single-ended impedance. |
+| `kct impedance diffpair` | Compute width/spacing for a target differential impedance. |
+| `kct impedance calculate` | Solve impedance from a given geometry. |
+| `kct impedance crosstalk` | Estimate crosstalk for a given geometry. |
+
+Source: `src/kicad_tools/cli/commands/impedance.py`.
+
+## See also
+
+- [02-clearance-and-classes.md](02-clearance-and-classes.md) — when
+  `target_diff_impedance` is unset, the literal `intra_pair_clearance` is
+  used as-is.
+- [06-drc-rules.md](06-drc-rules.md) — the `impedance` DRC rule validates
+  routed widths against the target.

--- a/docs/guides/diff-pairs/04-length-matching.md
+++ b/docs/guides/diff-pairs/04-length-matching.md
@@ -1,0 +1,80 @@
+# 04 — Length Matching (Skew Tolerance)
+
+Differential pairs must have matched P and N routed lengths to preserve
+signal integrity. Length matching is configured via `skew_tolerance_mm` on
+the net class — **not** `length_constraint` (which is for absolute lengths
+per Issue #630, not pair skew).
+
+## Field
+
+`NetClassRouting.skew_tolerance_mm` at `src/kicad_tools/router/rules.py:550`
+holds the maximum allowed `|L_p - L_n|` for pairs in this class:
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+usb3 = NetClassRouting(
+    name="USB3_SS",
+    skew_tolerance_mm=0.1,   # tight: USB 3.0 / PCIe Gen2+
+    coupled_routing=True,
+)
+```
+
+Read it via the accessor, which falls back to the rule's module-level
+default when the field is unset:
+
+```python
+nc = NetClassRouting(name="USB2", skew_tolerance_mm=None)
+assert nc.effective_skew_tolerance(default=0.5) == 0.5
+
+nc2 = NetClassRouting(name="MIPI", skew_tolerance_mm=0.04)
+assert nc2.effective_skew_tolerance() == 0.04
+```
+
+Defined at `rules.py:604`. Default of `0.5 mm` covers USB 3.0 / PCIe Gen 2+
+(~0.5–1 mm), MIPI D-PHY (~1 mm), and DDR4 DQ-strobe (~0.5 mm); set `3.0`
+for USB 2.0 HS.
+
+## Measurement: `Autorouter.update_diffpair_skew`
+
+After routing, populate the skew tracker with the detected pairs:
+
+```python
+from kicad_tools.router import Autorouter
+from kicad_tools.router.diffpair_detection import detect_diff_pairs
+
+router = Autorouter(...)
+router.route_all_with_diffpairs(...)
+pairs = detect_diff_pairs(...)
+tracker = router.update_diffpair_skew(
+    detected_pairs=pairs,
+    board_thickness_mm=1.6,
+    num_copper_layers=4,
+)
+# tracker exposes (L_p, L_n) and skew per pair
+```
+
+`update_diffpair_skew` is at `src/kicad_tools/router/core.py:6926`. The
+tracker (`DiffPairLengthTracker`) measures skew unconditionally per pair —
+no per-class gate. The `skew_tolerance_mm` field only governs whether the
+DRC rule fires (guide 06).
+
+## When serpentine inserts
+
+> **TODO (Phase 3I / Issue #2648)**: serpentine / meander insertion to repair
+> skew within `skew_tolerance_mm`. When this lands, this section will
+> document:
+>
+> - When the autorouter automatically inserts serpentines
+> - How to disable insertion (per pair, per class)
+> - Amplitude / spacing control
+>
+> Until then, post-route serpentine insertion is a manual `kct` step or a
+> KiCad operation. Track #2648 for the autorouter path.
+
+## See also
+
+- [05-protocol-recipes.md](05-protocol-recipes.md) — protocol-tuned
+  `skew_tolerance_mm` values.
+- [06-drc-rules.md](06-drc-rules.md) — `diffpair_length_skew` validates
+  routed skew.

--- a/docs/guides/diff-pairs/05-protocol-recipes.md
+++ b/docs/guides/diff-pairs/05-protocol-recipes.md
@@ -1,0 +1,93 @@
+# 05 — Protocol Recipes
+
+Copy-pasteable `NetClassRouting` blocks for common HSDI protocols. Each
+recipe sets only the protocol-essential fields; literal values are
+defaults rather than physical optima — adjust to your stackup.
+
+## USB 2.0 (Full / High Speed, 480 Mbps) — 90 Ω diff, loose skew
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+usb2 = NetClassRouting(
+    name="USB2",
+    trace_width=0.2,
+    clearance=0.15,
+    intra_pair_clearance=0.125,
+    target_diff_impedance=90.0,
+    skew_tolerance_mm=3.0,
+    coupled_routing=True,
+    diffpair_partner="USB_DM",
+)
+assert usb2.effective_intra_pair_clearance() == 0.125
+assert usb2.effective_skew_tolerance() == 3.0
+```
+
+## USB 3.0 SuperSpeed (5 Gbps per lane) — 90 Ω diff, tight skew
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+usb3 = NetClassRouting(
+    name="USB3_SS",
+    trace_width=0.2,
+    clearance=0.15,
+    intra_pair_clearance=0.075,
+    target_diff_impedance=90.0,
+    impedance_tolerance_percent=10.0,
+    skew_tolerance_mm=0.1,
+    coupled_continuity_threshold=0.9,
+    coupled_routing=True,
+    diffpair_partner="USB3_RX_N",
+)
+assert usb3.effective_intra_pair_clearance() == 0.075
+assert usb3.effective_skew_tolerance() == 0.1
+```
+
+## PCIe Gen 1 (2.5 GT/s) — 85 Ω diff, ±5 mil (≈0.127 mm) skew
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+pcie = NetClassRouting(
+    name="PCIe_Gen1",
+    trace_width=0.2,
+    clearance=0.15,
+    intra_pair_clearance=0.075,
+    target_diff_impedance=85.0,
+    skew_tolerance_mm=0.127,
+    coupled_continuity_threshold=0.9,
+    coupled_routing=True,
+    diffpair_partner="PCIE_TX_N",
+)
+assert pcie.effective_skew_tolerance() == 0.127
+```
+
+## MIPI D-PHY (HS Data / Clock Lane) — 100 Ω diff, ±1.5 mil (≈0.038 mm) skew
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+mipi = NetClassRouting(
+    name="MIPI_DPHY",
+    trace_width=0.2,
+    clearance=0.15,
+    intra_pair_clearance=0.075,
+    target_diff_impedance=100.0,
+    skew_tolerance_mm=0.038,
+    coupled_continuity_threshold=0.9,
+    coupled_routing=True,
+    diffpair_partner="MIPI_DATA0_N",
+)
+assert mipi.effective_intra_pair_clearance() == 0.075
+assert mipi.effective_skew_tolerance() == 0.038
+```
+
+## Notes
+
+- The pre-configured `NET_CLASS_HIGH_SPEED` (`router/rules.py:675`) is a
+  reasonable default for USB 3.0 / PCIe / MIPI when you opt nets in via
+  `Autorouter(..., high_speed_nets=[...])` — only fork your own
+  `NetClassRouting` when a per-protocol field above differs.
+- The `effective_*` accessors return finite floats — see guides
+  [02](02-clearance-and-classes.md) and [04](04-length-matching.md).

--- a/docs/guides/diff-pairs/06-drc-rules.md
+++ b/docs/guides/diff-pairs/06-drc-rules.md
@@ -1,0 +1,83 @@
+# 06 — Differential-Pair DRC Rules
+
+Four `rule_id`s in `kicad_tools.validate.rules.*` validate the routed result.
+Run via `kct check --rules=<rule_id>`. The rule_id strings below are the
+public CLI surface and match `ViolationType.from_string` aliases in
+`src/kicad_tools/drc/violation.py:245`.
+
+## `diffpair_clearance_intra`
+
+Source: `src/kicad_tools/validate/rules/diffpair_clearance_intra.py:97`.
+Validates the within-pair gap against
+`NetClassRouting.effective_intra_pair_clearance()`. Distinct from generic
+`clearance` because the intra-pair gap is allowed to be *tighter* than the
+manufacturer's inter-net floor.
+
+```bash
+kct check board.kicad_pcb --rules=diffpair_clearance_intra
+```
+
+Remediate: raise the routed gap to `effective_intra_pair_clearance()`, OR
+lower `intra_pair_clearance` on the net class if the tight gap is
+intentional (see guide 02).
+
+## `diffpair_routing_continuity`
+
+Source: `src/kicad_tools/validate/rules/diffpair_routing_continuity.py:218`.
+Fires when an engaged pair's coupled fraction (share of P's routed length
+whose nearest point on N is within the coupling window AND parallel within
+±15°) falls below `effective_coupled_continuity_threshold(default=0.7)`.
+Topology check, not edge-to-edge spacing.
+
+```bash
+kct check board.kicad_pcb --rules=diffpair_routing_continuity
+```
+
+Remediate: re-route the pair through `CoupledPathfinder` (set
+`coupled_routing=True`), tighten launch geometry, or lower the per-class
+threshold for hobby boards (see guide 02).
+
+## `diffpair_length_skew`
+
+Source: `src/kicad_tools/validate/rules/diffpair_length_skew.py:141`.
+Fires when an engaged pair's routed length skew (`|L_p - L_n|`) exceeds
+`effective_skew_tolerance(default=0.5)`. Total-length parity, not topology.
+
+```bash
+kct check board.kicad_pcb --rules=diffpair_length_skew
+```
+
+Remediate: insert serpentine on the shorter half (manual today; #2648 will
+automate), or relax `skew_tolerance_mm` on the net class (see guide 04).
+
+## `impedance`
+
+Source: `src/kicad_tools/validate/rules/impedance.py:101`. Validates routed
+trace geometry against `target_diff_impedance` or `target_single_impedance`
+on the class, allowing `impedance_tolerance_percent` (default 10 %)
+deviation.
+
+```bash
+kct check board.kicad_pcb --rules=impedance
+```
+
+Remediate: re-route with `apply_impedance_driven_sizing` (set
+`target_diff_impedance` so the router consumes the stackup), correct the
+stackup, or relax `impedance_tolerance_percent` (see guide 03).
+
+## Running all four together
+
+```bash
+kct check board.kicad_pcb \
+  --rules=diffpair_clearance_intra,diffpair_routing_continuity,diffpair_length_skew,impedance
+```
+
+Or use a manufacturer profile — `kct check --mfr jlcpcb` enables all four
+plus the manufacturer's inter-net floors.
+
+## ViolationType enumeration
+
+Each `rule_id` maps to a `ViolationType` enum member at
+`src/kicad_tools/drc/violation.py:133-150`. The `from_string` alias table at
+`violation.py:263-282` guarantees the rule_id strings round-trip without
+falling through the fuzzy fallback to `UNKNOWN`.

--- a/docs/guides/diff-pairs/README.md
+++ b/docs/guides/diff-pairs/README.md
@@ -1,0 +1,36 @@
+# Differential Pair Routing Guides
+
+Configure differential pairs per **net class** on `NetClassRouting` — not via
+imperative `Router.method(...)` calls. The full feature set landed across
+Epic #2556 (Phases 1–3).
+
+## Which guide do I need?
+
+| If you want to… | Read |
+|---|---|
+| Mark two nets as a pair | [01-declaring-pairs.md](01-declaring-pairs.md) |
+| Set within-pair clearance (tighter than the manufacturer's inter-net rule) | [02-clearance-and-classes.md](02-clearance-and-classes.md) |
+| Target a specific differential or single-ended impedance | [03-impedance-and-sizing.md](03-impedance-and-sizing.md) |
+| Length-match a pair within a skew tolerance | [04-length-matching.md](04-length-matching.md) |
+| Copy a working setup for USB / PCIe / MIPI | [05-protocol-recipes.md](05-protocol-recipes.md) |
+| Understand the diff-pair DRC rules (`kct check`) | [06-drc-rules.md](06-drc-rules.md) |
+
+## Canonical pre-configured class
+
+`NET_CLASS_HIGH_SPEED` in `src/kicad_tools/router/rules.py:675` already has
+`coupled_routing=True`, `intra_pair_clearance=0.075`, and
+`length_critical=True` — opt nets into it via `high_speed_nets=[...]` on
+`Autorouter` rather than building a class from scratch.
+
+```python
+from kicad_tools.router.rules import NET_CLASS_HIGH_SPEED
+```
+
+## How detection, engagement, and DRC fit together
+
+1. **Detection** decides which nets are a pair (guide 01).
+2. **Engagement** decides whether `CoupledPathfinder` routes them as a pair
+   (guide 02, `coupled_routing` flag).
+3. **Impedance / length matching** shape *how* the pair is routed (guides 03,
+   04).
+4. **DRC** validates the routed result (guide 06).

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -190,39 +190,21 @@ router.set_net_class_rules("HighSpeed", clearance=0.2)
 
 ## Differential Pairs
 
-### Automatic Detection
+Diff-pair routing is configured per net class on
+[`NetClassRouting`](../../src/kicad_tools/router/rules.py), not via imperative
+`Router.method(...)` calls. See the dedicated guides under
+[`docs/guides/diff-pairs/`](diff-pairs/README.md):
 
-```python
-# Detect pairs by naming convention (DATA_P/DATA_N)
-router.auto_detect_diff_pairs()
+- [Declaring a pair](diff-pairs/01-declaring-pairs.md) (`diffpair_partner`, suffix inference, single-ended refusal)
+- [Clearance](diff-pairs/02-clearance-and-classes.md) (`intra_pair_clearance`, `coupled_routing`)
+- [Impedance](diff-pairs/03-impedance-and-sizing.md) (`target_diff_impedance`, `kct impedance` CLI)
+- [Length matching](diff-pairs/04-length-matching.md) (`skew_tolerance_mm`, `Autorouter.update_diffpair_skew`)
+- [Protocol recipes](diff-pairs/05-protocol-recipes.md) (USB 2.0 / USB 3.0 / PCIe / MIPI)
+- [DRC rules](diff-pairs/06-drc-rules.md) (`diffpair_clearance_intra`, `_routing_continuity`, `_length_skew`, `impedance`)
 
-# Route as pairs
-result = router.route_diff_pairs()
-```
-
-### Manual Definition
-
-```python
-# Define diff pair
-router.add_diff_pair("USB_D", "USB_D+", "USB_D-",
-    spacing=0.15,           # Pair spacing
-    trace_width=0.2,
-    impedance=90,           # Target impedance
-)
-
-# Route it
-router.route_net("USB_D")
-```
-
-### Length Matching
-
-```python
-# Match lengths within tolerance
-router.set_length_match("USB_D+", "USB_D-", tolerance=0.5)  # mm
-
-# Add serpentine if needed
-router.enable_serpentine(min_amplitude=0.5, spacing=0.3)
-```
+The canonical pre-configured class is `NET_CLASS_HIGH_SPEED` in
+[`router/rules.py:675`](../../src/kicad_tools/router/rules.py) (already has
+`coupled_routing=True`).
 
 ---
 

--- a/tests/test_diffpair_docs.py
+++ b/tests/test_diffpair_docs.py
@@ -1,0 +1,214 @@
+"""Sanity tests for the diff-pair user-documentation set.
+
+Guards the doc/code coupling for ``docs/guides/diff-pairs/``:
+
+* the protocol recipes in ``05-protocol-recipes.md`` are valid Python that
+  produces ``NetClassRouting`` instances whose ``effective_*`` accessors
+  return finite floats (i.e. the recipe actually sets the fields it claims to
+  demonstrate);
+* every diff-pair / impedance ``rule_id`` registered in
+  ``ViolationType.from_string``'s alias table is documented in
+  ``06-drc-rules.md`` (forward direction), and every rule_id documented in
+  ``06-drc-rules.md`` exists in the alias table (reverse direction);
+* the stale Router-method API references previously documented in
+  ``docs/guides/routing.md`` (``router.auto_detect_diff_pairs``,
+  ``router.route_diff_pairs``, ``router.add_diff_pair``,
+  ``router.set_length_match``, ``router.enable_serpentine``, and the
+  diff-pair-shaped ``router.route_net("USB_D")`` example) are gone.
+
+Issue: #2659.  Epic: #2556 (Phase 4M).
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DIFFPAIR_DOCS = REPO_ROOT / "docs" / "guides" / "diff-pairs"
+ROUTING_GUIDE = REPO_ROOT / "docs" / "guides" / "routing.md"
+
+# Stale API tokens removed from docs/guides/routing.md by this issue.  These
+# names never existed on ``Router``/``Autorouter`` in ``src/kicad_tools/``;
+# they were placeholder docs for an API that was never implemented.
+STALE_API_TOKENS = (
+    "auto_detect_diff_pairs",
+    "route_diff_pairs",
+    "add_diff_pair",
+    "set_length_match",
+    "enable_serpentine",
+)
+
+
+def _read_python_code_blocks(md_path: Path) -> list[str]:
+    """Extract every ```python fenced block from a markdown file.
+
+    Blocks are returned in document order.  Indented code blocks and
+    other-language blocks are ignored.
+    """
+    text = md_path.read_text(encoding="utf-8")
+    pattern = re.compile(r"^```python\s*\n(.*?)^```\s*$", re.DOTALL | re.MULTILINE)
+    return [m.group(1) for m in pattern.finditer(text)]
+
+
+def test_protocol_recipes_compile() -> None:
+    """Each fenced ``python`` block in 05-protocol-recipes.md must:
+
+    1. execute end-to-end under ``exec()`` without raising,
+    2. construct at least one ``NetClassRouting`` instance, and
+    3. that instance's ``effective_intra_pair_clearance()`` and
+       ``effective_skew_tolerance()`` must return finite floats.
+
+    This catches the failure mode where a recipe builds a ``NetClassRouting``
+    but forgets to set the fields the recipe is *supposed* to demonstrate
+    (e.g. omitting ``skew_tolerance_mm`` from the MIPI block).
+    """
+    from kicad_tools.router.rules import NetClassRouting
+
+    recipes_path = DIFFPAIR_DOCS / "05-protocol-recipes.md"
+    blocks = _read_python_code_blocks(recipes_path)
+    assert len(blocks) >= 4, (
+        f"Expected at least 4 protocol recipes (USB 2.0 / USB 3.0 / PCIe / MIPI), "
+        f"got {len(blocks)} in {recipes_path}"
+    )
+
+    for i, src in enumerate(blocks):
+        ns: dict[str, object] = {}
+        try:
+            exec(compile(src, f"{recipes_path}:block-{i}", "exec"), ns)
+        except Exception as e:  # noqa: BLE001
+            pytest.fail(f"Recipe block {i} failed to exec: {e!r}\n---\n{src}")
+
+        # At least one NetClassRouting must be constructed in the block.
+        ncrs = [v for v in ns.values() if isinstance(v, NetClassRouting)]
+        assert ncrs, f"Recipe block {i} produced no NetClassRouting instance:\n---\n{src}"
+
+        # Each NetClassRouting's effective_* accessors must return finite floats.
+        for ncr in ncrs:
+            ipc = ncr.effective_intra_pair_clearance()
+            assert isinstance(ipc, float) and math.isfinite(ipc) and ipc > 0.0, (
+                f"effective_intra_pair_clearance() on {ncr.name!r} in block {i} "
+                f"returned non-finite/non-positive: {ipc!r}"
+            )
+            skew = ncr.effective_skew_tolerance()
+            assert isinstance(skew, float) and math.isfinite(skew) and skew > 0.0, (
+                f"effective_skew_tolerance() on {ncr.name!r} in block {i} "
+                f"returned non-finite/non-positive: {skew!r}"
+            )
+
+
+def _diffpair_rule_ids_from_violation_alias_table() -> set[str]:
+    """Return every ``diffpair_``-prefixed (plus ``impedance``) rule_id alias
+    registered in ``ViolationType.from_string``'s ``aliases`` table.
+
+    The aliases table is the canonical CLI surface — adding a rule_id there
+    without doc coverage is the drift this test exists to prevent.
+    """
+    from kicad_tools.drc.violation import ViolationType
+
+    # Build the alias table the same way ``from_string`` does internally:
+    # iterate the enum and collect every ``.value`` that participates in
+    # diff-pair / impedance DRC.
+    public_rule_ids: set[str] = set()
+    for vt in ViolationType:
+        v = vt.value
+        if isinstance(v, str) and (v.startswith("diffpair_") or v == "impedance"):
+            public_rule_ids.add(v)
+    return public_rule_ids
+
+
+def _rule_ids_documented_in_drc_guide() -> set[str]:
+    """Return every rule_id referenced in the 06-drc-rules.md guide.
+
+    A rule_id is recognized either as an inline-code reference like
+    ``` `diffpair_clearance_intra` ``` or as a ``--rules=<id>`` flag value.
+    """
+    doc_path = DIFFPAIR_DOCS / "06-drc-rules.md"
+    text = doc_path.read_text(encoding="utf-8")
+    # Inline code: `diffpair_*` or `impedance`
+    found = set(re.findall(r"`(diffpair_[a-z_]+|impedance)`", text))
+    # CLI flag values: --rules=<id> (comma-separated also accepted)
+    for m in re.finditer(r"--rules=([A-Za-z0-9_,]+)", text):
+        for token in m.group(1).split(","):
+            token = token.strip()
+            if token.startswith("diffpair_") or token == "impedance":
+                found.add(token)
+    return found
+
+
+def test_rule_ids_match_code() -> None:
+    """Bidirectional doc/code coupling for diff-pair DRC rule_ids.
+
+    * Forward: every ``diffpair_``/``impedance`` rule_id in the
+      ``ViolationType`` enum must appear in ``06-drc-rules.md``.  Prevents a
+      new DRC rule from being added to the enum (and exposed on the CLI)
+      without documentation.
+    * Reverse: every rule_id mentioned in ``06-drc-rules.md`` must exist in
+      ``ViolationType``.  Prevents docs from advertising a fictional CLI flag.
+    """
+    code_ids = _diffpair_rule_ids_from_violation_alias_table()
+    doc_ids = _rule_ids_documented_in_drc_guide()
+
+    missing_from_doc = code_ids - doc_ids
+    assert not missing_from_doc, (
+        f"rule_id(s) registered in ViolationType but not documented in "
+        f"06-drc-rules.md: {sorted(missing_from_doc)}.  "
+        f"Doc coverage is required before a rule_id can ship on the CLI."
+    )
+
+    missing_from_code = doc_ids - code_ids
+    assert not missing_from_code, (
+        f"rule_id(s) documented in 06-drc-rules.md but not present in "
+        f"ViolationType: {sorted(missing_from_code)}.  "
+        f"Either remove the doc reference or add the rule to the enum."
+    )
+
+
+def test_no_stale_api_references() -> None:
+    """``docs/guides/routing.md`` no longer references fictional Router methods.
+
+    The original diff-pair section (lines 191-225, pre-issue) documented six
+    Router methods that never existed in ``src/kicad_tools/``.  This issue
+    deleted that section and replaced it with a 10-line summary that links
+    into ``docs/guides/diff-pairs/``.
+    """
+    text = ROUTING_GUIDE.read_text(encoding="utf-8")
+    found = [tok for tok in STALE_API_TOKENS if tok in text]
+    assert not found, (
+        f"Stale Router-method tokens still present in {ROUTING_GUIDE}: "
+        f"{found}.  These APIs do not exist in src/kicad_tools/; the docs "
+        f"must not reference them."
+    )
+
+
+def test_all_guides_present() -> None:
+    """All six guides + README exist under ``docs/guides/diff-pairs/``."""
+    expected = [
+        "README.md",
+        "01-declaring-pairs.md",
+        "02-clearance-and-classes.md",
+        "03-impedance-and-sizing.md",
+        "04-length-matching.md",
+        "05-protocol-recipes.md",
+        "06-drc-rules.md",
+    ]
+    for name in expected:
+        path = DIFFPAIR_DOCS / name
+        assert path.is_file(), f"Missing required guide: {path}"
+
+
+def test_guide_length_caps() -> None:
+    """Each guide ≤ 100 lines; README ≤ 50 lines.
+
+    Enforces the epic's "don't create monster doc files" rule and the
+    curator's tightened acceptance criterion.  Counted as newline-delimited
+    lines (not "lines excluding code blocks") because the former is what a
+    reader actually scrolls through.
+    """
+    for path in sorted(DIFFPAIR_DOCS.glob("*.md")):
+        limit = 50 if path.name == "README.md" else 100
+        n_lines = sum(1 for _ in path.open(encoding="utf-8"))
+        assert n_lines <= limit, f"{path} has {n_lines} lines, exceeds cap of {limit}"


### PR DESCRIPTION
Closes #2659.  Epic #2556 Phase 4M.

## Summary

- Adds the six-guide diff-pair documentation set under `docs/guides/diff-pairs/` (README + six topic guides, each ≤ 100 lines, README ≤ 50 lines per the epic's "no monster doc files" rule).
- Replaces the 35-line diff-pair section in `docs/guides/routing.md` (lines 191-225, pre-PR) -- which documented six `Router` methods that **never existed** in `src/kicad_tools/` -- with a 10-line summary linking into the new guides.
- Adds `tests/test_diffpair_docs.py` guarding the doc/code coupling so future drift fails CI rather than rotting in place.

## What changed in `docs/guides/routing.md`

The original section referenced six fictional APIs:

| Stale reference | Status on `main` |
|---|---|
| `router.auto_detect_diff_pairs()` | does not exist |
| `router.route_diff_pairs()` | does not exist |
| `router.add_diff_pair(..., spacing=, impedance=)` | does not exist |
| `router.route_net("USB_D")` (diff-pair form) | not this signature |
| `router.set_length_match(p, n, tolerance=)` | does not exist |
| `router.enable_serpentine(min_amplitude=, spacing=)` | does not exist |

The replacement section explains that diff-pair handling is configured *declaratively* per net class on `NetClassRouting`, lists the six new guides, and points to the canonical pre-configured class `NET_CLASS_HIGH_SPEED` (`router/rules.py:675`).

## The six guides

1. **`01-declaring-pairs.md`** -- three detection paths: explicit `diffpair_partner` (authoritative), KiCad schematic DiffPair group, suffix inference (`_P`/`_N`, `+`/`-`). Single-ended refusal for USB-C `CC1`/`CC2` and `SBU1`/`SBU2` via `is_single_ended_refused` -- Issue #2527 curator lesson.
2. **`02-clearance-and-classes.md`** -- `intra_pair_clearance` vs `clearance`, the `effective_intra_pair_clearance()` fallback, `coupled_routing` opt-in, manufacturer-profile interaction, via-in-pad cross-link.
3. **`03-impedance-and-sizing.md`** -- `target_diff_impedance`, `target_single_impedance`, `impedance_tolerance_percent`, `StackupMismatchWarning`, JLCPCB tier-1 calibration, `kct impedance` CLI subcommands.
4. **`04-length-matching.md`** -- `skew_tolerance_mm` at `rules.py:550` (curator correction -- **not** `LengthConstraint`), `effective_skew_tolerance(default=0.5)`, `Autorouter.update_diffpair_skew`. Serpentine-insertion subsection marked TODO pending #2648 rather than fabricating an API.
5. **`05-protocol-recipes.md`** -- copy-pasteable `NetClassRouting` blocks for USB 2.0, USB 3.0 SuperSpeed, PCIe Gen 1, MIPI D-PHY. Each block sets the protocol-essential fields and includes inline `assert` checks against `effective_*` accessors.
6. **`06-drc-rules.md`** -- one paragraph per `rule_id` (`diffpair_clearance_intra`, `diffpair_routing_continuity`, `diffpair_length_skew`, `impedance`) with source path, `kct check --rules=` invocation, and remediation steps.

## Tests

`tests/test_diffpair_docs.py` adds five tests (all pass locally in 0.33s):

- `test_protocol_recipes_compile` -- each fenced ` ```python ` block in `05-protocol-recipes.md` execs cleanly, constructs at least one `NetClassRouting`, and that instance's `effective_intra_pair_clearance()` / `effective_skew_tolerance()` return **finite positive floats** (curator's tightened acceptance criterion -- catches the failure mode where a recipe builds a class but forgets to set the field it's supposed to demonstrate).
- `test_rule_ids_match_code` -- bidirectional doc/code coupling: every `diffpair_`/`impedance` rule_id in `ViolationType` appears in `06-drc-rules.md` AND every rule_id mentioned in the guide exists in the enum.
- `test_no_stale_api_references` -- asserts all six stale Router-method tokens are absent from `docs/guides/routing.md`.
- `test_all_guides_present` -- asserts 7 files (README + 6 guides) exist.
- `test_guide_length_caps` -- enforces ≤ 100 lines per guide / ≤ 50 lines for README.

## Test plan

- [x] `uv run pytest tests/test_diffpair_docs.py -v --no-cov` -- 5/5 pass
- [x] `uv run ruff check tests/test_diffpair_docs.py` -- clean
- [x] `uv run ruff format --check tests/test_diffpair_docs.py` -- clean
- [x] `grep -E "auto_detect_diff_pairs|add_diff_pair|set_length_match|route_diff_pairs|enable_serpentine" docs/guides/routing.md` -- no matches
- [x] All 7 guide files present under `docs/guides/diff-pairs/`
- [x] All file line counts within cap (README 36/50, longest guide 93/100)
- [x] All API line references verified against `origin/main` (`rules.py:425/448/451/486/504/515/526/550/572/583/604`, `diffpair.py:240/296/365`, `core.py:6926`, `violation.py:133-150/245/263-282`, `diffpair_impedance.py:76/235`)

## Soft-blocked TODOs noted in-place

- Guide 04's "when serpentine inserts" subsection is marked TODO pending Issue #2648 (Phase 3I autorouter serpentine insertion).
- Guide 06 documents `diffpair_length_skew` as live because PR #2662 (Phase 3J) merged at commit `18f75985`, two commits ahead of the branch fork-point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)