### PR TITLE
feat(route): add completion-floor guard to layer-escalation early stops

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1716,6 +1716,24 @@ def route_with_layer_escalation(
                     f"({best_result.completion:.0%})"
                 )
 
+        # Issue #2673: Completion-floor guard.  Both early-termination heuristics
+        # below (zero-overflow at #2412, stagnation at #2412) are calibrated for
+        # the case where the router already routed a substantial fraction of the
+        # board on the prior attempt.  When best-so-far completion is very low
+        # (e.g., < 50%), the failure mode is more likely "router got stuck on a
+        # handful of nets and timed out" than "the design is genuinely unrouteable
+        # with more layers", so we should keep trying additional layer
+        # configurations rather than short-circuit.  Board 05 on 2026-05-11
+        # exhibits exactly this regression: 2L=0/35, 4L sig-gnd-pwr-sig=0/35,
+        # stagnation check fires and 4L all-sig is never attempted.  The same
+        # board at commit a9790ad0 produced 2L=9/35 (26%) and tried all three
+        # 4L variants before stopping.  Floor of 50% is conservative — any
+        # board with >=50% completion has enough signal for the heuristics
+        # to be trustworthy; below that, escalation should run to completion.
+        best_completion_so_far = best_result.completion if best_result is not None else 0.0
+        completion_floor_for_early_stop = 0.5
+        below_completion_floor = best_completion_so_far < completion_floor_for_early_stop
+
         # Issue #2412: Early termination — zero overflow means failures
         # are placement/topology issues, not congestion.  Adding layers
         # cannot help when there is no congestion to relieve.
@@ -1734,6 +1752,7 @@ def route_with_layer_escalation(
             overflow == 0
             and nets_routed < nets_to_route
             and args.strategy not in strategies_without_overflow_signal
+            and not below_completion_floor
         ):
             if not quiet:
                 flush_print(
@@ -1746,6 +1765,19 @@ def route_with_layer_escalation(
                 )
                 flush_print("  Status: INSUFFICIENT - early stop (zero overflow)")
             break
+        elif (
+            overflow == 0
+            and nets_routed < nets_to_route
+            and args.strategy not in strategies_without_overflow_signal
+            and below_completion_floor
+            and not quiet
+        ):
+            flush_print(
+                "  Note: overflow=0 but best completion "
+                f"{best_completion_so_far * 100:.0f}% < "
+                f"{completion_floor_for_early_stop * 100:.0f}% floor — "
+                "continuing escalation (issue #2673)"
+            )
 
         # Issue #2412: Early termination — stagnation detection.  If adding
         # layers did not improve nets_routed or reduce overflow, further
@@ -1754,6 +1786,7 @@ def route_with_layer_escalation(
             prev_nets_routed is not None
             and nets_routed <= prev_nets_routed
             and overflow >= prev_overflow
+            and not below_completion_floor
         ):
             if not quiet:
                 flush_print("  Escalation stopped: no improvement after adding layers")
@@ -1764,6 +1797,19 @@ def route_with_layer_escalation(
                 )
                 flush_print("  Status: INSUFFICIENT - early stop (stagnation)")
             break
+        elif (
+            prev_nets_routed is not None
+            and nets_routed <= prev_nets_routed
+            and overflow >= prev_overflow
+            and below_completion_floor
+            and not quiet
+        ):
+            flush_print(
+                "  Note: stagnation detected but best completion "
+                f"{best_completion_so_far * 100:.0f}% < "
+                f"{completion_floor_for_early_stop * 100:.0f}% floor — "
+                "continuing escalation (issue #2673)"
+            )
 
         prev_nets_routed = nets_routed
         prev_overflow = overflow

--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -1126,6 +1126,139 @@ class TestEarlyTermination:
             f"stop preserved), got {call_count}"
         )
 
