### PR TITLE
fix(sch unconnected): cross-check netlist export + walk hierarchy

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -162,6 +162,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--include-power")
         if args.include_dnp:
             sub_argv.append("--include-dnp")
+        if not getattr(args, "check_netlist_export", True):
+            sub_argv.append("--no-check-netlist-export")
         return unconnected_main(sub_argv) or 0
 
     elif args.sch_command == "set-footprint":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -529,6 +529,13 @@ def _add_sch_parser(subparsers) -> None:
         "--include-power", action="store_true", help="Include power symbols"
     )
     sch_unconnected.add_argument("--include-dnp", action="store_true", help="Include DNP symbols")
+    sch_unconnected.add_argument(
+        "--no-check-netlist-export",
+        dest="check_netlist_export",
+        action="store_false",
+        default=True,
+        help="Skip the netlist-export cross-check (default: enabled)",
+    )
 
     # sch replace
     sch_replace = sch_subparsers.add_parser("replace", help="Replace a symbol's library ID")

--- a/src/kicad_tools/cli/sch_find_unconnected.py
+++ b/src/kicad_tools/cli/sch_find_unconnected.py
@@ -2,6 +2,21 @@
 """
 Find unconnected pins and potential issues in a KiCad schematic.
 
+This command performs two complementary checks:
+
+1. **Wire-graph analysis** -- walks the schematic's wire-graph and reports
+   pins that are not connected to any wire, label, or junction.  For
+   hierarchical schematics, the analysis is repeated for every sub-sheet
+   discovered via the ``Sheetfile`` property.
+
+2. **Netlist cross-check** -- exports the netlist via ``kicad-cli`` (no
+   Python fallback) and reports any pin that exists in the schematic but
+   is missing from the netlist.  This catches the false-negative observed
+   when a symbol's ``(instances)`` block contains only ``wrong_project``
+   entries: ``kicad-cli`` silently drops the symbol from the netlist but
+   the wire-graph analysis still sees it.  Use
+   ``--no-check-netlist-export`` to skip this cross-check.
+
 Usage:
     python3 sch-find-unconnected.py <schematic.kicad_sch> [options]
 
@@ -10,6 +25,7 @@ Options:
     --filter <pattern>         Filter by symbol reference (e.g., "U*")
     --include-power            Include power symbols in analysis
     --include-dnp              Include DNP (do not populate) symbols
+    --no-check-netlist-export  Skip the netlist-export cross-check
 
 Examples:
     # Find all unconnected pins
@@ -27,6 +43,7 @@ import fnmatch
 import json
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 from kicad_tools.cli.sch_connectivity import (
     Coord,
@@ -34,6 +51,7 @@ from kicad_tools.cli.sch_connectivity import (
     is_pin_connected,
     to_coord,
 )
+from kicad_tools.cli.sch_set_footprint import _collect_schematic_files
 from kicad_tools.schema import Schematic
 
 
@@ -48,6 +66,7 @@ class UnconnectedPin:
     symbol_value: str
     lib_id: str
     position: tuple[float, float]
+    sheet: str = ""  # Sub-sheet file name (empty for root)
 
 
 @dataclass
@@ -57,24 +76,46 @@ class ConnectionIssue:
     type: str  # "floating_wire", "stacked_symbols", "missing_junction"
     description: str
     position: tuple[float, float]
+    sheet: str = ""
 
 
-def analyze_schematic(
+@dataclass
+class MissingFromNetlist:
+    """A pin that exists in the schematic but is missing from the netlist export.
+
+    This indicates the symbol was silently dropped by ``kicad-cli`` --
+    most commonly because its ``(instances)`` block contains only
+    ``wrong_project`` entries (see ``kct sch repair-instances``).
+    """
+
+    reference: str
+    pin_number: str
+    pin_name: str
+    pin_type: str
+    symbol_value: str
+    lib_id: str
+    position: tuple[float, float]
+    sheet: str = ""
+
+
+def _analyze_single_sheet(
     schematic: Schematic,
-    include_power: bool = False,
-    include_dnp: bool = False,
-    pattern: str = None,
-) -> tuple[list[UnconnectedPin], list[ConnectionIssue]]:
-    """
-    Analyze schematic for unconnected pins and issues.
+    include_power: bool,
+    include_dnp: bool,
+    pattern: str | None,
+    sheet_name: str,
+) -> tuple[list[UnconnectedPin], list[ConnectionIssue], list[tuple]]:
+    """Run wire-graph analysis on one schematic file.
 
-    Uses the wire-graph BFS approach with per-pin position resolution
-    from embedded lib_symbols to accurately detect unconnected pins.
-
-    Returns tuple of (unconnected_pins, connection_issues)
+    Returns:
+        Tuple of (unconnected_pins, issues, symbol_data) where ``symbol_data``
+        is a list of ``(sym, lib_sym, pin_positions)`` tuples for every
+        symbol that survived filtering on this sheet.  The caller uses
+        ``symbol_data`` to build the global schematic-side pin set for the
+        netlist cross-check.
     """
