### PR TITLE
router: thread manufacturer through derived/library DesignRules sites (closes #2708)

### DIFF
--- a/src/kicad_tools/optim/place_route.py
+++ b/src/kicad_tools/optim/place_route.py
@@ -217,11 +217,13 @@ class PlaceRouteOptimizer:
         fixer = PlacementFixer(verbose=verbose, anchored=anchored)
 
         # Router factory - creates fresh router for each attempt
+        # Issue #2708: forward manufacturer so capability-gated routing
+        # features (e.g., via_in_pad_supported) opt in correctly.
         def router_factory() -> Autorouter:
             router = Autorouter(
                 width=board_width,
                 height=board_height,
-                rules=RouterDesignRules(),
+                rules=RouterDesignRules(manufacturer=manufacturer),
             )
             # Load components from PCB
             cls._load_components_into_router(router, pcb)

--- a/src/kicad_tools/reasoning/interpreter.py
+++ b/src/kicad_tools/reasoning/interpreter.py
@@ -193,6 +193,15 @@ class InterpreterConfig:
     use_negotiated: bool = False  # Use negotiated congestion routing
     layer_count: int = 2  # Number of copper layers
 
+    # Manufacturer identifier (Issue #2708)
+    # Optional; when set (e.g., ``"jlcpcb-tier1"``), it is forwarded to the
+    # router's ``DesignRules`` so manufacturer-capability-gated routing
+    # features (e.g., via-in-pad escape) can opt in.  Defaults to ``None``
+    # because the reasoning interpreter is typically driven by LLM prompts
+    # that do not carry manufacturer context — callers that do know the
+    # target manufacturer should set this field explicitly.
+    manufacturer: str | None = None
+
     # Zone defaults
     zone_min_thickness: float = 0.2
     zone_clearance: float = 0.3
@@ -235,7 +244,13 @@ class CommandInterpreter:
         self._design_rules: DesignRules | None = None
 
     def _get_design_rules(self) -> DesignRules:
-        """Get or create design rules from config."""
+        """Get or create design rules from config.
+
+        Issue #2708: forwards ``self.config.manufacturer`` so that
+        manufacturer-capability-gated routing features (e.g., via-in-pad
+        escape) opt in correctly when a caller has set the field on the
+        ``InterpreterConfig``.  Defaults to ``None``.
+        """
         if self._design_rules is None:
             self._design_rules = DesignRules(
                 trace_width=self.config.trace_width,
@@ -243,6 +258,7 @@ class CommandInterpreter:
                 via_drill=self.config.via_drill,
                 via_diameter=self.config.via_size,
                 grid_resolution=self.config.grid_size,
+                manufacturer=self.config.manufacturer,
             )
         return self._design_rules
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -8649,6 +8649,9 @@ class Autorouter:
         )
 
         # Create fine grid scoped to bounding box
