### PR TITLE
feat(router): layered match-group detection (closes #2689)

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -167,6 +167,10 @@ from .length import (
     ViolationType,
     create_match_group,
 )
+from .match_group_detection import (
+    BUS_GROUP_PATTERNS,
+    detect_match_groups,
+)
 from .match_group_length import (
     MatchGroup,
     MatchGroupSource,
@@ -412,6 +416,9 @@ __all__ = [
     "MatchGroup",
     "MatchGroupSource",
     "MatchGroupTracker",
+    # Match-group detection (Epic #2661 Phase 1C / Issue #2689)
+    "BUS_GROUP_PATTERNS",
+    "detect_match_groups",
     # I/O
     "route_pcb",
     "load_pcb_for_routing",

--- a/src/kicad_tools/router/match_group_detection.py
+++ b/src/kicad_tools/router/match_group_detection.py
@@ -1,0 +1,581 @@
+"""
+Layered match-group detection (Issue #2689, Epic #2661 Phase 1C).
+
+This module discovers length-match groups (N parallel traces that must
+arrive at their destination with matched lengths) from three priority-
+ordered sources:
+
+1. **Explicit declaration** -- per-class config via
+   :class:`kicad_tools.router.rules.NetClassRouting`
+   ``length_match_group`` field (Phase 1A / #2687).  AUTHORITATIVE;
+   overrides every other source.
+2. **Legacy API** -- groups already registered through
+   :meth:`kicad_tools.router.core.Autorouter.add_match_group` /
+   :func:`kicad_tools.router.length.create_match_group`.  Surfaced via
+   ``LengthTracker.match_groups`` (a ``dict[str, list[int]]``).
+3. **Suffix inference** -- opt-in heuristic using the
+   :data:`BUS_GROUP_PATTERNS` table to recognise common bus naming
+   conventions (DDR ``DQ\\d+``, MIPI ``CSI_DAT\\d+_[PN]``, HDMI
+   ``TMDS_D\\d+_[PN]``, generic ``A\\d+``).  Refuses low-confidence
+   matches (single-net groups, etc.) the same way
+   ``router/diffpair_detection.py`` refuses single-ended pairs.
+
+The output is a list of :class:`MatchGroup` instances annotated with a
+:class:`MatchGroupSource` enum so downstream consumers (DRC rule,
+serpentine tuner) can apply policy by source if needed.
+
+**Important parallel-development note**: Phase 1B (#2688) builds the
+companion ``MatchGroupTracker``.  This module defines its own
+``MatchGroup`` and ``MatchGroupSource`` types so it can land
+independently; the type shapes are coordinated with Phase 1B so the
+two modules can interoperate once both are merged.  See
+``MatchGroup``'s docstring for the type contract.
+
+The public entry point :func:`detect_match_groups` mirrors
+:func:`kicad_tools.router.diffpair_detection.detect_diff_pairs` (PR
+#2558) in shape and semantics.
+
+**Clock sentinel resolution**: when ``NetClassRouting.length_match_reference``
+is the literal string ``"clock"``, the resolver iterates over the
+group's members and picks the one whose name matches any of the four
+clock-discriminating regexes in
+:data:`kicad_tools.analysis.trace_length.CRITICAL_NET_PATTERNS` (the
+import is deliberate -- a drift-prevention test asserts this module
+does NOT reimplement those regexes).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from kicad_tools.analysis.trace_length import CRITICAL_NET_PATTERNS
+
+if TYPE_CHECKING:
+    from .length import LengthTracker
+    from .rules import NetClassRouting
+
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Type contract -- coordinated with Phase 1B (#2688)
+# =============================================================================
+
+
+class MatchGroupSource(Enum):
+    """Where a match group came from in the layered detector.
+
+    Three-tier (not four).  ``KICAD_GROUP`` is intentionally absent:
+    KiCad's PCB s-expression does not currently have a
+    ``(match_group ...)`` directive analogous to
+    ``(diff_pair_template ...)``, so the parallel ``KICAD_GROUP``
+    source from diff-pair detection has no analog here.  Phase 2 of
+    Epic #2661 (not this issue) may revisit if KiCad upstream adds
+    such a directive.
+
+    The ordering of values matches detection priority:
+    ``EXPLICIT > LEGACY_API > SUFFIX``.
+    """
+
+    EXPLICIT = "explicit"
+    """Declared via ``NetClassRouting.length_match_group``."""
+
+    LEGACY_API = "legacy_api"
+    """Registered via ``Autorouter.add_match_group(...)``.
+
+    The legacy Python API path that has existed since before this
+    epic.  Surfaced from ``LengthTracker.match_groups`` so already-
+    routed boards that pre-date Phase 1A don't lose their group
+    membership.
+    """
+
+    SUFFIX = "suffix"
+    """Opt-in inference from :data:`BUS_GROUP_PATTERNS`.
+
+    Only reported when ``enable_suffix_inference=True`` is passed to
+    :func:`detect_match_groups`.  Refuses low-confidence groups
+    (fewer than ``_MIN_GROUP_SIZE`` members) so that random GPIO
+    names (``A0`` alone, ``DQ0``/``DQ1`` pair) don't get incorrectly
+    classified.
+    """
+
+
+@dataclass
+class MatchGroup:
+    """A length-match group plus metadata about its source and policy.
+
+    Attributes:
+        group_id: Stable identifier for the group.  By convention
+            this is the group name from the source (the
+            ``length_match_group`` field, the ``add_match_group(name=...)``
+            argument, or the :data:`BUS_GROUP_PATTERNS` template).
+        members: Net IDs that belong to the group, in deterministic
+            sorted order (lowest net id first).
+        reference: Net ID to use as the reference (the "pace car") for
+            length-matching, or ``None`` to mean "use the longest
+            trace in the group".  Set by the reference resolver from
+            ``NetClassRouting.length_match_reference``.
+        source: Which detection path produced this group.
+
+    Notes:
+        This dataclass is intentionally minimal -- Phase 1B (#2688)
+        owns the measurement / tolerance logic and may extend the
+        contract with serialisation methods (``to_dict`` /
+        ``from_dict``).  This module does not invent such methods; if
+        Phase 1B adds them, the existing instances round-trip
+        trivially because all fields are JSON-compatible primitives.
+    """
+
+    group_id: str
+    members: list[int] = field(default_factory=list)
+    reference: int | None = None
+    source: MatchGroupSource = MatchGroupSource.EXPLICIT
+
+
+# =============================================================================
+# BUS_GROUP_PATTERNS -- suffix-inference table
+# =============================================================================
+#
+# Maps (regex, group_name_template) tuples for opt-in suffix-based
+# inference.  Group name template uses ``{}`` placeholders if any
+# capturing group from the regex should be substituted in (currently
+# only ``DDR_DATA_BYTE_{}`` uses this, with the high-order byte index).
+#
+# These regexes deliberately overlap with the per-net "is this
+# interesting?" gate at
+# :data:`kicad_tools.analysis.trace_length.CRITICAL_NET_PATTERNS` but
+# are NOT pure reuse -- the former classify nets, the latter name
+# groups.  A drift-prevention test asserts the discriminating
+# fragments (``DQ\d``, ``DQS``, ``DM\d``, ``A\d+$``, ``MIPI``,
+# ``HDMI``) are reachable from both tables so the two cannot
+# silently diverge.
+
+# Minimum members required for a suffix-inferred group to be reported.
+# Below this threshold, the inferer refuses the group (mirroring the
+# single-ended refusal in router/diffpair_detection.py).  Three is the
+# smallest size that exceeds "could be a diff pair" (2) plus "could be
+# a single GPIO" (1).
+_MIN_GROUP_SIZE = 3
+
+
+BUS_GROUP_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # DDR data byte: DQ0..DQ7 form an 8-bit byte; one group per byte
+    # boundary.  ``DQ\d+`` without explicit byte grouping collapses
+    # all matched DQ nets into a single group named "DDR_DATA".
+    # Designs that need per-byte separation can declare explicitly
+    # via NetClassRouting.length_match_group.
+    (re.compile(r"(?i)^DQ\d+$"), "DDR_DATA"),
+    # DDR strobe: DQS, DQS_P/N, DQS0..DQS3 -- often a pair, sometimes
+    # a single net.  Below the min-group threshold by itself; included
+    # here so the regex is present (the drift test verifies coverage)
+    # but the membership filter will refuse the group unless a board
+    # has >=3 strobe nets (rare; usually composed via diff-pair).
+    (re.compile(r"(?i)^DQS(?:\d+)?(?:_[PN])?$"), "DDR_STROBE"),
+    # DDR data mask: DM0..DM3 -- one mask per data byte.  Usually 1-2
+    # nets, refused by min-group threshold.  Present for drift-test
+    # symmetry.
+    (re.compile(r"(?i)^DM\d+$"), "DDR_DATA_MASK"),
+    # MIPI CSI data lanes (positive + negative halves).  Designs
+    # typically have 2 or 4 lanes per camera; ``CSI_DAT0_P`` style.
+    # Pair-aware composition is Phase 2F's job; Phase 1C just
+    # reports the data-lane group containing all P/N nets.
+    (re.compile(r"(?i)^CSI_DAT\d+_[PN]$"), "MIPI_CSI_DATA"),
+    # MIPI DSI data lanes (display-side).
+    (re.compile(r"(?i)^DSI_DAT\d+_[PN]$"), "MIPI_DSI_DATA"),
+    # HDMI TMDS data lanes: TMDS_D0_P/N, TMDS_D1_P/N, TMDS_D2_P/N.
+    # Clock (TMDS_CLK_P/N) is intentionally excluded -- it is the
+    # reference, not a group member.  Phase 2F composes the lanes-
+    # vs-clock relationship; Phase 1C only detects the data-lane
+    # group.
+    (re.compile(r"(?i)^TMDS_D\d+_[PN]$"), "HDMI_TMDS_DATA"),
+    # Generic address bus: A0..AN.  HIGHEST false-positive risk
+    # (matches GPIO names like ``A0``).  Min-group threshold of 3
+    # prevents single-GPIO false positives; the partial-coverage
+    # test exercises this case.  Documented in the module docstring.
+    (re.compile(r"(?i)^A\d+$"), "ADDR_BUS"),
+]
+
+
+# Clock-name patterns drawn from CRITICAL_NET_PATTERNS lines 31-34.
+# Compiled here from the existing list so this module does NOT
+# reimplement the regex set; the drift-prevention test asserts these
+# four entries appear in CRITICAL_NET_PATTERNS.
+_CLOCK_REGEX_INDICES = (0, 1, 2, 3)  # ^CLK, CLK$, CLOCK, _CLK_
+
+
+def _get_clock_regexes() -> list[re.Pattern[str]]:
+    """Return the four clock-discriminating regexes from
+    ``CRITICAL_NET_PATTERNS``.
+
+    Drift-prevention: this resolves the regexes at import time but
+    *via index lookup into the canonical list*, so renaming /
+    reordering CRITICAL_NET_PATTERNS will surface in tests rather
+    than silently produce wrong sentinel behaviour.
+    """
+    return [re.compile(CRITICAL_NET_PATTERNS[i]) for i in _CLOCK_REGEX_INDICES]
+
+
+# =============================================================================
+# Public entry point
+# =============================================================================
+
+
+def detect_match_groups(
+    net_names: dict[int, str],
+    *,
+    net_class_routing: dict[str, NetClassRouting] | None = None,
+    net_to_class: dict[str, str] | None = None,
+    length_tracker: LengthTracker | None = None,
+    enable_suffix_inference: bool = False,
+) -> list[MatchGroup]:
+    """Layered match-group detection.
+
+    Args:
+        net_names: ``{net_id: net_name}`` from the autorouter.
+        net_class_routing: Optional ``{class_name: NetClassRouting}``
+            map.  When a class has ``length_match_group`` set, every
+            net mapped to that class joins the named group.  Highest-
+            priority source (EXPLICIT).
+        net_to_class: Optional ``{net_name: class_name}`` map used to
+            look up which net class a net belongs to.  Required when
+            ``net_class_routing`` is supplied; otherwise explicit
+            declarations are skipped.
+        length_tracker: Optional :class:`LengthTracker` whose
+            ``match_groups`` dict surfaces groups registered through
+            the legacy ``Autorouter.add_match_group`` API.  Second-
+            priority source (LEGACY_API).  Groups already claimed by
+            an EXPLICIT source (by net-id overlap) are not re-emitted.
+        enable_suffix_inference: When ``True``, runs the
+            :data:`BUS_GROUP_PATTERNS` matcher over nets not yet
+            claimed by explicit / legacy sources.  Off by default
+            because suffix patterns have a non-trivial false-positive
+            rate; agents should declare explicitly when in doubt.
+
+    Returns:
+        A list of :class:`MatchGroup`, with ``source`` recording
+        which detection path produced each group.  Groups are
+        emitted in declaration order: EXPLICIT first, then
+        LEGACY_API, then SUFFIX.  Members within each group are
+        sorted by net id for deterministic output.
+
+    Notes:
+        - A net is assigned to AT MOST ONE group.  If an explicit
+          declaration and a suffix pattern both claim ``DQ0``, only
+          the explicit declaration is reported.
+        - Suffix inference refuses groups with fewer than three
+          members (``_MIN_GROUP_SIZE``).  The same lesson as the
+          USB-CC1/CC2 refusal in ``diffpair_detection.py``: small
+          groups are too likely to be false positives.
+        - The ``"clock"`` sentinel value of
+          ``NetClassRouting.length_match_reference`` is resolved
+          inside this function -- the returned ``MatchGroup.reference``
+          is a concrete net-id, never the sentinel string.
+    """
+    name_to_id = _name_to_id_map(net_names)
+    claimed_net_ids: set[int] = set()
+    out: list[MatchGroup] = []
+
+    # 1. Explicit declarations -- authoritative.
+    explicit_groups = _gather_explicit_groups(
+        net_names=net_names,
+        net_class_routing=net_class_routing,
+        net_to_class=net_to_class,
+    )
+    for group in explicit_groups:
+        group.members.sort()
+        group.reference = _resolve_reference(
+            group=group,
+            net_names=net_names,
+            name_to_id=name_to_id,
+            net_class_routing=net_class_routing,
+            net_to_class=net_to_class,
+        )
+        out.append(group)
+        claimed_net_ids.update(group.members)
+        logger.info(
+            "[match_group] %s (%d nets, source: explicit, ref=%s)",
+            group.group_id,
+            len(group.members),
+            net_names.get(group.reference) if group.reference is not None else "longest",
+        )
+
+    # 2. Legacy-API groups (existing add_match_group registrations).
+    if length_tracker is not None:
+        for name, net_ids in length_tracker.match_groups.items():
+            # Skip if any member of this legacy group is already
+            # claimed by an explicit declaration -- explicit wins.
+            net_id_set = set(net_ids)
+            if net_id_set & claimed_net_ids:
+                # Partial overlap means a higher-priority source has
+                # already claimed at least one member; drop the whole
+                # group to avoid double-counting.
+                logger.debug(
+                    "[match_group] legacy group %s overlaps with explicit declaration; skipping",
+                    name,
+                )
+                continue
+            members = sorted(net_id_set)
+            if not members:
+                continue
+            group = MatchGroup(
+                group_id=name,
+                members=members,
+                reference=None,  # Legacy API has no reference policy.
+                source=MatchGroupSource.LEGACY_API,
+            )
+            out.append(group)
+            claimed_net_ids.update(members)
+            logger.info(
+                "[match_group] %s (%d nets, source: legacy_api)",
+                name,
+                len(members),
+            )
+
+    # 3. Suffix inference -- opt-in, last priority.
+    if enable_suffix_inference:
+        remaining_names: dict[int, str] = {
+            nid: nm for nid, nm in net_names.items() if nid not in claimed_net_ids
+        }
+        suffix_groups = _infer_suffix_groups(remaining_names)
+        for group in suffix_groups:
+            # Re-check claim set in case two suffix patterns collide.
+            if set(group.members) & claimed_net_ids:
+                continue
+            group.members.sort()
+            out.append(group)
+            claimed_net_ids.update(group.members)
+            logger.info(
+                "[match_group] %s (%d nets, source: suffix)",
+                group.group_id,
+                len(group.members),
+            )
+
+    return out
+
+
+# =============================================================================
+# Source 1: Explicit declarations
+# =============================================================================
+
+
+def _gather_explicit_groups(
+    *,
+    net_names: dict[int, str],
+    net_class_routing: dict[str, NetClassRouting] | None,
+    net_to_class: dict[str, str] | None,
+) -> list[MatchGroup]:
+    """Collect groups declared via ``NetClassRouting.length_match_group``.
+
+    Multiple net classes may declare the same group name -- their
+    members are merged into a single :class:`MatchGroup`.  This is
+    the documented use case for MIPI lane composition: each lane has
+    its own class (so per-lane impedance / diff-pair settings can
+    differ) but they all share a ``length_match_group="MIPI_CSI"``.
+    """
+    if not net_class_routing or not net_to_class:
+        return []
+
+    # Build {group_name: [net_ids]} from the class membership map.
+    group_to_ids: dict[str, list[int]] = {}
+    for nid, net_name in net_names.items():
+        class_name = net_to_class.get(net_name)
+        if class_name is None:
+            continue
+        nc = net_class_routing.get(class_name)
+        if nc is None:
+            continue
+        group_name = nc.effective_length_match_group()
+        if group_name is None:
+            continue
+        group_to_ids.setdefault(group_name, []).append(nid)
+
+    return [
+        MatchGroup(
+            group_id=name,
+            members=sorted(ids),
+            reference=None,  # Resolved after the gather pass.
+            source=MatchGroupSource.EXPLICIT,
+        )
+        for name, ids in sorted(group_to_ids.items())
+    ]
+
+
+# =============================================================================
+# Source 3: Suffix inference
+# =============================================================================
+
+
+def _infer_suffix_groups(net_names: dict[int, str]) -> list[MatchGroup]:
+    """Run :data:`BUS_GROUP_PATTERNS` over ``net_names`` and assemble
+    candidate groups.
+
+    Each net is assigned to AT MOST ONE pattern (first match wins,
+    in BUS_GROUP_PATTERNS declaration order).  Groups with fewer
+    than ``_MIN_GROUP_SIZE`` members are refused.
+    """
+    # First pass: bucket nets by pattern (first match wins).
+    pattern_to_ids: dict[str, list[int]] = {}
+    for nid, name in net_names.items():
+        for pattern, group_name in BUS_GROUP_PATTERNS:
+            if pattern.match(name):
+                pattern_to_ids.setdefault(group_name, []).append(nid)
+                break
+
+    # Second pass: refuse small groups.
+    out: list[MatchGroup] = []
+    for group_name, ids in sorted(pattern_to_ids.items()):
+        if len(ids) < _MIN_GROUP_SIZE:
+            logger.debug(
+                "[match_group] suffix pattern %s matched %d nets (< %d "
+                "required); refusing low-confidence group",
+                group_name,
+                len(ids),
+                _MIN_GROUP_SIZE,
+            )
+            continue
+        out.append(
+            MatchGroup(
+                group_id=group_name,
+                members=sorted(ids),
+                reference=None,
+                source=MatchGroupSource.SUFFIX,
+            )
+        )
+    return out
+
+
+# =============================================================================
+# Reference resolution (clock sentinel)
+# =============================================================================
+
+
+def _resolve_reference(
+    *,
+    group: MatchGroup,
+    net_names: dict[int, str],
+    name_to_id: dict[str, int],
+    net_class_routing: dict[str, NetClassRouting] | None,
+    net_to_class: dict[str, str] | None,
+) -> int | None:
+    """Resolve ``NetClassRouting.length_match_reference`` to a net id.
+
+    Returns ``None`` (meaning "use the longest trace in the group")
+    when no reference policy is set, or when the sentinel ``"clock"``
+    cannot find a matching member.
+
+    The resolver consults the FIRST class in ``net_class_routing``
+    whose ``length_match_group`` equals ``group.group_id`` and uses
+    that class's ``length_match_reference`` value.  When multiple
+    classes share the same group name and disagree on the reference,
+    the first one wins (deterministic by ``sorted()`` order in
+    :func:`_gather_explicit_groups`).
+    """
+    if not net_class_routing or not net_to_class:
+        return None
+
+    # Find the reference policy attached to this group.
+    reference_policy: str | None = None
+    for class_name in sorted(net_class_routing.keys()):
+        nc = net_class_routing[class_name]
+        if nc.effective_length_match_group() == group.group_id:
+            reference_policy = nc.effective_length_match_reference()
+            if reference_policy is not None:
+                break
+
+    if reference_policy is None:
+        return None  # "longest" semantics handled by the tracker.
+
+    # Explicit net-name reference.
+    if reference_policy != "clock":
+        ref_id = name_to_id.get(reference_policy)
+        if ref_id is None:
+            logger.warning(
+                "[match_group] group %s declares reference net %r which is "
+                "not in the net list; falling back to longest",
+                group.group_id,
+                reference_policy,
+            )
+            return None
+        if ref_id not in group.members:
+            logger.warning(
+                "[match_group] group %s declares reference net %r which is "
+                "not a member of the group; falling back to longest",
+                group.group_id,
+                reference_policy,
+            )
+            return None
+        return ref_id
+
+    # "clock" sentinel -- find a member whose name matches a clock
+    # regex from CRITICAL_NET_PATTERNS.
+    return _resolve_clock_sentinel(group=group, net_names=net_names)
+
+
+def _resolve_clock_sentinel(
+    *,
+    group: MatchGroup,
+    net_names: dict[int, str],
+) -> int | None:
+    """Resolve the ``"clock"`` reference sentinel for a match group.
+
+    Iterates over the four clock regexes from
+    ``CRITICAL_NET_PATTERNS:31-34`` and finds any group member whose
+    name matches.  Multi-match resolution is deterministic: the
+    member with the lowest net id wins, with a ``logger.warning``
+    if more than one matched.
+
+    Returns the matching member's net id, or ``None`` (with a
+    ``logger.warning``) if no member matches any clock regex.
+    """
+    clock_regexes = _get_clock_regexes()
+
+    matches: list[int] = []
+    for nid in group.members:
+        name = net_names.get(nid)
+        if name is None:
+            continue
+        for rgx in clock_regexes:
+            if rgx.search(name):
+                matches.append(nid)
+                break
+
+    if not matches:
+        logger.warning(
+            "[match_group] group %s: 'clock' sentinel declared but no "
+            "member name matches any clock regex from CRITICAL_NET_PATTERNS; "
+            "falling back to longest",
+            group.group_id,
+        )
+        return None
+
+    matches.sort()
+    if len(matches) > 1:
+        logger.warning(
+            "[match_group] group %s: 'clock' sentinel matched %d members "
+            "(%s); picking lowest net id %d (%s) for determinism",
+            group.group_id,
+            len(matches),
+            [net_names.get(m) for m in matches],
+            matches[0],
+            net_names.get(matches[0]),
+        )
+    return matches[0]
+
+
+# =============================================================================
+# Internals
+# =============================================================================
+
+
+def _name_to_id_map(net_names: dict[int, str]) -> dict[str, int]:
+    """Reverse-index net names to net IDs.  First occurrence wins."""
+    out: dict[str, int] = {}
+    for nid, name in net_names.items():
+        if name not in out:
+            out[name] = nid
+    return out

--- a/src/kicad_tools/router/match_group_detection.py
+++ b/src/kicad_tools/router/match_group_detection.py
@@ -24,12 +24,19 @@ The output is a list of :class:`MatchGroup` instances annotated with a
 :class:`MatchGroupSource` enum so downstream consumers (DRC rule,
 serpentine tuner) can apply policy by source if needed.
 
-**Important parallel-development note**: Phase 1B (#2688) builds the
-companion ``MatchGroupTracker``.  This module defines its own
-``MatchGroup`` and ``MatchGroupSource`` types so it can land
-independently; the type shapes are coordinated with Phase 1B so the
-two modules can interoperate once both are merged.  See
-``MatchGroup``'s docstring for the type contract.
+**Type ownership (Epic #2661 Phase 1B / Issue #2688)**: ``MatchGroup``
+and ``MatchGroupSource`` are owned by
+:mod:`kicad_tools.router.match_group_length` (Phase 1B, PR #2693).
+This Phase 1C detector imports those types rather than redefining them
+so the detection layer and the measurement / tracker layer share a
+single canonical shape.  Phase 1B's enum has four values
+(``EXPLICIT``, ``KICAD_GROUP``, ``SUFFIX``, ``LEGACY_API``); this
+detector only produces three (``EXPLICIT``, ``LEGACY_API``,
+``SUFFIX``) because KiCad's PCB s-expression has no
+``(match_group ...)`` directive analogous to
+``(diff_pair_template ...)`` yet.  ``KICAD_GROUP`` remains a valid
+enum member -- this module simply never emits it; a future Phase 2
+detector for a hypothetical KiCad directive would be the producer.
 
 The public entry point :func:`detect_match_groups` mirrors
 :func:`kicad_tools.router.diffpair_detection.detect_diff_pairs` (PR
@@ -48,11 +55,11 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass, field
-from enum import Enum
 from typing import TYPE_CHECKING
 
 from kicad_tools.analysis.trace_length import CRITICAL_NET_PATTERNS
+
+from .match_group_length import MatchGroup, MatchGroupSource
 
 if TYPE_CHECKING:
     from .length import LengthTracker
@@ -62,79 +69,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# =============================================================================
-# Type contract -- coordinated with Phase 1B (#2688)
-# =============================================================================
-
-
-class MatchGroupSource(Enum):
-    """Where a match group came from in the layered detector.
-
-    Three-tier (not four).  ``KICAD_GROUP`` is intentionally absent:
-    KiCad's PCB s-expression does not currently have a
-    ``(match_group ...)`` directive analogous to
-    ``(diff_pair_template ...)``, so the parallel ``KICAD_GROUP``
-    source from diff-pair detection has no analog here.  Phase 2 of
-    Epic #2661 (not this issue) may revisit if KiCad upstream adds
-    such a directive.
-
-    The ordering of values matches detection priority:
-    ``EXPLICIT > LEGACY_API > SUFFIX``.
-    """
-
-    EXPLICIT = "explicit"
-    """Declared via ``NetClassRouting.length_match_group``."""
-
-    LEGACY_API = "legacy_api"
-    """Registered via ``Autorouter.add_match_group(...)``.
-
-    The legacy Python API path that has existed since before this
-    epic.  Surfaced from ``LengthTracker.match_groups`` so already-
-    routed boards that pre-date Phase 1A don't lose their group
-    membership.
-    """
-
-    SUFFIX = "suffix"
-    """Opt-in inference from :data:`BUS_GROUP_PATTERNS`.
-
-    Only reported when ``enable_suffix_inference=True`` is passed to
-    :func:`detect_match_groups`.  Refuses low-confidence groups
-    (fewer than ``_MIN_GROUP_SIZE`` members) so that random GPIO
-    names (``A0`` alone, ``DQ0``/``DQ1`` pair) don't get incorrectly
-    classified.
-    """
-
-
-@dataclass
-class MatchGroup:
-    """A length-match group plus metadata about its source and policy.
-
-    Attributes:
-        group_id: Stable identifier for the group.  By convention
-            this is the group name from the source (the
-            ``length_match_group`` field, the ``add_match_group(name=...)``
-            argument, or the :data:`BUS_GROUP_PATTERNS` template).
-        members: Net IDs that belong to the group, in deterministic
-            sorted order (lowest net id first).
-        reference: Net ID to use as the reference (the "pace car") for
-            length-matching, or ``None`` to mean "use the longest
-            trace in the group".  Set by the reference resolver from
-            ``NetClassRouting.length_match_reference``.
-        source: Which detection path produced this group.
-
-    Notes:
-        This dataclass is intentionally minimal -- Phase 1B (#2688)
-        owns the measurement / tolerance logic and may extend the
-        contract with serialisation methods (``to_dict`` /
-        ``from_dict``).  This module does not invent such methods; if
-        Phase 1B adds them, the existing instances round-trip
-        trivially because all fields are JSON-compatible primitives.
-    """
-
-    group_id: str
-    members: list[int] = field(default_factory=list)
-    reference: int | None = None
-    source: MatchGroupSource = MatchGroupSource.EXPLICIT
+# Re-export the canonical types so downstream callers can keep importing
+# them from this module if they wish (back-compat affordance; the
+# authoritative definition lives in :mod:`.match_group_length`).
+__all__ = [
+    "BUS_GROUP_PATTERNS",
+    "MatchGroup",
+    "MatchGroupSource",
+    "detect_match_groups",
+]
 
 
 # =============================================================================
@@ -273,8 +216,9 @@ def detect_match_groups(
           groups are too likely to be false positives.
         - The ``"clock"`` sentinel value of
           ``NetClassRouting.length_match_reference`` is resolved
-          inside this function -- the returned ``MatchGroup.reference``
-          is a concrete net-id, never the sentinel string.
+          inside this function -- the returned
+          ``MatchGroup.reference_net_id`` is a concrete net-id, never
+          the sentinel string.
     """
     name_to_id = _name_to_id_map(net_names)
     claimed_net_ids: set[int] = set()
@@ -287,8 +231,8 @@ def detect_match_groups(
         net_to_class=net_to_class,
     )
     for group in explicit_groups:
-        group.members.sort()
-        group.reference = _resolve_reference(
+        group.net_ids.sort()
+        group.reference_net_id = _resolve_reference(
             group=group,
             net_names=net_names,
             name_to_id=name_to_id,
@@ -296,12 +240,14 @@ def detect_match_groups(
             net_to_class=net_to_class,
         )
         out.append(group)
-        claimed_net_ids.update(group.members)
+        claimed_net_ids.update(group.net_ids)
         logger.info(
             "[match_group] %s (%d nets, source: explicit, ref=%s)",
-            group.group_id,
-            len(group.members),
-            net_names.get(group.reference) if group.reference is not None else "longest",
+            group.name,
+            len(group.net_ids),
+            net_names.get(group.reference_net_id)
+            if group.reference_net_id is not None
+            else "longest",
         )
 
     # 2. Legacy-API groups (existing add_match_group registrations).
@@ -323,9 +269,9 @@ def detect_match_groups(
             if not members:
                 continue
             group = MatchGroup(
-                group_id=name,
-                members=members,
-                reference=None,  # Legacy API has no reference policy.
+                name=name,
+                net_ids=members,
+                reference_net_id=None,  # Legacy API has no reference policy.
                 source=MatchGroupSource.LEGACY_API,
             )
             out.append(group)
@@ -344,15 +290,15 @@ def detect_match_groups(
         suffix_groups = _infer_suffix_groups(remaining_names)
         for group in suffix_groups:
             # Re-check claim set in case two suffix patterns collide.
-            if set(group.members) & claimed_net_ids:
+            if set(group.net_ids) & claimed_net_ids:
                 continue
-            group.members.sort()
+            group.net_ids.sort()
             out.append(group)
-            claimed_net_ids.update(group.members)
+            claimed_net_ids.update(group.net_ids)
             logger.info(
                 "[match_group] %s (%d nets, source: suffix)",
-                group.group_id,
-                len(group.members),
+                group.name,
+                len(group.net_ids),
             )
 
     return out
@@ -396,9 +342,9 @@ def _gather_explicit_groups(
 
     return [
         MatchGroup(
-            group_id=name,
-            members=sorted(ids),
-            reference=None,  # Resolved after the gather pass.
+            name=name,
+            net_ids=sorted(ids),
+            reference_net_id=None,  # Resolved after the gather pass.
             source=MatchGroupSource.EXPLICIT,
         )
         for name, ids in sorted(group_to_ids.items())
@@ -440,9 +386,9 @@ def _infer_suffix_groups(net_names: dict[int, str]) -> list[MatchGroup]:
             continue
         out.append(
             MatchGroup(
-                group_id=group_name,
-                members=sorted(ids),
-                reference=None,
+                name=group_name,
+                net_ids=sorted(ids),
+                reference_net_id=None,
                 source=MatchGroupSource.SUFFIX,
             )
         )
@@ -469,7 +415,7 @@ def _resolve_reference(
     cannot find a matching member.
 
     The resolver consults the FIRST class in ``net_class_routing``
-    whose ``length_match_group`` equals ``group.group_id`` and uses
+    whose ``length_match_group`` equals ``group.name`` and uses
     that class's ``length_match_reference`` value.  When multiple
     classes share the same group name and disagree on the reference,
     the first one wins (deterministic by ``sorted()`` order in
@@ -482,7 +428,7 @@ def _resolve_reference(
     reference_policy: str | None = None
     for class_name in sorted(net_class_routing.keys()):
         nc = net_class_routing[class_name]
-        if nc.effective_length_match_group() == group.group_id:
+        if nc.effective_length_match_group() == group.name:
             reference_policy = nc.effective_length_match_reference()
             if reference_policy is not None:
                 break
@@ -497,15 +443,15 @@ def _resolve_reference(
             logger.warning(
                 "[match_group] group %s declares reference net %r which is "
                 "not in the net list; falling back to longest",
-                group.group_id,
+                group.name,
                 reference_policy,
             )
             return None
-        if ref_id not in group.members:
+        if ref_id not in group.net_ids:
             logger.warning(
                 "[match_group] group %s declares reference net %r which is "
                 "not a member of the group; falling back to longest",
-                group.group_id,
+                group.name,
                 reference_policy,
             )
             return None
@@ -535,7 +481,7 @@ def _resolve_clock_sentinel(
     clock_regexes = _get_clock_regexes()
 
     matches: list[int] = []
-    for nid in group.members:
+    for nid in group.net_ids:
         name = net_names.get(nid)
         if name is None:
             continue
@@ -549,7 +495,7 @@ def _resolve_clock_sentinel(
             "[match_group] group %s: 'clock' sentinel declared but no "
             "member name matches any clock regex from CRITICAL_NET_PATTERNS; "
             "falling back to longest",
-            group.group_id,
+            group.name,
         )
         return None
 
@@ -558,7 +504,7 @@ def _resolve_clock_sentinel(
         logger.warning(
             "[match_group] group %s: 'clock' sentinel matched %d members "
             "(%s); picking lowest net id %d (%s) for determinism",
-            group.group_id,
+            group.name,
             len(matches),
             [net_names.get(m) for m in matches],
             matches[0],

--- a/tests/test_match_group_detection.py
+++ b/tests/test_match_group_detection.py
@@ -51,9 +51,9 @@ class TestExplicitDeclaration:
         )
         assert len(out) == 1
         assert out[0].source == MatchGroupSource.EXPLICIT
-        assert out[0].group_id == "DDR_BYTE0"
-        assert out[0].members == [1, 2, 3, 4]
-        assert out[0].reference is None  # No reference policy -> "longest"
+        assert out[0].name == "DDR_BYTE0"
+        assert out[0].net_ids == [1, 2, 3, 4]
+        assert out[0].reference_net_id is None  # No reference policy -> "longest"
 
     def test_multiple_classes_merge_into_single_group(self):
         """The MIPI-lane use case: per-pair classes share a group."""
@@ -79,8 +79,8 @@ class TestExplicitDeclaration:
             net_to_class=net_to_class,
         )
         assert len(out) == 1
-        assert out[0].group_id == "MIPI_CSI"
-        assert out[0].members == [1, 2, 3, 4]
+        assert out[0].name == "MIPI_CSI"
+        assert out[0].net_ids == [1, 2, 3, 4]
 
     def test_explicit_reference_resolution(self):
         net_names = {1: "DQ0", 2: "DQ1", 3: "DQ2", 4: "DQS_P"}
@@ -98,7 +98,7 @@ class TestExplicitDeclaration:
             net_to_class=net_to_class,
         )
         assert len(out) == 1
-        assert out[0].reference == 4  # DQS_P's net id.
+        assert out[0].reference_net_id == 4  # DQS_P's net id.
 
     def test_explicit_reference_missing_from_netlist_falls_back(self, caplog):
         net_names = {1: "DQ0", 2: "DQ1", 3: "DQ2"}
@@ -113,7 +113,7 @@ class TestExplicitDeclaration:
                 net_class_routing={"DDR": nc},
                 net_to_class=dict.fromkeys(net_names.values(), "DDR"),
             )
-        assert out[0].reference is None
+        assert out[0].reference_net_id is None
         assert any("not in the net list" in r.message for r in caplog.records)
 
     def test_explicit_reference_not_a_member_falls_back(self, caplog):
@@ -136,7 +136,7 @@ class TestExplicitDeclaration:
                 net_class_routing={"DDR": nc_ddr, "OTHER": nc_other},
                 net_to_class=net_to_class,
             )
-        assert out[0].reference is None
+        assert out[0].reference_net_id is None
         assert any("not a member of the group" in r.message for r in caplog.records)
 
     def test_no_net_class_routing_returns_empty(self):
@@ -170,9 +170,9 @@ class TestLegacyApiSource:
         out = detect_match_groups(net_names, length_tracker=tracker)
         assert len(out) == 1
         assert out[0].source == MatchGroupSource.LEGACY_API
-        assert out[0].group_id == "MEM_BUS"
-        assert out[0].members == [10, 11, 12, 13]
-        assert out[0].reference is None
+        assert out[0].name == "MEM_BUS"
+        assert out[0].net_ids == [10, 11, 12, 13]
+        assert out[0].reference_net_id is None
 
     def test_legacy_with_no_tracker_skipped(self):
         out = detect_match_groups({10: "MEM_D0"})
@@ -202,16 +202,16 @@ class TestSuffixInference:
         out = detect_match_groups(net_names, enable_suffix_inference=True)
         assert len(out) == 1
         assert out[0].source == MatchGroupSource.SUFFIX
-        assert out[0].group_id == "DDR_DATA"
-        assert out[0].members == list(range(8))
+        assert out[0].name == "DDR_DATA"
+        assert out[0].net_ids == list(range(8))
 
     def test_address_bus_16_nets(self):
         # Address-line false-positive risk -- only valid when group is large.
         net_names = {i: f"A{i}" for i in range(16)}
         out = detect_match_groups(net_names, enable_suffix_inference=True)
         assert len(out) == 1
-        assert out[0].group_id == "ADDR_BUS"
-        assert len(out[0].members) == 16
+        assert out[0].name == "ADDR_BUS"
+        assert len(out[0].net_ids) == 16
 
     def test_mipi_csi_lane_data(self):
         net_names = {
@@ -226,8 +226,8 @@ class TestSuffixInference:
         }
         out = detect_match_groups(net_names, enable_suffix_inference=True)
         assert len(out) == 1
-        assert out[0].group_id == "MIPI_CSI_DATA"
-        assert len(out[0].members) == 8
+        assert out[0].name == "MIPI_CSI_DATA"
+        assert len(out[0].net_ids) == 8
 
     def test_hdmi_tmds_data_lanes_clock_excluded(self):
         # 6 data nets (3 lanes x P/N) + 2 clock nets.  The clock is
@@ -246,11 +246,11 @@ class TestSuffixInference:
         out = detect_match_groups(net_names, enable_suffix_inference=True)
         # The data lanes form one group of 6 (TMDS_CLK_* doesn't match
         # the data pattern).
-        data_groups = [g for g in out if g.group_id == "HDMI_TMDS_DATA"]
+        data_groups = [g for g in out if g.name == "HDMI_TMDS_DATA"]
         assert len(data_groups) == 1
-        assert len(data_groups[0].members) == 6
-        assert 7 not in data_groups[0].members
-        assert 8 not in data_groups[0].members
+        assert len(data_groups[0].net_ids) == 6
+        assert 7 not in data_groups[0].net_ids
+        assert 8 not in data_groups[0].net_ids
 
 
 # =============================================================================
@@ -274,7 +274,7 @@ class TestSourcePriority:
         )
         # Exactly ONE group, named CUSTOM_BUS (not DDR_DATA), source EXPLICIT.
         assert len(out) == 1
-        assert out[0].group_id == "CUSTOM_BUS"
+        assert out[0].name == "CUSTOM_BUS"
         assert out[0].source == MatchGroupSource.EXPLICIT
 
     def test_explicit_preempts_legacy_on_overlap(self):
@@ -291,7 +291,7 @@ class TestSourcePriority:
         )
         # Only the EXPLICIT group is reported.
         assert len(out) == 1
-        assert out[0].group_id == "EXPLICIT_BUS"
+        assert out[0].name == "EXPLICIT_BUS"
         assert out[0].source == MatchGroupSource.EXPLICIT
 
     def test_legacy_preempts_suffix(self):
@@ -305,7 +305,7 @@ class TestSourcePriority:
             enable_suffix_inference=True,
         )
         assert len(out) == 1
-        assert out[0].group_id == "LEGACY_DDR"
+        assert out[0].name == "LEGACY_DDR"
         assert out[0].source == MatchGroupSource.LEGACY_API
 
     def test_legacy_partial_coverage_only_suffix_takes_rest(self):
@@ -331,7 +331,7 @@ class TestSourcePriority:
         # Legacy emits its 2-net group; suffix refuses the remaining 2.
         assert len(out) == 1
         assert out[0].source == MatchGroupSource.LEGACY_API
-        assert out[0].members == [0, 1]
+        assert out[0].net_ids == [0, 1]
 
 
 # =============================================================================
@@ -371,9 +371,9 @@ class TestFalsePositiveRefusal:
         out = detect_match_groups(net_names, enable_suffix_inference=True)
         # 3 DQ nets is exactly the min-group threshold; emit the group.
         assert len(out) == 1
-        assert out[0].group_id == "DDR_DATA"
-        assert out[0].members == [1, 2, 3]
-        assert 4 not in out[0].members
+        assert out[0].name == "DDR_DATA"
+        assert out[0].net_ids == [1, 2, 3]
+        assert 4 not in out[0].net_ids
 
 
 # =============================================================================
@@ -405,8 +405,8 @@ class TestDDRStrobeMaskInteraction:
         # Only the DDR_DATA group is reported; mask + strobe individually
         # are below min-group threshold.
         assert len(out) == 1
-        assert out[0].group_id == "DDR_DATA"
-        assert out[0].members == [1, 2, 3, 4, 5, 6, 7, 8]
+        assert out[0].name == "DDR_DATA"
+        assert out[0].net_ids == [1, 2, 3, 4, 5, 6, 7, 8]
 
 
 # =============================================================================
@@ -430,7 +430,7 @@ class TestClockSentinelResolution:
             net_to_class=dict.fromkeys(net_names.values(), "MIPI"),
         )
         assert len(out) == 1
-        assert out[0].reference == 1  # MIPI_CLK_P
+        assert out[0].reference_net_id == 1  # MIPI_CLK_P
 
     def test_sclk_resolved_via_clk_suffix(self):
         net_names = {1: "DATA0", 2: "DATA1", 3: "SCLK"}
@@ -445,7 +445,7 @@ class TestClockSentinelResolution:
             net_to_class=dict.fromkeys(net_names.values(), "SPI"),
         )
         assert len(out) == 1
-        assert out[0].reference == 3  # SCLK
+        assert out[0].reference_net_id == 3  # SCLK
 
     def test_clockdiv2_resolved_via_clock_pattern(self):
         net_names = {1: "DATA0", 2: "DATA1", 3: "CLOCKDIV2"}
@@ -459,7 +459,7 @@ class TestClockSentinelResolution:
             net_class_routing={"BUS": nc},
             net_to_class=dict.fromkeys(net_names.values(), "BUS"),
         )
-        assert out[0].reference == 3  # CLOCKDIV2
+        assert out[0].reference_net_id == 3  # CLOCKDIV2
 
     def test_no_clock_match_falls_back_with_warning(self, caplog):
         net_names = {1: "DATA0", 2: "DATA1", 3: "DATA2"}
@@ -474,7 +474,7 @@ class TestClockSentinelResolution:
                 net_class_routing={"BUS": nc},
                 net_to_class=dict.fromkeys(net_names.values(), "BUS"),
             )
-        assert out[0].reference is None
+        assert out[0].reference_net_id is None
         assert any(
             "'clock' sentinel" in r.message and "no member" in r.message for r in caplog.records
         )
@@ -492,7 +492,7 @@ class TestClockSentinelResolution:
                 net_class_routing={"BUS": nc},
                 net_to_class=dict.fromkeys(net_names.values(), "BUS"),
             )
-        assert out[0].reference == 1  # Lowest net id wins.
+        assert out[0].reference_net_id == 1  # Lowest net id wins.
         assert any("'clock' sentinel matched" in r.message for r in caplog.records)
 
 
@@ -562,7 +562,7 @@ class TestOutputDeterminism:
     def test_members_sorted_by_net_id(self):
         net_names = {30: "DQ0", 10: "DQ1", 20: "DQ2"}
         out = detect_match_groups(net_names, enable_suffix_inference=True)
-        assert out[0].members == [10, 20, 30]
+        assert out[0].net_ids == [10, 20, 30]
 
     def test_sources_emitted_in_priority_order(self):
         # Construct a netlist where each source emits one group, with
@@ -606,29 +606,53 @@ class TestOutputDeterminism:
 
 
 class TestMatchGroupDataclass:
-    def test_default_members_empty(self):
-        g = MatchGroup(group_id="TEST")
-        assert g.members == []
-        assert g.reference is None
-        assert g.source == MatchGroupSource.EXPLICIT
+    def test_default_construction(self):
+        # MatchGroup is now imported from Phase 1B
+        # (router.match_group_length, PR #2693); ``net_ids`` is
+        # required positional, ``reference_net_id`` defaults to
+        # ``None``, and the default source is ``LEGACY_API`` to match
+        # the legacy ``Autorouter.add_match_group`` entry point.
+        g = MatchGroup(name="TEST", net_ids=[])
+        assert g.net_ids == []
+        assert g.reference_net_id is None
+        assert g.source == MatchGroupSource.LEGACY_API
 
     def test_explicit_construction(self):
         g = MatchGroup(
-            group_id="DDR_DATA",
-            members=[1, 2, 3, 4],
-            reference=2,
+            name="DDR_DATA",
+            net_ids=[1, 2, 3, 4],
+            reference_net_id=2,
             source=MatchGroupSource.SUFFIX,
         )
-        assert g.group_id == "DDR_DATA"
-        assert g.members == [1, 2, 3, 4]
-        assert g.reference == 2
+        assert g.name == "DDR_DATA"
+        assert g.net_ids == [1, 2, 3, 4]
+        assert g.reference_net_id == 2
         assert g.source == MatchGroupSource.SUFFIX
 
-    def test_source_enum_has_three_values(self):
-        # No KICAD_GROUP -- intentionally absent (no KiCad analog
-        # for match groups yet).
+    def test_source_enum_includes_phase1b_kicad_group(self):
+        # Phase 1B (PR #2693) added ``KICAD_GROUP`` to the canonical
+        # ``MatchGroupSource`` enum so it stays parallel with
+        # :class:`~kicad_tools.router.diffpair_detection.DetectionSource`.
+        # This Phase 1C detector intentionally never EMITS ``KICAD_GROUP``
+        # (no KiCad ``(match_group ...)`` directive exists yet), but the
+        # enum value is part of the shared contract.
         values = {s.value for s in MatchGroupSource}
-        assert values == {"explicit", "legacy_api", "suffix"}
+        assert values == {"explicit", "kicad_group", "suffix", "legacy_api"}
+        # The detector never synthesises KICAD_GROUP itself; verify it
+        # doesn't appear when all three input paths are exercised.
+        net_names = {i: f"DQ{i}" for i in range(8)}
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_BYTE0")
+        constraints = create_match_group("LEGACY_BUS", [100, 101, 102], tolerance=0.2)
+        tracker = LengthTracker(constraints=constraints)
+        out = detect_match_groups(
+            net_names,
+            net_class_routing={"DDR": nc},
+            net_to_class=dict.fromkeys(net_names.values(), "DDR"),
+            length_tracker=tracker,
+            enable_suffix_inference=True,
+        )
+        sources = {g.source for g in out}
+        assert MatchGroupSource.KICAD_GROUP not in sources
 
 
 # =============================================================================
@@ -665,9 +689,9 @@ class TestExpandedFixtures:
             net_to_class=dict.fromkeys(net_names.values(), "DDR_BYTE0"),
         )
         assert len(out) == 1
-        assert out[0].group_id == "DDR_DATA_BYTE_0"
-        assert len(out[0].members) == 11
-        assert out[0].reference == 10  # DQS_P
+        assert out[0].name == "DDR_DATA_BYTE_0"
+        assert len(out[0].net_ids) == 11
+        assert out[0].reference_net_id == 10  # DQS_P
 
     def test_4_lane_mipi_csi_via_explicit(self):
         """4-lane MIPI CSI: 1 clock pair + 4 data pairs = 10 nets."""
@@ -694,7 +718,7 @@ class TestExpandedFixtures:
             net_to_class=dict.fromkeys(net_names.values(), "MIPI_CSI"),
         )
         assert len(out) == 1
-        assert len(out[0].members) == 10
+        assert len(out[0].net_ids) == 10
         # "clock" sentinel finds CSI_CLK_P (lowest id, matches ^CLK
         # via CLK_).
-        assert out[0].reference == 1
+        assert out[0].reference_net_id == 1

--- a/tests/test_match_group_detection.py
+++ b/tests/test_match_group_detection.py
@@ -1,0 +1,700 @@
+"""Tests for layered match-group detection (Issue #2689, Epic #2661 Phase 1C).
+
+Covers the three detection sources, tie-breaking, small-group refusal,
+clock-sentinel resolution, and drift-prevention against
+:data:`kicad_tools.analysis.trace_length.CRITICAL_NET_PATTERNS`.
+
+Test categories:
+
+1. EXPLICIT source -- ``NetClassRouting.length_match_group`` declarations.
+2. LEGACY_API source -- legacy ``LengthTracker.match_groups`` entries.
+3. SUFFIX source -- opt-in :data:`BUS_GROUP_PATTERNS` inference.
+4. Priority tie-breaking: EXPLICIT > LEGACY_API > SUFFIX.
+5. False-positive refusals: counter signals, GPIO-as-address, etc.
+6. Clock sentinel resolution.
+7. Drift prevention: CRITICAL_NET_PATTERNS coverage.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from kicad_tools.analysis.trace_length import CRITICAL_NET_PATTERNS
+from kicad_tools.router.length import LengthTracker, create_match_group
+from kicad_tools.router.match_group_detection import (
+    BUS_GROUP_PATTERNS,
+    MatchGroup,
+    MatchGroupSource,
+    detect_match_groups,
+)
+from kicad_tools.router.rules import NetClassRouting
+
+# =============================================================================
+# 1. EXPLICIT source
+# =============================================================================
+
+
+class TestExplicitDeclaration:
+    """Groups declared via ``NetClassRouting.length_match_group``."""
+
+    def test_single_class_single_group(self):
+        net_names = {1: "DQ0", 2: "DQ1", 3: "DQ2", 4: "DQ3"}
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_BYTE0")
+        net_class_routing = {"DDR": nc}
+        net_to_class = dict.fromkeys(net_names.values(), "DDR")
+
+        out = detect_match_groups(
+            net_names,
+            net_class_routing=net_class_routing,
+            net_to_class=net_to_class,
+        )
+        assert len(out) == 1
+        assert out[0].source == MatchGroupSource.EXPLICIT
+        assert out[0].group_id == "DDR_BYTE0"
+        assert out[0].members == [1, 2, 3, 4]
+        assert out[0].reference is None  # No reference policy -> "longest"
+
+    def test_multiple_classes_merge_into_single_group(self):
+        """The MIPI-lane use case: per-pair classes share a group."""
+        net_names = {
+            1: "CSI_DAT0_P",
+            2: "CSI_DAT0_N",
+            3: "CSI_DAT1_P",
+            4: "CSI_DAT1_N",
+        }
+        nc0 = NetClassRouting(name="MIPI_LANE0", length_match_group="MIPI_CSI")
+        nc1 = NetClassRouting(name="MIPI_LANE1", length_match_group="MIPI_CSI")
+        net_class_routing = {"MIPI_LANE0": nc0, "MIPI_LANE1": nc1}
+        net_to_class = {
+            "CSI_DAT0_P": "MIPI_LANE0",
+            "CSI_DAT0_N": "MIPI_LANE0",
+            "CSI_DAT1_P": "MIPI_LANE1",
+            "CSI_DAT1_N": "MIPI_LANE1",
+        }
+
+        out = detect_match_groups(
+            net_names,
+            net_class_routing=net_class_routing,
+            net_to_class=net_to_class,
+        )
+        assert len(out) == 1
+        assert out[0].group_id == "MIPI_CSI"
+        assert out[0].members == [1, 2, 3, 4]
+
+    def test_explicit_reference_resolution(self):
+        net_names = {1: "DQ0", 2: "DQ1", 3: "DQ2", 4: "DQS_P"}
+        nc = NetClassRouting(
+            name="DDR",
+            length_match_group="DDR_BYTE0",
+            length_match_reference="DQS_P",
+        )
+        net_class_routing = {"DDR": nc}
+        net_to_class = dict.fromkeys(net_names.values(), "DDR")
+
+        out = detect_match_groups(
+            net_names,
+            net_class_routing=net_class_routing,
+            net_to_class=net_to_class,
+        )
+        assert len(out) == 1
+        assert out[0].reference == 4  # DQS_P's net id.
+
+    def test_explicit_reference_missing_from_netlist_falls_back(self, caplog):
+        net_names = {1: "DQ0", 2: "DQ1", 3: "DQ2"}
+        nc = NetClassRouting(
+            name="DDR",
+            length_match_group="DDR_BYTE0",
+            length_match_reference="NONEXISTENT",
+        )
+        with caplog.at_level(logging.WARNING):
+            out = detect_match_groups(
+                net_names,
+                net_class_routing={"DDR": nc},
+                net_to_class=dict.fromkeys(net_names.values(), "DDR"),
+            )
+        assert out[0].reference is None
+        assert any("not in the net list" in r.message for r in caplog.records)
+
+    def test_explicit_reference_not_a_member_falls_back(self, caplog):
+        net_names = {1: "DQ0", 2: "DQ1", 3: "DQ2", 4: "OTHER_NET"}
+        nc_ddr = NetClassRouting(
+            name="DDR",
+            length_match_group="DDR_BYTE0",
+            length_match_reference="OTHER_NET",
+        )
+        nc_other = NetClassRouting(name="OTHER")
+        net_to_class = {
+            "DQ0": "DDR",
+            "DQ1": "DDR",
+            "DQ2": "DDR",
+            "OTHER_NET": "OTHER",
+        }
+        with caplog.at_level(logging.WARNING):
+            out = detect_match_groups(
+                net_names,
+                net_class_routing={"DDR": nc_ddr, "OTHER": nc_other},
+                net_to_class=net_to_class,
+            )
+        assert out[0].reference is None
+        assert any("not a member of the group" in r.message for r in caplog.records)
+
+    def test_no_net_class_routing_returns_empty(self):
+        out = detect_match_groups({1: "DQ0", 2: "DQ1"})
+        assert out == []
+
+    def test_class_without_group_field_skipped(self):
+        net_names = {1: "DQ0", 2: "DQ1"}
+        nc = NetClassRouting(name="DDR")  # No length_match_group set.
+        out = detect_match_groups(
+            net_names,
+            net_class_routing={"DDR": nc},
+            net_to_class=dict.fromkeys(net_names.values(), "DDR"),
+        )
+        assert out == []
+
+
+# =============================================================================
+# 2. LEGACY_API source
+# =============================================================================
+
+
+class TestLegacyApiSource:
+    """Groups already registered via ``Autorouter.add_match_group(...)``."""
+
+    def test_legacy_group_detected(self):
+        net_names = {10: "MEM_D0", 11: "MEM_D1", 12: "MEM_D2", 13: "MEM_D3"}
+        constraints = create_match_group("MEM_BUS", [10, 11, 12, 13], tolerance=0.2)
+        tracker = LengthTracker(constraints=constraints)
+
+        out = detect_match_groups(net_names, length_tracker=tracker)
+        assert len(out) == 1
+        assert out[0].source == MatchGroupSource.LEGACY_API
+        assert out[0].group_id == "MEM_BUS"
+        assert out[0].members == [10, 11, 12, 13]
+        assert out[0].reference is None
+
+    def test_legacy_with_no_tracker_skipped(self):
+        out = detect_match_groups({10: "MEM_D0"})
+        assert out == []
+
+    def test_empty_legacy_tracker_skipped(self):
+        tracker = LengthTracker()
+        out = detect_match_groups({10: "MEM_D0"}, length_tracker=tracker)
+        assert out == []
+
+
+# =============================================================================
+# 3. SUFFIX source
+# =============================================================================
+
+
+class TestSuffixInference:
+    """Opt-in suffix-based pattern matching via BUS_GROUP_PATTERNS."""
+
+    def test_off_by_default(self):
+        net_names = {i: f"DQ{i}" for i in range(8)}
+        out = detect_match_groups(net_names)
+        assert out == []
+
+    def test_ddr_data_byte_inferred_when_enabled(self):
+        net_names = {i: f"DQ{i}" for i in range(8)}
+        out = detect_match_groups(net_names, enable_suffix_inference=True)
+        assert len(out) == 1
+        assert out[0].source == MatchGroupSource.SUFFIX
+        assert out[0].group_id == "DDR_DATA"
+        assert out[0].members == list(range(8))
+
+    def test_address_bus_16_nets(self):
+        # Address-line false-positive risk -- only valid when group is large.
+        net_names = {i: f"A{i}" for i in range(16)}
+        out = detect_match_groups(net_names, enable_suffix_inference=True)
+        assert len(out) == 1
+        assert out[0].group_id == "ADDR_BUS"
+        assert len(out[0].members) == 16
+
+    def test_mipi_csi_lane_data(self):
+        net_names = {
+            1: "CSI_DAT0_P",
+            2: "CSI_DAT0_N",
+            3: "CSI_DAT1_P",
+            4: "CSI_DAT1_N",
+            5: "CSI_DAT2_P",
+            6: "CSI_DAT2_N",
+            7: "CSI_DAT3_P",
+            8: "CSI_DAT3_N",
+        }
+        out = detect_match_groups(net_names, enable_suffix_inference=True)
+        assert len(out) == 1
+        assert out[0].group_id == "MIPI_CSI_DATA"
+        assert len(out[0].members) == 8
+
+    def test_hdmi_tmds_data_lanes_clock_excluded(self):
+        # 6 data nets (3 lanes x P/N) + 2 clock nets.  The clock is
+        # excluded from the data-lane group (Phase 2F's job to
+        # compose lanes-vs-clock).
+        net_names = {
+            1: "TMDS_D0_P",
+            2: "TMDS_D0_N",
+            3: "TMDS_D1_P",
+            4: "TMDS_D1_N",
+            5: "TMDS_D2_P",
+            6: "TMDS_D2_N",
+            7: "TMDS_CLK_P",
+            8: "TMDS_CLK_N",
+        }
+        out = detect_match_groups(net_names, enable_suffix_inference=True)
+        # The data lanes form one group of 6 (TMDS_CLK_* doesn't match
+        # the data pattern).
+        data_groups = [g for g in out if g.group_id == "HDMI_TMDS_DATA"]
+        assert len(data_groups) == 1
+        assert len(data_groups[0].members) == 6
+        assert 7 not in data_groups[0].members
+        assert 8 not in data_groups[0].members
+
+
+# =============================================================================
+# 4. Priority tie-breaking
+# =============================================================================
+
+
+class TestSourcePriority:
+    """EXPLICIT > LEGACY_API > SUFFIX claim semantics."""
+
+    def test_explicit_preempts_suffix(self):
+        # 8 DDR-style nets that would otherwise be inferred as "DDR_DATA".
+        # An explicit class declaration claims them as "CUSTOM_BUS".
+        net_names = {i: f"DQ{i}" for i in range(8)}
+        nc = NetClassRouting(name="DDR", length_match_group="CUSTOM_BUS")
+        out = detect_match_groups(
+            net_names,
+            net_class_routing={"DDR": nc},
+            net_to_class=dict.fromkeys(net_names.values(), "DDR"),
+            enable_suffix_inference=True,
+        )
+        # Exactly ONE group, named CUSTOM_BUS (not DDR_DATA), source EXPLICIT.
+        assert len(out) == 1
+        assert out[0].group_id == "CUSTOM_BUS"
+        assert out[0].source == MatchGroupSource.EXPLICIT
+
+    def test_explicit_preempts_legacy_on_overlap(self):
+        net_names = {i: f"DQ{i}" for i in range(4)}
+        nc = NetClassRouting(name="DDR", length_match_group="EXPLICIT_BUS")
+        constraints = create_match_group("LEGACY_BUS", [0, 1, 2, 3], tolerance=0.2)
+        tracker = LengthTracker(constraints=constraints)
+
+        out = detect_match_groups(
+            net_names,
+            net_class_routing={"DDR": nc},
+            net_to_class=dict.fromkeys(net_names.values(), "DDR"),
+            length_tracker=tracker,
+        )
+        # Only the EXPLICIT group is reported.
+        assert len(out) == 1
+        assert out[0].group_id == "EXPLICIT_BUS"
+        assert out[0].source == MatchGroupSource.EXPLICIT
+
+    def test_legacy_preempts_suffix(self):
+        net_names = {i: f"DQ{i}" for i in range(8)}
+        constraints = create_match_group("LEGACY_DDR", list(range(8)), tolerance=0.2)
+        tracker = LengthTracker(constraints=constraints)
+
+        out = detect_match_groups(
+            net_names,
+            length_tracker=tracker,
+            enable_suffix_inference=True,
+        )
+        assert len(out) == 1
+        assert out[0].group_id == "LEGACY_DDR"
+        assert out[0].source == MatchGroupSource.LEGACY_API
+
+    def test_legacy_partial_coverage_only_suffix_takes_rest(self):
+        # 4 DQ nets; legacy claims [0,1]; suffix would want all 4.
+        # Legacy partially overlaps explicit-claim set -> dropped;
+        # then suffix sees all 4 unclaimed and emits.  Or: if legacy
+        # is allowed but only claims 2, suffix gets remaining 2 ->
+        # too small, refused.
+        #
+        # Concretely: a legacy group of 2 nets is below min size
+        # but the detector doesn't refuse legacy groups (legacy was
+        # already declared by an agent).  Legacy emits, leaving 2
+        # DQ-nets for suffix, which refuses (size 2 < 3).
+        net_names = {i: f"DQ{i}" for i in range(4)}
+        constraints = create_match_group("LEGACY_PAIR", [0, 1], tolerance=0.2)
+        tracker = LengthTracker(constraints=constraints)
+
+        out = detect_match_groups(
+            net_names,
+            length_tracker=tracker,
+            enable_suffix_inference=True,
+        )
+        # Legacy emits its 2-net group; suffix refuses the remaining 2.
+        assert len(out) == 1
+        assert out[0].source == MatchGroupSource.LEGACY_API
+        assert out[0].members == [0, 1]
+
+
+# =============================================================================
+# 5. False-positive refusal cases
+# =============================================================================
+
+
+class TestFalsePositiveRefusal:
+    """Suffix inference refuses low-confidence groups."""
+
+    def test_counter_signal_two_dq_nets_refused(self):
+        """Two DQ-named nets (counter signals) don't form a group."""
+        net_names = {1: "DQ0", 2: "DQ1"}
+        out = detect_match_groups(net_names, enable_suffix_inference=True)
+        assert out == []
+
+    def test_single_a_gpio_refused(self):
+        """A single ``A0`` net is not enough for an address bus."""
+        net_names = {1: "A0"}
+        out = detect_match_groups(net_names, enable_suffix_inference=True)
+        assert out == []
+
+    def test_two_address_lines_refused(self):
+        """Even two address-like nets are below the min-group threshold."""
+        net_names = {1: "A0", 2: "A1"}
+        out = detect_match_groups(net_names, enable_suffix_inference=True)
+        assert out == []
+
+    def test_partial_coverage_extracts_only_dq(self):
+        """DQ\\d+ matches but unrelated net is left alone."""
+        net_names = {
+            1: "DQ0",
+            2: "DQ1",
+            3: "DQ2",
+            4: "SOMETHING_ELSE",
+        }
+        out = detect_match_groups(net_names, enable_suffix_inference=True)
+        # 3 DQ nets is exactly the min-group threshold; emit the group.
+        assert len(out) == 1
+        assert out[0].group_id == "DDR_DATA"
+        assert out[0].members == [1, 2, 3]
+        assert 4 not in out[0].members
+
+
+# =============================================================================
+# 6. DDR strobe + mask interactions
+# =============================================================================
+
+
+class TestDDRStrobeMaskInteraction:
+    """The DDR strobe / mask patterns should be present but typically
+    refused due to small group size."""
+
+    def test_ddr_byte_with_mask_and_strobe(self):
+        # 8 DQ nets (form DDR_DATA), 1 DM (mask -- below threshold),
+        # 2 DQS (strobe -- below threshold).
+        net_names = {
+            1: "DQ0",
+            2: "DQ1",
+            3: "DQ2",
+            4: "DQ3",
+            5: "DQ4",
+            6: "DQ5",
+            7: "DQ6",
+            8: "DQ7",
+            9: "DM0",
+            10: "DQS_P",
+            11: "DQS_N",
+        }
+        out = detect_match_groups(net_names, enable_suffix_inference=True)
+        # Only the DDR_DATA group is reported; mask + strobe individually
+        # are below min-group threshold.
+        assert len(out) == 1
+        assert out[0].group_id == "DDR_DATA"
+        assert out[0].members == [1, 2, 3, 4, 5, 6, 7, 8]
+
+
+# =============================================================================
+# 7. Clock sentinel resolution
+# =============================================================================
+
+
+class TestClockSentinelResolution:
+    """``length_match_reference="clock"`` finds a clock-named member."""
+
+    def test_clock_p_resolved_via_clk_pattern(self):
+        net_names = {1: "MIPI_CLK_P", 2: "DAT0_P", 3: "DAT1_P"}
+        nc = NetClassRouting(
+            name="MIPI",
+            length_match_group="MIPI_LANE",
+            length_match_reference="clock",
+        )
+        out = detect_match_groups(
+            net_names,
+            net_class_routing={"MIPI": nc},
+            net_to_class=dict.fromkeys(net_names.values(), "MIPI"),
+        )
+        assert len(out) == 1
+        assert out[0].reference == 1  # MIPI_CLK_P
+
+    def test_sclk_resolved_via_clk_suffix(self):
+        net_names = {1: "DATA0", 2: "DATA1", 3: "SCLK"}
+        nc = NetClassRouting(
+            name="SPI",
+            length_match_group="SPI_BUS",
+            length_match_reference="clock",
+        )
+        out = detect_match_groups(
+            net_names,
+            net_class_routing={"SPI": nc},
+            net_to_class=dict.fromkeys(net_names.values(), "SPI"),
+        )
+        assert len(out) == 1
+        assert out[0].reference == 3  # SCLK
+
+    def test_clockdiv2_resolved_via_clock_pattern(self):
+        net_names = {1: "DATA0", 2: "DATA1", 3: "CLOCKDIV2"}
+        nc = NetClassRouting(
+            name="BUS",
+            length_match_group="BUS_GROUP",
+            length_match_reference="clock",
+        )
+        out = detect_match_groups(
+            net_names,
+            net_class_routing={"BUS": nc},
+            net_to_class=dict.fromkeys(net_names.values(), "BUS"),
+        )
+        assert out[0].reference == 3  # CLOCKDIV2
+
+    def test_no_clock_match_falls_back_with_warning(self, caplog):
+        net_names = {1: "DATA0", 2: "DATA1", 3: "DATA2"}
+        nc = NetClassRouting(
+            name="BUS",
+            length_match_group="BUS_GROUP",
+            length_match_reference="clock",
+        )
+        with caplog.at_level(logging.WARNING):
+            out = detect_match_groups(
+                net_names,
+                net_class_routing={"BUS": nc},
+                net_to_class=dict.fromkeys(net_names.values(), "BUS"),
+            )
+        assert out[0].reference is None
+        assert any(
+            "'clock' sentinel" in r.message and "no member" in r.message for r in caplog.records
+        )
+
+    def test_multiple_clock_matches_picks_lowest_id_with_warning(self, caplog):
+        net_names = {1: "CLK_IN", 2: "DATA0", 3: "CLK_OUT"}
+        nc = NetClassRouting(
+            name="BUS",
+            length_match_group="BUS_GROUP",
+            length_match_reference="clock",
+        )
+        with caplog.at_level(logging.WARNING):
+            out = detect_match_groups(
+                net_names,
+                net_class_routing={"BUS": nc},
+                net_to_class=dict.fromkeys(net_names.values(), "BUS"),
+            )
+        assert out[0].reference == 1  # Lowest net id wins.
+        assert any("'clock' sentinel matched" in r.message for r in caplog.records)
+
+
+# =============================================================================
+# 8. Drift prevention
+# =============================================================================
+
+
+class TestDriftPrevention:
+    """Ensure this module doesn't reimplement CRITICAL_NET_PATTERNS."""
+
+    def test_critical_net_patterns_import_resolves(self):
+        # If the symbol is renamed upstream, this import (and our
+        # module's import) breaks.  The test is the early-warning.
+        assert isinstance(CRITICAL_NET_PATTERNS, list)
+        assert len(CRITICAL_NET_PATTERNS) > 0
+
+    def test_clock_regex_indices_still_point_at_clock_patterns(self):
+        # CRITICAL_NET_PATTERNS[0..3] are the four clock regexes
+        # (^CLK, CLK$, CLOCK, _CLK_).  If any of those moves, the
+        # _CLOCK_REGEX_INDICES constant in match_group_detection
+        # must be updated.  Each index's fragment matches a distinct
+        # clock-naming convention.
+        expected_fragments = ["^CLK", "CLK$", "CLOCK", "_CLK_"]
+        for idx, fragment in zip(range(4), expected_fragments, strict=True):
+            assert fragment in CRITICAL_NET_PATTERNS[idx], (
+                f"CRITICAL_NET_PATTERNS[{idx}] no longer contains "
+                f"{fragment!r}; update _CLOCK_REGEX_INDICES in "
+                f"match_group_detection.py"
+            )
+
+    def test_bus_group_patterns_dq_fragment_overlaps_critical_net_patterns(self):
+        # The DQ regex in our table must align with the per-net
+        # classifier so the two cannot silently diverge.  Specifically:
+        # CRITICAL_NET_PATTERNS contains r"(?i)^DQ\d" and our
+        # BUS_GROUP_PATTERNS contains r"(?i)^DQ\d+$".  Both
+        # discriminate on "starts with DQ followed by digits".
+        bus_patterns_str = [p.pattern for p, _ in BUS_GROUP_PATTERNS]
+        assert any("DQ" in p for p in bus_patterns_str)
+        assert any("DQ" in p for p in CRITICAL_NET_PATTERNS)
+
+    def test_bus_group_patterns_dqs_fragment_aligned(self):
+        bus_patterns_str = [p.pattern for p, _ in BUS_GROUP_PATTERNS]
+        assert any("DQS" in p for p in bus_patterns_str)
+        assert any("DQS" in p for p in CRITICAL_NET_PATTERNS)
+
+    def test_bus_group_patterns_dm_fragment_aligned(self):
+        bus_patterns_str = [p.pattern for p, _ in BUS_GROUP_PATTERNS]
+        assert any(re.search(r"DM", p) for p in bus_patterns_str)
+        assert any(re.search(r"DM", p) for p in CRITICAL_NET_PATTERNS)
+
+    def test_bus_group_patterns_address_fragment_aligned(self):
+        bus_patterns_str = [p.pattern for p, _ in BUS_GROUP_PATTERNS]
+        assert any(re.search(r"A.*\\d", p) for p in bus_patterns_str)
+        assert any(re.search(r"A.*\\d", p) for p in CRITICAL_NET_PATTERNS)
+
+
+# =============================================================================
+# 9. Output determinism
+# =============================================================================
+
+
+class TestOutputDeterminism:
+    """Members within a group are sorted by net id; sources are emitted
+    in declaration order (EXPLICIT, LEGACY_API, SUFFIX)."""
+
+    def test_members_sorted_by_net_id(self):
+        net_names = {30: "DQ0", 10: "DQ1", 20: "DQ2"}
+        out = detect_match_groups(net_names, enable_suffix_inference=True)
+        assert out[0].members == [10, 20, 30]
+
+    def test_sources_emitted_in_priority_order(self):
+        # Construct a netlist where each source emits one group, with
+        # disjoint membership.
+        net_names = {
+            1: "EXPLICIT_NET_0",
+            2: "EXPLICIT_NET_1",
+            3: "EXPLICIT_NET_2",
+            10: "MEM_D0",
+            11: "MEM_D1",
+            12: "MEM_D2",
+            20: "DQ0",
+            21: "DQ1",
+            22: "DQ2",
+        }
+        nc = NetClassRouting(name="EX", length_match_group="EXPLICIT_GROUP")
+        net_to_class = {
+            "EXPLICIT_NET_0": "EX",
+            "EXPLICIT_NET_1": "EX",
+            "EXPLICIT_NET_2": "EX",
+        }
+        constraints = create_match_group("LEGACY_GROUP", [10, 11, 12], tolerance=0.2)
+        tracker = LengthTracker(constraints=constraints)
+
+        out = detect_match_groups(
+            net_names,
+            net_class_routing={"EX": nc},
+            net_to_class=net_to_class,
+            length_tracker=tracker,
+            enable_suffix_inference=True,
+        )
+        assert len(out) == 3
+        assert out[0].source == MatchGroupSource.EXPLICIT
+        assert out[1].source == MatchGroupSource.LEGACY_API
+        assert out[2].source == MatchGroupSource.SUFFIX
+
+
+# =============================================================================
+# 10. MatchGroup dataclass smoke
+# =============================================================================
+
+
+class TestMatchGroupDataclass:
+    def test_default_members_empty(self):
+        g = MatchGroup(group_id="TEST")
+        assert g.members == []
+        assert g.reference is None
+        assert g.source == MatchGroupSource.EXPLICIT
+
+    def test_explicit_construction(self):
+        g = MatchGroup(
+            group_id="DDR_DATA",
+            members=[1, 2, 3, 4],
+            reference=2,
+            source=MatchGroupSource.SUFFIX,
+        )
+        assert g.group_id == "DDR_DATA"
+        assert g.members == [1, 2, 3, 4]
+        assert g.reference == 2
+        assert g.source == MatchGroupSource.SUFFIX
+
+    def test_source_enum_has_three_values(self):
+        # No KICAD_GROUP -- intentionally absent (no KiCad analog
+        # for match groups yet).
+        values = {s.value for s in MatchGroupSource}
+        assert values == {"explicit", "legacy_api", "suffix"}
+
+
+# =============================================================================
+# 11. End-to-end fixture scenarios from the curator's expanded plan
+# =============================================================================
+
+
+class TestExpandedFixtures:
+    """The curator-spec'd fixture scenarios in the issue body."""
+
+    def test_ddr_data_byte_10_nets_explicit(self):
+        """DDR byte: 8 data + 1 mask + 2 strobe = 11 nets in one group."""
+        net_names = {
+            1: "DQ0",
+            2: "DQ1",
+            3: "DQ2",
+            4: "DQ3",
+            5: "DQ4",
+            6: "DQ5",
+            7: "DQ6",
+            8: "DQ7",
+            9: "DM0",
+            10: "DQS_P",
+            11: "DQS_N",
+        }
+        nc = NetClassRouting(
+            name="DDR_BYTE0",
+            length_match_group="DDR_DATA_BYTE_0",
+            length_match_reference="DQS_P",
+        )
+        out = detect_match_groups(
+            net_names,
+            net_class_routing={"DDR_BYTE0": nc},
+            net_to_class=dict.fromkeys(net_names.values(), "DDR_BYTE0"),
+        )
+        assert len(out) == 1
+        assert out[0].group_id == "DDR_DATA_BYTE_0"
+        assert len(out[0].members) == 11
+        assert out[0].reference == 10  # DQS_P
+
+    def test_4_lane_mipi_csi_via_explicit(self):
+        """4-lane MIPI CSI: 1 clock pair + 4 data pairs = 10 nets."""
+        net_names = {
+            1: "CSI_CLK_P",
+            2: "CSI_CLK_N",
+            3: "CSI_DAT0_P",
+            4: "CSI_DAT0_N",
+            5: "CSI_DAT1_P",
+            6: "CSI_DAT1_N",
+            7: "CSI_DAT2_P",
+            8: "CSI_DAT2_N",
+            9: "CSI_DAT3_P",
+            10: "CSI_DAT3_N",
+        }
+        nc = NetClassRouting(
+            name="MIPI_CSI",
+            length_match_group="MIPI_CSI_BUS",
+            length_match_reference="clock",
+        )
+        out = detect_match_groups(
+            net_names,
+            net_class_routing={"MIPI_CSI": nc},
+            net_to_class=dict.fromkeys(net_names.values(), "MIPI_CSI"),
+        )
+        assert len(out) == 1
+        assert len(out[0].members) == 10
+        # "clock" sentinel finds CSI_CLK_P (lowest id, matches ^CLK
+        # via CLK_).
+        assert out[0].reference == 1


### PR DESCRIPTION
## Summary

Adds `detect_match_groups()` at `src/kicad_tools/router/match_group_detection.py`, the Phase 1C detection layer of Epic #2661 (match-group meander routing for parallel buses). Mirrors the layered diff-pair detector at `router/diffpair_detection.py` (PR #2558) in shape and semantics.

Closes #2689.

## What lands

- **New module**: `router/match_group_detection.py` with `detect_match_groups()` public entry point.
- **New types**: `MatchGroup` dataclass + `MatchGroupSource` enum (`EXPLICIT`, `LEGACY_API`, `SUFFIX`) -- defined locally so this can land independently of Phase 1B (#2688, parallel in-flight); type shapes are coordinated.
- **New constant**: `BUS_GROUP_PATTERNS` table for opt-in suffix-based inference (DDR `DQ`/`DQS`/`DM`, MIPI `CSI_DAT`/`DSI_DAT`, HDMI `TMDS_D`, generic `A\d+`).
- **Clock-sentinel resolver**: when `NetClassRouting.length_match_reference == "clock"`, iterates the four clock regexes from `CRITICAL_NET_PATTERNS:31-34` (deliberately imported -- a drift-prevention test verifies the indices stay aligned). Multi-match resolution is deterministic (lowest net id wins with a warning).
- **Comprehensive tests**: 42 tests in `tests/test_match_group_detection.py` covering explicit/legacy/suffix sources, priority tie-breaking, false-positive refusals (counter signal, GPIO-as-address, partial coverage, explicit pre-emption), clock-sentinel resolution (4 paths + multi-match + no-match), DDR/MIPI/HDMI fixtures, and drift prevention against `CRITICAL_NET_PATTERNS`.

## Detection priority

`EXPLICIT > LEGACY_API > SUFFIX` (3-tier, no `KICAD_GROUP` -- KiCad has no `match_group` directive yet). Suffix inference refuses groups smaller than 3 nets, applying the same lesson as `diffpair_detection`'s single-ended refusal.

## Curator corrections honored

1. Used `CRITICAL_NET_PATTERNS` (the actual symbol), not the stale `HIGH_FREQ_PATTERNS` from the issue body.
2. Added a new `BUS_GROUP_PATTERNS` table for group-name extraction -- `CRITICAL_NET_PATTERNS` alone is a per-net classifier and cannot name groups.
3. 3-tier source enum (`EXPLICIT`, `LEGACY_API`, `SUFFIX`); de-duplication is a mechanism, not a source.
4. No `to_dict()`/`from_dict()` -- deferred to Phase 1B's choice (the `DetectedPair` precedent has no serialization either).
5. All four clock regexes from `CRITICAL_NET_PATTERNS:31-34` are consulted; multi-match resolution is deterministic with a warning.

## Test plan

- [x] `uv run pytest tests/test_match_group_detection.py` -> 42/42 pass.
- [x] `uv run pytest tests/test_match_group_declaration.py tests/test_diffpair_detection.py tests/test_diffpair_length.py tests/test_router_autorouter.py` -> 137/137 pass (no regressions in adjacent code).
- [x] `uv run ruff check src/kicad_tools/router/match_group_detection.py tests/test_match_group_detection.py` -> all checks passed.
- [x] `uv run ruff format` applied; module + tests pass formatter.

## Coordination notes

- Phase 1A (#2687, PR #2691 merged) provided the `NetClassRouting.length_match_group` / `length_match_reference` fields this consumes.
- Phase 1B (#2688) is in flight; its `MatchGroupTracker` will consume the types defined here. Type shapes have been coordinated; both modules can land in either order.
- Phase 2 (composition, serpentine tuning, DRC rule) and Phase 3 (CLI, test board) build on top of this detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)