### PR TITLE
feat(router): wire MatchGroupTracker into Autorouter._finalize_routing (closes #2690)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -49,8 +49,8 @@ from .cpp_backend import CppGrid, CppPathfinder, create_hybrid_router, get_backe
 from .diffpair import DifferentialPair, DifferentialPairConfig, LengthMismatchWarning
 from .diffpair_length import DiffPairLengthTracker
 from .diffpair_length_tuning import DiffPairTuneResult
-from .match_group_length import MatchGroup, MatchGroupTracker
 from .diffpair_routing import DiffPairRouter
+from .match_group_length import MatchGroup, MatchGroupTracker
 from .escape import EscapeRouter, PackageInfo, is_dense_package
 from .adaptive_grid import AdaptiveGridResult, AdaptiveGridRouter
 from .subgrid import SubGridResult, SubGridRouter

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -49,6 +49,7 @@ from .cpp_backend import CppGrid, CppPathfinder, create_hybrid_router, get_backe
 from .diffpair import DifferentialPair, DifferentialPairConfig, LengthMismatchWarning
 from .diffpair_length import DiffPairLengthTracker
 from .diffpair_length_tuning import DiffPairTuneResult
+from .match_group_length import MatchGroup, MatchGroupTracker
 from .diffpair_routing import DiffPairRouter
 from .escape import EscapeRouter, PackageInfo, is_dense_package
 from .adaptive_grid import AdaptiveGridResult, AdaptiveGridRouter
@@ -441,6 +442,18 @@ class Autorouter:
         # generic match-group / min/max constraints; this one is keyed on
         # detected diff pairs and exposes ``|L_p - L_n|`` for Phase 3I/J.
         self._diffpair_length_tracker: DiffPairLengthTracker = DiffPairLengthTracker()
+
+        # Per-group match-group skew tracking (Issue #2690, Epic #2661 Phase 1D).
+        # Sibling to ``_length_tracker`` and ``_diffpair_length_tracker`` -- the
+        # generic LengthTracker handles match-group min/max constraints (legacy
+        # v1 path), DiffPairLengthTracker handles N=2 pairs, and this one
+        # handles N>=3 match groups detected via the layered detector at
+        # router/match_group_detection.py.  Populated by
+        # :meth:`_finalize_routing` -> :meth:`update_match_group_skew` after
+        # every routing pass; exposes per-group skew via
+        # :meth:`MatchGroupTracker.get_all_skews` for Phase 2E (serpentine
+        # tuner) and Phase 2G (DRC rule) consumers.
+        self._match_group_tracker: MatchGroupTracker = MatchGroupTracker()
 
         # Sub-problem pattern cache (Issue #2336)
         # When set, enables cross-board reuse of routing solutions for
@@ -2509,12 +2522,21 @@ class Autorouter:
                 pass
 
     # ------------------------------------------------------------------
-    # Post-route diff-pair skew bookkeeping
-    # (Issue #2657 / Epic #2556 Phase 3H-cont)
+    # Post-route skew bookkeeping
+    # (Issue #2657 Phase 3H-cont -- diff pairs; Issue #2690 Phase 1D -- match groups)
     # ------------------------------------------------------------------
 
     def _finalize_routing(self) -> None:
-        """Post-route consolidation: populate the diff-pair skew tracker.
+        """Post-route consolidation: populate the skew trackers.
+
+        Populates two sibling trackers in sequence:
+
+        1. :attr:`_diffpair_length_tracker` (Issue #2657 / Epic #2556
+           Phase 3H-cont) -- N=2 differential-pair skew, consumed by
+           Phase 3I (serpentine insertion) and Phase 3J (length-skew DRC).
+        2. :attr:`_match_group_tracker` (Issue #2690 / Epic #2661
+           Phase 1D) -- N>=3 match-group skew, consumed by Phase 2E
+           (serpentine tuner) and Phase 2G (DRC rule).
 
         Issue #2657 / Epic #2556 Phase 3H-cont: PR #2654 (Phase 3H) added
         :meth:`update_diffpair_skew` and the sibling
@@ -2523,75 +2545,128 @@ class Autorouter:
         ``diffpair_length_tracker.get_all_skews()`` always returned ``{}``
         in real runs.  This helper closes the gap.
 
-        It must be invoked once at the tail of every ``route_all_*`` /
-        ``route_with_*`` entry point (after ``self.routes`` is in its
-        final state) so consumers like Phase 3I (serpentine insertion)
-        and Phase 3J (length-skew DRC) can read populated per-pair
-        skew data.
+        Issue #2690 / Epic #2661 Phase 1D extends the same gap-closing
+        pattern to the new :class:`MatchGroupTracker`: every
+        ``route_all_*`` entry point now also populates
+        ``match_group_tracker.get_all_skews()`` so the Phase 2 consumers
+        do not face a dormant signal.
 
-        Detection re-runs :func:`detect_diff_pairs` over the current
-        ``self.net_names`` and ``self.net_class_map`` to derive the
-        :class:`DetectedPair` list, mirroring the pattern used by
-        :meth:`_prepare_routing` (`core.py` start of every ``route_all_*``)
-        and :meth:`get_diff_pair_map` (Phase 2F).  Re-deriving (rather
-        than caching) avoids stale-state risk when callers add components
-        between passes and is consistent with PR #2653's
-        "consume on demand" approach for engaged_pairs.
+        Must be invoked once at the tail of every ``route_all_*`` /
+        ``route_with_*`` entry point (after ``self.routes`` is in its
+        final state) so consumers can read populated skew data.
+
+        Detection re-runs :func:`detect_diff_pairs` and
+        :func:`detect_match_groups` over the current ``self.net_names``
+        and ``self.net_class_map`` to derive the
+        :class:`DetectedPair` list and :class:`MatchGroup` list, mirroring
+        the pattern used by :meth:`_prepare_routing` (`core.py` start of
+        every ``route_all_*``) and :meth:`get_diff_pair_map` (Phase 2F).
+        Re-deriving (rather than caching) avoids stale-state risk when
+        callers add components between passes and is consistent with
+        PR #2653's "consume on demand" approach for engaged_pairs.
 
         ``board_thickness_mm`` is left as ``None`` -- the
-        ``DiffPairLengthTracker.record_routes`` contract documents this
-        as the zero-via-length default (vias contribute 0.0 mm).  See
-        the curator note on issue #2657 and the docstring at
+        ``DiffPairLengthTracker.record_routes`` and
+        ``MatchGroupTracker.record_routes`` contracts both document
+        this as the zero-via-length default (vias contribute 0.0 mm).
+        See the curator note on issue #2657 and the docstring at
         ``diffpair_length.py:172``: ``router.rules.DesignRules`` has no
         ``board_thickness_mm`` field (only ``manufacturers.base.DesignRules``
         does), so threading real thickness through is deferred to a
-        follow-up.  For the AC test target (USB D+/D- on board 03), both
-        halves are on F.Cu with no vias, so the via-length policy does
-        not affect the skew.
+        follow-up.
 
-        Safe to call when there are no diff pairs (no-op via
-        ``record_routes`` early-exit on empty ``detected_pairs``).  Safe
-        to call multiple times: ``record_routes`` overwrites
+        Safe to call when there are no diff pairs / match groups (no-op
+        via ``record_routes`` early-exit on empty detection results).
+        Safe to call multiple times: ``record_routes`` overwrites
         previously-recorded lengths for the same net ids.
-        """
-        # Detection: defensive imports keep this helper robust against
-        # circular-import scenarios on partial installs.
-        try:
-            from .diffpair_detection import detect_diff_pairs
-        except ImportError:
-            return
 
+        Block ordering: diff-pair block runs FIRST, match-group block
+        SECOND.  This ordering is load-bearing -- a hypothetical
+        Phase 1C ``detect_match_groups`` failure (e.g. ImportError on a
+        partial install, RuntimeError on malformed input) MUST NOT
+        bypass the working Phase 3H-cont diff-pair path.  The per-block
+        ``try/except`` scoping enforces this contract; see the inline
+        comments below.
+        """
         if not self.net_names:
             return
 
         # Build net_to_class for explicit-declaration consultation.
         # Identical construction to _prepare_routing / get_diff_pair_map.
+        # Built once here and reused by BOTH the diff-pair block below and
+        # the match-group block (Issue #2690, Epic #2661 Phase 1D) -- a
+        # single-source-of-truth idiom that avoids stale-state risk.
         net_to_class: dict[str, str] = {}
         for net_name, net_class in self.net_class_map.items():
             net_to_class[net_name] = net_class.name
 
+        # --- Diff-pair skew bookkeeping (Issue #2657 / Phase 3H-cont) ---
+        # Detection: defensive imports keep this helper robust against
+        # circular-import scenarios on partial installs.  Failures in the
+        # diff-pair block must NOT bypass the match-group block below --
+        # see Issue #2690 curator note: a Phase 1C detection failure
+        # cannot regress the working diff-pair path, but equally a missing
+        # diff-pair detector module must not silence the match-group
+        # tracker.  Hence the per-block try/except scoping.
         try:
-            detected_pairs = detect_diff_pairs(
+            from .diffpair_detection import detect_diff_pairs
+
+            try:
+                detected_pairs = detect_diff_pairs(
+                    self.net_names,
+                    net_class_routing=self.net_class_map,
+                    net_to_class=net_to_class,
+                    kicad_groups=getattr(self, "kicad_diff_pair_groups", None),
+                )
+            except Exception:
+                # Defensive: detection failure must not break routing.
+                detected_pairs = []
+
+            if detected_pairs:
+                # board_thickness_mm=None: zero-via-length default (see docstring).
+                # num_copper_layers=None: update_diffpair_skew defaults to
+                # len(self.layer_stack.layers) or 2 -- matches the per-call branch
+                # at the original ``update_diffpair_skew`` definition.
+                self.update_diffpair_skew(
+                    detected_pairs,
+                    board_thickness_mm=None,
+                    num_copper_layers=None,
+                )
+        except ImportError:
+            # diffpair_detection module unavailable -- silently skip the
+            # diff-pair block but continue to the match-group block.
+            pass
+
+        # --- Match-group skew bookkeeping (Issue #2690 / Phase 1D) ---
+        # Mirrors the diff-pair block above: defensive import + re-detect
+        # + unconditional tracker update.  Placed AFTER the diff-pair
+        # block so a Phase 1C detector failure cannot regress the
+        # working Phase 3H-cont diff-pair path.  Safe when no groups
+        # exist (record_routes is called only when detected_groups is
+        # non-empty).  The re-derivation idiom matches the diff-pair
+        # docstring rationale -- single source of truth, no stale cache.
+        try:
+            from .match_group_detection import detect_match_groups
+        except ImportError:
+            return
+
+        try:
+            detected_groups = detect_match_groups(
                 self.net_names,
                 net_class_routing=self.net_class_map,
                 net_to_class=net_to_class,
-                kicad_groups=getattr(self, "kicad_diff_pair_groups", None),
+                length_tracker=self._length_tracker,
+                enable_suffix_inference=False,  # opt-in only; see Phase 1C
             )
         except Exception:
             # Defensive: detection failure must not break routing.
             return
 
-        if not detected_pairs:
-            # No pairs -> nothing to record.  Keep tracker untouched so
-            # repeated finalize calls remain idempotent.
+        if not detected_groups:
             return
 
-        # board_thickness_mm=None: zero-via-length default (see docstring).
-        # num_copper_layers=None: update_diffpair_skew defaults to
-        # len(self.layer_stack.layers) or 2 -- matches the per-call branch
-        # at the original ``update_diffpair_skew`` definition.
-        self.update_diffpair_skew(
-            detected_pairs,
+        self.update_match_group_skew(
+            detected_groups,
             board_thickness_mm=None,
             num_copper_layers=None,
         )
@@ -7271,6 +7346,72 @@ class Autorouter:
         (serpentine insertion) and Phase 3J (DRC rule) consumers.
         """
         return self._diffpair_length_tracker
+
+    def update_match_group_skew(
+        self,
+        detected_groups: list[MatchGroup],
+        board_thickness_mm: float | None = None,
+        num_copper_layers: int | None = None,
+    ) -> MatchGroupTracker:
+        """Populate the match-group length tracker with current route skews.
+
+        Sibling to :meth:`update_diffpair_skew` (Issue #2690, Epic #2661
+        Phase 1D).  Measures the routed length of every member of every
+        detected match group and exposes per-group skew (``max - min``)
+        via :attr:`_match_group_tracker`.
+
+        Mirrors :meth:`update_diffpair_skew` byte-for-byte modulo the
+        ``MatchGroup`` vs ``DetectedPair`` type rename and the underlying
+        tracker's ``record_routes`` keyword (``groups`` instead of
+        ``detected_pairs``).
+
+        Args:
+            detected_groups: List of
+                :class:`~kicad_tools.router.match_group_length.MatchGroup`
+                instances from
+                :func:`~kicad_tools.router.match_group_detection.detect_match_groups`.
+            board_thickness_mm: Total stackup thickness in mm.  When
+                ``None``, vias contribute ``0.0`` to the length
+                (documented zero-via-length default mirrored from
+                :mod:`diffpair_length`).
+            num_copper_layers: Number of copper layers in the stack.
+                Defaults to the layer-stack count when ``None`` (or 2
+                when no stack has been configured).  Identical default
+                policy to :meth:`update_diffpair_skew`.
+
+        Returns:
+            The internal :class:`MatchGroupTracker` instance (also
+            accessible via :attr:`match_group_tracker` for inspection).
+        """
+        if num_copper_layers is None:
+            # Best-effort default: pull the count from the configured
+            # layer stack when available; otherwise fall back to 2.
+            # Identical to :meth:`update_diffpair_skew` -- a future
+            # change must touch both places (see drift-prevention
+            # guidance in :mod:`match_group_length`).
+            if self.layer_stack is not None:
+                num_copper_layers = len(self.layer_stack.layers)
+            else:
+                num_copper_layers = 2
+
+        self._match_group_tracker.record_routes(
+            routes=self.routes,
+            groups=detected_groups,
+            board_thickness_mm=board_thickness_mm,
+            num_copper_layers=num_copper_layers,
+        )
+        return self._match_group_tracker
+
+    @property
+    def match_group_tracker(self) -> MatchGroupTracker:
+        """Per-group match-group skew tracker (Issue #2690, Epic #2661 Phase 1D).
+
+        Returns the :class:`MatchGroupTracker` instance populated by
+        :meth:`update_match_group_skew`.  The tracker exposes per-net
+        routed lengths and per-group ``max(L) - min(L)`` skew for
+        Phase 2E (serpentine tuner) and Phase 2G (DRC rule) consumers.
+        """
+        return self._match_group_tracker
 
     def apply_length_tuning(
         self,

--- a/tests/test_match_group_length.py
+++ b/tests/test_match_group_length.py
@@ -12,12 +12,18 @@ This module tests:
   :class:`DiffPairLengthTracker.measure_net_from_pcb` (the Phase 2.5c sister
   primitive); a drift-prevention test asserts the two helpers stay byte-for-
   byte aligned.
+* Phase 1D wiring (Issue #2690): ``Autorouter._finalize_routing`` populates
+  the tracker after every ``route_all_*`` entry point; ``add_match_group``
+  flows through detection to the tracker; the no-group / detection-failure
+  paths preserve the working diff-pair path.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from unittest.mock import patch
+
+import pytest
 
 from kicad_tools.core.types import CopperLayer
 from kicad_tools.router.diffpair_length import DiffPairLengthTracker
@@ -794,3 +800,357 @@ class TestPublicExports:
         from kicad_tools.router import MatchGroupSource as Exported
 
         assert Exported is MatchGroupSource
+
+
+# =============================================================================
+# 11. Phase 1D wiring -- Autorouter._finalize_routing populates the tracker
+#     (Issue #2690 / Epic #2661 Phase 1D)
+# =============================================================================
+#
+# The #2587 dormant-signal lesson: a feature whose record_routes call is
+# unreachable from the production code path silently regresses.  These
+# tests pin the contract that every ``route_all_*`` strategy invokes
+# ``_finalize_routing`` which in turn invokes ``update_match_group_skew``
+# on the legacy-API-declared group below.
+#
+# The fixture uses a 4-net DDR-style group declared via the legacy
+# ``Autorouter.add_match_group(...)`` API.  The Phase 1C detector's
+# LEGACY_API source surfaces this group from ``LengthTracker.match_groups``;
+# Phase 1D then populates the tracker with the routed lengths.
+
+
+def _build_synthetic_ddr_group_autorouter():
+    """Build a minimal Autorouter with a 4-net DDR-style group routable end-to-end.
+
+    Two components (``J1`` and ``U1``) sit on opposite sides of a small
+    30x30 mm board, with four matching ``DDR_DQ0..DDR_DQ3`` nets.  The
+    legacy ``Autorouter.add_match_group("DDR_BUS", ...)`` call surfaces
+    the group via the Phase 1C detector's LEGACY_API source, so any
+    strategy that wires ``_finalize_routing`` correctly populates
+    ``match_group_tracker.get_all_skews()``.
+    """
+    from kicad_tools.router.core import Autorouter
+
+    ar = Autorouter(width=30.0, height=30.0)
+    ar.add_component(
+        "J1",
+        [
+            {
+                "number": "1",
+                "x": 2.0,
+                "y": 8.0,
+                "width": 0.5,
+                "height": 0.5,
+                "net": 1,
+                "net_name": "DDR_DQ0",
+            },
+            {
+                "number": "2",
+                "x": 2.0,
+                "y": 12.0,
+                "width": 0.5,
+                "height": 0.5,
+                "net": 2,
+                "net_name": "DDR_DQ1",
+            },
+            {
+                "number": "3",
+                "x": 2.0,
+                "y": 16.0,
+                "width": 0.5,
+                "height": 0.5,
+                "net": 3,
+                "net_name": "DDR_DQ2",
+            },
+            {
+                "number": "4",
+                "x": 2.0,
+                "y": 20.0,
+                "width": 0.5,
+                "height": 0.5,
+                "net": 4,
+                "net_name": "DDR_DQ3",
+            },
+        ],
+    )
+    ar.add_component(
+        "U1",
+        [
+            {
+                "number": "1",
+                "x": 28.0,
+                "y": 8.0,
+                "width": 0.5,
+                "height": 0.5,
+                "net": 1,
+                "net_name": "DDR_DQ0",
+            },
+            {
+                "number": "2",
+                "x": 28.0,
+                "y": 12.0,
+                "width": 0.5,
+                "height": 0.5,
+                "net": 2,
+                "net_name": "DDR_DQ1",
+            },
+            {
+                "number": "3",
+                "x": 28.0,
+                "y": 16.0,
+                "width": 0.5,
+                "height": 0.5,
+                "net": 3,
+                "net_name": "DDR_DQ2",
+            },
+            {
+                "number": "4",
+                "x": 28.0,
+                "y": 20.0,
+                "width": 0.5,
+                "height": 0.5,
+                "net": 4,
+                "net_name": "DDR_DQ3",
+            },
+        ],
+    )
+    # Legacy-API match group declaration -- the LEGACY_API source path.
+    ar.add_match_group("DDR_BUS", [1, 2, 3, 4], tolerance=0.5)
+    return ar
+
+
+class TestFinalizeRoutingWiresMatchGroupTracker:
+    """Drift-prevention gate -- ``_finalize_routing`` wires the match-group tracker.
+
+    Mirrors ``TestFinalizeRoutingDriftPrevention`` in
+    ``tests/test_diffpair_length.py:637-741`` byte-for-byte modulo the
+    diff-pair -> match-group renames.  Without these tests, a future
+    strategy that bypasses ``_finalize_routing`` would silently regress:
+    its routes would land on ``self.routes`` but
+    ``match_group_tracker.get_all_skews()`` would stay empty.
+    """
+
+    @pytest.mark.parametrize(
+        "strategy_name",
+        [
+            "route_all",
+            "route_all_negotiated",
+            "route_all_interleaved",
+        ],
+    )
+    def test_strategy_populates_match_group_tracker(self, strategy_name):
+        ar = _build_synthetic_ddr_group_autorouter()
+
+        # Each strategy is a top-level entry point on Autorouter that
+        # must end with a _finalize_routing call.  Invoked through
+        # getattr so the parametrize-id reflects which strategy regressed.
+        strategy = getattr(ar, strategy_name)
+        if strategy_name == "route_all_negotiated":
+            # max_iterations=2 keeps the test fast; the contract is
+            # invocation-shape, not convergence.
+            strategy(max_iterations=2)
+        else:
+            strategy()
+
+        # Acceptance criterion 1: tracker.lengths is non-empty.
+        # The #2587 dormant-signal gate -- if this is empty, the
+        # _finalize_routing call never reached update_match_group_skew.
+        assert ar.match_group_tracker.lengths, (
+            f"{strategy_name}: match_group_tracker.lengths is empty -- "
+            f"_finalize_routing is not being invoked on this strategy's "
+            f"return path, or update_match_group_skew is not reachable."
+        )
+
+        # Acceptance criterion 2: get_all_skews() returns a non-empty
+        # dict containing the legacy-API-declared "DDR_BUS" group.
+        skews = ar.match_group_tracker.get_all_skews()
+        assert skews, f"{strategy_name}: match_group_tracker.get_all_skews() is empty"
+        assert "DDR_BUS" in skews, f"{strategy_name}: DDR_BUS group missing from skews: {skews}"
+        # Skew is a real non-negative float (the contract is "non-None
+        # float", not a specific value -- routing is non-deterministic).
+        skew_mm = skews["DDR_BUS"]
+        assert isinstance(skew_mm, float)
+        assert skew_mm >= 0.0  # max(L) - min(L) is always non-negative
+
+    def test_finalize_routing_idempotent(self):
+        """``_finalize_routing`` can be called multiple times safely.
+
+        ``record_routes`` overwrites previously-recorded lengths, and
+        ``update_match_group_skew`` re-derives ``detected_groups`` each
+        call so repeated invocations leave the tracker in the same state
+        as a single invocation (modulo non-determinism in detection,
+        which is deterministic for these synthetic inputs).
+        """
+        ar = _build_synthetic_ddr_group_autorouter()
+        ar.route_all()
+        first_skew = dict(ar.match_group_tracker.get_all_skews())
+
+        # Direct second invocation must not corrupt the tracker.
+        ar._finalize_routing()
+        second_skew = dict(ar.match_group_tracker.get_all_skews())
+
+        assert first_skew == second_skew
+        assert first_skew  # non-empty
+
+    def test_finalize_routing_noop_when_no_groups(self):
+        """When no match groups are declared, ``_finalize_routing`` is a no-op.
+
+        Documents the contract that ``_finalize_routing`` does NOT
+        spuriously populate the tracker for boards without match groups
+        (no legacy API call, no explicit declaration, suffix inference off).
+        """
+        from kicad_tools.router.core import Autorouter
+
+        ar = Autorouter(width=20.0, height=20.0)
+        ar.add_component(
+            "J1",
+            [
+                {
+                    "number": "1",
+                    "x": 2.0,
+                    "y": 10.0,
+                    "width": 0.5,
+                    "height": 0.5,
+                    "net": 1,
+                    "net_name": "SIG_A",
+                },
+            ],
+        )
+        ar.add_component(
+            "U1",
+            [
+                {
+                    "number": "1",
+                    "x": 18.0,
+                    "y": 10.0,
+                    "width": 0.5,
+                    "height": 0.5,
+                    "net": 1,
+                    "net_name": "SIG_A",
+                },
+            ],
+        )
+        ar.route_all()
+
+        # No groups -> no skews recorded.  Tracker stays empty.
+        assert ar.match_group_tracker.get_all_skews() == {}
+        assert ar.match_group_tracker.lengths == {}
+
+    def test_finalize_routing_detection_failure_preserves_diff_pair_path(self):
+        """A failing match-group detector must NOT regress the diff-pair tracker.
+
+        Phase 1D's block ordering contract: the diff-pair block runs
+        FIRST.  If the match-group detector raises (ImportError, generic
+        Exception, ...), ``_finalize_routing`` returns cleanly and the
+        diff-pair tracker remains populated.  This is the regression
+        gate against the Phase 1D additions breaking the existing
+        Phase 3H-cont path.
+        """
+        from kicad_tools.router.core import Autorouter
+
+        # Build a USB pair AND a DDR group so both detectors have work.
+        ar = Autorouter(width=30.0, height=30.0)
+        ar.add_component(
+            "J1",
+            [
+                {
+                    "number": "1",
+                    "x": 2.0,
+                    "y": 8.0,
+                    "width": 0.5,
+                    "height": 0.5,
+                    "net": 1,
+                    "net_name": "USB_D+",
+                },
+                {
+                    "number": "2",
+                    "x": 2.0,
+                    "y": 10.0,
+                    "width": 0.5,
+                    "height": 0.5,
+                    "net": 2,
+                    "net_name": "USB_D-",
+                },
+            ],
+        )
+        ar.add_component(
+            "U1",
+            [
+                {
+                    "number": "1",
+                    "x": 28.0,
+                    "y": 8.0,
+                    "width": 0.5,
+                    "height": 0.5,
+                    "net": 1,
+                    "net_name": "USB_D+",
+                },
+                {
+                    "number": "2",
+                    "x": 28.0,
+                    "y": 10.0,
+                    "width": 0.5,
+                    "height": 0.5,
+                    "net": 2,
+                    "net_name": "USB_D-",
+                },
+            ],
+        )
+
+        # Monkey-patch detect_match_groups to raise so the match-group
+        # block enters its except branch.  The diff-pair block must run
+        # to completion regardless.
+        with patch(
+            "kicad_tools.router.match_group_detection.detect_match_groups",
+            side_effect=RuntimeError("synthetic Phase 1C detection failure"),
+        ):
+            ar.route_all()
+
+        # The diff-pair path is unbroken: USB_D+/USB_D- pair was
+        # detected and the diff-pair tracker is populated.
+        diff_skews = ar.diffpair_length_tracker.get_all_skews()
+        assert diff_skews, (
+            "diff-pair tracker is empty -- the Phase 1D additions broke "
+            "the Phase 3H-cont diff-pair path (block ordering violation)"
+        )
+        assert ("USB_D+", "USB_D-") in diff_skews
+
+        # The match-group path silently no-ops on detector failure.
+        assert ar.match_group_tracker.get_all_skews() == {}
+
+    def test_legacy_add_match_group_flows_to_tracker(self):
+        """Integration test: the legacy API populates the new tracker.
+
+        ``Autorouter.add_match_group("TEST", [...])`` writes into
+        ``self._length_tracker.match_groups``; the Phase 1C detector's
+        LEGACY_API source surfaces this; Phase 1D's
+        ``update_match_group_skew`` records routed lengths.  The whole
+        chain must work end-to-end without caller code change.
+        """
+        ar = _build_synthetic_ddr_group_autorouter()
+        ar.route_all()
+
+        skews = ar.match_group_tracker.get_all_skews()
+        assert "DDR_BUS" in skews
+        # The legacy-API source produces a real float skew (not None).
+        assert skews["DDR_BUS"] is not None
+        assert isinstance(skews["DDR_BUS"], float)
+
+        # And the underlying lengths are populated for all four members.
+        assert 1 in ar.match_group_tracker.lengths
+        assert 2 in ar.match_group_tracker.lengths
+        assert 3 in ar.match_group_tracker.lengths
+        assert 4 in ar.match_group_tracker.lengths
+
+    def test_match_group_tracker_property_returns_internal_tracker(self):
+        """The ``match_group_tracker`` property returns the live tracker.
+
+        Mirrors the diff-pair property contract: the returned object
+        IS the autorouter's internal tracker (no defensive copy).
+        """
+        from kicad_tools.router.core import Autorouter
+
+        ar = Autorouter(width=10.0, height=10.0)
+        assert ar.match_group_tracker is ar._match_group_tracker
+        # And it's a real MatchGroupTracker, not None.
+        assert isinstance(ar.match_group_tracker, MatchGroupTracker)


### PR DESCRIPTION
## Summary

Phase 1D of Epic #2661: producer-side wiring of the Phase 1B `MatchGroupTracker`
into `Autorouter`. Closes the #2587 dormant-signal gap so every `route_all_*`
entry point populates `match_group_tracker.get_all_skews()`; without this,
the tracker would remain permanently empty in real runs (the same trap that
PR #2668 closed for the diff-pair tracker via Phase 3H-cont).

Phase 1 of Epic #2661 is now complete (#2687 #2688 #2689 #2690 all landed).

## Changes

- **`src/kicad_tools/router/core.py`**
  - New `from .match_group_length import MatchGroup, MatchGroupTracker` import.
  - New field `Autorouter._match_group_tracker: MatchGroupTracker` initialized in `__init__` alongside `_diffpair_length_tracker`.
  - New method `Autorouter.update_match_group_skew(detected_groups, board_thickness_mm, num_copper_layers)` mirroring `update_diffpair_skew` byte-for-byte (modulo the `MatchGroup` vs `DetectedPair` type rename and the underlying tracker's `groups=` kwarg). Same `num_copper_layers is None -> layer_stack count or 2` default policy.
  - New `Autorouter.match_group_tracker` property mirroring `diffpair_length_tracker`.
  - `_finalize_routing` extended: after the existing diff-pair block, a parallel match-group block re-derives groups via `detect_match_groups(...)` and invokes `update_match_group_skew(...)`. Reuses the existing `net_to_class` local (single-source-of-truth idiom). Block ordering is load-bearing: diff-pair FIRST, match-group SECOND, with isolated `try/except` scoping so a Phase 1C detection failure cannot regress the working Phase 3H-cont diff-pair path.
  - Docstring on `_finalize_routing` updated to document both blocks.

- **`tests/test_match_group_length.py`** — new `TestFinalizeRoutingWiresMatchGroupTracker` class:
  - Parametrized over `[route_all, route_all_negotiated, route_all_interleaved]` on a synthetic 4-net `DDR_BUS` group declared via the legacy `add_match_group(...)` API. Each variant asserts `match_group_tracker.get_all_skews()["DDR_BUS"]` is a non-None float and `tracker.lengths` is non-empty.
  - `test_finalize_routing_idempotent`: two consecutive `_finalize_routing` calls produce byte-for-byte equal `get_all_skews()`.
  - `test_finalize_routing_noop_when_no_groups`: empty `Autorouter` finalize leaves `get_all_skews() == {}` and `lengths == {}`.
  - `test_finalize_routing_detection_failure_preserves_diff_pair_path`: monkey-patches `detect_match_groups` to raise `RuntimeError`; asserts the diff-pair tracker stays populated and the match-group tracker silently no-ops.
  - `test_legacy_add_match_group_flows_to_tracker`: end-to-end legacy API source path.
  - `test_match_group_tracker_property_returns_internal_tracker`: property contract.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_match_group_tracker` field initialized in `__init__` near line 443 | Done | `core.py:454` (alongside `_diffpair_length_tracker`) |
| `update_match_group_skew(detected_groups, board_thickness_mm, num_copper_layers)` method | Done | `core.py:7350` (immediately after `diffpair_length_tracker` property) |
| `match_group_tracker` property | Done | `core.py:7406` (sibling block after `update_match_group_skew`) |
| `_finalize_routing` calls `update_match_group_skew` after `update_diffpair_skew`, gated on non-empty groups, reuses `net_to_class` local | Done | `core.py:2616` (block placed AFTER diff-pair block; isolated `try/except` per curator note) |
| All 15 `_finalize_routing` call sites continue to function | Done | `grep -n "self._finalize_routing()" core.py` shows 15 sites; all 338 tests pass across `test_router_core.py`, `test_diffpair_length.py`, `test_match_group_*.py` |
| Drift-prevention test parametrized over 3 route_all_* variants | Done | `TestFinalizeRoutingWiresMatchGroupTracker.test_strategy_populates_match_group_tracker` |
| Idempotency test | Done | `test_finalize_routing_idempotent` |
| No-op when no groups declared | Done | `test_finalize_routing_noop_when_no_groups` |
| Detection-failure safety | Done | `test_finalize_routing_detection_failure_preserves_diff_pair_path` monkey-patches `detect_match_groups` to raise; diff-pair tracker remains populated |
| Legacy API end-to-end | Done | `test_legacy_add_match_group_flows_to_tracker` |
| Defensive try/except mirrors diff-pair block | Done | ImportError on `from .match_group_detection import` AND broad Exception around the detection call |

## Test Plan

- [x] `uv run pytest tests/test_match_group_length.py` -- 39 passed
- [x] `uv run pytest tests/test_diffpair_length.py tests/test_match_group_detection.py` -- 68 passed
- [x] `uv run pytest tests/test_router_core.py tests/test_match_group_declaration.py` -- 187 passed
- [x] Combined: 338 tests pass across all router/diffpair/match-group suites
- [x] `uv run ruff check tests/test_match_group_length.py` -- All checks passed
- [x] `uv run ruff format --check tests/test_match_group_length.py` -- formatter-clean
- [x] `uv run ruff check src/kicad_tools/router/core.py` -- 19 errors, all pre-existing (identical count on `origin/main`); no net errors introduced

## Notes for Reviewers

- The architect's `_extract_legacy_match_groups()` helper from the issue body was **not** added: the actual `detect_match_groups(...)` API accepts `length_tracker=LengthTracker` directly and reads `match_groups` internally, so the helper would have been an unused indirection. The curator's note also flagged the empty-group filter concern — that's already handled by the detector at `match_group_detection.py:269-270` (`if not members: continue`).
- Curator's stated `_finalize_routing` line was 2361 / 2516; actual position after PRs #2691, #2693, #2694 merged is `core.py:2529`. The 15-call-site count is confirmed (architect said 12).
- Block ordering and isolated `try/except` per curator's architectural clarification: a Phase 1C detector failure cannot regress the diff-pair path, and an ImportError on `diffpair_detection` cannot silence the match-group tracker.

Closes #2690