### PR TITLE
feat(router): in-pad via escape for fine-pitch LQFP/QFP (0.5mm pitch)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1488,6 +1488,10 @@ def route_with_layer_escalation(
         via_drill=args.via_drill,
         via_diameter=args.via_diameter,
         fine_pitch_clearance=fine_pitch_cl,
+        # Issue #2695: forward manufacturer so the escape router can opt in
+        # to in-pad escape for fine-pitch LQFP/QFP (and SSOP/TSSOP) when the
+        # manufacturer supports via-in-pad processing.
+        manufacturer=getattr(args, "manufacturer", None),
     )
 
     # Parse skip nets
@@ -2254,6 +2258,10 @@ def route_with_rule_relaxation(
             via_drill=tier.via_drill,
             via_diameter=tier.via_diameter,
             fine_pitch_clearance=fine_pitch_cl,
+            # Issue #2695: forward manufacturer so the escape router can opt
+            # in to in-pad escape for fine-pitch LQFP/QFP/SSOP/TSSOP when
+            # the manufacturer supports via-in-pad processing.
+            manufacturer=getattr(args, "manufacturer", None),
         )
 
         # Load PCB
@@ -2779,6 +2787,10 @@ def route_with_combined_escalation(
                 via_drill=tier.via_drill,
                 via_diameter=tier.via_diameter,
                 fine_pitch_clearance=fine_pitch_cl,
+                # Issue #2695: forward manufacturer so the escape router
+                # can opt in to in-pad escape for fine-pitch LQFP/QFP/SSOP/
+                # TSSOP when the manufacturer supports via-in-pad processing.
+                manufacturer=getattr(args, "manufacturer", None),
             )
 
             # Load PCB

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1745,6 +1745,36 @@ class EscapeRouter:
         # reserve the alternating pattern for true fine-pitch QFP/QFN.
         use_perpendicular_only = package.pin_pitch >= 0.65
 
+        # Issue #2695: For fine-pitch QFP/LQFP/TQFP at 0.5mm pitch and finer,
+        # the alternating scheme still cannot fit a 0.2mm trace + 0.15mm
+        # clearance between adjacent pads.  Inner pins fail surface escape
+        # and have historically been deferred to the main router, where they
+        # remain unrouted because the package perimeter is fully blocked.
+        # When the manufacturer supports via-in-pad processing (e.g.
+        # jlcpcb-tier1, pcbway), we fall back to ``_try_in_pad_escape`` --
+        # the same strategy PR #2608 introduced for SSOP/TSSOP.  Plain
+        # ``jlcpcb`` and unknown manufacturers continue to defer (no silent
+        # surcharge for users who did not opt into via-in-pad).
+        try_in_pad_fallback = (
+            package.pin_pitch <= 0.55
+            and self.via_in_pad_supported
+        )
+
+        # Effective clearance and escape width for the in-pad rescue
+        # fallback.  We mirror the values used inside
+        # ``_create_fine_pitch_row_escapes`` so the in-pad routes are
+        # geometrically consistent regardless of which dispatcher created
+        # them.
+        ref = package.ref
+        effective_clearance = self.rules.get_clearance_for_component(
+            ref, pin_pitch=package.pin_pitch,
+        )
+        escape_width = (
+            self.rules.min_trace_width
+            if self.rules.min_trace_width is not None
+            else self._get_trace_width_for_net(package.pads[0].net_name if package.pads else "")
+        )
+
         # Generate escapes for each edge
         for pads, primary_dir, alt_dir_cw, alt_dir_ccw in [
             (north_pads, EscapeDirection.NORTH, EscapeDirection.EAST, EscapeDirection.WEST),
@@ -1763,6 +1793,29 @@ class EscapeRouter:
                     direction=direction,
                     package=package,
                 )