+        # Issue #2708: propagate manufacturer so capability-gated routing
+        # features (e.g., via_in_pad_supported) remain active when the
+        # router escalates from the coarse grid into the fine-grid pass.
         fine_rules = DesignRules(
             grid_resolution=fine_resolution,
             trace_width=self.rules.trace_width,
@@ -8656,6 +8659,7 @@ class Autorouter:
             via_drill=self.rules.via_drill,
             via_diameter=self.rules.via_diameter,
             via_clearance=self.rules.via_clearance,
+            manufacturer=self.rules.manufacturer,
         )
 
         fine_grid = RoutingGrid(
@@ -8925,6 +8929,9 @@ class Autorouter:
             print(f"  Retrying {len(clearance_failed_nets)} failed net(s)")
 
             # Create relaxed design rules
+            # Issue #2708: propagate manufacturer so capability-gated routing
+            # features (e.g., via_in_pad_supported) remain active during the
+            # clearance-relaxation fallback pass.
             relaxed_rules = DesignRules(
                 grid_resolution=self.rules.grid_resolution,
                 trace_width=self.rules.trace_width,
@@ -8932,6 +8939,7 @@ class Autorouter:
                 via_drill=self.rules.via_drill,
                 via_diameter=self.rules.via_diameter,
                 via_clearance=relaxed_clearance,  # Also relax via clearance
+                manufacturer=self.rules.manufacturer,
             )
 
             # Create a relaxed router for these nets

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -156,12 +156,19 @@ class PCBDesignRules:
     def to_design_rules(
         self,
         grid_resolution: float | None = None,
+        manufacturer: str | None = None,
     ) -> DesignRules:
         """Convert to DesignRules for the router.
 
         Args:
             grid_resolution: Override grid resolution. If None, uses
                             clearance / 2 for DRC compliance.
+            manufacturer: Optional manufacturer identifier (e.g.,
+                            ``"jlcpcb-tier1"``) used by capability-gated
+                            routing features such as via-in-pad escape.
+                            See Issue #2708 — when omitted, the returned
+                            rules behave as if no manufacturer-specific
+                            capabilities are available.
 
         Returns:
             DesignRules configured with these constraints.
@@ -178,6 +185,7 @@ class PCBDesignRules:
             via_clearance=self.min_clearance,
             min_drill_clearance=self.min_drill_clearance,
             grid_resolution=grid_resolution,
+            manufacturer=manufacturer,
         )
 
 

--- a/tests/test_manufacturer_propagation_lint.py
+++ b/tests/test_manufacturer_propagation_lint.py
@@ -1,0 +1,343 @@
+"""Lint-style regression test for Issue #2708.
+
+Background
+----------
+PR #2608 (Issue #2605) added the ``manufacturer`` field to
+``kicad_tools.router.rules.DesignRules`` so the escape router can opt in
+to in-pad via escape on fine-pitch packages when the target manufacturer
+supports via-in-pad processing.
+
+PR #2704 (#2695) discovered that PR #2608 had wired ``manufacturer`` into
+only 1 of 4 ``DesignRules`` constructor sites in ``cli/route_cmd.py``.
+The other 3 sites — escalation/tier-fallback paths — silently dropped
+the CLI flag, disabling in-pad escape for any board that escalated past
+the initial routing pass.
+
+Issue #2708 audited the full codebase and found additional sites with
+the same omission:
+
+* ``router/core.py`` fine-grid and clearance-relaxation derived rules
+* ``router/io.py`` ``PCBDesignRules.to_design_rules``
+* ``reasoning/interpreter.py`` ``_get_design_rules``
+* ``optim/place_route.py`` ``router_factory``
+
+This file guards against future regressions by statically scanning every
+``router.rules.DesignRules(...)`` constructor call in ``src/`` and
+asserting that:
+
+1. The call passes ``manufacturer=`` explicitly, OR
+2. The call sits on an allowlisted line in ``_ALLOWLIST`` below with a
+   documented reason.
+
+The placement-side ``placement.analyzer.DesignRules`` is a different
+dataclass with no manufacturer field and is not at risk; the lint
+distinguishes the two by import-trace heuristics described below.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+# Repository root (parent of "tests")
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC_ROOT = _REPO_ROOT / "src" / "kicad_tools"
+
+# ----------------------------------------------------------------------------
+# Allowlist: files known to legitimately omit ``manufacturer=``.
+#
+# Each entry maps a file path (relative to ``src/kicad_tools``) to a set of
+# 1-based line numbers where ``DesignRules(...)`` is intentionally
+# constructed without ``manufacturer=``.  Add a brief reason next to the
+# tuple to document why omission is safe.
+# ----------------------------------------------------------------------------
+
+# Format: {relative_path: {line_number: reason}}
+_ALLOWLIST: dict[str, dict[int, str]] = {
+    # Router core: default-constructed router (line ~235 is the
+    # ``rules_dict``-spread default; line ~370 is the constructor
+    # default).  Reaching either means the caller did not pass rules.
+    "router/core.py": {
+        235: "Autorouter.__init__ rules_dict-spread default",
+        370: "Autorouter.__init__ rules-arg default fallback",
+    },
+    # AdaptiveRouter default fallback — same pattern as Autorouter.
+    "router/adaptive.py": {
+        110: "AdaptiveRouter.__init__ default fallback",
+    },
+    # Library API: ``route_pcb()`` synthesises default rules only when
+    # the caller explicitly passes ``rules=None`` (no PCB rules either).
+    # The CLI always supplies its own rules with manufacturer wired in.
+    "router/io.py": {
+        2057: "route_pcb() fallback when caller passes rules=None and no PCB rules",
+        2548: "route_pcb() inner fallback when neither rules nor pcb_rules supplied",
+    },
+    # Benchmark/synthetic fixture generators — no real CLI context.
+    "benchmark/runner.py": {
+        112: "Benchmark harness fixture; no manufacturer context",
+    },
+    "benchmark/generators.py": {
+        52: "Synthetic benchmark generator fixture",
+        147: "Synthetic benchmark generator fixture",
+    },
+    # Evolutionary algorithm: constructs DesignRules from a serialised
+    # rules_dict to recreate router state across worker processes.  The
+    # ``manufacturer`` field flows through ``rules_dict`` if present.
+    "router/algorithms/evolutionary.py": {
+        222: "Evolutionary worker rules_dict-spread; manufacturer flows via dict",
+    },
+}
+
+
+# ----------------------------------------------------------------------------
+# AST visitor
+# ----------------------------------------------------------------------------
+
+
+class _DesignRulesCallFinder(ast.NodeVisitor):
+    """Walk an AST and collect every ``DesignRules(...)`` call site.
+
+    The visitor resolves ``from X import DesignRules as Y`` aliases by
+    scanning ``ImportFrom`` nodes whose source module references the
+    router package, then matching call-site names against that alias
+    set.  Bare ``DesignRules`` and attribute access (``mod.DesignRules``)
+    are also matched.
+    """
+
+    def __init__(self, source_tree: ast.AST | None = None) -> None:
+        self.sites: list[tuple[int, list[str]]] = []
+        # Aliases that resolve to router.rules.DesignRules.
+        self.router_aliases: set[str] = {"DesignRules"}
+        if source_tree is not None:
+            self._collect_router_aliases(source_tree)
+
+    def _collect_router_aliases(self, tree: ast.AST) -> None:
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            module = node.module or ""
+            # Heuristic: only treat the import as a router alias when the
+            # source module is in the router package.  This excludes
+            # placement.analyzer.DesignRules.
+            if "router" not in module and not module.endswith("rules"):
+                continue
+            if module.startswith("kicad_tools.placement"):
+                continue
+            for alias in node.names:
+                if alias.name == "DesignRules":
+                    self.router_aliases.add(alias.asname or "DesignRules")
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        # Only match bare-name calls.  Attribute-access calls like
+        # ``router_cpp.DesignRules()`` refer to a different class (the
+        # C++ binding) and must not be flagged by this lint.
+        if isinstance(node.func, ast.Name) and node.func.id in self.router_aliases:
+            keywords = [kw.arg for kw in node.keywords if kw.arg is not None]
+            self.sites.append((node.lineno, keywords))
+        self.generic_visit(node)
+
+
+# ----------------------------------------------------------------------------
+# File-level filters
+# ----------------------------------------------------------------------------
+
+
+# Files where ``DesignRules`` is a *different* dataclass (different
+# fields, not at risk for the manufacturer-propagation bug class).
+# Skipped entirely by the lint.
+_NON_ROUTER_DESIGN_RULES_FILES = {
+    # placement.analyzer.DesignRules — placement-conflict rules, no
+    # manufacturer field.
+    "placement/analyzer.py",
+    "placement/fixer.py",
+    # manufacturers.base.DesignRules — manufacturer profile dataclass
+    # with ``min_trace_width_mm`` etc., independent class hierarchy.
+    "manufacturers/base.py",
+}
+
+
+def _imports_router_design_rules(tree: ast.AST) -> bool:
+    """Return True if the module imports ``DesignRules`` from the router.
+
+    Recognises both ``from kicad_tools.router.rules import DesignRules``
+    and ``from kicad_tools.router import DesignRules`` plus relative
+    forms within the package (``.rules``, ``.router.rules``, etc.).
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                if alias.name in ("DesignRules", "*"):
+                    if "router" in module or module.endswith("rules"):
+                        return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if "router" in alias.name:
+                    return True
+    return False
+
+
+def _imports_placement_design_rules(tree: ast.AST) -> bool:
+    """Return True if the module imports the *placement* DesignRules."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                if alias.name == "DesignRules" and "placement" in module:
+                    return True
+    return False
+
+
+# ----------------------------------------------------------------------------
+# Test
+# ----------------------------------------------------------------------------
+
+
+def _iter_python_files() -> list[Path]:
+    return [
+        p
+        for p in _SRC_ROOT.rglob("*.py")
+        if "__pycache__" not in p.parts
+    ]
+
+
+_NOQA_RE = re.compile(r"#\s*noqa\s*:\s*MFR001\b", re.IGNORECASE)
+
+
+def test_manufacturer_propagation_in_router_design_rules():
+    """Every ``router.rules.DesignRules(...)`` call must pass ``manufacturer=``.
+
+    Allowlisted sites (e.g., library-API default constructors, benchmark
+    fixtures) are exempt — see ``_ALLOWLIST`` above.
+
+    To suppress an individual call site without editing this test, add a
+    ``# noqa: MFR001 reason="..."`` comment on the same line as the
+    ``DesignRules(`` opening.
+    """
+    violations: list[str] = []
+
+    for path in _iter_python_files():
+        rel = path.relative_to(_SRC_ROOT).as_posix()
+        if rel in _NON_ROUTER_DESIGN_RULES_FILES:
+            continue
+
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            # Skip files we can't parse; they have bigger problems.
+            continue
+
+        # Skip files that don't import DesignRules at all.
+        if not (
+            _imports_router_design_rules(tree)
+            or "DesignRules(" in source
+        ):
+            continue
+
+        # If the file imports ONLY placement.DesignRules, skip it.
+        if (
+            _imports_placement_design_rules(tree)
+            and not _imports_router_design_rules(tree)
+        ):
+            continue
+
+        finder = _DesignRulesCallFinder(tree)
+        finder.visit(tree)
+
+        source_lines = source.splitlines()
+        allowlist = _ALLOWLIST.get(rel, {})
+
+        for lineno, keywords in finder.sites:
+            if "manufacturer" in keywords:
+                continue
+            if lineno in allowlist:
+                continue
+
+            # In-line noqa pragma escape hatch — search a small window
+            # around the opening paren, since the call may span lines.
+            window_start = max(0, lineno - 1)
+            window_end = min(len(source_lines), lineno + 1)
+            window = "\n".join(source_lines[window_start:window_end])
+            if _NOQA_RE.search(window):
+                continue
+
+            violations.append(
+                f"{rel}:{lineno}: DesignRules(...) constructed without "
+                f"manufacturer= and not in allowlist. Either thread "
+                f"manufacturer through, add the line to _ALLOWLIST in "
+                f"this test file with a reason, or add `# noqa: MFR001 "
+                f'reason="..."` on the same line.'
+            )
+
+    assert not violations, (
+        "manufacturer propagation regression (Issue #2708):\n  "
+        + "\n  ".join(violations)
+    )
+
+
+# ----------------------------------------------------------------------------
+# Sanity tests for the lint itself
+# ----------------------------------------------------------------------------
+
+
+def test_allowlist_entries_resolve_to_actual_call_sites():
+    """Each allowlist entry must point to a real ``DesignRules(`` call."""
+    stale: list[str] = []
+    for rel, lines in _ALLOWLIST.items():
+        path = _SRC_ROOT / rel
+        if not path.exists():
+            stale.append(f"{rel}: file does not exist")
+            continue
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        finder = _DesignRulesCallFinder(tree)
+        finder.visit(tree)
+        site_lines = {site[0] for site in finder.sites}
+        for lineno in lines:
+            if lineno not in site_lines:
+                stale.append(
+                    f"{rel}:{lineno}: no DesignRules() call at this line "
+                    f"(allowlist out of date)"
+                )
+
+    assert not stale, "Stale entries in _ALLOWLIST:\n  " + "\n  ".join(stale)
+
+
+@pytest.mark.parametrize(
+    "site_description",
+    [
+        ("router/core.py", "_route_fine_grid fine_rules"),
+        ("router/core.py", "clearance-relaxation relaxed_rules"),
+        ("router/io.py", "PCBDesignRules.to_design_rules"),
+        ("reasoning/interpreter.py", "_get_design_rules"),
+        ("optim/place_route.py", "router_factory"),
+    ],
+)
+def test_fixed_sites_pass_manufacturer(site_description):
+    """Spot-check each curator-identified site for Issue #2708.
+
+    The lint test above is the canonical guard; this parametrised test
+    documents *which specific* sites the curator audited and is intended
+    to fail loudly if any of them regress.
+    """
+    rel, description = site_description
+    source = (_SRC_ROOT / rel).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    finder = _DesignRulesCallFinder(tree)
+    finder.visit(tree)
+
+    sites_with_mfr = [
+        site for site in finder.sites if "manufacturer" in site[1]
+    ]
+    assert sites_with_mfr, (
+        f"{rel} ({description}): expected at least one DesignRules(...) "
+        f"call passing manufacturer=, found none. Issue #2708 audit must "
+        f"have regressed."
+    )


### PR DESCRIPTION
## Summary

Closes #2708.

PR #2704 fixed manufacturer propagation in `cli/route_cmd.py` (4 of 4 sites). The curator's #2708 audit found four additional sites elsewhere in the codebase with the same omission, plus one in `optim/place_route.py` that was overlooked.

### Sites fixed

1. **`router/core.py:_route_fine_grid`** — fine-grid derived rules: now copies `manufacturer` from `self.rules`.
2. **`router/core.py` clearance-relaxation loop** — relaxed rules: now copies `manufacturer` from `self.rules`.
3. **`router/io.py:PCBDesignRules.to_design_rules`** — accepts new optional `manufacturer: str | None = None` parameter and threads it into the returned `DesignRules`.
4. **`reasoning/interpreter.py:_get_design_rules`** — `InterpreterConfig` gained an optional `manufacturer` field (defaults to `None` because the reasoning interpreter is typically driven by LLM prompts without manufacturer context). The field is threaded into `DesignRules` when set.
5. **`optim/place_route.py:router_factory`** (bonus) — `manufacturer` parameter was already in scope for `drc_checker_factory` but not threaded into `RouterDesignRules`. Fixed.

### Regression test

`tests/test_manufacturer_propagation_lint.py` is an AST-walking lint test that:

- Scans every `DesignRules(...)` call site under `src/kicad_tools/`.
- Resolves `from kicad_tools.router.rules import DesignRules as ...` aliases so it catches calls through the `RouterDesignRules` rename in `optim/place_route.py`.
- Skips files where `DesignRules` is a *different* class (`placement.analyzer.DesignRules`, `manufacturers.base.DesignRules`).
- Skips attribute calls like `router_cpp.DesignRules()` (C++ binding, different class).
- Allowlists legitimate defaults (router/orchestrator constructors, library API fallbacks, benchmark fixtures) by file/line with a documented reason.
- Supports an in-line `# noqa: MFR001 reason="..."` escape hatch.
- Includes a parametrised spot-check for each curator-identified site.

The lint will fail loudly if any future code path drops `manufacturer=` without justification.

### Why the bug class keeps recurring

`DesignRules.manufacturer` is `Optional[str] = None` — silent default, no exception when omitted. Same pattern as issue #2684 (the `net_class_map` propagation gap fixed by PR #2692). The new lint is the static-analysis guardrail.

## Test plan

- [x] `tests/test_manufacturer_propagation_lint.py` — 7/7 pass
- [x] `tests/test_escape_via_in_pad.py`, `tests/test_escape_via_in_pad_lqfp.py`, `tests/test_validate_via_in_pad.py`, `tests/test_manufacturer_registry_sync.py`, `tests/test_interpreter_routing.py` — 74/74 pass
- [x] `tests/test_router_io.py` — 173/173 pass
- [x] `tests/test_router_core.py` — 160/160 pass
- [x] `ruff check` on changed files — no new warnings introduced
- [x] `mypy` on changed files — no new errors introduced

## Out of scope

- Changes to MCP routing tools (`mcp/tools/routing.py`) — these are library API entry points without manufacturer context; not at risk per the curator's audit.
- Re-architecting `DesignRules` to make `manufacturer` a required positional arg (curator's Option C — invasive, breaks public API).