-    unconnected = []
-    issues = []
+    unconnected: list[UnconnectedPin] = []
+    issues: list[ConnectionIssue] = []
 
     # First pass: collect all pin coordinates for wire-graph splitting
     all_pin_coords: set[Coord] = set()
@@ -109,6 +150,7 @@ def analyze_schematic(
                         symbol_value=sym.value,
                         lib_id=sym.lib_id,
                         position=sym.position,
+                        sheet=sheet_name,
                     )
                 )
             continue
@@ -146,6 +188,7 @@ def analyze_schematic(
                         symbol_value=sym.value,
                         lib_id=sym.lib_id,
                         position=pos,
+                        sheet=sheet_name,
                     )
                 )
 
@@ -157,6 +200,7 @@ def analyze_schematic(
                     type="stacked_symbols",
                     description=f"Multiple symbols at same position: {', '.join(refs)}",
                     position=pos,
+                    sheet=sheet_name,
                 )
             )
 
@@ -177,8 +221,7 @@ def analyze_schematic(
                 ]
             )
             junction_positions = {
-                (round(j.position[0], 1), round(j.position[1], 1))
-                for j in schematic.junctions
+                (round(j.position[0], 1), round(j.position[1], 1)) for j in schematic.junctions
             }
             label_positions = set()
             for lbl in schematic.labels:
@@ -198,10 +241,189 @@ def analyze_schematic(
                         type="possible_floating_wire",
                         description="Wire endpoint may be floating",
                         position=point,
+                        sheet=sheet_name,
                     )
                 )
 
