### PR TITLE
feat(pipeline): add SYNC step to reconcile schematic <-> PCB before routing (closes #2730)

### DIFF
--- a/src/kicad_tools/cli/commands/pipeline.py
+++ b/src/kicad_tools/cli/commands/pipeline.py
@@ -58,6 +58,10 @@ def run_pipeline_command(args) -> int:
     if getattr(args, "pipeline_sch", None):
         sub_argv.extend(["--sch", args.pipeline_sch])
 
+    # Apply sync drift in the sync step
+    if getattr(args, "pipeline_apply_sync", False):
+        sub_argv.append("--apply-sync")
+
     # Use global quiet or command-level quiet
     if getattr(args, "global_quiet", False):
         sub_argv.append("--quiet")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -4712,6 +4712,7 @@ def _add_pipeline_parser(subparsers) -> None:
         choices=[
             "erc",
             "fix-erc",
+            "sync",
             "fix-silkscreen",
             "route",
             "stitch",
@@ -4814,6 +4815,16 @@ def _add_pipeline_parser(subparsers) -> None:
         dest="pipeline_sch",
         default=None,
         help="Path to root .kicad_sch file (overrides auto-discovery)",
+    )
+    pipeline_parser.add_argument(
+        "--apply-sync",
+        dest="pipeline_apply_sync",
+        action="store_true",
+        default=False,
+        help=(
+            "In the sync step, auto-add missing footprints and apply"
+            " high-confidence value/footprint corrections in place."
+        ),
     )
 
 

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -4,17 +4,18 @@ Pipeline command for end-to-end repair workflow on existing PCBs.
 Orchestrates the full repair pipeline:
 0. ERC check (schematic validation)
 1. Fix ERC violations (auto-remediation when errors detected)
-2. Fix silkscreen (manufacturer line-width compliance)
-3. Fix vias (manufacturer compliance)
-4. [Optional] Route (if board is unrouted)
-5. Stitch (add stitching vias for plane connections on multi-layer boards)
-6. Optimize traces
-7. Zone fill (requires kicad-cli)
-8. Fix DRC violations
-9. Zone refill (recompute zones after trace nudges)
-10. Audit / check
-11. Report generation (manufacturing report)
-12. Export manufacturing package (gerbers, BOM, CPL, project ZIP)
+2. Sync schematic <-> PCB (reconcile component sets before routing)
+3. Fix silkscreen (manufacturer line-width compliance)
+4. Fix vias (manufacturer compliance)
+5. [Optional] Route (if board is unrouted)
+6. Stitch (add stitching vias for plane connections on multi-layer boards)
+7. Optimize traces
+8. Zone fill (requires kicad-cli)
+9. Fix DRC violations
+10. Zone refill (recompute zones after trace nudges)
+11. Audit / check
+12. Report generation (manufacturing report)
+13. Export manufacturing package (gerbers, BOM, CPL, project ZIP)
 
 The stitch step must run AFTER route (so traces exist) and BEFORE zones
 (so zone fill respects via clearances).  On 2-layer boards or boards
@@ -56,6 +57,7 @@ class PipelineStep(str, Enum):
 
     ERC = "erc"
     FIX_ERC = "fix-erc"
+    SYNC = "sync"
     FIX_SILKSCREEN = "fix-silkscreen"
     ROUTE = "route"
     STITCH = "stitch"
@@ -82,6 +84,7 @@ class PipelineStep(str, Enum):
 ALL_STEPS = [
     PipelineStep.ERC,
     PipelineStep.FIX_ERC,
+    PipelineStep.SYNC,
     PipelineStep.FIX_SILKSCREEN,
     PipelineStep.FIX_VIAS,
     PipelineStep.ROUTE,
@@ -126,6 +129,7 @@ class PipelineContext:
     no_cache: bool = False
     clear_cache: bool = False
     max_displacement: float = 2.0
+    apply_sync: bool = False
     erc_error_count: int = 0
     _check_data: dict | None = None  # cached kct check --format json result
 
@@ -513,6 +517,205 @@ def _run_step_fix_erc(ctx: PipelineContext, console: Console) -> PipelineResult:
         step=PipelineStep.FIX_ERC,
         success=success,
         message=f"fix-erc: {message}",
+    )
+
+
+def _print_sync_analysis_detail(analysis, console: Console) -> None:
+    """Print per-category sync analysis detail (mirrors sync_cmd._output_table)."""
+    if analysis.value_mismatches:
+        console.print(f"    Value mismatches ({len(analysis.value_mismatches)}):")
+        for mm in analysis.value_mismatches:
+            console.print(
+                f"      {mm['reference']}: sch={mm['schematic_value']} pcb={mm['pcb_value']}"
+            )
+
+    if analysis.footprint_mismatches:
+        console.print(f"    Footprint mismatches ({len(analysis.footprint_mismatches)}):")
+        for mm in analysis.footprint_mismatches:
+            console.print(
+                f"      {mm['reference']}: sch={mm['schematic_footprint']}"
+                f" pcb={mm['pcb_footprint']}"
+            )
+
+    if analysis.add_footprint_actions:
+        console.print(f"    Add footprint ({len(analysis.add_footprint_actions)}):")
+        for action in analysis.add_footprint_actions:
+            ref = action["reference"]
+            fp = action.get("footprint", "")
+            val = action.get("value", "")
+            console.print(f"      {ref}: {fp} ({val})")
+
+    if analysis.schematic_orphans:
+        console.print(f"    Schematic-only ({len(analysis.schematic_orphans)}):")
+        for ref in analysis.schematic_orphans:
+            console.print(f"      {ref} - missing from PCB")
+
+    if analysis.pcb_orphans:
+        console.print(f"    PCB-only ({len(analysis.pcb_orphans)}):")
+        for ref in analysis.pcb_orphans:
+            console.print(f"      {ref} - not in schematic")
+
+
+def _run_step_sync(ctx: PipelineContext, console: Console) -> PipelineResult:
+    """Reconcile schematic <-> PCB component sets in-process.
+
+    Uses :class:`kicad_tools.sync.reconciler.Reconciler` to analyse drift
+    between the schematic and PCB before routing.  Behaviour matches the
+    ERC step's blocking semantics:
+
+    - In sync: success with a one-line "sync: in sync" message.
+    - Schematic orphans (refs missing from PCB): blocking.  Halts the
+      pipeline unless ``--force`` (continue past drift) or ``--apply-sync``
+      (auto-add missing footprints and apply high-confidence corrections)
+      is set.
+    - Value/footprint mismatches or PCB-only refs without schematic
+      orphans: warning, pipeline continues.
+
+    Skips gracefully when no schematic is available.
+    """
+    # Skip if no schematic file available
+    if ctx.schematic_file is None:
+        return PipelineResult(
+            step=PipelineStep.SYNC,
+            success=True,
+            message="sync: no .kicad_sch found alongside PCB — skipped (use --sch to specify)",
+            skipped=True,
+        )
+
+    # Dry-run mode: preview without instantiating Reconciler
+    if ctx.dry_run:
+        return PipelineResult(
+            step=PipelineStep.SYNC,
+            success=True,
+            message=(
+                f"[dry-run] Would run: kct sync --analyze {ctx.schematic_file.name}"
+                f" --pcb {ctx.pcb_file.name}"
+            ),
+        )
+
+    if not ctx.quiet:
+        console.print(f"  Reconciling {ctx.schematic_file.name} <-> {ctx.pcb_file.name}...")
+
+    # Instantiate Reconciler in-process (no subprocess)
+    try:
+        from ..sync.reconciler import Reconciler
+
+        reconciler = Reconciler(
+            schematic=ctx.schematic_file,
+            pcb=ctx.pcb_file,
+        )
+        analysis = reconciler.analyze()
+    except Exception as e:
+        logger.warning("sync: failed to analyze: %s", e)
+        return PipelineResult(
+            step=PipelineStep.SYNC,
+            success=False,
+            message=f"sync: failed to analyze — {e}",
+        )
+
+    # Clean pass
+    if analysis.is_in_sync:
+        return PipelineResult(
+            step=PipelineStep.SYNC,
+            success=True,
+            message="sync: in sync",
+        )
+
+    # Print the summary plus per-category detail
+    if not ctx.quiet:
+        for line in analysis.summary().splitlines():
+            console.print(f"    {line}")
+        _print_sync_analysis_detail(analysis, console)
+
+    schematic_orphans = list(analysis.schematic_orphans)
+    value_mismatch_count = len(analysis.value_mismatches)
+    footprint_mismatch_count = len(analysis.footprint_mismatches)
+    pcb_orphan_count = len(analysis.pcb_orphans)
+
+    # --apply-sync: invoke Reconciler.apply() to auto-add missing footprints
+    # and apply high-confidence value/footprint corrections.
+    if ctx.apply_sync:
+        try:
+            changes = reconciler.apply(
+                analysis,
+                dry_run=False,
+                min_confidence="high",
+                remove_orphans=False,
+            )
+        except Exception as e:
+            logger.warning("sync: apply failed: %s", e)
+            return PipelineResult(
+                step=PipelineStep.SYNC,
+                success=False,
+                message=f"sync: apply failed — {e}",
+            )
+
+        applied = [c for c in changes if c.applied]
+        if not ctx.quiet:
+            console.print(f"    Applied {len(applied)} change(s) (of {len(changes)} proposed)")
+
+        # Re-run analyze() so the user sees the residual drift
+        try:
+            post_analysis = reconciler.analyze()
+        except Exception as e:
+            logger.warning("sync: post-apply analyze failed: %s", e)
+            post_analysis = None
+
+        if post_analysis is not None and not ctx.quiet:
+            console.print("    Post-apply summary:")
+            for line in post_analysis.summary().splitlines():
+                console.print(f"      {line}")
+
+        return PipelineResult(
+            step=PipelineStep.SYNC,
+            success=True,
+            message=(f"sync: applied {len(applied)} change(s) (min_confidence=high)"),
+            warning=bool(post_analysis is not None and not post_analysis.is_in_sync),
+        )
+
+    # Schematic orphans are blocking (parallels ERC's blocking semantics)
+    if schematic_orphans:
+        if ctx.force:
+            if not ctx.quiet:
+                console.print(
+                    f"  [yellow]sync: {len(schematic_orphans)} schematic-only ref(s)"
+                    " missing from PCB — continuing (--force)[/yellow]"
+                )
+            return PipelineResult(
+                step=PipelineStep.SYNC,
+                success=True,
+                message=(
+                    f"sync: {len(schematic_orphans)} schematic-only ref(s)"
+                    " missing from PCB — continuing (--force)"
+                ),
+                warning=True,
+            )
+
+        return PipelineResult(
+            step=PipelineStep.SYNC,
+            success=False,
+            message=(
+                f"sync: {len(schematic_orphans)} schematic-only ref(s) missing"
+                " from PCB (use --apply-sync to add, or --force to continue)"
+            ),
+        )
+
+    # No blocking schematic orphans, but other drift exists -> WARN, success=True
+    parts = []
+    if value_mismatch_count:
+        parts.append(f"{value_mismatch_count} value mismatch(es)")
+    if footprint_mismatch_count:
+        parts.append(f"{footprint_mismatch_count} footprint mismatch(es)")
+    if pcb_orphan_count:
+        parts.append(f"{pcb_orphan_count} PCB-only ref(s)")
+
+    return PipelineResult(
+        step=PipelineStep.SYNC,
+        success=True,
+        message=(
+            "sync: drift detected — " + (", ".join(parts) if parts else "non-blocking issues")
+        ),
+        warning=True,
     )
 
 
@@ -1436,6 +1639,7 @@ def _git_commit_result(
 STEP_RUNNERS = {
     PipelineStep.ERC: _run_step_erc,
     PipelineStep.FIX_ERC: _run_step_fix_erc,
+    PipelineStep.SYNC: _run_step_sync,
     PipelineStep.FIX_SILKSCREEN: _run_step_fix_silkscreen,
     PipelineStep.ROUTE: _run_step_route,
     PipelineStep.STITCH: _run_step_stitch,
@@ -1724,6 +1928,17 @@ Examples:
         default=None,
         help="Path to root .kicad_sch file (overrides auto-discovery)",
     )
+    parser.add_argument(
+        "--apply-sync",
+        action="store_true",
+        default=False,
+        help=(
+            "In the sync step, auto-add missing footprints and apply"
+            " high-confidence value/footprint corrections in place."
+            " Without this flag, sync drift is blocking (use --force to"
+            " continue past drift without modification)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     input_path = Path(args.input).resolve()
@@ -1807,6 +2022,7 @@ Examples:
         no_cache=args.no_cache,
         clear_cache=args.clear_cache,
         max_displacement=args.max_displacement,
+        apply_sync=args.apply_sync,
     )
 
     # Determine steps to run
@@ -1823,8 +2039,7 @@ Examples:
     #   1 = hard failure
     all_succeeded = all(r.success for r in results)
     has_route_warning = any(
-        r.step == PipelineStep.ROUTE and not r.success and r.warning
-        for r in results
+        r.step == PipelineStep.ROUTE and not r.success and r.warning for r in results
     )
 
     if not all_succeeded and not has_route_warning:

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -820,10 +820,11 @@ class TestPipelineStepOrder:
         assert set(ALL_STEPS) == set(PipelineStep)
 
     def test_step_order(self):
-        """Steps execute in the correct order: stitch after route, zones before fix-drc."""
+        """Steps execute in the correct order: sync after fix-erc, stitch after route, zones before fix-drc."""
         expected = [
             PipelineStep.ERC,
             PipelineStep.FIX_ERC,
+            PipelineStep.SYNC,
             PipelineStep.FIX_SILKSCREEN,
             PipelineStep.FIX_VIAS,
             PipelineStep.ROUTE,
@@ -2096,10 +2097,11 @@ class TestERCStep:
         assert results[1].success is True  # FIX_VIAS runs
 
     def test_erc_is_first_step(self):
-        """ERC is the first step in ALL_STEPS, followed by FIX_ERC, then FIX_SILKSCREEN."""
+        """ERC is the first step in ALL_STEPS, followed by FIX_ERC, SYNC, then FIX_SILKSCREEN."""
         assert ALL_STEPS[0] == PipelineStep.ERC
         assert ALL_STEPS[1] == PipelineStep.FIX_ERC
-        assert ALL_STEPS[2] == PipelineStep.FIX_SILKSCREEN
+        assert ALL_STEPS[2] == PipelineStep.SYNC
+        assert ALL_STEPS[3] == PipelineStep.FIX_SILKSCREEN
 
     @patch("kicad_tools.cli.runner.find_kicad_cli")
     @patch("kicad_tools.cli.runner.run_erc")

--- a/tests/test_pipeline_sync_step.py
+++ b/tests/test_pipeline_sync_step.py
@@ -1,0 +1,332 @@
+"""Tests for the pipeline sync step (kct pipeline --step sync).
+
+Covers the in-process Reconciler integration added by issue #2730.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from kicad_tools.cli.pipeline_cmd import (
+    ALL_STEPS,
+    STEP_RUNNERS,
+    PipelineContext,
+    PipelineStep,
+    _run_step_sync,
+)
+from kicad_tools.cli.pipeline_cmd import (
+    main as pipeline_main,
+)
+from kicad_tools.sync.reconciler import SyncAnalysis, SyncChange
+
+# Minimal PCB and schematic stubs used to exercise the runner without
+# actually constructing valid KiCad files.  The Reconciler is monkey-patched
+# in nearly every test, so the file contents don't need to parse.
+STUB_PCB = "(kicad_pcb)\n"
+STUB_SCH = "(kicad_sch)\n"
+
+
+@pytest.fixture
+def pcb_file(tmp_path: Path) -> Path:
+    p = tmp_path / "board.kicad_pcb"
+    p.write_text(STUB_PCB)
+    return p
+
+
+@pytest.fixture
+def sch_file(tmp_path: Path) -> Path:
+    p = tmp_path / "board.kicad_sch"
+    p.write_text(STUB_SCH)
+    return p
+
+
+def _ctx(pcb: Path, sch: Path | None = None, **overrides) -> PipelineContext:
+    """Build a minimal PipelineContext for tests."""
+    return PipelineContext(
+        pcb_file=pcb,
+        schematic_file=sch,
+        mfr="jlcpcb",
+        layers="2",
+        **overrides,
+    )
+
+
+class TestSyncStepOrdering:
+    """Ordering and registration of the SYNC step."""
+
+    def test_sync_step_in_all_steps(self) -> None:
+        """SYNC is present in ALL_STEPS."""
+        assert PipelineStep.SYNC in ALL_STEPS
+
+    def test_sync_step_in_step_runners(self) -> None:
+        """SYNC has a runner registered."""
+        assert PipelineStep.SYNC in STEP_RUNNERS
+        assert STEP_RUNNERS[PipelineStep.SYNC] is _run_step_sync
+
+    def test_sync_step_falls_between_fix_erc_and_fix_silkscreen(self) -> None:
+        """SYNC sits after FIX_ERC and before FIX_SILKSCREEN."""
+        order = ALL_STEPS
+        assert order.index(PipelineStep.FIX_ERC) < order.index(PipelineStep.SYNC)
+        assert order.index(PipelineStep.SYNC) < order.index(PipelineStep.FIX_SILKSCREEN)
+
+    def test_sync_step_before_route(self) -> None:
+        """SYNC must run before ROUTE so routing sees a complete footprint set."""
+        order = ALL_STEPS
+        assert order.index(PipelineStep.SYNC) < order.index(PipelineStep.ROUTE)
+
+    def test_sync_choice_advertised_in_help(self, pcb_file: Path) -> None:
+        """The --step argparse choice list includes 'sync'."""
+        # Trying an invalid value would raise SystemExit; 'sync' is accepted.
+        with patch(
+            "kicad_tools.cli.pipeline_cmd.run_pipeline",
+            return_value=[],
+        ):
+            rc = pipeline_main(["--step", "sync", str(pcb_file)])
+        assert rc in (0, 1)  # accepted by argparse (not 2)
+
+
+class TestSyncStepSkipBehavior:
+    """Skip / dry-run behavior of _run_step_sync."""
+
+    def test_skipped_when_no_schematic(self, pcb_file: Path) -> None:
+        """No schematic available -> skip with informative message."""
+        ctx = _ctx(pcb_file, sch=None)
+        console = Console(quiet=True)
+
+        result = _run_step_sync(ctx, console)
+
+        assert result.skipped is True
+        assert result.success is True
+        assert PipelineStep.SYNC in (result.step, PipelineStep.SYNC)
+        assert "no .kicad_sch" in result.message
+
+    def test_dry_run_skips_reconciler(self, pcb_file: Path, sch_file: Path) -> None:
+        """--dry-run never instantiates a Reconciler."""
+        ctx = _ctx(pcb_file, sch=sch_file, dry_run=True)
+        console = Console(quiet=True)
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_recon:
+            result = _run_step_sync(ctx, console)
+
+        mock_recon.assert_not_called()
+        assert result.success is True
+        assert result.message.startswith("[dry-run]")
+
+
+class TestSyncStepBehavior:
+    """Analyze / apply behavior of _run_step_sync."""
+
+    def test_in_sync_passes(self, pcb_file: Path, sch_file: Path) -> None:
+        """An in-sync analysis returns success without warnings."""
+        ctx = _ctx(pcb_file, sch=sch_file)
+        console = Console(quiet=True)
+
+        analysis = SyncAnalysis()  # empty analysis is in sync
+        assert analysis.is_in_sync
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            result = _run_step_sync(ctx, console)
+
+        assert result.success is True
+        assert result.warning is False
+        assert result.skipped is False
+        assert "in sync" in result.message
+
+    def test_orphans_block_without_force(self, pcb_file: Path, sch_file: Path) -> None:
+        """Schematic orphans halt the pipeline unless --force or --apply-sync."""
+        ctx = _ctx(pcb_file, sch=sch_file)
+        console = Console(quiet=True)
+
+        analysis = SyncAnalysis(schematic_orphans=["U99", "R42"])
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            result = _run_step_sync(ctx, console)
+
+        assert result.success is False
+        assert "schematic-only" in result.message
+        assert "--apply-sync" in result.message
+        assert "--force" in result.message
+
+    def test_force_continues_with_warning(self, pcb_file: Path, sch_file: Path) -> None:
+        """--force lets the pipeline proceed past orphan drift as a warning."""
+        ctx = _ctx(pcb_file, sch=sch_file, force=True)
+        console = Console(quiet=True)
+
+        analysis = SyncAnalysis(schematic_orphans=["U99"])
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            result = _run_step_sync(ctx, console)
+
+        assert result.success is True
+        assert result.warning is True
+        assert "continuing" in result.message.lower()
+
+    def test_value_mismatch_only_is_warning(self, pcb_file: Path, sch_file: Path) -> None:
+        """Value mismatches alone are non-blocking warnings."""
+        ctx = _ctx(pcb_file, sch=sch_file)
+        console = Console(quiet=True)
+
+        analysis = SyncAnalysis(
+            value_mismatches=[
+                {
+                    "reference": "R1",
+                    "schematic_value": "10k",
+                    "pcb_value": "1k",
+                }
+            ]
+        )
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            result = _run_step_sync(ctx, console)
+
+        assert result.success is True
+        assert result.warning is True
+        assert "value mismatch" in result.message.lower()
+
+    def test_apply_sync_invokes_apply(self, pcb_file: Path, sch_file: Path) -> None:
+        """--apply-sync calls Reconciler.apply with dry_run=False, min_confidence=high."""
+        ctx = _ctx(pcb_file, sch=sch_file, apply_sync=True)
+        console = Console(quiet=True)
+
+        analysis = SyncAnalysis(
+            schematic_orphans=["U99"],
+            add_footprint_actions=[
+                {
+                    "type": "add_footprint",
+                    "reference": "U99",
+                    "footprint": "Package_SO:SOIC-8",
+                    "value": "AMP",
+                }
+            ],
+        )
+        post_analysis = SyncAnalysis()  # in-sync after apply
+        applied_change = SyncChange(
+            reference="U99",
+            change_type="add_footprint",
+            old_value="",
+            new_value="Package_SO:SOIC-8",
+            applied=True,
+        )
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            inst = mock_cls.return_value
+            inst.analyze.side_effect = [analysis, post_analysis]
+            inst.apply.return_value = [applied_change]
+
+            result = _run_step_sync(ctx, console)
+
+        # apply() must be invoked with the expected contract
+        inst.apply.assert_called_once()
+        kwargs = inst.apply.call_args.kwargs
+        assert kwargs.get("dry_run") is False
+        assert kwargs.get("min_confidence") == "high"
+        assert kwargs.get("remove_orphans") is False
+
+        assert result.success is True
+        assert "applied" in result.message
+        # post-apply analysis was in sync -> no warning
+        assert result.warning is False
+
+    def test_apply_sync_residual_drift_marks_warning(self, pcb_file: Path, sch_file: Path) -> None:
+        """When apply leaves residual drift, the step is success+warning."""
+        ctx = _ctx(pcb_file, sch=sch_file, apply_sync=True)
+        console = Console(quiet=True)
+
+        analysis = SyncAnalysis(schematic_orphans=["U99", "U100"])
+        post_analysis = SyncAnalysis(schematic_orphans=["U100"])  # partial
+        applied_change = SyncChange(
+            reference="U99",
+            change_type="add_footprint",
+            old_value="",
+            new_value="x",
+            applied=True,
+        )
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            inst = mock_cls.return_value
+            inst.analyze.side_effect = [analysis, post_analysis]
+            inst.apply.return_value = [applied_change]
+
+            result = _run_step_sync(ctx, console)
+
+        assert result.success is True
+        assert result.warning is True
+
+    def test_apply_sync_failure_returns_failure(self, pcb_file: Path, sch_file: Path) -> None:
+        """If Reconciler.apply raises, the step reports failure."""
+        ctx = _ctx(pcb_file, sch=sch_file, apply_sync=True)
+        console = Console(quiet=True)
+
+        analysis = SyncAnalysis(schematic_orphans=["U99"])
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            inst = mock_cls.return_value
+            inst.analyze.return_value = analysis
+            inst.apply.side_effect = RuntimeError("boom")
+            result = _run_step_sync(ctx, console)
+
+        assert result.success is False
+        assert "apply failed" in result.message
+
+    def test_analyze_failure_returns_failure(self, pcb_file: Path, sch_file: Path) -> None:
+        """If analyze() raises, the step reports failure without halting elsewhere."""
+        ctx = _ctx(pcb_file, sch=sch_file)
+        console = Console(quiet=True)
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.side_effect = RuntimeError("cannot load")
+            result = _run_step_sync(ctx, console)
+
+        assert result.success is False
+        assert "failed to analyze" in result.message
+
+
+class TestSyncStepNoSubprocess:
+    """The sync step must use the in-process Reconciler API."""
+
+    def test_no_subprocess_in_runner_source(self) -> None:
+        """Static check: _run_step_sync source does not shell out via subprocess."""
+        import inspect
+
+        src = inspect.getsource(_run_step_sync)
+        # The runner must not call subprocess.run() or _run_subprocess_step()
+        assert "subprocess.run" not in src
+        assert "_run_subprocess_step" not in src
+
+
+class TestApplySyncFlag:
+    """Argparse plumbing for the --apply-sync flag."""
+
+    def test_apply_sync_threaded_into_context(self, pcb_file: Path) -> None:
+        """--apply-sync flag is threaded into PipelineContext.apply_sync."""
+        captured: dict = {}
+
+        def _capture(ctx, steps=None):
+            captured["apply_sync"] = ctx.apply_sync
+            return []
+
+        with patch("kicad_tools.cli.pipeline_cmd.run_pipeline", side_effect=_capture):
+            pipeline_main(["--step", "sync", "--apply-sync", str(pcb_file)])
+
+        assert captured.get("apply_sync") is True
+
+    def test_apply_sync_default_false(self, pcb_file: Path) -> None:
+        """Without --apply-sync, ctx.apply_sync defaults to False."""
+        captured: dict = {}
+
+        def _capture(ctx, steps=None):
+            captured["apply_sync"] = ctx.apply_sync
+            return []
+
+        with patch("kicad_tools.cli.pipeline_cmd.run_pipeline", side_effect=_capture):
+            pipeline_main(["--step", "sync", str(pcb_file)])
+
+        assert captured.get("apply_sync") is False


### PR DESCRIPTION
## Summary

Adds a new `sync` step to `kct pipeline` between `fix-erc` and `fix-silkscreen`, so the pipeline reconciles schematic and PCB component sets before routing. Resolves the case where `kct pipeline --sch board.kicad_sch board.kicad_pcb` happily exported a manufacturing package with 32 missing footprints because nothing reconciled the schematic into the PCB.

## Behavior

- **Default** (no flag): runs `Reconciler.analyze()` in-process. If any `schematic_orphans` exist, the pipeline halts with a message pointing the user at `--apply-sync` and `--force`. Other drift (value/footprint mismatches, PCB-only refs) is downgraded to a non-blocking warning.
- **`--apply-sync`**: calls `Reconciler.apply(dry_run=False, min_confidence="high", remove_orphans=False)` to add the missing footprints and apply high-confidence corrections, then re-runs `analyze()` and reports residual drift.
- **`--force`**: continues past sync drift without modifying the PCB (parallels ERC `--force` semantics).
- **`--dry-run`**: prints a preview without instantiating `Reconciler` or loading any files.
- Skips gracefully (same wording style as ERC) when no `.kicad_sch` is found alongside the PCB and `--sch` is not supplied.

The runner uses `kicad_tools.sync.reconciler.Reconciler` directly — no `subprocess.run([\"kct\", \"sync\", ...])` calls. The `--step` argparse choices auto-include `sync` from the `PipelineStep` enum, and the top-level `kct pipeline --step` choice list was updated to match.

## Files touched

- `src/kicad_tools/cli/pipeline_cmd.py`: new `PipelineStep.SYNC`, `_run_step_sync`, `_print_sync_analysis_detail`, `--apply-sync` argparse flag, `apply_sync` field on `PipelineContext`, slotted into `ALL_STEPS` and `STEP_RUNNERS`.
- `src/kicad_tools/cli/parser.py`: added `sync` to the top-level `--step` choices and `--apply-sync` (`pipeline_apply_sync`) flag.
- `src/kicad_tools/cli/commands/pipeline.py`: pass `--apply-sync` through to `pipeline_cmd.main`.
- `tests/test_pipeline_cmd.py`: updated two ordering tests (`test_step_order`, `test_erc_is_first_step`) to include the new step.
- `tests/test_pipeline_sync_step.py`: new test file with 18 tests covering ordering, skip, dry-run, in-sync, orphans-block, `--force`, `--apply-sync`, residual-drift warning, value-mismatch-warning, analyze failure, apply failure, no-subprocess static check, and argparse flag plumbing.

## Test plan

- [x] `uv run pytest tests/test_pipeline_sync_step.py` — 18/18 passing
- [x] `uv run pytest tests/test_pipeline_cmd.py tests/test_pipeline_cli_args.py` — 275 passing, 5 pre-existing failures unrelated to this PR (verified failing on `main` at the same commit)
- [x] `uv run pytest tests/test_sync.py tests/test_sync_cli.py` — 109/109 passing (no regression in Reconciler)
- [x] `uv run ruff check` and `uv run ruff format` clean on touched files
- [x] `kct pipeline --help` advertises `sync` in `--step` choices and `--apply-sync` flag
- [x] Smoke: `kct pipeline --dry-run --sch board.kicad_sch board.kicad_pcb` shows `Would run: kct sync --analyze board.kicad_sch --pcb board.kicad_pcb` between `fix-erc` and `fix-silkscreen`

## Manual smoke (chorus-test-revA repro, per curator)

\`\`\`
uv run kct pipeline projects/chorus-test-revA/kicad/chorus-test-revA.kicad_pcb \\
  --sch projects/chorus-test-revA/kicad/chorus-test-revA.kicad_sch
# expect: halt before route with sync drift summary

uv run kct pipeline projects/chorus-test-revA/kicad/chorus-test-revA.kicad_pcb \\
  --sch projects/chorus-test-revA/kicad/chorus-test-revA.kicad_sch --apply-sync
# expect: 32 footprints added, pipeline continues, BOM matches placed pads
\`\`\`

## Out of scope

- Removing PCB orphans (still requires explicit opt-in via the underlying API; `--apply-sync` calls `remove_orphans=False`).
- The duplicate `_run_step_fix_erc` definitions at `pipeline_cmd.py:389` and `:480` — pre-existing dead-code issue, deserves its own ticket.
- LVS / net-level reconciliation.

Closes #2730