+
+                # Issue #2695: For fine-pitch QFP packages on capable
+                # manufacturers, replace the surface escape with an
+                # in-pad via escape when the surface segment violates
+                # clearance against neighbouring pads on the same edge.
+                # The alternating scheme alone cannot fit traces between
+                # 0.5mm-pitch pads, so without this rescue inner pins
+                # never reach the main router successfully.
+                if try_in_pad_fallback and escape.segments:
+                    surface_seg = escape.segments[0]
+                    if self._segment_violates_pad_clearance(
+                        surface_seg, i, pads, effective_clearance,
+                    ):
+                        in_pad_route = self._try_in_pad_escape(
+                            pad=pad,
+                            direction=direction,
+                            effective_clearance=effective_clearance,
+                            escape_width=escape_width,
+                        )
+                        if in_pad_route is not None:
+                            escapes.append(in_pad_route)
+                            continue
+
                 escapes.append(escape)
 
         return escapes

--- a/tests/test_escape_via_in_pad_lqfp.py
+++ b/tests/test_escape_via_in_pad_lqfp.py
@@ -1,0 +1,413 @@
+"""Tests for issue #2695: in-pad via escape on fine-pitch LQFP/QFP packages.
+
+Verifies that the in-pad escape strategy (originally added for SSOP/TSSOP in
+PR #2608) is also reached from the QFP/LQFP/TQFP dispatcher
+(``_escape_qfp_alternating``) when:
+
+1. The package pitch is 0.5mm or finer (``pin_pitch <= 0.55``), and
+2. The manufacturer supports via-in-pad (``via_in_pad_supported=True``).
+
+Pre-#2695 behavior (preserved when manufacturer doesn't support in-pad):
+- Inner LQFP-48 pins fail surface escape and are deferred to the main
+  router, where they typically remain unrouted because the package
+  perimeter is fully blocked.
+
+Post-#2695 behavior (when via_in_pad_supported=True):
+- Inner LQFP-48 pins that fail surface clearance fall through to an in-pad
+  via escape: a via is placed dead-centre on the pad and the escape
+  segment runs from the via on an inner signal layer (In1.Cu on 4-layer
+  boards, B.Cu on 2-layer boards).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.escape import EscapeRouter, PackageType
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+
+def _make_lqfp48_0p5mm(
+    ref: str = "U2",
+    pitch: float = 0.5,
+    pad_short: float = 0.30,
+    pad_long: float = 1.50,
+    body_size: float | None = None,
+    pad_stick_out: float = 0.85,
+    pads_per_edge: int = 12,
+    start_net: int = 1,
+) -> list[Pad]:
+    """Build a synthetic LQFP-48 footprint at 0.5mm pitch.
+
+    Default geometry mimics ``Package_QFP:LQFP-48_7x7mm_P0.5mm``:
+    - 48 pins total, 12 per edge.
+    - Pitch: 0.5mm between adjacent pins along an edge.
+    - Pad dimensions: ~0.30mm (short axis, along edge) x ~1.50mm (long axis,
+      perpendicular -- sticks out from package body).
+    - Body: 7x7mm; pad center-line sits 0.85mm outside the body edge so
+      half the pad sits over the lead and half sticks out.
+
+    Pin numbering follows the standard LQFP convention:
+    - Pin 1 starts at the top of the west edge (after the corner marker)
+    - Numbering proceeds CCW: west (top->bottom), south (left->right),
+      east (bottom->top), north (right->left)
+
+    Each pad has a unique net so the escape router does not group them.
+
+    Args:
+        body_size: Package body size in mm.  Defaults to a value that
+            keeps corner-to-corner pad spacing >= 1.5x pitch (so the
+            min-pitch detection picks up the in-edge pin pitch rather
+            than a coincidentally close corner pair).
+    """
+    # Auto-size the body so corner pad spacing is well above in-edge pitch.
+    # Each edge spans (pads_per_edge - 1) * pitch.  Body needs >= span +
+    # comfortable corner gap (~3x pitch) so corner pads of adjacent
+    # edges are far enough apart.
+    span = (pads_per_edge - 1) * pitch
+    if body_size is None:
+        body_size = span + 3.0 * pitch + 2.0 * pad_long
+    half_body = body_size / 2
+    pad_center_offset = half_body + pad_stick_out / 2
+    pads: list[Pad] = []
+    pin_no = 1
+    half_span = span / 2
+
+    # WEST edge: vertical pads, sorted top->bottom.  Long axis = X
+    # (perpendicular to edge), short axis = Y (along edge).
+    # Pin 1 starts at the top of the west edge.
+    for i in range(pads_per_edge):
+        y = half_span - i * pitch  # top -> bottom
+        pads.append(
+            Pad(
+                x=-pad_center_offset,
+                y=y,
+                width=pad_long,    # long axis along X (perpendicular to edge)
+                height=pad_short,  # short axis along Y (along edge)
+                net=start_net + pin_no - 1,
+                net_name=f"NET{start_net + pin_no - 1}",
+                ref=ref,
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+
+    # SOUTH edge: horizontal pads, sorted left->right.  Long axis = Y,
+    # short axis = X.
+    for i in range(pads_per_edge):
+        x = -half_span + i * pitch  # left -> right
+        pads.append(
+            Pad(
+                x=x,
+                y=-pad_center_offset,
+                width=pad_short,
+                height=pad_long,
+                net=start_net + pin_no - 1,
+                net_name=f"NET{start_net + pin_no - 1}",
+                ref=ref,
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+
+    # EAST edge: vertical pads, sorted bottom->top.
+    for i in range(pads_per_edge):
+        y = -half_span + i * pitch  # bottom -> top
+        pads.append(
+            Pad(
+                x=pad_center_offset,
+                y=y,
+                width=pad_long,
+                height=pad_short,
+                net=start_net + pin_no - 1,
+                net_name=f"NET{start_net + pin_no - 1}",
+                ref=ref,
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+
+    # NORTH edge: horizontal pads, sorted right->left.
+    for i in range(pads_per_edge):
+        x = half_span - i * pitch  # right -> left
+        pads.append(
+            Pad(
+                x=x,
+                y=pad_center_offset,
+                width=pad_short,
+                height=pad_long,
+                net=start_net + pin_no - 1,
+                net_name=f"NET{start_net + pin_no - 1}",
+                ref=ref,
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+
+    return pads
+
+
+def _make_rules(manufacturer: str | None = None) -> DesignRules:
+    """Build DesignRules matching board 04 production settings."""
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        grid_resolution=0.05,
+        manufacturer=manufacturer,
+    )
+
+
+def _make_grid(rules: DesignRules, layer_stack: LayerStack | None = None) -> RoutingGrid:
+    return RoutingGrid(
+        width=30.0,
+        height=30.0,
+        rules=rules,
+        origin_x=-15.0,
+        origin_y=-15.0,
+        layer_stack=layer_stack or LayerStack.four_layer_sig_sig_gnd_pwr(),
+    )
+
+
+# ----------------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------------
+
+
+class TestLqfp48InPadEscape:
+    """Issue #2695: 0.5mm-pitch LQFP-48 in-pad escape on capable manufacturers."""
+
+    def test_lqfp48_classifies_as_qfp_family(self):
+        """The synthetic LQFP-48 fixture should be detected as one of
+        QFP/TQFP/QFN (which all route through ``_escape_qfp_alternating``).
+        """
+        rules = _make_rules(manufacturer="jlcpcb-tier1")
+        grid = _make_grid(rules)
+        escape_router = EscapeRouter(grid, rules)
+        pads = _make_lqfp48_0p5mm()
+
+        package_info = escape_router.analyze_package(pads)
+        assert package_info.package_type in (
+            PackageType.QFP, PackageType.TQFP, PackageType.QFN,
+        ), (
+            f"Expected QFP-family classification, got {package_info.package_type}"
+        )
+        assert package_info.pin_pitch <= 0.55, (
+            f"Expected pin_pitch <= 0.55, got {package_info.pin_pitch}"
+        )
+
+    def test_in_pad_escape_generated_when_supported(self):
+        """With manufacturer=jlcpcb-tier1, inner LQFP-48 pins that fail
+        surface escape should fall through to in-pad via escape."""
+        rules = _make_rules(manufacturer="jlcpcb-tier1")
+        grid = _make_grid(rules)
+        escape_router = EscapeRouter(grid, rules)
+        pads = _make_lqfp48_0p5mm()
+
+        package_info = escape_router.analyze_package(pads)
+        escapes = escape_router.generate_escapes(package_info)
+
+        # We expect at least some in-pad vias since 0.5mm-pitch with
+        # 0.2mm trace + 0.15mm clearance leaves no copper for parallel
+        # arms of the alternating pattern.
+        in_pad_vias = [
+            e for e in escapes
+            if e.via is not None and getattr(e.via, "in_pad", False)
+        ]
+        assert len(in_pad_vias) >= 1, (
+            f"Expected at least one in-pad via for 0.5mm-pitch LQFP-48 "
+            f"with via-in-pad enabled; got {len(in_pad_vias)} of {len(escapes)} "
+            f"escapes."
+        )
+
+        # Every in-pad via must sit dead-centre on its pad (within 1um).
+        for esc in in_pad_vias:
+            assert esc.via is not None
+            assert abs(esc.via.x - esc.pad.x) < 0.001
+            assert abs(esc.via.y - esc.pad.y) < 0.001
+            # 4-layer signal-signal-ground-power stack: inner escape lands
+            # on In1.Cu (a SIGNAL layer).
+            assert esc.via.layers[0] == esc.pad.layer
+            assert esc.via.layers[1] == Layer.IN1_CU
+
+    def test_no_in_pad_escape_when_unsupported(self):
+        """With manufacturer=jlcpcb (no via-in-pad capability), no in-pad
+        vias are produced.  Inner pins defer as before -- byte-identical
+        to pre-#2695 behaviour for users who haven't opted into the
+        capability+ tier."""
+        rules = _make_rules(manufacturer="jlcpcb")
+        grid = _make_grid(rules)
+        escape_router = EscapeRouter(grid, rules)
+        pads = _make_lqfp48_0p5mm()
+
+        package_info = escape_router.analyze_package(pads)
+        escapes = escape_router.generate_escapes(package_info)
+
+        in_pad_vias = [
+            e for e in escapes
+            if e.via is not None and getattr(e.via, "in_pad", False)
+        ]
+        assert in_pad_vias == [], (
+            f"Default JLCPCB profile must NOT produce in-pad vias on "
+            f"LQFP-48; got {len(in_pad_vias)}."
+        )
+
+    def test_no_in_pad_escape_when_manufacturer_is_none(self):
+        """With manufacturer=None (the default), no in-pad escapes."""
+        rules = _make_rules(manufacturer=None)
+        grid = _make_grid(rules)
+        escape_router = EscapeRouter(grid, rules)
+        pads = _make_lqfp48_0p5mm()
+
+        package_info = escape_router.analyze_package(pads)
+        escapes = escape_router.generate_escapes(package_info)
+
+        in_pad_vias = [
+            e for e in escapes
+            if e.via is not None and getattr(e.via, "in_pad", False)
+        ]
+        assert in_pad_vias == []
+
+    def test_in_pad_escape_uses_pcbway_when_supported(self):
+        """PCBWay is the other tier with ``via_in_pad_supported=True``;
+        verify the rescue fires for it too."""
+        rules = _make_rules(manufacturer="pcbway")
+        grid = _make_grid(rules)
+        escape_router = EscapeRouter(grid, rules)
+        pads = _make_lqfp48_0p5mm()
+
+        package_info = escape_router.analyze_package(pads)
+        escapes = escape_router.generate_escapes(package_info)
+
+        in_pad_vias = [
+            e for e in escapes
+            if e.via is not None and getattr(e.via, "in_pad", False)
+        ]
+        assert len(in_pad_vias) >= 1, (
+            "PCBWay (also via_in_pad_supported=True) must trigger the "
+            "in-pad rescue for LQFP-48 0.5mm-pitch inner pins."
+        )
+
+    def test_in_pad_skipped_at_0p65mm_pitch_qfp(self):
+        """Wider-pitch QFP packages (pitch >= 0.65mm) should NOT trigger
+        the in-pad rescue -- they have enough room for surface escape
+        already and would just pay an unnecessary via cost."""
+        rules = _make_rules(manufacturer="jlcpcb-tier1")
+        grid = _make_grid(rules)
+        escape_router = EscapeRouter(grid, rules)
+        # 0.65mm pitch -- above the 0.55mm rescue threshold.
+        pads = _make_lqfp48_0p5mm(pitch=0.65)
+
+        package_info = escape_router.analyze_package(pads)
+        escapes = escape_router.generate_escapes(package_info)
+
+        in_pad_vias = [
+            e for e in escapes
+            if e.via is not None and getattr(e.via, "in_pad", False)
+        ]
+        # At 0.65mm pitch the perpendicular-only scheme provides ample
+        # room (0.65 - 0.2 - 0.15 = 0.30mm gap each side); no need for
+        # via-in-pad and we should not pay for it.
+        assert in_pad_vias == [], (
+            f"At 0.65mm pitch the in-pad rescue should not fire (surface "
+            f"escape has room); got {len(in_pad_vias)} in-pad vias."
+        )
+
+    def test_in_pad_escape_on_2layer_board(self):
+        """On a 2-layer board with via-in-pad enabled, in-pad vias land on
+        B.Cu (the only available alternate signal layer)."""
+        rules = _make_rules(manufacturer="jlcpcb-tier1")
+        grid = _make_grid(rules, layer_stack=LayerStack.two_layer())
+        escape_router = EscapeRouter(grid, rules)
+        pads = _make_lqfp48_0p5mm()
+
+        package_info = escape_router.analyze_package(pads)
+        escapes = escape_router.generate_escapes(package_info)
+
+        in_pad_vias = [
+            e for e in escapes
+            if e.via is not None and getattr(e.via, "in_pad", False)
+        ]
+        assert len(in_pad_vias) >= 1, (
+            "Expected at least one in-pad via on the 2-layer LQFP fixture."
+        )
+        for esc in in_pad_vias:
+            assert esc.via is not None
+            assert esc.via.layers[1] == Layer.B_CU
+
+    def test_in_pad_skipped_when_pad_too_small(self):
+        """Pads too small to host the via + annular ring should bail
+        gracefully and leave the pin deferred (no in-pad via emitted)."""
+        rules = _make_rules(manufacturer="jlcpcb-tier1")
+        grid = _make_grid(rules)
+        escape_router = EscapeRouter(grid, rules)
+        # Both axes below the required dim for a 0.3mm drill + annular.
+        pads = _make_lqfp48_0p5mm(pad_short=0.20, pad_long=0.30)
+
+        package_info = escape_router.analyze_package(pads)
+        escapes = escape_router.generate_escapes(package_info)
+
+        in_pad_vias = [
+            e for e in escapes
+            if e.via is not None and getattr(e.via, "in_pad", False)
+        ]
+        assert in_pad_vias == [], (
+            "In-pad escape should bail out gracefully when pads are too "
+            "small for drill + annular ring."
+        )
+
+    def test_at_least_one_inner_pin_rescued_per_edge(self):
+        """With via-in-pad enabled on the 0.5mm LQFP-48 fixture, we expect
+        in-pad vias distributed across multiple edges (not all bunched on
+        one).  This guards against an edge-iteration bug where only the
+        first edge gets the rescue.
+
+        The exact count depends on how many surface escapes fail clearance
+        for the current pad geometry; we just require coverage on at
+        least 2 of the 4 edges.
+        """
+        rules = _make_rules(manufacturer="jlcpcb-tier1")
+        grid = _make_grid(rules)
+        escape_router = EscapeRouter(grid, rules)
+        pads = _make_lqfp48_0p5mm()
+
+        package_info = escape_router.analyze_package(pads)
+        center_x, center_y = package_info.center
+        escapes = escape_router.generate_escapes(package_info)
+
+        in_pad_vias = [
+            e for e in escapes
+            if e.via is not None and getattr(e.via, "in_pad", False)
+        ]
+
+        # Categorise each in-pad via by which edge its pad sits on.
+        edges: set[str] = set()
+        for esc in in_pad_vias:
+            pad = esc.pad
+            dx = pad.x - center_x
+            dy = pad.y - center_y
+            if abs(dx) > abs(dy):
+                edges.add("east" if dx > 0 else "west")
+            else:
+                edges.add("north" if dy > 0 else "south")
+
+        # Skip the assertion if no in-pad vias were produced at all (the
+        # other tests guard the >= 1 case); here we only check
+        # distribution when the rescue fires.
+        if in_pad_vias:
+            assert len(edges) >= 2, (
+                f"In-pad rescue should cover at least 2 edges; "
+                f"got {len(in_pad_vias)} vias on edges {edges}."
+            )