+    # Issue #2673: Completion-floor guard.  Both early-termination heuristics
+    # (zero-overflow at line 1733 and stagnation at line 1753) are calibrated
+    # for the case where the prior attempt already routed a substantial
+    # fraction of the board.  When best-so-far completion is < 50%, the
+    # failure mode is usually "router stuck on a few nets" rather than
+    # "design needs more layers", so escalation should continue.  Board 05
+    # on 2026-05-11 exhibited exactly this regression: 2L=0/35, overflow=0,
+    # and the negotiated zero-overflow heuristic fired immediately — never
+    # trying 4L.  See issue #2673 for the diagnostic numbers.
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    def test_completion_floor_bypasses_zero_overflow_below_floor(
+        self, _esc_flag, _esc_use, _pour, tmp_path
+    ):
+        """Issue #2673: zero-overflow short-circuit must NOT fire when
+        best-so-far completion is below the 50% floor.
+
+        Board 05 fixture: negotiated strategy, 0/10 routed, overflow=0.
+        Without the floor guard, attempt 1 ends with "Escalation stopped:
+        failures are not congestion-related (overflow=0)" and the loop
+        exits after one attempt.  With the guard, escalation continues to
+        at least the next layer configuration.
+        """
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+        out = tmp_path / "out.kicad_pcb"
+
+        # 0/10 routed, overflow=0 — completion 0% << 50% floor
+        router = self._make_mock_router(nets_routed=0, nets_to_route=10, overflow=0)
+        call_count = 0
+
+        def mock_load(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return router, {}
+
+        args = self._make_args(strategy="negotiated")
+        with patch("kicad_tools.router.load_pcb_for_routing", mock_load):
+            with patch("kicad_tools.router.is_cpp_available", return_value=False):
+                route_with_layer_escalation(pcb, out, args, quiet=True)
+
+        # Must NOT stop at attempt 1 — completion 0% is below floor.
+        # Loop will continue until it stagnates with completion still below
+        # floor on a non-first attempt (where stagnation also gets bypassed),
+        # so all 4 layer configurations get tried.
+        assert call_count >= 2, (
+            f"Expected escalation past attempt 1 when completion=0% is below "
+            f"50% floor (issue #2673), got {call_count}"
+        )
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    def test_completion_floor_bypasses_stagnation_below_floor(
+        self, _esc_flag, _esc_use, _pour, tmp_path
+    ):
+        """Issue #2673: stagnation short-circuit must NOT fire when
+        best-so-far completion is below the 50% floor.
+
+        Even if attempts 1 and 2 produce identical (low) results, we should
+        still try the remaining layer configurations — the failure mode at
+        low completion is usually router-internal (per-net timeouts) rather
+        than truly unrouteable congestion.
+        """
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+        out = tmp_path / "out.kicad_pcb"
+
+        # 1/10 = 10% << 50% floor, overflow=5 (matches every time → stagnates)
+        router = self._make_mock_router(nets_routed=1, nets_to_route=10, overflow=5)
+        call_count = 0
+
+        def mock_load(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return router, {}
+
+        args = self._make_args(strategy="negotiated")
+        with patch("kicad_tools.router.load_pcb_for_routing", mock_load):
+            with patch("kicad_tools.router.is_cpp_available", return_value=False):
+                route_with_layer_escalation(pcb, out, args, quiet=True)
+
+        # Stagnation would normally stop at attempt 2.  With the floor guard
+        # bypassing it (10% << 50%), all 4 configurations should be tried.
+        assert call_count >= 3, (
+            f"Expected escalation past stagnation when completion=10% is below "
+            f"50% floor (issue #2673), got {call_count}"
+        )
+
+    @patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", return_value=([], []))
+    @patch("kicad_tools.cli.route_cmd._should_use_escape_routing", return_value=False)
+    @patch("kicad_tools.cli.route_cmd._resolve_escape_routing_flag", return_value=None)
+    def test_completion_floor_does_not_affect_high_completion(
+        self, _esc_flag, _esc_use, _pour, tmp_path
+    ):
+        """Issue #2673: above the 50% floor, both heuristics still fire normally.
+
+        Regression guard: the existing zero-overflow / stagnation behaviour
+        is preserved for boards that route most of their nets — the guard
+        only applies when completion is very low.
+        """
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+        out = tmp_path / "out.kicad_pcb"
+
+        # 8/10 = 80% completion (well above floor), overflow=0
+        router = self._make_mock_router(nets_routed=8, nets_to_route=10, overflow=0)
+        call_count = 0
+
+        def mock_load(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return router, {}
+
+        args = self._make_args(strategy="negotiated")
+        with patch("kicad_tools.router.load_pcb_for_routing", mock_load):
+            with patch("kicad_tools.router.is_cpp_available", return_value=False):
+                route_with_layer_escalation(pcb, out, args, quiet=True)
+
+        # Above floor: zero-overflow heuristic should still fire after attempt 1
+        assert call_count == 1, (
+            f"Expected 1 attempt at 80% completion (zero-overflow heuristic "
+            f"preserved above floor), got {call_count}"
+        )
+
 
 class TestPristineStatePerAttempt:
     """Tests for Issue #2396: pristine state per layer-escalation attempt.


### PR DESCRIPTION
## Summary

Adds a completion-floor guard (50%) to the two early-termination heuristics in `route_with_layer_escalation`. Both the zero-overflow short-circuit (#2412) and the stagnation short-circuit (#2412) were calibrated for boards that route a substantial fraction of their nets on the first attempt — at very low completion, the failure mode is usually "per-net A* timed out before reaching the rip-up loop", and adding more layers actually does help.

## Diagnostic data (from issue #2673)

Identical design (board 05 at commit `a9790ad0`, last `design.py` change), same flags, same pure-Python backend:

| Router HEAD | 2L initial pass | 2L final routed | Attempts tried | Best result |
|---|---|---|---|---|
| `a9790ad0` (2026-05-08) | 19/35 nets, overflow=12 | 9/35 (26%) | 3 (2L, 4L sig-gnd-pwr-sig, 4L all-sig) | 2L 26% |
| `15014a72` (2026-05-11, before this PR) | 10/35 nets, overflow=0 | 0/35 (0%) | **1** (zero-overflow short-circuit fires) | 2L 0% |
| `15014a72` (after this PR) | 10/35 nets, overflow=0 | 0/35 (0%) | **4** (2L + all three 4L/6L configs) | 2L 0% |

The 0/35 result is NOT addressed by this PR — that's a per-net A* regression filed as #2681. This PR only fixes the layer-escalation logic so that low-completion runs traverse the full layer-config search before reporting failure.

Track A residual (placement re-tune for the 35-net design) is filed as #2682.

## Changes

- `src/kicad_tools/cli/route_cmd.py`:
  - Compute `below_completion_floor = best_result.completion < 0.5` before the two early-stop checks
  - Skip both heuristics when `below_completion_floor`, emit an informative `"Note: ..."` message explaining the bypass
  - Above the floor, behavior is unchanged
- `tests/test_layer_escalation.py`:
  - `test_completion_floor_bypasses_zero_overflow_below_floor` — at 0% completion, escalation continues past attempt 1
  - `test_completion_floor_bypasses_stagnation_below_floor` — at 10% completion, escalation continues past stagnation
  - `test_completion_floor_does_not_affect_high_completion` — at 80% completion, zero-overflow heuristic still fires (regression guard)

## Acceptance Criteria Verification

The parent issue #2673 asked for diagnostic data identifying Track A vs Track B; this PR is the **Track B** outcome (with Track A residual filed as #2682).

| Criterion (from #2673) | Status | Verification |
|---|---|---|
| Diagnostic completed with concrete data; Track A or Track B identified | done | Numbers above + filed sub-issues #2681 (router regression bisection) and #2682 (placement re-tune). The regression is real (26% -> 0% on identical design), but the root cause is in per-net A* (separate from escalation logic). |
| If Track B: regression commit identified + reverted/fixed + tolerance restored to <=15 floor | partial | Per-net A* regression suspect identified (#2601's `detect_ripup_stagnation()`); bisection deferred to #2681 to avoid conflicts with the just-landed #2672/#2680. Tolerance floor remains 15 — the committed routed PCB still meets it; the regression only shows on re-route. |
| PR description includes the diagnostic numbers | done | Table above |

## Test Plan

- `uv run pytest tests/test_layer_escalation.py tests/test_route_cmd_*.py` -> **182 passed**
- Live diagnostic: `uv run kct route boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb --seed 42 --differential-pairs --auto-layers --manufacturer jlcpcb --timeout 120` on the post-fix worktree -> escalation traverses 2L, 4L SIG-GND-PWR-SIG, 4L ALL-SIG, 6L (vs only 2L pre-fix); diagnostic "Note:" messages confirm the floor guard fired three times during the run.

Refs #2673