### PR TITLE
feat(impedance): gate default specs on controlled-impedance opt-in

### DIFF
--- a/src/kicad_tools/physics/stackup.py
+++ b/src/kicad_tools/physics/stackup.py
@@ -100,11 +100,22 @@ class Stackup:
         layers: Ordered list of layers from top to bottom
         board_thickness_mm: Total board thickness in mm
         copper_finish: Surface finish (e.g., "ENIG", "HASL")
+        has_explicit_data: True when the stackup was parsed from an actual
+            KiCad ``(setup (stackup ...))`` block. False when it was
+            constructed from a default (no stackup info in the PCB, generic
+            preset). Consumers (e.g.
+            :class:`~kicad_tools.validate.rules.impedance.ImpedanceRule`)
+            use this signal as a "controlled-impedance opt-in": a board
+            with an explicit stackup is presumed to care about impedance
+            and gets the validator's default impedance specs applied to
+            it; a board without one (hobbyist-grade 2-layer) does not.
+            See Issue #2696.
     """
 
     layers: list[StackupLayer] = field(default_factory=list)
     board_thickness_mm: float = 1.6
     copper_finish: str = ""
+    has_explicit_data: bool = False
 
     @classmethod
     def from_pcb(cls, pcb: PCB) -> Stackup:
@@ -152,6 +163,7 @@ class Stackup:
             layers=layers,
             board_thickness_mm=total_thickness if total_thickness > 0 else 1.6,
             copper_finish=setup.copper_finish if hasattr(setup, "copper_finish") else "",
+            has_explicit_data=True,
         )
 
     @classmethod

--- a/src/kicad_tools/validate/rules/impedance.py
+++ b/src/kicad_tools/validate/rules/impedance.py
@@ -127,7 +127,15 @@ class ImpedanceRule(DRCRule):
 
         Args:
             specs: Impedance specifications to check. If not provided,
-                uses default specs for common signal types.
+                uses default specs for common signal types.  The defaults
+                are auto-applied via net-name regex (``.*CLK.*`` -> 50Ω,
+                ``USB.*D[PM]?`` -> 90Ω differential, etc.). On boards
+                without a controlled-impedance stackup, these defaults
+                are suppressed (see :meth:`check`) — this prevents the
+                rule from demanding ~2.8mm-wide SWCLK traces on a generic
+                hobbyist 2-layer board (Issue #2696). Pass an explicit
+                ``specs`` list to force the rule to evaluate them
+                regardless of stackup.
             stackup: PCB stackup for impedance calculations. If not provided,
                 will try to extract from PCB during check.
             detected_pairs: Optional list of detected differential pairs
@@ -140,6 +148,11 @@ class ImpedanceRule(DRCRule):
                 3K single-ended-only behavior, which preserves backward
                 compatibility for standalone ``kct check`` invocations.
         """
+        # Remember whether the caller passed explicit specs.  When True,
+        # the rule unconditionally evaluates them.  When False, the rule
+        # uses its built-in defaults but suppresses them on boards that
+        # don't opt into controlled-impedance routing (see check()).
+        self._using_default_specs = specs is None
         self.specs = specs if specs is not None else self._get_default_specs()
         self._stackup = stackup
         self._tl: TransmissionLine | None = None
@@ -182,6 +195,45 @@ class ImpedanceRule(DRCRule):
         except Exception:
             return False
 
+    def _board_has_controlled_impedance(self) -> bool:
+        """Decide whether the current board "opts in" to controlled impedance.
+
+        A board opts in when either:
+
+        - The PCB file has an explicit ``(setup (stackup ...))`` block —
+          the designer took the trouble to declare dielectric thicknesses
+          and Er values, which is the standard signal of impedance-control
+          intent (``Stackup.has_explicit_data``); or
+        - The board has 4 or more copper layers — multi-layer boards have
+          reference planes close to signal layers, so 50Ω widths are
+          physically feasible at the geometric scales the autorouter
+          produces (~0.20 - 0.40 mm), and applying defaults does not
+          impose unrealistic constraints.
+
+        2-layer boards without an explicit stackup do NOT opt in.  On
+        such boards, 50Ω on a generic FR4 1.6mm core requires ~2.8 mm
+        wide traces — infeasible for typical 0.5 mm pad pitch — so
+        auto-applying the default ``.*CLK.*`` -> 50Ω rule produces
+        spurious DRC errors that the board can never satisfy (see
+        Issue #2696 for the board-04 SWCLK case).
+
+        Returns:
+            True when defaults should be applied; False when the board
+            looks like a generic hobbyist 2-layer and defaults should
+            be suppressed.
+        """
+        if self._stackup is None:
+            # Without a stackup we have no signal at all — preserve the
+            # original "apply defaults" behavior for backward compat.
+            return True
+        if getattr(self._stackup, "has_explicit_data", False):
+            return True
+        # No explicit stackup: opt in iff 4+ copper layers.
+        try:
+            return self._stackup.num_copper_layers >= 4
+        except AttributeError:
+            return True
+
     def check(
         self,
         pcb: PCB,
@@ -209,6 +261,16 @@ class ImpedanceRule(DRCRule):
                     location=None,
                 )
             )
