### PR TITLE
fix(sch-validate): detect wrong_project + loose_project_blocks as errors

### DIFF
--- a/src/kicad_tools/cli/sch_repair_instances.py
+++ b/src/kicad_tools/cli/sch_repair_instances.py
@@ -180,6 +180,9 @@ def _extract_symbols_with_instance_info(
     """
     symbols = []
     ref_pattern = re.compile(r'\(property "Reference" "([^"]+)"')
+    value_pattern = re.compile(r'\(property "Value" "([^"]*)"')
+    in_bom_pattern = re.compile(r'\(in_bom\s+(yes|no)\)')
+    on_board_pattern = re.compile(r'\(on_board\s+(yes|no)\)')
 
     # Find symbol block starts: lines matching <ws>(symbol\n<ws>(lib_id "...")
     start_pattern = re.compile(
@@ -204,6 +207,21 @@ def _extract_symbols_with_instance_info(
             continue
 
         ref = ref_match.group(1)
+
+        # Extract Value property + in_bom/on_board for downstream consumers
+        # (e.g. validate's "graphical-only symbol" skip filter).  These are
+        # optional — sub-sheet symbol blocks always carry them in KiCad 8+,
+        # but minimal hand-built fixtures may omit them.  When absent, the
+        # defaults (value="", in_bom=True, on_board=True) match KiCad's
+        # behaviour: a symbol with no explicit (in_bom no) is in the BOM.
+        value_match = value_pattern.search(block)
+        sym_value = value_match.group(1) if value_match else ""
+        in_bom_match = in_bom_pattern.search(block)
+        sym_in_bom = (in_bom_match.group(1) == "yes") if in_bom_match else True
+        on_board_match = on_board_pattern.search(block)
+        sym_on_board = (
+            (on_board_match.group(1) == "yes") if on_board_match else True
+        )
 
         # Structural scan: locate the direct-child (instances ...) form and
         # any direct-child (project ...) forms (the malformed shape).
@@ -281,6 +299,9 @@ def _extract_symbols_with_instance_info(
             "unit_suffix": unit_suffix,
             "lib_id": lib_id,
             "uuid": sym_uuid,
+            "value": sym_value,
+            "in_bom": sym_in_bom,
+            "on_board": sym_on_board,
             "has_project_instance": has_project,
             "has_wrong_project": has_wrong_project,
             "has_loose_project_blocks": has_loose_project_blocks,

--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -772,91 +772,168 @@ def check_connector_pinout(schematic_path: str) -> list[ValidationIssue]:
 
 
 def check_missing_project_instances(schematic_path: str) -> list[ValidationIssue]:
-    """Check for symbols missing the ``instances`` block.
+    """Check for symbols with missing or malformed ``(instances ...)`` blocks.
 
     In KiCad 8+, every placed symbol must have an ``(instances ...)`` child
-    node that registers it to a project path.  Without this block the
-    component is invisible to the netlist exporter and BOM generator despite
-    being visually present on the schematic.
+    node that registers it to the **current project**.  Three failure modes
+    are possible, and ``kicad-cli sch export netlist`` silently drops the
+    symbol from the netlist in all three:
+
+    1. **Missing** — no ``(instances ...)`` block at all.  Reported as a
+       ``warning`` (legacy behaviour; affects hand-built fixtures most).
+    2. **Wrong project** — ``(instances ...)`` exists but only names a
+       different project (e.g. the sub-sheet's old standalone-project name,
+       not the current root project).  Reported as an ``error``.
+    3. **Loose project blocks** — ``(project ...)`` forms appear at
+       symbol-child indent (siblings of ``(instances)`` rather than children
+       of it).  Reported as an ``error``.
+
+    All three are mechanically fixable via ``kct sch repair-instances``.
 
     The check skips:
-    - Power symbols (``lib_id`` starting with ``power:``)
-    - Symbols with both ``in_bom=no`` and ``on_board=no`` (graphical-only)
+    - Power symbols (``lib_id`` starting with ``power:``) **for the
+      missing-instances case only** — power symbols with wrong-project or
+      loose-project blocks are still flagged because they too need repair.
+    - Symbols with both ``in_bom=no`` and ``on_board=no`` (graphical-only).
 
-    Multi-unit symbols are deduplicated by (reference, lib_id) so that a missing
-    ``instances`` block on a two-unit IC produces a single warning, not one
-    per unit.
+    Detection reuses :func:`_extract_symbols_with_instance_info` from
+    ``sch_repair_instances`` so the validator and the repair tool share a
+    single structural-scan implementation (see issue #2664).
     """
+    # Imports are local to avoid a top-level cycle: sch_repair_instances
+    # transitively imports from this file's package on some test paths.
+    from kicad_tools.cli.sch_re_annotate import _detect_project_info
+    from kicad_tools.cli.sch_repair_instances import (
+        _extract_symbols_with_instance_info,
+    )
+    from kicad_tools.cli.sch_set_footprint import _collect_schematic_files
+
     issues: list[ValidationIssue] = []
 
     try:
-        hierarchy = build_hierarchy(schematic_path)
+        root = Path(schematic_path)
+        all_files = _collect_schematic_files(root)
+        project_name, _root_uuid, _paths = _detect_project_info(
+            root, all_files
+        )
 
-        for node in hierarchy.all_nodes():
+        # Deduplicate multi-unit ICs per-sheet, mirroring the legacy
+        # implementation's (reference, lib_id) dedup.
+        # ``_extract_symbols_with_instance_info`` returns one entry per
+        # ``(symbol ...)`` block, i.e. one entry per *unit*, so a two-unit
+        # IC produces two entries that share (reference, lib_id) — we want
+        # one issue per logical component.
+        for sch_file in all_files:
             try:
-                sch = Schematic.load(node.path)
-                # Track UUIDs already flagged to deduplicate multi-unit ICs.
-                # Multi-unit symbols share the same base UUID (only the first
-                # unit carries the instances block in the raw file, but after
-                # parsing each unit becomes a separate SymbolInstance sharing
-                # the same lib_id + reference).  Deduplicate by reference +
-                # lib_id so we report once per logical component.
-                seen: set[tuple[str, str]] = set()
+                text = sch_file.read_text(encoding="utf-8")
+            except OSError as e:
+                issues.append(
+                    ValidationIssue(
+                        severity="info",
+                        category="project_instances",
+                        message=(
+                            f"Skipped sheet {sch_file.name}: {e}"
+                        ),
+                        location=sch_file.name,
+                    )
+                )
+                continue
 
-                for sym in sch.symbols:
-                    # Skip power symbols
-                    if sym.lib_id.startswith("power:"):
-                        continue
-
-                    # Skip graphical-only symbols (not in BOM and not on board)
-                    if not sym.in_bom and not sym.on_board:
-                        continue
-
-                    # Deduplicate multi-unit symbols
-                    dedup_key = (sym.reference, sym.lib_id)
-                    if dedup_key in seen:
-                        continue
-
-                    # Check for instances block in raw S-expression
-                    has_instances = False
-                    if sym._sexp is not None:
-                        if sym._sexp.find("instances") is not None:
-                            has_instances = True
-                    else:
-                        # Programmatically-created symbol without _sexp:
-                        # skip with info if desired, but don't flag as missing
-                        continue
-
-                    if not has_instances:
-                        seen.add(dedup_key)
-                        ref = sym.reference or "?"
-                        val = sym.value or "?"
-                        issues.append(
-                            ValidationIssue(
-                                severity="warning",
-                                category="project_instances",
-                                message=(
-                                    f"Missing project instances block: "
-                                    f"{ref} ({val}) - will be absent from "
-                                    f"netlist and BOM"
-                                ),
-                                location=node.get_path_string(),
-                            )
-                        )
-                    else:
-                        # Mark as seen even when instances are present, so
-                        # other units of the same IC don't get flagged.
-                        seen.add(dedup_key)
-
+            try:
+                syms = _extract_symbols_with_instance_info(
+                    text, project_name
+                )
             except Exception as e:
                 issues.append(
                     ValidationIssue(
                         severity="info",
                         category="project_instances",
-                        message=f"Skipped sheet {node.get_path_string()}: {e}",
-                        location=node.get_path_string(),
+                        message=(
+                            f"Skipped sheet {sch_file.name}: {e}"
+                        ),
+                        location=sch_file.name,
                     )
                 )
+                continue
+
+            try:
+                loc = str(sch_file.relative_to(root.parent))
+            except ValueError:
+                loc = sch_file.name
+
+            seen: set[tuple[str, str]] = set()
+            for sym in syms:
+                ref = sym["reference"] or "?"
+                lib_id = sym["lib_id"]
+                value = sym.get("value") or "?"
+
+                # Skip graphical-only symbols (in_bom=no AND on_board=no).
+                # Note: _extract_symbols_with_instance_info already skips
+                # power symbols for the missing-instances case, but does
+                # *not* apply the graphical-only filter — we do it here so
+                # the filter is consistent across all three variants.
+                if not sym.get("in_bom", True) and not sym.get(
+                    "on_board", True
+                ):
+                    continue
+
+                dedup_key = (ref, lib_id)
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+
+                fix_hint = (
+                    f"Fix with: kct sch repair-instances {root.name}"
+                )
+
+                if sym.get("has_loose_project_blocks"):
+                    issues.append(
+                        ValidationIssue(
+                            severity="error",
+                            category="project_instances",
+                            message=(
+                                f"Loose (project) blocks outside "
+                                f"(instances): {ref} ({value}) - netlist "
+                                f"export will silently drop this symbol. "
+                                f"{fix_hint}"
+                            ),
+                            location=loc,
+                        )
+                    )
+                elif sym.get("has_wrong_project"):
+                    issues.append(
+                        ValidationIssue(
+                            severity="error",
+                            category="project_instances",
+                            message=(
+                                f"Wrong project name in (instances): "
+                                f"{ref} ({value}) - this entry names a "
+                                f"different project; netlist export will "
+                                f"drop pins. {fix_hint}"
+                            ),
+                            location=loc,
+                        )
+                    )
+                elif not sym.get("has_project_instance"):
+                    # Missing-instances case: preserve legacy behaviour by
+                    # skipping power symbols entirely.  (Power symbols with
+                    # wrong_project / loose_project_blocks are already
+                    # surfaced by _extract_symbols_with_instance_info and
+                    # handled by the branches above.)
+                    if lib_id.startswith("power:"):
+                        continue
+                    issues.append(
+                        ValidationIssue(
+                            severity="warning",
+                            category="project_instances",
+                            message=(
+                                f"Missing project instances block: "
+                                f"{ref} ({value}) - will be absent from "
+                                f"netlist and BOM. {fix_hint}"
+                            ),
+                            location=loc,
+                        )
+                    )
 
     except Exception as e:
         issues.append(

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -3021,7 +3021,11 @@ class TestSchValidateMissingProjectInstances:
 {sym}
 {extra_symbols}
 )"""
-        sch_file = tmp_path / "test_inst.kicad_sch"
+        # Filename stem MUST equal the (project "test"...) name embedded
+        # in _INSTANCES_BLOCK above — _detect_project_info uses the root
+        # schematic's filename stem as the canonical project name.  See
+        # sch_re_annotate._detect_project_info and issue #2664.
+        sch_file = tmp_path / "test.kicad_sch"
         sch_file.write_text(sch_text)
         return sch_file
 

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -3136,3 +3136,352 @@ class TestSchValidateMissingProjectInstances:
         pi_issues = [i for i in data["issues"] if i["category"] == "project_instances"]
         assert len(pi_issues) == 1
         assert pi_issues[0]["severity"] == "warning"
+
+    # -- new tests for issue #2664: wrong_project + loose_project_blocks ----
+
+    # Variant of _INSTANCES_BLOCK that names a *different* project.
+    # When the root schematic stem is "test", this instances block names
+    # "other-project" — kicad-cli will silently drop this symbol from the
+    # netlist because the project name does not match.
+    _WRONG_PROJECT_INSTANCES_BLOCK = """\
+    (instances
+      (project "other-project"
+        (path "/00000000-0000-0000-0000-000000000001"
+          (reference "{ref}")
+          (unit {unit})
+        )
+      )
+    )
+"""
+
+    # Variant where the (project ...) form is a *sibling* of (instances)
+    # at symbol-child indent — the malformed shape documented in #2624.
+    # (instances) itself is empty.  kicad-cli drops the symbol from the
+    # netlist because it only looks inside (instances).
+    _LOOSE_PROJECT_BLOCK = """\
+    (project "test"
+      (path "/00000000-0000-0000-0000-000000000001"
+        (reference "{ref}")
+        (unit {unit})
+      )
+    )
+    (instances)
+"""
+
+    def _make_schematic_with_block(
+        self,
+        tmp_path: Path,
+        block: str,
+        *,
+        lib_id: str = "Device:R",
+        ref: str = "R1",
+        value: str = "100k",
+        in_bom: str = "yes",
+        on_board: str = "yes",
+        uuid: str = "00000000-0000-0000-0000-000000000002",
+        unit: int = 1,
+        extra_symbols: str = "",
+    ) -> Path:
+        """Build a single-symbol schematic with the given child block.
+
+        ``block`` is the literal text (already formatted) to splice in at the
+        ``{instances}`` slot of ``_BASE_SYMBOL``.
+        """
+        sym = self._BASE_SYMBOL.format(
+            lib_id=lib_id,
+            ref=ref,
+            value=value,
+            in_bom=in_bom,
+            on_board=on_board,
+            uuid=uuid,
+            unit=unit,
+            instances=block,
+        )
+        sch_text = f"""(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols)
+{sym}
+{extra_symbols}
+)"""
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(sch_text)
+        return sch_file
+
+    def test_wrong_project_flagged_as_error(self, tmp_path: Path):
+        """A symbol whose (instances) names the wrong project errors out."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        block = self._WRONG_PROJECT_INSTANCES_BLOCK.format(ref="R1", unit=1)
+        sch_file = self._make_schematic_with_block(tmp_path, block)
+
+        issues = check_missing_project_instances(str(sch_file))
+
+        assert len(issues) == 1
+        assert issues[0].severity == "error"
+        assert issues[0].category == "project_instances"
+        assert "Wrong project" in issues[0].message
+        assert "R1" in issues[0].message
+        # Fix hint must be present so users can grep for the command
+        assert "repair-instances" in issues[0].message
+
+    def test_wrong_project_power_symbol_flagged(self, tmp_path: Path):
+        """Power symbols with wrong_project are still flagged (they need repair too)."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        block = self._WRONG_PROJECT_INSTANCES_BLOCK.format(
+            ref="#PWR01", unit=1
+        )
+        sch_file = self._make_schematic_with_block(
+            tmp_path,
+            block,
+            lib_id="power:GND",
+            ref="#PWR01",
+            value="GND",
+        )
+
+        issues = check_missing_project_instances(str(sch_file))
+
+        assert len(issues) == 1
+        assert issues[0].severity == "error"
+        assert "Wrong project" in issues[0].message
+
+    def test_loose_project_blocks_flagged_as_error(self, tmp_path: Path):
+        """A symbol with loose (project) blocks outside (instances) errors out."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        block = self._LOOSE_PROJECT_BLOCK.format(ref="R1", unit=1)
+        sch_file = self._make_schematic_with_block(tmp_path, block)
+
+        issues = check_missing_project_instances(str(sch_file))
+
+        assert len(issues) == 1
+        assert issues[0].severity == "error"
+        assert issues[0].category == "project_instances"
+        assert "Loose" in issues[0].message
+        assert "R1" in issues[0].message
+        assert "repair-instances" in issues[0].message
+
+    def test_loose_project_blocks_power_symbol_flagged(self, tmp_path: Path):
+        """Power symbols with loose_project_blocks are still flagged."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        block = self._LOOSE_PROJECT_BLOCK.format(ref="#PWR01", unit=1)
+        sch_file = self._make_schematic_with_block(
+            tmp_path,
+            block,
+            lib_id="power:GND",
+            ref="#PWR01",
+            value="GND",
+        )
+
+        issues = check_missing_project_instances(str(sch_file))
+
+        assert len(issues) == 1
+        assert issues[0].severity == "error"
+        assert "Loose" in issues[0].message
+
+    def test_missing_instances_message_includes_fix_hint(self, tmp_path: Path):
+        """The legacy missing-instances message must include the repair hint."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        sch_file = self._make_schematic(tmp_path, include_instances=False)
+        issues = check_missing_project_instances(str(sch_file))
+
+        assert len(issues) == 1
+        assert issues[0].severity == "warning"
+        assert "repair-instances" in issues[0].message
+
+    def test_wrong_project_in_bom_on_board_skip_applies(self, tmp_path: Path):
+        """Graphical-only (in_bom=no, on_board=no) symbols skipped for wrong_project too."""
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        block = self._WRONG_PROJECT_INSTANCES_BLOCK.format(ref="R1", unit=1)
+        sch_file = self._make_schematic_with_block(
+            tmp_path,
+            block,
+            in_bom="no",
+            on_board="no",
+        )
+
+        issues = check_missing_project_instances(str(sch_file))
+        assert len(issues) == 0
+
+    # List of unrelated checks to skip in end-to-end exit-code tests so the
+    # exit code reflects ONLY project_instances severity.  The minimal
+    # hand-built fixtures used here trigger noise from ERC, lib_symbols
+    # consistency, footprint completeness, etc. — none of which are
+    # relevant to whether project_instances raised the severity bar.
+    _OTHER_CHECKS = [
+        "erc",
+        "footprints",
+        "values",
+        "bom_variety",
+        "value_consistency",
+        "hierarchy",
+        "no_connect_input",
+        "global_label_directions",
+        "connector_pinout",
+        "duplicate_references",
+        "pin_assignment",
+        "swd_routing",
+        "power_short",
+        "power_polarity",
+        "i2c_pullups",
+        "boot0_pulldown",
+        "unconnected_component",
+        "nrst_filter",
+        "symbol_footprint_pin_count",
+        "lib_symbols_mismatch",
+        "matched_channel_symmetry",
+        "orphan_label",
+        "wire_stub",
+    ]
+
+    def _validate_argv(self, sch_file: Path) -> list[str]:
+        """Build argv that runs ONLY the project_instances check."""
+        argv = ["sch-validate", str(sch_file)]
+        for c in self._OTHER_CHECKS:
+            argv.extend(["--skip", c])
+        return argv
+
+    def test_exit_code_nonzero_on_wrong_project(
+        self, tmp_path: Path, capsys, monkeypatch
+    ):
+        """End-to-end: kct sch validate exits non-zero when wrong_project present."""
+        from kicad_tools.cli.sch_validate import main
+
+        block = self._WRONG_PROJECT_INSTANCES_BLOCK.format(ref="R1", unit=1)
+        sch_file = self._make_schematic_with_block(tmp_path, block)
+
+        monkeypatch.setattr("sys.argv", self._validate_argv(sch_file))
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        # error_count > 0 -> sys.exit(1)
+        assert exc_info.value.code == 1
+
+    def test_exit_code_nonzero_on_loose_project(
+        self, tmp_path: Path, capsys, monkeypatch
+    ):
+        """End-to-end: kct sch validate exits non-zero when loose_project_blocks present."""
+        from kicad_tools.cli.sch_validate import main
+
+        block = self._LOOSE_PROJECT_BLOCK.format(ref="R1", unit=1)
+        sch_file = self._make_schematic_with_block(tmp_path, block)
+
+        monkeypatch.setattr("sys.argv", self._validate_argv(sch_file))
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+
+    def test_exit_code_zero_on_missing_only(
+        self, tmp_path: Path, capsys, monkeypatch
+    ):
+        """End-to-end: missing-instances alone stays a warning (exit 0)."""
+        from kicad_tools.cli.sch_validate import main
+
+        sch_file = self._make_schematic(tmp_path, include_instances=False)
+
+        monkeypatch.setattr("sys.argv", self._validate_argv(sch_file))
+        # Either no SystemExit at all, or SystemExit(0).
+        try:
+            main()
+            exit_code = 0
+        except SystemExit as e:
+            exit_code = e.code or 0
+        assert exit_code == 0
+
+    def test_json_output_wrong_project_is_error(
+        self, tmp_path: Path, capsys, monkeypatch
+    ):
+        """JSON output for wrong_project surfaces severity=error in project_instances."""
+        from kicad_tools.cli.sch_validate import main
+
+        block = self._WRONG_PROJECT_INSTANCES_BLOCK.format(ref="R1", unit=1)
+        sch_file = self._make_schematic_with_block(tmp_path, block)
+
+        monkeypatch.setattr(
+            "sys.argv", ["sch-validate", str(sch_file), "--format", "json"]
+        )
+        with contextlib.suppress(SystemExit):
+            main()
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        pi_issues = [
+            i for i in data["issues"] if i["category"] == "project_instances"
+        ]
+        assert len(pi_issues) == 1
+        assert pi_issues[0]["severity"] == "error"
+
+    def test_validator_and_repair_dry_run_agree(
+        self, tmp_path: Path, capsys
+    ):
+        """Validator and repair-instances --dry-run report the same count."""
+        from kicad_tools.cli.sch_repair_instances import run_repair_instances
+        from kicad_tools.cli.sch_validate import check_missing_project_instances
+
+        # Schematic with one wrong_project symbol + one loose_project symbol.
+        wrong_block = self._WRONG_PROJECT_INSTANCES_BLOCK.format(
+            ref="R1", unit=1
+        )
+        loose_block = self._LOOSE_PROJECT_BLOCK.format(ref="R2", unit=1)
+
+        sym1 = self._BASE_SYMBOL.format(
+            lib_id="Device:R",
+            ref="R1",
+            value="10k",
+            in_bom="yes",
+            on_board="yes",
+            uuid="00000000-0000-0000-0000-000000000002",
+            unit=1,
+            instances=wrong_block,
+        )
+        sym2 = self._BASE_SYMBOL.format(
+            lib_id="Device:R",
+            ref="R2",
+            value="4.7k",
+            in_bom="yes",
+            on_board="yes",
+            uuid="00000000-0000-0000-0000-000000000003",
+            unit=1,
+            instances=loose_block,
+        )
+        sch_text = f"""(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols)
+{sym1}
+{sym2}
+)"""
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text(sch_text)
+
+        # Validator side
+        issues = check_missing_project_instances(str(sch_file))
+        validator_count = sum(1 for i in issues if i.severity == "error")
+        assert validator_count == 2  # one wrong + one loose
+
+        # Repair-instances dry-run side (JSON for stable counting)
+        run_repair_instances(
+            sch_file, dry_run=True, backup=False, format="json"
+        )
+        captured = capsys.readouterr()
+        # The JSON envelope reports a 'total' field
+        data = json.loads(captured.out)
+        repair_count = data["total"]
+
+        assert (
+            validator_count == repair_count
+        ), (
+            f"validate reported {validator_count} errors but "
+            f"repair-instances dry-run reported {repair_count}"
+        )