-    return unconnected, issues
+    return unconnected, issues, symbol_data
+
+
+def _cross_check_netlist(
+    root_path: Path,
+    schematic_pins: list[tuple[str, str, "UnconnectedPin"]],
+) -> tuple[list[MissingFromNetlist], str | None]:
+    """Cross-check schematic pins against the netlist export.
+
+    Args:
+        root_path: Path to the root .kicad_sch file.
+        schematic_pins: List of ``(reference, pin_number, pin_record)``
+            tuples for every schematic pin that should appear in the
+            netlist (after power/DNP filtering).  ``pin_record`` carries
+            the metadata used to build the finding.
+
+    Returns:
+        Tuple of ``(findings, warning)``.  ``warning`` is a human-readable
+        message if the cross-check could not run (kicad-cli unavailable,
+        crashed, or export missing); in that case ``findings`` is empty.
+    """
+    # Import here to avoid forcing operations/netlist deps for callers
+    # that pass ``--no-check-netlist-export``.
+    try:
+        from kicad_tools.operations.netlist import export_netlist
+    except Exception as e:
+        return [], f"netlist module unavailable: {e}"
+
+    # Export via kicad-cli with fallback=False -- we explicitly want to
+    # see what kicad-cli emits, since that is what every downstream
+    # consumer (pcbnew, KiCad, exported BOMs, fabrication outputs)
+    # actually sees.  The Python fallback would *hide* the bug by
+    # walking the hierarchy correctly.
+    try:
+        netlist = export_netlist(root_path, fallback=False)
+    except FileNotFoundError as e:
+        return [], f"kicad-cli not available, netlist cross-check skipped: {e}"
+    except RuntimeError as e:
+        return [], f"kicad-cli netlist export failed, cross-check skipped: {e}"
+    except Exception as e:  # pragma: no cover - defensive
+        return [], f"netlist export raised unexpected error, cross-check skipped: {e}"
+
+    # Build set of (reference, pin) tuples present in the netlist.
+    netlist_pin_set: set[tuple[str, str]] = set()
+    for net in netlist.nets:
+        for node in net.nodes:
+            netlist_pin_set.add((node.reference, node.pin))
+
+    findings: list[MissingFromNetlist] = []
+    for ref, pin_num, record in schematic_pins:
+        if (ref, pin_num) not in netlist_pin_set:
+            findings.append(
+                MissingFromNetlist(
+                    reference=ref,
+                    pin_number=pin_num,
+                    pin_name=record.pin_name,
+                    pin_type=record.pin_type,
+                    symbol_value=record.symbol_value,
+                    lib_id=record.lib_id,
+                    position=record.position,
+                    sheet=record.sheet,
+                )
+            )
+
+    return findings, None
+
+
+def analyze_schematic(
+    schematic: Schematic,
+    include_power: bool = False,
+    include_dnp: bool = False,
+    pattern: str | None = None,
+    *,
+    root_path: Path | None = None,
+    check_netlist_export: bool = True,
+) -> tuple[list[UnconnectedPin], list[ConnectionIssue], list[MissingFromNetlist]]:
+    """Analyze a schematic (and its hierarchy) for connectivity issues.
+
+    Performs three checks:
+
+    1. Wire-graph BFS on every sheet in the hierarchy (root + sub-sheets).
+    2. Stacked-symbol detection per sheet.
+    3. Netlist-export cross-check via ``kicad-cli`` (root only).
+
+    Args:
+        schematic: Root schematic (already loaded).
+        include_power: Include ``power:`` library symbols.
+        include_dnp: Include ``dnp`` symbols.
+        pattern: ``fnmatch`` pattern to filter symbol references.
+        root_path: Path to the root .kicad_sch file (required for sub-sheet
+            traversal and netlist export).  If omitted, the hierarchy walk
+            and netlist cross-check are skipped.
+        check_netlist_export: Run the netlist-export cross-check.
+
+    Returns:
+        Tuple of ``(unconnected_pins, connection_issues, missing_from_netlist)``.
+    """
+    unconnected: list[UnconnectedPin] = []
+    issues: list[ConnectionIssue] = []
+    # Build the global schematic-side pin set across the whole hierarchy,
+    # keyed on (reference, pin_number).  This is used for the netlist
+    # cross-check at the end.
+    schematic_pin_records: list[tuple[str, str, UnconnectedPin]] = []
+    # De-duplicate hierarchical instances of the same (ref, pin) so we
+    # don't report the same missing pin once per sheet.
+    seen_pins: set[tuple[str, str]] = set()
+
+    # Collect all sheets in the hierarchy.
+    if root_path is not None:
+        sheet_files = _collect_schematic_files(Path(root_path))
+    else:
+        sheet_files = []
+
+    # Always include the root schematic we were given.
+    sheets_to_analyze: list[tuple[Schematic, str]] = [(schematic, "")]
+
+    # Append sub-sheets (skip the root which we already loaded).
+    if sheet_files:
+        root_resolved = Path(root_path).resolve()
+        for sf in sheet_files:
+            if sf.resolve() == root_resolved:
+                continue
+            try:
+                sub = Schematic.load(sf)
+            except Exception as e:
+                # Don't fail the entire run if a sub-sheet won't parse;
+                # warn and continue.
+                print(
+                    f"Warning: could not load sub-sheet {sf}: {e}",
+                    file=sys.stderr,
+                )
+                continue
+            sheets_to_analyze.append((sub, sf.name))
+
+    for sub_sch, sheet_name in sheets_to_analyze:
+        sub_unconn, sub_issues, sub_symbol_data = _analyze_single_sheet(
+            sub_sch,
+            include_power=include_power,
+            include_dnp=include_dnp,
+            pattern=pattern,
+            sheet_name=sheet_name,
+        )
+        unconnected.extend(sub_unconn)
+        issues.extend(sub_issues)
+
+        # Record every schematic-side pin for the netlist cross-check.
+        # We use the position/value of the first instance we see; if the
+        # same (ref, pin) appears on multiple sheets (which shouldn't
+        # normally happen) we keep the first record.
+        for sym, lib_sym, pin_positions in sub_symbol_data:
+            for lib_pin in lib_sym.pins:
+                if lib_pin.number not in pin_positions:
+                    continue
+                key = (sym.reference, lib_pin.number)
+                if key in seen_pins:
+                    continue
+                seen_pins.add(key)
+                pos = pin_positions[lib_pin.number]
+                record = UnconnectedPin(
+                    reference=sym.reference,
+                    pin_number=lib_pin.number,
+                    pin_name=lib_pin.name,
+                    pin_type=lib_pin.type,
+                    symbol_value=sym.value,
+                    lib_id=sym.lib_id,
+                    position=pos,
+                    sheet=sheet_name,
+                )
+                schematic_pin_records.append((sym.reference, lib_pin.number, record))
+
+    missing_from_netlist: list[MissingFromNetlist] = []
+    if check_netlist_export and root_path is not None:
+        findings, warning = _cross_check_netlist(Path(root_path), schematic_pin_records)
+        if warning:
+            print(f"Warning: {warning}", file=sys.stderr)
+        else:
+            missing_from_netlist = findings
+
+    return unconnected, issues, missing_from_netlist
 
 
 def main(argv=None):
@@ -217,10 +439,18 @@ def main(argv=None):
     parser.add_argument("--filter", dest="pattern", help="Filter by symbol reference pattern")
     parser.add_argument("--include-power", action="store_true", help="Include power symbols")
     parser.add_argument("--include-dnp", action="store_true", help="Include DNP symbols")
+    parser.add_argument(
+        "--no-check-netlist-export",
+        dest="check_netlist_export",
+        action="store_false",
+        default=True,
+        help="Skip the netlist-export cross-check (default: enabled)",
+    )
 
     args = parser.parse_args(argv)
 
     try:
+        sch_path = Path(args.schematic)
         sch = Schematic.load(args.schematic)
     except FileNotFoundError:
         print(f"Error: File not found: {args.schematic}", file=sys.stderr)
@@ -229,21 +459,29 @@ def main(argv=None):
         print(f"Error loading schematic: {e}", file=sys.stderr)
         sys.exit(1)
 
