### PR TITLE
feat(validate): derive_group_skew_data producer wiring for match_group_length_skew

### DIFF
--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -354,34 +354,47 @@ class DRCChecker:
         own router / manual layout) where ``kicad_tools.router`` never
         runs but the board still needs its match-group skew validated.
 
-        Producer-side wiring is **deferred** to a separate Phase 2.5G
-        follow-up issue (mirroring PR #2685's ``derive_skew_data`` for
-        the diff-pair sibling).  Until that lands, this method is a
-        conservative no-op: it instantiates the rule with all defaults
-        (``group_skew_data=None``, ``tracker_match_groups=None``) which
-        yields ``rules_checked == 0`` and zero violations.  This
-        preserves the AC #1 graceful-degradation contract -- a board
-        with no router context (no ``--net-class-map`` sidecar) MUST
-        NOT report spurious skew violations because the caller had no
-        way to compute the skew.
+        Phase 2.5G (Issue #2710) wires the producer side: when this
+        checker was constructed with a ``net_class_map``, the per-group
+        skew is re-derived from the routed PCB by
+        :func:`~kicad_tools.validate.match_group_skew.derive_group_skew_data`
+        (sister of
+        :func:`~kicad_tools.validate.diffpair_skew.derive_skew_data`)
+        and threaded into the rule along with the detected groups list
+        and the per-group threshold map.  Re-running detection + length-
+        from-PCB-segments on the routed PCB is idempotent given the
+        same net classes and physical routing -- this avoids needing to
+        persist length / skew metadata in the PCB schema.
 
-        See Issue #2702 / Epic #2661 Phase 2G (the rule itself).
+        When invoked from the standalone ``kct check`` CLI (no
+        ``net_class_map``), no skew data is available, so the rule is
+        a conservative no-op (preserves the AC #1 graceful-degradation
+        contract -- mirrors the
+        :meth:`check_diffpair_length_skew` behaviour).
+
+        See Issue #2702 / Epic #2661 Phase 2G (the rule itself); Issue
+        #2710 / Epic #2661 Phase 2.5G (this producer wiring).
 
         Returns:
             :class:`DRCResults` containing match-group length-skew
             violations.  Empty on standalone ``kct check`` invocations
-            until the Phase 2.5G producer-side wiring lands.
+            (no router context to supply ``group_skew_data``).
         """
-        # Graceful-no-op: until the Phase 2.5G producer
-        # (derive_group_skew_data) is wired, this method instantiates
-        # the rule with no caller context, which yields zero violations
-        # and zero rules_checked.  The rule itself is fully tested via
-        # direct construction in tests/test_validate_match_group_length_skew.py
-        # -- this method's job is to be a future-ready dispatch seam
-        # that the upcoming follow-up issue can extend by threading
-        # derived data through, exactly like check_diffpair_length_skew
-        # was extended via PR #2685.
-        rule = MatchGroupLengthSkewRule()
+        if self.net_class_map is None:
+            # Graceful-no-op: no router context -> no skew data to
+            # validate.  Matches the standalone-``kct check`` contract.
+            rule = MatchGroupLengthSkewRule()
+        else:
+            from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+            group_skew_data, tracker_match_groups, threshold_map = derive_group_skew_data(
+                self.pcb, self.net_class_map
+            )
+            rule = MatchGroupLengthSkewRule(
+                group_skew_data=group_skew_data,
+                tracker_match_groups=tracker_match_groups,
+                threshold_map=threshold_map,
+            )
         return rule.check(self.pcb, self.design_rules)
 
     def check_silkscreen(self) -> DRCResults:

--- a/src/kicad_tools/validate/match_group_skew.py
+++ b/src/kicad_tools/validate/match_group_skew.py
@@ -1,0 +1,290 @@
+"""Re-derive match-group length-skew data from a routed PCB + net-class map.
+
+Issue #2710, Epic #2661 Phase 2.5G.
+
+The :class:`~kicad_tools.validate.rules.match_group_length_skew.MatchGroupLengthSkewRule`
+(Phase 2G / Issue #2702, PR #2711) consumes caller-supplied
+``group_skew_data: dict[str, float]`` (name-keyed), a
+``tracker_match_groups: list[MatchGroup]`` declaration list, and an
+optional per-group ``threshold_map: dict[str, float]``.  The rule
+itself deliberately does NOT re-derive any of these inputs to avoid
+drift between the router's per-group length tracker
+(:class:`~kicad_tools.router.match_group_length.MatchGroupTracker`) and
+the validator's skew check.
+
+This module provides the producer side -- a thin shim that:
+
+1. Detects match groups on a routed PCB using the same layered
+   detector the router uses (:func:`match_group_detection.detect_match_groups`).
+2. Sums per-net length from PCB-side segments + vias (via
+   :meth:`MatchGroupTracker.measure_net_from_pcb`, a thin forwarder to
+   :meth:`DiffPairLengthTracker.measure_net_from_pcb`) for every
+   declared member of each detected group.
+3. Builds the ``group_skew_data`` (``max(L) - min(L)`` across the
+   group), the detected ``tracker_match_groups`` list, and the per-group
+   ``threshold_map`` from each group's net class
+   :meth:`NetClassRouting.effective_length_match_tolerance`.
+
+Sister of :mod:`kicad_tools.validate.diffpair_skew` (Phase 2.5c, PR
+#2685) -- this is the third producer-side wiring follow-up in Epic
+#2661, mirroring the diff-pair counterpart byte-for-byte modulo type
+renames (group-name keying instead of net-name-tuple keying).
+
+Why re-derive instead of persist?
+
+The recommended approach per the curator review on #2702 / #2710 is to
+recover skew at validation time rather than persist it as PCB metadata.
+PCB segment/via geometry IS the source of truth for routed length; the
+skew is a pure function of (group_member_net_ids, geometry,
+net_class_map.length_match_tolerance).  This avoids needing to round-
+trip Phase 1B's :class:`MatchGroupTracker` state through the PCB schema
+and keeps the validate->router boundary thin.
+
+Boundary discipline:
+
+This module is the validate-side dependency on the router's match-group
+primitives.  The rule itself remains router-independent.  The
+:meth:`MatchGroupTracker.measure_net_from_pcb` forwarder is preferred
+over reaching into ``router/diffpair_length.py`` directly so the import
+boundary in this package stays clean (validate/match_group_skew.py
+imports from router/match_group_length.py only).  Tests live in
+``tests/test_validate_match_group_skew.py`` and the drift-prevention
+test mirrors PR #2685's pattern.
+
+Group-of-pairs note (Phase 2F reserve):
+
+The :class:`MatchGroup` dataclass has a ``pair_ids`` field reserved for
+Phase 2F group-of-pairs composition.  Phase 1B's measurement layer
+ignores it; this producer follows suit and only sums ``net_ids`` until
+Phase 2F lands.  This matches the Phase 1B forwarder semantics and the
+rule's current member-count documentation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.router.match_group_length import MatchGroup
+    from kicad_tools.router.rules import NetClassRouting
+    from kicad_tools.schema.pcb import PCB
+
+
+logger = logging.getLogger(__name__)
+
+
+def derive_group_skew_data(
+    pcb: PCB,
+    net_class_map: dict[str, NetClassRouting] | None,
+    board_thickness_mm: float | None = None,
+    num_copper_layers: int = 2,
+) -> tuple[dict[str, float], list[MatchGroup], dict[str, float]]:
+    """Re-derive ``(group_skew_data, tracker_match_groups, threshold_map)``.
+
+    Walks the PCB's net table, runs the layered match-group detector,
+    and sums per-net length from PCB-side segments + vias for each
+    detected group's members.  Returns the three inputs the
+    :class:`~kicad_tools.validate.rules.match_group_length_skew.MatchGroupLengthSkewRule`
+    expects.
+
+    Args:
+        pcb: The routed PCB to inspect.  ``pcb.nets`` is consulted for
+            the detector; ``pcb.segments_in_net`` and ``pcb.vias_in_net``
+            are consulted for length measurement.
+        net_class_map: Map of ``{net_name: NetClassRouting}`` (the
+            autorouter convention used by
+            :attr:`~kicad_tools.router.core.AutoRouter.net_class_map`).
+            ``None`` or empty returns ``({}, [], {})`` so the standalone
+            ``kct check`` path degrades gracefully to a no-op.
+        board_thickness_mm: Total stackup thickness in mm.  When
+            ``None`` (the default), vias contribute ``0.0`` to the
+            length.  Mirrors
+            :meth:`~kicad_tools.router.match_group_length.MatchGroupTracker.record_routes`
+            and the curator's documented policy on #2647.
+        num_copper_layers: Number of copper layers in the stack (used
+            to compute per-via drilled length when ``board_thickness_mm``
+            is supplied).  Defaults to ``2``.
+
+    Returns:
+        ``(group_skew_data, tracker_match_groups, threshold_map)`` where
+
+        * ``group_skew_data`` is a ``{group_name -> skew_mm}`` dict
+          matching :meth:`MatchGroupTracker.get_all_skews` shape.
+          Groups with any unrouted member are omitted (graceful
+          degradation, matching the producer-side tracker's "all
+          members routed" gating).
+        * ``tracker_match_groups`` is the detected list of
+          :class:`MatchGroup` instances.  Threaded through to the rule's
+          ``tracker_match_groups`` parameter so the rule knows which
+          groups are "declared" -- groups not in this list are ignored
+          per Phase 2G's declaration-gating contract (#2702 AC #6).
+        * ``threshold_map`` is a ``{group_name -> tolerance_mm}`` map of
+          per-group tolerance overrides.  Each group's tolerance comes
+          from :meth:`NetClassRouting.effective_length_match_tolerance`
+          on the net class of the group's first declared member (groups
+          should span one net class; when members diverge, the first
+          member by net id wins -- deterministic given
+          :class:`MatchGroup`'s sorted-by-net-id member ordering).
+
+    Notes:
+        Idempotence guarantee (drift-prevention AC): given the same
+        physical routing and the same net classes, this function returns
+        the same ``group_skew_data`` as the producer-side
+        :meth:`MatchGroupTracker.get_all_skews` for routes recorded
+        via :meth:`MatchGroupTracker.record_routes`.  This is the
+        property tested in ``tests/test_validate_match_group_skew.py``.
+
+        Suffix inference is OFF here (``enable_suffix_inference=False``,
+        the detector's default).  Standalone ``kct check`` follows the
+        conservative-validation convention -- groups must be explicitly
+        declared via ``NetClassRouting.length_match_group`` (or the
+        legacy ``add_match_group`` API).  Suffix inference is opt-in via
+        CLI flag, not on by default.
+    """
+    if not net_class_map:
+        return {}, [], {}
+
+    # Local imports keep the validate -> router boundary explicit: this
+    # is the validate-side dependency on the router's match-group
+    # primitives.  See module docstring.
+    from kicad_tools.router.match_group_detection import detect_match_groups
+    from kicad_tools.router.match_group_length import MatchGroupTracker
+    from kicad_tools.validate.rules.match_group_length_skew import (
+        DEFAULT_MATCH_GROUP_TOLERANCE_MM,
+    )
+
+    # Build the {net_id: net_name} map the detector expects.
+    net_names: dict[int, str] = {}
+    for net_id, net in pcb.nets.items():
+        net_name = getattr(net, "name", None)
+        if not net_name:
+            continue
+        net_names[net_id] = net_name
+
+    if not net_names:
+        return {}, [], {}
+
+    # Synthesise a {net_name: class_name} map + a class-name-keyed
+    # routing dict so the layered detector can consult
+    # ``NetClassRouting.length_match_group`` explicit declarations.
+    # Mirrors the autorouter convention -- see
+    # :func:`derive_skew_data` in ``diffpair_skew.py:126-149`` (byte-
+    # for-byte equivalent idiom).
+    net_to_class: dict[str, str] = {}
+    synth_routing: dict = dict(net_class_map)
+    for net_name, nc in net_class_map.items():
+        cls_name = getattr(nc, "name", None)
+        if cls_name is None:
+            continue
+        net_to_class[net_name] = cls_name
+        synth_routing.setdefault(cls_name, nc)
+
+    try:
+        detected = detect_match_groups(
+            net_names,
+            net_class_routing=synth_routing,
+            net_to_class=net_to_class,
+            # Conservative-validation: suffix inference is opt-in via CLI
+            # flag, not on by default in standalone ``kct check``.
+            enable_suffix_inference=False,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "[match-group-skew] detector raised %s; treating as no skew data",
+            exc,
+        )
+        return {}, [], {}
+
+    group_skew_data: dict[str, float] = {}
+    threshold_map: dict[str, float] = {}
+
+    # Build the {net_id -> net_name} reverse so we can look up the net
+    # class for any member via the autorouter's name-keyed map.
+    for grp in detected:
+        # Phase 2F reserve: pair_ids are ignored here -- the Phase 1B
+        # measurement layer does the same, and the rule's documented
+        # member-count today is len(net_ids) + 2 * len(pair_ids).  We
+        # match Phase 1B byte-for-byte (only net_ids contribute to the
+        # skew computation in this phase).
+        if not grp.net_ids:
+            logger.debug(
+                "[match-group-skew] %s skipped (no single-ended members in Phase 1B scope)",
+                grp.name,
+            )
+            continue
+
+        # Gating: every member must have at least one segment or via on
+        # the PCB.  This mirrors :meth:`MatchGroupTracker.get_all_skews`
+        # which only populates the name-keyed cache when ALL declared
+        # members are routed (a partially-routed group is excluded from
+        # the bulk skew report -- see match_group_length.py:310-316).
+        any_unrouted = False
+        measured: list[float] = []
+        for net_id in grp.net_ids:
+            if not _net_has_geometry(pcb, net_id):
+                any_unrouted = True
+                break
+            length = MatchGroupTracker.measure_net_from_pcb(
+                pcb,
+                net_id,
+                board_thickness_mm=board_thickness_mm,
+                num_copper_layers=num_copper_layers,
+            )
+            measured.append(length)
+
+        if any_unrouted or len(measured) < 2:
+            logger.debug(
+                "[match-group-skew] %s skipped (partial routing or <2 members)",
+                grp.name,
+            )
+            continue
+
+        skew_mm = max(measured) - min(measured)
+        group_skew_data[grp.name] = skew_mm
+
+        # Per-group threshold: use the net class of the first declared
+        # member (groups should span one class; if they diverge, the
+        # first-member-by-net-id wins -- deterministic given
+        # :class:`MatchGroup`'s sorted-by-net-id member ordering from
+        # detect_match_groups).
+        first_net_id = grp.net_ids[0]
+        first_net_name = net_names.get(first_net_id)
+        nc = net_class_map.get(first_net_name) if first_net_name else None
+        if nc is not None and hasattr(nc, "effective_length_match_tolerance"):
+            threshold_map[grp.name] = nc.effective_length_match_tolerance(
+                default=DEFAULT_MATCH_GROUP_TOLERANCE_MM,
+            )
+        else:
+            threshold_map[grp.name] = DEFAULT_MATCH_GROUP_TOLERANCE_MM
+
+        logger.info(
+            "[match-group-skew] %s skew=%.3f mm (members=%d, tolerance=%.3f)",
+            grp.name,
+            skew_mm,
+            len(measured),
+            threshold_map[grp.name],
+        )
+
+    # Sort the skew dict by group name for deterministic iteration --
+    # matches :meth:`MatchGroupTracker.get_all_skews` exactly (see
+    # match_group_length.py:447-448).
+    group_skew_data = dict(sorted(group_skew_data.items(), key=lambda kv: kv[0]))
+
+    return group_skew_data, detected, threshold_map
+
+
+def _net_has_geometry(pcb: PCB, net_id: int) -> bool:
+    """Return True if ``net_id`` has at least one segment or via on ``pcb``.
+
+    Used to mirror :meth:`MatchGroupTracker.get_all_skews` semantics:
+    groups where one member is entirely unrouted are omitted from the
+    ``group_skew_data`` dict.  Without this gate, an unrouted member
+    would emit a spurious ``skew_mm = max(L) - 0 = max(L)`` entry that
+    would fire a bogus DRC violation.
+    """
+    for _seg in pcb.segments_in_net(net_id):
+        return True
+    for _via in pcb.vias_in_net(net_id):
+        return True
+    return False

--- a/tests/test_validate_match_group_skew.py
+++ b/tests/test_validate_match_group_skew.py
@@ -1,0 +1,809 @@
+"""Tests for the validate-side match-group skew producer wiring (Issue #2710).
+
+Sister of ``tests/test_validate_diffpair_skew.py`` (PR #2685) -- the
+third producer-side wiring follow-up in Epic #2661, mirroring the
+diff-pair counterpart byte-for-byte modulo type renames (group-name
+keying instead of net-name-tuple keying).
+
+Covers:
+
+- ``derive_group_skew_data(pcb, None)`` -> empty result (standalone-CLI
+  graceful no-op).
+- Empty / no-nets PCB -> empty result.
+- Basic per-group skew measurement (symmetric, asymmetric, multi-group).
+- Partial-routing gating: groups with any unrouted member are omitted
+  (mirrors :meth:`MatchGroupTracker.get_all_skews` semantics).
+- Per-class tolerance override via ``length_match_tolerance_mm``.
+- **Drift-prevention**: ``derive_group_skew_data`` on a PCB matches
+  :meth:`MatchGroupTracker.get_all_skews` on the router-internal
+  :class:`Route` form of the same physical routing byte-for-byte.
+- Via-traversing routes: PCB-side measurement matches router-side when
+  ``board_thickness_mm`` is supplied (no router context-only state).
+- Drift-prevention: ``DEFAULT_MATCH_GROUP_TOLERANCE_MM`` matches
+  ``NetClassRouting.effective_length_match_tolerance`` default.
+- End-to-end via :class:`DRCChecker.check_match_group_length_skew`:
+  ``rules_checked_by_rule['match_group_length_skew'] >= 1`` on a routed
+  board with a declared group.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.router.primitives import Route
+
+# ---------------------------------------------------------------------------
+# Stubs (mirror tests/test_validate_diffpair_skew.py)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubNet:
+    number: int
+    name: str
+
+
+@dataclass
+class _StubSegment:
+    """PCB-schema-shape segment stub.
+
+    Matches :class:`kicad_tools.schema.pcb.Segment`:
+    ``start: tuple[float, float]`` / ``end: tuple[float, float]`` (NOT
+    the router-internal ``x1/y1/x2/y2`` fields).
+    """
+
+    start: tuple[float, float]
+    end: tuple[float, float]
+    width: float = 0.2
+    layer: str = "F.Cu"
+    net_number: int = 0
+    net_name: str = ""
+    uuid: str = ""
+
+
+@dataclass
+class _StubVia:
+    """PCB-schema-shape via stub.
+
+    Matches :class:`kicad_tools.schema.pcb.Via`: ``layers: list[str]`` of
+    KiCad layer name strings (e.g., ``["F.Cu", "B.Cu"]``).
+    """
+
+    position: tuple[float, float] = (0.0, 0.0)
+    size: float = 0.6
+    drill: float = 0.3
+    layers: list[str] = field(default_factory=lambda: ["F.Cu", "B.Cu"])
+    net_number: int = 0
+    net_name: str = ""
+    uuid: str = ""
+
+
+@dataclass
+class _StubPCB:
+    """Minimal PCB stub used by :func:`derive_group_skew_data`.
+
+    Implements ``nets``, ``segments_in_net``, ``vias_in_net`` -- the
+    only attributes/methods consulted by the helper.
+    """
+
+    _nets: dict[int, _StubNet] = field(default_factory=dict)
+    _segments: list[_StubSegment] = field(default_factory=list)
+    _vias: list[_StubVia] = field(default_factory=list)
+
+    @property
+    def nets(self) -> dict[int, _StubNet]:
+        return self._nets
+
+    def segments_in_net(self, net_number: int):
+        for seg in self._segments:
+            if seg.net_number == net_number:
+                yield seg
+
+    def vias_in_net(self, net_number: int):
+        for via in self._vias:
+            if via.net_number == net_number:
+                yield via
+
+
+def _make_ddr_pcb(
+    *,
+    net_lengths_mm: dict[int, float | None],
+    net_names_map: dict[int, str] | None = None,
+) -> _StubPCB:
+    """Construct a stub PCB with one horizontal segment per net.
+
+    ``net_lengths_mm`` maps net_number -> length (None to omit geometry).
+    Each segment is placed on F.Cu at y = (net_id * 1.0), starting at x=0.
+    """
+    if net_names_map is None:
+        # Default DDR-style names DQ0..DQN.
+        net_names_map = {nid: f"DQ{i}" for i, nid in enumerate(net_lengths_mm.keys())}
+
+    nets: dict[int, _StubNet] = {0: _StubNet(0, "")}
+    for nid, name in net_names_map.items():
+        nets[nid] = _StubNet(nid, name)
+
+    segs: list[_StubSegment] = []
+    for nid, length in net_lengths_mm.items():
+        if length is None:
+            continue
+        segs.append(
+            _StubSegment(
+                start=(0.0, float(nid)),
+                end=(length, float(nid)),
+                net_number=nid,
+                net_name=net_names_map[nid],
+            )
+        )
+    return _StubPCB(_nets=nets, _segments=segs)
+
+
+# ---------------------------------------------------------------------------
+# Graceful no-op tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveGroupSkewDataNoOp:
+    """Standalone-CLI graceful no-op paths."""
+
+    def test_no_net_class_map_returns_empty(self):
+        """``derive_group_skew_data(pcb, None)`` -> empty 3-tuple."""
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 10.0, 12: 10.0, 13: 10.0})
+        skew_data, groups, threshold_map = derive_group_skew_data(pcb, None)
+        assert skew_data == {}
+        assert groups == []
+        assert threshold_map == {}
+
+    def test_empty_net_class_map_returns_empty(self):
+        """``derive_group_skew_data(pcb, {})`` -> empty result (idempotent with None)."""
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 10.0, 12: 10.0, 13: 10.0})
+        skew_data, groups, threshold_map = derive_group_skew_data(pcb, {})
+        assert skew_data == {}
+        assert groups == []
+        assert threshold_map == {}
+
+    def test_pcb_with_no_nets_returns_empty(self):
+        """Edge case: a PCB whose net table has only the empty net 0."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {"DQ0": nc}
+
+        pcb = _StubPCB(_nets={0: _StubNet(0, "")})
+        skew_data, groups, threshold_map = derive_group_skew_data(pcb, net_class_map)
+        assert skew_data == {}
+        assert groups == []
+        assert threshold_map == {}
+
+    def test_no_declared_groups_returns_empty(self):
+        """net_class_map with nets but no ``length_match_group`` -> empty result.
+
+        Without an explicit group declaration AND with suffix inference
+        OFF (the producer's default), the detector finds no groups.
+        """
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        # Net class declared but NO length_match_group set.
+        nc = NetClassRouting(name="GENERAL")
+        net_class_map = {"DQ0": nc, "DQ1": nc, "DQ2": nc, "DQ3": nc}
+
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 10.0, 12: 10.0, 13: 10.0})
+        skew_data, groups, threshold_map = derive_group_skew_data(pcb, net_class_map)
+        assert skew_data == {}
+        assert groups == []
+        assert threshold_map == {}
+
+
+# ---------------------------------------------------------------------------
+# Basic per-group skew measurement
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveGroupSkewDataBasic:
+    """Basic measurement + per-group tolerance assignment."""
+
+    def test_symmetric_group_zero_skew(self):
+        """4-trace DDR group, all equal length -> skew_mm == 0.0."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {"DQ0": nc, "DQ1": nc, "DQ2": nc, "DQ3": nc}
+
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 10.0, 12: 10.0, 13: 10.0})
+        skew_data, groups, threshold_map = derive_group_skew_data(pcb, net_class_map)
+
+        assert "DDR_DATA" in skew_data
+        assert skew_data["DDR_DATA"] == 0.0
+        # Detector returned a single 4-member group.
+        assert len(groups) == 1
+        assert groups[0].name == "DDR_DATA"
+        assert sorted(groups[0].net_ids) == [10, 11, 12, 13]
+        # Threshold from class default (0.5).
+        assert threshold_map["DDR_DATA"] == 0.5
+
+    def test_asymmetric_group_returns_max_minus_min(self):
+        """4-trace group: lengths [10, 10.5, 11, 12] -> skew = 2.0."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {"DQ0": nc, "DQ1": nc, "DQ2": nc, "DQ3": nc}
+
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 10.5, 12: 11.0, 13: 12.0})
+        skew_data, _, _ = derive_group_skew_data(pcb, net_class_map)
+
+        assert "DDR_DATA" in skew_data
+        assert abs(skew_data["DDR_DATA"] - 2.0) < 1e-9
+
+    def test_per_class_tolerance_override_propagates(self):
+        """``length_match_tolerance_mm`` on the net class reaches threshold_map."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(
+            name="MIPI_CSI",
+            length_match_group="MIPI_CSI",
+            length_match_tolerance_mm=1.0,  # MIPI D-PHY budget
+        )
+        net_class_map = {"CSI0": nc, "CSI1": nc, "CSI2": nc, "CSI3": nc}
+
+        pcb = _make_ddr_pcb(
+            net_lengths_mm={10: 10.0, 11: 10.0, 12: 10.0, 13: 10.0},
+            net_names_map={10: "CSI0", 11: "CSI1", 12: "CSI2", 13: "CSI3"},
+        )
+        _, _, threshold_map = derive_group_skew_data(pcb, net_class_map)
+
+        assert threshold_map["MIPI_CSI"] == 1.0
+
+    def test_multiple_groups_independent(self):
+        """Two groups, distinct net classes, independent skew + tolerance."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc_ddr = NetClassRouting(
+            name="DDR_BYTE0",
+            length_match_group="DDR_BYTE0",
+            length_match_tolerance_mm=0.3,
+        )
+        nc_mipi = NetClassRouting(
+            name="MIPI",
+            length_match_group="MIPI",
+            length_match_tolerance_mm=1.5,
+        )
+        net_class_map = {
+            "DQ0": nc_ddr,
+            "DQ1": nc_ddr,
+            "DQ2": nc_ddr,
+            "DQ3": nc_ddr,
+            "CSI0": nc_mipi,
+            "CSI1": nc_mipi,
+            "CSI2": nc_mipi,
+            "CSI3": nc_mipi,
+        }
+
+        pcb = _make_ddr_pcb(
+            net_lengths_mm={
+                10: 10.0,
+                11: 10.0,
+                12: 10.0,
+                13: 10.5,  # skew = 0.5
+                20: 20.0,
+                21: 21.0,  # skew = 2.0
+                22: 22.0,
+                23: 22.0,
+            },
+            net_names_map={
+                10: "DQ0",
+                11: "DQ1",
+                12: "DQ2",
+                13: "DQ3",
+                20: "CSI0",
+                21: "CSI1",
+                22: "CSI2",
+                23: "CSI3",
+            },
+        )
+        skew_data, groups, threshold_map = derive_group_skew_data(pcb, net_class_map)
+
+        assert "DDR_BYTE0" in skew_data
+        assert abs(skew_data["DDR_BYTE0"] - 0.5) < 1e-9
+        assert threshold_map["DDR_BYTE0"] == 0.3
+
+        assert "MIPI" in skew_data
+        assert abs(skew_data["MIPI"] - 2.0) < 1e-9
+        assert threshold_map["MIPI"] == 1.5
+
+        # Detector returned both groups.
+        assert len(groups) == 2
+        names = {g.name for g in groups}
+        assert names == {"DDR_BYTE0", "MIPI"}
+
+    def test_skew_dict_is_alphabetically_sorted(self):
+        """Skew dict iteration matches MatchGroupTracker.get_all_skews ordering."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc_a = NetClassRouting(name="A", length_match_group="ZZZ_LATE")
+        nc_b = NetClassRouting(name="B", length_match_group="AAA_EARLY")
+        net_class_map = {
+            "NET_Z0": nc_a,
+            "NET_Z1": nc_a,
+            "NET_Z2": nc_a,
+            "NET_A0": nc_b,
+            "NET_A1": nc_b,
+            "NET_A2": nc_b,
+        }
+
+        pcb = _make_ddr_pcb(
+            net_lengths_mm={
+                10: 10.0,
+                11: 10.0,
+                12: 10.0,
+                20: 5.0,
+                21: 5.0,
+                22: 5.0,
+            },
+            net_names_map={
+                10: "NET_Z0",
+                11: "NET_Z1",
+                12: "NET_Z2",
+                20: "NET_A0",
+                21: "NET_A1",
+                22: "NET_A2",
+            },
+        )
+        skew_data, _, _ = derive_group_skew_data(pcb, net_class_map)
+        # Order: AAA_EARLY before ZZZ_LATE.
+        assert list(skew_data.keys()) == ["AAA_EARLY", "ZZZ_LATE"]
+
+
+# ---------------------------------------------------------------------------
+# Partial-routing gating
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveGroupSkewDataPartialRouting:
+    """Groups with any unrouted member are omitted (graceful degradation)."""
+
+    def test_unrouted_member_omits_group(self):
+        """One member unrouted -> group omitted from skew_data."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {"DQ0": nc, "DQ1": nc, "DQ2": nc, "DQ3": nc}
+
+        # DQ2 unrouted.
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 10.0, 12: None, 13: 10.0})
+        skew_data, _, threshold_map = derive_group_skew_data(pcb, net_class_map)
+
+        # Group omitted because partial routing.
+        assert skew_data == {}
+        assert threshold_map == {}
+
+    def test_all_members_unrouted_omits_group(self):
+        """Entirely unrouted group -> omitted."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {"DQ0": nc, "DQ1": nc, "DQ2": nc, "DQ3": nc}
+
+        pcb = _make_ddr_pcb(net_lengths_mm={10: None, 11: None, 12: None, 13: None})
+        skew_data, _, threshold_map = derive_group_skew_data(pcb, net_class_map)
+
+        assert skew_data == {}
+        assert threshold_map == {}
+
+
+# ---------------------------------------------------------------------------
+# Drift-prevention tests (the core property tested in this issue).
+# ---------------------------------------------------------------------------
+
+
+class TestGroupSkewDataMatchesRouter:
+    """``derive_group_skew_data`` MUST match ``MatchGroupTracker.get_all_skews``.
+
+    Builds the same physical routing in both forms (router-internal
+    Route + PCB-schema segments) and asserts byte-for-byte equality of
+    the resulting skew dicts.  If a future change touches segment-length
+    computation in one place but not the other, this test fires.
+
+    Three scenarios:
+
+    - Symmetric 4-trace group (skew = 0).
+    - Asymmetric 4-trace group (skew > 0).
+    - Via-traversing 4-trace group (validates ``board_thickness_mm`` parity).
+    """
+
+    def _build_both_forms(
+        self,
+        *,
+        net_segments: dict[int, list[tuple[tuple[float, float], tuple[float, float]]]],
+        net_vias_layers: dict[int, list[list[str]]] | None = None,
+        net_names_map: dict[int, str] | None = None,
+    ) -> tuple[_StubPCB, list[Route]]:
+        """Return ``(pcb_stub, routes)`` for the same physical routing."""
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Route, Segment, Via
+
+        if net_names_map is None:
+            net_names_map = {nid: f"DQ{i}" for i, nid in enumerate(net_segments.keys())}
+        if net_vias_layers is None:
+            net_vias_layers = {}
+
+        # PCB-schema-shape stub.
+        nets: dict[int, _StubNet] = {0: _StubNet(0, "")}
+        for nid, name in net_names_map.items():
+            nets[nid] = _StubNet(nid, name)
+
+        pcb_segments: list[_StubSegment] = []
+        for nid, segs in net_segments.items():
+            for start, end in segs:
+                pcb_segments.append(
+                    _StubSegment(
+                        start=start,
+                        end=end,
+                        net_number=nid,
+                        net_name=net_names_map[nid],
+                    )
+                )
+
+        pcb_vias: list[_StubVia] = []
+        for nid, vias_layers in net_vias_layers.items():
+            for layers in vias_layers:
+                pcb_vias.append(
+                    _StubVia(
+                        layers=list(layers),
+                        net_number=nid,
+                        net_name=net_names_map[nid],
+                    )
+                )
+
+        pcb = _StubPCB(_nets=nets, _segments=pcb_segments, _vias=pcb_vias)
+
+        # Router-internal Route shape.
+        _layer_lookup = {
+            "F.Cu": Layer.F_CU,
+            "B.Cu": Layer.B_CU,
+            "In1.Cu": Layer.IN1_CU,
+            "In2.Cu": Layer.IN2_CU,
+        }
+
+        routes: list[Route] = []
+        for nid, segs in net_segments.items():
+            route = Route(
+                net=nid,
+                net_name=net_names_map[nid],
+                segments=[
+                    Segment(
+                        x1=start[0],
+                        y1=start[1],
+                        x2=end[0],
+                        y2=end[1],
+                        width=0.2,
+                        layer=Layer.F_CU,
+                        net=nid,
+                        net_name=net_names_map[nid],
+                    )
+                    for start, end in segs
+                ],
+                vias=[
+                    Via(
+                        x=0.0,
+                        y=0.0,
+                        drill=0.3,
+                        diameter=0.6,
+                        layers=(
+                            _layer_lookup[layers[0]],
+                            _layer_lookup[layers[-1]],
+                        ),
+                        net=nid,
+                        net_name=net_names_map[nid],
+                    )
+                    for layers in net_vias_layers.get(nid, [])
+                ],
+            )
+            routes.append(route)
+
+        return pcb, routes
+
+    def _make_match_group(self, name: str, net_ids: list[int]):
+        from kicad_tools.router.match_group_length import MatchGroup, MatchGroupSource
+
+        return MatchGroup(
+            name=name,
+            net_ids=sorted(net_ids),
+            pair_ids=[],
+            source=MatchGroupSource.EXPLICIT,
+        )
+
+    def test_symmetric_group_byte_for_byte_match(self):
+        """Equal-length 4-trace group: both paths return {"DDR_DATA": 0.0}."""
+        from kicad_tools.router.match_group_length import MatchGroupTracker
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        net_ids = [10, 11, 12, 13]
+        names = {nid: f"DQ{i}" for i, nid in enumerate(net_ids)}
+        pcb, routes = self._build_both_forms(
+            net_segments={
+                10: [((0.0, 0.0), (10.0, 0.0))],
+                11: [((0.0, 1.0), (10.0, 1.0))],
+                12: [((0.0, 2.0), (10.0, 2.0))],
+                13: [((0.0, 3.0), (10.0, 3.0))],
+            },
+            net_names_map=names,
+        )
+
+        # Router-side: record routes via tracker.
+        tracker = MatchGroupTracker()
+        group = self._make_match_group("DDR_DATA", net_ids)
+        tracker.record_routes(routes=routes, groups=[group])
+        tracker_skews = tracker.get_all_skews()
+
+        # Validate-side: re-derive from PCB + net class map.
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {names[nid]: nc for nid in net_ids}
+        rederived_skews, _, _ = derive_group_skew_data(pcb, net_class_map)
+
+        assert rederived_skews == tracker_skews, (
+            "drift-prevention AC: validator-side derive_group_skew_data must match "
+            "producer-side MatchGroupTracker.get_all_skews byte-for-byte "
+            "for the same physical routing"
+        )
+        # Sanity: zero skew for symmetric group.
+        assert rederived_skews["DDR_DATA"] == 0.0
+
+    def test_asymmetric_group_byte_for_byte_match(self):
+        """Length-mismatched 4-trace group: both paths return the same skew."""
+        from kicad_tools.router.match_group_length import MatchGroupTracker
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        net_ids = [10, 11, 12, 13]
+        names = {nid: f"DQ{i}" for i, nid in enumerate(net_ids)}
+        pcb, routes = self._build_both_forms(
+            net_segments={
+                10: [((0.0, 0.0), (10.0, 0.0))],
+                11: [((0.0, 1.0), (10.5, 1.0))],
+                12: [((0.0, 2.0), (11.0, 2.0))],
+                13: [((0.0, 3.0), (12.5, 3.0))],
+            },
+            net_names_map=names,
+        )
+
+        tracker = MatchGroupTracker()
+        group = self._make_match_group("DDR_DATA", net_ids)
+        tracker.record_routes(routes=routes, groups=[group])
+        tracker_skews = tracker.get_all_skews()
+
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {names[nid]: nc for nid in net_ids}
+        rederived_skews, _, _ = derive_group_skew_data(pcb, net_class_map)
+
+        assert rederived_skews == tracker_skews
+        # Sanity: max - min = 12.5 - 10.0 = 2.5.
+        assert abs(rederived_skews["DDR_DATA"] - 2.5) < 1e-9
+
+    def test_via_traversing_group_byte_for_byte_match(self):
+        """Via on one member: PCB-side via length formula matches router-side.
+
+        Validates that :meth:`MatchGroupTracker.measure_net_from_pcb`
+        (the forwarder) produces the same result as the router-side
+        :meth:`MatchGroupTracker.record_routes` path when
+        ``board_thickness_mm`` is supplied to both.
+        """
+        from kicad_tools.router.match_group_length import MatchGroupTracker
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        net_ids = [10, 11, 12, 13]
+        names = {nid: f"DQ{i}" for i, nid in enumerate(net_ids)}
+        pcb, routes = self._build_both_forms(
+            net_segments={
+                10: [((0.0, 0.0), (10.0, 0.0))],
+                11: [((0.0, 1.0), (10.0, 1.0))],
+                12: [((0.0, 2.0), (10.0, 2.0))],
+                13: [((0.0, 3.0), (10.0, 3.0))],
+            },
+            net_vias_layers={10: [["F.Cu", "B.Cu"]]},  # F.Cu->B.Cu via on DQ0
+            net_names_map=names,
+        )
+
+        # Both sides supply the same board_thickness_mm.
+        board_thickness_mm = 1.6
+        num_copper_layers = 2
+
+        tracker = MatchGroupTracker()
+        group = self._make_match_group("DDR_DATA", net_ids)
+        tracker.record_routes(
+            routes=routes,
+            groups=[group],
+            board_thickness_mm=board_thickness_mm,
+            num_copper_layers=num_copper_layers,
+        )
+        tracker_skews = tracker.get_all_skews()
+
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {names[nid]: nc for nid in net_ids}
+        rederived_skews, _, _ = derive_group_skew_data(
+            pcb,
+            net_class_map,
+            board_thickness_mm=board_thickness_mm,
+            num_copper_layers=num_copper_layers,
+        )
+
+        assert rederived_skews == tracker_skews, (
+            "via-traversing drift-prevention: PCB-side via length formula "
+            "must produce the same result as router-side"
+        )
+        # Sanity: DQ0 has +1.6mm via length -> skew = 1.6.
+        assert abs(rederived_skews["DDR_DATA"] - 1.6) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Constants drift-prevention (mirrors test_validate_diffpair_skew.py)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultMatchGroupToleranceDriftPrevention:
+    """``DEFAULT_MATCH_GROUP_TOLERANCE_MM`` MUST equal accessor default.
+
+    If a future change touches one constant without the other, this
+    drift-prevention test fires.  Mirrors the equivalent test in
+    ``tests/test_validate_diffpair_skew.py``.
+    """
+
+    def test_module_default_matches_accessor_default(self):
+        import inspect
+
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.rules.match_group_length_skew import (
+            DEFAULT_MATCH_GROUP_TOLERANCE_MM,
+        )
+
+        sig = inspect.signature(NetClassRouting.effective_length_match_tolerance)
+        accessor_default = sig.parameters["default"].default
+
+        assert accessor_default == DEFAULT_MATCH_GROUP_TOLERANCE_MM, (
+            "DEFAULT_MATCH_GROUP_TOLERANCE_MM in validate/rules/match_group_length_skew "
+            "must match the default arg of NetClassRouting.effective_length_match_tolerance "
+            "(both 0.5 mm).  If you changed one, change the other."
+        )
+
+    def test_default_matches_via_constructed_instance(self):
+        """``NetClassRouting().effective_length_match_tolerance()`` matches constant."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.rules.match_group_length_skew import (
+            DEFAULT_MATCH_GROUP_TOLERANCE_MM,
+        )
+
+        nc = NetClassRouting(name="x")
+        assert nc.effective_length_match_tolerance() == DEFAULT_MATCH_GROUP_TOLERANCE_MM
+
+
+# ---------------------------------------------------------------------------
+# Integration: DRCChecker.check_match_group_length_skew uses the new wiring.
+# ---------------------------------------------------------------------------
+
+
+class TestCheckerIntegration:
+    """End-to-end: DRCChecker.check_match_group_length_skew picks up the wiring."""
+
+    def test_no_net_class_map_remains_no_op(self):
+        """Standalone-CLI invocation (no net_class_map) -> 0 violations, 0 rules_checked.
+
+        AC #1: graceful degradation contract preserved.
+        """
+        from kicad_tools.validate.checker import DRCChecker
+
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 12.0, 12: 14.0, 13: 16.0})
+        # No net_class_map -> rule is no-op.
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+        results = checker.check_match_group_length_skew()
+
+        assert len(results.violations) == 0
+        assert results.rules_checked == 0
+
+    def test_with_net_class_map_fires_when_over_tolerance(self):
+        """With net_class_map + over-tolerance group -> rule fires."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.checker import DRCChecker
+
+        # Skew = max - min = 12 - 10 = 2.0 mm, well over default 0.5.
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 10.5, 12: 11.0, 13: 12.0})
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {"DQ0": nc, "DQ1": nc, "DQ2": nc, "DQ3": nc}
+
+        checker = DRCChecker(
+            pcb,
+            manufacturer="jlcpcb",
+            layers=2,
+            net_class_map=net_class_map,
+        )
+        results = checker.check_match_group_length_skew()
+
+        assert results.rules_checked == 1
+        assert results.rules_checked_by_rule.get("match_group_length_skew") == 1
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert v.rule_id == "match_group_length_skew"
+        assert "DDR_DATA" in v.message
+        assert abs(v.actual_value - 2.0) < 1e-9
+        assert v.required_value == 0.5
+
+    def test_with_net_class_map_passes_when_under_tolerance(self):
+        """With net_class_map + within-tolerance group -> no fire, rule still checked."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.checker import DRCChecker
+
+        # Skew = 0.3 mm, under default 0.5.
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 10.1, 12: 10.2, 13: 10.3})
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {"DQ0": nc, "DQ1": nc, "DQ2": nc, "DQ3": nc}
+
+        checker = DRCChecker(
+            pcb,
+            manufacturer="jlcpcb",
+            layers=2,
+            net_class_map=net_class_map,
+        )
+        results = checker.check_match_group_length_skew()
+
+        assert results.rules_checked == 1
+        assert results.rules_checked_by_rule.get("match_group_length_skew") == 1
+        assert len(results.violations) == 0
+
+    def test_undeclared_group_does_not_fire(self):
+        """No ``length_match_group`` set -> no group detected, no fire."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.checker import DRCChecker
+
+        # Skew is large but no group is declared via length_match_group.
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 15.0, 12: 20.0, 13: 25.0})
+        nc = NetClassRouting(name="DEFAULT")  # no length_match_group
+        net_class_map = {"DQ0": nc, "DQ1": nc, "DQ2": nc, "DQ3": nc}
+
+        checker = DRCChecker(
+            pcb,
+            manufacturer="jlcpcb",
+            layers=2,
+            net_class_map=net_class_map,
+        )
+        results = checker.check_match_group_length_skew()
+
+        assert results.rules_checked == 0
+        assert len(results.violations) == 0
+
+    def test_partial_routing_silently_skipped(self):
+        """One unrouted member -> group dropped silently (no spurious violation)."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.checker import DRCChecker
+
+        # DQ2 unrouted: without gating, we'd see skew = max(10) - 0 = 10mm
+        # and fire a bogus violation.  With gating, the group is dropped.
+        pcb = _make_ddr_pcb(net_lengths_mm={10: 10.0, 11: 10.0, 12: None, 13: 10.0})
+        nc = NetClassRouting(name="DDR", length_match_group="DDR_DATA")
+        net_class_map = {"DQ0": nc, "DQ1": nc, "DQ2": nc, "DQ3": nc}
+
+        checker = DRCChecker(
+            pcb,
+            manufacturer="jlcpcb",
+            layers=2,
+            net_class_map=net_class_map,
+        )
+        results = checker.check_match_group_length_skew()
+
+        # Group dropped: no rules_checked, no violation.
+        assert results.rules_checked == 0
+        assert len(results.violations) == 0