--- a/tests/test_escape_via_in_pad_lqfp.py
+++ b/tests/test_escape_via_in_pad_lqfp.py
@@ -21,8 +21,6 @@ Post-#2695 behavior (when via_in_pad_supported=True):
 
 from __future__ import annotations
 
-import pytest
-
 from kicad_tools.router.escape import EscapeRouter, PackageType
 from kicad_tools.router.grid import RoutingGrid
 from kicad_tools.router.layers import Layer, LayerStack


### PR DESCRIPTION
## Summary

Extends the in-pad via escape strategy from PR #2608 (originally for fine-pitch SSOP/TSSOP at 0.65mm pitch) to QFP/LQFP/TQFP packages at 0.5mm pitch and finer. Also fixes a CLI plumbing bug where `--manufacturer` was only wired into one of four `DesignRules` constructors in `route_cmd.py`, so the in-pad rescue never activated end-to-end through `kct route` (even for SSOP/TSSOP).

End-to-end result: board 04 (`STM32F103C8Tx` LQFP-48, 0.5mm pitch) now routes 9/9 nets with `--manufacturer jlcpcb-tier1` (was 8/9 with `OSC_OUT` U2.6 unrouted).

## Changes

- `src/kicad_tools/router/escape.py` `_escape_qfp_alternating`:
  - When `package.pin_pitch <= 0.55` AND `self.via_in_pad_supported`, check each generated surface escape against neighbouring pads via `_segment_violates_pad_clearance`.
  - On violation, call `_try_in_pad_escape` (already present from PR #2608) to place a via dead-centre on the pad and escape on an inner signal layer (In1.Cu on 4-layer, B.Cu on 2-layer).
  - The shared `_try_in_pad_escape` helper's geometry check (drill + 2 x annular fits inside the LARGER pad axis) accepts LQFP-48 pads (0.30 x 1.50mm) and rejects pads too small to host the drill.
- `src/kicad_tools/cli/route_cmd.py`: forward `args.manufacturer` to the three additional `DesignRules` constructors at lines 1484, 2250, 2775 (only line 4339 was wired by PR #2608). Without this fix, `--auto-layers` and other branches silently dropped the manufacturer to `None`, disabling the in-pad rescue in production routes.
- `tests/test_escape_via_in_pad_lqfp.py` (NEW): 9 unit tests on a synthetic LQFP-48 0.5mm-pitch fixture covering classification, jlcpcb-tier1 + pcbway activation, byte-identical fallback for plain jlcpcb / None, 2-layer board B.Cu landing, 0.65mm-pitch threshold gate, graceful skip on too-small pads, and per-edge distribution of the rescue.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_try_in_pad_escape` reachable from `_escape_qfp_alternating` when pin pitch <= 0.55mm AND `via_in_pad_supported=True` | OK | `_escape_qfp_alternating` now calls `_try_in_pad_escape` on clearance-violating surface escapes when both conditions hold. Tests `test_in_pad_escape_generated_when_supported`, `test_in_pad_escape_uses_pcbway_when_supported`. |
| Unit test on synthetic LQFP-48 0.5mm fixture: in-pad vias for inner pins when supported, byte-identical when not | OK | `tests/test_escape_via_in_pad_lqfp.py::TestLqfp48InPadEscape` (9 tests, all passing). |
| Regression on board 04: net OSC_OUT (Y1.2, C11.1, U2.6) routes all 3 pads under `--manufacturer jlcpcb-tier1` | OK | `kct route boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb --seed 42 --differential-pairs --auto-layers --manufacturer jlcpcb-tier1 --timeout 240` -> "Result: Design routed successfully on 2 layers (100% completion)", "Nets routed: 9/9". The output PCB contains a via at (126.8375, 121.75) (U2.6 pad center) and a B.Cu segment to (126.8375, 122.4) -- the in-pad escape. |
| Plain `--manufacturer jlcpcb` still defers (no silent surcharge) | OK | Same route command with `--manufacturer jlcpcb` -> 8/9 nets, OSC_OUT 2/3 (same as pre-fix). Output PCB has no via at U2.6, only the surface escape segment. |
| Existing fine-pitch SSOP/TSSOP tests pass | OK | `pytest tests/test_escape_via_in_pad.py tests/test_escape_fine_pitch_clearance.py tests/test_fine_pitch_ssop.py tests/test_fine_pitch.py tests/test_escape.py` -> 162 passed, 1 skipped (chorus-test board not present). |

## Test Plan

Tests run from the worktree on macOS / Python 3.12.11:

```
pytest tests/test_escape_via_in_pad_lqfp.py  # 9 passed
pytest tests/test_escape_via_in_pad.py tests/test_escape.py tests/test_escape_fine_pitch_clearance.py tests/test_fine_pitch.py tests/test_fine_pitch_ssop.py  # 162 passed, 1 skipped
pytest tests/test_route_cmd_params.py tests/test_route_cmd_input_preservation.py tests/test_route_exit_codes.py tests/test_router_algorithms.py  # 128 passed
ruff check src/kicad_tools/router/escape.py src/kicad_tools/cli/route_cmd.py tests/test_escape_via_in_pad_lqfp.py  # All checks passed
```

End-to-end board 04 route (tier1, with fix) for the regression assertion:
- 9/9 nets routed on 2 layers (100% completion)
- In-pad via at U2.6 position (126.8375, 121.75) confirmed in output PCB
- B.Cu segment from (126.8375, 121.75) to (126.8375, 122.4) on inner-layer escape

## Coordination Notes

- This PR also benefits the SSOP/TSSOP in-pad escape from PR #2608: the `route_cmd.py` plumbing fix was needed for that path too. The earlier 0.65mm SSOP/TSSOP escape tests still pass byte-identically, but production users with `--manufacturer jlcpcb-tier1` will now actually receive in-pad vias on SSOP/TSSOP escapes through `kct route` (they only saw it through the test fixtures before).
- DRC reports two `clearance_segment_via` "violations" at (126.84, 121.75) which is a known modelling limitation: the inner-layer escape segment starts at the via center, so half its width sits within the via's clearance ring. These are not real DRC issues -- the segment is electrically the via. Fixing the DRC checker to recognise in-pad-escape segments is out of scope (filed elsewhere).

Closes #2695