### PR TITLE
feat(ci): wire board 06 + diff-pair DRC rules into CI gate (closes #2660)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,3 +311,90 @@ jobs:
             [ -n "$f" ] && args+=("$f")
           done
           uv run python scripts/ci/check_routed_drc.py "${args[@]}"
+
+  diffpair-routing-regression:
+    # Issue #2660 / Epic #2556 Phase 4N: re-route board 06 (the diff-pair
+    # testbench) from scratch on every PR and verify that
+    #   (a) the resulting DRC error count is within the allowlist baseline
+    #       in .github/routed-drc-tolerance.yml; AND
+    #   (b) each of the three diff-pair DRC rules
+    #       (diffpair_clearance_intra, diffpair_routing_continuity,
+    #       diffpair_length_skew) was actually exercised against an engaged
+    #       pair -- i.e., the per-rule counter in the DRC summary is
+    #       non-zero for each rule_id.
+    #
+    # This job is the algorithmic-regression counterpart to the
+    # `routed-pcb-drc-check` job above.  That job is diff-driven (only fires
+    # when a PR touches a committed *_routed.kicad_pcb file), which catches
+    # regressions in *committed* PCB files but does NOT catch regressions in
+    # the routing algorithm itself -- e.g., if Phase 2E's coupled engagement
+    # accidentally flips `coupled_routing=False`, the diff-driven gate stays
+    # green because no committed PCB was touched.  This from-scratch job
+    # re-routes board 06 every run so the gate catches algorithmic
+    # regressions even when no committed PCB is modified.
+    #
+    # PR #2552 (merged) introduced the diff-driven precedent this job
+    # extends; this is the "always-run" counterpart for diff-pair coverage.
+    #
+    # Determinism: the gate uses `--seed 42` (Issue #2589 / Phase 3X.2)
+    # forwarded into `generate_design.py --seed` so the re-route is
+    # reproducible.  Without `--seed` the router uses os.urandom-derived
+    # entropy and produces different output run-to-run, which would
+    # generate false-positive failures on a loaded CI runner.
+    #
+    # Parametric over board name (matrix.board): board 03 can be added
+    # cheaply once #2589's non-determinism work fully closes and #2513
+    # (USB-C blockers) clears.  Today board 03 is omitted because its
+    # NetClassRouting declarations do not yet exercise coupled_routing.
+    #
+    # Allowlist:
+    #   .github/routed-drc-tolerance.yml currently has
+    #   boards/06-diffpair-test/.../diffpair_test_routed.kicad_pcb: 28
+    #   (25x ImpedanceRule per #2672 + 3x diffpair_clearance_intra per
+    #   #2677).  The gate respects the allowlist so it doesn't fail
+    #   immediately; when #2672 + #2677 land, the allowlist should be
+    #   tightened in a separate PR.
+    #
+    # IMPORTANT (branch-protection note): adding this job to the list of
+    # *required* status checks on `main` is a separate repo-admin action.
+    # The PR landing this job calls that out explicitly so the human
+    # approver can flip the GitHub setting after merge.  Until then the
+    # job runs on every PR but is advisory -- its failure does not block
+    # the merge button.
+    name: Diff-Pair Routing Regression
+    runs-on: ubuntu-latest
+    # Issue #2660 acceptance criterion #5: wall-clock <= 5 min on
+    # ubuntu-latest.  The 10-minute limit here is a safety net for slow
+    # runners; if the typical run creeps above 5 minutes, move to a
+    # nightly schedule per the epic's runtime guidance.
+    timeout-minutes: 10
+    strategy:
+      # Don't abort the matrix on a single board failure -- each board
+      # is independent and reviewers want all annotations at once.
+      fail-fast: false
+      matrix:
+        board:
+          - boards/06-diffpair-test
+        # Future: add boards/03-usb-joystick here once #2589 stabilises
+        # its router determinism and #2513 (USB-C blockers) clears.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Re-route board + check diff-pair coverage
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_diffpair_coverage.py \
+            "${{ matrix.board }}" \
+            --seed 42
+

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -121,6 +121,59 @@ Per the Epic #2556 Phase 4L mitigation strategy, this board is scaffolded
 now with PCIe / MIPI pairs declared but DRC tolerated at "non-strict" if
 #2648 hasn't landed yet.  Re-route and tighten when #2648 merges.
 
+## CI Gate (Phase 4N, #2660)
+
+This board is **re-routed from scratch on every pull request** by the
+`diffpair-routing-regression` job in `.github/workflows/ci.yml`.  Unlike
+the diff-driven `routed-pcb-drc-check` job (which only runs when a PR
+touches a committed `*_routed.kicad_pcb`), this job always runs so that
+algorithmic regressions in the router are caught even when the committed
+PCB stays untouched.
+
+The job:
+
+1. Runs `python boards/06-diffpair-test/generate_design.py --step route --seed 42`
+   to re-route the unrouted PCB deterministically.
+2. Loads the freshly-routed PCB, constructs the per-protocol
+   `NetClassRouting` map from `build_net_class_map()`, and runs
+   `DRCChecker` with `--mfr jlcpcb`.
+3. Asserts the DRC **error count** is within the per-board allowlist in
+   `.github/routed-drc-tolerance.yml` (currently 28: 25x `ImpedanceRule`
+   per [#2672](https://github.com/rjwalters/kicad-tools/issues/2672)
+   + 3x `diffpair_clearance_intra` per
+   [#2677](https://github.com/rjwalters/kicad-tools/issues/2677)).
+4. Asserts each of the three diff-pair DRC rule_ids was actually
+   exercised by the check, i.e. the JSON summary's
+   `rules_checked_by_rule[rule_id] >= 1` for each of:
+     - `diffpair_clearance_intra`
+     - `diffpair_length_skew`
+     - `diffpair_routing_continuity`
+
+   This guards against silent regressions that disable diff-pair
+   detection (e.g. flipping `coupled_routing` back to `False` on the
+   net classes).  Without this assertion a regression that produces 0
+   diff-pair violations because no rule ran would slip through the
+   allowlist check.
+
+### Interpreting a failure
+
+| Failure mode                                                | Likely cause                                                      |
+|-------------------------------------------------------------|-------------------------------------------------------------------|
+| `Diff-pair rule(s) NOT exercised`                           | Detection broken: `coupled_routing` flag flipped, suffix detection broken, or the routed PCB has no matching pair traces. |
+| `DRC regression: <N> error(s) exceeds allowlist value 28`   | The router introduced new DRC errors beyond the documented #2672/#2677 baseline.  Bisect against the routing algorithm. |
+| Re-route step fails with non-zero exit                      | Routing algorithm regression (board hangs or crashes during `route_all`).  Reproduce locally with `--seed 42`. |
+
+### Tightening the allowlist
+
+When [#2672](https://github.com/rjwalters/kicad-tools/issues/2672)
+(impedance-width selection) and
+[#2677](https://github.com/rjwalters/kicad-tools/issues/2677) (BGA
+partner-via escape) land, the board 06 entry in
+`.github/routed-drc-tolerance.yml` should be reduced.  Eventually the
+entry should be **removed** entirely (per the YAML's "absence == strict
+0 errors" convention) once the board routes cleanly under JLCPCB tier-1
+rules.
+
 ## Out of Scope
 
 Per issue [#2658](https://github.com/rjwalters/kicad-tools/issues/2658)

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -476,44 +476,145 @@ def run_drc(pcb_path: Path) -> bool:
 
 
 def main() -> int:
-    """Entry point."""
-    if len(sys.argv) > 1:
-        output_dir = Path(sys.argv[1])
+    """Entry point.
+
+    Supports the following invocations:
+
+    .. code-block:: bash
+
+        # Default: run all steps (schematic + PCB + route + DRC) into ./output/
+        python generate_design.py
+
+        # Custom output dir (positional, backwards compatible)
+        python generate_design.py /tmp/my-output
+
+        # Phase 4N (#2660): re-route only for the CI regression gate.
+        # ``--step route`` skips schematic + PCB regeneration and re-routes
+        # the existing committed unrouted PCB into a new ``*_routed.kicad_pcb``.
+        # ``--seed`` is forwarded to ``random.seed()`` before routing for
+        # deterministic CI runs (Issue #2589 / Phase 3X.2).
+        python generate_design.py --step route --seed 42
+    """
+    import argparse
+    import random
+
+    parser = argparse.ArgumentParser(
+        prog="generate_design",
+        description="Board 06 (diffpair-test) design generator + Phase 4N CI re-route hook.",
+    )
+    parser.add_argument(
+        "output_dir",
+        nargs="?",
+        default=None,
+        help=(
+            "Output directory (default: ./output relative to this script).  "
+            "Positional for backwards compatibility with pre-#2660 callers."
+        ),
+    )
+    parser.add_argument(
+        "--step",
+        choices=["all", "schematic", "pcb", "route"],
+        default="all",
+        help=(
+            "Run only the specified step.  ``route`` re-routes the existing "
+            "committed unrouted PCB into ``output/diffpair_test_routed.kicad_pcb``  "
+            "without regenerating the schematic or unrouted PCB; used by the "
+            "Phase 4N (#2660) CI gate to detect routing-algorithm regressions."
+        ),
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Seed the global ``random`` module with N before routing for "
+            "reproducible output (Issue #2589 / Phase 3X.2).  Required by "
+            "the Phase 4N CI gate so re-routes are deterministic across "
+            "PRs."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.output_dir is not None:
+        output_dir = Path(args.output_dir)
     else:
         output_dir = Path(__file__).parent / "output"
 
     output_dir = output_dir.resolve()
 
+    # Apply seed before any router call so all downstream ``random.shuffle``
+    # / ``random.sample`` consumers (escape strategies, MST trial ordering)
+    # are deterministic.  See ``kct route --seed`` (#2589) for the same
+    # pattern.
+    if args.seed is not None:
+        random.seed(args.seed)
+        print(f"[seed] Seeded global random with --seed {args.seed}")
+
     try:
-        project_path = create_project(output_dir, "diffpair_test")
-        sch_path = create_schematic(output_dir)
-        pcb_path = create_pcb(output_dir)
+        if args.step == "all":
+            project_path = create_project(output_dir, "diffpair_test")
+            sch_path = create_schematic(output_dir)
+            pcb_path = create_pcb(output_dir)
+            routed_path = output_dir / "diffpair_test_routed.kicad_pcb"
+            route_success = route_pcb(pcb_path, routed_path)
+            drc_ok = run_drc(routed_path)
 
-        routed_path = output_dir / "diffpair_test_routed.kicad_pcb"
-        route_success = route_pcb(pcb_path, routed_path)
+            print("\n" + "=" * 60)
+            print("SUMMARY")
+            print("=" * 60)
+            print(f"\nOutput dir: {output_dir}")
+            print(f"  Project:   {project_path.name}")
+            print(f"  Schematic: {sch_path.name}")
+            print(f"  PCB:       {pcb_path.name}")
+            print(f"  Routed:    {routed_path.name}")
+            print("\nResults:")
+            print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
+            print(f"  DRC:     {'PASS' if drc_ok else 'FAIL (see above)'}")
 
-        drc_ok = run_drc(routed_path)
+            return 0 if route_success else 1
 
-        # Summary
-        print("\n" + "=" * 60)
-        print("SUMMARY")
-        print("=" * 60)
-        print(f"\nOutput dir: {output_dir}")
-        print(f"  Project:   {project_path.name}")
-        print(f"  Schematic: {sch_path.name}")
-        print(f"  PCB:       {pcb_path.name}")
-        print(f"  Routed:    {routed_path.name}")
-        print("\nResults:")
-        print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
-        print(f"  DRC:     {'PASS' if drc_ok else 'FAIL (see above)'}")
+        if args.step == "schematic":
+            create_schematic(output_dir)
+            return 0
 
-        # AC#2 (0 DRC errors) is the goal but the curator notes it is
-        # acceptable to land the scaffold with DRC tolerated until
-        # Phase 3I serpentine insertion (#2648) is fully wired into
-        # the router pipeline.  We return success on the scaffold
-        # itself (route step) and let the routed-DRC CI gate enforce
-        # the 0-error invariant once the scaffold is in place.
-        return 0 if route_success else 1
+        if args.step == "pcb":
+            create_pcb(output_dir)
+            return 0
+
+        if args.step == "route":
+            # Phase 4N (#2660): the CI gate calls this path to re-route the
+            # *committed* unrouted PCB.  Do NOT regenerate the unrouted PCB
+            # here -- if the unrouted PCB has drifted from the committed
+            # one, that's a separate issue (board scaffolding bug, caught
+            # by tests/test_board_06_diffpair_test.py).
+            pcb_path = output_dir / "diffpair_test.kicad_pcb"
+            if not pcb_path.exists():
+                print(
+                    f"Error: unrouted PCB not found at {pcb_path}.  Run "
+                    "``python generate_design.py --step pcb`` first or "
+                    "use ``--step all``.",
+                    file=sys.stderr,
+                )
+                return 1
+            routed_path = output_dir / "diffpair_test_routed.kicad_pcb"
+            # PARTIAL is the expected outcome today (USB3_TX1+/- blocked by
+            # the BGA partner-via escape, tracked in #2677).  As long as the
+            # routed PCB was written, the CI gate's DRC check determines
+            # pass/fail -- not the route_pcb() "all-or-nothing" boolean.
+            # Verify routed_path exists to confirm route_pcb() didn't crash.
+            route_pcb(pcb_path, routed_path)
+            if not routed_path.exists():
+                print(
+                    f"Error: routed PCB not written to {routed_path}.",
+                    file=sys.stderr,
+                )
+                return 1
+            return 0
+
+        # argparse choices already constrains this, but be explicit.
+        print(f"Error: unknown step {args.step!r}", file=sys.stderr)
+        return 1
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)
         import traceback

--- a/scripts/ci/check_diffpair_coverage.py
+++ b/scripts/ci/check_diffpair_coverage.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""Diff-pair "rule exercised" CI gate (Issue #2660, Epic #2556 Phase 4N).
+
+This script is the second pillar of the diff-pair CI strategy.  Its sibling
+``check_routed_drc.py`` (Issue #2546) catches regressions in *committed*
+``*_routed.kicad_pcb`` files; this script catches regressions in the
+**routing algorithm itself** by re-routing a board from scratch and
+asserting:
+
+  1. The post-route DRC error count is within the per-board allowlist
+     (same semantic as ``check_routed_drc.py``).
+  2. Each of the three diff-pair DRC rules was actually exercised by the
+     check (i.e., the per-rule counter is > 0).  Without this assertion
+     a regression that disables diff-pair detection (e.g., flipping
+     ``coupled_routing`` back to ``False``) would silently produce a
+     0-error report and hide the defect.
+
+The three rule_ids this script asserts coverage of are:
+
+  * ``diffpair_clearance_intra`` (#2560, Epic #2556 Phase 1D)
+  * ``diffpair_routing_continuity`` (#2640, Epic #2556 Phase 2G)
+  * ``diffpair_length_skew`` (#2649, Epic #2556 Phase 3J)
+
+The script is parametric over the board directory so additional boards
+(e.g., board 03 once #2589's determinism work + USB-C blockers #2513
+close) can be added cheaply.
+
+Usage::
+
+    # Re-route + check board 06 (the canonical diff-pair testbench):
+    python scripts/ci/check_diffpair_coverage.py boards/06-diffpair-test
+
+    # Check an already-routed board (skip the route step; useful for
+    # debugging the assertion logic locally):
+    python scripts/ci/check_diffpair_coverage.py boards/06-diffpair-test \
+        --skip-route
+
+Exit codes (mirror ``check_routed_drc.py``):
+
+    0 -- Gate passed (errors within tolerance AND all 3 rules exercised).
+    1 -- Tool failure (board dir missing, route step crashed, allowlist
+         parse error, etc.).
+    2 -- Gate failed: errors exceed allowlist OR at least one of the 3
+         diff-pair rules did not run.
+
+GitHub-Actions ``::error file=...::`` annotations are emitted on failure
+so the PR Files-changed view surfaces the failure inline.
+
+Reusing logic from ``check_routed_drc.py``:
+
+    * Allowlist loading (``load_allowlist``)
+    * Allowlist comparison (``check_file``)
+    * Annotation helpers (``annotate_error``)
+
+Why a separate script (not folded into ``check_routed_drc.py``):
+
+    The "rule exercised" assertion is a sibling concern from the
+    per-board error allowlist; it needs router-level context (a
+    ``net_class_map`` from the board's ``generate_design.build_net_class_map``)
+    that the committed-PCB gate intentionally does not require.
+    Keeping the two concerns in separate scripts preserves each gate's
+    minimal blast radius.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+# --- shared with check_routed_drc.py ------------------------------------------
+
+DEFAULT_ALLOWLIST = Path(".github/routed-drc-tolerance.yml")
+
+# The three diff-pair rule_ids that MUST be exercised on a board that
+# declares engaged diff pairs (board 06 declares 9 pairs across 4
+# protocols, so all three rules should run with rules_checked_by_rule
+# entries >= 1).  See ``src/kicad_tools/drc/violation.py`` and
+# ``src/kicad_tools/validate/rules/diffpair_*.py`` for the canonical
+# rule_id strings + per-rule counter increments (Issue #2660).
+DIFFPAIR_RULE_IDS: tuple[str, ...] = (
+    "diffpair_clearance_intra",
+    "diffpair_length_skew",
+    "diffpair_routing_continuity",
+)
+
+
+def load_allowlist(allowlist_path: Path) -> dict[str, int]:
+    """Load the per-board DRC tolerance allowlist.
+
+    Behaviour matches ``check_routed_drc.load_allowlist`` exactly so the
+    two gates share the same YAML contract; duplicated here to keep this
+    script self-contained (the CI environment runs both as separate
+    ``python`` processes).
+    """
+    if not allowlist_path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(allowlist_path.read_text())
+    except yaml.YAMLError as e:
+        raise ValueError(f"Malformed allowlist YAML at {allowlist_path}: {e}") from e
+
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Allowlist {allowlist_path} must be a YAML mapping at the top level, "
+            f"got {type(data).__name__}"
+        )
+
+    tolerances = data.get("tolerances", {})
+    if not isinstance(tolerances, dict):
+        raise ValueError(
+            f"Allowlist {allowlist_path} 'tolerances' field must be a mapping, "
+            f"got {type(tolerances).__name__}"
+        )
+
+    result: dict[str, int] = {}
+    for key, value in tolerances.items():
+        if not isinstance(key, str):
+            raise ValueError(f"Allowlist {allowlist_path}: key {key!r} must be a string")
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(
+                f"Allowlist {allowlist_path}: value for {key!r} must be a "
+                f"non-negative integer, got {value!r}"
+            )
+        result[key] = value
+    return result
+
+
+def annotate_error(file: str, message: str) -> None:
+    """Emit a GitHub-Actions ``::error file=...::`` annotation."""
+    print(f"::error file={file}::{message}", flush=True)
+
+
+# --- script-specific logic ----------------------------------------------------
+
+
+def re_route_board(board_dir: Path, seed: int) -> bool:
+    """Re-route the board's PCB from scratch using ``generate_design.py``.
+
+    Args:
+        board_dir: Path to the board directory (e.g.,
+            ``boards/06-diffpair-test``).
+        seed: Seed for ``random.seed()`` (Issue #2589).  Required for
+            determinism so the gate produces the same artifact run-to-run.
+
+    Returns:
+        True on success (return code 0), False otherwise.
+
+    Notes:
+        Runs ``python generate_design.py --step route --seed N`` via
+        ``subprocess.run`` so the route logic runs in a fresh process
+        (no inherited state).  Stdout/stderr are streamed to the
+        CI log for diagnostic visibility.
+    """
+    script = board_dir / "generate_design.py"
+    if not script.is_file():
+        print(
+            f"::error::generate_design.py not found at {script} -- "
+            "cannot re-route board.",
+            flush=True,
+        )
+        return False
+
+    cmd = [
+        sys.executable,
+        str(script),
+        "--step",
+        "route",
+        "--seed",
+        str(seed),
+    ]
+    print(f"\n[re-route] Running: {' '.join(cmd)}", flush=True)
+    proc = subprocess.run(cmd, capture_output=False, text=True, check=False)
+    if proc.returncode != 0:
+        print(
+            f"::error::Re-route failed for {board_dir} (exit code {proc.returncode}).",
+            flush=True,
+        )
+        return False
+    return True
+
+
+def find_routed_pcb(board_dir: Path) -> Path | None:
+    """Locate the board's freshly-routed PCB.
+
+    Walks ``board_dir/output`` looking for the canonical
+    ``*_routed.kicad_pcb`` artifact emitted by ``generate_design.py``.
+    Returns ``None`` if not found (caller emits the error).
+    """
+    out = board_dir / "output"
+    if not out.is_dir():
+        return None
+    candidates = list(out.glob("*_routed.kicad_pcb"))
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        print(
+            f"::warning::Multiple routed PCBs found in {out}; using first: {candidates[0]}",
+            flush=True,
+        )
+    return candidates[0]
+
+
+def _import_module_from_path(module_name: str, path: Path):
+    """Import a module by file path without adding it to sys.path permanently."""
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot create import spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_net_class_map_for_board(board_dir: Path) -> dict | None:
+    """Import ``generate_design.build_net_class_map()`` from a board dir.
+
+    Returns ``None`` if the board's ``generate_design.py`` does not
+    expose a ``build_net_class_map`` function (e.g., boards 01-05).
+    In that case the diff-pair routing-continuity rule will degrade to
+    a no-op (the design doesn't declare diff-pair net classes), which is
+    correct behaviour for non-diff-pair boards.
+    """
+    script = board_dir / "generate_design.py"
+    if not script.is_file():
+        return None
+
+    # The board's generate_design.py imports its sibling modules via a
+    # ``sys.path.insert(0, str(Path(__file__).parent))`` -- replicate that
+    # so the import resolves correctly.
+    saved_path = list(sys.path)
+    sys.path.insert(0, str(board_dir))
+    try:
+        mod = _import_module_from_path(
+            f"_diffpair_coverage_generate_design_{board_dir.name.replace('-', '_')}",
+            script,
+        )
+    finally:
+        sys.path[:] = saved_path
+
+    return getattr(mod, "build_net_class_map", lambda: None)()
+
+
+def _measure_skew_data_from_pcb(pcb, engaged_pairs: set[tuple[int, int]]) -> dict[tuple[str, str], float]:
+    """Compute per-pair length skew from segments on a routed PCB.
+
+    The :class:`~kicad_tools.validate.rules.diffpair_length_skew.DiffPairLengthSkewRule`
+    requires both ``engaged_pairs`` and a ``skew_data`` map populated
+    by the autorouter side.  When running standalone DRC on a routed
+    PCB from disk, no router context is available -- but the routed
+    segments themselves carry enough information to compute the skew.
+
+    For each engaged pair, sum the geometric segment lengths per net
+    (across all copper layers), then take the absolute difference.
+    Via drilled length is ignored (we'd need ``board_thickness_mm`` to
+    convert layer-deltas into Z-length, which is not on the PCB at
+    DRC time).  This matches the producer-side behaviour when
+    ``board_thickness_mm=None`` -- see
+    :meth:`DiffPairLengthTracker._measure_route`.
+
+    Args:
+        pcb: Loaded :class:`~kicad_tools.schema.pcb.PCB`.
+        engaged_pairs: Set of ``(min_net_id, max_net_id)`` tuples (the
+            engagement-state output from ``derive_engagement_state``).
+
+    Returns:
+        Mapping of ``(net_name_a, net_name_b)`` -> ``skew_mm``.  The
+        rule consumes this directly; keys are normalised to a sorted
+        name-tuple internally by the rule's constructor.
+    """
+    import math
+
+    if not engaged_pairs:
+        return {}
+
+    # Build net_id -> net_name map for the engaged pairs.
+    net_id_to_name: dict[int, str] = {}
+    for net in pcb.nets.values():
+        name = getattr(net, "name", None)
+        if name:
+            net_id_to_name[net.number] = name
+
+    # Sum segment lengths per net id; only for nets that appear in
+    # engaged_pairs (cheap filter -- avoids scanning every segment).
+    engaged_net_ids: set[int] = set()
+    for a, b in engaged_pairs:
+        engaged_net_ids.add(a)
+        engaged_net_ids.add(b)
+
+    lengths_by_net: dict[int, float] = dict.fromkeys(engaged_net_ids, 0.0)
+    for layer in pcb.copper_layers:
+        for seg in pcb.segments_on_layer(layer.name):
+            if seg.net_number in lengths_by_net:
+                x1, y1 = seg.start
+                x2, y2 = seg.end
+                lengths_by_net[seg.net_number] += math.hypot(x2 - x1, y2 - y1)
+
+    # Build the {(p_name, n_name): skew_mm} dict for the rule.
+    skew_data: dict[tuple[str, str], float] = {}
+    for a, b in engaged_pairs:
+        l_a = lengths_by_net.get(a, 0.0)
+        l_b = lengths_by_net.get(b, 0.0)
+        # Skip pairs where neither half is routed (both 0.0); these
+        # cannot produce a meaningful skew measurement and the rule's
+        # graceful-degradation contract says "unrouted -> omit".
+        if l_a <= 0.0 and l_b <= 0.0:
+            continue
+        name_a = net_id_to_name.get(a)
+        name_b = net_id_to_name.get(b)
+        if not name_a or not name_b:
+            continue
+        skew_data[(name_a, name_b)] = abs(l_a - l_b)
+    return skew_data
+
+
+def count_errors_via_kct_check(pcb_path: Path) -> int:
+    """Count errors via ``kct check --mfr jlcpcb --errors-only --format json``.
+
+    Mirrors ``check_routed_drc.count_errors`` so the allowlist semantic
+    matches the sibling diff-driven CI gate exactly -- a value of 28
+    on the same routed PCB must mean the same thing across both gates.
+
+    Uses a subprocess invocation (not in-process) because:
+
+    1. The sibling gate's behaviour is what reviewers calibrate the
+       allowlist against; in-process variants risk silent drift.
+    2. The same ``kct check`` exit-code (0/2) + JSON envelope this
+       script depends on is what users see when they reproduce the
+       check locally.
+    """
+    cmd = [
+        "uv",
+        "run",
+        "kct",
+        "check",
+        str(pcb_path),
+        "--mfr",
+        "jlcpcb",
+        "--errors-only",
+        "--format",
+        "json",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode == 1:
+        raise RuntimeError(
+            f"kct check failed on {pcb_path} (exit 1). stderr:\n{proc.stderr.strip()}"
+        )
+    if proc.returncode not in (0, 2):
+        raise RuntimeError(
+            f"kct check returned unexpected exit code {proc.returncode} on "
+            f"{pcb_path}. stderr:\n{proc.stderr.strip()}"
+        )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"kct check produced invalid JSON on {pcb_path}: {e}"
+        ) from e
+
+    summary = data.get("summary", {})
+    errors = summary.get("errors")
+    if not isinstance(errors, int):
+        raise RuntimeError(f"kct check JSON missing summary.errors field for {pcb_path}: {data!r}")
+    return errors
+
+
+def compute_rule_coverage(
+    pcb_path: Path,
+    net_class_map: dict | None,
+) -> dict[str, int]:
+    """Compute per-rule check counts for the diff-pair rules.
+
+    Invokes :class:`kicad_tools.validate.DRCChecker` directly so the
+    per-rule counter is accessible without re-parsing JSON.  The
+    ``net_class_map`` is threaded through to the checker so the
+    diff-pair routing-continuity rule can derive its engaged-pairs set
+    (the same way the autorouter does).  For the length-skew rule,
+    ``skew_data`` is measured from the routed PCB itself (no router
+    context required) so AC-#4 can be satisfied without spinning up
+    the autorouter twice.
+
+    This is a SEPARATE pass from the error-count check (which uses
+    the standalone ``kct check`` for allowlist parity).  The two passes
+    serve different purposes: error-count gates regression in the
+    committed-or-re-routed PCB, while coverage gates regression in
+    the detection logic.
+
+    Args:
+        pcb_path: Path to the routed PCB.
+        net_class_map: Optional ``{net_name: NetClassRouting}`` map from
+            the board's ``build_net_class_map()``.  Required for the
+            diff-pair rules to engage.
+
+    Returns:
+        ``rules_checked_by_rule`` dict mapping rule_id -> count.
+
+    Raises:
+        RuntimeError: If the PCB cannot be loaded.
+    """
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.validate import DRCChecker
+    from kicad_tools.validate.diffpair_engagement import derive_engagement_state
+    from kicad_tools.validate.rules.diffpair_length_skew import DiffPairLengthSkewRule
+
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        raise RuntimeError(f"Failed to load PCB {pcb_path}: {e}") from e
+
+    detected = len(pcb.copper_layers)
+    layers = detected if detected > 0 else 2
+
+    checker = DRCChecker(
+        pcb,
+        manufacturer="jlcpcb",
+        layers=layers,
+        copper_oz=1.0,
+        net_class_map=net_class_map,
+    )
+
+    # Run all rules via the standard checker entry point.
+    results = checker.check_all()
+
+    # Phase 4N (#2660) AC #4: also exercise the diffpair_length_skew
+    # rule with skew_data MEASURED FROM THE ROUTED PCB.  The standalone
+    # checker.check_diffpair_length_skew() constructs the rule with empty
+    # skew_data (no router context), so the rule never increments its
+    # per-rule counter.  Compute skew_data here from the segment lengths
+    # and re-run the rule so the per-rule counter records the
+    # engagement -- WITHOUT requiring the autorouter to be re-spun.
+    engaged_pairs, threshold_map = derive_engagement_state(pcb, net_class_map)
+    if engaged_pairs:
+        skew_data = _measure_skew_data_from_pcb(pcb, engaged_pairs)
+        if skew_data:
+            skew_rule = DiffPairLengthSkewRule(
+                skew_data=skew_data,
+                engaged_pairs=engaged_pairs,
+                threshold_map=threshold_map,
+            )
+            skew_results = skew_rule.check(pcb, checker.design_rules)
+            results.merge(skew_results)
+
+    return dict(results.rules_checked_by_rule)
+
+
+def check_rule_coverage(
+    rules_checked_by_rule: dict[str, int],
+    required_rule_ids: tuple[str, ...] = DIFFPAIR_RULE_IDS,
+) -> list[str]:
+    """Return the list of rule_ids that did NOT run (counter < 1 or missing).
+
+    A returned list is empty iff every required rule was exercised at
+    least once.  The ordering matches ``required_rule_ids`` so error
+    messages list rules in a stable order.
+    """
+    missing: list[str] = []
+    for rule_id in required_rule_ids:
+        if rules_checked_by_rule.get(rule_id, 0) < 1:
+            missing.append(rule_id)
+    return missing
+
+
+def check_board(
+    board_dir: Path,
+    allowlist: dict[str, int],
+    seed: int,
+    skip_route: bool,
+) -> int:
+    """Run the full gate for a single board.
+
+    Returns the exit code (0 = pass, 1 = tool failure, 2 = gate failure).
+    Mirrors the exit-code convention from ``check_routed_drc.py``.
+    """
+    if not board_dir.is_dir():
+        annotate_error(str(board_dir), f"Board directory not found: {board_dir}")
+        return 1
+
+    if not skip_route:
+        if not re_route_board(board_dir, seed):
+            return 1
+    else:
+        print(f"\n[skip-route] Using existing routed PCB in {board_dir}/output/")
+
+    routed_pcb = find_routed_pcb(board_dir)
+    if routed_pcb is None:
+        annotate_error(
+            str(board_dir),
+            "No *_routed.kicad_pcb found in board output dir after re-route.",
+        )
+        return 1
+
+    # Build the net_class_map from the board's generate_design module
+    # so diff-pair detection in the DRC rules has the per-protocol
+    # net-class context (coupled_routing flags, skew_tolerance_mm, etc.).
+    try:
+        net_class_map = build_net_class_map_for_board(board_dir)
+    except Exception as e:
+        annotate_error(
+            str(board_dir),
+            f"Failed to import build_net_class_map from {board_dir}: {e}",
+        )
+        return 1
+
+    # Compute the allowlist key in the same way check_routed_drc.py does:
+    # repo-relative path string.
+    try:
+        rel = routed_pcb.resolve().relative_to(Path.cwd())
+        lookup_key = str(rel)
+    except ValueError:
+        lookup_key = str(routed_pcb)
+    allowed = allowlist.get(lookup_key, 0)
+
+    # Two-pass strategy (see docstrings on count_errors_via_kct_check
+    # and compute_rule_coverage for the rationale):
+    #   1. Error count via subprocess ``kct check`` -- matches the
+    #      sibling allowlist semantic exactly.
+    #   2. Rule coverage via in-process DRCChecker(..., net_class_map=...)
+    #      -- the only way to exercise the diff-pair rules whose
+    #      engagement is gated on router context.
+    try:
+        error_count = count_errors_via_kct_check(routed_pcb)
+    except RuntimeError as e:
+        annotate_error(str(routed_pcb), f"kct check failed: {e}")
+        return 1
+    try:
+        rules_by_rule = compute_rule_coverage(routed_pcb, net_class_map)
+    except RuntimeError as e:
+        annotate_error(str(routed_pcb), f"Rule-coverage probe failed: {e}")
+        return 1
+
+    print(f"\n[diffpair-coverage] Board: {board_dir.name}")
+    print(f"[diffpair-coverage] Routed PCB: {routed_pcb}")
+    print(f"[diffpair-coverage] DRC error count: {error_count} (allowed: {allowed})")
+    print(f"[diffpair-coverage] rules_checked_by_rule: {rules_by_rule}")
+
+    failed = False
+
+    # AC #4: each of the three diff-pair rules must have been exercised.
+    missing = check_rule_coverage(rules_by_rule)
+    if missing:
+        msg = (
+            f"Diff-pair rule(s) NOT exercised on {routed_pcb}: "
+            f"{', '.join(missing)}.  This is a silent regression -- the rule "
+            "short-circuited because no engaged pairs were detected.  Likely "
+            "causes: ``coupled_routing`` flag flipped to False on the net "
+            "class, diff-pair suffix-inference broken, or the routed PCB has "
+            "no traces matching the declared pairs.  See "
+            "src/kicad_tools/validate/rules/diffpair_*.py for the per-rule "
+            "engagement conditions."
+        )
+        annotate_error(str(routed_pcb), msg)
+        failed = True
+    else:
+        print(
+            f"[diffpair-coverage] OK: all {len(DIFFPAIR_RULE_IDS)} diff-pair "
+            "rules exercised."
+        )
+
+    # AC #1 (allowlist semantic): error count must be <= allowed.
+    if error_count > allowed:
+        if allowed == 0:
+            msg = (
+                f"DRC errors detected on re-routed {routed_pcb}: {error_count} "
+                f"error(s).  Boards NOT in .github/routed-drc-tolerance.yml must "
+                "report 0 errors.  Fix the routing regression or add an explicit "
+                "allowlist entry with reviewer sign-off."
+            )
+        else:
+            msg = (
+                f"DRC regression on re-routed {routed_pcb}: {error_count} "
+                f"error(s) exceeds allowlist value {allowed} in "
+                ".github/routed-drc-tolerance.yml.  Either fix the new "
+                "violations or (if intentional) raise the allowlist value."
+            )
+        annotate_error(str(routed_pcb), msg)
+        failed = True
+    else:
+        if allowed == 0:
+            print("[diffpair-coverage] OK: 0 errors (strict gate).")
+        else:
+            print(
+                f"[diffpair-coverage] OK: {error_count} errors "
+                f"(within allowlist max {allowed})."
+            )
+
+    return 2 if failed else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check_diffpair_coverage",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "boards",
+        nargs="+",
+        help=(
+            "One or more board directories to check (e.g., boards/06-diffpair-test).  "
+            "Each board must contain generate_design.py with --step route + --seed support."
+        ),
+    )
+    parser.add_argument(
+        "--allowlist",
+        default=str(DEFAULT_ALLOWLIST),
+        help=f"Path to the tolerance allowlist YAML (default: {DEFAULT_ALLOWLIST}).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        metavar="N",
+        help=(
+            "Seed forwarded to generate_design.py --seed for deterministic "
+            "re-routes (default: 42, matches Issue #2589 / Phase 3X.2 examples)."
+        ),
+    )
+    parser.add_argument(
+        "--skip-route",
+        action="store_true",
+        help=(
+            "Skip the re-route step and check the existing committed routed "
+            "PCB.  Useful for local debugging of the rule-coverage assertion."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        allowlist = load_allowlist(Path(args.allowlist))
+    except ValueError as e:
+        print(f"::error::{e}", flush=True)
+        return 1
+
+    overall = 0
+    for raw in args.boards:
+        board_dir = Path(raw).resolve()
+        rc = check_board(board_dir, allowlist, args.seed, args.skip_route)
+        if rc > overall:
+            overall = rc
+
+    if overall:
+        print(
+            f"\nGate failed (exit {overall}).  See ::error:: annotations "
+            "above; offending boards are also surfaced in the PR Files-changed "
+            "view.",
+            flush=True,
+        )
+    return overall
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -446,6 +446,16 @@ def output_json(
         "warnings": warning_count,
         "infos": info_count,
         "rules_checked": results.rules_checked,
+        # Issue #2660 / Epic #2556 Phase 4N: per-rule check counter.
+        # The single ``rules_checked`` integer cannot tell a CI consumer
+        # WHICH rules ran -- only the aggregate.  Without this map, a
+        # diff-pair CI gate cannot distinguish "rule X ran and reported
+        # 0 violations" from "rule X did not run at all" (e.g., the rule
+        # short-circuited because no engaged pairs were detected, which
+        # would be a silent regression in detection).  Always emitted
+        # (even when empty) so downstream consumers can rely on the
+        # field being present.
+        "rules_checked_by_rule": dict(results.rules_checked_by_rule),
         "passed": error_count == 0,
     }
     if results.suppressed_count > 0:
@@ -479,6 +489,10 @@ def write_json_report(
         "warnings": warning_count,
         "infos": info_count,
         "rules_checked": results.rules_checked,
+        # See ``output_json`` for the rationale on emitting this field
+        # alongside the aggregate ``rules_checked`` integer.  Issue
+        # #2660 / Epic #2556 Phase 4N.
+        "rules_checked_by_rule": dict(results.rules_checked_by_rule),
         "passed": error_count == 0,
     }
     if results.suppressed_count > 0:

--- a/src/kicad_tools/validate/rules/diffpair_clearance_intra.py
+++ b/src/kicad_tools/validate/rules/diffpair_clearance_intra.py
@@ -161,7 +161,15 @@ class DiffPairClearanceIntraRule(DRCRule):
                 results.add(v)
 
         # One rule check per layer (matches ClearanceRule convention).
+        # Phase 4N (#2660): the *per-rule* counter records how many pairs
+        # were actually inspected -- this is the CI signal "rule actually
+        # ran on this board".  Bumping this only when ``diff_pair_set``
+        # is non-empty matches the "rule was exercised" semantic: a board
+        # with no detected pairs does NOT exercise the rule, even if the
+        # layer-walk loop ran.
         results.rules_checked = len(pcb.copper_layers)
+        if diff_pair_set:
+            results.rules_checked_by_rule["diffpair_clearance_intra"] = len(diff_pair_set)
 
         return results
 

--- a/src/kicad_tools/validate/rules/diffpair_length_skew.py
+++ b/src/kicad_tools/validate/rules/diffpair_length_skew.py
@@ -257,8 +257,13 @@ class DiffPairLengthSkewRule(DRCRule):
                 continue
 
             # This pair counts toward rules_checked (one check per
-            # engaged pair with measured skew).
+            # engaged pair with measured skew).  Phase 4N (#2660): also
+            # bump the per-rule counter so the CI gate can confirm the
+            # rule was exercised on at least one pair.
             results.rules_checked += 1
+            results.rules_checked_by_rule["diffpair_length_skew"] = (
+                results.rules_checked_by_rule.get("diffpair_length_skew", 0) + 1
+            )
 
             tolerance_mm = self._threshold_map.get(key, self._default_tolerance_mm)
             if skew_mm > tolerance_mm:

--- a/src/kicad_tools/validate/rules/diffpair_routing_continuity.py
+++ b/src/kicad_tools/validate/rules/diffpair_routing_continuity.py
@@ -293,6 +293,12 @@ class DiffPairRoutingContinuityRule(DRCRule):
         # of the rule).  Empty engaged set means 0 checks; the rule has
         # nothing to validate.
         results.rules_checked = len(self._engaged)
+        # Phase 4N (#2660): per-rule counter for CI "rule exercised"
+        # assertion.  Only populated when the engaged set is non-empty
+        # so a board with no engaged pairs has no entry (which the
+        # CI gate reads as "rule did not run").
+        if self._engaged:
+            results.rules_checked_by_rule["diffpair_routing_continuity"] = len(self._engaged)
 
         if not self._engaged:
             return results

--- a/src/kicad_tools/validate/violations.py
+++ b/src/kicad_tools/validate/violations.py
@@ -95,11 +95,27 @@ class DRCResults:
 
     Attributes:
         violations: List of all violations found
-        rules_checked: Number of rules that were checked
+        rules_checked: Number of rules that were checked (aggregate)
+        rules_checked_by_rule: Per-rule check counter mapping
+            ``rule_id -> count`` of times the rule actually ran (Issue
+            #2660 / Epic #2556 Phase 4N).  Rules that short-circuit
+            (e.g., a diff-pair rule on a board with no engaged pairs)
+            contribute ``0`` -- and the absence of an entry / a value of
+            ``0`` is the CI-side signal that the rule did NOT exercise
+            on the board.  Allows the ``diffpair-routing-regression``
+            CI gate to assert that the three diff-pair rules
+            (``diffpair_clearance_intra``, ``diffpair_length_skew``,
+            ``diffpair_routing_continuity``) actually ran against
+            board 06 on every PR, catching regressions in detection
+            logic (e.g., accidentally flipping ``coupled_routing`` back
+            to ``False``) that would otherwise silently report 0
+            errors.
+        suppressed_count: Number of violations suppressed by filters
     """
 
     violations: list[DRCViolation] = field(default_factory=list)
     rules_checked: int = 0
+    rules_checked_by_rule: dict[str, int] = field(default_factory=dict)
     suppressed_count: int = 0
 
     @property
@@ -154,9 +170,20 @@ class DRCResults:
         self.violations.append(violation)
 
     def merge(self, other: DRCResults) -> None:
-        """Merge violations from another DRCResults into this one."""
+        """Merge violations from another DRCResults into this one.
+
+        Sums ``rules_checked`` (aggregate counter) and per-rule entries
+        in ``rules_checked_by_rule`` so a downstream consumer can ask
+        "how many times did rule X run across all categories" after
+        ``DRCChecker.check_all()`` has called ``merge()`` on every
+        per-rule result.
+        """
         self.violations.extend(other.violations)
         self.rules_checked += other.rules_checked
+        for rule_id, count in other.rules_checked_by_rule.items():
+            self.rules_checked_by_rule[rule_id] = (
+                self.rules_checked_by_rule.get(rule_id, 0) + count
+            )
         self.suppressed_count += other.suppressed_count
 
     def filter_by_rule(self, rule_id: str) -> list[DRCViolation]:
@@ -175,6 +202,7 @@ class DRCResults:
             "warning_count": self.warning_count,
             "info_count": self.info_count,
             "rules_checked": self.rules_checked,
+            "rules_checked_by_rule": dict(self.rules_checked_by_rule),
             "violations": [v.to_dict() for v in self.violations],
         }
 

--- a/tests/test_check_diffpair_coverage.py
+++ b/tests/test_check_diffpair_coverage.py
@@ -1,0 +1,426 @@
+"""Tests for the diff-pair routing-regression CI gate (Issue #2660).
+
+Covers:
+
+1. ``scripts/ci/check_diffpair_coverage.py`` helper functions
+   (``check_rule_coverage``, ``load_allowlist``, ``find_routed_pcb``).
+2. The ``diffpair-routing-regression`` CI job in
+   ``.github/workflows/ci.yml`` (job exists, runs on ubuntu-latest,
+   matrix is parametric over board, calls the helper, no diff-driven
+   short-circuit).
+3. The new ``rules_checked_by_rule`` field in ``DRCResults`` /
+   ``kct check --format json`` output (Phase 4N JSON schema extension).
+4. The three diff-pair rules populate ``rules_checked_by_rule`` with
+   their rule_id when they actually run (i.e., on a board with engaged
+   diff pairs).
+
+Out of scope (covered by sibling tests):
+
+* The DRC rules themselves -- see ``test_cli_check_diffpair_*.py``.
+* The diff-driven ``routed-pcb-drc-check`` job -- see
+  ``test_ci_routed_drc_workflow.py``.
+
+Architecture: Mock-heavy unit tests for the assertion logic + a
+``yaml.safe_load`` structural test for the CI workflow.  Full
+end-to-end re-route of board 06 is NOT exercised here (it's the CI
+job's job to do that); the assertion logic is tested with synthesised
+``rules_checked_by_rule`` dictionaries so the test remains fast.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_diffpair_coverage.py"
+ALLOWLIST_PATH = REPO_ROOT / ".github" / "routed-drc-tolerance.yml"
+
+JOB_NAME = "diffpair-routing-regression"
+
+
+def _load_helper_module():
+    """Import ``scripts/ci/check_diffpair_coverage.py`` as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "check_diffpair_coverage_test_module", HELPER_SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_diffpair_coverage_test_module"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the assertion logic
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRuleCoverage:
+    """The "rule exercised" assertion is the critical correctness check.
+
+    A regression in this function would silently let a defective router
+    pass the gate, so the truth table is pinned exhaustively here.
+    """
+
+    def test_all_three_rules_exercised_returns_empty(self):
+        mod = _load_helper_module()
+        rules_by_rule = {
+            "diffpair_clearance_intra": 9,
+            "diffpair_length_skew": 2,
+            "diffpair_routing_continuity": 4,
+        }
+        assert mod.check_rule_coverage(rules_by_rule) == []
+
+    def test_missing_rule_id_returns_missing(self):
+        mod = _load_helper_module()
+        rules_by_rule = {
+            "diffpair_clearance_intra": 9,
+            # diffpair_length_skew omitted entirely (no entry)
+            "diffpair_routing_continuity": 4,
+        }
+        missing = mod.check_rule_coverage(rules_by_rule)
+        assert missing == ["diffpair_length_skew"]
+
+    def test_zero_count_returns_missing(self):
+        mod = _load_helper_module()
+        rules_by_rule = {
+            "diffpair_clearance_intra": 9,
+            "diffpair_length_skew": 0,  # explicit zero
+            "diffpair_routing_continuity": 4,
+        }
+        missing = mod.check_rule_coverage(rules_by_rule)
+        assert missing == ["diffpair_length_skew"]
+
+    def test_all_three_missing_returns_all_three(self):
+        mod = _load_helper_module()
+        missing = mod.check_rule_coverage({})
+        assert missing == [
+            "diffpair_clearance_intra",
+            "diffpair_length_skew",
+            "diffpair_routing_continuity",
+        ]
+
+    def test_returned_order_is_stable(self):
+        """Stable order so error messages don't churn run-to-run."""
+        mod = _load_helper_module()
+        # Two missing rules; expect deterministic order matching
+        # DIFFPAIR_RULE_IDS tuple.
+        rules_by_rule = {"diffpair_routing_continuity": 1}
+        missing = mod.check_rule_coverage(rules_by_rule)
+        assert missing == [
+            "diffpair_clearance_intra",
+            "diffpair_length_skew",
+        ]
+
+    def test_extra_rule_ids_ignored(self):
+        """A rule outside the required set doesn't satisfy the gate.
+
+        e.g., ``clearance_segment_segment`` ran 50 times but no
+        diffpair rule ran.  Gate must still fail.
+        """
+        mod = _load_helper_module()
+        rules_by_rule = {
+            "clearance_segment_segment": 50,
+            "impedance": 10,
+        }
+        missing = mod.check_rule_coverage(rules_by_rule)
+        assert set(missing) == set(mod.DIFFPAIR_RULE_IDS)
+
+    def test_custom_required_set(self):
+        """The function accepts a custom required_rule_ids for future reuse."""
+        mod = _load_helper_module()
+        rules_by_rule = {"clearance_segment_segment": 1}
+        missing = mod.check_rule_coverage(
+            rules_by_rule, required_rule_ids=("clearance_segment_segment",)
+        )
+        assert missing == []
+
+
+class TestAllowlistLoading:
+    """Sanity check that the helper's allowlist loader matches the
+    sibling ``check_routed_drc.py`` semantic.  Without this, a divergence
+    in the two scripts could let one gate pass while the other fails
+    on the same allowlist file."""
+
+    def test_load_real_allowlist(self):
+        """The committed allowlist must parse with the helper's loader."""
+        mod = _load_helper_module()
+        data = mod.load_allowlist(ALLOWLIST_PATH)
+        assert isinstance(data, dict)
+        # Today board 06 IS in the allowlist (28 errors); curator notes
+        # the eventual goal is to remove it once #2672 and #2677 close.
+        # Pin the schema, not the value: the value can change as the
+        # baseline tightens.
+        key = "boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb"
+        assert key in data
+        assert isinstance(data[key], int)
+        assert data[key] >= 0
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        mod = _load_helper_module()
+        result = mod.load_allowlist(tmp_path / "does-not-exist.yml")
+        assert result == {}
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        mod = _load_helper_module()
+        f = tmp_path / "empty.yml"
+        f.write_text("")
+        assert mod.load_allowlist(f) == {}
+
+    def test_malformed_yaml_raises(self, tmp_path):
+        mod = _load_helper_module()
+        f = tmp_path / "bad.yml"
+        f.write_text("this: is: not: valid:")
+        with pytest.raises(ValueError, match="Malformed allowlist YAML"):
+            mod.load_allowlist(f)
+
+    def test_non_mapping_raises(self, tmp_path):
+        mod = _load_helper_module()
+        f = tmp_path / "list.yml"
+        f.write_text("- not\n- a\n- mapping\n")
+        with pytest.raises(ValueError, match="must be a YAML mapping"):
+            mod.load_allowlist(f)
+
+    def test_non_int_value_raises(self, tmp_path):
+        mod = _load_helper_module()
+        f = tmp_path / "bad-val.yml"
+        f.write_text('tolerances:\n  "some/path_routed.kicad_pcb": "not-a-number"\n')
+        with pytest.raises(ValueError, match="non-negative integer"):
+            mod.load_allowlist(f)
+
+
+class TestFindRoutedPcb:
+    """The locator must find the right artifact without false positives."""
+
+    def test_returns_none_for_missing_dir(self, tmp_path):
+        mod = _load_helper_module()
+        assert mod.find_routed_pcb(tmp_path / "nope") is None
+
+    def test_returns_none_for_empty_output_dir(self, tmp_path):
+        mod = _load_helper_module()
+        (tmp_path / "output").mkdir()
+        assert mod.find_routed_pcb(tmp_path) is None
+
+    def test_returns_routed_pcb(self, tmp_path):
+        mod = _load_helper_module()
+        out = tmp_path / "output"
+        out.mkdir()
+        target = out / "foo_routed.kicad_pcb"
+        target.write_text("(kicad_pcb)")
+        result = mod.find_routed_pcb(tmp_path)
+        assert result == target
+
+    def test_ignores_unrouted_pcb(self, tmp_path):
+        mod = _load_helper_module()
+        out = tmp_path / "output"
+        out.mkdir()
+        (out / "foo.kicad_pcb").write_text("(kicad_pcb)")
+        # No *_routed.kicad_pcb -- locator should return None.
+        assert mod.find_routed_pcb(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# CI workflow YAML structural tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowJob:
+    """Pin the structure of the new ``diffpair-routing-regression`` job."""
+
+    @pytest.fixture
+    def workflow(self) -> dict:
+        assert CI_WORKFLOW_PATH.is_file()
+        return yaml.safe_load(CI_WORKFLOW_PATH.read_text())
+
+    def test_job_exists(self, workflow: dict) -> None:
+        assert JOB_NAME in workflow["jobs"], (
+            f"Expected job '{JOB_NAME}' in .github/workflows/ci.yml. "
+            f"Found: {sorted(workflow['jobs'].keys())}"
+        )
+
+    def test_job_runs_on_ubuntu_no_container(self, workflow: dict) -> None:
+        """Pure-Python; don't pay container-pull cost."""
+        job = workflow["jobs"][JOB_NAME]
+        assert job["runs-on"] == "ubuntu-latest"
+        assert "container" not in job
+
+    def test_job_has_reasonable_timeout(self, workflow: dict) -> None:
+        """Issue #2660 AC #5: <= 5 min on ubuntu-latest.  Timeout-minutes
+        is the upper-bound safety net; 10 min matches the sibling
+        ``routed-pcb-drc-check`` job."""
+        job = workflow["jobs"][JOB_NAME]
+        timeout = job.get("timeout-minutes")
+        assert isinstance(timeout, int) and 1 <= timeout <= 30
+
+    def test_job_is_matrix_parametric_over_board(self, workflow: dict) -> None:
+        """Per the curator: must be parametric over board name so board 03
+        can be added cheaply when #2589 + #2513 close."""
+        job = workflow["jobs"][JOB_NAME]
+        strategy = job.get("strategy", {})
+        matrix = strategy.get("matrix", {})
+        assert "board" in matrix, (
+            f"Expected ``matrix.board`` in {JOB_NAME} strategy so additional "
+            "boards can be added without job duplication."
+        )
+        boards = matrix["board"]
+        assert isinstance(boards, list) and boards
+        # Board 06 must be in the initial matrix.
+        assert any("06-diffpair-test" in str(b) for b in boards)
+
+    def test_job_invokes_helper_script(self, workflow: dict) -> None:
+        steps = workflow["jobs"][JOB_NAME]["steps"]
+        run_blocks = [s.get("run", "") for s in steps if isinstance(s, dict) and "run" in s]
+        joined = "\n".join(run_blocks)
+        assert "scripts/ci/check_diffpair_coverage.py" in joined
+
+    def test_job_passes_seed_42(self, workflow: dict) -> None:
+        """Curator-mandated: ``--seed 42`` for determinism (Issue #2589)."""
+        steps = workflow["jobs"][JOB_NAME]["steps"]
+        run_blocks = [s.get("run", "") for s in steps if isinstance(s, dict) and "run" in s]
+        joined = "\n".join(run_blocks)
+        assert "--seed 42" in joined or "--seed=42" in joined, (
+            f"Expected ``--seed 42`` in {JOB_NAME} run step (Issue #2589 "
+            "/ Phase 3X.2 determinism)."
+        )
+
+    def test_job_has_no_diff_driven_short_circuit(self, workflow: dict) -> None:
+        """The job runs on every PR, no ``files`` short-circuit (per issue
+        scope: catches algorithmic regressions even when no committed PCB
+        is touched)."""
+        steps = workflow["jobs"][JOB_NAME]["steps"]
+        # No ``if: steps.changed.outputs.files`` guards on any step.
+        for s in steps:
+            if isinstance(s, dict) and "if" in s:
+                assert "files" not in str(s["if"]), (
+                    "diffpair-routing-regression must NOT be diff-driven; "
+                    "it must run on every PR to catch routing-algorithm "
+                    "regressions."
+                )
+
+    def test_no_kicad_cli_dependency(self, workflow: dict) -> None:
+        """Like sibling job: pure Python.  No kicad-cli setup steps."""
+        steps = workflow["jobs"][JOB_NAME]["steps"]
+        for s in steps:
+            if not isinstance(s, dict):
+                continue
+            uses = s.get("uses", "")
+            run = s.get("run", "")
+            assert "kicad" not in uses.lower(), (
+                f"Unexpected kicad-cli setup step: {s}"
+            )
+            assert "apt-get install" not in run or "kicad" not in run.lower()
+
+
+# ---------------------------------------------------------------------------
+# rules_checked_by_rule field (validate + JSON output extension)
+# ---------------------------------------------------------------------------
+
+
+class TestRulesCheckedByRule:
+    """Pin the per-rule counter field added in Phase 4N (#2660)."""
+
+    def test_drc_results_has_per_rule_counter_field(self):
+        from kicad_tools.validate.violations import DRCResults
+
+        results = DRCResults()
+        # Initially empty, never None.
+        assert isinstance(results.rules_checked_by_rule, dict)
+        assert results.rules_checked_by_rule == {}
+
+    def test_merge_sums_per_rule_counters(self):
+        from kicad_tools.validate.violations import DRCResults
+
+        a = DRCResults()
+        a.rules_checked_by_rule["foo"] = 3
+        a.rules_checked_by_rule["bar"] = 1
+
+        b = DRCResults()
+        b.rules_checked_by_rule["foo"] = 5
+        b.rules_checked_by_rule["baz"] = 2
+
+        a.merge(b)
+        assert a.rules_checked_by_rule == {
+            "foo": 8,
+            "bar": 1,
+            "baz": 2,
+        }
+
+    def test_to_dict_includes_per_rule_counter(self):
+        from kicad_tools.validate.violations import DRCResults
+
+        results = DRCResults()
+        results.rules_checked_by_rule["foo"] = 7
+        d = results.to_dict()
+        assert "rules_checked_by_rule" in d
+        assert d["rules_checked_by_rule"] == {"foo": 7}
+
+    def test_cli_json_output_contains_per_rule_counter(self, tmp_path):
+        """``kct check --format json`` MUST emit ``summary.rules_checked_by_rule``
+        so the CI script can read it.  Uses an existing committed routed PCB.
+        """
+        # Use board 03's routed PCB (smaller / faster than board 06).
+        pcb = REPO_ROOT / "boards" / "03-usb-joystick" / "output" / "usb_joystick_routed.kicad_pcb"
+        if not pcb.is_file():
+            pytest.skip(f"Board 03 routed PCB not found at {pcb}")
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "kicad_tools.cli.check_cmd",
+                str(pcb),
+                "--mfr",
+                "jlcpcb",
+                "--format",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        # Exit code 0 or 2 is fine (errors are tolerated, what we care about
+        # is JSON structure).
+        assert proc.returncode in (0, 2), (
+            f"kct check exited {proc.returncode}; stderr:\n{proc.stderr}"
+        )
+        data = json.loads(proc.stdout)
+        assert "summary" in data
+        assert "rules_checked_by_rule" in data["summary"], (
+            f"Expected ``summary.rules_checked_by_rule`` in JSON output.  "
+            f"Got keys: {sorted(data['summary'].keys())}"
+        )
+        assert isinstance(data["summary"]["rules_checked_by_rule"], dict)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point exit code tests
+# ---------------------------------------------------------------------------
+
+
+class TestCliExitCodes:
+    """End-to-end check that the helper's main() returns the right codes
+    for the documented contract.  Uses --skip-route to avoid spinning up
+    the full route pipeline in unit tests."""
+
+    def test_missing_board_dir_returns_1(self, tmp_path):
+        mod = _load_helper_module()
+        rc = mod.main([str(tmp_path / "nope"), "--skip-route"])
+        assert rc == 1
+
+    def test_skip_route_without_routed_pcb_returns_1(self, tmp_path):
+        """Skip-route can't run if there's no committed routed PCB."""
+        mod = _load_helper_module()
+        # Synthesise a minimal board dir with generate_design.py but no
+        # output/.  Must return tool-failure (1), not gate-failure (2),
+        # because no DRC ran.
+        (tmp_path / "generate_design.py").write_text("def build_net_class_map(): return {}\n")
+        rc = mod.main([str(tmp_path), "--skip-route"])
+        assert rc == 1


### PR DESCRIPTION
Closes #2660.

## Summary

- Add a new ``diffpair-routing-regression`` CI job that re-routes
  ``boards/06-diffpair-test`` from scratch on every PR and verifies:
    1. DRC error count is within the per-board allowlist baseline
       (currently 28: 25x ImpedanceRule per #2672 + 3x intra-pair clearance
       per #2677).
    2. **All three diff-pair DRC rules actually exercised at least one
       engaged pair** (catches silent regressions in diff-pair detection
       that would otherwise pass the allowlist check).

- Extend ``DRCResults`` with ``rules_checked_by_rule: dict[str, int]``
  and emit it from ``kct check --format json``, so a CI consumer can
  tell which rules ran (not just the aggregate count). Curator-recommended
  Option B from issue body.

- Add ``--step {all,schematic,pcb,route}`` and ``--seed N`` flags to
  ``boards/06-diffpair-test/generate_design.py`` for deterministic
  re-routes (forwarded to ``random.seed()`` per #2589).

- Parametric over board name (``matrix.board``) so board 03 can be added
  cheaply when #2589 + #2513 close.

## Determinism check (curator-mandated, AC #5)

Ran ``check_diffpair_coverage.py --seed 42`` 10 consecutive times on
the committed routed PCB; **10/10 runs produced identical output**:

  - DRC error count: 28 (allowed: 28)
  - rules_checked_by_rule: ``{'diffpair_clearance_intra': 9, 'diffpair_routing_continuity': 9, 'diffpair_length_skew': 8}``

Re-route timing on M3 Pro: ~53s for the route step, ~95s for the
full check_diffpair_coverage.py gate — comfortably under the 5-min
epic budget.

## Mutation test (curator-mandated, AC #4)

Manually set ``coupled_routing=False`` on all board 06 net classes;
the gate correctly reports ``diffpair_length_skew`` and
``diffpair_routing_continuity`` as not exercised, exiting 2 as
designed.  See the test file's ``TestCheckRuleCoverage`` class for
the unit-test mirror of this assertion.

## Branch protection (AC #7 — repo-admin action required)

**This PR cannot enable branch protection programmatically.** After
merge, the repo admin should add ``diffpair-routing-regression`` to
the list of required status checks on ``main`` (Settings → Rules →
Rulesets).  Until then the job runs on every PR but is advisory.

## Curator deviations

1. **AC #4 reframing (Option B chosen)**: The original AC #4 required
   asserting per-rule exercise via the JSON output, but the existing
   ``rules_checked`` is a single global integer.  Per the curator's
   Option B recommendation, this PR extends the JSON schema with
   ``rules_checked_by_rule`` rather than introducing a new CLI flag.

2. **Allowlist tightening**: The original spec said "board 06
   deliberately omitted from routed-drc-tolerance.yml to enforce
   strict 0-error floor."  Since #2671 (just-merged) committed a 28-
   error baseline for board 06 (waiting on #2672 + #2677), the gate
   now respects the existing allowlist rather than fighting it.
   Tightening the allowlist is a separate follow-up.

3. **#2552 reference**: The curator noted #2552 is a merged PR, not
   an issue.  The new job's docstring references it as the precedent
   it extends.

4. **diffpair_length_skew engagement via PCB segments**: Standalone
   ``kct check`` cannot exercise ``DiffPairLengthSkewRule`` because
   the rule requires router-side ``skew_data``.  Rather than add a
   CLI flag (forbidden by issue scope), the CI script measures
   skew_data from the routed PCB's segments and invokes the rule
   directly — same observable outcome from the CI gate's
   perspective, no new CLI surface.

## Test plan

- [x] ``uv run pytest tests/test_check_diffpair_coverage.py`` (31 new tests pass)
- [x] ``uv run pytest tests/test_ci_routed_drc_workflow.py tests/test_cli_check.py tests/test_validation_models.py tests/test_validate_diffpair_routing_continuity.py tests/test_cli_check_diffpair_length_skew.py`` (135 sibling tests pass)
- [x] ``uv run ruff check`` (all checks pass on changed files)
- [x] Local 10x deterministic-stability run (10/10 identical)
- [x] Local mutation test (gate detects ``coupled_routing=False``)
- [ ] CI green on this PR (verified post-push)