### PR DESCRIPTION
## Summary

Wires the producer side for the Phase 2G ``MatchGroupLengthSkewRule``
(PR #2711) so that ``kct check --net-class-map ...`` on a routed board
with declared match groups reports non-zero
``rules_checked_by_rule['match_group_length_skew']``.  Sister of
PR #2685's ``derive_skew_data`` (diff-pair), mirroring its structure
byte-for-byte modulo type renames (group-name keying instead of
net-name-tuple keying).

## Changes

- NEW ``src/kicad_tools/validate/match_group_skew.py``:
  - ``derive_group_skew_data(pcb, net_class_map, board_thickness_mm,
    num_copper_layers) -> tuple[dict[str, float], list[MatchGroup],
    dict[str, float]]`` -- the 3-tuple matches the rule's full DI
    contract (``group_skew_data``, ``tracker_match_groups``,
    ``threshold_map``).
  - Uses ``MatchGroupTracker.measure_net_from_pcb`` (the Phase 1B
    forwarder) rather than reaching into ``DiffPairLengthTracker``
    directly to keep the import boundary clean
    (``validate/match_group_skew.py`` imports from
    ``router/match_group_length.py`` only).
  - Runs ``detect_match_groups`` with
    ``enable_suffix_inference=False`` (conservative-validation default
    -- suffix inference is opt-in via CLI flag, not on by default in
    standalone ``kct check``).
  - Gates out partially-routed groups (any unrouted member silences
    the group), mirroring ``MatchGroupTracker.get_all_skews``
    semantics (``match_group_length.py:310-316``).
  - Per-group threshold from
    ``NetClassRouting.effective_length_match_tolerance`` on the first
    member's net class (groups should span one class; deterministic
    via :class:`MatchGroup`'s sorted-by-net-id member ordering).
  - Phase 2F ``pair_ids`` field is ignored (Phase 1B
    parity -- documented as a known limitation pending Phase 2F).

- MODIFY ``src/kicad_tools/validate/checker.py``:
  - ``DRCChecker.check_match_group_length_skew`` replaces the
    PR #2711 no-op body with a conditional producer-wiring branch
    (mirrors ``check_diffpair_length_skew``).  When
    ``self.net_class_map is None`` -> still a graceful no-op; when
    supplied -> ``derive_group_skew_data`` -> construct rule with the
    3-tuple unpacked.

- NEW ``tests/test_validate_match_group_skew.py`` (21 tests):
  - Graceful no-op (None, empty map, no nets, no declared groups).
  - Basic measurement (symmetric, asymmetric, multi-group, sorting).
  - Partial-routing gating (one unrouted member, all unrouted).
  - Per-class tolerance override propagates to threshold_map.
  - **Drift-prevention** (the mandated AC): byte-for-byte equality
    between ``derive_group_skew_data(pcb)[0]`` and
    ``MatchGroupTracker.get_all_skews()`` for the same physical
    routing -- symmetric, asymmetric, and via-traversing 4-trace DDR
    groups.
  - ``DEFAULT_MATCH_GROUP_TOLERANCE_MM ==
    NetClassRouting().effective_length_match_tolerance()`` (mirrors
    PR #2685's drift-prevention).
  - End-to-end ``DRCChecker.check_match_group_length_skew`` exercise
    (fires over-tolerance, passes under-tolerance, no-ops without
    net_class_map or without declared groups, silences partial
    routing).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New module ``validate/match_group_skew.py`` mirrors ``diffpair_skew.py`` structure | Done | Module docstring + function shape + helper layout mirror ``diffpair_skew.py`` byte-for-byte modulo type renames |
| Wiring in ``validate/checker.py``: ``kct check --net-class-map ...`` on routed board reports ``rules_checked_by_rule['match_group_length_skew'] >= 1`` | Done | ``TestCheckerIntegration::test_with_net_class_map_fires_when_over_tolerance`` and ``test_with_net_class_map_passes_when_under_tolerance`` both assert ``rules_checked_by_rule.get('match_group_length_skew') == 1`` |
| Drift-prevention test: ``derive_group_skew_data(pcb, net_class_map)[0]`` matches ``MatchGroupTracker.get_all_skews()`` byte-for-byte for same router-routed PCB | Done | ``TestGroupSkewDataMatchesRouter`` (3 tests: symmetric, asymmetric, via-traversing) asserts dict equality |
| Graceful no-op when ``net_class_map is None`` or no groups detected | Done | ``TestDeriveGroupSkewDataNoOp`` (4 tests) + ``TestCheckerIntegration::test_no_net_class_map_remains_no_op`` + ``test_undeclared_group_does_not_fire`` |

## Test Plan

- ``uv run pytest tests/test_validate_match_group_skew.py`` -- 21
  passed.
- ``uv run pytest tests/test_validate_match_group_length_skew.py
  tests/test_validate_diffpair_skew.py
  tests/test_validate_diffpair_length_skew.py`` -- 80 passed (no
  regression in the rule's own suite or the diff-pair sister
  producer/rule).
- ``uv run pytest tests/test_validate_*.py`` -- 284 passed (full
  validate suite green).
- ``uv run ruff check`` + ``ruff format --check`` on the new + modified
  files -- clean.

Closes #2710