### PR DESCRIPTION
## Summary

`check_missing_project_instances` previously used a binary
`sym._sexp.find("instances") is not None` check, which silently passed
the two malformed shapes that `kicad-cli sch export netlist` quietly
drops from the netlist:

- **wrong_project** — `(instances ...)` block exists but only names a
  different project (e.g. the sub-sheet's old standalone-project name).
- **loose_project_blocks** — `(project ...)` forms appear at
  symbol-child indent as siblings of, not children of, `(instances)`.

Both shapes are now reused-detected from `sch_repair_instances`
(`_extract_symbols_with_instance_info`) so there is a single source of
truth between the validator and the repair tool, and both shapes are
surfaced at `severity="error"` so the existing `sys.exit(1)` in `main()`
triggers automatically.

## Changes

- **`src/kicad_tools/cli/sch_validate.py`** — replaced the body of
  `check_missing_project_instances` with a structural scan that reuses
  `_extract_symbols_with_instance_info` and `_detect_project_info`.
  Walks all schematic files in the hierarchy via
  `_collect_schematic_files`. Wrong-project and loose-project-block
  variants emit `severity="error"`; missing-instances stays at
  `severity="warning"`. All three message variants include the literal
  `repair-instances` hint so users can grep the fix command.
  Category name `project_instances` is unchanged so JSON consumers and
  `--skip` users are unaffected.
- **`src/kicad_tools/cli/sch_repair_instances.py`** — extended
  `_extract_symbols_with_instance_info` to surface `value`, `in_bom`,
  `on_board` fields (additive — no existing test breaks). These are
  needed so the validator can apply its `in_bom=no, on_board=no`
  graphical-only-symbol skip filter without re-parsing the block.
- **`tests/test_cli_sch.py`** — renamed test fixture file from
  `test_inst.kicad_sch` to `test.kicad_sch` so the embedded
  `(project "test" ...)` matches the filename stem that
  `_detect_project_info` uses for the project-name lookup. Added 11
  new tests under `TestSchValidateMissingProjectInstances` covering
  the new failure modes and end-to-end exit-code behaviour.

## Acceptance Criteria Verification

### Detection

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `has_wrong_project=True` flagged as `severity="error"` | yes | `test_wrong_project_flagged_as_error` |
| `has_loose_project_blocks=True` flagged as `severity="error"` | yes | `test_loose_project_blocks_flagged_as_error` |
| Missing-instances stays `severity="warning"` | yes | `test_symbol_without_instances_flagged` (regression-preserved) |
| All three messages include literal `repair-instances` | yes | `test_missing_instances_message_includes_fix_hint`, `test_wrong_project_flagged_as_error`, `test_loose_project_blocks_flagged_as_error` |
| Power symbols w/ wrong_project ARE flagged | yes | `test_wrong_project_power_symbol_flagged` |
| Power symbols w/ loose_project_blocks ARE flagged | yes | `test_loose_project_blocks_power_symbol_flagged` |
| Power symbols with missing-only still skipped | yes | `test_power_symbol_not_flagged` (regression-preserved) |
| `in_bom=no, on_board=no` skip applies to all variants | yes | `test_in_bom_false_on_board_false_skipped`, `test_wrong_project_in_bom_on_board_skip_applies` |
| Multi-unit ICs deduplicate by `(reference, lib_id)` per sheet | yes | `test_multi_unit_ic_flagged_once` (regression-preserved) |

### Exit code

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Exit 1 on wrong_project | yes | `test_exit_code_nonzero_on_wrong_project` (asserts `SystemExit.code == 1`) |
| Exit 1 on loose_project_blocks | yes | `test_exit_code_nonzero_on_loose_project` |
| Exit 0 on missing-only (warning-only) | yes | `test_exit_code_zero_on_missing_only` |

### Regression / integration

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All 7 existing `*project_instances*` tests still pass without assertion changes | yes | Fixture renamed (file stem); assertions untouched. 7/7 pass. |
| New tests for wrong_project (>=2) | yes | Added 2 (`test_wrong_project_flagged_as_error`, `test_wrong_project_power_symbol_flagged`) |
| New tests for loose_project_blocks (>=2) | yes | Added 2 (`test_loose_project_blocks_flagged_as_error`, `test_loose_project_blocks_power_symbol_flagged`) |
| End-to-end exit-code test via `main()` + `sys.argv` | yes | `test_exit_code_nonzero_on_wrong_project`, `test_exit_code_nonzero_on_loose_project`, `test_exit_code_zero_on_missing_only` |

### Observability

| Criterion | Status | Verification |
|-----------|--------|--------------|
| JSON output preserves `category: "project_instances"` for all three variants | yes | `test_json_output_includes_project_instances` (warning) + `test_json_output_wrong_project_is_error` (error) |
| Text output severity icon driven by per-issue severity | yes | `print_result` is unchanged; severity-driven icon at sch_validate.py:3648-3653 already handles error rendering |

### Cross-tool consistency

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Validator error count == `repair-instances --dry-run` total on a mixed-defect schematic | yes | `test_validator_and_repair_dry_run_agree` — uses one wrong_project + one loose_project symbol, both tools report 2 |

## Test Plan

```bash
# 1. New + existing unit tests for the project_instances check
uv run pytest tests/test_cli_sch.py::TestSchValidateMissingProjectInstances -v --no-cov
# Result: 18 passed (7 existing + 11 new)

# 2. Repair-instances tests still pass after extending _extract_symbols_with_instance_info
uv run pytest tests/test_sch_repair_instances.py --no-cov
# Result: 42 passed

# 3. Broader validate sweep
uv run pytest tests/ -k 'validate or project_instance' \
  --ignore=tests/test_optimize_placement_cmd.py \
  --ignore=tests/test_placement_benchmark.py \
  --ignore=tests/test_placement_strategy.py --no-cov -q
# Result: 1054 passed (no regressions from project_instances changes)
```

The one failing test in the broader test_cli_sch.py sweep
(`TestSchSummary::test_existing_hierarchical_fixture_aggregation`) is
**pre-existing on `origin/main`** and unrelated to this change — verified
by running the same test against the stashed-clean tree before applying
this PR's changes.

Closes #2664