### PR TITLE
feat(validate): wire diffpair_length_skew producer side (closes #2675)

### DIFF
--- a/src/kicad_tools/router/diffpair_length.py
+++ b/src/kicad_tools/router/diffpair_length.py
@@ -48,12 +48,15 @@ Design notes
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from .length import LengthTracker
 
 if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import PCB
+
     from .diffpair_detection import DetectedPair
     from .primitives import Route, Via
 
@@ -296,6 +299,101 @@ class DiffPairLengthTracker:
         # normal call shape).  To make this method usable in isolation
         # we cache the pair name mapping when record_routes runs.
         return dict(sorted(self._skew_map.items(), key=lambda kv: kv[0][0]))
+
+    # =========================================================================
+    # PCB-side measurement primitive (Phase 2.5c / Issue #2675)
+    # =========================================================================
+
+    @staticmethod
+    def measure_net_from_pcb(
+        pcb: PCB,
+        net_id: int,
+        board_thickness_mm: float | None = None,
+        num_copper_layers: int = 2,
+    ) -> float:
+        """Return the geometric routed length of a net in mm, read from a routed PCB.
+
+        Sister primitive to :meth:`_measure_route` -- the latter consumes the
+        router-internal :class:`~kicad_tools.router.primitives.Route` shape
+        (``segments[i].x1/y1/x2/y2``), while this method consumes the PCB
+        schema shape exposed by :meth:`~kicad_tools.schema.pcb.PCB.segments_in_net`
+        and :meth:`~kicad_tools.schema.pcb.PCB.vias_in_net` (segments use
+        ``start: tuple[float, float]`` / ``end: tuple[float, float]``, vias
+        use ``layers: list[str]`` of KiCad layer name strings).
+
+        Used by :func:`kicad_tools.validate.diffpair_skew.derive_skew_data`
+        (Phase 2.5c, Epic #2556) to re-derive per-pair skew from a routed
+        PCB without round-tripping through the router-internal Route form.
+        Keeping the formula here (rather than duplicating it in the
+        validate package) preserves single source of truth for diff-pair
+        length-with-vias computation -- if a future change touches one
+        primitive, the byte-for-byte drift-prevention test in
+        ``tests/test_validate_diffpair_skew.py`` fires.
+
+        Args:
+            pcb: The routed PCB to measure.
+            net_id: The net number whose segments + vias to sum.
+            board_thickness_mm: Total stackup thickness in mm.  When
+                ``None`` (the default), vias contribute ``0.0`` to the
+                length (documented behavior -- mirrors
+                :meth:`record_routes`).
+            num_copper_layers: Number of copper layers in the stack (used
+                to compute per-via drilled length when
+                ``board_thickness_mm`` is supplied).  Defaults to ``2``.
+
+        Returns:
+            Total geometric length (segments + vias) in mm.
+
+        Notes:
+            * Segment length is computed via the same
+              ``sqrt(dx*dx + dy*dy)`` formula used by
+              :meth:`~kicad_tools.router.length.LengthTracker.calculate_route_length`
+              (router-internal Route form).  The drift-prevention test
+              in ``tests/test_validate_diffpair_skew.py`` confirms the
+              two paths produce identical results for the same physical
+              routing.
+            * Via length uses the same stack-position formula as
+              :meth:`_via_length` -- the via's ``layers: list[str]`` is
+              mapped to :class:`~kicad_tools.core.types.CopperLayer`
+              enums via :meth:`CopperLayer.from_kicad_name` before the
+              delta is computed.
+            * Vias with malformed layer names (not a known KiCad copper
+              layer) contribute ``0.0`` to the length rather than
+              crashing -- defensive against legacy / hand-edited PCBs.
+        """
+        from kicad_tools.core.types import CopperLayer
+
+        # Segment portion: identical formula to LengthTracker.calculate_route_length
+        # (length.py:139) and DiffPairLengthTracker._measure_route (above).
+        total = 0.0
+        for seg in pcb.segments_in_net(net_id):
+            dx = seg.end[0] - seg.start[0]
+            dy = seg.end[1] - seg.start[1]
+            total += math.sqrt(dx * dx + dy * dy)
+
+        # Via portion: identical formula to _via_length (above) but the
+        # input shape differs (PCB-side Via.layers is list[str] of KiCad
+        # layer name strings, not a tuple of CopperLayer enums).
+        if board_thickness_mm is None or num_copper_layers <= 1:
+            return total
+
+        for via in pcb.vias_in_net(net_id):
+            layers = via.layers
+            if not layers or len(layers) < 2:
+                # Malformed via (no layer span) -- skip rather than crash.
+                continue
+            try:
+                layer_start = CopperLayer.from_kicad_name(layers[0])
+                layer_end = CopperLayer.from_kicad_name(layers[-1])
+            except ValueError:
+                # Unknown layer name -- conservative skip.
+                continue
+            idx_start = DiffPairLengthTracker._stack_position(layer_start, num_copper_layers)
+            idx_end = DiffPairLengthTracker._stack_position(layer_end, num_copper_layers)
+            delta = abs(idx_start - idx_end)
+            total += board_thickness_mm * delta / (num_copper_layers - 1)
+
+        return total
 
     # =========================================================================
     # Internal name cache (populated by record_routes; used by get_all_skews)

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -189,18 +189,23 @@ class DRCChecker:
         one whose net class has ``coupled_routing == True`` AND which
         passed the engagement-layer single-ended refusal check.
 
-        This rule is a **conservative no-op when invoked from the
-        standalone** ``kct check`` **CLI** -- there is no router context
-        on disk to supply the per-pair skew data, so the rule's
-        ``skew_data`` injection is empty and the rule returns 0
-        violations / 0 ``rules_checked``.  The intended call site is
-        the autorouter consumer (after
-        :meth:`~kicad_tools.router.diffpair_length.DiffPairLengthTracker.record_routes`
-        has run); that consumer constructs
-        :class:`DiffPairLengthSkewRule` directly with the
-        ``skew_data`` from
-        :meth:`~kicad_tools.router.diffpair_length.DiffPairLengthTracker.get_all_skews`
-        and the producer-side ``engaged_pairs`` set.
+        Phase 2.5c (Issue #2675) wires the producer side: when this
+        checker was constructed with a ``net_class_map``, the per-pair
+        skew is re-derived from the routed PCB by
+        :func:`~kicad_tools.validate.diffpair_skew.derive_skew_data`
+        (sister of
+        :func:`~kicad_tools.validate.diffpair_engagement.derive_engagement_state`)
+        and threaded into the rule along with the engagement state.
+        Re-running detection + length-from-PCB-segments on the routed
+        PCB is idempotent given the same net classes and physical
+        routing -- this avoids needing to persist length / skew
+        metadata in the PCB schema.
+
+        When invoked from the standalone ``kct check`` CLI (no
+        ``net_class_map``), no skew data is available, so the rule is
+        a conservative no-op (preserves the AC #4 graceful-degradation
+        contract -- mirrors the
+        :meth:`check_diffpair_routing_continuity` behaviour).
 
         Phase 3J is **independent of Phase 3I** (serpentine insertion):
         the rule fires on routed-as-found geometry regardless of
@@ -209,14 +214,24 @@ class DRCChecker:
         KiCad's own router, manual layout) where the kicad-tools tuner
         never runs but the board still needs its skew validated.
 
-        See Issue #2649 / Epic #2556 Phase 3J.
+        See Issue #2649 / Epic #2556 Phase 3J (the rule itself); Issue
+        #2675 / Epic #2556 Phase 2.5c (this producer wiring).
 
         Returns:
             :class:`DRCResults` containing length-skew violations.
             Empty on standalone ``kct check`` invocations (no router
             context to supply ``skew_data``).
         """
-        rule = DiffPairLengthSkewRule()
+        from kicad_tools.validate.diffpair_engagement import derive_engagement_state
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        skew_data, skew_threshold_map = derive_skew_data(self.pcb, self.net_class_map)
+        engaged_pairs, _ = derive_engagement_state(self.pcb, self.net_class_map)
+        rule = DiffPairLengthSkewRule(
+            skew_data=skew_data,
+            engaged_pairs=engaged_pairs,
+            threshold_map=skew_threshold_map,
+        )
         return rule.check(self.pcb, self.design_rules)
 
     def check_diffpair_routing_continuity(self) -> DRCResults:

--- a/src/kicad_tools/validate/diffpair_skew.py
+++ b/src/kicad_tools/validate/diffpair_skew.py
@@ -1,0 +1,245 @@
+"""Re-derive diff-pair length-skew data from a routed PCB + net-class map.
+
+Issue #2675, Epic #2556 Phase 2.5c.
+
+The :class:`~kicad_tools.validate.rules.diffpair_length_skew.DiffPairLengthSkewRule`
+(Phase 3J / Issue #2649) consumes caller-supplied ``skew_data:
+dict[tuple[str, str], float]`` and per-pair ``threshold_map``.  The rule
+itself deliberately does NOT re-derive skew data to avoid drift between
+the router's per-pair length tracker
+(:class:`~kicad_tools.router.diffpair_length.DiffPairLengthTracker`) and
+the validator's skew check.
+
+This module provides the producer side -- a thin shim that:
+
+1. Detects differential pairs on a routed PCB using the same layered
+   detector the router uses (``diffpair_detection.detect_diff_pairs``).
+2. Sums per-net length from PCB-side segments + vias (via
+   :meth:`DiffPairLengthTracker.measure_net_from_pcb`) for each detected
+   pair's two halves.
+3. Builds the ``skew_data`` and per-pair ``threshold_map`` from each
+   pair's net class :meth:`NetClassRouting.effective_skew_tolerance`.
+
+Mirrors the shape of :mod:`kicad_tools.validate.diffpair_engagement`
+(Phase 2.5b, PR #2653) exactly -- this is the sister producer-side wiring
+for the skew rule.
+
+Why re-derive instead of persist?
+
+The recommended approach per the curator review on #2652 / #2675 is to
+recover skew at validation time rather than persist it as PCB metadata.
+PCB segment/via geometry IS the source of truth for routed length; the
+skew is a pure function of (net_id, geometry, net_class_map.skew_tolerance).
+This avoids needing to round-trip Phase 3H's
+:class:`DiffPairLengthTracker` state through the PCB schema and keeps
+the validate->router boundary thin.
+
+Boundary discipline:
+
+This module is one of TWO places the ``validate/`` package depends on
+the ``router/`` package's diff-pair primitives (the other being
+:mod:`kicad_tools.validate.diffpair_engagement`).  The rule itself
+remains router-independent.  Tests live in
+``tests/test_validate_diffpair_skew.py`` and the drift-prevention test
+mirrors PR #2653's pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.router.rules import NetClassRouting
+    from kicad_tools.schema.pcb import PCB
+
+
+logger = logging.getLogger(__name__)
+
+
+def derive_skew_data(
+    pcb: PCB,
+    net_class_map: dict[str, NetClassRouting] | None,
+    board_thickness_mm: float | None = None,
+    num_copper_layers: int = 2,
+) -> tuple[dict[tuple[str, str], float], dict[tuple[int, int], float]]:
+    """Re-derive ``(skew_data, threshold_map)`` from a routed PCB.
+
+    Walks the PCB's net table, runs the layered differential-pair
+    detector, and sums per-net length from PCB-side segments + vias for
+    each detected pair.  Returns the inputs the
+    :class:`~kicad_tools.validate.rules.diffpair_length_skew.DiffPairLengthSkewRule`
+    expects.
+
+    Args:
+        pcb: The routed PCB to inspect.  ``pcb.nets`` is consulted for
+            the detector; ``pcb.segments_in_net`` and ``pcb.vias_in_net``
+            are consulted for length measurement.
+        net_class_map: Map of ``{net_name: NetClassRouting}`` (the
+            autorouter convention used by
+            :attr:`~kicad_tools.router.core.AutoRouter.net_class_map`).
+            ``None`` or empty returns ``({}, {})`` so the standalone
+            ``kct check`` path degrades gracefully to a no-op.
+        board_thickness_mm: Total stackup thickness in mm.  When
+            ``None`` (the default), vias contribute ``0.0`` to the
+            length.  Mirrors
+            :meth:`~kicad_tools.router.diffpair_length.DiffPairLengthTracker.record_routes`
+            and the curator's documented policy on #2647.
+        num_copper_layers: Number of copper layers in the stack (used
+            to compute per-via drilled length when ``board_thickness_mm``
+            is supplied).  Defaults to ``2``.
+
+    Returns:
+        ``(skew_data, threshold_map)`` where
+
+        * ``skew_data`` is a ``{(p_net_name, n_net_name) -> skew_mm}``
+          dict matching :meth:`DiffPairLengthTracker.get_all_skews`
+          shape.  Pairs with neither half routed are omitted (graceful
+          degradation, matching the producer-side tracker's behaviour).
+        * ``threshold_map`` is a ``{(min_net_id, max_net_id) ->
+          tolerance_mm}`` map of per-pair skew tolerance overrides.
+          Each pair's tolerance comes from
+          :meth:`NetClassRouting.effective_skew_tolerance` on its net
+          class (with the rule's module-level
+          :data:`DEFAULT_SKEW_TOLERANCE_MM` 0.5 mm fallback).
+
+    Notes:
+        Idempotence guarantee (drift-prevention AC): given the same
+        physical routing and the same net classes, this function returns
+        the same ``skew_data`` as the producer-side
+        :meth:`DiffPairLengthTracker.get_all_skews` for routes recorded
+        via :meth:`DiffPairLengthTracker.record_routes`.  This is the
+        property tested in ``tests/test_validate_diffpair_skew.py``.
+    """
+    if not net_class_map:
+        return {}, {}
+
+    # Local imports keep the validate -> router boundary explicit: this
+    # is one of two modules in validate/ that depend on router/ diff-pair
+    # primitives.  See module docstring.
+    from kicad_tools.router.diffpair_detection import detect_diff_pairs
+    from kicad_tools.router.diffpair_length import DiffPairLengthTracker
+    from kicad_tools.validate.rules.diffpair_length_skew import (
+        DEFAULT_SKEW_TOLERANCE_MM,
+    )
+
+    # Build the {net_id: net_name} map the detector expects.
+    net_names: dict[int, str] = {}
+    for net_id, net in pcb.nets.items():
+        net_name = getattr(net, "name", None)
+        if not net_name:
+            continue
+        net_names[net_id] = net_name
+
+    if not net_names:
+        return {}, {}
+
+    # Synthesise a {net_name: class_name} map so the layered detector
+    # can consult ``NetClassRouting.diffpair_partner`` explicit
+    # declarations.  Mirrors the autorouter convention -- see
+    # ``DiffPairRouter._resolve_detection_inputs`` (router-side) and the
+    # sister :func:`derive_engagement_state` (validate-side).
+    net_to_class: dict[str, str] = {}
+    synth_routing: dict = dict(net_class_map)
+    for net_name, nc in net_class_map.items():
+        cls_name = getattr(nc, "name", None)
+        if cls_name is None:
+            continue
+        net_to_class[net_name] = cls_name
+        synth_routing.setdefault(cls_name, nc)
+
+    # KiCad-group templates declared in the PCB itself (optional).
+    # Mirrors derive_engagement_state.
+    kicad_groups = getattr(pcb, "kicad_diff_pair_groups", None)
+
+    try:
+        detected = detect_diff_pairs(
+            net_names,
+            net_class_routing=synth_routing,
+            net_to_class=net_to_class,
+            kicad_groups=kicad_groups,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "[diffpair-skew] detector raised %s; treating as no skew data",
+            exc,
+        )
+        return {}, {}
+
+    skew_data: dict[tuple[str, str], float] = {}
+    threshold_map: dict[tuple[int, int], float] = {}
+
+    for detected_pair in detected:
+        pair = detected_pair.pair
+        p_id = pair.positive.net_id
+        n_id = pair.negative.net_id
+        p_name = pair.positive.net_name
+        n_name = pair.negative.net_name
+
+        # Measure each side.  ``measure_net_from_pcb`` returns 0.0 for
+        # unrouted nets (no segments + no vias = 0.0), which matches the
+        # producer-side tracker's "missing half is omitted" behaviour
+        # ONLY if we also gate-out pairs where neither side has any
+        # geometry.  We mirror the tracker semantics exactly: skip pairs
+        # where at least one side has zero recorded geometry.
+        p_has_geom = _net_has_geometry(pcb, p_id)
+        n_has_geom = _net_has_geometry(pcb, n_id)
+        if not p_has_geom or not n_has_geom:
+            logger.debug(
+                "[diffpair-skew] %s <-> %s skipped (P routed=%s, N routed=%s)",
+                p_name,
+                n_name,
+                p_has_geom,
+                n_has_geom,
+            )
+            continue
+
+        l_p = DiffPairLengthTracker.measure_net_from_pcb(
+            pcb, p_id, board_thickness_mm, num_copper_layers
+        )
+        l_n = DiffPairLengthTracker.measure_net_from_pcb(
+            pcb, n_id, board_thickness_mm, num_copper_layers
+        )
+        skew_mm = abs(l_p - l_n)
+        skew_data[(p_name, n_name)] = skew_mm
+
+        # Per-pair threshold: prefer the positive side's net class, fall
+        # back to the negative side's, then to the module-level default.
+        # Mirrors the one-sided-declaration policy in
+        # :func:`derive_engagement_state` (diffpair_engagement.py:179-187).
+        key = (p_id, n_id) if p_id <= n_id else (n_id, p_id)
+        nc_p = net_class_map.get(p_name)
+        nc_n = net_class_map.get(n_name)
+        nc = nc_p if nc_p is not None else nc_n
+        if nc is not None and hasattr(nc, "effective_skew_tolerance"):
+            threshold_map[key] = nc.effective_skew_tolerance(
+                default=DEFAULT_SKEW_TOLERANCE_MM,
+            )
+        else:
+            threshold_map[key] = DEFAULT_SKEW_TOLERANCE_MM
+
+        logger.info(
+            "[diffpair-skew] %s <-> %s skew=%.3f mm (tolerance=%.3f)",
+            p_name,
+            n_name,
+            skew_mm,
+            threshold_map[key],
+        )
+
+    return skew_data, threshold_map
+
+
+def _net_has_geometry(pcb: PCB, net_id: int) -> bool:
+    """Return True if ``net_id`` has at least one segment or via on ``pcb``.
+
+    Used to mirror :meth:`DiffPairLengthTracker.get_all_skews` semantics:
+    pairs where one half is entirely unrouted are omitted from the
+    skew_data dict.  Without this gate, an unrouted pair would emit a
+    spurious ``skew_mm = |L_p - 0| = L_p`` entry that would fire a
+    bogus DRC violation.
+    """
+    for _seg in pcb.segments_in_net(net_id):
+        return True
+    for _via in pcb.vias_in_net(net_id):
+        return True
+    return False

--- a/tests/test_validate_diffpair_skew.py
+++ b/tests/test_validate_diffpair_skew.py
@@ -1,0 +1,753 @@
+"""Tests for the validate-side diff-pair skew producer wiring (Issue #2675).
+
+Mirrors the pattern from
+``tests/test_validate_diffpair_routing_continuity.py``
+(``TestEngagementDriftPrevention``) -- this is the sister Phase 2.5c
+producer-side wiring for the ``diffpair_length_skew`` DRC rule
+(Phase 3J / Issue #2649).
+
+Covers:
+
+- ``derive_skew_data(pcb, None)`` -> empty result (standalone-CLI graceful
+  no-op).
+- One-sided-declaration policy (P-only or N-only in net_class_map) ->
+  same engaged behaviour as :func:`derive_engagement_state`.
+- **Drift-prevention**: ``derive_skew_data`` on a PCB byte-for-byte
+  matches :meth:`DiffPairLengthTracker.get_all_skews` on the
+  router-internal :class:`Route` form of the same physical routing.
+- Pairs where one half has no geometry are omitted (graceful
+  degradation mirroring tracker semantics).
+- Via-traversing routes: PCB-side measurement matches router-side when
+  ``board_thickness_mm`` is supplied (no router context-only state).
+- Drift-prevention: ``DEFAULT_SKEW_TOLERANCE_MM`` matches
+  ``NetClassRouting.effective_skew_tolerance`` default (already covered
+  by ``test_validate_diffpair_length_skew.py``; we mirror here so a
+  future change touching only one of the two paths fires this test
+  too).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.router.primitives import Route
+
+# ---------------------------------------------------------------------------
+# Stubs (mirror test_validate_diffpair_routing_continuity.py)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubNet:
+    number: int
+    name: str
+
+
+@dataclass
+class _StubSegment:
+    """PCB-schema-shape segment stub.
+
+    Matches :class:`kicad_tools.schema.pcb.Segment`:
+    ``start: tuple[float, float]`` / ``end: tuple[float, float]`` (NOT
+    the router-internal ``x1/y1/x2/y2`` fields).
+    """
+
+    start: tuple[float, float]
+    end: tuple[float, float]
+    width: float = 0.2
+    layer: str = "F.Cu"
+    net_number: int = 0
+    net_name: str = ""
+    uuid: str = ""
+
+
+@dataclass
+class _StubVia:
+    """PCB-schema-shape via stub.
+
+    Matches :class:`kicad_tools.schema.pcb.Via`: ``layers: list[str]`` of
+    KiCad layer name strings (e.g., ``["F.Cu", "B.Cu"]``), NOT the
+    router-internal ``tuple[CopperLayer, CopperLayer]``.
+    """
+
+    position: tuple[float, float] = (0.0, 0.0)
+    size: float = 0.6
+    drill: float = 0.3
+    layers: list[str] = field(default_factory=lambda: ["F.Cu", "B.Cu"])
+    net_number: int = 0
+    net_name: str = ""
+    uuid: str = ""
+
+
+@dataclass
+class _StubPCB:
+    """Minimal PCB stub used by :func:`derive_skew_data`.
+
+    Implements ``nets``, ``segments_in_net``, ``vias_in_net`` -- the
+    only attributes/methods consulted by the helper.
+    """
+
+    _nets: dict[int, _StubNet] = field(default_factory=dict)
+    _segments: list[_StubSegment] = field(default_factory=list)
+    _vias: list[_StubVia] = field(default_factory=list)
+
+    @property
+    def nets(self) -> dict[int, _StubNet]:
+        return self._nets
+
+    def segments_in_net(self, net_number: int):
+        for seg in self._segments:
+            if seg.net_number == net_number:
+                yield seg
+
+    def vias_in_net(self, net_number: int):
+        for via in self._vias:
+            if via.net_number == net_number:
+                yield via
+
+
+def _make_pair_pcb(
+    *,
+    p_net: int = 4,
+    n_net: int = 5,
+    p_name: str = "USB_D+",
+    n_name: str = "USB_D-",
+    p_len_mm: float | None = None,
+    n_len_mm: float | None = None,
+) -> _StubPCB:
+    """Construct a stub PCB with a single horizontal segment for each net.
+
+    Segments are placed on F.Cu at y=0 (positive) and y=1 (negative)
+    starting at x=0.  Pass ``None`` for either length to omit that
+    half's geometry (test the "one-side-unrouted" path).
+    """
+    nets: dict[int, _StubNet] = {
+        0: _StubNet(0, ""),
+        p_net: _StubNet(p_net, p_name),
+        n_net: _StubNet(n_net, n_name),
+    }
+    segs: list[_StubSegment] = []
+    if p_len_mm is not None:
+        segs.append(
+            _StubSegment(
+                start=(0.0, 0.0),
+                end=(p_len_mm, 0.0),
+                net_number=p_net,
+                net_name=p_name,
+            )
+        )
+    if n_len_mm is not None:
+        segs.append(
+            _StubSegment(
+                start=(0.0, 1.0),
+                end=(n_len_mm, 1.0),
+                net_number=n_net,
+                net_name=n_name,
+            )
+        )
+    return _StubPCB(_nets=nets, _segments=segs)
+
+
+# ---------------------------------------------------------------------------
+# derive_skew_data tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveSkewDataNoOp:
+    """Standalone-CLI graceful no-op paths."""
+
+    def test_no_net_class_map_returns_empty(self):
+        """``derive_skew_data(pcb, None)`` -> empty tuple.
+
+        Preserves the standalone ``kct check`` graceful-no-op contract
+        (mirrors ``derive_engagement_state(pcb, None)``).
+        """
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=10.0)
+        skew_data, threshold_map = derive_skew_data(pcb, None)
+        assert skew_data == {}
+        assert threshold_map == {}
+
+    def test_empty_net_class_map_returns_empty(self):
+        """``derive_skew_data(pcb, {})`` -> empty result (idempotent with None)."""
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=10.0)
+        skew_data, threshold_map = derive_skew_data(pcb, {})
+        assert skew_data == {}
+        assert threshold_map == {}
+
+    def test_pcb_with_no_nets_returns_empty(self):
+        """Edge case: a PCB whose net table has only the empty net 0."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        pcb = _StubPCB(_nets={0: _StubNet(0, "")})
+        skew_data, threshold_map = derive_skew_data(pcb, net_class_map)
+        assert skew_data == {}
+        assert threshold_map == {}
+
+
+class TestDeriveSkewDataBasic:
+    """Basic measurement + per-pair tolerance assignment."""
+
+    def test_symmetric_pair_zero_skew(self):
+        """Equal-length P and N -> skew_mm == 0.0."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=10.0)
+        skew_data, threshold_map = derive_skew_data(pcb, net_class_map)
+
+        # One entry, keyed on (p_name, n_name).
+        assert ("USB_D+", "USB_D-") in skew_data
+        assert skew_data[("USB_D+", "USB_D-")] == 0.0
+
+        # Threshold map populated for the engaged pair (default 0.5).
+        assert (4, 5) in threshold_map
+        assert threshold_map[(4, 5)] == 0.5
+
+    def test_asymmetric_pair_returns_absolute_skew(self):
+        """Length-mismatched P (10mm) / N (12mm) -> skew_mm == 2.0."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=12.0)
+        skew_data, _ = derive_skew_data(pcb, net_class_map)
+
+        assert ("USB_D+", "USB_D-") in skew_data
+        assert skew_data[("USB_D+", "USB_D-")] == 2.0
+
+    def test_per_class_skew_tolerance_override_propagates(self):
+        """``skew_tolerance_mm`` on the net class reaches threshold_map."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        nc = NetClassRouting(
+            name="USB2_HS",
+            coupled_routing=True,
+            skew_tolerance_mm=3.0,  # USB 2.0 HS budget
+        )
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=10.0)
+        _, threshold_map = derive_skew_data(pcb, net_class_map)
+
+        assert threshold_map[(4, 5)] == 3.0
+
+    def test_one_sided_declaration_policy(self):
+        """P-only declaration -> still produces skew_data + threshold_map.
+
+        Mirrors the one-sided-declaration policy in
+        :func:`derive_engagement_state` (diffpair_engagement.py:179-187):
+        a net class declared on the positive side alone still gates the
+        pair, and the tolerance comes from the declared side.
+        """
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        nc = NetClassRouting(
+            name="USB2_HS",
+            coupled_routing=True,
+            skew_tolerance_mm=3.0,
+        )
+        # Only positive side declared (USB_D+ in map, USB_D- absent).
+        net_class_map = {"USB_D+": nc}
+
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=12.0)
+        skew_data, threshold_map = derive_skew_data(pcb, net_class_map)
+
+        # The detector still pairs USB_D+/USB_D- via suffix inference;
+        # the threshold comes from the positive side's declared class.
+        assert ("USB_D+", "USB_D-") in skew_data
+        assert skew_data[("USB_D+", "USB_D-")] == 2.0
+        assert threshold_map[(4, 5)] == 3.0
+
+    def test_n_only_declaration_falls_back_to_negative_side(self):
+        """N-only declaration -> threshold comes from negative side."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        nc = NetClassRouting(
+            name="USB2_HS",
+            coupled_routing=True,
+            skew_tolerance_mm=3.0,
+        )
+        # Only negative side declared.
+        net_class_map = {"USB_D-": nc}
+
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=12.0)
+        skew_data, threshold_map = derive_skew_data(pcb, net_class_map)
+
+        assert ("USB_D+", "USB_D-") in skew_data
+        assert threshold_map[(4, 5)] == 3.0
+
+
+class TestDeriveSkewDataUnroutedHalf:
+    """Pairs where one half has no geometry are omitted (graceful degradation)."""
+
+    def test_unrouted_positive_omitted(self):
+        """P has no segments -> pair omitted from skew_data."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        pcb = _make_pair_pcb(p_len_mm=None, n_len_mm=10.0)  # P unrouted
+        skew_data, threshold_map = derive_skew_data(pcb, net_class_map)
+
+        # Pair is omitted (no half can be unrouted while the other has
+        # an arbitrary skew).  This mirrors DiffPairLengthTracker.get_all_skews.
+        assert skew_data == {}
+        assert threshold_map == {}
+
+    def test_unrouted_negative_omitted(self):
+        """N has no segments -> pair omitted from skew_data."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=None)  # N unrouted
+        skew_data, threshold_map = derive_skew_data(pcb, net_class_map)
+
+        assert skew_data == {}
+        assert threshold_map == {}
+
+
+# ---------------------------------------------------------------------------
+# Drift-prevention tests (the core property tested in this issue).
+# ---------------------------------------------------------------------------
+
+
+class TestSkewDriftPrevention:
+    """``derive_skew_data`` MUST match :meth:`DiffPairLengthTracker.get_all_skews`.
+
+    Builds the same physical routing in both forms (router-internal
+    Route + PCB-schema segments) and asserts byte-for-byte equality of
+    the resulting skew dicts.  If a future change touches
+    segment-length computation in one place but not the other, this
+    test fires.
+
+    Three scenarios:
+
+    - Symmetric pair (skew = 0).
+    - Asymmetric pair (skew > 0).
+    - Via-traversing pair (validates ``board_thickness_mm`` parity).
+    """
+
+    def _build_both_forms(
+        self,
+        *,
+        p_segments: list[tuple[tuple[float, float], tuple[float, float]]],
+        n_segments: list[tuple[tuple[float, float], tuple[float, float]]],
+        p_vias_layers: list[list[str]] | None = None,
+        n_vias_layers: list[list[str]] | None = None,
+        p_net: int = 4,
+        n_net: int = 5,
+        p_name: str = "USB_D+",
+        n_name: str = "USB_D-",
+    ) -> tuple[_StubPCB, Route, Route]:
+        """Return (pcb_stub, p_route, n_route) for the same physical routing."""
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Route, Segment, Via
+
+        # PCB-schema-shape stub.
+        pcb_segments: list[_StubSegment] = []
+        for start, end in p_segments:
+            pcb_segments.append(
+                _StubSegment(
+                    start=start,
+                    end=end,
+                    net_number=p_net,
+                    net_name=p_name,
+                )
+            )
+        for start, end in n_segments:
+            pcb_segments.append(
+                _StubSegment(
+                    start=start,
+                    end=end,
+                    net_number=n_net,
+                    net_name=n_name,
+                )
+            )
+
+        pcb_vias: list[_StubVia] = []
+        if p_vias_layers:
+            for layers in p_vias_layers:
+                pcb_vias.append(_StubVia(layers=list(layers), net_number=p_net, net_name=p_name))
+        if n_vias_layers:
+            for layers in n_vias_layers:
+                pcb_vias.append(_StubVia(layers=list(layers), net_number=n_net, net_name=n_name))
+
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                p_net: _StubNet(p_net, p_name),
+                n_net: _StubNet(n_net, n_name),
+            },
+            _segments=pcb_segments,
+            _vias=pcb_vias,
+        )
+
+        # Router-internal Route shape.
+        _layer_lookup = {
+            "F.Cu": Layer.F_CU,
+            "B.Cu": Layer.B_CU,
+            "In1.Cu": Layer.IN1_CU,
+            "In2.Cu": Layer.IN2_CU,
+        }
+
+        p_route = Route(
+            net=p_net,
+            net_name=p_name,
+            segments=[
+                Segment(
+                    x1=start[0],
+                    y1=start[1],
+                    x2=end[0],
+                    y2=end[1],
+                    width=0.2,
+                    layer=Layer.F_CU,
+                    net=p_net,
+                    net_name=p_name,
+                )
+                for start, end in p_segments
+            ],
+            vias=[
+                Via(
+                    x=0.0,
+                    y=0.0,
+                    drill=0.3,
+                    diameter=0.6,
+                    layers=(
+                        _layer_lookup[layers[0]],
+                        _layer_lookup[layers[-1]],
+                    ),
+                    net=p_net,
+                    net_name=p_name,
+                )
+                for layers in (p_vias_layers or [])
+            ],
+        )
+        n_route = Route(
+            net=n_net,
+            net_name=n_name,
+            segments=[
+                Segment(
+                    x1=start[0],
+                    y1=start[1],
+                    x2=end[0],
+                    y2=end[1],
+                    width=0.2,
+                    layer=Layer.F_CU,
+                    net=n_net,
+                    net_name=n_name,
+                )
+                for start, end in n_segments
+            ],
+            vias=[
+                Via(
+                    x=0.0,
+                    y=0.0,
+                    drill=0.3,
+                    diameter=0.6,
+                    layers=(
+                        _layer_lookup[layers[0]],
+                        _layer_lookup[layers[-1]],
+                    ),
+                    net=n_net,
+                    net_name=n_name,
+                )
+                for layers in (n_vias_layers or [])
+            ],
+        )
+        return pcb, p_route, n_route
+
+    def _make_detected_pair(
+        self,
+        p_id: int,
+        p_name: str,
+        n_id: int,
+        n_name: str,
+    ):
+        """Construct a DetectedPair matching the routes."""
+        from kicad_tools.router.diffpair import (
+            DifferentialPair,
+            DifferentialPairType,
+            DifferentialSignal,
+        )
+        from kicad_tools.router.diffpair_detection import (
+            DetectedPair,
+            DetectionSource,
+        )
+
+        return DetectedPair(
+            pair=DifferentialPair(
+                name="USB_D",
+                positive=DifferentialSignal(
+                    net_name=p_name,
+                    net_id=p_id,
+                    base_name="USB_D",
+                    polarity="P",
+                    notation="plus_minus",
+                ),
+                negative=DifferentialSignal(
+                    net_name=n_name,
+                    net_id=n_id,
+                    base_name="USB_D",
+                    polarity="N",
+                    notation="plus_minus",
+                ),
+                pair_type=DifferentialPairType.USB2,
+            ),
+            source=DetectionSource.EXPLICIT,
+        )
+
+    def test_symmetric_pair_byte_for_byte_match(self):
+        """Equal-length pair: both paths return the same {("P", "N"): 0.0}."""
+        from kicad_tools.router.diffpair_length import DiffPairLengthTracker
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        pcb, p_route, n_route = self._build_both_forms(
+            p_segments=[((0.0, 0.0), (10.0, 0.0))],
+            n_segments=[((0.0, 1.0), (10.0, 1.0))],
+        )
+
+        # Router-side: record routes via tracker.
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes(
+            routes=[p_route, n_route],
+            detected_pairs=[self._make_detected_pair(4, "USB_D+", 5, "USB_D-")],
+        )
+        tracker_skews = tracker.get_all_skews()
+
+        # Validate-side: re-derive from PCB + net class map.
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+        rederived_skews, _ = derive_skew_data(pcb, net_class_map)
+
+        assert rederived_skews == tracker_skews, (
+            "drift-prevention AC: validator-side derive_skew_data must match "
+            "producer-side DiffPairLengthTracker.get_all_skews byte-for-byte "
+            "for the same physical routing"
+        )
+        # Sanity: zero skew for symmetric pair.
+        assert rederived_skews[("USB_D+", "USB_D-")] == 0.0
+
+    def test_asymmetric_pair_byte_for_byte_match(self):
+        """Length-mismatched pair: both paths return the same skew."""
+        from kicad_tools.router.diffpair_length import DiffPairLengthTracker
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        pcb, p_route, n_route = self._build_both_forms(
+            p_segments=[((0.0, 0.0), (10.0, 0.0))],
+            n_segments=[((0.0, 1.0), (12.5, 1.0))],
+        )
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes(
+            routes=[p_route, n_route],
+            detected_pairs=[self._make_detected_pair(4, "USB_D+", 5, "USB_D-")],
+        )
+        tracker_skews = tracker.get_all_skews()
+
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+        rederived_skews, _ = derive_skew_data(pcb, net_class_map)
+
+        assert rederived_skews == tracker_skews
+        # Sanity: 2.5 mm skew expected.
+        assert abs(rederived_skews[("USB_D+", "USB_D-")] - 2.5) < 1e-9
+
+    def test_via_traversing_pair_byte_for_byte_match(self):
+        """Via on both halves: PCB-side measurement matches router-side when
+        ``board_thickness_mm`` is supplied to both paths.
+
+        Validates that the PCB-side via length formula (using
+        :meth:`CopperLayer.from_kicad_name`) produces the same result as
+        the router-side formula (using the enum directly).
+        """
+        from kicad_tools.router.diffpair_length import DiffPairLengthTracker
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        pcb, p_route, n_route = self._build_both_forms(
+            p_segments=[((0.0, 0.0), (10.0, 0.0))],
+            n_segments=[((0.0, 1.0), (10.0, 1.0))],
+            p_vias_layers=[["F.Cu", "B.Cu"]],  # F.Cu->B.Cu through-via on P
+            n_vias_layers=[],  # no via on N
+        )
+
+        # Both sides supply the same board_thickness_mm.
+        board_thickness_mm = 1.6
+        num_copper_layers = 2
+
+        tracker = DiffPairLengthTracker()
+        tracker.record_routes(
+            routes=[p_route, n_route],
+            detected_pairs=[self._make_detected_pair(4, "USB_D+", 5, "USB_D-")],
+            board_thickness_mm=board_thickness_mm,
+            num_copper_layers=num_copper_layers,
+        )
+        tracker_skews = tracker.get_all_skews()
+
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+        rederived_skews, _ = derive_skew_data(
+            pcb,
+            net_class_map,
+            board_thickness_mm=board_thickness_mm,
+            num_copper_layers=num_copper_layers,
+        )
+
+        assert rederived_skews == tracker_skews, (
+            "via-traversing drift-prevention: PCB-side via length formula "
+            "must produce the same result as router-side"
+        )
+        # Sanity: P has +1.6mm via length, so skew is 1.6 mm.
+        assert abs(rederived_skews[("USB_D+", "USB_D-")] - 1.6) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Constants drift-prevention (already in test_validate_diffpair_length_skew.py;
+# mirrored here so the contract is asserted from both producer + rule sides).
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultSkewToleranceDriftPrevention:
+    """``DEFAULT_SKEW_TOLERANCE_MM`` MUST equal ``effective_skew_tolerance`` default.
+
+    If a future change touches one constant without the other, this
+    drift-prevention test fires.  Mirrors the equivalent test in
+    ``tests/test_validate_diffpair_length_skew.py``.
+    """
+
+    def test_module_default_matches_accessor_default(self):
+        import inspect
+
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.rules.diffpair_length_skew import (
+            DEFAULT_SKEW_TOLERANCE_MM,
+        )
+
+        sig = inspect.signature(NetClassRouting.effective_skew_tolerance)
+        accessor_default = sig.parameters["default"].default
+
+        assert accessor_default == DEFAULT_SKEW_TOLERANCE_MM, (
+            "DEFAULT_SKEW_TOLERANCE_MM in validate/rules/diffpair_length_skew "
+            "must match the default arg of NetClassRouting.effective_skew_tolerance "
+            "(both 0.5 mm).  If you changed one, change the other."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: DRCChecker.check_diffpair_length_skew uses the new wiring.
+# ---------------------------------------------------------------------------
+
+
+class TestCheckerIntegration:
+    """End-to-end: DRCChecker.check_diffpair_length_skew picks up the wiring."""
+
+    def test_no_net_class_map_remains_no_op(self):
+        """Standalone-CLI invocation (no net_class_map) -> 0 violations, 0 rules_checked.
+
+        AC #4: graceful degradation contract preserved.
+        """
+        from kicad_tools.validate.checker import DRCChecker
+
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=12.0)
+        # No net_class_map -> rule is no-op.
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+        results = checker.check_diffpair_length_skew()
+
+        assert len(results.violations) == 0
+        assert results.rules_checked == 0
+
+    def test_with_net_class_map_fires_when_over_tolerance(self):
+        """With net_class_map + over-tolerance pair -> rule fires."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.checker import DRCChecker
+
+        # 5mm skew at 0.5mm default tolerance -> firing.
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=15.0)
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        checker = DRCChecker(
+            pcb,
+            manufacturer="jlcpcb",
+            layers=2,
+            net_class_map=net_class_map,
+        )
+        results = checker.check_diffpair_length_skew()
+
+        assert results.rules_checked == 1
+        assert results.rules_checked_by_rule.get("diffpair_length_skew") == 1
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert v.rule_id == "diffpair_length_skew"
+        assert v.actual_value == 5.0
+        assert v.required_value == 0.5
+
+    def test_with_net_class_map_passes_when_under_tolerance(self):
+        """With net_class_map + within-tolerance pair -> no fire, but rule
+        was exercised (rules_checked > 0).
+        """
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.checker import DRCChecker
+
+        # 0.3mm skew at 0.5mm default tolerance -> no fire.
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=10.3)
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        checker = DRCChecker(
+            pcb,
+            manufacturer="jlcpcb",
+            layers=2,
+            net_class_map=net_class_map,
+        )
+        results = checker.check_diffpair_length_skew()
+
+        assert results.rules_checked == 1
+        assert results.rules_checked_by_rule.get("diffpair_length_skew") == 1
+        assert len(results.violations) == 0
+
+    def test_un_engaged_pair_does_not_fire_even_with_skew(self):
+        """``coupled_routing=False`` -> pair is not engaged, rule does not fire."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.checker import DRCChecker
+
+        pcb = _make_pair_pcb(p_len_mm=10.0, n_len_mm=15.0)  # 5mm skew
+        nc = NetClassRouting(name="DEFAULT", coupled_routing=False)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        checker = DRCChecker(
+            pcb,
+            manufacturer="jlcpcb",
+            layers=2,
+            net_class_map=net_class_map,
+        )
+        results = checker.check_diffpair_length_skew()
+
+        # Pair is not engaged -> rule short-circuits, no checks.
+        assert results.rules_checked == 0
+        assert len(results.violations) == 0


### PR DESCRIPTION
## Summary

Phase 2.5c of Epic #2556. Wires the producer side of the
``diffpair_length_skew`` DRC rule, mirroring the exact shape PR #2653
used for the sister ``diffpair_routing_continuity`` rule (Phase 2.5b).

Before this PR, ``DRCChecker.check_diffpair_length_skew`` constructed
``DiffPairLengthSkewRule()`` with all defaults -- the rule's guard
short-circuited to a no-op (``rules_checked == 0``) even when the
autorouter consumer supplied a ``net_class_map``.

## What changed

- **New static helper** ``DiffPairLengthTracker.measure_net_from_pcb``
  in ``router/diffpair_length.py`` -- sums geometric length
  (segments + vias) from the PCB-schema shape
  (``PCB.segments_in_net`` / ``PCB.vias_in_net``).  Sister primitive
  to the existing ``_measure_route`` (which consumes the
  router-internal ``Route`` form).  Single source of truth for the
  length-with-vias formula.

- **New module** ``validate/diffpair_skew.py`` exporting
  ``derive_skew_data(pcb, net_class_map, board_thickness_mm,
  num_copper_layers)``.  Mirrors the shape of
  ``validate/diffpair_engagement.derive_engagement_state`` (PR #2653).
  Re-runs detection + per-net length measurement against the routed
  PCB, returning ``(skew_data, threshold_map)`` matching the
  ``DiffPairLengthSkewRule`` constructor.

- **Wired** ``derive_skew_data`` + ``derive_engagement_state`` into
  ``DRCChecker.check_diffpair_length_skew`` (``validate/checker.py``).
  When ``net_class_map`` is provided, the rule now receives non-empty
  ``skew_data``, ``engaged_pairs``, and ``threshold_map``.

- **Drift-prevention tests** (``tests/test_validate_diffpair_skew.py``,
  18 new tests):
  - ``derive_skew_data`` matches ``DiffPairLengthTracker.get_all_skews``
    byte-for-byte for the same physical routing expressed in both
    forms (symmetric, asymmetric, via-traversing).
  - ``DEFAULT_SKEW_TOLERANCE_MM == NetClassRouting.effective_skew_tolerance()`` default.
  - Standalone-CLI graceful no-op (``net_class_map=None`` -> empty).
  - One-sided-declaration policy (P-only / N-only in ``net_class_map``).
  - End-to-end ``DRCChecker.check_diffpair_length_skew`` integration
    asserting ``rules_checked > 0`` when ``net_class_map`` is supplied.

## CLI plumbing gap -- filed as sub-issue #2684

The audit step from #2675 found that the standalone ``kct check
--mfr jlcpcb`` CLI does NOT thread ``net_class_map`` into
``DRCChecker.__init__`` -- the PCB schema does not persist net
classes.  Verified on board 03's routed PCB after this PR:
``rules_checked_by_rule['diffpair_length_skew']`` is still 0 from
the CLI.

The autorouter consumer (which already has ``net_class_map`` in
memory) gets the wiring effect of this PR immediately; the CLI gap
needs PCB-schema net-class parsing or a ``--net-class-map`` CLI flag.
Filed as #2684 (explicitly listed as out-of-scope by the curator on
#2675).

## Test plan

- [x] ``uv run pytest tests/test_validate_diffpair_skew.py`` -- 18 new
  tests pass.
- [x] ``uv run pytest tests/test_validate*.py`` -- 321 tests pass
  (excluding pre-existing ``test_drc_tolerance`` failure unrelated to
  this PR -- ``MockPCB._nets`` vs ``pcb.nets`` bug in
  ``rules/clearance.py``).
- [x] ``uv run pytest tests/test_diffpair*.py`` -- all diff-pair tests
  pass (router-side and validate-side).
- [x] ``uv run ruff check`` + ``uv run ruff format --check`` clean on
  all modified files.

## Acceptance criteria (per issue #2675)

- [x] New module ``src/kicad_tools/validate/diffpair_skew.py`` exporting
  ``derive_skew_data(pcb, net_class_map, ...) -> (skew_data,
  threshold_map)``.
- [x] ``DRCChecker.check_diffpair_length_skew`` constructs
  ``DiffPairLengthSkewRule`` with ``skew_data``, ``engaged_pairs``,
  and ``threshold_map`` derived from the routed PCB.
- [x] Drift-prevention test asserts byte-for-byte parity between
  ``derive_skew_data`` and ``DiffPairLengthTracker.get_all_skews``.
- [x] Drift-prevention test asserts ``DEFAULT_SKEW_TOLERANCE_MM ==
  effective_skew_tolerance()`` default.
- [x] Standalone ``DRCChecker`` invocation without ``net_class_map``
  continues to no-op gracefully.
- [x] One-sided-declaration policy honored.
- [ ] CLI ``kct check --mfr jlcpcb`` exercises the rule -- **deferred
  to #2684** per the issue body's "Out of scope" list (PCB-schema
  net-class plumbing is a separate change).

Closes #2675