+            return results
+
+        # Gate auto-applied defaults on a controlled-impedance opt-in.
+        # When the caller did not pass explicit ``specs``, only apply
+        # built-in name-pattern defaults (``.*CLK.*`` -> 50Ω, etc.) if
+        # the board's stackup declares controlled-impedance intent.
+        # Otherwise return empty results — a hobbyist 2-layer board
+        # never claimed to be impedance-controlled and should not fail
+        # DRC over a target it didn't set (Issue #2696).
+        if self._using_default_specs and not self._board_has_controlled_impedance():
             return results
 
         # Collect all traces from PCB

--- a/tests/test_impedance_default_gating.py
+++ b/tests/test_impedance_default_gating.py
@@ -101,8 +101,7 @@ class TestImpedanceDefaultGating:
             w for w in results.warnings if "physics module not available" not in w.message
         ]
         assert non_physics_warnings == [], (
-            f"Expected no non-physics warnings, got: "
-            f"{[w.message for w in non_physics_warnings]}"
+            f"Expected no non-physics warnings, got: {[w.message for w in non_physics_warnings]}"
         )
 
     def test_user_specs_evaluated_on_two_layer(self, two_layer_swclk_pcb: Path):

--- a/tests/test_impedance_default_gating.py
+++ b/tests/test_impedance_default_gating.py
@@ -1,0 +1,215 @@
+"""Tests for the controlled-impedance opt-in gating of ``ImpedanceRule``.
+
+Issue #2696: On 2-layer hobbyist boards with no explicit stackup, the
+default ``.*CLK.*`` -> 50Ω auto-applied spec produces spurious DRC
+errors because 50Ω is infeasible on a 1.6mm core (~2.8mm trace width
+required). The rule now suppresses its auto-applied defaults when the
+board has neither an explicit ``(setup (stackup ...))`` block nor 4+
+copper layers.
+
+These tests cover:
+
+- 2-layer default stackup + SWCLK trace -> zero violations under defaults
+- 4-layer default stackup + SWCLK trace -> defaults still apply
+- 2-layer with explicit stackup data -> defaults still apply
+- User-supplied specs are always evaluated regardless of stackup
+- The ``Stackup.has_explicit_data`` flag round-trips through ``from_pcb``
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Skip the entire module if yaml (and therefore the validate package)
+# isn't available — mirrors test_physics_integration.py's gating.
+pytest.importorskip("yaml")
+
+
+# 2-layer SWCLK PCB fixture (mimics board 04's relevant geometry).
+TWO_LAYER_SWCLK_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SWCLK")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (segment (start 110 120) (end 140 120) (width 0.2) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000020"))
+  (segment (start 110 121) (end 140 121) (width 0.2) (layer "B.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000021"))
+)
+"""
+
+
+@pytest.fixture
+def two_layer_swclk_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "two_layer_swclk.kicad_pcb"
+    pcb_file.write_text(TWO_LAYER_SWCLK_PCB)
+    return pcb_file
+
+
+class TestImpedanceDefaultGating:
+    """Tests for the 2-layer / non-controlled-impedance opt-out (#2696)."""
+
+    def test_two_layer_default_swclk_no_violations(self, two_layer_swclk_pcb: Path):
+        """2-layer board with SWCLK + no explicit stackup -> zero violations.
+
+        Before #2696, this fixture fired 2 ImpedanceRule errors (one per
+        layer) because the default ``.*CLK.*`` -> 50Ω spec auto-applied
+        and 0.2 mm traces on default 2-layer FR4 give ~133Ω / ~64Ω
+        (well outside the 10% tolerance).
+
+        With the gating fix, the rule sees a generic 2-layer stackup
+        (no ``(setup (stackup ...))`` block, 2 copper layers) and skips
+        its default name-pattern matching entirely.
+        """
+        from kicad_tools.manufacturers import get_profile
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.impedance import ImpedanceRule
+
+        pcb = PCB.load(str(two_layer_swclk_pcb))
+        design_rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
+
+        rule = ImpedanceRule()
+        results = rule.check(pcb, design_rules)
+
+        # Defaults gated off — no violations expected.
+        assert len(results.errors) == 0, (
+            f"Expected 0 errors on 2-layer SWCLK board with default specs, "
+            f"got {len(results.errors)}: {[e.message for e in results.errors]}"
+        )
+        # Also: no warnings from the rule itself (only the
+        # "physics module unavailable" path emits a warning, and that
+        # path is not exercised here).
+        non_physics_warnings = [
+            w for w in results.warnings if "physics module not available" not in w.message
+        ]
+        assert non_physics_warnings == [], (
+            f"Expected no non-physics warnings, got: "
+            f"{[w.message for w in non_physics_warnings]}"
+        )
+
+    def test_user_specs_evaluated_on_two_layer(self, two_layer_swclk_pcb: Path):
+        """Explicit user-supplied specs are evaluated regardless of stackup.
+
+        If the caller passes a spec list explicitly, they have opted in
+        to controlled impedance checking and the rule must evaluate
+        their specs — the gating only suppresses auto-applied defaults.
+        """
+        from kicad_tools.manufacturers import get_profile
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.impedance import ImpedanceRule, NetImpedanceSpec
+
+        pcb = PCB.load(str(two_layer_swclk_pcb))
+        design_rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
+
+        # User explicitly requests a 50Ω target on CLK nets.  This should
+        # fire (just like the old default behavior) because the caller
+        # opted in by passing specs explicitly.
+        user_specs = [NetImpedanceSpec(r".*CLK.*", target_z0=50.0)]
+        rule = ImpedanceRule(specs=user_specs)
+        results = rule.check(pcb, design_rules)
+
+        # Expect violations: 0.2mm on 2-layer FR4 != 50Ω.
+        assert len(results.errors) + len(results.warnings) > 0, (
+            "Expected violations when user explicitly passes 50Ω spec on 2-layer board"
+        )
+
+    def test_board_has_controlled_impedance_logic(self):
+        """Direct unit test of the gating helper.
+
+        Covers the three branches: explicit stackup flag, 4+ layer
+        threshold, and the 2-layer default fallback.
+        """
+        from kicad_tools.physics import Stackup
+        from kicad_tools.validate.rules.impedance import ImpedanceRule
+
+        # 1) 2-layer default stackup, no explicit data -> opt out.
+        rule = ImpedanceRule()
+        rule._stackup = Stackup.default_2layer()
+        assert rule._board_has_controlled_impedance() is False
+
+        # 2) 4-layer JLCPCB stackup, no explicit data -> opt in (>=4 copper).
+        rule2 = ImpedanceRule()
+        rule2._stackup = Stackup.jlcpcb_4layer()
+        assert rule2._board_has_controlled_impedance() is True
+
+        # 3) 2-layer with explicit data flag set -> opt in.
+        rule3 = ImpedanceRule()
+        rule3._stackup = Stackup.default_2layer()
+        rule3._stackup.has_explicit_data = True
+        assert rule3._board_has_controlled_impedance() is True
+
+        # 4) No stackup at all -> preserve original behavior (opt in).
+        rule4 = ImpedanceRule()
+        rule4._stackup = None
+        assert rule4._board_has_controlled_impedance() is True
+
+    def test_using_default_specs_flag(self):
+        """``_using_default_specs`` tracks whether caller supplied specs."""
+        from kicad_tools.validate.rules.impedance import ImpedanceRule, NetImpedanceSpec
+
+        # Default: no specs -> using defaults.
+        rule_default = ImpedanceRule()
+        assert rule_default._using_default_specs is True
+
+        # User supplies specs -> not using defaults.
+        rule_user = ImpedanceRule(specs=[NetImpedanceSpec(r".*", target_z0=50.0)])
+        assert rule_user._using_default_specs is False
+
+        # Empty list is still user-supplied (caller signaled "no specs").
+        rule_empty = ImpedanceRule(specs=[])
+        assert rule_empty._using_default_specs is False
+
+
+class TestStackupExplicitDataFlag:
+    """Tests for ``Stackup.has_explicit_data`` round-tripping."""
+
+    def test_default_2layer_has_no_explicit_data(self):
+        """Default presets are NOT marked as explicit."""
+        from kicad_tools.physics import Stackup
+
+        stackup = Stackup.default_2layer()
+        assert stackup.has_explicit_data is False
+
+    def test_jlcpcb_4layer_has_no_explicit_data(self):
+        """Manufacturer presets are NOT marked as explicit either.
+
+        ``has_explicit_data`` specifically signals "this came from a real
+        PCB file's stackup block". A preset constructed in code is not
+        explicit board data — but it doesn't matter for the gating since
+        4-layer boards opt in via the copper-count branch anyway.
+        """
+        from kicad_tools.physics import Stackup
+
+        stackup = Stackup.jlcpcb_4layer()
+        assert stackup.has_explicit_data is False
+
+    def test_from_pcb_no_stackup_data_is_not_explicit(self, tmp_path: Path):
+        """A PCB with no ``(setup (stackup ...))`` -> ``has_explicit_data=False``."""
+        from kicad_tools.physics import Stackup
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "no_stackup.kicad_pcb"
+        pcb_file.write_text(TWO_LAYER_SWCLK_PCB)
+
+        pcb = PCB.load(str(pcb_file))
+        stackup = Stackup.from_pcb(pcb)
+        assert stackup.has_explicit_data is False
+        assert stackup.num_copper_layers == 2


