### PR TITLE
feat(router): tune_match_group_v2 for N-trace serpentine tuning (closes #2700)

### DIFF
--- a/src/kicad_tools/router/match_group_tuning.py
+++ b/src/kicad_tools/router/match_group_tuning.py
@@ -1,0 +1,860 @@
+"""N-trace match-group length-skew (serpentine) tuner.
+
+Issue #2700, Epic #2661 Phase 2E.
+
+This module implements :func:`tune_match_group_v2`, a router-internal
+helper that inserts serpentines (trombones) on the *shorter* members of a
+detected N-trace match group (DDR data byte, MIPI lane group, generic
+parallel bus) until the group's skew is within the per-group
+:attr:`~kicad_tools.router.match_group_length.MatchGroup.tolerance`
+window, OR a cascade-safety budget is exhausted.
+
+It is the direct generalization from N=2 (a differential pair, handled by
+:mod:`~kicad_tools.router.diffpair_length_tuning`) to N>=3 of the
+outer-normal bulges + per-insertion DRC self-check + byte-for-byte
+rollback pattern landed for pairs in PR #2663 (Epic #2556 Phase 3I).
+
+Design notes
+============
+
+* **Outer-normal bulges only, generalized to N-trace.**  For each
+  candidate insertion segment on a non-reference member we compute the
+  *nearest other group member's* closest point at the segment midpoint,
+  then return the unit vector AWAY from that nearest neighbor (the
+  curator's "Option (a): nearest-other-trace" heuristic).  Bulging the
+  shorter member toward another group member would consume intra-group
+  coupling room and trigger an intra-group clearance violation
+  immediately.  See :func:`_outer_normal_hint_group`.
+
+* **Per-insertion DRC self-check.**  Two-pronged:
+
+  1. **Intra-group** -- every new serpentine segment is checked against
+     every segment of every *other* group member at threshold
+     ``intra_group_clearance_mm``.
+  2. **Inter-net** -- every new segment is checked against every segment
+     of every routed net that is NOT a group member at the same
+     threshold.
+
+  See :func:`_post_insertion_clearance_ok_group`.  On rejection the
+  tuner discards the proposed ``new_route`` and returns the **original**
+  ``route`` reference (and its original ``.segments`` list reference) --
+  the byte-for-byte rollback contract.
+
+* **Cascade-safety budget**.  For groups with ``len(net_ids) <= 4`` the
+  budget per member is :data:`MAX_INSERTS_PER_GROUP_MEMBER_SMALL`
+  (3, matching :data:`~kicad_tools.router.diffpair_length_tuning.MAX_INSERTS_PER_PAIR`);
+  for larger groups (DDR bytes, MIPI lane groups) the budget drops to
+  :data:`MAX_INSERTS_PER_GROUP_MEMBER_LARGE` (2) because the cumulative
+  geometric perturbation against neighboring nets grows linearly with N.
+  An absolute ceiling :data:`MAX_TOTAL_INSERTS_PER_GROUP` (16) is
+  enforced across all members so a worst-case DDR-byte (N=10 x 2 = 20
+  cumulative bulges) cannot saturate the per-insertion DRC check on
+  dense boards.
+
+* **Reference-net policy.**  Delegates to
+  :meth:`MatchGroupTracker.get_reference_length`: ``None`` ->
+  longest-in-group (legacy ``tune_match_group`` semantic); explicit net
+  id -> "pace-car" semantic.  When a group member is already *longer*
+  than the reference the tuner cannot remove length (we never cut), so
+  that member is left unchanged with ``reason="longer_than_reference"``
+  -- distinct from the pair tuner's ``"reference"`` reason because for
+  N>=3 the over-length case is genuinely different from the
+  "you are the reference" case.
+
+* **Phase 2F handoff.**  ``MatchGroup.pair_ids`` is reserved for the
+  group-of-pairs composition (Phase 2F) where both halves of a pair must
+  receive identical serpentine geometry.  Phase 2E treats every member
+  as an independent net -- the entry guard
+  ``assert not group.pair_ids`` ensures that a future Phase 2F caller
+  cannot silently fall through to per-net serpentines (which would break
+  within-pair coupling).
+
+Out of scope for Phase 2E:
+
+* Group-of-pairs symmetric serpentine (Phase 2F, Issue #2701).
+* Pipeline wiring -- ``Autorouter._finalize_routing`` calling
+  :func:`tune_match_group_v2` is a separate Phase 2.5 wiring issue.
+* CLI flag -- ``--length-match-groups`` (Phase 3H of this epic) is a
+  separate issue.
+* Modifying the legacy :func:`~kicad_tools.router.optimizer.serpentine.tune_match_group`
+  at ``serpentine.py:484``.  Kept for backward compat with
+  :func:`~kicad_tools.router.length_tuning.apply_length_tuning`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .diffpair_length_tuning import (
+    MAX_INSERTS_PER_PAIR,
+    _closest_point_on_segment,
+)
+from .optimizer.serpentine import (
+    SerpentineConfig,
+    SerpentineGenerator,
+    SerpentineResult,
+)
+
+if TYPE_CHECKING:
+    from .match_group_length import MatchGroup
+    from .primitives import Route, Segment
+
+
+# ---------------------------------------------------------------------------
+# Cascade-safety budget constants
+# ---------------------------------------------------------------------------
+
+
+#: Cascade budget per group member for small groups (``len(net_ids) <= 4``).
+#: Equal to :data:`MAX_INSERTS_PER_PAIR` (3) by design -- the small-group
+#: case generalizes the N=2 pair budget without tightening it.  A drift-
+#: prevention test asserts the byte-for-byte equality so a future change
+#: touching one without the other fires.
+MAX_INSERTS_PER_GROUP_MEMBER_SMALL: int = 3
+
+#: Cascade budget per group member for large groups (``len(net_ids) > 4``).
+#: Reduced to 2 because the cumulative geometric perturbation against
+#: neighboring nets grows linearly with N -- a DDR byte (N=10) at the
+#: small-group budget would attempt up to 30 cumulative serpentine
+#: insertions, well past what the per-insertion DRC self-check can
+#: absorb on a dense board.
+MAX_INSERTS_PER_GROUP_MEMBER_LARGE: int = 2
+
+#: Absolute ceiling on cumulative serpentine insertions per group, across
+#: all members.  At the LARGE budget (2) a 10-net DDR byte could still
+#: produce 20 cumulative bulges -- 16 is a conservative safety net that
+#: lets a typical group reach tolerance while bounding the worst case.
+#: Defended by a drift-prevention test:
+#: ``MAX_TOTAL_INSERTS_PER_GROUP >= 2 * MAX_INSERTS_PER_GROUP_MEMBER_LARGE``.
+MAX_TOTAL_INSERTS_PER_GROUP: int = 16
+
+
+# Backwards-friendly alias for the "default per-member budget" used in
+# the public API signature.  Set to the small-group default; the function
+# downshifts to LARGE automatically when ``len(group.net_ids) > 4``.
+MAX_INSERTS_PER_GROUP_MEMBER: int = MAX_INSERTS_PER_GROUP_MEMBER_SMALL
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TuneResult:
+    """Outcome of a per-member length-match tuning attempt.
+
+    Per-member analog of
+    :class:`~kicad_tools.router.diffpair_length_tuning.DiffPairTuneResult`.
+    One ``TuneResult`` is returned for every member of a group from
+    :func:`tune_match_group_v2`, keyed by net id in the returned
+    ``dict[int, tuple[Route, TuneResult]]``.
+
+    Attributes:
+        success: True if this member is now within ``tolerance_mm`` of
+            the reference length AND every committed insertion passed
+            the post-insertion DRC self-check.  False otherwise.
+        reason: Short machine-readable reason code.  One of:
+
+            * ``"already_within_tolerance"`` -- this member was already
+              within tolerance vs the reference; no change was made.
+            * ``"tuned"`` -- one or more trombones brought the member
+              into tolerance.
+            * ``"reference"`` -- this member IS the reference net (per
+              the explicit-net policy).  Always returned unchanged.
+            * ``"longer_than_reference"`` -- this member is *longer*
+              than the reference length and the tuner cannot remove
+              length.  Distinct from ``"reference"``; useful for the
+              "pace-car" policy where one member is intentionally
+              shorter than another that the bus must be matched to.
+            * ``"exceeded_max_inserts"`` -- the per-member cascade
+              budget was exhausted before reaching tolerance.
+            * ``"cascade_budget_exhausted"`` -- the group-level
+              cumulative ceiling (:data:`MAX_TOTAL_INSERTS_PER_GROUP`)
+              was hit; this member could not be tuned because the
+              tuner refused to attempt any more insertions on the
+              group as a whole.
+            * ``"post_insertion_drc_violation"`` -- a candidate trombone
+              would violate intra-group or neighbor clearance; the
+              insertion was rolled back and no further attempts were
+              made on this member.
+            * ``"no_suitable_segment"`` -- the member has no segment
+              long enough to host any trombone amplitude.
+            * ``"unrouted"`` -- the member was not in ``routes_by_net``.
+            * ``"not_length_critical"`` -- the engagement gate fired:
+              ``length_critical=False``, no change was made.
+        attempts: Number of trombone insertions actually attempted for
+            this member.
+        inserts_applied: Number of trombones whose post-insertion check
+            passed and were committed.
+        length_before_mm: Member's routed length at entry.
+        length_after_mm: Member's routed length after the (possibly
+            empty) sequence of successful insertions.
+        message: Human-readable summary.
+        serpentine_results: Per-attempt results from the trombone
+            generator (including rejected attempts).
+    """
+
+    success: bool = False
+    reason: str = ""
+    attempts: int = 0
+    inserts_applied: int = 0
+    length_before_mm: float = 0.0
+    length_after_mm: float = 0.0
+    message: str = ""
+    serpentine_results: list[SerpentineResult] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def tune_match_group_v2(
+    group: MatchGroup,
+    routes_by_net: dict[int, Route],
+    *,
+    tolerance_mm: float | None = None,
+    intra_group_clearance_mm: float,
+    config: SerpentineConfig | None = None,
+    max_inserts_per_member: int | None = None,
+    length_critical: bool = True,
+) -> dict[int, tuple[Route, TuneResult]]:
+    """Tune the lengths of an N-trace match group to within tolerance.
+
+    Generalizes :func:`~kicad_tools.router.diffpair_length_tuning.tune_diff_pair_skew`
+    from N=2 (a pair) to N>=3 (a match group) while preserving the same
+    safety invariants: outer-normal bulges, per-insertion DRC
+    self-check with byte-for-byte rollback, and an explicit cascade-
+    safety budget.
+
+    Args:
+        group: A declared / detected
+            :class:`~kicad_tools.router.match_group_length.MatchGroup`.
+            ``group.pair_ids`` MUST be empty for Phase 2E -- pair-aware
+            composition (group of pairs) is the responsibility of
+            Phase 2F.  An assertion error fires with a clear pointer
+            when this precondition is violated.
+        routes_by_net: ``{net_id: Route}`` lookup for all routed nets on
+            the board.  Used both to fetch the group's members AND as
+            the corpus against which the post-insertion DRC self-check
+            looks for newly-introduced clearance violations against
+            non-group nets.
+        tolerance_mm: Per-group skew tolerance.  When ``None`` defaults
+            to ``group.tolerance`` (the value set when the group was
+            declared / detected).  A member is considered "matched" to
+            the reference when ``abs(L_member - L_ref) <= tolerance_mm``.
+        intra_group_clearance_mm: Edge-to-edge clearance floor used by
+            the post-insertion DRC self-check.  Applied as the
+            conservative same-value threshold for both the intra-group
+            pass and the neighbor pass (mirrors PR #2663's
+            single-threshold policy for the pair case).
+        config: Optional :class:`SerpentineConfig` override.  When
+            supplied its ``side`` and ``outer_normal_hint`` fields are
+            overwritten per-insertion by the tuner; other fields
+            (amplitude, gap_factor, ...) are honored.
+        max_inserts_per_member: Optional override for the per-member
+            cascade budget.  When ``None`` (the default) the tuner
+            picks :data:`MAX_INSERTS_PER_GROUP_MEMBER_SMALL` for
+            ``len(group.net_ids) <= 4`` and
+            :data:`MAX_INSERTS_PER_GROUP_MEMBER_LARGE` for larger
+            groups.  Regardless of this argument the group-level
+            ceiling :data:`MAX_TOTAL_INSERTS_PER_GROUP` is enforced.
+        length_critical: Engagement gate (default ``True``).  When
+            ``False`` every member is returned unchanged with
+            ``reason="not_length_critical"`` (matches the pair tuner's
+            gate at :func:`tune_diff_pair_skew`).
+
+    Returns:
+        ``{net_id: (route, result)}`` for every member of ``group``.
+        The route for a member that was *not* tuned (reference,
+        already-within-tolerance, longer-than-reference, unrouted,
+        rolled back, etc.) is returned **by reference** -- the same
+        object the caller passed in ``routes_by_net``, with the same
+        ``.segments`` list object.  Drift-prevention tests assert this
+        via ``is`` identity.
+
+    Rollback contract:
+        When the post-insertion DRC self-check fails for a candidate
+        on a given member, the proposed new Route is discarded and the
+        original Route reference (the one in ``routes_by_net``) is
+        returned with its original ``.segments`` list object intact.
+        Mirrors the pair tuner's contract; tested via ``is`` identity.
+    """
+    # --- Phase 2F handoff guard -----------------------------------------
+    # MatchGroup.pair_ids is reserved for Phase 2F's group-of-pairs
+    # composition (Issue #2701).  Phase 2E treats every member as an
+    # independent single-ended net; silently allowing pair_ids here would
+    # break within-pair coupling.  See diffpair_length_tuning.py for the
+    # N=2 pair-aware case.
+    assert not group.pair_ids, (
+        f"tune_match_group_v2 (Phase 2E) does not support group-of-pairs "
+        f"composition (group={group.name!r} has {len(group.pair_ids)} pair_ids). "
+        f"Use Phase 2F's tune_match_pair_group_v2 (Issue #2701) instead."
+    )
+
+    # --- Defaults --------------------------------------------------------
+    if tolerance_mm is None:
+        tolerance_mm = group.tolerance
+
+    if max_inserts_per_member is None:
+        if len(group.net_ids) > 4:
+            max_inserts_per_member = MAX_INSERTS_PER_GROUP_MEMBER_LARGE
+        else:
+            max_inserts_per_member = MAX_INSERTS_PER_GROUP_MEMBER_SMALL
+
+    base_config = config or SerpentineConfig()
+    results: dict[int, tuple[Route, TuneResult]] = {}
+
+    # --- Engagement gate: length_critical=False -------------------------
+    # Every member returned by reference with reason="not_length_critical".
+    if not length_critical:
+        for net_id in group.net_ids:
+            route = routes_by_net.get(net_id)
+            if route is None:
+                results[net_id] = (
+                    _empty_route(net_id),
+                    TuneResult(
+                        success=False,
+                        reason="unrouted",
+                        message=f"Net {net_id} is unrouted; nothing to tune.",
+                    ),
+                )
+            else:
+                results[net_id] = (
+                    route,
+                    TuneResult(
+                        success=True,
+                        reason="not_length_critical",
+                        message=(
+                            f"Group {group.name!r} is not length_critical; "
+                            "skipping tuning per engagement gate."
+                        ),
+                    ),
+                )
+        return results
+
+    # --- Determine the reference length ---------------------------------
+    # Use the same policy as MatchGroupTracker.get_reference_length, but
+    # compute it locally from the (possibly mutated) routes_by_net so
+    # the tuner is self-contained and does not require a tracker
+    # instance.  See match_group_length.py:407-436 for the canonical
+    # spec.
+    from .length import LengthTracker  # avoid cycle
+
+    member_lengths: dict[int, float] = {}
+    for net_id in group.net_ids:
+        route = routes_by_net.get(net_id)
+        if route is None:
+            continue
+        member_lengths[net_id] = LengthTracker.calculate_route_length(route)
+
+    # Resolve the reference length per policy.
+    ref_length: float | None
+    if group.reference_net_id is not None:
+        ref_length = member_lengths.get(group.reference_net_id)
+    else:
+        # Longest-in-group default.
+        ref_length = max(member_lengths.values()) if member_lengths else None
+
+    # --- Per-member iteration -------------------------------------------
+    total_inserts_committed = 0  # group-level cumulative counter
+
+    for net_id in group.net_ids:
+        route = routes_by_net.get(net_id)
+        if route is None:
+            results[net_id] = (
+                _empty_route(net_id),
+                TuneResult(
+                    success=False,
+                    reason="unrouted",
+                    message=f"Net {net_id} is unrouted; nothing to tune.",
+                ),
+            )
+            continue
+
+        current_length = member_lengths[net_id]
+
+        # If we couldn't derive a reference, nothing to do.
+        if ref_length is None:
+            results[net_id] = (
+                route,
+                TuneResult(
+                    success=False,
+                    reason="unrouted",
+                    length_before_mm=current_length,
+                    length_after_mm=current_length,
+                    message=(
+                        f"Group {group.name!r} has no derivable reference length "
+                        "(reference net unrouted or no members routed)."
+                    ),
+                ),
+            )
+            continue
+
+        # Explicit-reference member is the pace car; never touch.
+        if group.reference_net_id == net_id:
+            results[net_id] = (
+                route,
+                TuneResult(
+                    success=True,
+                    reason="reference",
+                    length_before_mm=current_length,
+                    length_after_mm=current_length,
+                    message=(
+                        f"Net {net_id} is the explicit reference for group "
+                        f"{group.name!r}; never modified."
+                    ),
+                ),
+            )
+            continue
+
+        delta = ref_length - current_length
+
+        # Already within tolerance -- byte-for-byte unchanged.
+        if abs(delta) <= tolerance_mm:
+            results[net_id] = (
+                route,
+                TuneResult(
+                    success=True,
+                    reason="already_within_tolerance",
+                    length_before_mm=current_length,
+                    length_after_mm=current_length,
+                    message=(
+                        f"Net {net_id} already matched: "
+                        f"|delta|={abs(delta):.4f}mm <= tol={tolerance_mm:.4f}mm"
+                    ),
+                ),
+            )
+            continue
+
+        # Member is LONGER than the reference -- we cannot shorten;
+        # leave it alone.  This is the explicit "longer_than_reference"
+        # case the curator called out as a new reason value vs the
+        # pair tuner.  In the longest-in-group default policy this
+        # branch never fires because the reference IS the longest.
+        # In the explicit "pace-car" policy it fires for any member
+        # that's already longer than the pace-car length.
+        if delta < 0:
+            results[net_id] = (
+                route,
+                TuneResult(
+                    success=True,
+                    reason="longer_than_reference",
+                    length_before_mm=current_length,
+                    length_after_mm=current_length,
+                    message=(
+                        f"Net {net_id} is longer than reference "
+                        f"({current_length:.4f}mm > {ref_length:.4f}mm); "
+                        "tuner cannot remove length."
+                    ),
+                ),
+            )
+            continue
+
+        # --- Cascade loop on this member -----------------------------
+        original_route = route
+        original_segments = route.segments
+        current_route = route
+        current_skew = abs(delta)
+
+        per_member_result = TuneResult(
+            length_before_mm=current_length,
+        )
+
+        # Group-level ceiling check before entering the per-member loop.
+        if total_inserts_committed >= MAX_TOTAL_INSERTS_PER_GROUP:
+            per_member_result.reason = "cascade_budget_exhausted"
+            per_member_result.length_after_mm = current_length
+            per_member_result.message = (
+                f"Group {group.name!r} cumulative budget "
+                f"({MAX_TOTAL_INSERTS_PER_GROUP}) exhausted before tuning "
+                f"net {net_id}; no insertion attempted."
+            )
+            results[net_id] = (original_route, per_member_result)
+            continue
+
+        target_length = ref_length
+
+        # Each iteration: pick segment, compute outer-normal hint
+        # against the rest of the group, attempt one trombone, run
+        # the self-check, commit or reject.
+        for attempt in range(max_inserts_per_member):
+            per_member_result.attempts = attempt + 1
+
+            # Group-level ceiling can trip mid-loop too.
+            if total_inserts_committed >= MAX_TOTAL_INSERTS_PER_GROUP:
+                per_member_result.reason = "cascade_budget_exhausted"
+                per_member_result.message = (
+                    f"Group {group.name!r} cumulative budget "
+                    f"({MAX_TOTAL_INSERTS_PER_GROUP}) exhausted "
+                    f"during tuning of net {net_id}."
+                )
+                current_route = original_route
+                break
+
+            # Pick the insertion segment (shared by both the generator
+            # and the outer-normal calculation).
+            provisional = SerpentineGenerator(base_config)
+            best = provisional.find_best_segment(current_route)
+            if best is None:
+                per_member_result.reason = "no_suitable_segment"
+                per_member_result.message = (
+                    f"No segment long enough for a trombone on net {net_id} "
+                    f"(skew={current_skew:.4f}mm > tol={tolerance_mm:.4f}mm)"
+                )
+                current_route = original_route
+                break
+            _seg_idx, insertion_segment = best
+
+            # Outer-normal hint vs the NEAREST other group member.
+            hint = _outer_normal_hint_group(
+                insertion_segment,
+                candidate_net_id=net_id,
+                group_routes={
+                    other_id: routes_by_net[other_id]
+                    for other_id in group.net_ids
+                    if other_id != net_id and other_id in routes_by_net
+                },
+            )
+
+            # Build the per-attempt config.
+            attempt_config = SerpentineConfig(
+                style=base_config.style,
+                amplitude=base_config.amplitude,
+                min_spacing=base_config.min_spacing,
+                min_segment_length=base_config.min_segment_length,
+                gap_factor=base_config.gap_factor,
+                max_iterations=base_config.max_iterations,
+                side="outer",
+                outer_normal_hint=hint,
+            )
+            attempt_generator = SerpentineGenerator(attempt_config)
+
+            candidate_route, serp_result = attempt_generator.add_serpentine(
+                current_route, target_length
+            )
+            per_member_result.serpentine_results.append(serp_result)
+
+            if not serp_result.success:
+                per_member_result.reason = "no_suitable_segment"
+                per_member_result.message = (
+                    f"Trombone generation failed on net {net_id}: "
+                    f"{serp_result.message}"
+                )
+                current_route = original_route
+                break
+
+            # Post-insertion DRC self-check.
+            if not _post_insertion_clearance_ok_group(
+                new_segments=serp_result.new_segments,
+                candidate_net_id=net_id,
+                group_net_ids=set(group.net_ids),
+                routes_by_net=routes_by_net,
+                intra_group_clearance_mm=intra_group_clearance_mm,
+            ):
+                per_member_result.reason = "post_insertion_drc_violation"
+                per_member_result.length_after_mm = current_length
+                per_member_result.message = (
+                    f"Post-insertion DRC self-check failed on net {net_id} "
+                    f"(intra={intra_group_clearance_mm:.4f}mm); rolled back."
+                )
+                current_route = original_route
+                # Drift-prevention invariant:
+                assert current_route is original_route
+                assert current_route.segments is original_segments
+                break
+
+            # Commit this attempt.
+            current_route = candidate_route
+            per_member_result.inserts_applied += 1
+            total_inserts_committed += 1
+
+            new_length = LengthTracker.calculate_route_length(current_route)
+            current_skew = abs(target_length - new_length)
+
+            if current_skew <= tolerance_mm:
+                per_member_result.success = True
+                per_member_result.reason = "tuned"
+                break
+        else:
+            # for/else: completed max_inserts_per_member without break.
+            per_member_result.reason = (
+                per_member_result.reason or "exceeded_max_inserts"
+            )
+
+        if per_member_result.reason in ("", "exceeded_max_inserts"):
+            per_member_result.message = per_member_result.message or (
+                f"Cascade budget exhausted on net {net_id} "
+                f"(attempts={per_member_result.attempts}, "
+                f"inserts_applied={per_member_result.inserts_applied}, "
+                f"skew={current_skew:.4f}mm vs tol={tolerance_mm:.4f}mm)"
+            )
+
+        # Final length.
+        if per_member_result.inserts_applied > 0:
+            per_member_result.length_after_mm = LengthTracker.calculate_route_length(
+                current_route
+            )
+        else:
+            per_member_result.length_after_mm = current_length
+
+        # Drift-prevention: when rolled back / no inserts committed, the
+        # returned route reference IS the original route reference.
+        if per_member_result.inserts_applied == 0:
+            assert current_route is original_route
+            assert current_route.segments is original_segments
+
+        results[net_id] = (current_route, per_member_result)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Outer-normal hint (N-trace generalization of _outer_normal_hint)
+# ---------------------------------------------------------------------------
+
+
+def _outer_normal_hint_group(
+    segment: Segment,
+    candidate_net_id: int,
+    group_routes: dict[int, Route],
+) -> tuple[float, float]:
+    """Return a unit vector pointing AWAY from the nearest other group member.
+
+    Generalization of
+    :func:`~kicad_tools.router.diffpair_length_tuning._outer_normal_hint`
+    from N=2 (a partner) to N>=3.  Strategy (the curator's "Option (a):
+    nearest-other-trace"):
+
+    1. Compute the midpoint of ``segment``.
+    2. For every other group member, find the closest point on its
+       route to that midpoint (reusing
+       :func:`~kicad_tools.router.diffpair_length_tuning._closest_point_on_segment`
+       byte-for-byte -- no math duplication).
+    3. Pick the *nearest* such closest point as the "partner" for this
+       insertion.
+    4. Return the unit vector from that closest point to the midpoint
+       (i.e. AWAY from that nearest neighbor).
+
+    Args:
+        segment: The segment selected for trombone insertion on the
+            candidate member.
+        candidate_net_id: The net id of the candidate member (excluded
+            from the search; we don't want to bulge "away from ourself").
+        group_routes: ``{net_id: Route}`` lookup for the *other* group
+            members (the candidate is expected to be already removed by
+            the caller; an empty dict triggers the fallback).
+
+    Returns:
+        A unit vector ``(rx, ry)`` in the segment's layer plane.
+        Fallback paths (segment's own geometric perpendicular) fire
+        when:
+
+        * ``group_routes`` is empty (the candidate is the only routed
+          member).
+        * No other member has any segments.
+        * The nearest closest point coincides with the midpoint
+          (magnitude-zero case; same fallback as the pair helper at
+          ``diffpair_length_tuning.py:458-466``).
+    """
+    import math
+
+    # The candidate net id parameter is intentionally accepted for
+    # caller-side clarity (the caller documents the exclusion).  We do
+    # NOT re-filter inside this helper -- the contract is that
+    # ``group_routes`` already excludes the candidate.
+    _ = candidate_net_id
+
+    mx = (segment.x1 + segment.x2) / 2.0
+    my = (segment.y1 + segment.y2) / 2.0
+
+    # Fallback path: no other group members to bulge away from.
+    if not group_routes:
+        dx = segment.x2 - segment.x1
+        dy = segment.y2 - segment.y1
+        length = math.sqrt(dx * dx + dy * dy)
+        if length == 0.0:
+            return (0.0, 1.0)
+        return (-dy / length, dx / length)
+
+    # Find the nearest closest-point across all other members.
+    best_dist_sq = float("inf")
+    best_cx, best_cy = 0.0, 0.0
+    found_any = False
+    for other_route in group_routes.values():
+        for pseg in other_route.segments:
+            cx, cy = _closest_point_on_segment(mx, my, pseg.x1, pseg.y1, pseg.x2, pseg.y2)
+            d2 = (cx - mx) ** 2 + (cy - my) ** 2
+            if d2 < best_dist_sq:
+                best_dist_sq = d2
+                best_cx, best_cy = cx, cy
+                found_any = True
+
+    if not found_any:
+        # All other members have empty segments lists -- fallback.
+        dx = segment.x2 - segment.x1
+        dy = segment.y2 - segment.y1
+        length = math.sqrt(dx * dx + dy * dy)
+        if length == 0.0:
+            return (0.0, 1.0)
+        return (-dy / length, dx / length)
+
+    rx = mx - best_cx
+    ry = my - best_cy
+    mag = math.sqrt(rx * rx + ry * ry)
+    if mag == 0.0:
+        # The nearest neighbor crosses the midpoint exactly; pick the
+        # segment's own perpendicular (same fallback as the pair helper).
+        dx = segment.x2 - segment.x1
+        dy = segment.y2 - segment.y1
+        length = math.sqrt(dx * dx + dy * dy)
+        if length == 0.0:
+            return (0.0, 1.0)
+        return (-dy / length, dx / length)
+    return (rx / mag, ry / mag)
+
+
+# ---------------------------------------------------------------------------
+# Post-insertion DRC self-check (N-trace generalization)
+# ---------------------------------------------------------------------------
+
+
+def _post_insertion_clearance_ok_group(
+    *,
+    new_segments: list[Segment],
+    candidate_net_id: int,
+    group_net_ids: set[int],
+    routes_by_net: dict[int, Route],
+    intra_group_clearance_mm: float,
+) -> bool:
+    """Return True if the proposed serpentine segments are DRC-safe.
+
+    Two-pronged generalization of
+    :func:`~kicad_tools.router.diffpair_length_tuning._post_insertion_clearance_ok`
+    from N=2 (one partner) to N>=3 (the rest of the group + the rest of
+    the board).
+
+    1. **Intra-group clearance**: every new segment is checked against
+       every segment of every OTHER group member (excluding the
+       candidate, whose old segments are being replaced).  Threshold is
+       ``intra_group_clearance_mm``.
+
+    2. **Inter-net clearance**: every new segment is checked against
+       every segment of every routed net that is NOT a group member.
+       Threshold is also ``intra_group_clearance_mm`` as a conservative
+       floor (mirrors the pair tuner's single-threshold policy).
+
+    Reuses :func:`segment_clearance` and the ``clearance + 1e-9 <
+    threshold`` epsilon byte-for-byte from
+    :func:`~kicad_tools.router.diffpair_length_tuning._post_insertion_clearance_ok`
+    (do NOT inline alternate geometry).
+
+    Args:
+        new_segments: The trombone segments produced by
+            :meth:`SerpentineGenerator.generate_trombone`.
+        candidate_net_id: Net id of the trace receiving the trombone.
+            Used as the exclusion set for the inter-net pass; the
+            intra-group pass excludes it implicitly (the candidate is
+            checked against the OTHER group members).
+        group_net_ids: The full set of group member net ids.  Used to
+            partition the board into "group members" (pass 1) and
+            "non-group neighbors" (pass 2).
+        routes_by_net: ``{net_id: Route}`` lookup for all routed nets.
+        intra_group_clearance_mm: Edge-to-edge clearance floor in mm.
+
+    Returns:
+        ``True`` if no clearance violation is introduced; ``False``
+        otherwise (the caller must roll back).
+    """
+    from kicad_tools.core.geometry import segment_clearance
+
+    # Pass 1: intra-group.  Every other group member.
+    for other_id in group_net_ids:
+        if other_id == candidate_net_id:
+            continue
+        other_route = routes_by_net.get(other_id)
+        if other_route is None:
+            continue
+        for new_seg in new_segments:
+            for pseg in other_route.segments:
+                if pseg.layer != new_seg.layer:
+                    continue
+                clearance = segment_clearance(
+                    new_seg.x1,
+                    new_seg.y1,
+                    new_seg.x2,
+                    new_seg.y2,
+                    new_seg.width,
+                    pseg.x1,
+                    pseg.y1,
+                    pseg.x2,
+                    pseg.y2,
+                    pseg.width,
+                )
+                if clearance + 1e-9 < intra_group_clearance_mm:
+                    return False
+
+    # Pass 2: inter-net.  Every non-group routed net.
+    for other_net_id, other_route in routes_by_net.items():
+        if other_net_id == candidate_net_id:
+            continue
+        if other_net_id in group_net_ids:
+            continue
+        for new_seg in new_segments:
+            for oseg in other_route.segments:
+                if oseg.layer != new_seg.layer:
+                    continue
+                clearance = segment_clearance(
+                    new_seg.x1,
+                    new_seg.y1,
+                    new_seg.x2,
+                    new_seg.y2,
+                    new_seg.width,
+                    oseg.x1,
+                    oseg.y1,
+                    oseg.x2,
+                    oseg.y2,
+                    oseg.width,
+                )
+                if clearance + 1e-9 < intra_group_clearance_mm:
+                    return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _empty_route(net_id: int) -> Route:
+    """Return an empty :class:`Route` shell for an unrouted net.
+
+    Used as a placeholder in the return value of
+    :func:`tune_match_group_v2` when a group member is unrouted.  The
+    caller can detect the situation via
+    ``result.reason == "unrouted"`` and the empty ``.segments`` list.
+    """
+    from .primitives import Route
+
+    return Route(net=net_id, net_name=f"net_{net_id}", segments=[], vias=[])
+
+
+# Compatibility re-exports.
+__all__ = [
+    "MAX_INSERTS_PER_GROUP_MEMBER",
+    "MAX_INSERTS_PER_GROUP_MEMBER_LARGE",
+    "MAX_INSERTS_PER_GROUP_MEMBER_SMALL",
+    "MAX_TOTAL_INSERTS_PER_GROUP",
+    "TuneResult",
+    "tune_match_group_v2",
+]
+
+
+# Reference suppression for static linters: MAX_INSERTS_PER_PAIR is
+# imported so the drift-prevention test
+# (MAX_INSERTS_PER_GROUP_MEMBER_SMALL == MAX_INSERTS_PER_PAIR) does not
+# require an extra import side.
+_ = MAX_INSERTS_PER_PAIR  # noqa: F401

--- a/src/kicad_tools/router/match_group_tuning.py
+++ b/src/kicad_tools/router/match_group_tuning.py
@@ -540,8 +540,7 @@ def tune_match_group_v2(
             if not serp_result.success:
                 per_member_result.reason = "no_suitable_segment"
                 per_member_result.message = (
-                    f"Trombone generation failed on net {net_id}: "
-                    f"{serp_result.message}"
+                    f"Trombone generation failed on net {net_id}: {serp_result.message}"
                 )
                 current_route = original_route
                 break
@@ -580,9 +579,7 @@ def tune_match_group_v2(
                 break
         else:
             # for/else: completed max_inserts_per_member without break.
-            per_member_result.reason = (
-                per_member_result.reason or "exceeded_max_inserts"
-            )
+            per_member_result.reason = per_member_result.reason or "exceeded_max_inserts"
 
         if per_member_result.reason in ("", "exceeded_max_inserts"):
             per_member_result.message = per_member_result.message or (
@@ -594,9 +591,7 @@ def tune_match_group_v2(
 
         # Final length.
         if per_member_result.inserts_applied > 0:
-            per_member_result.length_after_mm = LengthTracker.calculate_route_length(
-                current_route
-            )
+            per_member_result.length_after_mm = LengthTracker.calculate_route_length(current_route)
         else:
             per_member_result.length_after_mm = current_length
 

--- a/tests/test_match_group_tuning.py
+++ b/tests/test_match_group_tuning.py
@@ -1,0 +1,790 @@
+"""N-trace match-group serpentine tuner tests.
+
+Issue #2700, Epic #2661 Phase 2E.
+
+This module verifies the curator-specified mitigations of
+:func:`kicad_tools.router.match_group_tuning.tune_match_group_v2`:
+
+1. **Reference-policy semantics** (longest + pace-car + longer-than-reference).
+2. **Outer-normal generalization to N>=3** (nearest-other-trace heuristic).
+3. **Per-insertion DRC self-check** with byte-for-byte rollback (intra-group
+   AND non-group neighbor variants).
+4. **Cascade-safety budget** (per-member SMALL / LARGE branches + group-level
+   ceiling).
+5. **Phase 2F handoff guard** (``pair_ids`` precondition).
+6. **Drift-prevention** -- ``LengthTracker.calculate_route_length`` is the
+   single source of truth; tuner's untouched routes preserve ``is``-identity.
+7. **Module-level invariants** (constants drift-prevention).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.router.diffpair_length_tuning import MAX_INSERTS_PER_PAIR
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.match_group_length import MatchGroup, MatchGroupSource
+from kicad_tools.router.match_group_tuning import (
+    MAX_INSERTS_PER_GROUP_MEMBER,
+    MAX_INSERTS_PER_GROUP_MEMBER_LARGE,
+    MAX_INSERTS_PER_GROUP_MEMBER_SMALL,
+    MAX_TOTAL_INSERTS_PER_GROUP,
+    TuneResult,
+    _outer_normal_hint_group,
+    _post_insertion_clearance_ok_group,
+    tune_match_group_v2,
+)
+from kicad_tools.router.optimizer.serpentine import (
+    SerpentineConfig,
+    SerpentineGenerator,
+)
+from kicad_tools.router.primitives import Route, Segment
+
+# =============================================================================
+# Test helpers
+# =============================================================================
+
+
+def _straight_route(
+    net_id: int,
+    name: str,
+    length_mm: float,
+    y: float = 0.0,
+    layer: Layer = Layer.F_CU,
+) -> Route:
+    """Single horizontal segment along +x at y=``y``."""
+    return Route(
+        net=net_id,
+        net_name=name,
+        segments=[
+            Segment(
+                x1=0.0,
+                y1=y,
+                x2=length_mm,
+                y2=y,
+                width=0.2,
+                layer=layer,
+                net=net_id,
+                net_name=name,
+            )
+        ],
+    )
+
+
+def _ddr_group(
+    name: str = "DDR_DATA",
+    net_ids: list[int] | None = None,
+    tolerance: float = 0.1,
+    reference_net_id: int | None = None,
+) -> MatchGroup:
+    if net_ids is None:
+        net_ids = [1, 2, 3, 4]
+    return MatchGroup(
+        name=name,
+        net_ids=net_ids,
+        tolerance=tolerance,
+        reference_net_id=reference_net_id,
+        source=MatchGroupSource.LEGACY_API,
+    )
+
+
+# =============================================================================
+# 1. Reference policy -- longest-in-group default
+# =============================================================================
+
+
+class TestReferencePolicyLongest:
+    """When ``reference_net_id is None`` the target is the longest member."""
+
+    def test_longest_is_target_for_4_net_group(self):
+        # Lengths: 10, 11, 12, 9 mm.  Reference = longest = 12.
+        # Net 3 (12mm) should be left alone; the others need lengthening.
+        group = _ddr_group(net_ids=[1, 2, 3, 4], tolerance=0.1)
+        routes = {
+            1: _straight_route(1, "D0", 20.0, y=0.0),
+            2: _straight_route(2, "D1", 20.0, y=2.0),
+            3: _straight_route(3, "D2", 22.0, y=4.0),
+            4: _straight_route(4, "D3", 18.0, y=6.0),
+        }
+        # Override actual lengths via the segment x2 above: 20, 20, 22, 18.
+        # Reference = 22.  Deltas: net1=2, net2=2, net3=0, net4=4.
+
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.5,
+            intra_group_clearance_mm=0.2,
+            config=SerpentineConfig(amplitude=0.5, gap_factor=2.0),
+        )
+
+        # Net 3 is the longest -> already_within_tolerance.
+        assert results[3][1].reason == "already_within_tolerance"
+        assert results[3][0] is routes[3]
+        assert results[3][0].segments is routes[3].segments
+        # Net 1, 2, 4 need tuning.  They should at least attempt.
+        for nid in (1, 2, 4):
+            assert results[nid][1].attempts >= 1 or results[nid][1].reason == "tuned"
+
+
+# =============================================================================
+# 2. Reference policy -- pace-car (explicit reference net)
+# =============================================================================
+
+
+class TestReferencePolicyPaceCar:
+    """``reference_net_id = N`` targets net N's length (pace-car)."""
+
+    def test_pace_car_net_is_never_modified(self):
+        # Reference = net 2 (11mm).  Net 3 (12mm) is LONGER than reference
+        # -> longer_than_reference (the curator's new reason value).
+        group = _ddr_group(
+            net_ids=[1, 2, 3, 4],
+            tolerance=0.1,
+            reference_net_id=2,
+        )
+        routes = {
+            1: _straight_route(1, "D0", 10.0, y=0.0),
+            2: _straight_route(2, "D1", 11.0, y=2.0),
+            3: _straight_route(3, "D2", 12.0, y=4.0),
+            4: _straight_route(4, "D3", 9.0, y=6.0),
+        }
+
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.5,
+            intra_group_clearance_mm=0.2,
+            config=SerpentineConfig(amplitude=0.5, gap_factor=2.0),
+        )
+
+        # Net 2 is the explicit reference -> reason="reference", unchanged.
+        assert results[2][1].reason == "reference"
+        assert results[2][0] is routes[2]
+        assert results[2][0].segments is routes[2].segments
+        assert results[2][1].success is True
+
+    def test_longer_than_reference_reason_is_distinct(self):
+        # Reference = net 2 (11mm).  Net 3 (12mm) is longer -> can't shorten.
+        # This must use the new reason "longer_than_reference", NOT
+        # "reference" (which is for THE reference itself).
+        group = _ddr_group(
+            net_ids=[1, 2, 3, 4],
+            tolerance=0.1,
+            reference_net_id=2,
+        )
+        routes = {
+            1: _straight_route(1, "D0", 10.0, y=0.0),
+            2: _straight_route(2, "D1", 11.0, y=2.0),
+            3: _straight_route(3, "D2", 12.0, y=4.0),
+            4: _straight_route(4, "D3", 9.0, y=6.0),
+        }
+
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.1,
+            intra_group_clearance_mm=0.2,
+            config=SerpentineConfig(amplitude=0.5, gap_factor=2.0),
+        )
+
+        # Net 3 is longer than the 11mm pace-car.
+        assert results[3][1].reason == "longer_than_reference"
+        assert results[3][0] is routes[3]
+        assert results[3][0].segments is routes[3].segments
+        # Distinct from "reference" -- the reference itself has the other reason.
+        assert results[2][1].reason == "reference"
+        assert results[2][1].reason != results[3][1].reason
+
+
+# =============================================================================
+# 3. Engagement gate -- length_critical=False
+# =============================================================================
+
+
+class TestEngagementGate:
+    """Groups whose net class is not length-critical are not tuned."""
+
+    def test_length_critical_false_returns_unchanged(self):
+        group = _ddr_group(net_ids=[1, 2, 3, 4], tolerance=0.1)
+        routes = {
+            1: _straight_route(1, "D0", 10.0, y=0.0),
+            2: _straight_route(2, "D1", 11.0, y=2.0),
+            3: _straight_route(3, "D2", 12.0, y=4.0),
+            4: _straight_route(4, "D3", 9.0, y=6.0),
+        }
+        original_segments = {nid: r.segments for nid, r in routes.items()}
+
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.1,
+            intra_group_clearance_mm=0.2,
+            length_critical=False,
+        )
+
+        for nid in group.net_ids:
+            assert results[nid][1].reason == "not_length_critical"
+            assert results[nid][1].success is True
+            assert results[nid][0] is routes[nid]
+            assert results[nid][0].segments is original_segments[nid]
+
+
+# =============================================================================
+# 4. Outer-normal generalization (nearest-other-trace heuristic)
+# =============================================================================
+
+
+class TestOuterNormalGeneralization:
+    """Three parallel traces: the inserted serpentine bulges to one side only."""
+
+    def test_three_traces_bulge_does_not_cross_other_members(self):
+        # Stacked horizontal traces at y=0, y=2, y=4 (mm).  Tune the
+        # MIDDLE trace (y=2).  Lengths 6, 5, 8 -- middle is 5, reference
+        # is the longest (8mm @ y=4) so the middle should bulge UP toward
+        # the reference's outer side OR DOWN toward y=0.  Either is OK,
+        # but NOT both (verifies outer-normal-only).
+        group = _ddr_group(net_ids=[1, 2, 3], tolerance=0.1)
+        routes = {
+            1: _straight_route(1, "T0", 6.0, y=0.0),
+            2: _straight_route(2, "T1", 5.0, y=2.0),
+            3: _straight_route(3, "T2", 8.0, y=4.0),
+        }
+        # Reference = longest = net 3 (8mm); net 2 needs +3mm.
+
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.5,
+            intra_group_clearance_mm=0.1,
+            config=SerpentineConfig(amplitude=0.5, gap_factor=2.0),
+        )
+
+        net2_route = results[2][0]
+        net2_result = results[2][1]
+        if net2_result.inserts_applied >= 1:
+            ys: list[float] = []
+            for seg in net2_route.segments:
+                ys.append(seg.y1)
+                ys.append(seg.y2)
+            # NOT both sides simultaneously.  Verifies single-sided
+            # outer-normal-only bulge.
+            went_up = max(ys) > 2.0 + 1e-6
+            went_down = min(ys) < 2.0 - 1e-6
+            assert went_up != went_down, (
+                f"Trombone leaked to both sides: y range = [{min(ys)}, {max(ys)}]; "
+                "outer-normal-only invariant violated."
+            )
+
+    def test_outer_normal_hint_falls_back_when_no_other_members(self):
+        """The helper falls back to the segment's perpendicular when no neighbors."""
+        seg = Segment(
+            x1=0.0,
+            y1=0.0,
+            x2=10.0,
+            y2=0.0,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=1,
+            net_name="T0",
+        )
+        hint = _outer_normal_hint_group(seg, candidate_net_id=1, group_routes={})
+        # Horizontal segment -> perpendicular is +/-y.  The default
+        # fallback yields (0, 1) for a horizontal segment.
+        import math
+
+        mag = math.sqrt(hint[0] ** 2 + hint[1] ** 2)
+        assert mag == pytest.approx(1.0, abs=1e-9), "Fallback hint must be unit vector"
+
+    def test_outer_normal_hint_uses_nearest_neighbor(self):
+        """When two other members are present, the hint points away from the nearer."""
+        # Segment at y=2 (the candidate).  Other members at y=0 (closer)
+        # and y=10 (farther).  The hint should point AWAY from y=0,
+        # i.e. +y direction.
+        seg = Segment(
+            x1=0.0,
+            y1=2.0,
+            x2=10.0,
+            y2=2.0,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=99,
+            net_name="cand",
+        )
+        near = _straight_route(1, "near", 10.0, y=0.0)
+        far = _straight_route(2, "far", 10.0, y=10.0)
+        hint = _outer_normal_hint_group(
+            seg,
+            candidate_net_id=99,
+            group_routes={1: near, 2: far},
+        )
+        # Y component should be positive (away from y=0, the nearer one).
+        assert hint[1] > 0.0, (
+            f"Hint y-component {hint[1]} should be positive "
+            "(pointing AWAY from nearer neighbor at y=0)"
+        )
+
+
+# =============================================================================
+# 5. Cascade-safety budget
+# =============================================================================
+
+
+class TestCascadeBudget:
+    """Per-member SMALL / LARGE branches + group-level cumulative ceiling."""
+
+    def test_small_group_default_is_three(self):
+        """``len(net_ids) <= 4`` -> MAX_INSERTS_PER_GROUP_MEMBER_SMALL."""
+        # 4-net group; unreachable target.  Spy on add_serpentine; the
+        # cumulative count for the four members must be at most 4*3 = 12.
+        group = _ddr_group(net_ids=[1, 2, 3, 4], tolerance=0.01)
+        routes = {
+            1: _straight_route(1, "D0", 50.0, y=0.0),
+            2: _straight_route(2, "D1", 50.0, y=2.0),
+            3: _straight_route(3, "D2", 50.0, y=4.0),
+            4: _straight_route(4, "D3", 100.0, y=6.0),  # unreachable target
+        }
+        cfg = SerpentineConfig(
+            amplitude=0.1,
+            min_spacing=0.2,
+            gap_factor=2.0,
+            max_iterations=2,
+        )
+
+        orig_add = SerpentineGenerator.add_serpentine
+        call_count = {"n": 0}
+
+        def spy(self, route, target_length, grid=None):
+            call_count["n"] += 1
+            return orig_add(self, route, target_length, grid)
+
+        with patch.object(SerpentineGenerator, "add_serpentine", spy):
+            tune_match_group_v2(
+                group,
+                routes,
+                tolerance_mm=0.01,
+                intra_group_clearance_mm=0.2,
+                config=cfg,
+            )
+
+        # 4 members, 3 of which need tuning, at MAX_INSERTS_SMALL=3 each
+        # -> 3 * 3 = 9 attempts max.  (Reference net is unchanged.)
+        # The group-level ceiling (16) is permissive enough to not fire.
+        assert call_count["n"] <= 3 * MAX_INSERTS_PER_GROUP_MEMBER_SMALL
+
+    def test_large_group_default_is_two(self):
+        """``len(net_ids) > 4`` -> MAX_INSERTS_PER_GROUP_MEMBER_LARGE."""
+        # 6 nets, no override -> LARGE branch active.  All members need
+        # unreachable tuning except the longest.  Per-member cap is 2,
+        # not 3 -- verify by spy.
+        net_ids = list(range(1, 7))  # 1..6
+        group = _ddr_group(net_ids=net_ids, tolerance=0.01)
+        routes = {
+            nid: _straight_route(nid, f"D{nid}", 50.0, y=float(nid) * 2.0) for nid in net_ids[:-1]
+        }
+        # Last net is the reference (longest).
+        routes[net_ids[-1]] = _straight_route(net_ids[-1], "DR", 100.0, y=12.0)
+
+        cfg = SerpentineConfig(
+            amplitude=0.1,
+            min_spacing=0.2,
+            gap_factor=2.0,
+            max_iterations=2,
+        )
+
+        orig_add = SerpentineGenerator.add_serpentine
+        call_count = {"n": 0}
+
+        def spy(self, route, target_length, grid=None):
+            call_count["n"] += 1
+            return orig_add(self, route, target_length, grid)
+
+        with patch.object(SerpentineGenerator, "add_serpentine", spy):
+            results = tune_match_group_v2(
+                group,
+                routes,
+                tolerance_mm=0.01,
+                intra_group_clearance_mm=0.2,
+                config=cfg,
+            )
+
+        # 5 non-reference members at MAX_INSERTS_LARGE=2 each -> 10 max.
+        # Also constrained by the group ceiling (16) -- which doesn't trip.
+        assert call_count["n"] <= 5 * MAX_INSERTS_PER_GROUP_MEMBER_LARGE
+        # Each non-reference member reports the correct attempts ceiling.
+        for nid in net_ids[:-1]:
+            assert results[nid][1].attempts <= MAX_INSERTS_PER_GROUP_MEMBER_LARGE
+
+    def test_max_total_inserts_per_group_caps_cumulative_count(self):
+        """The group-level ceiling fires for pathological cases."""
+        # 10-net group, unreachable target.  Per-member budget = LARGE = 2;
+        # cumulative worst case = 10*2 = 20, but MAX_TOTAL = 16 caps it.
+        net_ids = list(range(1, 11))
+        group = _ddr_group(net_ids=net_ids, tolerance=0.01)
+        routes = {
+            nid: _straight_route(nid, f"D{nid}", 50.0, y=float(nid) * 2.0) for nid in net_ids[:-1]
+        }
+        routes[net_ids[-1]] = _straight_route(net_ids[-1], "DR", 200.0, y=20.0)
+
+        cfg = SerpentineConfig(
+            amplitude=0.1,
+            min_spacing=0.2,
+            gap_factor=2.0,
+            max_iterations=2,
+        )
+
+        # Set the threshold so DRC always passes (huge clearance, no
+        # neighbors at distance).  Inserts should commit each time.
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.01,
+            intra_group_clearance_mm=0.2,
+            config=cfg,
+        )
+
+        total = sum(r[1].inserts_applied for r in results.values())
+        assert total <= MAX_TOTAL_INSERTS_PER_GROUP, (
+            f"Total inserts {total} exceeded MAX_TOTAL_INSERTS_PER_GROUP "
+            f"({MAX_TOTAL_INSERTS_PER_GROUP})"
+        )
+
+    def test_override_max_inserts_per_member(self):
+        """Explicit ``max_inserts_per_member`` overrides the SMALL/LARGE default."""
+        group = _ddr_group(net_ids=[1, 2, 3, 4], tolerance=0.01)
+        routes = {
+            1: _straight_route(1, "D0", 50.0, y=0.0),
+            2: _straight_route(2, "D1", 50.0, y=2.0),
+            3: _straight_route(3, "D2", 50.0, y=4.0),
+            4: _straight_route(4, "D3", 100.0, y=6.0),
+        }
+        cfg = SerpentineConfig(amplitude=0.1, max_iterations=2)
+
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.01,
+            intra_group_clearance_mm=0.2,
+            config=cfg,
+            max_inserts_per_member=1,  # override
+        )
+
+        for nid in (1, 2, 3):
+            assert results[nid][1].attempts <= 1
+
+
+# =============================================================================
+# 6. Post-insertion DRC self-check + byte-for-byte rollback
+# =============================================================================
+
+
+class TestPostInsertionDRC:
+    """Rollback fires for intra-group AND non-group neighbor variants."""
+
+    def test_intra_group_rollback(self):
+        """A bulge that would collide with another group member is rolled back."""
+        # 3 traces stacked.  We want to tune net 1 (shorter) and have its
+        # bulge land into net 2's clearance zone.
+        group = _ddr_group(net_ids=[1, 2, 3], tolerance=0.1)
+        # net 1 at y=0 (short, 10mm); net 2 at y=0.5 (very close!);
+        # net 3 at y=5 (the reference, 15mm).  Net 1's bulge in either
+        # direction near y=0.5 will collide with net 2.
+        # The bulge direction is determined by the nearest-other-trace
+        # heuristic: closest neighbor to net 1's mid-segment is net 2
+        # (y=0.5), so the bulge goes to y<0 (negative).  But then
+        # the DRC pass 1 against other group members will check vs
+        # net 3 (y=5, layer F_CU) -- no collision there.
+        # To force rollback let's place net 2 at y=-0.1 (below net 1
+        # by 0.1mm).  Net 2 is the nearest neighbor; bulge points to
+        # y>0.  Net 3 sits at y=5, no collision.  But we want rollback.
+        # Instead: place net 2 such that whichever way the bulge goes,
+        # it collides.  Simpler: place net 3 (large group member) very
+        # close to net 1 on the OPPOSITE side from net 2.  But this is
+        # what we want to test.
+        # Concrete: net 1 at y=0; net 2 at y=2 (the nearest neighbor);
+        # net 3 at y=-0.3 (also a group member, very close on the other side).
+        # The bulge will go to y<0 (away from net 2 @ y=2) -> bulges
+        # into net 3 @ y=-0.3 -> intra-group rollback.
+        routes = {
+            1: _straight_route(1, "D0", 10.0, y=0.0),
+            2: _straight_route(2, "D1", 10.0, y=2.0),
+            3: _straight_route(3, "D2", 15.0, y=-0.3),
+        }
+        original_net1 = routes[1]
+        original_net1_segments = routes[1].segments
+
+        cfg = SerpentineConfig(amplitude=0.5, min_spacing=0.2, gap_factor=2.0)
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.1,
+            intra_group_clearance_mm=0.4,  # large enough to trip
+            config=cfg,
+            max_inserts_per_member=1,
+        )
+
+        # Net 1's bulge collides with net 3 (intra-group) -> rollback.
+        assert results[1][1].reason == "post_insertion_drc_violation"
+        assert results[1][0] is original_net1
+        assert results[1][0].segments is original_net1_segments
+
+    def test_non_group_neighbor_rollback(self):
+        """A bulge that would collide with a non-group routed net is rolled back."""
+        # 3 group members + 1 non-group neighbor placed where the bulge
+        # would land.
+        group = _ddr_group(net_ids=[1, 2, 3], tolerance=0.1)
+        routes = {
+            1: _straight_route(1, "D0", 10.0, y=0.0),
+            2: _straight_route(2, "D1", 10.0, y=2.0),
+            3: _straight_route(3, "D2", 15.0, y=4.0),
+            # Non-group net 99: close enough to net 1's outer-normal bulge
+            # (which is away from the nearest other group member -- net 2 @ y=2 --
+            # so the bulge goes to y < 0).  Place neighbor at y=-0.5.
+            99: _straight_route(99, "VCC", 10.0, y=-0.5),
+        }
+        original_net1 = routes[1]
+        original_net1_segments = routes[1].segments
+
+        cfg = SerpentineConfig(amplitude=0.5, min_spacing=0.2, gap_factor=2.0)
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.1,
+            intra_group_clearance_mm=0.6,  # tight enough to trip
+            config=cfg,
+            max_inserts_per_member=1,
+        )
+
+        # Net 1's bulge collides with net 99 (non-group) -> rollback.
+        assert results[1][1].reason == "post_insertion_drc_violation"
+        assert results[1][0] is original_net1
+        assert results[1][0].segments is original_net1_segments
+
+    def test_post_insertion_clearance_ok_group_pass(self):
+        """Direct unit test on the DRC helper -- happy path."""
+        new_seg = Segment(
+            x1=0.0,
+            y1=10.0,
+            x2=5.0,
+            y2=10.0,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=1,
+            net_name="D0",
+        )
+        # Other group member far away.
+        other = _straight_route(2, "D1", 10.0, y=0.0)
+        routes_by_net = {1: _straight_route(1, "D0", 5.0, y=0.0), 2: other}
+        ok = _post_insertion_clearance_ok_group(
+            new_segments=[new_seg],
+            candidate_net_id=1,
+            group_net_ids={1, 2},
+            routes_by_net=routes_by_net,
+            intra_group_clearance_mm=0.5,
+        )
+        assert ok is True
+
+    def test_post_insertion_clearance_ok_group_fail_intra(self):
+        """Direct unit test on the DRC helper -- intra-group failure."""
+        new_seg = Segment(
+            x1=0.0,
+            y1=0.1,
+            x2=5.0,
+            y2=0.1,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=1,
+            net_name="D0",
+        )
+        other = _straight_route(2, "D1", 10.0, y=0.0)
+        routes_by_net = {1: _straight_route(1, "D0", 5.0, y=5.0), 2: other}
+        ok = _post_insertion_clearance_ok_group(
+            new_segments=[new_seg],
+            candidate_net_id=1,
+            group_net_ids={1, 2},
+            routes_by_net=routes_by_net,
+            intra_group_clearance_mm=0.5,
+        )
+        assert ok is False
+
+
+# =============================================================================
+# 7. Already within tolerance -- byte-for-byte unchanged
+# =============================================================================
+
+
+class TestAlreadyWithinTolerance:
+    """A group already meeting tolerance returns every member by reference."""
+
+    def test_all_members_within_tolerance_unchanged(self):
+        # All four members within 0.1mm of the longest.
+        group = _ddr_group(net_ids=[1, 2, 3, 4], tolerance=0.5)
+        routes = {
+            1: _straight_route(1, "D0", 10.00, y=0.0),
+            2: _straight_route(2, "D1", 10.05, y=2.0),
+            3: _straight_route(3, "D2", 10.10, y=4.0),
+            4: _straight_route(4, "D3", 10.02, y=6.0),
+        }
+        original_segments = {nid: r.segments for nid, r in routes.items()}
+
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.5,
+            intra_group_clearance_mm=0.2,
+        )
+
+        for nid in group.net_ids:
+            assert results[nid][1].reason == "already_within_tolerance"
+            assert results[nid][1].success is True
+            assert results[nid][0] is routes[nid]
+            assert results[nid][0].segments is original_segments[nid]
+
+
+# =============================================================================
+# 8. Drift-prevention -- single source of truth for segment math
+# =============================================================================
+
+
+class TestDriftPrevention:
+    """``LengthTracker.calculate_route_length`` is the single source of truth."""
+
+    @pytest.mark.parametrize("group_size", [3, 5, 10])
+    def test_calculate_route_length_is_called_on_every_member(self, group_size):
+        """The tuner must use LengthTracker, not inline its own segment math."""
+        net_ids = list(range(1, group_size + 1))
+        group = _ddr_group(net_ids=net_ids, tolerance=0.001)
+        # Make ALL members the same length so the tuner short-circuits
+        # to already_within_tolerance after measuring; no serpentine
+        # generation happens.  This isolates the measurement call site.
+        routes = {nid: _straight_route(nid, f"D{nid}", 10.0, y=float(nid) * 2.0) for nid in net_ids}
+        original_segments = {nid: r.segments for nid, r in routes.items()}
+
+        from kicad_tools.router.length import LengthTracker
+
+        orig_calc = LengthTracker.calculate_route_length
+        call_count = {"n": 0}
+
+        def spy(route):
+            call_count["n"] += 1
+            return orig_calc(route)
+
+        with patch.object(LengthTracker, "calculate_route_length", spy):
+            results = tune_match_group_v2(
+                group,
+                routes,
+                tolerance_mm=0.001,
+                intra_group_clearance_mm=0.2,
+            )
+
+        # At minimum, the tuner measures every member once (entry).
+        assert call_count["n"] >= group_size, (
+            f"Expected >= {group_size} calls to calculate_route_length, "
+            f"got {call_count['n']}; tuner may have inlined segment math."
+        )
+
+        # Equal lengths -> already_within_tolerance for every member.
+        for nid in net_ids:
+            assert results[nid][1].reason == "already_within_tolerance"
+            assert results[nid][0] is routes[nid]
+            assert results[nid][0].segments is original_segments[nid]
+
+
+# =============================================================================
+# 9. Phase 2F handoff guard -- pair_ids precondition
+# =============================================================================
+
+
+class TestPhase2FHandoff:
+    """``MatchGroup.pair_ids`` must be empty for Phase 2E."""
+
+    def test_pair_ids_assertion_fires_with_clear_message(self):
+        group = MatchGroup(
+            name="MIPI_LANE0",
+            net_ids=[1],
+            pair_ids=[(2, 3)],  # Phase 2F territory
+            tolerance=0.05,
+            source=MatchGroupSource.LEGACY_API,
+        )
+        routes = {
+            1: _straight_route(1, "CLK_P", 10.0, y=0.0),
+            2: _straight_route(2, "DAT0_P", 10.0, y=2.0),
+            3: _straight_route(3, "DAT0_N", 10.0, y=4.0),
+        }
+        with pytest.raises(AssertionError, match="Phase 2F"):
+            tune_match_group_v2(
+                group,
+                routes,
+                tolerance_mm=0.05,
+                intra_group_clearance_mm=0.2,
+            )
+
+
+# =============================================================================
+# 10. Unrouted members
+# =============================================================================
+
+
+class TestUnroutedMembers:
+    """Unrouted members are reported but do not crash the tuner."""
+
+    def test_one_unrouted_member_returns_unrouted_reason(self):
+        group = _ddr_group(net_ids=[1, 2, 3, 4], tolerance=0.1)
+        routes = {
+            1: _straight_route(1, "D0", 10.0, y=0.0),
+            2: _straight_route(2, "D1", 11.0, y=2.0),
+            # Net 3 missing.
+            4: _straight_route(4, "D3", 12.0, y=6.0),
+        }
+
+        results = tune_match_group_v2(
+            group,
+            routes,
+            tolerance_mm=0.5,
+            intra_group_clearance_mm=0.2,
+        )
+
+        assert 3 in results
+        assert results[3][1].reason == "unrouted"
+        assert results[3][1].success is False
+        # Net 4 is the longest among the routed -> already_within_tolerance.
+        assert results[4][1].reason == "already_within_tolerance"
+
+
+# =============================================================================
+# 11. Module-level invariants -- constants drift-prevention
+# =============================================================================
+
+
+class TestModuleInvariants:
+    """Constants must stay aligned with the pair tuner and with each other."""
+
+    def test_max_inserts_small_equals_max_inserts_per_pair(self):
+        """SMALL budget MUST equal pair budget (the curator's drift-prevention)."""
+        # A future change touching either constant without the other fires.
+        assert MAX_INSERTS_PER_GROUP_MEMBER_SMALL == MAX_INSERTS_PER_PAIR == 3
+
+    def test_max_inserts_large_is_two(self):
+        assert MAX_INSERTS_PER_GROUP_MEMBER_LARGE == 2
+
+    def test_max_total_inserts_per_group_is_sixteen(self):
+        assert MAX_TOTAL_INSERTS_PER_GROUP == 16
+
+    def test_max_total_inserts_per_group_floor(self):
+        """Sanity: total ceiling >= 2 * per-member-large."""
+        assert MAX_TOTAL_INSERTS_PER_GROUP >= 2 * MAX_INSERTS_PER_GROUP_MEMBER_LARGE
+
+    def test_default_alias_matches_small(self):
+        """``MAX_INSERTS_PER_GROUP_MEMBER`` (alias) == SMALL."""
+        assert MAX_INSERTS_PER_GROUP_MEMBER == MAX_INSERTS_PER_GROUP_MEMBER_SMALL
+
+    def test_tune_result_dataclass_defaults(self):
+        r = TuneResult()
+        assert r.success is False
+        assert r.reason == ""
+        assert r.attempts == 0
+        assert r.inserts_applied == 0
+        assert r.length_before_mm == 0.0
+        assert r.length_after_mm == 0.0
+        assert r.serpentine_results == []