-    unconnected, issues = analyze_schematic(
+    unconnected, issues, missing_from_netlist = analyze_schematic(
         sch,
         include_power=args.include_power,
         include_dnp=args.include_dnp,
         pattern=args.pattern,
+        root_path=sch_path,
+        check_netlist_export=args.check_netlist_export,
     )
 
     if args.format == "json":
-        output_json(unconnected, issues)
+        output_json(unconnected, issues, missing_from_netlist)
     else:
-        output_table(unconnected, issues)
+        output_table(unconnected, issues, missing_from_netlist)
 
 
-def output_table(unconnected: list[UnconnectedPin], issues: list[ConnectionIssue]):
+def output_table(
+    unconnected: list[UnconnectedPin],
+    issues: list[ConnectionIssue],
+    missing_from_netlist: list[MissingFromNetlist] | None = None,
+):
     """Output as formatted table."""
+    missing_from_netlist = missing_from_netlist or []
+
     by_symbol: dict[str, list[UnconnectedPin]] = {}
     for pin in unconnected:
         if pin.reference not in by_symbol:
@@ -277,9 +515,34 @@ def output_table(unconnected: list[UnconnectedPin], issues: list[ConnectionIssue
             print(f"  [{issue.type}] {issue.description}")
             print(f"   Position: ({issue.position[0]:.1f}, {issue.position[1]:.1f})")
 
+    if missing_from_netlist:
+        print("\nMissing from Netlist Export")
+        print("=" * 60)
+        print(
+            "These pins exist in the schematic but were dropped by kicad-cli during netlist export."
+        )
+        print(
+            "Most commonly caused by wrong_project (instances) entries"
+            " -- run `kct sch repair-instances` to fix."
+        )
+        print("-" * 60)
+        by_ref: dict[str, list[MissingFromNetlist]] = {}
+        for p in missing_from_netlist:
+            by_ref.setdefault(p.reference, []).append(p)
+        for ref in sorted(by_ref.keys()):
+            pins = by_ref[ref]
+            pin_nums = sorted(p.pin_number for p in pins)
+            print(f"  {ref}: pin(s) {', '.join(pin_nums)}")
+        print(f"\nTotal: {len(missing_from_netlist)} pin(s) missing from netlist")
 
-def output_json(unconnected: list[UnconnectedPin], issues: list[ConnectionIssue]):
+
+def output_json(
+    unconnected: list[UnconnectedPin],
+    issues: list[ConnectionIssue],
+    missing_from_netlist: list[MissingFromNetlist] | None = None,
+):
     """Output as JSON."""
+    missing_from_netlist = missing_from_netlist or []
     data = {
         "unconnected_pins": [
             {
@@ -290,6 +553,7 @@ def output_json(unconnected: list[UnconnectedPin], issues: list[ConnectionIssue]
                 "symbol_value": p.symbol_value,
                 "lib_id": p.lib_id,
                 "position": list(p.position),
+                "sheet": p.sheet,
             }
             for p in unconnected
         ],
@@ -298,13 +562,33 @@ def output_json(unconnected: list[UnconnectedPin], issues: list[ConnectionIssue]
                 "type": i.type,
                 "description": i.description,
                 "position": list(i.position),
+                "sheet": i.sheet,
             }
             for i in issues
+        ],
+        "missing_from_netlist": [
+            {
+                "reference": p.reference,
+                "pin_number": p.pin_number,
+                "pin_name": p.pin_name,
+                "pin_type": p.pin_type,
+                "symbol_value": p.symbol_value,
+                "lib_id": p.lib_id,
+                "position": list(p.position),
+                "sheet": p.sheet,
+                "remediation": (
+                    "Pin exists in schematic but is missing from netlist"
+                    " export -- run `kct sch repair-instances` to fix"
+                    " wrong_project (instances) entries."
+                ),
+            }
+            for p in missing_from_netlist
         ],
         "summary": {
             "unconnected_pin_count": len(unconnected),
             "issue_count": len(issues),
             "symbols_with_issues": len({p.reference for p in unconnected}),
+            "missing_from_netlist_count": len(missing_from_netlist),
         },
     }
     print(json.dumps(data, indent=2))

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -246,7 +246,9 @@ class TestSchListLabels:
         """Test that --filter pattern works across all sheets."""
         from kicad_tools.cli.sch_list_labels import main
 
-        main([str(hierarchical_schematic), "--type", "global", "--filter", "CLK", "--format", "json"])
+        main(
+            [str(hierarchical_schematic), "--type", "global", "--filter", "CLK", "--format", "json"]
+        )
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -1553,9 +1555,7 @@ class TestSchValidateNoConnectInput:
         from kicad_tools.cli.sch_validate import main
 
         sch_file = self._make_schematic(tmp_path, pin_type="input")
-        monkeypatch.setattr(
-            "sys.argv", ["sch-validate", str(sch_file), "--quiet"]
-        )
+        monkeypatch.setattr("sys.argv", ["sch-validate", str(sch_file), "--quiet"])
         with contextlib.suppress(SystemExit):
             main()
 
@@ -1569,9 +1569,7 @@ class TestSchValidateNoConnectInput:
         from kicad_tools.cli.sch_validate import main
 
         sch_file = self._make_schematic(tmp_path, pin_type="input")
-        monkeypatch.setattr(
-            "sys.argv", ["sch-validate", str(sch_file), "--format", "json"]
-        )
+        monkeypatch.setattr("sys.argv", ["sch-validate", str(sch_file), "--format", "json"])
         with contextlib.suppress(SystemExit):
             main()
 
@@ -1769,9 +1767,7 @@ class TestSchValidateGlobalLabelDirections:
         sch_file = tmp_path / "top.kicad_sch"
         sch_file.write_text(sch)
 
-        monkeypatch.setattr(
-            "sys.argv", ["sch-validate", str(sch_file), "--format", "json"]
-        )
+        monkeypatch.setattr("sys.argv", ["sch-validate", str(sch_file), "--format", "json"])
         import contextlib
 
         with contextlib.suppress(SystemExit):
@@ -1793,7 +1789,6 @@ class TestSchValidateGlobalLabelDirections:
 
         result = validate_schematic(str(sch_file))
         assert "global_label_directions" in result.checks_run
-
 
     def test_input_bidirectional_no_warning(self, tmp_path: Path):
         """input + bidirectional is a valid complementary pair -- no warning."""
@@ -1841,9 +1836,7 @@ class TestSchValidateGlobalLabelDirections:
 
         issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
         consistency_issues = [
-            i
-            for i in issues
-            if i.category == "global_label" and "inconsistent" in i.message
+            i for i in issues if i.category == "global_label" and "inconsistent" in i.message
         ]
         assert len(consistency_issues) == 0
 
@@ -1860,9 +1853,7 @@ class TestSchValidateGlobalLabelDirections:
 
         issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
         consistency_issues = [
-            i
-            for i in issues
-            if i.category == "global_label" and "inconsistent" in i.message
+            i for i in issues if i.category == "global_label" and "inconsistent" in i.message
         ]
         assert len(consistency_issues) == 0
 
@@ -1921,9 +1912,7 @@ class TestSchValidateGlobalLabelDirections:
 
         issues = check_global_label_directions(str(tmp_path / "top.kicad_sch"))
         conflict_issues = [
-            i
-            for i in issues
-            if i.category == "global_label" and "conflicting" in i.message
+            i for i in issues if i.category == "global_label" and "conflicting" in i.message
         ]
 
         assert len(conflict_issues) == 1
@@ -2074,7 +2063,8 @@ class TestSchValidateSheetParseFailure:
         # The parent sheet itself may also fail to parse, so we check for at least 2
         # broken sub-sheet issues (sub1 and sub2)
         info_issues = [
-            i for i in issues
+            i
+            for i in issues
             if i.severity == "info" and i.category == "footprint" and "Skipped sheet" in i.message
         ]
         assert len(info_issues) >= 2
@@ -2230,9 +2220,7 @@ class TestSchCheckConnections:
             assert "pins" in data
             assert "summary" in data
 
-    def test_argv_parameter(
-        self, minimal_schematic: Path, minimal_symbol_library: Path, capsys
-    ):
+    def test_argv_parameter(self, minimal_schematic: Path, minimal_symbol_library: Path, capsys):
         """Test calling main() with an explicit argv list (CLI runner path)."""
         from kicad_tools.cli.sch_check_connections import main
 
@@ -2259,9 +2247,7 @@ class TestSchCheckConnections:
             data = json.loads(captured.out)
             assert "pins" in data
             # Should report LIBRARY_NOT_FOUND for symbols without embedded definitions
-            found_not_found = any(
-                p["pin_name"] == "LIBRARY_NOT_FOUND" for p in data["pins"]
-            )
+            found_not_found = any(p["pin_name"] == "LIBRARY_NOT_FOUND" for p in data["pins"])
             assert found_not_found, "Expected LIBRARY_NOT_FOUND for symbol without embedded lib"
 
     def test_embedded_symbols_no_lib_path(self, capsys, tmp_path):
@@ -2678,6 +2664,229 @@ class TestSchFindUnconnected:
             data = json.loads(captured.out)
             assert isinstance(data, dict)
             assert "unconnected_pins" in data
+
+    # ---- Regression tests for issue #2665 (netlist cross-check + hierarchy walk) ----
+
+    # Hierarchical schematic: root sheet that references a child sheet
+    # via (sheet ... (property "Sheetfile" "child.kicad_sch" ...)).
+    # The child sheet contains an isolated symbol whose pin has no wire,
+    # so wire-graph analysis on the root would miss it -- only the
+    # hierarchy walk will surface it.
+    _HIERARCHY_ROOT = """\
+(kicad_sch
+  (version 20231120) (generator "test") (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001") (paper "A4")
+  (lib_symbols)
+  (sheet (at 50 50) (size 30 20)
+    (uuid "00000000-0000-0000-0000-0000000000aa")
+    (property "Sheetname" "Child" (at 50 49 0))
+    (property "Sheetfile" "child.kicad_sch" (at 50 71 0))
+  )
+)
+"""
+
+    _HIERARCHY_CHILD = """\
+(kicad_sch
+  (version 20231120) (generator "test") (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000002") (paper "A4")
+  (lib_symbols
+    (symbol "Device:R"
+      (property "Reference" "R" (at 0 0 0) (effects (font (size 1.27 1.27))))
+      (property "Value" "R" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+      (symbol "Device:R_0_1"
+        (pin passive line (at 0 -3.81 90) (length 2.54) (name "1") (number "1"))
+        (pin passive line (at 0 3.81 270) (length 2.54) (name "2") (number "2"))
+      )
+    )
+  )
+  (symbol (lib_id "Device:R") (at 100 100 0)
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (property "Reference" "R99" (at 100 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "10k" (at 100 110 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "" (at 100 100 0) (effects (hide yes)))
+    (property "Datasheet" "" (at 100 100 0) (effects (hide yes)))
+    (pin "1" (uuid "00000000-0000-0000-0000-000000000011"))
+    (pin "2" (uuid "00000000-0000-0000-0000-000000000012"))
+    (instances (project "test" (path "/00000000-0000-0000-0000-000000000002" (reference "R99") (unit 1))))
+  )
+)
+"""
+
+    def test_unconnected_json_schema_includes_new_keys(self, tmp_path: Path, capsys):
+        """sch unconnected JSON output exposes missing_from_netlist + summary count.
+
+        Even when the cross-check is skipped (kicad-cli unavailable), the
+        JSON structure must include the new keys so downstream consumers
+        can rely on them.
+        """
+        from kicad_tools.cli.sch_find_unconnected import main
+
+        sch_file = tmp_path / "minimal.kicad_sch"
+        sch_file.write_text(TestConnectionsSubGridTolerance._SCH_UNCONNECTED)
+
+        # Skip the cross-check entirely so the test does not depend on kicad-cli.
+        main([str(sch_file), "--format", "json", "--no-check-netlist-export"])
+        data = json.loads(capsys.readouterr().out)
+        assert "missing_from_netlist" in data, "JSON output must include missing_from_netlist list"
+        assert isinstance(data["missing_from_netlist"], list)
+        assert "missing_from_netlist_count" in data["summary"], (
+            "summary must include missing_from_netlist_count"
+        )
+        # With --no-check-netlist-export, no findings should be produced.
+        assert data["summary"]["missing_from_netlist_count"] == 0
+        # The existing schema must still work.
+        assert data["summary"]["unconnected_pin_count"] >= 1
+
+    def test_unconnected_no_check_netlist_export_skip(self, tmp_path: Path, capsys, monkeypatch):
+        """--no-check-netlist-export disables the cross-check (no kicad-cli call)."""
+        from kicad_tools.cli import sch_find_unconnected as mod
+
+        sch_file = tmp_path / "minimal.kicad_sch"
+        sch_file.write_text(TestConnectionsSubGridTolerance._SCH_UNCONNECTED)
+
+        # Patch export_netlist to raise if it is unexpectedly invoked.
+        def _boom(*args, **kwargs):  # pragma: no cover - assertion path
+            raise AssertionError(
+                "export_netlist should not be called when --no-check-netlist-export is passed"
+            )
+
+        # Import the source module to patch it as referenced from the CLI module.
+        import kicad_tools.operations.netlist as netlist_mod
+
+        monkeypatch.setattr(netlist_mod, "export_netlist", _boom)
+
+        mod.main([str(sch_file), "--format", "json", "--no-check-netlist-export"])
+        data = json.loads(capsys.readouterr().out)
+        assert data["summary"]["missing_from_netlist_count"] == 0
+        assert data["missing_from_netlist"] == []
+
+    def test_unconnected_netlist_export_unavailable_skips_gracefully(
+        self, tmp_path: Path, capsys, monkeypatch
+    ):
+        """If kicad-cli is unavailable, the cross-check is skipped with a stderr warning.
+
+        Important: the command MUST still produce its normal output -- a
+        silent pass would defeat the purpose of the check.
+        """
+        from kicad_tools.cli import sch_find_unconnected as mod
+
+        sch_file = tmp_path / "minimal.kicad_sch"
+        sch_file.write_text(TestConnectionsSubGridTolerance._SCH_UNCONNECTED)
+
+        # Simulate kicad-cli being unavailable.
+        import kicad_tools.operations.netlist as netlist_mod
+
+        def _missing(*args, **kwargs):
+            raise FileNotFoundError("kicad-cli not found")
+
+        monkeypatch.setattr(netlist_mod, "export_netlist", _missing)
+
+        mod.main([str(sch_file), "--format", "json"])
+        out = capsys.readouterr()
+        # JSON output is still produced with the schematic-graph findings.
+        data = json.loads(out.out)
+        assert data["summary"]["unconnected_pin_count"] == 2  # R1 pins 1 + 2
+        assert data["summary"]["missing_from_netlist_count"] == 0
+        # And a warning is printed to stderr -- not a silent pass.
+        assert "skipped" in out.err.lower() or "warning" in out.err.lower()
+
+    def test_unconnected_detects_dropped_pin_via_netlist(self, tmp_path: Path, capsys, monkeypatch):
+        """If kicad-cli drops a symbol from the netlist, the pin is reported.
+
+        This is the core regression test for #2665: a pin that exists in
+        the schematic but is missing from the kicad-cli netlist export
+        MUST be surfaced as missing_from_netlist (not silently classified
+        as "connected" because a wire happens to touch its coordinates).
+        """
+        from kicad_tools.cli import sch_find_unconnected as mod
+
+        sch_file = tmp_path / "dropped.kicad_sch"
+        # Use the existing connected-pins schematic where R1 has wires on
+        # both pins; the wire-graph analysis will report 0 unconnected.
+        sch_file.write_text(TestConnectionsSubGridTolerance._SCH_EXACT)
+
+        # Fake an empty netlist: kicad-cli "ran" but dropped every symbol.
+        import kicad_tools.operations.netlist as netlist_mod
+        from kicad_tools.operations.netlist import Netlist
+
+        def _empty_netlist(*args, **kwargs):
+            return Netlist()  # no components, no nets
+
+        monkeypatch.setattr(netlist_mod, "export_netlist", _empty_netlist)
+
+        mod.main([str(sch_file), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+
+        # Wire-graph still reports zero unconnected (the wires exist).
+        assert data["summary"]["unconnected_pin_count"] == 0
+        # But the netlist cross-check surfaces both of R1's pins.
+        assert data["summary"]["missing_from_netlist_count"] >= 2
+        refs = {(p["reference"], p["pin_number"]) for p in data["missing_from_netlist"]}
+        assert ("R1", "1") in refs
+        assert ("R1", "2") in refs
+        # Each finding includes a remediation hint pointing at repair-instances.
+        for finding in data["missing_from_netlist"]:
+            assert "repair-instances" in finding["remediation"]
+
+    def test_unconnected_no_false_positives_when_netlist_matches(
+        self, tmp_path: Path, capsys, monkeypatch
+    ):
+        """When the netlist contains every schematic pin, no findings are emitted."""
+        import kicad_tools.operations.netlist as netlist_mod
+        from kicad_tools.cli import sch_find_unconnected as mod
+        from kicad_tools.operations.netlist import (
+            Netlist,
+            NetlistNet,
+            NetNode,
+        )
+
+        sch_file = tmp_path / "good.kicad_sch"
+        sch_file.write_text(TestConnectionsSubGridTolerance._SCH_EXACT)
+
+        # Synthesize a netlist that contains both R1.1 and R1.2.
+        def _matching_netlist(*args, **kwargs):
+            return Netlist(
+                nets=[
+                    NetlistNet(
+                        code=1,
+                        name="N1",
+                        nodes=[NetNode(reference="R1", pin="1"), NetNode(reference="R1", pin="2")],
+                    )
+                ]
+            )
+
+        monkeypatch.setattr(netlist_mod, "export_netlist", _matching_netlist)
+
+        mod.main([str(sch_file), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert data["summary"]["missing_from_netlist_count"] == 0
+
+    def test_unconnected_hierarchy_walk_includes_subsheet_pins(self, tmp_path: Path, capsys):
+        """sch unconnected walks the hierarchy and analyses sub-sheets.
+
+        Previously only the root sheet was analysed; symbols on sub-sheets
+        were silently ignored.  This test sets up a root sheet with no
+        symbols and a child sheet with an unwired resistor.  After the
+        fix, both pins of the child's resistor should be reported.
+        """
+        from kicad_tools.cli.sch_find_unconnected import main
+
+        root = tmp_path / "root.kicad_sch"
+        child = tmp_path / "child.kicad_sch"
+        root.write_text(self._HIERARCHY_ROOT)
+        child.write_text(self._HIERARCHY_CHILD)
+
+        # Skip the netlist cross-check -- this test is specifically about
+        # the wire-graph hierarchy walk, not kicad-cli availability.
+        main([str(root), "--format", "json", "--no-check-netlist-export"])
+        data = json.loads(capsys.readouterr().out)
+        # R99 lives on the child sheet and has two unwired pins.
+        refs = {(p["reference"], p["pin_number"]) for p in data["unconnected_pins"]}
+        assert ("R99", "1") in refs, f"expected R99.1 in unconnected pins, got {refs}"
+        assert ("R99", "2") in refs, f"expected R99.2 in unconnected pins, got {refs}"
+        # And the sheet name is propagated in the JSON output for clarity.
+        sheets = {p["sheet"] for p in data["unconnected_pins"]}
+        assert "child.kicad_sch" in sheets
 
 
 class TestSchRenameSignal:
@@ -3114,16 +3323,12 @@ class TestSchValidateMissingProjectInstances:
         pi_issues = [i for i in result.issues if i.category == "project_instances"]
         assert len(pi_issues) == 1
 
-    def test_json_output_includes_project_instances(
-        self, tmp_path: Path, capsys, monkeypatch
-    ):
+    def test_json_output_includes_project_instances(self, tmp_path: Path, capsys, monkeypatch):
         """JSON output should include the project_instances category."""
         from kicad_tools.cli.sch_validate import main
 
         sch_file = self._make_schematic(tmp_path, include_instances=False)
-        monkeypatch.setattr(
-            "sys.argv", ["sch-validate", str(sch_file), "--format", "json"]
-        )
+        monkeypatch.setattr("sys.argv", ["sch-validate", str(sch_file), "--format", "json"])
         with contextlib.suppress(SystemExit):
             main()
 


### PR DESCRIPTION
## Summary

`kct sch unconnected` previously walked only the schematic's wire-graph and
never opened the exported netlist. When `kicad-cli` silently drops a symbol
from the netlist (most commonly because its `(instances)` block contains
only `wrong_project` entries -- see #2664), the symbol's pins were still
reported as "connected" if a wire happened to touch their coordinates --
exactly the class of defect the command exists to catch.

Two structural fixes:

1. **Netlist cross-check** (default-on, opt-out via `--no-check-netlist-export`).
   After the wire-graph pass, export the netlist via `kicad-cli` (no
   Python fallback -- we want what every downstream consumer actually
   sees) and emit a new `missing_from_netlist` finding for every
   `(reference, pin)` present in the schematic but absent from the
   exported nets. The remediation message points at `kct sch repair-instances`.
2. **Hierarchy walk**. Reuses `_collect_schematic_files` from
   `sch_set_footprint` to walk every sub-sheet referenced by
   `(property "Sheetfile" ...)` and analyses each one's wire-graph
   independently. Previously only the root sheet was analysed.

## Changes

- `src/kicad_tools/cli/sch_find_unconnected.py`: new `MissingFromNetlist`
  dataclass, `_analyze_single_sheet` helper (per-sheet wire-graph), and
  `_cross_check_netlist` helper (kicad-cli export + diff). `analyze_schematic`
  now walks the hierarchy and runs the netlist cross-check.
- `src/kicad_tools/cli/parser.py`: new `--no-check-netlist-export` flag.
- `src/kicad_tools/cli/commands/schematic.py`: forwards the new flag.
- `tests/test_cli_sch.py`: 6 new regression tests covering JSON schema,
  the opt-out path, the kicad-cli-unavailable graceful-skip path, the
  core dropped-pin detection, the false-positive guard, and the
  hierarchy walk.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New `missing_from_netlist` finding category | done | `MissingFromNetlist` dataclass; `test_unconnected_detects_dropped_pin_via_netlist` asserts `("R1", "1")` and `("R1", "2")` appear |
| Finding message references `kct sch repair-instances` | done | `remediation` field in JSON output; test asserts `"repair-instances" in finding["remediation"]` |
| Power and DNP symbols excluded unless flags set | done | Existing `include_power`/`include_dnp` logic is reused -- only filtered symbols are recorded into the schematic-pin set used for the cross-check |
| `--format json` exposes new findings + `missing_from_netlist_count` | done | `output_json` adds `missing_from_netlist` list and `missing_from_netlist_count` in summary; `test_unconnected_json_schema_includes_new_keys` asserts both |
| kicad-cli unavailable -> skip with stderr warning (not silent pass) | done | `_cross_check_netlist` catches `FileNotFoundError`/`RuntimeError` and prints `"Warning: ... skipped"` to stderr; `test_unconnected_netlist_export_unavailable_skips_gracefully` asserts both the JSON output and the warning |
| Hierarchy walk: sub-sheets analysed | done | `_collect_schematic_files` walk in `analyze_schematic`; `test_unconnected_hierarchy_walk_includes_subsheet_pins` builds a parent + child sheet and asserts the child's pins appear |
| Regression test for wrong_project dropout | done | `test_unconnected_detects_dropped_pin_via_netlist` simulates kicad-cli dropping every symbol (the wrong_project failure mode) and asserts `missing_from_netlist_count >= 2` |
| Test for all-good schematic produces 0 findings | done | `test_unconnected_no_false_positives_when_netlist_matches` |

## Test Plan

- [x] `uv run pytest tests/test_cli_sch.py::TestSchFindUnconnected` -- 11/11 pass
- [x] `uv run pytest tests/test_cli_sch.py::TestConnectionsSubGridTolerance` -- 6/6 pass (no regression)
- [x] `uv run pytest tests/test_cli_sch.py` -- 134/135 pass; the 1 failure (`TestSchSummary::test_existing_hierarchical_fixture_aggregation`) is **pre-existing on main** (verified by `git stash` + re-run)
- [x] `uv run ruff check` on changed files -- clean
- [x] `uv run ruff format --check` on changed files -- clean

## Relationship to #2664

#2664 makes `sch validate` refuse `wrong_project` entries (preventive).
This PR makes `sch unconnected` catch any dropped pin regardless of
cause (defensive). They land in different files and reinforce each
other -- neither subsumes the other.

Closes #2665