### PR DESCRIPTION
## Summary

The validator's default impedance specs (``.*CLK.*`` -> 50Ω, ``USB.*D[PM]?`` -> 90Ω, etc.) used to auto-apply via net-name regex on every PCB, regardless of stackup. On a 2-layer hobbyist board with default FR4 1.6mm core, 50Ω requires ~2.8mm trace widths — infeasible for typical 0.5mm pad pitch — so any net named ``SWCLK`` or ``MCLK`` would fail DRC with errors the design could never satisfy. Board 04 (STM32 devboard) hit this on SWCLK: 5 ImpedanceRule errors that no realistic trace width could resolve.

This PR implements **Option C** from the issue: gate the validator's auto-applied default specs on a **controlled-impedance opt-in** signal. Boards that don't declare controlled-impedance intent are no longer subjected to defaults they can't satisfy.

## Changes

- **`src/kicad_tools/physics/stackup.py`**: New ``Stackup.has_explicit_data: bool`` field (default ``False``). Set to ``True`` in ``Stackup.from_pcb`` when the PCB has a non-empty ``(setup (stackup ...))`` block. Manufacturer presets (``default_2layer``, ``jlcpcb_4layer``, ``oshpark_4layer``) keep it ``False`` — they opt in via the copper-count branch instead.
- **`src/kicad_tools/validate/rules/impedance.py`**:
  - ``ImpedanceRule._using_default_specs`` tracks whether the caller passed ``specs=`` explicitly.
  - ``ImpedanceRule._board_has_controlled_impedance()`` encapsulates the gating logic: opt in iff the stackup is explicit OR the board has 4+ copper layers.
  - ``ImpedanceRule.check`` short-circuits to empty results when using defaults AND the board doesn't opt in.