### PR DESCRIPTION
## Summary

Implements Phase 2E of Epic #2661: N-trace generalization of the differential-pair length-skew tuner (PR #2663) from N=2 to N>=3. Introduces `tune_match_group_v2` for DDR data bytes, MIPI lane groups, and generic parallel buses, with byte-for-byte rollback, nearest-other-trace outer-normal heuristic, and cascade-safety budget tuned for N>4.

## Changes

- **NEW** `src/kicad_tools/router/match_group_tuning.py` (~480 LoC including docstrings)
  - `tune_match_group_v2(group, routes_by_net, *, tolerance_mm, intra_group_clearance_mm, config, max_inserts_per_member, length_critical) -> dict[net_id, (Route, TuneResult)]`
  - `TuneResult` dataclass with reasons: `tuned`, `already_within_tolerance`, `reference`, `longer_than_reference` (NEW for the pace-car case), `exceeded_max_inserts`, `cascade_budget_exhausted` (NEW for group ceiling), `post_insertion_drc_violation`, `no_suitable_segment`, `unrouted`, `not_length_critical`
  - `_outer_normal_hint_group` -- nearest-other-trace heuristic (curator's Option (a)), reuses `_closest_point_on_segment` from the pair tuner byte-for-byte
  - `_post_insertion_clearance_ok_group` -- two-pronged DRC self-check (intra-group + inter-net) reusing `segment_clearance` and the `1e-9` epsilon byte-for-byte
  - `MAX_INSERTS_PER_GROUP_MEMBER_SMALL=3` (N<=4, matches `MAX_INSERTS_PER_PAIR`)
  - `MAX_INSERTS_PER_GROUP_MEMBER_LARGE=2` (N>4)
  - `MAX_TOTAL_INSERTS_PER_GROUP=16` (curator's hard cap)
  - `assert not group.pair_ids` Phase 2F handoff guard with clear error message
- **NEW** `tests/test_match_group_tuning.py` (27 tests, all passing)

NO modifications to existing files (legacy `tune_match_group` at `serpentine.py:484` is untouched per spec).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| 1. Reference policy -- longest | PASS | `TestReferencePolicyLongest::test_longest_is_target_for_4_net_group` |
| 2. Reference policy -- pace-car (incl. `longer_than_reference`) | PASS | `TestReferencePolicyPaceCar` (2 tests) |
| 3. Engagement gate -- `length_critical=False` | PASS | `TestEngagementGate::test_length_critical_false_returns_unchanged` |
| 4. Outer-normal generalization (3-trace fixture) | PASS | `TestOuterNormalGeneralization::test_three_traces_bulge_does_not_cross_other_members` + direct unit tests on `_outer_normal_hint_group` |
| 5. Cascade budget -- small (N<=4) | PASS | `TestCascadeBudget::test_small_group_default_is_three` |
| 6. Cascade budget -- large (N>4) | PASS | `TestCascadeBudget::test_large_group_default_is_two` |
| 7. DRC self-check -- intra-group rollback | PASS | `TestPostInsertionDRC::test_intra_group_rollback` (Route + segments `is`-identity) |
| 8. DRC self-check -- non-group neighbor rollback | PASS | `TestPostInsertionDRC::test_non_group_neighbor_rollback` |
| 9. Already-within-tolerance no-op | PASS | `TestAlreadyWithinTolerance::test_all_members_within_tolerance_unchanged` |
| 10. Drift-prevention -- `LengthTracker.calculate_route_length` is SoT | PASS | `TestDriftPrevention` parametrized N=3,5,10 |
| 11. `MAX_INSERTS_PER_GROUP_MEMBER_SMALL == MAX_INSERTS_PER_PAIR` | PASS | `TestModuleInvariants::test_max_inserts_small_equals_max_inserts_per_pair` |
| Phase 2F handoff guard (`pair_ids` precondition) | PASS | `TestPhase2FHandoff::test_pair_ids_assertion_fires_with_clear_message` |
| `MAX_TOTAL_INSERTS_PER_GROUP=16` ceiling enforced | PASS | `TestCascadeBudget::test_max_total_inserts_per_group_caps_cumulative_count` |

## Test Plan

```
$ uv run pytest tests/test_match_group_tuning.py --no-cov -v
============== 27 passed in 0.22s ==============

$ uv run pytest tests/test_diffpair_length_tuning.py tests/test_match_group_length.py \
                tests/test_match_group_detection.py tests/test_match_group_declaration.py --no-cov
============== 121 passed in 1.75s ==============

$ uv run ruff check src/kicad_tools/router/match_group_tuning.py tests/test_match_group_tuning.py
All checks passed!

$ uv run mypy src/kicad_tools/router/match_group_tuning.py
(no errors in the new module; pre-existing errors in unrelated files unchanged)
```

## Coordination Notes

- Builder on #2681 (router bisect) touches `router/core.py`; this PR touches a new file + tests only. No conflict expected.
- Builder on #2695 (in-pad escape) operates in different files.
- Phase 2F (#2701) depends on this; Phase 2G (#2702) is independent.

Closes #2700