### PR TITLE
docs(board-04): document MFG-readiness residuals + upstream tracking issues (closes #2676)

### DIFF
--- a/boards/04-stm32-devboard/README.md
+++ b/boards/04-stm32-devboard/README.md
@@ -69,6 +69,27 @@ output/
 
 Open the schematic in KiCad to view and continue the design.
 
+## Manufacturing readiness status
+
+As of the 2026-05-11 audit, board 04 routes **8/9 nets (89%)** with two residuals
+tracked as upstream issues — both with concrete, documented root causes:
+
+| Residual | Pads / nets affected | Tracking issue | Status |
+|---|---|---|---|
+| OSC_OUT 2/3 pad completion | Y1.2 + C11.1 route; U2.6 (LQFP-48 0.5mm-pitch pin) defers | [#2695](https://github.com/rjwalters/kicad-tools/issues/2695) | In-pad via escape for fine-pitch LQFP/QFP (extends the #2605/#2608 pattern from 0.65mm SSOP to 0.5mm QFP) |
+| 5 ImpedanceRule errors on SWCLK | 50Ω target on a 2-layer stackup requires ~2.812mm width on F.Cu | [#2696](https://github.com/rjwalters/kicad-tools/issues/2696) | Either upgrade board 04 to 4-layer (Option A) or suppress validator's default `*CLK*` 50Ω spec for 2-layer hobbyist boards (Option C) |
+
+Board 04's `generate_design.py` does **not** set `target_single_impedance` on
+any net class. The 5 ImpedanceRule errors come from
+`ImpedanceRule._get_default_specs()` matching `SWCLK` via the regex `.*CLK.*`
+and asserting a 50Ω default. Per PR #2680's caveat, that target is physically
+infeasible on the 2-layer JLCPCB default stackup.
+
+Both #2695 and #2696 must resolve before board 04 reaches 0 DRC + 0 ERC.
+Until then, board 04 is **partial-mfg-ready**: the routed PCB is structurally
+valid except for the OSC_OUT escape gap, and the impedance errors reflect a
+spec-vs-stackup mismatch rather than a wiring or sizing bug.
+
 ## Schematic Layout
 
 ```


### PR DESCRIPTION
## Summary

Tracking-issue closeout for #2676. After investigation, all remaining work on board 04 is upstream and tracked under two new issues:

- **#2695** (NEW): `router: in-pad via escape for fine-pitch LQFP/QFP (0.5mm pitch and finer)` — extends the #2605/#2608 SSOP pattern from 0.65mm to 0.5mm-pitch QFP packages. Blocks the OSC_OUT 2/3 pad completion (U2.6 cannot escape).
- **#2696** (NEW): `board 04: resolve SWCLK ImpedanceRule conflict on 2-layer stackup` — enumerates three resolution options (4-layer upgrade, per-class targets, or suppress validator defaults) for the 5 ImpedanceRule errors that come from `ImpedanceRule._get_default_specs()` regex-matching SWCLK to a 50Ω default.

## Why doc-only

The user's curation note explicitly framed the valid completion as "open a PR with just the issue filing and the documentation update — no code changes needed" when the conclusion is "all remaining work is upstream." That is exactly the conclusion of this investigation:

1. Board 04's `generate_design.py` does NOT set `target_single_impedance` on any net class (confirmed by grep). The 5 errors come from the validator's built-in default specs firing on `.*CLK.*`.
2. Board 04 is 2-layer (`F.Cu` + `B.Cu` only, confirmed in the PCB header). Per PR #2680's caveat, 50Ω at 2-layer requires ~2.812mm widths -- physically infeasible. Setting a net-class target would be a no-op (the clamp pins the width at the trace floor).
3. The OSC_OUT residual is a fine-pitch LQFP escape problem, not a placement problem (distances ~6.4mm and ~12mm between unrouted pads are nominal).

So there is nothing for the builder to "fix" in board 04 itself. The right deliverable is to file the upstream blockers, document the situation in the board's README, and update #2676's body so #2394's per-board status table can point to the new tracking issues.

## Changes

- `boards/04-stm32-devboard/README.md`: new "Manufacturing readiness status" section with a residuals table pointing to #2695 and #2696, plus a short explanation of why the 5 ImpedanceRule errors are inevitable on a 2-layer stackup.

## Verification (2026-05-11 builder pass at HEAD ${PWD##*/})

`kct route output/stm32_devboard.kicad_pcb --seed 42 --differential-pairs --auto-layers --manufacturer jlcpcb --timeout 240`:
- 8/9 nets routed (89%) -- **matches the May-11 baseline**
- Partial: OSC_OUT 2/3 pads (Y1.2 + C11.1 routed; U2.6 deferred)
- 1 clearance violation at (126.66, 122.17) -- the router's failed escape attempt at U2.6 (same root cause as #2695)

`kct check --mfr jlcpcb output/stm32_devboard_routed.kicad_pcb`:
- 6 errors: 5 ImpedanceRule (all on SWCLK; 2 on F.Cu, 3 on B.Cu) + 1 clearance_segment_segment
- 60 pad_grid warnings (pre-existing footprint off-grid issue, out of scope)

No board artifacts regenerated.

## Test plan

- [x] `gh issue view 2695` confirms the new escape issue is filed with concrete repro + acceptance criteria.
- [x] `gh issue view 2696` confirms the new SWCLK stackup-conflict issue is filed with Options A/B/C enumerated.
- [x] `gh issue view 2676` body updated with post-investigation acceptance criteria pointing at #2695 and #2696.
- [x] `boards/04-stm32-devboard/README.md` renders cleanly (table + paragraph; no markdown syntax issues).
- [x] No code changes, so no test runs needed beyond the verification routing/check above.

## Related

- Epic #2556 (diffpair / impedance support)
- #2394 (overall MFG-READY tracking; board 04 row)
- #2605, #2608 (in-pad via escape for 0.65mm SSOP/TSSOP -- pattern #2695 extends)
- #2672 / PR #2680 (impedance resolver wiring; documents the 2-layer infeasibility caveat that #2696 builds on)
- **#2695 (NEW upstream blocker for OSC_OUT)**
- **#2696 (NEW resolution paths for SWCLK impedance)**

Closes #2676