- **`tests/test_impedance_default_gating.py`** (new): 7 regression tests covering all gating branches plus user-supplied spec pass-through and stackup explicit-data round-tripping.

The opt-in is bypassed when the caller passes ``specs=`` explicitly, preserving the existing per-class ``target_*_impedance`` flow (``router/diffpair_impedance.py``).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board 04 ``kct check --mfr jlcpcb`` reports 0 ImpedanceRule errors on SWCLK | Pass | Ran ``kct check --only impedance`` on ``boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb``: 0 errors, 0 warnings (previously 5 errors on SWCLK F.Cu/B.Cu). |
| 2-layer synthetic board with SWCLK has zero ImpedanceRule violations under defaults | Pass | ``tests/test_impedance_default_gating.py::TestImpedanceDefaultGating::test_two_layer_default_swclk_no_violations`` asserts 0 errors. |
| Existing 4-layer boards with controlled impedance still get defaults applied | Pass | ``test_board_has_controlled_impedance_logic`` verifies 4-layer JLCPCB stackup returns ``True`` from the gating helper. All 50 existing impedance/diffpair tests still pass. |
| Existing impedance test suite still passes | Pass | ``pytest tests/test_physics_integration.py tests/test_cli_check_impedance.py tests/test_diffpair_impedance.py tests/test_diffpair_impedance_wiring.py`` → 50/50 pass. |

## Test Plan

- [x] New regression tests (7 tests in `test_impedance_default_gating.py`) pass.
- [x] Existing impedance / physics / stackup tests (105 tests across physics + stackup matchers) all pass.
- [x] Board 04 routed PCB reports 0 ImpedanceRule errors after the change.
- [x] `ruff check` and `ruff format --check` clean on changed files (pre-existing repo-wide lint errors are out of scope).
- [x] Smoke-tested all 4 gating branches via direct `_board_has_controlled_impedance` invocation.

Closes #2696