### PR TITLE
feat(router): NetClassRouting match-group declaration fields (closes #2687)

### DIFF
--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -569,6 +569,75 @@ class NetClassRouting:
     measured).
     """
 
+    # Match-group declaration (Issue #2687, Epic #2661 Phase 1A)
+    length_match_group: str | None = None
+    """Group name for nets in this class that must arrive length-matched.
+
+    When set, declares this net class's nets are members of the named
+    match group (e.g. ``"DDR_DATA"``, ``"MIPI_CSI_LANE0"``).  Multiple
+    net classes may declare the same group name -- e.g. the lanes of a
+    MIPI bus may live in different per-pair classes that all share a
+    ``length_match_group="MIPI_CSI"``.
+
+    AUTHORITATIVE.  Overrides suffix inference at Phase 1C (#2661).
+
+    Cross-reference: a pre-existing field of the same name lives on a
+    *different* dataclass at
+    :attr:`kicad_tools.reasoning.vocabulary.RoutingPriority.length_match_group`
+    (the reasoning-layer intermediate).  These are NOT in conflict -- they
+    sit on different classes (router-layer vs reasoning-layer).  The
+    reasoning-layer field, where used, maps INTO this router-layer field;
+    it does not duplicate the semantic.  This router-layer field is the
+    AUTHORITATIVE source for downstream routing/measurement consumers.
+
+    Drift-prevention test asserts both fields share type annotation
+    (``str | None``) and default (``None``).  See
+    :class:`tests.test_match_group_declaration.TestDriftPrevention`.
+
+    Phase 1A scope (#2687) is types only; accessor returns the field
+    unchanged.  Phase 1B (#2688) consumes it via ``MatchGroupTracker``;
+    Phase 1C (#2689) integrates with detection; Phase 1D (#2690) wires
+    the producer side.
+    """
+
+    length_match_reference: str | None = None
+    """Reference-selection policy for length-matching within the group.
+
+    Semantics:
+
+    - ``None`` (default) -- use the **longest trace in the group** as the
+      reference (matches the legacy ``tune_match_group`` behavior at
+      ``router/optimizer/serpentine.py:438``).
+    - An **explicit net name** (e.g. ``"DQS_P"``) -- that net is the
+      reference; every other group member is meandered to match its
+      length.  Use this when one trace is hard to perturb (e.g. a DDR
+      strobe whose timing budget can't absorb serpentines).
+    - The **sentinel string** ``"clock"`` -- protocol-aware lookup,
+      deferred to Phase 2/3 (MIPI/HDMI clock-relative case).  Phase 1A
+      accepts the sentinel for forward-compat but does NOT implement
+      protocol resolution.
+
+    Phase 1A scope (#2687) is types only; accessor returns the field
+    unchanged.  Phase 1B (#2688) consumes it via
+    ``MatchGroupTracker.get_reference_length``.
+    """
+
+    length_match_tolerance_mm: float | None = None
+    """Maximum allowed length skew (mm) across members of a match group.
+
+    Mirrors the :attr:`skew_tolerance_mm` pattern (Issue #2647 / Phase 3H)
+    but applies at the match-group level rather than the pair level.
+
+    ``None`` (the default) means "use the rule's module-level default of
+    0.5 mm" -- the same conservative default as :attr:`skew_tolerance_mm`.
+    Setting ``0.1`` is appropriate for tight DDR data-byte groups; setting
+    ``0.5`` accommodates MIPI lane-to-lane skew.
+
+    Phase 1A (#2687) declares the field; Phase 1B (#2688) consumes it via
+    :meth:`MatchGroupTracker.is_within_tolerance`; Phase 2G (#2661 issue G)
+    consumes it via the future ``match_group_length_skew`` DRC rule.
+    """
+
     def effective_intra_pair_clearance(self) -> float:
         """Return the clearance to apply to within-pair diff-pair edges.
 
@@ -623,6 +692,51 @@ class NetClassRouting:
         """
         if self.skew_tolerance_mm is not None:
             return self.skew_tolerance_mm
+        return default
+
+    def effective_length_match_group(self) -> str | None:
+        """Return the match-group name for this net class.
+
+        Backward-compatible accessor (Issue #2687 / Epic #2661 Phase 1A):
+        returns :attr:`length_match_group` directly.  Provided for API
+        uniformity with :meth:`effective_intra_pair_clearance` /
+        :meth:`effective_skew_tolerance`; no fallback chain is needed
+        because ``None`` already means "no group".
+        """
+        return self.length_match_group
+
+    def effective_length_match_reference(self) -> str | None:
+        """Return the reference-selection policy for length-matching.
+
+        Backward-compatible accessor (Issue #2687 / Epic #2661 Phase 1A):
+        returns :attr:`length_match_reference` directly.  ``None`` means
+        "use longest in group"; an explicit net name means "use this net
+        as the reference"; the sentinel ``"clock"`` is reserved for
+        Phase 2/3 protocol-aware resolution.
+        """
+        return self.length_match_reference
+
+    def effective_length_match_tolerance(self, default: float = 0.5) -> float:
+        """Return the match-group length-skew tolerance (mm).
+
+        Backward-compatible accessor (Issue #2687 / Epic #2661 Phase 1A):
+        returns ``default`` when :attr:`length_match_tolerance_mm` is
+        unset (``None``).  Mirrors the :meth:`effective_skew_tolerance`
+        pattern so the future ``match_group_length_skew`` DRC rule
+        (Phase 2G) can override the floor consistently.
+
+        Args:
+            default: Fallback value (in mm) when no per-class tolerance
+                is set.  Defaults to ``0.5`` to mirror the diff-pair
+                :meth:`effective_skew_tolerance` default; the future
+                Phase 2G rule's ``DEFAULT_MATCH_GROUP_TOLERANCE_MM``
+                constant should equal this byte-for-byte.
+
+        Returns:
+            The per-class tolerance in mm if set, else ``default``.
+        """
+        if self.length_match_tolerance_mm is not None:
+            return self.length_match_tolerance_mm
         return default
 
 

--- a/tests/test_match_group_declaration.py
+++ b/tests/test_match_group_declaration.py
@@ -1,0 +1,285 @@
+"""Match-group declaration field tests (Issue #2687, Epic #2661 Phase 1A).
+
+This module tests the **declaration-ergonomics** foundation of Phase 1 of
+Epic #2661: ``NetClassRouting.length_match_group`` /
+``length_match_reference`` / ``length_match_tolerance_mm`` fields plus
+their ``effective_*`` accessors.
+
+Mirrors the pattern of:
+
+* ``tests/test_diffpair_length.py::TestEffectiveSkewTolerance`` -- the
+  per-class round-trip + default-fallback semantics template.
+* ``tests/test_diffpair_length.py::TestDriftPrevention`` -- the
+  cross-link / two-copies-of-the-same-default drift-prevention template.
+
+This is types-only.  No routing/measurement behavior is exercised here;
+Phase 1B (#2688) tests the ``MatchGroupTracker`` consumption.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+
+from kicad_tools.reasoning.vocabulary import RoutingPriority
+from kicad_tools.router.rules import NetClassRouting
+
+# =============================================================================
+# 1. length_match_group field declaration + round-trip
+# =============================================================================
+
+
+class TestLengthMatchGroupField:
+    """Field declaration, default, and dataclass round-trip semantics."""
+
+    def test_default_is_none(self):
+        nc = NetClassRouting(name="Default")
+        assert nc.length_match_group is None
+
+    def test_explicit_value_round_trips(self):
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        assert nc.length_match_group == "DDR_DATA"
+
+    def test_field_round_trip_via_repr_and_equality(self):
+        nc1 = NetClassRouting(name="MIPI", length_match_group="MIPI_CSI")
+        nc2 = NetClassRouting(name="MIPI", length_match_group="MIPI_CSI")
+        assert nc1 == nc2
+        assert nc1.length_match_group == "MIPI_CSI"
+        assert "length_match_group='MIPI_CSI'" in repr(nc1)
+
+    def test_multiple_classes_may_share_group_name(self):
+        # The lanes of a MIPI bus may live in different per-pair classes
+        # that all share a single ``length_match_group="MIPI_CSI"``.  The
+        # field doesn't enforce uniqueness; that is a higher-layer concern
+        # (Phase 1C detection).
+        lane0 = NetClassRouting(name="MIPI_CSI_LANE0", length_match_group="MIPI_CSI")
+        lane1 = NetClassRouting(name="MIPI_CSI_LANE1", length_match_group="MIPI_CSI")
+        assert lane0.length_match_group == lane1.length_match_group == "MIPI_CSI"
+
+    def test_field_has_correct_type_annotation(self):
+        # Drift guard: the field annotation must remain ``str | None`` so
+        # the cross-link with ``RoutingPriority.length_match_group``
+        # documented in the field's docstring stays valid.
+        field_map = {f.name: f for f in fields(NetClassRouting)}
+        assert field_map["length_match_group"].type == (str | None)
+        assert field_map["length_match_group"].default is None
+
+
+# =============================================================================
+# 2. length_match_reference field declaration + round-trip + sentinel
+# =============================================================================
+
+
+class TestLengthMatchReferenceField:
+    """Field declaration, default, sentinel passthrough, and round-trip."""
+
+    def test_default_is_none(self):
+        # ``None`` means "use longest in group" -- the documented default
+        # semantics.  No magic string at the field layer.
+        nc = NetClassRouting(name="Default")
+        assert nc.length_match_reference is None
+
+    def test_explicit_net_name_round_trips(self):
+        # "Pace-car" mode: explicit net name as the reference.
+        nc = NetClassRouting(name="DDR", length_match_reference="DQS_P")
+        assert nc.length_match_reference == "DQS_P"
+
+    def test_clock_sentinel_passes_through(self):
+        # Forward-compat: Phase 1A accepts the ``"clock"`` sentinel but
+        # does not interpret it.  Phase 2/3 wires protocol-aware lookup.
+        nc = NetClassRouting(name="MIPI", length_match_reference="clock")
+        assert nc.length_match_reference == "clock"
+
+    def test_field_round_trip_via_dataclass_construction(self):
+        nc1 = NetClassRouting(name="HS", length_match_reference="DQS_P")
+        nc2 = NetClassRouting(name="HS", length_match_reference="DQS_P")
+        assert nc1 == nc2
+        assert "length_match_reference='DQS_P'" in repr(nc1)
+
+    def test_field_has_correct_type_annotation(self):
+        field_map = {f.name: f for f in fields(NetClassRouting)}
+        assert field_map["length_match_reference"].type == (str | None)
+        assert field_map["length_match_reference"].default is None
+
+
+# =============================================================================
+# 3. length_match_tolerance_mm field declaration + accessor
+# =============================================================================
+
+
+class TestLengthMatchToleranceField:
+    """Field declaration + ``effective_length_match_tolerance`` accessor.
+
+    Bundled into Phase 1A from the Phase 1B follow-up because the field
+    mirrors the :attr:`skew_tolerance_mm` shape and Phase 1B will need it
+    immediately.  Mirrors :meth:`effective_skew_tolerance` semantics.
+    """
+
+    def test_default_is_none(self):
+        nc = NetClassRouting(name="Default")
+        assert nc.length_match_tolerance_mm is None
+
+    def test_default_accessor_returns_half_mm(self):
+        # The accessor default arg is 0.5 (mirrors
+        # ``effective_skew_tolerance``); the future Phase 2G DRC rule's
+        # ``DEFAULT_MATCH_GROUP_TOLERANCE_MM`` constant must equal this.
+        nc = NetClassRouting(name="Default")
+        assert nc.effective_length_match_tolerance() == 0.5
+
+    def test_override_returns_explicit_value(self):
+        nc = NetClassRouting(name="DDR_DATA", length_match_tolerance_mm=0.1)
+        assert nc.effective_length_match_tolerance() == 0.1
+        # Explicit default arg must be ignored when the field is set.
+        assert nc.effective_length_match_tolerance(default=99.0) == 0.1
+
+    def test_default_arg_overrides_module_default_when_field_unset(self):
+        nc = NetClassRouting(name="Default")
+        assert nc.effective_length_match_tolerance(default=1.0) == 1.0
+
+
+# =============================================================================
+# 4. effective_length_match_group accessor
+# =============================================================================
+
+
+class TestEffectiveLengthMatchGroup:
+    """Parameter-free accessor; returns the field as-is."""
+
+    def test_default_unset_returns_none(self):
+        nc = NetClassRouting(name="Default")
+        assert nc.effective_length_match_group() is None
+
+    def test_explicit_value_passes_through(self):
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        assert nc.effective_length_match_group() == "DDR_DATA"
+
+    def test_acceptance_criterion_ddr_data_round_trip(self):
+        # Acceptance: ``NetClassRouting(name="DDR", length_match_group="DDR_DATA")``
+        # round-trips through ``effective_length_match_group()`` returning
+        # ``"DDR_DATA"``.
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        assert nc.effective_length_match_group() == "DDR_DATA"
+
+
+# =============================================================================
+# 5. effective_length_match_reference accessor
+# =============================================================================
+
+
+class TestEffectiveLengthMatchReference:
+    """Parameter-free accessor; returns the field as-is."""
+
+    def test_default_unset_returns_none(self):
+        # Acceptance: ``NetClassRouting(name="DDR").effective_length_match_reference()
+        # is None`` (default = longest).
+        nc = NetClassRouting(name="DDR")
+        assert nc.effective_length_match_reference() is None
+
+    def test_explicit_pace_car_net_passes_through(self):
+        # Acceptance: ``NetClassRouting(name="DDR", length_match_reference="DQS_P")
+        # .effective_length_match_reference() == "DQS_P"``.
+        nc = NetClassRouting(name="DDR", length_match_reference="DQS_P")
+        assert nc.effective_length_match_reference() == "DQS_P"
+
+    def test_clock_sentinel_passes_through_unchanged(self):
+        # Forward-compat: the sentinel is preserved by the accessor so
+        # Phase 2/3 protocol-aware consumers can pattern-match on it.
+        nc = NetClassRouting(name="MIPI", length_match_reference="clock")
+        assert nc.effective_length_match_reference() == "clock"
+
+
+# =============================================================================
+# 6. Drift-prevention: RoutingPriority field cross-link
+# =============================================================================
+
+
+class TestDriftPrevention:
+    """Cross-link drift-prevention between router-layer and reasoning-layer.
+
+    A pre-existing ``length_match_group: str | None = None`` field lives
+    on a DIFFERENT dataclass at
+    :class:`kicad_tools.reasoning.vocabulary.RoutingPriority`.  These are
+    NOT in conflict -- they sit on different classes (router-layer vs
+    reasoning-layer).  The router-layer field
+    (:class:`NetClassRouting.length_match_group`) is AUTHORITATIVE.
+
+    These tests assert both fields share type annotation and default so
+    if either side changes type or default, this test fails fast and the
+    docstring cross-link must be re-verified.  Mirrors the #2521 / #2640
+    alias-drift failure-mode lessons.
+    """
+
+    def test_router_field_type_annotation(self):
+        field_map = {f.name: f for f in fields(NetClassRouting)}
+        assert field_map["length_match_group"].type == (str | None)
+
+    def test_reasoning_field_type_annotation(self):
+        field_map = {f.name: f for f in fields(RoutingPriority)}
+        assert field_map["length_match_group"].type == (str | None)
+
+    def test_router_and_reasoning_field_alignment(self):
+        # Both fields must share type annotation (``str | None``) AND
+        # default (``None``).  If either diverges, this assertion fails
+        # and the docstring cross-link must be re-verified.
+        router_fields = {f.name: f for f in fields(NetClassRouting)}
+        reasoning_fields = {f.name: f for f in fields(RoutingPriority)}
+        router_field = router_fields["length_match_group"]
+        reasoning_field = reasoning_fields["length_match_group"]
+        assert router_field.type == (str | None)
+        assert reasoning_field.type == (str | None)
+        assert router_field.type == reasoning_field.type
+        assert router_field.default is None
+        assert reasoning_field.default is None
+
+    def test_accessor_tolerance_default_is_half_mm(self):
+        # The literal 0.5 must appear in exactly two places per repo
+        # (mirroring the #2647 / #2649 drift-prevention contract): the
+        # accessor default arg here, and the future Phase 2G rule's
+        # ``DEFAULT_MATCH_GROUP_TOLERANCE_MM`` constant.  Any third copy
+        # is drift.
+        nc = NetClassRouting(name="Default")
+        assert nc.effective_length_match_tolerance() == 0.5
+
+    def test_tolerance_accessor_matches_phase_2g_constant_when_available(self):
+        # Best-effort cross-check: if Phase 2G has already landed, import
+        # the constant and assert byte-for-byte equality.  Until then the
+        # accessor-default assertion above anchors the 0.5 unilaterally.
+        try:
+            from kicad_tools.validate.rules.match_group_length_skew import (
+                DEFAULT_MATCH_GROUP_TOLERANCE_MM,
+            )
+        except ImportError:
+            # Phase 2G not yet merged -- the accessor-default assertion
+            # above anchors 0.5 unilaterally.
+            return
+        nc = NetClassRouting(name="Default")
+        assert nc.effective_length_match_tolerance() == DEFAULT_MATCH_GROUP_TOLERANCE_MM
+
+
+# =============================================================================
+# 7. Backward-compatibility -- no regressions for callers that don't set fields
+# =============================================================================
+
+
+class TestBackwardCompatibility:
+    """Callers that don't set the new fields see no behavior change."""
+
+    def test_no_field_changes_when_not_set(self):
+        # The default-constructed dataclass keeps all pre-#2687 fields at
+        # their previous defaults.  This guards against accidental
+        # collateral default flips.
+        nc = NetClassRouting(name="X")
+        assert nc.length_match_group is None
+        assert nc.length_match_reference is None
+        assert nc.length_match_tolerance_mm is None
+        # Spot-check unrelated fields stay at their documented defaults.
+        assert nc.priority == 5
+        assert nc.trace_width == 0.2
+        assert nc.clearance == 0.2
+        assert nc.skew_tolerance_mm is None
+        assert nc.diffpair_partner is None
+
+    def test_construction_with_only_required_args_succeeds(self):
+        # The new fields are optional (default ``None``) so no caller
+        # signature changes.
+        nc = NetClassRouting(name="X")
+        assert nc.name == "X"


### PR DESCRIPTION
## Summary

Phase 1A of Epic #2661 (match-group meander routing for DDR/MIPI/TMDS parallel buses).

Type-system + accessor addition only -- **no routing/measurement behavior change yet**. Phase 1B (#2688), Phase 1C (#2689), Phase 1D (#2690) consume these fields.

## Changes

### `src/kicad_tools/router/rules.py`

Adds three optional fields to `NetClassRouting`, placed adjacent to `skew_tolerance_mm` for grouping clarity (mirrors the #2647 / Phase 3H placement):

- **`length_match_group: str | None = None`** -- authoritative group name (e.g. `"DDR_DATA"`, `"MIPI_CSI"`). Multiple net classes may share a group name; overrides Phase 1C suffix inference.
- **`length_match_reference: str | None = None`** -- reference-selection policy. `None` means "longest in group"; an explicit net name is the "pace-car" reference; the sentinel `"clock"` is forward-compat for Phase 2/3 protocol-aware resolution (accepted but not interpreted in Phase 1A).
- **`length_match_tolerance_mm: float | None = None`** -- per-class skew tolerance (mm). Bundled in from the Phase 1B follow-up to avoid a `#2687-cont` issue.

Adds three accessors mirroring the `effective_skew_tolerance` precedent:

- `effective_length_match_group(self) -> str | None` -- parameter-free; returns field as-is.
- `effective_length_match_reference(self) -> str | None` -- parameter-free; returns field as-is.
- `effective_length_match_tolerance(self, default: float = 0.5) -> float` -- mirrors `effective_skew_tolerance` shape so the future Phase 2G `match_group_length_skew` DRC rule can drop in a `DEFAULT_MATCH_GROUP_TOLERANCE_MM = 0.5` constant byte-for-byte.

The `length_match_group` docstring explicitly cross-links to the pre-existing reasoning-layer field at `vocabulary.RoutingPriority.length_match_group`, labels the router-layer field as **AUTHORITATIVE**, and references the new drift-prevention test.

### `tests/test_match_group_declaration.py` (new)

Seven test classes / 27 tests, mirroring the `tests/test_diffpair_length.py::TestEffectiveSkewTolerance` + `TestDriftPrevention` template:

1. `TestLengthMatchGroupField` -- field declaration, default `None`, dataclass round-trip, shared-group-name semantics, type-annotation drift guard.
2. `TestLengthMatchReferenceField` -- same, plus `"clock"` sentinel passthrough.
3. `TestLengthMatchToleranceField` -- field + `effective_length_match_tolerance` accessor; 0.5-mm default; explicit-value override; default-arg fallback.
4. `TestEffectiveLengthMatchGroup` -- parameter-free accessor returns field as-is.
5. `TestEffectiveLengthMatchReference` -- same; explicit and sentinel passthrough.
6. `TestDriftPrevention` -- the cross-link drift test: both `NetClassRouting.length_match_group` and `RoutingPriority.length_match_group` share type (`str | None`) and default (`None`); 0.5-mm accessor default cross-check with future `match_group_length_skew` rule's `DEFAULT_MATCH_GROUP_TOLERANCE_MM` constant (best-effort import-and-compare).
7. `TestBackwardCompatibility` -- callers that don't set the new fields see no collateral default flips on unrelated fields.

## Acceptance criteria (from #2687)

- [x] `NetClassRouting(name="DDR", length_match_group="DDR_DATA").effective_length_match_group() == "DDR_DATA"`
- [x] `NetClassRouting(name="DDR", length_match_reference="DQS_P").effective_length_match_reference() == "DQS_P"`
- [x] `NetClassRouting(name="DDR").effective_length_match_reference() is None`
- [x] `NetClassRouting(name="MIPI", length_match_reference="clock").effective_length_match_reference() == "clock"` (forward-compat sentinel passes through)
- [x] Docstring on `NetClassRouting.length_match_group` cross-links to `vocabulary.RoutingPriority.length_match_group` and labels which is authoritative
- [x] Drift-prevention test asserts both fields share type annotation (`str | None`) and default (`None`)
- [x] No regressions in `tests/test_diffpair_length.py`, `tests/test_length_matching.py`, `tests/test_reasoning_vocabulary.py`, `tests/test_intra_pair_clearance.py`, `tests/test_net_class_trace_width.py`, `tests/test_router_io.py` (315 tests pass)
- [x] `ruff check` and `ruff format` pass on `rules.py` + new test file

## Test plan

- [x] `uv run pytest tests/test_match_group_declaration.py` -- 27 passed
- [x] `uv run pytest tests/test_diffpair_length.py tests/test_length_matching.py tests/test_diffpair.py tests/test_diffpair_detection.py` -- 181 passed, no regressions
- [x] `uv run pytest tests/test_reasoning_vocabulary.py tests/test_net_class_trace_width.py tests/test_intra_pair_clearance.py tests/test_router_io.py tests/test_match_group_declaration.py` -- 315 passed
- [x] `uv run ruff check src/kicad_tools/router/rules.py tests/test_match_group_declaration.py` -- All checks passed
- [x] `uv run ruff format --check ...` -- 2 files already formatted

## Notes

- The issue body's reference to `rules.py:449` for the insertion point was stale -- that line is the start of `coupled_routing`. Per the curator note, the new fields are placed at the `skew_tolerance_mm`-adjacent block (~line 570) and the accessors are appended after `effective_skew_tolerance` (~line 626).
- The user's request asked to bundle the `length_match_tolerance_mm` field + `effective_length_match_tolerance` accessor in from the Phase 1B follow-up so the Phase 1B builder (#2688) doesn't need a `#2687-cont` issue. This adds three fields/accessors instead of two; the additional ones follow the `skew_tolerance_mm` / `effective_skew_tolerance` shape exactly.
- The `uv.lock` modification visible in the worktree's `git status` is a pre-existing local change unrelated to this issue and was **not** staged.

Closes #2687

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>