### PR TITLE
fix(pipeline): use NetStatusAnalyzer for route-skip decision (#2731)

### DIFF
--- a/src/kicad_tools/cli/commands/pipeline.py
+++ b/src/kicad_tools/cli/commands/pipeline.py
@@ -44,6 +44,11 @@ def run_pipeline_command(args) -> int:
     if max_disp is not None and max_disp != 2.0:
         sub_argv.extend(["--max-displacement", str(max_disp)])
 
+    # Route skip threshold (signal-net completion percent gating the route skip)
+    route_skip_threshold = getattr(args, "pipeline_route_skip_threshold", None)
+    if route_skip_threshold is not None and route_skip_threshold != 95.0:
+        sub_argv.extend(["--route-skip-threshold", str(route_skip_threshold)])
+
     # Best-effort mode
     if getattr(args, "pipeline_best_effort", False):
         sub_argv.append("--best-effort")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -4789,6 +4789,19 @@ def _add_pipeline_parser(subparsers) -> None:
         ),
     )
     pipeline_parser.add_argument(
+        "--route-skip-threshold",
+        dest="pipeline_route_skip_threshold",
+        type=float,
+        default=95.0,
+        metavar="PERCENT",
+        help=(
+            "Minimum signal-net completion percentage required to skip the "
+            "route step (default: 95.0). Single-pad nets and zone-fillable "
+            "plane nets are excluded from the signal-net subset and never "
+            "block the skip."
+        ),
+    )
+    pipeline_parser.add_argument(
         "--best-effort",
         dest="pipeline_best_effort",
         action="store_true",

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -282,10 +282,13 @@ def _assess_routing_completeness(
     2. Skip iff:
 
        * The board has at least one top-level routing segment, AND
-       * The routing-required subset is at least ``threshold_percent``
-         complete, AND
-       * Any remaining incomplete nets are zone-fillable plane nets
-         only (the stitch + zone-fill steps will close those).
+       * The routing-required subset (signal nets only -- single-pad
+         and plane nets are bucketed out per step 1) is at least
+         ``threshold_percent`` complete.
+
+       Any remaining incomplete plane nets are tracked separately in
+       ``incomplete_zone_fillable`` and do NOT block the skip; the
+       stitch + zone-fill steps close those connections.
 
     Args:
         pcb_file: Path to .kicad_pcb file.
@@ -953,9 +956,7 @@ def _run_step_route(ctx: PipelineContext, console: Console) -> PipelineResult:
     other pipeline steps (or are inherently complete).  ``--force`` always
     re-runs the router.
     """
-    assessment = _assess_routing_completeness(
-        ctx.pcb_file, ctx.route_skip_threshold
-    )
+    assessment = _assess_routing_completeness(ctx.pcb_file, ctx.route_skip_threshold)
 
     if assessment.recommend_skip and not ctx.force:
         return PipelineResult(

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -130,6 +130,7 @@ class PipelineContext:
     clear_cache: bool = False
     max_displacement: float = 2.0
     apply_sync: bool = False
+    route_skip_threshold: float = 95.0
     erc_error_count: int = 0
     _check_data: dict | None = None  # cached kct check --format json result
 
@@ -150,26 +151,30 @@ class PipelineContext:
             return 2
 
 
-def _detect_routing_status(pcb_file: Path) -> tuple[bool, int, int]:
-    """Detect whether a PCB has been routed by counting top-level segments and nets.
+def _has_routing_segments(pcb_file: Path) -> tuple[bool, int]:
+    """Detect whether a PCB has any top-level routed traces.
 
     Reads the PCB file and counts ``(segment ...)`` and ``(arc ...)`` nodes that
     are direct children of the root ``(kicad_pcb ...)`` node (depth 1).  Segments
     and arcs nested inside ``(zone ...)`` or ``(filled_polygon ...)`` blocks are
     excluded so that zone fill polygons are not mistaken for routed traces.
 
+    This is a fast probe used as a precondition for routing-completeness
+    assessment -- it is NOT a connectivity oracle.  Use
+    :func:`_assess_routing_completeness` for skip/route decisions.
+
     Args:
         pcb_file: Path to .kicad_pcb file
 
     Returns:
-        Tuple of (is_routed, segment_count, net_count) where is_routed
-        is True if the board has top-level routing segments.
+        Tuple of (is_routed, segment_count) where is_routed is True if the
+        board has any top-level routing segments or arcs.
     """
     try:
         content = pcb_file.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as e:
         logger.warning("Could not read PCB file %s: %s", pcb_file, e)
-        return False, 0, 0
+        return False, 0
 
     # Count only top-level (segment ...) and (arc ...) entries.
     # In KiCad s-expression format, routed traces live at depth 1 (direct
@@ -198,12 +203,188 @@ def _detect_routing_status(pcb_file: Path) -> tuple[bool, int, int]:
 
     total_traces = segment_count + arc_count
 
-    # Count nets (excluding net 0 which is the unconnected net)
-    net_count = content.count("(net ") - content.count("(net 0 ")
+    return total_traces > 0, total_traces
 
-    is_routed = total_traces > 0
 
-    return is_routed, total_traces, net_count
+@dataclass
+class RoutingAssessment:
+    """Per-net connectivity assessment with a skip recommendation.
+
+    Produced by :func:`_assess_routing_completeness`, which delegates to
+    :class:`~kicad_tools.analysis.net_status.NetStatusAnalyzer` so the
+    pipeline always agrees with ``kct net-status`` on the same board.
+
+    Routing-required subset rules (mirroring the issue #2731 acceptance
+    criteria):
+
+    * **Single-pad nets** are not counted as signal nets -- they have no
+      possible trace topology and cannot block a skip.  See
+      :attr:`NetStatus.status <kicad_tools.analysis.net_status.NetStatus.status>`
+      lines 98-114 for the underlying rule.
+    * **Zone-fillable plane nets** (``is_plane_net`` with the zone closing
+      the remaining unconnected pads) are likewise excluded from the
+      signal-net total -- the stitch + zone-fill steps close those.
+
+    Attributes:
+        total_signal_nets: Number of nets that need traces (excludes
+            single-pad nets and plane nets).
+        complete_signal_nets: Subset of ``total_signal_nets`` whose
+            connectivity status is "complete".
+        incomplete_signal_nets: Signal nets that are not "complete".
+        zone_fillable_nets: Names of plane nets handled by zones.
+        single_pad_nets: Names of single-pad nets (always complete).
+        signal_completion_percent: ``complete_signal_nets / total_signal_nets``
+            as a percent (or 100.0 when ``total_signal_nets == 0``).
+        recommend_skip: True iff the pipeline should skip the route step.
+        summary: Human-readable summary suitable for the skip message.
+        trace_count: Top-level segment+arc count (for diagnostics).
+    """
+
+    total_signal_nets: int = 0
+    complete_signal_nets: int = 0
+    incomplete_signal_nets: int = 0
+    zone_fillable_nets: list[str] = None  # type: ignore[assignment]
+    single_pad_nets: list[str] = None  # type: ignore[assignment]
+    signal_completion_percent: float = 0.0
+    recommend_skip: bool = False
+    summary: str = ""
+    trace_count: int = 0
+
+    def __post_init__(self) -> None:
+        if self.zone_fillable_nets is None:
+            self.zone_fillable_nets = []
+        if self.single_pad_nets is None:
+            self.single_pad_nets = []
+
+
+def _assess_routing_completeness(
+    pcb_file: Path,
+    threshold_percent: float = 95.0,
+) -> RoutingAssessment:
+    """Return per-net connectivity status with a skip recommendation.
+
+    Uses :class:`~kicad_tools.analysis.net_status.NetStatusAnalyzer` -- the
+    same engine ``kct net-status`` uses -- so the pipeline never disagrees
+    with the net-status command on the same board.
+
+    The recommendation logic (issue #2731):
+
+    1. Compute the **routing-required subset**: nets that need traces.
+       Excluded from this subset:
+
+       * Single-pad nets (``net.total_pads <= 1``) -- they are always
+         "complete" by definition (``NetStatus.status`` at
+         ``net_status.py:108-109``).
+       * Pure plane nets where the zone closes connectivity
+         (``net.is_plane_net`` and ``net.status == "complete"``).  The
+         zone-fill step handles those.
+
+    2. Skip iff:
+
+       * The board has at least one top-level routing segment, AND
+       * The routing-required subset is at least ``threshold_percent``
+         complete, AND
+       * Any remaining incomplete nets are zone-fillable plane nets
+         only (the stitch + zone-fill steps will close those).
+
+    Args:
+        pcb_file: Path to .kicad_pcb file.
+        threshold_percent: Minimum percentage of signal nets that must
+            be complete for the skip to be recommended.  Defaults to
+            95.0 to match the issue's recommended threshold.
+
+    Returns:
+        RoutingAssessment carrying counts, names, and the boolean
+        ``recommend_skip`` decision plus a human-readable ``summary``.
+    """
+    from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+    is_routed, trace_count = _has_routing_segments(pcb_file)
+
+    try:
+        result = NetStatusAnalyzer(pcb_file).analyze()
+    except Exception as exc:
+        # If we cannot analyze, fall back to "do not skip" so the router runs.
+        logger.warning("Could not analyze net connectivity for %s: %s", pcb_file, exc)
+        summary = f"net-status unavailable ({exc.__class__.__name__}); routing required"
+        return RoutingAssessment(
+            recommend_skip=False,
+            summary=summary,
+            trace_count=trace_count,
+        )
+
+    # Bucket nets according to the issue rules.
+    single_pad_nets: list[str] = []
+    zone_fillable_nets: list[str] = []
+    incomplete_zone_fillable: list[str] = []
+    signal_nets_total = 0
+    signal_nets_complete = 0
+
+    for net in result.nets:
+        # Single-pad: never a routing candidate.
+        if net.total_pads <= 1:
+            single_pad_nets.append(net.net_name)
+            continue
+        # Plane nets: handled by zone fill / stitching.  Track them so we
+        # can mention them in the skip summary, but they do NOT count
+        # toward the signal-net totals (they cannot block a skip).
+        if net.is_plane_net:
+            zone_fillable_nets.append(net.net_name)
+            if net.status != "complete":
+                incomplete_zone_fillable.append(net.net_name)
+            continue
+        # Everything else is a signal net.
+        signal_nets_total += 1
+        if net.status == "complete":
+            signal_nets_complete += 1
+
+    incomplete_signal = signal_nets_total - signal_nets_complete
+    if signal_nets_total > 0:
+        percent = 100.0 * signal_nets_complete / signal_nets_total
+    else:
+        # Empty signal subset (board has only plane/single-pad nets):
+        # nothing to route, treat as 100%.
+        percent = 100.0
+
+    threshold_ok = percent >= threshold_percent
+
+    # Recommend skip only when:
+    # - top-level segments exist (so a router has actually run before), AND
+    # - signal-net completion meets the threshold.
+    # Zone-fillable plane nets that are still incomplete do NOT block the
+    # skip -- the stitch + zone-fill steps will close those connections.
+    recommend_skip = is_routed and threshold_ok
+
+    # Build a human-readable summary matching `kct net-status` numbers.
+    parts: list[str] = []
+    parts.append(f"{signal_nets_complete}/{signal_nets_total} signal nets complete")
+    if zone_fillable_nets:
+        parts.append(f"{len(zone_fillable_nets)} plane nets zone-fillable")
+    if single_pad_nets:
+        parts.append(f"{len(single_pad_nets)} single-pad nets")
+
+    detail = ", ".join(parts)
+    if recommend_skip:
+        summary = f"route: skipped ({detail})"
+    elif not is_routed:
+        summary = f"route: no top-level segments -- routing required ({detail})"
+    else:
+        summary = (
+            f"route: signal completion {percent:.1f}% below threshold "
+            f"{threshold_percent:.1f}% -- routing required ({detail})"
+        )
+
+    return RoutingAssessment(
+        total_signal_nets=signal_nets_total,
+        complete_signal_nets=signal_nets_complete,
+        incomplete_signal_nets=incomplete_signal,
+        zone_fillable_nets=zone_fillable_nets,
+        single_pad_nets=single_pad_nets,
+        signal_completion_percent=percent,
+        recommend_skip=recommend_skip,
+        summary=summary,
+        trace_count=trace_count,
+    )
 
 
 def _resolve_pcb_from_project(project_file: Path) -> Path | None:
@@ -762,14 +943,25 @@ def _run_subprocess_step(
 
 
 def _run_step_route(ctx: PipelineContext, console: Console) -> PipelineResult:
-    """Run routing step if board is unrouted."""
-    is_routed, trace_count, net_count = _detect_routing_status(ctx.pcb_file)
+    """Run routing step if the board is not yet sufficiently routed.
 
-    if is_routed and not ctx.force:
+    Skip semantics (issue #2731): the route step is skipped only when
+    :class:`~kicad_tools.analysis.net_status.NetStatusAnalyzer` reports the
+    routing-required signal-net subset as at least
+    ``ctx.route_skip_threshold`` percent complete.  Single-pad nets and
+    zone-fillable plane nets do not block the skip -- those are handled by
+    other pipeline steps (or are inherently complete).  ``--force`` always
+    re-runs the router.
+    """
+    assessment = _assess_routing_completeness(
+        ctx.pcb_file, ctx.route_skip_threshold
+    )
+
+    if assessment.recommend_skip and not ctx.force:
         return PipelineResult(
             step=PipelineStep.ROUTE,
             success=True,
-            message=f"route: Board already routed ({trace_count} traces, {net_count} nets) - skipped",
+            message=assessment.summary,
             skipped=True,
         )
 
@@ -781,7 +973,7 @@ def _run_step_route(ctx: PipelineContext, console: Console) -> PipelineResult:
             cache_flags += " --no-cache"
         if ctx.clear_cache:
             cache_flags += " --clear-cache"
-        if is_routed:
+        if assessment.recommend_skip:
             return PipelineResult(
                 step=PipelineStep.ROUTE,
                 success=True,
@@ -1630,15 +1822,15 @@ def _build_commit_message(
     routed_nets: int | None = None
     total_nets: int | None = None
 
-    # Try to get routing status from the final PCB file
+    # Pull routing status from NetStatusAnalyzer so the commit message
+    # matches the numbers ``kct net-status`` would print (issue #2731).
     try:
-        _, _, net_count = _detect_routing_status(ctx.pcb_file)
-        if net_count > 0:
-            # The net count from _detect_routing_status is a rough count.
-            # Use it as both routed and total since the pipeline aims for
-            # full routing.
-            routed_nets = net_count
-            total_nets = net_count
+        from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+        net_result = NetStatusAnalyzer(ctx.pcb_file).analyze()
+        if net_result.total_nets > 0:
+            routed_nets = net_result.complete_count
+            total_nets = net_result.total_nets
     except Exception:
         pass
 
@@ -2001,6 +2193,18 @@ Examples:
         help="Force all steps (e.g., re-route even if already routed)",
     )
     parser.add_argument(
+        "--route-skip-threshold",
+        type=float,
+        default=95.0,
+        metavar="PERCENT",
+        help=(
+            "Minimum signal-net completion percentage required to skip the "
+            "route step (default: 95.0). Single-pad nets and zone-fillable "
+            "plane nets are excluded from the signal-net subset and never "
+            "block the skip."
+        ),
+    )
+    parser.add_argument(
         "--commit",
         action="store_true",
         default=False,
@@ -2139,6 +2343,7 @@ Examples:
         clear_cache=args.clear_cache,
         max_displacement=args.max_displacement,
         apply_sync=args.apply_sync,
+        route_skip_threshold=args.route_skip_threshold,
     )
 
     # Determine steps to run

--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -237,6 +237,21 @@ class ReportDataCollector:
         # Board dimensions via Edge.Cuts parsing (same pattern as ManufacturingAudit)
         board_width, board_height = self._get_board_dimensions(pcb)
 
+        # Net count consistency (issue #2731): use NetStatusAnalyzer.total_nets
+        # so the report agrees with `kct net-status` and the pipeline route
+        # skip message.  ``len(pcb.nets)`` includes net 0 and unnamed nets
+        # which are not real signal/plane nets; expose that as
+        # ``declared_net_count`` for diagnostics/backward compatibility.
+        declared_net_count = len(pcb.nets)
+        try:
+            from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+            net_count = NetStatusAnalyzer(pcb).analyze().total_nets
+        except Exception:
+            # Fall back to the declared count when analysis fails; keep the
+            # report from erroring out on the board-summary path.
+            net_count = declared_net_count
+
         return {
             "layer_count": len(copper_layers),
             "layer_names": layer_names,
@@ -244,7 +259,8 @@ class ReportDataCollector:
             "footprint_smd": smd_count,
             "footprint_tht": tht_count,
             "footprint_other": other_count,
-            "net_count": len(pcb.nets),
+            "net_count": net_count,
+            "declared_net_count": declared_net_count,
             "segment_count": pcb.segment_count,
             "via_count": pcb.via_count,
             "board_width_mm": round(board_width, 2),

--- a/tests/test_pipeline_cli_args.py
+++ b/tests/test_pipeline_cli_args.py
@@ -13,9 +13,8 @@ from unittest.mock import patch
 
 import pytest
 
-from kicad_tools.cli.parser import create_parser
 from kicad_tools.cli.commands.pipeline import run_pipeline_command
-
+from kicad_tools.cli.parser import create_parser
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -133,26 +132,50 @@ class TestForwarding:
 
     def test_no_cache_forwarded(self):
         argv = self._capture_argv(
-            {"pipeline_input": "b.kicad_pcb", "pipeline_no_cache": True, "pipeline_clear_cache": False, "pipeline_sch": None, "global_quiet": False}
+            {
+                "pipeline_input": "b.kicad_pcb",
+                "pipeline_no_cache": True,
+                "pipeline_clear_cache": False,
+                "pipeline_sch": None,
+                "global_quiet": False,
+            }
         )
         assert "--no-cache" in argv
 
     def test_clear_cache_forwarded(self):
         argv = self._capture_argv(
-            {"pipeline_input": "b.kicad_pcb", "pipeline_no_cache": False, "pipeline_clear_cache": True, "pipeline_sch": None, "global_quiet": False}
+            {
+                "pipeline_input": "b.kicad_pcb",
+                "pipeline_no_cache": False,
+                "pipeline_clear_cache": True,
+                "pipeline_sch": None,
+                "global_quiet": False,
+            }
         )
         assert "--clear-cache" in argv
 
     def test_both_cache_flags_forwarded(self):
         argv = self._capture_argv(
-            {"pipeline_input": "b.kicad_pcb", "pipeline_no_cache": True, "pipeline_clear_cache": True, "pipeline_sch": None, "global_quiet": False}
+            {
+                "pipeline_input": "b.kicad_pcb",
+                "pipeline_no_cache": True,
+                "pipeline_clear_cache": True,
+                "pipeline_sch": None,
+                "global_quiet": False,
+            }
         )
         assert "--no-cache" in argv
         assert "--clear-cache" in argv
 
     def test_sch_forwarded(self):
         argv = self._capture_argv(
-            {"pipeline_input": "b.kicad_pcb", "pipeline_no_cache": False, "pipeline_clear_cache": False, "pipeline_sch": "my.kicad_sch", "global_quiet": False}
+            {
+                "pipeline_input": "b.kicad_pcb",
+                "pipeline_no_cache": False,
+                "pipeline_clear_cache": False,
+                "pipeline_sch": "my.kicad_sch",
+                "global_quiet": False,
+            }
         )
         assert "--sch" in argv
         idx = argv.index("--sch")
@@ -160,8 +183,93 @@ class TestForwarding:
 
     def test_no_flags_when_defaults(self):
         argv = self._capture_argv(
-            {"pipeline_input": "b.kicad_pcb", "pipeline_no_cache": False, "pipeline_clear_cache": False, "pipeline_sch": None, "global_quiet": False}
+            {
+                "pipeline_input": "b.kicad_pcb",
+                "pipeline_no_cache": False,
+                "pipeline_clear_cache": False,
+                "pipeline_sch": None,
+                "global_quiet": False,
+            }
         )
         assert "--no-cache" not in argv
         assert "--clear-cache" not in argv
         assert "--sch" not in argv
+
+
+# ---------------------------------------------------------------------------
+# --route-skip-threshold parsing + forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestRouteSkipThresholdParsing:
+    """Verify --route-skip-threshold is exposed by the top-level CLI parser."""
+
+    def test_default_is_95(self):
+        ns = _parse_pipeline_args(["board.kicad_pcb"])
+        assert ns.pipeline_route_skip_threshold == 95.0
+
+    def test_custom_value_parsed(self):
+        ns = _parse_pipeline_args(["board.kicad_pcb", "--route-skip-threshold", "80.0"])
+        assert ns.pipeline_route_skip_threshold == 80.0
+
+    def test_value_is_float(self):
+        ns = _parse_pipeline_args(["board.kicad_pcb", "--route-skip-threshold", "50"])
+        assert isinstance(ns.pipeline_route_skip_threshold, float)
+        assert ns.pipeline_route_skip_threshold == 50.0
+
+
+class TestRouteSkipThresholdForwarding:
+    """Verify commands/pipeline.py forwards --route-skip-threshold into sub_argv."""
+
+    def _capture_argv(self, args_dict: dict) -> list[str]:
+        ns = SimpleNamespace(**args_dict)
+        captured: list[str] = []
+
+        def _fake_main(argv):
+            captured.extend(argv)
+            return 0
+
+        with patch("kicad_tools.cli.pipeline_cmd.main", _fake_main):
+            run_pipeline_command(ns)
+        return captured
+
+    def test_default_threshold_not_forwarded(self):
+        """When threshold equals 95.0 default, the flag is omitted from sub_argv."""
+        argv = self._capture_argv(
+            {
+                "pipeline_input": "b.kicad_pcb",
+                "pipeline_route_skip_threshold": 95.0,
+                "global_quiet": False,
+            }
+        )
+        assert "--route-skip-threshold" not in argv
+
+    def test_custom_threshold_forwarded(self):
+        argv = self._capture_argv(
+            {
+                "pipeline_input": "b.kicad_pcb",
+                "pipeline_route_skip_threshold": 80.0,
+                "global_quiet": False,
+            }
+        )
+        assert "--route-skip-threshold" in argv
+        idx = argv.index("--route-skip-threshold")
+        assert argv[idx + 1] == "80.0"
+
+    def test_round_trip_parser_to_main(self):
+        """Full chain: top-level parser -> shim -> pipeline_cmd.main argv."""
+        ns = _parse_pipeline_args(["board.kicad_pcb", "--route-skip-threshold", "75.0"])
+        # Forwarding picks up the parsed namespace value.
+        captured: list[str] = []
+
+        def _fake_main(argv):
+            captured.extend(argv)
+            return 0
+
+        with patch("kicad_tools.cli.pipeline_cmd.main", _fake_main):
+            # The top-level namespace lacks `global_quiet` by default; supply it.
+            ns.global_quiet = False
+            run_pipeline_command(ns)
+        assert "--route-skip-threshold" in captured
+        idx = captured.index("--route-skip-threshold")
+        assert captured[idx + 1] == "75.0"

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -13,9 +13,10 @@ from kicad_tools.cli.pipeline_cmd import (
     PipelineContext,
     PipelineResult,
     PipelineStep,
+    _assess_routing_completeness,
     _build_commit_message,
-    _detect_routing_status,
     _fetch_check_results,
+    _has_routing_segments,
     _is_git_repo,
     _print_final_summary,
     _resolve_pcb_from_project,
@@ -238,51 +239,205 @@ def project_with_pcb(tmp_path: Path) -> tuple[Path, Path]:
     return pro_file, pcb_file
 
 
-class TestDetectRoutingStatus:
-    """Tests for _detect_routing_status helper."""
+class TestHasRoutingSegments:
+    """Tests for _has_routing_segments helper (replaces _detect_routing_status)."""
 
     def test_routed_board_detected(self, routed_pcb: Path):
         """A PCB with segments is detected as routed."""
-        is_routed, trace_count, net_count = _detect_routing_status(routed_pcb)
+        is_routed, trace_count = _has_routing_segments(routed_pcb)
         assert is_routed is True
         assert trace_count == 2
-        assert net_count > 0
 
     def test_unrouted_board_detected(self, unrouted_pcb: Path):
         """A PCB without segments is detected as unrouted."""
-        is_routed, trace_count, net_count = _detect_routing_status(unrouted_pcb)
+        is_routed, trace_count = _has_routing_segments(unrouted_pcb)
         assert is_routed is False
         assert trace_count == 0
 
     def test_empty_board(self, empty_pcb: Path):
         """An empty PCB is detected as unrouted."""
-        is_routed, trace_count, net_count = _detect_routing_status(empty_pcb)
+        is_routed, trace_count = _has_routing_segments(empty_pcb)
         assert is_routed is False
         assert trace_count == 0
-        assert net_count == 0
 
     def test_zone_fill_only_not_routed(self, zone_fill_only_pcb: Path):
         """A PCB with only zone fills (no top-level segments) is unrouted (#1835)."""
-        is_routed, trace_count, net_count = _detect_routing_status(zone_fill_only_pcb)
+        is_routed, trace_count = _has_routing_segments(zone_fill_only_pcb)
         assert is_routed is False
         assert trace_count == 0
-        assert net_count > 0
 
     def test_zone_fill_with_traces_detected(self, zone_fill_with_traces_pcb: Path):
         """A PCB with zone fills AND top-level segments is detected as routed."""
-        is_routed, trace_count, net_count = _detect_routing_status(zone_fill_with_traces_pcb)
+        is_routed, trace_count = _has_routing_segments(zone_fill_with_traces_pcb)
         assert is_routed is True
         assert trace_count == 1
-        assert net_count > 0
 
     def test_nonexistent_file(self, tmp_path: Path):
         """Non-existent file returns unrouted with zero counts."""
-        is_routed, trace_count, net_count = _detect_routing_status(
+        is_routed, trace_count = _has_routing_segments(
             tmp_path / "nonexistent.kicad_pcb"
         )
         assert is_routed is False
         assert trace_count == 0
-        assert net_count == 0
+
+
+class TestAssessRoutingCompleteness:
+    """Tests for _assess_routing_completeness (the new connectivity-based gate).
+
+    Validates the issue #2731 contract:
+
+    * Skip decision is based on NetStatusAnalyzer, not on the bogus
+      (net N) token count.
+    * Single-pad nets do not block the skip.
+    * Zone-fillable plane nets do not block the skip.
+    * Threshold is respected (default 95%, configurable).
+    """
+
+    def test_routed_board_recommends_skip(self, routed_pcb: Path):
+        """A board with traces and only single-pad nets recommends skip."""
+        assessment = _assess_routing_completeness(routed_pcb)
+        assert assessment.recommend_skip is True
+        # ROUTED_PCB has 3 named nets, all single-pad (VIN, NET1) or empty
+        # (GND).  None are signal nets that need routing.
+        assert assessment.total_signal_nets == 0
+        assert assessment.summary.startswith("route: skipped")
+
+    def test_unrouted_board_does_not_recommend_skip(self, unrouted_pcb: Path):
+        """A board with no top-level segments does not recommend skip."""
+        assessment = _assess_routing_completeness(unrouted_pcb)
+        assert assessment.recommend_skip is False
+        # Summary should explain why
+        assert "routing required" in assessment.summary
+
+    def test_empty_board_does_not_recommend_skip(self, empty_pcb: Path):
+        """An empty board does not skip (no segments to indicate prior routing)."""
+        assessment = _assess_routing_completeness(empty_pcb)
+        assert assessment.recommend_skip is False
+
+    def test_single_pad_nets_do_not_block_skip(self, tmp_path: Path):
+        """Single-pad nets must not count toward signal-net totals (#2731)."""
+        # Board with one trace and a single-pad net that should NOT block.
+        pcb_text = """\
+(kicad_pcb
+  (version 20240108) (generator "test") (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no)) (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SINGLE")
+  (net 2 "ROUTED")
+  (footprint "Resistor_SMD:R_0603_1608Metric" (layer "F.Cu") (uuid "fp-r1") (at 100 50)
+    (property "Reference" "R1" (at 0 -1 0) (layer "F.SilkS"))
+    (pad "1" smd roundrect (at -0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 1 "SINGLE"))
+  )
+  (footprint "Resistor_SMD:R_0603_1608Metric" (layer "F.Cu") (uuid "fp-r2") (at 100 60)
+    (property "Reference" "R2" (at 0 -1 0) (layer "F.SilkS"))
+    (pad "1" smd roundrect (at -0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 2 "ROUTED"))
+    (pad "2" smd roundrect (at 0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 2 "ROUTED"))
+  )
+  (segment (start 99.2 60) (end 100.8 60) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-1"))
+)
+"""
+        pcb_file = tmp_path / "single_pad.kicad_pcb"
+        pcb_file.write_text(pcb_text)
+
+        assessment = _assess_routing_completeness(pcb_file)
+        # SINGLE has 1 pad -> single-pad bucket; ROUTED has 2 pads, both at
+        # the segment endpoints -> 1/1 signal nets complete.
+        assert "SINGLE" in assessment.single_pad_nets
+        assert assessment.total_signal_nets == 1
+        assert assessment.complete_signal_nets == 1
+        assert assessment.recommend_skip is True
+
+    def test_threshold_blocks_skip_when_signal_incomplete(self, tmp_path: Path):
+        """When signal nets are below threshold, do not skip."""
+        # Two 2-pad signal nets; one is routed, the other is not.
+        pcb_text = """\
+(kicad_pcb
+  (version 20240108) (generator "test") (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no)) (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "A")
+  (net 2 "B")
+  (footprint "Resistor_SMD:R_0603_1608Metric" (layer "F.Cu") (uuid "fp-r1") (at 100 50)
+    (property "Reference" "R1" (at 0 -1 0) (layer "F.SilkS"))
+    (pad "1" smd roundrect (at -0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 1 "A"))
+    (pad "2" smd roundrect (at 0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 1 "A"))
+  )
+  (footprint "Resistor_SMD:R_0603_1608Metric" (layer "F.Cu") (uuid "fp-r2") (at 100 60)
+    (property "Reference" "R2" (at 0 -1 0) (layer "F.SilkS"))
+    (pad "1" smd roundrect (at -0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 2 "B"))
+    (pad "2" smd roundrect (at 0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 2 "B"))
+  )
+  (segment (start 99.2 50) (end 100.8 50) (width 0.25) (layer "F.Cu") (net 1) (uuid "seg-1"))
+)
+"""
+        pcb_file = tmp_path / "half_routed.kicad_pcb"
+        pcb_file.write_text(pcb_text)
+
+        # Default threshold (95%): 1/2 = 50% -> route
+        assessment = _assess_routing_completeness(pcb_file)
+        assert assessment.total_signal_nets == 2
+        assert assessment.complete_signal_nets == 1
+        assert assessment.recommend_skip is False
+        assert "below threshold" in assessment.summary
+
+        # 50% threshold: 50% meets it -> skip
+        assessment_low = _assess_routing_completeness(pcb_file, threshold_percent=50.0)
+        assert assessment_low.recommend_skip is True
+
+    def test_zone_fillable_plane_does_not_block_skip(self, tmp_path: Path):
+        """An incomplete plane net must NOT block the skip (#2731).
+
+        Construct a PCB with one routed signal net plus a GND plane net
+        where the GND pads are unconnected (no segments, no via in
+        zone).  Without the issue #2731 fix, the incomplete GND would
+        block the skip; with the fix, the route step skips because GND
+        is zone-fillable.
+        """
+        pcb_text = """\
+(kicad_pcb
+  (version 20240108) (generator "test") (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no)) (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "SIG")
+  (footprint "Resistor_SMD:R_0603_1608Metric" (layer "F.Cu") (uuid "fp-r1") (at 100 50)
+    (property "Reference" "R1" (at 0 -1 0) (layer "F.SilkS"))
+    (pad "1" smd roundrect (at -0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 2 "SIG"))
+  )
+  (footprint "Resistor_SMD:R_0603_1608Metric" (layer "F.Cu") (uuid "fp-r2") (at 110 50)
+    (property "Reference" "R2" (at 0 -1 0) (layer "F.SilkS"))
+    (pad "1" smd roundrect (at -0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 2 "SIG"))
+    (pad "2" smd roundrect (at 0.8 0) (size 0.9 0.95) (layers "F.Cu") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+  (segment (start 100.8 50) (end 109.2 50) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-1"))
+  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "zone-1") (hatch edge 0.5)
+    (connect_pads (clearance 0.2)) (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 90 40) (xy 120 40) (xy 120 60) (xy 90 60)))
+  )
+)
+"""
+        pcb_file = tmp_path / "zone_plane.kicad_pcb"
+        pcb_file.write_text(pcb_text)
+
+        assessment = _assess_routing_completeness(pcb_file)
+        # GND has a zone -> plane net, bucketed as zone-fillable
+        assert "GND" in assessment.zone_fillable_nets
+        # SIG is a 2-pad signal net with the routing segment between the
+        # two pad positions -> complete signal net.
+        assert assessment.total_signal_nets == 1
+        assert assessment.complete_signal_nets == 1
+        # Even though GND is incomplete (no copper connecting its pads
+        # apart from the zone, which is on B.Cu while the pads are F.Cu),
+        # the skip must still be recommended because GND is zone-fillable.
+        assert assessment.recommend_skip is True
 
 
 class TestResolveProjectPcb:
@@ -389,16 +544,18 @@ class TestRoutingSkip:
     """Tests for automatic routing detection and skip."""
 
     def test_routing_skipped_when_routed(self, routed_pcb: Path):
-        """Pipeline skips routing when board already has traces."""
+        """Pipeline skips routing when board has traces and signal nets are complete."""
         ctx = PipelineContext(pcb_file=routed_pcb, quiet=True)
         results = run_pipeline(ctx, [PipelineStep.ROUTE])
 
         assert len(results) == 1
         assert results[0].success is True
         assert results[0].skipped is True
-        assert "already routed" in results[0].message
+        assert "skipped" in results[0].message
         # Verify message uses "route: " prefix convention
         assert results[0].message.startswith("route: ")
+        # Message should mention signal nets (matches kct net-status numbers)
+        assert "signal nets" in results[0].message
 
     @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
     def test_routing_invoked_when_unrouted(self, mock_run, unrouted_pcb: Path):

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -99,6 +99,7 @@ class TestCollectBoardSummary:
             "footprint_tht",
             "footprint_other",
             "net_count",
+            "declared_net_count",
             "segment_count",
             "via_count",
             "board_width_mm",


### PR DESCRIPTION
Closes #2731.

## Summary

The pipeline's "board already routed" gate previously fired on any
top-level `(segment ...)` token plus a raw `(net N)` token count, which
also counts pad/seg/via attributions. On boards with stale net
references this silently skipped the most important step. This PR
replaces the heuristic with a connectivity-based check that delegates
to `NetStatusAnalyzer` -- the same engine `kct net-status` uses -- so
the pipeline never disagrees with the net-status command on the same
board.

## Changes

- **`pipeline_cmd.py`**:
  - `_detect_routing_status` (mixed-purpose token counter) replaced by
    `_has_routing_segments` (pure "has top-level segments" probe).
  - New `_assess_routing_completeness(pcb_file, threshold_percent)`
    returns a `RoutingAssessment` dataclass with per-net buckets and
    a boolean `recommend_skip`.
  - Skip rules (issue #2731 acceptance):
    - Single-pad nets (`total_pads <= 1`) are bucketed separately and
      do NOT count toward signal-net totals -- they cannot block a skip.
    - Plane nets (`is_plane_net`) are bucketed as `zone_fillable_nets`
      and likewise excluded from the signal-net subset; the stitch
      and zone-fill steps close those connections.
    - Skip iff `is_routed` AND signal-net completion >= threshold.
  - `_run_step_route` rewritten on top of `_assess_routing_completeness`;
    skip message is now `"route: skipped (N/M signal nets complete,
    K plane nets zone-fillable)"` and matches `kct net-status` numbers.
  - `_build_commit_message` now reads complete/total nets from the
    analyzer so commit messages agree with the skip message.
- **New CLI flag**: `--route-skip-threshold PERCENT` (default `95.0`).
  `--force` still overrides.
- **`report/collector.py:collect_board_summary`** switches `net_count`
  from `len(pcb.nets)` to `NetStatusAnalyzer.analyze().total_nets`,
  with the prior value exposed as `declared_net_count`. The three
  surfaces (pipeline skip, `kct net-status`, `kct report` board stats)
  now report consistent numbers.

## Test plan

- [x] Unit: `_has_routing_segments` (6 cases, replaces old
      `_detect_routing_status` tests).
- [x] Unit: `_assess_routing_completeness`
      - routed board with only single-pad nets -> recommend skip
      - unrouted board -> do not skip
      - empty board -> do not skip
      - single-pad net does NOT block skip
      - threshold gating (50% completion vs default 95% vs --threshold 50)
      - zone-fillable plane net does NOT block skip even when incomplete
- [x] Integration: existing `TestRoutingSkip` (routed/unrouted/force)
      continues to pass with the new skip message.
- [x] `tests/test_report_collector.py` updated for the new
      `declared_net_count` key.
- [x] `--route-skip-threshold` is wired through argparse -> context ->
      assessment (verified via `kct pipeline --help`).
- [x] Dry-run path preserved (re-route message gated on
      `assessment.recommend_skip`).

The 5 unrelated `TestReportStep`/`TestFixERCStep`/`TestExportStep`
failures observed on the branch are pre-existing on `main` (confirmed
by stashing this PR's changes and re-running).

## Acceptance criteria checklist

- [x] `_run_step_route` no longer uses the bogus token-count `net_count`
- [x] Skip decision derived from `NetStatusAnalyzer`
- [x] On a board with stale `(net N)` tokens, the pipeline now routes
      (or prints a skip summary with `kct net-status`-matching numbers)
- [x] Single-pad nets and zone-fillable plane nets do not block skip
- [x] `--route-skip-threshold PERCENT` exposed, default 95.0
- [x] `--force` still overrides
- [x] `pipeline`, `net-status`, and `report` board stats agree on the
      net count for the same board
- [x] `_detect_routing_status` deleted; `_has_routing_segments` is a
      pure "has top-level segments" probe; the misleading `net_count`
      tuple field is gone
- [x] Skip path still works in dry-run mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)